### PR TITLE
DigitizerContext: Check vertex matching

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -78,6 +78,9 @@ class DigitizationContext
   /// return boolean saying if input simchains was modified or not
   bool initSimKinematicsChains(std::vector<TChain*>& simkinematicschains) const;
 
+  /// Check collision parts for vertex consistency.
+  bool checkVertexCompatibility(bool verbose = false) const;
+
   /// function reading the hits from a chain (previously initialized with initSimChains
   /// The hits pointer will be initialized (what to we do about ownership??)
   template <typename T>

--- a/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
@@ -38,8 +38,9 @@ class MCEventHeader : public FairMCEventHeader
   ~MCEventHeader() override = default;
 
   /** setters **/
-  void setEmbeddingFileName(std::string value) { mEmbeddingFileName = value; };
+  void setEmbeddingFileName(std::string const& value) { mEmbeddingFileName = value; };
   void setEmbeddingEventIndex(Int_t value) { mEmbeddingEventIndex = value; };
+  int getEmbeddedIndex() const { return mEmbeddingEventIndex; }
 
   /** methods **/
   virtual void Reset();


### PR DESCRIPTION
Introducing a function to check the matching of vertices
in the digitization (context). Meant as a first diagnostic.

In a later step, this will be actually taken into account
during the construction of the collisions themselves.