### PR TITLE
RawFileReader/Writer can work with any RDH version, incl. v6

### DIFF
--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -11,8 +11,9 @@
 o2_add_library(Headers
                SOURCES src/DataHeader.cxx src/NameHeader.cxx
                        src/HeartbeatFrame.cxx src/TimeStamp.cxx
-                       src/DAQID.cxx
-               PUBLIC_LINK_LIBRARIES O2::MemoryResources)
+                       src/DAQID.cxx src/RDHAny.cxx
+               PUBLIC_LINK_LIBRARIES O2::MemoryResources
+                                     O2::GPUCommon)
 
 o2_add_test(DataHeader
             SOURCES test/testDataHeader.cxx

--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -11,6 +11,7 @@
 o2_add_library(Headers
                SOURCES src/DataHeader.cxx src/NameHeader.cxx
                        src/HeartbeatFrame.cxx src/TimeStamp.cxx
+                       src/DAQID.cxx
                PUBLIC_LINK_LIBRARIES O2::MemoryResources)
 
 o2_add_test(DataHeader
@@ -36,3 +37,9 @@ o2_add_test(RAWDataHeader
             PUBLIC_LINK_LIBRARIES O2::Headers
             LABELS dataformats
             COMPONENT_NAME Headers)
+
+o2_add_test(DAQID
+            SOURCES test/testDAQID.cxx
+            PUBLIC_LINK_LIBRARIES O2::Headers
+            COMPONENT_NAME Headers
+            LABELS dataformats)

--- a/DataFormats/Headers/include/Headers/DAQID.h
+++ b/DataFormats/Headers/include/Headers/DAQID.h
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// @brief Class for mapping between DAQ sourceIDs and O2 DataOrigins
+// @author ruben.shahoyan@cern.ch
+
+#ifndef DETECTOR_BASE_RAWDAQID_H
+#define DETECTOR_BASE_RAWDAQID_H
+
+#include "Headers/DataHeader.h"
+
+namespace o2
+{
+namespace header
+{
+/// Source IDs used by DAQ
+
+class DAQID
+{
+
+ public:
+  typedef std::uint8_t ID;
+
+  static constexpr ID TPC = 3;
+  static constexpr ID TRD = 4;
+  static constexpr ID TOF = 5;
+  static constexpr ID HMP = 6;
+  static constexpr ID PHS = 7;
+  static constexpr ID CPV = 8;
+  static constexpr ID INVALID = 9; // 1st invalid slot starting from meaningful values
+  static constexpr ID MCH = 10;
+  static constexpr ID ZDC = 15;
+  static constexpr ID TRG = 17;
+  static constexpr ID EMC = 18;
+  static constexpr ID TST = 19;
+  static constexpr ID ITS = 32;
+  static constexpr ID FDD = 33;
+  static constexpr ID FT0 = 34;
+  static constexpr ID FV0 = 35;
+  static constexpr ID MFT = 36;
+  static constexpr ID MID = 37;
+  static constexpr ID DCS = 38;
+  static constexpr ID FOC = 39;
+  static constexpr ID MINDAQ = TPC;
+  static constexpr ID MAXDAQ = FOC;
+
+  DAQID() : mID(INVALID) {}
+  DAQID(ID i) : mID(i) {}
+  operator ID() const { return static_cast<ID>(mID); }
+
+  ID getID() const { return mID; }
+  constexpr o2::header::DataOrigin getO2Origin() { return DAQtoO2(mID); }
+
+  static constexpr o2::header::DataOrigin DAQtoO2(ID daq)
+  {
+    return (daq < MAXDAQ + 1) ? MAP_DAQtoO2[daq] : MAP_DAQtoO2[INVALID];
+  }
+
+  static constexpr ID O2toDAQ(o2::header::DataOrigin o2orig)
+  {
+    return or2daq(o2orig, MINDAQ);
+  }
+
+ private:
+  ID mID = INVALID;
+
+  static constexpr o2::header::DataOrigin MAP_DAQtoO2[] = {
+    "NIL", "NIL", "NIL",
+    "TPC", "TRD", "TOF", "HMP", "PHS", "CPV",
+    "NIL",
+    "MCH",
+    "NIL", "NIL", "NIL", "NIL",
+    "ZDC",
+    "NIL",
+    "TRG", "EMC", "TST",
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL",
+    "ITS", "FDD", "FT0", "FV0", "MFT", "MID", "DCS", "FOC"};
+
+  static constexpr ID or2daq(o2::header::DataOrigin origin, ID id)
+  {
+    return id > MAXDAQ ? INVALID : (origin == MAP_DAQtoO2[id] ? id : or2daq(origin, id + 1));
+  }
+};
+
+} // namespace header
+} // namespace o2
+
+#endif

--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -424,7 +424,10 @@ struct RAWDataHeaderV2 {
   };
 };
 
-using RAWDataHeader = RAWDataHeaderV4;
+using RAWDataHeader = RAWDataHeaderV4; // default version
+using RDHLowest = RAWDataHeaderV4;     // link this to lowest version
+using RDHHighest = RAWDataHeaderV6;    // link this to highest version
+
 } // namespace header
 } // namespace o2
 

--- a/DataFormats/Headers/include/Headers/RDHAny.h
+++ b/DataFormats/Headers/include/Headers/RDHAny.h
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// @brief placeholder class for arbitraty-version 64B-lonh RDH
+// @author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_HEADER_RDHANY_H
+#define ALICEO2_HEADER_RDHANY_H
+#include "GPUCommonDef.h"
+#include "Headers/RAWDataHeader.h"
+#include <type_traits>
+#include <stdexcept>
+
+namespace o2
+{
+namespace header
+{
+
+struct RDHAny {
+  uint64_t word0 = 0x0;
+  uint64_t word1 = 0x0;
+  uint64_t word2 = 0x0;
+  uint64_t word3 = 0x0;
+  uint64_t word4 = 0x0;
+  uint64_t word5 = 0x0;
+  uint64_t word6 = 0x0;
+  uint64_t word7 = 0x0;
+
+  RDHAny(int v = 0); // 0 for default version
+
+  template <typename H>
+  RDHAny(const H& rdh);
+
+  template <typename H>
+  RDHAny& operator=(const H& rdh);
+
+  //------------------ service methods
+  using RDHv4 = o2::header::RAWDataHeaderV4; // V3 == V4
+  using RDHv5 = o2::header::RAWDataHeaderV5;
+  using RDHv6 = o2::header::RAWDataHeaderV6; // update this for every new version
+
+  /// make sure we RDH is a legitimate RAWDataHeader
+  template <typename RDH>
+  GPUhdi() static void sanityCheckStrict()
+  {
+#ifndef __OPENCL__
+    static_assert(std::is_same<RDH, RDHv4>::value || std::is_same<RDH, RDHv5>::value ||
+                    std::is_same<RDH, RDHv6>::value,
+                  "not an RDH");
+#endif
+  }
+
+  /// make sure we RDH is a legitimate RAWDataHeader or generic RDHAny placeholder
+  template <typename RDH>
+  GPUhdi() static void sanityCheckLoose()
+  {
+#ifndef __OPENCL__
+    static_assert(std::is_same<RDH, RDHv4>::value || std::is_same<RDH, RDHv5>::value ||
+                    std::is_same<RDH, RDHv6>::value || std::is_same<RDHAny, RDH>::value,
+                  "not an RDH or RDHAny");
+#endif
+  }
+
+  template <typename H>
+  GPUhdi() static const void* voidify(const H& rdh)
+  {
+    sanityCheckLoose<H>();
+    return reinterpret_cast<const void*>(&rdh);
+  }
+
+  template <typename H>
+  GPUhdi() static void* voidify(H& rdh)
+  {
+    sanityCheckLoose<H>();
+    return reinterpret_cast<void*>(&rdh);
+  }
+
+  GPUhdi() const void* voidify() const { return voidify(*this); }
+  GPUhdi() void* voidify() { return voidify(*this); }
+
+  template <typename H>
+  GPUhdi() H* as_ptr()
+  {
+    sanityCheckLoose<H>();
+    return reinterpret_cast<H*>(this);
+  }
+
+  template <typename H>
+  GPUhdi() H& as_ref()
+  {
+    sanityCheckLoose<H>();
+    return reinterpret_cast<H&>(this);
+  }
+
+ protected:
+  void copyFrom(const void* rdh);
+};
+
+///_________________________________
+/// create from arbitrary RDH version
+template <typename H>
+inline RDHAny::RDHAny(const H& rdh)
+{
+  sanityCheckLoose<H>();
+  copyFrom(&rdh);
+}
+
+///_________________________________
+/// copy from arbitrary RDH version
+template <typename H>
+inline RDHAny& RDHAny::operator=(const H& rdh)
+{
+  sanityCheckLoose<H>();
+  if (this != voidify(rdh)) {
+    copyFrom(&rdh);
+  }
+  return *this;
+}
+
+} // namespace header
+} // namespace o2
+
+#endif

