### PR TITLE
GPU: Propagate clustersNative found by ca-clusterer back to tpc workflow

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -288,6 +288,9 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
   }
   outClusRefs->resize(clBuff); // remove overhead
   data->compressedClusters = ptrs.tpcCompressedClusters;
+  if (data->o2Digits || data->tpcZS) {
+    data->clusters = ptrs.clustersNative;
+  }
   mTrackingCAO2Interface->Clear(false);
 
   return (retVal);


### PR DESCRIPTION
minor fix, this was not propagated back to the workflow.