### PR TITLE
[O2-1338] Implement writing of TPC clusters found by ca-clusterer

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -29,11 +29,15 @@ enum struct Operation {
   CAClusterer,        // run the CA clusterer
   ZSDecoder,          // run the ZS raw data decoder
   OutputTracks,       // publish tracks
+  OutputCAClusters,   // publish the clusters produced by CA clusterer
   OutputCompClusters, // publish CompClusters container
   ProcessMC,          // process MC labels
   Noop,               // skip argument on the constructor
 };
 
+/// Helper struct to pass the individual ca::Operation flags to
+/// the processor spec. The struct is initialized by a variable list of
+/// constructor arguments.
 struct Config {
   template <typename... Args>
   Config(Args&&... args)
@@ -57,6 +61,9 @@ struct Config {
       case Operation::OutputCompClusters:
         outputCompClusters = true;
         break;
+      case Operation::OutputCAClusters:
+        outputCAClusters = true;
+        break;
       case Operation::ProcessMC:
         processMC = true;
         break;
@@ -74,14 +81,29 @@ struct Config {
   bool zsDecoder = false;
   bool outputTracks = false;
   bool outputCompClusters = false;
+  bool outputCAClusters = false;
   bool processMC = false;
 };
 
 } // namespace ca
 
-/// create a processor spec
-/// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> const& inputIds);
+/// create a processor spec for the CATracker
+/// The CA tracker is actually much more than the tracker it has evolved to a
+/// general interface processor for TPC GPU algorithms. This includes currently
+/// decoding of zero-suppressed raw data, ca clusterer and ca tracking. The input
+/// is chosen depending on the mode.
+///
+/// The input specs are created depending on the list of tpc sectors, with separate
+/// routes per sector. If the processor is also runnig the clusterer and cluster
+/// output is enabled, the outputs are created based on the list of TPC sectors.
+///
+/// The individual operations of the CA processor can be switched using enum
+/// @ca::Operations, a configuration object @a ca::Config is used to pass the
+/// configuration to the processor spec.
+///
+/// @param config     configuration option for the processor spec
+/// @param tpcsectors list of sector numbers
+framework::DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> const& tpcsectors);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -615,6 +615,14 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> co
       if (processAttributes->clusterOutputIds.size() > 0 && ptrs.clusters == nullptr) {
         throw std::logic_error("No cluster index object provided by GPU processor");
       }
+      if (processAttributes->clusterOutputIds.size() > 0 && activeSectors == 0) {
+        // there is no sector header shipped with the ZS raw data and thus we do not have
+        // a valid activeSector variable, though it will be needed downstream
+        // FIXME: check if this can be provided upstream
+        for (auto const& sector : processAttributes->clusterOutputIds) {
+          activeSectors |= 0x1 << sector;
+        }
+      }
       for (auto const& sector : processAttributes->clusterOutputIds) {
         o2::tpc::TPCSectorHeader header{sector};
         o2::header::DataHeader::SubSpecificationType subspec = sector;

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -102,8 +102,8 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   if (inputType == InputType::Clusters && (isEnabled(OutputType::Digits) || isEnabled(OutputType::ClustersHardware))) {
     throw std::invalid_argument("input/output type mismatch, can not produce 'digits', nor 'clustershardware' from 'clusters'");
   }
-  if (inputType == InputType::ZSRaw && (isEnabled(OutputType::Clusters) || isEnabled(OutputType::Digits) || isEnabled(OutputType::ClustersHardware))) {
-    throw std::invalid_argument("input/output type mismatch, can not produce 'digits', 'clusters' nor 'clustershardware' from 'zsraw'");
+  if (inputType == InputType::ZSRaw && (isEnabled(OutputType::Digits) || isEnabled(OutputType::ClustersHardware))) {
+    throw std::invalid_argument("input/output type mismatch, can not produce 'digits' nor 'clustershardware' from 'zsraw'");
   }
 
   if (inputType == InputType::ZSRaw && !caClusterer) {
@@ -112,8 +112,8 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   if (caClusterer && (inputType == InputType::Clusters || inputType == InputType::ClustersHardware)) {
     throw std::invalid_argument("ca-clusterer requires digits as input");
   }
-  if (caClusterer && (isEnabled(OutputType::Clusters) || isEnabled(OutputType::ClustersHardware))) {
-    throw std::invalid_argument("ca-clusterer cannot produce clusters or clustershardware output");
+  if (caClusterer && (isEnabled(OutputType::ClustersHardware))) {
+    throw std::invalid_argument("ca-clusterer cannot produce clustershardware output");
   }
 
   WorkflowSpec specs;
@@ -394,6 +394,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
                                                    zsDecoder ? ca::Operation::ZSDecoder : ca::Operation::Noop,
                                                    produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
                                                    produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
+                                                   isEnabled(OutputType::Clusters) && caClusterer ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
                                                  },
                                                  laneConfiguration));
   }


### PR DESCRIPTION
https://alice.its.cern.ch/jira/browse/O2-1338

Test sequence to produce the ca clusters and store in `tpc-native-clusters.root`
```
o2-tpc-reco-workflow --infile tpcdigits.root --output-type tracks,clusters --tracker-options "cont refX=83 bz=-5.0068597793 qa" --ca-clusterer
```

Run tracking from the stored clusters
```
o2-tpc-reco-workflow --input-type clusters --infile tpc-native-clusters.root --output-type tracks --tracker-options "cont refX=83 bz=-5.0068597793 qa"
```

The resulting tracks and qa blocks are from first glimpse identical.