### PR TITLE
Adding TPCdEdxCalibrationSplines class to correct the dEdx for geometrical and track topological effects

### DIFF
--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -25,6 +25,7 @@
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 
 #include "TPCFastTransform.h"
+#include "TPCdEdxCalibrationSplines.h"
 #include "GPUO2InterfaceConfiguration.h"
 
 using namespace o2::gpu;
@@ -73,6 +74,8 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
 
   std::unique_ptr<TPCFastTransform> fastTransform(TPCFastTransformHelperO2::instance()->create(0));
   config.configCalib.fastTransform = fastTransform.get();
+  std::unique_ptr<o2::gpu::TPCdEdxCalibrationSplines> dEdxSplines(new TPCdEdxCalibrationSplines);
+  config.configCalib.dEdxSplines = dEdxSplines.get();
 
   tracker.initialize(config);
   std::vector<ClusterNativeContainer> cont(Constants::MAXGLOBALPADROW);

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -66,6 +66,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 class TPCFastTransform;
+class TPCdEdxCalibrationSplines;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
@@ -161,6 +162,7 @@ struct GPUCalibObjectsTemplate {
   typename S<TPCFastTransform>::type* fastTransform = nullptr;
   typename S<o2::base::MatLayerCylSet>::type* matLUT = nullptr;
   typename S<o2::trd::TRDGeometryFlat>::type* trdGeometry = nullptr;
+  typename S<TPCdEdxCalibrationSplines>::type* dEdxSplines = nullptr;
 };
 typedef GPUCalibObjectsTemplate<DefaultPtr> GPUCalibObjects;
 typedef GPUCalibObjectsTemplate<ConstPtr> GPUCalibObjectsConst;

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -119,6 +119,7 @@ set(HDRS_INSTALL
     Base/GPUMemorySizeScalers.h
     Base/GPURawData.h
     dEdx/GPUdEdxInfo.h
+    dEdx/TPCdEdxCalibrationSplines.h
     TPCConvert/GPUTPCConvertImpl.h
     Base/GPUReconstructionKernelMacros.h
     Base/GPUO2FakeClasses.h
@@ -143,6 +144,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR CONFIG_O2_EXTENSIONS)
         ITS/GPUITSFitter.cxx
         ITS/GPUITSFitterKernels.cxx
         dEdx/GPUdEdx.cxx
+        dEdx/TPCdEdxCalibrationSplines.cxx
         TPCConvert/GPUTPCConvert.cxx
         TPCConvert/GPUTPCConvertKernel.cxx
         DataCompression/GPUTPCCompression.cxx

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -57,7 +57,8 @@ set(SRCS
     TRDTracking/GPUTRDTracker.cxx
     TRDTracking/GPUTRDTrackletWord.cxx
     TRDTracking/GPUTRDTrackerKernels.cxx
-    Base/GPUParam.cxx)
+    Base/GPUParam.cxx
+    dEdx/TPCdEdxCalibrationSplines.cxx)
 
 set(SRCS_NO_CINT
     Base/GPUDataTypes.cxx
@@ -128,7 +129,7 @@ set(HDRS_INSTALL
 # Sources only for O2
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   set(SRCS ${SRCS} Interface/GPUO2Interface.cxx)
-  set(HDRS_CINT_O2 ${HDRS_CINT_O2} Interface/GPUO2Interface.h)
+  set(HDRS_CINT_O2 ${HDRS_CINT_O2} Interface/GPUO2Interface.h dEdx/TPCdEdxCalibrationSplines.h)
 endif()
 
 # Sources for O2 and for Standalone if requested in config file
@@ -167,7 +168,6 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR CONFIG_O2_EXTENSIONS)
     set(HDRS_INSTALL ${HDRS_INSTALL}
                      Interface/GPUO2InterfaceConfiguration.h
                      ITS/GPUITSTrack.h
-                     dEdx/GPUdEdxInfo.h
                      TPCClusterFinder/Array2D.h
                      TPCClusterFinder/CfConsts.h
                      TPCClusterFinder/CfFragment.h

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
@@ -18,5 +18,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::gpu::GPUTPCO2Interface + ;
+#pragma link C++ class o2::gpu::TPCdEdxCalibrationSplines + ;
 
 #endif

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -230,6 +230,10 @@ bool GPUChainTracking::ValidateSteps()
     GPUError("No TRD Tracker Output available");
     return false;
   }
+  if ((GetRecoSteps() & GPUDataTypes::RecoStep::TPCdEdx) && processors()->calibObjects.dEdxSplines == nullptr) {
+    GPUError("Cannot run dE/dx without calibration splines");
+    return false;
+  }
   return true;
 }
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -56,6 +56,7 @@ class GPUQA;
 class GPUTPCClusterStatistics;
 class GPUTRDGeometry;
 class TPCFastTransform;
+class TPCdEdxCalibrationSplines;
 class GPUTrackingInputProvider;
 
 class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelegateBase
@@ -138,13 +139,16 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   // Getters / setters for parameters
   const TPCFastTransform* GetTPCTransform() const { return processors()->calibObjects.fastTransform; }
