### PR TITLE
DataInputDirector to customize the internal-dpl-aod-reader

### DIFF
--- a/Framework/Core/ANALYSIS.md
+++ b/Framework/Core/ANALYSIS.md
@@ -400,16 +400,16 @@ The options to consider are:
 
 #### --keep
 
-`keep` is a comma-separated list of `DataOuputDescriptions`.
+`keep` is a comma-separated list of `DataOuputDescriptors`.
 
 `keep`
 ```csh
-DataOuputDescription1,DataOuputDescription2, ...
+DataOuputDescriptor1,DataOuputDescriptor2, ...
 ```
 
-Each `DataOuputDescription` is a colon-separated list of 4 items
+Each `DataOuputDescriptor` is a colon-separated list of 4 items
 
-`DataOuputDescription`
+`DataOuputDescriptor`
 ```csh
 table:tree:columns:file
 ```
@@ -417,7 +417,7 @@ and instructs the internal-dpl-aod-writer, to save the columns `columns` of tabl
 
 By default `x` is incremented with every time frame. This behavior can be modified with the command line option `--ntfmerge`. The value of `ntfmerge` specifies the number of time frames to merge into one file. 
 
-The first item of a `DataOuputDescription` (`table`) is mandatory and needs to be specified, otherwise the `DataOuputDescription` is ignored. The other three items are optional and are filled by default values if missing.
+The first item of a `DataOuputDescriptor` (`table`) is mandatory and needs to be specified, otherwise the `DataOuputDescriptor` is ignored. The other three items are optional and are filled by default values if missing.
 
 The format of `table` is
 
