### PR TITLE
Fix macros assuming global namespace std

### DIFF
--- a/Detectors/CPV/calib/macros/PostCalibCCDB.C
+++ b/Detectors/CPV/calib/macros/PostCalibCCDB.C
@@ -36,7 +36,7 @@ void PostCalibCCDB()
 
     hGains[mod] = (TH2F*)fGains->Get(Form("mod%d", mod));
     if (!o2cpvCalib->setGain(hGains[mod], mod)) {
-      cout << " Can not set gain for module " << mod << endl;
+      std::cout << " Can not set gain for module " << mod << std::endl;
       return;
     }
   }

--- a/Detectors/CPV/testsimulation/plot_dig_cpv.C
+++ b/Detectors/CPV/testsimulation/plot_dig_cpv.C
@@ -31,7 +31,7 @@ void plot_dig_cpv(int ievent = 0, std::string inputfile = "o2dig.root")
   hitTree->SetBranchAddress("CPVDigit", &mDigitsArray);
 
   if (!mDigitsArray) {
-    cout << "CPV digits not found in the file. Exiting ..." << endl;
+    std::cout << "CPV digits not found in the file. Exiting ..." << std::endl;
     return;
   }
   hitTree->GetEvent(ievent);

--- a/Detectors/CPV/testsimulation/plot_hit_cpv.C
+++ b/Detectors/CPV/testsimulation/plot_hit_cpv.C
@@ -33,7 +33,7 @@ void plot_hit_cpv(int ievent = 0, std::string inputprefix = "o2sim")
   hitTree->SetBranchAddress("CPVHit", &mHitsArray);
 
   if (!mHitsArray) {
-    cout << "CPV hits not registered in the FairRootManager. Exiting ..." << endl;
+    std::cout << "CPV hits not registered in the FairRootManager. Exiting ..." << std::endl;
     return;
   }
   hitTree->GetEvent(ievent);

