### PR TITLE
DPL Analysis: grouping extension for empty sets

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -17,8 +17,8 @@
 #include "Framework/CompilerBuiltins.h"
 #include "Framework/Traits.h"
 #include "Framework/Expressions.h"
-#include "Framework/Kernels.h"
 #include "Framework/ArrowCompatibility.h"
+#include "Framework/ArrowTypes.h"
 #include <arrow/table.h>
 #include <arrow/array.h>
 #include <arrow/util/variant.h>
@@ -93,69 +93,6 @@ constexpr auto make_originals_from_type()
     return framework::concatenate_pack(framework::pack<decayed>{}, make_originals_from_type<T...>());
   }
 }
-
-template <typename T>
-struct arrow_array_for {
-};
-template <>
-struct arrow_array_for<bool> {
-  using type = arrow::BooleanArray;
-};
-template <>
-struct arrow_array_for<int8_t> {
-  using type = arrow::Int8Array;
-};
-template <>
-struct arrow_array_for<uint8_t> {
-  using type = arrow::UInt8Array;
-};
-template <>
-struct arrow_array_for<int16_t> {
-  using type = arrow::Int16Array;
-};
-template <>
-struct arrow_array_for<uint16_t> {
-  using type = arrow::UInt16Array;
-};
-template <>
-struct arrow_array_for<int32_t> {
-  using type = arrow::Int32Array;
-};
-template <>
-struct arrow_array_for<int64_t> {
-  using type = arrow::Int64Array;
-};
-template <>
-struct arrow_array_for<uint32_t> {
-  using type = arrow::UInt32Array;
-};
-template <>
-struct arrow_array_for<uint64_t> {
-  using type = arrow::UInt64Array;
-};
-template <>
-struct arrow_array_for<float> {
-  using type = arrow::FloatArray;
-};
-template <>
-struct arrow_array_for<double> {
-  using type = arrow::DoubleArray;
-};
-template <int N>
-struct arrow_array_for<float[N]> {
-  using type = arrow::FixedSizeBinaryArray;
-};
-template <int N>
-struct arrow_array_for<int[N]> {
-  using type = arrow::FixedSizeBinaryArray;
-};
-template <int N>
-struct arrow_array_for<double[N]> {
-  using type = arrow::FixedSizeBinaryArray;
-};
-
-template <typename T>
-using arrow_array_for_t = typename arrow_array_for<T>::type;
 
 /// Policy class for columns which are chunked. This
 /// will make the compiler take the most generic (and
@@ -852,6 +789,12 @@ class Table
     RowViewBase& operator=(RowViewBase const&) = default;
     RowViewBase& operator=(RowViewBase&&) = default;
 
+    RowViewBase& operator=(RowViewSentinel const& other)
+    {
+      this->mRowIndex = other.index;
+      return *this;
+    }
+
     using RowViewCore<IP, C...>::operator++;
 
     /// Allow incrementing by more than one the iterator
@@ -885,15 +828,22 @@ class Table
   using filtered_iterator = RowViewFiltered<table_t, table_t>;
   using filtered_const_iterator = RowViewFiltered<table_t, table_t>;
 
+  template <typename Col>
+  using column_pair_t = std::pair<Col*, BackendColumnType*>;
+  using column_index_t = std::tuple<column_pair_t<C>...>;
+
   Table(std::shared_ptr<arrow::Table> table, uint64_t offset = 0)
     : mTable(table),
-      mColumnIndex{
-        std::pair<C*, BackendColumnType*>{nullptr,
-                                          lookupColumn<C>()}...},
-      mBegin(mColumnIndex, {table->num_rows(), offset}),
       mEnd{static_cast<uint64_t>(table->num_rows())},
       mOffset(offset)
   {
+    if (mTable->num_rows() == 0) {
+      mColumnIndex = column_index_t{column_pair_t<C>{nullptr, nullptr}...};
+      mBegin = mEnd;
+    } else {
+      mColumnIndex = column_index_t{column_pair_t<C>{nullptr, lookupColumn<C>()}...};
+      mBegin = unfiltered_iterator{mColumnIndex, {table->num_rows(), offset}};
+    }
   }
 
   /// FIXME: this is to be able to construct a Filtered without explicit Join
