### PR TITLE
Support decoding old ITS/MFT format

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -109,17 +109,31 @@ struct GBTTrigger;
 
 /// support for the GBT single link data
 struct GBTLink {
-  enum CollectedDataStatus { None, // set before starting collectROFCableData
-                             AbortedOnError,
-                             StoppedOnEndOfData,
-                             DataSeen };
-  enum ErrorType { NoError,
-                   Warning,
-                   Abort };
-  using RDH = o2::header::RDHAny;
 
-  int8_t verbosity = 0;
+  enum Format : int8_t { OldFormat,
+                         NewFormat,
+                         NFormats };
+
+  enum CollectedDataStatus : int8_t { None,
+                                      AbortedOnError,
+                                      StoppedOnEndOfData,
+                                      DataSeen }; // None is set before starting collectROFCableData
+
+  enum ErrorType : int8_t { NoError,
+                            Warning,
+                            Abort };
+
+  enum Verbosity : int8_t { Silent = -1,
+                            VerboseErrors,
+                            VerboseHeaders,
+                            VerboseData };
+
+  using RDH = o2::header::RDHAny;
+  using RDHUtils = o2::raw::RDHUtils;
+
   CollectedDataStatus status = None;
+  Format format = NewFormat;
+  Verbosity verbosity = VerboseErrors;
   uint8_t idInRU = 0;     // link ID within the RU
   uint8_t idInCRU = 0;    // link ID within the CRU
   uint8_t endPointID = 0; // endpoint ID of the CRU
@@ -222,7 +236,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     }
     if (!dataOffset) { // here we always start with the RDH
       const auto* rdh = reinterpret_cast<const RDH*>(&currRawPiece->data[dataOffset]);
-      if (verbosity) {
+      if (verbosity >= VerboseHeaders) {
         printRDH(*rdh);
       }
       GBTLINK_DECODE_ERRORCHECK(checkErrorsRDH(*rdh));              // make sure we are dealing with RDH
@@ -236,27 +250,30 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
 
     ruPtr->nCables = ruPtr->ruInfo->nCables; // RSTODO is this needed? TOREMOVE
 
-    // data must start with GBT trigger word
-    auto gbtTrg = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]); // process GBT trigger
-    dataOffset += GBTPaddedWordLength;
-    if (verbosity) {
-      printTrigger(gbtTrg);
+    // data must start with GBT trigger word (unless we work with old format)
+    const GBTTrigger* gbtTrg = nullptr;
+    if (format == NewFormat) {
+      gbtTrg = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]); // process GBT trigger
+      dataOffset += GBTPaddedWordLength;
+      if (verbosity >= VerboseHeaders) {
+        printTrigger(gbtTrg);
+      }
+      GBTLINK_DECODE_ERRORCHECK(checkErrorsTriggerWord(gbtTrg));
     }
-    GBTLINK_DECODE_ERRORCHECK(checkErrorsTriggerWord(gbtTrg));
+
     // next the GBTHeader must come
     auto gbtH = reinterpret_cast<const GBTDataHeader*>(&currRawPiece->data[dataOffset]); // process GBT header
     dataOffset += GBTPaddedWordLength;