+  const TPCdEdxCalibrationSplines* GetdEdxSplines() const { return processors()->calibObjects.dEdxSplines; }
   const o2::base::MatLayerCylSet* GetMatLUT() const { return processors()->calibObjects.matLUT; }
   const GPUTRDGeometry* GetTRDGeometry() const { return (GPUTRDGeometry*)processors()->calibObjects.trdGeometry; }
   const o2::tpc::ClusterNativeAccess* GetClusterNativeAccess() const { return mClusterNativeAccess.get(); }
   void SetTPCFastTransform(std::unique_ptr<TPCFastTransform>&& tpcFastTransform);
+  void SetdEdxSplines(std::unique_ptr<TPCdEdxCalibrationSplines>&& dEdxSplines);
   void SetMatLUT(std::unique_ptr<o2::base::MatLayerCylSet>&& lut);
   void SetTRDGeometry(std::unique_ptr<o2::trd::TRDGeometryFlat>&& geo);
   void SetTPCFastTransform(const TPCFastTransform* tpcFastTransform) { processors()->calibObjects.fastTransform = tpcFastTransform; }
+  void SetdEdxSplines(const TPCdEdxCalibrationSplines* dEdxSplines) { processors()->calibObjects.dEdxSplines = dEdxSplines; }
   void SetMatLUT(const o2::base::MatLayerCylSet* lut) { processors()->calibObjects.matLUT = lut; }
   void SetTRDGeometry(const o2::trd::TRDGeometryFlat* geo) { processors()->calibObjects.trdGeometry = geo; }
   void LoadClusterErrors();
@@ -157,6 +161,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     GPUChainTracking* mChainTracking = nullptr;
     GPUCalibObjects mCalibObjects;
     char* mTpcTransformBuffer = nullptr;
+    char* mdEdxSplinesBuffer = nullptr;
     char* mMatLUTBuffer = nullptr;
     short mMemoryResFlat = -1;
     void* SetPointersFlatObjects(void* mem);
@@ -204,6 +209,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   std::unique_ptr<o2::tpc::ClusterNativeAccess> mClusterNativeAccess; // Internal memory for clusterNativeAccess
   std::unique_ptr<GPUTrackingInOutDigits> mDigitMap;                  // Internal memory for digit-map, if needed
   std::unique_ptr<TPCFastTransform> mTPCFastTransformU;               // Global TPC fast transformation object
+  std::unique_ptr<TPCdEdxCalibrationSplines> mdEdxSplinesU;           // TPC dEdx calibration splines
   std::unique_ptr<o2::base::MatLayerCylSet> mMatLUTU;                 // Material Lookup Table
   std::unique_ptr<o2::trd::TRDGeometryFlat> mTRDGeometryU;            // TRD Geometry
   std::unique_ptr<unsigned long long int[]> mTPCZSBuffer;             // Memory to store TPC ZS pages

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -49,6 +49,7 @@
 #endif
 
 #include "TPCFastTransform.h"
+#include "TPCdEdxCalibrationSplines.h"
 
 #include "utils/linux_helpers.h"
 
@@ -251,21 +252,26 @@ int GPUChainTracking::ReadData(const char* filename)
 void GPUChainTracking::DumpSettings(const char* dir)
 {
   std::string f;
-  f = dir;
-  f += "tpctransform.dump";
   if (processors()->calibObjects.fastTransform != nullptr) {
+    f = dir;
+    f += "tpctransform.dump";
     DumpFlatObjectToFile(processors()->calibObjects.fastTransform, f.c_str());
   }
 
 #ifdef HAVE_O2HEADERS
-  f = dir;
-  f += "matlut.dump";
+  if (processors()->calibObjects.dEdxSplines != nullptr) {
+    f = dir;
+    f += "dedxsplines.dump";
+    DumpFlatObjectToFile(processors()->calibObjects.dEdxSplines, f.c_str());
+  }
   if (processors()->calibObjects.matLUT != nullptr) {
+    f = dir;
+    f += "matlut.dump";
     DumpFlatObjectToFile(processors()->calibObjects.matLUT, f.c_str());
   }
-  f = dir;
-  f += "trdgeometry.dump";
   if (processors()->calibObjects.trdGeometry != nullptr) {
+    f = dir;
+    f += "matlut.dump";
     DumpStructToFile(processors()->calibObjects.trdGeometry, f.c_str());
   }
 
@@ -280,6 +286,10 @@ void GPUChainTracking::ReadSettings(const char* dir)
   mTPCFastTransformU = ReadFlatObjectFromFile<TPCFastTransform>(f.c_str());
   processors()->calibObjects.fastTransform = mTPCFastTransformU.get();
 #ifdef HAVE_O2HEADERS
+  f = dir;
+  f += "dedxsplines.dump";
+  mdEdxSplinesU = ReadFlatObjectFromFile<TPCdEdxCalibrationSplines>(f.c_str());
+  processors()->calibObjects.dEdxSplines = mdEdxSplinesU.get();
   f = dir;
   f += "matlut.dump";
   mMatLUTU = ReadFlatObjectFromFile<o2::base::MatLayerCylSet>(f.c_str());

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -52,6 +52,7 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
   }
   mRec->SetSettings(&mConfig->configEvent, &mConfig->configReconstruction, &mConfig->configDeviceProcessing, &mConfig->configWorkflow);
   mChain->SetTPCFastTransform(mConfig->configCalib.fastTransform);
