### PR TITLE
Rec.objects readers treat each tree entry as a new TF 

### DIFF
--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointReaderSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_FDD_RECPOINTREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -35,7 +36,11 @@ class RecPointReader : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  bool mFinished = false;
+  void connectTree(const std::string& filename);
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+
   bool mUseMC = true; // use MC truth
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginFDD;
 

--- a/Detectors/FIT/workflow/include/FITWorkflow/FT0RecPointReaderSpec.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/FT0RecPointReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_FT0_RECPOINTREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -35,7 +36,11 @@ class RecPointReader : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  bool mFinished = false;
+  void connectTree(const std::string& filename);
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+
   bool mUseMC = true; // use MC truth
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginFT0;
 

--- a/Detectors/FIT/workflow/src/FT0RecPointReaderSpec.cxx
+++ b/Detectors/FIT/workflow/src/FT0RecPointReaderSpec.cxx
@@ -37,41 +37,39 @@ RecPointReader::RecPointReader(bool useMC)
 void RecPointReader::init(InitContext& ic)
 {
   mInputFileName = ic.options().get<std::string>("ft0-recpoints-infile");
+  connectTree(mInputFileName);
 }
 
 void RecPointReader::run(ProcessingContext& pc)
 {
-  if (mFinished) {
-    return;
-  }
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
 
-  { // load data from files
-    TFile rpFile(mInputFileName.c_str(), "read");
-    if (rpFile.IsZombie()) {
-      LOG(FATAL) << "Failed to open FT0 recpoints file " << mInputFileName;
-    }
-    TTree* rpTree = (TTree*)rpFile.Get(mRecPointTreeName.c_str());
-    if (!rpTree) {
-      LOG(FATAL) << "Failed to load FT0 recpoints tree " << mRecPointTreeName << " from " << mInputFileName;
-    }
-    LOG(INFO) << "Loaded FT0 recpoints tree " << mRecPointTreeName << " from " << mInputFileName;
-
-    rpTree->SetBranchAddress(mRecPointBranchName.c_str(), &mRecPoints);
-    if (mUseMC) {
-      LOG(WARNING) << "MC-truth is not supported for FT0 recpoints currently";
-      mUseMC = false;
-    }
-
-    rpTree->GetEntry(0);
-    delete rpTree;
-    rpFile.Close();
-  }
-
-  LOG(INFO) << "FT0 RecPointReader pushes " << mRecPoints->size() << " recpoints";
+  LOG(INFO) << "FT0 RecPointReader pushes " << mRecPoints->size() << " recpoints at entry " << ent;
   pc.outputs().snapshot(Output{mOrigin, "RECPOINTS", 0, Lifetime::Timeframe}, *mRecPoints);
 
-  mFinished = true;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void RecPointReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mRecPointTreeName.c_str()));
+  assert(mTree);
+
+  mTree->SetBranchAddress(mRecPointBranchName.c_str(), &mRecPoints);
+  if (mUseMC) {
+    LOG(WARNING) << "MC-truth is not supported for FT0 recpoints currently";
+    mUseMC = false;
+  }
+
+  LOG(INFO) << "Loaded FT0 RecPoints tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
 
 DataProcessorSpec getFT0RecPointReaderSpec(bool useMC)

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TrackTPCITSReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TrackTPCITSReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_GLOBAL_TRACKITSTPCREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -36,12 +37,14 @@ class TrackTPCITSReader : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  int mState = 0;
+  void connectTree(const std::string& filename);
   bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::vector<o2::dataformats::TrackTPCITS> mTracks, *mPtracks = &mTracks;
-  std::vector<o2::MCCompLabel> mTPCLabels, *mPTPCLabels = &mTPCLabels;
-  std::vector<o2::MCCompLabel> mITSLabels, *mPITSLabels = &mITSLabels;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mFileName = "";
+  std::vector<o2::dataformats::TrackTPCITS> mTracks, *mTracksPtr = &mTracks;
+  std::vector<o2::MCCompLabel> mTPCLabels, *mTPCLabelsPtr = &mTPCLabels;
+  std::vector<o2::MCCompLabel> mITSLabels, *mITSLabelsPtr = &mITSLabels;
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_ITS_TRACKREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -40,7 +41,7 @@ class TrackReader : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
 
  protected:
