### PR TITLE
make FlatObject streamer work from GPUTracker library

### DIFF
--- a/GPU/Common/FlatObject.h
+++ b/GPU/Common/FlatObject.h
@@ -25,10 +25,6 @@
 #include <cassert>
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
-#include "TFile.h"
-#endif
-
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "GPUCommonLogger.h"
@@ -285,14 +281,14 @@ class FlatObject
     return (ptr != nullptr) ? reinterpret_cast<T*>(newBase + (reinterpret_cast<const char*>(ptr) - oldBase)) : nullptr;
   }
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU
 
   /// write a child class object to the file
-  template <class T>
+  template <class T, class TFile>
   static int writeToFile(T& obj, TFile& outf, const char* name);
 
   /// read a child class object from the file
-  template <class T>
+  template <class T, class TFile>
   static T* readFromFile(TFile& inpf, const char* name);
 #endif
 
@@ -454,8 +450,8 @@ inline void FlatObject::setFutureBufferAddress(char* futureFlatBufferPtr)
   mFlatBufferContainer = nullptr;
 }
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU
-template <class T>
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU
+template <class T, class TFile>
 inline int FlatObject::writeToFile(T& obj, TFile& outf, const char* name)
 {
   /// store to file
@@ -477,7 +473,7 @@ inline int FlatObject::writeToFile(T& obj, TFile& outf, const char* name)
   return 0;
 }
 
-template <class T>
+template <class T, class TFile>
 inline T* FlatObject::readFromFile(TFile& inpf, const char* name)
 {
   /// read from file

--- a/GPU/TPCFastTransformation/CMakeLists.txt
+++ b/GPU/TPCFastTransformation/CMakeLists.txt
@@ -84,13 +84,15 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "ALIROOT")
   set(SRCS ${SRCS} TPCFastTransformManager.cxx TPCFastTransformQA.cxx
            ${AliRoot_SOURCE_DIR}/HLT/TPCLib/AliHLTTPCGeometry.cxx
            ${AliRoot_SOURCE_DIR}/HLT/TPCLib/AliHLTTPCLog.cxx)
-  set(HDRS_CINT ${HDRS_CINT} TPCFastTransformManager.h TPCFastTransformQA.h)
+  #set(HDRS_CINT ${HDRS_CINT_O2} TPCFastTransformManager.h TPCFastTransformQA.h )
+  set(HDRS_CINT TPCFastTransformManager.h TPCFastTransformQA.h )
 
   # Enable Vc
   alice_usevc()
 
   include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
   include_directories(${AliRoot_SOURCE_DIR}/GPU/TPCFastTransformation
+                      ${AliRoot_SOURCE_DIR}/GPU/TPCFastTransformation/devtools
                       ${AliRoot_SOURCE_DIR}/GPU/Common
                       ${AliRoot_SOURCE_DIR}/HLT/BASE
                       ${AliRoot_SOURCE_DIR}/HLT/TPCLib
@@ -99,7 +101,7 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "ALIROOT")
 
   # Generate the dictionary
   get_directory_property(incdirs INCLUDE_DIRECTORIES)