+  mChain->SetdEdxSplines(mConfig->configCalib.dEdxSplines);
   mChain->SetMatLUT(mConfig->configCalib.matLUT);
   mChain->SetTRDGeometry(mConfig->configCalib.trdGeometry);
   if (mRec->Init()) {

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -39,7 +39,6 @@ namespace o2::gpu
 class GPUReconstruction;
 class GPUChainTracking;
 struct GPUO2InterfaceConfiguration;
-class TPCFastTransform;
 
 class GPUTPCO2Interface
 {

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -300,10 +300,10 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* GPUrestrict() merger, 
         }
         if (dEdxOut && iWay == nWays - 1 && clusters[ihit].leg == clusters[maxN - 1].leg) {
           if (merger->GetConstantMem()->ioPtrs.clustersNative == nullptr) {
-            dEdx.fillCluster(clusters[ihit].amp, 0, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines);
+            dEdx.fillCluster(clusters[ihit].amp, 0, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines, zz);
           } else {
             const ClusterNative& cl = merger->GetConstantMem()->ioPtrs.clustersNative->clustersLinear[clusters[ihit].num];
-            dEdx.fillCluster(cl.qTot, cl.qMax, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines);
+            dEdx.fillCluster(cl.qTot, cl.qMax, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines, zz);
           }
         }
       } else if (retVal == 2) { // cluster far away form the track

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -300,10 +300,10 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* GPUrestrict() merger, 
         }
         if (dEdxOut && iWay == nWays - 1 && clusters[ihit].leg == clusters[maxN - 1].leg) {
           if (merger->GetConstantMem()->ioPtrs.clustersNative == nullptr) {
-            dEdx.fillCluster(clusters[ihit].amp, 0, clusters[ihit].row, mP[2], mP[3], param);
+            dEdx.fillCluster(clusters[ihit].amp, 0, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines);
           } else {
             const ClusterNative& cl = merger->GetConstantMem()->ioPtrs.clustersNative->clustersLinear[clusters[ihit].num];
-            dEdx.fillCluster(cl.qTot, cl.qMax, clusters[ihit].row, mP[2], mP[3], param);
+            dEdx.fillCluster(cl.qTot, cl.qMax, clusters[ihit].row, mP[2], mP[3], param, merger->GetConstantMem()->calibObjects.dEdxSplines);
           }
         }
       } else if (retVal == 2) { // cluster far away form the track

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -103,8 +103,13 @@ GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trac
   const float sec2 = 1.f / (1.f - snp2);
   // angleZ: z angle - dz/dx (cm/cm)
   const float angleZ = CAMath::Sqrt(tgl2 * sec2); // fast
-
+  if (angleZ > 3) {
+    angleZ = 3;
+  }
+  
   const int region = param.tpcGeometry.GetRegion(padRow);
+  z = CAMath::Abs(z);
+
   const float qMaxCorr = splines->interpolateqMax(region, angleZ, z);
   const float qTotCorr = splines->interpolateqTot(region, angleZ, z);
   qmax /= qMaxCorr;

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -43,7 +43,7 @@ class GPUdEdx
  public:
   // The driver must call clear(), fill clusters row by row outside-in, then run computedEdx() to get the result
   GPUd() void clear();
-  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param, const TPCdEdxCalibrationSplines* splines);
+  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param, const TPCdEdxCalibrationSplines* splines, float z);
   GPUd() void fillSubThreshold(int padRow, const GPUParam& param);
   GPUd() void computedEdx(GPUdEdxInfo& output, const GPUParam& param);
 
@@ -83,7 +83,7 @@ GPUdi() void GPUdEdx::checkSubThresh(int roc)
   mLastROC = roc;
 }
 
-GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& GPUrestrict() param, const TPCdEdxCalibrationSplines* splines)
+GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& GPUrestrict() param, const TPCdEdxCalibrationSplines* splines, float z)
 {
   if (mCount >= MAX_NCL) {
     return;
@@ -94,10 +94,21 @@ GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trac
   if (snp2 > GPUCA_MAX_SIN_PHI_LOW) {
     snp2 = GPUCA_MAX_SIN_PHI_LOW;
   }
-  float factor = CAMath::Sqrt((1 - snp2) / (1 + trackTgl * trackTgl));
+  float tgl2 = trackTgl * trackTgl;
+  float factor = CAMath::Sqrt((1 - snp2) / (1 + tgl2));
   factor /= param.tpcGeometry.PadHeight(padRow);
   qtot *= factor;
-  qmax *= factor / param.tpcGeometry.PadWidth(padRow);
+  qmax *= factor;
+
+  const float sec2 = 1.f / (1.f - snp2);
+  // angleZ: z angle - dz/dx (cm/cm)
+  const float angleZ = CAMath::Sqrt(tgl2 * sec2); // fast
+
+  const int region = param.tpcGeometry.GetRegion(padRow);
+  const float qMaxCorr = splines->interpolateqMax(region, angleZ, z);
+  const float qTotCorr = splines->interpolateqTot(region, angleZ, z);
+  qmax /= qMaxCorr;
+  qtot /= qTotCorr;
 
   mChargeTot[mCount] = qtot;
   mChargeMax[mCount++] = qmax;

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -102,7 +102,7 @@ GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trac
 
   const float sec2 = 1.f / (1.f - snp2);
   // angleZ: z angle - dz/dx (cm/cm)
-  const float angleZ = CAMath::Sqrt(tgl2 * sec2); // fast
+  float angleZ = CAMath::Sqrt(tgl2 * sec2); // fast
   if (angleZ > 3) {
     angleZ = 3;
   }

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -19,6 +19,7 @@
 #include "GPUCommonMath.h"
 #include "GPUParam.h"
 #include "GPUdEdxInfo.h"
+#include "TPCdEdxCalibrationSplines.h"
 
 namespace GPUCA_NAMESPACE
 {
@@ -30,7 +31,7 @@ class GPUdEdx
 {
  public:
   GPUd() void clear() {}
-  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param) {}
+  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param, const TPCdEdxCalibrationSplines* splines) {}
   GPUd() void fillSubThreshold(int padRow, const GPUParam& param) {}
   GPUd() void computedEdx(GPUdEdxInfo& output, const GPUParam& param) {}
 };
@@ -42,7 +43,7 @@ class GPUdEdx
  public:
   // The driver must call clear(), fill clusters row by row outside-in, then run computedEdx() to get the result
   GPUd() void clear();
-  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param);
+  GPUd() void fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& param, const TPCdEdxCalibrationSplines* splines);
   GPUd() void fillSubThreshold(int padRow, const GPUParam& param);
   GPUd() void computedEdx(GPUdEdxInfo& output, const GPUParam& param);
 
@@ -82,7 +83,7 @@ GPUdi() void GPUdEdx::checkSubThresh(int roc)
   mLastROC = roc;
 }
 
-GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& GPUrestrict() param)
+GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trackSnp, float trackTgl, const GPUParam& GPUrestrict() param, const TPCdEdxCalibrationSplines* splines)
 {
   if (mCount >= MAX_NCL) {
     return;

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -94,22 +94,23 @@ GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trac
   if (snp2 > GPUCA_MAX_SIN_PHI_LOW) {
     snp2 = GPUCA_MAX_SIN_PHI_LOW;
   }
-  float tgl2 = trackTgl * trackTgl;
+  const float tgl2 = trackTgl * trackTgl;
   float factor = CAMath::Sqrt((1 - snp2) / (1 + tgl2));
   factor /= param.tpcGeometry.PadHeight(padRow);
   qtot *= factor;
   qmax *= factor;
 
   const float sec2 = 1.f / (1.f - snp2);
-  // angleZ: z angle - dz/dx (cm/cm)
-  float angleZ = CAMath::Sqrt(tgl2 * sec2); // fast
+  // angleZ local dip angle: z angle - dz/dx (cm/cm)
+  float angleZ = CAMath::Sqrt(tgl2 * sec2);
   if (angleZ > 3) {
     angleZ = 3;
   }
-  
+
   const int region = param.tpcGeometry.GetRegion(padRow);
   z = CAMath::Abs(z);
 
+  // get the correction for qMax and qTot from the splines for given angle and drift length
   const float qMaxCorr = splines->interpolateqMax(region, angleZ, z);
   const float qTotCorr = splines->interpolateqTot(region, angleZ, z);
   qmax /= qMaxCorr;

--- a/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
+++ b/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
@@ -1,0 +1,152 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  dEdxCalibrationSplines.cxx
+/// \brief Definition of dEdxCalibrationSplines class
+///
+/// \author  Matthias Kleiner <matthias.kleiner@cern.ch>
+
+#include "TPCdEdxCalibrationSplines.h"
+
+using namespace GPUCA_NAMESPACE::gpu;
+
+#if !defined(GPUCA_GPUCODE)
+TPCdEdxCalibrationSplines::TPCdEdxCalibrationSplines()
+  : FlatObject()
+{
+  /// Default constructor
+  int nKnots[mFSplines];
+  for (int i = 0; i < mFSplines; i++) {
+    nKnots[i] = 2;
+  }
+  recreate(nKnots, nKnots);
+}
+
+TPCdEdxCalibrationSplines::TPCdEdxCalibrationSplines(const TPCdEdxCalibrationSplines& obj)
+  : FlatObject()
+{
+  /// Copy constructor
+  this->cloneFromObject(obj, nullptr);
+}
+
+TPCdEdxCalibrationSplines& TPCdEdxCalibrationSplines::operator=(const TPCdEdxCalibrationSplines& obj)
+{
+  /// Assignment operator
+  this->cloneFromObject(obj, nullptr);
+  return *this;
+}
+
+void TPCdEdxCalibrationSplines::recreate(int nKnotsU1[], int nKnotsU2[])
+{
+  /// Default constructor
+
+  FlatObject::startConstruction();
+
+  int buffSize = 0;
+  int offsets1[mFSplines];
+  int offsets2[mFSplines];
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqMax[i].recreate(nKnotsU1[i], nKnotsU2[i]);
+    buffSize = alignSize(buffSize, mCalibSplinesqMax[i].getBufferAlignmentBytes());
+    offsets1[i] = buffSize;
+    buffSize += mCalibSplinesqMax[i].getFlatBufferSize();
+  }
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqTot[i].recreate(nKnotsU1[i], nKnotsU2[i]);
+    buffSize = alignSize(buffSize, mCalibSplinesqTot[i].getBufferAlignmentBytes());
+    offsets2[i] = buffSize;
+    buffSize += mCalibSplinesqTot[i].getFlatBufferSize();
+  }
+
+  FlatObject::finishConstruction(buffSize);
+
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqMax[i].moveBufferTo(mFlatBufferPtr + offsets1[i]);
+  }
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqTot[i].moveBufferTo(mFlatBufferPtr + offsets2[i]);
+  }
+}
+
+#endif
+
+#if !defined(GPUCA_GPUCODE)
+
+void TPCdEdxCalibrationSplines::cloneFromObject(const TPCdEdxCalibrationSplines& obj, char* newFlatBufferPtr)
+{
+  /// See FlatObject for description
+
+  const char* oldFlatBufferPtr = obj.mFlatBufferPtr;
+  FlatObject::cloneFromObject(obj, newFlatBufferPtr);
+
+  for (int i = 0; i < mFSplines; i++) {
+    char* buffer = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mCalibSplinesqMax[i].getFlatBufferPtr());
+    mCalibSplinesqMax[i].cloneFromObject(obj.mCalibSplinesqMax[i], buffer);
+  }
+
+  for (int i = 0; i < mFSplines; i++) {
+    char* buffer = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mCalibSplinesqTot[i].getFlatBufferPtr());
+    mCalibSplinesqTot[i].cloneFromObject(obj.mCalibSplinesqTot[i], buffer);
+  }
+}
+
+void TPCdEdxCalibrationSplines::moveBufferTo(char* newFlatBufferPtr)
+{
+  /// See FlatObject for description
+  char* oldFlatBufferPtr = mFlatBufferPtr;
+  FlatObject::moveBufferTo(newFlatBufferPtr);
+  char* currFlatBufferPtr = mFlatBufferPtr;
+  mFlatBufferPtr = oldFlatBufferPtr;
+  setActualBufferAddress(currFlatBufferPtr);
+}
+#endif
+
+void TPCdEdxCalibrationSplines::destroy()
+{
+  /// See FlatObject for description
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqMax[i].destroy();
+    mCalibSplinesqTot[i].destroy();
+  }
+  FlatObject::destroy();
+}
+
+void TPCdEdxCalibrationSplines::setActualBufferAddress(char* actualFlatBufferPtr)
+{
+  /// See FlatObject for description
+
+  FlatObject::setActualBufferAddress(actualFlatBufferPtr);
+  int offset = 0;
+  for (int i = 0; i < mFSplines; i++) {
+    offset = alignSize(offset, mCalibSplinesqMax[i].getBufferAlignmentBytes());
+    mCalibSplinesqMax[i].setActualBufferAddress(mFlatBufferPtr + offset);
+    offset += mCalibSplinesqMax[i].getFlatBufferSize();
+  }
+  for (int i = 0; i < mFSplines; i++) {
+    offset = alignSize(offset, mCalibSplinesqTot[i].getBufferAlignmentBytes());
+    mCalibSplinesqTot[i].setActualBufferAddress(mFlatBufferPtr + offset);
+    offset += mCalibSplinesqTot[i].getFlatBufferSize();
+  }
+}
+
+void TPCdEdxCalibrationSplines::setFutureBufferAddress(char* futureFlatBufferPtr)
+{
+  /// See FlatObject for description
+
+  for (int i = 0; i < mFSplines; i++) {
+    char* buffer = relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mCalibSplinesqMax[i].getFlatBufferPtr());
+    mCalibSplinesqMax[i].setFutureBufferAddress(buffer);
+  }
+  for (int i = 0; i < mFSplines; i++) {
+    char* buffer = relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mCalibSplinesqTot[i].getFlatBufferPtr());
+    mCalibSplinesqTot[i].setFutureBufferAddress(buffer);
+  }
+  FlatObject::setFutureBufferAddress(futureFlatBufferPtr);
+}

--- a/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
+++ b/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
@@ -21,16 +21,18 @@
 
 using namespace GPUCA_NAMESPACE::gpu;
 
