### PR TITLE
Fixes usage of HBFUtils::nOrbitsPerTF in TOF (e.g. raw data generation with non-standard) 

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -53,6 +53,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
   workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
   workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -84,7 +85,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     LOG(ERROR) << "This workflow needs a valid GRP file to start";
     return specs;
   }
-
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
 
   // the lane configuration defines the subspecification ids to be distributed among the lanes.

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -25,8 +25,6 @@ namespace tof
 class Geo
 {
  public:
-  static int ORBIT_IN_TF; // N. orbits crossing in 1 TF
-  static double NS_IN_TF;
   //  static void updateNSinTF() { NS_IN_TF = o2::constants::lhc::LHCOrbitNS * o2::raw::HBFUtils::getNOrbitsPerTF(); }
 
   // From AliTOFGeometry

--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -14,6 +14,7 @@
 #include "TOFBase/Geo.h"
 #include "TOFBase/Digit.h"
 #include "TOFBase/Strip.h"
+#include "DetectorsRaw/HBFUtils.h"
 
 namespace o2
 {
@@ -35,7 +36,13 @@ class WindowFiller
 
   Int_t getCurrentReadoutWindow() const { return mReadoutWindowCurrent; }
   void setCurrentReadoutWindow(Double_t value) { mReadoutWindowCurrent = value; }
-  void setEventTime(double value) { mEventTime = value - mTF * Geo::NS_IN_TF; }
+  void setEventTime(double value)
+  {
+    mEventTime = value;
+    if (mTF) {
+      mEventTime -= mTF * o2::constants::lhc::LHCOrbitNS * o2::raw::HBFUtils::Instance().getNOrbitsPerTF(); // RS: is this needed?
+    }
+  }
 
   std::vector<Digit>* getDigitPerTimeFrame() { return &mDigitsPerTimeFrame; }
   std::vector<ReadoutWindowData>* getReadoutWindowData() { return &mReadoutWindowData; }

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -18,9 +18,6 @@ ClassImp(o2::tof::Geo);
 
 using namespace o2::tof;
 
-int Geo::ORBIT_IN_TF = o2::raw::HBFUtils::Instance().getNOrbitsPerTF(); // RS This should not be in GEO!!!
-double Geo::NS_IN_TF = o2::constants::lhc::LHCOrbitNS * o2::raw::HBFUtils::Instance().getNOrbitsPerTF();
-
 constexpr Float_t Geo::ANGLES[NPLATES][NMAXNSTRIP];
 constexpr Float_t Geo::HEIGHTS[NPLATES][NMAXNSTRIP];
 constexpr Float_t Geo::DISTANCES[NPLATES][NMAXNSTRIP];

--- a/Detectors/TOF/reconstruction/src/Encoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Encoder.cxx
@@ -262,7 +262,7 @@ bool Encoder::encode(std::vector<std::vector<o2::tof::Digit>> digitWindow, int t
   mEventCounter = tofwindow; // tof window index
   mIR.orbit = mEventCounter / Geo::NWINDOW_IN_ORBIT;
 
-  if (!(mIR.orbit % Geo::ORBIT_IN_TF)) { // new TF
+  if (!(mIR.orbit % mHBFSampler.getNOrbitsPerTF())) { // new TF
     flush();
   }
 
@@ -418,7 +418,7 @@ void Encoder::openRDH(int icrate)
     //    mRDH[icrate]->triggerType |= mIsContinuous ? o2::trigger::SOC : o2::trigger::SOT;
     mRDH[icrate]->triggerType |= o2::trigger::SOT;
   }
-  if (!(mIR.orbit % Geo::ORBIT_IN_TF))
+  if (!(mIR.orbit % mHBFSampler.getNOrbitsPerTF()))
     mRDH[icrate]->triggerType |= o2::trigger::TF;
 
   // word6
@@ -478,7 +478,7 @@ void Encoder::closeRDH(int icrate)
     //    mRDH[icrate]->triggerType |= mIsContinuous ? o2::trigger::SOC : o2::trigger::SOT;
     mRDH[icrate]->triggerType |= o2::trigger::SOT;
   }
-  if (!(mIR.orbit % Geo::ORBIT_IN_TF))
+  if (!(mIR.orbit % mHBFSampler.getNOrbitsPerTF()))
     mRDH[icrate]->triggerType |= o2::trigger::TF;
 
   // word6

--- a/Detectors/TOF/simulation/src/Digitizer.cxx
+++ b/Detectors/TOF/simulation/src/Digitizer.cxx
@@ -101,9 +101,6 @@ int Digitizer::process(const std::vector<HitType>* hits, std::vector<Digit>* dig
     } // close loop readout window
   }   // close if continuous
 
-  // if (mReadoutWindowCurrent >= Geo::ORBIT_IN_TF * Geo::NWINDOW_IN_ORBIT) // new TF
-  //   return 1;
-
   for (auto& hit : *hits) {
     //TODO: put readout window counting/selection
 

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -108,7 +108,7 @@ void CompressedDecodingTask::rdhHandler(const o2::header::RAWDataHeader* rdh)
 {
 
   // rdh close
-  if (rdh->stop && rdh->heartbeatOrbit == Geo::ORBIT_IN_TF - 1 + mInitOrbit) {
+  if (rdh->stop && rdh->heartbeatOrbit == o2::raw::HBFUtils::Instance().getNOrbitsPerTF() - 1 + mInitOrbit) {
     mNCrateCloseTF++;
     printf("New TF close RDH %d\n", int(rdh->feeId));
     return;

--- a/Detectors/TOF/workflow/src/TOFRawWriterSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFRawWriterSpec.cxx
@@ -13,6 +13,7 @@
 #include "TOFWorkflow/TOFRawWriterSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "DetectorsRaw/HBFUtils.h"
 #include "TOFBase/Geo.h"
 
 using namespace o2::framework;
@@ -49,7 +50,7 @@ void RawWriter::run(ProcessingContext& pc)
   encoder.alloc(cache);
 
   int nwindowperorbit = Geo::NWINDOW_IN_ORBIT;
-  int nwindowintimeframe = Geo::ORBIT_IN_TF * nwindowperorbit;
+  int nwindowintimeframe = o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * nwindowperorbit;
   int nwindowFilled = nwindow;
   if (nwindowFilled % nwindowintimeframe) {
     nwindowFilled = (nwindowFilled / nwindowintimeframe + 1) * nwindowintimeframe;


### PR DESCRIPTION
Hi @noferini 
Since you were caching the HBFUtils::getNOrbitsPerTF in  ``Geo::ORBIT_IN_TF``, the eventual changes in the former were not propagating to the code which needed this parameter.
This PR changes the caching to direct use of HBFUtils. Also, it allows to pass the ``configKeyValues`` option to TOF workflow, needed e.g. to set non-standard values in HBFUtils. No I am at least able to generate raw data with e.g. 128 HB per TF.

Still, I see some problems in  the raw data generation, please see comments I am adding to this PR.