### PR TITLE
Add TF id member to DataHeader

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -628,9 +628,10 @@ struct DataHeader : public BaseHeader {
   using SplitPayloadIndexType = uint32_t;
   using SplitPayloadPartsType = uint32_t;
   using PayloadSizeType = uint64_t;
+  using TForbitType = uint32_t;
 
   //static data for this header type/version
-  static constexpr uint32_t sVersion{1};
+  static constexpr uint32_t sVersion{2};
   static constexpr o2::header::HeaderType sHeaderType{String2<uint64_t>("DataHead")};
   static constexpr o2::header::SerializationMethod sSerializationMethod{gSerializationMethodNone};
 
@@ -672,6 +673,11 @@ struct DataHeader : public BaseHeader {
   //___NEVER MODIFY THE ABOVE
   //___NEW STUFF GOES BELOW
 
+  ///
+  /// first orbit of time frame as unique identifier within the run
+  ///
+  TForbitType firstTForbit;
+
   //___the functions:
   //__________________________________________________________________________________________________
   constexpr DataHeader()
@@ -682,7 +688,8 @@ struct DataHeader : public BaseHeader {
       payloadSerializationMethod(gSerializationMethodInvalid),
       subSpecification(0),
       splitPayloadIndex(0),
-      payloadSize(0)
+      payloadSize(0),
+      firstTForbit{0}
   {
   }
 
@@ -695,7 +702,8 @@ struct DataHeader : public BaseHeader {
       payloadSerializationMethod(gSerializationMethodInvalid),
       subSpecification(subspec),
       splitPayloadIndex(0),
-      payloadSize(size)
+      payloadSize(size),
+      firstTForbit{0}
   {
   }
 
@@ -708,7 +716,8 @@ struct DataHeader : public BaseHeader {
       payloadSerializationMethod(gSerializationMethodInvalid),
       subSpecification(subspec),
       splitPayloadIndex(partIndex),
-      payloadSize(size)
+      payloadSize(size),
+      firstTForbit{0}
   {
   }
 
@@ -762,8 +771,8 @@ static_assert(sizeof(BaseHeader) == 32,
               "BaseHeader struct must be of size 32");
 static_assert(sizeof(DataOrigin) == 4,
               "DataOrigin struct must be of size 4");
-static_assert(sizeof(DataHeader) == 80,
-              "DataHeader struct must be of size 80");
+static_assert(sizeof(DataHeader) == 88,
+              "DataHeader struct must be of size 88");
 static_assert(gSizeMagicString == sizeof(BaseHeader::magicStringInt),
               "Size mismatch in magic string union");
 static_assert(sizeof(BaseHeader::sMagicString) == sizeof(BaseHeader::magicStringInt),

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -236,9 +236,9 @@ BOOST_AUTO_TEST_CASE(DataHeader_test)
               << "size " << std::setw(2) << sizeof(dh.payloadSize) << " at " << (char*)(&dh.payloadSize) - (char*)(&dh) << std::endl;
   }
 
-  // DataHeader must have size 80
-  static_assert(sizeof(DataHeader) == 80,
-                "DataHeader struct must be of size 80");
+  // DataHeader must have size 88
+  static_assert(sizeof(DataHeader) == 88,
+                "DataHeader struct must be of size 88");
   DataHeader dh2;
   BOOST_CHECK(dh == dh2);
   DataHeader dh3{gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{0}, 0};

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -120,7 +120,7 @@ DataProcessorSpec getSinkSpec()
         ASSERT_ERROR(std::string("extended_info") == auxHeader->getName());
         o2::header::hexDump("", auxHeader, auxHeader->headerSize);
         auto dummyheader = auxHeader->next();
-        ASSERT_ERROR(dummyheader != nullptr && dummyheader->size() == 80);
+        ASSERT_ERROR(dummyheader != nullptr && dummyheader->size() == sizeof(o2::header::DataHeader));
       }
     }
 

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -89,6 +89,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
   }
 
   {
+    int sizeofDataHeader = sizeof(o2::header::DataHeader);
     struct elem {
       int i;
       int j;
@@ -105,7 +106,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
                  std::move(vec));
     BOOST_CHECK(message.Size() == 2);
     BOOST_CHECK(vec.size() == 0);
-    BOOST_CHECK(message[0].GetSize() == 80);
+    BOOST_CHECK(message[0].GetSize() == sizeofDataHeader);
     BOOST_CHECK(message[1].GetSize() == 2 * sizeof(elem)); //check the size of the buffer is set correctly
 
     //check contents
@@ -122,7 +123,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
                  factoryZMQ->CreateMessage(10));
     int size{0};
     forEach(message, [&](auto header, auto data) { size += header.size() + data.size(); });
-    BOOST_CHECK(size == 80 + 2 * sizeof(elem) + 80 + 10);
+    BOOST_CHECK(size == sizeofDataHeader + 2 * sizeof(elem) + sizeofDataHeader + 10);
 
     //check contents (headers)
     int checkOK{0};


### PR DESCRIPTION
Since all data parts are equipped with this there is enough reason to move this into the DataHeader, as was envisioned and agreed. Please do comment on the exact layout of this, for now it is long uint. 8 bytes should be enough for everybody.