-#if !defined(GPUCA_GPUCODE)
+#if !defined(GPUCA_GPUCODE) && defined(GPUCA_STANDALONE)
+TPCdEdxCalibrationSplines::TPCdEdxCalibrationSplines()
+  : FlatObject()
+{
+  /// Empty constructor
+}
+#elif !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
 TPCdEdxCalibrationSplines::TPCdEdxCalibrationSplines()
   : FlatObject()
 {
   /// Default constructor
-  int nKnots[mFSplines];
-  for (int i = 0; i < mFSplines; i++) {
-    nKnots[i] = 2;
-  }
-  recreate(nKnots, nKnots);
+  setDefaultSplines();
 }
 
 TPCdEdxCalibrationSplines::TPCdEdxCalibrationSplines(const TPCdEdxCalibrationSplines& obj)
@@ -54,15 +56,15 @@ void TPCdEdxCalibrationSplines::recreate(int nKnotsU1[], int nKnotsU2[])
   FlatObject::startConstruction();
 
   int buffSize = 0;
-  int offsets1[mFSplines];
-  int offsets2[mFSplines];
-  for (int i = 0; i < mFSplines; i++) {
+  int offsets1[FSplines];
+  int offsets2[FSplines];
+  for (unsigned int i = 0; i < FSplines; i++) {
     mCalibSplinesqMax[i].recreate(nKnotsU1[i], nKnotsU2[i]);
     buffSize = alignSize(buffSize, mCalibSplinesqMax[i].getBufferAlignmentBytes());
     offsets1[i] = buffSize;
     buffSize += mCalibSplinesqMax[i].getFlatBufferSize();
   }
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     mCalibSplinesqTot[i].recreate(nKnotsU1[i], nKnotsU2[i]);
     buffSize = alignSize(buffSize, mCalibSplinesqTot[i].getBufferAlignmentBytes());
     offsets2[i] = buffSize;
@@ -71,17 +73,13 @@ void TPCdEdxCalibrationSplines::recreate(int nKnotsU1[], int nKnotsU2[])
 
   FlatObject::finishConstruction(buffSize);
 
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     mCalibSplinesqMax[i].moveBufferTo(mFlatBufferPtr + offsets1[i]);
   }
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     mCalibSplinesqTot[i].moveBufferTo(mFlatBufferPtr + offsets2[i]);
   }
 }
-
-#endif
-
-#if !defined(GPUCA_GPUCODE)
 
 void TPCdEdxCalibrationSplines::cloneFromObject(const TPCdEdxCalibrationSplines& obj, char* newFlatBufferPtr)
 {
@@ -90,12 +88,12 @@ void TPCdEdxCalibrationSplines::cloneFromObject(const TPCdEdxCalibrationSplines&
   const char* oldFlatBufferPtr = obj.mFlatBufferPtr;
   FlatObject::cloneFromObject(obj, newFlatBufferPtr);
 
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     char* buffer = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mCalibSplinesqMax[i].getFlatBufferPtr());
     mCalibSplinesqMax[i].cloneFromObject(obj.mCalibSplinesqMax[i], buffer);
   }
 
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     char* buffer = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mCalibSplinesqTot[i].getFlatBufferPtr());
     mCalibSplinesqTot[i].cloneFromObject(obj.mCalibSplinesqTot[i], buffer);
   }
@@ -115,7 +113,7 @@ void TPCdEdxCalibrationSplines::moveBufferTo(char* newFlatBufferPtr)
 void TPCdEdxCalibrationSplines::destroy()
 {
   /// See FlatObject for description
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     mCalibSplinesqMax[i].destroy();
     mCalibSplinesqTot[i].destroy();
   }
@@ -128,12 +126,12 @@ void TPCdEdxCalibrationSplines::setActualBufferAddress(char* actualFlatBufferPtr
 
   FlatObject::setActualBufferAddress(actualFlatBufferPtr);
   int offset = 0;
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     offset = alignSize(offset, mCalibSplinesqMax[i].getBufferAlignmentBytes());
     mCalibSplinesqMax[i].setActualBufferAddress(mFlatBufferPtr + offset);
     offset += mCalibSplinesqMax[i].getFlatBufferSize();
   }
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     offset = alignSize(offset, mCalibSplinesqTot[i].getBufferAlignmentBytes());
     mCalibSplinesqTot[i].setActualBufferAddress(mFlatBufferPtr + offset);
     offset += mCalibSplinesqTot[i].getFlatBufferSize();
@@ -144,11 +142,11 @@ void TPCdEdxCalibrationSplines::setFutureBufferAddress(char* futureFlatBufferPtr
 {
   /// See FlatObject for description
 
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     char* buffer = relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mCalibSplinesqMax[i].getFlatBufferPtr());
     mCalibSplinesqMax[i].setFutureBufferAddress(buffer);
   }
-  for (int i = 0; i < mFSplines; i++) {
+  for (unsigned int i = 0; i < FSplines; i++) {
     char* buffer = relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mCalibSplinesqTot[i].getFlatBufferPtr());
     mCalibSplinesqTot[i].setFutureBufferAddress(buffer);
   }
