### PR TITLE
[O2-1363] Remove buffering of input data from the TPC CA tracker spec

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -106,9 +106,9 @@ struct Config {
 /// @ca::Operations, a configuration object @a ca::Config is used to pass the
 /// configuration to the processor spec.
 ///
-/// @param config     configuration option for the processor spec
+/// @param specconfig configuration options for the processor spec
 /// @param tpcsectors list of sector numbers
-framework::DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> const& tpcsectors);
+framework::DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int> const& tpcsectors);
 
 o2::framework::CompletionPolicy getCATrackerCompletionPolicy();
 } // end namespace tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -18,6 +18,11 @@
 
 namespace o2
 {
+namespace framework
+{
+struct CompletionPolicy;
+}
+
 namespace tpc
 {
 
@@ -105,5 +110,6 @@ struct Config {
 /// @param tpcsectors list of sector numbers
 framework::DataProcessorSpec getCATrackerSpec(ca::Config const& config, std::vector<int> const& tpcsectors);
 
+o2::framework::CompletionPolicy getCATrackerCompletionPolicy();
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -20,6 +20,7 @@
 #include "Framework/DispatchPolicy.h"
 #include "Framework/PartRef.h"
 #include "TPCWorkflow/RecoWorkflow.h"
+#include "TPCWorkflow/CATrackerSpec.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "CommonUtils/ConfigurableParam.h"
@@ -79,6 +80,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
 }
 
 #include "Framework/runDataProcessing.h" // the main driver


### PR DESCRIPTION
Keep the messages in the DPL internal input queue instead of buffering in the
CA tracker. 
- Using DPL CompletionPolicy to Wait for complete input.
- Also removing all custom code for buffering of input data.
- Removing custom end-of-stream handling, both digitizer and reco workflow are adapted to use only DPL eos, namely there are no data sets with negative sector number in the TPC sector header anymore.