### PR TITLE
Custom streamer for the TPC CompClusters container

### DIFF
--- a/Algorithm/CMakeLists.txt
+++ b/Algorithm/CMakeLists.txt
@@ -52,3 +52,9 @@ o2_add_test(RangeTokenizer
             SOURCES test/test_RangeTokenizer.cxx
             COMPONENT_NAME Algorithm
             LABELS algorithm)
+
+
+o2_add_test(FlattenRestore
+            SOURCES test/test_FlattenRestore.cxx
+            COMPONENT_NAME Algorithm
+            LABELS algorithm)

--- a/Algorithm/include/Algorithm/FlattenRestore.h
+++ b/Algorithm/include/Algorithm/FlattenRestore.h
@@ -1,0 +1,109 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FLATTERRESTORE_H
+#define FLATTERRESTORE_H
+
+/// @file   FlattenRestore.h
+/// @author Matthias Richter
+/// @since  2020-04-05
+/// @brief  Utilities to copy complex objects to flat buffer and restore
+
+#include <type_traits>
+
+namespace o2::algorithm
+{
+namespace flatten
+{
+
+/// Calculate cumulative value size of a variable number of arguments
+/// The function takes parameters by reference and calculates the memory size of
+/// all parameters together. The pointer attribute is removed.
+///
+/// Example:
+///   char* array1;
+///   int* array2;
+///   float* array3;
+///   size = value_size(array1, array2, array3);
+///   // size is sizeof(char) + sizeof(int) + sizeof(float)
+template <typename ValueType, typename... Args>
+constexpr size_t value_size(ValueType const& value, Args&&... args)
+{
+  size_t size = sizeof(typename std::remove_pointer<typename std::remove_reference<ValueType>::type>::type);
+  if constexpr (sizeof...(Args) > 0) {
+    size += value_size(std::forward<Args>(args)...);
+  }
+  return size;
+}
+
+/// Copy the content of variable number of arrays with the same extent to a buffer
+/// The target pointer is passed be reference and incremented while copying
+/// @param wrtptr write pointer
+/// @param count  extent of the arrays
+/// @param args   a variable number of pointers to arrays
+/// @return copied size in bytes
+template <typename TargetType, typename ValueType, typename... Args>
+static size_t copy_to(TargetType& wrtptr, size_t count, ValueType* array, Args&&... args)
+{
+  static_assert(std::is_pointer<TargetType>::value == true, "need reference to pointer");
+  static_assert(sizeof(typename std::remove_pointer<TargetType>::type) == 1, "need char-like pointer");
+
+  size_t copySize = 0;
+  if (array != nullptr) {
+    copySize = count * value_size(array);
+    memcpy(wrtptr, array, copySize);
+    wrtptr += copySize;
+  } else if (count > 0) {
+    throw std::runtime_error("invalid nullptr to array of " + std::to_string(count) + " element(s)");
+  }
+  if constexpr (sizeof...(Args) > 0) {
+    copySize += copy_to(wrtptr, count, std::forward<Args>(args)...);
+  }
+  return copySize;
+}
+
+/// Set pointers to regions in source buffer
+/// A variable number of pointer arguments of consecutive arrays in a buffer are set according
+/// to the type size and the extent of arrays
+/// The read pointer is passed be reference and incremented while copying
+/// @param readptr the source buffer
+/// @param count   extent of the arrays
+/// @param args    a variable number of references of pointers to arrays
+/// @return handled raw size in bytes
+template <typename BufferType, typename ValueType, typename... Args>
+static size_t set_from(BufferType& readptr, size_t count, ValueType& array, Args&&... args)
+{
+  static_assert(std::is_pointer<typename std::remove_reference<ValueType>::type>::value == true, "need reference to pointer");
+  array = reinterpret_cast<typename std::remove_reference<ValueType>::type>(readptr);
+  size_t readSize = count * value_size(array);
+  readptr += readSize;
+  if constexpr (sizeof...(Args) > 0) {
+    readSize += set_from(readptr, count, std::forward<Args>(args)...);
+  }
+  return readSize;
+}
+
+/// Calculate the total size of a sequence of arrays with the same extent
+/// the first argument is a dummy argument to have the same signature as copy_to
+/// and set_from
+/// @param dummyptr unused
+/// @param count    extent of the arrays
+/// @param args     a variable number of references of pointers to arrays
+/// @return total size
+template <typename BufferType, typename... Args>
+static size_t calc_size(BufferType const& dummyptr, size_t count, Args&&... args)
+{
+  return count * value_size(std::forward<Args>(args)...);
+}
+
+} // namespace flatten
+} // namespace o2::algorithm
+
+#endif

