### PR TITLE
Options to suppress error check in RawReader and empty HBFs in RawWriter

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -277,6 +277,7 @@ Data from the same detector may be split to multiple files link-wise and/or time
 o2-raw-file-reader-workflow
   ...
   --loop arg (=1)                       loop N times (infinite for N<0)
+  --max-tf (=0xffffffff)                max number of TF to process
   --message-per-tf                      send TF of each link as a single FMQ message rather than multipart with message per HB
   --output-per-link                     send message per Link rather than per FMQ output route
   --delay arg (=0)                      delay in seconds between consecutive TFs sending
@@ -319,6 +320,7 @@ Usage:   o2-raw-file-check [options] file0 [... fileN]
 Options:
   -h [ --help ]                     print this help message.
   -c [ --conf ] arg                 read input from configuration file
+  -m [ --max-tf] arg (=0xffffffff)  max.number of TF to read
   -v [ --verbosity ] arg (=0)    1: long report, 2 or 3: print or dump all RDH
   -s [ --spsize ]    arg (=1048576) nominal super-page size in bytes
   -t [ --hbfpertf ]  arg (=256)     nominal number of HBFs per TF

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -276,11 +276,22 @@ Data from the same detector may be split to multiple files link-wise and/or time
 ```cpp
 o2-raw-file-reader-workflow
   ...
-  --conf arg                            configuration file to init from (obligatory)
-  --loop arg (=0)                       loop N times (infinite for N<0)
-  --message-per-tf                      send TF of each link as a single FMQ message rather part per HBF
+  --loop arg (=1)                       loop N times (infinite for N<0)
+  --message-per-tf                      send TF of each link as a single FMQ message rather than multipart with message per HB
   --output-per-link                     send message per Link rather than per FMQ output route
   --delay arg (=0)                      delay in seconds between consecutive TFs sending
+  --configKeyValues arg                 semicolon separated key=value strings
+
+  # to suppress various error checks / reporting
+  --nocheck-packet-increment            ignore /Wrong RDH.packetCounter increment/
+  --nocheck-page-increment              ignore /Wrong RDH.pageCnt increment/
+  --nocheck-stop-on-page0               ignore /RDH.stop set of 1st HBF page/
+  --nocheck-missing-stop                ignore /New HBF starts w/o closing old one/
+  --nocheck-starts-with-tf              ignore /Data does not start with TF/HBF/
+  --nocheck-hbf-per-tf                  ignore /Number of HBFs per TF not as expected/
+  --nocheck-tf-per-link                 ignore /Number of TFs is less than expected/
+  --nocheck-hbf-jump                    ignore /Wrong HBF orbit increment/
+  --nocheck-no-spage-for-tf             ignore /TF does not start by new superpage/
 ```
 
 The workflow takes an input from the configuration file (as described in `RawFileReader` section), reads the data and sends them as DPL messages

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -138,6 +138,8 @@ rdh     : RDH of the CRU page opening empty RDH
 toAdd   : a vector (supplied empty) to be filled to a size multipe of 16 bytes
 ```
 
+Adding empty HBF pages for HB's w/o data can be avoided by setting `writer.setDontFillEmptyHBF(true)` before starting conversion. Note that the empty HBFs still will be added for HBs which are supposed to open a new TF.
+
 The data `toAdd` will be inserted between the star/stop RDHs of the empty HBF.
 
 The behaviour descibed above can be modified by providing an extra argument in the `addData` method

--- a/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/RDHUtils.h
@@ -658,14 +658,15 @@ struct RDHUtils {
     // meaningfull DAQ sourceID means that it comes from RDHv6, in this case we use feeID as a subspec
     if (srcid != o2::header::DAQID::INVALID) {
       return feeId;
-    } else {
-      int linkValue = (LinkSubSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
-      return (LinkSubSpec_t(cru) << 16) | linkValue;
     }
+    //else { // this may lead to ambiguities
+    //  int linkValue = (LinkSubSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
+    //  return (LinkSubSpec_t(cru) << 16) | linkValue;
+    //}
     //
     // RS At the moment suppress getting the subspec as a hash
-    // uint16_t seq[3] = {cru, uint16_t((uint16_t(link) << 8) | endpoint), feeId};
-    // return fletcher32(seq, 3);
+    uint16_t seq[3] = {cru, uint16_t((uint16_t(link) << 8) | endpoint), feeId};
+    return fletcher32(seq, 3);
   }
   template <typename H>
   static LinkSubSpec_t getSubSpec(const H& rdh, NOTPTR(H)) // will be used for all RDH versions but >=6

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -180,9 +180,6 @@ class RawFileReader
   void setNominalSPageSize(int n = 0x1 << 20) { mNominalSPageSize = n > (0x1 << 15) ? n : (0x1 << 15); }
   int getNominalSPageSize() const { return mNominalSPageSize; }
 
-  void setNominalHBFperTF(int n = 256) { mNominalHBFperTF = n > 1 ? n : 1; }
-  int getNominalHBFperTF() const { return mNominalHBFperTF; }
-
   uint32_t getNTimeFrames() const { return mNTimeFrames; }
   uint32_t getOrbitMin() const { return mOrbitMin; }
   uint32_t getOrbitMax() const { return mOrbitMax; }
@@ -193,6 +190,8 @@ class RawFileReader
   static o2::header::DataOrigin getDataOrigin(const std::string& ors);
   static o2::header::DataDescription getDataDescription(const std::string& ors);
   static InputsMap parseInput(const std::string& confUri);
+  static std::string nochk_opt(ErrTypes e);
+  static std::string nochk_expl(ErrTypes e);
 
  private:
   int getLinkLocalID(const RDHAny& rdh, o2::header::DataOrigin orig);
@@ -217,7 +216,6 @@ class RawFileReader
   uint32_t mOrbitMin = 0xffffffff;                  // lowest orbit seen by any link
   uint32_t mOrbitMax = 0;                           // highest orbit seen by any link
   int mNominalSPageSize = 0x1 << 20;                // expected super-page size in B
-  int mNominalHBFperTF = 256;                       // expected N HBF per TF
   int mCurrentFileID = 0;                           // current file being processed
   long int mPosInFile = 0;                          // current position in the file
   bool mMultiLinkFile = false;                      // was > than 1 link seen in the file?

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -108,8 +108,8 @@ class RawFileReader
     LinkSubSpec_t subspec = 0; // subspec according to DataDistribution
     uint32_t nTimeFrames = 0;
     uint32_t nHBFrames = 0;
-    uint32_t nCRUPages = 0;
     uint32_t nSPages = 0;
+    uint64_t nCRUPages = 0;
     o2::header::DataOrigin origin = o2::header::gDataOriginInvalid;
     o2::header::DataDescription description = o2::header::gDataDescriptionInvalid;
     std::string fairMQChannel{}; // name of the fairMQ channel for the output
@@ -180,6 +180,8 @@ class RawFileReader
   void setNominalSPageSize(int n = 0x1 << 20) { mNominalSPageSize = n > (0x1 << 15) ? n : (0x1 << 15); }
   int getNominalSPageSize() const { return mNominalSPageSize; }
 
+  void setMaxTFToRead(uint32_t n) { mMaxTFToRead = n; }
+  uint32_t getMaxTFToRead() const { return mMaxTFToRead; }
   uint32_t getNTimeFrames() const { return mNTimeFrames; }
   uint32_t getOrbitMin() const { return mOrbitMin; }
   uint32_t getOrbitMax() const { return mOrbitMax; }
@@ -211,6 +213,7 @@ class RawFileReader
   std::unordered_map<LinkSpec_t, int> mLinkEntries; // mapping between RDH specs and link entry in the mLinksData
   std::vector<LinkData> mLinksData;                 // info on links data in the files
   std::vector<int> mOrderedIDs;                     // links entries ordered in Specs
+  uint32_t mMaxTFToRead = 0xffffffff;               // max TFs to process
   uint32_t mNTimeFrames = 0;                        // total number of time frames
   uint32_t mNextTF2Read = 0;                        // next TF to read
   uint32_t mOrbitMin = 0xffffffff;                  // lowest orbit seen by any link

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -100,7 +100,7 @@ class RawFileWriter
     void addHBFPage(bool stop = false);
     void closeHBFPage() { addHBFPage(true); }
     void flushSuperPage(bool keepLastPage = false);
-    void fillEmptyHBHs(const IR& ir);
+    void fillEmptyHBHs(const IR& ir, bool dataAdded);
     void addPreformattedCRUPage(const gsl::span<char> data);
 
     /// expand buffer by positive increment and return old size
@@ -285,6 +285,9 @@ class RawFileWriter
     mUseRDHVersion = v;
   }
 
+  bool getDontFillEmptyHBF() const { return mDontFillEmptyHBF; }
+  void setDontFillEmptyHBF(bool v) { mDontFillEmptyHBF = v; }
+
  private:
   enum RoMode_t { NotSet,
                   Continuous,
@@ -303,6 +306,7 @@ class RawFileWriter
   int mUseRDHVersion = RDHUtils::getVersion<o2::header::RAWDataHeader>(); // by default, use default version
   int mSuperPageSize = 1024 * 1024; // super page size
   bool mStartTFOnNewSPage = true;   // every TF must start on a new SPage
+  bool mDontFillEmptyHBF = false;   // skipp adding empty HBFs (uness it must have TF flag)
   RoMode_t mROMode = NotSet;
   IR mFirstIRAdded; // 1st IR seen
   ClassDefNV(RawFileWriter, 1);

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -22,6 +22,7 @@
 #include "Headers/DAQID.h"
 #include "CommonConstants/Triggers.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "DetectorsRaw/HBFUtils.h"
 #include "Framework/Logger.h"
 
 #include <Common/Configuration.h>
@@ -231,10 +232,10 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDHAny& rdh, bool newSPage
       }
       // check if number of HBFs in the TF is as expected
       if (newTF) {
-        if (nHBFinTF != reader->mNominalHBFperTF &&
+        if (nHBFinTF != HBFUtils::Instance().getNOrbitsPerTF() &&
             (reader->mCheckErrors & (0x1 << ErrWrongHBFsPerTF))) {
           LOG(ERROR) << ErrNames[ErrWrongHBFsPerTF] << ": "
-                     << nHBFinTF << " instead of " << reader->mNominalHBFperTF;
+                     << nHBFinTF << " instead of " << HBFUtils::Instance().getNOrbitsPerTF();
           ok = false;
           nErrors++;
         }
@@ -648,4 +649,16 @@ RawFileReader::InputsMap RawFileReader::parseInput(const std::string& confUri)
   }
 
   return entries;
+}
+
+std::string RawFileReader::nochk_opt(RawFileReader::ErrTypes e)
+{
+  std::string ignore = "nocheck-";
+  return ignore + RawFileReader::ErrNamesShort[e].data();
+}
+
+std::string RawFileReader::nochk_expl(RawFileReader::ErrTypes e)
+{
+  std::string ignore = "ignore /";
+  return ignore + RawFileReader::ErrNames[e].data() + '/';
 }

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -44,10 +44,12 @@ namespace o2h = o2::header;
 class rawReaderSpecs : public o2f::Task
 {
  public:
-  explicit rawReaderSpecs(const std::string& config, bool tfAsMessage = false, bool outPerRoute = true, int loop = 1, uint32_t delay_us = 0, uint32_t errmap = 0xffffffff)
+  explicit rawReaderSpecs(const std::string& config, bool tfAsMessage = false, bool outPerRoute = true, int loop = 1, uint32_t delay_us = 0,
+                          uint32_t errmap = 0xffffffff, uint32_t maxTF = 0xffffffff)
     : mLoop(loop < 1 ? 1 : loop), mHBFPerMessage(!tfAsMessage), mOutPerRoute(outPerRoute), mDelayUSec(delay_us), mReader(std::make_unique<o2::raw::RawFileReader>(config))
   {
     mReader->setCheckErrors(errmap);
+    mReader->setMaxTFToRead(maxTF);
     LOG(INFO) << "Number of loops over whole data requested: " << mLoop;
     if (mHBFPerMessage) {
       LOG(INFO) << "Every link TF will be sent as multipart of HBF messages";
@@ -219,7 +221,7 @@ class rawReaderSpecs : public o2f::Task
   std::unique_ptr<o2::raw::RawFileReader> mReader; // matching engine
 };
 
-o2f::DataProcessorSpec getReaderSpec(std::string config, bool tfAsMessage, bool outPerRoute, int loop, uint32_t delay_us, uint32_t errmap)
+o2f::DataProcessorSpec getReaderSpec(std::string config, bool tfAsMessage, bool outPerRoute, int loop, uint32_t delay_us, uint32_t errmap, uint32_t maxTF)
 {
   // check which inputs are present in files to read
   o2f::Outputs outputs;
@@ -236,14 +238,14 @@ o2f::DataProcessorSpec getReaderSpec(std::string config, bool tfAsMessage, bool 
     "raw-file-reader",
     o2f::Inputs{},
     outputs,
-    o2f::AlgorithmSpec{o2f::adaptFromTask<rawReaderSpecs>(config, tfAsMessage, outPerRoute, loop, delay_us, errmap)},
+    o2f::AlgorithmSpec{o2f::adaptFromTask<rawReaderSpecs>(config, tfAsMessage, outPerRoute, loop, delay_us, errmap, maxTF)},
     o2f::Options{}};
 }
 
 o2f::WorkflowSpec o2::raw::getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage, bool outPerRoute,
-                                                    int loop, uint32_t delay_us, uint32_t errmap)
+                                                    int loop, uint32_t delay_us, uint32_t errmap, uint32_t maxTF)
 {
   o2f::WorkflowSpec specs;
-  specs.emplace_back(getReaderSpec(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap));
+  specs.emplace_back(getReaderSpec(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap, maxTF));
   return specs;
 }

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -21,7 +21,7 @@ namespace raw
 {
 
 framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true,
-                                                 int loop = 1, uint32_t delay_us = 0, uint32_t noerr = 0);
+                                                 int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff, uint32_t maxTF = 0xffffffff);
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -20,7 +20,8 @@ namespace o2
 namespace raw
 {
 
-framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true, int loop = 1, uint32_t delay_us = 0);
+framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true,
+                                                 int loop = 1, uint32_t delay_us = 0, uint32_t noerr = 0);
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -23,6 +23,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options;
   options.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
+  options.push_back(ConfigParamSpec{"max-tf", o2::framework::VariantType::Int64, 0xffffffffL, {"max number of TF to process"}});
   options.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
   options.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
   options.push_back(ConfigParamSpec{"output-per-link", o2::framework::VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
@@ -49,10 +50,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   auto inifile = configcontext.options().get<std::string>("conf");
   auto loop = configcontext.options().get<int>("loop");
+  uint32_t maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
   auto tfAsMessage = configcontext.options().get<bool>("message-per-tf");
   auto outPerRoute = !configcontext.options().get<bool>("output-per-link");
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<int>("delay")); // delay in microseconds
+  uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
   uint32_t errmap = 0xffffffff;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
@@ -62,5 +64,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap));
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap, maxTF));
 }

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -9,19 +9,36 @@
 // or submit itself to any jurisdiction.
 
 #include "RawFileReaderWorkflow.h"
+#include "DetectorsRaw/RawFileReader.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/Logger.h"
 #include <string>
 
 using namespace o2::framework;
+using namespace o2::raw;
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  workflowOptions.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
-  workflowOptions.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
-  workflowOptions.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
-  workflowOptions.push_back(ConfigParamSpec{"output-per-link", o2::framework::VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
-  workflowOptions.push_back(ConfigParamSpec{"delay", o2::framework::VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
+  std::vector<o2::framework::ConfigParamSpec> options;
+  options.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
+  options.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
+  options.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
+  options.push_back(ConfigParamSpec{"output-per-link", o2::framework::VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
+  options.push_back(ConfigParamSpec{"delay", o2::framework::VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
+  options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
+  // options for error-check suppression
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongPacketCounterIncrement), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongPacketCounterIncrement)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongPageCounterIncrement), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongPageCounterIncrement)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFStopOnFirstPage), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFStopOnFirstPage)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFNoStop), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFNoStop)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongFirstPage), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongFirstPage)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongHBFsPerTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongHBFsPerTF)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongNumberOfTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongNumberOfTF)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFJump), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFJump)}});
+  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrNoSuperPageForTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrNoSuperPageForTF)}});
+  std::swap(workflowOptions, options);
 }
 
 // ------------------------------------------------------------------
@@ -34,6 +51,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto loop = configcontext.options().get<int>("loop");
   auto tfAsMessage = configcontext.options().get<bool>("message-per-tf");
   auto outPerRoute = !configcontext.options().get<bool>("output-per-link");
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<int>("delay")); // delay in microseconds
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us));
+
+  uint32_t errmap = 0xffffffff;
+  for (int i = RawFileReader::NErrorsDefined; i--;) {
+    if (configcontext.options().get<bool>(RawFileReader::nochk_opt(RawFileReader::ErrTypes(i)).c_str())) {
+      errmap ^= 0x1 << i;
+      LOGF(INFO, "ignore  check for /%s/", RawFileReader::ErrNames[i].data());
+    }
+  }
+
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap));
 }

--- a/Detectors/Raw/src/rawfileCheck.cxx
+++ b/Detectors/Raw/src/rawfileCheck.cxx
@@ -13,6 +13,7 @@
 /// @brief  Checker for raw data conformity with CRU format
 
 #include "DetectorsRaw/RawFileReader.h"
+#include "CommonUtils/ConfigurableParam.h"
 #include "Framework/Logger.h"
 #include <TStopwatch.h>
 #include <boost/program_options.hpp>
@@ -24,23 +25,11 @@ namespace bpo = boost::program_options;
 
 using namespace o2::raw;
 
-std::string nochk_expl(RawFileReader::ErrTypes e)
-{
-  std::string ignore = "ignore /";
-  return ignore + RawFileReader::ErrNames[e].data() + '/';
-}
-
-std::string nochk_opt(RawFileReader::ErrTypes e)
-{
-  std::string ignore = "nocheck-";
-  return ignore + RawFileReader::ErrNamesShort[e].data();
-}
-
 int main(int argc, char* argv[])
 {
   RawFileReader reader;
   std::vector<std::string> fnames;
-  std::string config;
+  std::string config, configKeyValues;
   bpo::variables_map vm;
   bpo::options_description descOpt("Options");
   descOpt.add_options()(
@@ -48,16 +37,16 @@ int main(int argc, char* argv[])
     "conf,c", bpo::value(&config)->default_value(""), "read input from configuration file")(
     "verbosity,v", bpo::value<int>()->default_value(reader.getVerbosity()), "1: long report, 2 or 3: print or dump all RDH")(
     "spsize,s", bpo::value<int>()->default_value(reader.getNominalSPageSize()), "nominal super-page size in bytes")(
-    "hbfpertf,t", bpo::value<int>()->default_value(reader.getNominalHBFperTF()), "nominal number of HBFs per TF")(
-    nochk_opt(RawFileReader::ErrWrongPacketCounterIncrement).c_str(), nochk_expl(RawFileReader::ErrWrongPacketCounterIncrement).c_str())(
-    nochk_opt(RawFileReader::ErrWrongPageCounterIncrement).c_str(), nochk_expl(RawFileReader::ErrWrongPageCounterIncrement).c_str())(
-    nochk_opt(RawFileReader::ErrHBFStopOnFirstPage).c_str(), nochk_expl(RawFileReader::ErrHBFStopOnFirstPage).c_str())(
-    nochk_opt(RawFileReader::ErrHBFNoStop).c_str(), nochk_expl(RawFileReader::ErrHBFNoStop).c_str())(
-    nochk_opt(RawFileReader::ErrWrongFirstPage).c_str(), nochk_expl(RawFileReader::ErrWrongFirstPage).c_str())(
-    nochk_opt(RawFileReader::ErrWrongHBFsPerTF).c_str(), nochk_expl(RawFileReader::ErrWrongHBFsPerTF).c_str())(
-    nochk_opt(RawFileReader::ErrWrongNumberOfTF).c_str(), nochk_expl(RawFileReader::ErrWrongNumberOfTF).c_str())(
-    nochk_opt(RawFileReader::ErrHBFJump).c_str(), nochk_expl(RawFileReader::ErrHBFJump).c_str())(
-    nochk_opt(RawFileReader::ErrNoSuperPageForTF).c_str(), nochk_expl(RawFileReader::ErrNoSuperPageForTF).c_str());
+    "configKeyValues", bpo::value(&configKeyValues)->default_value(""), "semicolon separated key=value strings")(
+    RawFileReader::nochk_opt(RawFileReader::ErrWrongPacketCounterIncrement).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrWrongPacketCounterIncrement).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrWrongPageCounterIncrement).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrWrongPageCounterIncrement).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrHBFStopOnFirstPage).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrHBFStopOnFirstPage).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrHBFNoStop).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrHBFNoStop).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrWrongFirstPage).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrWrongFirstPage).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrWrongHBFsPerTF).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrWrongHBFsPerTF).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrWrongNumberOfTF).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrWrongNumberOfTF).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrHBFJump).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrHBFJump).c_str())(
+    RawFileReader::nochk_opt(RawFileReader::ErrNoSuperPageForTF).c_str(), RawFileReader::nochk_expl(RawFileReader::ErrNoSuperPageForTF).c_str());
 
   bpo::options_description hiddenOpt("hidden");
   hiddenOpt.add_options()("files", bpo::value(&fnames)->composing(), "");
@@ -86,7 +75,7 @@ int main(int argc, char* argv[])
       printHelp(std::cout);
       return 0;
     }
-
+    o2::conf::ConfigurableParam::updateFromString(configKeyValues);
   } catch (const bpo::error& e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Error parsing command line arguments\n";
@@ -99,11 +88,10 @@ int main(int argc, char* argv[])
 
   reader.setVerbosity(vm["verbosity"].as<int>());
   reader.setNominalSPageSize(vm["spsize"].as<int>());
-  reader.setNominalHBFperTF(vm["hbfpertf"].as<int>());
 
   uint32_t errmap = 0xffffffff;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
-    if (vm.count(nochk_opt(RawFileReader::ErrTypes(i)).c_str())) {
+    if (vm.count(RawFileReader::nochk_opt(RawFileReader::ErrTypes(i)).c_str())) {
       errmap ^= 0x1 << i;
       LOGF(INFO, "ignore  check for /%s/", RawFileReader::ErrNames[i].data());
     }

--- a/Detectors/Raw/src/rawfileCheck.cxx
+++ b/Detectors/Raw/src/rawfileCheck.cxx
@@ -35,6 +35,7 @@ int main(int argc, char* argv[])
   descOpt.add_options()(
     "help,h", "print this help message.")(
     "conf,c", bpo::value(&config)->default_value(""), "read input from configuration file")(
+    "max-tf,m", bpo::value<uint32_t>()->default_value(0xffffffff), "max.number of TF to read")(
     "verbosity,v", bpo::value<int>()->default_value(reader.getVerbosity()), "1: long report, 2 or 3: print or dump all RDH")(
     "spsize,s", bpo::value<int>()->default_value(reader.getNominalSPageSize()), "nominal super-page size in bytes")(
     "configKeyValues", bpo::value(&configKeyValues)->default_value(""), "semicolon separated key=value strings")(
@@ -88,7 +89,7 @@ int main(int argc, char* argv[])
 
   reader.setVerbosity(vm["verbosity"].as<int>());
   reader.setNominalSPageSize(vm["spsize"].as<int>());
-
+  reader.setMaxTFToRead(vm["max-tf"].as<uint32_t>());
   uint32_t errmap = 0xffffffff;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     if (vm.count(RawFileReader::nochk_opt(RawFileReader::ErrTypes(i)).c_str())) {


### PR DESCRIPTION
* Checking for non-fatal errors can be suppressed in the raw-file-reader-workflow
* Adding for empty HBF may be optionally avoided in the writer except for 1st HBFs of TF