### PR TITLE
change from vector to span in tof reco workflow

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -85,7 +85,7 @@ class MatchTOF
   void init();
 
   ///< perform all initializations
-  void initWorkflow(const gsl::span<const o2::dataformats::TrackTPCITS>* trackArray, const gsl::span<const Cluster>* clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* toflab, const gsl::span<const o2::MCCompLabel>* itslab, const gsl::span<const o2::MCCompLabel>* tpclab);
+  void initWorkflow(const gsl::span<const o2::dataformats::TrackTPCITS>& trackArray, const gsl::span<const Cluster>& clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& toflab, const gsl::span<const o2::MCCompLabel>& itslab, const gsl::span<const o2::MCCompLabel>& tpclab);
 
   ///< set tree/chain containing tracks
   void setInputTreeTracks(TTree* tree) { mInputTreeTracks = tree; }
@@ -238,17 +238,20 @@ class MatchTOF
 
   ///>>>------ these are input arrays which should not be modified by the matching code
   //           since this info is provided by external device
-  const gsl::span<const o2::dataformats::TrackTPCITS>* mTracksArrayInp = nullptr; ///< input tracks
-  const std::vector<o2::dataformats::TrackTPCITS>* mTracksArrayInpVect = nullptr; ///< input tracks (vector to read tree)
-  const std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = nullptr;             ///< input TPC tracks
-  const gsl::span<const Cluster>* mTOFClustersArrayInp = nullptr;                 ///< input TOF clusters
-  const std::vector<Cluster>* mTOFClustersArrayInpVect = nullptr;                 ///< input TOF clusters (vector to read tree)
+  gsl::span<const o2::dataformats::TrackTPCITS> mTracksArrayInp;  ///< input tracks
+  std::vector<o2::dataformats::TrackTPCITS>* mTracksArrayInpVect; ///< input tracks (vector to read from tree)
+  std::vector<o2::tpc::TrackTPC> mTPCTracksArrayInp;              ///< input TPC tracks
+  gsl::span<const Cluster> mTOFClustersArrayInp;                  ///< input TOF clusters
+  std::vector<Cluster>* mTOFClustersArrayInpVect;                 ///< input TOF clusters (vector to read from tree)
 
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTOFClusLabels = nullptr; ///< input TOF clusters MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mTOFClusLabels;                  ///< input TOF clusters MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTOFClusLabelsPtr;              ///< input TOF clusters MC labels (pointer to read from tree)
   std::vector<o2::MCCompLabel> mTracksLblWork;                                        ///<TPCITS track labels
 
-  const gsl::span<const o2::MCCompLabel>* mTPCLabels = nullptr; ///< TPC label of input tracks
-  const gsl::span<const o2::MCCompLabel>* mITSLabels = nullptr; ///< ITS label of input tracks
+  gsl::span<const o2::MCCompLabel> mTPCLabels;  ///< TPC label of input tracks
+  gsl::span<const o2::MCCompLabel> mITSLabels;  ///< ITS label of input tracks
+  std::vector<o2::MCCompLabel>* mTPCLabelsVect; ///< TPC label of input tracks (vector to read from tree)
+  std::vector<o2::MCCompLabel>* mITSLabelsVect; ///< ITS label of input tracks (vector to read from tree)
 
   gsl::span<o2::ft0::RecPoints const> mFITRecPoints; ///< FIT recpoints
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -33,6 +33,7 @@
 #include "GlobalTracking/MatchTPCITS.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "ReconstructionDataFormats/PID.h"
+#include <gsl/span>
 
 // from FIT
 #include "DataFormatsFT0/RecPoints.h"
@@ -84,7 +85,7 @@ class MatchTOF
   void init();
 
   ///< perform all initializations
-  void initWorkflow(const std::vector<o2::dataformats::TrackTPCITS>* trackArray, const std::vector<Cluster>* clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* toflab, const std::vector<o2::MCCompLabel>* itslab, const std::vector<o2::MCCompLabel>* tpclab);
+  void initWorkflow(const gsl::span<const o2::dataformats::TrackTPCITS>* trackArray, const gsl::span<const Cluster>* clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* toflab, const gsl::span<const o2::MCCompLabel>* itslab, const gsl::span<const o2::MCCompLabel>* tpclab);
 
   ///< set tree/chain containing tracks
   void setInputTreeTracks(TTree* tree) { mInputTreeTracks = tree; }
@@ -237,15 +238,17 @@ class MatchTOF
 
   ///>>>------ these are input arrays which should not be modified by the matching code
   //           since this info is provided by external device
