### PR TITLE
[MCH] Fix a bug in findPadPairByPosition

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
@@ -98,7 +98,12 @@ inline bool Segmentation::findPadPairByPosition(double x, double y, int& b, int&
 {
   b = mBending.findPadByPosition(x, y);
   nb = mNonBending.findPadByPosition(x, y);
-  if (!mBending.isValid(b) || !mNonBending.isValid(nb)) {
+  if (!mBending.isValid(b)) {
+    nb = padC2DE(nb, false);
+    return false;
+  }
+  if (!mNonBending.isValid(nb)) {
+    b = padC2DE(b, true);
     return false;
   }
   b = padC2DE(b, true);

--- a/Detectors/MUON/MCH/Mapping/test/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/test/CMakeLists.txt
@@ -15,7 +15,7 @@ o2_add_test(StressTest
             COMPONENT_NAME mchmapping
             PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl3 O2::MCHMappingSegContour
                                   RapidJSON::RapidJSON
-            LABELS "muon;mch;long" CONFIGURATIONS RelWithDebInfo)
+            LABELS "muon;mch;long")
 
 if(benchmark_FOUND)
   o2_add_executable(segmentation3

--- a/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
@@ -393,6 +393,18 @@ BOOST_AUTO_TEST_CASE(CheckOnePadPositionPresentOnOnlyBendingPlane)
   BOOST_CHECK_EQUAL(seg.isValid(nb), false);
 }
 
+BOOST_AUTO_TEST_CASE(WhenOnlyOneCathodeHasAPadTheValidIndexMustRelativeToDeNotToCathode)
+{
+  double x = 8.8;
+  double y = 18;
+  int b, nb;
+  bool ok = seg.findPadPairByPosition(x, y, b, nb);
+  BOOST_CHECK_EQUAL(ok, false);
+  BOOST_CHECK_EQUAL(seg.isValid(nb), true);
+  BOOST_CHECK_EQUAL(seg.isValid(b), false);
+  BOOST_CHECK_EQUAL(seg.isBendingPad(nb), false);
+}
+
 BOOST_AUTO_TEST_CASE(CheckCopy)
 {
   Segmentation copy{seg};


### PR DESCRIPTION
In the cases where only one cathode has a pad under the position used in
findPadPairByPosition the returned padIndex was relative to the cathode
 and not to the detection element as it should have been.