--- a/Algorithm/test/test_FlattenRestore.cxx
+++ b/Algorithm/test/test_FlattenRestore.cxx
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//  @file   test_FlattenRestore.cxx
+//  @author Matthias Richter
+//  @since  2020-04-05
+//  @brief  Test program flatten/restore tools
+
+#define BOOST_TEST_MODULE Algorithm FlattenRestore test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "../include/Algorithm/FlattenRestore.h"
+#include <vector>
+#include <algorithm>
+
+namespace flatten = o2::algorithm::flatten;
+
+namespace o2::test
+{
+struct DataAccess {
+  size_t count = 0;
+  char* chars = nullptr;
+  int* ints = nullptr;
+  float* floats = nullptr;
+};
+} // namespace o2::test
+BOOST_AUTO_TEST_CASE(test_flattenrestore)
+{
+  o2::test::DataAccess access{static_cast<size_t>(rand() % 32)};
+  std::vector<char> chars(access.count);
+  std::generate(chars.begin(), chars.end(), []() { return rand() % 256; });
+  std::vector<int> ints(access.count);
+  std::generate(ints.begin(), ints.end(), []() { return rand() % 256; });
+  std::vector<float> floats(access.count);
+  std::generate(floats.begin(), floats.end(), []() { return rand() % 256; });
+  access.chars = chars.data();
+  access.ints = ints.data();
+  access.floats = floats.data();
+
+  std::vector<char> raw(flatten::value_size(access.chars, access.ints, access.floats) * access.count);
+  char* wrtptr = raw.data();
+  auto copied = flatten::copy_to(wrtptr, access.count, access.chars, access.ints, access.floats);
+  BOOST_CHECK(copied == raw.size());
+  char* checkptr = raw.data();
+  BOOST_CHECK(memcmp(checkptr, chars.data(), chars.size() * sizeof(decltype(chars)::value_type)) == 0);
+  checkptr += flatten::calc_size(nullptr, chars.size(), chars.data());
+  BOOST_CHECK(memcmp(checkptr, ints.data(), ints.size() * sizeof(decltype(ints)::value_type)) == 0);
+  checkptr += flatten::calc_size(nullptr, ints.size(), ints.data());
+  BOOST_CHECK(memcmp(checkptr, floats.data(), floats.size() * sizeof(decltype(floats)::value_type)) == 0);
+  checkptr += flatten::calc_size(nullptr, floats.size(), floats.data());
+
+  o2::test::DataAccess target{access.count, nullptr, nullptr, nullptr};
+  char* readptr = raw.data();
+  auto readsize = flatten::set_from(readptr, target.count, target.chars, target.ints, target.floats);
+  BOOST_CHECK(readsize == copied);
+  checkptr = raw.data();
+  BOOST_CHECK(reinterpret_cast<decltype(target.chars)>(checkptr) == target.chars);
+  checkptr += flatten::calc_size(nullptr, chars.size(), chars.data());
+  BOOST_CHECK(reinterpret_cast<decltype(target.ints)>(checkptr) == target.ints);
+  checkptr += flatten::calc_size(nullptr, ints.size(), ints.data());
+  BOOST_CHECK(reinterpret_cast<decltype(target.floats)>(checkptr) == target.floats);
+  checkptr += flatten::calc_size(nullptr, floats.size(), floats.data());
+}

