### PR TITLE
Optionally mask neighbours of overflown pixel

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -15,15 +15,20 @@
 
 #include <fstream>
 
+#include "ITSMFTReconstruction/Clusterer.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-
-#include "ITSMFTReconstruction/Clusterer.h"
 
 using namespace o2::framework;
 
 namespace o2
 {
+
+namespace itsmft
+{
+class Clusterer;
+}
+
 namespace its
 {
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -17,6 +17,7 @@
 #include "ITSWorkflow/ClustererSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -64,7 +65,9 @@ void ClustererDPL::init(InitContext& ic)
 
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + 10);
+  const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance();
+  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + clParams.maxBCDiffToMaskBias);
+  mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
   std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
   std::string dictFile = o2::base::NameConf::getDictionaryFileName(o2::detectors::DetID::ITS, dictPath, ".bin");

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -29,6 +29,7 @@
 #include "ITSMFTBase/DPLAlpideParam.h"
 #include "CommonConstants/LHCConstants.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 
@@ -67,7 +68,9 @@ void ClustererDPL::init(InitContext& ic)
 
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
-  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + 10);
+  const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance();
+  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + clParams.maxBCDiffToMaskBias);
+  mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
   std::string dictPath = ic.options().get<std::string>("mft-dictionary-path");
   std::string dictFile = o2::base::NameConf::getDictionaryFileName(o2::detectors::DetID::MFT, dictPath, ".bin");

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(ITSMFTReconstruction
                        src/ChipMappingMFT.cxx
                        src/DigitPixelReader.cxx
                        src/Clusterer.cxx
+                       src/ClustererParam.cxx
                        src/PixelData.cxx
                        src/BuildTopologyDictionary.cxx
                        src/LookUp.cxx
@@ -43,6 +44,7 @@ o2_target_root_dictionary(
           include/ITSMFTReconstruction/RawPixelReader.h
           include/ITSMFTReconstruction/PixelData.h
           include/ITSMFTReconstruction/Clusterer.h
+          include/ITSMFTReconstruction/ClustererParam.h
           include/ITSMFTReconstruction/BuildTopologyDictionary.h
           include/ITSMFTReconstruction/LookUp.h
           include/ITSMFTReconstruction/TopologyFastSimulation.h

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -159,6 +159,9 @@ class Clusterer
   int getMaxBCSeparationToMask() const { return mMaxBCSeparationToMask; }
   void setMaxBCSeparationToMask(int n) { mMaxBCSeparationToMask = n; }
 
+  int getMaxRowColDiffToMask() const { return mMaxRowColDiffToMask; }
+  void setMaxRowColDiffToMask(int v) { mMaxRowColDiffToMask = v; }
+
   void setWantFullClusters(bool v) { mWantFullClusters = v; }
   void setWantCompactClusters(bool v) { mWantCompactClusters = v; }
 
@@ -212,6 +215,7 @@ class Clusterer
 
   ///< mask continuosly fired pixels in frames separated by less than this amount of BCs (fired from hit in prev. ROF)
   int mMaxBCSeparationToMask = 6000. / o2::constants::lhc::LHCBunchSpacingNS + 10;
+  int mMaxRowColDiffToMask = 0; ///< provide their difference in col/row is <= than this
 
   std::vector<std::unique_ptr<ClustererThread>> mThreads; // buffers for threads
   std::vector<ChipPixelData> mChips;                      // currently processed ROF's chips data

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClustererParam.h
+/// \brief Definition of the ITS/MFT clusterer settings
+
+#ifndef ALICEO2_ITSMFTCLUSTERERPARAM_H_
+#define ALICEO2_ITSMFTCLUSTERERPARAM_H_
+
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include <string_view>
+
+namespace o2
+{
+namespace itsmft
+{
+template <int N>
+struct ClustererParam : public o2::conf::ConfigurableParamHelper<ClustererParam<N>> {
+  static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");
+
+  static constexpr std::string_view getParamName()
+  {
+    return N == o2::detectors::DetID::ITS ? ParamName[0] : ParamName[1];
+  }
+
+  int maxRowColDiffToMask = 0;  ///< pixel may be masked as overflow if such a neighbour in prev frame was fired
+  int maxBCDiffToMaskBias = 10; ///< mask if 2 ROFs differ by <= StrobeLength + Bias BCs, use value <0 to disable masking
+
+  O2ParamDef(ClustererParam, getParamName().data());
+
+ private:
+  static constexpr std::string_view ParamName[2] = {"ITSClustererParam", "MFTClustererParam"};
+};
+
+template <int N>
+ClustererParam<N> ClustererParam<N>::sInstance;
+
+} // namespace itsmft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -64,6 +64,13 @@ class PixelData
     return getCol() < dt.getCol();
   }
 
+  bool isNeighbour(const PixelData& dt, int maxDist) const
+  {
+    ///< check if one pixel is in proximity of another
+    return (std::abs(static_cast<int>(getCol()) - static_cast<int>(dt.getCol())) <= maxDist &&
+            std::abs(static_cast<int>(getRow()) - static_cast<int>(dt.getRow())) <= maxDist);
+  }
+
   int compare(const PixelData& dt) const
   {
     ///< compare to pixels (first column then row)
@@ -156,6 +163,52 @@ class ChipPixelData
         itC++;
       } else {
         itS++;
+      }
+    }
+  }
+
+  void maskFiredInSample(const ChipPixelData& sample, int maxDist)
+  {
+    ///< mask in the current data pixels (or their neighbours) fired in provided sample
+    const auto& pixelsS = sample.getData();
+    int nC = mPixels.size();
+    if (!nC) {
+      return;
+    }
+    int nS = pixelsS.size();
+    if (!nS) {
+      return;
+    }
+    for (int itC = 0, itS = 0; itC < nC; itC++) {
+      auto& pix0 = mPixels[itC];
+
+      // seek to itS which is inferior than itC - maxDist
+      auto mincol = pix0.getCol() > maxDist ? pix0.getCol() - maxDist : 0;
+      auto minrow = pix0.getRowDirect() > maxDist ? pix0.getRowDirect() - maxDist : 0;
+      if (itS == nS) { // in case itS lool below reached the end
+        itS--;
+      }
+      while ((pixelsS[itS].getCol() > mincol || pixelsS[itS].getRow() > minrow) && itS > 0) {
+        itS--;
+      }
+      for (; itS < nS; itS++) {
+        const auto& pixC = pixelsS[itS];
+
+        auto drow = static_cast<int>(pixC.getRow()) - static_cast<int>(pix0.getRowDirect());
+        auto dcol = static_cast<int>(pixC.getCol()) - static_cast<int>(pix0.getCol());
+
+        if (dcol > maxDist || (dcol == maxDist && drow > maxDist)) {
+          break; // all higher itS will not match to this itC also
+        }
+        if (dcol < -maxDist || (drow > maxDist || drow < -maxDist)) {
+          continue;
+        } else {
+          pix0.setMask();
+          if (mFirstUnmasked == itC) { // mFirstUnmasked should flag 1st unmasked pixel entry
+            mFirstUnmasked = itC + 1;
+          }
+          break;
+        }
       }
     }
   }

