### PR TITLE
DPL Analysis: calculate branch name

### DIFF
--- a/Analysis/DataModel/include/Analysis/Jet.h
+++ b/Analysis/DataModel/include/Analysis/Jet.h
@@ -21,12 +21,12 @@ namespace o2::aod
 namespace jet
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
-DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
-DECLARE_SOA_COLUMN(Pt, pt, float, "fPt");
-DECLARE_SOA_COLUMN(Area, area, float, "fArea");
-DECLARE_SOA_COLUMN(Energy, energy, float, "fEnergy");
-DECLARE_SOA_COLUMN(Mass, mass, float, "fMass");
+DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(Phi, phi, float);
+DECLARE_SOA_COLUMN(Pt, pt, float);
+DECLARE_SOA_COLUMN(Area, area, float);
+DECLARE_SOA_COLUMN(Energy, energy, float);
+DECLARE_SOA_COLUMN(Mass, mass, float);
 } // namespace jet
 
 DECLARE_SOA_TABLE(Jets, "AOD", "JET",

--- a/Analysis/DataModel/include/Analysis/SecondaryVertex.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertex.h
@@ -20,36 +20,36 @@ namespace secvtx2prong
 using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra>;
 
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(Posdecayx, posdecayx, float, "fPosdecayx");
-DECLARE_SOA_COLUMN(Posdecayy, posdecayy, float, "fPosdecayy");
-DECLARE_SOA_COLUMN(Posdecayz, posdecayz, float, "fPosdecayz");
+DECLARE_SOA_COLUMN(Posdecayx, posdecayx, float);
+DECLARE_SOA_COLUMN(Posdecayy, posdecayy, float);
+DECLARE_SOA_COLUMN(Posdecayz, posdecayz, float);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
-DECLARE_SOA_COLUMN(Px0, px0, float, "fPx0");
-DECLARE_SOA_COLUMN(Py0, py0, float, "fPy0");
-DECLARE_SOA_COLUMN(Pz0, pz0, float, "fPz0");
-DECLARE_SOA_COLUMN(Y0, y0, float, "fY0");
+DECLARE_SOA_COLUMN(Px0, px0, float);
+DECLARE_SOA_COLUMN(Py0, py0, float);
+DECLARE_SOA_COLUMN(Pz0, pz0, float);
+DECLARE_SOA_COLUMN(Y0, y0, float);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
-DECLARE_SOA_COLUMN(Px1, px1, float, "fPx1");
-DECLARE_SOA_COLUMN(Py1, py1, float, "fPy1");
-DECLARE_SOA_COLUMN(Pz1, pz1, float, "fPz1");
-DECLARE_SOA_COLUMN(Y1, y1, float, "fY1");
-DECLARE_SOA_COLUMN(Mass, mass, float, "fMass");
-DECLARE_SOA_COLUMN(Massbar, massbar, float, "fMassbar");
+DECLARE_SOA_COLUMN(Px1, px1, float);
+DECLARE_SOA_COLUMN(Py1, py1, float);
+DECLARE_SOA_COLUMN(Pz1, pz1, float);
+DECLARE_SOA_COLUMN(Y1, y1, float);
+DECLARE_SOA_COLUMN(Mass, mass, float);
+DECLARE_SOA_COLUMN(Massbar, massbar, float);
 DECLARE_SOA_DYNAMIC_COLUMN(DecaylengthXY, decaylengthXY,
                            [](float xvtxd, float yvtxd, float xvtxp, float yvtxp) { return sqrtf((yvtxd - yvtxp) * (yvtxd - yvtxp) + (xvtxd - xvtxp) * (xvtxd - xvtxp)); });
 DECLARE_SOA_DYNAMIC_COLUMN(Decaylength, decaylength,
                            [](float xvtxd, float yvtxd, float zvtxd, float xvtxp,
                               float yvtxp, float zvtxp) { return sqrtf((yvtxd - yvtxp) * (yvtxd - yvtxp) + (xvtxd - xvtxp) * (xvtxd - xvtxp) + (zvtxd - zvtxp) * (zvtxd - zvtxp)); });
 //old way of doing it
-//DECLARE_SOA_COLUMN(Decaylength, decaylength, float, "fDecaylength");
-//DECLARE_SOA_COLUMN(DecaylengthXY, decaylengthXY, float, "fDecaylengthXY");
+//DECLARE_SOA_COLUMN(Decaylength, decaylength, float);
+//DECLARE_SOA_COLUMN(DecaylengthXY, decaylengthXY, float);
 
 } // namespace secvtx2prong
 namespace cand2prong
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(MassD0, massD0, float, "fMassD0");
-DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float, "fMassD0bar");
+DECLARE_SOA_COLUMN(MassD0, massD0, float);
+DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float);
 } // namespace cand2prong
 
 DECLARE_SOA_TABLE(SecVtx2Prong, "AOD", "VTX2PRONG",

--- a/Analysis/DataModel/include/Analysis/TrackSelectionTables.h
+++ b/Analysis/DataModel/include/Analysis/TrackSelectionTables.h
@@ -18,9 +18,8 @@ namespace o2::aod
 namespace track
 {
 // Columns to store track filter decisions
-DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool, "fIsGlobalTrack");
-DECLARE_SOA_COLUMN(IsGlobalTrackSDD, isGlobalTrackSDD, bool,
-                   "fIsGlobalTrackSDD");
+DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);
+DECLARE_SOA_COLUMN(IsGlobalTrackSDD, isGlobalTrackSDD, bool);
 
 } // namespace track
 

