### PR TITLE
TRD Digitizer: moving temporary variables to class members

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -84,16 +84,16 @@ class Digitizer
   int mSrcID = 0;
 
   // Digitization parameters
-  static constexpr float mAmWidth = TRDGeometry::amThick();  // Width of the amplification region
-  static constexpr float mDrWidth = TRDGeometry::drThick();  // Width of the drift retion
-  static constexpr float mDrMin = -0.5 * mAmWidth;           // Drift + Amplification region
-  static constexpr float mDrMax = mDrWidth + 0.5 * mAmWidth; // Drift + Amplification region
-  float mSamplingRate = 0;                                   // The sampling rate
-  float mElAttachProp = 0;                                   // Propability for electron attachment (for 1m)
-  int mNpad = 0;                                             // Number of pads included in the pad response
-  int mTimeBinTRFend = 0;                                    // time bin TRF ends
-  int mMaxTimeBins = 30;                                     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
-  int mMaxTimeBinsTRAP = 30;                                 // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
+  static constexpr float AmWidth = TRDGeometry::amThick(); // Width of the amplification region
+  static constexpr float DrWidth = TRDGeometry::drThick(); // Width of the drift retion
+  static constexpr float DrMin = -0.5 * AmWidth;           // Drift + Amplification region
+  static constexpr float DrMax = DrWidth + 0.5 * AmWidth;  // Drift + Amplification region
+  float mSamplingRate = 0;                                 // The sampling rate
+  float mElAttachProp = 0;                                 // Propability for electron attachment (for 1m)
+  int mNpad = 0;                                           // Number of pads included in the pad response
+  int mTimeBinTRFend = 0;                                  // time bin TRF ends
+  int mMaxTimeBins = 30;                                   // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
+  int mMaxTimeBinsTRAP = 30;                               // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
   // Digitization containers
   std::vector<HitType> mHitContainer;                       // the container of hits in a given detector

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -83,20 +83,21 @@ class Digitizer
   int mEventID = 0;
   int mSrcID = 0;
 
-  // Simulation parameters
-  float mAmWidth = 0;        // Width of the amplification region
-  float mDrWidth = 0;        // Width of the drift retion
-  float mDrMin = 0;          // Drift + Amplification region
-  float mDrMax = 0;          // Drift + Amplification region
-  float mSamplingRate = 0;   // The sampling rate
-  float mElAttachProp = 0;   // Propability for electron attachment (for 1m)
-  int mNpad = 0;             // Number of pads included in the pad response
-  int mTimeBinTRFend = 0;    // time bin TRF ends
-  int mMaxTimeBins = 30;     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
-  int mMaxTimeBinsTRAP = 30; // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
+  // Digitization parameters
+  static constexpr float mAmWidth = TRDGeometry::amThick();  // Width of the amplification region
+  static constexpr float mDrWidth = TRDGeometry::drThick();  // Width of the drift retion
+  static constexpr float mDrMin = -0.5 * mAmWidth;           // Drift + Amplification region
+  static constexpr float mDrMax = mDrWidth + 0.5 * mAmWidth; // Drift + Amplification region
+  float mSamplingRate = 0;                                   // The sampling rate
+  float mElAttachProp = 0;                                   // Propability for electron attachment (for 1m)
+  int mNpad = 0;                                             // Number of pads included in the pad response
+  int mTimeBinTRFend = 0;                                    // time bin TRF ends
+  int mMaxTimeBins = 30;                                     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
+  int mMaxTimeBinsTRAP = 30;                                 // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
-  std::vector<HitType> mHitContainer;                      // the container of hits in a given detector
-  std::vector<MCLabel> mMergedLabels;                      // temporary label container
+  // Digitization containers
+  std::vector<HitType> mHitContainer;                       // the container of hits in a given detector
+  std::vector<MCLabel> mMergedLabels;                       // temporary label container
   std::array<SignalContainer, kNdet> mSignalsMapCollection; // container for caching signals over a timeframe
   std::array<DigitContainer, kNdet> mDigitsCollection;      // container for caching digits for paralellization
 
