### PR TITLE
Digitization: Allow to process random sample of events

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -114,6 +114,8 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
       }
 
       mgr.getInteractionSampler().init();
+      // doing a random event selection/subsampling?
+      mgr.setRandomEventSequence(ctx.options().get<int>("randomsample") > 0);
 
       // number of collisions asked?
       auto col = ctx.options().get<int>("ncollisions");
@@ -155,7 +157,8 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
       {"ncollisions,n",
        VariantType::Int,
        0,
-       {"number of collisions to sample (default is given by number of entries in chain"}}}};
+       {"number of collisions to sample (default is given by number of entries in chain"}},
+      {"randomsample", VariantType::Int, 0, {"Draw collisions random instead of linear sequence. (Default no = 0)"}}}};
 }
 } // namespace steer
 } // namespace o2

--- a/Steer/include/Steer/HitProcessingManager.h
+++ b/Steer/include/Steer/HitProcessingManager.h
@@ -70,9 +70,13 @@ class HitProcessingManager
   // setup run from serialized context; returns true if ok
   bool setupRunFromExistingContext(const char* filename);
 
+  void setRandomEventSequence(bool b) { mSampleCollisionsRandomly = b; }
+
  private:
   HitProcessingManager() : mSimChains() {}
   bool setupChain();
+
+  bool checkConsistency() const;
 
   std::vector<RunFunct_t> mRegisteredRunFunctions;
   o2::steer::DigitizationContext mDigitizationContext;
@@ -85,81 +89,11 @@ class HitProcessingManager
   o2::steer::InteractionSampler mInteractionSampler;
 
   int mNumberOfCollisions; // how many collisions we want to generate and process
+  bool mSampleCollisionsRandomly = false; // if we sample the sequence of event ids randomly (with possible repetition)
 
   std::vector<TChain*> mSimChains;
   // ClassDefOverride(HitProcessingManager, 0);
 };
-
-inline void HitProcessingManager::sampleCollisionTimes()
-{
-  mDigitizationContext.getEventRecords().resize(mDigitizationContext.getNCollisions());
-  mInteractionSampler.generateCollisionTimes(mDigitizationContext.getEventRecords());
-  mDigitizationContext.getBunchFilling() = mInteractionSampler.getBunchFilling();
-  mDigitizationContext.setMuPerBC(mInteractionSampler.getMuPerBC());
-}
-
-inline void HitProcessingManager::sampleCollisionConstituents()
-{
-  auto getBackgroundRoundRobin = [this]() {
-    static int bgcounter = 0;
-    int numbg = mSimChains[0]->GetEntries();
-    if (bgcounter == numbg) {
-      bgcounter = 0;
-    }
-    return EventPart(0, bgcounter++);
-  };
-
-  const int nsignalids = mSimChains.size() - 1;
-  auto getSignalRoundRobin = [this, nsignalids]() {
-    static int bgcounter = 0;
-    static int signalid = 0;
-    static std::vector<int> counter(nsignalids, 0);
-    if (signalid == nsignalids) {
-      signalid = 0;
-    }
-    const auto realsourceid = signalid + 1;
-    int numentries = mSimChains[realsourceid]->GetEntries();
-    if (counter[signalid] == numentries) {
-      counter[signalid] = 0;
-    }
-    EventPart e(realsourceid, counter[signalid]);
-    counter[signalid]++;
-    signalid++;
-    return e;
-  };
-
-  // we fill mDigitizationContext.mEventParts
-  auto& eventparts = mDigitizationContext.getEventParts();
-  eventparts.clear();
-  eventparts.resize(mDigitizationContext.getEventRecords().size());
-  for (int i = 0; i < mDigitizationContext.getEventRecords().size(); ++i) {
-    eventparts[i].clear();
-    // push any number of constituents?
-    // for the moment just 2 : one background and one signal
-    eventparts[i].emplace_back(getBackgroundRoundRobin());
-    if (mSimChains.size() > 1) {
-      eventparts[i].emplace_back(getSignalRoundRobin());
-    }
-  }
-
-  // push any number of constituents?
-  // for the moment just max 2 : one background and one signal
-  mDigitizationContext.setMaxNumberParts(1);
-  if (mSimChains.size() > 1) {
-    mDigitizationContext.setMaxNumberParts(2);
-  }
-
-  mDigitizationContext.printCollisionSummary();
-}
-
-inline void HitProcessingManager::run()
-{
-  setupRun();
-  // sample other stuff
-  for (auto& f : mRegisteredRunFunctions) {
-    f(mDigitizationContext);
-  }
-}
 
 inline void HitProcessingManager::registerRunFunction(RunFunct_t&& f) { mRegisteredRunFunctions.emplace_back(f); }
 


### PR DESCRIPTION
Allow random selection of events in digitization

This feature is for power users, mainly intended to allow some sort
of event sequence engineering to stress-test reconstruction
with different input without the need to simulate more events.
(A more generic solution for event sequence engineering can be attacked
later.)

Usage is:
```
o2-sim-digitizer-workflow -n 10 --randomsample 1
```
which will take a sequence of 10 arbitrary events
(from the available pool, regardless of how many we have).

For the moment, each call to this process will result
in a different sequence.

At the same time, this commit also moves some
functions from header to source because there is no
need for them being inline.