@@ -168,5 +166,45 @@ int TPCdEdxCalibrationSplines::writeToFile(TFile& outf, const char* name)
 {
   /// write a class object to the file
   return FlatObject::writeToFile(*this, outf, name);
+}
+
+void TPCdEdxCalibrationSplines::setDefaultSplines()
+{
+  FlatObject::startConstruction();
+
+  int buffSize = 0;
+  int offsets1[FSplines];
+  int offsets2[FSplines];
+
+  auto defaultFnd2D = [&](float x1, float x2, float f[]) {
+    f[0] = 1.f;
+  };
+
+  for (unsigned int ireg = 0; ireg < FSplines; ++ireg) {
+    o2::gpu::Spline2D<float, 1> splineTmpqMax;
+    splineTmpqMax.approximateFunction(0., 1., 0., 1., defaultFnd2D);
+    mCalibSplinesqMax[ireg] = splineTmpqMax;
+    buffSize = alignSize(buffSize, mCalibSplinesqMax[ireg].getBufferAlignmentBytes());
+    offsets1[ireg] = buffSize;
+    buffSize += mCalibSplinesqMax[ireg].getFlatBufferSize();
+  }
+
+  for (unsigned int ireg = 0; ireg < FSplines; ++ireg) {
+    o2::gpu::Spline2D<float, 1> splineTmpqTot;
+    splineTmpqTot.approximateFunction(0., 1., 0., 1., defaultFnd2D);
+    mCalibSplinesqTot[ireg] = splineTmpqTot;
+    buffSize = alignSize(buffSize, mCalibSplinesqTot[ireg].getBufferAlignmentBytes());
+    offsets2[ireg] = buffSize;
+    buffSize += mCalibSplinesqTot[ireg].getFlatBufferSize();
+  }
+
+  FlatObject::finishConstruction(buffSize);
+
+  for (unsigned int i = 0; i < FSplines; i++) {
+    mCalibSplinesqMax[i].moveBufferTo(mFlatBufferPtr + offsets1[i]);
+  }
+  for (unsigned int i = 0; i < FSplines; i++) {
+    mCalibSplinesqTot[i].moveBufferTo(mFlatBufferPtr + offsets2[i]);
+  }
 }
 #endif

--- a/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
+++ b/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.cxx
@@ -15,6 +15,10 @@
 
 #include "TPCdEdxCalibrationSplines.h"
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+#include "TFile.h"
+#endif
+
 using namespace GPUCA_NAMESPACE::gpu;
 
 #if !defined(GPUCA_GPUCODE)
@@ -150,3 +154,19 @@ void TPCdEdxCalibrationSplines::setFutureBufferAddress(char* futureFlatBufferPtr
   }
   FlatObject::setFutureBufferAddress(futureFlatBufferPtr);
 }
+
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+
+TPCdEdxCalibrationSplines* TPCdEdxCalibrationSplines::readFromFile(
+  TFile& inpf, const char* name)
+{
+  /// read a class object from the file
+  return FlatObject::readFromFile<TPCdEdxCalibrationSplines>(inpf, name);
+}
+
+int TPCdEdxCalibrationSplines::writeToFile(TFile& outf, const char* name)
+{
+  /// write a class object to the file
+  return FlatObject::writeToFile(*this, outf, name);
+}
+#endif