@@ -104,7 +105,7 @@ class Digitizer
   void clearCollections();
   void setSimulationParameters();
 
-  // Digitization chaing methods
+  // Digitization chain methods
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful
   bool convertSignalsToADC(const int, SignalContainer&, DigitContainer&, int thread = 0);     // True if signal-to-ADC conversion is successful
   void addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -100,7 +100,7 @@ class Digitizer
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   void clearCollections();
-  void setupSimulationValues();
+  void setSimulationParameters();
 
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -82,22 +82,24 @@ class Digitizer
   double mLastTime = 1.0e10; // starts in the future
   int mEventID = 0;
   int mSrcID = 0;
-  int kNpad = 0;            // Number of pads included in the pad response
-  float kAmWidth = 0;       // Width of the amplification region
-  float kDrWidth = 0;       // Width of the drift retion
-  float kDrMin = 0;         // Drift + Amplification region
-  float kDrMax = 0;         // Drift + Amplification region
-  int timeBinTRFend = 0;    // time bin TRF ends
-  int maxTimeBins = 30;     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
-  int maxTimeBinsTRAP = 30; // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
-  float samplingRate = 0;
-  float elAttachProp = 0;
+
+  // Simulation parameters
+  float mAmWidth = 0;        // Width of the amplification region
+  float mDrWidth = 0;        // Width of the drift retion
+  float mDrMin = 0;          // Drift + Amplification region
+  float mDrMax = 0;          // Drift + Amplification region
+  float mSamplingRate = 0;   // The sampling rate
+  float mElAttachProp = 0;   // Propability for electron attachment (for 1m)
+  int mNpad = 0;             // Number of pads included in the pad response
+  int mTimeBinTRFend = 0;    // time bin TRF ends
+  int mMaxTimeBins = 30;     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
+  int mMaxTimeBinsTRAP = 30; // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
   bool mSDigits{false};                                    // true: convert signals to summable digits, false by defaults
   std::vector<HitType> mHitContainer;                      // the container of hits in a given detector
   std::vector<MCLabel> mMergedLabels;                      // temporary label container
-  std::array<SignalContainer, kNdet> signalsMapCollection; // container for caching signals over a timeframe
-  std::array<DigitContainer, kNdet> digitsCollection;      // container for caching digits for paralellization
+  std::array<SignalContainer, kNdet> mSignalsMapCollection; // container for caching signals over a timeframe
+  std::array<DigitContainer, kNdet> mDigitsCollection;      // container for caching digits for paralellization
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   void clearCollections();

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -95,7 +95,6 @@ class Digitizer
   int mMaxTimeBins = 30;     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
   int mMaxTimeBinsTRAP = 30; // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
-  bool mSDigits{false};                                    // true: convert signals to summable digits, false by defaults
   std::vector<HitType> mHitContainer;                      // the container of hits in a given detector
   std::vector<MCLabel> mMergedLabels;                      // temporary label container
   std::array<SignalContainer, kNdet> mSignalsMapCollection; // container for caching signals over a timeframe

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -82,13 +82,14 @@ class Digitizer
   double mLastTime = 1.0e10; // starts in the future
   int mEventID = 0;
   int mSrcID = 0;
-  int kNpad = 0;         // Number of pads included in the pad response
-  float kAmWidth = 0;    // Width of the amplification region
-  float kDrWidth = 0;    // Width of the drift retion
-  float kDrMin = 0;      // Drift + Amplification region
-  float kDrMax = 0;      // Drift + Amplification region
-  int timeBinTRFend = 0; // time bin TRF ends
-  int nTimeTotal = 30;   // PLEASE FIX ME when CCDB is ready
+  int kNpad = 0;            // Number of pads included in the pad response
+  float kAmWidth = 0;       // Width of the amplification region
+  float kDrWidth = 0;       // Width of the drift retion
+  float kDrMin = 0;         // Drift + Amplification region
+  float kDrMax = 0;         // Drift + Amplification region
+  int timeBinTRFend = 0;    // time bin TRF ends
+  int maxTimeBins = 30;     // Maximum number of time bins for processing signals, usually set at 30 tb = 3 microseconds
+  int maxTimeBinsTRAP = 30; // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
   float samplingRate = 0;
   float elAttachProp = 0;
 