-  void accumulate();
+  void connectTree(const std::string& filename);
 
   std::vector<o2::itsmft::ROFRecord> mROFRec, *mROFRecInp = &mROFRec;
   std::vector<o2::itsmft::ROFRecord> mVerticesROFRec, *mVerticesROFRecInp = &mVerticesROFRec;
@@ -51,9 +52,10 @@ class TrackReader : public o2::framework::Task
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 
-  bool mFinished = false;
   bool mUseMC = true; // use MC truth
 
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
   std::string mInputFileName = "";
   std::string mTrackTreeName = "o2sim";
   std::string mROFBranchName = "ITSTracksROF";

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/VertexReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/VertexReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_ITS_VERTEXREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -37,15 +38,17 @@ class VertexReader : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
 
  protected:
+  void connectTree(const std::string& filename);
   void accumulate();
 
-  std::vector<o2::itsmft::ROFRecord> mVerticesROFRec, *mVerticesROFRecInp = &mVerticesROFRec;
-  std::vector<Vertex> mVertices, *mVerticesInp = &mVertices;
+  std::vector<o2::itsmft::ROFRecord> mVerticesROFRec, *mVerticesROFRecPtr = &mVerticesROFRec;
+  std::vector<Vertex> mVertices, *mVerticesPtr = &mVertices;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 
-  bool mFinished = false;
-  std::string mInputFileName = "";
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mFileName = "";
   std::string mVertexTreeName = "o2sim";
   std::string mVertexBranchName = "Vertices";
   std::string mVertexROFBranchName = "VerticesROF";

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_ITSMFT_CLUSTERREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -41,17 +42,19 @@ class ClusterReader : public Task
   void run(ProcessingContext& pc) final;
 
  protected:
-  void read();
+  void connectTree(const std::string& filename);
 
   std::vector<o2::itsmft::ROFRecord> mClusROFRec, *mClusROFRecPtr = &mClusROFRec;
   std::vector<o2::itsmft::Cluster> mClusterArray, *mClusterArrayPtr = &mClusterArray;
   std::vector<o2::itsmft::CompClusterExt> mClusterCompArray, *mClusterCompArrayPtr = &mClusterCompArray;
   std::vector<unsigned char> mPatternsArray, *mPatternsArrayPtr = &mPatternsArray;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mClusterMCTruth, *mClusterMCTruthPtr = &mClusterMCTruth;
+  std::vector<o2::itsmft::MC2ROFRecord> mClusMC2ROFs, *mClusMC2ROFsPtr = &mClusMC2ROFs;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
 
-  bool mFinished = false;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
 
   bool mUseMC = true;     // use MC truth
   bool mUseClFull = true; // use full clusters
@@ -60,14 +63,14 @@ class ClusterReader : public Task
 
   std::string mDetName = "";
   std::string mDetNameLC = "";
-  std::string mInputFileName = "";
-
+  std::string mFileName = "";
   std::string mClusTreeName = "o2sim";
   std::string mClusROFBranchName = "ClustersROF";
   std::string mClusterBranchName = "Cluster";
   std::string mClusterPattBranchName = "ClusterPatt";
   std::string mClusterCompBranchName = "ClusterComp";
   std::string mClustMCTruthBranchName = "ClusterMCTruth";
+  std::string mClustMC2ROFBranchName = "ClustersMC2ROF";
 };
 
 class ITSClusterReader : public ClusterReader

--- a/Detectors/TOF/workflow/include/TOFWorkflow/ClusterReaderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/ClusterReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_TOF_CLUSTERREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -37,11 +38,15 @@ class ClusterReader : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  int mState = 0;
+  void connectTree(const std::string& filename);
+
   bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::vector<Cluster> mClusters, *mPclusters = &mClusters;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels, *mPlabels = &mLabels;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mFileName = "";
+
+  std::vector<Cluster> mClusters, *mClustersPtr = &mClusters;
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
 };
 
 /// create a processor spec

