### PR TITLE
Multi-threading for ITS/MFT data decoding/clusterization + minor fixes

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -74,8 +74,6 @@ class ClusterTopology
     }
   }
 
-  friend class Clusterer;
-
  private:
   void setHash(unsigned long hash) { mHash = hash; }
   ClusterPattern mPattern; ///< Pattern of pixels

--- a/Detectors/ITSMFT/ITS/README.md
+++ b/Detectors/ITSMFT/ITS/README.md
@@ -10,6 +10,8 @@
 
 *   `o2-its-reco-workflow`: reconstruction of ITS tracks starting from simulated digits.
 
+*   `o2-itsmft-stf-decoder-workflow`: raw data STF decoder and clusterizer. Provides either cluster or digits or both. Supports multi-threading.
+
 Can be extended to reconstruction from the raw data by disabling the digits reader and piping it to the output of the STF reader:
 
 ```bash

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -78,7 +78,7 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
   if (mRawDataMode) {
 
     mReaderRaw->openInput(inpName);
-    mClusterer.process(*mReaderRaw.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, nullptr);
+    mClusterer.process(1, *mReaderRaw.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, nullptr);
 
     auto basename = outName.substr(0, outName.size() - sizeof("root"));
     auto nFiles = int(mROFRecVec.size() / maxROframe);
@@ -123,7 +123,7 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
 
     // loop over entries of the input tree
     while (mReaderMC->readNextEntry()) {
-      mClusterer.process(*mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
+      mClusterer.process(1, *mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
     }
 
     outTree.Branch("ITSClusterPatt", &mPatterns);

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -40,6 +40,7 @@ class ClustererDPL : public Task
   bool mUseMC = true;
   bool mFullClusters = true; // RSTODO: TO BE ELIMINATED but MFT is not ready yet
   bool mPatterns = true;
+  int mNThreads = 1;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;
 };

--- a/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
@@ -80,7 +80,7 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
   if (mRawDataMode) {
 
     mReaderRaw->openInput(inpName);
-    mClusterer.process(*mReaderRaw.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, nullptr);
+    mClusterer.process(1, *mReaderRaw.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, nullptr);
 
     auto basename = outName.substr(0, outName.size() - sizeof("root"));
     auto nFiles = int(mROFRecVec.size() / maxROframe);
@@ -125,7 +125,7 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
 
     // loop over entries of the input tree
     while (mReaderMC->readNextEntry()) {
-      mClusterer.process(*mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
+      mClusterer.process(1, *mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
     }
 
     outTree.Branch("MFTClusterPatt", &mPatterns);

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClustererSpec.h
@@ -40,6 +40,7 @@ class ClustererDPL : public Task
   bool mUseMC = true;
   bool mFullClusters = true; // RSTODO TO BE ELINIMATED but the MFT is not ready yet
   bool mPatterns = true;
+  int mNThreads = 1;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;
 };

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -63,6 +63,7 @@ void ClustererDPL::init(InitContext& ic)
 
   mFullClusters = ic.options().get<bool>("full-clusters");
   mPatterns = !ic.options().get<bool>("no-patterns");
+  mNThreads = ic.options().get<int>("nthreads");
 
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
@@ -104,24 +105,20 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   reader.init();
   auto orig = o2::header::gDataOriginMFT;
-  std::vector<o2::itsmft::Cluster, boost::container::pmr::polymorphic_allocator<o2::itsmft::Cluster>>* clusVec = nullptr;
-  std::vector<o2::itsmft::CompClusterExt, boost::container::pmr::polymorphic_allocator<o2::itsmft::CompClusterExt>>* clusCompVec = nullptr;
-  std::vector<o2::itsmft::ROFRecord, boost::container::pmr::polymorphic_allocator<o2::itsmft::ROFRecord>>* clusROFVec = nullptr;
-  std::vector<unsigned char, boost::container::pmr::polymorphic_allocator<unsigned char>>* clusPattVec = nullptr;
+  std::vector<o2::itsmft::Cluster> clusVec;
+  std::vector<o2::itsmft::CompClusterExt> clusCompVec;
+  std::vector<o2::itsmft::ROFRecord> clusROFVec;
+  std::vector<unsigned char> clusPattVec;
 
   std::unique_ptr<o2::dataformats::MCTruthContainer<o2::MCCompLabel>> clusterLabels;
   if (mUseMC) {
     clusterLabels = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
   }
-
-  clusCompVec = &pc.outputs().make<std::vector<o2::itsmft::CompClusterExt>>(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe});
-  clusROFVec = &pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{orig, "MFTClusterROF", 0, Lifetime::Timeframe});
-  //  if (mFullClusters) // in principle, we don't need to send empty array, but other devices expecting it do not know about options of this device: problem?
-  clusVec = &pc.outputs().make<std::vector<o2::itsmft::Cluster>>(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe});
-  //  if (mPatterns) // idem
-  clusPattVec = &pc.outputs().make<std::vector<unsigned char>>(Output{orig, "PATTERNS", 0, Lifetime::Timeframe});
-
-  mClusterer->process(reader, mFullClusters ? clusVec : nullptr, clusCompVec, mPatterns ? clusPattVec : nullptr, clusROFVec, clusterLabels.get());
+  mClusterer->process(mNThreads, reader, mFullClusters ? &clusVec : nullptr, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
+  pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
+  pc.outputs().snapshot(Output{orig, "MFTClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec);
+  pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
 
   if (mUseMC) {
     pc.outputs().snapshot(Output{orig, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get()); // at the moment requires snapshot
@@ -134,7 +131,7 @@ void ClustererDPL::run(ProcessingContext& pc)
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
   // -> consider recalculationg maxROF
-  LOG(INFO) << "MFTClusterer pushed " << clusCompVec->size() << " clusters, in " << clusROFVec->size() << " RO frames";
+  LOG(INFO) << "MFTClusterer pushed " << clusCompVec.size() << " clusters, in " << clusROFVec.size() << " RO frames";
 }
 
 DataProcessorSpec getClustererSpec(bool useMC)
@@ -165,7 +162,8 @@ DataProcessorSpec getClustererSpec(bool useMC)
       {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"full-clusters", o2::framework::VariantType::Bool, true, {"Produce full clusters"}}, // RSTODO temporary set to true
-      {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}}}};
+      {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
+      {"nthreads", VariantType::Int, 0, {"Number of clustering threads (<1: rely on openMP default)"}}}};
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -9,6 +9,7 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(ITSMFTReconstruction
+               TARGETVARNAME targetName
                SOURCES src/ChipMappingITS.cxx
                        src/ChipMappingMFT.cxx
                        src/DigitPixelReader.cxx
@@ -52,3 +53,9 @@ o2_target_root_dictionary(
           include/ITSMFTReconstruction/PayLoadCont.h
           include/ITSMFTReconstruction/PayLoadSG.h	  
           include/ITSMFTReconstruction/RUInfo.h)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()
+  

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -73,6 +73,9 @@ class Clusterer
   //=========================================================
   /// methods and transient data used within a thread
   struct ClustererThread {
+    static constexpr float SigmaX2 = SegmentationAlpide::PitchRow * SegmentationAlpide::PitchRow / 12.;
+    static constexpr float SigmaY2 = SegmentationAlpide::PitchCol * SegmentationAlpide::PitchCol / 12.;
+
     Clusterer* parent = nullptr; // parent clusterer
     // buffers for entries in preClusterIndices in 2 columns, to avoid boundary checks, we reserve
     // extra elements in the beginning and the end
@@ -125,7 +128,10 @@ class Clusterer
     void fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled);
     void initChip(const ChipPixelData* curChipData, uint32_t first);
     void updateChip(const ChipPixelData* curChipData, uint32_t ip);
-    void finishChip(ChipPixelData* curChipData, FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns, const MCTruth* labelsDig, MCTruth* labelsClus);
+    void finishChip(ChipPixelData* curChipData, FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns,
+                    const MCTruth* labelsDig, MCTruth* labelsClus);
+    void finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, FullClusCont* fullClusPtr, CompClusCont* compClusPtr,
+                                 PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr);
     void process(gsl::span<ChipPixelData*> chipPtrs, FullClusCont* fullClusPtr, CompClusCont* compClusPtr, PatternCont* patternsPtr,
                  const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord* rofPtr);
 
@@ -138,7 +144,7 @@ class Clusterer
   //=========================================================
 
   Clusterer();
-  ~Clusterer();
+  ~Clusterer() = default;
 
   Clusterer(const Clusterer&) = delete;
   Clusterer& operator=(const Clusterer&) = delete;
@@ -176,6 +182,7 @@ class Clusterer
   void loadDictionary(const std::string& fileName) { mPattIdConverter.loadDictionary(fileName); }
 
   TStopwatch& getTimer() { return mTimer; } // cannot be const
+  TStopwatch& getTimerMerge() { return mTimerMerge; } // cannot be const
 
  private:
 
@@ -220,6 +227,7 @@ class Clusterer
   TTree* mClusTree = nullptr;    //! externally provided tree to write clusters output (if needed)
 
   TStopwatch mTimer;
+  TStopwatch mTimerMerge;
 };
 
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -18,7 +18,8 @@
 #include <utility>
 #include <vector>
 #include <cstring>
-#include "ITSMFTBase/GeometryTGeo.h"
+#include <memory>
+#include <gsl/span>
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "DataFormatsITSMFT/CompCluster.h"
@@ -27,14 +28,14 @@
 #include "ITSMFTReconstruction/PixelData.h"
 #include "ITSMFTReconstruction/LookUp.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "CommonDataFormat/InteractionRecord.h"
 #include "CommonConstants/LHCConstants.h"
 #include "Rtypes.h"
-#include "TTree.h"
 
 #ifdef _PERFORM_TIMING_
 #include <TStopwatch.h>
 #endif
+
+class TTree;
 
 namespace o2
 {
@@ -47,6 +48,16 @@ class MCTruthContainer;
 
 namespace itsmft
 {
+
+class GeometryTGeo;
+
+using FullClusCont = std::vector<Cluster>;
+using CompClusCont = std::vector<CompClusterExt>;
+using PatternCont = std::vector<unsigned char>;
+using ROFRecCont = std::vector<ROFRecord>;
+
+//template <class FullClusCont, class CompClusCont, class PatternCont, class ROFRecCont> // container types (PMR or std::vectors)
+
 class Clusterer
 {
   using PixelReader = o2::itsmft::PixelReader;
@@ -58,24 +69,82 @@ class Clusterer
   using Label = o2::MCCompLabel;
   using MCTruth = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
-  using BCData = o2::InteractionRecord;
-
  public:
+  //=========================================================
+  /// methods and transient data used within a thread
+  struct ClustererThread {
+    Clusterer* parent = nullptr; // parent clusterer
+    // buffers for entries in preClusterIndices in 2 columns, to avoid boundary checks, we reserve
+    // extra elements in the beginning and the end
+    int column1[SegmentationAlpide::NRows + 2];
+    int column2[SegmentationAlpide::NRows + 2];
+    int* curr = nullptr; // pointer on the 1st row of currently processed columnsX
+    int* prev = nullptr; // pointer on the 1st row of previously processed columnsX
+    // pixels[].first is the index of the next pixel of the same precluster in the pixels
+    // pixels[].second is the index of the referred pixel in the ChipPixelData (element of mChips)
+    std::vector<std::pair<int, uint32_t>> pixels;
+    std::vector<int> preClusterHeads; // index of precluster head in the pixels
+    std::vector<int> preClusterIndices;
+    uint16_t currCol = 0xffff;                                      ///< Column being processed
+    bool noLeftCol = true;                                          ///< flag that there is no column on the left to check
+    std::array<Label, Cluster::maxLabels> labelsBuff;               //! temporary buffer for building cluster labels
+    std::array<PixelData, Cluster::kMaxPatternBits * 2> pixArrBuff; //! temporary buffer for pattern calc.
+    //
+    /// temporary storage for the thread output
+    FullClusCont fullClusters;
+    CompClusCont compClusters;
+    PatternCont patterns;
+    MCTruth labels;
+    ///
+    ///< reset column buffer, for the performance reasons we use memset
+    void resetColumn(int* buff) { std::memset(buff, -1, sizeof(int) * SegmentationAlpide::NRows); }
+
+    ///< swap current and previous column buffers
+    void swapColumnBuffers() { std::swap(prev, curr); }
+
+    ///< add cluster at row (entry ip in the ChipPixeData) to the precluster with given index
+    void expandPreCluster(uint32_t ip, uint16_t row, int preClusIndex)
+    {
+      auto& firstIndex = preClusterHeads[preClusterIndices[preClusIndex]];
+      pixels.emplace_back(firstIndex, ip);
+      firstIndex = pixels.size() - 1;
+      curr[row] = preClusIndex;
+    }
+
+    ///< add new precluster at given row of current column for the fired pixel with index ip in the ChipPixelData
+    void addNewPrecluster(uint32_t ip, uint16_t row)
+    {
+      preClusterHeads.push_back(pixels.size());
+      // new head does not point yet (-1) on other pixels, store just the entry of the pixel in the ChipPixelData
+      pixels.emplace_back(-1, ip);
+      int lastIndex = preClusterIndices.size();
+      preClusterIndices.push_back(lastIndex);
+      curr[row] = lastIndex; // store index of the new precluster in the current column buffer
+    }
+
+    void fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled);
+    void initChip(const ChipPixelData* curChipData, uint32_t first);
+    void updateChip(const ChipPixelData* curChipData, uint32_t ip);
+    void finishChip(ChipPixelData* curChipData, FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns, const MCTruth* labelsDig, MCTruth* labelsClus);
+    void process(gsl::span<ChipPixelData*> chipPtrs, FullClusCont* fullClusPtr, CompClusCont* compClusPtr, PatternCont* patternsPtr,
+                 const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord* rofPtr);
+
+    ClustererThread(Clusterer* par = nullptr) : parent(par), curr(column2 + 1), prev(column1 + 1)
+    {
+      std::fill(std::begin(column1), std::end(column1), -1);
+      std::fill(std::begin(column2), std::end(column2), -1);
+    }
+  };
+  //=========================================================
+
   Clusterer();
   ~Clusterer();
 
   Clusterer(const Clusterer&) = delete;
   Clusterer& operator=(const Clusterer&) = delete;
 
-  template <class FullClusCont, class CompClusCont, class PatternCont, class ROFRecCont>
-  void process(PixelReader& r,
-               FullClusCont* fullClus = nullptr,
-               CompClusCont* compClus = nullptr,
-               PatternCont* patterns = nullptr,
-               ROFRecCont* vecROFRec = nullptr,
-               MCTruth* labelsCl = nullptr);
+  void process(int nThreads, PixelReader& r, FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns, ROFRecCont* vecROFRec, MCTruth* labelsCl = nullptr);
 
-  // provide the common itsmft::GeometryTGeo to access matrices
   void setGeometry(const o2::itsmft::GeometryTGeo* gm) { mGeometry = gm; }
 
   bool isContinuousReadOut() const { return mContinuousReadout; }
@@ -90,7 +159,7 @@ class Clusterer
   bool getWantFullClusters() const { return mWantFullClusters; }
   bool getWantCompactClusters() const { return mWantCompactClusters; }
 
-  UInt_t getCurrROF() const { return mROFRef.getROFrame(); }
+  uint32_t getCurrROF() const { return mROFRef.getROFrame(); }
 
   void print() const;
   void clear();
@@ -104,99 +173,30 @@ class Clusterer
   }
 
   ///< load the dictionary of cluster topologies
-  void loadDictionary(std::string fileName)
-  {
-    mPattIdConverter.loadDictionary(fileName);
-  }
+  void loadDictionary(const std::string& fileName) { mPattIdConverter.loadDictionary(fileName); }
 
   TStopwatch& getTimer() { return mTimer; } // cannot be const
 
  private:
-  void initChip(UInt_t first);
-
-  ///< add new precluster at given row of current column for the fired pixel with index ip in the ChipPixelData
-  void addNewPrecluster(UInt_t ip, UShort_t row)
-  {
-    mPreClusterHeads.push_back(mPixels.size());
-    // new head does not point yet (-1) on other pixels, store just the entry of the pixel in the ChipPixelData
-    mPixels.emplace_back(-1, ip);
-    int lastIndex = mPreClusterIndices.size();
-    mPreClusterIndices.push_back(lastIndex);
-    mCurr[row] = lastIndex; // store index of the new precluster in the current column buffer
-  }
-
-  ///< add cluster at row (entry ip in the ChipPixeData) to the precluster with given index
-  void expandPreCluster(UInt_t ip, UShort_t row, int preClusIndex)
-  {
-    auto& firstIndex = mPreClusterHeads[mPreClusterIndices[preClusIndex]];
-    mPixels.emplace_back(firstIndex, ip);
-    firstIndex = mPixels.size() - 1;
-    mCurr[row] = preClusIndex;
-  }
 
   ///< recalculate min max row and column of the cluster accounting for the position of pix
-  void adjustBoundingBox(const o2::itsmft::PixelData pix, UShort_t& rMin, UShort_t& rMax,
-                         UShort_t& cMin, UShort_t& cMax) const
+  static void adjustBoundingBox(uint16_t row, uint16_t col, uint16_t& rMin, uint16_t& rMax, uint16_t& cMin, uint16_t& cMax)
   {
-    if (pix.getRowDirect() < rMin) {
-      rMin = pix.getRowDirect();
+    if (row < rMin) {
+      rMin = row;
     }
-    if (pix.getRowDirect() > rMax) {
-      rMax = pix.getRowDirect();
+    if (row > rMax) {
+      rMax = row;
     }
-    if (pix.getCol() < cMin) {
-      cMin = pix.getCol();
+    if (col < cMin) {
+      cMin = col;
     }
-    if (pix.getCol() > cMax) {
-      cMax = pix.getCol();
+    if (col > cMax) {
+      cMax = col;
     }
   }
 
-  ///< swap current and previous column buffers
-  void swapColumnBuffers()
-  {
-    int* tmp = mCurr;
-    mCurr = mPrev;
-    mPrev = tmp;
-  }
-
-  ///< reset column buffer, for the performance reasons we use memset
-  void resetColumn(int* buff)
-  {
-    std::memset(buff, -1, sizeof(int) * SegmentationAlpide::NRows);
-    //std::fill(buff, buff + SegmentationAlpide::NRows, -1);
-  }
-
-  void updateChip(UInt_t ip);
-
-  template <class FullClusCont, class CompClusCont, class PatternCont>
-  void finishChip(FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns,
-                  const MCTruth* labelsDig = nullptr, MCTruth* labelsClus = nullptr);
-
-  void fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled);
-
-  ///< flush cluster data accumulated so far into the tree
-  template <class FullClusCont, class CompClusCont>
-  void flushClusters(FullClusCont* fullClus, CompClusCont* compClus, MCTruth* labels)
-  {
-#ifdef _PERFORM_TIMING_
-    mTimer.Stop();
-#endif
-
-    mClusTree->Fill();
-#ifdef _PERFORM_TIMING_
-    mTimer.Start(kFALSE);
-#endif
-    if (fullClus) {
-      fullClus->clear();
-    }
-    if (compClus) {
-      compClus->clear();
-    }
-    if (labels) {
-      labels->clear();
-    }
-  }
+  void flushClusters(FullClusCont* fullClus, CompClusCont* compClus, MCTruth* labels);
 
   // clusterization options
   bool mContinuousReadout = true;    ///< flag continuous readout
@@ -206,316 +206,22 @@ class Clusterer
   ///< mask continuosly fired pixels in frames separated by less than this amount of BCs (fired from hit in prev. ROF)
   int mMaxBCSeparationToMask = 6000. / o2::constants::lhc::LHCBunchSpacingNS + 10;
 
-  // aux data for clusterization
-  ChipPixelData* mChipData = nullptr; //! pointer on the current single chip data provided by the reader
+  std::vector<std::unique_ptr<ClustererThread>> mThreads; // buffers for threads
+  std::vector<ChipPixelData> mChips;                      // currently processed ROF's chips data
+  std::vector<ChipPixelData> mChipsOld;                   // previously processed ROF's chips data (for masking)
+  std::vector<ChipPixelData*> mFiredChipsPtr;             // pointers on the fired chips data in the decoder cache
 
-  ///< array of chips, at the moment index corresponds to chip ID.
-  ///< for the processing of fraction of chips only consider mapping of IDs range on mChips
-  std::vector<ChipPixelData> mChips;    // currently processed chips data
-  std::vector<ChipPixelData> mChipsOld; // previously processed chips data (for masking)
-
-  // buffers for entries in mPreClusterIndices in 2 columns, to avoid boundary checks, we reserve
-  // extra elements in the beginning and the end
-  int mColumn1[SegmentationAlpide::NRows + 2];
-  int mColumn2[SegmentationAlpide::NRows + 2];
-  int* mCurr; // pointer on the 1st row of currently processed mColumnsX
-  int* mPrev; // pointer on the 1st row of previously processed mColumnsX
-
-  o2::itsmft::ROFRecord mROFRef; // ROF reference
-
-  // mPixels[].first is the index of the next pixel of the same precluster in the mPixels
-  // mPixels[].second is the index of the referred pixel in the ChipPixelData (element of mChips)
-  std::vector<std::pair<int, UInt_t>> mPixels;
-  std::vector<int> mPreClusterHeads; // index of precluster head in the mPixels
-  std::vector<int> mPreClusterIndices;
-  UShort_t mCol = 0xffff; ///< Column being processed
-
-  bool mNoLeftColumn = true;                           ///< flag that there is no column on the left to check
   const o2::itsmft::GeometryTGeo* mGeometry = nullptr; //! ITS OR MFT upgrade geometry
 
-  TTree* mClusTree = nullptr;                                      //! externally provided tree to write clusters output (if needed)
-  std::array<Label, Cluster::maxLabels> mLabelsBuff;               //! temporary buffer for building cluster labels
-  std::array<PixelData, Cluster::kMaxPatternBits * 2> mPixArrBuff; //! temporary buffer for pattern calc.
-
   LookUp mPattIdConverter; //! Convert the cluster topology to the corresponding entry in the dictionary.
+
+  // this makes sense only for single-threaded execution with autosaving of the tree: legacy, TOREM
+  o2::itsmft::ROFRecord mROFRef; // ROF reference
+  TTree* mClusTree = nullptr;    //! externally provided tree to write clusters output (if needed)
 
   TStopwatch mTimer;
 };
 
-//__________________________________________________
-template <class FullClusCont, class CompClusCont, class PatternCont, class ROFRecCont>
-void Clusterer::process(PixelReader& reader, FullClusCont* fullClus, CompClusCont* compClus,
-                        PatternCont* patterns, ROFRecCont* vecROFRec, MCTruth* labelsCl)
-{
-
-#ifdef _PERFORM_TIMING_
-  mTimer.Start(kFALSE);
-#endif
-
-  o2::itsmft::ROFRecord* rof = nullptr;
-  auto clustersCount = compClus->size(); // RSTODO: in principle, the compClus is never supposed to be 0
-
-  while ((mChipData = reader.getNextChipData(mChips))) {
-    if (!rof || !(mChipData->getInteractionRecord() == rof->getBCData())) { // new ROF starts
-      if (rof) {                                                            // finalize previous slot
-        auto cntUpd = compClus->size();
-        rof->setNEntries(cntUpd - clustersCount); // update
-        clustersCount = cntUpd;
-        if (mClusTree) {  // if necessary, flush existing data
-          mROFRef = *rof; // just for the legacy way of writing to the tree
-          flushClusters(fullClus, compClus, labelsCl);
-        }
-      }
-      rof = &vecROFRec->emplace_back(mChipData->getInteractionRecord(), mChipData->getROFrame(), clustersCount, 0); // create new ROF
-    }
-    auto chipID = mChipData->getChipID();
-
-    if (mMaxBCSeparationToMask > 0) { // mask pixels fired from the previous ROF
-      if (mChipsOld.size() < mChips.size()) {
-        mChipsOld.resize(mChips.size()); // expand buffer of previous ROF data
-      }
-      const auto& chipInPrevROF = mChipsOld[chipID];
-      if (std::abs(rof->getBCData().differenceInBC(chipInPrevROF.getInteractionRecord())) < mMaxBCSeparationToMask) {
-        mChipData->maskFiredInSample(mChipsOld[chipID]);
-      }
-    }
-    auto validPixID = mChipData->getFirstUnmasked();
-
-    if (validPixID < mChipData->getData().size()) { // chip data may have all of its pixels masked!
-      initChip(validPixID++);
-      for (; validPixID < mChipData->getData().size(); validPixID++) {
-        if (!mChipData->getData()[validPixID].isMasked()) {
-          updateChip(validPixID);
-        }
-      }
-      finishChip(fullClus, compClus, patterns, reader.getDigitsMCTruth(), labelsCl);
-    }
-    if (mMaxBCSeparationToMask > 0) { // current chip data will be used in the next ROF to mask overflow pixels
-      mChipsOld[chipID].swap(*mChipData);
-    }
-  }
-  // finalize last ROF
-  if (rof) {
-    auto cntUpd = compClus->size();
-    rof->setNEntries(cntUpd - clustersCount); // update
-    if (mClusTree) {                          // if necessary, flush existing data
-      mROFRef = *rof;
-      flushClusters(fullClus, compClus, labelsCl);
-    }
-  }
-#ifdef _PERFORM_TIMING_
-  mTimer.Stop();
-#endif
-}
-
-/*
-//__________________________________________________
-template<class FullClusCont, class  CompClusCont, class PatternCont, class ROFRecCont>
-void Clusterer::process(PixelReader& reader, FullClusCont* fullClus, CompClusCont* compClus,
-                        PatternCont* patterns, ROFRecCont* vecROFRec, MCTruth* labelsCl)
-{
-
-#ifdef _PERFORM_TIMING_
-  mTimer.Start(kFALSE);
-#endif
-  mClustersCount = compClus ? compClus->size() : (fullClus ? fullClus->size() : 0);
-
-  while ((mChipData = reader.getNextChipData(mChips))) { // read next chip data to corresponding
-    // vector in the mChips and return the pointer on it 
-    if (!(mChipData->getInteractionRecord() == mROFRef.getBCData())) { // new ROF starts
-      mROFRef.setNEntries(mClustersCount - mROFRef.getEntry().getFirstEntry()); // number of entries in previous ROF
-      if (!mROFRef.getBCData().isDummy()) {
-        if (mClusTree) { // if necessary, flush existing data
-          mROFRef.setFirstEntry(mClusTree->GetEntries());
-          flushClusters(fullClus, compClus, labelsCl);
-        }
-        if (vecROFRec) {
-          vecROFRec->emplace_back(mROFRef);
-        }
-      }
-      mROFRef.getEntry().setFirstEntry(mClustersCount);
-      mROFRef.getBCData() = mChipData->getInteractionRecord();
-      mROFRef.setROFrame(mChipData->getROFrame()); // TODO: outphase this
-    }
-
-    auto chipID = mChipData->getChipID();
-    
-    if (mMaxBCSeparationToMask > 0) { // mask pixels fired from the previous ROF
-      if (mChipsOld.size() < mChips.size()) {
-        mChipsOld.resize(mChips.size()); // expand buffer of previous ROF data
-      }
-      const auto& chipInPrevROF = mChipsOld[chipID];
-      if (std::abs(mROFRef.getBCData().differenceInBC(chipInPrevROF.getInteractionRecord())) < mMaxBCSeparationToMask) {
-        mChipData->maskFiredInSample(mChipsOld[chipID]);
-      }
-    }
-    auto validPixID = mChipData->getFirstUnmasked();
-    
-    if (validPixID < mChipData->getData().size()) { // chip data may have all of its pixels masked!
-      initChip(validPixID++);
-      for (; validPixID < mChipData->getData().size(); validPixID++) {
-        if (!mChipData->getData()[validPixID].isMasked()) {
-          updateChip(validPixID);
-        }
-      }
-      finishChip(fullClus, compClus, patterns, reader.getDigitsMCTruth(), labelsCl);
-    }
-    if (mMaxBCSeparationToMask > 0) { // current chip data will be used in the next ROF to mask overflow pixels
-      mChipsOld[chipID].swap(*mChipData);
-    }
-  }
-  mROFRef.setNEntries(mClustersCount - mROFRef.getEntry().getFirstEntry()); // number of entries in this ROF
-
-  // flush last ROF
-  if (!mROFRef.getBCData().isDummy()) {
-    if (mClusTree) { // if necessary, flush existing data
-      mROFRef.setFirstEntry(mClusTree->GetEntries());
-      flushClusters(fullClus, compClus, labelsCl);
-    }
-    if (vecROFRec) {
-      vecROFRec->emplace_back(mROFRef); // the ROFrecords vector is stored outside, in a single entry of the tree
-    }
-  }
-#ifdef _PERFORM_TIMING_
-  mTimer.Stop();
-#endif
-}
-
- */
-
-//__________________________________________________
-template <class FullClusCont, class CompClusCont, class PatternCont>
-void Clusterer::finishChip(FullClusCont* fullClus, CompClusCont* compClus, PatternCont* patterns,
-                           const MCTruth* labelsDig, MCTruth* labelsClus)
-{
-  constexpr Float_t SigmaX2 = SegmentationAlpide::PitchRow * SegmentationAlpide::PitchRow / 12.; // FIXME
-  constexpr Float_t SigmaY2 = SegmentationAlpide::PitchCol * SegmentationAlpide::PitchCol / 12.; // FIXME
-  auto clustersCount = compClus->size();
-  const auto& pixData = mChipData->getData();
-  int nadd = 0;
-  for (int i1 = 0; i1 < mPreClusterHeads.size(); ++i1) {
-    const auto ci = mPreClusterIndices[i1];
-    if (ci < 0) {
-      continue;
-    }
-    UShort_t rowMax = 0, rowMin = 65535;
-    UShort_t colMax = 0, colMin = 65535;
-    int nlab = 0, npix = 0;
-    int next = mPreClusterHeads[i1];
-    while (next >= 0) {
-      const auto& pixEntry = mPixels[next];
-      const auto pix = pixData[pixEntry.second];
-      if (npix < mPixArrBuff.size()) {
-        mPixArrBuff[npix++] = pix; // needed for cluster topology
-        adjustBoundingBox(pix, rowMin, rowMax, colMin, colMax);
-        if (labelsClus) { // the MCtruth for this pixel is at mChipData->startID+pixEntry.second
-          fetchMCLabels(pixEntry.second + mChipData->getStartID(), labelsDig, nlab);
-        }
-        next = pixEntry.first;
-      }
-    }
-    mPreClusterIndices[i1] = -1;
-    for (int i2 = i1 + 1; i2 < mPreClusterHeads.size(); ++i2) {
-      if (mPreClusterIndices[i2] != ci) {
-        continue;
-      }
-      next = mPreClusterHeads[i2];
-      while (next >= 0) {
-        const auto& pixEntry = mPixels[next];
-        const auto pix = pixData[pixEntry.second]; // PixelData
-        if (npix < mPixArrBuff.size()) {
-          mPixArrBuff[npix++] = pix; // needed for cluster topology
-          adjustBoundingBox(pix, rowMin, rowMax, colMin, colMax);
-          if (labelsClus) { // the MCtruth for this pixel is at mChipData->startID+pixEntry.second
-            fetchMCLabels(pixEntry.second + mChipData->getStartID(), labelsDig, nlab);
-          }
-          next = pixEntry.first;
-        }
-      }
-      mPreClusterIndices[i2] = -1;
-    }
-    UShort_t rowSpan = rowMax - rowMin + 1, colSpan = colMax - colMin + 1;
-    Cluster clus;
-    clus.setSensorID(mChipData->getChipID());
-    clus.setNxNzN(rowSpan, colSpan, npix);
-    UShort_t colSpanW = colSpan, rowSpanW = rowSpan;
-    if (colSpan * rowSpan > Cluster::kMaxPatternBits) { // need to store partial info
-      // will curtail largest dimension
-      if (colSpan > rowSpan) {
-        if ((colSpanW = Cluster::kMaxPatternBits / rowSpan) == 0) {
-          colSpanW = 1;
-          rowSpanW = Cluster::kMaxPatternBits;
-        }
-      } else {
-        if ((rowSpanW = Cluster::kMaxPatternBits / colSpan) == 0) {
-          rowSpanW = 1;
-          colSpanW = Cluster::kMaxPatternBits;
-        }
-      }
-    }
-#ifdef _ClusterTopology_
-    clus.setPatternRowSpan(rowSpanW, rowSpanW < rowSpan);
-    clus.setPatternColSpan(colSpanW, colSpanW < colSpan);
-    clus.setPatternRowMin(rowMin);
-    clus.setPatternColMin(colMin);
-    for (int i = 0; i < npix; i++) {
-      const auto pix = mPixArrBuff[i];
-      unsigned short ir = pix.getRowDirect() - rowMin, ic = pix.getCol() - colMin;
-      if (ir < rowSpanW && ic < colSpanW) {
-        clus.setPixel(ir, ic);
-      }
-    }
-#endif              //_ClusterTopology_
-    if (fullClus) { // do we need conventional clusters with full topology and coordinates?
-      fullClus->push_back(clus);
-      Cluster& c = fullClus->back();
-      Float_t x = 0., z = 0.;
-      for (int i = npix; i--;) {
-        x += mPixArrBuff[i].getRowDirect();
-        z += mPixArrBuff[i].getCol();
-      }
-      Point3D<float> xyzLoc;
-      SegmentationAlpide::detectorToLocalUnchecked(x / npix, z / npix, xyzLoc);
-      auto xyzTra = mGeometry->getMatrixT2L(mChipData->getChipID()) ^ (xyzLoc); // inverse transform from Local to Tracking frame
-      c.setPos(xyzTra);
-      c.setErrors(SigmaX2, SigmaY2, 0.f);
-    }
-
-    if (labelsClus) { // MC labels were requested
-      auto cnt = compClus->size();
-      for (int i = nlab; i--;) {
-        labelsClus->addElement(cnt, mLabelsBuff[i]);
-      }
-    }
-
-    // add to compact clusters, which must be always filled
-    unsigned char patt[Cluster::kMaxPatternBytes] = {0}; // RSTODO FIX pattern filling
-    for (int i = 0; i < npix; i++) {
-      const auto pix = mPixArrBuff[i];
-      unsigned short ir = pix.getRowDirect() - rowMin, ic = pix.getCol() - colMin;
-      if (ir < rowSpanW && ic < colSpanW) {
-        int nbits = ir * colSpanW + ic;
-        patt[nbits >> 3] |= (0x1 << (7 - (nbits % 8)));
-      }
-    }
-    UShort_t pattID = (mPattIdConverter.size() == 0) ? CompCluster::InvalidPatternID : mPattIdConverter.findGroupID(rowSpanW, colSpanW, patt);
-    if (pattID == CompCluster::InvalidPatternID || mPattIdConverter.isGroup(pattID)) {
-      float xCOG = 0., zCOG = 0.;
-      ClusterPattern::getCOG(rowSpanW, colSpanW, patt, xCOG, zCOG);
-      rowMin += round(xCOG);
-      colMin += round(zCOG);
-      if (patterns) {
-        patterns->emplace_back((unsigned char)rowSpanW);
-        patterns->emplace_back((unsigned char)colSpanW);
-        int nBytes = rowSpanW * colSpanW / 8;
-        if (((rowSpanW * colSpanW) % 8) != 0)
-          nBytes++;
-        patterns->insert(patterns->end(), std::begin(patt), std::begin(patt) + nBytes);
-      }
-    }
-    compClus->emplace_back(rowMin, colMin, pattID, mChipData->getChipID());
-  }
-}
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
@@ -74,10 +74,12 @@ class DigitPixelReader : public PixelReader
 
   void init() override
   {
-    mLastDigit = nullptr;
     mIdDig = 0;
     mIdROF = -1;
   }
+
+  // prepare next trigger
+  int decodeNextTrigger() override;
 
   // methods for standalone reading
   void openInput(const std::string rawInput, o2::detectors::DetID det);
@@ -104,9 +106,8 @@ class DigitPixelReader : public PixelReader
   gsl::span<const o2::itsmft::MC2ROFRecord> mMC2ROFRecVec;
 
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mDigitsMCTruth = nullptr;
-  const Digit* mLastDigit = nullptr;
-  Int_t mIdDig = 0; // last Digits slot read
-  Int_t mIdROF = 0; // last ROFRecord slot read
+  Int_t mIdDig = 0; // Digits slot read within ROF
+  Int_t mIdROF = 0; // ROFRecord being red
 
   std::unique_ptr<TTree> mInputTree;       // input tree for digits
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
@@ -42,6 +42,9 @@ class PixelReader
   virtual void init() = 0;
   virtual bool getNextChipData(ChipPixelData& chipData) = 0;
   virtual ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) = 0;
+
+  // prepare data of next trigger, return number of non-empty links or chips
+  virtual int decodeNextTrigger() = 0;
   virtual const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* getDigitsMCTruth() const
   {
     return nullptr;
@@ -58,12 +61,16 @@ class PixelReader
   {
     return mTrigger;
   }
+
+  bool getDecodeNextAuto() const { return mDecodeNextAuto; }
+  void setDecodeNextAuto(bool v) { mDecodeNextAuto = v; }
   //
  protected:
   //
   o2::InteractionRecord mInteractionRecordHB = {}; // interation record for the HB
   o2::InteractionRecord mInteractionRecord = {};   // interation record for the trigger
   uint32_t mTrigger = 0;
+  bool mDecodeNextAuto = true; // try to fetch/decode next trigger when getNextChipData does not see any decoded data
 
   ClassDef(PixelReader, 1);
 };

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -52,7 +52,7 @@ class RawPixelDecoder : public PixelReader
 
   void startNewTF(o2::framework::InputRecord& inputs);
 
-  int decodeNextTrigger();
+  int decodeNextTrigger() final;
   int decodeNextTrigger(int il);
 
   template <class DigitContainer, class ROFContainer>
@@ -60,11 +60,11 @@ class RawPixelDecoder : public PixelReader
 
   const RUDecodeData* getRUDecode(int ruSW) const { return mRUEntry[ruSW] < 0 ? nullptr : &mRUDecodeVec[mRUEntry[ruSW]]; }
 
+  void setNThreads(int n);
+  int getNThreads() const { return mNThreads; }
+
   void setVerbosity(int v);
   int getVerbosity() const { return mVerbosity; }
-
-  bool getDecodeNextAuto() const { return mDecodeNextAuto; }
-  void setDecodeNextAuto(bool v) { mDecodeNextAuto = v; }
 
   void printReport() const;
 
@@ -95,17 +95,17 @@ class RawPixelDecoder : public PixelReader
 
   std::vector<RUDecodeData> mRUDecodeVec;       // set of active RUs
   std::array<int, Mapping::getNRUs()> mRUEntry; // entry of the RU with given SW ID in the mRUDecodeVec
+  std::string mSelfName;                        // self name
   uint16_t mCurRUDecodeID = NORUDECODED;        // index of currently processed RUDecode container
   Mapping mMAP;                                 // chip mapping
   int mVerbosity = 0;
-
+  int mNThreads = 1; // number of decoding threads
   // statistics
   o2::itsmft::ROFRecord::ROFtype mROFCounter = 0; // RSTODO is this needed? eliminate from ROFRecord ?
   uint32_t mNChipsFiredROF = 0;                   // counter within the ROF
   uint32_t mNPixelsFiredROF = 0;                  // counter within the ROF
   size_t mNChipsFired = 0;                        // global counter
   size_t mNPixelsFired = 0;                       // global counter
-  bool mDecodeNextAuto = true;                    // try to decode next trigger when getNextChipData does not see any decoded data
   TStopwatch mTimerTFStart;
   TStopwatch mTimerDecode;
   TStopwatch mTimerFetchData;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -45,7 +45,7 @@ class RawPixelDecoder : public PixelReader
 
  public:
   RawPixelDecoder();
-  ~RawPixelDecoder() final;
+  ~RawPixelDecoder() final = default;
   void init() final {}
   bool getNextChipData(ChipPixelData& chipData) final;
   ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) final;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -178,6 +178,9 @@ class RawPixelReader : public PixelReader
       mCurRUDecodeID = 0; // no more decoded data if reached this place,
     }
     // will need to decode new trigger
+    if (!mDecodeNextAuto) { // no more data in the current ROF and no automatic decoding of next one was requested
+      return nullptr;
+    }
     if (mMinTriggersCached < 2) { // last trigger might be incomplete, need to cache more data
       cacheLinksData(mRawBuffer);
     }
@@ -608,7 +611,7 @@ class RawPixelReader : public PixelReader
   }
 
   //_____________________________________
-  int decodeNextTrigger()
+  int decodeNextTrigger() final
   {
     // Decode next trigger from the cached links data and decrease cached triggers counter, return N links decoded
     if (mMinTriggersCached < 1) {
@@ -1308,7 +1311,12 @@ class RawPixelReader : public PixelReader
       }
       mCurRUDecodeID = 0; // no more decoded data if reached this place,
     }
+
     // will need to decode new trigger
+    if (!mDecodeNextAuto) { // no more data in the current ROF and no automatic decoding of next one was requested
+      return false;
+    }
+
     if (mMinTriggersCached < 2) { // last trigger might be incomplete, need to cache more data
       cacheLinksData(mRawBuffer);
     }

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -92,6 +92,7 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
   if (resetStat) {
     statistics.clear();
   }
+  status = None;
 }
 
 ///_________________________________________________________________

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -35,14 +35,6 @@ RawPixelDecoder<Mapping>::RawPixelDecoder()
 }
 
 ///______________________________________________________________
-/// D-tor
-template <class Mapping>
-RawPixelDecoder<Mapping>::~RawPixelDecoder()
-{
-  printReport();
-}
-
-///______________________________________________________________
 ///
 template <class Mapping>
 void RawPixelDecoder<Mapping>::printReport() const

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include <memory>
+#include <string>
 #include <string_view>
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
@@ -47,6 +48,8 @@ class STFDecoder : public Task
   bool mDoClusters = false;
   bool mDoPatterns = false;
   bool mDoDigits = false;
+  int mNThreads = 1;
+  std::string mSelfName;
   std::string mDictName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;
   std::unique_ptr<Clusterer> mClusterer;

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -38,9 +38,10 @@ class STFDecoder : public Task
 {
  public:
   STFDecoder(bool clusters = true, bool pattern = true, bool digits = false, std::string_view dict = "");
-  ~STFDecoder() override;
+  ~STFDecoder() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
 
  private:
   std::unique_ptr<o2::itsmft::Clusterer> setupClusterer(const std::string& dictName);


### PR DESCRIPTION
-- Multi-threading for ITS/MFT data decoding/clusterization
*  All PixelReader derived classes got possibility of per HBF-reading
*  Raw data decoding (via DigitPixelReader) supports multithreding on particular RU level
*  Clusterizer support multithreding by splitting HBF clusterization to n nearly equal parts
   in n-hits and running 1 thread per part.
   (at the moment gave up using output.make in favor of snapshot to avoid propagation of the PMR
   vectors to clusterizer buffers and exposing them in the headers to non-framework code.

-- Pass configKeyValues to ITS digi2raw (e.g. to manipulate HBFUtil settings)