--- a/Analysis/Tasks/correlationsCollection.cxx
+++ b/Analysis/Tasks/correlationsCollection.cxx
@@ -22,9 +22,9 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta2, eta2, float, "fEta2");
-DECLARE_SOA_COLUMN(Phi2, phi2, float, "fPhi2");
-DECLARE_SOA_COLUMN(Pt2, pt2, float, "fPt2");
+DECLARE_SOA_COLUMN(Eta2, eta2, float);
+DECLARE_SOA_COLUMN(Phi2, phi2, float);
+DECLARE_SOA_COLUMN(Pt2, pt2, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta2, etaphi::Phi2, etaphi::Pt2);

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -31,13 +31,13 @@ namespace evsel
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 // TODO bool arrays are not supported? Storing in int32 for the moment
-DECLARE_SOA_COLUMN(Alias, alias, int32_t[nAliases], "fAlias");
-DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool, "fBBV0A"); // beam-beam time in V0A
-DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool, "fBBV0C"); // beam-beam time in V0C
-DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool, "fBGV0A"); // beam-gas time in V0A
-DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool, "fBGV0C"); // beam-gas time in V0C
-DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool, "fBBZNA"); // beam-beam time in ZNA
-DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool, "fBBZNC"); // beam-beam time in ZNC
+DECLARE_SOA_COLUMN(Alias, alias, int32_t[nAliases]);
+DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool); // beam-beam time in V0A
+DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool); // beam-beam time in V0C
+DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool); // beam-gas time in V0A
+DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool); // beam-gas time in V0C
+DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool); // beam-beam time in ZNA
+DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool); // beam-beam time in ZNC
 DECLARE_SOA_DYNAMIC_COLUMN(SEL7, sel7, [](bool bbV0A, bool bbV0C, bool bbZNA, bool bbZNC) -> bool { return bbV0A && bbV0C && bbZNA && bbZNC; });
 
 } // namespace evsel
@@ -49,8 +49,8 @@ using EvSel = EvSels::iterator;
 namespace mult
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(MultV0A, multV0A, float, "fMultV0A");
-DECLARE_SOA_COLUMN(MultV0C, multV0C, float, "fMultV0C");
+DECLARE_SOA_COLUMN(MultV0A, multV0A, float);
+DECLARE_SOA_COLUMN(MultV0C, multV0C, float);
 DECLARE_SOA_DYNAMIC_COLUMN(MultV0M, multV0M, [](float multV0A, float multV0C) -> float { return multV0A + multV0C; });
 } // namespace mult
 DECLARE_SOA_TABLE(Mults, "AOD", "MULT", mult::CollisionId, mult::MultV0A, mult::MultV0C, mult::MultV0M<mult::MultV0A, mult::MultV0C>);
@@ -59,7 +59,7 @@ using Mult = Mults::iterator;
 namespace cent
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(CentV0M, centV0M, float, "fCentV0M");
+DECLARE_SOA_COLUMN(CentV0M, centV0M, float);
 } // namespace cent
 DECLARE_SOA_TABLE(Cents, "AOD", "CENT", cent::CollisionId, cent::CentV0M);
 } // namespace o2::aod

--- a/Analysis/Tutorials/src/aodreader.cxx
+++ b/Analysis/Tutorials/src/aodreader.cxx
@@ -15,9 +15,9 @@ namespace o2::aod
 {
 namespace uno
 {
-DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
-DECLARE_SOA_COLUMN(Phi, phi, int, "fPhi1");
-DECLARE_SOA_COLUMN(Mom, mom, double, "fMom1");
+DECLARE_SOA_COLUMN_FULL(Eta, eta, float, "fEta1");
+DECLARE_SOA_COLUMN_FULL(Phi, phi, int, "fPhi1");
+DECLARE_SOA_COLUMN_FULL(Mom, mom, double, "fMom1");
 } // namespace uno
 
 DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
@@ -25,8 +25,8 @@ DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
 
 namespace due
 {
-DECLARE_SOA_COLUMN(Eta, eta, double, "fEta2");
-DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
+DECLARE_SOA_COLUMN_FULL(Eta, eta, double, "fEta2");
+DECLARE_SOA_COLUMN_FULL(Phi, phi, double, "fPhi2");
 } // namespace due
 
 DECLARE_SOA_TABLE(Due, "AOD", "DUE",

--- a/Analysis/Tutorials/src/aodwriter.cxx
+++ b/Analysis/Tutorials/src/aodwriter.cxx
@@ -15,9 +15,9 @@ namespace o2::aod
 {
 namespace uno
 {
-DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
-DECLARE_SOA_COLUMN(Phi, phi, int, "fPhi1");
-DECLARE_SOA_COLUMN(Mom, mom, double, "fMom1");
+DECLARE_SOA_COLUMN_FULL(Eta, eta, float, "fEta1");
+DECLARE_SOA_COLUMN_FULL(Phi, phi, int, "fPhi1");
+DECLARE_SOA_COLUMN_FULL(Mom, mom, double, "fMom1");
 } // namespace uno
 
 DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
@@ -25,8 +25,8 @@ DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
 
 namespace due
 {
-DECLARE_SOA_COLUMN(Eta, eta, short int, "fEta2");
-DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
+DECLARE_SOA_COLUMN_FULL(Eta, eta, short int, "fEta2");
+DECLARE_SOA_COLUMN_FULL(Phi, phi, double, "fPhi2");
 } // namespace due
 
 DECLARE_SOA_TABLE(Due, "AOD", "DUE",

--- a/Analysis/Tutorials/src/associatedExample.cxx
+++ b/Analysis/Tutorials/src/associatedExample.cxx
@@ -15,9 +15,9 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta, etas, float, "fEta");
-DECLARE_SOA_COLUMN(Phi, phis, float, "fPhi");
-DECLARE_SOA_COLUMN(Pt, pts, float, "fPt");
+DECLARE_SOA_COLUMN(Eta, etas, float);
+DECLARE_SOA_COLUMN(Phi, phis, float);
+DECLARE_SOA_COLUMN(Pt, pts, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);

--- a/Analysis/Tutorials/src/dynamicColumns.cxx
+++ b/Analysis/Tutorials/src/dynamicColumns.cxx
@@ -15,9 +15,9 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Tgl, tgl, float, "fTgl");
-DECLARE_SOA_COLUMN(Snp, snp, float, "fSnp");
-DECLARE_SOA_COLUMN(Alpha, alpha, float, "fAlpha");
+DECLARE_SOA_COLUMN(Tgl, tgl, float);
+DECLARE_SOA_COLUMN(Snp, snp, float);
+DECLARE_SOA_COLUMN(Alpha, alpha, float);
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float tgl) { return log(tan(0.25 * M_PI - 0.5 * atan(tgl))); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float snp, float alpha) { return asin(snp) + alpha + M_PI; });
 } // namespace etaphi

