### PR TITLE
[MFT] Several improvements on MFT track fitting

### DIFF
--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -74,6 +74,14 @@ class TrackMFT
   Double_t getInvPt() const { return TMath::Abs(mParameters(4)); }
   Double_t getSigmaInvQPt() const { return mCovariances(4, 4); }
 
+  // Charge and momentum from quadratic regression of clusters X,Y positions
+  void setInvQPtQuadtratic(Double_t invqpt) { mInvQPtQuadtratic = invqpt; }
+  const Double_t getInvQPtQuadtratic() const { return mInvQPtQuadtratic; } // Inverse charged pt
+  const Double_t getPtQuadtratic() const { return TMath::Abs(1.f / getInvQPtQuadtratic()); }
+  const Double_t getChargeQuadratic() const { return TMath::Sign(1., getInvQPtQuadtratic()); }
+  void setChi2QPtQuadtratic(Double_t chi2) { mQuadraticFitChi2 = chi2; }
+  const Double_t getChi2QPtQuadtratic() const { return mQuadraticFitChi2; }
+
   Double_t getPx() const { return TMath::Cos(getPhi()) * getPt(); } // return px
   Double_t getInvPx() const { return 1. / getPx(); }                // return invpx
 
@@ -149,6 +157,9 @@ class TrackMFT
   void print() const;
   void printMCCompLabels() const;
 
+  // Extrapolate this track to
+  void extrapHelixToZ(double zEnd, double Field);
+
  private:
   std::uint32_t mROFrame = 0;       ///< RO Frame
   Int_t mNPoints{0};                // Number of clusters
@@ -174,6 +185,16 @@ class TrackMFT
   /// <X,INVQPT>   <Y,INVQPT>     <PHI,INVQPT>   <TANL,INVQPT>   <INVQPT,INVQPT>  </pre>
   SMatrix55 mCovariances;      ///< \brief Covariance matrix of track parameters
   Double_t mTrackChi2 = 0.;    ///< Chi2 of the track when the associated cluster was attached
+
+  // Results from quadratic regression of clusters X,Y positions
+  // Chi2 of the quadratic regression used to estimate track pT and charge
+  Double_t mQuadraticFitChi2 = 0.;
+  // inversed charged momentum from quadratic regression
+  Double_t mInvQPtQuadtratic;
+
+  // Extrapolate covariances
+  void extrapHelixToZCov(double zEnd, double Field);
+
   ClassDefNV(TrackMFT, 1);
 };
 

--- a/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
+++ b/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
@@ -16,6 +16,7 @@
 #include "DataFormatsMFT/TrackMFT.h"
 #include "CommonConstants/MathConstants.h"
 #include "DataFormatsITSMFT/Cluster.h"
+#include "MathUtils/Utils.h"
 #include <TMath.h>
 
 using namespace o2::mft;
@@ -66,20 +67,21 @@ void TrackMFT::extrapHelixToZ(double zEnd, double Field)
 
   // Extrapolate track parameters
   double dZ = (zEnd - getZ()); // Propagate in meters
-  double cosphi0 = TMath::Cos(getPhi());
-  double sinphi0 = TMath::Sin(getPhi());
+  double cosphi0, sinphi0;
+  o2::utils::sincos(getPhi(), sinphi0, cosphi0);
   double tanl0 = getTanl();
+  double invtanl0 = 1.0 / tanl0;
   double invqpt0 = getInvQPt();
 
   double k = Field * o2::constants::math::B2C;
-  double deltax = (dZ * cosphi0 / tanl0 - dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0));
-  double deltay = (dZ * sinphi0 / tanl0 + dZ * dZ * k * invqpt0 * cosphi0 / (2. * tanl0 * tanl0));
+  double deltax = dZ * cosphi0 * invtanl0 - 0.5 * dZ * dZ * k * invqpt0 * sinphi0 * invtanl0 * invtanl0;
+  double deltay = dZ * sinphi0 * invtanl0 + 0.5 * dZ * dZ * k * invqpt0 * cosphi0 * invtanl0 * invtanl0;
 
   double x = getX() + deltax;
   double y = getY() + deltay;
-  double deltaphi = +dZ * k * invqpt0 / tanl0;
+  double deltaphi = +dZ * k * invqpt0 * invtanl0;
 
-  float phi = getPhi() + deltaphi;
+  double phi = getPhi() + deltaphi;
   double tanl = tanl0;
   double invqpt = invqpt0;
   setX(x);
@@ -100,19 +102,19 @@ void TrackMFT::extrapHelixToZCov(double zEnd, double Field)
   double tanl0 = getTanl();
   double invqpt0 = getInvQPt();
   double dZ2 = dZ * dZ;