-  const std::vector<o2::dataformats::TrackTPCITS>* mTracksArrayInp = nullptr; ///< input tracks
-  const std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = nullptr;         ///< input TPC tracks
-  const std::vector<Cluster>* mTOFClustersArrayInp = nullptr;                 ///< input TOF clusters
+  const gsl::span<const o2::dataformats::TrackTPCITS>* mTracksArrayInp = nullptr; ///< input tracks
+  const std::vector<o2::dataformats::TrackTPCITS>* mTracksArrayInpVect = nullptr; ///< input tracks (vector to read tree)
+  const std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = nullptr;             ///< input TPC tracks
+  const gsl::span<const Cluster>* mTOFClustersArrayInp = nullptr;                 ///< input TOF clusters
+  const std::vector<Cluster>* mTOFClustersArrayInpVect = nullptr;                 ///< input TOF clusters (vector to read tree)
 
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTOFClusLabels = nullptr; ///< input TOF clusters MC labels
   std::vector<o2::MCCompLabel> mTracksLblWork;                                        ///<TPCITS track labels
 
-  const std::vector<o2::MCCompLabel>* mTPCLabels = nullptr; ///< TPC label of input tracks
-  const std::vector<o2::MCCompLabel>* mITSLabels = nullptr; ///< ITS label of input tracks
+  const gsl::span<const o2::MCCompLabel>* mTPCLabels = nullptr; ///< TPC label of input tracks
+  const gsl::span<const o2::MCCompLabel>* mITSLabels = nullptr; ///< ITS label of input tracks
 
   gsl::span<o2::ft0::RecPoints const> mFITRecPoints; ///< FIT recpoints
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -99,11 +99,9 @@ class TOFDPLRecoWorkflowTask
       itslab = pc.inputs().get<gsl::span<o2::MCCompLabel>>("itstracklabel");
       tpclab = pc.inputs().get<gsl::span<o2::MCCompLabel>>("tpctracklabel");
       toflab = std::move(*toflabel);
-
-      mMatcher.initWorkflow(&tracksRO, &clustersRO, &toflab, &itslab, &tpclab);
-    } else {
-      mMatcher.initWorkflow(&tracksRO, &clustersRO, nullptr, nullptr, nullptr);
     }