--- a/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.h
+++ b/GPU/GPUTracking/dEdx/TPCdEdxCalibrationSplines.h
@@ -1,0 +1,187 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  dEdxCalibrationSplines.h
+/// \brief Definition of dEdxCalibrationSplines class
+///
+/// \author  Matthias Kleiner <matthias.kleiner@cern.ch>
+
+#ifndef TPCdEdxCalibrationSplines_H
+#define TPCdEdxCalibrationSplines_H
+
+#include "FlatObject.h"
+#include "Spline2D.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+///
+/// The dEdxCalibrationSplines class represents the calibration of the dEdx of mostly geometrical effects
+///
+
+class TPCdEdxCalibrationSplines : public FlatObject
+{
+ public:
+  typedef Spline2D<float, 1, 1> SplineType;
+
+  /// _____________  Constructors / destructors __________________________
+
+#if !defined(GPUCA_GPUCODE)
+  /// Default constructor
+  TPCdEdxCalibrationSplines();
+
+  /// Copy constructor
+  TPCdEdxCalibrationSplines(const TPCdEdxCalibrationSplines&);
+
+  /// Assignment operator
+  TPCdEdxCalibrationSplines& operator=(const TPCdEdxCalibrationSplines&);
+
+  void recreate(int nKnotsU1[], int nKnotsU2[]);
+#else
+  /// Disable constructors for the GPU implementation
+
+  TPCdEdxCalibrationSplines() CON_DELETE;
+  TPCdEdxCalibrationSplines(const TPCdEdxCalibrationSplines&) CON_DELETE;
+  TPCdEdxCalibrationSplines& operator=(const TPCdEdxCalibrationSplines&) CON_DELETE;
+#endif
+
+  /// Destructor
+  ~TPCdEdxCalibrationSplines() CON_DEFAULT;
+
+  /// _____________  FlatObject functionality, see FlatObject class for description  ____________
+
+  using FlatObject::getBufferAlignmentBytes;
+  using FlatObject::getClassAlignmentBytes;
+
+#if !defined(GPUCA_GPUCODE)
+  void cloneFromObject(const TPCdEdxCalibrationSplines& obj, char* newFlatBufferPtr);
+  void moveBufferTo(char* newBufferPtr);
+#endif
+
+  using FlatObject::releaseInternalBuffer;
+
+  void destroy();
+  void setActualBufferAddress(char* actualFlatBufferPtr);
+  void setFutureBufferAddress(char* futureFlatBufferPtr);
+
+  /// ______________
+
+  /// Gives pointer to a spline
+  GPUd() const SplineType& getSpline(int chargeType, int region) const;
+
+#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+  /// sets the splines from an input file
+  void setSplinesFromFile(TFile& inpf);
+#endif
+
+  /// returns the number of splines stored in the calibration object
+  GPUd() unsigned int getFSplines() const
+  {
+    return mFSplines;
+  };
+
+  GPUd() float interpolateqMax(const int splineInd, const float angleZ, const float z) const
+  {
+    return mCalibSplinesqMax[splineInd].interpolate(angleZ, z);
+  };
+
+  GPUd() float interpolateqTot(const int splineInd, const float angleZ, const float z) const
+  {
+    return mCalibSplinesqTot[splineInd].interpolate(angleZ, z);
+  };
+
+  GPUd() SplineType& getSplineqMax(const int splineInd)
+  {
+    return mCalibSplinesqMax[splineInd];
+  };
+
+  GPUd() SplineType& getSplineqTot(const int splineInd)
+  {
+    return mCalibSplinesqTot[splineInd];
+  };
+
+    /// _______________  IO   ________________________
+#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+  /// write a class object to the file
+  int writeToFile(TFile& outf, const char* name);
+
+  /// read a class object from the file
+  static TPCdEdxCalibrationSplines* readFromFile(TFile& inpf, const char* name);
+#endif
+
+ private:
+  constexpr static unsigned int mFSplines = 10; ///< number of splines stored for each type
+  SplineType mCalibSplinesqMax[mFSplines];      ///< spline objects storage for the splines for qMax
+  SplineType mCalibSplinesqTot[mFSplines];      ///< spline objects storage for the splines for qTot
+
+  ClassDefNV(TPCdEdxCalibrationSplines, 1);
+};
+
+#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+
+inline void TPCdEdxCalibrationSplines::setSplinesFromFile(TFile& inpf)
+{
+  FlatObject::startConstruction();
+
+  int buffSize = 0;
+  int offsets1[mFSplines];
+  int offsets2[mFSplines];
+
+  for (int ireg = 0; ireg < mFSplines; ++ireg) {
+    o2::gpu::Spline2D<float, 1>* splineTmpqMax = o2::gpu::Spline2D<float, 1>::readFromFile(inpf, Form("spline_qMax_region%d", ireg));
+    mCalibSplinesqMax[ireg] = *splineTmpqMax;
+    buffSize = alignSize(buffSize, mCalibSplinesqMax[ireg].getBufferAlignmentBytes());
+    offsets1[ireg] = buffSize;
+    buffSize += mCalibSplinesqMax[ireg].getFlatBufferSize();
+  }
+
+  for (int ireg = 0; ireg < mFSplines; ++ireg) {
+    o2::gpu::Spline2D<float, 1>* splineTmpqTot = o2::gpu::Spline2D<float, 1>::readFromFile(inpf, Form("spline_qTot_region%d", ireg));
+    mCalibSplinesqTot[ireg] = *splineTmpqTot;
+    buffSize = alignSize(buffSize, mCalibSplinesqTot[ireg].getBufferAlignmentBytes());
+    offsets2[ireg] = buffSize;
+    buffSize += mCalibSplinesqTot[ireg].getFlatBufferSize();
+  }
+
+  FlatObject::finishConstruction(buffSize);
+
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqMax[i].moveBufferTo(mFlatBufferPtr + offsets1[i]);
+  }
+  for (int i = 0; i < mFSplines; i++) {
+    mCalibSplinesqTot[i].moveBufferTo(mFlatBufferPtr + offsets2[i]);
+  }
+}
+
+#endif
+
+#if !defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_STANDALONE)
+
+TPCdEdxCalibrationSplines* TPCdEdxCalibrationSplines::readFromFile(
+  TFile& inpf, const char* name)
+{
+  /// read a class object from the file
+  return FlatObject::readFromFile<TPCdEdxCalibrationSplines>(inpf, name);
+}
+
+int TPCdEdxCalibrationSplines::writeToFile(TFile& outf, const char* name)
+{
+  /// write a class object to the file
+  return FlatObject::writeToFile(*this, outf, name);
+}
+
+#endif
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif


### PR DESCRIPTION
The splines which will be used to correct the dE/dx for detector effects like different pad sizes and track topologies (local dip angle: z angle - dz/dx and diffusion from electron drift) are created by the Random Forest ML algorithm. The training data is created by the O2 simulation with artificial tracks (no Landau distribution, constant dE/dx, fixed GEM amplification of 2000). For each region and for qMax/qTot an individual spline is created which leads to a total of 20 splines. 
It is planned to make further topological corrections also with the splines: relative pad and time position of a track, local inclination angle: y angle = dy/dx (improves dE/dx at low momenta) and threshold effects.