### PR TITLE
Fix: properly reset printout stream after flushing

### DIFF
--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -62,7 +62,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
               if (dh != lastDataHeader) {
                 if (!rdhprintout.str().empty()) {
                   LOG(INFO) << rdhprintout.str();
-                  rdhprintout.str().clear();
+                  rdhprintout.str(std::string());
                 }
                 // print the DataHeader information only for the first part or if we have high verbosity
                 if (loglevel > 1 || dh->splitPayloadIndex == 0) {


### PR DESCRIPTION
printout stream was accumulating the output due to the improper reset after flushing