### PR TITLE
Removing unused variable

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -48,8 +48,6 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   const auto tracksTPCClRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
   const auto trackMatchesTOF = pc.inputs().get<gsl::span<o2::dataformats::MatchInfoTOF>>("matchTOF"); // FIXME missing reader
   const auto clustersTOFInp = pc.inputs().get<std::vector<o2::tof::Cluster>>("clustersTOF");          // FIXME o2::tof::Cluster is not messageable type which is required to create span
-  // make copy of TOF clusters... Is it needed?
-  std::vector<o2::tof::Cluster> clustersTOFCopy = clustersTOFInp;
   auto clustersTOF = gsl::make_span(clustersTOFInp);
 
   // TPC Cluster loading part is copied from TPCITSMatchingSpec.cxx


### PR DESCRIPTION
There is an upcoming API change for the InputRecord which will return
spectator vector. Depending on the serialization type, the spectator
vector will use the either the input buffer directly without copy or
deserialize the message.

The recommended way of accessing the data is already implemented, using
auto type to hold the returned input object and create a span to be used
in further processing.