-  double cosphi0 = TMath::Cos(phi0);
-  double sinphi0 = TMath::Sin(phi0);
+  double cosphi0, sinphi0;
+  o2::utils::sincos(phi0, sinphi0, cosphi0);
   double tanl0sq = tanl0 * tanl0;
   double k = Field * o2::constants::math::B2C;
   /*
   TMatrixD jacob(5, 5);
   jacob.UnitMatrix();
-  jacob(0, 2) = -dZ2 * k * invqpt0 * cosphi0 / 2. / tanl0sq - dZ * sinphi0 / tanl0;
+  jacob(0, 2) = -dZ2 * k * invqpt0 * cosphi0 * 0.5 / tanl0sq - dZ * sinphi0 / tanl0;
   jacob(0, 3) = dZ2 * k * invqpt0 * sinphi0 / tanl0sq / tanl0 - dZ * cosphi0 / tanl0sq;
-  jacob(0, 4) = -dZ2 * k * sinphi0 / 2. / tanl0sq;
-  jacob(1, 2) = -dZ2 * k * invqpt0 * sinphi0 / 2. / tanl0sq + dZ * cosphi0 / tanl0;
+  jacob(0, 4) = -dZ2 * k * sinphi0 * 0.5 / tanl0sq;
+  jacob(1, 2) = -dZ2 * k * invqpt0 * sinphi0 * 0.5 / tanl0sq + dZ * cosphi0 / tanl0;
   jacob(1, 3) = -dZ2 * k * invqpt0 * cosphi0 / tanl0sq / tanl0 - dZ * sinphi0 / tanl0sq;
-  jacob(1, 4) = dZ2 * k * cosphi0 / 2. / tanl0sq;
+  jacob(1, 4) = dZ2 * k * cosphi0 * 0.5 / tanl0sq;
   jacob(2, 3) = -dZ * k * invqpt0 / tanl0sq;
   jacob(2, 4) = dZ * k / tanl0;
 

--- a/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
+++ b/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
@@ -52,6 +52,77 @@ void TrackMFT::setCovariances(const SMatrix55& covariances)
   mCovariances = covariances;
 }
 
+//_________________________________________________________________________________________________
+void TrackMFT::extrapHelixToZ(double zEnd, double Field)
+{
+  /// Track extrapolated to the plane at "zEnd" considering a helix
+
+  if (getZ() == zEnd) {
+    return; // nothing to be done if same z
+  }
+
+  // Extrapolate covariances
+  extrapHelixToZCov(zEnd, Field);
+
+  // Extrapolate track parameters
+  double dZ = (zEnd - getZ()); // Propagate in meters
+  double cosphi0 = TMath::Cos(getPhi());
+  double sinphi0 = TMath::Sin(getPhi());
+  double tanl0 = getTanl();
+  double invqpt0 = getInvQPt();
+
+  double k = Field * o2::constants::math::B2C;
+  double deltax = (dZ * cosphi0 / tanl0 - dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0));
+  double deltay = (dZ * sinphi0 / tanl0 + dZ * dZ * k * invqpt0 * cosphi0 / (2. * tanl0 * tanl0));
+
+  double x = getX() + deltax;
+  double y = getY() + deltay;
+  double deltaphi = +dZ * k * invqpt0 / tanl0;
+
+  float phi = getPhi() + deltaphi;
+  double tanl = tanl0;
+  double invqpt = invqpt0;
+  setX(x);
+  setY(y);
+  setZ(zEnd);
+  setPhi(phi);
+  setTanl(tanl);
+  setInvQPt(invqpt);
+}
+
+//__________________________________________________________________________
+void TrackMFT::extrapHelixToZCov(double zEnd, double Field)
+{
+
+  // Calculate the jacobian related to the track parameters helix extrapolation to "zEnd"
+  double dZ = (zEnd - getZ());
+  double phi0 = getPhi();
+  double tanl0 = getTanl();
+  double invqpt0 = getInvQPt();
+  double dZ2 = dZ * dZ;
+  double cosphi0 = TMath::Cos(phi0);
+  double sinphi0 = TMath::Sin(phi0);
+  double tanl0sq = tanl0 * tanl0;
+  double k = Field * o2::constants::math::B2C;
+  /*
+  TMatrixD jacob(5, 5);
+  jacob.UnitMatrix();
+  jacob(0, 2) = -dZ2 * k * invqpt0 * cosphi0 / 2. / tanl0sq - dZ * sinphi0 / tanl0;
+  jacob(0, 3) = dZ2 * k * invqpt0 * sinphi0 / tanl0sq / tanl0 - dZ * cosphi0 / tanl0sq;
+  jacob(0, 4) = -dZ2 * k * sinphi0 / 2. / tanl0sq;
+  jacob(1, 2) = -dZ2 * k * invqpt0 * sinphi0 / 2. / tanl0sq + dZ * cosphi0 / tanl0;
+  jacob(1, 3) = -dZ2 * k * invqpt0 * cosphi0 / tanl0sq / tanl0 - dZ * sinphi0 / tanl0sq;
+  jacob(1, 4) = dZ2 * k * cosphi0 / 2. / tanl0sq;
+  jacob(2, 3) = -dZ * k * invqpt0 / tanl0sq;
+  jacob(2, 4) = dZ * k / tanl0;
+
+  // Extrapolate track parameter covariances to "zEnd"
+  TMatrixD tmp(getCovariances(), TMatrixD::kMultTranspose, jacob);
+  TMatrixD tmp2(jacob, TMatrixD::kMult, tmp);
+  setCovariances(tmp2);
+*/
+}
+
 //__________________________________________________________________________
 void TrackMFT::print() const
 {

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
@@ -108,6 +108,14 @@ class FitterTrackMFT
 
   const Int_t getNPoints() const { return mNPoints; }
 
+  // Charge and momentum from quadratic regression of clusters X,Y positions
+  void setInvQPtQuadtratic(Double_t invqpt) { mInvQPtQuadtratic = invqpt; }
+  const Double_t getInvQPtQuadtratic() const { return mInvQPtQuadtratic; } // Inverse charged pt
+  const Double_t getPtQuadtratic() const { return TMath::Abs(1.f / getInvQPtQuadtratic()); }
+  const Double_t getChargeQuadratic() const { return TMath::Sign(1., getInvQPtQuadtratic()); }
+  void setChi2QPtQuadtratic(Double_t chi2) { mQuadraticFitChi2 = chi2; }
+  const Double_t getChi2QPtQuadtratic() const { return mQuadraticFitChi2; }
+
  private:
   TrackParamMFT mParamAtVertex{};                 ///< track parameters at vertex
   std::list<TrackParamMFT> mParamAtClusters{};    ///< list of track parameters at each cluster
@@ -117,6 +125,12 @@ class FitterTrackMFT
   bool mRemovable = false;                        ///< flag telling if this track should be deleted
   Int_t mNPoints{0};                              // Number of clusters
   std::array<MCCompLabel, 10> mMCCompLabels;      // constants::mft::LayersNumber = 10
+
+  // Results from quadratic regression of clusters X,Y positions
+  // Chi2 of the quadratic regression used to estimate track pT and charge
+  Double_t mQuadraticFitChi2 = 0.;
+  // inversed charged momentum from quadratic regression
+  Double_t mInvQPtQuadtratic;
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackExtrap.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackExtrap.h
@@ -55,7 +55,7 @@ class TrackExtrap
   void addMCSEffect(TrackParamMFT* TrackParamMFT, double dZ, double x0, bool isFieldON = true);
 
  private:
-  Float_t mBZField = 0.5;  // Tesla.
+  Float_t mBZField;        // kiloGauss.
   bool mIsFieldON = false; ///< true if the field is switched ON
 };
 

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
@@ -53,20 +53,20 @@ class TrackFitter
   /// Return the smoother enable/disable flag
   bool isSmootherEnabled() { return mSmooth; }
 
-  void fit(FitterTrackMFT& track, bool smooth = true, bool finalize = true,
+  bool fit(FitterTrackMFT& track, bool smooth = true, bool finalize = true,
            std::list<TrackParamMFT>::reverse_iterator* itStartingParam = nullptr);
 
-  void runKalmanFilter(TrackParamMFT& trackParam);
+  bool runKalmanFilter(TrackParamMFT& trackParam);
 
   /// Return the maximum chi2 above which the track can be considered as abnormal
   static constexpr double getMaxChi2() { return SMaxChi2; }
 
  private:
   void initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param);
-  void addCluster(const TrackParamMFT& startingParam, const o2::itsmft::Cluster& cl, TrackParamMFT& param);
-  void smoothTrack(FitterTrackMFT& track, bool finalize);
-  void runSmoother(const TrackParamMFT& previousParam, TrackParamMFT& param);
-  Float_t mBZField = 0.5;                   // Tesla.
+  bool addCluster(const TrackParamMFT& startingParam, const o2::itsmft::Cluster& cl, TrackParamMFT& param);
+  bool smoothTrack(FitterTrackMFT& track, bool finalize);
+  bool runSmoother(const TrackParamMFT& previousParam, TrackParamMFT& param);
+  Float_t mBZField;                         // kiloGauss.
   static constexpr double SMaxChi2 = 2.e10; ///< maximum chi2 above which the track can be considered as abnormal
   /// default layer thickness in X0 for reconstruction  //FIXME: set values for the MFT
   static constexpr double SLayerThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
@@ -74,8 +74,13 @@ class TrackFitter
 
   bool mSmooth = false; ///< switch ON/OFF the smoother
   bool mFieldON = true;
+  bool mVerbose = true;
   o2::mft::TrackExtrap mTrackExtrap;
 };
+
+// Functions to estimate momentum and charge from track curvature
+Double_t invQPtFromParabola(const FitterTrackMFT& track, double bFieldZ, Double_t& chi2);
+Double_t QuadraticRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t& p0, Double_t& p1, Double_t& p2);
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
@@ -114,8 +114,8 @@ void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   double invqpt0 = trackParam->getInvQPt();
 
   double k = getBz() * o2::constants::math::B2C;
-  double deltax = (dZ * cosphi0 / tanl0 - dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0));
-  double deltay = (dZ * sinphi0 / tanl0 + dZ * dZ * k * invqpt0 * cosphi0 / (2. * tanl0 * tanl0));
+  double deltax = dZ * cosphi0 / tanl0 - dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0);
+  double deltay = dZ * sinphi0 / tanl0 + dZ * dZ * k * invqpt0 * cosphi0 / (2. * tanl0 * tanl0);
 
   double x = x0 + deltax;
   double y = y0 + deltay;