@@ -114,9 +115,7 @@ class Digitizer
   int calculateKey(const int det, const int row, const int col)
   {
     int key = ((det << 12) | (row << 8) | col);
-    if (key < KEY_MIN || key > KEY_MAX) {
-      LOG(FATAL) << "Wrong TRD key " << key << " for (det,row,col) = (" << det << ", " << row << ", " << col << ")";
-    }
+    assert(!(key < KEY_MIN || key > KEY_MAX));
     return key;
   }
   int getDetectorFromKey(const int key) { return (key >> 12) & 0xFFF; }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -69,7 +69,6 @@ void Digitizer::init()
     mDriftEstimators.emplace_back();
   }
 
-  mSDigits = false;
   setSimulationParameters();
 }
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -216,7 +216,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
 
   // Loop over hits
   for (const auto& hit : hits) {
-    bool isDigit = false;
     const int qTotal = hit.GetCharge();
     /*
       Now the real local coordinate system of the ROC

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -70,10 +70,10 @@ void Digitizer::init()
   }
 
   mSDigits = false;
-  setupSimulationValues();
+  setSimulationParameters();
 }
 
-void Digitizer::setupSimulationValues()
+void Digitizer::setSimulationParameters()
 {
   kNpad = mSimParam->getNumberOfPadsInPadResponse(); // Number of pads included in the pad response
   kAmWidth = TRDGeometry::amThick();                 // Width of the amplification region

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -75,10 +75,6 @@ void Digitizer::init()
 void Digitizer::setSimulationParameters()
 {
   mNpad = mSimParam->getNumberOfPadsInPadResponse(); // Number of pads included in the pad response
-  mAmWidth = TRDGeometry::amThick();                 // Width of the amplification region
-  mDrWidth = TRDGeometry::drThick();                 // Width of the drift retion
-  mDrMin = -0.5 * mAmWidth;                          // Drift + Amplification region
-  mDrMax = mDrWidth + 0.5 * mAmWidth;                // Drift + Amplification region
   if (mSimParam->TRFOn()) {
     mTimeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->GetSamplingFrequency())) - 1;
   }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -234,7 +234,7 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
       if ((locR < rowEndROC) || (locR > row0)) {
         continue;
       }
-      if ((driftLength < mDrMin) || (driftLength > mDrMax)) {
+      if ((driftLength < DrMin) || (driftLength > DrMax)) {
         continue;
       }
     }
@@ -309,7 +309,7 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
           zz = 0.5 - zz;
         }
         // Use drift time map (GARFIELD)
-        driftTime = mDriftEstimators[thread].TimeStruct(driftVelocity, 0.5 * mAmWidth - 1.0 * locTd, zz) + hit.GetTime();
+        driftTime = mDriftEstimators[thread].TimeStruct(driftVelocity, 0.5 * AmWidth - 1.0 * locTd, zz) + hit.GetTime();
       } else {
         // Use constant drift velocity
         driftTime = std::fabs(locTd) / driftVelocity + hit.GetTime(); // drift time in microseconds


### PR DESCRIPTION
Two minor improvements were spotted while developing the pileup implementation for the TRD digitizer: 

- Make several variables class members rather than local variables. They are initialized at the construction of the digitizer.
- Swapped a for-if loop for a if-for loop to minimize the number of if-else comparisons.

I prefer to make this small PR now and do not mix this with the pileup implementation.

In 10 pp events:
(Now) `TRD: Digitization took 0.949013s`
(Before) `TRD: Digitization took 1.11397s`

In 1 hi event:
(Now) `TRD: Digitization took 124.626s`
(Before) `TRD: Digitization took 136.157s`
