### PR TITLE
More work on Zero-Suppression

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -138,7 +138,7 @@ struct RDHUtils {
   template <typename RDH>
   static void setMemorySize(RDH& rdh, uint16_t v)
   {
-    rdh.offsetToNext = v;
+    rdh.memorySize = v;
   } // same for all
   static void setMemorySize(void* rdhP, uint16_t v) { setMemorySize(*reinterpret_cast<RDHDef*>(rdhP), v); }
 

--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -130,11 +130,11 @@ struct RDHUtils {
   static void setOffsetToNext(void* rdhP, uint16_t v) { setOffsetToNext(*reinterpret_cast<RDHDef*>(rdhP), v); }
 
   template <typename RDH>
-  static uint16_t getMemorySize(const RDH& rdh)
+  GPUhdi() static uint16_t getMemorySize(const RDH& rdh)
   {
     return rdh.memorySize;
   } // same for all
-  static uint16_t getMemorySize(const void* rdhP) { return getMemorySize(*reinterpret_cast<const RDHDef*>(rdhP)); }
+  GPUhdi() static uint16_t getMemorySize(const void* rdhP) { return getMemorySize(*reinterpret_cast<const RDHDef*>(rdhP)); }
   template <typename RDH>
   static void setMemorySize(RDH& rdh, uint16_t v)
   {

--- a/Detectors/TPC/base/CMakeLists.txt
+++ b/Detectors/TPC/base/CMakeLists.txt
@@ -34,7 +34,7 @@ o2_add_library(TPCBase
                        src/Sector.cxx
                        src/Utils.cxx
                PUBLIC_LINK_LIBRARIES Vc::Vc Boost::boost O2::DataFormatsTPC
-                                     O2::CCDB FairRoot::Base)
+                                     O2::DetectorsRaw O2::CCDB FairRoot::Base)
 
 o2_target_root_dictionary(TPCBase
                           HEADERS include/TPCBase/CalArray.h
@@ -86,6 +86,12 @@ o2_add_test(Parameters
             COMPONENT_NAME tpc
             PUBLIC_LINK_LIBRARIES O2::TPCBase
             SOURCES test/testTPCParameters.cxx
+            LABELS tpc)
+
+o2_add_test(RDHUtils
+            COMPONENT_NAME tpc
+            PUBLIC_LINK_LIBRARIES O2::TPCBase
+            SOURCES test/testRDHUtils.cxx
             LABELS tpc)
 
 #o2_add_test(CCDBInterface

--- a/Detectors/TPC/base/include/TPCBase/RDHUtils.h
+++ b/Detectors/TPC/base/include/TPCBase/RDHUtils.h
@@ -1,0 +1,103 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef AliceO2_TPC_RDHUtils_H
+#define AliceO2_TPC_RDHUtils_H
+
+#include "DetectorsRaw/RDHUtils.h"
+//#include "Headers/RAWDataHeader.h"
+
+namespace o2
+{
+namespace tpc
+{
+namespace rdh_utils
+{
+
+using o2::raw::RDHUtils;
+using FEEIDType = uint16_t;
+static constexpr FEEIDType UserLogicLinkID = 15;
+
+/// compose feeid from cru, endpoint and link
+static constexpr FEEIDType getFEEID(const FEEIDType cru, const FEEIDType endpoint, const FEEIDType link) { return FEEIDType((cru << 7) | ((endpoint & 1) << 6) | (link & 0x3F)); }
+template <typename T>
+static constexpr FEEIDType getFEEID(const T cru, const T endpoint, const T link)
+{
+  return getFEEID(FEEIDType(cru), FEEIDType(endpoint), FEEIDType(link));
+}
+
+/// extract cru number from feeid
+static constexpr FEEIDType getCRU(const FEEIDType feeID) { return (feeID >> 7); }
+
+/// extract endpoint from feeid
+static constexpr FEEIDType getEndPoint(const FEEIDType feeID) { return (feeID >> 6) & 0x1; }
+
+/// extract endpoint from feeid
+static constexpr FEEIDType getLink(const FEEIDType feeID) { return feeID & 0x3F; }
+
+/// extract cru, endpoint and link from feeid
+static constexpr void getMapping(const FEEIDType feeID, FEEIDType& cru, FEEIDType& endpoint, FEEIDType& link)
+{
+  cru = getCRU(feeID);
+  endpoint = getEndPoint(feeID);
+  link = getLink(feeID);
+}
+
+/// if link in feeID is from user logic
+static constexpr bool isFromUserLogic(const FEEIDType feeID) { return (getLink(feeID) == UserLogicLinkID); }
+
+/// extract cru number from RDH
+template <typename RDH>
+static constexpr FEEIDType getCRU(const RDH& rdh)
+{
+  return getCRU(RDHUtils::getFEEID(rdh));
+}
+
+/// extract endpoint from RDH
+template <typename RDH>
+static constexpr FEEIDType getEndPoint(const RDH& rdh)
+{
+  return getEndPoint(RDHUtils::getFEEID(rdh));
+}
+
+/// extract link from RDH
+template <typename RDH>
+static constexpr FEEIDType getLink(const RDH& rdh)
+{
+  return getLink(RDHUtils::getFEEID(rdh));
+}
+
+/// if link in feeID is from user logic
+template <typename RDH>
+static constexpr bool isFromUserLogic(const RDH& rdh)
+{
+  return isFromUserLogic(RDHUtils::getFEEID(rdh));
+}
+
+template <typename RDH, typename T>
+static constexpr void setFEEID(RDH& rdh, const T cru, const T endpoint, const T link)
+{
+  RDHUtils::setFEEID(rdh, getFEEID(cru, endpoint, link));
+}
+
+/// extract cru, endpoint and link from RDH
+template <typename RDH>
+static constexpr void getMapping(const RDH& rdh, FEEIDType& cru, FEEIDType& endpoint, FEEIDType& link)
+{
+  cru = getCRU(rdh);
+  endpoint = getEndPoint(rdh);
+  link = getLink(rdh);
+}
+
+} // namespace rdh_utils
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/base/test/testRDHUtils.cxx
+++ b/Detectors/TPC/base/test/testRDHUtils.cxx
@@ -1,0 +1,107 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TPC CalDet class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+#include "Headers/RAWDataHeader.h"
+#include "TPCBase/RDHUtils.h"
+
+namespace o2
+{
+namespace tpc
+{
+using namespace rdh_utils;
+
+struct FEEDetails {
+  FEEDetails(FEEIDType c, FEEIDType e, FEEIDType l) : cru(c), endpoint(e), link(l), feeID((cru << 7) | (endpoint << 6) | link), userLogic(l == UserLogicLinkID) {}
+  FEEIDType cru{};
+  FEEIDType endpoint{};
+  FEEIDType link{};
+  FEEIDType feeID{};
+  bool userLogic{};
+};
+
+BOOST_AUTO_TEST_CASE(testRDHUtils)
+{
+  // coose some random values
+  std::vector<FEEDetails> testDetails;
+  testDetails.emplace_back(359, 1, 15);
+  testDetails.emplace_back(1, 0, 10);
+  testDetails.emplace_back(100, 1, 8);
+  testDetails.emplace_back(142, 0, 1);
+  testDetails.emplace_back(225, 1, 9);
+
+  o2::header::RAWDataHeaderV4 rdh4;
+  o2::header::RAWDataHeaderV5 rdh5;
+  o2::header::RAWDataHeaderV6 rdh6;
+
+  for (const auto& fee : testDetails) {
+    const auto feeID = getFEEID(fee.cru, fee.endpoint, fee.link);
+
+    // default checks
+    auto cru = getCRU(feeID);
+    auto link = getLink(feeID);
+    auto endpoint = getEndPoint(feeID);
+    bool userLogic = isFromUserLogic(feeID);
+
+    BOOST_CHECK_EQUAL(feeID, fee.feeID);
+    BOOST_CHECK_EQUAL(cru, fee.cru);
+    BOOST_CHECK_EQUAL(endpoint, fee.endpoint);
+    BOOST_CHECK_EQUAL(link, fee.link);
+    BOOST_CHECK_EQUAL(userLogic, fee.userLogic);
+
+    // RDH v4 checks
+    rdh4.feeId = feeID;
+    cru = getCRU(rdh4);
+    link = getLink(rdh4);
+    endpoint = getEndPoint(rdh4);
+    userLogic = isFromUserLogic(rdh4);
+
+    BOOST_CHECK_EQUAL(feeID, fee.feeID);
+    BOOST_CHECK_EQUAL(cru, fee.cru);
+    BOOST_CHECK_EQUAL(endpoint, fee.endpoint);
+    BOOST_CHECK_EQUAL(link, fee.link);
+    BOOST_CHECK_EQUAL(userLogic, fee.userLogic);
+
+    // RDH v5 checks
+    rdh5.feeId = feeID;
+    cru = getCRU(rdh5);
+    link = getLink(rdh5);
+    endpoint = getEndPoint(rdh5);
+    userLogic = isFromUserLogic(rdh5);
+
+    BOOST_CHECK_EQUAL(feeID, fee.feeID);
+    BOOST_CHECK_EQUAL(cru, fee.cru);
+    BOOST_CHECK_EQUAL(endpoint, fee.endpoint);
+    BOOST_CHECK_EQUAL(link, fee.link);
+    BOOST_CHECK_EQUAL(userLogic, fee.userLogic);
+
+    // RDH v6 checks
+    rdh6.feeId = feeID;
+    cru = getCRU(rdh6);
+    link = getLink(rdh6);
+    endpoint = getEndPoint(rdh6);
+    userLogic = isFromUserLogic(rdh6);
+
+    BOOST_CHECK_EQUAL(feeID, fee.feeID);
+    BOOST_CHECK_EQUAL(cru, fee.cru);
+    BOOST_CHECK_EQUAL(endpoint, fee.endpoint);
+    BOOST_CHECK_EQUAL(link, fee.link);
+    BOOST_CHECK_EQUAL(userLogic, fee.userLogic);
+  }
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -126,7 +126,7 @@ void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::
   GPUParam _GPUParam;
   _GPUParam.SetDefaults(5.00668);
   const GPUParam mGPUParam = _GPUParam;
-  const float zsThreshold = 0;
+  const float zsThreshold = 2;
 
   o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
   zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, verify, zsThreshold);

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -35,6 +35,7 @@
 #include "DataFormatsTPC/ZeroSuppression.h"
 #include "DataFormatsTPC/Helpers.h"
 #include "DetectorsRaw/HBFUtils.h"
+#include "TPCBase/RDHUtils.h"
 
 namespace bpo = boost::program_options;
 
@@ -87,7 +88,7 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   // raw data output
   o2::raw::RawFileWriter writer;
 
-  const unsigned int defaultLink = 15;
+  const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
 
   // set up raw writer
   std::string outDir{outputPath};
@@ -101,8 +102,8 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
     for (unsigned int j = 0; j < NEndpoints; j++) {
       const unsigned int cruInSector = j / 2;
       const unsigned int cruID = i * 10 + cruInSector;
-      const unsigned int feeid = (cruID << 7) | ((j & 1) << 6) | (defaultLink & 0x3F);
-      writer.registerLink(feeid, cruID, defaultLink, j % 2, fmt::format("{}cru{}.raw", outDir, cruID));
+      const rdh_utils::FEEIDType feeid = rdh_utils::getFEEID(cruID, j & 1, defaultLink);
+      writer.registerLink(feeid, cruID, defaultLink, j & 1, fmt::format("{}cru{}.raw", outDir, cruID));
     }
   }
   for (Long64_t ievent = 0; ievent < treeSim->GetEntries(); ++ievent) {

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -415,13 +415,13 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
                 tpcZSmetaSizes[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].emplace_back(count);
               }
               count = 0;
-              if (it.size() == 0) {
-                ptr = nullptr;
-                continue;
-              }
               lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
               rawcru = rdh_utils::getCRU(lastFEE);
               rawendpoint = rdh_utils::getEndPoint(lastFEE);
+              if (it.size() == 0 && tpcZSmetaPointers[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].size()) {
+                ptr = nullptr;
+                continue;
+              }
               ptr = current;
             }
             count++;

--- a/GPU/GPUTracking/Base/GPURawData.h
+++ b/GPU/GPUTracking/Base/GPURawData.h
@@ -44,6 +44,7 @@ class GPURawDataUtils
  public:
   static GPUd() unsigned int getOrbit(const o2::header::RAWDataHeader* rdh);
   static GPUd() unsigned int getBC(const o2::header::RAWDataHeader* rdh);
+  static GPUd() unsigned int getSize(const o2::header::RAWDataHeader* rdh);
 };
 
 GPUdi() unsigned int GPURawDataUtils::getOrbit(const o2::header::RAWDataHeader* rdh)
@@ -61,6 +62,15 @@ GPUdi() unsigned int GPURawDataUtils::getBC(const o2::header::RAWDataHeader* rdh
   return o2::raw::RDHUtils::getHeartBeatBC(*rdh);
 #else
   return ((rdh->words[4] >> 48) & 0xFFF); // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
+#endif
+}
+
+GPUdi() unsigned int GPURawDataUtils::getSize(const o2::header::RAWDataHeader* rdh)
+{
+#ifndef __OPENCL__
+  return o2::raw::RDHUtils::getMemorySize(*rdh);
+#else
+  return ((rdh->words[1] >> 16) & 0xFFFF); // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
 #endif
 }
 

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -344,6 +344,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
             o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)page;
             o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, hbf);
             o2::raw::RDHUtils::setHeartBeatBC(*rdh, bcShiftInFirstHBF);
+            o2::raw::RDHUtils::setMemorySize(*rdh, TPCZSHDR::TPC_ZS_PAGE_SIZE);
           }
         }
         if (k >= tmpBuffer.size()) {
@@ -361,14 +362,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
             o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)page;
             o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, 0);
             o2::raw::RDHUtils::setHeartBeatBC(*rdh, bcShiftInFirstHBF);