--- a/Detectors/ITSMFT/common/reconstruction/src/ClustererParam.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ClustererParam.cxx
@@ -1,0 +1,22 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSMFTReconstruction/ClustererParam.h"
+
+namespace o2
+{
+namespace itsmft
+{
+// this makes sure that the constructor of the parameters is statically called
+// so that these params are part of the parameter database
+static auto& sClustererParamITS = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance();
+static auto& sClustererParamMFT = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance();
+} // namespace itsmft
+} // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -44,4 +44,9 @@
 
 #pragma link C++ class std::map < unsigned long, std::pair < o2::itsmft::ClusterTopology, unsigned long>> + ;
 
+#pragma link C++ class o2::itsmft::ClustererParam < o2::detectors::DetID::ITS> + ;
+#pragma link C++ class o2::itsmft::ClustererParam < o2::detectors::DetID::MFT> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::ClustererParam < o2::detectors::DetID::ITS>> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::itsmft::ClustererParam < o2::detectors::DetID::MFT>> + ;
+
 #endif

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -21,6 +21,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTReconstruction/RawPixelDecoder.h"
 #include "ITSMFTReconstruction/Clusterer.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 #include "ITSMFTWorkflow/STFDecoderSpec.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DataFormatsParameters/GRPObject.h"
@@ -76,7 +77,9 @@ void STFDecoder<Mapping>::init(InitContext& ic)
 
     // settings for the fired pixel overflow masking
     const auto& alpParams = DPLAlpideParam<Mapping::getDetID()>::Instance();
-    mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + 10);
+    const auto& clParams = ClustererParam<Mapping::getDetID()>::Instance();
+    mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + clParams.maxBCDiffToMaskBias);
+    mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
     std::string dictFile = o2::base::NameConf::getDictionaryFileName(detID, mDictName, ".bin");
     if (o2::base::NameConf::pathExists(dictFile)) {

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -8,8 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "Framework/ConfigParamSpec.h"
 #include "ITSMFTWorkflow/STFDecoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
 
 using namespace o2::framework;
 
@@ -24,7 +25,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"no-clusters", VariantType::Bool, false, {"do not produce clusters (def: produce)"}},
     ConfigParamSpec{"no-cluster-patterns", VariantType::Bool, false, {"do not produce clusters patterns (def: produce)"}},
     ConfigParamSpec{"digits", VariantType::Bool, false, {"produce digits (def: skip)"}},
-    ConfigParamSpec{"dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}}};
+    ConfigParamSpec{"dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}},
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -40,6 +42,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto doPatterns = doClusters && !cfgc.options().get<bool>("no-cluster-patterns");
   auto doDigits = cfgc.options().get<bool>("digits");
   auto dict = cfgc.options().get<std::string>("dict-file");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   if (cfgc.options().get<bool>("mft")) {
     wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, dict));


### PR DESCRIPTION
With ``o2::itsmft::ClustererParam.maxRowColDiffToMask>0`` a special version of maskFiredInSample 
is called which allows to mask neighbours in the vicinity +-maxRowColDiffToMask (both in col.and row) of the overflown fired pixel.
Needed to eliminate corona from lately fired pixels.