@@ -1107,7 +1057,7 @@ class TableMetadata
   static const o2::framework::expressions::BindingNode _Getter_##Id { _Label_,     \
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
-#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "f" #_Name_ "sID")
+#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int64_t, _Name_##s, "f" #_Name_ "sID")
 /// A dynamic column is a column whose values are derived
 /// from those of other real columns. These can be used for
 /// example to provide different coordinate systems (e.g. polar,
@@ -1394,26 +1344,6 @@ template <typename T>
 auto filter(T&& t, framework::expressions::Filter const& expr)
 {
   return Filtered<T>(t.asArrowTable(), expr);
-}
-
-template <typename T>
-std::vector<std::decay_t<T>> slice(T&& t, std::string const& columnName)
-{
-  arrow::compute::FunctionContext ctx;
-  std::vector<arrow::compute::Datum> splittedDatums;
-  std::vector<std::decay_t<T>> splittedTables;
-  std::vector<uint64_t> offsets;
-  auto status = framework::sliceByColumn(&ctx, columnName, arrow::compute::Datum(t.asArrowTable()), &splittedDatums, &offsets);
-  if (status.ok() == false) {
-    throw std::runtime_error("Unable to slice table");
-  }
-  splittedTables.reserve(splittedDatums.size());
-  for (size_t ti = 0; ti < splittedDatums.size(); ++ti) {
-    auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(splittedDatums[ti].value);
-    auto offset = offsets[ti];
-    splittedTables.emplace_back(table, offset);
-  }
-  return splittedTables;
 }
 
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1057,7 +1057,7 @@ class TableMetadata
   static const o2::framework::expressions::BindingNode _Getter_##Id { _Label_,     \
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
-#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int64_t, _Name_##s, "f" #_Name_ "sID")
+#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "f" #_Name_ "sID")
 /// A dynamic column is a column whose values are derived
 /// from those of other real columns. These can be used for
 /// example to provide different coordinate systems (e.g. polar,

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -24,6 +24,27 @@
 
 namespace o2::soa
 {
+//// table slicer function
+//// FIXME: current implementation of sliceByColumn is _only_ for indices!
+//template <typename T, typename I>
+//std::vector<std::decay_t<T>> slice(T&& t, I nGroups, std::string const& columnName)
+//{
+//  arrow::compute::FunctionContext ctx;
+//  std::vector<arrow::compute::Datum> splittedDatums;
+//  std::vector<std::decay_t<T>> splittedTables;
+//  std::vector<uint64_t> offsets;
+//  auto status = o2::framework::sliceByColumn(&ctx, columnName, nGroups, arrow::compute::Datum(t.asArrowTable()), &splittedDatums, &offsets);
+//  if (status.ok() == false) {
+//    throw std::runtime_error("Unable to slice table");
+//  }
+//  splittedTables.reserve(splittedDatums.size());
+//  for (size_t ti = 0; ti < splittedDatums.size(); ++ti) {
+//    auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(splittedDatums[ti].value);
+//    auto offset = offsets[ti];
+//    splittedTables.emplace_back(table, offset);
+//  }
+//  return splittedTables;
+//}
 
 // Functions to enable looping over tuples
 template <std::size_t V>

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -24,28 +24,6 @@
 
 namespace o2::soa
 {
-//// table slicer function
-//// FIXME: current implementation of sliceByColumn is _only_ for indices!
-//template <typename T, typename I>
-//std::vector<std::decay_t<T>> slice(T&& t, I nGroups, std::string const& columnName)
-//{
-//  arrow::compute::FunctionContext ctx;
-//  std::vector<arrow::compute::Datum> splittedDatums;
-//  std::vector<std::decay_t<T>> splittedTables;
-//  std::vector<uint64_t> offsets;
-//  auto status = o2::framework::sliceByColumn(&ctx, columnName, nGroups, arrow::compute::Datum(t.asArrowTable()), &splittedDatums, &offsets);
-//  if (status.ok() == false) {
-//    throw std::runtime_error("Unable to slice table");
-//  }
-//  splittedTables.reserve(splittedDatums.size());
-//  for (size_t ti = 0; ti < splittedDatums.size(); ++ti) {
-//    auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(splittedDatums[ti].value);
-//    auto offset = offsets[ti];
-//    splittedTables.emplace_back(table, offset);
-//  }
-//  return splittedTables;
-//}
-
 // Functions to enable looping over tuples
 template <std::size_t V>
 struct Num {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -11,7 +11,7 @@
 #ifndef FRAMEWORK_ANALYSIS_TASK_H_
 #define FRAMEWORK_ANALYSIS_TASK_H_
 
-#include "Framework/ASoA.h"
+#include "Framework/Kernels.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/CallbackService.h"
@@ -21,7 +21,6 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Expressions.h"
 #include "Framework/EndOfStreamContext.h"
-#include "Framework/Kernels.h"
 #include "Framework/Logger.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/StructToTuple.h"
@@ -393,6 +392,9 @@ struct AnalysisDataProcessorBuilder {
     return std::tuple<>{};
   }
 
+  template <typename T, typename C>
+  using is_external_index_to_t = std::is_same<typename C::binding_t, T>;
+
   template <typename G, typename... A>
   struct GroupSlicer {
     using grouping_t = std::decay_t<G>;
@@ -431,6 +433,7 @@ struct AnalysisDataProcessorBuilder {
           constexpr auto index = framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{});
           if (hasIndexTo<std::decay_t<G>>(typename xt::persistent_columns_t{})) {
             auto result = o2::framework::sliceByColumn(&ctx, indexColumnName,
+                                                       gt.size(),
                                                        x.asArrowTable(),
                                                        &groups[index],
                                                        &offsets[index]);

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -433,7 +433,7 @@ struct AnalysisDataProcessorBuilder {
           constexpr auto index = framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{});
           if (hasIndexTo<std::decay_t<G>>(typename xt::persistent_columns_t{})) {
             auto result = o2::framework::sliceByColumn(&ctx, indexColumnName,
-                                                       gt.size(),
+                                                       static_cast<int32_t>(gt.size()),
                                                        x.asArrowTable(),
                                                        &groups[index],
                                                        &offsets[index]);

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_ARROWTYPES_H
+#define O2_FRAMEWORK_ARROWTYPES_H
+#include "arrow/type_fwd.h"
+
+namespace o2::soa {
+template <typename T>
+struct arrow_array_for {
+};
+template <>
+struct arrow_array_for<bool> {
+  using type = arrow::BooleanArray;
+};
+template <>
+struct arrow_array_for<int8_t> {
+  using type = arrow::Int8Array;
+};
+template <>
+struct arrow_array_for<uint8_t> {
+  using type = arrow::UInt8Array;
+};
+template <>
+struct arrow_array_for<int16_t> {
+  using type = arrow::Int16Array;
+};
+template <>
+struct arrow_array_for<uint16_t> {
+  using type = arrow::UInt16Array;
+};
+template <>
+struct arrow_array_for<int32_t> {
+  using type = arrow::Int32Array;
+};
+template <>
+struct arrow_array_for<int64_t> {
+  using type = arrow::Int64Array;
+};
+template <>
+struct arrow_array_for<uint32_t> {
+  using type = arrow::UInt32Array;
+};
+template <>
+struct arrow_array_for<uint64_t> {
+  using type = arrow::UInt64Array;
+};
+template <>
+struct arrow_array_for<float> {
+  using type = arrow::FloatArray;
+};
+template <>
+struct arrow_array_for<double> {
+  using type = arrow::DoubleArray;
+};
+template <int N>
+struct arrow_array_for<float[N]> {
+  using type = arrow::FixedSizeBinaryArray;
+};
+template <int N>
+struct arrow_array_for<int[N]> {
+  using type = arrow::FixedSizeBinaryArray;
+};
+template <int N>
+struct arrow_array_for<double[N]> {
+  using type = arrow::FixedSizeBinaryArray;
+};
+
+template <typename T>
+using arrow_array_for_t = typename arrow_array_for<T>::type;
+}
+#endif // O2_FRAMEWORK_ARROWTYPES_H

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -12,7 +12,8 @@
 #define O2_FRAMEWORK_ARROWTYPES_H
 #include "arrow/type_fwd.h"
 
-namespace o2::soa {
+namespace o2::soa
+{
 template <typename T>
 struct arrow_array_for {
 };
@@ -75,5 +76,5 @@ struct arrow_array_for<double[N]> {
 
 template <typename T>
 using arrow_array_for_t = typename arrow_array_for<T>::type;
-}
+} // namespace o2::soa
 #endif // O2_FRAMEWORK_ARROWTYPES_H

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_KERNELS_H_
 
 #include "Framework/BasicOps.h"
+#include "Framework/TableBuilder.h"
 
 #include <arrow/compute/kernel.h>
 #include <arrow/status.h>
@@ -67,18 +68,31 @@ class ARROW_EXPORT HashByColumnKernel : public arrow::compute::UnaryKernel
   std::shared_ptr<arrow::DataType> mType;
 };
 
+template <typename T>
 struct ARROW_EXPORT GroupByOptions {
   std::string columnName;
+  T size;
 };
 
 /// Build ranges
+template <typename T, typename ARRAY>
 class ARROW_EXPORT SortedGroupByKernel : public arrow::compute::UnaryKernel
 {
  public:
-  explicit SortedGroupByKernel(GroupByOptions options = {});
+  explicit SortedGroupByKernel(GroupByOptions<T> options = {}) : mOptions(options){};
   arrow::Status Call(arrow::compute::FunctionContext* ctx,
                      arrow::compute::Datum const& table,
-                     arrow::compute::Datum* outputRanges) override;
+                     arrow::compute::Datum* outputRanges) override
+  {
+    using namespace arrow;
+    if (table.kind() == arrow::compute::Datum::TABLE) {
+      auto atable = util::get<std::shared_ptr<arrow::Table>>(table.value);
+      auto columnIndex = atable->schema()->GetFieldIndex(mOptions.columnName);
+      auto chunkedArray = getBackendColumnData(atable->column(columnIndex));
+      return doGrouping(chunkedArray, outputRanges);
+    };
+    return arrow::Status::OK();
+  };
 #pragma GCC diagnostic push
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
@@ -90,8 +104,44 @@ class ARROW_EXPORT SortedGroupByKernel : public arrow::compute::UnaryKernel
 #pragma GCC diagnostic pop
 
  private:
+  arrow::Status doGrouping(std::shared_ptr<arrow::ChunkedArray> chunkedArray, arrow::compute::Datum* outputRanges)
+  {
+    o2::framework::TableBuilder builder;
+    auto writer = builder.persist<T, T, T>({"start", "count", "index"});
+    auto zeroChunk = std::static_pointer_cast<ARRAY>(chunkedArray->chunk(0));
+    if (zeroChunk->length() == 0) {
+      *outputRanges = std::move(builder.finalize());
+      return arrow::Status::OK();
+    }
+    T currentIndex = 0;
+    T currentCount = 0;
+    T currentOffset = 0;
+    for (auto ci = 0; ci < chunkedArray->num_chunks(); ++ci) {
+      auto chunk = chunkedArray->chunk(ci);
+      T const* data = std::static_pointer_cast<ARRAY>(chunk)->raw_values();
+      for (auto ai = 0; ai < chunk->length(); ++ai) {
+        if (currentIndex == data[ai]) {
+          currentCount++;
+        } else {
+          writer(0, currentOffset, currentCount, currentIndex);
+          currentOffset += currentCount;
+          while (data[ai] - currentIndex > 1) {
+            writer(0, currentOffset, 0, ++currentIndex);
+          }
+          currentIndex++;
+          currentCount = 1;
+        }
+      }
+    }
+    writer(0, currentOffset, currentCount, currentIndex);
+    while (currentIndex < mOptions.size - 1) {
+      writer(0, currentOffset, 0, ++currentIndex);
+    }
+    *outputRanges = std::move(builder.finalize());
+    return arrow::Status::OK();
+  }
   std::shared_ptr<arrow::DataType> mType;
-  GroupByOptions mOptions;
+  GroupByOptions<T> mOptions;
 };
 
 /// Slice a given table is a vector of tables each containing a slice.
@@ -99,11 +149,55 @@ class ARROW_EXPORT SortedGroupByKernel : public arrow::compute::UnaryKernel
 /// is split into.
 /// @a offset the offset in the original table at which the corresponding
 /// slice was split.
+/// Slice a given table is a vector of tables each containing a slice.
+template <typename T>
 arrow::Status sliceByColumn(arrow::compute::FunctionContext* context,
                             std::string const& key,
+                            T size,
                             arrow::compute::Datum const& inputTable,
                             std::vector<arrow::compute::Datum>* outputSlices,
-                            std::vector<uint64_t>* offsets = nullptr);
+                            std::vector<uint64_t>* offsets)
+{
+  if (inputTable.kind() != arrow::compute::Datum::TABLE) {
+    return arrow::Status::Invalid("Input Datum was not a table");
+  }
+  // build all the ranges on the fly.
+  arrow::compute::Datum outRanges;
+  auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
+  o2::framework::SortedGroupByKernel<T, soa::arrow_array_for_t<T>> kernel{GroupByOptions<T>{key, size}};
+
+  ARROW_RETURN_NOT_OK(kernel.Call(context, inputTable, &outRanges));
+  auto ranges = arrow::util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
+  outputSlices->reserve(ranges->num_rows());
+  if (offsets) {
+    offsets->reserve(ranges->num_rows());
+  }
+
+  auto startChunks = getBackendColumnData(ranges->column(0));
+  assert(startChunks->num_chunks() == 1);
+  auto countChunks = getBackendColumnData(ranges->column(1));
+  assert(countChunks->num_chunks() == 1);
+  auto startData = std::static_pointer_cast<soa::arrow_array_for_t<T>>(startChunks->chunk(0))->raw_values();
+  auto countData = std::static_pointer_cast<soa::arrow_array_for_t<T>>(countChunks->chunk(0))->raw_values();
+
+  for (auto ri = 0; ri < ranges->num_rows(); ++ri) {
+    auto start = startData[ri];
+    auto count = countData[ri];
+    auto schema = table->schema();
+    std::vector<std::shared_ptr<BackendColumnType>> slicedColumns;
+    slicedColumns.reserve(schema->num_fields());
+    //    if (count != 0) {
+    for (auto ci = 0; ci < schema->num_fields(); ++ci) {
+      slicedColumns.emplace_back(table->column(ci)->Slice(start, count));
+    }
+    //    }
+    outputSlices->emplace_back(arrow::compute::Datum(arrow::Table::Make(table->schema(), slicedColumns)));
+    if (offsets) {
+      offsets->emplace_back(start);
+    }
+  }
+  return arrow::Status::OK();
+}
 
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -156,7 +156,7 @@ arrow::Status sliceByColumn(arrow::compute::FunctionContext* context,
                             T size,
                             arrow::compute::Datum const& inputTable,
                             std::vector<arrow::compute::Datum>* outputSlices,
-                            std::vector<uint64_t>* offsets)
+                            std::vector<uint64_t>* offsets = nullptr)
 {
   if (inputTable.kind() != arrow::compute::Datum::TABLE) {
     return arrow::Status::Invalid("Input Datum was not a table");

--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -8,7 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/Kernels.h"
-#include "Framework/TableBuilder.h"
+#include "Framework/ArrowTypes.h"
+
 #include "ArrowDebugHelpers.h"
 
 #include <arrow/builder.h>
@@ -41,114 +42,6 @@ Status HashByColumnKernel::Call(FunctionContext* ctx, Datum const& inputTable, D
     return arrow::Status::OK();
   }
   return Status::Invalid("Input Datum was not a table");
-}
-
-SortedGroupByKernel::SortedGroupByKernel(GroupByOptions options)
-  : mOptions(options)
-{
-}
-
-template <typename T, typename ARRAY>
-Status doGrouping(std::shared_ptr<ChunkedArray> chunkedArray, Datum* outputRanges)
-{
-  TableBuilder builder;
-  auto writer = builder.persist<uint64_t, uint64_t, uint64_t>({"start", "count", "index"});
-  auto zeroChunk = std::static_pointer_cast<ARRAY>(chunkedArray->chunk(0));
-  if (zeroChunk->length() == 0) {
-    *outputRanges = std::move(builder.finalize());
-    return arrow::Status::OK();
-  }
-  uint64_t currentIndex = 0;
-  uint64_t currentCount = 0;
-  uint64_t currentOffset = 0;
-  for (auto ci = 0; ci < chunkedArray->num_chunks(); ++ci) {
-    auto chunk = chunkedArray->chunk(ci);
-    T const* data = std::static_pointer_cast<ARRAY>(chunk)->raw_values();
-    for (auto ai = 0; ai < chunk->length(); ++ai) {
-      if (currentIndex == data[ai]) {
-        currentCount++;
-      } else {
-        writer(0, currentOffset, currentCount, currentIndex);
-        currentOffset += currentCount;
-        while (data[ai] - currentIndex > 1) {
-          writer(0, currentOffset, 0, ++currentIndex);
-        }
-        currentIndex++;
-        currentCount = 1;
-      }
-    }
-  }
-  writer(0, currentOffset, currentCount, currentIndex);
-  *outputRanges = std::move(builder.finalize());
-  return arrow::Status::OK();
-}
-
-Status SortedGroupByKernel::Call(FunctionContext*, Datum const& inputTable, Datum* outputRanges)
-{
-  using namespace arrow;
-  if (inputTable.kind() == Datum::TABLE) {
-    auto table = util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
-    auto columnIndex = table->schema()->GetFieldIndex(mOptions.columnName);
-    auto dataType = table->schema()->field(columnIndex)->type();
-    auto chunkedArray = getBackendColumnData(table->column(columnIndex));
-    switch (dataType->id()) {
-      case Type::INT32:
-        return doGrouping<int32_t, arrow::Int32Array>(chunkedArray, outputRanges);
-      case Type::UINT32:
-        return doGrouping<uint32_t, arrow::UInt32Array>(chunkedArray, outputRanges);
-      case Type::INT64:
-        return doGrouping<int64_t, arrow::Int64Array>(chunkedArray, outputRanges);
-      case Type::UINT64:
-        return doGrouping<uint64_t, arrow::UInt64Array>(chunkedArray, outputRanges);
-      default:
-        return arrow::Status::TypeError("Unsupported index type");
-    }
-  }
-  return arrow::Status::OK();
-}
-
-/// Slice a given table is a vector of tables each containing a slice.
-arrow::Status sliceByColumn(FunctionContext* context, std::string const& key,
-                            Datum const& inputTable, std::vector<Datum>* outputSlices,
-                            std::vector<uint64_t>* offsets)
-{
-  if (inputTable.kind() != Datum::TABLE) {
-    return Status::Invalid("Input Datum was not a table");
-  }
-
-  // build all the ranges on the fly.
-  Datum outRanges;
-  SortedGroupByKernel groupBy({GroupByOptions{key}});
-  ARROW_RETURN_NOT_OK(groupBy.Call(context, inputTable, &outRanges));
-  auto ranges = util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
-  outputSlices->reserve(ranges->num_rows());
-  if (offsets) {
-    offsets->reserve(ranges->num_rows());
-  }
-
-  auto startChunks = getBackendColumnData(ranges->column(0));
-  assert(startChunks->num_chunks() == 1);
-  auto countChunks = getBackendColumnData(ranges->column(1));
-  assert(countChunks->num_chunks() == 1);
-  auto startData = std::static_pointer_cast<UInt64Array>(startChunks->chunk(0))->raw_values();
-  auto countData = std::static_pointer_cast<UInt64Array>(countChunks->chunk(0))->raw_values();
-
-  auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
-  for (size_t ri = 0; ri < ranges->num_rows(); ++ri) {
-    auto start = startData[ri];
-    auto count = countData[ri];
-    auto schema = table->schema();
-    std::vector<std::shared_ptr<BackendColumnType>> slicedColumns;
-    slicedColumns.reserve(schema->num_fields());
-    for (size_t ci = 0; ci < schema->num_fields(); ++ci) {
-      slicedColumns.emplace_back(table->column(ci)->Slice(start, count));
-    }
-    outputSlices->emplace_back(Datum(arrow::Table::Make(table->schema(), slicedColumns)));
-    if (offsets) {
-      offsets->emplace_back(start);
-    }
-  }
-  return arrow::Status::OK();
 }
 
 } // namespace framework

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -416,33 +416,6 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   BOOST_CHECK_EQUAL(i, 3);
 }
 
-//BOOST_AUTO_TEST_CASE(TestTableSlicing)
-//{
-//  TableBuilder builderA;
-//  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
-//  rowWriterA(0, 0, 0);
-//  rowWriterA(0, 1, 0);
-//  rowWriterA(0, 2, 0);
-//  rowWriterA(0, 3, 1);
-//  rowWriterA(0, 4, 1);
-//  rowWriterA(0, 5, 1);
-//  rowWriterA(0, 6, 1);
-//  rowWriterA(0, 7, 2);
-//  auto tableA = builderA.finalize();
-//  BOOST_REQUIRE_EQUAL(tableA->num_rows(), 8);
-//  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
-
-//  TestA t = TestA{tableA};
-//  auto s = slice(t, 3, "y");
-//  BOOST_CHECK_EQUAL(s.size(), 3);
-
-//  for (auto r : s[1]) {
-//    BOOST_CHECK_EQUAL(r.x(), r.index() + 3);
-//    BOOST_CHECK_EQUAL(r.y(), 1);
-//    BOOST_CHECK_EQUAL(r.globalIndex(), r.index() + 3);
-//  }
-//}
-
 BOOST_AUTO_TEST_CASE(TestDereference)
 {
   TableBuilder builderA;

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -13,7 +13,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/ASoA.h"
-#include "Framework/TableBuilder.h"
+#include "Framework/ASoAHelpers.h"
 #include "gandiva/tree_expr_builder.h"
 #include "arrow/status.h"
 #include "gandiva/filter.h"
@@ -416,32 +416,32 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   BOOST_CHECK_EQUAL(i, 3);
 }
 
-BOOST_AUTO_TEST_CASE(TestTableSlicing)
-{
-  TableBuilder builderA;
-  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
-  rowWriterA(0, 0, 0);
-  rowWriterA(0, 1, 0);
-  rowWriterA(0, 2, 0);
-  rowWriterA(0, 3, 1);
-  rowWriterA(0, 4, 1);
-  rowWriterA(0, 5, 1);
-  rowWriterA(0, 6, 1);
-  rowWriterA(0, 7, 2);
-  auto tableA = builderA.finalize();
-  BOOST_REQUIRE_EQUAL(tableA->num_rows(), 8);
-  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+//BOOST_AUTO_TEST_CASE(TestTableSlicing)
+//{
+//  TableBuilder builderA;
+//  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
+//  rowWriterA(0, 0, 0);
+//  rowWriterA(0, 1, 0);
+//  rowWriterA(0, 2, 0);
+//  rowWriterA(0, 3, 1);
+//  rowWriterA(0, 4, 1);
+//  rowWriterA(0, 5, 1);
+//  rowWriterA(0, 6, 1);
+//  rowWriterA(0, 7, 2);
+//  auto tableA = builderA.finalize();
+//  BOOST_REQUIRE_EQUAL(tableA->num_rows(), 8);
+//  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
 
-  TestA t = TestA{tableA};
-  auto s = slice(t, "y");
-  BOOST_CHECK_EQUAL(s.size(), 3);
+//  TestA t = TestA{tableA};
+//  auto s = slice(t, 3, "y");
+//  BOOST_CHECK_EQUAL(s.size(), 3);
 
-  for (auto r : s[1]) {
-    BOOST_CHECK_EQUAL(r.x(), r.index() + 3);
-    BOOST_CHECK_EQUAL(r.y(), 1);
-    BOOST_CHECK_EQUAL(r.globalIndex(), r.index() + 3);
-  }
-}
+//  for (auto r : s[1]) {
+//    BOOST_CHECK_EQUAL(r.x(), r.index() + 3);
+//    BOOST_CHECK_EQUAL(r.y(), 1);
+//    BOOST_CHECK_EQUAL(r.globalIndex(), r.index() + 3);
+//  }
+//}
 
 BOOST_AUTO_TEST_CASE(TestDereference)
 {

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -52,14 +52,14 @@ BOOST_AUTO_TEST_CASE(TestHashByColumnKernel)
   BOOST_CHECK_EQUAL(uniqueValues->length(), 3);
 
   arrow::compute::Datum outRanges;
-  SortedGroupByKernel groupBy{{"x"}};
+  SortedGroupByKernel<uint64_t, arrow::UInt64Array> groupBy{{"x", 3}};
   BOOST_CHECK_EQUAL(groupBy.Call(&ctx, arrow::compute::Datum(table), &outRanges).ok(), true);
   auto result = arrow::util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
   BOOST_REQUIRE(result.get() != nullptr);
   BOOST_CHECK_EQUAL(result->num_rows(), 3);
 
   std::vector<Datum> splitted;
-  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "x", arrow::compute::Datum(table), &splitted).ok(), true);
+  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "x", static_cast<uint64_t>(3), arrow::compute::Datum(table), &splitted).ok(), true);
   BOOST_REQUIRE_EQUAL(splitted.size(), 3);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[0].value)->num_rows(), 4);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[1].value)->num_rows(), 4);