--- a/DataFormats/Headers/src/DAQID.cxx
+++ b/DataFormats/Headers/src/DAQID.cxx
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DAQID.cxx
+/// @author ruben.shahoyan@cern.ch
+/// @brief  dummy implementation for DAQ source IDs (to addit it to library)
+
+#include "Headers/DAQID.h"
+
+using namespace o2::header;

--- a/DataFormats/Headers/src/RDHAny.cxx
+++ b/DataFormats/Headers/src/RDHAny.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// @brief implementations for placeholder class of arbitraty-version 64B-lonh RDH
+// @author ruben.shahoyan@cern.ch
+
+#include "Headers/RDHAny.h"
+#include <string>
+#include <cstring>
+
+using namespace o2::header;
+
+//_________________________________________________
+/// placeholder copied from specific version
+RDHAny::RDHAny(int v)
+{
+  if (v == 0) {
+    *this = RAWDataHeader{};
+  } else if (v == 6) {
+    *this = RAWDataHeaderV6{};
+  } else if (v == 5) {
+    *this = RAWDataHeaderV5{};
+  } else if (v == 3 || v == 4) {
+    *this = RAWDataHeaderV4{};
+  } else {
+    throw std::runtime_error(std::string("unsupported RDH version ") + std::to_string(v));
+  }
+}
+
+//_________________________________________________
+void RDHAny::copyFrom(const void* rdh)
+{
+  std::memcpy(this, rdh, sizeof(RDHAny));
+}

--- a/DataFormats/Headers/test/testDAQID.cxx
+++ b/DataFormats/Headers/test/testDAQID.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test DAQID class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Headers/DAQID.h"
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+// @brief consistency test for O2 origin <-> DAQ Source ID mapping
+// @author ruben.shahoyan@cern.ch
+
+using namespace o2::header;
+
+BOOST_AUTO_TEST_CASE(DAQIDTEST)
+{
+  for (int i = 0; i < DAQID::MAXDAQ + 5; i++) {
+    auto vo2 = DAQID::DAQtoO2(i);
+    auto daq = DAQID::O2toDAQ(vo2);
+    if (vo2 != DAQID::DAQtoO2(DAQID::INVALID)) {
+      std::cout << "DAQ SourceID " << i << " <-> " << vo2.str << std::endl;
+    }
+    BOOST_CHECK(i == daq || vo2 == DAQID::DAQtoO2(DAQID::INVALID));
+  }
+  std::cout << "DAQ INVALID  " << int(DAQID::INVALID) << " <-> " << DAQID::DAQtoO2(DAQID::INVALID).str << std::endl;
+}

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -766,7 +766,7 @@ class RawPixelReader : public PixelReader
     mMAP.expandFEEId(rdh->feeId, lr, ruOnLr, linkIDinRU);
     auto* ruLink = getGBTLink(ruDecData.links[linkIDinRU]);
     auto& ruLinkStat = ruLink->statistics;
-    ruLink->lastRDH = rdh;
+    ruLink->lastRDH = reinterpret_cast<o2::header::RDHAny*>(rdh); // hack but this reader should be outphased anyway
     ruLinkStat.nPackets++;
 
 #ifdef _RAW_READER_ERROR_CHECKS_
@@ -939,7 +939,7 @@ class RawPixelReader : public PixelReader
       }
 #endif
       rdh = rdhN;
-      ruLink->lastRDH = rdh;
+      ruLink->lastRDH = reinterpret_cast<o2::header::RDHAny*>(rdh);
     }
 
 #ifdef _RAW_READER_ERROR_CHECKS_
@@ -1035,7 +1035,7 @@ class RawPixelReader : public PixelReader
 
     auto ruLink = getGBTLink(ruDecode.links[linkIDinRU]);
     auto& ruLinkStat = ruLink->statistics;
-    ruLink->lastRDH = rdh;
+    ruLink->lastRDH = reinterpret_cast<o2::header::RDHAny*>(rdh); // hack but this reader should be outphased anyway
     ruLinkStat.nPackets++;
 
 #ifdef _RAW_READER_ERROR_CHECKS_
@@ -1211,7 +1211,7 @@ class RawPixelReader : public PixelReader
       }
 #endif
       rdh = rdhN;
-      ruLink->lastRDH = rdh;
+      ruLink->lastRDH = reinterpret_cast<o2::header::RDHAny*>(rdh); // hack but this reader should be outphased anyway
     }
 
 #ifdef _RAW_READER_ERROR_CHECKS_
@@ -1260,7 +1260,7 @@ class RawPixelReader : public PixelReader
         LOG(ERROR) << "FEEId:" << OUTHEX(decData.ruInfo->idHW, 4) << " cable " << icab
                    << " data does not start with ChipHeader or ChipEmpty";
         ruLinkStat.errorCounts[GBTLinkDecodingStat::ErrCableDataHeadWrong]++;
-        printRDH(getGBTLink(decData.links[decData.cableLinkID[icab]])->lastRDH);
+        printRDH(reinterpret_cast<const o2::header::RAWDataHeader*>(getGBTLink(decData.links[decData.cableLinkID[icab]])->lastRDH));
       }
 #endif
 
@@ -1273,7 +1273,7 @@ class RawPixelReader : public PixelReader
               LOG(ERROR) << "FEEId:" << OUTHEX(decData.ruInfo->idHW, 4) << " IB cable " << icab
                          << " shipped chip ID= " << chipData->getChipID();
               ruLinkStat.errorCounts[GBTLinkDecodingStat::ErrIBChipLaneMismatch]++;
