### PR TITLE
Make sure compile options (particularly -Werror) are not lost for CUDA

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,5 +8,5 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-include("${CMAKE_CURRENT_LIST_DIR}/O2Dependencies.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/O2CompileFlags.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/O2Dependencies.cmake")

--- a/dependencies/FindO2GPU.cmake
+++ b/dependencies/FindO2GPU.cmake
@@ -59,10 +59,13 @@ if(ENABLE_CUDA)
 
     # Forward CXX flags to CUDA C++ Host compiler (for warnings, gdb, etc.)
     STRING(REGEX REPLACE "\-std=[^ ]*" "" CMAKE_CXX_FLAGS_NOSTD ${CMAKE_CXX_FLAGS}) # Need to strip c++17 imposed by alidist defaults
-    set(CMAKE_CUDA_FLAGS "-Xcompiler \"${CMAKE_CXX_FLAGS_NOSTD}\" --expt-relaxed-constexpr -Xptxas -v")
-    set(CMAKE_CUDA_FLAGS_DEBUG "-lineinfo -Xcompiler \"${CMAKE_CXX_FLAGS_DEBUG}\" -Xptxas -O0 -Xcompiler -O0")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler \"${CMAKE_CXX_FLAGS_NOSTD}\" --expt-relaxed-constexpr -Xptxas -v")
+    set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -lineinfo -Xcompiler \"${CMAKE_CXX_FLAGS_DEBUG}\" -Xptxas -O0 -Xcompiler -O0")
     if(NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-      set(CMAKE_CUDA_FLAGS_${CMAKE_BUILD_TYPE} "-Xcompiler \"${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}\" -Xptxas -O4 -Xcompiler -O4 -use_fast_math --ftz=true")
+      set(CMAKE_CUDA_FLAGS_${CMAKE_BUILD_TYPE} "${CMAKE_CUDA_FLAGS_${CMAKE_BUILD_TYPE}} -Xcompiler \"${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}\" -Xptxas -O4 -Xcompiler -O4 -use_fast_math --ftz=true")
+    endif()
+    if(CMAKE_CXX_FLAGS MATCHES "(^| )-Werror( |$)")
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror=cross-execution-space-call")
     endif()
     if(CUDA_COMPUTETARGET)
       set(


### PR DESCRIPTION
@shahor02 : This fixes the -Werror, which was lost before in the CUDA compilation. In addition, it enables -Werror for the device functions (triggering an error on the problem discussed in #3408).
This means, the warnings in RDHUtils.h must be fixed before this can be merged.