### PR TITLE
Work on TPC ZS encoding and decoding

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -14,7 +14,8 @@
 #ifndef ALICEO2_RDHUTILS_H
 #define ALICEO2_RDHUTILS_H
 
-#include <Rtypes.h>
+#include "GPUCommonDef.h"
+#include "GPUCommonRtypes.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "Headers/RAWDataHeader.h"
 
@@ -36,10 +37,10 @@ struct RDHUtils {
   static constexpr int GBTWord = 16; // length of GBT word
   static constexpr int MAXCRUPage = 512 * GBTWord;
 
-  static uint8_t getVersion(const RDHv4& rdh) { return rdh.version; } // same for all // why template does not work here?
-  static uint8_t getVersion(const RDHv5& rdh) { return rdh.version; } // same for all
-  static uint8_t getVersion(const RDHv6& rdh) { return rdh.version; } // same for all
-  static uint8_t getVersion(const void* rdhP)
+  GPUhdi() static uint8_t getVersion(const RDHv4& rdh) { return rdh.version; } // same for all // why template does not work here?
+  GPUhdi() static uint8_t getVersion(const RDHv5& rdh) { return rdh.version; } // same for all
+  GPUhdi() static uint8_t getVersion(const RDHv6& rdh) { return rdh.version; } // same for all
+  GPUhdi() static uint8_t getVersion(const void* rdhP)
   {
     auto v = getVersion((*reinterpret_cast<const RDHDef*>(rdhP)));
     if (v > MaxRDHVersion) {
@@ -62,11 +63,11 @@ struct RDHUtils {
   static int getHeaderSize(const void* rdhP) { return getHeaderSize(*reinterpret_cast<const RDHDef*>(rdhP)); }
 
   template <typename RDH>
-  static uint16_t getFEEID(const RDH& rdh)
+  GPUhdi() static uint16_t getFEEID(const RDH& rdh)
   {
     return rdh.feeId;
   } // same for all
-  static uint16_t getFEEID(const void* rdhP) { return getFEEID(*reinterpret_cast<const RDHDef*>(rdhP)); }
+  GPUhdi() static uint16_t getFEEID(const void* rdhP) { return getFEEID(*reinterpret_cast<const RDHDef*>(rdhP)); }
   template <typename RDH>
   static void setFEEID(RDH& rdh, uint16_t v)
   {
@@ -88,13 +89,13 @@ struct RDHUtils {
   static void setPriorityBit(void* rdhP, bool v) { setPriorityBit(*reinterpret_cast<RDHDef*>(rdhP), v); }
 
   template <typename RDH>
-  static uint8_t getSourceID(const RDH& rdh)
+  GPUhdi() static uint8_t getSourceID(const RDH& rdh)
   { // does not exist before V6
     processError(getVersion(rdh), "sourceID");
     return 0xff;
   }
-  static uint8_t getSourceID(const RDHv6& rdh) { return rdh.sourceID; }
-  static uint8_t getSourceID(const void* rdhP)
+  GPUhdi() static uint8_t getSourceID(const RDHv6& rdh) { return rdh.sourceID; }
+  GPUhdi() static uint8_t getSourceID(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 5) {
@@ -193,10 +194,10 @@ struct RDHUtils {
   } // same for all
   static void setEndPointID(void* rdhP, uint8_t v) { setEndPointID(*reinterpret_cast<RDHDef*>(rdhP), v); }
 
-  static uint16_t getHeartBeatBC(const RDHv4& rdh) { return rdh.heartbeatBC; }
-  static uint16_t getHeartBeatBC(const RDHv5& rdh) { return rdh.bunchCrossing; } // starting from V5 no distiction trigger or HB
-  static uint16_t getHeartBeatBC(const RDHv6& rdh) { return rdh.bunchCrossing; }
-  static uint16_t getHeartBeatBC(const void* rdhP)
+  GPUhdi() static uint16_t getHeartBeatBC(const RDHv4& rdh) { return rdh.heartbeatBC; }
+  GPUhdi() static uint16_t getHeartBeatBC(const RDHv5& rdh) { return rdh.bunchCrossing; } // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint16_t getHeartBeatBC(const RDHv6& rdh) { return rdh.bunchCrossing; }
+  GPUhdi() static uint16_t getHeartBeatBC(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
@@ -218,10 +219,10 @@ struct RDHUtils {
     }
   }
 
-  static uint32_t getHeartBeatOrbit(const RDHv4& rdh) { return rdh.heartbeatOrbit; }
-  static uint32_t getHeartBeatOrbit(const RDHv5& rdh) { return rdh.orbit; } // starting from V5 no distiction trigger or HB
-  static uint32_t getHeartBeatOrbit(const RDHv6& rdh) { return rdh.orbit; }
-  static uint32_t getHeartBeatOrbit(const void* rdhP)
+  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv4& rdh) { return rdh.heartbeatOrbit; }
+  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv5& rdh) { return rdh.orbit; } // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv6& rdh) { return rdh.orbit; }
+  GPUhdi() static uint32_t getHeartBeatOrbit(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
@@ -476,7 +477,13 @@ struct RDHUtils {
 
  private:
   static uint32_t fletcher32(const uint16_t* data, int len);
-  static void processError(int v, std::string_view field);
+#if defined(GPUCA_GPUCODE_DEVICE) || defined(GPUCA_STANDALONE)
+  GPUhdi() static void processError(int v, const char* field)
+  {
+  }
+#else
+  GPUhdni() static void processError(int v, const char* field);
+#endif
 
   ClassDefNV(RDHUtils, 1);
 };

--- a/Detectors/Raw/src/RDHUtils.cxx
+++ b/Detectors/Raw/src/RDHUtils.cxx
@@ -245,7 +245,7 @@ uint32_t RDHUtils::fletcher32(const uint16_t* data, int len)
 }
 
 /// process access to non-existing field
-void RDHUtils::processError(int v, std::string_view field)
+void RDHUtils::processError(int v, const char* field)
 {
   LOG(ERROR) << "Wrong field " << field << " for RDHv" << v;
   throw std::runtime_error("wrong RDH field accessed");

--- a/Detectors/TPC/base/include/TPCBase/Digit.h
+++ b/Detectors/TPC/base/include/TPCBase/Digit.h
@@ -15,8 +15,8 @@
 #ifndef ALICEO2_TPC_DIGIT_H_
 #define ALICEO2_TPC_DIGIT_H_
 
+#include "GPUCommonRtypes.h"
 #include "CommonDataFormat/TimeStamp.h"
-#include "TObject.h"
 
 namespace o2
 {

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
@@ -58,7 +58,6 @@ class GPUCATracking
   int runTracking(o2::gpu::GPUO2InterfaceIOPtrs* data);
 
   float getPseudoVDrift();                                              //Return artificial VDrift used to convert time to Z
-  float getTFReferenceLength() { return sContinuousTFReferenceLength; } //Return reference time frame length used to obtain Z from T in continuous data
   int getNTracksASide() { return mNTracksASide; }
   void GetClusterErrors2(int row, float z, float sinPhi, float DzDs, short clusterState, float& ErrY2, float& ErrZ2) const;
 
@@ -67,7 +66,6 @@ class GPUCATracking
                                                                       //The tracking code itself is not included in the O2 package, but contained in the CA library.
                                                                       //The GPUCATracking class interfaces this library via this pointer to GPUTPCO2Interface class.
 
-  static constexpr float sContinuousTFReferenceLength = 0.023 * 5e6;
   static constexpr float sTrackMCMaxFake = 0.1;
   int mNTracksASide = 0;
 };

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -125,34 +125,10 @@ void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::
   GPUParam _GPUParam;
   _GPUParam.SetDefaults(5.00668);
   const GPUParam mGPUParam = _GPUParam;
-
-  std::vector<deprecated::PackedDigit> gpuDigits[NSectors];
-  GPUTrackingInOutDigits gpuDigitsMap;
-
-  //convert to GPU digits
   const float zsThreshold = 0;
-  for (int i = 0; i < NSectors; i++) {
-    const auto& d = inputDigits[i];
-    gpuDigits[i].reserve(d.size());
-    for (int j = 0; j < d.size(); j++) {
-      if (d[j].getChargeFloat() >= zsThreshold) {
-        gpuDigits[i].emplace_back(
-          deprecated::PackedDigit{
-            d[j].getChargeFloat(),
-            (Timestamp)d[j].getTimeStamp(),
-            (Pad)d[j].getPad(),
-            (Row)d[j].getRow()});
-      }
-    }
 
-    gpuDigitsMap.tpcDigits[i] = gpuDigits[i].data();
-    gpuDigitsMap.nTPCDigits[i] = gpuDigits[i].size();
-  }
-
-  const GPUTrackingInOutDigits gpuDigitsMap2 = std::move(gpuDigitsMap);
   o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
-
-  zsEncoder->RunZSEncoder(&gpuDigitsMap, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, verify);
+  zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, verify, zsThreshold);
 }
 
 int main(int argc, char** argv)

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -118,9 +118,9 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
 
       const auto grp = o2::parameters::GRPObject::loadFrom("o2sim_grp.root");
       if (grp) {
-        LOG(INFO) << "Initializing run paramerers from GRP";
         solenoidBz *= grp->getL3Current() / 30000.;
         continuous = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC);
+        LOG(INFO) << "Initializing run paramerers from GRP bz=" << solenoidBz << " cont=" << continuous;
       } else {
         LOG(ERROR) << "Failed to initialize run parameters from GRP";
         // should we call fatal here?
@@ -206,7 +206,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
       config.configDeviceProcessing.debugLevel = debugLevel; // Debug verbosity
 
       config.configEvent.solenoidBz = solenoidBz;
-      config.configEvent.continuousMaxTimeBin = continuous ? 0.023 * 5e6 : 0; // Number of timebins in timeframe if continuous, 0 otherwise
+      int maxContTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + Constants::LHCBCPERTIMEBIN - 1) / Constants::LHCBCPERTIMEBIN;
+      config.configEvent.continuousMaxTimeBin = continuous ? maxContTimeBin : 0; // Number of timebins in timeframe if continuous, 0 otherwise
 
       config.configReconstruction.NWays = 3;               // Should always be 3!
       config.configReconstruction.NWaysOuter = true;       // Will create outer param for TRD

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -564,10 +564,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
       ptrs.outputTracks = &tracks;
       ptrs.outputClusRefs = &clusRefs;
       ptrs.outputTracksMCTruth = (processMC ? &tracksMCTruth : nullptr);
-      o2::InteractionRecord ir = raw::HBFUtils::Instance().getFirstIR();
       if (caClusterer) {
         if (zsDecoder) {
-          processAttributes->tpcZS.ir = &ir;
           ptrs.tpcZS = &processAttributes->tpcZS;
           if (processMC) {
             throw std::runtime_error("Cannot process MC information, none available"); // In fact, passing in MC data with ZS TPC Raw is not yet available

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -44,7 +44,6 @@ using CompressedClusters = CompressedClustersPtrs_helper<CompressedClustersCount
 
 namespace o2
 {
-struct InteractionRecord;
 class MCCompLabel;
 namespace base
 {
@@ -192,7 +191,6 @@ struct GPUTrackingInOutZS {
     unsigned int n[NSLICES][NENDPOINTS];
   };
   GPUTrackingInOutZSSlice slice[NSLICES];
-  o2::InteractionRecord* ir;
 };
 
 struct GPUTrackingInOutDigits {

--- a/GPU/GPUTracking/Base/GPURawData.h
+++ b/GPU/GPUTracking/Base/GPURawData.h
@@ -20,6 +20,7 @@
 #include "GPUCommonDef.h"
 #ifndef __OPENCL__
 #include "Headers/RAWDataHeader.h"
+#include "DetectorsRaw/RDHUtils.h"
 #else
 namespace o2
 {
@@ -42,14 +43,24 @@ class GPURawDataUtils
 {
  public:
   static GPUd() unsigned int getOrbit(const o2::header::RAWDataHeader* rdh);
+  static GPUd() unsigned int getBC(const o2::header::RAWDataHeader* rdh);
 };
 
 GPUdi() unsigned int GPURawDataUtils::getOrbit(const o2::header::RAWDataHeader* rdh)
 {
 #ifndef __OPENCL__
-  return rdh->heartbeatOrbit;
+  return o2::raw::RDHUtils::getHeartBeatOrbit(*rdh);
 #else
-  return (rdh->words[2] >> 32);
+  return (rdh->words[2] >> 32);           // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
+#endif
+}
+
+GPUdi() unsigned int GPURawDataUtils::getBC(const o2::header::RAWDataHeader* rdh)
+{
+#ifndef __OPENCL__
+  return o2::raw::RDHUtils::getHeartBeatBC(*rdh);
+#else
+  return ((rdh->words[4] >> 48) & 0xFFF); // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
 #endif
 }
 

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -53,7 +53,8 @@ class GPUReconstructionConvert
   constexpr static unsigned int NSLICES = GPUCA_NSLICES;
   static void ConvertNativeToClusterData(o2::tpc::ClusterNativeAccess* native, std::unique_ptr<GPUTPCClusterData[]>* clusters, unsigned int* nClusters, const TPCFastTransform* transform, int continuousMaxTimeBin = 0);
   static void ConvertRun2RawToNative(o2::tpc::ClusterNativeAccess& native, std::unique_ptr<o2::tpc::ClusterNative[]>& nativeBuffer, const AliHLTTPCRawCluster** rawClusters, unsigned int* nRawClusters);
-  static void RunZSEncoder(const GPUTrackingInOutDigits* in, std::unique_ptr<unsigned long long int[]>* outBuffer, unsigned int* outSizes, o2::raw::RawFileWriter* raw, const o2::InteractionRecord* ir, const GPUParam& param, bool zs12bit, bool verify);
+  template <class T, class S>
+  static void RunZSEncoder(const S& in, std::unique_ptr<unsigned long long int[]>* outBuffer, unsigned int* outSizes, o2::raw::RawFileWriter* raw, const o2::InteractionRecord* ir, const GPUParam& param, bool zs12bit, bool verify, float threshold = 0.f);
   static void RunZSEncoderCreateMeta(const unsigned long long int* buffer, const unsigned int* sizes, void** ptrs, GPUTrackingInOutZS* out);
   static void RunZSFilter(std::unique_ptr<deprecated::PackedDigit[]>* buffers, const deprecated::PackedDigit* const* ptrs, size_t* nsb, const size_t* ns, const GPUParam& param, bool zs12bit);
   static int GetMaxTimeBin(const o2::tpc::ClusterNativeAccess& native);

--- a/GPU/GPUTracking/Base/GPUReconstructionKernels.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionKernels.h
@@ -46,7 +46,7 @@ GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanUp     ), (single, REG, (GPUCA
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanTop    ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int nElems), (, iBuf, nElems))
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanDown   ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, unsigned int offset, int nElems), (, iBuf, offset, nElems))
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   compact          ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int stage, GPUPtr1(ChargePos*, in), GPUPtr1(ChargePos*, out)), (, iBuf, stage, GPUPtr2(ChargePos*, in), GPUPtr2(ChargePos*, out)))
-GPUCA_KRNL((GPUTPCCFDecodeZS                             ), (single, REG, (GPUCA_THREAD_COUNT_CFDECODE, GPUCA_MINBLOCK_COUNT_DECODE)), (, int bcShiftInFirstHBF), (, bcShiftInFirstHBF))
+GPUCA_KRNL((GPUTPCCFDecodeZS                             ), (single, REG, (GPUCA_THREAD_COUNT_CFDECODE, GPUCA_MINBLOCK_COUNT_DECODE)), (, int firstHBF), (, firstHBF))
 #endif
 #endif
 // clang-format on

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -241,6 +241,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
                  TARGETVARNAME targetName
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::DataFormatsTPC
+                                       O2::TPCBase
                                        O2::TRDBase
                                        O2::ITStracking
                                        O2::TPCFastTransformation

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -594,7 +594,7 @@ void GPUChainTracking::ConvertZSEncoder(bool zs12bit)
   mTPCZSSizes.reset(new unsigned int[NSLICES * GPUTrackingInOutZS::NENDPOINTS]);
   mTPCZSPtrs.reset(new void*[NSLICES * GPUTrackingInOutZS::NENDPOINTS]);
   mTPCZS.reset(new GPUTrackingInOutZS);
-  GPUReconstructionConvert::RunZSEncoder(mIOPtrs.tpcPackedDigits, &mTPCZSBuffer, mTPCZSSizes.get(), nullptr, nullptr, param(), zs12bit, true);
+  GPUReconstructionConvert::RunZSEncoder<deprecated::PackedDigit>(*mIOPtrs.tpcPackedDigits, &mTPCZSBuffer, mTPCZSSizes.get(), nullptr, nullptr, param(), zs12bit, true);
   GPUReconstructionConvert::RunZSEncoderCreateMeta(mTPCZSBuffer.get(), mTPCZSSizes.get(), mTPCZSPtrs.get(), mTPCZS.get());
   mIOPtrs.tpcZS = mTPCZS.get();
   if (GetDeviceProcessingSettings().registerStandaloneInputMemory) {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -893,13 +893,8 @@ int GPUChainTracking::RunTPCClusterizer()
       }
 
       if (mIOPtrs.tpcZS) {
-#ifdef GPUCA_O2_LIB
-        const o2::header::RAWDataHeader* hdr = (const o2::header::RAWDataHeader*)mIOPtrs.tpcZS->slice[0].zsPtr[0][0];
-        int bcShiftInFirstHBF = o2::raw::RDHUtils::getHeartBeatBC(hdr);
-#else
-        int bcShiftInFirstHBF = 0;
-#endif
-        runKernel<GPUTPCCFDecodeZS, GPUTPCCFDecodeZS::decodeZS>({doGPU ? clusterer.mPmemory->counters.nPages : GPUTrackingInOutZS::NENDPOINTS, CFDecodeThreadCount(), lane}, {iSlice}, {}, bcShiftInFirstHBF);
+        int firstHBF = mIOPtrs.tpcZS->slice[0].count[0] ? o2::raw::RDHUtils::getHeartBeatOrbit((const o2::header::RAWDataHeader*)mIOPtrs.tpcZS->slice[0].zsPtr[0][0]) : 0;
+        runKernel<GPUTPCCFDecodeZS, GPUTPCCFDecodeZS::decodeZS>({doGPU ? clusterer.mPmemory->counters.nPages : GPUTrackingInOutZS::NENDPOINTS, CFDecodeThreadCount(), lane}, {iSlice}, {}, firstHBF);
         TransferMemoryResourceLinkToHost(RecoStep::TPCClusterFinding, clusterer.mMemoryId, lane);
         SynchronizeStream(lane);
       } else {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -47,6 +47,7 @@
 #include "GPUTPCClusterStatistics.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
 #include "Headers/RAWDataHeader.h"
+#include "DetectorsRaw/RDHUtils.h"
 #include "GPUHostDataTypes.h"
 #else
 #include "GPUO2FakeClasses.h"
@@ -893,7 +894,8 @@ int GPUChainTracking::RunTPCClusterizer()
 
       if (mIOPtrs.tpcZS) {
 #ifdef GPUCA_O2_LIB
-        int bcShiftInFirstHBF = mIOPtrs.tpcZS->ir ? mIOPtrs.tpcZS->ir->bc : 0;
+        const o2::header::RAWDataHeader* hdr = (const o2::header::RAWDataHeader*)mIOPtrs.tpcZS->slice[0].zsPtr[0][0];
+        int bcShiftInFirstHBF = o2::raw::RDHUtils::getHeartBeatBC(hdr);
 #else
         int bcShiftInFirstHBF = 0;
 #endif

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -95,6 +95,9 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data)
 
   mChain->mIOPtrs = *data;
   int retVal = mRec->RunChains();
+  if (retVal == 2) {
+    retVal = 0; // 2 signals end of event display, ignore
+  }
   if (retVal) {
     mRec->ClearAllocatedMemory();
     return retVal;

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -135,6 +135,7 @@ include_directories(${CMAKE_SOURCE_DIR}/TPCClusterFinder
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/ITSMFT/ITS/tracking/cuda/src
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/ITSMFT/ITS/tracking/hip/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/ITSMFT/ITS/tracking/hip/src
+                    ${CMAKE_SOURCE_DIR}/../../../Detectors/Raw/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/TPC/base/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/TRD/base/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/TRD/base/src)

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -25,12 +25,12 @@ using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
 
 template <>
-GPUdii() void GPUTPCCFDecodeZS::Thread<GPUTPCCFDecodeZS::decodeZS>(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, int bcShiftInFirstHBF)
+GPUdii() void GPUTPCCFDecodeZS::Thread<GPUTPCCFDecodeZS::decodeZS>(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, int firstHBF)
 {
-  GPUTPCCFDecodeZS::decode(clusterer, smem, nBlocks, nThreads, iBlock, iThread, bcShiftInFirstHBF);
+  GPUTPCCFDecodeZS::decode(clusterer, smem, nBlocks, nThreads, iBlock, iThread, firstHBF);
 }
 
-GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread, int bcShiftInFirstHBF)
+GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread, int firstHBF)
 {
   const unsigned int slice = clusterer.mISlice;
 #ifdef GPUCA_GPUCODE
@@ -79,7 +79,7 @@ GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUShared
       const TPCZSHDR* hdr = reinterpret_cast<const TPCZSHDR*>(pagePtr);
       pagePtr += sizeof(*hdr);
       unsigned int mask = (1 << s.decodeBits) - 1;
-      int timeBin = hdr->timeOffset + (GPURawDataUtils::getOrbit(rdh) * o2::constants::lhc::LHCMaxBunches + Constants::LHCBCPERTIMEBIN - 1 - bcShiftInFirstHBF) / Constants::LHCBCPERTIMEBIN;
+      int timeBin = (hdr->timeOffset + (GPURawDataUtils::getOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
       const int rowOffset = s.regionStartRow + ((endpoint & 1) ? (s.nRowsRegion / 2) : 0);
       const int nRows = (endpoint & 1) ? (s.nRowsRegion - s.nRowsRegion / 2) : (s.nRowsRegion / 2);
 

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.h
@@ -45,7 +45,7 @@ class GPUTPCCFDecodeZS : public GPUKernelTemplate
     decodeZS,
   };
 
-  static GPUd() void decode(GPUTPCClusterFinder& clusterer, GPUSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread, int bcShiftInFirstHBF);
+  static GPUd() void decode(GPUTPCClusterFinder& clusterer, GPUSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread, int firstHBF);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -121,7 +121,6 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
   }
 
   float artificialVDrift = tracker.getPseudoVDrift();
-  float tfReferenceLength = tracker.getTFReferenceLength();
 
   // partial printout of 100 tracks
   int step = tracks.size() / 100;


### PR DESCRIPTION
- Utilize `RDHUtils` where possible instead of accessing the RDH directly. (Currently, OpenCL doesn't support bitfields, so I had to place some `#ifdef`s in `GPURawData.h`. We could also move all these `#ifdef`s to `RAWDataHeader.h` and `RDHUtils.h`, but that would be quite messy. I filed a bug report to Clang C++ for OpenCL asking to support bitfields. I'd wait what comes out there first.)
- The TPC reco workflow does not longer cash the raw data for all subspecifications internally after this was fixed in the raw reader workflow.
- Raw data encoder should now support multiple TFs (still testing this feature while the CI runs...).
- Use correct time frame length from `HBFUtils.h`
- Cleaned up computation of tpc timebins in decoding after longer discussion via mail.

Still missing are:
- Use mapper to compute fee ID
- Clean up RDH reading for OpenCL (postponed)
- The normal TPC workflow (without ZS encoding / decoding) breaks when the timebin range of the digits exceeds the length of the time frame. Not sure if this needs to be fixed, but currently the workflow cannot split the digits in time frames, and the tracker can only process one time frame at a time.

@shahor02 : This implements basically everything that was discussed via mail.