### PR TITLE
Notify generators of embedding into background

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -18,6 +18,8 @@
 #include "Generators/Trigger.h"
 #include <vector>
 
+class FairMCEventHeader;
+
 namespace o2
 {
 namespace eventgen
@@ -68,6 +70,9 @@ class Generator : public FairGenerator
   void setTriggerMode(ETriggerMode_t val) { mTriggerMode = val; };
   void addTrigger(Trigger trigger) { mTriggers.push_back(trigger); };
   void addDeepTrigger(DeepTrigger trigger) { mDeepTriggers.push_back(trigger); };
+
+  /** notification methods **/
+  virtual void notifyEmbedding(const FairMCEventHeader* mcHeader){};
 
  protected:
   /** copy constructor **/

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -60,6 +60,9 @@ Bool_t
 {
   /** read event **/
 
+  /** clear particle vector **/
+  mParticles.clear();
+
   /** endless generate-and-trigger loop **/
   while (true) {
 

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -101,8 +101,6 @@ Bool_t GeneratorHepMC::importParticles()
 {
   /** import particles **/
 
-  mParticles.clear();
-
   /** loop over particles **/
   auto particles = mEvent->particles();
   for (int i = 0; i < particles.size(); ++i) {

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -94,8 +94,6 @@ Bool_t
 {
   /** import particles **/
 
-  mParticles.clear();
-
   /* loop over particles */
   //  auto weight = mPythia.info.weight(); // TBD: use weights
   auto nParticles = mPythia.event.size();

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -78,7 +78,6 @@ Bool_t
 {
   /** import particles **/
 
-  mParticles.clear();
   mTGenerator->ImportParticles(mCloneParticles, "All");
   auto nparticles = mCloneParticles->GetEntries();
   for (Int_t iparticle = 0; iparticle < nparticles; iparticle++) {

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -11,6 +11,7 @@
 /// \author R+Preghenella - June 2017
 
 #include "Generators/PrimaryGenerator.h"
+#include "Generators/Generator.h"
 #include "Generators/InteractionDiamondParam.h"
 #include "SimulationDataFormat/MCEventHeader.h"
 #include "FairLogger.h"
@@ -83,6 +84,14 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
   /** setup interaction vertex **/
   mEmbedTree->GetEntry(mEmbedIndex);
   setInteractionVertex(mEmbedEvent);
+
+  /** notify event generators **/
+  auto genList = GetListOfGenerators();
+  for (int igen = 0; igen < genList->GetEntries(); ++igen) {
+    auto o2gen = dynamic_cast<Generator*>(genList->At(igen));
+    if (o2gen)
+      o2gen->notifyEmbedding(mEmbedEvent);
+  }
 
   /** generate event **/
   if (!FairPrimaryGenerator::GenerateEvent(pStack))

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -451,6 +451,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | Example               | Short Description                                                                      |
 | --------------------- | -------------------------------------------------------------------------------------- |
 | [AliRoot_Hijing](../run/SimExamples/AliRoot_Hijing) | Example showing how to use Hijing from AliRoot for event generation |
+| [Adaptive_Pythia8](../run/SimExamples/Adaptive_Pythia8) | Complex example showing **generator configuration for embedding** that cat adapt the response based on the background event |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/Adaptive_Pythia8/README.md
+++ b/run/SimExamples/Adaptive_Pythia8/README.md
@@ -1,0 +1,10 @@
+This is a simple simulation example showing
+
+a) how to run a simple background event simulation with some parameter customization
+b) how to run a simulation producing signal events based on a custom external generator that can adapt its behaviour depending on the characteristics of the background event.
+
+Pythia8 events are generated according to the configuration given in the file `adaptive_pythia8.macro`.
+The settings are as such that Pythia8 is initialised using the `pythia8_inel.cfg` configuration file.
+The customisation allows the generator to receive and react to a notification that signals the embedding status of the simulation, giving the header of the background event for determination of the subsequent actions. In this case, the number of pythia8 events to be embedded is calculated according to a formula that uses the number of primary particles of the background events.
+
+The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieve the configuration and define the formula is specified via the argument of `--extGenFunc`.

--- a/run/SimExamples/Adaptive_Pythia8/adaptive_pythia8.macro
+++ b/run/SimExamples/Adaptive_Pythia8/adaptive_pythia8.macro
@@ -1,0 +1,52 @@
+/// \author R+Preghenella - April 2020
+
+// Example of an implementation of an external event generator
+// that is used and adapts it behavior in an embedding scenario.
+//
+//   usage: o2sim -g extgen --extGenFile adaptive_pythia8.C
+// options:                 --extGenFunc "adaptive_pythia8(\"0.001 * x\")
+
+using namespace o2::eventgen;
+
+class Adaptive_Pythia8 : public GeneratorPythia8
+{
+public:
+  Adaptive_Pythia8(char *formula = "0.01 * x") :
+    GeneratorPythia8(), mFormula("formula", formula) { };
+  ~Adaptive_Pythia8() = default;
+
+  // update the number of events to be generated
+  // according to background primaries and formula
+  void notifyEmbedding(const FairMCEventHeader *bkgHeader) override {
+    auto nPrimaries = bkgHeader->GetNPrim();
+    mEvents = mFormula.Eval(nPrimaries);
+  };
+  
+  // generate event and import particles
+  // multiple times according to background and formula
+  Bool_t generateEvent() override {
+    for (int iev = 0; iev < mEvents; ++iev) {
+      if (!GeneratorPythia8::generateEvent()) return false;
+      if (!GeneratorPythia8::importParticles()) return false;
+    }
+    return true; };
+
+  // override this function to avoid importing particles
+  // of the last event again as this is called by the base class
+  Bool_t importParticles() override { return true; }
+
+private:
+
+  int mEvents = 1;
+  TFormula mFormula;
+  
+};
+
+FairGenerator*
+adaptive_pythia8(char *formula = "0.01 * x")
+{
+  std::cout << " --- adaptive_pythia8 initialising with formula: " << formula << std::endl;
+  auto py8 = new Adaptive_Pythia8(formula);
+  py8->setConfig("pythia8_inel.cfg");
+  return py8;
+}

--- a/run/SimExamples/Adaptive_Pythia8/pythia8_inel.cfg
+++ b/run/SimExamples/Adaptive_Pythia8/pythia8_inel.cfg
@@ -1,0 +1,11 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 14000. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 0.001	

--- a/run/SimExamples/Adaptive_Pythia8/run.sh
+++ b/run/SimExamples/Adaptive_Pythia8/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# This is a simple simulation example showing the following things
+#
+
+# a) how to run a simple background event simulation with some parameter customization
+# b) how to run a simulation producing signal events based on a custom external generator
+#    that can adapt its behaviour depending on the characteristics of the background event.
+
+set -x
+
+# PART a)
+NBGR=5
+o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValue \
+       "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
+
+# PART b)
+# produce pythia8 events generated according to the configuration given in a file 'adaptive_pythia8.macro'.
+# the settings as such that pythia8 is initialised using the 'pythia8_inel.cfg' configuration file.
+# the customisation allows the user to generator to receive and react to a notification that signals
+# the embedding status of the simulation, giving the header of the background event for determination
+# of subsequent actions. In this case, the number of pythia8 events to be embedded is calculated according
+# to a formula that uses the number of primary particles of the background events
+NSGN=10
+o2-sim -j 20 -n ${NSGN} extgen -m PIPE ITS \
+       -g extgen --extGenFile pythia8_adaptive.macro --extGenFunc "pythia8_adaptive(\"0.002 * x\")" \
+       --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1


### PR DESCRIPTION
This PR provides a new functionality for event generators in case of embedding into a background event. Event generators are notified of the embedding via the `notifyEmbedding` function.
The `MCEventHeader` of the background event is passed via the function.

Event generators can override the `notifyEmbedding` function and adapt the event generation according to the information that comes in the background `MCEventHeader`.

This is a basic ingredient to be able to embed events that are dependent on the background characteristics. A classical example if it it to embed a signal whose multiplicity depends on the multiplicity of the background event. 

Futher developments will provide dedicated support for specialised event signatures in the `MCEventHeader`. This PR is the backbone if it. 

An example of implementation of an external event generator based on Pythia8 will be provided shortly in this PR to illustrate the use and the customisation flexibility.

The example will be located in `run/SimExamples/Pythia8_Adaptive` directory.
Pythia8 will generate a given number of events depending on the number of primary particles in the background event. The actual number is steered by a formula.

