### PR TITLE
[TEST] Brute-force silencing of some cuda warnings

### DIFF
--- a/DataFormats/Headers/include/Headers/DAQID.h
+++ b/DataFormats/Headers/include/Headers/DAQID.h
@@ -14,7 +14,9 @@
 #ifndef DETECTOR_BASE_RAWDAQID_H
 #define DETECTOR_BASE_RAWDAQID_H
 
+#ifndef GPUCA_GPUCODE
 #include "Headers/DataHeader.h"
+#endif
 
 namespace o2
 {
@@ -56,6 +58,8 @@ class DAQID
   operator ID() const { return static_cast<ID>(mID); }
 
   ID getID() const { return mID; }
+
+#ifndef GPUCA_GPUCODE
   constexpr o2::header::DataOrigin getO2Origin() { return DAQtoO2(mID); }
 
   static constexpr o2::header::DataOrigin DAQtoO2(ID daq)
@@ -67,10 +71,12 @@ class DAQID
   {
     return or2daq(o2orig, MINDAQ);
   }
+#endif
 
  private:
   ID mID = INVALID;
 
+#ifndef GPUCA_GPUCODE
   static constexpr o2::header::DataOrigin MAP_DAQtoO2[] = {
     "NIL", "NIL", "NIL",
     "TPC", "TRD", "TOF", "HMP", "PHS", "CPV",
@@ -87,6 +93,7 @@ class DAQID
   {
     return id > MAXDAQ ? INVALID : (origin == MAP_DAQtoO2[id] ? id : or2daq(origin, id + 1));
   }
+#endif
 };
 
 } // namespace header

--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -19,10 +19,7 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
-
-#ifndef GPUCA_GPUCODE
 #include "Headers/DAQID.h"
-#endif // GPUCA_GPUCODE
 
 namespace o2
 {
@@ -33,7 +30,6 @@ using IR = o2::InteractionRecord;
 
 struct RDHUtils {
 
-// disable is the type is a pointer
 #define NOTPTR(T) typename std::enable_if<!std::is_pointer<T>::value>::type* = 0
 // dereference SRC pointer as DST type reference
 #define TOREF(DST, SRC) *reinterpret_cast<DST*>(SRC)
@@ -71,6 +67,7 @@ struct RDHUtils {
   }
 
   ///_______________________________
+#pragma hd_warning_disable
   template <typename H>
   GPUhdi() static uint8_t getVersion(const H& rdh, NOTPTR(H))
   {
@@ -369,6 +366,7 @@ struct RDHUtils {
   }
 
   ///_______________________________
+#pragma hd_warning_disable
   template <typename H>
   GPUhdi() static IR getHeartBeatIR(const H& rdh, NOTPTR(H))
   {
@@ -386,6 +384,7 @@ struct RDHUtils {
   }
 
   ///_______________________________
+#pragma hd_warning_disable
   template <typename H>
   GPUhdi() static IR getTriggerIR(const H& rdh, NOTPTR(H))
   {
@@ -647,8 +646,7 @@ struct RDHUtils {
   static bool checkRDH(const void* rdhP, bool verbose = true);
 
   ///_______________________________
-#ifndef GPUCA_GPUCODE
-  static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId, o2::header::DAQID::ID srcid = o2::header::DAQID::INVALID)
+  GPUhdi() static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId, o2::header::DAQID::ID srcid = o2::header::DAQID::INVALID)
   {
     // Adapt the same definition as DataDistribution
     // meaningfull DAQ sourceID means that it comes from RDHv6, in this case we use feeID as a subspec
@@ -664,11 +662,10 @@ struct RDHUtils {
     // return fletcher32(seq, 3);
   }
   template <typename H>
-  static LinkSubSpec_t getSubSpec(const H& rdh, NOTPTR(H)) // will be used for all RDH versions but >=6
+  GPUhdi() static LinkSubSpec_t getSubSpec(const H& rdh, NOTPTR(H)) // will be used for all RDH versions but >=6
   {
     return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId, o2::header::DAQID::INVALID);
   }
-#endif // GPUCA_GPUCODE
   GPUhdi() static LinkSubSpec_t getSubSpec(const RDHv6& rdh)
   {
     return getFEEID(rdh);


### PR DESCRIPTION
@davidrohr I did not understand if the warnings like:
````
warning: calling a __host__ function from a __host__ __device__ function is not allowed
          detected during instantiation of "o2::raw::IR o2::raw::RDHUtils::getHeartBeatIR(const H &, std::enable_if<<expression>, void>::type *) [with H=o2::raw::RDHUtils::RDHv4]" 
````
are about a real problem or fake, since there are no non-GPUhdi-tagged functions explicitly involved.

The brute force silencing the warnings by adding ``#pragma hd_warning_disable`` in front of the functions it complains about works, but then I am not sure if it is really enough.