### PR TITLE
Cleaning-up TPC ClusterNativeHelper

### DIFF
--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -172,7 +172,7 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex, st
   return result;
 }
 
-int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, std::vector<MCLabelContainer>& mcinput, ClusterNativeAccess& clusterIndex,
+int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, gsl::span<MCLabelContainer const> const& mcinput, ClusterNativeAccess& clusterIndex,
                                              const MCLabelContainer* (&clustersMCTruth)[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW])
 {
   if (!buffer || size == 0) {

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -74,7 +74,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
     // data set is complete, have to think about a DPL feature to take
     // ownership of an input
     std::array<std::vector<char>, NSectors> bufferedInputs;
-    std::array<std::vector<MCLabelContainer>, NSectors> mcInputs;
+    using CachedMCLabelContainer = decltype(std::declval<InputRecord>().get<std::vector<MCLabelContainer>>(DataRef{nullptr, nullptr, nullptr}));
+    std::array<CachedMCLabelContainer, NSectors> mcInputs;
     std::bitset<NSectors> validInputs = 0;
     std::bitset<NSectors> validMcInputs = 0;
     std::unique_ptr<ClusterGroupParser> parser;


### PR DESCRIPTION
This makes the code more flexible with respect to the input, e.g support vectors with different
allocators.
- using const input arrays and use spans to be more flexible for the read-only input data
- adding method descriptions

Another side note:
With PR #2155 (65e17cb) restoring the access index always involves
a copy of the data. This is contradictory to the idea of the index simply
providing pointers to data and we should rethink the concept. Very likely
the partitioning of the data pad-row wise does not make sense any more
and the monolithic data set should be produced already by the decoder.