--- a/Detectors/TOF/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/TOF/workflow/src/ClusterReaderSpec.cxx
@@ -12,8 +12,6 @@
 
 #include <vector>
 
-#include "TTree.h"
-
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TOFWorkflow/ClusterReaderSpec.h"
@@ -30,50 +28,40 @@ namespace tof
 void ClusterReader::init(InitContext& ic)
 {
   LOG(INFO) << "Init Cluster reader!";
-  auto filename = ic.options().get<std::string>("tof-cluster-infile");
-  mFile = std::make_unique<TFile>(filename.c_str(), "OLD");
-  if (!mFile->IsOpen()) {
-    LOG(ERROR) << "Cannot open the " << filename.c_str() << " file !";
-    mState = 0;
-    return;
-  }
-  mState = 1;
+  mFileName = ic.options().get<std::string>("tof-cluster-infile");
+  connectTree(mFileName);
 }
 
 void ClusterReader::run(ProcessingContext& pc)
 {
-  if (mState != 1) {
-    return;
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(INFO) << "Pushing " << mClustersPtr->size() << " TOF clusters at entry " << ent;
+
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0, Lifetime::Timeframe}, mClusters);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mLabels);
   }
 
-  std::unique_ptr<TTree> treeClu((TTree*)mFile->Get("o2sim"));
-
-  if (treeClu) {
-    treeClu->SetBranchAddress("TOFCluster", &mPclusters);
-
-    if (mUseMC) {
-      treeClu->SetBranchAddress("TOFClusterMCTruth", &mPlabels);
-    }
-
-    treeClu->GetEntry(0);
-
-    // add clusters loaded in the output snapshot
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERS", 0, Lifetime::Timeframe}, mClusters);
-    if (mUseMC)
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mLabels);
-
-    static o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::CONTINUOUS;
-
-    LOG(INFO) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe}, roMode);
-  } else {
-    LOG(ERROR) << "Cannot read the TOF clusters !";
-    return;
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
+}
 
-  mState = 2;
-  pc.services().get<ControlService>().endOfStream();
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+void ClusterReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get("o2sim"));
+  assert(mTree);
+  mTree->SetBranchAddress("TOFCluster", &mClustersPtr);
+  if (mUseMC) {
+    mTree->SetBranchAddress("TOFClusterMCTruth", &mLabelsPtr);
+  }
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
 
 DataProcessorSpec getClusterReaderSpec(bool useMC)
@@ -83,7 +71,6 @@ DataProcessorSpec getClusterReaderSpec(bool useMC)
   if (useMC) {
     outputs.emplace_back(o2::header::gDataOriginTOF, "CLUSTERSMCTR", 0, Lifetime::Timeframe);
   }
-  outputs.emplace_back(o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "tof-cluster-reader",

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
@@ -14,6 +14,7 @@
 #define O2_TPC_TRACKREADER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -39,13 +40,16 @@ class TrackReader : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  void accumulate();
+  void accumulate(int from, int n);
+  void connectTree(const std::string& filename);
 
   std::vector<o2::tpc::TrackTPC>*mTracksInp = nullptr, mTracksOut;
   std::vector<o2::tpc::TPCClRefElem>*mCluRefVecInp = nullptr, mCluRefVecOut;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
 
-  bool mFinished = false;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+
   bool mUseMC = true; // use MC truth
 
   std::string mInputFileName = "tpctracks.root";

--- a/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
@@ -11,9 +11,6 @@
 /// @file   TrackReaderSpec.cxx
 
 #include <vector>
-
-#include "TTree.h"
-
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCWorkflow/TrackReaderSpec.h"
@@ -33,65 +30,41 @@ TrackReader::TrackReader(bool useMC)
 void TrackReader::init(InitContext& ic)
 {
   mInputFileName = ic.options().get<std::string>("tpc-tracks-infile");
+  connectTree(mInputFileName);
 }
 
 void TrackReader::run(ProcessingContext& pc)
 {
+  auto ent = mTree->GetReadEntry() + 1;
+  accumulate(ent, 1);                // to really accumulate all, use accumulate(ent,mTree->GetEntries());
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
 
-  if (mFinished) {
-    return;
-  }
-  accumulate();
-
-  LOG(INFO) << "TPCTrackReader pushes " << mTracksOut.size() << " tracks";
   pc.outputs().snapshot(Output{"TPC", "TRACKS", 0, Lifetime::Timeframe}, mTracksOut);
   pc.outputs().snapshot(Output{"TPC", "CLUSREFS", 0, Lifetime::Timeframe}, mCluRefVecOut);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe}, mMCTruthOut);
   }
 
