### PR TITLE
Add simple trigger selection based on trigger bit in the vertexerhf task

### DIFF
--- a/Analysis/Tasks/vertexerhf.cxx
+++ b/Analysis/Tasks/vertexerhf.cxx
@@ -44,11 +44,32 @@ struct DecayVertexBuilder2Prong {
 
   Produces<aod::SecVtx2Prong> secvtx2prong;
   //Configurable<std::string> triggersel{"triggersel", "test", "A string configurable"};
+  Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
 
-  void process(aod::Collision const& collision, soa::Join<aod::Tracks,
-                                                          aod::TracksCov, aod::TracksExtra> const& tracks)
+  aod::Trigger getTrigger(aod::Collision const& collision, aod::Triggers const& triggers)
+  {
+    for (auto trigger : triggers)
+      if (trigger.globalBC() == collision.globalBC())
+        return trigger;
+    aod::Trigger dummy;
+    return dummy;
+  }
+
+  void process(aod::Collision const& collision,
+               aod::Triggers const& triggers,
+               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
   {
     //LOGP(error, "Trigger selection {}", std::string{triggersel});
+    int trigindex = int{triggerindex};
+    if (trigindex !=-1){
+      LOGF(info, "Selecting on trigger bit %d", trigindex);
+      auto trigger = getTrigger(collision, triggers);
+      uint64_t triggerMask = trigger.triggerMask();
+      bool isTriggerClassFired = triggerMask & 1ul << (trigindex -1);
+      if (!isTriggerClassFired)
+        return;
+    }
+
     LOGF(info, "N. of Tracks for collision: %d", tracks.size());
     o2::vertexing::DCAFitterN<2> df;
     df.setBz(5.0);

--- a/Analysis/Tasks/vertexerhf.cxx
+++ b/Analysis/Tasks/vertexerhf.cxx
@@ -61,11 +61,11 @@ struct DecayVertexBuilder2Prong {
   {
     //LOGP(error, "Trigger selection {}", std::string{triggersel});
     int trigindex = int{triggerindex};
-    if (trigindex !=-1){
+    if (trigindex !=-1) {
       LOGF(info, "Selecting on trigger bit %d", trigindex);
       auto trigger = getTrigger(collision, triggers);
       uint64_t triggerMask = trigger.triggerMask();
-      bool isTriggerClassFired = triggerMask & 1ul << (trigindex -1);
+      bool isTriggerClassFired = triggerMask & 1ul << (trigindex - 1);
       if (!isTriggerClassFired)
         return;
     }

--- a/Analysis/Tasks/vertexerhf.cxx
+++ b/Analysis/Tasks/vertexerhf.cxx
@@ -61,7 +61,7 @@ struct DecayVertexBuilder2Prong {
   {
     //LOGP(error, "Trigger selection {}", std::string{triggersel});
     int trigindex = int{triggerindex};
-    if (trigindex !=-1) {
+    if (trigindex != -1) {
       LOGF(info, "Selecting on trigger bit %d", trigindex);
       auto trigger = getTrigger(collision, triggers);
       uint64_t triggerMask = trigger.triggerMask();


### PR DESCRIPTION
With the help of @ekryshen, I included in the vertexerhf task a simple trigger selection based on the converted trigger bit. We plan to replace this preliminary selection with the event selection task that will soon be released. This implementation was validated with respect to the Run2 framework. 