### PR TITLE
GPU: HLT components should propagate the error when GPU initialization fails

### DIFF
--- a/GPU/GPUTracking/Base/GPUSettings.cxx
+++ b/GPU/GPUTracking/Base/GPUSettings.cxx
@@ -26,7 +26,7 @@ void GPUSettingsRec::SetDefaults()
   ClusterError2CorrectionZ = 1.f;
   MinNTrackClusters = -1;
   MaxTrackQPt = 1.f / GPUCA_MIN_TRACK_PT_DEFAULT;
-  NWays = 1;
+  NWays = 3;
   NWaysOuter = false;
   RejectMode = 5;
   GlobalTracking = true;

--- a/GPU/GPUTracking/Merger/GPUTPCGlobalMergerComponent.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGlobalMergerComponent.cxx
@@ -302,6 +302,7 @@ int GPUTPCGlobalMergerComponent::Configure(const char* cdbEntry, const char* cha
   }
   rec.NWays = fNWays;
   rec.NWaysOuter = fNWaysOuter;
+  rec.mergerInterpolateErrors = false;
   rec.NonConsecutiveIDs = true;
 
   GPURecoStepConfiguration steps;
@@ -311,7 +312,9 @@ int GPUTPCGlobalMergerComponent::Configure(const char* cdbEntry, const char* cha
 
   fRec->SetSettings(&ev, &rec, &devProc, &steps);
   fChain->LoadClusterErrors();
-  fRec->Init();
+  if (fRec->Init()) {
+    return -EINVAL;
+  }
   fChain->GetTPCMerger().OverrideSliceTracker(nullptr);
 
   return 0;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.cxx
@@ -365,7 +365,7 @@ int GPUTPCTrackerComponent::Configure(const char* cdbEntry, const char* chainId,
   return iResult1 ? iResult1 : (iResult2 ? iResult2 : iResult3);
 }
 
-void GPUTPCTrackerComponent::ConfigureSlices()
+int GPUTPCTrackerComponent::ConfigureSlices()
 {
   // Initialize the tracker slices
   GPUSettingsRec rec;
@@ -398,7 +398,7 @@ void GPUTPCTrackerComponent::ConfigureSlices()
 
   fRec->SetSettings(&ev, &rec, &devProc, &steps);
   fChain->LoadClusterErrors();
-  fRec->Init();
+  return fRec->Init();
 }
 
 void* GPUTPCTrackerComponent::TrackerInit(void* par)
@@ -410,7 +410,9 @@ void* GPUTPCTrackerComponent::TrackerInit(void* par)
   }
   fChain = fRec->AddChain<GPUChainTracking>();
 
-  ConfigureSlices();
+  if (ConfigureSlices()) {
+    return ((void*)-1);
+  }
   return (nullptr);
 }
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.h
@@ -126,7 +126,7 @@ class GPUTPCTrackerComponent : public AliHLTProcessor
   int ReadConfigurationString(const char* arguments);
   int ReadCDBEntry(const char* cdbEntry, const char* chainId);
   int Configure(const char* cdbEntry, const char* chainId, const char* commandLine);
-  void ConfigureSlices();
+  int ConfigureSlices();
 
   AliHLTAsyncMemberProcessor<GPUTPCTrackerComponent> fAsyncProcessor;
   void* TrackerInit(void*);


### PR DESCRIPTION
Sync over fixes needed for AliRoot AliGPU