-            pagePtr = reinterpret_cast<unsigned char*>(page);
-            pagePtr += sizeof(o2::header::RAWDataHeader);
-            hdr = reinterpret_cast<TPCZSHDR*>(pagePtr);
-            hdr->version = zs12bit ? 2 : 1;
-            hdr->cruID = i * 10 + region;
-            hdr->timeOffset = 0;
-            hdr->nTimeBins = 0;
-            hdr->nADCsamples = 0;
+            o2::raw::RDHUtils::setMemorySize(*rdh, sizeof(o2::header::RAWDataHeader));
             totalPages++;
           }
           buffer[i][endpoint].emplace_back();
@@ -436,6 +430,9 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           page = &buffer[i][j][k];
           pagePtr = reinterpret_cast<unsigned char*>(page);
           const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)pagePtr;
+          if (o2::raw::RDHUtils::getMemorySize(*rdh) == sizeof(o2::header::RAWDataHeader)) {
+            continue;
+          }
           pagePtr += sizeof(o2::header::RAWDataHeader);
           hdr = reinterpret_cast<TPCZSHDR*>(pagePtr);
           pagePtr += sizeof(*hdr);

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -34,6 +34,7 @@
 #include "DataFormatsTPC/Constants.h"
 #include "GPURawData.h"
 #include "CommonConstants/LHCConstants.h"