--- a/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
+++ b/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
@@ -48,7 +48,7 @@ void RawFitterTESTs()
   while (rawreader.hasNext()) {
 
     rawreader.next();
-    cout << "next page \n";
+    std::cout << "next page \n";
 
     //std::cout<<rawreader.getRawHeader()<<std::endl;
 

--- a/Detectors/ITSMFT/ITS/macros/EVE/simple_geom_ITS.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/simple_geom_ITS.C
@@ -18,6 +18,8 @@
 
 #endif
 
+using namespace std;
+
 void AddNodes(TGeoNode* node, TEveGeoNode* parent, Int_t depth, Int_t depthmax, TObjArray* list);
 
 void simple_geom_ITS(std::string inputGeom = "o2sim_geometry.root")

--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusterShape.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusterShape.C
@@ -21,6 +21,7 @@
 using o2::itsmft::Digit;
 using o2::itsmft::SegmentationAlpide;
 using namespace o2::its;
+using namespace std;
 
 //////////////////////////////////////////
 //////////////////////////////////////////
@@ -166,7 +167,7 @@ class Cluster
 //////////////////////////////////////////
 void AnalyzeClusters(Int_t nev, const map<UInt_t, Cluster>& clusters, TH1F* freqDist, TH1F* cSizeDist)
 {
-  cout << ">>> Event " << nev << endl;
+  std::cout << ">>> Event " << nev << std::endl;
   Float_t x, z;
   Long64_t shapeId;
   map<Long64_t, Int_t> csFrequency;
@@ -181,33 +182,33 @@ void AnalyzeClusters(Int_t nev, const map<UInt_t, Cluster>& clusters, TH1F* freq
       o2::itsmft::ClusterShape* cs = Cluster::PixelsToClusterShape(pv);
       shapeId = cs->GetShapeID();
       cSizeDist->Fill(cs->GetNFiredPixels());
-      cout << endl
-           << shapeId << ":" << endl
-           << *cs << endl
-           << endl;
+      std::cout << std::endl
+                << shapeId << ":" << std::endl
+                << *cs << std::endl
+                << std::endl;
 
       if (csFrequency.find(shapeId) == csFrequency.end())
         csFrequency[shapeId] = 0;
       csFrequency[shapeId] += 1;
 
       // if (cls.GetNClusters(i) > 0) {
-      //   cout << " [";
+      //   std::cout << " [";
       //   for (auto j = 0; j < cls.GetNClusters(i); ++j) {
       //     Pixel p = cls.GetPixel(i, j);
-      //     cout << "(" << p.GetRow() << "," << p.GetCol() << ")";
+      //     std::cout << "(" << p.GetRow() << "," << p.GetCol() << ")";
       //     //SegmentationAlpide::detectorToLocal(p.GetRow(),p.GetCol(),x,z);
       //     //cout << "(" << x << "," << z << ")";
-      //     if (j < cls.GetNClusters(i)-1) cout << "  ";
+      //     if (j < cls.GetNClusters(i)-1) std::cout << "  ";
       //   }
-      //   cout << "]";
+      //   std::cout << "]";
       // }
 
-      //if (i < 6) cout << ", ";
-      //else cout << endl;
+      //if (i < 6) std::cout << ", ";
+      //else std::cout << std::endl;
     }
   }
-  cout << ">>>>>>>>>>>>>>>>>" << endl
-       << endl;
+  std::cout << ">>>>>>>>>>>>>>>>>" << std::endl
+            << std::endl;
 
   int i = 0;
   std::multimap<Int_t, Long64_t> fmap = flip_map(csFrequency);

--- a/Detectors/ITSMFT/ITS/macros/test/CheckLUtime.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckLUtime.C
@@ -22,6 +22,8 @@
 
 #endif
 
+using namespace std;
+
 void CheckLUtime(std::string clusfile = "o2clus_its.root", std::string dictfile = "")
 {
   using o2::itsmft::Cluster;
@@ -81,6 +83,6 @@ void CheckLUtime(std::string clusfile = "o2clus_its.root", std::string dictfile 
   realtime.close();
   cputime << timerLookUp.CpuTime() / nevCl << std::endl;
   cputime.close();
-  time_output << "Real time (s): " << timerLookUp.RealTime() / nevCl << "CPU time (s): " << timerLookUp.CpuTime() / nevCl << endl;
-  cout << "Real time (s): " << timerLookUp.RealTime() / nevCl << " CPU time (s): " << timerLookUp.CpuTime() / nevCl << endl;
+  time_output << "Real time (s): " << timerLookUp.RealTime() / nevCl << "CPU time (s): " << timerLookUp.CpuTime() / nevCl << std::endl;
+  std::cout << "Real time (s): " << timerLookUp.RealTime() / nevCl << " CPU time (s): " << timerLookUp.CpuTime() / nevCl << std::endl;
 }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -23,6 +23,8 @@
 
 #endif
 
+using namespace std;
+
 struct DataFrames {
   void update(int frame, long index)
   {

--- a/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
+++ b/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
@@ -26,6 +26,8 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #endif
 
+using namespace std;
+
 void DisplayTrack(Int_t event = 0, Int_t track = 0, std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "")
 {
   using namespace o2::base;
@@ -104,7 +106,7 @@ void DisplayTrack(Int_t event = 0, Int_t track = 0, std::string tracfile = "o2tr
       n++;
     }
   }
-  cout << "Number of hits: " << n << endl;
+  std::cout << "Number of hits: " << n << std::endl;
 
   gEve->AddElement(points, 0);
   f->Close();
@@ -158,7 +160,7 @@ found:
       n++;
     }
   }
-  cout << "Number of clusters: " << n << endl;
+  std::cout << "Number of clusters: " << n << std::endl;
 
   gEve->AddElement(points, 0);
   f->Close();
@@ -204,7 +206,7 @@ found:
     }
     break;
   }
-  cout << "Number of attached clusters: " << n << endl;
+  std::cout << "Number of attached clusters: " << n << std::endl;
 
   gEve->AddElement(points, 0);
   f->Close();

--- a/Detectors/PHOS/testsimulation/plot_dig_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_dig_phos.C
@@ -15,6 +15,8 @@
 #include "PHOSBase/Geometry.h"
 #endif
 