--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(
           src/LaserTrack.cxx
           src/TPCSectorHeader.cxx
           src/ClusterNativeHelper.cxx
+          src/CompressedClusters.cxx
   PUBLIC_LINK_LIBRARIES O2::GPUCommon
                         O2::SimulationDataFormat
                         O2::CommonDataFormat

--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -58,3 +58,10 @@ o2_add_test(
   COMPONENT_NAME DataFormats-TPC
   PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
   LABELS tpc dataformats)
+
+o2_add_test(
+  CompressedClusters
+  SOURCES test/testCompressedClusters.cxx
+  COMPONENT_NAME DataFormats-TPC
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
+  LABELS tpc dataformats)

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -28,39 +28,44 @@ struct CompressedClustersCounters {
   unsigned int nAttachedClustersReduced = 0;
   unsigned int nSliceRows = 36 * 152;
   unsigned char nComppressionModes = 0;
+
   ClassDefNV(CompressedClustersCounters, 1);
 };
 
 template <class T>
 struct CompressedClustersPtrs_helper : public T {
-  unsigned short* qTotA = nullptr;        //[nAttachedClusters]
-  unsigned short* qMaxA = nullptr;        //[nAttachedClusters]
-  unsigned char* flagsA = nullptr;        //[nAttachedClusters]
-  unsigned char* rowDiffA = nullptr;      //[nAttachedClustersReduced]
-  unsigned char* sliceLegDiffA = nullptr; //[nAttachedClustersReduced]
-  unsigned short* padResA = nullptr;      //[nAttachedClustersReduced]
-  unsigned int* timeResA = nullptr;       //[nAttachedClustersReduced]
-  unsigned char* sigmaPadA = nullptr;     //[nAttachedClusters]
-  unsigned char* sigmaTimeA = nullptr;    //[nAttachedClusters]
+  unsigned short* qTotA = nullptr;        //! [nAttachedClusters]
+  unsigned short* qMaxA = nullptr;        //! [nAttachedClusters]
+  unsigned char* flagsA = nullptr;        //! [nAttachedClusters]
+  unsigned char* rowDiffA = nullptr;      //! [nAttachedClustersReduced]
+  unsigned char* sliceLegDiffA = nullptr; //! [nAttachedClustersReduced]
+  unsigned short* padResA = nullptr;      //! [nAttachedClustersReduced]
+  unsigned int* timeResA = nullptr;       //! [nAttachedClustersReduced]
+  unsigned char* sigmaPadA = nullptr;     //! [nAttachedClusters]
+  unsigned char* sigmaTimeA = nullptr;    //! [nAttachedClusters]
 
-  unsigned char* qPtA = nullptr;   //[nTracks]
-  unsigned char* rowA = nullptr;   //[nTracks]
-  unsigned char* sliceA = nullptr; //[nTracks]
-  unsigned int* timeA = nullptr;   //[nTracks]
-  unsigned short* padA = nullptr;  //[nTracks]
+  unsigned char* qPtA = nullptr;   //! [nTracks]
+  unsigned char* rowA = nullptr;   //! [nTracks]
+  unsigned char* sliceA = nullptr; //! [nTracks]
+  unsigned int* timeA = nullptr;   //! [nTracks]
+  unsigned short* padA = nullptr;  //! [nTracks]
 
-  unsigned short* qTotU = nullptr;     //[nUnattachedClusters]
-  unsigned short* qMaxU = nullptr;     //[nUnattachedClusters]
-  unsigned char* flagsU = nullptr;     //[nUnattachedClusters]
-  unsigned short* padDiffU = nullptr;  //[nUnattachedClusters]
-  unsigned int* timeDiffU = nullptr;   //[nUnattachedClusters]
-  unsigned char* sigmaPadU = nullptr;  //[nUnattachedClusters]
-  unsigned char* sigmaTimeU = nullptr; //[nUnattachedClusters]
+  unsigned short* qTotU = nullptr;     //! [nUnattachedClusters]
+  unsigned short* qMaxU = nullptr;     //! [nUnattachedClusters]
+  unsigned char* flagsU = nullptr;     //! [nUnattachedClusters]
+  unsigned short* padDiffU = nullptr;  //! [nUnattachedClusters]
+  unsigned int* timeDiffU = nullptr;   //! [nUnattachedClusters]
+  unsigned char* sigmaPadU = nullptr;  //! [nUnattachedClusters]
+  unsigned char* sigmaTimeU = nullptr; //! [nUnattachedClusters]
 
-  unsigned short* nTrackClusters = nullptr;  //[nTracks]
-  unsigned int* nSliceRowClusters = nullptr; //[nSliceRows]
+  unsigned short* nTrackClusters = nullptr;  //! [nTracks]
+  unsigned int* nSliceRowClusters = nullptr; //! [nSliceRows]
 
-  ClassDefNV(CompressedClustersPtrs_helper, 1);
+  // flatbuffer used for streaming
+  int flatdataSize = 0;
+  char* flatdata = nullptr; //[flatdataSize]
+
+  ClassDefNV(CompressedClustersPtrs_helper, 2);
 };
 
 struct CompressedClustersDummy_helper {

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClustersHelpers.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClustersHelpers.h
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CompressedClustersHelpers.h
+/// \brief Helper for the CompressedClusters container
+/// \author Matthias Richter
+
+#ifndef ALICEO2_DATAFORMATSTPC_COMPRESSEDCLUSTERSHELPERS_H
+#define ALICEO2_DATAFORMATSTPC_COMPRESSEDCLUSTERSHELPERS_H
+
+#include <type_traits>
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+#include "Algorithm/FlattenRestore.h"
+#include "DataFormatsTPC/CompressedClusters.h"
+
+namespace flatten = o2::algorithm::flatten;
+
+namespace o2::tpc
+{
+struct CompressedClustersHelpers {
+  /// Apply an operation to the layout of the class
+  /// This method is the single place defining the mapping of the class layout
+  /// to an underlying buffer for the flatten/restore functionality
+  /// @param op       the operation to be applied, e.g. calculate raw buffer size,
+  ///                 copy to and restore from buffer
+  /// @param ptr      buffer pointer, passed onto to operation
+  /// @param counters the counters object CompressedClustersCounters
+  template <typename Op, typename BufferType>
+  static size_t apply(Op op, BufferType& ptr, CompressedClusters& c)
+  {
+    size_t size = 0;
+    size += op(ptr, c.nAttachedClusters, c.qTotA, c.qMaxA, c.flagsA, c.sigmaPadA, c.sigmaTimeA);
+    size += op(ptr, c.nUnattachedClusters, c.qTotU, c.qMaxU, c.flagsU, c.padDiffU, c.timeDiffU, c.sigmaPadU, c.sigmaTimeU);
+    size += op(ptr, c.nAttachedClustersReduced, c.rowDiffA, c.sliceLegDiffA, c.padResA, c.timeResA);
+    size += op(ptr, c.nTracks, c.qPtA, c.rowA, c.sliceA, c.timeA, c.padA, c.nTrackClusters);
+    size += op(ptr, c.nSliceRows, c.nSliceRowClusters);
+    return size;
+  }
+
+  /// Create a flat copy of the class
+  /// The target container is resized accordingly
+  template <typename ContainerType>
+  static size_t flattenTo(ContainerType& container, CompressedClusters& clusters)
+  {
+    static_assert(sizeof(typename ContainerType::value_type) == 1);
+    char* dummyptr = nullptr;
+    auto calc_size = [](auto&... args) { return flatten::calc_size(args...); };
+    auto copy_to = [](auto&... args) { return flatten::copy_to(args...); };
+    size_t size = apply(calc_size, dummyptr, clusters);
+    container.resize(size);
+    auto wrtptr = container.data();
+    size_t copySize = apply(copy_to, wrtptr, clusters);
+    assert(copySize == size);
+    return copySize;
+  }
+
+  /// Restore the array pointers from the data in the container
+  template <typename ContainerType>
+  static size_t restoreFrom(ContainerType& container, CompressedClusters& clusters)
+  {
+    static_assert(sizeof(typename ContainerType::value_type) == 1);
+    char* dummyptr = nullptr;
+    auto calc_size = [](auto&... args) { return flatten::calc_size(args...); };
+    auto set_from = [](auto&... args) { return flatten::set_from(args...); };
+    size_t size = apply(calc_size, dummyptr, clusters);
+    if (container.size() != size) {
+      // for the moment we don not support changes in the member layout, we can implement the
+      // handling in the custom streamer
+      throw std::runtime_error("mismatch between raw buffer size and counters, schema evolution is not yet supported");
+    }
+    auto readptr = container.data();
+    size_t checkSize = apply(set_from, readptr, clusters);
+    assert(checkSize == size);
+    return checkSize;
+  }
+};
+
+} // namespace o2::tpc
+
+#endif // ALICEO2_DATAFORMATSTPC_COMPRESSEDCLUSTERSHELPERS_H

--- a/DataFormats/Detectors/TPC/src/CompressedClusters.cxx
+++ b/DataFormats/Detectors/TPC/src/CompressedClusters.cxx
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CompressedClusters.cxx
+/// \brief Container to store compressed TPC cluster data
+
+#include "DataFormatsTPC/CompressedClusters.h"
+#include "DataFormatsTPC/CompressedClustersHelpers.h"
+#include "TBuffer.h"
+#include <vector>
+#include <gsl/span>
+
+namespace o2::tpc
+{
+
+template <>
+void CompressedClusters::Streamer(TBuffer& R__b)
+{
+  // the custom streamer for CompressedClusters
+  if (R__b.IsReading()) {
+    R__b.ReadClassBuffer(CompressedClusters::Class(), this);
+    gsl::span flatdata{this->flatdata, this->flatdataSize};
+    CompressedClustersHelpers::restoreFrom(flatdata, *this);
+  } else {
+    std::vector<char> flatdata;
+    // member flatdata is nullptr unless it is an already extracted object which
+    // is streamed again. Overriding the existing flatbuffer is a potential
+    // memory leak
+    // Note: lots of cornercases here which are diffucult to catch with the design
+    // of CompClusters container (which is optimized to be used with GPU). Main concern
+    // is if an extracted object is not read-only and the counters are changed.
+    // TODO: we can add a consistency check whether the size of the flatbuffer
+    // and the pointers match the object.
+    bool isflat = this->flatdata != nullptr;
+    if (!isflat) {
+      CompressedClustersHelpers::flattenTo(flatdata, *this);
+      this->flatdataSize = flatdata.size();
+      this->flatdata = flatdata.data();
+    }
+    R__b.WriteClassBuffer(CompressedClusters::Class(), this);
+    if (!isflat) {
+      this->flatdataSize = 0;
+      this->flatdata = nullptr;
+    }
+  }
+}
+
+} // namespace o2::tpc

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -37,8 +37,8 @@
 #pragma link C++ class std::vector < o2::tpc::ClusterNativeHelper::TreeWriter::BranchData> + ;
 #pragma link C++ class o2::tpc::dEdxInfo + ;
 #pragma link C++ class o2::tpc::CompressedClustersCounters + ;
-#pragma link C++ class o2::tpc::CompressedClustersPtrs_helper < o2::tpc::CompressedClustersCounters> + ;
-#pragma link C++ class o2::tpc::CompressedClusters + ;
+#pragma link C++ class o2::tpc::CompressedClustersPtrs_helper < o2::tpc::CompressedClustersCounters> - ;
+#pragma link C++ class o2::tpc::CompressedClusters - ;
 #pragma link C++ enum o2::tpc::StatisticsType;
 
 #endif

--- a/DataFormats/Detectors/TPC/test/testCompressedClusters.cxx
+++ b/DataFormats/Detectors/TPC/test/testCompressedClusters.cxx
@@ -1,0 +1,148 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   testClusterNative.cxx
+/// @since  2018-01-17
+/// @brief  Unit test for the TPC ClusterNative data struct
+
+#define BOOST_TEST_MODULE Test TPC DataFormats
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include "../include/DataFormatsTPC/CompressedClusters.h"
+#include "../include/DataFormatsTPC/CompressedClustersHelpers.h"
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <vector>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TBranch.h>
+
+namespace o2::tpc
+{
+
+template <typename ContainerType>
+void fillRandom(ContainerType& target, size_t size)
+{
+  target.resize(size);
+  std::generate(target.begin(), target.end(), []() { return rand() % 256; });
+}
+
+struct ClustersData {
+  std::vector<unsigned short> qTotA;        //! [nAttachedClusters]
+  std::vector<unsigned short> qMaxA;        //! [nAttachedClusters]
+  std::vector<unsigned char> flagsA;        //! [nAttachedClusters]
+  std::vector<unsigned char> rowDiffA;      //! [nAttachedClustersReduced]
+  std::vector<unsigned char> sliceLegDiffA; //! [nAttachedClustersReduced]
+  std::vector<unsigned short> padResA;      //! [nAttachedClustersReduced]
+  std::vector<unsigned int> timeResA;       //! [nAttachedClustersReduced]
+  std::vector<unsigned char> sigmaPadA;     //! [nAttachedClusters]
+  std::vector<unsigned char> sigmaTimeA;    //! [nAttachedClusters]
+
+  std::vector<unsigned char> qPtA;   //! [nTracks]
+  std::vector<unsigned char> rowA;   //! [nTracks]
+  std::vector<unsigned char> sliceA; //! [nTracks]
+  std::vector<unsigned int> timeA;   //! [nTracks]
+  std::vector<unsigned short> padA;  //! [nTracks]
+
+  std::vector<unsigned short> qTotU;     //! [nUnattachedClusters]
+  std::vector<unsigned short> qMaxU;     //! [nUnattachedClusters]
+  std::vector<unsigned char> flagsU;     //! [nUnattachedClusters]
+  std::vector<unsigned short> padDiffU;  //! [nUnattachedClusters]
+  std::vector<unsigned int> timeDiffU;   //! [nUnattachedClusters]
+  std::vector<unsigned char> sigmaPadU;  //! [nUnattachedClusters]
+  std::vector<unsigned char> sigmaTimeU; //! [nUnattachedClusters]
+
+  std::vector<unsigned short> nTrackClusters;  //! [nTracks]
+  std::vector<unsigned int> nSliceRowClusters; //! [nSliceRows]
+};
+
+void fillClusters(CompressedClusters& clusters, ClustersData& data)
+{
+  clusters.nAttachedClusters = rand() % 32;
+  fillRandom(data.qTotA, clusters.nAttachedClusters);
+  clusters.qTotA = data.qTotA.data();
+  fillRandom(data.qMaxA, clusters.nAttachedClusters);
+  clusters.qMaxA = data.qMaxA.data();
+  fillRandom(data.flagsA, clusters.nAttachedClusters);
+  clusters.flagsA = data.flagsA.data();
+  fillRandom(data.sigmaPadA, clusters.nAttachedClusters);
+  clusters.sigmaPadA = data.sigmaPadA.data();
+  fillRandom(data.sigmaTimeA, clusters.nAttachedClusters);
+  clusters.sigmaTimeA = data.sigmaTimeA.data();
+
+  clusters.nAttachedClustersReduced = rand() % 32;
+  fillRandom(data.rowDiffA, clusters.nAttachedClustersReduced);
+  clusters.rowDiffA = data.rowDiffA.data();
+  fillRandom(data.sliceLegDiffA, clusters.nAttachedClustersReduced);
+  clusters.sliceLegDiffA = data.sliceLegDiffA.data();
+  fillRandom(data.padResA, clusters.nAttachedClustersReduced);
+  clusters.padResA = data.padResA.data();
+  fillRandom(data.timeResA, clusters.nAttachedClustersReduced);
+  clusters.timeResA = data.timeResA.data();
+
+  clusters.nTracks = rand() % 32;
+  fillRandom(data.qPtA, clusters.nTracks);
+  clusters.qPtA = data.qPtA.data();
+  fillRandom(data.rowA, clusters.nTracks);
+  clusters.rowA = data.rowA.data();
+  fillRandom(data.sliceA, clusters.nTracks);
+  clusters.sliceA = data.sliceA.data();
+  fillRandom(data.timeA, clusters.nTracks);
+  clusters.timeA = data.timeA.data();
+  fillRandom(data.padA, clusters.nTracks);
+  clusters.padA = data.padA.data();
+  fillRandom(data.nTrackClusters, clusters.nTracks);
+  clusters.nTrackClusters = data.nTrackClusters.data();
+
+  clusters.nUnattachedClusters = rand() % 32;
+  fillRandom(data.qTotU, clusters.nUnattachedClusters);
+  clusters.qTotU = data.qTotU.data();
+  fillRandom(data.qMaxU, clusters.nUnattachedClusters);
+  clusters.qMaxU = data.qMaxU.data();
+  fillRandom(data.flagsU, clusters.nUnattachedClusters);
+  clusters.flagsU = data.flagsU.data();
+  fillRandom(data.padDiffU, clusters.nUnattachedClusters);
+  clusters.padDiffU = data.padDiffU.data();
+  fillRandom(data.timeDiffU, clusters.nUnattachedClusters);
+  clusters.timeDiffU = data.timeDiffU.data();
+  fillRandom(data.sigmaPadU, clusters.nUnattachedClusters);
+  clusters.sigmaPadU = data.sigmaPadU.data();
+  fillRandom(data.sigmaTimeU, clusters.nUnattachedClusters);
+  clusters.sigmaTimeU = data.sigmaTimeU.data();
+
+  clusters.nSliceRows = rand() % 32;
+  fillRandom(data.nSliceRowClusters, clusters.nSliceRows);
+  clusters.nSliceRowClusters = data.nSliceRowClusters.data();
+}
+
+BOOST_AUTO_TEST_CASE(test_tpc_compressedclusters)
+{
+  CompressedClusters clusters;
+  ClustersData data;
+  fillClusters(clusters, data);
+  std::vector<char> buffer;
+  CompressedClustersHelpers::flattenTo(buffer, clusters);
+  CompressedClusters restored{static_cast<CompressedClustersCounters&>(clusters)};
+  BOOST_REQUIRE(restored.qTotA == nullptr);
+  CompressedClustersHelpers::restoreFrom(buffer, restored);
+
+  // check one entry from each category
+  BOOST_CHECK(restored.nAttachedClusters == data.qMaxA.size());
+  BOOST_CHECK(memcmp(restored.qMaxA, data.qMaxA.data(), restored.nAttachedClusters * sizeof(decltype(data.qMaxA)::value_type)) == 0);
+  BOOST_CHECK(restored.nTracks == data.nTrackClusters.size());
+  BOOST_CHECK(memcmp(restored.nTrackClusters, data.nTrackClusters.data(), restored.nTracks * sizeof(decltype(data.nTrackClusters)::value_type)) == 0);
+  BOOST_CHECK(restored.nUnattachedClusters == data.qMaxU.size());
+  BOOST_CHECK(memcmp(restored.qMaxU, data.qMaxU.data(), restored.nUnattachedClusters * sizeof(decltype(data.qMaxU)::value_type)) == 0);
+  BOOST_CHECK(restored.nSliceRows == data.nSliceRowClusters.size());
+  BOOST_CHECK(memcmp(restored.nSliceRowClusters, data.nSliceRowClusters.data(), restored.nSliceRows * sizeof(decltype(data.nSliceRowClusters)::value_type)) == 0);
+}
+
+} // namespace o2::tpc


### PR DESCRIPTION
We have observed a problem with serialization of the CompClusters container. It's not fully debugged in ROOT, unpacking the streamed object is sometimes failing.

Implemented a custom streamer to flatten the object before streaming. The buffer is stored instead of the arrays behind the pointers. All pointers are now transient. This reduces the complexity of the container. After deserialization, the pointers are set to the content in the flat buffer.

The flatten/restore functionality can also be used to transport the container unserialized.

Adding also some generic tools for flatten and restore.