### PR TITLE
Example to run STARlight via HepMC file

### DIFF
--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -452,6 +452,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | --------------------- | -------------------------------------------------------------------------------------- |
 | [AliRoot_Hijing](../run/SimExamples/AliRoot_Hijing) | Example showing how to use Hijing from AliRoot for event generation |
 | [Adaptive_Pythia8](../run/SimExamples/Adaptive_Pythia8) | Complex example showing **generator configuration for embedding** that cat adapt the response based on the background event |
+| [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/HepMC_STARlight/README.md
+++ b/run/SimExamples/HepMC_STARlight/README.md
@@ -1,0 +1,25 @@
+This is a simple simulation example showing how to run event simulation using the `STARlight` event generator.
+The `STARlight` event generation process is launched in a clean environment by the script `run-starlight.sh`.
+
+The `run-starlight.sh` script performs initialisation operations of the enviroment to run `STARlight`.
+It copies in the currect directory the relevant files need for the operation from the `STARlight` installation directory.
+The relevant files are
+* `slight.in` to configure the event generator
+* `starlight2hepmc.awk` and `pdgMass.awk to convert the output in `HepMC2` format.
+
+At the end of the `STARlight` process, the `HepMC2` output file is `startlight.hepmc` and can be used for the `o2` simulation in the second part of this example.
+
+# IMPORTANT
+To run this example you need to have the STARlight package installed on your system.
+```
+$ aliBuild build STARlight --defaults o2
+```
+Notice that it is not mandatory to have `--defaults o2` given that in this example `STARlight` runs in a completely separate environment than the one used by the `o2` simulation. 
+
+# WARNING
+This example takes the `STARlight` configuration file `slight.in` directly from the `STARlight` installation directory. In that file, the number of events to be generated is hardcoded to `N_EVENTS = 1000`. Therefore, the number of events that can be injected in the `o2` is at maximum `NEV = 1000`. Of course this can be taken care in a dynamic way, such that `STARlight` is instructed to generated the number of events that the `o2` expects.
+
+# IMPROVEMENT
+This example can be improved by running `STARlight` event generator in background and sending the `HepMC` data into a pipe that is then read by the `o2` simulation. For the sake of simplicity of the example, this is not done.
+
+

--- a/run/SimExamples/HepMC_STARlight/run-starlight.sh
+++ b/run/SimExamples/HepMC_STARlight/run-starlight.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+echo " --- run-starlight.sh ---"
+
+set -x
+
+# prepare environment
+VERSION=latest
+eval $(alienv printenv -q STARlight/$VERSION)
+STARLIGHT_ROOT=$(starlight-config)
+
+# populate working directory
+cp $STARLIGHT_ROOT/config/slight.in .
+cp $STARLIGHT_ROOT/HepMC/*.awk .
+
+# run STARlight
+starlight slight.in | tee slight.log
+cat slight.log slight.out | \
+    awk -f pdgMass.awk -f starlight2hepmc.awk > starlight.hepmc

--- a/run/SimExamples/HepMC_STARlight/run.sh
+++ b/run/SimExamples/HepMC_STARlight/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# This is a simple simulation example showing the following things
+#
+
+# a) how to start STARlight event generator in a clean environment to produce HepMC files
+# b) how to run simulation reading from the HepMC file
+
+set -x
+
+# PART a)
+env -i HOME="$HOME" USER="$USER" PATH="/bin:/usr/bin:/usr/local/bin" \
+    ALIBUILD_WORK_DIR="$ALIBUILD_WORK_DIR" ./run-starlight.sh 
+
+# PART b)
+NEV=1000
+o2-sim -j 20 -n ${NEV} -g hepmc -m PIPE ITS -o sim \
+       --HepMCFile starlight.hepmc \
+       --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"


### PR DESCRIPTION
This is a simple simulation example showing how to run event simulation using the `STARlight` event generator.
The `STARlight` event generation process is launched in a clean environment by the script `run-starlight.sh`.

The `run-starlight.sh` script performs initialisation operations of the enviroment to run `STARlight`.
It copies in the currect directory the relevant files need for the operation from the `STARlight` installation directory.
The relevant files are
* `slight.in` to configure the event generator
* `starlight2hepmc.awk` and `pdgMass.awk to convert the output in `HepMC2` format.

At the end of the `STARlight` process, the `HepMC2` output file is `startlight.hepmc` and can be used for the `o2` simulation in the second part of this example.

# IMPORTANT
To run this example you need to have the STARlight package installed on your system.
```
$ aliBuild build STARlight --defaults o2
```
Notice that it is not mandatory to have `--defaults o2` given that in this example `STARlight` runs in a completely separate environment than the one used by the `o2` simulation. 

# WARNING
This example takes the `STARlight` configuration file `slight.in` directly from the `STARlight` installation directory. In that file, the number of events to be generated is hardcoded to `N_EVENTS = 1000`. Therefore, the number of events that can be injected in the `o2` is at maximum `NEV = 1000`. Of course this can be taken care in a dynamic way, such that `STARlight` is instructed to generated the number of events that the `o2` expects.

# IMPROVEMENT
This example can be improved by running `STARlight` event generator in background and sending the `HepMC` data into a pipe that is then read by the `o2` simulation. For the sake of simplicity of the example, this is not done.