-    if (verbosity) {
+    if (verbosity >= VerboseHeaders) {
       printHeader(gbtH);
     }
     GBTLINK_DECODE_ERRORCHECK(checkErrorsHeaderWord(gbtH));
     lanesActive = gbtH->activeLanes; // TODO do we need to update this for every page?
     GBTLINK_DECODE_ERRORCHECK(checkErrorsActiveLanes(chmap.getCablesOnRUType(ruPtr->ruInfo->ruType)));
-    //    if (RDHUtils::getPageCnt(*lastRDH)) { // RSTODO reset flags in case of 1st page of new ROF (old format: judge by RDH)
-    //      lanesStop = 0;
-    //      lanesWithData = 0;
-    //    }
-    if (gbtH->packetIdx == 0) { // reset flags in case of 1st page of new ROF (new format: judge by header)
+    if (format == OldFormat && RDHUtils::getPageCounter(*lastRDH)) { // RSTODO reset flags in case of 1st page of new ROF (old format: judge by RDH)
+      lanesStop = 0;
+      lanesWithData = 0;
+    } else if (gbtH->packetIdx == 0) { // reset flags in case of 1st page of new ROF (new format: judge by header)
       lanesStop = 0;
       lanesWithData = 0;
     }
@@ -264,7 +281,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     while (!gbtD->isDataTrailer()) { // start reading real payload
       nw++;
       int cableHW = gbtD->getCableID(), cableSW = chmap.cableHW2SW(ruPtr->ruInfo->ruType, cableHW);
-      if (verbosity > 1) {
+      if (verbosity >= VerboseData) {
         gbtD->printX();
       }
       GBTLINK_DECODE_ERRORCHECK(checkErrorsGBTData(cableHW, cableSW));
@@ -278,7 +295,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
 
     auto gbtT = reinterpret_cast<const o2::itsmft::GBTDataTrailer*>(&currRawPiece->data[dataOffset]); // process GBT trailer
     dataOffset += GBTPaddedWordLength;
-    if (verbosity) {
+    if (verbosity >= VerboseHeaders) {
       printTrailer(gbtT);
     }
     GBTLINK_DECODE_ERRORCHECK(checkErrorsTrailerWord(gbtT));
@@ -291,9 +308,14 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     // accumulate packet states
     statistics.packetStates[gbtT->getPacketState()]++;
     // before quitting, store the trigger and IR
-    ir.bc = gbtTrg->bc;
-    ir.orbit = gbtTrg->orbit;
-    trigger = gbtTrg->triggerType;
+    if (format == NewFormat) {
+      ir.bc = gbtTrg->bc;
+      ir.orbit = gbtTrg->orbit;
+      trigger = gbtTrg->triggerType;
+    } else {
+      ir = RDHUtils::getTriggerIR(lastRDH);
+      trigger = RDHUtils::getTriggerType(lastRDH);
+    }
     return (status = DataSeen);
   }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -46,6 +46,10 @@ class RawPixelDecoder : public PixelReader
  public:
   RawPixelDecoder();
   ~RawPixelDecoder() final = default;
+
+  GBTLink::Format getFormat() const { return mFormat; }
+  void setFormat(GBTLink::Format f);
+
   void init() final {}
   bool getNextChipData(ChipPixelData& chipData) final;
   ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) final;
@@ -100,6 +104,7 @@ class RawPixelDecoder : public PixelReader
   Mapping mMAP;                                 // chip mapping
   int mVerbosity = 0;
   int mNThreads = 1; // number of decoding threads
+  GBTLink::Format mFormat = GBTLink::NewFormat; // ITS Data Format (old: 1 ROF per CRU page)
   // statistics
   o2::itsmft::ROFRecord::ROFtype mROFCounter = 0; // RSTODO is this needed? eliminate from ROFRecord ?
   uint32_t mNChipsFiredROF = 0;                   // counter within the ROF

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -164,7 +164,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDH(const RDH& rdh)
 /// Check RDH Stop correctness
 GBTLink::ErrorType GBTLink::checkErrorsRDHStop(const RDH& rdh)
 {
-  if (lastRDH && RDHUtils::getHeartBeatOrbit(*lastRDH) != RDHUtils::getHeartBeatOrbit(rdh) // new HB starts
+  if (format == NewFormat && lastRDH && RDHUtils::getHeartBeatOrbit(*lastRDH) != RDHUtils::getHeartBeatOrbit(rdh) // new HB starts
       && !RDHUtils::getStop(*lastRDH)) {
     statistics.errorCounts[GBTS::ErrPageNotStopped]++;
     if (verbosity >= VerboseErrors) {
@@ -182,7 +182,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDHStop(const RDH& rdh)
 /// Check if the RDH Stop page is empty
 GBTLink::ErrorType GBTLink::checkErrorsRDHStopPageEmpty(const RDH& rdh)
 {
-  if (format != OldFormat && RDHUtils::getStop(rdh) && RDHUtils::getMemorySize(rdh) != sizeof(RDH)) {
+  if (format == NewFormat && RDHUtils::getStop(rdh) && RDHUtils::getMemorySize(rdh) != sizeof(RDH)) {
     statistics.errorCounts[GBTS::ErrStopPageNotEmpty]++;
     if (verbosity >= VerboseErrors) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTS::ErrStopPageNotEmpty];

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -168,7 +168,8 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
       lnkref.entry = int(mGBTLinks.size());
       auto& lnk = mGBTLinks.emplace_back(RDHUtils::getCRUID(rdh), RDHUtils::getFEEID(rdh), RDHUtils::getEndPointID(rdh), RDHUtils::getLinkID(rdh), lnkref.entry);
       getCreateRUDecode(mMAP.FEEId2RUSW(RDHUtils::getFEEID(rdh))); // make sure there is a RU for this link
-      lnk.verbosity = mVerbosity;
+      lnk.verbosity = GBTLink::Verbosity(mVerbosity);
+      lnk.format = mFormat;
       LOG(INFO) << mSelfName << " registered new link " << lnk.describe() << " RUSW=" << int(mMAP.FEEId2RUSW(lnk.feeID));
       linksAdded++;
     }
@@ -274,7 +275,7 @@ void RawPixelDecoder<Mapping>::setVerbosity(int v)
 {
   mVerbosity = v;
   for (auto& link : mGBTLinks) {
-    link.verbosity = v;
+    link.verbosity = GBTLink::Verbosity(v);
   }
 }
 
@@ -288,6 +289,14 @@ void RawPixelDecoder<Mapping>::setNThreads(int n)
   LOG(WARNING) << mSelfName << " Multithreading is not supported, imposing single thread";
   mNThreads = 1;
 #endif
+}
+
+///______________________________________________________________________
+template <class Mapping>
+void RawPixelDecoder<Mapping>::setFormat(GBTLink::Format f)
+{
+  assert(int(f) >= 0 && int(f) < NFormats);
+  mFormat = f;
 }
 
 template class o2::itsmft::RawPixelDecoder<o2::itsmft::ChipMappingITS>;

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -295,7 +295,7 @@ void RawPixelDecoder<Mapping>::setNThreads(int n)
 template <class Mapping>
 void RawPixelDecoder<Mapping>::setFormat(GBTLink::Format f)
 {
-  assert(int(f) >= 0 && int(f) < NFormats);
+  assert(int(f) >= 0 && int(f) < GBTLink::NFormats);
   mFormat = f;
 }
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -50,6 +50,7 @@ class STFDecoder : public Task
   bool mDoPatterns = false;
   bool mDoDigits = false;
   int mNThreads = 1;
+  size_t mTFCounter = 0;
   std::string mSelfName;
   std::string mDictName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -22,6 +22,7 @@
 #include "ITSMFTReconstruction/RawPixelDecoder.h"
 #include "ITSMFTReconstruction/Clusterer.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
+#include "ITSMFTReconstruction/GBTLink.h"
 #include "ITSMFTWorkflow/STFDecoderSpec.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DataFormatsParameters/GRPObject.h"
@@ -61,6 +62,8 @@ void STFDecoder<Mapping>::init(InitContext& ic)
   auto detID = Mapping::getDetID();
   mNThreads = ic.options().get<int>("nthreads");
   mDecoder->setNThreads(mNThreads);
+  mDecoder->setFormat(ic.options().get<bool>("old-format") ? GBTLink::OldFormat : GBTLink::NewFormat);
+  mDecoder->setVerbosity(ic.options().get<int>("decoder-verbosity"));
   if (mDoClusters) {
     o2::base::GeometryManager::loadGeometry(); // for generating full clusters
     GeometryTGeo* geom = nullptr;
@@ -137,7 +140,8 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     LOG(INFO) << mSelfName << " Decoded " << digVec.size() << " Digits in " << digROFVec.size() << " ROFs";
   }
   mTimer.Stop();
-  LOG(INFO) << mSelfName << " Total time for this TF: CPU: " << mTimer.CpuTime() - timeCPU0 << " Real: " << mTimer.RealTime() - timeReal0;
+  LOG(INFO) << mSelfName << " Total time for TF " << mTFCounter << " : CPU: " << mTimer.CpuTime() - timeCPU0 << " Real: " << mTimer.RealTime() - timeReal0;
+  mTFCounter++;
 }
 
 ///_______________________________________
@@ -199,7 +203,9 @@ DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool do
     outputs,
     AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(doClusters, doPatterns, doDigits, dict)},
     Options{
-      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}}}};
+      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}},
+      {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},
+      {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data)"}}}};
 }
 
 DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict)
@@ -227,7 +233,9 @@ DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool do
     outputs,
     AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(doClusters, doPatterns, doDigits, dict)},
     Options{
-      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}}}};
+      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}},
+      {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},
+      {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data)"}}}};
 }
 
 } // namespace itsmft


### PR DESCRIPTION
With option --old-format provided the STFDecoderSpec will interpret data as
in old format: single trigger per HBF, no GBT trigger word