### PR TITLE
Fix invalid read for FilteredIndexPolicy

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -610,9 +610,11 @@ struct FilteredIndexPolicy : IndexPolicyBase {
  private:
   inline void updateRow()
   {
-    /// FIXME: there should be a way to detect and gracefully handle empty
-    ///        selections outside the index policy
-    this->mRowIndex = O2_BUILTIN_LIKELY(mMaxSelection != 0) ? mSelectedRows[mSelectionRow] : mSelectionRow;
+    this->mRowIndex = O2_BUILTIN_LIKELY(mSelectionRow < mMaxSelection) ? mSelectedRows[mSelectionRow] : -1;
+
+    // this->mRowIndex = O2_BUILTIN_LIKELY(mMaxSelection != 0) ?
+    //  (mSelectionRow < mMaxSelection ? mSelectedRows[mSelectionRow] : -1)
+    //  : mSelectionRow;
   }
   SelectionVector mSelectedRows;
   int64_t mSelectionRow = 0;


### PR DESCRIPTION
Add check to protect against invalid read from mapping array (`mSelectedRows[mMaxSelection]`) when the iterator reaches `end` as it also does in every range-based for loop. 

@aalkin Probably I am missing something but I don't quite understand the logic of using `mSelectionRow` directly in case the selection is empty? Why don't we invalidate the view in this case (which also happens in `moveToEnd()` in the current code)?