### PR TITLE
TPC digitizer workflow: Extracting unserialized TPC digit data by gsl::span

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -440,7 +440,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   if (isEnabled(o2::detectors::DetID::TPC)) {
     tpcsectors = o2::RangeTokenizer::tokenize<int>(configcontext.options().get<std::string>("tpc-sectors"));
-    auto lanes = getNumTPCLanes(tpcsectors, configcontext);
+    // only one lane for the help printout
+    auto lanes = helpasked ? 1 : getNumTPCLanes(tpcsectors, configcontext);
     detList.emplace_back(o2::detectors::DetID::TPC);
 
     WorkflowSpec tpcPipelines = o2::tpc::getTPCDigitizerSpec(lanes, tpcsectors);


### PR DESCRIPTION
The span is directly using the raw input data without copy, for writing an
std vector of digits the data needs to be copied to such an object. For the triggered data,
this avoids an extra copy.

In addition, minor change to define only one lane if help printout is produced.