-  generate_dictionary("Ali${MODULE}" "TPCFastTransformationLinkDef_AliRoot.h"
+  generate_dictionary_flat("Ali${MODULE}" "TPCFastTransformationLinkDef_AliRoot.h"
                       "${HDRS_CINT}" "${incdirs}")
 
   # Generate the ROOT map Dependecies

--- a/GPU/TPCFastTransformation/Spline1D.cxx
+++ b/GPU/TPCFastTransformation/Spline1D.cxx
@@ -13,6 +13,10 @@
 ///
 /// \author  Sergey Gorbunov <sergey.gorbunov@cern.ch>
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#include "Rtypes.h"
+#endif
+
 #include "Spline1D.h"
 #include <cmath>
 
@@ -228,7 +232,7 @@ void Spline1D<DataT>::print() const
   printf("\n");
 }
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 template <typename DataT>
 int Spline1D<DataT>::writeToFile(TFile& outf, const char* name)
 {
@@ -244,7 +248,7 @@ Spline1D<DataT>* Spline1D<DataT>::readFromFile(TFile& inpf, const char* name)
 }
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 
 template <typename DataT>
 void Spline1D<DataT>::approximateFunction(DataT xMin, DataT xMax,

--- a/GPU/TPCFastTransformation/Spline1D.h
+++ b/GPU/TPCFastTransformation/Spline1D.h
@@ -156,7 +156,7 @@ class Spline1D : public FlatObject
   void recreate(int numberOfKnots, const int knots[], int nFDimensions);
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
   /// approximate a function F with this spline.
   void approximateFunction(DataT xMin, DataT xMax, std::function<void(DataT x, DataT f[/*mFdimensions*/])> F,
                            int nAxiliaryDataPoints = 4);
@@ -172,7 +172,7 @@ class Spline1D : public FlatObject
 
   /// _______________  IO   ________________________
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
   /// write a class object to the file
   int writeToFile(TFile& outf, const char* name);
 
@@ -276,7 +276,7 @@ class Spline1D : public FlatObject
   /// Print method
   void print() const;
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
   /// Test the class functionality
   static int test(const bool draw = 0, const bool drawDataPoints = 1);
 #endif
@@ -385,10 +385,10 @@ GPUhd() DataT Spline1D<DataT>::interpolate(DataT x) const
 
 template <typename DataT>
 template <typename T>
-GPUhdi() void Spline1D<DataT>::interpolateU(int nFdim, const Spline1D<DataT>::Knot& knotL,
-                                            GPUgeneric() const T Sl[/*nFdim*/], GPUgeneric() const T Dl[/*nFdim*/],
-                                            GPUgeneric() const T Sr[/*nFdim*/], GPUgeneric() const T Dr[/*nFdim*/],
-                                            DataT u, GPUgeneric() T Su[/*nFdim*/])
+GPUhd() void Spline1D<DataT>::interpolateU(int nFdim, const Spline1D<DataT>::Knot& knotL,
+                                           GPUgeneric() const T Sl[/*nFdim*/], GPUgeneric() const T Dl[/*nFdim*/],
+                                           GPUgeneric() const T Sr[/*nFdim*/], GPUgeneric() const T Dr[/*nFdim*/],
+                                           DataT u, GPUgeneric() T Su[/*nFdim*/])
 {
   /// A static method.
   /// Gives interpolated value of N-dimensional S(u) at u

--- a/GPU/TPCFastTransformation/Spline2D.cxx
+++ b/GPU/TPCFastTransformation/Spline2D.cxx
@@ -13,6 +13,10 @@
 ///
 /// \author  Sergey Gorbunov <sergey.gorbunov@cern.ch>
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#include "Rtypes.h"
+#endif
+
 #include "Spline2D.h"
 
 #if !defined(GPUCA_GPUCODE)
@@ -208,7 +212,7 @@ void Spline2DBase<DataT, isConsistentT>::recreate(
 
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 
 template <typename DataT, bool isConsistentT>
 int Spline2DBase<DataT, isConsistentT>::writeToFile(TFile& outf, const char* name)
@@ -226,7 +230,7 @@ Spline2DBase<DataT, isConsistentT>* Spline2DBase<DataT, isConsistentT>::readFrom
 }
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
 
 template <typename DataT, bool isConsistentT>
 void Spline2DBase<DataT, isConsistentT>::approximateFunction(
@@ -255,7 +259,7 @@ int Spline2DBase<DataT, isConsistentT>::test(const bool draw, const bool drawDat
   constexpr int uMax = nKnots * 3;
 
   auto F = [&](DataT u, DataT v, DataT Fuv[]) {
-    constexpr double scale = TMath::Pi() / uMax;
+    const double scale = TMath::Pi() / uMax;
     double uu = u * scale;
     double vv = v * scale;
     double cosu[Fdegree + 1], sinu[Fdegree + 1], cosv[Fdegree + 1], sinv[Fdegree + 1];
@@ -496,7 +500,7 @@ int Spline2DBase<DataT, isConsistentT>::test(const bool draw, const bool drawDat
   return 0;
 }
 
-#endif // GPUCA_ALIGPUCODE
+#endif // GPUCA_GPUCODE
 
 template class GPUCA_NAMESPACE::gpu::Spline2DBase<float, false>;
 template class GPUCA_NAMESPACE::gpu::Spline2DBase<float, true>;

--- a/GPU/TPCFastTransformation/Spline2D.h
+++ b/GPU/TPCFastTransformation/Spline2D.h
@@ -91,7 +91,7 @@ class Spline2DBase : public FlatObject
   void recreate(int numberOfKnotsU1, const int knotsU1[], int numberOfKnotsU2, const int knotsU2[]);
 #endif
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
   /// approximate a function F with this spline.
   void approximateFunction(DataT x1Min, DataT x1Max, DataT x2Min, DataT x2Max,
                            std::function<void(DataT x1, DataT x2, DataT f[])> F,
@@ -100,7 +100,7 @@ class Spline2DBase : public FlatObject
 
   /// _______________  IO   ________________________
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
   /// write a class object to the file
   int writeToFile(TFile& outf, const char* name);
 
@@ -163,7 +163,7 @@ class Spline2DBase : public FlatObject
   /// Print method
   void print() const;
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
   /// Test the class functionality
   static int test(const bool draw = 0, const bool drawDataPoints = 1);
 #endif
@@ -257,7 +257,7 @@ class Spline2D : public Spline2DBase<DataT, isConsistentT>
 
   /// _______________  IO   ________________________
 
-#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
   /// write a class object to the file
   using TBase::writeToFile;
 
@@ -339,8 +339,8 @@ GPUhdi() Spline2D<DataT, nFdimT, isConsistentT>::
 }
 
 template <typename DataT, int nFdimT, bool isConsistentT>
-GPUhdi() Spline2D<DataT, nFdimT, isConsistentT>& Spline2D<DataT, nFdimT, isConsistentT>::
-  operator=(const Spline2D& spline)
+GPUhd() Spline2D<DataT, nFdimT, isConsistentT>& Spline2D<DataT, nFdimT, isConsistentT>::
+  operator=(const Spline2D<DataT, nFdimT, isConsistentT>& spline)
 {
   this->cloneFromObject(spline, nullptr);
   return *this;

--- a/GPU/TPCFastTransformation/SplineHelper1D.h
+++ b/GPU/TPCFastTransformation/SplineHelper1D.h
@@ -55,10 +55,10 @@ class SplineHelper1D
   SplineHelper1D();
 
   /// Copy constructor: disabled
-  SplineHelper1D(const SplineHelper1D&) CON_DELETE;
+  SplineHelper1D(const SplineHelper1D&) CON_DEFAULT;
 
   /// Assignment operator: disabled
-  SplineHelper1D& operator=(const SplineHelper1D&) CON_DELETE;
+  SplineHelper1D& operator=(const SplineHelper1D&) CON_DEFAULT;
 
   /// Destructor
   ~SplineHelper1D() CON_DEFAULT;

--- a/GPU/TPCFastTransformation/TPCFastTransform.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransform.cxx
@@ -13,6 +13,10 @@
 ///
 /// \author  Sergey Gorbunov <sergey.gorbunov@cern.ch>
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+#include "Rtypes.h"
+#endif
+
 #include "TPCFastTransform.h"
 
 #if !defined(GPUCA_GPUCODE)
@@ -147,7 +151,7 @@ void TPCFastTransform::print() const
 #endif
 }
 
-#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIROOT_LIB)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 
 int TPCFastTransform::writeToFile(std::string outFName, std::string name)
 {

--- a/GPU/TPCFastTransformation/TPCFastTransform.h
+++ b/GPU/TPCFastTransformation/TPCFastTransform.h
@@ -25,10 +25,6 @@
 #include <string>
 #endif // !GPUCA_GPUCODE
 
-#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
-//#include "Rtypes.h"
-#endif
-
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
@@ -186,7 +182,7 @@ class TPCFastTransform : public FlatObject
   /// Return a value of the last timebin where correction map is valid
   GPUd() float getLastCalibratedTimeBin(int slice) const;
 
-#if !defined(GPUCA_GPUCODE)
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 
   int writeToFile(std::string outFName = "", std::string name = "");
 

--- a/GPU/TPCFastTransformation/TPCFastTransformationLinkDef_AliRoot.h
+++ b/GPU/TPCFastTransformation/TPCFastTransformationLinkDef_AliRoot.h
@@ -16,7 +16,37 @@
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
+/*
+#pragma link C++ nestedclasses;
+#pragma link C++ nestedtypedef;
 
-//#pragma link C++ class AliGPU::gpu::IrregularSpline1D+;
+#pragma link C++ namespace AliGPU::gpu;
+
+#pragma link C++ class AliGPU::gpu::Spline1D < float> + ;
+#pragma link C++ class AliGPU::gpu::Spline1D < double> + ;
+#pragma link C++ class AliGPU::gpu::Spline2DBase < float, false> + ;
+#pragma link C++ class AliGPU::gpu::Spline2DBase < double, false> + ;
+#pragma link C++ class AliGPU::gpu::Spline2DBase < float, true> + ;
+#pragma link C++ class AliGPU::gpu::Spline2DBase < double, true> + ;
+
+#pragma link C++ class AliGPU::gpu::Spline2D < float, 1> - ;
+
+#pragma link C++ class AliGPU::gpu::SplineHelper1D < float>;
+#pragma link C++ class AliGPU::gpu::SplineHelper1D < double>;
+#pragma link C++ class AliGPU::gpu::SplineHelper2D < float>;
+#pragma link C++ class AliGPU::gpu::SplineHelper2D < double>;
+
+#pragma link C++ class AliGPU::gpu::RegularSpline1D + ;
+#pragma link C++ class AliGPU::gpu::IrregularSpline1D + ;
+#pragma link C++ class AliGPU::gpu::IrregularSpline2D3D + ;
+#pragma link C++ class AliGPU::gpu::SemiregularSpline2D3D + ;
+#pragma link C++ class AliGPU::gpu::IrregularSpline2D3DCalibrator + ;
+#pragma link C++ class AliGPU::gpu::TPCFastTransformGeo + ;
+#pragma link C++ class AliGPU::gpu::TPCFastTransformGeo::SliceInfo + ;
+#pragma link C++ class AliGPU::gpu::TPCFastTransformGeo::RowInfo + ;
+#pragma link C++ class AliGPU::gpu::TPCFastTransform + ;
+
+#pragma link C++ class AliGPU::gpu::TPCFastSpaceChargeCorrection + ;
+*/
 
 #endif


### PR DESCRIPTION
#include "TFile.h"  is replaced by a template argument in FlatObject.h.
The reason is that ROOT classes can not be included from GPUTracker headers, 
because ROOT types are redefined in the GPUTracker.  
TFile.h can only be included from a source file.