### PR TITLE
Bugfix: Defining a default termination condition in MakeRootTreeWriterSpec

### DIFF
--- a/Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h
+++ b/Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h
@@ -218,9 +218,11 @@ class MakeRootTreeWriterSpec
     /// @param dataref  the DPL DataRef object
     /// @return true if ready
     using CheckReady = std::function<bool(o2::framework::DataRef const&)>;
+    /// default condition
+    using CheckDefault = std::function<bool()>;
 
     /// the actual evaluator
-    std::variant<CheckReady, CheckProcessing> check;
+    std::variant<CheckDefault, CheckReady, CheckProcessing> check = []() { return true; };
   };
 
   /// unary helper functor to extract the input key from the InputSpec


### PR DESCRIPTION
The content of the variant with the termination conditions was uninitialized,
leading to an invalid instance when extracting a concrete type from the variant.