@@ -124,44 +124,43 @@ void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   //std::cout << "      Deltax extrap = " << deltax << " = " << (dZ * cosphi0 / tanl0)*100 << " + " << (- dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0))*100 << std::endl;
   //std::cout << "      Deltay extrap = " << deltay << std::endl;
 
-  float phi = phi0 + deltaphi;
+  double phi = phi0 + deltaphi;
   //o2::utils::BringToPMPi(phi);
-  double tanl = tanl0;
-  double invqpt = invqpt0;
   trackParam->setX(x);
   trackParam->setY(y);
   trackParam->setZ(zEnd);
   trackParam->setPhi(phi);
-  trackParam->setTanl(tanl);
-  trackParam->setInvQPt(invqpt);
 }
 
 //__________________________________________________________________________
 void TrackExtrap::helixExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool updatePropagator)
 {
-  helixExtrapToZ(trackParam, zEnd);
 
-  // Calculate the jacobian related to the track parameters linear extrapolation to "zEnd"
-  double dZ = (zEnd - trackParam->getZ()); // Propagate in meters
+  // Calculate the jacobian related to the track parameters extrapolated to "zEnd"
+  double dZ = 0.0; // FIXME: Disabling non diagonal terms of the covariance matrix// (zEnd - trackParam->getZ());
   double phi0 = trackParam->getPhi();
   double tanl0 = trackParam->getTanl();
   double invqpt0 = trackParam->getInvQPt();
-  double dZ2 = dZ * dZ;
   double cosphi0 = TMath::Cos(phi0);
   double sinphi0 = TMath::Sin(phi0);
-  double tanl0sq = tanl0 * tanl0;
   double k = getBz() * o2::constants::math::B2C;
+  double l = dZ / (tanl0 * tanl0);
+  double m = dZ / tanl0;
+  double n = dZ * k * invqpt0 / tanl0;
+
+  // Extrapolate track parameters to "zEnd"
+  helixExtrapToZ(trackParam, zEnd);
 
   TMatrixD jacob(5, 5);
   jacob.UnitMatrix();
-  jacob(0, 2) = -dZ2 * k * invqpt0 * cosphi0 / 2. / tanl0sq - dZ * sinphi0 / tanl0;
-  jacob(0, 3) = dZ2 * k * invqpt0 * sinphi0 / tanl0sq / tanl0 - dZ * cosphi0 / tanl0sq;
-  jacob(0, 4) = -dZ2 * k * sinphi0 / 2. / tanl0sq;
-  jacob(1, 2) = -dZ2 * k * invqpt0 * sinphi0 / 2. / tanl0sq + dZ * cosphi0 / tanl0;
-  jacob(1, 3) = -dZ2 * k * invqpt0 * cosphi0 / tanl0sq / tanl0 - dZ * sinphi0 / tanl0sq;
-  jacob(1, 4) = dZ2 * k * cosphi0 / 2. / tanl0sq;
-  jacob(2, 3) = -dZ * k * invqpt0 / tanl0sq;
-  jacob(2, 4) = dZ * k / tanl0;
+  jacob(0, 2) = -m * n * cosphi0 / 2. - m * sinphi0;
+  jacob(0, 3) = l * n * sinphi0 - l * cosphi0;
+  jacob(0, 4) = -k * l * dZ * sinphi0 / 2.;
+  jacob(1, 2) = -m * n * sinphi0 / 2. + m * cosphi0;
+  jacob(1, 3) = -l * n * cosphi0 - l * sinphi0;
+  jacob(1, 4) = k * l * dZ * cosphi0 / 2.;
+  jacob(2, 3) = -n / tanl0;
+  jacob(2, 4) = k * m;
 
   // Extrapolate track parameter covariances to "zEnd"
   TMatrixD tmp(trackParam->getCovariances(), TMatrixD::kMultTranspose, jacob);
@@ -211,6 +210,7 @@ void TrackExtrap::addMCSEffect(TrackParamMFT* trackParam, double dZ, double x0, 
   /// assuming linear propagation and using the small angle approximation.
   /// dZ = zOut - zIn (sign is important) and "param" is assumed to be given zOut.
   /// If x0 <= 0., assume dZ = pathLength/x0 and consider the material thickness as negligible.
+  /// TODO: Port to MFT
 
   double xSlope = trackParam->getPx() / trackParam->getPz();
   double ySlope = trackParam->getPy() / trackParam->getPz();

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
@@ -104,7 +104,7 @@ void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   }
 
   // Compute track parameters
-  double dZ = (zEnd - trackParam->getZ()); // Propagate in meters
+  double dZ = (zEnd - trackParam->getZ());
   double x0 = trackParam->getX();
   double y0 = trackParam->getY();
   double phi0 = trackParam->getPhi();
@@ -113,7 +113,7 @@ void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   double tanl0 = trackParam->getTanl();
   double invqpt0 = trackParam->getInvQPt();
 
-  double k = -getBz() * o2::constants::math::B2C;
+  double k = getBz() * o2::constants::math::B2C;
   double deltax = (dZ * cosphi0 / tanl0 - dZ * dZ * k * invqpt0 * sinphi0 / (2. * tanl0 * tanl0));
   double deltay = (dZ * sinphi0 / tanl0 + dZ * dZ * k * invqpt0 * cosphi0 / (2. * tanl0 * tanl0));
 
@@ -150,7 +150,7 @@ void TrackExtrap::helixExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool
   double cosphi0 = TMath::Cos(phi0);
   double sinphi0 = TMath::Sin(phi0);
   double tanl0sq = tanl0 * tanl0;
-  double k = -getBz() * o2::constants::math::B2C;
+  double k = getBz() * o2::constants::math::B2C;
 
   TMatrixD jacob(5, 5);
   jacob.UnitMatrix();

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -138,6 +138,8 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   double tanl = pz / pt;
   double r0sq = cl.getX() * cl.getX() + cl.getY() * cl.getY();
   double r0cu = r0sq * TMath::Sqrt(r0sq);
+  double invr0sq = 1.0 / r0sq;
+  double invr0cu = 1.0 / r0cu;
   double sigmax0sq = cl.getSigmaZ2(); // FIXME: from cluster
   double sigmay0sq = cl.getSigmaY2(); // FIXME: from cluster
   double sigmaDeltaZsq = 5.0;         // Primary vertex distribution: beam interaction diamond
@@ -189,23 +191,23 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   lastParamCov.Zero();
   lastParamCov(0, 0) = sigmax0sq;                   // <X,X>
   lastParamCov(0, 1) = 0;                           // <Y,X>
-  lastParamCov(0, 2) = -sigmax0sq * y0 / r0sq;      // <PHI,X>
-  lastParamCov(0, 3) = -z0 * sigmax0sq * x0 / r0cu; // <TANL,X>
-  lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq / r0cu; // <INVQPT,X>
+  lastParamCov(0, 2) = -sigmax0sq * y0 * invr0sq;   // <PHI,X>
+  lastParamCov(0, 3) = -z0 * sigmax0sq * x0 * invr0cu;         // <TANL,X>
+  lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq * invr0cu; // <INVQPT,X>
 
   lastParamCov(1, 1) = sigmay0sq;                   // <Y,Y>
-  lastParamCov(1, 2) = sigmay0sq * x0 / r0sq;       // <PHI,Y>
-  lastParamCov(1, 3) = -z0 * sigmay0sq * y0 / r0cu; // <TANL,Y>
-  lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq / r0cu; //1e-2; // <INVQPT,Y>
+  lastParamCov(1, 2) = sigmay0sq * x0 * invr0sq;    // <PHI,Y>
+  lastParamCov(1, 3) = -z0 * sigmay0sq * y0 * invr0cu;        // <TANL,Y>
+  lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq * invr0cu; //1e-2; // <INVQPT,Y>
 
-  lastParamCov(2, 2) = (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) / r0sq / r0sq;    // <PHI,PHI>
-  lastParamCov(2, 3) = z0 * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu;         //  <TANL,PHI>
-  lastParamCov(2, 4) = sigmaboost * y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq); //  <INVQPT,PHI>
+  lastParamCov(2, 2) = (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) * invr0sq * invr0sq;    // <PHI,PHI>
+  lastParamCov(2, 3) = z0 * x0 * y0 * (sigmax0sq - sigmay0sq) * invr0sq * invr0cu;         //  <TANL,PHI>
+  lastParamCov(2, 4) = sigmaboost * y0 * x0 * invr0cu * invr0sq * (sigmax0sq - sigmay0sq); //  <INVQPT,PHI>
 
