### PR TITLE
Introduce o2_add_dpl_workflow

### DIFF
--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -15,72 +15,69 @@
 # set(HEADERS src/o2_sim_its_ALP3.h src/o2_sim_tpc.h )
 #
 
-o2_add_executable(histogram-track-selection
-                  SOURCES src/histogramTrackSelection.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore
-                  COMPONENT_NAME AnalysisTutorial)
+o2_add_dpl_workflow(histogram-track-selection
+                    SOURCES src/histogramTrackSelection.cxx
+                    PUBLIC_LINK_LIBRARIES O2::AnalysisDataModel O2::AnalysisCore
+                    COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(track-collection-iteration
+o2_add_dpl_workflow(track-collection-iteration
                   SOURCES src/trackCollectionIteration.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(track-iteration
+o2_add_dpl_workflow(track-iteration
                   SOURCES src/trackIteration.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(full-track-iteration
+o2_add_dpl_workflow(full-track-iteration
                   SOURCES src/fullTrackIteration.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(collision-tracks-iteration
+o2_add_dpl_workflow(collision-tracks-iteration
                   SOURCES src/collisionTracksIteration.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(new-collections
+o2_add_dpl_workflow(new-collections
                   SOURCES src/newCollections.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(associated-derived
+o2_add_dpl_workflow(associated-derived
                   SOURCES src/associatedExample.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(dynamic-columns
+o2_add_dpl_workflow(dynamic-columns
                   SOURCES src/dynamicColumns.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(histograms
+o2_add_dpl_workflow(histograms
                   SOURCES src/histograms.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(filters
+o2_add_dpl_workflow(filters
                   SOURCES src/filters.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(aodwriter
+o2_add_dpl_workflow(aodwriter
                   SOURCES src/aodwriter.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(aodreader
+o2_add_dpl_workflow(aodreader
                   SOURCES src/aodreader.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(outputs
+o2_add_dpl_workflow(outputs
                   SOURCES src/outputs.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
-o2_add_executable(jet-analysis
+o2_add_dpl_workflow(jet-analysis
                   SOURCES src/jetAnalysis.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel
                   COMPONENT_NAME AnalysisTutorial)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ include(O2AddTestRootMacro)
 include(O2TargetRootDictionary)
 include(O2DataFile)
 include(O2TargetManPage)
+include(O2AddWorkflow)
 
 # Main targets of the project in various subdirectories. Order matters.
 add_subdirectory(Common)

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -15,87 +15,71 @@
 # set(HEADERS src/o2_sim_its_ALP3.h src/o2_sim_tpc.h )
 #
 
-o2_add_executable(dummy-workflow
+o2_add_dpl_workflow(dummy-workflow
                   SOURCES src/o2DummyWorkflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(o2rootmessage-workflow
+o2_add_dpl_workflow(o2rootmessage-workflow
                   SOURCES "src/test_o2RootMessageWorkflow.cxx"
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(diamond-workflow
+o2_add_dpl_workflow(diamond-workflow
                   SOURCES src/o2DiamondWorkflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(output-wildcard-workflow
+o2_add_dpl_workflow(output-wildcard-workflow
                   SOURCES src/o2OutputWildcardWorkflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(parallel-workflow
+o2_add_dpl_workflow(parallel-workflow
                   SOURCES src/o2ParallelWorkflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(flp-qualification
+o2_add_dpl_workflow(flp-qualification
                   SOURCES src/flpQualification.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(sync-reconstruction-dummy
+o2_add_dpl_workflow(sync-reconstruction-dummy
                   SOURCES src/o2SyncReconstructionDummy.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(aod-dummy-workflow
+o2_add_dpl_workflow(aod-dummy-workflow
                   SOURCES src/o2AODDummy.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(d0-analysis
+o2_add_dpl_workflow(d0-analysis
                   SOURCES src/o2D0Analysis.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(simple-tracks-analysis
+o2_add_dpl_workflow(simple-tracks-analysis
                   SOURCES src/o2SimpleTracksAnalysis.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(analysis-task-example
+o2_add_dpl_workflow(analysis-task-example
                   SOURCES src/o2AnalysisTaskExample.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(data-query-workflow
+o2_add_dpl_workflow(data-query-workflow
                   SOURCES src/o2DataQueryWorkflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
 # FIXME: given its name, should this one be a test instead of an executable ?
-o2_add_executable(test_MakeDPLObjects
+o2_add_dpl_workflow(test_MakeDPLObjects
                   SOURCES test/test_MakeDPLObjects.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
 # FIXME: given its name, should this one be a test instead of an executable ?
-o2_add_executable(test_RawDeviceInjector
+o2_add_dpl_workflow(test_RawDeviceInjector
                   SOURCES src/test_RawDeviceInjector.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
 # FIXME: given its name, should this one be a test instead of an executable ?
-o2_add_executable(test_CompletionPolicies
+o2_add_dpl_workflow(test_CompletionPolicies
                   SOURCES src/test_CompletionPolicies.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(datasampling-pod-and-root
+o2_add_dpl_workflow(datasampling-pod-and-root
                   SOURCES src/dataSamplingPodAndRoot.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
 o2_add_executable(datasampling-parallel
@@ -108,20 +92,18 @@ o2_add_executable(datasampling-time-pipeline
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(ccdb-fetch-to-timeframe
+o2_add_dpl_workflow(ccdb-fetch-to-timeframe
                   SOURCES src/test_CCDBFetchToTimeframe.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
-o2_add_executable(datasampling-benchmark
+o2_add_dpl_workflow(datasampling-benchmark
                   SOURCES src/dataSamplingBenchmark.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
 # Detector specific dummy workflows
-o2_add_executable(tof-dummy-ccdb
+o2_add_dpl_workflow(tof-dummy-ccdb
                   SOURCES src/tof-dummy-ccdb.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework O2::TOFReconstruction
+                  PUBLIC_LINK_LIBRARIES O2::TOFReconstruction
                   COMPONENT_NAME TestWorkflows)
 
 if(BUILD_SIMULATION)

--- a/cmake/O2AddWorkflow.cmake
+++ b/cmake/O2AddWorkflow.cmake
@@ -1,0 +1,60 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+include_guard()
+
+#
+# o2_add_dpl_workflow(basename SOURCES ...) add a new dpl workflow
+# executable. Besides building the executable, this will also generate
+# a configuration json file via <executable-name> --dump so that it can
+# be easily registered and deployed e.g. in the train infrastructure.
+#
+# For most of the options please see how o2_add_executable works.
+#
+# The installed executable will be named o2[-exeType][-component_name]-basename
+# The installed JSON file will be named o2-[exeType][-component_name]-basename.json.
+#
+
+function(o2_add_dpl_workflow baseTargetName)
+
+  cmake_parse_arguments(PARSE_ARGV
+                        1
+                        A
+                        ""
+                        "COMPONENT_NAME;TARGETVARNAME"
+                        "SOURCES;PUBLIC_LINK_LIBRARIES")
+
+  if(A_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Got trailing arguments ${A_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(A_COMPONENT_NAME)
+    string(TOLOWER ${A_COMPONENT_NAME} component)
+    set(comp -${component})
+  endif()
+  set(exeName o2${exeType}${comp}-${baseTargetName})
+
+  o2_add_executable(${baseTargetName} 
+                    COMPONENT_NAME ${A_COMPONENT_NAME}
+                    TARGETVARNAME ${A_TARGETVARNAME}
+                    SOURCES ${A_SOURCES}
+                    PUBLIC_LINK_LIBRARIES O2::Framework ${A_PUBLIC_LINK_LIBRARIES})
+  add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json 
+                     DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}
+                     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName} | cat > ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
+                    )
+  
+  add_custom_target(${exeName}_dpl_config 
+                    DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
+                   )
+  install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
+          DESTINATION ${CMAKE_INSTALL_DATADIR}/dpl
+  )
+endfunction()

--- a/cmake/O2AddWorkflow.cmake
+++ b/cmake/O2AddWorkflow.cmake
@@ -11,50 +11,48 @@
 include_guard()
 
 #
-# o2_add_dpl_workflow(basename SOURCES ...) add a new dpl workflow
-# executable. Besides building the executable, this will also generate
-# a configuration json file via <executable-name> --dump so that it can
-# be easily registered and deployed e.g. in the train infrastructure.
+# o2_add_dpl_workflow(basename SOURCES ...) add a new dpl workflow executable.
+# Besides building the executable, this will also generate a configuration json
+# file via <executable-name> --dump so that it can be easily registered and
+# deployed e.g. in the train infrastructure.
 #
 # For most of the options please see how o2_add_executable works.
 #
-# The installed executable will be named o2[-exeType][-component_name]-basename
-# The installed JSON file will be named o2-[exeType][-component_name]-basename.json.
+# The installed executable will be named as regular executables (see
+# o2_add_executable for details)
+#
+# The installed JSON file will be named <executable-name>.json and installed
+# under share/dpl directory
 #
 
 function(o2_add_dpl_workflow baseTargetName)
 
-  cmake_parse_arguments(PARSE_ARGV
-                        1
-                        A
-                        ""
-                        "COMPONENT_NAME;TARGETVARNAME"
+  cmake_parse_arguments(PARSE_ARGV 1 A "" "COMPONENT_NAME;TARGETVARNAME"
                         "SOURCES;PUBLIC_LINK_LIBRARIES")
 
   if(A_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "Got trailing arguments ${A_UNPARSED_ARGUMENTS}")
   endif()
 
-  if(A_COMPONENT_NAME)
-    string(TOLOWER ${A_COMPONENT_NAME} component)
-    set(comp -${component})
-  endif()
-  set(exeName o2${exeType}${comp}-${baseTargetName})
+  o2_add_executable(${baseTargetName}
+    COMPONENT_NAME ${A_COMPONENT_NAME} TARGETVARNAME targetExeName
+    SOURCES ${A_SOURCES}
+    PUBLIC_LINK_LIBRARIES O2::Framework ${A_PUBLIC_LINK_LIBRARIES})
 
-  o2_add_executable(${baseTargetName} 
-                    COMPONENT_NAME ${A_COMPONENT_NAME}
-                    TARGETVARNAME ${A_TARGETVARNAME}
-                    SOURCES ${A_SOURCES}
-                    PUBLIC_LINK_LIBRARIES O2::Framework ${A_PUBLIC_LINK_LIBRARIES})
-  add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json 
-                     DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}
-                     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName} | cat > ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
-                    )
-  
-  add_custom_target(${exeName}_dpl_config 
-                    DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
-                   )
-  install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exeName}.json
-          DESTINATION ${CMAKE_INSTALL_DATADIR}/dpl
-  )
+  if(A_TARGETVARNAME)
+    set(${A_TARGETVARNAME}
+        ${targetExeName}
+        PARENT_SCOPE)
+  endif()
+
+  set(jsonFile $<TARGET_FILE_BASE_NAME:${targetExeName}>.json)
+
+  add_custom_command(
+    TARGET ${targetExeName} POST_BUILD
+    COMMAND $<TARGET_FILE:${targetExeName}> -b | cat > ${jsonFile})
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/${jsonFile}
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/dpl)
+
 endfunction()


### PR DESCRIPTION
Such an helper can be used to generate executables which are
known to be DPL workflows. Besides adding automatically the dependency
on O2::Framework, this helper will also make sure that the workflow
is executed once with the `--dump` flag so that a JSON representation
is generated and put in `${CMAKE_INSTALL_DATADIR}/dpl` for the sake
of consumption by various deployment mechanisms, e.g. the AliHyperloop
infrastructure. Notice it's also valid to start one of those workflows
with:

  o2-dpl-run < $O2_ROOT/share/dpl/some-workflow.json