@@ -450,19 +450,19 @@ this case all dangling output tables are saved. For the parameters `tree`, `colu
 
 #### --res-file
 
-`res-file` specifies the default base name of the results files to which tables are saved. If in any of the `DataOutputDescriptions` the `file` value is missing it will be set to this default value.
+`res-file` specifies the default base name of the results files to which tables are saved. If in any of the `DataOutputDescriptors` the `file` value is missing it will be set to this default value.
 
 #### --json-file
 
 `json-file` specifies the name of a json-file which contains the full information needed to customize the behavior of the internal-dpl-aod-writer. It can replace the other three options completely. Nevertheless, currently all options are supported ([see also discussion below](#redundancy)).
 
 An example file is shown in the highlighted field below. The relevant
-information is contained in an json object `OutputDirector`. The
+information is contained in a json object `OutputDirector`. The
 `OutputDirector` can include three different items:
 
   1. `resfile` is a string and corresponds to the `res-file` command line option  
   2.`ntfmerge` is an integer and corresponds to the `ntfmerge` command line option  
-  3.`OutputDescriptions` is an array of objects and corresponds to the `keep` command line option. The objects are equivalent to the `DataOuputDescriptions` of the `keep` option and are composed of 4 items which correspond to the 4 items of a `DataOuputDescription`.
+  3.`OutputDescriptors` is an array of objects and corresponds to the `keep` command line option. The objects are equivalent to the `DataOuputDescriptors` of the `keep` option and are composed of 4 items which correspond to the 4 items of a `DataOuputDescriptor`.
   
      a. `table` is a string  
      b. `treename` is a string  
@@ -470,13 +470,13 @@ information is contained in an json object `OutputDirector`. The
      d. `filename` is a string  
   
   
-`Example json file`
+`Example json file for the internal-dpl-aod-writer`
 ```csh
 {
   "OutputDirector": {
       "resfile": "defresults",
       "ntfmerge": 10,
-      "OutputDescriptions": [
+      "OutputDescriptors": [
           {
             "table": "AOD/UNO/0",
             "columns": [
@@ -532,14 +532,152 @@ This hierarchy of the options is summarized in the following table. The columns 
  # Merge 50 time frames in each file.
 
 --json-file myconfig.json
- # accordng to the contents of myconfig.json
+ # according to the contents of myconfig.json
 ```
 
 #### Limitations
 
-If in any case two `DataOuputDescriptions` are provided which have equal combinations of
+If in any case two `DataOuputDescriptors` are provided which have equal combinations of
 the `tree` and `file` parameters then the processing is stopped! It is not possible to save
 two trees with equal name to a given file.
+
+
+### Reading tables from files
+
+The internal-dpl-aod-reader reads trees from root files and provides them as arrow tables to the requesting workflows. Its behavior is customized with the following command line options:
+
+* --aod-file
+* --json-file
+
+#### --aod-file
+
+`aod-file` takes a string as option value, which either is the name of the input root file or, if starting with an `@`-character, is an ASCII-file which contains a list of input files. 
+
+```csh
+--aod-file AnalysisResults_0.root
+ # uses AnalysisResults_0.root as input file
+
+--aod-file @AnalysisResults.txt
+ # uses files listed in AnalysisResults.txt as input files
+
+```
+
+#### --json-file
+
+'json-file' is a string and specifies a json file, which contains the
+customization information for the internal-dpl-aod-reader. An example file is
+shown in the highlighted field below. The relevant information is contained in
+a json object `InputDirector`. The `InputDirector` can include the following
+three items:
+
+  1. `resfiles` is a string or an array of strings and corresponds to the `aod-file` command line option. As the `aod-file` option it can specify a single input file or, when the option value starts with a `@`-character, an ASCII file with a list of input files. In addition `resfiles` can be an array of strings, which contains a list of input files.
+  2.`fileregex` is a regex string which is used to select the input files from the file list specified by `resfiles`.
+  3.`InputDescriptors` is an array of objects, the so called `DataInputDescriptors`, which are composed of 4 items.
+  
+     a. `table` is a string and specifies the table to fill. The `table` needs to be provided in the format `AOD/tablename/0`, where `tablename` is the name of the table as defined in the workflow definition.
+     b. `treename` is a string and specifies the tree which is to be used to fill `table`  
+     c. `resfiles` is either a string or an array of strings. It specifies a list of possible input files (see discussion of `resfiles` above).
+     d. `fileregex` is a regular expression string which is used to select the
+input files from the file list specified by `resfiles`  
+
+The information contained in a `DataInputDescriptor` instructs the internal-dpl-aod-reader to fill table `table` with the values from the tree `treename` in the files which are defined by `resfiles` and which names match the regex `fileregex`.
+
+Of the four items of a `DataInputDescriptor`, `table` is the only required information. If one of the other items is missing its value will be set as follows:
+
+  1. `treename` is set to `tablename` of the respective `table` item.  
+  2. `resfiles` is set to `resfiles` of the `InputDirector` (1. item of the `InputDirector`). If that is missing, then the value of the `aod-file` option is used. If that is missing, then `AnalysisResults.root` is used.  
+  3. `fileregex` is set to `fileregex` of the `InputDirector` (2. item of the `InputDirector`). If that is missing, then `.*` is used.
+
+
+`Example json file for the internal-dpl-aod-reader`
+```csh
+{
+  "InputDirector": {
+    "resfiles": "@resfiles.txt",
+    "fileregex": ".*",
+    "InputDescriptors": [
+      {
+        "table": "AOD/COLLISION/0",
+        "treename": "uno",
+        "resfiles": [
+          "unoresults_1.root",
+          "unoresults_2.root",
+          "unoresults_3.root",
+          "unoresults_4.root"
+        ]
+      },
+      {
+        "table": "AOD/DUE/0",
+        "treename": "due",
+        "resfiles": "@dueresults.txt",
+        "fileregex": "(dueresults)(.*)"
+      },
+      {
+        "table": "AOD/TRE/0",
+        "treename": "tre"
+      }
+    ]
+  }
+```
+
+When the internal-dpl-aod-reader receives the request to fill a given table `tablename` it searches in the provided `InputDirector` for the corresponding `InputDescriptor` and proceeds as defined there. However, if there is no corresponding `InputDescriptor` it falls back to the information provided by the `resfiles` and `fileregex` options of the `InputDirector` and uses the `tablename` as `treename`.
+
+#### Some practical comments
+
+The `json-file` option allows to setup the reading of tables in a rather
+flexible way. Here a few presumably practical cases are discussed:
+
+  1. Let's assume a case where data from tables `tableA` and `tableB` need to
+be processed together. Table `tableA` was previously saved as tree `tableA` to
+files `tableAResults_x.root`, where `x` is a number and `tableB` was saved as
+tree `tableB` to `tableBResults_x.root`. The following json-file could be used
+to read these tables:
+
+```csh
+{
+  # file resfiles.txt lists all tableAResults_x.root and tableBResults_x.root files.
+
+  "InputDirector": {
+    "resfiles": "@resfiles.txt",
+    "InputDescriptors": [
+      {
+        "table": "AOD/tableA/0",
+        "fileregex": "(tableAResult)(.*)"
+      },
+      {
+        "table": "AOD/tableB/0",
+        "fileregex": "(tableBResult)(.*)"
+      }
+    ]
+  }
+```
+
+  2. In this case several tables need to be provided. All tables can be read from files `tableResult_x.root`, except for one table, namely `tableA`, which is saved as tree `treeA` in files `tableAResult_x.root`.
+  
+```csh
+  # file resfiles.txt lists all tableResults_x.root and tableAResults_x.root files.
+
+  "InputDirector": {
+    "resfiles": "@resfiles.txt",
+    "fileregex": "(tableResult)(.*)"
+    "InputDescriptors": [
+      {
+        "table": "AOD/tableA/0",
+        "treename": "treeA",
+        "fileregex": "(tableAResult)(.*)"
+      }
+    ]
+  }
+```
+  
+
+#### Limitations
+
+  1. It is required that all `InputDescriptors` have the same number of selected input files. This is internally checked and the processing is stopped if it turns out that this is not the case.
+  2. The internal-dpl-aod-reader loops over the selected input files in the order as they are listed. It is the duty of the user to make sure that the order is correct and that the order in the file lists
+of the various `InputDescriptors` are corresponding to each other.
+  3. The regular expression `fileregex` is evaluated with the c++ Regular expressions library. Thus check there for the proper syntax of regexes.
+  
 
 ### Possible ideas
 

--- a/Framework/Core/ANALYSIS.md
+++ b/Framework/Core/ANALYSIS.md
@@ -574,11 +574,10 @@ three items:
   2.`fileregex` is a regex string which is used to select the input files from the file list specified by `resfiles`.
   3.`InputDescriptors` is an array of objects, the so called `DataInputDescriptors`, which are composed of 4 items.
   
-     a. `table` is a string and specifies the table to fill. The `table` needs to be provided in the format `AOD/tablename/0`, where `tablename` is the name of the table as defined in the workflow definition.
+     a. `table` is a string and specifies the table to fill. The `table` needs to be provided in the format `AOD/tablename/0`, where `tablename` is the name of the table as defined in the workflow definition.  
      b. `treename` is a string and specifies the tree which is to be used to fill `table`  
-     c. `resfiles` is either a string or an array of strings. It specifies a list of possible input files (see discussion of `resfiles` above).
-     d. `fileregex` is a regular expression string which is used to select the
-input files from the file list specified by `resfiles`  
+     c. `resfiles` is either a string or an array of strings. It specifies a list of possible input files (see discussion of `resfiles` above).  
+     d. `fileregex` is a regular expression string which is used to select the input files from the file list specified by `resfiles`  
 
 The information contained in a `DataInputDescriptor` instructs the internal-dpl-aod-reader to fill table `table` with the values from the tree `treename` in the files which are defined by `resfiles` and which names match the regex `fileregex`.
 

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -89,6 +89,7 @@ o2_add_library(Framework
                        src/TMessageSerializer.cxx
                        src/TableBuilder.cxx
                        src/TableConsumer.cxx
+                       src/DataInputDirector.cxx
                        src/DataOutputDirector.cxx
                        src/Task.cxx
                        src/TextControlService.cxx

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -1,0 +1,112 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef o2_framework_DataInputDirector_H_INCLUDED
+#define o2_framework_DataInputDirector_H_INCLUDED
+
+#include "TFile.h"
+#include "TTreeReader.h"
+
+#include "Framework/DataDescriptorMatcher.h"
+
+#include <regex>
+#include "rapidjson/fwd.h"
+
+namespace o2
+{
+namespace framework
+{
+using namespace rapidjson;
+
+struct DataInputDescriptor {
+  /// Holds information concerning the reading of an aod table.
+  /// The information includes the table specification, treename,
+  /// and the input files
+
+  std::string tablename = "";
+  std::string treename = "";
+  std::unique_ptr<data_matcher::DataDescriptorMatcher> matcher;
+
+  DataInputDescriptor();
+
+  void printOut();
+
+  // setters
+  void setInputfilesFile(std::string dffn) { minputfilesFile = dffn; }
+  void setInputfilesFile(std::string* dffnptr) { minputfilesFilePtr = dffnptr; }
+  void setFilenamesRegex(std::string fn) { mFilenameRegex = fn; }
+  void setFilenamesRegex(std::string* fnptr) { mFilenameRegexPtr = fnptr; }
+
+  void setDefaultInputfiles(std::vector<std::string>* difnptr) { mdefaultFilenamesPtr = difnptr; }
+
+  void addFilename(std::string fn);
+  int fillInputfiles();
+
+  // getters
+  std::string getInputfilesFilename();
+  std::string getFilenamesRegexString();
+  std::regex getFilenamesRegex();
+  int getNumberInputfiles() { return mfilenames.size(); }
+
+  TFile* getDataFile(int counter);
+  std::string getInputFilename(int counter);
+
+ private:
+  std::string minputfilesFile = "";
+  std::string* minputfilesFilePtr = nullptr;
+  std::string mFilenameRegex = "";
+  std::string* mFilenameRegexPtr = nullptr;
+  std::vector<std::string> mfilenames;
+  std::vector<std::string>* mdefaultFilenamesPtr = nullptr;
+};
+
+struct DataInputDirector {
+  /// Holds a list of DataInputDescriptor
+  /// Provides functionality to access the matching DataInputDescriptor
+  /// and the related input files
+
+  DataInputDirector();
+  DataInputDirector(std::string inputFile);
+
+  void reset();
+  void createDefaultDataInputDescriptor();
+  void printOut();
+  bool atEnd(int counter);
+
+  // setters
+  void setInputfilesFile(std::string iffn) { minputfilesFile = iffn; }
+  void setFilenamesRegex(std::string dfn) { mFilenameRegex = dfn; }
+  bool readJson(std::string const& fnjson);
+
+  // getters
+  DataInputDescriptor* getDataInputDescriptor(header::DataHeader dh);
+  std::unique_ptr<TTreeReader> getTreeReader(header::DataHeader dh, int counter, std::string treeName);
+  std::string getInputFilename(header::DataHeader dh, int counter);
+  TTree* getDataTree(header::DataHeader dh, int counter);
+  int getNumberInputDescriptors() { return mdataInputDescriptors.size(); }
+
+ private:
+  std::string minputfilesFile;
+  std::string* const minputfilesFilePtr = &minputfilesFile;
+  std::string mFilenameRegex;
+  std::string* const mFilenameRegexPtr = &mFilenameRegex;
+  DataInputDescriptor* mdefaultDataInputDescriptor = nullptr;
+  std::vector<std::string> mdefaultInputFiles;
+  std::vector<DataInputDescriptor*> mdataInputDescriptors;
+
+  bool mdebugmode = false;
+
+  bool readJsonDocument(Document* doc);
+  bool isValid();
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // o2_framework_DataInputDirector_H_INCLUDED

--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -37,15 +37,15 @@ struct DataOutputDescriptor {
 
   DataOutputDescriptor(std::string sin);
 
-  void setFilename(std::string fn) { filename = fn; }
-  void setFilename(std::string* fnptr) { dfnptr = fnptr; }
-  std::string getFilename();
+  void setFilenameBase(std::string fn) { mfilenameBase = fn; }
+  void setFilenameBase(std::string* fnptr) { mfilenameBasePtr = fnptr; }
+  std::string getFilenameBase();
 
   void printOut();
 
  private:
-  std::string filename;
-  std::string* dfnptr = nullptr;
+  std::string mfilenameBase;
+  std::string* mfilenameBasePtr = nullptr;
 
   std::string remove_ws(const std::string& s);
 };
@@ -77,23 +77,24 @@ struct DataOutputDirector {
   // get the matching TFile
   TFile* getDataOutputFile(DataOutputDescriptor* dod,
                            int ntf, int ntfmerge, std::string filemode);
-  void closeDataOutputFiles();
+  void closeDataFiles();
 
-  void setDefaultfname(std::string dfn);
+  void setFilenameBase(std::string dfn);
 
   void printOut();
 
  private:
-  int ndod = 0;
-  std::string defaultfname;
-  std::string* const dfnptr = &defaultfname;
-  std::vector<DataOutputDescriptor*> dodescrs;
-  std::vector<std::string> tnfns;
-  std::vector<std::string> fnames;
-  std::vector<int> fcnts;
-  std::vector<TFile*> fouts;
+  std::string mfilenameBase;
+  std::string* const mfilenameBasePtr = &mfilenameBase;
+  std::vector<DataOutputDescriptor*> mDataOutputDescriptors;
+  std::vector<std::string> mtreeFilenames;
+  std::vector<std::string> mfilenameBases;
+  std::vector<int> mfileCounts;
+  std::vector<TFile*> mfilePtrs;
+  bool mdebugmode = false;
 
   std::tuple<std::string, std::string, int> readJsonDocument(Document* doc);
+  const std::tuple<std::string, std::string, int> memptyanswer = std::make_tuple(std::string(""), std::string(""), -1);
 };
 
 } // namespace framework

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -18,6 +18,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/DataInputDirector.h"
 #include "Framework/SourceInfoHeader.h"
 #include "Framework/ChannelInfo.h"
 #include "Framework/Logger.h"
@@ -169,7 +170,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
     auto nEvents = options.get<int>("events");
 
     if (filename.empty()) {
-      LOG(error) << "Option --esd-file did not provide a filename";
+      LOGP(ERROR, "Option --esd-file did not provide a filename");
       control.readyToQuit(QuitRequest::All);
       return adaptStateless([](RawDeviceService& service) {
         service.device()->WaitFor(std::chrono::milliseconds(1000));
@@ -186,7 +187,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
           filenames.push_back(filename);
         }
       } catch (...) {
-        LOG(error) << "Unable to process file list: " << filename;
+        LOGP(ERROR, "Unable to process file list: {}", filename);
       }
     } else {
       filenames.push_back(filename);
@@ -212,7 +213,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
       }
       FILE* pipe = popen((command + " " + f).c_str(), "r");
       if (pipe == nullptr) {
-        LOG(ERROR) << "Unable to run converter: " << (command + " " + f).c_str() << f;
+        LOGP(ERROR, "Unable to run converter: {} {}", (command + " " + f), f);
         ctrl.endOfStream();
         ctrl.readyToQuit(QuitRequest::All);
         return;
@@ -232,7 +233,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
         auto input = std::make_shared<FileStream>(pipe);
         auto readerStatus = arrow::ipc::RecordBatchStreamReader::Open(input, &reader);
         if (readerStatus.ok() == false) {
-          LOG(ERROR) << "Reader status not ok: " << readerStatus.message();
+          LOGP(ERROR, "Reader status not ok: {}", readerStatus.message());
           break;
         }
 
@@ -275,7 +276,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
         }
       }
       if (ferror(pipe)) {
-        LOG(ERROR) << "Error while reading from PIPE";
+        LOGP(ERROR, "Error while reading from PIPE");
       }
       pclose(pipe);
     });
@@ -288,60 +289,51 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
 {
   auto callback = AlgorithmSpec{adaptStateful([](ConfigParamRegistry const& options,
                                                  DeviceSpec const& spec) {
-    std::vector<std::string> filenames;
     auto filename = options.get<std::string>("aod-file");
 
-    // If option starts with a @, we consider the file as text which contains a list of
-    // files.
-    if (filename.size() && filename[0] == '@') {
-      try {
-        filename.erase(0, 1);
-        std::ifstream filelist(filename);
-        while (std::getline(filelist, filename)) {
-          filenames.push_back(filename);
-        }
-      } catch (...) {
-        LOG(error) << "Unable to process file list: " << filename;
+    // create a DataInputDirector
+    auto didir = std::make_shared<DataInputDirector>(filename);
+    if (options.isSet("json-file")) {
+      auto jsonFile = options.get<std::string>("json-file");
+      if (!didir->readJson(jsonFile)) {
+        LOGP(ERROR, "Check the JSON document! Can not be properly parsed!");
       }
-    } else {
-      filenames.push_back(filename);
     }
 
     // analyze type of requested tables
     uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{"AOD"});
     std::vector<OutputRoute> unknowns;
-    if (readMask & AODTypeMask::Unknown)
+    if (readMask & AODTypeMask::Unknown) {
       unknowns = getListOfUnknown(spec.outputs);
+    }
 
     auto counter = std::make_shared<int>(0);
     return adaptStateless([readMask,
                            unknowns,
                            counter,
-                           filenames](DataAllocator& outputs, ControlService& control, DeviceSpec const& device) {
+                           didir](DataAllocator& outputs, ControlService& control, DeviceSpec const& device) {
       // Each parallel reader reads the files whose index is associated to
       // their inputTimesliceId
       assert(device.inputTimesliceId < device.maxInputTimeslices);
       size_t fi = (*counter * device.maxInputTimeslices) + device.inputTimesliceId;
-      if (fi >= filenames.size()) {
-        LOG(info) << "All input files processed";
+      *counter += 1;
+
+      if (didir->atEnd(fi)) {
+        LOGP(INFO, "All input files processed");
         control.endOfStream();
         control.readyToQuit(QuitRequest::Me);
         return;
       }
-      auto f = filenames[fi];
-      LOG(INFO) << "Processing " << f;
-      auto infile = std::make_unique<TFile>(f.c_str());
-      *counter += 1;
-      if (infile.get() == nullptr || infile->IsOpen() == false) {
-        LOG(ERROR) << "File not found: " + f;
-        return;
-      }
-      auto tableMaker = [&infile, &readMask, &outputs, &f](auto metadata, AODTypeMask mask, char const* treeName) {
+
+      auto tableMaker = [&readMask, &outputs, fi, didir](auto metadata, AODTypeMask mask, char const* treeName) {
         if (readMask & mask) {
+
+          auto dh = header::DataHeader(decltype(metadata)::description(), decltype(metadata)::origin(), 0);
+          auto reader = didir->getTreeReader(dh, fi, treeName);
+
           using table_t = typename decltype(metadata)::table_t;
-          std::unique_ptr<TTreeReader> reader = std::make_unique<TTreeReader>(treeName, infile.get());
-          if (reader->IsInvalid()) {
-            LOGP(ERROR, "Requested {} tree not found in file {}", treeName, f);
+          if (!reader || (reader && reader->IsInvalid())) {
+            LOGP(ERROR, "Requested \"{}\" tree not found in input file \"{}\"", treeName, didir->getInputFilename(dh, fi));
           } else {
             auto& builder = outputs.make<TableBuilder>(Output{decltype(metadata)::origin(), decltype(metadata)::description()});
             RootTableBuilderHelpers::convertASoA<table_t>(builder, *reader);
@@ -359,23 +351,25 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
       tableMaker(o2::aod::TriggersMetadata{}, AODTypeMask::Trigger, "O2trigger");
 
       // tables not included in the DataModel
+      std::unique_ptr<TTree> tr = nullptr;
       if (readMask & AODTypeMask::Unknown) {
 
         // loop over unknowns
         for (auto route : unknowns) {
-          auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
 
-          // get the tree from infile
-          auto trname = concrete.description.str;
-          auto tr = (TTree*)infile.get()->Get(trname);
+          // create a TreeToTable object
+          auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
+          auto dh = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
+
+          auto tr = didir->getDataTree(dh, fi);
           if (!tr) {
-            LOG(ERROR) << "Tree " << trname << "is not contained in file " << f;
+            char* table;
+            sprintf(table, "%s/%s/%" PRIu32, concrete.origin.str, concrete.description.str, concrete.subSpec);
+            LOGP(ERROR, "Error while retrieving the tree for \"{}\"!", table);
             return;
           }
 
-          // create a TreeToTable object
-          auto h = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
-          auto o = Output(h);
+          auto o = Output(dh);
           auto& t2t = outputs.make<TreeToTable>(o, tr);
 
           // fill the table

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -268,7 +268,7 @@ DataProcessorSpec
         dod->readString(keepString);
       }
     }
-    dod->setDefaultfname(fnbase);
+    dod->setFilenameBase(fnbase);
 
     // find out if any table needs to be saved
     bool hasOutputsToWrite = false;
@@ -293,7 +293,7 @@ DataProcessorSpec
 
     // end of data functor is called at the end of the data stream
     auto endofdatacb = [dod](EndOfStreamContext& context) {
-      dod->closeDataOutputFiles();
+      dod->closeDataFiles();
 
       context.services().get<ControlService>().readyToQuit(QuitRequest::All);
     };

--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -1,0 +1,488 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/DataInputDirector.h"
+#include "Framework/DataDescriptorQueryBuilder.h"
+#include "Framework/Logger.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/filereadstream.h"
+
+namespace o2
+{
+namespace framework
+{
+using namespace rapidjson;
+
+DataInputDescriptor::DataInputDescriptor()
+{
+}
+
+std::string DataInputDescriptor::getInputfilesFilename()
+{
+  return (minputfilesFile.empty() && minputfilesFilePtr) ? (std::string)*minputfilesFilePtr : minputfilesFile;
+}
+
+std::string DataInputDescriptor::getFilenamesRegexString()
+{
+  return (mFilenameRegex.empty() && mFilenameRegexPtr) ? (std::string)*mFilenameRegexPtr : mFilenameRegex;
+}
+
+std::regex DataInputDescriptor::getFilenamesRegex()
+{
+  return std::regex(getFilenamesRegexString());
+}
+
+void DataInputDescriptor::addFilename(std::string fn)
+{
+  mfilenames.emplace_back(fn);
+}
+
+TFile* DataInputDescriptor::getDataFile(int counter)
+{
+  TFile* file = nullptr;
+
+  if (counter < getNumberInputfiles()) {
+    file = new TFile(mfilenames[counter].c_str());
+  }
+
+  return file;
+}
+
+int DataInputDescriptor::fillInputfiles()
+{
+  if (getNumberInputfiles() > 0) {
+    // 1. mfilenames
+    return getNumberInputfiles();
+  }
+
+  auto fileName = getInputfilesFilename();
+  if (!fileName.empty()) {
+    // 2. getFilenamesRegex() @ getInputfilesFilename()
+    try {
+      std::ifstream filelist(fileName);
+      while (std::getline(filelist, fileName)) {
+        if (getFilenamesRegexString().empty() ||
+            std::regex_match(fileName, getFilenamesRegex())) {
+          addFilename(fileName);
+        }
+      }
+    } catch (...) {
+      LOGP(ERROR, "Check the input files file! Unable to process \"{}\"!", getInputfilesFilename());
+      return 0;
+    }
+  } else {
+    // 3. getFilenamesRegex() @ mdefaultFilenamesPtr
+    if (mdefaultFilenamesPtr) {
+      for (auto fileName : *mdefaultFilenamesPtr) {
+        if (getFilenamesRegexString().empty() ||
+            std::regex_match(fileName, getFilenamesRegex())) {
+          addFilename(fileName);
+        }
+      }
+    }
+  }
+
+  return getNumberInputfiles();
+}
+
+std::string DataInputDescriptor::getInputFilename(int counter)
+{
+  std::string filename("");
+  if (counter >= 0 && counter < getNumberInputfiles()) {
+    filename = mfilenames[counter];
+  }
+
+  return filename;
+}
+
+void DataInputDescriptor::printOut()
+{
+  LOGP(INFO, "DataInputDescriptor");
+  LOGP(INFO, "  Table name        : {}", tablename);
+  LOGP(INFO, "  Tree name         : {}", treename);
+  LOGP(INFO, "  Input files file  : {}", getInputfilesFilename());
+  LOGP(INFO, "  File name regex   : {}", getFilenamesRegexString());
+  LOGP(INFO, "  Input files       : {}", mfilenames.size());
+  for (auto fn : mfilenames)
+    LOGP(INFO, "    {}", fn);
+}
+
+DataInputDirector::DataInputDirector()
+{
+  createDefaultDataInputDescriptor();
+}
+
+DataInputDirector::DataInputDirector(std::string inputFile)
+{
+  if (inputFile.size() && inputFile[0] == '@') {
+    inputFile.erase(0, 1);
+    setInputfilesFile(inputFile);
+  } else {
+    mdefaultInputFiles.emplace_back(inputFile);
+  }
+
+  createDefaultDataInputDescriptor();
+}
+
+void DataInputDirector::reset()
+{
+  mdataInputDescriptors.clear();
+  mdefaultInputFiles.clear();
+  mFilenameRegex = std::string("");
+};
+
+void DataInputDirector::createDefaultDataInputDescriptor()
+{
+  if (mdefaultDataInputDescriptor) {
+    delete mdefaultDataInputDescriptor;
+  }
+  mdefaultDataInputDescriptor = new DataInputDescriptor();
+
+  mdefaultDataInputDescriptor->setInputfilesFile(minputfilesFile);
+  mdefaultDataInputDescriptor->setFilenamesRegex(mFilenameRegex);
+  mdefaultDataInputDescriptor->setDefaultInputfiles(&mdefaultInputFiles);
+  mdefaultDataInputDescriptor->tablename = "any";
+  mdefaultDataInputDescriptor->treename = "any";
+  mdefaultDataInputDescriptor->fillInputfiles();
+}
+
+bool DataInputDirector::readJson(std::string const& fnjson)
+{
+  // open the file
+  FILE* f = fopen(fnjson.c_str(), "r");
+  if (!f) {
+    LOGP(ERROR, "Could not open JSON file \"{}\"!", fnjson);
+    return false;
+  }
+
+  // create streamer
+  char readBuffer[65536];
+  FileReadStream inputStream(f, readBuffer, sizeof(readBuffer));
+
+  // parse the json file
+  Document jsonDoc;
+  jsonDoc.ParseStream(inputStream);
+  auto status = readJsonDocument(&jsonDoc);
+
+  // clean up
+  fclose(f);
+
+  return status;
+}
+
+bool DataInputDirector::readJsonDocument(Document* jsonDoc)
+{
+  // initialisations
+  std::string fileName("");
+  int ntfm = -1;
+  const char* itemName;
+
+  // is it a proper json document?
+  if (jsonDoc->HasParseError()) {
+    LOGP(ERROR, "Check the JSON document! There is a problem with the format!");
+    return false;
+  }
+
+  // InputDirector
+  itemName = "InputDirector";
+  const Value& didirItem = (*jsonDoc)[itemName];
+  if (!didirItem.IsObject()) {
+    LOGP(ERROR, "Check the JSON document! Couldn't find an \"{}\" object!", itemName);
+    return false;
+  }
+
+  // now read various items
+  itemName = "debugmode";
+  if (didirItem.HasMember(itemName)) {
+    if (didirItem[itemName].IsBool()) {
+      mdebugmode = (didirItem[itemName].GetBool());
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a boolean!", itemName);
+      return false;
+    }
+  } else {
+    mdebugmode = false;
+  }
+
+  if (mdebugmode) {
+    StringBuffer buffer;
+    buffer.Clear();
+    PrettyWriter<StringBuffer> writer(buffer);
+    didirItem.Accept(writer);
+    LOGP(INFO, "InputDirector object: {}", std::string(buffer.GetString()));
+  }
+
+  itemName = "fileregex";
+  if (didirItem.HasMember(itemName)) {
+    if (didirItem[itemName].IsString()) {
+      setFilenamesRegex(didirItem[itemName].GetString());
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+      return false;
+    }
+  }
+
+  itemName = "resfiles";
+  if (didirItem.HasMember(itemName)) {
+    if (didirItem[itemName].IsString()) {
+      fileName = didirItem[itemName].GetString();
+      if (fileName.size() && fileName[0] == '@') {
+        fileName.erase(0, 1);
+        setInputfilesFile(fileName);
+      } else {
+        setInputfilesFile("");
+        mdefaultInputFiles.emplace_back(fileName);
+      }
+    } else if (didirItem[itemName].IsArray()) {
+      setInputfilesFile("");
+      auto fns = didirItem[itemName].GetArray();
+      for (auto& fn : fns) {
+        mdefaultInputFiles.emplace_back(fn.GetString());
+      }
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string or an array!", itemName);
+      return false;
+    }
+  }
+
+  itemName = "InputDescriptors";
+  if (didirItem.HasMember(itemName)) {
+    if (!didirItem[itemName].IsArray()) {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be an array!", itemName);
+      return false;
+    }
+
+    // loop over DataInputDescriptors
+    for (auto& didescItem : didirItem[itemName].GetArray()) {
+      if (!didescItem.IsObject()) {
+        LOGP(ERROR, "Check the JSON document! \"{}\" must be objects!", itemName);
+        return false;
+      }
+      // create a new dataInputDescriptor
+      auto didesc = new DataInputDescriptor();
+      didesc->setDefaultInputfiles(&mdefaultInputFiles);
+
+      itemName = "table";
+      if (didescItem.HasMember(itemName)) {
+        if (didescItem[itemName].IsString()) {
+          didesc->tablename = didescItem[itemName].GetString();
+          didesc->matcher = DataDescriptorQueryBuilder::buildNode(didesc->tablename);
+        } else {
+          LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+          return false;
+        }
+      } else {
+        LOGP(ERROR, "Check the JSON document! Item \"{}\" is missing!", itemName);
+        return false;
+      }
+
+      itemName = "treename";
+      if (didescItem.HasMember(itemName)) {
+        if (didescItem[itemName].IsString()) {
+          didesc->treename = didescItem[itemName].GetString();
+        } else {
+          LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+          return false;
+        }
+      } else {
+        auto m = DataDescriptorQueryBuilder::getTokens(didesc->tablename);
+        didesc->treename = m[2];
+      }
+
+      itemName = "fileregex";
+      if (didescItem.HasMember(itemName)) {
+        if (didescItem[itemName].IsString()) {
+          if (didesc->getNumberInputfiles() == 0) {
+            didesc->setFilenamesRegex(didescItem[itemName].GetString());
+          }
+        } else {
+          LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+          return false;
+        }
+      } else {
+        if (didesc->getNumberInputfiles() == 0) {
+          didesc->setFilenamesRegex(mFilenameRegexPtr);
+        }
+      }
+
+      itemName = "resfiles";
+      if (didescItem.HasMember(itemName)) {
+        if (didescItem[itemName].IsString()) {
+          fileName = didescItem[itemName].GetString();
+          if (fileName.size() && fileName[0] == '@') {
+            didesc->setInputfilesFile(fileName.erase(0, 1));
+          } else {
+            if (didesc->getFilenamesRegexString().empty() ||
+                std::regex_match(fileName, didesc->getFilenamesRegex())) {
+              didesc->addFilename(fileName);
+            }
+          }
+        } else if (didescItem[itemName].IsArray()) {
+          auto fns = didescItem[itemName].GetArray();
+          for (auto& fn : fns) {
+            if (didesc->getFilenamesRegexString().empty() ||
+                std::regex_match(fn.GetString(), didesc->getFilenamesRegex())) {
+              didesc->addFilename(fn.GetString());
+            }
+          }
+        } else {
+          LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string or an array!", itemName);
+          return false;
+        }
+      } else {
+        didesc->setInputfilesFile(minputfilesFilePtr);
+      }
+
+      // fill mfilenames and add InputDescriptor to InputDirector
+      if (didesc->fillInputfiles() > 0) {
+        mdataInputDescriptors.emplace_back(didesc);
+      } else {
+        didesc->printOut();
+        LOGP(INFO, "This DataInputDescriptor is ignored because its file list is empty!");
+      }
+    }
+  }
+
+  // add a default DataInputDescriptor
+  createDefaultDataInputDescriptor();
+
+  // check that all DataInputDescriptors have the same number of input files
+  if (!isValid()) {
+    printOut();
+    return false;
+  }
+
+  // print the DataIputDirector
+  if (mdebugmode) {
+    printOut();
+  }
+
+  return true;
+}
+
+DataInputDescriptor* DataInputDirector::getDataInputDescriptor(header::DataHeader dh)
+{
+  DataInputDescriptor* result = nullptr;
+
+  // compute list of matching outputs
+  data_matcher::VariableContext context;
+
+  for (auto didesc : mdataInputDescriptors) {
+    if (didesc->matcher->match(dh, context)) {
+      result = didesc;
+      break;
+    }
+  }
+
+  return result;
+}
+
+std::unique_ptr<TTreeReader> DataInputDirector::getTreeReader(header::DataHeader dh, int counter, std::string treename)
+{
+  std::unique_ptr<TTreeReader> reader = nullptr;
+  auto didesc = getDataInputDescriptor(dh);
+  // if NOT match then use defaultDataInputDescriptor
+  if (!didesc) {
+    didesc = mdefaultDataInputDescriptor;
+  }
+  auto file = didesc->getDataFile(counter);
+  if (file->IsOpen()) {
+    reader = std::make_unique<TTreeReader>(treename.c_str(), file);
+    if (!reader) {
+      LOGP(ERROR, "Couldn't create TTreeReader for tree \"{}\" in file \"{}\"", treename, file->GetName());
+    }
+  } else {
+    LOGP(ERROR, "Couldn't open file \"{}\"", file->GetName());
+  }
+
+  return reader;
+}
+
+std::string DataInputDirector::getInputFilename(header::DataHeader dh, int counter)
+{
+  auto didesc = getDataInputDescriptor(dh);
+  // if NOT match then use defaultDataInputDescriptor
+  if (!didesc) {
+    didesc = mdefaultDataInputDescriptor;
+  }
+  auto filename = didesc->getInputFilename(counter);
+
+  return filename;
+}
+
+TTree* DataInputDirector::getDataTree(header::DataHeader dh, int counter)
+{
+  const char* treename;
+  TTree* tree = nullptr;
+
+  auto didesc = getDataInputDescriptor(dh);
+  if (didesc) {
+    // if match then use filename and treename from DataInputDescriptor
+    treename = didesc->treename.c_str();
+  } else {
+    // if NOT match then use
+    //  . filename from defaultDataInputDescriptor
+    //  . treename from DataHeader
+    didesc = mdefaultDataInputDescriptor;
+    treename = dh.dataDescription.str;
+  }
+  auto file = didesc->getDataFile(counter);
+
+  if (file->IsOpen()) {
+    tree = (TTree*)file->Get(treename);
+    if (!tree) {
+      LOGP(ERROR, "Couldn't get TTree \"{}\" from \"{}\"", treename, file->GetName());
+    }
+  } else {
+    LOGP(ERROR, "Couldn't open file \"{}\"", file->GetName());
+  }
+
+  return tree;
+}
+
+bool DataInputDirector::isValid()
+{
+  bool status = true;
+  int numberFiles = mdefaultDataInputDescriptor->getNumberInputfiles();
+  for (auto didesc : mdataInputDescriptors) {
+    status &= didesc->getNumberInputfiles() == numberFiles;
+  }
+
+  return status;
+}
+
+bool DataInputDirector::atEnd(int counter)
+{
+  bool status = mdefaultDataInputDescriptor->getNumberInputfiles() <= counter;
+  for (auto didesc : mdataInputDescriptors) {
+    status &= (didesc->getNumberInputfiles() <= counter);
+  }
+
+  return status;
+}
+
+void DataInputDirector::printOut()
+{
+  LOGP(INFO, "DataInputDirector");
+  LOGP(INFO, "  Default input files file   : {}", minputfilesFile);
+  LOGP(INFO, "  Default file name regex    : {}", mFilenameRegex);
+  LOGP(INFO, "  Default file names         : {}", mdefaultInputFiles.size());
+  for (auto const& fn : mdefaultInputFiles)
+    LOGP(INFO, "    {}", fn);
+  LOGP(INFO, "  Default DataInputDescriptor:");
+  mdefaultDataInputDescriptor->printOut();
+  LOGP(INFO, "  DataInputDescriptors       : {}", getNumberInputDescriptors());
+  for (auto const& didesc : mdataInputDescriptors)
+    didesc->printOut();
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -8,8 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/DataOutputDirector.h"
+#include "Framework/Logger.h"
 
 #include "rapidjson/document.h"
+#include "rapidjson/prettywriter.h"
 #include "rapidjson/filereadstream.h"
 
 namespace o2
@@ -18,25 +20,25 @@ namespace framework
 {
 using namespace rapidjson;
 
-DataOutputDescriptor::DataOutputDescriptor(std::string sin)
+DataOutputDescriptor::DataOutputDescriptor(std::string inString)
 {
-  // sin is an item consisting of 4 parts which are separated by a ':'
+  // inString is an item consisting of 4 parts which are separated by a ':'
   // "origin/description/subSpec:treename:col1/col2/col3:filename"
   // the 1st part is used to create a DataDescriptorMatcher
   // the other parts are used to fill treename, colnames, and filename
   // remove all spaces
-  auto s = remove_ws(sin);
+  auto cleanString = remove_ws(inString);
 
   // reset
   treename = "";
   colnames.clear();
-  filename = "";
+  mfilenameBase = "";
 
   // analyze the  parts of the input string
   static const std::regex delim1(":");
   std::sregex_token_iterator end;
-  std::sregex_token_iterator iter1(s.begin(),
-                                   s.end(),
+  std::sregex_token_iterator iter1(cleanString.begin(),
+                                   cleanString.end(),
                                    delim1,
                                    -1);
 
@@ -44,13 +46,13 @@ DataOutputDescriptor::DataOutputDescriptor(std::string sin)
   if (iter1 == end) {
     return;
   }
-  auto a = iter1->str();
-  matcher = DataDescriptorQueryBuilder::buildNode(a);
+  auto tableString = iter1->str();
+  matcher = DataDescriptorQueryBuilder::buildNode(tableString);
 
   // get the table name
-  auto m = DataDescriptorQueryBuilder::getTokens(a);
-  if (!std::string(m[2]).empty()) {
-    tablename = m[2];
+  auto tableItems = DataDescriptorQueryBuilder::getTokens(tableString);
+  if (!std::string(tableItems[2]).empty()) {
+    tablename = tableItems[2];
   }
 
   // get the tree name
@@ -84,34 +86,34 @@ DataOutputDescriptor::DataOutputDescriptor(std::string sin)
     }
   }
 
-  // get the filename
+  // get the file name base
   ++iter1;
   if (iter1 == end) {
     return;
   }
   if (!iter1->str().empty()) {
-    filename = iter1->str();
+    mfilenameBase = iter1->str();
   }
 }
 
-std::string DataOutputDescriptor::getFilename()
+std::string DataOutputDescriptor::getFilenameBase()
 {
-  return (filename.empty() && dfnptr) ? (std::string)*dfnptr : filename;
+  return (mfilenameBase.empty() && mfilenameBasePtr) ? (std::string)*mfilenameBasePtr : mfilenameBase;
 }
 
 void DataOutputDescriptor::printOut()
 {
-  LOG(INFO) << "DataOutputDescriptor";
-  LOG(INFO) << "  table name: " << tablename;
-  LOG(INFO) << "  file name : " << getFilename();
-  LOG(INFO) << "  tree name : " << treename;
+  LOGP(INFO, "DataOutputDescriptor");
+  LOGP(INFO, "  Table name     : {}", tablename);
+  LOGP(INFO, "  File name base : {}", getFilenameBase());
+  LOGP(INFO, "  Tree name      : {}", treename);
   if (colnames.empty()) {
-    LOG(INFO) << "  columns   : all";
+    LOGP(INFO, "  Columns      : \"all\"");
   } else {
-    LOG(INFO) << "  columns   : " << colnames.size();
+    LOGP(INFO, "  Columns      : {}", colnames.size());
   }
   for (auto cn : colnames)
-    LOG(INFO) << "  " << cn;
+    LOGP(INFO, "    {}", cn);
 }
 
 std::string DataOutputDescriptor::remove_ws(const std::string& s)
@@ -127,19 +129,18 @@ std::string DataOutputDescriptor::remove_ws(const std::string& s)
 
 DataOutputDirector::DataOutputDirector()
 {
-  defaultfname = std::string("");
+  mfilenameBase = std::string("");
 }
 
 void DataOutputDirector::reset()
 {
-  dodescrs.clear();
-  fnames.clear();
-  tnfns.clear();
-  closeDataOutputFiles();
-  fouts.clear();
-  fcnts.clear();
-  defaultfname = std::string("");
-  ndod = 0;
+  mDataOutputDescriptors.clear();
+  mfilenameBases.clear();
+  mtreeFilenames.clear();
+  closeDataFiles();
+  mfilePtrs.clear();
+  mfileCounts.clear();
+  mfilenameBase = std::string("");
 };
 
 void DataOutputDirector::readString(std::string const& keepString)
@@ -155,101 +156,99 @@ void DataOutputDirector::readString(std::string const& keepString)
 
   // loop over ','-separated items
   for (; iter != end; ++iter) {
-    auto s = iter->str();
+    auto itemString = iter->str();
 
     // create a new DataOutputDescriptor and add it to the list
-    auto dod = new DataOutputDescriptor(s);
-    if (dod->getFilename().empty()) {
-      dod->setFilename(dfnptr);
+    auto dodesc = new DataOutputDescriptor(itemString);
+    if (dodesc->getFilenameBase().empty()) {
+      dodesc->setFilenameBase(mfilenameBasePtr);
     }
-    dodescrs.emplace_back(dod);
-    fnames.emplace_back(dod->getFilename());
-    tnfns.emplace_back(dod->treename + dod->getFilename());
+    mDataOutputDescriptors.emplace_back(dodesc);
+    mfilenameBases.emplace_back(dodesc->getFilenameBase());
+    mtreeFilenames.emplace_back(dodesc->treename + dodesc->getFilenameBase());
   }
 
   // the combination [tree name/file name] must be unique
   // throw exception if this is not the case
-  auto it = std::unique(tnfns.begin(), tnfns.end());
-  if (it != tnfns.end()) {
+  auto it = std::unique(mtreeFilenames.begin(), mtreeFilenames.end());
+  if (it != mtreeFilenames.end()) {
     printOut();
-    LOG(FATAL) << "Dublicate tree names in a file!";
+    LOGP(FATAL, "Dublicate tree names in a file!");
   }
 
-  // make unique/sorted list of fnames
-  std::sort(fnames.begin(), fnames.end());
-  auto last = std::unique(fnames.begin(), fnames.end());
-  fnames.erase(last, fnames.end());
+  // make unique/sorted list of filenameBases
+  std::sort(mfilenameBases.begin(), mfilenameBases.end());
+  auto last = std::unique(mfilenameBases.begin(), mfilenameBases.end());
+  mfilenameBases.erase(last, mfilenameBases.end());
 
-  // prepare list fouts of TFile and fcnts
-  for (auto fn : fnames) {
-    fouts.emplace_back(new TFile());
-    fcnts.emplace_back(-1);
+  // prepare list mfilePtrs of TFile and mfileCounts
+  for (auto fn : mfilenameBases) {
+    mfilePtrs.emplace_back(new TFile());
+    mfileCounts.emplace_back(-1);
   }
-
-  // number of DataOutputDescriptors
-  ndod = dodescrs.size();
 }
 
 // creates a keep string from a InputSpec
 std::string SpectoString(InputSpec input)
 {
-  std::string s;
+  std::string keepString;
   std::string delim("/");
 
   auto matcher = DataSpecUtils::asConcreteDataMatcher(input);
-  s += matcher.origin.str + delim;
-  s += matcher.description.str + delim;
-  s += std::to_string(matcher.subSpec);
+  keepString += matcher.origin.str + delim;
+  keepString += matcher.description.str + delim;
+  keepString += std::to_string(matcher.subSpec);
 
-  return s;
+  return keepString;
 }
 
 void DataOutputDirector::readSpecs(std::vector<InputSpec> inputs)
 {
   for (auto input : inputs) {
-    auto s = SpectoString(input);
-    readString(s);
+    auto keepString = SpectoString(input);
+    readString(keepString);
   }
 }
 
 std::tuple<std::string, std::string, int> DataOutputDirector::readJson(std::string const& fnjson)
 {
   // open the file
-  FILE* f = fopen(fnjson.c_str(), "r");
-  if (!f) {
-    LOG(INFO) << "Could not open JSON file " << fnjson;
-    return std::make_tuple(std::string(""), std::string(""), -1);
+  FILE* fjson = fopen(fnjson.c_str(), "r");
+  if (!fjson) {
+    LOGP(INFO, "Could not open JSON file \"{}\"", fnjson);
+    return memptyanswer;
   }
 
   // create streamer
   char readBuffer[65536];
-  FileReadStream is(f, readBuffer, sizeof(readBuffer));
+  FileReadStream jsonStream(fjson, readBuffer, sizeof(readBuffer));
 
   // parse the json file
-  Document doc;
-  doc.ParseStream(is);
-  auto [dfn, fmode, ntfm] = readJsonDocument(&doc);
+  Document jsonDocument;
+  jsonDocument.ParseStream(jsonStream);
+  auto [dfn, fmode, ntfm] = readJsonDocument(&jsonDocument);
 
   // clean up
-  fclose(f);
+  fclose(fjson);
 
   return std::make_tuple(dfn, fmode, ntfm);
 }
 
-std::tuple<std::string, std::string, int> DataOutputDirector::readJsonString(std::string const& stjson)
+std::tuple<std::string, std::string, int> DataOutputDirector::readJsonString(std::string const& jsonString)
 {
   // parse the json string
-  Document doc;
-  doc.Parse(stjson.c_str());
-  auto [dfn, fmode, ntfm] = readJsonDocument(&doc);
+  Document jsonDocument;
+  jsonDocument.Parse(jsonString.c_str());
+  auto [dfn, fmode, ntfm] = readJsonDocument(&jsonDocument);
 
   return std::make_tuple(dfn, fmode, ntfm);
 }
 
-std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(Document* doc)
+std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(Document* jsonDocument)
 {
   std::string smc(":");
   std::string slh("/");
+  const char* itemName;
 
   // initialisations
   std::string dfn("");
@@ -257,75 +256,137 @@ std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(D
   int ntfm = -1;
 
   // is it a proper json document?
-  if (!doc->HasParseError()) {
+  if (jsonDocument->HasParseError()) {
+    LOGP(ERROR, "Check the JSON document! There is a problem with the format!");
+    return memptyanswer;
+  }
 
-    // OutputDirector
-    const Value& dod = (*doc)["OutputDirector"];
-    if (dod.IsObject()) {
+  // OutputDirector
+  itemName = "OutputDirector";
+  const Value& dodirItem = (*jsonDocument)[itemName];
+  if (!dodirItem.IsObject()) {
+    LOGP(ERROR, "Check the JSON document! Couldn't find an \"{}\" object!", itemName);
+    return memptyanswer;
+  }
 
-      // loop over the dod members
-      for (auto item = dod.MemberBegin(); item != dod.MemberEnd(); ++item) {
-
-        // get item name and value
-        auto itemname = item->name.GetString();
-        const Value& v = dod[itemname];
-
-        // check possible items
-        if (std::strcmp(itemname, "resfile") == 0) {
-          // default result file name
-          if (v.IsString()) {
-            dfn = v.GetString();
-            setDefaultfname(dfn);
-          }
-        } else if (std::strcmp(itemname, "resfilemode") == 0) {
-          // open mode for result file
-          if (v.IsString()) {
-            fmode = v.GetString();
-          }
-        } else if (std::strcmp(itemname, "ntfmerge") == 0) {
-          // number of time frames to merge
-          if (v.IsNumber()) {
-            ntfm = v.GetInt();
-          }
-        } else if (std::strcmp(itemname, "OutputDescriptions") == 0) {
-          // array of DataOutputDescriptions
-          if (v.IsArray()) {
-            for (auto& od : v.GetArray()) {
-              if (od.IsObject()) {
-                // DataOutputDescription
-                std::string s = "";
-                if (od.HasMember("table")) {
-                  s += od["table"].GetString();
-                }
-                s += smc;
-                if (od.HasMember("treename")) {
-                  s += od["treename"].GetString();
-                }
-                s += smc;
-                if (od.HasMember("columns")) {
-                  if (od["columns"].IsArray()) {
-                    auto cs = od["columns"].GetArray();
-                    for (auto& c : cs)
-                      s += (c == cs[0]) ? c.GetString() : slh + c.GetString();
-                  }
-                }
-                s += smc;
-                if (od.HasMember("filename")) {
-                  s += od["filename"].GetString();
-                }
-
-                // convert s to DataOutputDescription object
-                readString(s);
-              }
-            }
-          }
-        }
-      }
+  // now read various items
+  itemName = "debugmode";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsBool()) {
+      mdebugmode = dodirItem[itemName].GetBool();
     } else {
-      LOG(INFO) << "Couldn't find an OutputDirector in JSON document";
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a boolean!", itemName);
+      return memptyanswer;
     }
   } else {
-    LOG(INFO) << "Problem with JSON document";
+    mdebugmode = false;
+  }
+
+  if (mdebugmode) {
+    StringBuffer buffer;
+    buffer.Clear();
+    Writer<rapidjson::StringBuffer> writer(buffer);
+    dodirItem.Accept(writer);
+    LOGP(INFO, "OutputDirector object: {}", std::string(buffer.GetString()));
+  }
+
+  itemName = "resfile";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsString()) {
+      dfn = dodirItem[itemName].GetString();
+      setFilenameBase(dfn);
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+      return memptyanswer;
+    }
+  }
+
+  itemName = "resfilemode";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsString()) {
+      fmode = dodirItem[itemName].GetString();
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+      return memptyanswer;
+    }
+  }
+
+  itemName = "ntfmerge";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsNumber()) {
+      ntfm = dodirItem[itemName].GetInt();
+    } else {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be a number!", itemName);
+      return memptyanswer;
+    }
+  }
+
+  itemName = "OutputDescriptors";
+  if (dodirItem.HasMember(itemName)) {
+    if (!dodirItem[itemName].IsArray()) {
+      LOGP(ERROR, "Check the JSON document! Item \"{}\" must be an array!", itemName);
+      return memptyanswer;
+    }
+
+    // loop over DataOutputDescriptors
+    for (auto& dodescItem : dodirItem[itemName].GetArray()) {
+      if (!dodescItem.IsObject()) {
+        LOGP(ERROR, "Check the JSON document! \"{}\" must be objects!", itemName);
+        return memptyanswer;
+      }
+
+      std::string dodString = "";
+      itemName = "table";
+      if (dodescItem.HasMember(itemName)) {
+        if (dodescItem[itemName].IsString()) {
+          dodString += dodescItem[itemName].GetString();
+        } else {
+          LOGP(ERROR, "Check the JSON document! \"{}\" must be a string!", itemName);
+          return memptyanswer;
+        }
+      }
+      dodString += smc;
+      itemName = "treename";
+      if (dodescItem.HasMember(itemName)) {
+        if (dodescItem[itemName].IsString()) {
+          dodString += dodescItem[itemName].GetString();
+        } else {
+          LOGP(ERROR, "Check the JSON document! \"{}\" must be a string!", itemName);
+          return memptyanswer;
+        }
+      }
+      dodString += smc;
+      itemName = "columns";
+      if (dodescItem.HasMember(itemName)) {
+        if (dodescItem[itemName].IsArray()) {
+          auto columnNames = dodescItem[itemName].GetArray();
+          for (auto& c : columnNames) {
+            dodString += (c == columnNames[0]) ? c.GetString() : slh + c.GetString();
+          }
+        } else {
+          LOGP(ERROR, "Check the JSON document! \"{}\" must be an array!", itemName);
+          return memptyanswer;
+        }
+      }
+      dodString += smc;
+      itemName = "filename";
+      if (dodescItem.HasMember(itemName)) {
+        if (dodescItem[itemName].IsString()) {
+          dodString += dodescItem[itemName].GetString();
+        } else {
+          LOGP(ERROR, "Check the JSON document! \"{}\" must be a string!", itemName);
+          return memptyanswer;
+        }
+      }
+
+      // convert s to DataOutputDescription object
+      readString(dodString);
+    }
+  }
+
+  // print the DataOutputDirector
+  if (mdebugmode) {
+    printOut();
   }
 
   return std::make_tuple(dfn, fmode, ntfm);
@@ -338,7 +399,7 @@ std::vector<DataOutputDescriptor*> DataOutputDirector::getDataOutputDescriptors(
   // compute list of matching outputs
   data_matcher::VariableContext context;
 
-  for (auto dodescr : dodescrs) {
+  for (auto dodescr : mDataOutputDescriptors) {
     if (dodescr->matcher->match(dh, context)) {
       result.emplace_back(dodescr);
     }
@@ -355,7 +416,7 @@ std::vector<DataOutputDescriptor*> DataOutputDirector::getDataOutputDescriptors(
   data_matcher::VariableContext context;
   auto concrete = std::get<ConcreteDataMatcher>(spec.matcher);
 
-  for (auto dodescr : dodescrs) {
+  for (auto dodescr : mDataOutputDescriptors) {
     if (dodescr->matcher->match(concrete, context)) {
       result.emplace_back(dodescr);
     }
@@ -364,93 +425,92 @@ std::vector<DataOutputDescriptor*> DataOutputDirector::getDataOutputDescriptors(
   return result;
 }
 
-TFile* DataOutputDirector::getDataOutputFile(DataOutputDescriptor* dod,
+TFile* DataOutputDirector::getDataOutputFile(DataOutputDescriptor* dodesc,
                                              int ntf, int ntfmerge,
                                              std::string filemode)
 {
   // initialisation
-  TFile* fout = nullptr;
+  TFile* filePtr = nullptr;
 
-  // search dod->filename in fnames and return corresponding fout
-  auto it = std::find(fnames.begin(), fnames.end(), dod->getFilename());
-  if (it != fnames.end()) {
-    int ind = std::distance(fnames.begin(), it);
+  // search dodesc->filename in mfilenameBases and return corresponding filePtr
+  auto it = std::find(mfilenameBases.begin(), mfilenameBases.end(), dodesc->getFilenameBase());
+  if (it != mfilenameBases.end()) {
+    int ind = std::distance(mfilenameBases.begin(), it);
 
     // check if new version of file needs to be opened
     int fcnt = (int)(ntf / ntfmerge);
-    if ((ntf % ntfmerge) == 0 && fcnt > fcnts[ind]) {
-      if (fouts[ind]) {
-        fouts[ind]->Close();
+    if ((ntf % ntfmerge) == 0 && fcnt > mfileCounts[ind]) {
+      if (mfilePtrs[ind]) {
+        mfilePtrs[ind]->Close();
       }
 
-      fcnts[ind] = fcnt;
-      auto fn = fnames[ind] + "_" + std::to_string(fcnts[ind]) + ".root";
-      fouts[ind] = new TFile(fn.c_str(), filemode.c_str());
+      mfileCounts[ind] = fcnt;
+      auto fn = mfilenameBases[ind] + "_" + std::to_string(mfileCounts[ind]) + ".root";
+      mfilePtrs[ind] = new TFile(fn.c_str(), filemode.c_str());
     }
-    fout = fouts[ind];
+    filePtr = mfilePtrs[ind];
   }
 
-  return fout;
+  return filePtr;
 }
 
-void DataOutputDirector::closeDataOutputFiles()
+void DataOutputDirector::closeDataFiles()
 {
-  for (auto fout : fouts)
-    if (fout) {
-      fout->Close();
+  for (auto filePtr : mfilePtrs)
+    if (filePtr) {
+      filePtr->Close();
     }
 }
 
 void DataOutputDirector::printOut()
 {
-  LOG(INFO) << "DataOutputDirector";
-  LOG(INFO) << "  Default file name: " << defaultfname;
-  LOG(INFO) << "  Number of dods   : " << ndod;
-  LOG(INFO) << "  Number of files  : " << fnames.size();
+  LOGP(INFO, "DataOutputDirector");
+  LOGP(INFO, "  Default file name    : {}", mfilenameBase);
+  LOGP(INFO, "  Number of files      : {}", mfilenameBases.size());
 
-  LOG(INFO) << "  dods:";
-  for (auto const& ds : dodescrs)
+  LOGP(INFO, "  DataOutputDescriptors: {}", mDataOutputDescriptors.size());
+  for (auto const& ds : mDataOutputDescriptors)
     ds->printOut();
 
-  LOG(INFO) << "  File names:";
-  for (auto const& fb : fnames)
-    LOG(INFO) << fb;
+  LOGP(INFO, "  File name bases      :");
+  for (auto const& fb : mfilenameBases)
+    LOGP(INFO, fb);
 }
 
-void DataOutputDirector::setDefaultfname(std::string dfn)
+void DataOutputDirector::setFilenameBase(std::string dfn)
 {
   // reset
-  defaultfname = dfn;
+  mfilenameBase = dfn;
 
-  fnames.clear();
-  tnfns.clear();
-  closeDataOutputFiles();
-  fouts.clear();
-  fcnts.clear();
+  mfilenameBases.clear();
+  mtreeFilenames.clear();
+  closeDataFiles();
+  mfilePtrs.clear();
+  mfileCounts.clear();
 
   // loop over DataOutputDescritors
-  for (auto dod : dodescrs) {
-    fnames.emplace_back(dod->getFilename());
-    tnfns.emplace_back(dod->treename + dod->getFilename());
+  for (auto dodesc : mDataOutputDescriptors) {
+    mfilenameBases.emplace_back(dodesc->getFilenameBase());
+    mtreeFilenames.emplace_back(dodesc->treename + dodesc->getFilenameBase());
   }
 
   // the combination [tree name/file name] must be unique
   // throw exception if this is not the case
-  auto it = std::unique(tnfns.begin(), tnfns.end());
-  if (it != tnfns.end()) {
+  auto it = std::unique(mtreeFilenames.begin(), mtreeFilenames.end());
+  if (it != mtreeFilenames.end()) {
     printOut();
     LOG(FATAL) << "Dublicate tree names in a file!";
   }
 
-  // make unique/sorted list of fnames
-  std::sort(fnames.begin(), fnames.end());
-  auto last = std::unique(fnames.begin(), fnames.end());
-  fnames.erase(last, fnames.end());
+  // make unique/sorted list of filenameBases
+  std::sort(mfilenameBases.begin(), mfilenameBases.end());
+  auto last = std::unique(mfilenameBases.begin(), mfilenameBases.end());
+  mfilenameBases.erase(last, mfilenameBases.end());
 
-  // prepare list fouts of TFile and fcnts
-  for (auto fn : fnames) {
-    fouts.emplace_back(new TFile());
-    fcnts.emplace_back(-1);
+  // prepare list mfilePtrs of TFile and mfileCounts
+  for (auto fn : mfilenameBases) {
+    mfilePtrs.emplace_back(new TFile());
+    mfileCounts.emplace_back(-1);
   }
 }
 

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -58,6 +58,12 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema, b
         default:
           throw std::runtime_error("Unknown variant type");
       }
+    } catch (std::runtime_error& re) {
+      throw re;
+    } catch (std::exception& e) {
+      throw std::invalid_argument(std::string("missing option: ") + key + " (" + e.what() + ")");
+    } catch (...) {
+      throw std::invalid_argument(std::string("missing option: ") + key);
     }
   }
 }

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -58,12 +58,6 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema, b
         default:
           throw std::runtime_error("Unknown variant type");
       }
-    } catch (std::runtime_error& re) {
-      throw re;
-    } catch (std::exception& e) {
-      throw std::invalid_argument(std::string("missing option: ") + key + " (" + e.what() + ")");
-    } catch (...) {
-      throw std::invalid_argument(std::string("missing option: ") + key);
     }
   }
 }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -192,6 +192,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {},
     readers::AODReaderHelpers::rootFileReaderCallback(),
     {ConfigParamSpec{"aod-file", VariantType::String, "aod.root", {"Input AOD file"}},
+     ConfigParamSpec{"json-file", VariantType::String, {"json configuration file"}},
      ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
      ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
      ConfigParamSpec{"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}}}};

--- a/Framework/Core/test/test_DataInputDirector.cxx
+++ b/Framework/Core/test/test_DataInputDirector.cxx
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DatainputDirector
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "Headers/DataHeader.h"
+#include "Framework/DataInputDirector.h"
+
+BOOST_AUTO_TEST_CASE(TestDatainputDirector)
+{
+  using namespace o2::header;
+  using namespace o2::framework;
+
+  // test json file reader
+  std::string jsonFile("testO2config.json");
+  std::ofstream jf(jsonFile, std::ofstream::out);
+  jf << R"({)" << std::endl;
+  jf << R"(  "InputDirector": {)" << std::endl;
+  jf << R"(    "resfiles": [)" << std::endl;
+  jf << R"(      "Aresults_0.root",)" << std::endl;
+  jf << R"(      "Aresults_1.root",)" << std::endl;
+  jf << R"(      "Bresults_0.root",)" << std::endl;
+  jf << R"(      "Bresults_1.root")" << std::endl;
+  jf << R"(    ],)" << std::endl;
+  jf << R"delimiter(    "fileregex": "(Ares)(.*)",)delimiter" << std::endl;
+  jf << R"(    "InputDescriptors": [)" << std::endl;
+  jf << R"(      {)" << std::endl;
+  jf << R"(        "table": "AOD/UNO/0",)" << std::endl;
+  jf << R"(        "treename": "uno")" << std::endl;
+  jf << R"(      },)" << std::endl;
+  jf << R"(      {)" << std::endl;
+  jf << R"(        "table": "AOD/DUE/0",)" << std::endl;
+  jf << R"(        "treename": "due",)" << std::endl;
+  jf << R"delimiter(        "fileregex": "(Bres)(.*)")delimiter" << std::endl;
+  jf << R"(      })" << std::endl;
+  jf << R"(    ])" << std::endl;
+  jf << R"(  })" << std::endl;
+  jf << R"(})" << std::endl;
+  jf.close();
+
+  DataInputDirector didir;
+  BOOST_CHECK(didir.readJson(jsonFile));
+  //didir.printOut(); printf("\n\n");
+
+  BOOST_CHECK_EQUAL(didir.getNumberInputDescriptors(), 2);
+
+  auto dh = DataHeader(DataDescription{"DUE"},
+                       DataOrigin{"AOD"},
+                       DataHeader::SubSpecificationType{0});
+  BOOST_CHECK_EQUAL(didir.getInputFilename(dh, 1), "Bresults_1.root");
+
+  auto didesc = didir.getDataInputDescriptor(dh);
+  BOOST_CHECK(didesc);
+  BOOST_CHECK_EQUAL(didesc->getNumberInputfiles(), 2);
+}

--- a/Framework/Core/test/test_DataOutputDirector.cxx
+++ b/Framework/Core/test/test_DataOutputDirector.cxx
@@ -30,8 +30,8 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   // test keepString reader
   std::string keepString("AOD/UNO/0:tr1:c1/c2/c3:fn1,AOD/UNO/0::c4");
   dod.readString(keepString);
-  dod.setDefaultfname(mydfn);
-  // dod.printOut(); printf("\n\n");
+  dod.setFilenameBase(mydfn);
+  //dod.printOut(); printf("\n\n");
 
   auto ds = dod.getDataOutputDescriptors(dh);
 
@@ -40,12 +40,12 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   BOOST_CHECK_EQUAL(ds[0]->tablename, std::string("UNO"));
   BOOST_CHECK_EQUAL(ds[0]->treename, std::string("tr1"));
   BOOST_CHECK_EQUAL(ds[0]->colnames.size(), 3);
-  BOOST_CHECK_EQUAL(ds[0]->getFilename(), std::string("fn1"));
+  BOOST_CHECK_EQUAL(ds[0]->getFilenameBase(), std::string("fn1"));
 
   BOOST_CHECK_EQUAL(ds[1]->tablename, std::string("UNO"));
   BOOST_CHECK_EQUAL(ds[1]->treename, std::string("UNO"));
   BOOST_CHECK_EQUAL(ds[1]->colnames.size(), 1);
-  BOOST_CHECK_EQUAL(ds[1]->getFilename(), std::string("myresultfile"));
+  BOOST_CHECK_EQUAL(ds[1]->getFilenameBase(), std::string("myresultfile"));
 
   // test jsonString reader
   std::string dfn("");
@@ -55,11 +55,11 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   dh = DataHeader(DataDescription{"DUE"},
                   DataOrigin{"AOD"},
                   DataHeader::SubSpecificationType{0});
-  std::string jsonString(R"({"OutputDirector": {"resfile": "defresults", "resfilemode": "RECREATE", "ntfmerge": 10, "OutputDescriptions": [{"table": "AOD/UNO/0", "columns": ["fEta1","fMom1"], "treename": "uno", "filename": "unoresults"}, {"table": "AOD/DUE/0", "columns": ["fPhi2"], "treename": "due"}]}})");
+  std::string jsonString(R"({"OutputDirector": {"resfile": "defresults", "resfilemode": "RECREATE", "ntfmerge": 10, "OutputDescriptors": [{"table": "AOD/UNO/0", "columns": ["fEta1","fMom1"], "treename": "uno", "filename": "unoresults"}, {"table": "AOD/DUE/0", "columns": ["fPhi2"], "treename": "due"}]}})");
 
   dod.reset();
   std::tie(dfn, fmode, ntf) = dod.readJsonString(jsonString);
-  // dod.printOut(); printf("\n\n");
+  //dod.printOut(); printf("\n\n");
   ds = dod.getDataOutputDescriptors(dh);
 
   BOOST_CHECK_EQUAL(ds.size(), 1);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   BOOST_CHECK_EQUAL(ds[0]->tablename, std::string("DUE"));
   BOOST_CHECK_EQUAL(ds[0]->treename, std::string("due"));
   BOOST_CHECK_EQUAL(ds[0]->colnames.size(), 1);
-  BOOST_CHECK_EQUAL(ds[0]->getFilename(), std::string("defresults"));
+  BOOST_CHECK_EQUAL(ds[0]->getFilenameBase(), std::string("defresults"));
 
   // test json file reader
   std::string jsonFile("testO2config.json");
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   jf << R"(    "resfile": "defresults",)" << std::endl;
   jf << R"(    "resfilemode": "NEW",)" << std::endl;
   jf << R"(    "ntfmerge": 10,)" << std::endl;
-  jf << R"(    "OutputDescriptions": [)" << std::endl;
+  jf << R"(    "OutputDescriptors": [)" << std::endl;
   jf << R"(      {)" << std::endl;
   jf << R"(        "table": "AOD/DUE/0",)" << std::endl;
   jf << R"(        "columns": [)" << std::endl;
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
 
   dod.reset();
   std::tie(dfn, fmode, ntf) = dod.readJson(jsonFile);
-  dod.setDefaultfname("AnalysisResults");
+  dod.setFilenameBase("AnalysisResults");
   //dod.printOut(); printf("\n\n");
   ds = dod.getDataOutputDescriptors(dh);
 
@@ -114,12 +114,12 @@ BOOST_AUTO_TEST_CASE(TestDataOutputDirector)
   BOOST_CHECK_EQUAL(fmode, std::string("NEW"));
   BOOST_CHECK_EQUAL(ntf, 10);
 
-  BOOST_CHECK_EQUAL(ds[0]->getFilename(), std::string("unoresults"));
+  BOOST_CHECK_EQUAL(ds[0]->getFilenameBase(), std::string("unoresults"));
   BOOST_CHECK_EQUAL(ds[0]->tablename, std::string("DUE"));
   BOOST_CHECK_EQUAL(ds[0]->treename, std::string("uno"));
   BOOST_CHECK_EQUAL(ds[0]->colnames.size(), 2);
 
-  BOOST_CHECK_EQUAL(ds[1]->getFilename(), std::string("dueresults"));
+  BOOST_CHECK_EQUAL(ds[1]->getFilenameBase(), std::string("dueresults"));
   BOOST_CHECK_EQUAL(ds[1]->tablename, std::string("DUE"));
   BOOST_CHECK_EQUAL(ds[1]->treename, std::string("due"));
   BOOST_CHECK_EQUAL(ds[1]->colnames.size(), 1);


### PR DESCRIPTION
Added functionality which allows the  internal-dpl-aod-reader to read tables from different sets of files. 
The required information is encoded in a JSON file, which is provided to the internal-dpl-aod-reader via the json-file command line option. More information can be found in the Framework/Core/ANALYSIS.md file.