-  lastParamCov(3, 3) = z0 * z0 * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu + sigmaDeltaZsq / r0sq; // <TANL,TANL>
-  lastParamCov(3, 4) = sigmaboost * z0 / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);                // <INVQPT,TANL>
+  lastParamCov(3, 3) = z0 * z0 * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) * invr0cu * invr0cu + sigmaDeltaZsq * invr0sq; // <TANL,TANL>
+  lastParamCov(3, 4) = sigmaboost * z0 * invr0cu * invr0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);                   // <INVQPT,TANL>
 
-  lastParamCov(4, 4) = sigmaboost * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu; // <INVQPT,INVQPT>
+  lastParamCov(4, 4) = sigmaboost * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) * invr0cu * invr0cu; // <INVQPT,INVQPT>
 
   lastParamCov(1, 0) = lastParamCov(0, 1); //
   lastParamCov(2, 0) = lastParamCov(0, 2); //

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -43,26 +43,34 @@ void TrackFitter::setBz(float bZ)
   /// Set the magnetic field for the MFT
   mBZField = bZ;
   mTrackExtrap.setBz(bZ);
+  if (mVerbose)
+    LOG(INFO) << "Setting Fitter field = " << bZ;
 }
 
 //_________________________________________________________________________________________________
-void TrackFitter::fit(FitterTrackMFT& track, bool smooth, bool finalize,
+bool TrackFitter::fit(FitterTrackMFT& track, bool smooth, bool finalize,
                       std::list<TrackParamMFT>::reverse_iterator* itStartingParam)
 {
   /// Fit a track to its attached clusters
   /// Smooth the track if requested and the smoother enabled
   /// If finalize = true: copy the smoothed parameters, if any, into the regular ones
   /// Fit the entire track or only the part upstream itStartingParam
-  /// Throw an exception in case of failure
+  /// Returns false in case of failure
 
-  std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
+  if (mVerbose)
+    std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
 
   // initialize the starting track parameters and cluster
+  double chi2invqptquad;
+  double invpqtquad;
+
   auto itParam(track.rbegin());
   if (itStartingParam != nullptr) {
     // use the ones pointed to by itStartingParam
     if (*itStartingParam == track.rend()) {
-      throw std::runtime_error("invalid starting parameters");
+      LOG(INFO) << "MFT Fit ERROR: invalid track starting parameters";
+      track.removable();
+      return false;
     }
     itParam = *itStartingParam;
   } else {
@@ -70,40 +78,44 @@ void TrackFitter::fit(FitterTrackMFT& track, bool smooth, bool finalize,
     // and the one of the first previous cluster found on a different layer
     auto itPreviousParam(itParam);
     ++itPreviousParam;
-    // TODO: Refine criteria for initTrack: cluster from next MFT layer or next disk?
-    //(*itParam).setInvPx(1.0); // TODO: Improve initial momentum estimate
-    //(*itParam).setInvPy(1.0); // TODO: Improve initial momentum estimate
-    //(*itParam).setInvQPz(1.0); // TODO: Improve initial momentum estimate
+    invpqtquad = invQPtFromParabola(track, mBZField, chi2invqptquad);
+    track.setInvQPtQuadtratic(invpqtquad);
+    track.setChi2QPtQuadtratic(chi2invqptquad);
+    (*itParam).setInvQPt(track.getInvQPtQuadtratic()); // Initial momentum estimate
     initTrack(*itParam->getClusterPtr(), *itParam);
   }
 
-  std::cout << "Seed covariances:";
-  itParam->getCovariances().Print();
+  if (mVerbose) {
+    std::cout << "Seed covariances:";
+    itParam->getCovariances().Print();
+  }
 
   // recusively add the upstream clusters and update the track parameters
   TrackParamMFT* startingParam = &*itParam;
   while (++itParam != track.rend()) {
-    try {
-      addCluster(*startingParam, *itParam->getClusterPtr(), *itParam);
-      startingParam = &*itParam;
-    } catch (std::exception const&) {
-      throw;
+    if (!addCluster(*startingParam, *itParam->getClusterPtr(), *itParam)) {
+      track.removable();
+      return false;
     }
+    startingParam = &*itParam;
   }
 
-  std::cout << "Track covariances:";
   itParam--;
-  itParam->getCovariances().Print();
-  std::cout << "Track Chi2 = " << itParam->getTrackChi2() << std::endl;
-  std::cout << " ***************************** Done fitting *****************************\n";
+  if (mVerbose) {
+    std::cout << "Track covariances:";
+    itParam->getCovariances().Print();
+    std::cout << "Track Chi2 = " << itParam->getTrackChi2() << std::endl;
+    std::cout << " ***************************** Done fitting *****************************\n";
+  }
+
   // smooth the track if requested and the smoother enabled
   if (smooth && mSmooth) {
-    try {
-      smoothTrack(track, finalize);
-    } catch (std::exception const&) {
-      throw;
+    if (!smoothTrack(track, finalize)) {
+      track.removable();
+      return false;
     }
   }
+  return true;
 }
 
 //_________________________________________________________________________________________________
@@ -117,35 +129,60 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
 
   // compute the track parameters at the last cluster
 
-  //double k = -mBZField * o2::constants::math::B2C;
   double x0 = cl.getX();
   double y0 = cl.getY();
-  double dZ = cl.getZ();
-  double pt = TMath::Sqrt(x0 * x0 + y0 * y0) * 1;
-  double pz = dZ * 1;
-  //double phi1 = TMath::ATan2(cl1.getY(), cl1.getX());
-  double phi2 = TMath::ATan2(cl.getY(), cl.getX());
+  double z0 = cl.getZ();
+  double pt = TMath::Sqrt(x0 * x0 + y0 * y0);
+  double pz = z0;
+  double phi0 = TMath::ATan2(cl.getY(), cl.getX());
   double tanl = pz / pt;
   double r0sq = cl.getX() * cl.getX() + cl.getY() * cl.getY();
   double r0cu = r0sq * TMath::Sqrt(r0sq);
-  double sigmax0sq = cl.getSigmaZ2();       // FIXME: from cluster
-  double sigmay0sq = cl.getSigmaY2();       // FIXME: from cluster
-  double sigmaDeltaZsq = 5;        // Primary vertex distribution: beam interaction diamond
-  double sigmaboost = 5e3;         // Boost q/pt seed covariances
-  double sigmainvqptsq = sigmaboost / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0); // .25 / pt; // Very large uncertainty on pt
-
-  std::cout << "initTrack: pt = " << pt << std::endl;
-  std::cout << " -iniTrack: cluster    X =  " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << " phi2 = " << phi2 << std::endl;
-
-  //std::cout << " mBZField = " << mBZField << std::endl;
+  double sigmax0sq = cl.getSigmaZ2(); // FIXME: from cluster
+  double sigmay0sq = cl.getSigmaY2(); // FIXME: from cluster
+  double sigmaDeltaZsq = 5.0;         // Primary vertex distribution: beam interaction diamond
+  double sigmaboost = 1e0;            // Boost q/pt seed covariances
+  double seedH_k = 5.0;               // SeedH constant
 
   param.setX(cl.getX());
   param.setY(cl.getY());
   param.setZ(cl.getZ());
-  param.setPhi(phi2);
-  param.setInvQPt(1.0 / pt);
+  param.setPhi(phi0);
   param.setTanl(tanl);
-  std::cout << "  seed Phi, Tanl, InvQpt = " << param.getPhi() << " " << param.getTanl() << " " << param.getInvQPt() << std::endl;
+
+  // Configure the track seed
+  enum kSeeds {
+    kSeedAB,
+    kSeedCE,
+    kSeedDH
+  };
+  auto seed = kSeedDH;
+  switch (seed) {
+    case kSeedAB:
+      if (mVerbose)
+        std::cout << " Init track with Seed A / B; sigmaboost = " << sigmaboost << ".\n";
+      param.setInvQPt(1.0 / pt); // Seeds A & B
+      break;
+    case kSeedCE:
+      if (mVerbose)
+        std::cout << " Init track with Seed C / E; sigmaboost = " << sigmaboost << ".\n";
+      param.setInvQPt(std::copysign(1.0, param.getInvQPt()) / pt); // Seeds C & E
+      break;
+    case kSeedDH:
+      if (mVerbose)
+        std::cout << " Init track with Seed H; (k = " << seedH_k << "); sigmaboost = " << sigmaboost << ".\n";
+      param.setInvQPt(param.getInvQPt() / seedH_k); // SeedH
+      break;
+    default:
+      if (mVerbose)
+        std::cout << " Init track with Seed D.\n";
+      break;
+  }
+
+  if (mVerbose) {
+    std::cout << "initTrack Cluster    X =  " << cl.getX() << "   Y = " << cl.getY() << "   Z = " << cl.getZ() << std::endl;
+    std::cout << "  seed Phi, Tanl, InvQpt = " << param.getPhi() << " " << param.getTanl() << " " << param.getInvQPt() << std::endl;
+  }
 
   // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)
   TMatrixD lastParamCov(5, 5);
@@ -153,22 +190,22 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   lastParamCov(0, 0) = sigmax0sq;                   // <X,X>
   lastParamCov(0, 1) = 0;                           // <Y,X>
   lastParamCov(0, 2) = -sigmax0sq * y0 / r0sq;      // <PHI,X>
-  lastParamCov(0, 3) = -dZ * sigmax0sq * x0 / r0cu; // <TANL,X>
+  lastParamCov(0, 3) = -z0 * sigmax0sq * x0 / r0cu; // <TANL,X>
   lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq / r0cu; // <INVQPT,X>
 
   lastParamCov(1, 1) = sigmay0sq;                   // <Y,Y>
   lastParamCov(1, 2) = sigmay0sq * x0 / r0sq;       // <PHI,Y>
-  lastParamCov(1, 3) = -dZ * sigmay0sq * y0 / r0cu; // <TANL,Y>
+  lastParamCov(1, 3) = -z0 * sigmay0sq * y0 / r0cu; // <TANL,Y>
   lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq / r0cu; //1e-2; // <INVQPT,Y>
 
   lastParamCov(2, 2) = (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) / r0sq / r0sq;    // <PHI,PHI>
-  lastParamCov(2, 3) = dZ * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu; //  <TANL,PHI>
-  lastParamCov(2, 4) = sigmaboost *  y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq); //  <INVQPT,PHI>
+  lastParamCov(2, 3) = z0 * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu;         //  <TANL,PHI>
+  lastParamCov(2, 4) = sigmaboost * y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq); //  <INVQPT,PHI>
 
-  lastParamCov(3, 3) = dZ * dZ * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu + sigmaDeltaZsq / r0sq; // <TANL,TANL>
-  lastParamCov(3, 4) = sigmaboost * dZ / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);         // <INVQPT,TANL>
+  lastParamCov(3, 3) = z0 * z0 * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu + sigmaDeltaZsq / r0sq; // <TANL,TANL>
+  lastParamCov(3, 4) = sigmaboost * z0 / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);                // <INVQPT,TANL>
 
