### PR TITLE
TPCClusterFinder: Fix a race condition when using digits as input.

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -941,6 +941,7 @@ int GPUChainTracking::RunTPCClusterizer()
         if (propagateMCLabels || not mIOPtrs.tpcZS) {
           runKernel<GPUTPCCFChargeMapFiller, GPUTPCCFChargeMapFiller::findFragmentStart>(GetGrid(1, lane), {iSlice}, {});
           TransferMemoryResourceLinkToHost(RecoStep::TPCClusterFinding, clusterer.mMemoryId, lane);
+          SynchronizeStream(lane);
           if (clusterer.mPmemory->counters.nPositions == 0) {
             continue;
           }


### PR DESCRIPTION
@davidrohr This should fix the clusters on GPU when skipping ZS.