### PR TITLE
MCH custom electronics mapping

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/CruLinkHandler.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/CruLinkHandler.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_CRU_LINK_HANDLER_H
+#define O2_MCH_RAW_CRU_LINK_HANDLER_H
+
+#include <functional>
+
+#include "MCHRawElecMap/FeeLinkId.h"
+
+namespace o2
+{
+namespace mch
+{
+namespace raw
+{
+/// A CruLinkHandler is a function that takes a FeeLinkId and returns the corresponding LinkId
+using CruLinkHandler = std::function<std::optional<uint16_t>(FeeLinkId)>;
+} // namespace raw
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/PageDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/PageDecoder.h
@@ -15,6 +15,7 @@
 #include <gsl/span>
 #include <map>
 #include "MCHRawDecoder/SampaChannelHandler.h"
+#include "MCHRawDecoder/CruLinkHandler.h"
 
 namespace o2::mch::raw
 {
@@ -38,7 +39,8 @@ using RawBuffer = gsl::span<const std::byte>;
 // it does not really make sense to not provide it.
 //
 PageDecoder createPageDecoder(RawBuffer rdhBuffer,
-                              SampaChannelHandler channelHandler = nullptr);
+                              SampaChannelHandler channelHandler = nullptr,
+                              CruLinkHandler linkHandler = nullptr);
 
 // A PageParser loops over the given buffer and apply the given page decoder
 // to each page.

--- a/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
@@ -74,9 +74,8 @@ template <typename RDH, typename FORMAT, typename CHARGESUM>
 class PageDecoderImpl
 {
  public:
-  PageDecoderImpl(SampaChannelHandler sampaChannelHandler, CruLinkHandler linkHandler) :
-    mSampaChannelHandler{sampaChannelHandler},
-    mLinkHandler(linkHandler)
+  PageDecoderImpl(SampaChannelHandler sampaChannelHandler, CruLinkHandler linkHandler) : mSampaChannelHandler{sampaChannelHandler},
+                                                                                         mLinkHandler(linkHandler)
   {
   }
 

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -72,11 +72,165 @@ int ds2manu(int i)
   return refDs2manu_st345[i];
 }
 
+//=============
+// Classes for custom mapping implementation
+#define MCH_MAX_FEEID 64
+#define MCH_MAX_CRU_LINK 12
+#define LINKID_MAX 0x7FF
+
+class MapSolar
+{
+ public:
+  int mLink; // link ID
+
+  MapSolar()
+  {
+    mLink = -1;
+  }
+  ~MapSolar() {}
+};
+
+class MapCRU
+{
+  bool mInitialized;
+  MapSolar mSolarMap[MCH_MAX_FEEID][MCH_MAX_CRU_LINK];
+
+ public:
+  MapCRU();
+  bool load(std::string mapFile);
+  bool initialized() { return mInitialized; }
+  int32_t getLink(int32_t c, int32_t l);
+};
+
+// CRU mapping
+MapCRU::MapCRU()
+{
+  mInitialized = false;
+}
+
+bool MapCRU::load(std::string mapFile)
+{
+  std::ifstream file;
+  file.open(mapFile);
+  if (!file) {
+    std::cout << "[MapCRU::readMapping] can't open file " << mapFile << std::endl;
+    return false;
+  }
+
+  int c, l, link_id;
+  char tstr[500];
+  while (file.getline(tstr, 499)) {
+    std::string s(tstr);
+    std::istringstream line(s);
+    line >> link_id >> c >> l;
+    if (c < 0 || c >= MCH_MAX_FEEID)
+      continue;
+    if (l < 0 || l >= MCH_MAX_CRU_LINK)
+      continue;
+    mSolarMap[c][l].mLink = link_id;
+  }
+  mInitialized = true;
+  return true;
+}
+
+int32_t MapCRU::getLink(int32_t c, int32_t l)
+{
+  int32_t result = -1;
+  if (c < 0 || c >= MCH_MAX_FEEID)
+    return result;
+  if (l < 0 || l >= MCH_MAX_CRU_LINK)
+    return result;
+  return mSolarMap[c][l].mLink;
+}
+
+class MapDualSampa
+{
+ public:
+  int mDE;    // detector element
+  int mIndex; // DS index
+  int mBad;   // if = 1 bad pad (not used for analysis)
+
+  MapDualSampa()
+  {
+    mDE = mIndex = -1;
+    mBad = 1;
+  }
+
+  ~MapDualSampa() {}
+};
+
+class MapFEC
+{
+  bool mInitialized;
+  MapDualSampa mDsMap[LINKID_MAX + 1][40];
+
+ public:
+  MapFEC();
+  bool load(std::string mapFile);
+  bool initialized() { return mInitialized; }
+  bool getDsId(uint32_t link_id, uint32_t ds_addr, int& de, int& dsid);
+};
+
+// Electronics mapping
+MapFEC::MapFEC()
+{
+  mInitialized = false;
+}
+
+bool MapFEC::load(std::string mapFile)
+{
+  std::ifstream file;
+  file.open(mapFile);
+  if (!file) {
+    std::cout << "[MapFEC::readDSMapping] can't open file " << mapFile << std::endl;
+    return false;
+  }
+
+  int link_id, group_id, de, ds_id[5];
+  while (!file.eof()) {
+    file >> link_id >> group_id >> de >> ds_id[0] >> ds_id[1] >> ds_id[2] >> ds_id[3] >> ds_id[4];
+    if (link_id < 0 || link_id > LINKID_MAX)
+      continue;
+    for (int i = 0; i < 5; i++) {
+      if (ds_id[i] <= 0)
+        continue;
+      int ds_addr = group_id * 5 + i;
+      if (ds_addr < 0 || ds_addr >= 40)
+        continue;
+      mDsMap[link_id][ds_addr].mDE = de;
+      mDsMap[link_id][ds_addr].mIndex = ds_id[i];
+      mDsMap[link_id][ds_addr].mBad = 0;
+    }
+  }
+  mInitialized = true;
+  return true;
+}
+
+bool MapFEC::getDsId(uint32_t link_id, uint32_t ds_addr, int& de, int& dsid)
+{
+  if (mDsMap[link_id][ds_addr].mBad == 1)
+    return false;
+  de = mDsMap[link_id][ds_addr].mDE;
+  dsid = mDsMap[link_id][ds_addr].mIndex;
+  return true;
+}
+
+//=======================
+// Data decoder
 class DataDecoderTask
 {
   void decodeBuffer(gsl::span<const std::byte> page, std::vector<o2::mch::Digit>& digits)
   {
     size_t ndigits{0};
+
+    auto linkHandler = [&](FeeLinkId feeLinkId) -> std::optional<uint16_t> {
+      std::optional<uint16_t> result;
+      uint16_t link = mMapCRU.getLink(feeLinkId.feeId(), feeLinkId.linkId());
+      result = link;
+      if (mPrint)
+        std::cout << "[linkHandler] (" << (int)feeLinkId.feeId() << "," << (int)feeLinkId.linkId() << ") -> " << result.value() << std::endl;
+      return result;
+    };
 
     auto channelHandler = [&](DsElecId dsElecId, uint8_t channel, o2::mch::raw::SampaCluster sc) {
       if (mDs2manu)
@@ -94,7 +248,11 @@ class DataDecoderTask
 
       int deId;
       int dsIddet;
-      if (auto opt = mElec2Det(dsElecId); opt.has_value()) {
+      if (mMapFEC.initialized()) {
+        if (!mMapFEC.getDsId(dsElecId.solarId(), dsElecId.elinkId(), deId, dsIddet)) {
+          deId = dsIddet = -1;
+        }
+      } else if (auto opt = mElec2Det(dsElecId); opt.has_value()) {
         DsDetId dsDetId = opt.value();
         dsIddet = dsDetId.dsId();
         deId = dsDetId.deId();
@@ -107,10 +265,11 @@ class DataDecoderTask
         if (mPrint)
           std::cout << "DS " << (int)dsElecId.elinkId() << "  CHIP " << ((int)channel) / 32 << "  CH " << ((int)channel) % 32 << "  ADC " << digitadc << "  DE# " << deId << "  DSid " << dsIddet << "  PadId " << padId << std::endl;
       } catch (const std::exception& e) {
+        std::cout << "Failed to get padId: " << e.what() << std::endl;
         return;
       }
 
-      int time = 0;
+      int time = sc.timestamp;
 
       digits.emplace_back(o2::mch::Digit(time, deId, padId, digitadc));
 
@@ -125,12 +284,13 @@ class DataDecoderTask
       mNrdhs++;
       auto cruId = rdhCruId(rdh);
       rdhFeeId(rdh, cruId * 2 + rdhEndpoint(rdh));
-      if (true) {
+      if (mPrint) {
         std::cout << mNrdhs << "--" << rdh << "\n";
       }
     };
 
-    o2::mch::raw::PageDecoder decode = o2::mch::raw::createPageDecoder(page, channelHandler);
+    o2::mch::raw::PageDecoder decode =
+      mMapCRU.initialized() ? o2::mch::raw::createPageDecoder(page, channelHandler, linkHandler) : o2::mch::raw::createPageDecoder(page, channelHandler);
     patchPage(page);
     decode(page);
   }
@@ -153,13 +313,19 @@ class DataDecoderTask
 
     mDs2manu = ic.options().get<bool>("ds2manu");
     mPrint = ic.options().get<bool>("print");
+
+    auto mapCRUfile = ic.options().get<std::string>("cru-map");
+    auto mapFECfile = ic.options().get<std::string>("fec-map");
+
+    if (!mapCRUfile.empty())
+      mMapCRU.load(mapCRUfile);
+    if (!mapFECfile.empty())
+      mMapFEC.load(mapFECfile);
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void decodeTF(framework::ProcessingContext& pc, std::vector<o2::mch::Digit>& digits)
   {
-    std::vector<o2::mch::Digit> digits;
-
     // get the input buffer
     auto& inputs = pc.inputs();
     DPLRawParser parser(inputs, o2::framework::select("TF:MCH/RAWDATA"));
@@ -177,6 +343,51 @@ class DataDecoderTask
 
       gsl::span<const std::byte> buffer(reinterpret_cast<const std::byte*>(raw), sizeof(o2::header::RAWDataHeaderV4) + payloadSize);
       decodeBuffer(buffer, digits);
+    }
+  }
+
+  //_________________________________________________________________________________________________
+  void decodeReadout(const o2::framework::DataRef& input, std::vector<o2::mch::Digit>& digits)
+  {
+    static int nFrame = 1;
+    // get the input buffer
+    if (input.spec->binding != "readout")
+      return;
+
+    const auto* header = o2::header::get<header::DataHeader*>(input.header);
+    if (false)
+      printf("Header: %p\n", (void*)header);
+    if (!header)
+      return;
+
+    if (false)
+      printf("payloadSize: %d\n", (int)header->payloadSize);
+    if (false)
+      printf("payload: %p\n", input.payload);
+
+    auto const* raw = input.payload;
+    // size of payload
+    size_t payloadSize = header->payloadSize;
+
+    if (mPrint)
+      std::cout << nFrame << "  payloadSize=" << payloadSize << std::endl;
+    nFrame += 1;
+    if (payloadSize == 0)
+      return;
+
+    gsl::span<const std::byte> buffer(reinterpret_cast<const std::byte*>(raw), payloadSize);
+    decodeBuffer(buffer, digits);
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    std::vector<o2::mch::Digit> digits;
+
+    decodeTF(pc, digits);
+    for (auto&& input : pc.inputs()) {
+      if (input.spec->binding == "readout")
+        decodeReadout(input, digits);
     }
 
     if (mPrint) {
@@ -199,11 +410,14 @@ class DataDecoderTask
 
  private:
   std::function<std::optional<DsDetId>(DsElecId)> mElec2Det;
+  std::function<std::optional<uint16_t>(FeeLinkId)> mFee2LinkId{nullptr};
   size_t mNrdhs{0};
 
   std::ifstream mInputFile{}; ///< input file
   bool mDs2manu = false;      ///< print convert channel numbering from Run3 to Run1-2 order
   bool mPrint = false;        ///< print digits
+  MapCRU mMapCRU;
+  MapFEC mMapFEC;
 };
 
 //_________________________________________________________________________________________________
@@ -211,10 +425,14 @@ o2::framework::DataProcessorSpec getDecodingSpec()
 {
   return DataProcessorSpec{
     "DataDecoder",
-    o2::framework::select("TF:MCH/RAWDATA"),
+    //o2::framework::select("TF:MCH/RAWDATA, re:ROUT/RAWDATA"),
+    o2::framework::select("readout:ROUT/RAWDATA"),
     Outputs{OutputSpec{"MCH", "DIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<DataDecoderTask>()},
-    Options{{"print", VariantType::Bool, false, {"print digits"}}, {"ds2manu", VariantType::Bool, false, {"convert channel numbering from Run3 to Run1-2 order"}}}};
+    Options{{"print", VariantType::Bool, false, {"print digits"}},
+            {"cru-map", VariantType::String, "", {"custom CRU mapping"}},
+            {"fec-map", VariantType::String, "", {"custom FEC mapping"}},
+            {"ds2manu", VariantType::Bool, false, {"convert channel numbering from Run3 to Run1-2 order"}}}};
 }
 
 } // end namespace raw

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -87,7 +87,7 @@ class MapSolar
   {
     mLink = -1;
   }
-  ~MapSolar() {}
+  ~MapSolar() = default;
 };
 
 class MapCRU
@@ -156,7 +156,7 @@ class MapDualSampa
     mBad = 1;
   }
 
-  ~MapDualSampa() {}
+  ~MapDualSampa() = default;
 };
 
 class MapFEC

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -81,32 +81,27 @@ int ds2manu(int i)
 class MapSolar
 {
  public:
-  int mLink; // link ID
+  int mLink = {-1}; // link ID
 
-  MapSolar()
-  {
-    mLink = -1;
-  }
+  MapSolar() = default;
   ~MapSolar() = default;
 };
 
+
+// CRU mapping
 class MapCRU
 {
-  bool mInitialized;
+  bool mInitialized = {false};
   MapSolar mSolarMap[MCH_MAX_FEEID][MCH_MAX_CRU_LINK];
 
  public:
-  MapCRU();
+  MapCRU() = default;
+  ~MapCRU() = default;
   bool load(std::string mapFile);
   bool initialized() { return mInitialized; }
   int32_t getLink(int32_t c, int32_t l);
 };
 
-// CRU mapping
-MapCRU::MapCRU()
-{
-  mInitialized = false;
-}
 
 bool MapCRU::load(std::string mapFile)
 {
@@ -135,6 +130,8 @@ bool MapCRU::load(std::string mapFile)
 
 int32_t MapCRU::getLink(int32_t c, int32_t l)
 {
+  if (!initialized()) return -1;
+
   int32_t result = -1;
   if (c < 0 || c >= MCH_MAX_FEEID)
     return result;
@@ -143,39 +140,32 @@ int32_t MapCRU::getLink(int32_t c, int32_t l)
   return mSolarMap[c][l].mLink;
 }
 
+
 class MapDualSampa
 {
  public:
-  int mDE;    // detector element
-  int mIndex; // DS index
-  int mBad;   // if = 1 bad pad (not used for analysis)
+  int mDE = {-1};    // detector element
+  int mIndex = {-1}; // DS index
+  int mBad = {-1};   // if = 1 bad pad (not used for analysis)
 
-  MapDualSampa()
-  {
-    mDE = mIndex = -1;
-    mBad = 1;
-  }
-
+  MapDualSampa() = default;
   ~MapDualSampa() = default;
 };
 
+
+// Electronics mapping
 class MapFEC
 {
-  bool mInitialized;
+  bool mInitialized = {false};
   MapDualSampa mDsMap[LINKID_MAX + 1][40];
 
  public:
-  MapFEC();
+  MapFEC() = default;
+  ~MapFEC() = default;
   bool load(std::string mapFile);
   bool initialized() { return mInitialized; }
   bool getDsId(uint32_t link_id, uint32_t ds_addr, int& de, int& dsid);
 };
-
-// Electronics mapping
-MapFEC::MapFEC()
-{
-  mInitialized = false;
-}
 
 bool MapFEC::load(std::string mapFile)
 {
@@ -208,6 +198,8 @@ bool MapFEC::load(std::string mapFile)
 
 bool MapFEC::getDsId(uint32_t link_id, uint32_t ds_addr, int& de, int& dsid)
 {
+  if (!initialized()) return false;
+
   if (mDsMap[link_id][ds_addr].mBad == 1)
     return false;
   de = mDsMap[link_id][ds_addr].mDE;
@@ -398,7 +390,7 @@ class DataDecoderTask
 
     const size_t OUT_SIZE = sizeof(o2::mch::Digit) * digits.size();
 
-    /// send the output buffer via DPL
+    // send the output buffer via DPL
     char* outbuffer = nullptr;
     outbuffer = (char*)realloc(outbuffer, OUT_SIZE);
     memcpy(outbuffer, digits.data(), OUT_SIZE);

--- a/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
@@ -61,11 +61,9 @@ class DigitSamplerTask
     mUseRun2DigitUID = ic.options().get<bool>("useRun2DigitUID");
     mPrint = ic.options().get<bool>("print");
     mNevents = ic.options().get<int>("nevents");
-    if (mNevents == 0)
-      mNevents = -1;
 
     auto stop = [this]() {
-      /// close the input file
+      // close the input file
       LOG(INFO) << "stop digit sampler";
       this->mInputFile.close();
     };
@@ -79,13 +77,12 @@ class DigitSamplerTask
 
     if (mNevents == 0) {
       pc.services().get<ControlService>().endOfStream();
-      return; // probably reached eof
+      return;
     } else if (mNevents > 0) {
       mNevents -= 1;
     }
 
-    /// send the digits of the current event
-
+    // send the digits of the current event
     int nDigits(0);
     mInputFile.read(reinterpret_cast<char*>(&nDigits), sizeof(int));
     if (mInputFile.fail()) {
@@ -151,7 +148,7 @@ o2::framework::DataProcessorSpec getDigitSamplerSpec()
     Options{{"infile", VariantType::String, "", {"input file name"}},
             {"useRun2DigitUID", VariantType::Bool, false, {"mPadID = digit UID in run2 format"}},
             {"print", VariantType::Bool, false, {"print digits"}},
-            {"nevents", VariantType::Int, 0, {"number of events to process (0 = all events in the file)"}}}};
+            {"nevents", VariantType::Int, -1, {"number of events to process (-1 = all events in the file)"}}}};
 }
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
@@ -59,6 +59,10 @@ class DigitSamplerTask
     }
 
     mUseRun2DigitUID = ic.options().get<bool>("useRun2DigitUID");
+    mPrint = ic.options().get<bool>("print");
+    mNevents = ic.options().get<int>("nevents");
+    if (mNevents == 0)
+      mNevents = -1;
 
     auto stop = [this]() {
       /// close the input file
@@ -71,6 +75,15 @@ class DigitSamplerTask
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
+    /// check the number of processed events
+
+    if (mNevents == 0) {
+      pc.services().get<ControlService>().endOfStream();
+      return; // probably reached eof
+    } else if (mNevents > 0) {
+      mNevents -= 1;
+    }
+
     /// send the digits of the current event
 
     int nDigits(0);
@@ -111,6 +124,8 @@ class DigitSamplerTask
       int manuCh = (digitID & 0x3F000000) >> 24;
 
       int padID = mapping::segmentation(deID).findPadByFEE(manuID, manuCh);
+      if (mPrint)
+        cout << deID << "  " << digitID << "  " << manuID << "  " << manuCh << "  " << padID << endl;
       if (padID < 0) {
         throw runtime_error(std::string("digitID ") + digitID + " does not exist in the mapping");
       }
@@ -121,6 +136,8 @@ class DigitSamplerTask
 
   std::ifstream mInputFile{};    ///< input file
   bool mUseRun2DigitUID = false; ///< true if Digit.mPadID = digit UID in run2 format
+  bool mPrint = false;           ///< print digits to terminal
+  int mNevents = 0;              ///< number of events to process
 };
 
 //_________________________________________________________________________________________________
@@ -132,7 +149,9 @@ o2::framework::DataProcessorSpec getDigitSamplerSpec()
     Outputs{OutputSpec{"MCH", "DIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<DigitSamplerTask>()},
     Options{{"infile", VariantType::String, "", {"input file name"}},
-            {"useRun2DigitUID", VariantType::Bool, false, {"mPadID = digit UID in run2 format"}}}};
+            {"useRun2DigitUID", VariantType::Bool, false, {"mPadID = digit UID in run2 format"}},
+            {"print", VariantType::Bool, false, {"print digits"}},
+            {"nevents", VariantType::Int, 0, {"number of events to process (0 = all events in the file)"}}}};
 }
 
 } // end namespace mch


### PR DESCRIPTION
This PR adds the possibility to apply a custom mapping of CRU links and DS boards.

The decoding DPL workflow has now two options for loading a custom mapping from external text files, like this:
```
o2-mch-raw-to-digits-workflow -b --cru-map cru.map --fec-map fec.map
```

@aphecetche could you please review the changes?