### PR TITLE
DPL Analysis: Grouping kernel now adds empty ranges

### DIFF
--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -53,24 +53,27 @@ Status doGrouping(std::shared_ptr<ChunkedArray> chunkedArray, Datum* outputRange
 {
   TableBuilder builder;
   auto writer = builder.persist<uint64_t, uint64_t, uint64_t>({"start", "count", "index"});
-  auto chunk = std::static_pointer_cast<ARRAY>(chunkedArray->chunk(0));
-  if (chunk->length() == 0) {
+  auto zeroChunk = std::static_pointer_cast<ARRAY>(chunkedArray->chunk(0));
+  if (zeroChunk->length() == 0) {
     *outputRanges = std::move(builder.finalize());
     return arrow::Status::OK();
   }
-  T currentIndex = chunk->raw_values()[0];
-  T currentCount = 0;
-  T currentOffset = 0;
-  for (size_t ci = 0; ci < chunkedArray->num_chunks(); ++ci) {
+  uint64_t currentIndex = 0;
+  uint64_t currentCount = 0;
+  uint64_t currentOffset = 0;
+  for (auto ci = 0; ci < chunkedArray->num_chunks(); ++ci) {
     auto chunk = chunkedArray->chunk(ci);
     T const* data = std::static_pointer_cast<ARRAY>(chunk)->raw_values();
-    for (size_t ai = 0; ai < chunk->length(); ++ai) {
+    for (auto ai = 0; ai < chunk->length(); ++ai) {
       if (currentIndex == data[ai]) {
         currentCount++;
-      } else if (currentIndex != -1) {
+      } else {
         writer(0, currentOffset, currentCount, currentIndex);
-        currentIndex = data[ai];
         currentOffset += currentCount;
+        while (data[ai] - currentIndex > 1) {
+          writer(0, currentOffset, 0, ++currentIndex);
+        }
+        currentIndex++;
         currentCount = 1;
       }
     }
@@ -80,22 +83,25 @@ Status doGrouping(std::shared_ptr<ChunkedArray> chunkedArray, Datum* outputRange
   return arrow::Status::OK();
 }
 
-Status SortedGroupByKernel::Call(FunctionContext* ctx, Datum const& inputTable, Datum* outputRanges)
+Status SortedGroupByKernel::Call(FunctionContext*, Datum const& inputTable, Datum* outputRanges)
 {
   using namespace arrow;
   if (inputTable.kind() == Datum::TABLE) {
     auto table = util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
     auto columnIndex = table->schema()->GetFieldIndex(mOptions.columnName);
     auto dataType = table->column(columnIndex)->type();
-    auto chunkedArray = getBackendColumnData(table->column(columnIndex));
-    if (dataType->id() == Type::UINT64) {
-      return doGrouping<uint64_t, arrow::UInt64Array>(chunkedArray, outputRanges);
-    } else if (dataType->id() == Type::INT64) {
-      return doGrouping<int64_t, arrow::Int64Array>(chunkedArray, outputRanges);
-    } else if (dataType->id() == Type::UINT32) {
-      return doGrouping<uint32_t, arrow::UInt32Array>(chunkedArray, outputRanges);
-    } else if (dataType->id() == Type::INT32) {
-      return doGrouping<int32_t, arrow::Int32Array>(chunkedArray, outputRanges);
+    auto chunkedArray = table->column(columnIndex)->data();
+    switch (dataType->id()) {
+      case Type::INT32:
+        return doGrouping<int32_t, arrow::Int32Array>(chunkedArray, outputRanges);
+      case Type::UINT32:
+        return doGrouping<uint32_t, arrow::UInt32Array>(chunkedArray, outputRanges);
+      case Type::INT64:
+        return doGrouping<int64_t, arrow::Int64Array>(chunkedArray, outputRanges);
+      case Type::UINT64:
+        return doGrouping<uint64_t, arrow::UInt64Array>(chunkedArray, outputRanges);
+      default:
+        return arrow::Status::TypeError("Unsupported index type");
     }
   }
   return arrow::Status::OK();


### PR DESCRIPTION
Initial support for handling grouping derived tables that do not have entries referring to some of the rows of the grouping table, for example if we have groups of tracks not from all collisions. 