-              printRDH(getGBTLink(decData.links[decData.cableLinkID[icab]])->lastRDH);
+              printRDH(reinterpret_cast<const o2::header::RAWDataHeader*>(getGBTLink(decData.links[decData.cableLinkID[icab]])->lastRDH));
             }
           }
 #endif

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/MC2RawEncoder.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/MC2RawEncoder.h
@@ -21,9 +21,11 @@
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
 #include "ITSMFTReconstruction/RUDecodeData.h"
 #include "DetectorsRaw/RawFileWriter.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 namespace o2
 {
+
 namespace itsmft
 {
 
@@ -31,7 +33,6 @@ template <class Mapping>
 class MC2RawEncoder
 {
   using Coder = o2::itsmft::AlpideCoder;
-  using RDH = o2::header::RAWDataHeader;
 
  public:
   MC2RawEncoder()
@@ -83,7 +84,7 @@ class MC2RawEncoder
     }
   }
 
-  int carryOverMethod(const RDH& rdh, const gsl::span<char> data, const char* ptr, int maxSize, int splitID,
+  int carryOverMethod(const o2::header::RDHAny* rdh, const gsl::span<char> data, const char* ptr, int maxSize, int splitID,
                       std::vector<char>& trailer, std::vector<char>& header) const;
 
   // create new gbt link
@@ -107,7 +108,7 @@ class MC2RawEncoder
                   Continuous,
                   Triggered };
   o2::InteractionRecord mCurrIR;               // currently processed int record
-  o2::raw::RawFileWriter mWriter;
+  o2::raw::RawFileWriter mWriter{Mapping::getOrigin()}; // set origin of data
   std::string mDefaultSinkName = "dataSink.raw";
   Mapping mMAP;
   Coder mCoder;

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -10,11 +10,12 @@
 
 #include "ITSMFTSimulation/MC2RawEncoder.h"
 #include "CommonConstants/Triggers.h"
-#include "DetectorsRaw/RDHUtils.h"
 #include "ITSMFTReconstruction/GBTLink.h"
 #include "Framework/Logger.h"
 
 using namespace o2::itsmft;
+using namespace o2::raw;
+using RDHUtils = o2::raw::RDHUtils;
 
 ///______________________________________________________________________
 template <class Mapping>
@@ -244,7 +245,7 @@ RUDecodeData& MC2RawEncoder<Mapping>::getCreateRUDecode(int ruSW)
 
 ///______________________________________________________________________
 template <class Mapping>
-int MC2RawEncoder<Mapping>::carryOverMethod(const RDH& rdh, const gsl::span<char> data,
+int MC2RawEncoder<Mapping>::carryOverMethod(const header::RDHAny* rdh, const gsl::span<char> data,
                                             const char* ptr, int maxSize, int splitID,
                                             std::vector<char>& trailer, std::vector<char>& header) const
 {

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -15,10 +15,10 @@
 #define ALICEO2_HBFUTILS_H
 
 #include <Rtypes.h>
+#include "DetectorsRaw/RDHUtils.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
 #include "CommonDataFormat/InteractionRecord.h"
-#include "Headers/RAWDataHeader.h"
 #include "CommonConstants/Triggers.h"
 
 namespace o2
@@ -74,11 +74,11 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   }
 
   ///< create RDH for given IR
-  template <class H>
+  template <typename H>
   H createRDH(const IR& rec) const;
 
   ///< update RDH for with given IR info
-  template <class H>
+  template <typename H>
   void updateRDH(H& rdh, const IR& rec) const;
 
   /*//-------------------------------------------------------------------------------------
@@ -101,12 +101,12 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
       for (int j=0;j<nHBF-1;j++) {
         auto rdh = sampler.createRDH<RAWDataHeader>( HBIRVec[j] );
         // dress rdh with cruID/FEE/Link ID
-        rdh.packetCounter = packetCounter++;
-        rdh.memorySize = sizeof(rdh);
-        rdh.offsetToNext = sizeof(rdh);
+        RDHUtils::setPacketCounter(rdh, packetCounter++);
+        RDHUtils::setMemorySize(rdh, sizeof(rdh));
+        RDHUtils::setOffsetToNext(rdh, sizeof(rdh));
         FLUSH_TO_SINK(&rdh, sizeof(rdh));  // open empty HBF
-        rdh.stop = 0x1;
-        rdh.pageCnt++;
+        RDHUtils::setStop(rdh, 0x1);
+        RDHUtils::setPageCounter(rdh, RDHUtils::getPageCounter()+1 );
         FLUSH_TO_SINK(&rdh, sizeof(rdh));  // close empty HBF
       }
       // write RDH for the HBF with data
@@ -128,58 +128,34 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
 };
 
 //_________________________________________________
-template <>
-inline void HBFUtils::updateRDH<o2::header::RAWDataHeaderV5>(o2::header::RAWDataHeaderV5& rdh, const o2::InteractionRecord& rec) const
+template <typename H>
+void HBFUtils::updateRDH(H& rdh, const IR& rec) const
 {
   auto tfhb = getTFandHBinTF(rec);
-  rdh.bunchCrossing = bcFirst;
-  rdh.orbit = rec.orbit;
-  //
+  RDHUtils::setHeartBeatBC(rdh, bcFirst);
+  RDHUtils::setHeartBeatOrbit(rdh, rec.orbit);
+  if (RDHUtils::getVersion(rdh) < 5) { // v3,4 have separate fields for trigger IR
+    RDHUtils::setTriggerBC(rdh, bcFirst);
+    RDHUtils::setTriggerOrbit(rdh, rec.orbit);
+  }
+
   if (rec.bc == bcFirst) { // if we are starting new HB, set the HB trigger flag
-    rdh.triggerType |= o2::trigger::ORBIT | o2::trigger::HB;
+    auto trg = RDHUtils::getTriggerType(rdh) | (o2::trigger::ORBIT | o2::trigger::HB);
     if (tfhb.second == 0) { // if we are starting new TF, set the TF trigger flag
-      rdh.triggerType |= o2::trigger::TF;
+      trg |= o2::trigger::TF;
     }
+    RDHUtils::setTriggerType(rdh, trg);
   }
 }
 
 //_________________________________________________
-template <>
-inline void HBFUtils::updateRDH<o2::header::RAWDataHeaderV4>(o2::header::RAWDataHeaderV4& rdh, const o2::InteractionRecord& rec) const
+template <typename H>
+inline H HBFUtils::createRDH(const o2::InteractionRecord& rec) const
 {
-  auto tfhb = getTFandHBinTF(rec);
-  rdh.triggerBC = rec.bc;
-  rdh.triggerOrbit = rec.orbit;
-
-  rdh.heartbeatBC = bcFirst;
-  rdh.heartbeatOrbit = rec.orbit;
-  //
-  if (rec.bc == bcFirst) { // if we are starting new HB, set the HB trigger flag
-    rdh.triggerType |= o2::trigger::ORBIT | o2::trigger::HB;
-    if (tfhb.second == 0) { // if we are starting new TF, set the TF trigger flag
-      rdh.triggerType |= o2::trigger::TF;
-    }
-  }
-}
-
-//_________________________________________________
-template <>
-inline o2::header::RAWDataHeaderV4 HBFUtils::createRDH<o2::header::RAWDataHeaderV4>(const o2::InteractionRecord& rec) const
-{
-  o2::header::RAWDataHeaderV4 rdh;
+  H rdh;
   updateRDH(rdh, rec);
   return rdh;
 }
-
-//_________________________________________________
-template <>
-inline o2::header::RAWDataHeaderV5 HBFUtils::createRDH<o2::header::RAWDataHeaderV5>(const o2::InteractionRecord& rec) const
-{
-  o2::header::RAWDataHeaderV5 rdh;
-  updateRDH(rdh, rec);
-  return rdh;
-}
-
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -18,6 +18,11 @@
 #include "GPUCommonRtypes.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "Headers/RAWDataHeader.h"
+#include "Headers/RDHAny.h"
+
+#ifndef GPUCA_GPUCODE
+#include "Headers/DAQID.h"
+#endif // GPUCA_GPUCODE
 
 namespace o2
 {
@@ -27,453 +32,657 @@ using LinkSubSpec_t = uint32_t;
 using IR = o2::InteractionRecord;
 
 struct RDHUtils {
+
+// disable is the type is a pointer
+#define NOTPTR(T) typename std::enable_if<!std::is_pointer<T>::value>::type* = 0
+// dereference SRC pointer as DST type reference
+#define TOREF(DST, SRC) *reinterpret_cast<DST*>(SRC)
+// dereference SRC pointer as DST type const reference
+#define TOCREF(DST, SRC) *reinterpret_cast<const DST*>(SRC)
+
   using RDHDef = o2::header::RAWDataHeader; // wathever is default
-  //using RDHv3 = o2::header::RAWDataHeaderV3; // V3 == V4
-  using RDHv4 = o2::header::RAWDataHeaderV4;
+  using RDHAny = o2::header::RDHAny;
+  using RDHv4 = o2::header::RAWDataHeaderV4; // V3 == V4
   using RDHv5 = o2::header::RAWDataHeaderV5;
-  using RDHv6 = o2::header::RAWDataHeaderV6;
-  static constexpr uint8_t MaxRDHVersion = 6;
+  using RDHv6 = o2::header::RAWDataHeaderV6; // update this for every new version
 
   static constexpr int GBTWord = 16; // length of GBT word
   static constexpr int MAXCRUPage = 512 * GBTWord;
+  /// get numeric version of the RDH
 
-  GPUhdi() static uint8_t getVersion(const RDHv4& rdh) { return rdh.version; } // same for all // why template does not work here?
-  GPUhdi() static uint8_t getVersion(const RDHv5& rdh) { return rdh.version; } // same for all
-  GPUhdi() static uint8_t getVersion(const RDHv6& rdh) { return rdh.version; } // same for all
-  GPUhdi() static uint8_t getVersion(const void* rdhP)
+  ///_______________________________
+  template <typename H>
+  static constexpr int getVersion()
   {
-    auto v = getVersion((*reinterpret_cast<const RDHDef*>(rdhP)));
-    if (v > MaxRDHVersion) {
-      processError(v, "version");
+#ifndef __OPENCL__
+    RDHAny::sanityCheckStrict<H>();
+    if (std::is_same<H, RDHv6>::value) {
+      return 6;
     }
-    return v;
+    if (std::is_same<H, RDHv5>::value) {
+      return 5;
+    }
+    if (std::is_same<H, RDHv4>::value) {
+      return 4;
+    }
+#else
+    return -1; // dummy value as this method will be used on the CPU only
+#endif // __OPENCL__
   }
-  template <typename RDH>
-  static void setVersion(RDH& rdh, uint8_t v)
+
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getVersion(const H& rdh, NOTPTR(H))
+  {
+    return rdh.version;
+  } // same for all
+  GPUhdi() static uint8_t getVersion(const RDHAny& rdh) { return getVersion(rdh.voidify()); }
+  GPUhdi() static uint8_t getVersion(const void* rdhP) { return getVersion(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setVersion(H& rdh, uint8_t v, NOTPTR(H))
   {
     rdh.version = v;
   } // same for all
-  static void setVersion(void* rdhP, uint8_t v) { setVersion(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setVersion(RDHAny& rdh, uint8_t v) { setVersion(rdh.voidify(), v); }
+  static void setVersion(void* rdhP, uint8_t v) { setVersion(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  static int getHeaderSize(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static int getHeaderSize(const H& rdh, NOTPTR(H))
   {
     return rdh.headerSize;
   } // same for all
-  static int getHeaderSize(const void* rdhP) { return getHeaderSize(*reinterpret_cast<const RDHDef*>(rdhP)); }
+  GPUhdi() static int getHeaderSize(const RDHAny& rdh) { return getHeaderSize(rdh.voidify()); }
+  GPUhdi() static int getHeaderSize(const void* rdhP) { return getHeaderSize(TOCREF(RDHDef, rdhP)); }
 
-  template <typename RDH>
-  GPUhdi() static uint16_t getFEEID(const RDH& rdh)
+  ///_______________________________
+  GPUhdi() static uint16_t getBlockLength(const RDHv4& rdh) { return rdh.blockLength; } // exists in v4 only
+  GPUhdi() static uint16_t getBlockLength(const RDHAny& rdh) { return getBlockLength(rdh.voidify()); }
+  GPUhdi() static uint16_t getBlockLength(const void* rdhP)
+  {
+    int version = getVersion(rdhP);
+    if (version == 4) {
+      return getBlockLength(TOCREF(RDHv4, rdhP));
+    } else {
+      processError(getVersion(rdhP), "blockLength");
+      return 0;
+    }
+  }
+  static void setBlockLength(RDHv4& rdh, uint16_t s) { rdh.blockLength = s; }
+  static void setBlockLength(RDHAny& rdh, uint16_t s) { setBlockLength(rdh.voidify(), s); }
+  static void setBlockLength(void* rdhP, uint16_t s)
+  {
+    int version = getVersion(rdhP);
+    if (version == 4) {
+      setBlockLength(TOREF(RDHv4, rdhP), s);
+    } else {
+      processError(getVersion(rdhP), "blockLength");
+    }
+  }
+
+  ///_______________________________
+  GPUhdi() static uint16_t getFEEID(const RDHv4& rdh) { return rdh.feeId; } // same name differen position in v3,4
+  template <typename H>
+  GPUhdi() static uint16_t getFEEID(const H& rdh, NOTPTR(H))
   {
     return rdh.feeId;
-  } // same for all
-  GPUhdi() static uint16_t getFEEID(const void* rdhP) { return getFEEID(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setFEEID(RDH& rdh, uint16_t v)
+  }
+  GPUhdi() static uint16_t getFEEID(const RDHAny& rdh) { return getFEEID(rdh.voidify()); }
+  GPUhdi() static uint16_t getFEEID(const void* rdhP)
+  {
+    int version = getVersion(rdhP);
+    if (version > 4) {
+      return getFEEID(TOCREF(RDHv5, rdhP));
+    } else {
+      return getFEEID(TOCREF(RDHv4, rdhP));
+    }
+  }
+  static void setFEEID(RDHv4& rdh, uint16_t v)
   {
     rdh.feeId = v;
-  } // same for all
-  static void setFEEID(void* rdhP, uint16_t v) { setFEEID(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  }
+  template <typename H>
+  static void setFEEID(H& rdh, uint16_t v, NOTPTR(H))
+  {
+    rdh.feeId = v;
+  } //
+  static void setFEEID(RDHAny& rdh, uint16_t v) { setFEEID(rdh.voidify(), v); }
+  static void setFEEID(void* rdhP, uint16_t v)
+  {
+    int version = getVersion(rdhP);
+    if (version > 4) {
+      setFEEID(TOREF(RDHv5, rdhP), v);
+    } else {
+      setFEEID(TOREF(RDHv4, rdhP), v);
+    }
+  }
 
-  template <typename RDH>
-  static bool getPriorityBit(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static bool getPriorityBit(const H& rdh, NOTPTR(H))
   {
     return rdh.priority;
   } // same for all
-  static bool getPriorityBit(const void* rdhP) { return getPriorityBit(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setPriorityBit(RDH& rdh, bool v)
+  GPUhdi() static bool getPriorityBit(const RDHAny& rdh) { return getPriorityBit(rdh.voidify()); }
+  GPUhdi() static bool getPriorityBit(const void* rdhP) { return getPriorityBit(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setPriorityBit(H& rdh, bool v, NOTPTR(H))
   {
     rdh.priority = v;
   } // same for all
-  static void setPriorityBit(void* rdhP, bool v) { setPriorityBit(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setPriorityBit(RDHAny& rdh, bool v) { setPriorityBit(rdh.voidify(), v); }
+  static void setPriorityBit(void* rdhP, bool v) { setPriorityBit(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  GPUhdi() static uint8_t getSourceID(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getSourceID(const H& rdh, NOTPTR(H))
   { // does not exist before V6
     processError(getVersion(rdh), "sourceID");
     return 0xff;
   }
   GPUhdi() static uint8_t getSourceID(const RDHv6& rdh) { return rdh.sourceID; }
+  GPUhdi() static uint8_t getSourceID(const RDHAny& rdh) { return getSourceID(rdh.voidify()); }
   GPUhdi() static uint8_t getSourceID(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 5) {
-      return getSourceID(*reinterpret_cast<const RDHv6*>(rdhP));
+      return getSourceID(TOCREF(RDHv6, rdhP));
     } else {
       processError(version, "sourceID");
       return 0xff;
     }
   }
   static void setSourceID(RDHv6& rdh, uint8_t s) { rdh.sourceID = s; }
+  static void setSourceID(RDHAny& rdh, uint8_t s) { setSourceID(rdh.voidify(), s); }
   static void setSourceID(void* rdhP, uint8_t s)
   {
     int version = getVersion(rdhP);
     if (version > 5) {
-      setSourceID(*reinterpret_cast<RDHv6*>(rdhP), s);
+      setSourceID(TOREF(RDHv6, rdhP), s);
     } else {
       processError(version, "sourceID");
     }
   }
 
-  template <typename RDH>
-  static uint16_t getOffsetToNext(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint16_t getOffsetToNext(const H& rdh, NOTPTR(H))
   {
     return rdh.offsetToNext;
   } // same for all
-  static uint16_t getOffsetToNext(const void* rdhP) { return getOffsetToNext(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setOffsetToNext(RDH& rdh, uint16_t v)
+  GPUhdi() static uint16_t getOffsetToNext(const RDHAny& rdh) { return getOffsetToNext(rdh.voidify()); }
+  GPUhdi() static uint16_t getOffsetToNext(const void* rdhP) { return getOffsetToNext(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setOffsetToNext(H& rdh, uint16_t v, NOTPTR(H))
   {
     rdh.offsetToNext = v;
   } // same for all
-  static void setOffsetToNext(void* rdhP, uint16_t v) { setOffsetToNext(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setOffsetToNext(RDHAny& rdh, uint16_t v) { setOffsetToNext(rdh.voidify(), v); }
+  static void setOffsetToNext(void* rdhP, uint16_t v) { setOffsetToNext(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  GPUhdi() static uint16_t getMemorySize(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint16_t getMemorySize(const H& rdh, NOTPTR(H))
   {
     return rdh.memorySize;
   } // same for all
-  GPUhdi() static uint16_t getMemorySize(const void* rdhP) { return getMemorySize(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setMemorySize(RDH& rdh, uint16_t v)
+  GPUhdi() static uint16_t getMemorySize(const RDHAny& rdh) { return getMemorySize(rdh.voidify()); }
+  GPUhdi() static uint16_t getMemorySize(const void* rdhP) { return getMemorySize(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setMemorySize(H& rdh, uint16_t v, NOTPTR(H))
   {
     rdh.memorySize = v;
   } // same for all
-  static void setMemorySize(void* rdhP, uint16_t v) { setMemorySize(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setMemorySize(RDHAny& rdh, uint16_t v) { setMemorySize(rdh.voidify(), v); }
+  static void setMemorySize(void* rdhP, uint16_t v) { setMemorySize(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  static uint8_t getLinkID(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getLinkID(const H& rdh, NOTPTR(H))
   {
     return rdh.linkID;
   } // same for all
-  static uint8_t getLinkID(const void* rdhP) { return getLinkID(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setLinkID(RDH& rdh, uint8_t v)
+  GPUhdi() static uint8_t getLinkID(const RDHAny& rdh) { return getLinkID(rdh.voidify()); }
+  GPUhdi() static uint8_t getLinkID(const void* rdhP) { return getLinkID(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setLinkID(H& rdh, uint8_t v, NOTPTR(H))
   {
     rdh.linkID = v;
   } // same for all
-  static void setLinkID(void* rdhP, uint8_t v) { setLinkID(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setLinkID(RDHAny& rdh, uint8_t v) { setLinkID(rdh.voidify(), v); }
+  static void setLinkID(void* rdhP, uint8_t v) { setLinkID(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  static uint8_t getPacketCounter(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getPacketCounter(const H& rdh, NOTPTR(H))
   {
     return rdh.packetCounter;
   } // same for all
-  static uint8_t getPacketCounter(const void* rdhP) { return getPacketCounter(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setPacketCounter(RDH& rdh, uint8_t v)
+  GPUhdi() static uint8_t getPacketCounter(const RDHAny& rdh) { return getPacketCounter(rdh.voidify()); }
+  GPUhdi() static uint8_t getPacketCounter(const void* rdhP) { return getPacketCounter(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setPacketCounter(H& rdh, uint8_t v, NOTPTR(H))
   {
     rdh.packetCounter = v;
   } // same for all
-  static void setPacketCounter(void* rdhP, uint8_t v) { setPacketCounter(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setPacketCounter(RDHAny& rdh, uint8_t v) { setPacketCounter(rdh.voidify(), v); }
+  static void setPacketCounter(void* rdhP, uint8_t v) { setPacketCounter(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  static uint16_t getCRUID(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint16_t getCRUID(const H& rdh, NOTPTR(H))
   {
     return rdh.cruID;
   } // same for all
-  static uint16_t getCRUID(const void* rdhP) { return getCRUID(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setCRUID(RDH& rdh, uint16_t v)
+  GPUhdi() static uint16_t getCRUID(const RDHAny& rdh) { return getCRUID(rdh.voidify()); }
+  GPUhdi() static uint16_t getCRUID(const void* rdhP) { return getCRUID(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setCRUID(H& rdh, uint16_t v, NOTPTR(H))
   {
     rdh.cruID = v;
   } // same for all
-  static void setCRUID(void* rdhP, uint16_t v) { setCRUID(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setCRUID(RDHAny& rdh, uint16_t v) { setCRUID(rdh.voidify(), v); }
+  static void setCRUID(void* rdhP, uint16_t v) { setCRUID(TOREF(RDHDef, rdhP), v); }
 
-  template <typename RDH>
-  static uint8_t getEndPointID(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getEndPointID(const H& rdh, NOTPTR(H))
   {
     return rdh.endPointID;
   } // same for all
-  static uint8_t getEndPointID(const void* rdhP) { return getEndPointID(*reinterpret_cast<const RDHDef*>(rdhP)); }
-  template <typename RDH>
-  static void setEndPointID(RDH& rdh, uint8_t v)
+  GPUhdi() static uint8_t getEndPointID(const RDHAny& rdh) { return getEndPointID(rdh.voidify()); }
+  GPUhdi() static uint8_t getEndPointID(const void* rdhP) { return getEndPointID(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setEndPointID(H& rdh, uint8_t v, NOTPTR(H))
   {
     rdh.endPointID = v;
   } // same for all
-  static void setEndPointID(void* rdhP, uint8_t v) { setEndPointID(*reinterpret_cast<RDHDef*>(rdhP), v); }
+  static void setEndPointID(RDHAny& rdh, uint8_t v) { setEndPointID(rdh.voidify(), v); }
+  static void setEndPointID(void* rdhP, uint8_t v) { setEndPointID(TOREF(RDHDef, rdhP), v); }
 
+  ///_______________________________
   GPUhdi() static uint16_t getHeartBeatBC(const RDHv4& rdh) { return rdh.heartbeatBC; }
-  GPUhdi() static uint16_t getHeartBeatBC(const RDHv5& rdh) { return rdh.bunchCrossing; } // starting from V5 no distiction trigger or HB
-  GPUhdi() static uint16_t getHeartBeatBC(const RDHv6& rdh) { return rdh.bunchCrossing; }
+  template <typename H>
+  GPUhdi() static uint16_t getHeartBeatBC(const H& rdh, NOTPTR(H))
+  {
+    return rdh.bunchCrossing;
+  }                                                                                                    // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint16_t getHeartBeatBC(const RDHAny& rdh) { return getHeartBeatBC(rdh.voidify()); } // starting from V5 no distiction trigger or HB
   GPUhdi() static uint16_t getHeartBeatBC(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getHeartBeatBC(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getHeartBeatBC(TOCREF(RDHv5, rdhP));
     } else {
-      return getHeartBeatBC(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getHeartBeatBC(TOCREF(RDHv4, rdhP));
     }
   }
-  static void setHeartBeatBC(RDHv4& rdh, uint16_t v) { rdh.heartbeatBC = v; }
-  static void setHeartBeatBC(RDHv5& rdh, uint16_t v) { rdh.bunchCrossing = v; } // starting from V5 no distiction trigger or HB
-  static void setHeartBeatBC(RDHv6& rdh, uint16_t v) { rdh.bunchCrossing = v; }
-  static void setHeartBeatBC(void* rdhP, uint16_t v)
+  GPUhdi() static void setHeartBeatBC(RDHv4& rdh, uint16_t v) { rdh.heartbeatBC = v; }
+  template <typename H>
+  GPUhdi() static void setHeartBeatBC(H& rdh, uint16_t v, NOTPTR(H))
+  {
+    rdh.bunchCrossing = v;
+  } // starting from V5 no distiction trigger or HB
+  GPUhdi() static void setHeartBeatBC(RDHAny& rdh, uint16_t v) { setHeartBeatBC(rdh.voidify(), v); }
+  GPUhdi() static void setHeartBeatBC(void* rdhP, uint16_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setHeartBeatBC(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setHeartBeatBC(TOREF(RDHv5, rdhP), v);
     } else {
-      setHeartBeatBC(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setHeartBeatBC(TOREF(RDHv4, rdhP), v);
     }
   }
 
+  ///_______________________________
   GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv4& rdh) { return rdh.heartbeatOrbit; }
-  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv5& rdh) { return rdh.orbit; } // starting from V5 no distiction trigger or HB
-  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHv6& rdh) { return rdh.orbit; }
+  template <typename H>
+  GPUhdi() static uint32_t getHeartBeatOrbit(const H& rdh, NOTPTR(H))
+  {
+    return rdh.orbit;
+  } // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint32_t getHeartBeatOrbit(const RDHAny& rdh) { return getHeartBeatOrbit(rdh.voidify()); }
   GPUhdi() static uint32_t getHeartBeatOrbit(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getHeartBeatOrbit(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getHeartBeatOrbit(TOCREF(RDHv5, rdhP));
     } else {
-      return getHeartBeatOrbit(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getHeartBeatOrbit(TOCREF(RDHv4, rdhP));
     }
   }
   static void setHeartBeatOrbit(RDHv4& rdh, uint32_t v) { rdh.heartbeatOrbit = v; }
-  static void setHeartBeatOrbit(RDHv5& rdh, uint32_t v) { rdh.orbit = v; } // starting from V5 no distiction trigger or HB
-  static void setHeartBeatOrbit(RDHv6& rdh, uint32_t v) { rdh.orbit = v; }
+  template <typename H>
+  static void setHeartBeatOrbit(H& rdh, uint32_t v, NOTPTR(H))
+  {
+    rdh.orbit = v;
+  } // starting from V5 no distiction trigger or HB
+  static void setHeartBeatOrbit(RDHAny& rdh, uint32_t v) { setHeartBeatOrbit(rdh.voidify(), v); }
   static void setHeartBeatOrbit(void* rdhP, uint32_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setHeartBeatOrbit(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setHeartBeatOrbit(TOREF(RDHv5, rdhP), v);
     } else {
-      setHeartBeatOrbit(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setHeartBeatOrbit(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  template <typename RDH>
-  static IR getHeartBeatIR(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static IR getHeartBeatIR(const H& rdh, NOTPTR(H))
   {
     return {getHeartBeatBC(rdh), getHeartBeatOrbit(rdh)};
   } // custom extension
-  static IR getHeartBeattIR(const void* rdhP)
+  GPUhdi() static IR getHeartBeatIR(const RDHAny& rdh) { return getHeartBeattIR(rdh.voidify()); }
+  GPUhdi() static IR getHeartBeattIR(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getHeartBeatIR(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getHeartBeatIR(TOCREF(RDHv5, rdhP));
     } else {
-      return getHeartBeatIR(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getHeartBeatIR(TOCREF(RDHv4, rdhP));
     }
   }
 
-  template <typename RDH>
-  static IR getTriggerIR(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static IR getTriggerIR(const H& rdh, NOTPTR(H))
   {
     return {getTriggerBC(rdh), getTriggerOrbit(rdh)};
   } // custom extension
-  static IR getTriggerIR(const void* rdhP)
+  GPUhdi() static IR getTriggerIR(const RDHAny& rdh) { return getTriggerIR(rdh.voidify()); }
+  GPUhdi() static IR getTriggerIR(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getTriggerIR(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getTriggerIR(TOCREF(RDHv5, rdhP));
     } else {
-      return getTriggerIR(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getTriggerIR(TOCREF(RDHv4, rdhP));
     }
   }
 
-  static uint16_t getTriggerBC(const RDHv4& rdh) { return rdh.triggerBC; }
-  static uint16_t getTriggerBC(const RDHv5& rdh) { return rdh.bunchCrossing; } // starting from V5 no distiction trigger or HB
-  static uint16_t getTriggerBC(const RDHv6& rdh) { return rdh.bunchCrossing; }
-  static uint16_t getTriggerBC(const void* rdhP)
+  ///_______________________________
+  GPUhdi() static uint16_t getTriggerBC(const RDHv4& rdh) { return rdh.triggerBC; }
+  template <typename H>
+  GPUhdi() static uint16_t getTriggerBC(const H& rdh, NOTPTR(H))
+  {
+    return rdh.bunchCrossing;
+  } // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint16_t getTriggerBC(const RDHAny& rdh) { return getTriggerBC(rdh.voidify()); }
+  GPUhdi() static uint16_t getTriggerBC(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getTriggerBC(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getTriggerBC(TOCREF(RDHv5, rdhP));
     } else {
-      return getTriggerBC(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getTriggerBC(TOCREF(RDHv4, rdhP));
     }
   }
   static void setTriggerBC(RDHv4& rdh, uint16_t v) { rdh.triggerBC = v; }
-  static void setTriggerBC(RDHv5& rdh, uint16_t v) { rdh.bunchCrossing = v; } // starting from V5 no distiction trigger or HB
-  static void setTriggerBC(RDHv6& rdh, uint16_t v) { rdh.bunchCrossing = v; }
+  template <typename H>
+  static void setTriggerBC(H& rdh, uint16_t v, NOTPTR(H))
+  {
+    rdh.bunchCrossing = v;
+  } // starting from V5 no distiction trigger or HB
+  static void setTriggerBC(RDHAny& rdh, uint16_t v) { setTriggerBC(rdh.voidify(), v); }
   static void setTriggerBC(void* rdhP, uint16_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setTriggerBC(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setTriggerBC(TOREF(RDHv5, rdhP), v);
     } else {
-      setTriggerBC(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setTriggerBC(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  static uint32_t getTriggerOrbit(const RDHv4& rdh) { return rdh.triggerOrbit; }
-  static uint32_t getTriggerOrbit(const RDHv5& rdh) { return rdh.orbit; } // starting from V5 no distiction trigger or HB
-  static uint32_t getTriggerOrbit(const RDHv6& rdh) { return rdh.orbit; }
-  static uint32_t getTriggerOrbit(const void* rdhP)
+  ///_______________________________
+  GPUhdi() static uint32_t getTriggerOrbit(const RDHv4& rdh) { return rdh.triggerOrbit; }
+  template <typename H>
+  GPUhdi() static uint32_t getTriggerOrbit(const H& rdh, NOTPTR(H))
+  {
+    return rdh.orbit;
+  } // starting from V5 no distiction trigger or HB
+  GPUhdi() static uint32_t getTriggerOrbit(const RDHAny& rdh) { return getTriggerOrbit(rdh.voidify()); }
+  GPUhdi() static uint32_t getTriggerOrbit(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getTriggerOrbit(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getTriggerOrbit(TOCREF(RDHv5, rdhP));
     } else {
-      return getTriggerOrbit(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getTriggerOrbit(TOCREF(RDHv4, rdhP));
     }
   }
   static void setTriggerOrbit(RDHv4& rdh, uint32_t v) { rdh.triggerOrbit = v; }
-  static void setTriggerOrbit(RDHv5& rdh, uint32_t v) { rdh.orbit = v; } // starting from V5 no distiction trigger or HB
-  static void setTriggerOrbit(RDHv6& rdh, uint32_t v) { rdh.orbit = v; }
+  template <typename H>
+  static void setTriggerOrbit(H& rdh, uint32_t v, NOTPTR(H))
+  {
+    rdh.orbit = v;
+  } // starting from V5 no distiction trigger or HB
+  static void setTriggerOrbit(RDHAny& rdh, uint32_t v) { setTriggerOrbit(rdh.voidify(), v); }
   static void setTriggerOrbit(void* rdhP, uint32_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setTriggerOrbit(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setTriggerOrbit(TOREF(RDHv5, rdhP), v);
     } else {
-      setTriggerOrbit(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setTriggerOrbit(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  template <typename RDH>
-  static uint32_t getTriggerType(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint32_t getTriggerType(const H& rdh, NOTPTR(H))
   {
     return rdh.triggerType;
   }
-  static uint32_t getTriggerType(const RDHv5& rdh) { return rdh.triggerType; } // same name but different positions starting from v5
-  static uint32_t getTriggerType(const void* rdhP)
+  GPUhdi() static uint32_t getTriggerType(const RDHv5& rdh) { return rdh.triggerType; } // same name but different positions starting from v5
+  GPUhdi() static uint32_t getTriggerType(const RDHAny& rdh) { return getTriggerType(rdh.voidify()); }
+  GPUhdi() static uint32_t getTriggerType(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getTriggerType(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getTriggerType(TOCREF(RDHv5, rdhP));
     } else {
-      return getTriggerType(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getTriggerType(TOCREF(RDHv4, rdhP));
     }
   }
-  template <typename RDH>
-  static void setTriggerType(RDH& rdh, uint32_t v)
+  template <typename H>
+  static void setTriggerType(H& rdh, uint32_t v, NOTPTR(H))
   {
     rdh.triggerType = v;
   }
   static void setTriggerType(RDHv5& rdh, uint32_t v) { rdh.triggerType = v; } // same name but different positions starting from v5
+  static void setTriggerType(RDHAny& rdh, uint32_t v) { setTriggerType(rdh.voidify(), v); }
   static void setTriggerType(void* rdhP, uint32_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setTriggerType(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setTriggerType(TOREF(RDHv5, rdhP), v);
     } else {
-      setTriggerType(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setTriggerType(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  template <typename RDH>
-  static uint16_t getPageCounter(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint16_t getPageCounter(const H& rdh, NOTPTR(H))
   {
     return rdh.pageCnt;
   } // same name but different positions from V4
-  static uint16_t getPageCounter(const RDHv5& rdh) { return rdh.pageCnt; }
-  static uint16_t getPageCounter(const void* rdhP)
+  GPUhdi() static uint16_t getPageCounter(const RDHv5& rdh) { return rdh.pageCnt; }
+  GPUhdi() static uint16_t getPageCounter(const RDHAny& rdh) { return getPageCounter(rdh.voidify()); }
+  GPUhdi() static uint16_t getPageCounter(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getPageCounter(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getPageCounter(TOCREF(RDHv5, rdhP));
     } else {
-      return getPageCounter(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getPageCounter(TOCREF(RDHv4, rdhP));
     }
   }
-  template <typename RDH>
-  static void setPageCounter(RDH& rdh, uint16_t v)
+  template <typename H>
+  static void setPageCounter(H& rdh, uint16_t v, NOTPTR(H))
   {
     rdh.pageCnt = v;
   } // same name but different positions from V4
   static void setPageCounter(RDHv5& rdh, uint16_t v) { rdh.pageCnt = v; }
+  static void setPageCounter(RDHAny& rdh, uint16_t v) { setPageCounter(rdh.voidify(), v); }
   static void setPageCounter(void* rdhP, uint16_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setPageCounter(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setPageCounter(TOREF(RDHv5, rdhP), v);
     } else {
-      setPageCounter(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setPageCounter(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  template <typename RDH>
-  static uint32_t getDetectorField(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint32_t getDetectorField(const H& rdh, NOTPTR(H))
   {
     return rdh.detectorField;
   }                                                                                                                       // same for all
-  static uint32_t getDetectorField(const void* rdhP) { return getDetectorField(*reinterpret_cast<const RDHDef*>(rdhP)); } // same for all
-  template <typename RDH>
-  static void setDetectorField(RDH& rdh, uint32_t v)
+  GPUhdi() static uint32_t getDetectorField(const RDHAny& rdh) { return getDetectorField(rdh.voidify()); }
+  GPUhdi() static uint32_t getDetectorField(const void* rdhP) { return getDetectorField(TOCREF(RDHDef, rdhP)); }
+  template <typename H>
+  static void setDetectorField(H& rdh, uint32_t v, NOTPTR(H))
   {
     rdh.detectorField = v;
   }                                                                                                               // same for all
-  static void setDetectorField(void* rdhP, uint32_t v) { setDetectorField(*reinterpret_cast<RDHDef*>(rdhP), v); } // same for all
+  static void setDetectorField(RDHAny& rdh, uint32_t v) { setDetectorField(rdh.voidify(), v); }
+  static void setDetectorField(void* rdhP, uint32_t v) { setDetectorField(TOREF(RDHDef, rdhP), v); } // same for all
 
-  static uint16_t getDetectorPAR(const RDHv4& rdh) { return rdh.par; }
-  static uint16_t getDetectorPAR(const RDHv5& rdh) { return rdh.detectorPAR; } // different names starting from V5
-  static uint16_t getDetectorPAR(const RDHv6& rdh) { return rdh.detectorPAR; }
-  static uint16_t getDetectorPAR(const void* rdhP)
+  ///_______________________________
+  GPUhdi() static uint16_t getDetectorPAR(const RDHv4& rdh) { return rdh.par; }
+  template <typename H>
+  GPUhdi() static uint16_t getDetectorPAR(const H& rdh, NOTPTR(H))
+  {
+    return rdh.detectorPAR;
+  } // different names starting from V5
+  GPUhdi() static uint16_t getDetectorPAR(const RDHAny& rdh) { return getDetectorPAR(rdh.voidify()); }
+  GPUhdi() static uint16_t getDetectorPAR(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getDetectorPAR(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getDetectorPAR(TOCREF(RDHv5, rdhP));
     } else {
-      return getDetectorPAR(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getDetectorPAR(TOCREF(RDHv4, rdhP));
     }
   }
   static void setDetectorPAR(RDHv4& rdh, uint16_t v) { rdh.par = v; }
-  static void setDetectorPAR(RDHv5& rdh, uint16_t v) { rdh.detectorPAR = v; } // different names starting from V5
-  static void setDetectorPAR(RDHv6& rdh, uint16_t v) { rdh.detectorPAR = v; }
+  template <typename H>
+  static void setDetectorPAR(H& rdh, uint16_t v, NOTPTR(H))
+  {
+    rdh.detectorPAR = v;
+  } // different names starting from V5
+  static void setDetectorPAR(RDHAny& rdh, uint16_t v) { setDetectorPAR(rdh.voidify(), v); }
   static void setDetectorPAR(void* rdhP, uint16_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setDetectorPAR(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setDetectorPAR(TOREF(RDHv5, rdhP), v);
     } else {
-      setDetectorPAR(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setDetectorPAR(TOREF(RDHv4, rdhP), v);
     }
   }
 
-  template <typename RDH>
-  static uint8_t getStop(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  GPUhdi() static uint8_t getStop(const H& rdh, NOTPTR(H))
+  {
+    return rdh.stop;
+  }
+  GPUhdi() static uint8_t getStop(const RDHv5& rdh)
   {
     return rdh.stop;
   } // same name but different positions starting from v5
-  static uint8_t getStop(const void* rdhP)
+  GPUhdi() static uint8_t getStop(const RDHAny& rdh) { return getStop(rdh.voidify()); }
+  GPUhdi() static uint8_t getStop(const void* rdhP)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      return getStop(*reinterpret_cast<const RDHv5*>(rdhP));
+      return getStop(TOCREF(RDHv5, rdhP));
     } else {
-      return getStop(*reinterpret_cast<const RDHv4*>(rdhP));
+      return getStop(TOCREF(RDHv4, rdhP));
     }
   }
-  template <typename RDH>
-  static void setStop(RDH& rdh, uint8_t v)
+  template <typename H>
+  static void setStop(H& rdh, uint8_t v, NOTPTR(H))
   {
     rdh.stop = v;
   } // same name but different positions starting from v5
+  static void setStop(RDHAny& rdh, uint8_t v) { setStop(rdh.voidify(), v); }
   static void setStop(void* rdhP, uint8_t v)
   {
     int version = getVersion(rdhP);
     if (version > 4) {
-      setStop(*reinterpret_cast<RDHv5*>(rdhP), v);
+      setStop(TOREF(RDHv5, rdhP), v);
     } else {
-      setStop(*reinterpret_cast<RDHv4*>(rdhP), v);
+      setStop(TOREF(RDHv4, rdhP), v);
     }
   }
 
+  ///_______________________________
   static void printRDH(const RDHv4& rdh);
   static void printRDH(const RDHv5& rdh);
   static void printRDH(const RDHv6& rdh);
+  static void printRDH(const RDHAny& rdh) { printRDH(rdh.voidify()); }
   static void printRDH(const void* rdhP);
 
-  template <typename RDH>
-  static void dumpRDH(const RDH& rdh)
+  ///_______________________________
+  template <typename H>
+  static void dumpRDH(const H& rdh, NOTPTR(H))
   {
     dumpRDH(reinterpret_cast<const void*>(&rdh));
   }
   static void dumpRDH(const void* rdhP);
 
+  ///_______________________________
   static bool checkRDH(const RDHv4& rdh, bool verbose = true);
   static bool checkRDH(const RDHv5& rdh, bool verbose = true);
   static bool checkRDH(const RDHv6& rdh, bool verbose = true);
+  static bool checkRDH(const RDHAny rdh, bool verbose = true) { return checkRDH(rdh.voidify(), verbose); }
   static bool checkRDH(const void* rdhP, bool verbose = true);
 
-  static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId);
-  static LinkSubSpec_t getSubSpec(const RDHv4& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId); }
-  static LinkSubSpec_t getSubSpec(const RDHv5& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId); }
-  static LinkSubSpec_t getSubSpec(const RDHv6& rdh) { return getFEEID(rdh); }
+  ///_______________________________
+#ifndef GPUCA_GPUCODE
+  static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId, o2::header::DAQID::ID srcid = o2::header::DAQID::INVALID)
+  {
+    // Adapt the same definition as DataDistribution
+    // meaningfull DAQ sourceID means that it comes from RDHv6, in this case we use feeID as a subspec
+    if (srcid != o2::header::DAQID::INVALID) {
+      return feeId;
+    } else {
+      int linkValue = (LinkSubSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
+      return (LinkSubSpec_t(cru) << 16) | linkValue;
+    }
+    //
+    // RS At the moment suppress getting the subspec as a hash
+    // uint16_t seq[3] = {cru, uint16_t((uint16_t(link) << 8) | endpoint), feeId};
+    // return fletcher32(seq, 3);
+  }
+  template <typename H>
+  static LinkSubSpec_t getSubSpec(const H& rdh, NOTPTR(H)) // will be used for all RDH versions but >=6
+  {
+    return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId, o2::header::DAQID::INVALID);
+  }
+#endif // GPUCA_GPUCODE
+  GPUhdi() static LinkSubSpec_t getSubSpec(const RDHv6& rdh)
+  {
+    return getFEEID(rdh);
+  } // starting from V6 use FEEID only
+  GPUhdi() static LinkSubSpec_t getSubSpec(const RDHAny& rdh) { return getSubSpec(rdh.voidify()); }
+  GPUhdi() static LinkSubSpec_t getSubSpec(const void* rdhP)
+  {
+    int version = getVersion(rdhP);
+    if (version > 5) {
+      return getSubSpec(TOCREF(RDHv6, rdhP));
+    } else {
+      return getSubSpec(TOCREF(RDHv4, rdhP));
+    }
+  }
 
  private:
   static uint32_t fletcher32(const uint16_t* data, int len);
@@ -487,20 +696,6 @@ struct RDHUtils {
 
   ClassDefNV(RDHUtils, 1);
 };
-
-//_____________________________________________________________________
-inline LinkSubSpec_t RDHUtils::getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId)
-{
-  /*
-  // RS Temporarily suppress this way since such a subspec does not define the TOF/TPC links in a unique way
-  // define subspecification as in DataDistribution
-  int linkValue = (LinkSubSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
-  return (LinkSubSpec_t(cru) << 16) | linkValue;
-  */
-  // RS Temporarily suppress this way since such a link is ambiguous
-  uint16_t seq[3] = {cru, uint16_t((uint16_t(link) << 8) | endpoint), feeId};
-  return fletcher32(seq, 3);
-}
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -35,7 +35,8 @@ class RawFileReader
 {
   using LinkSpec_t = uint64_t; // = (origin<<32) | LinkSubSpec
  public:
-  using RDH = o2::header::RAWDataHeader;
+  using RDHAny = header::RDHAny;
+  using RDH = o2::header::RAWDataHeaderV4;
   using OrDesc = std::pair<o2::header::DataOrigin, o2::header::DataDescription>;
   using InputsMap = std::map<OrDesc, std::vector<std::string>>;
   //================================================================================
@@ -102,8 +103,8 @@ class RawFileReader
 
   //=====================================================================================
   struct LinkData {
-    RDH rdhl;             // RDH with the running info of the last RDH seen
-    LinkSpec_t spec = 0;  // Link subspec augmented by its origin
+    RDHAny rdhl;               // RDH with the running info of the last RDH seen
+    LinkSpec_t spec = 0;       // Link subspec augmented by its origin
     LinkSubSpec_t subspec = 0; // subspec according to DataDistribution
     uint32_t nTimeFrames = 0;
     uint32_t nHBFrames = 0;
@@ -121,9 +122,11 @@ class RawFileReader
     int nextBlock2Read = 0; // next block which should be read
 
     LinkData() = default;
-    LinkData(const o2::header::RAWDataHeaderV4& rdh, const RawFileReader* r);
-    LinkData(const o2::header::RAWDataHeaderV5& rdh, const RawFileReader* r);
-    bool preprocessCRUPage(const RDH& rdh, bool newSPage);
+    template <typename H>
+    LinkData(const H& rdh, const RawFileReader* r) : rdhl(rdh), reader(r)
+    {
+    }
+    bool preprocessCRUPage(const RDHAny& rdh, bool newSPage);
     size_t getLargestSuperPage() const;
     size_t getLargestTF() const;
     size_t getNextHBFSize() const;
@@ -192,7 +195,7 @@ class RawFileReader
   static InputsMap parseInput(const std::string& confUri);
 
  private:
-  int getLinkLocalID(const RDH& rdh, o2::header::DataOrigin orig);
+  int getLinkLocalID(const RDHAny& rdh, o2::header::DataOrigin orig);
   bool preprocessFile(int ifl);
   static LinkSpec_t createSpec(o2::header::DataOrigin orig, LinkSubSpec_t ss) { return (LinkSpec_t(orig) << 32) | ss; }
 

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -10,7 +10,6 @@
 
 #include "Framework/Logger.h"
 #include "DetectorsRaw/HBFUtils.h"
-#include "DetectorsRaw/RDHUtils.h"
 #include <FairLogger.h>
 #include <bitset>
 #include <cassert>

--- a/Detectors/Raw/src/RDHUtils.cxx
+++ b/Detectors/Raw/src/RDHUtils.cxx
@@ -10,6 +10,7 @@
 
 #include "Framework/Logger.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "CommonUtils/StringUtils.h"
 #include <FairLogger.h>
 #include <bitset>
 #include <cassert>
@@ -17,6 +18,8 @@
 
 using namespace o2::raw;
 using namespace o2::header;
+
+//=================================================
 
 //_________________________________________________
 void RDHUtils::printRDH(const RAWDataHeaderV4& rdh)
@@ -46,8 +49,8 @@ void RDHUtils::printRDH(const RAWDataHeaderV5& rdh)
 void RDHUtils::printRDH(const RAWDataHeaderV6& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x SrcID:0x%02x Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
-       int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), int(rdh.sourceID), int(rdh.packetCounter),
+  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x SrcID:%s[%d] Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
+       int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), DAQID::DAQtoO2(rdh.sourceID).str, int(rdh.sourceID), int(rdh.packetCounter),
        int(rdh.memorySize), int(rdh.offsetToNext), int(rdh.priority), int(rdh.headerSize), int(rdh.version));
   LOGF(INFO, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
        rdh.orbit, int(rdh.bunchCrossing), int(rdh.stop), int(rdh.pageCnt), trb.to_string().c_str(),


### PR DESCRIPTION
*   DAQ<->O2 origin mapping + test (RDHv6 contains DQA source ID)

*   Support for arbitrary RDH via RDHAny placeholder
*   RDHUtils::RDHAny can be used operate on the fields of arbitrary RDH version (4,5,6 at the 
    moment), provided the statis getter and setters of RDHUtils are used
*   In case of RDH v6 the DAQ source ID is set to the RDH.
*   RawFileWriter can be attributed an O2 origin which in case of RDHv6 is propagated as DAQID to 
    the RDH. 
*   User can request to create data with any RDH version by setting awFileWriter::useRDHVersion(xx)
*   RawFileReader will detect/parse the RDH version automatically.
*    Modifications are propagated to ITS/MFT RawPixelDecoder and MC2RawEncoder

*  TPC and ITS mc->raw encoders can use any RDH version.
    By dafault, the RDH version linked to RAWDataHeader will be used.