+using namespace std;
+
 void plot_dig_phos(int ievent = 0, TString inputfile = "o2dig.root")
 {
 

--- a/Detectors/PHOS/testsimulation/plot_hit_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_hit_phos.C
@@ -27,7 +27,7 @@ void plot_hit_phos(int ievent = 0, TString inputfile = "AliceO2_TGeant3.phos.mc_
   //  digTree->SetBranchAddress("PHSDigitMCTruth", &labels);
 
   if (!mHitsArray) {
-    cout << "PHOS hits not present. Exiting ..." << endl;
+    std::cout << "PHOS hits not present. Exiting ..." << std::endl;
     return;
   }
   hitTree->GetEvent(ievent);

--- a/Detectors/TPC/calibration/macro/dumpDigits.C
+++ b/Detectors/TPC/calibration/macro/dumpDigits.C
@@ -37,7 +37,7 @@ void dumpDigits(std::vector<std::string_view> fileInfos, TString outputFileName 
 
     for (int i = 0; i < nevents; ++i) {
       status = dig.processEvent(i);
-      cout << "Processing event " << i << " with status " << int(status) << '\n';
+      std::cout << "Processing event " << i << " with status " << int(status) << '\n';
       if (status == CalibRawBase::ProcessStatus::IncompleteEvent) {
         continue;
       } else if (status != CalibRawBase::ProcessStatus::Ok) {

--- a/Detectors/TPC/calibration/macro/runPedestal.C
+++ b/Detectors/TPC/calibration/macro/runPedestal.C
@@ -37,7 +37,7 @@ void runPedestal(std::vector<std::string_view> fileInfos, TString outputFileName
 
     for (Int_t i = firstEvent; i < firstEvent + nevents; ++i) {
       status = ped.processEvent(i);
-      cout << "Processing event " << i << " with status " << int(status) << '\n';
+      std::cout << "Processing event " << i << " with status " << int(status) << '\n';
       if (status == CalibRawBase::ProcessStatus::IncompleteEvent) {
         continue;
       } else if (status != CalibRawBase::ProcessStatus::Ok) {

--- a/Detectors/TPC/calibration/macro/runPulser.C
+++ b/Detectors/TPC/calibration/macro/runPulser.C
@@ -58,7 +58,7 @@ void runPulser(std::vector<std::string_view> fileInfos, TString outputFileName =
 
     for (Int_t i = 0; i < nevents; ++i) {
       status = calib.processEvent(i);
-      cout << "Processing event " << i << " with status " << int(status) << '\n';
+      std::cout << "Processing event " << i << " with status " << int(status) << '\n';
       if (status == CalibRawBase::ProcessStatus::IncompleteEvent) {
         continue;
       } else if (status != CalibRawBase::ProcessStatus::Ok) {

--- a/Detectors/TPC/reconstruction/macro/testRawRead.C
+++ b/Detectors/TPC/reconstruction/macro/testRawRead.C
@@ -51,7 +51,7 @@ void testRawRead(std::string filename)
     digits.clear();
   }
 
-  cout << "MaxPad: " << maxPad << "\n";
+  std::cout << "MaxPad: " << maxPad << "\n";
   TCanvas* c1 = new TCanvas("c1", "c1");
   hDigits->Draw();
   TCanvas* c2 = new TCanvas("c2", "c2");

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -16,10 +16,12 @@
 #include "ZDCBase/Constants.h"
 #include <string>
 #include <TFile.h>
+#include <map>
 
 #endif
 
 using namespace o2::zdc;
+using namespace std;
 
 void CreateModuleConfig(long tmin = 0, long tmax = -1,
                         std::string ccdbHost = "http://ccdb-test.cern.ch:8080")

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -20,6 +20,8 @@
 #include "ZDCSimulation/SimCondition.h"
 #include "ZDCBase/Constants.h"
 
+using namespace std;
+
 void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
                         long tmin = 0, long tmax = -1,
                         std::string ccdbHost = "http://ccdb-test.cern.ch:8080")

--- a/Detectors/gconfig/UserDecay.C
+++ b/Detectors/gconfig/UserDecay.C
@@ -15,7 +15,7 @@
 
 void UserDecayConfig()
 {
-  cout << "Loading User Decay Config from macro" << endl;
+  std::cout << "Loading User Decay Config from macro" << std::endl;
   TDatabasePDG* db = TDatabasePDG::Instance();
   TParticlePDG* p = 0;
 
@@ -34,7 +34,7 @@ void UserDecayConfig()
     mode[kz][0] = 0;
     mode[kz][1] = 0;
     mode[kz][2] = 0;
-    //  cout << mode[kz][0] << " " << 	mode[kz][1] << " " << mode[kz][2] << endl;
+    //  std::cout << mode[kz][0] << " " << 	mode[kz][1] << " " << mode[kz][2] << std::endl;
   }
   bratio[0] = 100.;
   mode[0][0] = 2112;

--- a/Detectors/gconfig/g3Config.C
+++ b/Detectors/gconfig/g3Config.C
@@ -25,10 +25,10 @@ void Config()
   TGeant3* geant3 = nullptr;
   if (strncmp(gModel->Data(), "TGeo", 4) == 0) {
     geant3 = new TGeant3TGeo("C++ Interface to Geant3");
-    cout << "-I- G3Config: Geant3 with TGeo has been created." << endl;
+    std::cout << "-I- G3Config: Geant3 with TGeo has been created." << std::endl;
   } else {
     geant3 = new TGeant3("C++ Interface to Geant3");
-    cout << "-I- G3Config: Geant3 native has been created." << endl;
+    std::cout << "-I- G3Config: Geant3 native has been created." << std::endl;
   }
   stackSetup(geant3, run);
 

--- a/Detectors/gconfig/g3libs.C
+++ b/Detectors/gconfig/g3libs.C
@@ -21,7 +21,7 @@ Bool_t isLibrary(const char* libName)
 
 void g3libs()
 {
-  cout << "Loading Geant3 libraries ..." << endl;
+  std::cout << "Loading Geant3 libraries ..." << std::endl;
 
   if (isLibrary("libdummies"))
     gSystem->Load("libdummies.so");
@@ -29,5 +29,5 @@ void g3libs()
 
   gSystem->Load("libgeant321");
 
-  cout << "Loading Geant3 libraries ... finished" << endl;
+  std::cout << "Loading Geant3 libraries ... finished" << std::endl;
 }

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -57,13 +57,13 @@ void Config()
                                  // any other choice is dangerously inconsistent with the FinishPrimary() interface of VMCApp
 
   auto& physicsSetup = ::o2::conf::G4Params::Instance().getPhysicsConfigString();
-  cout << "PhysicsSetup wanted " << physicsSetup << "\n";
+  std::cout << "PhysicsSetup wanted " << physicsSetup << "\n";
   auto runConfiguration = new TG4RunConfiguration("geomRoot", physicsSetup, "stepLimiter+specialCuts",
                                                   specialStacking, mtMode);
 
   /// Create the G4 VMC
   TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);
-  cout << "Geant4 has been created." << endl;
+  std::cout << "Geant4 has been created." << std::endl;
 
   // setup the stack
   stackSetup(geant4, FairRunSim::Instance());
@@ -84,5 +84,5 @@ void Config()
   // Enter in Geant4 Interactive mode
   // geant4->StartGeantUI();
 
-  cout << "g4Config.C finished" << endl;
+  std::cout << "g4Config.C finished" << std::endl;
 }

--- a/GPU/TPCFastTransformation/devtools/IrregularSpline1DTest.C
+++ b/GPU/TPCFastTransformation/devtools/IrregularSpline1DTest.C
@@ -44,26 +44,26 @@ int IrregularSpline1DTest()
 
   using namespace GPUCA_NAMESPACE::gpu;
 
-  cout << "Test roundf(): " << endl;
+  std::cout << "Test roundf(): " << std::endl;
   for (float x = 0.; x <= 1.; x += 0.1) {
-    cout << "roundf(" << x << ") = " << roundf(x) << " " << (int)roundf(x) << endl;
+    std::cout << "roundf(" << x << ") = " << roundf(x) << " " << (int)roundf(x) << std::endl;
   }
 
-  cout << "Test 5 knots for n bins:" << endl;
+  std::cout << "Test 5 knots for n bins:" << std::endl;
   for (int n = 4; n < 20; n++) {
     int bin1 = (int)roundf(.25 * n);
     int bin2 = (int)roundf(.50 * n);
     int bin3 = (int)roundf(.75 * n);
-    cout << n << ": 0 " << bin1 << " " << bin2 << " " << bin3 << " " << n << endl;
+    std::cout << n << ": 0 " << bin1 << " " << bin2 << " " << bin3 << " " << n << std::endl;
   }
 
-  cout << "Test interpolation.." << endl;
+  std::cout << "Test interpolation.." << std::endl;
 
   gRandom->SetSeed(0);
   UInt_t seed = gRandom->Integer(100000); // 605
 
   gRandom->SetSeed(seed);
-  cout << "Random seed: " << seed << " " << gRandom->GetSeed() << endl;
+  std::cout << "Random seed: " << seed << " " << gRandom->GetSeed() << std::endl;
   for (int i = 0; i <= PolynomDegree; i++) {
     coeff[i] = gRandom->Uniform(-1, 1);
   }
@@ -87,9 +87,9 @@ int IrregularSpline1DTest()
   spline.construct(initNKnotsU, knotsU, nAxisBinsU);
 
   int nKnotsTot = spline.getNumberOfKnots();
-  cout << "Knots: initial " << initNKnotsU << ", created " << nKnotsTot << endl;
+  std::cout << "Knots: initial " << initNKnotsU << ", created " << nKnotsTot << std::endl;
   for (int i = 0; i < nKnotsTot; i++) {
-    cout << "knot " << i << ": " << spline.getKnot(i).u << endl;
+    std::cout << "knot " << i << ": " << spline.getKnot(i).u << std::endl;
   }
 
   const IrregularSpline1D& gridU = spline;
@@ -126,7 +126,7 @@ int IrregularSpline1DTest()
     double fs = spline.getSpline(data, u);
     diff += (fs - f0) * (fs - f0);
   }
-  cout << "mean diff at knots: " << sqrt(diff) / nu << endl;
+  std::cout << "mean diff at knots: " << sqrt(diff) / nu << std::endl;
 
   knots->SetMarkerSize(1.);
   knots->SetMarkerStyle(8);

--- a/GPU/TPCFastTransformation/devtools/IrregularSpline2D3DCalibratorTest.C
+++ b/GPU/TPCFastTransformation/devtools/IrregularSpline2D3DCalibratorTest.C
@@ -69,7 +69,7 @@ void initF()
   splineF.construct(nKnotsU, knotsU, nKnotsU,
                     nKnotsV, knotsV, nKnotsV);
 
-  cout << "number of knots: " << splineF.getNumberOfKnots() << endl;
+  std::cout << "number of knots: " << splineF.getNumberOfKnots() << std::endl;
 
   splineF_data = new float[splineF.getNumberOfKnots() * 3];
   for (int i = 0; i < splineF.getNumberOfKnots(); i++) {
@@ -97,12 +97,12 @@ bool initTPC(const char* fileName, int slice, int row)
 
   TFile file(fileName, "READ");
   if (!file.IsOpen()) {
-    cout << "distortion file not found!" << endl;
+    std::cout << "distortion file not found!" << std::endl;
     exit(0);
   }
   TNtuple* nt = (TNtuple*)file.Get("dist");
   if (!nt) {
-    cout << "distortion ntuple is not found in the file!" << endl;
+    std::cout << "distortion ntuple is not found in the file!" << std::endl;
     exit(0);
   }
 
@@ -128,7 +128,7 @@ bool initTPC(const char* fileName, int slice, int row)
     if (nearbyint(fslice) != slice || nearbyint(frow) != row)
       continue;
     if (nent >= splineF.getNumberOfKnots()) {
-      cout << "Init TPC: unexpected entries: entry " << nent << " expected n entries " << splineF.getNumberOfKnots() << endl;
+      std::cout << "Init TPC: unexpected entries: entry " << nent << " expected n entries " << splineF.getNumberOfKnots() << std::endl;
       return 0;
     }
     splineF_data[3 * nent + 0] = dx;
@@ -137,7 +137,7 @@ bool initTPC(const char* fileName, int slice, int row)
     nent++;
   }
   if (nent != splineF.getNumberOfKnots()) {
-    cout << "Init TPC: unexpected N entries: read " << nent << " expected " << splineF.getNumberOfKnots() << endl;
+    std::cout << "Init TPC: unexpected N entries: read " << nent << " expected " << splineF.getNumberOfKnots() << std::endl;
     return 0;
   }
   return 1;
@@ -150,7 +150,7 @@ int IrregularSpline2D3DCalibratorTest()
   const bool kAsk = 0;
   const bool kTestTPC = 0;
 
-  cout << "Spline calibration starts" << endl;
+  std::cout << "Spline calibration starts" << std::endl;
 
   IrregularSpline2D3DCalibrator finder;
 
@@ -202,8 +202,8 @@ int IrregularSpline2D3DCalibratorTest()
 
     do {
 
-      cout << "n knots: u " << finder.getSpline().getGridU().getNumberOfKnots()
-           << " v " << finder.getSpline().getGridV().getNumberOfKnots() << endl;
+      std::cout << "n knots: u " << finder.getSpline().getGridU().getNumberOfKnots()
+                << " v " << finder.getSpline().getGridV().getNumberOfKnots() << std::endl;
 
       delete gknotsF;
       delete gknots;
@@ -330,7 +330,7 @@ int IrregularSpline2D3DCalibratorTest()
     std::cout << " output spline: " << std::endl;
     finder.getSpline().getGrid(0).print();
     finder.getSpline().getGrid(1).print();
-    cout << "seed = " << seed << std::endl;
+    std::cout << "seed = " << seed << std::endl;
 
     if (kAsk)
       keyPressed = getchar();

--- a/GPU/TPCFastTransformation/devtools/IrregularSpline2D3DTest.C
+++ b/GPU/TPCFastTransformation/devtools/IrregularSpline2D3DTest.C
@@ -71,7 +71,7 @@ int IrregularSpline2D3DTest()
   gRandom->SetSeed(0);
   UInt_t seed = gRandom->Integer(100000); // 605
   gRandom->SetSeed(seed);
-  cout << "Random seed: " << seed << " " << gRandom->GetSeed() << endl;
+  std::cout << "Random seed: " << seed << " " << gRandom->GetSeed() << std::endl;
 
   IrregularSpline2D3D spline;
 
@@ -160,7 +160,7 @@ int IrregularSpline2D3DTest()
       gknots->SetPoint(gknotsN++, u, v, fx0);
     }
   }
-  cout << "mean diff at knots: " << sqrt(diff) / gknotsN << endl;
+  std::cout << "mean diff at knots: " << sqrt(diff) / gknotsN << std::endl;
 
   knots->SetMarkerSize(1.);
   knots->SetMarkerStyle(8);

--- a/GPU/TPCFastTransformation/devtools/RegularSpline1DTest.C
+++ b/GPU/TPCFastTransformation/devtools/RegularSpline1DTest.C
@@ -61,20 +61,20 @@ typedef double myfloat;
 int RegularSpline1DTest()
 {
 
-  cout << "Test roundf(): " << endl;
+  std::cout << "Test roundf(): " << std::endl;
   for (float x = 0.; x <= 1.; x += 0.1) {
-    cout << "roundf(" << x << ") = " << roundf(x) << " " << (int)roundf(x) << endl;
+    std::cout << "roundf(" << x << ") = " << roundf(x) << " " << (int)roundf(x) << std::endl;
   }
 
-  cout << "Test 5 knots for n bins:" << endl;
+  std::cout << "Test 5 knots for n bins:" << std::endl;
   for (int n = 4; n < 20; n++) {
     int bin1 = (int)roundf(.25 * n);
     int bin2 = (int)roundf(.50 * n);
     int bin3 = (int)roundf(.75 * n);
-    cout << n << ": 0 " << bin1 << " " << bin2 << " " << bin3 << " " << n << endl;
+    std::cout << n << ": 0 " << bin1 << " " << bin2 << " " << bin3 << " " << n << std::endl;
   }
 
-  cout << "Test interpolation.." << endl;
+  std::cout << "Test interpolation.." << std::endl;
 
   const int initNKnotsU = 10;
   int nAxisBinsU = 10;
@@ -95,9 +95,9 @@ int RegularSpline1DTest()
   spline.construct(initNKnotsU);
 
   int nKnotsTot = spline.getNumberOfKnots();
-  cout << "Knots: initial " << initNKnotsU << ", created " << nKnotsTot << endl;
+  std::cout << "Knots: initial " << initNKnotsU << ", created " << nKnotsTot << std::endl;
   for (int i = 0; i < nKnotsTot; i++) {
-    cout << "knot " << i << ": " << spline.knotIndexToU(i) << endl;
+    std::cout << "knot " << i << ": " << spline.knotIndexToU(i) << std::endl;
   }
 
   myfloat* data0 = new myfloat[nKnotsTot]; // original data
@@ -113,7 +113,7 @@ int RegularSpline1DTest()
   }
 
   for (int i = 1; i < nKnotsTot; i++) {
-    cout << "data[" << i << "]: " << data[i] << endl;
+    std::cout << "data[" << i << "]: " << data[i] << std::endl;
   }
 
   spline.correctEdges(data);
@@ -133,7 +133,7 @@ int RegularSpline1DTest()
     double fs = spline.getSpline(data, u);
     diff += (fs - f0) * (fs - f0);
   }
-  cout << "mean diff at knots: " << sqrt(diff) / nu << endl;
+  std::cout << "mean diff at knots: " << sqrt(diff) / nu << std::endl;
 
   knots->SetMarkerSize(1.);
   knots->SetMarkerStyle(8);

--- a/GPU/TPCFastTransformation/devtools/SemiregularSpline2D3DTest.C
+++ b/GPU/TPCFastTransformation/devtools/SemiregularSpline2D3DTest.C
@@ -33,6 +33,8 @@
 
 #endif
 
+using namespace std;
+
 float Fx(float u, float v)
 {
   const int PolynomDegree = 7;
@@ -67,11 +69,11 @@ template <typename T>
 bool equalityCheck(const string title, const T expected, const T received)
 {
   bool check = expected == received;
-  cout << "=== " << title << " ===" << endl;
-  cout << "  expected:\t" << expected << endl;
-  cout << "  received:\t" << received << endl;
-  cout << "  check:\t" << check << "\t\t\t" << (check ? "Success!" : "Error") << endl;
-  cout << endl;
+  std::cout << "=== " << title << " ===" << std::endl;
+  std::cout << "  expected:\t" << expected << std::endl;
+  std::cout << "  received:\t" << received << std::endl;
+  std::cout << "  check:\t" << check << "\t\t\t" << (check ? "Success!" : "Error") << std::endl;
+  std::cout << std::endl;
   return check;
 }
 
@@ -135,9 +137,9 @@ int SemiregularSpline2D3DTest()
     data[i] = data0[i];
   }
 
-  cout << "Start correcting edges..." << endl;
+  std::cout << "Start correcting edges..." << std::endl;
   spline.correctEdges(data);
-  cout << "corrected edges!" << endl;
+  std::cout << "corrected edges!" << std::endl;
 
   TCanvas* canv = new TCanvas("cQA", "2D splines  QA", 1500, 1500);
   canv->Draw();
@@ -171,7 +173,7 @@ int SemiregularSpline2D3DTest()
   }
 
   checker.push_back(equalityCheck("inserted points", nKnotsTot, gknotsN));
-  cout << "mean diff at knots: " << sqrt(diff) / gknotsN << endl;
+  std::cout << "mean diff at knots: " << sqrt(diff) / gknotsN << std::endl;
 
   knots->SetMarkerSize(1.);
   knots->SetMarkerStyle(8);
@@ -228,12 +230,12 @@ int SemiregularSpline2D3DTest()
   for (unsigned int i = 0; i < checker.size(); i++) {
     success = success && checker[i];
     if (!success) {
-      cout << "Something went wrong!" << endl;
+      std::cout << "Something went wrong!" << std::endl;
       break;
     }
   }
   if (success) {
-    cout << "Everything worked fine" << endl;
+    std::cout << "Everything worked fine" << std::endl;
   }
 
   return success;

--- a/GPU/TPCFastTransformation/macro/SplineDemo.C
+++ b/GPU/TPCFastTransformation/macro/SplineDemo.C
@@ -78,13 +78,13 @@ bool drawConstruction = 1;
 bool ask()
 {
   canv->Update();
-  cout << "type: 'q'-exit";
-  cout << ", 's'-individual steps";
-  cout << ", 'l'-local splines";
-  cout << ", 'c'-chebychev";
-  cout << ", 'p'-construction points";
+  std::cout << "type: 'q'-exit";
+  std::cout << ", 's'-individual steps";
+  std::cout << ", 'l'-local splines";
+  std::cout << ", 'c'-chebychev";
+  std::cout << ", 'p'-construction points";
 
-  cout << endl;
+  std::cout << std::endl;
 
   std::string str;
   std::getline(std::cin, str);
@@ -113,7 +113,7 @@ int SplineDemo()
 
   using namespace o2::gpu;
 
-  cout << "Test interpolation.." << endl;
+  std::cout << "Test interpolation.." << std::endl;
 
   //TCanvas* canv = new TCanvas("cQA", "Spline1D  QA", 2000, 1000);
 
@@ -129,7 +129,7 @@ int SplineDemo()
     //seed = gRandom->Integer(100000); // 605
 
     gRandom->SetSeed(seed);
-    cout << "Random seed: " << seed << " " << gRandom->GetSeed() << endl;
+    std::cout << "Random seed: " << seed << " " << gRandom->GetSeed() << std::endl;
 
     for (int i = 0; i < 2 * (Fdegree + 1); i++) {
       Fcoeff[i] = gRandom->Uniform(-1, 1);
@@ -245,13 +245,13 @@ int SplineDemo()
     histMinMaxBestFit->Fill(statMinMaxBestFit);
     histMinMaxCheb->Fill(statMinMaxCheb);
 
-    cout << "\n"
-         << std::endl;
-    cout << "\nRandom seed: " << seed << " " << gRandom->GetSeed() << endl;
-    cout << "Classical : std dev " << sqrt(statDfClass / statN) << " minmax " << statMinMaxClass << std::endl;
-    cout << "Local     : std dev " << sqrt(statDfLocal / statN) << " minmax " << statMinMaxLocal << std::endl;
-    cout << "Best-fit  : std dev " << sqrt(statDfBestFit / statN) << " minmax " << statMinMaxBestFit << std::endl;
-    cout << "Chebyshev : std dev " << sqrt(statDfCheb / statN) << " minmax " << statMinMaxCheb << std::endl;
+    std::cout << "\n"
+              << std::endl;
+    std::cout << "\nRandom seed: " << seed << " " << gRandom->GetSeed() << std::endl;
+    std::cout << "Classical : std dev " << sqrt(statDfClass / statN) << " minmax " << statMinMaxClass << std::endl;
+    std::cout << "Local     : std dev " << sqrt(statDfLocal / statN) << " minmax " << statMinMaxLocal << std::endl;
+    std::cout << "Best-fit  : std dev " << sqrt(statDfBestFit / statN) << " minmax " << statMinMaxBestFit << std::endl;
+    std::cout << "Chebyshev : std dev " << sqrt(statDfCheb / statN) << " minmax " << statMinMaxCheb << std::endl;
 
     /*
       canv->cd(1);

--- a/GPU/TPCFastTransformation/macro/fastTransformQA.C
+++ b/GPU/TPCFastTransformation/macro/fastTransformQA.C
@@ -48,7 +48,7 @@ int fastTransformQA()
 
   for (int i = 0; i < nt->GetEntriesFast(); i++) {
     if (i % 10000000 == 0) {
-      cout << "processing " << i << " out of " << nt->GetEntriesFast() << "  (" << ((long)i) * 100 / nt->GetEntriesFast() << " %)" << endl;
+      std::cout << "processing " << i << " out of " << nt->GetEntriesFast() << "  (" << ((long)i) * 100 / nt->GetEntriesFast() << " %)" << std::endl;
       canv->cd(1);
       qaX->Draw();
       canv->cd(2);
@@ -60,7 +60,7 @@ int fastTransformQA()
     }
     int ret = nt->GetEntry(i);
     if (ret <= 0) {
-      cout << "Wrong entry, ret == " << ret << endl;
+      std::cout << "Wrong entry, ret == " << ret << std::endl;
       continue;
     }
     qaX->Fill(1.e4 * (fx - x));

--- a/GPU/TPCFastTransformation/macro/generateTPCCorrectionNTuple.C
+++ b/GPU/TPCFastTransformation/macro/generateTPCCorrectionNTuple.C
@@ -117,7 +117,7 @@ void generateTPCCorrectionNTuple()
           float dx = x1 - x;
           float du = u1 - u;
           float dv = v1 - v;
-          cout << slice << " " << row << " " << su << " " << sv << " " << dx << " " << du << " " << dv << endl;
+          std::cout << slice << " " << row << " " << su << " " << sv << " " << dx << " " << du << " " << dv << std::endl;
           nt->Fill(slice, row, su, sv, dx, du, dv);
         }
       }

--- a/macro/CreateBCPattern.C
+++ b/macro/CreateBCPattern.C
@@ -7,6 +7,8 @@
 
 #include "FairLogger.h"
 
+using namespace std;
+
 void CreateBCPattern(const std::string& outFileName = "bcPattern.root", const string& objName = "")
 {
   // example of interacting BC pattern creation

--- a/macro/compareTopologyDistributions.C
+++ b/macro/compareTopologyDistributions.C
@@ -17,6 +17,8 @@
 
 // Compare the topology distribution from the cluster finder with that in the dictionary
 
+using namespace std;
+
 void compareTopologyDistributions(
   string cluster_file_name = "o2clus_its.root",
   string dictionary_file_name = "",

--- a/macro/run_calib_tof.C
+++ b/macro/run_calib_tof.C
@@ -74,13 +74,13 @@ void run_calib_tof(std::string path = "./", std::string outputfile = "o2calparam
         perror("fork");
         abort();
       } else if (pids[i] == 0) {
-        cout << "child " << i << endl;
+        std::cout << "child " << i << std::endl;
         TFile outFile((path + namefile.Data() + Form("_fork%i.root", i)).data(), "recreate");
         TTree outTree("calibrationTOF", "Calibration TOF params");
         calib.setOutputTree(&outTree);
         calib.init();
-        cout << i << ") Child process: My process id = " << getpid() << endl;
-        cout << "Child process: Value returned by fork() = " << pids[i] << endl;
+        std::cout << i << ") Child process: My process id = " << getpid() << std::endl;
+        std::cout << "Child process: Value returned by fork() = " << pids[i] << std::endl;
 
         // only for the first child
 

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -185,10 +185,10 @@ void run_trac_ca_its(std::string path = "./",
 
     if (!vertITS.empty()) {
       // Using only the first vertex in the list
-      cout << " - Reconstructed vertexer: x = " << vertITS[0].getX() << " y = " << vertITS[0].getY() << " x = " << vertITS[0].getZ() << std::endl;
+      std::cout << " - Reconstructed vertexer: x = " << vertITS[0].getX() << " y = " << vertITS[0].getY() << " x = " << vertITS[0].getZ() << std::endl;
       event.addPrimaryVertex(vertITS[0].getX(), vertITS[0].getY(), vertITS[0].getZ());
     } else {
-      cout << " - Vertex not reconstructed, tracking skipped" << std::endl;
+      std::cout << " - Vertex not reconstructed, tracking skipped" << std::endl;
     }
     trackClIdx.clear();
     tracksITS.clear();

--- a/macro/run_trac_mft.C
+++ b/macro/run_trac_mft.C
@@ -85,17 +85,17 @@ void run_trac_mft(float rate, std::string outputfile, std::string inputfile, std
   Double_t ctime = timer.CpuTime();
 
   Float_t cpuUsage = ctime / rtime;
-  cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
-  cout << cpuUsage;
-  cout << "</DartMeasurement>" << endl;
-  cout << endl
-       << endl;
+  std::cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
+  std::cout << cpuUsage;
+  std::cout << "</DartMeasurement>" << std::endl;
+  std::cout << std::endl
+            << std::endl;
   std::cout << "Macro finished succesfully" << std::endl;
 
-  std::cout << endl
+  std::cout << std::endl
             << std::endl;
   std::cout << "Output file is " << outputfile.data() << std::endl;
   std::cout << "Parameter file is " << paramfile.data() << std::endl;
-  std::cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl
-            << endl;
+  std::cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << std::endl
+            << std::endl;
 }


### PR DESCRIPTION
Plenty of macros are we passing compiled tests due to the {using namespace std;}
declared by the rootcling during ACLiC dictionary generation, which is wrong in
the 1st places. With https://github.com/root-project/root/pull/5296 fix they all
fail. Adding {using namespace std;} in macros body