--- a/Analysis/Tutorials/src/filters.cxx
+++ b/Analysis/Tutorials/src/filters.cxx
@@ -15,8 +15,8 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta, eta2, float, "fEta");
-DECLARE_SOA_COLUMN(Phi, phi2, float, "fPhi");
+DECLARE_SOA_COLUMN(Eta, eta2, float);
+DECLARE_SOA_COLUMN(Phi, phi2, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);

--- a/Analysis/Tutorials/src/newCollections.cxx
+++ b/Analysis/Tutorials/src/newCollections.cxx
@@ -15,8 +15,8 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
-DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
+DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(Phi, phi, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1023,7 +1023,7 @@ class TableMetadata
     using metadata = std::void_t<T>; \
   }
 
-#define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_, _Label_)                  \
+#define DECLARE_SOA_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)             \
   struct _Name_ : o2::soa::Column<_Type_, _Name_> {                            \
     static constexpr const char* mLabel = _Label_;                             \
     using base = o2::soa::Column<_Type_, _Name_>;                              \
@@ -1045,6 +1045,9 @@ class TableMetadata
   };                                                                           \
   static const o2::framework::expressions::BindingNode _Getter_ { _Label_,     \
                                                                   o2::framework::expressions::selectArrowType<_Type_>() }
+
+#define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_) \
+  DECLARE_SOA_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_)
 
 /// An index column is a column of indices to elements / of another table named
 /// _Name_##s. The column name will be _Name_##Id and will always be stored in

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -24,23 +24,23 @@ DECLARE_SOA_STORE();
 
 namespace collision
 {
-// DECLARE_SOA_COLUMN(TimeframeId, timeframeId, uint64_t, "timeframeID");
-DECLARE_SOA_COLUMN(RunNumber, runNumber, int, "fRunNumber");
-DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t, "fGlobalBC");
-DECLARE_SOA_COLUMN(PosX, posX, float, "fX");
-DECLARE_SOA_COLUMN(PosY, posY, float, "fY");
-DECLARE_SOA_COLUMN(PosZ, posZ, float, "fZ");
-DECLARE_SOA_COLUMN(CovXX, covXX, float, "fCovXX");
-DECLARE_SOA_COLUMN(CovXY, covXY, float, "fCovXY");
-DECLARE_SOA_COLUMN(CovXZ, covXZ, float, "fCovXZ");
-DECLARE_SOA_COLUMN(CovYY, covYY, float, "fCovYY");
-DECLARE_SOA_COLUMN(CovYZ, covYZ, float, "fCovYZ");
-DECLARE_SOA_COLUMN(CovZZ, covZZ, float, "fCovZZ");
-DECLARE_SOA_COLUMN(Chi2, chi2, float, "fChi2");
-DECLARE_SOA_COLUMN(NumContrib, numContrib, uint32_t, "fN");
-DECLARE_SOA_COLUMN(CollisionTime, collisionTime, float, "fCollisionTime");
-DECLARE_SOA_COLUMN(CollisionTimeRes, collisionTimeRes, float, "fCollisionTimeRes");
-DECLARE_SOA_COLUMN(CollisionTimeMask, collisionTimeMask, uint8_t, "fCollisionTimeMask");
+// DECLARE_SOA_COLUMN(TimeframeId, timeframeId, uint64_t);
+DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
+DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);
+DECLARE_SOA_COLUMN(PosX, posX, float);
+DECLARE_SOA_COLUMN(PosY, posY, float);
+DECLARE_SOA_COLUMN(PosZ, posZ, float);
+DECLARE_SOA_COLUMN(CovXX, covXX, float);
+DECLARE_SOA_COLUMN(CovXY, covXY, float);
+DECLARE_SOA_COLUMN(CovXZ, covXZ, float);
+DECLARE_SOA_COLUMN(CovYY, covYY, float);
+DECLARE_SOA_COLUMN(CovYZ, covYZ, float);
+DECLARE_SOA_COLUMN(CovZZ, covZZ, float);
+DECLARE_SOA_COLUMN(Chi2, chi2, float);
+DECLARE_SOA_COLUMN_FULL(NumContrib, numContrib, uint32_t, "fN");
+DECLARE_SOA_COLUMN(CollisionTime, collisionTime, float);
+DECLARE_SOA_COLUMN(CollisionTimeRes, collisionTimeRes, float);
+DECLARE_SOA_COLUMN(CollisionTimeMask, collisionTimeMask, uint8_t);
 } // namespace collision
 
 DECLARE_SOA_TABLE(Collisions, "AOD", "COLLISION", o2::soa::Index<>, collision::RunNumber, collision::GlobalBC, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2, collision::NumContrib, collision::CollisionTime, collision::CollisionTimeRes, collision::CollisionTimeMask);