@@ -69,11 +69,6 @@ BOOST_AUTO_TEST_CASE(TestHashByColumnKernel)
 BOOST_AUTO_TEST_CASE(TestWithSOATables)
 {
   using namespace o2;
-  TableBuilder builder1;
-  auto collisionsCursor = builder1.cursor<aod::Collisions>();
-  collisionsCursor(0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-  collisionsCursor(0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-  auto collisions = builder1.finalize();
   TableBuilder builder2;
   auto tracksCursor = builder2.cursor<aod::Tracks>();
   tracksCursor(0, 0, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -87,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TestWithSOATables)
 
   arrow::compute::FunctionContext ctx;
   arrow::compute::Datum outRanges;
-  SortedGroupByKernel groupBy{{"fCollisionsID"}};
+  SortedGroupByKernel<int64_t, arrow::Int64Array> groupBy{{"fCollisionsID", 3}};
   BOOST_CHECK_EQUAL(groupBy.Call(&ctx, arrow::compute::Datum(tracks), &outRanges).ok(), true);
   auto result = arrow::util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
   BOOST_REQUIRE(result.get() != nullptr);
@@ -95,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestWithSOATables)
 
   std::vector<Datum> splitted;
   std::vector<uint64_t> offsets;
-  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "fCollisionsID", arrow::compute::Datum(tracks), &splitted, &offsets).ok(), true);
+  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "fCollisionsID", static_cast<int64_t>(3), arrow::compute::Datum(tracks), &splitted, &offsets).ok(), true);
   BOOST_REQUIRE_EQUAL(splitted.size(), 3);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[0].value)->num_rows(), 2);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[1].value)->num_rows(), 4);

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TestWithSOATables)
 
   arrow::compute::FunctionContext ctx;
   arrow::compute::Datum outRanges;
-  SortedGroupByKernel<int64_t, arrow::Int64Array> groupBy{{"fCollisionsID", 3}};
+  SortedGroupByKernel<int32_t, arrow::Int32Array> groupBy{{"fCollisionsID", 3}};
   BOOST_CHECK_EQUAL(groupBy.Call(&ctx, arrow::compute::Datum(tracks), &outRanges).ok(), true);
   auto result = arrow::util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
   BOOST_REQUIRE(result.get() != nullptr);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestWithSOATables)
 
   std::vector<Datum> splitted;
   std::vector<uint64_t> offsets;
-  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "fCollisionsID", static_cast<int64_t>(3), arrow::compute::Datum(tracks), &splitted, &offsets).ok(), true);
+  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "fCollisionsID", static_cast<int32_t>(3), arrow::compute::Datum(tracks), &splitted, &offsets).ok(), true);
   BOOST_REQUIRE_EQUAL(splitted.size(), 3);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[0].value)->num_rows(), 2);
   BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[1].value)->num_rows(), 4);


### PR DESCRIPTION
* Added support for empty underlying tables in soa::Table
* Improved type handling for table slicing kernel
* Temporary removed slicing test in test_ASoA

Now it is possible to not have exact correspondence between grouping
table entries and groups in a grouped table.