+#include "TPCBase/RDHUtils.h"
 #endif
 
 using namespace GPUCA_NAMESPACE::gpu;
@@ -228,7 +229,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
   for (unsigned int i = 0; i < NSLICES; i++) {
     std::array<long long int, TPCZSHDR::TPC_ZS_PAGE_SIZE / sizeof(long long int)> singleBuffer;
 #ifdef GPUCA_O2_LIB
-    int rawlnk = 15;
+    int rawlnk = rdh_utils::UserLogicLinkID;
     int bcShiftInFirstHBF = ir ? ir->bc : 0;
 #else
     int bcShiftInFirstHBF = 0;
@@ -335,7 +336,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         if (page && (k >= tmpBuffer.size() || endpoint != lastEndpoint)) {
 #ifdef GPUCA_O2_LIB
           if (raw) {
-            const int rawfeeid = (rawcru << 7) | (rawendpoint << 6) | rawlnk;
+            const rdh_utils::FEEIDType rawfeeid = rdh_utils::getFEEID(rawcru, rawendpoint, rawlnk);
             raw->addData(rawfeeid, rawcru, rawlnk, rawendpoint, *ir + hbf * o2::constants::lhc::LHCMaxBunches, gsl::span<char>((char*)page + sizeof(o2::header::RAWDataHeader), (char*)page + TPCZSHDR::TPC_ZS_PAGE_SIZE), true);
           } else
 #endif

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -157,7 +157,7 @@ AddOption(overrideMaxTimebin, bool, false, "overrideMaxTimebin", 0, "Override ma
 AddOption(encodeZS, int, -1, "encodeZS", 0, "Zero-Suppress TPC data", def(1))
 AddOption(zsFilter, int, -1, "zsFilter", 0, "Apply Zero-Suppression when loading digits and remove those below threshold", def(1))
 AddOption(zsThreshold, float, 2.0f, "zsThreshold", 0, "Zero-Suppression threshold")
-AddOption(zs12bit, bool, false, "zs12bit", 0, "Perform 12 bit zero-suppression encoding / filter")
+AddOption(zs12bit, bool, true, "zs12bit", 0, "Perform 12 bit zero-suppression encoding / filter")
 AddOption(dumpEvents, bool, false, "dumpEvents", 0, "Dump events (after transformation such as encodeZS")
 AddOption(stripDumpedEvents, bool, false, "stripDumpedEvents", 0, "Remove redundant inputs (e.g. digits and ZS) before dumping")
 AddOption(referenceX, float, 500.f, "referenceX", 0, "Reference X position to transport track to after fit")

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -75,6 +75,13 @@ GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUShared
       GPUbarrier();
       const unsigned char* page = (const unsigned char*)pageCache;
       const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)page;
+      if (GPURawDataUtils::getSize(rdh) == sizeof(o2::header::RAWDataHeader)) {
+#ifdef GPUCA_GPUCODE
+        return;
+#else
+        continue;
+#endif
+      }
       const unsigned char* pagePtr = page + sizeof(o2::header::RAWDataHeader);
       const TPCZSHDR* hdr = reinterpret_cast<const TPCZSHDR*>(pagePtr);
       pagePtr += sizeof(*hdr);

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.h
@@ -36,9 +36,7 @@ class GPUTPCCFDecodeZS : public GPUKernelTemplate
     unsigned int regionStartRow;
     unsigned int nThreadsPerRow;
     unsigned int rowStride;
-    unsigned int decodeBits;
     GPUAtomic(unsigned int) rowOffsetCounter;
-    float decodeBitsFactor;
   };
 
   enum K : int {

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
@@ -53,8 +53,9 @@ void* GPUTPCClusterFinder::SetPointersInput(void* mem)
 
 void* GPUTPCClusterFinder::SetPointersZSOffset(void* mem)
 {
-  if (mNMaxPages) {
-    computePointerWithAlignment(mem, mPzsOffsets, (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding) ? mNMaxPages : GPUTrackingInOutZS::NENDPOINTS);
+  const int n = (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding) ? mNMaxPages : GPUTrackingInOutZS::NENDPOINTS;
+  if (n) {
+    computePointerWithAlignment(mem, mPzsOffsets, n);
   }
   return mem;
 }


### PR DESCRIPTION
This requires #3372 and #3369, so I just included the commits here, should be clean after rebasing.
Changes are:
- Fix a problem in TPC ZS decoding when the first HBF does not contain any payload.
- Fix decoding when storing 12 bit values instead of 10
- Use the TPC cru --> feeid mapper instead of in place computation.
Hopefully this store is closed now...