### PR TITLE
Some fixes for TPC workflow

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -580,7 +580,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
       int retVal = tracker->runTracking(&ptrs);
       if (retVal != 0) {
         // FIXME: error policy
-        LOG(ERROR) << "tracker returned error code " << retVal;
+        LOG(FATAL) << "tracker returned error code " << retVal;
       }
       LOG(INFO) << "found " << tracks.size() << " track(s)";
       // tracks are published if the output channel is configured

--- a/GPU/GPUTracking/Base/GPUMemorySizeScalers.h
+++ b/GPU/GPUTracking/Base/GPUMemorySizeScalers.h
@@ -29,11 +29,11 @@ struct GPUMemorySizeScalers {
 
   // Offset
   static constexpr double offset = 1000.;
+  static constexpr double hitOffset = 20000;
 
   // Scaling Factors
   static constexpr double tpcPeaksPerDigit = 0.2;
   static constexpr double tpcClustersPerPeak = 0.9;
-  static constexpr double tpcClustersNoiseOffset = 20000;
   static constexpr double tpcStartHitsPerHit = 0.08;
   static constexpr double tpcTrackletsPerStartHit = 0.8;
   static constexpr double tpcTrackletHitsPerHit = 5;
@@ -42,11 +42,11 @@ struct GPUMemorySizeScalers {
   static constexpr double tpcTracksPerHit = 0.012;
   static constexpr double tpcTrackHitsPerHit = 0.7;
 
-  double NTPCPeaks(double tpcDigits) { return offset + tpcDigits * tpcPeaksPerDigit * factor + tpcClustersNoiseOffset; }
+  double NTPCPeaks(double tpcDigits) { return hitOffset + tpcDigits * tpcPeaksPerDigit * factor; }
   double NTPCClusters(double tpcDigits) { return tpcClustersPerPeak * NTPCPeaks(tpcDigits) * factor; }
   double NTPCStartHits(double tpcHits) { return offset + tpcHits * tpcStartHitsPerHit * factor; }
   double NTPCTracklets(double tpcHits) { return NTPCStartHits(tpcHits) * tpcTrackletsPerStartHit * factor; }
-  double NTPCTrackletHits(double tpcHits) { return offset + tpcHits * tpcTrackletHitsPerHit * factor; }
+  double NTPCTrackletHits(double tpcHits) { return hitOffset + tpcHits * tpcTrackletHitsPerHit * factor; }
   double NTPCSectorTracks(double tpcHits) { return offset + tpcHits * tpcSectorTracksPerHit * factor; }
   double NTPCSectorTrackHits(double tpcHits) { return offset + tpcHits * tpcSectorTrackHitsPerHit * factor; }
   double NTPCTracks(double tpcHits) { return offset + tpcHits * tpcTracksPerHit * factor; }

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -490,6 +490,9 @@ void GPUReconstruction::FreeRegisteredMemory(GPUProcessor* proc, bool freeCustom
 void GPUReconstruction::FreeRegisteredMemory(short ires)
 {
   GPUMemoryResource* res = &mMemoryResources[ires];
+  if (mDeviceProcessingSettings.debugLevel >= 5 && (res->mPtr || res->mPtrDevice)) {
+    std::cout << "Freeing " << res->mName << ": size " << res->mSize << " (reused " << res->mReuse << ")\n";
+  }
   if (mDeviceProcessingSettings.memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL && res->mReuse == -1) {
     operator delete(res->mPtrDevice);
   }

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -14,6 +14,7 @@
 #include "GPUO2Interface.h"
 #include "GPUReconstruction.h"
 #include "GPUChainTracking.h"
+#include "GPUMemorySizeScalers.h"
 #include "GPUO2InterfaceConfiguration.h"
 #include "GPUParam.inc"
 #include <iostream>
@@ -55,6 +56,9 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
   mChain->SetTRDGeometry(mConfig->configCalib.trdGeometry);
   if (mRec->Init()) {
     return (1);
+  }
+  if (!mRec->IsGPU() && mConfig->configDeviceProcessing.memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {
+    mRec->MemoryScalers()->factor *= 2;
   }
   mInitialized = true;
   return (0);

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -90,7 +90,11 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data)
   }
 
   mChain->mIOPtrs = *data;
-  mRec->RunChains();
+  int retVal = mRec->RunChains();
+  if (retVal) {
+    mRec->ClearAllocatedMemory();
+    return retVal;
+  }
   *data = mChain->mIOPtrs;
 
   const o2::tpc::ClusterNativeAccess* ext = mChain->GetClusterNativeAccess();

--- a/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.cxx
@@ -44,12 +44,12 @@ GPUdii() void GPUTPCStartHitsFinder::Thread<0>(int /*nBlocks*/, int nThreads, in
       GPUglobalref() GPUTPCHitId* const GPUrestrict() startHits = tracker.mTrackletTmpStartHits + s.mIRow * tracker.mNMaxRowStartHits;
       unsigned int nextRowStartHits = CAMath::AtomicAddShared(&s.mNRowStartHits, 1);
       CONSTEXPR int errCode = GPUCA_ERROR_ROWSTARTHIT_OVERFLOW;
-      if (nextRowStartHits + 1 >= tracker.mNMaxRowStartHits)
+      if (nextRowStartHits >= tracker.mNMaxRowStartHits)
 #else
       GPUglobalref() GPUTPCHitId* const GPUrestrict() startHits = tracker.mTrackletStartHits;
       unsigned int nextRowStartHits = CAMath::AtomicAdd(&tracker.mCommonMem->nStartHits, 1);
       CONSTEXPR int errCode = GPUCA_ERROR_STARTHIT_OVERFLOW;
-      if (nextRowStartHits + 1 >= tracker.mNMaxStartHits)
+      if (nextRowStartHits >= tracker.mNMaxStartHits)
 #endif
       {
         trackerX.CommonMemory()->kernelError = errCode;
@@ -65,7 +65,7 @@ GPUdii() void GPUTPCStartHitsFinder::Thread<0>(int /*nBlocks*/, int nThreads, in
   if (iThread == 0) {
     unsigned int nOffset = CAMath::AtomicAdd(&tracker.mCommonMem->nStartHits, s.mNRowStartHits);
     tracker.mRowStartHitCountOffset[s.mIRow] = s.mNRowStartHits;
-    if (nOffset + s.mNRowStartHits >= tracker.mNMaxStartHits) {
+    if (nOffset + s.mNRowStartHits > tracker.mNMaxStartHits) {
       trackerX.CommonMemory()->kernelError = GPUCA_ERROR_STARTHIT_OVERFLOW;
       CAMath::AtomicExch(&tracker.mCommonMem->nStartHits, 0);
     }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
@@ -349,7 +349,7 @@ GPUh() int GPUTPCTracker::PerformGlobalTrackingRun(GPUTPCTracker& GPUrestrict() 
   if (nHits >= GPUCA_GLOBAL_TRACKING_MIN_HITS) {
     // GPUInfo("%d hits found", nHits);
     unsigned int hitId = CAMath::AtomicAdd(&mCommonMem->nTrackHits, nHits);
-    if ((hitId + nHits) >= mNMaxTrackHits) {
+    if (hitId + nHits > mNMaxTrackHits) {
       mCommonMem->kernelError = GPUCA_ERROR_GLOBAL_TRACKING_TRACK_HIT_OVERFLOW;
       CAMath::AtomicExch(&mCommonMem->nTrackHits, mNMaxTrackHits);
       return (0);
@@ -399,7 +399,7 @@ GPUh() void GPUTPCTracker::PerformGlobalTracking(GPUTPCTracker& GPUrestrict() sl
         int rowIndex = mTrackHits[tmpHit].RowIndex();
         const GPUTPCRow& GPUrestrict() row = Row(rowIndex);
         float Y = (float)Data().HitDataY(row, mTrackHits[tmpHit].HitIndex()) * row.HstepY() + row.Grid().YMin();
-        if (sliceTarget.mCommonMem->nTracks >= sliceTarget.mNMaxTracks) {
+        if (sliceTarget.mCommonMem->nTracks >= sliceTarget.mNMaxTracks) { // >= since will increase by 1
           sliceTarget.mCommonMem->kernelError = GPUCA_ERROR_GLOBAL_TRACKING_TRACK_OVERFLOW;
           return;
         }
@@ -420,7 +420,7 @@ GPUh() void GPUTPCTracker::PerformGlobalTracking(GPUTPCTracker& GPUrestrict() sl
         int rowIndex = mTrackHits[tmpHit].RowIndex();
         const GPUTPCRow& GPUrestrict() row = Row(rowIndex);
         float Y = (float)Data().HitDataY(row, mTrackHits[tmpHit].HitIndex()) * row.HstepY() + row.Grid().YMin();
-        if (sliceTarget.mCommonMem->nTracks >= sliceTarget.mNMaxTracks) {
+        if (sliceTarget.mCommonMem->nTracks >= sliceTarget.mNMaxTracks) { // >= since will increase by 14
           sliceTarget.mCommonMem->kernelError = GPUCA_ERROR_GLOBAL_TRACKING_TRACK_OVERFLOW;
           return;
         }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
@@ -153,7 +153,8 @@ void GPUTPCTracker::SetMaxData(const GPUTrackingInOutPointers& io)
 void GPUTPCTracker::UpdateMaxData()
 {
   mNMaxTracklets = mCommonMem->nStartHits;
-  mNMaxTracks = mCommonMem->nStartHits * 2 + 50;
+  mNMaxTracks = mNMaxTracklets * 2 + 50;
+  mNMaxRowHits = mNMaxTracklets * GPUCA_ROW_COUNT;
 }
 
 void GPUTPCTracker::SetupCommonMemory() { new (mCommonMem) commonMemoryStruct; }


### PR DESCRIPTION
@shahor02 :
- This fixes the memory corruption, which was however only a secondary symptom of the insufficient buffer size.
- If the buffer size is exceeded, the workflow will now die with a fatal.
- Buffer size estimation improved, and adding a factor 2 safety margin for now on the CPU (only increases the virtual memory size, no memory should be allocated if not needed. This should allow the workflow to work also with "abnormal" input data.