-  lastParamCov(4, 4) = sigmainvqptsq; // <INVQPT,INVQPT>
+  lastParamCov(4, 4) = sigmaboost * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu; // <INVQPT,INVQPT>
 
   lastParamCov(1, 0) = lastParamCov(0, 1); //
   lastParamCov(2, 0) = lastParamCov(0, 2); //
@@ -189,19 +226,19 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
 }
 
 //_________________________________________________________________________________________________
-void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmft::Cluster& cl, TrackParamMFT& param)
+bool TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmft::Cluster& cl, TrackParamMFT& param)
 {
   /// Extrapolate the starting track parameters to the z position of the new cluster
   /// accounting for MCS dispersion in the current layer and the other(s) crossed
   /// Recompute the parameters adding the cluster constraint with the Kalman filter
-  /// Throw an exception in case of failure
+  /// Returns false in case of failure
 
   if (cl.getZ() <= startingParam.getZ()) {
-    LOG(ERROR) << "AddCluster ERROR: The new cluster must be upstream! ********************* ";
-    // FIXME! This should throw an error. Skiping due to bug on track finding.
-    //throw std::runtime_error("The new cluster must be upstream");
+    LOG(INFO) << "AddCluster ERROR: The new cluster must be upstream! Bug on TrackFinder. ";
+    return false;
   }
-  std::cout << "addCluster:     X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << std::endl;
+  if (mVerbose)
+    std::cout << "addCluster:     X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << std::endl;
   // copy the current parameters into the new ones
   param.setParameters(startingParam.getParameters());
   param.setZ(startingParam.getZ());
@@ -209,8 +246,8 @@ void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmf
   param.setTrackChi2(startingParam.getTrackChi2());
 
   // add MCS effect in the current layer
-  o2::itsmft::ChipMappingMFT mftChipMapper;
-  int currentLayer(mftChipMapper.chip2Layer(startingParam.getClusterPtr()->getSensorID()));
+  //o2::itsmft::ChipMappingMFT mftChipMapper;
+  //int currentLayer(mftChipMapper.chip2Layer(startingParam.getClusterPtr()->getSensorID()));
   //mTrackExtrap.addMCSEffect(&param, SLayerThicknessInX0[currentLayer], -1.);
 
   // reset propagator for smoother
@@ -218,26 +255,30 @@ void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmf
     param.resetPropagator();
   }
 
-  std::cout << "  BeforeExtrap: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " pt = " << param.getPt() << std::endl;
+  if (mVerbose)
+    std::cout << "  BeforeExtrap: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
   //param.getCovariances().Print();
 
+  /*
   // add MCS in missing layers if any
   int expectedLayer(currentLayer - 1);
   currentLayer = mftChipMapper.chip2Layer(cl.getSensorID());
   while (currentLayer < expectedLayer) {
     if (!mTrackExtrap.extrapToZCov(&param, o2::mft::constants::LayerZPosition[expectedLayer], mSmooth)) {
-      throw std::runtime_error("1. Track extrapolation failed");
+      return false;
     }
     //mTrackExtrap.addMCSEffect(&param, SLayerThicknessInX0[expectedLayer], -1.);
     expectedLayer--;
   }
+  */
 
   // extrapolate to the z position of the new cluster
   if (!mTrackExtrap.extrapToZCov(&param, cl.getZ(), mSmooth)) {
-    throw std::runtime_error("2. Track extrapolation failed");
+    return false;
   }
 
