### PR TITLE
GPU: Break with with failure about broken compiler only for standalone tests

### DIFF
--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -179,9 +179,11 @@ void GPUReconstructionHIPBackend::GetITSTraits(std::unique_ptr<o2::its::TrackerT
 
 int GPUReconstructionHIPBackend::InitDevice_Runtime()
 {
+#ifdef GPUCA_STANDALONE
   if (mDeviceProcessingSettings.mergerSortTracks) {
     GPUFatal("sorting merger track indizes unsupported by HIP (compiler bug), please use --PROCmergerSortTracks option!"); // TODO: BUG: remove me, workaround for bug in hipcc compiler
   }
+#endif
 
   // Find best HIP device, initialize and allocate memory
   GPUCA_GPUReconstructionUpdateDefailts();


### PR DESCRIPTION
@mconcas : that should fix your problem
This is just a warning to myself in order not to run into a compiler problem because I keep forgetting about it.
Obviously not needed in ITS GPU initialization...