@@ -51,13 +51,13 @@ namespace track
 {
 // TRACKPAR TABLE definition
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(X, x, float, "fX");
-DECLARE_SOA_COLUMN(Alpha, alpha, float, "fAlpha");
-DECLARE_SOA_COLUMN(Y, y, float, "fY");
-DECLARE_SOA_COLUMN(Z, z, float, "fZ");
-DECLARE_SOA_COLUMN(Snp, snp, float, "fSnp");
-DECLARE_SOA_COLUMN(Tgl, tgl, float, "fTgl");
-DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float, "fSigned1Pt");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Alpha, alpha, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
+DECLARE_SOA_COLUMN(Snp, snp, float);
+DECLARE_SOA_COLUMN(Tgl, tgl, float);
+DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float);
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float snp, float alpha) -> float { return asinf(snp) + alpha + static_cast<float>(M_PI); });
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float tgl) -> float { return logf(tanf(0.25f * static_cast<float>(M_PI) - 0.5f * atanf(tgl))); });
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float signed1Pt) -> float { return std::abs(1.0f / signed1Pt); });
@@ -88,39 +88,39 @@ DECLARE_SOA_DYNAMIC_COLUMN(P2, p2, [](float signed1Pt, float tgl) -> float {
 });
 
 // TRACKPARCOV TABLE definition
-DECLARE_SOA_COLUMN(CYY, cYY, float, "fCYY");
-DECLARE_SOA_COLUMN(CZY, cZY, float, "fCZY");
-DECLARE_SOA_COLUMN(CZZ, cZZ, float, "fCZZ");
-DECLARE_SOA_COLUMN(CSnpY, cSnpY, float, "fCSnpY");
-DECLARE_SOA_COLUMN(CSnpZ, cSnpZ, float, "fCSnpZ");
-DECLARE_SOA_COLUMN(CSnpSnp, cSnpSnp, float, "fCSnpSnp");
-DECLARE_SOA_COLUMN(CTglY, cTglY, float, "fCTglY");
-DECLARE_SOA_COLUMN(CTglZ, cTglZ, float, "fCTglZ");
-DECLARE_SOA_COLUMN(CTglSnp, cTglSnp, float, "fCTglSnp");
-DECLARE_SOA_COLUMN(CTglTgl, cTglTgl, float, "fCTglTgl");
-DECLARE_SOA_COLUMN(C1PtY, c1PtY, float, "fC1PtY");
-DECLARE_SOA_COLUMN(C1PtZ, c1PtZ, float, "fC1PtZ");
-DECLARE_SOA_COLUMN(C1PtSnp, c1PtSnp, float, "fC1PtSnp");
-DECLARE_SOA_COLUMN(C1PtTgl, c1PtTgl, float, "fC1PtTgl");
-DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, "fC1Pt21Pt2");
+DECLARE_SOA_COLUMN(CYY, cYY, float);
+DECLARE_SOA_COLUMN(CZY, cZY, float);
+DECLARE_SOA_COLUMN(CZZ, cZZ, float);
+DECLARE_SOA_COLUMN(CSnpY, cSnpY, float);
+DECLARE_SOA_COLUMN(CSnpZ, cSnpZ, float);
+DECLARE_SOA_COLUMN(CSnpSnp, cSnpSnp, float);
+DECLARE_SOA_COLUMN(CTglY, cTglY, float);
+DECLARE_SOA_COLUMN(CTglZ, cTglZ, float);
+DECLARE_SOA_COLUMN(CTglSnp, cTglSnp, float);
+DECLARE_SOA_COLUMN(CTglTgl, cTglTgl, float);
+DECLARE_SOA_COLUMN(C1PtY, c1PtY, float);
+DECLARE_SOA_COLUMN(C1PtZ, c1PtZ, float);
+DECLARE_SOA_COLUMN(C1PtSnp, c1PtSnp, float);
+DECLARE_SOA_COLUMN(C1PtTgl, c1PtTgl, float);
+DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float);
 
 // TRACKEXTRA TABLE definition
-DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float, "fTPCinnerP");
-DECLARE_SOA_COLUMN(Flags, flags, uint64_t, "fFlags");
-DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, uint8_t, "fITSClusterMap");
-DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t, "fTPCnclsFindable");
-DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t, "fTPCnclsFindableMinusFound");
-DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t, "fTPCnclsFindableMinusCrossedRows");
-DECLARE_SOA_COLUMN(TPCNClsShared, tpcNClsShared, uint8_t, "fTPCnclsShared");
-DECLARE_SOA_COLUMN(TRDNTracklets, trdNTracklets, uint8_t, "fTRDntracklets");
-DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float, "fITSchi2Ncl");
-DECLARE_SOA_COLUMN(TPCchi2Ncl, tpcChi2Ncl, float, "fTPCchi2Ncl");
-DECLARE_SOA_COLUMN(TRDchi2, trdChi2, float, "fTRDchi2");
-DECLARE_SOA_COLUMN(TOFchi2, tofChi2, float, "fTOFchi2");
-DECLARE_SOA_COLUMN(TPCsignal, tpcSignal, float, "fTPCsignal");
-DECLARE_SOA_COLUMN(TRDsignal, trdSignal, float, "fTRDsignal");
-DECLARE_SOA_COLUMN(TOFsignal, tofSignal, float, "fTOFsignal");
-DECLARE_SOA_COLUMN(Length, length, float, "fLength");
+DECLARE_SOA_COLUMN_FULL(TPCInnerParam, tpcInnerParam, float, "fTPCinnerP");
+DECLARE_SOA_COLUMN(Flags, flags, uint64_t);
+DECLARE_SOA_COLUMN_FULL(ITSClusterMap, itsClusterMap, uint8_t, "fITSClusterMap");
+DECLARE_SOA_COLUMN_FULL(TPCNClsFindable, tpcNClsFindable, uint8_t, "fTPCnclsFindable");
+DECLARE_SOA_COLUMN_FULL(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t, "fTPCnclsFindableMinusFound");
+DECLARE_SOA_COLUMN_FULL(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t, "fTPCnclsFindableMinusCrossedRows");
+DECLARE_SOA_COLUMN_FULL(TPCNClsShared, tpcNClsShared, uint8_t, "fTPCnclsShared");
+DECLARE_SOA_COLUMN_FULL(TRDNTracklets, trdNTracklets, uint8_t, "fTRDntracklets");
+DECLARE_SOA_COLUMN_FULL(ITSChi2NCl, itsChi2NCl, float, "fITSchi2Ncl");
+DECLARE_SOA_COLUMN(TPCchi2Ncl, tpcChi2Ncl, float);
+DECLARE_SOA_COLUMN(TRDchi2, trdChi2, float);
+DECLARE_SOA_COLUMN(TOFchi2, tofChi2, float);
+DECLARE_SOA_COLUMN(TPCsignal, tpcSignal, float);
+DECLARE_SOA_COLUMN(TRDsignal, trdSignal, float);
+DECLARE_SOA_COLUMN(TOFsignal, tofSignal, float);
+DECLARE_SOA_COLUMN(Length, length, float);
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsFound, tpcNClsFound, [](uint8_t tpcNClsFindable, uint8_t tpcNClsFindableMinusFound) -> int16_t { return tpcNClsFindable - tpcNClsFindableMinusFound; });
 DECLARE_SOA_DYNAMIC_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, [](uint8_t tpcNClsFindable, uint8_t TPCNClsFindableMinusCrossedRows) -> int16_t { return tpcNClsFindable - TPCNClsFindableMinusCrossedRows; });
 