-  std::cout << "   AfterExtrap: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " pt = " << param.getPt() << std::endl;
+  if (mVerbose)
+    std::cout << "   AfterExtrap: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
   //param.getCovariances().Print();
 
   // save extrapolated parameters and covariances for smoother
@@ -248,26 +289,25 @@ void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmf
 
   // recompute the parameters
   param.setClusterPtr(&cl);
-  try {
-    runKalmanFilter(param);
-  } catch (std::exception const&) {
-    throw;
-  }
-
-  std::cout << "   New Cluster: X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << std::endl;
-
-  std::cout << "   AfterKalman: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " pt = " << param.getPt() << std::endl;
-  //param.getCovariances().Print();
-  std::cout << std::endl;
+  if (runKalmanFilter(param)) {
+    if (mVerbose) {
+      std::cout << "   New Cluster: X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << std::endl;
+      std::cout << "   AfterKalman: X = " << param.getX() << " Y = " << param.getY() << " Z = " << param.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
+      //param.getCovariances().Print();
+      std::cout << std::endl;
+    }
+    return true;
+  } else
+    return false;
 }
 
 //_________________________________________________________________________________________________
-void TrackFitter::smoothTrack(FitterTrackMFT& track, bool finalize)
+bool TrackFitter::smoothTrack(FitterTrackMFT& track, bool finalize)
 {
   /// Recompute the track parameters at each cluster using the Smoother
   /// Smoothed parameters are stored in dedicated data members
   /// If finalize, they are copied in the regular parameters in case of success
-  /// Throw an exception in case of failure
+  /// Returns false in case of failure
 
   auto itCurrentParam(track.begin());
   auto itPreviousParam(itCurrentParam);
@@ -282,10 +322,8 @@ void TrackFitter::smoothTrack(FitterTrackMFT& track, bool finalize)
 
   // recursively smooth the next parameters and covariances
   do {
-    try {
-      runSmoother(*itPreviousParam, *itCurrentParam);
-    } catch (std::exception const&) {
-      throw;
+    if (!runSmoother(*itPreviousParam, *itCurrentParam)) {
+      return false;
     }
     ++itPreviousParam;
   } while (++itCurrentParam != track.end());
@@ -297,14 +335,15 @@ void TrackFitter::smoothTrack(FitterTrackMFT& track, bool finalize)
       param.setCovariances(param.getSmoothCovariances());
     }
   }
+  return true;
 }
 
 //_________________________________________________________________________________________________
-void TrackFitter::runKalmanFilter(TrackParamMFT& trackParam)
+bool TrackFitter::runKalmanFilter(TrackParamMFT& trackParam)
 {
   /// Compute the new track parameters including the attached cluster with the Kalman filter
   /// The current parameters are supposed to have been extrapolated to the cluster z position
-  /// Throw an exception in case of failure
+  /// Retruns false in case of failure
 
   // get actual track parameters (p)
   TMatrixD param(trackParam.getParameters());
@@ -321,7 +360,8 @@ void TrackFitter::runKalmanFilter(TrackParamMFT& trackParam)
   if (paramWeight.Determinant() != 0) {
     paramWeight.Invert();
   } else {
-    throw std::runtime_error("Determinant = 0");
+    LOG(INFO) << "runKalmanFilter ERROR: Determinant = 0";
+    return false;
   }
 
   // compute the new cluster weight (U)
@@ -335,7 +375,8 @@ void TrackFitter::runKalmanFilter(TrackParamMFT& trackParam)
   if (newParamCov.Determinant() != 0) {
     newParamCov.Invert();
   } else {
-    throw std::runtime_error("Determinant = 0");
+    LOG(INFO) << "runKalmanFilter ERROR: Determinant = 0";
+    return false;
   }
   trackParam.setCovariances(newParamCov);
 
@@ -356,13 +397,15 @@ void TrackFitter::runKalmanFilter(TrackParamMFT& trackParam)
   TMatrixD tmp4(clusterWeight, TMatrixD::kMult, tmp);            // U(p'-m)
   addChi2Track += TMatrixD(tmp, TMatrixD::kTransposeMult, tmp4); // ((p'-p)^-1)W(p'-p) + ((p'-m)^-1)U(p'-m)
   trackParam.setTrackChi2(trackParam.getTrackChi2() + addChi2Track(0, 0));
+
+  return true;
 }
 
 //_________________________________________________________________________________________________
