### PR TITLE
Rework of the TPC reco workflow to support compressed clusters

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(TPCWorkflow
                        src/ClustererSpec.cxx
                        src/ClusterDecoderRawSpec.cxx
                        src/CATrackerSpec.cxx
+                       src/EntropyEncoderSpec.cxx
                        src/TrackReaderSpec.cxx
                        src/RawToDigitsSpec.cxx
                        src/LinkZSToDigitsSpec.cxx

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -14,15 +14,74 @@
 /// @brief  Processor spec for running TPC CA tracking
 
 #include "Framework/DataProcessorSpec.h"
+#include <utility> // std::forward
 
 namespace o2
 {
 namespace tpc
 {
 
+namespace ca
+{
+// The CA tracker is now a wrapper to not only the actual tracking on GPU but
+// also the decoding of the zero-suppressed raw format and the clusterer.
+enum struct Operation {
+  CAClusterer,        // run the CA clusterer
+  ZSDecoder,          // run the ZS raw data decoder
+  OutputTracks,       // publish tracks
+  OutputCompClusters, // publish CompClusters container
+  ProcessMC,          // process MC labels
+  Noop,               // skip argument on the constructor
+};
+
+struct Config {
+  template <typename... Args>
+  Config(Args&&... args)
+  {
+    init(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  void init(Operation const& op, Args&&... args)
+  {
+    switch (op) {
+      case Operation::CAClusterer:
+        caClusterer = true;
+        break;
+      case Operation::ZSDecoder:
+        zsDecoder = true;
+        break;
+      case Operation::OutputTracks:
+        outputTracks = true;
+        break;
+      case Operation::OutputCompClusters:
+        outputCompClusters = true;
+        break;
+      case Operation::ProcessMC:
+        processMC = true;
+        break;
+      case Operation::Noop:
+        break;
+      default:
+        throw std::runtime_error("invalid CATracker operation");
+    }
+    if constexpr (sizeof...(args) > 0) {
+      init(std::forward<Args>(args)...);
+    }
+  }
+
+  bool caClusterer = false;
+  bool zsDecoder = false;
+  bool outputTracks = false;
+  bool outputCompClusters = false;
+  bool processMC = false;
+};
+
+} // namespace ca
+
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getCATrackerSpec(bool processMC, bool caClusterer, bool zsDecoder, std::vector<int> const& inputIds);
+framework::DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> const& inputIds);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_ENTROPYENCODERSPEC_H
+#define O2_TPC_ENTROPYENCODERSPEC_H
+/// @file   EntropyEncoderSpec.h
+/// @author Michael Lettrich, Matthias Richter
+/// @since  2020-01-16
+/// @brief  ProcessorSpec for the TPC cluster entropy encoding
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // end namespace tpc
+} // end namespace o2
+
+#endif // O2_TPC_ENTROPYENCODERSPEC_H

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -32,12 +32,24 @@ enum struct InputType { Digitizer,        // directly read digits from channel {
                         Digits,           // read digits from file
                         ClustersHardware, // read hardware clusters in raw page format from file
                         Clusters,         // read native clusters from file
+                        CompClusters,     // read compressed cluster container
+                        EncodedClusters,  // read encoded clusters
                         ZSRaw,
 };
+
+/// Output types of the workflow, workflow layout is built depending on configured types
+/// - Digits           simulated digits
+/// - ClustersHardware the first attempt of a raw format storing ClusterHardware in 8k pages
+/// - Clusters         decoded clusters, ClusterNative, as input to the tracker
+/// - Tracks           tracks
+/// - CompClusters     compressed clusters, CompClusters container
+/// - EncodedClusters  the encoded CompClusters container
 enum struct OutputType { Digits,
                          ClustersHardware,
                          Clusters,
                          Tracks,
+                         CompClusters,
+                         EncodedClusters,
                          DisableWriter,
 };
 

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,78 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+/// @author Michael Lettrich, Matthias Richter
+/// @since  2020-01-16
+/// @brief  ProcessorSpec for the TPC cluster entropy encoding
+
+#include "TPCWorkflow/EntropyEncoderSpec.h"
+#include "Headers/DataHeader.h"
+#include "Framework/WorkflowSpec.h" // o2::framework::mergeInputs
+#include "Framework/DataRefUtils.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "DataFormatsTPC/CompressedClusters.h"
+//#include "TPCClusterDecompressor.cxx"
+#include <memory> // for make_shared
+#include <vector>
+
+// TEMP: as a test, the processor simply writes the data to file, remove this
+#include <TFile.h>
+#include <TTree.h>
+
+using namespace o2::framework;
+using namespace o2::header;
+
+namespace o2
+{
+namespace tpc
+{
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  struct ProcessAttributes {
+    int verbosity = 1;
+  };
+
+  auto initFunction = [](InitContext& ic) {
+    auto processAttributes = std::make_shared<ProcessAttributes>();
+
+    auto processingFct = [processAttributes](ProcessingContext& pc) {
+      auto compressed = pc.inputs().get<CompressedClusters*>("input");
+      if (compressed == nullptr) {
+        LOG(ERROR) << "invalid input";
+        return;
+      }
+      LOG(INFO) << "input data with " << compressed->nTracks << " track(s) and " << compressed->nAttachedClusters << " attached clusters";
+
+      std::unique_ptr<TFile> testFile(TFile::Open("tpc-cluster-encoder.root", "RECREATE"));
+      testFile->WriteObject(compressed.get(), "TPCCompressedClusters");
+      testFile->Write();
+      testFile->Close();
+
+      //o2::tpc::ClusterNativeAccess clustersNativeDecoded; // Cluster native access structure as used by the tracker
+      //std::vector<o2::tpc::ClusterNative> clusterBuffer; // std::vector that will hold the actual clusters, clustersNativeDecoded will point inside here
+      //mDecoder.decompress(clustersCompressed, clustersNativeDecoded, clusterBuffer, param); // Run decompressor
+    };
+
+    return processingFct;
+  };
+
+  return DataProcessorSpec{"tpc-entropy-encoder", // process id
+                           {{"input", "TPC", "COMPCLUSTERS", 0, Lifetime::Timeframe}},
+                           {},
+                           AlgorithmSpec(initFunction)};
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -15,22 +15,24 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/Logger.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TPCWorkflow/RecoWorkflow.h"
 #include "TPCWorkflow/PublisherSpec.h"
 #include "TPCWorkflow/ClustererSpec.h"
 #include "TPCWorkflow/ClusterDecoderRawSpec.h"
 #include "TPCWorkflow/CATrackerSpec.h"
+#include "TPCWorkflow/EntropyEncoderSpec.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "TPCBase/Digit.h"
 #include "DataFormatsTPC/Constants.h"
 #include "DataFormatsTPC/ClusterGroupAttribute.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
+#include "DataFormatsTPC/CompressedClusters.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
-#include "FairMQLogger.h"
 #include <string>
 #include <stdexcept>
 #include <fstream>
@@ -59,6 +61,8 @@ const std::unordered_map<std::string, InputType> InputMap{
   {"clustershardware", InputType::ClustersHardware},
   {"clusters", InputType::Clusters},
   {"zsraw", InputType::ZSRaw},
+  {"compressed-clusters", InputType::CompClusters},
+  {"encoded-clusters", InputType::EncodedClusters},
 };
 
 const std::unordered_map<std::string, OutputType> OutputMap{
@@ -66,6 +70,8 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"clustershardware", OutputType::ClustersHardware},
   {"clusters", OutputType::Clusters},
   {"tracks", OutputType::Tracks},
+  {"compressed-clusters", OutputType::CompClusters},
+  {"encoded-clusters", OutputType::EncodedClusters},
   {"disable-writer", OutputType::DisableWriter},
 };
 
@@ -153,18 +159,53 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
                                                    laneConfiguration,
                                                  },
                                                  propagateMC));
+  } else if (inputType == InputType::CompClusters) {
+    // TODO: need to check if we want to store the MC labels alongside with compressed clusters
+    // for the moment reading of labels is disabled (last parameter is false)
+    // TODO: make a different publisher spec for only one output spec, for now using the
+    // PublisherSpec with only sector 0, '_0' is thus appended to the branch name
+    specs.emplace_back(o2::tpc::getPublisherSpec(PublisherConf{
+                                                   "tpc-compressed-cluster-reader",
+                                                   "tpcrec",
+                                                   {"clusterbranch", "TPCCompClusters", "Branch with TPC compressed clusters"},
+                                                   {"clustermcbranch", "TPCClusterNativeMCTruth", "MC label branch"},
+                                                   OutputSpec{"TPC", "COMPCLUSTERS"},
+                                                   OutputSpec{"TPC", "CLNATIVEMCLBL"},
+                                                   std::vector<int>(1, 0),
+                                                   std::vector<int>(1, 0),
+                                                 },
+                                                 false));
+  } else if (inputType == InputType::EncodedClusters) {
+    // TODO: need to check if we want to store the MC labels alongside with encoded clusters
+    // for the moment reading of labels is disabled (last parameter is false)
+    specs.emplace_back(o2::tpc::getPublisherSpec(PublisherConf{
+                                                   "tpc-encoded-cluster-reader",
+                                                   "tpcrec",
+                                                   {"clusterbranch", "TPCEncodedClusters", "Branch with TPC encoded clusters"},
+                                                   {"clustermcbranch", "TPCClusterNativeMCTruth", "MC label branch"},
+                                                   OutputSpec{"TPC", "ENCCLUSTERS"},
+                                                   OutputSpec{"TPC", "CLNATIVEMCLBL"},
+                                                   std::vector<int>(1, 0),
+                                                   std::vector<int>(1, 0),
+                                                 },
+                                                 false));
   }
 
   // output matrix
