### PR TITLE
TPC: Add sector-by-sector option for TPC ZS encoder and do not read MC labels

### DIFF
--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -55,13 +55,13 @@ struct ProcessAttributes {
   std::unique_ptr<o2::gpu::GPUReconstructionConvert> zsEncoder;
   std::vector<int> inputIds;
   bool zs12bit = true;
-  bool verify = false;
+  float zsThreshold = 2.f;
   int verbosity = 1;
 };
 
 void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::raw::RawFileWriter& writer);
 #include "DetectorsRaw/HBFUtils.h"
-void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view outputPath)
+void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view outputPath, bool sectorBySector)
 {
 
   // ===| open file and get tree |==============================================
@@ -71,18 +71,8 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   gROOT->cd();
 
   // ===| set up branch addresses |=============================================
-  MCLabelContainer* vLabelContainers[Sector::MAXSECTOR];             // label container per sector
-  std::vector<Digit>* vDigitsPerSectorCollection[Sector::MAXSECTOR]; // container that keeps Digits per sector
+  std::vector<Digit>* vDigitsPerSectorCollection[Sector::MAXSECTOR] = {nullptr}; // container that keeps Digits per sector
 
-  for (int iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
-    vDigitsPerSectorCollection[iSec] = nullptr;
-    treeSim->SetBranchAddress(TString::Format("TPCDigit_%d", iSec), &vDigitsPerSectorCollection[iSec]);
-
-    vLabelContainers[iSec] = nullptr;
-    treeSim->SetBranchAddress(TString::Format("TPCDigitMCTruth_%d", iSec), &vLabelContainers[iSec]);
-  }
-
-  DigitArray inputDigits;
   ProcessAttributes attr;
 
   // raw data output
@@ -106,13 +96,47 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
       writer.registerLink(feeid, cruID, defaultLink, j & 1, fmt::format("{}cru{}.raw", outDir, cruID));
     }
   }
-  for (Long64_t ievent = 0; ievent < treeSim->GetEntries(); ++ievent) {
-    treeSim->GetEntry(ievent);
 
+  treeSim->SetBranchStatus("*", 0);
+  treeSim->SetBranchStatus("TPCDigit_*", 1);
+  for (int iSecBySec = 0; iSecBySec < Sector::MAXSECTOR; ++iSecBySec) {
+    treeSim->ResetBranchAddresses();
     for (int iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
-      inputDigits[iSec] = *vDigitsPerSectorCollection[iSec]; //????
+      if (sectorBySector) {
+        iSec = iSecBySec;
+      }
+      vDigitsPerSectorCollection[iSec] = nullptr;
+      treeSim->SetBranchAddress(TString::Format("TPCDigit_%d", iSec), &vDigitsPerSectorCollection[iSec]);
+      if (sectorBySector) {
+        break;
+      }
     }
-    convert(inputDigits, &attr, writer);
+    for (Long64_t ievent = 0; ievent < treeSim->GetEntries(); ++ievent) {
+      DigitArray inputDigits;
+      if (sectorBySector) {
+        treeSim->GetBranch(TString::Format("TPCDigit_%d", iSecBySec))->GetEntry(ievent);
+      } else {
+        treeSim->GetEntry(ievent);
+      }
+
+      for (int iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
+        if (sectorBySector) {
+          iSec = iSecBySec;
+        }
+        inputDigits[iSec] = *vDigitsPerSectorCollection[iSec]; //????
+        if (sectorBySector) {
+          break;
+        }
+      }
+      convert(inputDigits, &attr, writer);
+      for (int iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
+        delete vDigitsPerSectorCollection[iSec];
+        vDigitsPerSectorCollection[iSec] = nullptr;
+      }
+    }
+    if (!sectorBySector) {
+      break;
+    }
   }
   // for further use we write the configuration file for the output
   writer.writeConfFile("TPC", "RAWDATA", fmt::format("{}tpcraw.cfg", outDir));
@@ -121,15 +145,14 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
 void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::raw::RawFileWriter& writer)
 {
   auto& zsEncoder = processAttributes->zsEncoder;
-  const auto verify = processAttributes->verify;
+  const auto zsThreshold = processAttributes->zsThreshold;
   const auto zs12bit = processAttributes->zs12bit;
   GPUParam _GPUParam;
   _GPUParam.SetDefaults(5.00668);
   const GPUParam mGPUParam = _GPUParam;
-  const float zsThreshold = 2;
 
   o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
-  zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, verify, zsThreshold);
+  zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, zsThreshold);
 }
 
 int main(int argc, char** argv)
@@ -149,6 +172,7 @@ int main(int argc, char** argv)
     add_option("verbose,v", bpo::value<uint32_t>()->default_value(0), "Select verbosity level [0 = no output]");
     add_option("input-file,i", bpo::value<std::string>()->required(), "Specifies input file.");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "Specify output directory");
+    add_option("sector-by-sector,s", bpo::value<bool>()->default_value(false), "Run one TPC sector after another");
 
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
@@ -171,7 +195,8 @@ int main(int argc, char** argv)
 
   convertDigitsToZSfinal(
     vm["input-file"].as<std::string>(),
-    vm["output-dir"].as<std::string>());
+    vm["output-dir"].as<std::string>(),
+    vm["sector-by-sector"].as<bool>());
 
   return 0;
 }


### PR DESCRIPTION
@shahor02 (@wiechula ): I am looking into the memory issue you reported, but I believe there is no memory leak. It just needs that much memory because it reads all the digits in memory.
This PR tries to help this in 2 ways:
- Do not set the branch address for MC labels, since they are not needed anyway.
- Add an option to go sector by sector instead of parallelizing over the sectors.

However, I have tried the 200 PbPb events you have on CernBox with this patch, and on my system with 64GB of memory it still runs out of memory.
I traced where the memory is allocated, and actually the very first call to `treeSim->GetEntry(ievent);` already exhaust my memory. I am no expert to ROOT, but I was assuming if I set only 1 single branch address for the sector I want to read, ROOT would only read that data to memory, but perhaps I am wrong here?
In any case, the problem is the `treeSim->GetEntry(ievent);`, we have to reduce its memory consumption. And I think this PR makes sense in any case.