-void TrackFitter::runSmoother(const TrackParamMFT& previousParam, TrackParamMFT& param)
+bool TrackFitter::runSmoother(const TrackParamMFT& previousParam, TrackParamMFT& param)
 {
   /// Recompute the track parameters starting from the previous ones
-  /// Throw an exception in case of failure
+  /// Returns false in case of failure
 
   // get variables
   const TMatrixD& extrapParameters = previousParam.getExtrapParameters();           // X(k+1 k)
@@ -378,7 +421,8 @@ void TrackFitter::runSmoother(const TrackParamMFT& previousParam, TrackParamMFT&
   if (extrapWeight.Determinant() != 0) {
     extrapWeight.Invert(); // (C(k+1 k))^-1
   } else {
-    throw std::runtime_error("Determinant = 0");
+    LOG(INFO) << "Smoother ERROR: Determinant = 0";
+    return false;
   }
   TMatrixD smootherGain(filteredCovariances, TMatrixD::kMultTranspose, propagator); // C(kk) * F(k)^t
   smootherGain *= extrapWeight;                                                     // C(kk) * F(k)^t * (C(k+1 k))^-1
@@ -412,13 +456,100 @@ void TrackFitter::runSmoother(const TrackParamMFT& previousParam, TrackParamMFT&
   if (smoothResidualWeight.Determinant() != 0) {
     smoothResidualWeight.Invert();
   } else {
-    throw std::runtime_error("Determinant = 0");
+    LOG(INFO) << "Smoother ERROR: Determinant = 0";
+    return false;
   }
 
   // compute local chi2 = (r(k n))^t * W(k n) * r(k n)
   TMatrixD tmpChi2(smoothResidual, TMatrixD::kTransposeMult, smoothResidualWeight); // (r(k n))^t * W(k n)
   TMatrixD localChi2(tmpChi2, TMatrixD::kMult, smoothResidual);                     // (r(k n))^t * W(k n) * r(k n)
   param.setLocalChi2(localChi2(0, 0));
+  return true;
+}
+
+//__________________________________________________________________________
+Double_t invQPtFromParabola(const FitterTrackMFT& track, Double_t bFieldZ, Double_t& chi2)
+{
+  //rotate track to stabilize quadratic fitting
+  auto deltax = track.rbegin()->getX() - track.first().getX();
+  auto deltay = track.rbegin()->getY() - track.first().getY();
+  auto x_m = (track.rbegin()->getX() + track.first().getX()) / 2;
+  auto y_m = (track.rbegin()->getY() + track.first().getY()) / 2;
+  auto theta = -TMath::ATan2(deltay, deltax);
+  auto costheta = TMath::Cos(theta), sintheta = TMath::Sin(theta);
+
+  bool verbose = false;
+  if (verbose) {
+    std::cout << "First and last cluster X,Y => " << track.first().getX() << " , " << track.first().getY() << "     /  " << track.rbegin()->getX() << " , " << track.rbegin()->getY() << std::endl;
+    std::cout << " Angle to rotate: " << theta << " ( " << theta * TMath::RadToDeg() << " deg ) " << std::endl;
+  }
+
+  auto nPoints = track.getNClusters();
+  Double_t* x = new Double_t[nPoints];
+  Double_t* y = new Double_t[nPoints];
+  int n = 0;
+  for (auto trackparam = track.begin(); trackparam != track.end(); trackparam++) {
+    auto x_0 = trackparam->getClusterPtr()->getX() - x_m;
+    auto y_0 = trackparam->getClusterPtr()->getY() - y_m;
+    x[n] = x_0 * costheta - y_0 * sintheta;
+    y[n] = x_0 * sintheta + y_0 * costheta;
+    //std::cout << "    adding rotated point to fit at z = " << trackparam->getClusterPtr()->getZ() << " (" << x[n] <<  "," << y[n]  <<  ") "<< std::endl;
+    n++;
+  }
+
+  Double_t q0, q1, q2;
+  chi2 = QuadraticRegression(nPoints, x, y, q0, q1, q2);
+  Double_t radiusParabola = 0.5 / q2;
+  auto invqpt_parabola = q2 / (o2::constants::math::B2C * bFieldZ * 0.5); // radiusParabola; // radius = 0.5/q2
+
+  if (verbose) {
+    std::cout << "--------------------------------------------" << std::endl;
+    std::cout << " Fit QuadraticRegression: " << std::endl;
+    std::cout << " Fit Parameters [0] = " << q0 << " [1] =  " << q1 << " [2] = " << q2 << std::endl;
+    std::cout << " Radius from QuadraticRegression = " << 0.5 / q2 << std::endl;
+    std::cout << " Seed qpt = " << 1.0 / invqpt_parabola << std::endl;
+    std::cout << "--------------------------------------------" << std::endl;
+  }
+
+  return invqpt_parabola;
+}
+
+//__________________________________________________________________________
+Double_t QuadraticRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t& p0, Double_t& p1, Double_t& p2)
+{
+  /// Perform a Quadratic Regression
+  /// Assume same error on all clusters = 1
+  /// Return ~ Chi2
+
+  TMatrixD y(nVal, 1);
+  TMatrixD x(nVal, 3);
+  TMatrixD xtrans(3, nVal);
+
+  for (int i = 0; i < nVal; i++) {
+    y(i, 0) = yVal[i];
+    x(i, 0) = 1.;
+    x(i, 1) = xVal[i];
+    x(i, 2) = xVal[i] * xVal[i];
+    xtrans(0, i) = 1.;
+    xtrans(1, i) = xVal[i];
+    xtrans(2, i) = xVal[i] * xVal[i];
+  }
+  TMatrixD tmp(xtrans, TMatrixD::kMult, x);
+  tmp.Invert();
+
+  TMatrixD tmp2(xtrans, TMatrixD::kMult, y);
+  TMatrixD b(tmp, TMatrixD::kMult, tmp2);
+
+  p0 = b(0, 0);
+  p1 = b(1, 0);
+  p2 = b(2, 0);
+
+  // chi2 = (y-xb)^t . W . (y-xb)
+  TMatrixD tmp3(x, TMatrixD::kMult, b);
+  TMatrixD tmp4(y, TMatrixD::kMinus, tmp3);
+  TMatrixD chi2(tmp4, TMatrixD::kTransposeMult, tmp4);
+
+  return chi2(0, 0);
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -120,19 +120,19 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   //double k = -mBZField * o2::constants::math::B2C;
   double x0 = cl.getX();
   double y0 = cl.getY();
-  double dZ = -(cl.getZ());
-  double pt = TMath::Sqrt(x0 * x0 + y0 * y0) * 10;
-  double pz = -dZ * 10;
+  double dZ = cl.getZ();
+  double pt = TMath::Sqrt(x0 * x0 + y0 * y0) * 1;
+  double pz = dZ * 1;
   //double phi1 = TMath::ATan2(cl1.getY(), cl1.getX());
   double phi2 = TMath::ATan2(cl.getY(), cl.getX());
   double tanl = pz / pt;
   double r0sq = cl.getX() * cl.getX() + cl.getY() * cl.getY();
   double r0cu = r0sq * TMath::Sqrt(r0sq);
-  double sigmax0sq = 0.0005;       // FIXME: from cluster
-  double sigmay0sq = 0.0005;       // FIXME: from cluster
+  double sigmax0sq = cl.getSigmaZ2();       // FIXME: from cluster
+  double sigmay0sq = cl.getSigmaY2();       // FIXME: from cluster
   double sigmaDeltaZsq = 5;        // Primary vertex distribution: beam interaction diamond
-  double sigmaboost = 1e7;         // Boost q/pt seed covariances
-  double sigmainvqptsq = sigmaboost * 1e-8 / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0); // .25 / pt; // Very large uncertainty on pt
+  double sigmaboost = 5e3;         // Boost q/pt seed covariances
+  double sigmainvqptsq = sigmaboost / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0); // .25 / pt; // Very large uncertainty on pt
 
   std::cout << "initTrack: pt = " << pt << std::endl;
   std::cout << " -iniTrack: cluster    X =  " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << " phi2 = " << phi2 << std::endl;
@@ -154,19 +154,19 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   lastParamCov(0, 1) = 0;                           // <Y,X>
   lastParamCov(0, 2) = -sigmax0sq * y0 / r0sq;      // <PHI,X>
   lastParamCov(0, 3) = -dZ * sigmax0sq * x0 / r0cu; // <TANL,X>
-  lastParamCov(0, 4) = sigmaboost * -1e-4 * x0 * sigmax0sq / r0cu; // <INVQPT,X>
+  lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq / r0cu; // <INVQPT,X>
 
   lastParamCov(1, 1) = sigmay0sq;                   // <Y,Y>
   lastParamCov(1, 2) = sigmay0sq * x0 / r0sq;       // <PHI,Y>
   lastParamCov(1, 3) = -dZ * sigmay0sq * y0 / r0cu; // <TANL,Y>
-  lastParamCov(1, 4) = sigmaboost * -1e-4 * y0 * sigmay0sq / r0cu; //1e-2; // <INVQPT,Y>
+  lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq / r0cu; //1e-2; // <INVQPT,Y>
 
   lastParamCov(2, 2) = (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) / r0sq / r0sq;    // <PHI,PHI>
-  lastParamCov(2, 3) = dZ * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu + 1e-10; //  <TANL,PHI>
-  lastParamCov(2, 4) = sigmaboost * 1e-4 * y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq) + 1e-10; //  <INVQPT,PHI>
+  lastParamCov(2, 3) = dZ * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu; //  <TANL,PHI>
+  lastParamCov(2, 4) = sigmaboost *  y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq); //  <INVQPT,PHI>
 
   lastParamCov(3, 3) = dZ * dZ * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu + sigmaDeltaZsq / r0sq; // <TANL,TANL>