-  bool runTracker = isEnabled(OutputType::Tracks);
-  bool runDecoder = !caClusterer && (runTracker || isEnabled(OutputType::Clusters));
-  bool runClusterer = !caClusterer && (runDecoder || isEnabled(OutputType::ClustersHardware));
+  // Note: the ClusterHardware format is probably a deprecated legacy format and also the
+  // ClusterDecoderRawSpec
+  bool produceCompClusters = isEnabled(OutputType::CompClusters) || isEnabled(OutputType::EncodedClusters);
+  bool produceTracks = isEnabled(OutputType::Tracks);
+  bool runTracker = produceTracks || produceCompClusters;
+  bool runHWDecoder = !caClusterer && (runTracker || isEnabled(OutputType::Clusters));
+  bool runClusterer = !caClusterer && (runHWDecoder || isEnabled(OutputType::ClustersHardware));
   bool zsDecoder = inputType == InputType::ZSRaw;
+  bool runClusterEncoder = isEnabled(OutputType::EncodedClusters);
 
   // input matrix
   runClusterer &= inputType == InputType::Digitizer || inputType == InputType::Digits;
-  runDecoder &= runClusterer || inputType == InputType::ClustersHardware;
-  runTracker &= caClusterer || (runDecoder || inputType == InputType::Clusters);
+  runHWDecoder &= runClusterer || inputType == InputType::ClustersHardware;
+  runTracker &= caClusterer || (runHWDecoder || inputType == InputType::Clusters);
 
   WorkflowSpec parallelProcessors;
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -181,7 +222,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // cluster decoder process(es)
   //
   //
