### PR TITLE
Example to run AliRoot Hijing simulation

### DIFF
--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -450,6 +450,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 
 | Example               | Short Description                                                                      |
 | --------------------- | -------------------------------------------------------------------------------------- |
+| [AliRoot_Hijing](../run/SimExamples/AliRoot_Hijing) | Example showing how to use Hijing from AliRoot for event generation |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/AliRoot_Hijing/README.md
+++ b/run/SimExamples/AliRoot_Hijing/README.md
@@ -1,0 +1,8 @@
+This is a simple simulation example showing how to run event simulation using the Hijing event generator interface from AliRoot.
+The configuration of AliGenHijing is performed by the function `hijing(double energy = 5020., double bMin = 0., double bMax = 20.)` defined in the macro `aliroot_hijing.macro`.
+
+The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieven the configuration is specified via the argument of `--extGenFunc`.
+ 
+# IMPORTANT
+To run this example you need to load an AliRoot package compatible with the O2.
+for more details, https://alice.its.cern.ch/jira/browse/AOGM-246

--- a/run/SimExamples/AliRoot_Hijing/aliroot_hijing.macro
+++ b/run/SimExamples/AliRoot_Hijing/aliroot_hijing.macro
@@ -1,0 +1,36 @@
+// configures a AliGenHijing class from AliRoot
+//   usage: o2sim -g extgen --extGenFile hijing.C
+// options:                 --extGenFunc hijing(5020., 0., 20.)
+
+/// \author R+Preghenella - October 2018
+
+R__LOAD_LIBRARY(libTHijing)
+
+FairGenerator*
+  hijing(double energy = 5020., double bMin = 0., double bMax = 20.)
+{
+  // instance and configure Hijing
+  auto hij = new AliGenHijing(-1);
+  hij->SetEnergyCMS(energy);
+  hij->SetImpactParameterRange(bMin, bMax);
+  hij->SetReferenceFrame("CMS");
+  hij->SetProjectile("A", 208, 82);
+  hij->SetTarget("A", 208, 82);
+  hij->SetSpectators(0);
+  hij->KeepFullEvent();
+  hij->SetJetQuenching(0);
+  hij->SetShadowing(1);
+  hij->SetDecaysOff(1);
+  hij->SetSelectAll(0);
+  hij->SetPtHardMin(2.9);
+  hij->Init();
+
+  // instance and configure TGenerator interface
+  auto tgen = new o2::eventgen::GeneratorTGenerator();
+  tgen->setMomentumUnit(1.);        // [GeV/c]
+  tgen->setEnergyUnit(1.);          // [GeV/c]
+  tgen->setPositionUnit(0.1);       // [cm]
+  tgen->setTimeUnit(3.3356410e-12); // [s]
+  tgen->setTGenerator(hij->GetMC());
+  return tgen;
+}

--- a/run/SimExamples/AliRoot_Hijing/run.sh
+++ b/run/SimExamples/AliRoot_Hijing/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This is a simple simulation example showing how to run event simulation
+# using the Hijing event generator interface from AliRoot
+#
+# The configuration of AliGenHijing is performed by the function
+# 'hijing(double energy = 5020., double bMin = 0., double bMax = 20.)' defined 
+# in the macro 'aliroot_hijing.macro'.
+#
+# The macro file is specified via the argument of '--extGenFile'
+# whereas the specific function call to retrieven the configuration
+# is specified via the argument of '--extGenFunc'
+# 
+# IMPORTANT
+# To run this example you need to load an AliRoot package compatible with the O2.
+# for more details, https://alice.its.cern.ch/jira/browse/AOGM-246
+#
+#
+
+set -x
+
+NEV=5
+ENERGY=5020.
+BMIN=0
+BMAX=20.
+o2-sim-serial -j 20 -n ${NEV} -g extgen -m PIPE ITS TPC -o sim \
+	      --extGenFile "aliroot_hijing.macro" --extGenFunc "hijing(${ENERGY}, ${BMIN}, ${BMAX})" \
+	      --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"


### PR DESCRIPTION
This is a simple simulation example showing how to run event simulation using the Hijing event generator interface from AliRoot.
The configuration of AliGenHijing is performed by the function `hijing(double energy = 5020., double bMin = 0., double bMax = 20.)` defined in the macro `aliroot_hijing.macro`.

The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieven the configuration is specified via the argument of `--extGenFunc`.
 
# IMPORTANT
To run this example you need to load an AliRoot package compatible with the O2.
for more details, https://alice.its.cern.ch/jira/browse/AOGM-246