@@ -199,11 +199,11 @@ using UnassignedTrack = UnassignedTracks::iterator;
 namespace calo
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(CellNumber, cellNumber, int16_t, "fCellNumber");
-DECLARE_SOA_COLUMN(Amplitude, amplitude, float, "fAmplitude");
-DECLARE_SOA_COLUMN(Time, time, float, "fTime");
-DECLARE_SOA_COLUMN(CellType, cellType, int8_t, "fCellType");
-DECLARE_SOA_COLUMN(CaloType, caloType, int8_t, "fType");
+DECLARE_SOA_COLUMN(CellNumber, cellNumber, int16_t);
+DECLARE_SOA_COLUMN(Amplitude, amplitude, float);
+DECLARE_SOA_COLUMN(Time, time, float);
+DECLARE_SOA_COLUMN(CellType, cellType, int8_t);
+DECLARE_SOA_COLUMN_FULL(CaloType, caloType, int8_t, "fType");
 } // namespace calo
 
 DECLARE_SOA_TABLE(Calos, "AOD", "CALO",
@@ -213,13 +213,13 @@ using Calo = Calos::iterator;
 namespace calotrigger
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(FastorAbsId, fastorAbsId, int32_t, "fFastorAbsID");
-DECLARE_SOA_COLUMN(L0Amplitude, l0Amplitude, float, "fL0Amplitude");
-DECLARE_SOA_COLUMN(L0Time, l0Time, float, "fL0Time");
-DECLARE_SOA_COLUMN(L1Timesum, l1Timesum, int32_t, "fL1TimeSum");
-DECLARE_SOA_COLUMN(NL0Times, nl0Times, int8_t, "fNL0Times");
-DECLARE_SOA_COLUMN(Triggerbits, triggerbits, int32_t, "fTriggerBits");
-DECLARE_SOA_COLUMN(CaloType, caloType, int8_t, "fType");
+DECLARE_SOA_COLUMN_FULL(FastorAbsId, fastorAbsId, int32_t, "fFastorAbsID");
+DECLARE_SOA_COLUMN(L0Amplitude, l0Amplitude, float);
+DECLARE_SOA_COLUMN(L0Time, l0Time, float);
+DECLARE_SOA_COLUMN_FULL(L1Timesum, l1Timesum, int32_t, "fL1TimeSum");
+DECLARE_SOA_COLUMN(NL0Times, nl0Times, int8_t);
+DECLARE_SOA_COLUMN_FULL(Triggerbits, triggerbits, int32_t, "fTriggerBits");
+DECLARE_SOA_COLUMN_FULL(CaloType, caloType, int8_t, "fType");
 } // namespace calotrigger
 
 DECLARE_SOA_TABLE(CaloTriggers, "AOD", "CALOTRIGGER",
@@ -229,16 +229,16 @@ using CaloTrigger = CaloTriggers::iterator;
 namespace muon
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(InverseBendingMomentum, inverseBendingMomentum, float, "fInverseBendingMomentum");
-DECLARE_SOA_COLUMN(ThetaX, thetaX, float, "fThetaX");
-DECLARE_SOA_COLUMN(ThetaY, thetaY, float, "fThetaY");
-DECLARE_SOA_COLUMN(ZMu, zMu, float, "fZ");
-DECLARE_SOA_COLUMN(BendingCoor, bendingCoor, float, "fBendingCoor");
-DECLARE_SOA_COLUMN(NonBendingCoor, nonBendingCoor, float, "fNonBendingCoor");
+DECLARE_SOA_COLUMN(InverseBendingMomentum, inverseBendingMomentum, float);
+DECLARE_SOA_COLUMN(ThetaX, thetaX, float);
+DECLARE_SOA_COLUMN(ThetaY, thetaY, float);
+DECLARE_SOA_COLUMN_FULL(ZMu, zMu, float, "fZ");
+DECLARE_SOA_COLUMN(BendingCoor, bendingCoor, float);
+DECLARE_SOA_COLUMN(NonBendingCoor, nonBendingCoor, float);
 // FIXME: need to implement array columns...
 // DECLARE_SOA_COLUMN(Covariances, covariances, float[], "fCovariances");
-DECLARE_SOA_COLUMN(Chi2, chi2, float, "fChi2");
-DECLARE_SOA_COLUMN(Chi2MatchTrigger, chi2MatchTrigger, float, "fChi2MatchTrigger");
+DECLARE_SOA_COLUMN(Chi2, chi2, float);
+DECLARE_SOA_COLUMN(Chi2MatchTrigger, chi2MatchTrigger, float);
 } // namespace muon
 
 DECLARE_SOA_TABLE(Muons, "AOD", "MUON",
@@ -252,13 +252,13 @@ namespace muoncluster
 {
 /// FIXME: where does this point to???? Tracks or Muons?
 DECLARE_SOA_INDEX_COLUMN_FULL(Track, track, int, Muons, "fMuonsID");
-DECLARE_SOA_COLUMN(X, x, float, "fX");
-DECLARE_SOA_COLUMN(Y, y, float, "fY");
-DECLARE_SOA_COLUMN(Z, z, float, "fZ");
-DECLARE_SOA_COLUMN(ErrX, errX, float, "fErrX");
-DECLARE_SOA_COLUMN(ErrY, errY, float, "fErrY");
-DECLARE_SOA_COLUMN(Charge, charge, float, "fCharge");
-DECLARE_SOA_COLUMN(Chi2, chi2, float, "fChi2");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
+DECLARE_SOA_COLUMN(ErrX, errX, float);
+DECLARE_SOA_COLUMN(ErrY, errY, float);
+DECLARE_SOA_COLUMN(Charge, charge, float);
+DECLARE_SOA_COLUMN(Chi2, chi2, float);
 } // namespace muoncluster
 
 DECLARE_SOA_TABLE(MuonClusters, "AOD", "MUONCLUSTER",
@@ -272,18 +272,18 @@ using MuonCluster = MuonClusters::iterator;
 namespace zdc
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(ZEM1Energy, zem1Energy, float, "fZEM1Energy");
-DECLARE_SOA_COLUMN(ZEM2Energy, zem2Energy, float, "fZEM2Energy");
-DECLARE_SOA_COLUMN(ZNCTowerEnergy, zncTowerEnergy, float[5], "fZNCTowerEnergy");
-DECLARE_SOA_COLUMN(ZNATowerEnergy, znaTowerEnergy, float[5], "fZNATowerEnergy");
-DECLARE_SOA_COLUMN(ZPCTowerEnergy, zpcTowerEnergy, float[5], "fZPCTowerEnergy");
-DECLARE_SOA_COLUMN(ZPATowerEnergy, zpaTowerEnergy, float[5], "fZPATowerEnergy");
-DECLARE_SOA_COLUMN(ZNCTowerEnergyLR, zncTowerEnergyLR, float[5], "fZNCTowerEnergyLR");
-DECLARE_SOA_COLUMN(ZNATowerEnergyLR, znaTowerEnergyLR, float[5], "fZNATowerEnergyLR");
-DECLARE_SOA_COLUMN(ZPCTowerEnergyLR, zpcTowerEnergyLR, float[5], "fZPCTowerEnergyLR");
-DECLARE_SOA_COLUMN(ZPATowerEnergyLR, zpaTowerEnergyLR, float[5], "fZPATowerEnergyLR");
-//DECLARE_SOA_COLUMN(fZDCTDCCorrected, fZDCTDCCorrected, float[32][4], "fZDCTDCCorrected");
-DECLARE_SOA_COLUMN(Fired, fired, uint8_t, "fFired");
+DECLARE_SOA_COLUMN(ZEM1Energy, zem1Energy, float);
+DECLARE_SOA_COLUMN(ZEM2Energy, zem2Energy, float);
+DECLARE_SOA_COLUMN(ZNCTowerEnergy, zncTowerEnergy, float[5]);
+DECLARE_SOA_COLUMN(ZNATowerEnergy, znaTowerEnergy, float[5]);
+DECLARE_SOA_COLUMN(ZPCTowerEnergy, zpcTowerEnergy, float[5]);
+DECLARE_SOA_COLUMN(ZPATowerEnergy, zpaTowerEnergy, float[5]);
+DECLARE_SOA_COLUMN(ZNCTowerEnergyLR, zncTowerEnergyLR, float[5]);
+DECLARE_SOA_COLUMN(ZNATowerEnergyLR, znaTowerEnergyLR, float[5]);
+DECLARE_SOA_COLUMN(ZPCTowerEnergyLR, zpcTowerEnergyLR, float[5]);
+DECLARE_SOA_COLUMN(ZPATowerEnergyLR, zpaTowerEnergyLR, float[5]);
+//DECLARE_SOA_COLUMN(fZDCTDCCorrected, fZDCTDCCorrected, float[32][4]);
+DECLARE_SOA_COLUMN(Fired, fired, uint8_t);
 } // namespace zdc
 
 DECLARE_SOA_TABLE(Zdcs, "AOD", "ZDC", zdc::CollisionId,
@@ -296,11 +296,11 @@ using Zdc = Zdcs::iterator;
 namespace vzero
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(Adc, adc, float[64], "fAdc");
-DECLARE_SOA_COLUMN(Time, time, float[64], "fTime");
-DECLARE_SOA_COLUMN(Width, width, float[64], "fWidth");
-DECLARE_SOA_COLUMN(BBFlag, bbFlag, uint64_t, "fBBFlag");
-DECLARE_SOA_COLUMN(BGFlag, bgFlag, uint64_t, "fBGFlag");
+DECLARE_SOA_COLUMN(Adc, adc, float[64]);
+DECLARE_SOA_COLUMN(Time, time, float[64]);
+DECLARE_SOA_COLUMN(Width, width, float[64]);
+DECLARE_SOA_COLUMN(BBFlag, bbFlag, uint64_t);
+DECLARE_SOA_COLUMN(BGFlag, bgFlag, uint64_t);
 } // namespace vzero
 
 DECLARE_SOA_TABLE(VZeros, "AOD", "VZERO", vzero::CollisionId,
@@ -328,8 +328,8 @@ using Casecade = Cascades::iterator;
 
 namespace trigger
 {
-DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t, "fGlobalBC");
-DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t, "fTriggerMask");
+DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);
+DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t);
 } // namespace trigger
 
 DECLARE_SOA_TABLE(Triggers, "AOD", "TRIGGER", trigger::TriggerMask, trigger::GlobalBC);
