### PR TITLE
First part of TPC tracking with continuous data and distortions

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -666,7 +666,7 @@ bool MatchTPCITS::prepareTPCTracks()
       mTPCLblWork.emplace_back(mTPCTrkLabels->getLabels(it)[0]);
     }
 
-    float time0 = trcOrig.getTime0() - mNTPCBinsFullDrift;
+    float time0 = trcOrig.getTime0();
     trc.timeBins.set(time0 - trcOrig.getDeltaTBwd() - mTPCTimeEdgeTSafeMargin,
                      time0 + trcOrig.getDeltaTFwd() + mTPCTimeEdgeTSafeMargin);
     // assign min max possible Z for this track which still respects the clusters A/C side
@@ -1496,7 +1496,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
 
   /// precise time estimate
   auto tpcTrOrig = mTPCTracksArray[tTPC.sourceID];
-  float timeTB = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
+  float timeTB = tpcTrOrig.getTime0();
   if (tpcTrOrig.hasASideClustersOnly()) {
     timeTB += deltaT;
   } else if (tpcTrOrig.hasCSideClustersOnly()) {
@@ -1690,7 +1690,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
 
   /// precise time estimate
   const auto& tpcTrOrig = mTPCTracksArray[tTPC.sourceID];
-  float timeTB = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
+  float timeTB = tpcTrOrig.getTime0();
   if (tpcTrOrig.hasASideClustersOnly()) {
     timeTB += deltaT;
   } else if (tpcTrOrig.hasCSideClustersOnly()) {
@@ -2443,7 +2443,7 @@ float MatchTPCITS::correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTP
   if (tpcTrOrig.hasBothSidesClusters()) {
     return 0.;
   }
-  float timeIC = cand.timeBins.mean(), timeTrc = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
+  float timeIC = cand.timeBins.mean(), timeTrc = tpcTrOrig.getTime0();
   float driftErr = cand.timeBins.delta() * mTPCBin2Z;
 
   // we use this for refit

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -136,7 +136,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
   for (char cside = 0; cside < 2; cside++) {
     for (int i = 0; i < nTracks; i++) {
       if (tracks[i].OK() && tracks[i].CSide() == cside) {
-        trackSort[tmp++] = {i, (cside == 0 ? 1.f : -1.f) * tracks[i].GetParam().GetZOffset()};
+        trackSort[tmp++] = {i, tracks[i].GetParam().GetTZOffset()};
         auto ncl = tracks[i].NClusters();
         clBuff += ncl + (ncl + 1) / 2; // actual N clusters to store will be less
       }
@@ -159,8 +159,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
     float time0 = 0.f, tFwd = 0.f, tBwd = 0.f;
 
     if (mTrackingCAO2Interface->GetParamContinuous()) {
-      float zoffset = tracks[i].CSide() ? -tracks[i].GetParam().GetZOffset() : tracks[i].GetParam().GetZOffset();
-      time0 = sContinuousTFReferenceLength - zoffset * vzbinInv;
+      time0 = tracks[i].GetParam().GetTZOffset();
 
       if (tracks[i].CCE()) {
         bool lastSide = trackClusters[tracks[i].FirstClusterRef()].slice < Sector::MAXSECTOR / 2;
@@ -183,8 +182,8 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
         float t1 = clusters->clusters[c1.slice][c1.row][c1.num].getTime();
         float t2 = clusters->clusters[c2.slice][c2.row][c2.num].getTime();
         auto times = std::minmax(t1, t2);
-        tFwd = times.first - time0 + detParam.TPClength * vzbinInv;
-        tBwd = time0 - times.second;
+        tFwd = times.first - time0;
+        tBwd = time0 - (times.second - detParam.TPClength * vzbinInv);
       }
     }
 

--- a/GPU/Common/GPUCommonDef.h
+++ b/GPU/Common/GPUCommonDef.h
@@ -75,6 +75,8 @@
 
 #if (defined(__CUDACC__) && defined(GPUCA_CUDA_NO_CONSTANT_MEMORY)) || (defined(__HIPCC__) && defined(GPUCA_HIP_NO_CONSTANT_MEMORY)) || (defined(__OPENCL__) && !defined(__OPENCLCPP__) && defined(GPUCA_OPENCL_NO_CONSTANT_MEMORY)) || (defined(__OPENCLCPP__) && defined(GPUCA_OPENCLCPP_NO_CONSTANT_MEMORY))
   #define GPUCA_NO_CONSTANT_MEMORY
+#elif defined(__CUDACC__) || defined(__HIPCC__)
+  #define GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM
 #endif
 #if (defined(__HIPCC__) && defined(GPUCA_HIP_CONSTANT_AS_ARGUMENT))
   #define GPUCA_CONSTANT_AS_ARGUMENT

--- a/GPU/Common/GPUCommonDefAPI.h
+++ b/GPU/Common/GPUCommonDefAPI.h
@@ -132,7 +132,7 @@
   #else
     #define GPUglobal()
   #endif
-  #define GPUconstant()
+  #define GPUconstant() __constant__
   #define GPUconstexpr() __constant__
   #define GPUprivate()
   #define GPUgeneric()
@@ -151,7 +151,7 @@
   #define GPUg() __global__
   #define GPUshared() __shared__
   #define GPUglobal()
-  #define GPUconstant()
+  #define GPUconstant() __constant__
   #define GPUconstexpr() __constant__
   #define GPUprivate()
   #define GPUgeneric()

--- a/GPU/GPUTracking/Base/GPUConstantMem.h
+++ b/GPU/GPUTracking/Base/GPUConstantMem.h
@@ -103,8 +103,44 @@ union GPUConstantMemCopyable {
 };
 #endif
 
+#if defined(GPUCA_GPUCODE) && defined(GPUCA_NOCOMPAT)
+static constexpr size_t gGPUConstantMemBufferSize = (sizeof(GPUConstantMem) + sizeof(uint4) - 1);
+#if defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+#ifdef GPUCA_CONSMEM_UINT4_BACKEND
+GPUconstant() uint4 gGPUConstantMemBuffer[o2::gpu::gGPUConstantMemBufferSize / sizeof(uint4)];
+#else
+GPUconstant() o2::gpu::GPUConstantMemCopyable gGPUConstantMemBuffer; // HIP constant memory symbol address cannot be obtained when in namespace
+#endif
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+#endif
+#ifdef GPUCA_CONSTANT_AS_ARGUMENT
+static GPUConstantMemCopyable gGPUConstantMemBufferHost;
+#endif
+#endif
+
 // Must be placed here, to avoid circular header dependency
-GPUdi() GPUconstantref() const MEM_CONSTANT(GPUParam) & GPUProcessor::Param() const { return mConstantMem->param; }
+GPUdi() GPUconstantref() const MEM_CONSTANT(GPUParam) & GPUProcessor::Param() const
+{
+#if defined(GPUCA_GPUCODE_DEVICE) && defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
+  return GPUCA_CONSMEM.param;
+#else
+  return mConstantMem->param;
+#endif
+}
+
+GPUdi() GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * GPUProcessor::GetConstantMem() const
+{
+#if defined(GPUCA_GPUCODE_DEVICE) && defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
+  return &GPUCA_CONSMEM;
+#else
+  return mConstantMem;
+#endif
+}
 
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Base/GPUConstantMem.h
+++ b/GPU/GPUTracking/Base/GPUConstantMem.h
@@ -108,11 +108,7 @@ static constexpr size_t gGPUConstantMemBufferSize = (sizeof(GPUConstantMem) + si
 #if defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
-#ifdef GPUCA_CONSMEM_UINT4_BACKEND
-GPUconstant() uint4 gGPUConstantMemBuffer[o2::gpu::gGPUConstantMemBufferSize / sizeof(uint4)];
-#else
 GPUconstant() o2::gpu::GPUConstantMemCopyable gGPUConstantMemBuffer; // HIP constant memory symbol address cannot be obtained when in namespace
-#endif
 namespace GPUCA_NAMESPACE
 {
 namespace gpu

--- a/GPU/GPUTracking/Base/GPUProcessor.h
+++ b/GPU/GPUTracking/Base/GPUProcessor.h
@@ -51,11 +51,8 @@ class GPUProcessor
   GPUProcessor& operator=(const GPUProcessor&) CON_DELETE;
 #endif
 
-  GPUd() GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * GetConstantMem() const
-  {
-    return mConstantMem;
-  }
-  GPUd() GPUconstantref() const MEM_CONSTANT(GPUParam) & Param() const; // Body in GPUConstantMem.h to avoid circular headers
+  GPUd() GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * GetConstantMem() const; // Body in GPUConstantMem.h to avoid circular headers
+  GPUd() GPUconstantref() const MEM_CONSTANT(GPUParam) & Param() const;                // ...
   const GPUReconstruction& GetRec() const { return *mRec; }
 
 #ifndef __OPENCL__

--- a/GPU/GPUTracking/Base/GPURawData.h
+++ b/GPU/GPUTracking/Base/GPURawData.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPURawData.h
+/// \author David Rohr
+
+#ifndef O2_GPU_RAW_DATA_H
+#define O2_GPU_RAW_DATA_H
+
+// Raw data parser is not accessible from GPU, therefore we use this header to wrap direct access to the current RDH
+// Since OpenCL currently doesn't support bit fields, we have to access the members directly
+
+#include "GPUCommonDef.h"
+#ifndef __OPENCL__
+#include "Headers/RAWDataHeader.h"
+#else
+namespace o2
+{
+namespace header
+{
+struct RAWDataHeader {
+  union {
+    unsigned int words[8];
+  };
+};
+} // namespace header
+} // namespace o2
+#endif
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+class GPURawDataUtils
+{
+ public:
+  static GPUd() unsigned int getOrbit(const o2::header::RAWDataHeader* rdh);
+};
+
+GPUdi() unsigned int GPURawDataUtils::getOrbit(const o2::header::RAWDataHeader* rdh)
+{
+#ifndef __OPENCL__
+  return rdh->heartbeatOrbit;
+#else
+  return (rdh->words[2] >> 32);
+#endif
+}
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -30,7 +30,7 @@
 #include "Digit.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
 #include "DataFormatsTPC/Constants.h"
-#include "Headers/RAWDataHeader.h"
+#include "GPURawData.h"
 #include "CommonConstants/LHCConstants.h"
 #endif
 
@@ -153,8 +153,9 @@ int GPUReconstructionConvert::GetMaxTimeBin(const GPUTrackingInOutZS& zspages)
       for (unsigned int k = 0; k < zspages.slice[i].count[j]; k++) {
         const char* page = (const char*)zspages.slice[i].zsPtr[j][k];
         for (unsigned int l = 0; l < zspages.slice[i].nZSPtr[j][k]; l++) {
+          o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE);
           TPCZSHDR* hdr = (TPCZSHDR*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE + sizeof(o2::header::RAWDataHeader));
-          unsigned int timeBin = (unsigned int)hdr->timeOffset + hdr->nTimeBins;
+          unsigned int timeBin = GPURawDataUtils::getOrbit(rdh) * o2::constants::lhc::LHCMaxBunches / o2::tpc::Constants::LHCBCPERTIMEBIN + (unsigned int)hdr->timeOffset + hdr->nTimeBins;
           if (timeBin > retVal) {
             retVal = timeBin;
           }

--- a/GPU/GPUTracking/Base/GPUSettings.cxx
+++ b/GPU/GPUTracking/Base/GPUSettings.cxx
@@ -47,6 +47,7 @@ void GPUSettingsRec::SetDefaults()
   fwdTPCDigitsAsClusters = 0;
   bz0Pt = 60;
   dropLoopers = false;
+  mergerCovSource = 2;
 }
 
 void GPUSettingsEvent::SetDefaults()

--- a/GPU/GPUTracking/Base/GPUSettings.h
+++ b/GPU/GPUTracking/Base/GPUSettings.h
@@ -78,6 +78,7 @@ struct GPUSettingsRec {
   unsigned char fwdTPCDigitsAsClusters;  // Simply forward TPC digits as clusters
   unsigned char bz0Pt;                   // Nominal Pt to set when bz = 0 (in 10 MeV)
   unsigned char dropLoopers;             // Drop all clusters after starting from the second loop from tracks
+  unsigned char mergerCovSource;         // 0 = simpleFilterErrors, 1 = use from track following
 };
 
 // Settings describing the events / time frames

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -27,10 +27,10 @@ using namespace GPUCA_NAMESPACE::gpu;
 
 constexpr size_t gGPUConstantMemBufferSize = (sizeof(GPUConstantMem) + sizeof(uint4) - 1);
 #ifndef GPUCA_NO_CONSTANT_MEMORY
-__constant__ uint4 gGPUConstantMemBuffer[gGPUConstantMemBufferSize / sizeof(uint4)];
+__constant__ GPUConstantMemCopyable gGPUConstantMemBuffer;
 #define GPUCA_CONSMEM_PTR
 #define GPUCA_CONSMEM_CALL
-#define GPUCA_CONSMEM (GPUConstantMem&)gGPUConstantMemBuffer
+#define GPUCA_CONSMEM gGPUConstantMemBuffer.v
 #else
 #define GPUCA_CONSMEM_PTR const GPUConstantMem *gGPUConstantMemBuffer,
 #define GPUCA_CONSMEM_CALL me->mDeviceConstantMem,

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -19,23 +19,23 @@
 #define assert(...)
 #endif
 
+#include "GPUDef.h"
+
+#ifndef GPUCA_NO_CONSTANT_MEMORY
+#define GPUCA_CONSMEM_PTR
+#define GPUCA_CONSMEM_CALL
+#define GPUCA_CONSMEM (gGPUConstantMemBuffer.v)
+#else
+#define GPUCA_CONSMEM_PTR const GPUConstantMem *gGPUConstantMemBuffer,
+#define GPUCA_CONSMEM_CALL me->mDeviceConstantMem,
+#define GPUCA_CONSMEM ((GPUConstantMem&)(*gGPUConstantMemBuffer))
+#endif
+
 #include "GPUReconstructionCUDA.h"
 #include "GPUReconstructionCUDAInternals.h"
 #include "GPUReconstructionIncludes.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
-
-constexpr size_t gGPUConstantMemBufferSize = (sizeof(GPUConstantMem) + sizeof(uint4) - 1);
-#ifndef GPUCA_NO_CONSTANT_MEMORY
-__constant__ GPUConstantMemCopyable gGPUConstantMemBuffer;
-#define GPUCA_CONSMEM_PTR
-#define GPUCA_CONSMEM_CALL
-#define GPUCA_CONSMEM gGPUConstantMemBuffer.v
-#else
-#define GPUCA_CONSMEM_PTR const GPUConstantMem *gGPUConstantMemBuffer,
-#define GPUCA_CONSMEM_CALL me->mDeviceConstantMem,
-#define GPUCA_CONSMEM (GPUConstantMem&)(*gGPUConstantMemBuffer)
-#endif
 
 #ifdef GPUCA_USE_TEXTURES
 texture<cahit2, cudaTextureType1D, cudaReadModeElementType> gAliTexRefu2;

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -32,8 +32,7 @@
   #else
     #define GPUCA_CONSMEM_PTR
     #define GPUCA_CONSMEM_CALL
-    #define GPUCA_CONSMEM ((GPUConstantMem&)gGPUConstantMemBuffer)
-    #define GPUCA_CONSMEM_UINT4_BACKEND
+    #define GPUCA_CONSMEM (gGPUConstantMemBuffer.v)
   #endif
 #else
   #define GPUCA_CONSMEM_PTR const GPUConstantMem *gGPUConstantMemBuffer,

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -21,28 +21,19 @@
 #include <hip/hip_ext.h>
 #endif
 
-#include "GPUReconstructionHIP.h"
-#include "GPUReconstructionHIPInternals.h"
-#include "GPUReconstructionIncludes.h"
-
-using namespace GPUCA_NAMESPACE::gpu;
+#include "GPUDef.h"
 
 // clang-format off
-constexpr size_t gGPUConstantMemBufferSize = sizeof(GPUConstantMem);
 #ifndef GPUCA_NO_CONSTANT_MEMORY
-  // __constant__ GPUConstantMem gGPUConstantMemBuffer; // This compiles, but still doesn't work correctly at runtime
-  // #define GPUCA_CONSMEM gGPUConstantMemBuffer
-  __constant__ uint4 gGPUConstantMemBuffer[gGPUConstantMemBufferSize / sizeof(uint4)];
-  __global__ void gGPUConstantMemBuffer_dummy(int* p) { *p = *(int*)&gGPUConstantMemBuffer; }
   #ifdef GPUCA_CONSTANT_AS_ARGUMENT
     #define GPUCA_CONSMEM_PTR const GPUConstantMemCopyable gGPUConstantMemBufferByValue,
     #define GPUCA_CONSMEM_CALL gGPUConstantMemBufferHost,
-    #define GPUCA_CONSMEM const_cast<GPUConstantMem&>(gGPUConstantMemBufferByValue.v)
-    static GPUConstantMemCopyable gGPUConstantMemBufferHost;
+    #define GPUCA_CONSMEM (const_cast<GPUConstantMem&>(gGPUConstantMemBufferByValue.v))
   #else
     #define GPUCA_CONSMEM_PTR
     #define GPUCA_CONSMEM_CALL
-    #define GPUCA_CONSMEM (GPUConstantMem&)gGPUConstantMemBuffer
+    #define GPUCA_CONSMEM ((GPUConstantMem&)gGPUConstantMemBuffer)
+    #define GPUCA_CONSMEM_UINT4_BACKEND
   #endif
 #else
   #define GPUCA_CONSMEM_PTR const GPUConstantMem *gGPUConstantMemBuffer,
@@ -50,6 +41,16 @@ constexpr size_t gGPUConstantMemBufferSize = sizeof(GPUConstantMem);
   #define GPUCA_CONSMEM const_cast<GPUConstantMem&>(*gGPUConstantMemBuffer)
 #endif
 // clang-format on
+
+#include "GPUReconstructionHIP.h"
+#include "GPUReconstructionHIPInternals.h"
+#include "GPUReconstructionIncludes.h"
+
+#ifdef GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM
+__global__ void gGPUConstantMemBuffer_dummy(int* p) { *p = *(int*)&gGPUConstantMemBuffer; }
+#endif
+
+using namespace GPUCA_NAMESPACE::gpu;
 
 __global__ void gHIPMemSetWorkaround(char* ptr, char val, size_t size)
 {

--- a/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cl
+++ b/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cl
@@ -78,7 +78,7 @@
 #define GPUCA_KRNL_LOAD_single(x_class, x_attributes, x_arguments, x_forward) GPUCA_KRNLGPU_SINGLE(x_class, x_attributes, x_arguments, x_forward)
 #define GPUCA_KRNL_LOAD_multi(x_class, x_attributes, x_arguments, x_forward) GPUCA_KRNLGPU_MULTI(x_class, x_attributes, x_arguments, x_forward)
 #define GPUCA_CONSMEM_PTR GPUglobal() char *gpu_mem, GPUconstant() MEM_CONSTANT(GPUConstantMem) * pConstant,
-#define GPUCA_CONSMEM *pConstant
+#define GPUCA_CONSMEM (*pConstant)
 #include "GPUReconstructionKernels.h"
 #undef GPUCA_KRNL
 #undef GPUCA_KRNL_LOAD_single

--- a/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cxx
+++ b/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cxx
@@ -25,8 +25,6 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include <typeinfo>
 #include <cstdlib>
 
-constexpr size_t gGPUConstantMemBufferSize = sizeof(GPUConstantMem);
-
 #define quit(...)          \
   {                        \
     GPUError(__VA_ARGS__); \

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -116,6 +116,7 @@ set(HDRS_INSTALL
     Base/GPUO2DataTypes.h
     Base/GPUHostDataTypes.h
     Base/GPUMemorySizeScalers.h
+    Base/GPURawData.h
     dEdx/GPUdEdxInfo.h
     TPCConvert/GPUTPCConvertImpl.h
     Base/GPUReconstructionKernelMacros.h

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -81,7 +81,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
       int cidx = trk.FirstClusterRef() + nClustersStored++;
       if (nClustersStored == 1) {
         unsigned char qpt = fabs(trk.GetParam().GetQPt()) < 20.f ? (trk.GetParam().GetQPt() * (127.f / 20.f) + 127.5f) : (trk.GetParam().GetQPt() > 0 ? 254 : 0);
-        track.Init(x, y, z, param.SliceParam[hit.slice].Alpha, qpt, param);
+        track.Init(x, y, z, param.SliceParam[hit.slice].Alpha, qpt, param); // TODO: Compression track model must respect Z offset!
 
         myTrack = CAMath::AtomicAdd(&compressor.mMemory->nStoredTracks, 1);
         compressor.mAttachedClusterFirstIndex[myTrack] = trk.FirstClusterRef();

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -139,7 +139,7 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
       temporaryTrack.SinPhi() = crv * (x3 - x0);
       temporaryTrack.DzDs() = 0.5f * (tgl12 + tgl23);
       temporaryTrack.QPt() = CAMath::Abs(bz) < constants::math::Almost0 ? constants::math::Almost0 : crv / (bz * constants::math::B2C);
-      temporaryTrack.ZOffset() = 0;
+      temporaryTrack.TZOffset() = 0;
       temporaryTrack.Cov()[0] = s2;
       temporaryTrack.Cov()[1] = 0.f;
       temporaryTrack.Cov()[2] = s2;

--- a/GPU/GPUTracking/Merger/GPUTPCGMBorderTrack.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMBorderTrack.h
@@ -42,7 +42,7 @@ class GPUTPCGMBorderTrack
   GPUd() short NClusters() const { return mNClusters; }
   GPUd() short Row() const { return mRow; }
   GPUd() const float* Par() const { return mP; }
-  GPUd() float ZOffset() const { return mZOffset; }
+  GPUd() float ZOffsetLinear() const { return mZOffsetLinear; }
   GPUd() const float* Cov() const { return mC; }
   GPUd() const float* CovD() const { return mD; }
 
@@ -50,7 +50,7 @@ class GPUTPCGMBorderTrack
   GPUd() void SetNClusters(short v) { mNClusters = v; }
   GPUd() void SetRow(short v) { mRow = v; }
   GPUd() void SetPar(int i, float x) { mP[i] = x; }
-  GPUd() void SetZOffset(float v) { mZOffset = v; }
+  GPUd() void SetZOffsetLinear(float v) { mZOffsetLinear = v; }
   GPUd() void SetCov(int i, float x) { mC[i] = x; }
   GPUd() void SetCovD(int i, float x) { mD[i] = x; }
 
@@ -75,7 +75,7 @@ class GPUTPCGMBorderTrack
 
   GPUd() bool CheckChi2Z(const GPUTPCGMBorderTrack& t, float chi2cut) const
   {
-    float d = mP[1] - t.mP[1] + (mZOffset - t.mZOffset);
+    float d = mP[1] - t.mP[1] + (mZOffsetLinear - t.mZOffsetLinear);
     return (d * d < chi2cut * (mC[1] + t.mC[1]));
   }
 
@@ -90,7 +90,7 @@ class GPUTPCGMBorderTrack
 
   GPUd() bool CheckChi2YS(const GPUTPCGMBorderTrack& t, float chi2cut) const { return CheckChi2(mP[0], mP[2], mC[0], mD[0], mC[2], t.mP[0], t.mP[2], t.mC[0], t.mD[0], t.mC[2], chi2cut); }
 
-  GPUd() bool CheckChi2ZT(const GPUTPCGMBorderTrack& t, float chi2cut) const { return CheckChi2(mP[1], mP[3], mC[1], mD[1], mC[3], t.mP[1] + (t.mZOffset - mZOffset), t.mP[3], t.mC[1], t.mD[1], t.mC[3], chi2cut); }
+  GPUd() bool CheckChi2ZT(const GPUTPCGMBorderTrack& t, float chi2cut) const { return CheckChi2(mP[1], mP[3], mC[1], mD[1], mC[3], t.mP[1] + (t.mZOffsetLinear - mZOffsetLinear), t.mP[3], t.mC[1], t.mD[1], t.mC[3], chi2cut); }
 
   GPUd() void LimitCov()
   {
@@ -127,7 +127,7 @@ class GPUTPCGMBorderTrack
   short mNClusters; // n clusters
   short mRow;
   float mP[5];
-  float mZOffset;
+  float mZOffsetLinear; // Z Offset, in case of T offset scaled linearly to Z with nominal vDrift. Used only for matching / merging
   float mC[5];
   float mD[2];
 };

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -144,7 +144,7 @@ int GPUTPCGMMerger::GetTrackLabel(const GPUTPCGMBorderTrack& trk)
   std::vector<int> labels;
   for (int i = 0; i < nClusters; i++) {
     for (int j = 0; j < 3; j++) {
-      int label = mChainTracking->mIOPtrs.mcLabelsTPC[clusters[i].GetId()].mClusterID[j].fMCID;
+      int label = mChainTracking->mIOPtrs.mcLabelsTPC[clusters[i].GetId()].fClusterID[j].fMCID;
       if (label >= 0) {
         labels.push_back(label);
       }
@@ -559,9 +559,9 @@ void GPUTPCGMMerger::MergeBorderTracks(int iSlice1, GPUTPCGMBorderTrack B1[], in
 #endif
       {
         CADEBUG(
-          printf("Comparing track %3d to %3d: ", r1.fId, r2.fId); for (int i = 0; i < 5; i++) { printf("%8.3f ", b1.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b1.Cov()[i]); } printf("\n%28s", ""));
+          if (mChainTracking->mIOPtrs.mcLabelsTPC) {printf("Comparing track %3d to %3d: ", r1.fId, r2.fId); for (int i = 0; i < 5; i++) { printf("%8.3f ", b1.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b1.Cov()[i]); } printf("\n%28s", ""); });
         CADEBUG(
-          for (int i = 0; i < 5; i++) { printf("%8.3f ", b2.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b2.Cov()[i]); } printf("   -   %5s   -   ", GetTrackLabel(b1) == GetTrackLabel(b2) ? "CLONE" : "FAKE"));
+          if (mChainTracking->mIOPtrs.mcLabelsTPC) {for (int i = 0; i < 5; i++) { printf("%8.3f ", b2.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b2.Cov()[i]); } printf("   -   %5s   -   ", GetTrackLabel(b1) == GetTrackLabel(b2) ? "CLONE" : "FAKE"); });
         if (b2.NClusters() < lBest2) {
           CADEBUG2(continue, printf("!NCl1\n"));
         }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -270,7 +270,15 @@ int GPUTPCGMMerger::RefitSliceTrack(GPUTPCGMSliceTrack& sliceTrack, const GPUTPC
   trk.X() = inTrack->Param().GetX();
   trk.Y() = inTrack->Param().GetY();
   trk.Z() = inTrack->Param().GetZ();
-  trk.ZOffset() = inTrack->Param().GetZOffset();
+  if (Param().earlyTpcTransform) {
+    trk.TZOffset() = inTrack->Param().GetZOffset();
+  } else {
+    trk.TZOffset() = GetConstantMem()->calibObjects.fastTransform->convZOffsetToVertexTime(slice, inTrack->Param().GetZOffset(), Param().continuousMaxTimeBin);
+    const ClusterNative* cls = GetConstantMem()->ioPtrs.clustersNative->clustersLinear;
+    // printf("Setup: (slice %d maxTime %d vDrift %f) ZOffset %f --> TOffset %f (Chk %f) Cluster 0: Z %f Time %f - Cluster N: Z %f Time %f\n", slice, Param().continuousMaxTimeBin, GetConstantMem()->calibObjects.fastTransform->getVDrift(),
+    //        inTrack->Param().GetZOffset(), trk.TZOffset(), GetConstantMem()->calibObjects.fastTransform->convTimeToZinTimeFrame(slice, trk.TZOffset(), Param().continuousMaxTimeBin),
+    //        inTrack->Cluster(0).GetZ(), cls[inTrack->Cluster(0).GetId()].getTime(), inTrack->Cluster(inTrack->NClusters() - 1).GetZ(), cls[inTrack->Cluster(inTrack->NClusters() - 1).GetId()].getTime());
+  }
   trk.SinPhi() = inTrack->Param().GetSinPhi();
   trk.DzDs() = inTrack->Param().GetDzDs();
   trk.QPt() = inTrack->Param().GetQPt();
@@ -281,17 +289,17 @@ int GPUTPCGMMerger::RefitSliceTrack(GPUTPCGMSliceTrack& sliceTrack, const GPUTPC
     if (Param().earlyTpcTransform) {
       x = inTrack->Cluster(i).GetX();
       y = inTrack->Cluster(i).GetY();
-      z = inTrack->Cluster(i).GetZ();
+      z = inTrack->Cluster(i).GetZ() - trk.TZOffset();
     } else {
       const GPUTPCSliceOutCluster& clo = inTrack->Cluster(i);
       const ClusterNative& cl = GetConstantMem()->ioPtrs.clustersNative->clustersLinear[clo.GetId()];
-      GPUTPCConvertImpl::convert(*GetConstantMem(), slice, clo.GetRow(), cl.getPad(), cl.getTime(), x, y, z);
+      GetConstantMem()->calibObjects.fastTransform->Transform(slice, clo.GetRow(), cl.getPad(), cl.getTime(), x, y, z, trk.TZOffset());
     }
     if (prop.PropagateToXAlpha(x, alpha, true)) {
       return 1;
     }
     trk.ConstrainSinPhi();
-    if (prop.Update(y, z - trk.ZOffset(), inTrack->Cluster(i).GetRow(), Param(), inTrack->Cluster(i).GetFlags() & GPUTPCGMMergedTrackHit::clustererAndSharedFlags, false, false)) {
+    if (prop.Update(y, z, inTrack->Cluster(i).GetRow(), Param(), inTrack->Cluster(i).GetFlags() & GPUTPCGMMergedTrackHit::clustererAndSharedFlags, false, false)) {
       return 1;
     }
     trk.ConstrainSinPhi();
@@ -335,12 +343,12 @@ void GPUTPCGMMerger::UnpackSlices()
     for (unsigned int itr = 0; itr < slice.NLocalTracks(); itr++, sliceTr = sliceTr->GetNextTrack()) {
       GPUTPCGMSliceTrack& track = mSliceTrackInfos[nTracksCurrent];
       if (Param().rec.mergerCovSource == 0) {
-        track.Set(sliceTr, alpha, iSlice);
+        track.Set(this, sliceTr, alpha, iSlice);
         if (!track.FilterErrors(this, iSlice, GPUCA_MAX_SIN_PHI, 0.1f)) {
           continue;
         }
       } else if (Param().rec.mergerCovSource == 1) {
-        track.Set(sliceTr, alpha, iSlice);
+        track.Set(this, sliceTr, alpha, iSlice);
         track.CopyBaseTrackCov();
       } else if (Param().rec.mergerCovSource == 2) {
         if (RefitSliceTrack(track, sliceTr, alpha, iSlice)) {
@@ -371,7 +379,7 @@ void GPUTPCGMMerger::UnpackSlices()
         continue;
       }
       GPUTPCGMSliceTrack& track = mSliceTrackInfos[nTracksCurrent];
-      track.Set(sliceTr, alpha, iSlice);
+      track.Set(this, sliceTr, alpha, iSlice);
       track.SetGlobalSectorTrackCov();
       track.SetPrevNeighbour(-1);
       track.SetNextNeighbour(-1);
@@ -421,7 +429,7 @@ void GPUTPCGMMerger::MakeBorderTracks(int iSlice, int iBorder, GPUTPCGMBorderTra
     if (track->PrevSegmentNeighbour() >= 0 && track->Slice() == mSliceTrackInfos[track->PrevSegmentNeighbour()].Slice()) {
       continue;
     }
-    if (useOrigTrackParam) {
+    if (useOrigTrackParam) { // TODO: Check how far this makes sense with slice track refit
       if (fabsf(track->QPt()) < GPUCA_MERGER_LOOPER_QPT_LIMIT) {
         continue;
       }
@@ -434,7 +442,7 @@ void GPUTPCGMMerger::MakeBorderTracks(int iSlice, int iBorder, GPUTPCGMBorderTra
       }
       trackTmp = *trackMin;
       track = &trackTmp;
-      trackTmp.Set(trackMin->OrigTrack(), trackMin->Alpha(), trackMin->Slice());
+      trackTmp.Set(this, trackMin->OrigTrack(), trackMin->Alpha(), trackMin->Slice());
     } else {
       if (fabsf(track->QPt()) < GPUCA_MERGER_HORIZONTAL_DOUBLE_QPT_LIMIT) {
         if (iBorder == 0 && track->NextNeighbour() >= 0) {
@@ -447,7 +455,7 @@ void GPUTPCGMMerger::MakeBorderTracks(int iSlice, int iBorder, GPUTPCGMBorderTra
     }
     GPUTPCGMBorderTrack& b = B[nB];
 
-    if (track->TransportToXAlpha(x0, sinAlpha, cosAlpha, fieldBz, b, maxSin)) {
+    if (track->TransportToXAlpha(this, x0, sinAlpha, cosAlpha, fieldBz, b, maxSin)) {
       b.SetTrackID(itr);
       b.SetNClusters(track->NClusters());
       for (int i = 0; i < 4; i++) {
@@ -499,8 +507,8 @@ void GPUTPCGMMerger::MergeBorderTracks(int iSlice1, GPUTPCGMBorderTrack B1[], in
       CADEBUG(
         printf("  Input Slice 1 %d Track %d: ", iSlice1, itr); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Cov()[i]); } printf(" - D %8.3f\n", d));
       range1[itr].fId = itr;
-      range1[itr].fMin = b.Par()[1] + b.ZOffset() - d;
-      range1[itr].fMax = b.Par()[1] + b.ZOffset() + d;
+      range1[itr].fMin = b.Par()[1] + b.ZOffsetLinear() - d;
+      range1[itr].fMax = b.Par()[1] + b.ZOffsetLinear() + d;
     }
     std::sort(range1, range1 + N1, GPUTPCGMBorderTrack::Range::CompMin);
     if (sameSlice) {
@@ -522,8 +530,8 @@ void GPUTPCGMMerger::MergeBorderTracks(int iSlice1, GPUTPCGMBorderTrack B1[], in
         CADEBUG(
           printf("  Input Slice 2 %d Track %d: ", iSlice2, itr); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Cov()[i]); } printf(" - D %8.3f\n", d));
         range2[itr].fId = itr;
-        range2[itr].fMin = b.Par()[1] + b.ZOffset() - d;
-        range2[itr].fMax = b.Par()[1] + b.ZOffset() + d;
+        range2[itr].fMin = b.Par()[1] + b.ZOffsetLinear() - d;
+        range2[itr].fMax = b.Par()[1] + b.ZOffsetLinear() + d;
       }
       std::sort(range2, range2 + N2, GPUTPCGMBorderTrack::Range::CompMax);
     }
@@ -626,7 +634,7 @@ void GPUTPCGMMerger::MergeWithingSlices()
     for (int itr = SliceTrackInfoFirst(iSlice); itr < SliceTrackInfoLast(iSlice); itr++) {
       GPUTPCGMSliceTrack& track = mSliceTrackInfos[itr];
       GPUTPCGMBorderTrack& b = mBorder[iSlice][nBord];
-      if (track.TransportToX(x0, Param().ConstBz, b, maxSin)) {
+      if (track.TransportToX(this, x0, Param().ConstBz, b, maxSin)) {
         b.SetTrackID(itr);
         CADEBUG(
           printf("WITHIN SLICE %d Track %d - ", iSlice, itr); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Cov()[i]); } printf("\n"));
@@ -900,32 +908,30 @@ void GPUTPCGMMerger::MergeCEFill(const GPUTPCGMSliceTrack* track, const GPUTPCGM
 #endif
 
   float z = 0;
-  if (!Param().earlyTpcTransform) {
+  if (Param().earlyTpcTransform) {
+    z = cls.z;
+  } else {
     float x, y;
     auto& cln = mConstantMem->ioPtrs.clustersNative->clustersLinear[cls.num];
     GPUTPCConvertImpl::convert(*mConstantMem, cls.slice, cls.row, cln.getPad(), cln.getTime(), x, y, z);
   }
 
-  if (!Param().ContinuousTracking && fabsf(Param().earlyTpcTransform ? cls.z : z) > 10) {
+  if (!Param().ContinuousTracking && fabsf(z) > 10) {
     return;
   }
   int slice = track->Slice();
   for (int attempt = 0; attempt < 2; attempt++) {
     GPUTPCGMBorderTrack& b = attempt == 0 ? mBorder[slice][mBorderCETracks[0][slice]] : mBorder[slice][mkSlices[slice]->NTracks() - 1 - mBorderCETracks[1][slice]];
     const float x0 = Param().tpcGeometry.Row2X(attempt == 0 ? 63 : cls.row);
-    if (track->TransportToX(x0, Param().ConstBz, b, GPUCA_MAX_SIN_PHI_LOW)) {
+    if (track->TransportToX(this, x0, Param().ConstBz, b, GPUCA_MAX_SIN_PHI_LOW)) {
       b.SetTrackID(itr);
       b.SetNClusters(mOutputTracks[itr].NClusters());
       if (fabsf(b.Cov()[4]) >= 0.5) {
         b.SetCov(4, 0.5); // TODO: Is this needed and better than the cut in BorderTrack?
       }
       if (track->CSide()) {
-        if (Param().earlyTpcTransform) {
-          b.SetPar(1, b.Par()[1] - 2 * (cls.z - b.ZOffset()));
-        } else {
-          b.SetPar(1, b.Par()[1] - 2 * (z - b.ZOffset()));
-        }
-        b.SetZOffset(-b.ZOffset());
+        b.SetPar(1, b.Par()[1] - 2 * (z - b.ZOffsetLinear()));
+        b.SetZOffsetLinear(-b.ZOffsetLinear());
       }
       b.SetRow(cls.row);
       mBorderCETracks[attempt][slice]++;
@@ -994,22 +1000,19 @@ void GPUTPCGMMerger::MergeCE()
       }
 
       if (Param().ContinuousTracking) {
-        float offset;
         if (Param().earlyTpcTransform) {
           const float z0 = trk[0]->CSide() ? CAMath::Max(mClusters[trk[0]->FirstClusterRef()].z, mClusters[trk[0]->FirstClusterRef() + trk[0]->NClusters() - 1].z) : CAMath::Min(mClusters[trk[0]->FirstClusterRef()].z, mClusters[trk[0]->FirstClusterRef() + trk[0]->NClusters() - 1].z);
           const float z1 = trk[1]->CSide() ? CAMath::Max(mClusters[trk[1]->FirstClusterRef()].z, mClusters[trk[1]->FirstClusterRef() + trk[1]->NClusters() - 1].z) : CAMath::Min(mClusters[trk[1]->FirstClusterRef()].z, mClusters[trk[1]->FirstClusterRef() + trk[1]->NClusters() - 1].z);
-          offset = fabsf(z1) > fabsf(z0) ? -z0 : z1;
+          const float offset = fabsf(z1) > fabsf(z0) ? -z0 : z1;
+          trk[1]->Param().Z() += trk[1]->Param().TZOffset() - offset;
+          trk[1]->Param().TZOffset() = offset;
         } else {
-          GPUTPCGMMergedTrackHit *r0, *r1, *r;
-          const float t0 = CAMath::MaxWithRef(cls[mClusters[trk[0]->FirstClusterRef()].num].getTime(), cls[mClusters[trk[0]->FirstClusterRef() + trk[0]->NClusters() - 1].num].getTime(), &mClusters[trk[0]->FirstClusterRef()], &mClusters[trk[0]->FirstClusterRef() + trk[0]->NClusters() - 1], r0);
-          const float t1 = CAMath::MaxWithRef(cls[mClusters[trk[1]->FirstClusterRef()].num].getTime(), cls[mClusters[trk[1]->FirstClusterRef() + trk[1]->NClusters() - 1].num].getTime(), &mClusters[trk[1]->FirstClusterRef()], &mClusters[trk[1]->FirstClusterRef() + trk[1]->NClusters() - 1], r1);
-          offset = CAMath::MaxWithRef(t0, t1, r0, r1, r); // Offset in time
-          float x, y, z;
-          mConstantMem->calibObjects.fastTransform->TransformInTimeFrame(r->slice, r->row, cls[r->num].getPad(), cls[r->num].getTime(), x, y, z, mConstantMem->param.continuousMaxTimeBin);
-          offset = trk[1]->CSide() ? -CAMath::Abs(z) : CAMath::Abs(z); // Offset in z
+          const float t0 = CAMath::Max(cls[mClusters[trk[0]->FirstClusterRef()].num].getTime(), cls[mClusters[trk[0]->FirstClusterRef() + trk[0]->NClusters() - 1].num].getTime());
+          const float t1 = CAMath::Max(cls[mClusters[trk[1]->FirstClusterRef()].num].getTime(), cls[mClusters[trk[1]->FirstClusterRef() + trk[1]->NClusters() - 1].num].getTime());
+          const float offset = CAMath::Max(CAMath::Max(t0, t1) - 250.f / mConstantMem->calibObjects.fastTransform->getVDrift(), 0.f); // TODO: Replace me by correct drift time
+          trk[1]->Param().Z() += mConstantMem->calibObjects.fastTransform->convDeltaTimeToDeltaZinTimeFrame(trk[1]->CSide() * NSLICES / 2, trk[1]->Param().TZOffset() - offset);
+          trk[1]->Param().TZOffset() = offset;
         }
-        trk[1]->Param().Z() += trk[1]->Param().ZOffset() - offset;
-        trk[1]->Param().ZOffset() = offset;
       }
 
       int newRef = mNOutputTrackClusters;
@@ -1355,7 +1358,7 @@ void GPUTPCGMMerger::CollectMergedTracks()
 
     GPUTPCGMBorderTrack b;
     const float toX = Param().earlyTpcTransform ? cl[0].x : Param().tpcGeometry.Row2X(cl[0].row);
-    if (p2.TransportToX(toX, Param().ConstBz, b, GPUCA_MAX_SIN_PHI, false)) {
+    if (p2.TransportToX(this, toX, Param().ConstBz, b, GPUCA_MAX_SIN_PHI, false)) {
       p1.X() = toX;
       p1.Y() = b.Par()[0];
       p1.Z() = b.Par()[1];
@@ -1366,7 +1369,7 @@ void GPUTPCGMMerger::CollectMergedTracks()
       p1.Z() = p2.Z();
       p1.SinPhi() = p2.SinPhi();
     }
-    p1.ZOffset() = p2.ZOffset();
+    p1.TZOffset() = p2.TZOffset();
     p1.DzDs() = p2.DzDs();
     p1.QPt() = p2.QPt();
     mergedTrack.SetAlpha(p2.Alpha());

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -270,15 +270,21 @@ int GPUTPCGMMerger::RefitSliceTrack(GPUTPCGMSliceTrack& sliceTrack, const GPUTPC
   trk.X() = inTrack->Param().GetX();
   trk.Y() = inTrack->Param().GetY();
   trk.Z() = inTrack->Param().GetZ();
+  float tzInner, tzOuter;
   if (Param().earlyTpcTransform) {
     trk.TZOffset() = inTrack->Param().GetZOffset();
+    tzInner = inTrack->Cluster(0).GetZ();
+    tzOuter = inTrack->Cluster(inTrack->NClusters() - 1).GetZ();
   } else {
     trk.TZOffset() = GetConstantMem()->calibObjects.fastTransform->convZOffsetToVertexTime(slice, inTrack->Param().GetZOffset(), Param().continuousMaxTimeBin);
     const ClusterNative* cls = GetConstantMem()->ioPtrs.clustersNative->clustersLinear;
     // printf("Setup: (slice %d maxTime %d vDrift %f) ZOffset %f --> TOffset %f (Chk %f) Cluster 0: Z %f Time %f - Cluster N: Z %f Time %f\n", slice, Param().continuousMaxTimeBin, GetConstantMem()->calibObjects.fastTransform->getVDrift(),
     //        inTrack->Param().GetZOffset(), trk.TZOffset(), GetConstantMem()->calibObjects.fastTransform->convTimeToZinTimeFrame(slice, trk.TZOffset(), Param().continuousMaxTimeBin),
     //        inTrack->Cluster(0).GetZ(), cls[inTrack->Cluster(0).GetId()].getTime(), inTrack->Cluster(inTrack->NClusters() - 1).GetZ(), cls[inTrack->Cluster(inTrack->NClusters() - 1).GetId()].getTime());
+    tzInner = cls[inTrack->Cluster(0).GetId()].getTime();
+    tzOuter = cls[inTrack->Cluster(inTrack->NClusters() - 1).GetId()].getTime();
   }
+  trk.ShiftZ(this, slice, tzInner, tzOuter);
   trk.SinPhi() = inTrack->Param().GetSinPhi();
   trk.DzDs() = inTrack->Param().GetDzDs();
   trk.QPt() = inTrack->Param().GetQPt();

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -108,6 +108,8 @@ class GPUTPCGMMerger : public GPUProcessor
   short MemoryResMerger() { return mMemoryResMerger; }
   short MemoryResRefit() { return mMemoryResRefit; }
 
+  int RefitSliceTrack(GPUTPCGMSliceTrack& sliceTrack, const GPUTPCSliceOutTrack* inTrack, float alpha, int slice);
+
   void UnpackSlices();
   void MergeCEInit();
   void MergeCE();

--- a/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.cxx
@@ -25,6 +25,32 @@
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
 
+void GPUTPCGMSliceTrack::Set(const GPUTPCGMTrackParam& trk, const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice)
+{
+  mOrigTrack = sliceTr;
+  mX = trk.GetX();
+  mY = trk.GetY();
+  mZ = trk.GetZ();
+  mDzDs = trk.GetDzDs();
+  mSinPhi = trk.GetSinPhi();
+  mQPt = trk.GetQPt();
+  mCosPhi = sqrt(1.f - mSinPhi * mSinPhi);
+  mSecPhi = 1.f / mCosPhi;
+  mAlpha = alpha;
+  mSlice = slice;
+  mZOffset = trk.GetZOffset();
+  mNClusters = sliceTr->NClusters();
+  mC0 = trk.GetCov(0);
+  mC2 = trk.GetCov(2);
+  mC3 = trk.GetCov(3);
+  mC5 = trk.GetCov(5);
+  mC7 = trk.GetCov(7);
+  mC9 = trk.GetCov(9);
+  mC10 = trk.GetCov(10);
+  mC12 = trk.GetCov(12);
+  mC14 = trk.GetCov(14);
+}
+
 bool GPUTPCGMSliceTrack::FilterErrors(const GPUTPCGMMerger* merger, int iSlice, float maxSinPhi, float sinPhiMargin)
 {
   float lastX;
@@ -409,4 +435,18 @@ bool GPUTPCGMSliceTrack::TransportToXAlpha(float newX, float sinAlpha, float cos
   b.LimitCov();
 
   return 1;
+}
+
+void GPUTPCGMSliceTrack::CopyBaseTrackCov()
+{
+  const float* GPUrestrict() cov = mOrigTrack->Param().mC;
+  mC0 = cov[0];
+  mC2 = cov[2];
+  mC3 = cov[3];
+  mC5 = cov[5];
+  mC7 = cov[7];
+  mC9 = cov[9];
+  mC10 = cov[10];
+  mC12 = cov[12];
+  mC14 = cov[14];
 }

--- a/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.h
@@ -28,6 +28,7 @@ namespace gpu
  *
  * The class describes TPC slice tracks used in GPUTPCGMMerger
  */
+class GPUTPCGMMerger;
 class GPUTPCGMSliceTrack
 {
  public:
@@ -50,7 +51,7 @@ class GPUTPCGMSliceTrack
   float SecPhi() const { return mSecPhi; }
   float DzDs() const { return mDzDs; }
   float QPt() const { return mQPt; }
-  float ZOffset() const { return mZOffset; }
+  float TZOffset() const { return mTZOffset; }
   float Leg() const { return mLeg; }
 
   int LocalTrackId() const { return mLocalTrackId; }
@@ -64,24 +65,7 @@ class GPUTPCGMSliceTrack
   GPUd() float MinClusterT(const o2::tpc::ClusterNative* cls) { return CAMath::Min(cls[mOrigTrack->Clusters()->GetId()].getTime(), cls[(mOrigTrack->Clusters() + mOrigTrack->NClusters() - 1)->GetId()].getTime()); }
 
   void Set(const GPUTPCGMTrackParam& trk, const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice);
-
-  void Set(const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice)
-  {
-    const GPUTPCBaseTrackParam& t = sliceTr->Param();
-    mOrigTrack = sliceTr;
-    mX = t.GetX();
-    mY = t.GetY();
-    mZ = t.GetZ();
-    mDzDs = t.GetDzDs();
-    mSinPhi = t.GetSinPhi();
-    mQPt = t.GetQPt();
-    mCosPhi = sqrt(1.f - mSinPhi * mSinPhi);
-    mSecPhi = 1.f / mCosPhi;
-    mAlpha = alpha;
-    mSlice = slice;
-    mZOffset = t.GetZOffset();
-    mNClusters = sliceTr->NClusters();
-  }
+  void Set(const GPUTPCGMMerger* merger, const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice);
 
   void SetGlobalSectorTrackCov()
   {
@@ -117,23 +101,23 @@ class GPUTPCGMSliceTrack
   }
 
   bool FilterErrors(const GPUTPCGMMerger* merger, int iSlice, float maxSinPhi = GPUCA_MAX_SIN_PHI, float sinPhiMargin = 0.f);
-  bool TransportToX(float x, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi, bool doCov = true) const;
-  bool TransportToXAlpha(float x, float sinAlpha, float cosAlpha, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi) const;
+  bool TransportToX(GPUTPCGMMerger* merger, float x, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi, bool doCov = true) const;
+  bool TransportToXAlpha(GPUTPCGMMerger* merger, float x, float sinAlpha, float cosAlpha, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi) const;
   void CopyBaseTrackCov();
 
  private:
   const GPUTPCSliceOutTrack* mOrigTrack;                    // pointer to original slice track
   float mX, mY, mZ, mSinPhi, mDzDs, mQPt, mCosPhi, mSecPhi; // parameters
-  float mZOffset;
-  float mC0, mC2, mC3, mC5, mC7, mC9, mC10, mC12, mC14; // covariances
-  float mAlpha;                                         // alpha angle
-  int mSlice;                                           // slice of this track segment
-  int mNClusters;                                       // N clusters
-  int mNeighbour[2];                                    //
-  int mSegmentNeighbour[2];                             //
-  int mLocalTrackId;                                    // Corrected local track id in terms of GMSliceTracks array
-  int mGlobalTrackIds[2];                               // IDs of associated global tracks
-  unsigned char mLeg;                                   // Leg of this track segment
+  float mTZOffset;                                          // Z offset with early transform, T offset otherwise
+  float mC0, mC2, mC3, mC5, mC7, mC9, mC10, mC12, mC14;     // covariances
+  float mAlpha;                                             // alpha angle
+  int mSlice;                                               // slice of this track segment
+  int mNClusters;                                           // N clusters
+  int mNeighbour[2];                                        //
+  int mSegmentNeighbour[2];                                 //
+  int mLocalTrackId;                                        // Corrected local track id in terms of GMSliceTracks array
+  int mGlobalTrackIds[2];                                   // IDs of associated global tracks
+  unsigned char mLeg;                                       // Leg of this track segment
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMSliceTrack.h
@@ -63,6 +63,8 @@ class GPUTPCGMSliceTrack
   GPUd() float MaxClusterT(const o2::tpc::ClusterNative* cls) { return CAMath::Max(cls[mOrigTrack->Clusters()->GetId()].getTime(), cls[(mOrigTrack->Clusters() + mOrigTrack->NClusters() - 1)->GetId()].getTime()); }
   GPUd() float MinClusterT(const o2::tpc::ClusterNative* cls) { return CAMath::Min(cls[mOrigTrack->Clusters()->GetId()].getTime(), cls[(mOrigTrack->Clusters() + mOrigTrack->NClusters() - 1)->GetId()].getTime()); }
 
+  void Set(const GPUTPCGMTrackParam& trk, const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice);
+
   void Set(const GPUTPCSliceOutTrack* sliceTr, float alpha, int slice)
   {
     const GPUTPCBaseTrackParam& t = sliceTr->Param();
@@ -115,10 +117,9 @@ class GPUTPCGMSliceTrack
   }
 
   bool FilterErrors(const GPUTPCGMMerger* merger, int iSlice, float maxSinPhi = GPUCA_MAX_SIN_PHI, float sinPhiMargin = 0.f);
-
   bool TransportToX(float x, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi, bool doCov = true) const;
-
   bool TransportToXAlpha(float x, float sinAlpha, float cosAlpha, float Bz, GPUTPCGMBorderTrack& b, float maxSinPhi) const;
+  void CopyBaseTrackCov();
 
  private:
   const GPUTPCSliceOutTrack* mOrigTrack;                    // pointer to original slice track

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -720,14 +720,6 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMergedTrackHit* GPUrestrict
   // printf("Tan %f %f (%f %f)\n", atana, atanb, mX - xp, mP[0] - yp);
   const float dS = (xp > 0 ? (atana + atanb) : (atanb - atana)) * r;
   float dz = dS * mP[3];
-  // printf("Track Z %f (Offset %f), dz %f, V %f (dS %f, dZds %f, qPt %f)             - Z span %f to %f: diff %f\n", mP[1], mZOffset, dz, mP[1] - dz, dS, mP[3], mP[4], clusters[0].z, clusters[N - 1].z, clusters[0].z - clusters[N - 1].z);
-  if (CAMath::Abs(dz) > 250.f) {
-    dz = dz > 0 ? 250.f : -250.f;
-  }
-  float dZOffset = mP[1] - dz;
-  mZOffset += dZOffset;
-  mP[1] -= dZOffset;
-  dZOffset = 0;
   float z0, z1;
   if (merger->Param().earlyTpcTransform) {
     z0 = clusters[0].z;
@@ -740,6 +732,15 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMergedTrackHit* GPUrestrict
     GPUTPCConvertImpl::convert(*merger->GetConstantMem(), clusters[0].slice, clusters[0].row, cls[clusters[0].num].getPad(), cls[clusters[0].num].getTime(), x, y, z0);
     GPUTPCConvertImpl::convert(*merger->GetConstantMem(), clusters[N - 1].slice, clusters[N - 1].row, cls[clusters[N - 1].num].getPad(), cls[clusters[N - 1].num].getTime(), x, y, z1);
   }
+
+  // printf("Track Z %f (Offset %f), dz %f, V %f (dS %f, dZds %f, qPt %f)             - Z span %f to %f: diff %f\n", mP[1], mZOffset, dz, mP[1] - dz, dS, mP[3], mP[4], z0, z1, z0 - z1);
+  if (CAMath::Abs(dz) > 250.f) {
+    dz = dz > 0 ? 250.f : -250.f;
+  }
+  float dZOffset = mP[1] - dz;
+  mZOffset += dZOffset;
+  mP[1] -= dZOffset;
+  dZOffset = 0;
   float zMax = CAMath::Max(z0, z1);
   float zMin = CAMath::Min(z0, z1);
   if (zMin < 0 && zMin - mZOffset < -250) {
@@ -752,7 +753,7 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMergedTrackHit* GPUrestrict
   } else if (zMax > 0 && zMin - mZOffset < 0) {
     dZOffset = zMin - mZOffset;
   }
-  // if (dZOffset != 0) printf("Moving clusters to TPC Range: Side %f, Shift %f: %f to %f --> %f to %f\n", clusters[0].z, dZOffset, clusters[0].z - mZOffset, clusters[N - 1].z - mZOffset, clusters[0].z - mZOffset - dZOffset, clusters[N - 1].z - mZOffset - dZOffset);
+  // if (dZOffset != 0) printf("Moving clusters to TPC Range: Side %f, Shift %f: %f to %f --> %f to %f\n", z0, dZOffset, z0 - mZOffset, z1 - mZOffset, z0 - mZOffset - dZOffset, z1 - mZOffset - dZOffset);
   mZOffset += dZOffset;
   mP[1] -= dZOffset;
   // printf("\n");

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
@@ -77,9 +77,9 @@ class GPUTPCGMTrackParam
   {
     return mP[4];
   }
-  GPUd() float& ZOffset()
+  GPUd() float& TZOffset()
   {
-    return mZOffset;
+    return mTZOffset;
   }
 
   GPUhd() float GetX() const { return mX; }
@@ -88,7 +88,7 @@ class GPUTPCGMTrackParam
   GPUd() float GetSinPhi() const { return mP[2]; }
   GPUd() float GetDzDs() const { return mP[3]; }
   GPUd() float GetQPt() const { return mP[4]; }
-  GPUd() float GetZOffset() const { return mZOffset; }
+  GPUd() float GetTZOffset() const { return mTZOffset; }
 
   GPUd() float GetKappa(float Bz) const { return -mP[4] * Bz; }
 
@@ -176,7 +176,8 @@ class GPUTPCGMTrackParam
   }
 
   GPUd() bool Rotate(float alpha);
-  GPUd() void ShiftZ(const GPUTPCGMMergedTrackHit* clusters, const GPUTPCGMMerger* merger, int N);
+  GPUd() void ShiftZ(const GPUTPCGMMerger* merger, int slice, float tzInner, float tzOuter);
+  GPUd() void ShiftZ2(const GPUTPCGMMergedTrackHit* clusters, const GPUTPCGMMerger* merger, int N);
 
   GPUd() static float Reciprocal(float x) { return 1.f / x; }
   GPUd() static void Assign(float& x, bool mask, float v)
@@ -213,12 +214,12 @@ class GPUTPCGMTrackParam
   GPUd() bool FollowCircleChk(float lrFactor, float toY, float toX, bool up, bool right);
   GPUd() int initResetT0();
 
-  float mX; // x position
-  float mZOffset;
-  float mP[5];  // 'active' track parameters: Y, Z, SinPhi, DzDs, q/Pt
-  float mC[15]; // the covariance matrix for Y,Z,SinPhi,..
-  float mChi2;  // the chi^2 value
-  int mNDF;     // the Number of Degrees of Freedom
+  float mX;        // x position
+  float mTZOffset; // Z offset with early transform, T offset otherwise
+  float mP[5];     // 'active' track parameters: Y, Z, SinPhi, DzDs, q/Pt
+  float mC[15];    // the covariance matrix for Y,Z,SinPhi,..
+  float mChi2;     // the chi^2 value
+  int mNDF;        // the Number of Degrees of Freedom
 };
 
 GPUdi() int GPUTPCGMTrackParam::initResetT0()

--- a/GPU/GPUTracking/SliceTracker/GPUTPCBaseTrackParam.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCBaseTrackParam.h
@@ -31,9 +31,7 @@ class GPUTPCTrackParam;
  * This class is used for transfer between tracker and merger and does not contain the covariance matrice
  */
 MEM_CLASS_PRE()
-class GPUTPCBaseTrackParam
-{
- public:
+struct GPUTPCBaseTrackParam {
   GPUd() float X() const { return mX; }
   GPUd() float Y() const { return mP[0]; }
   GPUd() float Z() const { return mP[1]; }
@@ -41,6 +39,15 @@ class GPUTPCBaseTrackParam
   GPUd() float DzDs() const { return mP[3]; }
   GPUd() float QPt() const { return mP[4]; }
   GPUd() float ZOffset() const { return mZOffset; }
+
+  GPUd() float Err2Y() const { return mC[0]; }
+  GPUd() float Err2Z() const { return mC[2]; }
+  GPUd() float Err2SinPhi() const { return mC[5]; }
+  GPUd() float Err2DzDs() const { return mC[9]; }
+  GPUd() float Err2QPt() const { return mC[14]; }
+  GPUhd() const float* Cov() const { return mC; }
+  GPUd() float GetCov(int i) const { return mC[i]; }
+  GPUhd() void SetCov(int i, float v) { mC[i] = v; }
 
   GPUhd() float GetX() const { return mX; }
   GPUhd() float GetY() const { return mP[0]; }
@@ -66,13 +73,13 @@ class GPUTPCBaseTrackParam
   GPUd() void SetQPt(float v) { mP[4] = v; }
   GPUd() void SetZOffset(float v) { mZOffset = v; }
 
- private:
   // WARNING, Track Param Data is copied in the GPU Tracklet Constructor element by element instead of using copy constructor!!!
   // This is neccessary for performance reasons!!!
   // Changes to Elements of this class therefore must also be applied to TrackletConstructor!!!
-  float mX; // x position
-  float mZOffset;
-  float mP[5]; // 'active' track parameters: Y, Z, SinPhi, DzDs, q/Pt
+  float mX;       // x position
+  float mC[15];   // the covariance matrix for Y,Z,SinPhi,..
+  float mZOffset; // z offset
+  float mP[5];    // 'active' track parameters: Y, Z, SinPhi, DzDs, q/Pt
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.cxx
@@ -177,41 +177,41 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::TransportToX(float x, GPUTPCTrackLinearisa
   SetPar(1, Z() + dz + dS * d[3]);
   SetPar(2, t0.SinPhi() + d[2] + dxBz * d[4]);
 
-  float c00 = mC[0];
-  float c10 = mC[1];
-  float c11 = mC[2];
-  float c20 = mC[3];
-  float c21 = mC[4];
-  float c22 = mC[5];
-  float c30 = mC[6];
-  float c31 = mC[7];
-  float c32 = mC[8];
-  float c33 = mC[9];
-  float c40 = mC[10];
-  float c41 = mC[11];
-  float c42 = mC[12];
-  float c43 = mC[13];
-  float c44 = mC[14];
+  float c00 = mParam.mC[0];
+  float c10 = mParam.mC[1];
+  float c11 = mParam.mC[2];
+  float c20 = mParam.mC[3];
+  float c21 = mParam.mC[4];
+  float c22 = mParam.mC[5];
+  float c30 = mParam.mC[6];
+  float c31 = mParam.mC[7];
+  float c32 = mParam.mC[8];
+  float c33 = mParam.mC[9];
+  float c40 = mParam.mC[10];
+  float c41 = mParam.mC[11];
+  float c42 = mParam.mC[12];
+  float c43 = mParam.mC[13];
+  float c44 = mParam.mC[14];
 
-  mC[0] = c00 + h2 * h2 * c22 + h4 * h4 * c44 + 2 * (h2 * c20 + h4 * c40 + h2 * h4 * c42);
+  mParam.mC[0] = c00 + h2 * h2 * c22 + h4 * h4 * c44 + 2 * (h2 * c20 + h4 * c40 + h2 * h4 * c42);
 
-  mC[1] = c10 + h2 * c21 + h4 * c41 + dS * (c30 + h2 * c32 + h4 * c43);
-  mC[2] = c11 + 2 * dS * c31 + dS * dS * c33;
+  mParam.mC[1] = c10 + h2 * c21 + h4 * c41 + dS * (c30 + h2 * c32 + h4 * c43);
+  mParam.mC[2] = c11 + 2 * dS * c31 + dS * dS * c33;
 
-  mC[3] = c20 + h2 * c22 + h4 * c42 + dxBz * (c40 + h2 * c42 + h4 * c44);
-  mC[4] = c21 + dS * c32 + dxBz * (c41 + dS * c43);
-  mC[5] = c22 + 2 * dxBz * c42 + dxBz * dxBz * c44;
+  mParam.mC[3] = c20 + h2 * c22 + h4 * c42 + dxBz * (c40 + h2 * c42 + h4 * c44);
+  mParam.mC[4] = c21 + dS * c32 + dxBz * (c41 + dS * c43);
+  mParam.mC[5] = c22 + 2 * dxBz * c42 + dxBz * dxBz * c44;
 
-  mC[6] = c30 + h2 * c32 + h4 * c43;
-  mC[7] = c31 + dS * c33;
-  mC[8] = c32 + dxBz * c43;
-  mC[9] = c33;
+  mParam.mC[6] = c30 + h2 * c32 + h4 * c43;
+  mParam.mC[7] = c31 + dS * c33;
+  mParam.mC[8] = c32 + dxBz * c43;
+  mParam.mC[9] = c33;
 
-  mC[10] = c40 + h2 * c42 + h4 * c44;
-  mC[11] = c41 + dS * c43;
-  mC[12] = c42 + dxBz * c44;
-  mC[13] = c43;
-  mC[14] = c44;
+  mParam.mC[10] = c40 + h2 * c42 + h4 * c44;
+  mParam.mC[11] = c41 + dS * c43;
+  mParam.mC[12] = c42 + dxBz * c44;
+  mParam.mC[13] = c43;
+  mParam.mC[14] = c44;
 
   return 1;
 }
@@ -256,43 +256,43 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::TransportToX(float x, float sinPhi0, float
   SetPar(1, GetPar(1) + dS * DzDs());
   SetPar(2, sinPhi);
 
-  float c00 = mC[0];
-  float c10 = mC[1];
-  float c11 = mC[2];
-  float c20 = mC[3];
-  float c21 = mC[4];
-  float c22 = mC[5];
-  float c30 = mC[6];
-  float c31 = mC[7];
-  float c32 = mC[8];
-  float c33 = mC[9];
-  float c40 = mC[10];
-  float c41 = mC[11];
-  float c42 = mC[12];
-  float c43 = mC[13];
-  float c44 = mC[14];
+  float c00 = mParam.mC[0];
+  float c10 = mParam.mC[1];
+  float c11 = mParam.mC[2];
+  float c20 = mParam.mC[3];
+  float c21 = mParam.mC[4];
+  float c22 = mParam.mC[5];
+  float c30 = mParam.mC[6];
+  float c31 = mParam.mC[7];
+  float c32 = mParam.mC[8];
+  float c33 = mParam.mC[9];
+  float c40 = mParam.mC[10];
+  float c41 = mParam.mC[11];
+  float c42 = mParam.mC[12];
+  float c43 = mParam.mC[13];
+  float c44 = mParam.mC[14];
 
   // This is not the correct propagation!!! The max ensures the positional error does not decrease during track finding.
   // A different propagation method is used for the fit.
-  mC[0] = CAMath::Max(c00, c00 + h2 * h2 * c22 + h4 * h4 * c44 + 2 * (h2 * c20 + h4 * c40 + h2 * h4 * c42));
+  mParam.mC[0] = CAMath::Max(c00, c00 + h2 * h2 * c22 + h4 * h4 * c44 + 2 * (h2 * c20 + h4 * c40 + h2 * h4 * c42));
 
-  mC[1] = c10 + h2 * c21 + h4 * c41 + dS * (c30 + h2 * c32 + h4 * c43);
-  mC[2] = CAMath::Max(c11, c11 + 2 * dS * c31 + dS * dS * c33);
+  mParam.mC[1] = c10 + h2 * c21 + h4 * c41 + dS * (c30 + h2 * c32 + h4 * c43);
+  mParam.mC[2] = CAMath::Max(c11, c11 + 2 * dS * c31 + dS * dS * c33);
 
-  mC[3] = c20 + h2 * c22 + h4 * c42 + dxBz * (c40 + h2 * c42 + h4 * c44);
-  mC[4] = c21 + dS * c32 + dxBz * (c41 + dS * c43);
-  mC[5] = c22 + 2 * dxBz * c42 + dxBz * dxBz * c44;
+  mParam.mC[3] = c20 + h2 * c22 + h4 * c42 + dxBz * (c40 + h2 * c42 + h4 * c44);
+  mParam.mC[4] = c21 + dS * c32 + dxBz * (c41 + dS * c43);
+  mParam.mC[5] = c22 + 2 * dxBz * c42 + dxBz * dxBz * c44;
 
-  mC[6] = c30 + h2 * c32 + h4 * c43;
-  mC[7] = c31 + dS * c33;
-  mC[8] = c32 + dxBz * c43;
-  mC[9] = c33;
+  mParam.mC[6] = c30 + h2 * c32 + h4 * c43;
+  mParam.mC[7] = c31 + dS * c33;
+  mParam.mC[8] = c32 + dxBz * c43;
+  mParam.mC[9] = c33;
 
-  mC[10] = c40 + h2 * c42 + h4 * c44;
-  mC[11] = c41 + dS * c43;
-  mC[12] = c42 + dxBz * c44;
-  mC[13] = c43;
-  mC[14] = c44;
+  mParam.mC[10] = c40 + h2 * c42 + h4 * c44;
+  mParam.mC[11] = c41 + dS * c43;
+  mParam.mC[12] = c42 + dxBz * c44;
+  mParam.mC[13] = c43;
+  mParam.mC[14] = c44;
 
   return 1;
 }
@@ -441,7 +441,7 @@ GPUd() void MEM_LG(GPUTPCTrackParam)::CalculateFitParameters(GPUTPCTrackFitParam
   //*!
 
   float qpt = GetPar(4);
-  if (mC[14] >= 1.f) {
+  if (mParam.mC[14] >= 1.f) {
     qpt = 1.f / 0.35f;
   }
 
@@ -479,13 +479,13 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::CorrectForMeanMaterial(float xOverX0, floa
   // "xTimesRho" - is the product length*density (g/cm^2).
   //------------------------------------------------------------------
 
-  float& mC22 = mC[5];
-  float& mC33 = mC[9];
-  float& mC40 = mC[10];
-  float& mC41 = mC[11];
-  float& mC42 = mC[12];
-  float& mC43 = mC[13];
-  float& mC44 = mC[14];
+  float& mC22 = mParam.mC[5];
+  float& mC33 = mParam.mC[9];
+  float& mC40 = mParam.mC[10];
+  float& mC41 = mParam.mC[11];
+  float& mC42 = mParam.mC[12];
+  float& mC43 = mParam.mC[13];
+  float& mC44 = mParam.mC[14];
 
   // Energy losses************************
 
@@ -549,32 +549,32 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::Rotate(float alpha, float maxSinPhi)
   //                    {  0, 0, 0,  1,  0 }, // DzDs
   //                    {  0, 0, 0,  0,  1 } }; // Kappa
   // cout<<"alpha="<<alpha<<" "<<x<<" "<<y<<" "<<sP<<" "<<cP<<" "<<j0<<" "<<j2<<endl;
-  // cout<<"      "<<mC[0]<<" "<<mC[1]<<" "<<mC[6]<<" "<<mC[10]<<" "<<mC[4]<<" "<<mC[5]<<" "<<mC[8]<<" "<<mC[12]<<endl;
-  mC[0] *= j0 * j0;
-  mC[1] *= j0;
-  mC[3] *= j0;
-  mC[6] *= j0;
-  mC[10] *= j0;
+  // cout<<"      "<<mParam.mC[0]<<" "<<mParam.mC[1]<<" "<<mParam.mC[6]<<" "<<mParam.mC[10]<<" "<<mParam.mC[4]<<" "<<mParam.mC[5]<<" "<<mParam.mC[8]<<" "<<mParam.mC[12]<<endl;
+  mParam.mC[0] *= j0 * j0;
+  mParam.mC[1] *= j0;
+  mParam.mC[3] *= j0;
+  mParam.mC[6] *= j0;
+  mParam.mC[10] *= j0;
 
-  mC[3] *= j2;
-  mC[4] *= j2;
-  mC[5] *= j2 * j2;
-  mC[8] *= j2;
-  mC[12] *= j2;
+  mParam.mC[3] *= j2;
+  mParam.mC[4] *= j2;
+  mParam.mC[5] *= j2 * j2;
+  mParam.mC[8] *= j2;
+  mParam.mC[12] *= j2;
 
   if (cosPhi < 0) {
     SetSinPhi(-SinPhi());
     SetDzDs(-DzDs());
     SetQPt(-QPt());
-    mC[3] = -mC[3];
-    mC[4] = -mC[4];
-    mC[6] = -mC[6];
-    mC[7] = -mC[7];
-    mC[10] = -mC[10];
-    mC[11] = -mC[11];
+    mParam.mC[3] = -mParam.mC[3];
+    mParam.mC[4] = -mParam.mC[4];
+    mParam.mC[6] = -mParam.mC[6];
+    mParam.mC[7] = -mParam.mC[7];
+    mParam.mC[10] = -mParam.mC[10];
+    mParam.mC[11] = -mParam.mC[11];
   }
 
-  // cout<<"      "<<mC[0]<<" "<<mC[1]<<" "<<mC[6]<<" "<<mC[10]<<" "<<mC[4]<<" "<<mC[5]<<" "<<mC[8]<<" "<<mC[12]<<endl;
+  // cout<<"      "<<mParam.mC[0]<<" "<<mParam.mC[1]<<" "<<mParam.mC[6]<<" "<<mParam.mC[10]<<" "<<mParam.mC[4]<<" "<<mParam.mC[5]<<" "<<mParam.mC[8]<<" "<<mParam.mC[12]<<endl;
   return 1;
 }
 
@@ -610,17 +610,17 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::Rotate(float alpha, GPUTPCTrackLinearisati
 
   SetSinPhi(sinPhi + j2 * d[1]);
 
-  mC[0] *= j0 * j0;
-  mC[1] *= j0;
-  mC[3] *= j0;
-  mC[6] *= j0;
-  mC[10] *= j0;
+  mParam.mC[0] *= j0 * j0;
+  mParam.mC[1] *= j0;
+  mParam.mC[3] *= j0;
+  mParam.mC[6] *= j0;
+  mParam.mC[10] *= j0;
 
-  mC[3] *= j2;
-  mC[4] *= j2;
-  mC[5] *= j2 * j2;
-  mC[8] *= j2;
-  mC[12] *= j2;
+  mParam.mC[3] *= j2;
+  mParam.mC[4] *= j2;
+  mParam.mC[5] *= j2 * j2;
+  mParam.mC[8] *= j2;
+  mParam.mC[12] *= j2;
 
   return 1;
 }
@@ -630,7 +630,7 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::Filter(float y, float z, float err2Y, floa
 {
   //* Add the y,z measurement with the Kalman filter
 
-  float c00 = mC[0], c11 = mC[2], c20 = mC[3], c31 = mC[7], c40 = mC[10];
+  float c00 = mParam.mC[0], c11 = mParam.mC[2], c20 = mParam.mC[3], c31 = mParam.mC[7], c40 = mParam.mC[10];
 
   err2Y += c00;
   err2Z += c11;
@@ -673,16 +673,16 @@ GPUd() bool MEM_LG(GPUTPCTrackParam)::Filter(float y, float z, float err2Y, floa
   mNDF += 2;
   mChi2 += mS0 * z0 * z0 + mS2 * z1 * z1;
 
-  mC[0] -= k00 * c00;
-  mC[3] -= k20 * c00;
-  mC[5] -= k20 * c20;
-  mC[10] -= k40 * c00;
-  mC[12] -= k40 * c20;
-  mC[14] -= k40 * c40;
+  mParam.mC[0] -= k00 * c00;
+  mParam.mC[3] -= k20 * c00;
+  mParam.mC[5] -= k20 * c20;
+  mParam.mC[10] -= k40 * c00;
+  mParam.mC[12] -= k40 * c20;
+  mParam.mC[14] -= k40 * c40;
 
-  mC[2] -= k11 * c11;
-  mC[7] -= k31 * c11;
-  mC[9] -= k31 * c31;
+  mParam.mC[2] -= k11 * c11;
+  mParam.mC[7] -= k31 * c11;
+  mParam.mC[9] -= k31 * c31;
 
   return 1;
 }
@@ -735,6 +735,6 @@ GPUd() void MEM_LG(GPUTPCTrackParam)::Print() const
 
 #if !defined(GPUCA_GPUCODE)
   std::cout << "track: x=" << GetX() << " c=" << GetSignCosPhi() << ", P= " << GetY() << " " << GetZ() << " " << GetSinPhi() << " " << GetDzDs() << " " << GetQPt() << std::endl;
-  std::cout << "errs2: " << GetErr2Y() << " " << GetErr2Z() << " " << GetErr2SinPhi() << " " << GetErr2DzDs() << " " << GetErr2QPt() << std::endl;
+  std::cout << "errs2: " << Err2Y() << " " << Err2Z() << " " << Err2SinPhi() << " " << Err2DzDs() << " " << Err2QPt() << std::endl;
 #endif
 }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
@@ -54,11 +54,11 @@ class GPUTPCTrackParam
   GPUd() float Chi2() const { return mChi2; }
   GPUd() int NDF() const { return mNDF; }
 
-  GPUd() float Err2Y() const { return mC[0]; }
-  GPUd() float Err2Z() const { return mC[2]; }
-  GPUd() float Err2SinPhi() const { return mC[5]; }
-  GPUd() float Err2DzDs() const { return mC[9]; }
-  GPUd() float Err2QPt() const { return mC[14]; }
+  GPUd() float Err2Y() const { return mParam.Err2Y(); }
+  GPUd() float Err2Z() const { return mParam.Err2Z(); }
+  GPUd() float Err2SinPhi() const { return mParam.Err2SinPhi(); }
+  GPUd() float Err2DzDs() const { return mParam.Err2DzDs(); }
+  GPUd() float Err2QPt() const { return mParam.Err2QPt(); }
 
   GPUd() float GetX() const { return mParam.GetX(); }
   GPUd() float GetY() const { return mParam.GetY(); }
@@ -73,22 +73,15 @@ class GPUTPCTrackParam
   GPUd() float GetKappa(float Bz) const { return mParam.GetKappa(Bz); }
   GPUd() float GetCosPhi() const { return mSignCosPhi * CAMath::Sqrt(1 - SinPhi() * SinPhi()); }
 
-  GPUd() float GetErr2Y() const { return mC[0]; }
-  GPUd() float GetErr2Z() const { return mC[2]; }
-  GPUd() float GetErr2SinPhi() const { return mC[5]; }
-  GPUd() float GetErr2DzDs() const { return mC[9]; }
-  GPUd() float GetErr2QPt() const { return mC[14]; }
-
   GPUhd() MakeType(const float*) Par() const { return mParam.Par(); }
-  GPUhd() const float* Cov() const { return mC; }
+  GPUhd() const float* Cov() const { return mParam.Cov(); }
 
   GPUd() const float* GetPar() const { return mParam.GetPar(); }
   GPUd() float GetPar(int i) const { return (mParam.GetPar(i)); }
-  GPUd() const float* GetCov() const { return mC; }
-  GPUd() float GetCov(int i) const { return mC[i]; }
+  GPUd() float GetCov(int i) const { return mParam.GetCov(i); }
 
   GPUhd() void SetPar(int i, float v) { mParam.SetPar(i, v); }
-  GPUhd() void SetCov(int i, float v) { mC[i] = v; }
+  GPUhd() void SetCov(int i, float v) { mParam.SetCov(i, v); }
 
   GPUd() void SetX(float v) { mParam.SetX(v); }
   GPUd() void SetY(float v) { mParam.SetY(v); }
@@ -145,7 +138,6 @@ class GPUTPCTrackParam
   // WARNING, Track Param Data is copied in the GPU Tracklet Constructor element by element instead of using copy constructor!!!
   // This is neccessary for performance reasons!!!
   // Changes to Elements of this class therefore must also be applied to TrackletConstructor!!!
-  float mC[15];      // the covariance matrix for Y,Z,SinPhi,..
   float mSignCosPhi; // sign of cosPhi
   float mChi2;       // the chi^2 value
   int mNDF;          // the Number of Degrees of Freedom

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.cxx
@@ -181,8 +181,8 @@ GPUd() void GPUTPCTrackletConstructor::UpdateTracklet(int /*nBlocks*/, int /*nTh
 
         if (r.mNHits >= 10) {
           const float kFactor = tracker.Param().rec.HitPickUpFactor * tracker.Param().rec.HitPickUpFactor * 3.5f * 3.5f;
-          float sy2 = kFactor * (tParam.GetErr2Y() + err2Y);
-          float sz2 = kFactor * (tParam.GetErr2Z() + err2Z);
+          float sy2 = kFactor * (tParam.Err2Y() + err2Y);
+          float sz2 = kFactor * (tParam.Err2Z() + err2Z);
           if (sy2 > 2.f) {
             sy2 = 2.f;
           }
@@ -265,8 +265,8 @@ GPUd() void GPUTPCTrackletConstructor::UpdateTracklet(int /*nBlocks*/, int /*nTh
       { // search for the closest hit
         tracker.GetErrors2Seeding(iRow, *((MEM_LG2(GPUTPCTrackParam)*)&tParam), err2Y, err2Z);
         const float kFactor = tracker.Param().rec.HitPickUpFactor * tracker.Param().rec.HitPickUpFactor * 3.5f * 3.5f;
-        float sy2 = kFactor * (tParam.GetErr2Y() + err2Y);
-        float sz2 = kFactor * (tParam.GetErr2Z() + err2Z);
+        float sy2 = kFactor * (tParam.Err2Y() + err2Y);
+        float sz2 = kFactor * (tParam.Err2Z() + err2Z);
         if (sy2 > 2.f) {
           sy2 = 2.f;
         }

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -955,14 +955,15 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
         float alpha = param().Alpha(slice);
         if (iMC == 0) {
           trkParam.Set(track->GetParam());
-          ZOffset = track->GetParam().GetZOffset();
           auto cl = mMerger.Clusters()[track->FirstClusterRef() + lastCluster];
           if (mMerger.Param().earlyTpcTransform) {
             x = cl.x;
+            ZOffset = track->GetParam().GetTZOffset();
           } else {
             const auto& cln = mMerger.GetConstantMem()->ioPtrs.clustersNative->clustersLinear[cl.num];
             float y, z;
             GPUTPCConvertImpl::convert(*mMerger.GetConstantMem(), cl.slice, cl.row, cln.getPad(), cln.getTime(), x, y, z);
+            ZOffset = mMerger.GetConstantMem()->calibObjects.fastTransform->convTimeToZinTimeFrame(slice, track->GetParam().GetTZOffset(), mMerger.Param().continuousMaxTimeBin);
           }
         } else {
           const GPUTPCMCInfo& mc = ioptrs().mcInfosTPC[i];

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -1006,7 +1006,7 @@ void GPUQA::RunQA(bool matchOnly)
 #ifdef GPUCA_TPC_GEOMETRY_O2 // ignore z here, larger difference in X due to shifted reference
       if (mConfig.strict && (param.X() - mclocal[0]) * (param.X() - mclocal[0]) + (param.Y() - mclocal[1]) * (param.Y() - mclocal[1]) + (merger.Param().continuousMaxTimeBin ? 0 : ((param.Z() - mc1.z) * (param.Z() - mc1.z))) > (5 + abs(81 - TRACK_EXPECTED_REFERENCE_X)) * (5 + abs(81 - TRACK_EXPECTED_REFERENCE_X))) {
 #else // Consider Z offset (pseudo-tf mc tracks have shifted z)
-      if (mConfig.strict && (param.X() - mclocal[0]) * (param.X() - mclocal[0]) + (param.Y() - mclocal[1]) * (param.Y() - mclocal[1]) + (param.Z() + param.ZOffset() - mc1.z) * (param.Z() + param.ZOffset() - mc1.z) > 25) {
+      if (mConfig.strict && (param.X() - mclocal[0]) * (param.X() - mclocal[0]) + (param.Y() - mclocal[1]) * (param.Y() - mclocal[1]) + (param.Z() + param.TZOffset() - mc1.z) * (param.Z() + param.TZOffset() - mc1.z) > 25) { // TODO: fix TZOffset
 #endif
         continue;
       }
@@ -1015,9 +1015,9 @@ void GPUQA::RunQA(bool matchOnly)
         continue;
       }
 #ifdef GPUCA_TPC_GEOMETRY_O2 // ignore z here, larger difference in X due to shifted reference
-      if (fabsf(param.Y() - mclocal[1]) > (mConfig.strict ? 1.f : 4.f) || (merger.Param().continuousMaxTimeBin == 0 && fabsf(param.Z() + param.ZOffset() - mc1.z) > (mConfig.strict ? 1.f : 4.f))) {
+      if (fabsf(param.Y() - mclocal[1]) > (mConfig.strict ? 1.f : 4.f) || (merger.Param().continuousMaxTimeBin == 0 && fabsf(param.Z() + param.TZOffset() - mc1.z) > (mConfig.strict ? 1.f : 4.f))) { // TODO: fix TZOffset here
 #else
-      if (fabsf(param.Y() - mclocal[1]) > (mConfig.strict ? 1.f : 4.f) || fabsf(param.Z() + param.ZOffset() - mc1.z) > (mConfig.strict ? 1.f : 4.f)) {
+      if (fabsf(param.Y() - mclocal[1]) > (mConfig.strict ? 1.f : 4.f) || fabsf(param.Z() + param.TZOffset() - mc1.z) > (mConfig.strict ? 1.f : 4.f)) {                                                                         // TODO: fix TZOffset here
 #endif
         continue;
       }
@@ -1025,7 +1025,7 @@ void GPUQA::RunQA(bool matchOnly)
       float charge = mc1.charge > 0 ? 1.f : -1.f;
 
       float deltaY = param.GetY() - mclocal[1];
-      float deltaZ = param.GetZ() + param.ZOffset() - mc1.z;
+      float deltaZ = param.GetZ() + param.TZOffset() - mc1.z; // TODO: fix TZOffset here
       float deltaPhiNative = param.GetSinPhi() - mclocal[3] / mc2.pt;
       float deltaPhi = std::asin(param.GetSinPhi()) - std::atan2(mclocal[3], mclocal[2]);
       float deltaLambdaNative = param.GetDzDs() - mc1.pZ / mc2.pt;

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -79,6 +79,7 @@ AddOption(tpcCompressionSort, int, 0, "tpcCompressionSort", 0, "Sort order of TP
 AddOption(ForceEarlyTPCTransform, int, -1, "ForceEarlyTPCTransform", 0, "Force early TPC transformation also for continuous data (-1 = auto)")
 AddOption(fwdTPCDigitsAsClusters, bool, false, "forwardTPCdigits", 0, "Forward TPC digits as clusters (if they pass the ZS threshold)")
 AddOption(dropLoopers, bool, false, "dropLoopers", 0, "Drop looping tracks starting from second loop")
+AddOption(mergerCovSource, int, -1, "mergerCovSource", 0, "Method to obtain covariance in track merger: 0 = simple filterErrors method, 1 = use cov from track following")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -163,6 +163,12 @@ int ReadConfiguration(int argc, char** argv)
     return (1);
   }
 #endif
+  if (configStandalone.qa) {
+    if (getenv("LC_NUMERIC")) {
+      printf("Please unset the LC_NUMERIC env variable, otherwise ROOT will not be able to fit correctly"); // BUG: ROOT Problem
+      return (1);
+    }
+  }
 #ifndef GPUCA_BUILD_EVENT_DISPLAY
   if (configStandalone.eventDisplay) {
     printf("EventDisplay not enabled in build\n");

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -285,6 +285,9 @@ int SetupReconstruction()
   recSet.ForceEarlyTPCTransform = configStandalone.configRec.ForceEarlyTPCTransform;
   recSet.fwdTPCDigitsAsClusters = configStandalone.configRec.fwdTPCDigitsAsClusters;
   recSet.dropLoopers = configStandalone.configRec.dropLoopers;
+  if (configStandalone.configRec.mergerCovSource != -1) {
+    recSet.mergerCovSource = configStandalone.configRec.mergerCovSource;
+  }
   if (configStandalone.referenceX < 500.) {
     recSet.TrackReferenceX = configStandalone.referenceX;
   }


### PR DESCRIPTION
@shahor02 : This PR changes the offset during the TPC tracking from a z-offset to a vertex time.
Accordingly, the time0 stored in the TPC track no longer has the shift by the TPC drift time.
It is simply the time of the vertex in TPC time bins since beginning of the time frame.
I assume this will require a small modification in the TPC / ITS matching.
Could you indicate what I need to change or send a patch, such that this can be merged together?