-  if (runDecoder) {
+  if (runHWDecoder) {
     parallelProcessors.push_back(o2::tpc::getClusterDecoderRawSpec(propagateMC));
   }
 
@@ -347,7 +388,23 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   //
   // selected by output type 'tracks'
   if (runTracker) {
-    specs.emplace_back(o2::tpc::getCATrackerSpec(propagateMC, caClusterer, zsDecoder, laneConfiguration));
+    specs.emplace_back(o2::tpc::getCATrackerSpec(ca::Config{
+                                                   propagateMC ? ca::Operation::ProcessMC : ca::Operation::Noop,
+                                                   caClusterer ? ca::Operation::CAClusterer : ca::Operation::Noop,
+                                                   zsDecoder ? ca::Operation::ZSDecoder : ca::Operation::Noop,
+                                                   produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
+                                                   produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
+                                                 },
+                                                 laneConfiguration));
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  //
+  // tracker process
+  //
+  // selected by output type 'encoded-clusters'
+  if (runClusterEncoder) {
+    specs.emplace_back(o2::tpc::getEntropyEncoderSpec());
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -355,7 +412,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // a writer process for tracks
   //
   // selected by output type 'tracks'
-  if (isEnabled(OutputType::Tracks) && !isEnabled(OutputType::DisableWriter)) {
+  if (produceTracks && !isEnabled(OutputType::DisableWriter)) {
     // defining the track writer process using the generic RootTreeWriter and generator tool
     //
     // defaults
@@ -390,6 +447,30 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
                                              MakeRootTreeWriterSpec::TerminationCondition{checkReady}, //
                                              std::move(tracksdef), std::move(clrefdef))());            //
     }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  //
+  // a writer process for compressed clusters container
+  //
+  // selected by output type 'compressed-clusters'
+  if (produceCompClusters && !isEnabled(OutputType::DisableWriter)) {
+    // defining the track writer process using the generic RootTreeWriter and generator tool
+    //
+    // defaults
+    const char* processName = "tpc-compcluster-writer";
+    const char* defaultFileName = "tpc-compclusters.root";
+    const char* defaultTreeName = "tpcrec";
+
+    //branch definitions for RootTreeWriter spec
+    using CCluSerializedType = ROOTSerialized<CompressedClusters>;
+    auto ccldef = BranchDefinition<CCluSerializedType>{InputSpec{"inputCompCl", "TPC", "COMPCLUSTERS"}, //
+                                                       "TPCCompClusters_0", "compcluster-branch-name"}; //
+
+    specs.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,            //
+                                           MakeRootTreeWriterSpec::TerminationPolicy::Process,       //
+                                           MakeRootTreeWriterSpec::TerminationCondition{checkReady}, //
+                                           std::move(ccldef))());                                    //
   }
 
   return std::move(specs);


### PR DESCRIPTION
New output types added
 - compressed-clusters
 - encoded-clusters

Changes
- integrating the handling of compressed clusters object produced by
  the CA track, data is sent out with spec TPC/COMPCLUSTERS/0
- adding a skeleton for the TPC cluster encoder

Adding also support for objects marked as ROOT serialized in the DPL ROOTTreeWriter