@@ -337,7 +337,7 @@ using Trigger = Triggers::iterator;
 
 namespace timeframe
 {
-DECLARE_SOA_COLUMN(Timestamp, timestamp, uint64_t, "timestamp");
+DECLARE_SOA_COLUMN(Timestamp, timestamp, uint64_t);
 } // namespace timeframe
 
 DECLARE_SOA_TABLE(Timeframes, "AOD", "TIMEFRAME",

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -21,9 +21,9 @@ using namespace o2::soa;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "x");
-DECLARE_SOA_COLUMN(Y, y, float, "y");
-DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_COLUMN_FULL(X, x, float, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
+DECLARE_SOA_COLUMN_FULL(Z, z, float, "z");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace test
 

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -21,9 +21,9 @@ using namespace o2::soa;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "x");
-DECLARE_SOA_COLUMN(Y, y, float, "y");
-DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_COLUMN_FULL(X, x, float, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
+DECLARE_SOA_COLUMN_FULL(Z, z, float, "z");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace test
 

--- a/Framework/Core/test/benchmark_TableBuilder.cxx
+++ b/Framework/Core/test/benchmark_TableBuilder.cxx
@@ -126,9 +126,9 @@ BENCHMARK(BM_TableBuilderSimple2)->Range(8, 8 << 16);
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "x");
-DECLARE_SOA_COLUMN(Y, y, float, "y");
-DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
 } // namespace test
 
 using TestVectors = o2::soa::Table<test::X, test::Y, test::Z>;

--- a/Framework/Core/test/benchmark_TableToTree.cxx
+++ b/Framework/Core/test/benchmark_TableToTree.cxx
@@ -22,9 +22,9 @@ using namespace o2::soa;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "x");
-DECLARE_SOA_COLUMN(Y, y, float, "y");
-DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace test
 

--- a/Framework/Core/test/benchmark_TreeToTable.cxx
+++ b/Framework/Core/test/benchmark_TreeToTable.cxx
@@ -22,9 +22,9 @@ using namespace o2::soa;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "x");
-DECLARE_SOA_COLUMN(Y, y, float, "y");
-DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_COLUMN_FULL(X, x, float, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
+DECLARE_SOA_COLUMN_FULL(Z, z, float, "z");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace test
 

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -26,9 +26,9 @@ using namespace o2::soa;
 DECLARE_SOA_STORE();
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, int32_t, "x");
-DECLARE_SOA_COLUMN(Y, y, int32_t, "y");
-DECLARE_SOA_COLUMN(Z, z, int32_t, "z");
+DECLARE_SOA_COLUMN_FULL(X, x, int32_t, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, int32_t, "y");
+DECLARE_SOA_COLUMN_FULL(Z, z, int32_t, "z");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](int32_t x, int32_t y) { return x + y; });
 } // namespace test
 