-  mFinished = true;
-  pc.services().get<ControlService>().endOfStream();
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
 }
 
-void TrackReader::accumulate()
+void TrackReader::accumulate(int from, int n)
 {
-  // load data from files
-  TFile trFile(mInputFileName.c_str(), "read");
-  if (trFile.IsZombie()) {
-    LOG(FATAL) << "Failed to open tracks file " << mInputFileName;
-  }
-  TTree* trTree = (TTree*)trFile.Get(mTrackTreeName.c_str());
-  if (!trTree) {
-    LOG(FATAL) << "Failed to load tracks tree " << mTrackTreeName << " from " << mInputFileName;
-  }
-  LOG(INFO) << "Loaded tracks tree " << mTrackTreeName << " from " << mInputFileName;
-
-  trTree->SetBranchAddress(mTrackBranchName.c_str(), &mTracksInp);
-  trTree->SetBranchAddress(mClusRefBranchName.c_str(), &mCluRefVecInp);
-  if (mUseMC) {
-    if (trTree->GetBranch(mTrackMCTruthBranchName.c_str())) {
-      trTree->SetBranchAddress(mTrackMCTruthBranchName.c_str(), &mMCTruthInp);
-      LOG(INFO) << "Will use MC-truth from " << mTrackMCTruthBranchName;
-    } else {
-      LOG(INFO) << "MC-truth is missing";
-      mUseMC = false;
-    }
-  }
-  int nEnt = trTree->GetEntries();
-  if (nEnt == 1) {
-    trTree->GetEntry(0);
+  assert(from + n <= mTree->GetEntries());
+  if (n == 1) {
+    mTree->GetEntry(from);
     mTracksOut.swap(*mTracksInp);
     mCluRefVecOut.swap(*mCluRefVecInp);
     if (mUseMC) {
       mMCTruthOut.mergeAtBack(*mMCTruthInp);
     }
   } else {
-    int lastEntry = -1;
-    int ntrAcc = 0;
-    for (int iev = 0; iev < nEnt; iev++) {
-      trTree->GetEntry(iev);
+    for (int iev = 0; iev < n; iev++) {
+      mTree->GetEntry(from + iev);
       //
       uint32_t shift = mCluRefVecOut.size(); // during accumulation clusters refs need to be shifted
 
@@ -114,6 +87,29 @@ void TrackReader::accumulate()
       }
     }
   }
+  LOG(INFO) << "TPCTrackReader pushes " << mTracksOut.size() << " tracks from entries " << from << " : " << from + n - 1;
+}
+
+void TrackReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mTrackTreeName.c_str()));
+  assert(mTree);
+
+  mTree->SetBranchAddress(mTrackBranchName.c_str(), &mTracksInp);
+  mTree->SetBranchAddress(mClusRefBranchName.c_str(), &mCluRefVecInp);
+  if (mUseMC) {
+    if (mTree->GetBranch(mTrackMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mTrackMCTruthBranchName.c_str(), &mMCTruthInp);
+      LOG(INFO) << "Will use MC-truth from " << mTrackMCTruthBranchName;
+    } else {
+      LOG(INFO) << "MC-truth is missing";
+      mUseMC = false;
+    }
+  }
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
 
 DataProcessorSpec getTPCTrackReaderSpec(bool useMC)


### PR DESCRIPTION
To allow feeding multiple TFs into the DPL workflows, the readers for reco objects (clusters, tracks etc.) will treat each tree entry as a separate TF. Behaviour for trees with single entry is unchanged.

Suppressed ``mState`` and ``mFinished`` data members of readers: the stat of the device will be determined by availability of further data to send and ReadToQuit call.