-  lastParamCov(3, 4) = sigmaboost * 1e-4 * dZ / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);         // <INVQPT,TANL>
+  lastParamCov(3, 4) = sigmaboost * dZ / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);         // <INVQPT,TANL>
 
   lastParamCov(4, 4) = sigmainvqptsq; // <INVQPT,INVQPT>
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -158,8 +158,8 @@ void convertTrack(const T& inTrack, O& outTrack, C& clusters)
   // TODO: get rid of this cluster vector
   for (auto cls = 0; cls < nClusters; cls++) {
     o2::itsmft::Cluster& tempcluster = clusters.emplace_back(clusterIDs[cls], xpos[cls], ypos[cls], zpos[cls]);
-    tempcluster.setSigmaY2(0.0001); // FIXME:
-    tempcluster.setSigmaZ2(0.0001); // FIXME: Use clusters errors once available
+    tempcluster.setSigmaY2(5.43e-4); // FIXME:
+    tempcluster.setSigmaZ2(5.0e-4); // FIXME: Use clusters errors once available
     outTrack.createParamAtCluster(tempcluster);
   }
   outTrack.setMCCompLabels(inTrack.getMCCompLabels(), nClusters);

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -87,8 +87,6 @@ void TrackFitterTask::run(ProcessingContext& pc)
   for (const auto& track : tracksLTF) {
     auto& temptrack = fittertracks.at(nTracksLTF + nFailedTracksLTF);
     convertTrack(track, temptrack, clusters);
-    std::cout << "Fitter Speck: nTracksLTF = " << nTracksLTF << std::endl;
-    std::cout << "Fitter Speck: nFailedTracksLTF = " << nFailedTracksLTF << std::endl;
     mTrackFitter->fit(temptrack, false) ? nTracksLTF++ : nFailedTracksLTF++;
   } // end fit LTF tracks
 
@@ -96,8 +94,6 @@ void TrackFitterTask::run(ProcessingContext& pc)
   for (const auto& track : tracksCA) {
     auto& temptrack = fittertracks.at(nTracksLTF + nFailedTracksLTF + nTracksCA + nFailedTracksCA);
     convertTrack(track, temptrack, clusters);
-    std::cout << "Fitter Speck: nTracksCA = " << nTracksLTF << std::endl;
-    std::cout << "Fitter Speck: nFailedTracksCA = " << nFailedTracksLTF << std::endl;
     mTrackFitter->fit(temptrack, false) ? nTracksCA++ : nFailedTracksCA++;
   } // end fit CA tracks
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -77,45 +77,55 @@ void TrackFitterTask::run(ProcessingContext& pc)
   auto tracksCA = pc.inputs().get<gsl::span<o2::mft::TrackCA>>("tracksca");
 
   int nTracksCA = 0;
+  int nFailedTracksCA = 0;
   int nTracksLTF = 0;
+  int nFailedTracksLTF = 0;
   std::vector<o2::mft::FitterTrackMFT> fittertracks(tracksLTF.size() + tracksCA.size());
-  auto& finalMFTtracks = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
-  finalMFTtracks.resize(tracksLTF.size() + tracksCA.size());
   std::list<o2::itsmft::Cluster> clusters;
 
   // Fit LTF tracks
   for (const auto& track : tracksLTF) {
-    auto& temptrack = fittertracks.at(nTracksLTF);
+    auto& temptrack = fittertracks.at(nTracksLTF + nFailedTracksLTF);
     convertTrack(track, temptrack, clusters);
-    mTrackFitter->fit(temptrack, false);
-    nTracksLTF++;
-  }
+    std::cout << "Fitter Speck: nTracksLTF = " << nTracksLTF << std::endl;
+    std::cout << "Fitter Speck: nFailedTracksLTF = " << nFailedTracksLTF << std::endl;
+    mTrackFitter->fit(temptrack, false) ? nTracksLTF++ : nFailedTracksLTF++;
+  } // end fit LTF tracks
 
   // Fit CA tracks
   for (const auto& track : tracksCA) {
-    auto& temptrack = fittertracks.at(nTracksLTF + nTracksCA);
+    auto& temptrack = fittertracks.at(nTracksLTF + nFailedTracksLTF + nTracksCA + nFailedTracksCA);
     convertTrack(track, temptrack, clusters);
-    mTrackFitter->fit(temptrack, false);
-    nTracksCA++;
-  }
+    std::cout << "Fitter Speck: nTracksCA = " << nTracksLTF << std::endl;
+    std::cout << "Fitter Speck: nFailedTracksCA = " << nFailedTracksLTF << std::endl;
+    mTrackFitter->fit(temptrack, false) ? nTracksCA++ : nFailedTracksCA++;
+  } // end fit CA tracks
+
+  auto& finalMFTtracks = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
+  finalMFTtracks.resize(nTracksLTF + nTracksCA);
+
   auto nTotalTracks = 0;
   // Convert fitter tracks to the final Standalone MFT Track
   for (const auto& track : fittertracks) {
-    //o2::mft::TrackMFT& temptrack = finalMFTtracks.emplace_back();
-    auto& temptrack = finalMFTtracks.at(nTotalTracks);
-
-    temptrack.setZ(track.first().getZ());
-    temptrack.setParameters(TtoSMatrix5(track.first().getParameters()));
-    temptrack.setCovariances(TtoSMatrixSym55(track.first().getCovariances()));
-    temptrack.setTrackChi2(track.first().getTrackChi2());
-    temptrack.setMCCompLabels(track.getMCCompLabels(), track.getNPoints());
-    //finalMFTtracks.back().printMCCompLabels();
-    nTotalTracks++;
+    if (!track.isRemovable()) {
+      auto& temptrack = finalMFTtracks.at(nTotalTracks);
+      temptrack.setZ(track.first().getZ());
+      temptrack.setParameters(TtoSMatrix5(track.first().getParameters()));
+      temptrack.setCovariances(TtoSMatrixSym55(track.first().getCovariances()));
+      temptrack.setTrackChi2(track.first().getTrackChi2());
+      temptrack.setMCCompLabels(track.getMCCompLabels(), track.getNPoints());
+      temptrack.setInvQPtQuadtratic(track.getInvQPtQuadtratic());
+      temptrack.setChi2QPtQuadtratic(track.getChi2QPtQuadtratic());
+      //finalMFTtracks.back().printMCCompLabels();
+      nTotalTracks++;
+    }
   }
 
   LOG(INFO) << "MFTFitter loaded " << tracksLTF.size() << " LTF tracks";
   LOG(INFO) << "MFTFitter loaded " << tracksCA.size() << " CA tracks";
   LOG(INFO) << "MFTFitter pushed " << fittertracks.size() << " tracks";
+  LOG(INFO) << "MFTFitter dropped " << nFailedTracksLTF << " LTF tracks";
+  LOG(INFO) << "MFTFitter dropped " << nFailedTracksCA << " CA tracks";
 
   mState = 2;
   pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
@@ -159,7 +169,7 @@ void convertTrack(const T& inTrack, O& outTrack, C& clusters)
   for (auto cls = 0; cls < nClusters; cls++) {
     o2::itsmft::Cluster& tempcluster = clusters.emplace_back(clusterIDs[cls], xpos[cls], ypos[cls], zpos[cls]);
     tempcluster.setSigmaY2(5.43e-4); // FIXME:
-    tempcluster.setSigmaZ2(5.0e-4); // FIXME: Use clusters errors once available
+    tempcluster.setSigmaZ2(5.0e-4);  // FIXME: Use clusters errors once available
     outTrack.createParamAtCluster(tempcluster);
   }
   outTrack.setMCCompLabels(inTrack.getMCCompLabels(), nClusters);


### PR DESCRIPTION
         - MFT Fitter: seed charge and momentum from quadratic fit
         - Optimizing seed for MFT Track fitter
         - Supression of verbose fitting output (to be added to a configurable
        parameter)
         - TrackMFT storing pt and chi2 from quadratic fit
         - Adding choices for seeds
         - Droping failed tracks instead of throwing errors (FIX https://alice.its.cern.ch/jira/browse/O2-1343 )
         - Explictly disabling propagation of covariance matrix on MFT Track fitting.