+
+    mMatcher.initWorkflow(tracksRO, clustersRO, toflab, itslab, tpclab);
     mMatcher.run();
 
     // in run_match_tof aggiugnere esplicitamente la chiamata a fill del tree (nella classe MatchTOF) e il metodo per leggere i vettori di output

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -47,6 +47,7 @@ install(FILES CheckClusters_mft.C
               run_digi2raw_tof.C
               run_cmp2digit_tof.C
               compareTOFDigits.C
+              compareTOFClusters.C
               run_match_tof.C
               run_primary_vertexer_ITS.C
               run_rawdecoding_its.C
@@ -301,6 +302,10 @@ o2_add_test_root_macro(run_cmp2digit_tof.C
 
 o2_add_test_root_macro(compareTOFDigits.C
                        PUBLIC_LINK_LIBRARIES O2::TOFBase
+                       LABELS tof)
+
+o2_add_test_root_macro(compareTOFClusters.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsTOF
                        LABELS tof)
 
 # FIXME: move to subsystem dir

--- a/macro/compareTOFClusters.C
+++ b/macro/compareTOFClusters.C
@@ -1,0 +1,151 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include <TTree.h>
+#include <TMath.h>
+#include <TFile.h>
+#include <vector>
+#include <string>
+
+#include "DataFormatsTOF/Cluster.h"
+
+#endif
+
+bool compareTOFClusters(std::string inpName1 = "tofclustersOr.root", std::string inpName2 = "tofclusters.root")
+{
+  bool status = true;
+  int ngood = 0;
+  int nfake = 0;
+
+  TFile* f1 = TFile::Open(inpName1.c_str());
+  TFile* f2 = TFile::Open(inpName2.c_str());
+
+  TTree* t1 = (TTree*)f1->Get("o2sim");
+  TTree* t2 = (TTree*)f2->Get("o2sim");
+
+  std::vector<o2::tof::Cluster> clusters1, *pClusters1 = &clusters1;
+  t1->SetBranchAddress("TOFCluster", &pClusters1);
+  std::vector<o2::tof::Cluster> clusters2, *pClusters2 = &clusters2;
+  t2->SetBranchAddress("TOFCluster", &pClusters2);
+
+  t1->GetEvent(0);
+  t2->GetEvent(0);
+
+  int ncl1 = clusters1.size();
+  int ncl2 = clusters2.size();
+
+  if (ncl1 != ncl2) {
+    printf("N clusters different!!!! %d != %d \n", ncl1, ncl2);
+    status = false;
+    return status;
+  }
+
+  printf("N clusters = %d\n", ncl1);
+
+  for (int i = 0; i < ncl1; i++) {
+    auto cl1 = clusters1.at(i);
+    auto cl2 = clusters2.at(i);
+
+    bool clstatus = true;
+
+    if (cl1.getMainContributingChannel() != cl2.getMainContributingChannel()) {
+      printf("cluster %d - Different Main Contributing Channels %d != %d \n", i, cl1.getMainContributingChannel(), cl2.getMainContributingChannel());
+      clstatus = false;
+    }
+
+    if (cl1.getNumOfContributingChannels() != cl2.getNumOfContributingChannels()) {
+      printf("cluster %d - Different N contributing channels %d != %d \n", i, cl1.getNumOfContributingChannels(), cl2.getNumOfContributingChannels());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getTimeRaw() - cl2.getTimeRaw()) > 1E-6) {
+      printf("cluster %d - Different Raw Times %lf != %lf \n", i, cl1.getTimeRaw(), cl2.getTimeRaw());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getTime() - cl2.getTime()) > 1E-6) {
+      printf("cluster %d - Different Calbrated Times %lf != %lf \n", i, cl1.getTime(), cl2.getTime());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getTot() - cl2.getTot()) > 1E-6) {
+      printf("cluster %d - Different ToTs %f != %f \n", i, cl1.getTot(), cl2.getTot());
+      clstatus = false;
+    }
+
+    if (cl1.getBC() != cl2.getBC()) {
+      printf("cluster %d - Different Bunch Crossing IDs %d != %d \n", i, cl1.getBC(), cl2.getBC());
+      clstatus = false;
+    }
+
+    if (cl1.getL0L1Latency() != cl2.getL0L1Latency()) {
+      printf("cluster %d - Different L0L1 Latencies %d != %d \n", i, cl1.getL0L1Latency(), cl2.getL0L1Latency());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getX() - cl2.getX()) > 1E-6) {
+      printf("cluster %d - Different X positions %lf != %lf \n", i, cl1.getX(), cl2.getX());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getY() - cl2.getY()) > 1E-6) {
+      printf("cluster %d - Different Y positions %lf != %lf \n", i, cl1.getY(), cl2.getY());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getZ() - cl2.getZ()) > 1E-6) {
+      printf("cluster %d - Different Z positions %lf != %lf \n", i, cl1.getZ(), cl2.getZ());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getSigmaY2() - cl2.getSigmaY2()) > 1E-6) {
+      printf("cluster %d - Different Y2 sigmas %lf != %lf \n", i, cl1.getSigmaY2(), cl2.getSigmaY2());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getSigmaZ2() - cl2.getSigmaZ2()) > 1E-6) {
+      printf("cluster %d - Different Z2 sigmas %lf != %lf \n", i, cl1.getSigmaZ2(), cl2.getSigmaZ2());
+      clstatus = false;
+    }
+
+    if (TMath::Abs(cl1.getSigmaYZ() - cl2.getSigmaYZ()) > 1E-6) {
+      printf("cluster %d - Different YZ sigmas %lf != %lf \n", i, cl1.getSigmaYZ(), cl2.getSigmaYZ());
+      clstatus = false;
+    }
+
+    if (cl1.getCount() != cl2.getCount()) {
+      printf("cluster %d - Different Sensor IDs %d != %d \n", i, cl1.getCount(), cl2.getCount());
+      clstatus = false;
+    }
+
+    if (cl1.getBits() != cl2.getBits()) {
+      printf("cluster %d - Different Sensor IDs %d != %d \n", i, cl1.getBits(), cl2.getBits());
+      clstatus = false;
+    }
+
+    if (cl1.getSensorID() != cl2.getSensorID()) {
+      printf("cluster %d - Different Sensor IDs %d != %d \n", i, cl1.getSensorID(), cl2.getSensorID());
+      clstatus = false;
+    }
+
+    if (!clstatus) {
+      status = false;
+      nfake++;
+    } else
+      ngood++;
+  }
+
+  printf("Clusters good = %d\n", ngood);
+  printf("Clusters fake = %d\n", nfake);
+
+  return status;
+}


### PR DESCRIPTION
Acccordingly to suggestion from PR #3443(Force TOF cluster to be messageable) also tof reco workflow was changed to use span instead of vector from inputs