### PR TITLE
Fix: RawFileReader was making 1 extra loop

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -45,7 +45,6 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
 
   IR getFirstIR() const { return {bcFirst, orbitFirst}; }
 
-  void setNOrbitsPerTF(int n) { nHBFPerTF = n > 0 ? n : 1; }
   int getNOrbitsPerTF() const { return nHBFPerTF; }
 
   ///< get IR corresponding to start of the HBF

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -44,7 +44,7 @@ class rawReaderSpecs : public o2f::Task
 {
  public:
   explicit rawReaderSpecs(const std::string& config, bool tfAsMessage = false, bool outPerRoute = true, int loop = 1, uint32_t delay_us = 0)
-    : mLoop(loop), mHBFPerMessage(!tfAsMessage), mOutPerRoute(outPerRoute), mDelayUSec(delay_us), mReader(std::make_unique<o2::raw::RawFileReader>(config))
+    : mLoop(loop < 1 ? 1 : loop), mHBFPerMessage(!tfAsMessage), mOutPerRoute(outPerRoute), mDelayUSec(delay_us), mReader(std::make_unique<o2::raw::RawFileReader>(config))
   {
     LOG(INFO) << "Number of loops over whole data requested: " << mLoop;
     if (mHBFPerMessage) {
@@ -100,7 +100,7 @@ class rawReaderSpecs : public o2f::Task
     }
 
     if (tfID >= mReader->getNTimeFrames()) {
-      if (mReader->getNTimeFrames() && mLoop--) {
+      if (mReader->getNTimeFrames() && --mLoop) {
         tfID = 0;
         mReader->setNextTFToRead(tfID);
         loopsDone++;

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace raw
 {
 
-framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true, int loop = 0, uint32_t delay_us = 0);
+framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true, int loop = 1, uint32_t delay_us = 0);
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -18,7 +18,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   workflowOptions.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
-  workflowOptions.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 0, {"loop N times (infinite for N<0)"}});
+  workflowOptions.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
   workflowOptions.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
   workflowOptions.push_back(ConfigParamSpec{"output-per-link", o2::framework::VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
   workflowOptions.push_back(ConfigParamSpec{"delay", o2::framework::VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});


### PR DESCRIPTION
rawfile-reader-workflow was doing n+1 passes over data when --loops n was asked, now does
exactly n and and not asking anything == asking 1

Eliminate wrong setter of HBFUtils (as CongigurableParam it cannoot have ones)