### PR TITLE
Re-enable check of run_trac_ca_its.C as json.h is fixed

### DIFF
--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -45,7 +45,6 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             macro/SetIncludePath.C
             macro/loadExtDepLib.C
             macro/load_all_libs.C
-            macro/run_trac_its.C # temporarily, untile json.h is fixed 
             macro/putCondition.C
             macro/rootlogon.C)
 

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -359,20 +359,18 @@ o2_add_test_root_macro(run_trac_ca_its.C
                        LABELS its COMPILE_ONLY)
 
 # FIXME: move to subsystem dir
-# PH: temporary switch off the test below until an issue in Detectors/ITSMFT/ITS/tracking/include/ITStracking/json.h
-# is fixed
-# o2_add_test_root_macro(run_trac_its.C
-#                        PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats
-#                                              O2::DataFormatsITSMFT
-#                                              O2::DataFormatsParameters
-#                                              O2::DetectorsBase
-#                                              O2::Field
-#                                              O2::ITSBase
-#                                              O2::ITSReconstruction
-#                                              O2::ITStracking
-#                                              O2::MathUtils
-#                                              O2::SimulationDataFormat
-#                        LABELS its)
+o2_add_test_root_macro(run_trac_its.C
+                       PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats
+                                             O2::DataFormatsITSMFT
+                                             O2::DataFormatsParameters
+                                             O2::DetectorsBase
+                                             O2::Field
+                                             O2::ITSBase
+                                             O2::ITSReconstruction
+                                             O2::ITStracking
+                                             O2::MathUtils
+                                             O2::SimulationDataFormat
+                        LABELS its)
 
 # FIXME: move to subsystem dir
 o2_add_test_root_macro(run_trac_mft.C


### PR DESCRIPTION
@pzhristov since the `json.h was fixed (thanks @max !) I am enabling it back.