### PR TITLE
Fix length --> size (length not supported by new ms_gsl)

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
@@ -88,7 +88,7 @@ class DigitsSinkTask
         mOutputFile << " DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC() << " time " << d.getTimeStamp() << std::endl;
       }
     } else {
-      int nDigits = digits.length();
+      int nDigits = digits.size();
       mOutputFile.write(reinterpret_cast<char*>(&nDigits), sizeof(int));
       mOutputFile.write(reinterpret_cast<const char*>(digits.data()), digits.size_bytes());
     }


### PR DESCRIPTION
length doesn't work for me with my system ms_gsl. The ms_gsl we have in alidist has length() but it is quite old, so I assume it is removed.
So should we use size()?