### PR TITLE
Fix codechecker errors

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -45,7 +45,7 @@ class Generator : public FairGenerator
   /** constructor **/
   Generator(const Char_t* name, const Char_t* title = "ALICEo2 Generator");
   /** destructor **/
-  ~Generator() override;
+  ~Generator() override = default;
 
   /** Initialize the generator if needed **/
   Bool_t Init() override;

--- a/Generators/include/Generators/GeneratorPythia6.h
+++ b/Generators/include/Generators/GeneratorPythia6.h
@@ -33,10 +33,10 @@ class GeneratorPythia6 : public GeneratorTGenerator
   /** constructor **/
   GeneratorPythia6(const Char_t* name, const Char_t* title = "ALICEo2 Pythia6 Generator");
   /** destructor **/
-  virtual ~GeneratorPythia6() = default;
+  ~GeneratorPythia6() override = default;
 
   /** Initialize the generator if needed **/
-  virtual Bool_t Init() override;
+  Bool_t Init() override;
 
   /** setters **/
   void setConfig(std::string val) { mConfig = val; };

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -44,13 +44,6 @@ Generator::Generator(const Char_t* name, const Char_t* title) : FairGenerator(na
 
 /*****************************************************************/
 
-Generator::~Generator()
-{
-  /** default destructor **/
-}
-
-/*****************************************************************/
-
 Bool_t
   Generator::Init()
 {


### PR DESCRIPTION
Fixes:

Generator.cxx:47:12: error: use '= default' to define a trivial destructor [modernize-use-equals-default]
GeneratorPythia6.h:36:11: error: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
GeneratorPythia6.h:39:18: error: 'virtual' is redundant since the function is already declared 'override' [modernize-use-override]
GeneratorPythia6.h:36:11: error: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
GeneratorPythia6.h:39:18: error: 'virtual' is redundant since the function is already declared 'override' [modernize-use-override]