### PR TITLE
Skip the creation of the DiskSupport by default

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/MFTBaseParam.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/MFTBaseParam.h
@@ -34,7 +34,7 @@ struct MFTBaseParam : public o2::conf::ConfigurableParamHelper<MFTBaseParam> {
   bool buildCone = true;
   bool buildBarrel = true;
   bool buildPatchPanel = true;
-  bool buildPCBSupports = true;
+  bool buildPCBSupports = false;
   bool buildPCBs = true;
   bool buildPSU = true;
 


### PR DESCRIPTION
To avoid several overlapping volumes, the disk support are not created by default. MFT experts are working to solve that.