@@ -36,19 +36,19 @@ DECLARE_SOA_TABLE(Points, "TST", "POINTS", test::X, test::Y);
 
 namespace test
 {
-DECLARE_SOA_COLUMN(SomeBool, someBool, bool, "someBool");
-DECLARE_SOA_COLUMN(Color, color, int32_t, "color");
+DECLARE_SOA_COLUMN_FULL(SomeBool, someBool, bool, "someBool");
+DECLARE_SOA_COLUMN_FULL(Color, color, int32_t, "color");
 } // namespace test
 
 DECLARE_SOA_TABLE(Infos, "TST", "INFOS", test::Color, test::SomeBool);
 
 namespace test
 {
-DECLARE_SOA_COLUMN(N, n, int, "fN");
+DECLARE_SOA_COLUMN(N, n, int);
 DECLARE_SOA_INDEX_COLUMN_FULL(Info, info, int, Infos, "fInfosID");
 DECLARE_SOA_INDEX_COLUMN_FULL(PointA, pointA, int, Points, "fPointAID");
 DECLARE_SOA_INDEX_COLUMN_FULL(PointB, pointB, int, Points, "fPointBID");
-DECLARE_SOA_COLUMN(Thickness, thickness, int, "thickness");
+DECLARE_SOA_COLUMN_FULL(Thickness, thickness, int, "thickness");
 } // namespace test
 
 DECLARE_SOA_TABLE(Segments, "TST", "SEGMENTS", test::N, test::PointAId, test::PointBId, test::InfoId);

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -22,10 +22,10 @@ using namespace o2::soa;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, int32_t, "x");
-DECLARE_SOA_COLUMN(Y, y, int32_t, "y");
-DECLARE_SOA_COLUMN(Z, z, int32_t, "z");
-DECLARE_SOA_COLUMN(FloatZ, floatZ, float, "floatZ");
+DECLARE_SOA_COLUMN_FULL(X, x, int32_t, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, int32_t, "y");
+DECLARE_SOA_COLUMN_FULL(Z, z, int32_t, "z");
+DECLARE_SOA_COLUMN_FULL(FloatZ, floatZ, float, "floatZ");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](int32_t x, int32_t y) { return x + y; });
 } // namespace test
 

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -23,12 +23,12 @@ namespace o2::aod
 {
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, float, "fX");
-DECLARE_SOA_COLUMN(Y, y, float, "fY");
-DECLARE_SOA_COLUMN(Z, z, float, "fZ");
-DECLARE_SOA_COLUMN(Foo, foo, float, "fBar");
-DECLARE_SOA_COLUMN(Bar, bar, float, "fFoo");
-DECLARE_SOA_COLUMN(EventProperty, eventProperty, float, "fEventProperty");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
+DECLARE_SOA_COLUMN(Foo, foo, float);
+DECLARE_SOA_COLUMN(Bar, bar, float);
+DECLARE_SOA_COLUMN(EventProperty, eventProperty, float);
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace test
 DECLARE_SOA_TABLE(Foos, "AOD", "FOO",

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -24,9 +24,9 @@ namespace o2::aod
 {
 namespace test
 {
-DECLARE_SOA_COLUMN(Foo, foo, float, "fBar");
-DECLARE_SOA_COLUMN(Bar, bar, float, "fFoo");
-DECLARE_SOA_COLUMN(EventProperty, eventProperty, float, "fEventProperty");
+DECLARE_SOA_COLUMN(Foo, foo, float);
+DECLARE_SOA_COLUMN(Bar, bar, float);
+DECLARE_SOA_COLUMN(EventProperty, eventProperty, float);
 } // namespace test
 DECLARE_SOA_TABLE(Events, "AOD", "EVTS",
                   o2::soa::Index<>,
@@ -39,9 +39,9 @@ using Event = Events::iterator;
 namespace test
 {
 DECLARE_SOA_INDEX_COLUMN(Event, event);
-DECLARE_SOA_COLUMN(X, x, float, "fX");
-DECLARE_SOA_COLUMN(Y, y, float, "fY");
-DECLARE_SOA_COLUMN(Z, z, float, "fZ");
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
 } // namespace test
 
 DECLARE_SOA_TABLE(TrksX, "AOD", "TRKSX",

--- a/Framework/Core/test/test_Root2ArrowTable.cxx
+++ b/Framework/Core/test/test_Root2ArrowTable.cxx
@@ -108,13 +108,13 @@ namespace o2::aod
 DECLARE_SOA_STORE();
 namespace test
 {
-DECLARE_SOA_COLUMN(Px, px, float, "px");
-DECLARE_SOA_COLUMN(Py, py, float, "py");
-DECLARE_SOA_COLUMN(Pz, pz, float, "pz");
-DECLARE_SOA_COLUMN(Xyz, xyz, float[3], "xyz");
-DECLARE_SOA_COLUMN(Ij, ij, int[2], "ij");
-DECLARE_SOA_COLUMN(Random, random, double, "random");
-DECLARE_SOA_COLUMN(Ev, ev, int, "ev");
+DECLARE_SOA_COLUMN_FULL(Px, px, float, "px");
+DECLARE_SOA_COLUMN_FULL(Py, py, float, "py");
+DECLARE_SOA_COLUMN_FULL(Pz, pz, float, "pz");
+DECLARE_SOA_COLUMN_FULL(Xyz, xyz, float[3], "xyz");
+DECLARE_SOA_COLUMN_FULL(Ij, ij, int[2], "ij");
+DECLARE_SOA_COLUMN_FULL(Random, random, double, "random");
+DECLARE_SOA_COLUMN_FULL(Ev, ev, int, "ev");
 } // namespace test
 
 DECLARE_SOA_TABLE(Test, "AOD", "ETAPHI",

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -32,9 +32,9 @@ using namespace o2::framework;
 
 namespace test
 {
-DECLARE_SOA_COLUMN(X, x, uint64_t, "x");
-DECLARE_SOA_COLUMN(Y, y, uint64_t, "y");
-DECLARE_SOA_COLUMN(Pos, pos, int[3], "pos");
+DECLARE_SOA_COLUMN_FULL(X, x, uint64_t, "x");
+DECLARE_SOA_COLUMN_FULL(Y, y, uint64_t, "y");
+DECLARE_SOA_COLUMN_FULL(Pos, pos, int[3], "pos");
 } // namespace test
 
 using TestTable = o2::soa::Table<test::X, test::Y>;

--- a/Framework/TestWorkflows/src/o2SimpleTracksAnalysis.cxx
+++ b/Framework/TestWorkflows/src/o2SimpleTracksAnalysis.cxx
@@ -26,8 +26,8 @@ namespace aod
 {
 namespace tracks
 {
-DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
-DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
+DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(Phi, phi, float);
 } // namespace tracks
 
 using TracksDerived = o2::soa::Table<tracks::Eta, tracks::Phi>;


### PR DESCRIPTION
This changes the API of the column so that by default the branch
is called "f"#_Name_. Where _Name_ is the first argument of the macro.

The old API is still available using DECLARE_SOA_COLUMN_FULL.