### PR TITLE
Some work to make TPC Creation of Grid for fast cluster search runable on GPU

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
@@ -61,6 +61,9 @@ class GPUCATracking
   int getNTracksASide() { return mNTracksASide; }
   void GetClusterErrors2(int row, float z, float sinPhi, float DzDs, short clusterState, float& ErrY2, float& ErrZ2) const;
 
+  int registerMemoryForGPU(const void* ptr, size_t size);
+  int unregisterMemoryForGPU(const void* ptr);
+
  private:
   std::unique_ptr<o2::gpu::GPUTPCO2Interface> mTrackingCAO2Interface; //Pointer to Interface class in HLT O2 CA Tracking library.
                                                                       //The tracking code itself is not included in the O2 package, but contained in the CA library.

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -305,3 +305,13 @@ void GPUCATracking::GetClusterErrors2(int row, float z, float sinPhi, float DzDs
   }
   mTrackingCAO2Interface->GetClusterErrors2(row, z, sinPhi, DzDs, clusterState, ErrY2, ErrZ2);
 }
+
+int GPUCATracking::registerMemoryForGPU(const void* ptr, size_t size)
+{
+  return mTrackingCAO2Interface->registerMemoryForGPU(ptr, size);
+}
+
+int GPUCATracking::unregisterMemoryForGPU(const void* ptr)
+{
+  return mTrackingCAO2Interface->unregisterMemoryForGPU(ptr);
+}

--- a/GPU/Common/GPUCommonDefAPI.h
+++ b/GPU/Common/GPUCommonDefAPI.h
@@ -107,6 +107,8 @@
     #define GPUCA_USE_TEMPLATE_ADDRESS_SPACES // TODO: check if we can make this (partially, where it is already implemented) compatible with OpenCL CPP
     #define GPUsharedref() GPUshared()
     #define GPUglobalref() GPUglobal()
+    #undef GPUgeneric()
+    #define GPUgeneric()
   #endif
   #if (!defined(__OPENCLCPP__) || !defined(GPUCA_NO_CONSTANT_MEMORY))
     #define GPUconstantref() GPUconstant()

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -46,6 +46,7 @@ class GPUCommonMath
   template <class T, class S>
   GPUhd() static T MaxWithRef(T x, T y, S refX, S refY, S& r);
   GPUhdni() static float Sqrt(float x);
+  GPUhdni() static float FastInvSqrt(float x);
   template <class T>
   GPUhd() static T Abs(T x);
   GPUhdni() static float ASin(float x);
@@ -239,6 +240,19 @@ GPUhdi() T GPUCommonMath::MaxWithRef(T x, T y, S refX, S refY, S& r)
 }
 
 GPUhdi() float GPUCommonMath::Sqrt(float x) { return CHOICE(sqrtf(x), sqrtf(x), sqrt(x)); }
+
+GPUhdi() float GPUCommonMath::FastInvSqrt(float _x)
+{
+  // the function calculates fast inverse sqrt
+  union {
+    float f;
+    int i;
+  } x = {_x};
+  const float xhalf = 0.5f * x.f;
+  x.i = 0x5f3759df - (x.i >> 1);
+  x.f = x.f * (1.5f - xhalf * x.f * x.f);
+  return x.f;
+}
 
 template <>
 GPUhdi() float GPUCommonMath::Abs<float>(float x)

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -66,14 +66,46 @@ class GPUCommonMath
   GPUhdni() static unsigned int Popcount(unsigned int val);
 
   GPUhdni() static float Log(float x);
-  GPUdi() static unsigned int AtomicExch(GPUglobalref() GPUAtomic(unsigned int) * addr, unsigned int val) { return GPUCommonMath::AtomicExchInt(addr, val); }
-  GPUdi() static unsigned int AtomicAdd(GPUglobalref() GPUAtomic(unsigned int) * addr, unsigned int val) { return GPUCommonMath::AtomicAddInt(addr, val); }
-  GPUdi() static void AtomicMax(GPUglobalref() GPUAtomic(unsigned int) * addr, unsigned int val) { GPUCommonMath::AtomicMaxInt(addr, val); }
-  GPUdi() static void AtomicMin(GPUglobalref() GPUAtomic(unsigned int) * addr, unsigned int val) { GPUCommonMath::AtomicMinInt(addr, val); }
-  GPUdi() static unsigned int AtomicExchShared(GPUsharedref() GPUAtomic(unsigned int) * addr, unsigned int val) { return GPUCommonMath::AtomicExchInt(addr, val); }
-  GPUdi() static unsigned int AtomicAddShared(GPUsharedref() GPUAtomic(unsigned int) * addr, unsigned int val) { return GPUCommonMath::AtomicAddInt(addr, val); }
-  GPUdi() static void AtomicMaxShared(GPUsharedref() GPUAtomic(unsigned int) * addr, unsigned int val) { GPUCommonMath::AtomicMaxInt(addr, val); }
-  GPUdi() static void AtomicMinShared(GPUsharedref() GPUAtomic(unsigned int) * addr, unsigned int val) { GPUCommonMath::AtomicMinInt(addr, val); }
+  template <class T>
+  GPUdi() static T AtomicExch(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    return GPUCommonMath::AtomicExchInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static T AtomicAdd(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    return GPUCommonMath::AtomicAddInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static void AtomicMax(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    GPUCommonMath::AtomicMaxInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static void AtomicMin(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    GPUCommonMath::AtomicMinInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static T AtomicExchShared(GPUsharedref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    return GPUCommonMath::AtomicExchInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static T AtomicAddShared(GPUsharedref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    return GPUCommonMath::AtomicAddInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static void AtomicMaxShared(GPUsharedref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    GPUCommonMath::AtomicMaxInt(addr, val);
+  }
+  template <class T>
+  GPUdi() static void AtomicMinShared(GPUsharedref() GPUgeneric() GPUAtomic(T) * addr, T val)
+  {
+    GPUCommonMath::AtomicMinInt(addr, val);
+  }
   GPUd() static int Mul24(int a, int b);
   GPUd() static float FMulRZ(float a, float b);
 

--- a/GPU/Common/GPUDefConstantsAndSettings.h
+++ b/GPU/Common/GPUDefConstantsAndSettings.h
@@ -55,6 +55,9 @@
 #define GPUCA_MAX_SIN_PHI_LOW 0.99f                   // Limits for maximum sin phi during fit
 #define GPUCA_MAX_SIN_PHI 0.999f                      // Must be preprocessor define because c++ pre 11 cannot use static constexpr for initializes
 
+#define GPUCA_MIN_BIN_SIZE 2.f                        // Minimum bin size in TPC fast access grid
+#define GPUCA_MAX_BIN_SIZE 1000.f                     // Maximum bin size in TPC fast access grid
+
 #define GPUCA_TPC_COMP_CHUNK_SIZE 1024                // Chunk size of sorted unattached TPC cluster in compression
 
 #if defined(HAVE_O2HEADERS) && (!defined(__OPENCL__) || defined(__OPENCLCPP__)) && !(defined(ROOT_VERSION_CODE) && ROOT_VERSION_CODE < 393216)

--- a/GPU/Common/GPUDefGPUParameters.h
+++ b/GPU/Common/GPUDefGPUParameters.h
@@ -30,6 +30,7 @@
 #if defined(GPUCA_GPUTYPE_VEGA)
   #define GPUCA_WARP_SIZE 64
   #define GPUCA_THREAD_COUNT 256
+  #define GPUCA_LB_GPUTPCCreateSliceData 256
   #define GPUCA_LB_GPUTPCStartHitsSorter 1024, 2
   #define GPUCA_LB_GPUTPCStartHitsFinder 1024
   #define GPUCA_LB_GPUTPCTrackletConstructor 512, 1
@@ -73,6 +74,7 @@
 #elif defined(GPUCA_GPUTYPE_TURING)
   #define GPUCA_WARP_SIZE 32
   #define GPUCA_THREAD_COUNT 512
+  #define GPUCA_LB_GPUTPCCreateSliceData 256
   #define GPUCA_LB_GPUTPCStartHitsSorter 512, 1
   #define GPUCA_LB_GPUTPCStartHitsFinder 512
   #define GPUCA_LB_GPUTPCTrackletConstructor 384, 1
@@ -124,6 +126,9 @@
   // Default settings, if not already set for selected GPU type
   #ifndef GPUCA_THREAD_COUNT
     #define GPUCA_THREAD_COUNT 256
+  #endif
+  #ifndef GPUCA_LB_GPUTPCCreateSliceData
+    #define GPUCA_LB_GPUTPCCreateSliceData 256
   #endif
   #ifndef GPUCA_LB_GPUTPCTrackletConstructor
     #define GPUCA_LB_GPUTPCTrackletConstructor 256

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -193,6 +193,7 @@ class GPUReconstruction
   DeviceType GetDeviceType() const { return (DeviceType)mProcessingSettings.deviceType; }
   bool IsGPU() const { return GetDeviceType() != DeviceType::INVALID_DEVICE && GetDeviceType() != DeviceType::CPU; }
   const GPUParam& GetParam() const { return mHostConstantMem->param; }
+  const GPUConstantMem& GetConstantMem() const { return *mHostConstantMem; }
   const GPUSettingsEvent& GetEventSettings() const { return mEventSettings; }
   const GPUSettingsProcessing& GetProcessingSettings() { return mProcessingSettings; }
   const GPUSettingsDeviceProcessing& GetDeviceProcessingSettings() const { return mDeviceProcessingSettings; }

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -165,6 +165,7 @@ class GPUReconstruction
   void PrepareEvent();
   virtual int RunChains() = 0;
   unsigned int getNEventsProcessed() { return mNEventsProcessed; }
+  unsigned int getNEventsProcessedInStat() { return mStatNEvents; }
   virtual int registerMemoryForGPU(const void* ptr, size_t size) = 0;
   virtual int unregisterMemoryForGPU(const void* ptr) = 0;
 

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -226,7 +226,11 @@ int GPUReconstructionCPU::RunChains()
         kernelStepTimes[stepNum] += time;
       }
       type = type == 0 ? 'K' : 'C';
-      printf("Execution Time: Task (%c %8ux): %50s Time: %'10d us\n", type, count, mTimers[i]->name.c_str(), (int)(time * 1000000 / mStatNEvents));
+      char bandwidth[256] = "";
+      if (mTimers[i]->memSize && mStatNEvents && time != 0.) {
+        snprintf(bandwidth, 256, " (%6.3f GB/s - %'14lu bytes)", mTimers[i]->memSize / time * 1e-9, (unsigned long)(mTimers[i]->memSize / mStatNEvents));
+      }
+      printf("Execution Time: Task (%c %8ux): %50s Time: %'10d us%s\n", type, count, mTimers[i]->name.c_str(), (int)(time * 1000000 / mStatNEvents), bandwidth);
     }
     for (int i = 0; i < N_RECO_STEPS; i++) {
       if (kernelStepTimes[i] != 0.) {
@@ -295,7 +299,7 @@ GPUReconstructionCPU::timerMeta* GPUReconstructionCPU::insertTimer(unsigned int 
     if (J >= 0) {
       name += std::to_string(J);
     }
-    mTimers[id].reset(new timerMeta{std::unique_ptr<HighResTimer[]>{new HighResTimer[num]}, name, num, type, 1u, step});
+    mTimers[id].reset(new timerMeta{std::unique_ptr<HighResTimer[]>{new HighResTimer[num]}, name, num, type, 1u, step, (size_t)0});
   }
   timerMeta* retVal = mTimers[id].get();
   timerFlag.clear();

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "GPUGeneralKernels.h"
+#include "GPUTPCCreateSliceData.h"
 #include "GPUTPCNeighboursFinder.h"
 #include "GPUTPCNeighboursCleaner.h"
 #include "GPUTPCStartHitsFinder.h"

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -258,7 +258,7 @@ inline int GPUReconstructionCPU::runKernel(const krnlExec& x, const krnlRunRange
     throw std::runtime_error("GPUCA_MAX_THREADS exceeded");
   }
   if (mDeviceProcessingSettings.debugLevel >= 3) {
-    GPUInfo("Running %s (Stream %d, Range %d/%d, Grid %d/%d) on %s", GetKernelName<S, I>(), x.stream, y.start, y.num, nBlocks, nThreads, cpuFallback == 2 ? "CPU (forced)" : cpuFallback ? "CPU (fallback)" : mDeviceName.c_str());
+    GPUInfo("Running kernel %s (Stream %d, Range %d/%d, Grid %d/%d) on %s", GetKernelName<S, I>(), x.stream, y.start, y.num, nBlocks, nThreads, cpuFallback == 2 ? "CPU (forced)" : cpuFallback ? "CPU (fallback)" : mDeviceName.c_str());
   }
   if (nThreads == 0 || nBlocks == 0) {
     return 0;

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -316,8 +316,7 @@ HighResTimer& GPUReconstructionCPU::getKernelTimer(RecoStep step, int num, size_
   static int id = getNextTimerId();
   timerMeta* timer = getTimerById(id);
   if (timer == nullptr) {
-    int max = step == GPUCA_RECO_STEP::NoRecoStep || step == GPUCA_RECO_STEP::TPCSliceTracking || step == GPUCA_RECO_STEP::TPCClusterFinding ? NSLICES : 1;
-    timer = insertTimer(id, GetKernelName<T, I>(), J, max, 0, step);
+    timer = insertTimer(id, GetKernelName<T, I>(), J, NSLICES, 0, step);
   }
   if (addMemorySize) {
     timer->memSize += addMemorySize;

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -50,6 +50,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "GPUTPCGMPhysicalTrackModel.cxx"
 #include "GPUTPCGMPropagator.cxx"
 #include "GPUTPCSliceData.cxx"
+#include "GPUTPCCreateSliceData.cxx"
 
 #if defined(HAVE_O2HEADERS)
 // Files for propagation with material

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -49,6 +49,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "GPUTPCGMTrackParam.cxx"
 #include "GPUTPCGMPhysicalTrackModel.cxx"
 #include "GPUTPCGMPropagator.cxx"
+#include "GPUTPCSliceData.cxx"
 
 #if defined(HAVE_O2HEADERS)
 // Files for propagation with material

--- a/GPU/GPUTracking/Base/GPUReconstructionKernels.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionKernels.h
@@ -25,6 +25,7 @@ GPUCA_KRNL((GPUTPCTrackletSelector                       ), (both, REG, (GPUCA_L
 GPUCA_KRNL((GPUMemClean16                                ), (simple, REG, (GPUCA_THREAD_COUNT, 1)), (, GPUPtr1(void*, ptr), unsigned long size), (, GPUPtr2(void*, ptr), size))
 GPUCA_KRNL((GPUTPCGlobalTrackingCopyNumbers              ), (single), (, int n), (, n))
 #if !defined(GPUCA_OPENCL1) && (!defined(GPUCA_ALIROOT_LIB) || !defined(GPUCA_GPUCODE))
+GPUCA_KRNL((GPUTPCCreateSliceData                        ), (single, REG, (GPUCA_LB_GPUTPCCreateSliceData)), (), ())
 GPUCA_KRNL((GPUTPCGlobalTracking                         ), (single, REG, (GPUCA_LB_GPUTPCGlobalTracking)), (), ())
 GPUCA_KRNL((GPUTPCGMMergerTrackFit                       ), (simple, REG, (GPUCA_LB_GPUTPCGMMergerTrackFit)), (, int mode), (, mode))
 GPUCA_KRNL((GPUTPCGMMergerFollowLoopers                  ), (simple, REG, (GPUCA_LB_GPUTPCGMMergerFollowLoopers)), (), ())

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRCS
     SliceTracker/GPUTPCTrackletSelector.cxx
     SliceTracker/GPUTPCRow.cxx
     SliceTracker/GPUTPCGlobalTracking.cxx
+    SliceTracker/GPUTPCCreateSliceData.cxx
     Merger/GPUTPCGMMerger.cxx
     Merger/GPUTPCGMSliceTrack.cxx
     Merger/GPUTPCGMTrackParam.cxx

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -39,7 +39,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
       continue;
     }
     bool rejectTrk = CAMath::Abs(trk.GetParam().GetQPt()) > processors.param.rec.tpcRejectQPt;
-    int nClustersStored = 0;
+    unsigned int nClustersStored = 0;
     CompressedClustersPtrsOnly& GPUrestrict() c = compressor.mPtrs;
     unsigned int lastRow = 0, lastSlice = 0; // BUG: These should be unsigned char, but then CUDA breaks
     GPUTPCCompressionTrackModel track;
@@ -86,7 +86,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
         unsigned char qpt = fabs(trk.GetParam().GetQPt()) < 20.f ? (trk.GetParam().GetQPt() * (127.f / 20.f) + 127.5f) : (trk.GetParam().GetQPt() > 0 ? 254 : 0);
         track.Init(x, y, z, param.SliceParam[hit.slice].Alpha, qpt, param); // TODO: Compression track model must respect Z offset!
 
-        myTrack = CAMath::AtomicAdd(&compressor.mMemory->nStoredTracks, 1);
+        myTrack = CAMath::AtomicAdd(&compressor.mMemory->nStoredTracks, 1u);
         compressor.mAttachedClusterFirstIndex[myTrack] = trk.FirstClusterRef();
         lastLeg = hit.leg;
         c.qPtA[myTrack] = qpt;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -329,7 +329,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step2ga
   GPUTPCCompression& GPUrestrict() compressor = processors.tpcCompressor;
   const o2::tpc::ClusterNativeAccess* GPUrestrict() clusters = processors.tpcConverter.getClustersNative();
   compressorMemcpy(compressor.mOutput->nSliceRowClusters, compressor.mPtrs.nSliceRowClusters, compressor.NSLICES * GPUCA_ROW_COUNT * sizeof(compressor.mOutput->nSliceRowClusters[0]));
-  compressorMemcpy(compressor.mOutput->nTrackClusters, compressor.mPtrs.nTrackClusters, compressor.mOutput->nTracks * sizeof(compressor.mOutput->nTrackClusters[0]));
+  compressorMemcpy(compressor.mOutput->nTrackClusters, compressor.mPtrs.nTrackClusters, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->nTrackClusters[0]));
   unsigned int offset = 0;
   for (unsigned int i = 0; i < compressor.NSLICES; i++) {
     for (unsigned int j = 0; j < GPUCA_ROW_COUNT; j++) {
@@ -344,7 +344,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step2ga
     }
   }
   offset = 0;
-  for (unsigned int i = 0; i < compressor.mOutput->nTracks; i++) {
+  for (unsigned int i = 0; i < compressor.mMemory->nStoredTracks; i++) {
     compressorMemcpy(compressor.mOutput->qTotA + offset, compressor.mPtrs.qTotA + compressor.mAttachedClusterFirstIndex[i], compressor.mPtrs.nTrackClusters[i] * sizeof(compressor.mOutput->qTotA[0]));
     compressorMemcpy(compressor.mOutput->qMaxA + offset, compressor.mPtrs.qMaxA + compressor.mAttachedClusterFirstIndex[i], compressor.mPtrs.nTrackClusters[i] * sizeof(compressor.mOutput->qMaxA[0]));
     compressorMemcpy(compressor.mOutput->flagsA + offset, compressor.mPtrs.flagsA + compressor.mAttachedClusterFirstIndex[i], compressor.mPtrs.nTrackClusters[i] * sizeof(compressor.mOutput->flagsA[0]));
@@ -358,9 +358,9 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step2ga
     compressorMemcpy(compressor.mOutput->timeResA + offset - i, compressor.mPtrs.timeResA + compressor.mAttachedClusterFirstIndex[i] + 1, (compressor.mPtrs.nTrackClusters[i] - 1) * sizeof(compressor.mOutput->timeResA[0]));
     offset += compressor.mPtrs.nTrackClusters[i];
   }
-  compressorMemcpy(compressor.mOutput->qPtA, compressor.mPtrs.qPtA, compressor.mOutput->nTracks * sizeof(compressor.mOutput->qPtA[0]));
-  compressorMemcpy(compressor.mOutput->rowA, compressor.mPtrs.rowA, compressor.mOutput->nTracks * sizeof(compressor.mOutput->rowA[0]));
-  compressorMemcpy(compressor.mOutput->sliceA, compressor.mPtrs.sliceA, compressor.mOutput->nTracks * sizeof(compressor.mOutput->sliceA[0]));
-  compressorMemcpy(compressor.mOutput->timeA, compressor.mPtrs.timeA, compressor.mOutput->nTracks * sizeof(compressor.mOutput->timeA[0]));
-  compressorMemcpy(compressor.mOutput->padA, compressor.mPtrs.padA, compressor.mOutput->nTracks * sizeof(compressor.mOutput->padA[0]));
+  compressorMemcpy(compressor.mOutput->qPtA, compressor.mPtrs.qPtA, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->qPtA[0]));
+  compressorMemcpy(compressor.mOutput->rowA, compressor.mPtrs.rowA, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->rowA[0]));
+  compressorMemcpy(compressor.mOutput->sliceA, compressor.mPtrs.sliceA, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->sliceA[0]));
+  compressorMemcpy(compressor.mOutput->timeA, compressor.mPtrs.timeA, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->timeA[0]));
+  compressorMemcpy(compressor.mOutput->padA, compressor.mPtrs.padA, compressor.mMemory->nStoredTracks * sizeof(compressor.mOutput->padA[0]));
 }

--- a/GPU/GPUTracking/Global/GPUChain.cxx
+++ b/GPU/GPUTracking/Global/GPUChain.cxx
@@ -30,10 +30,10 @@ GPUChain::krnlExec GPUChain::GetGrid(unsigned int totalItems, int stream, GPURec
 
 GPUChain::krnlExec GPUChain::GetGridBlk(unsigned int nBlocks, int stream, GPUReconstruction::krnlDeviceType d, GPUCA_RECO_STEP st)
 {
-  return {nBlocks, (unsigned int)-1, stream, d, st};
+  return {(unsigned int)-2, nBlocks, stream, d, st};
 }
 
 GPUChain::krnlExec GPUChain::GetGridBlkStep(unsigned int nBlocks, int stream, GPUCA_RECO_STEP st)
 {
-  return {nBlocks, (unsigned int)-1, stream, GPUReconstruction::krnlDeviceType::Auto, st};
+  return {(unsigned int)-2, nBlocks, stream, GPUReconstruction::krnlDeviceType::Auto, st};
 }

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -170,9 +170,9 @@ class GPUChain
   }
 
   template <class T, int I = 0, int J = -1>
-  HighResTimer& getKernelTimer(int num = 0)
+  HighResTimer& getKernelTimer(RecoStep step, int num = 0, size_t addMemorySize = 0)
   {
-    return mRec->getKernelTimer<T, I, J>(num);
+    return mRec->getKernelTimer<T, I, J>(step, num, addMemorySize);
   }
   template <class T, int J = -1>
   HighResTimer& getTimer(const char* name, int num = -1)

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1686,66 +1686,74 @@ int GPUChainTracking::RunTPCCompression()
   runKernel<GPUTPCCompressionKernels, GPUTPCCompressionKernels::step1unattached>(GetGridBlk(BlockCount(), 0), krnlRunRangeNone, krnlEventNone);
   TransferMemoryResourcesToHost(myStep, &Compressor, 0);
   SynchronizeGPU();
-  memset((void*)Compressor.mOutput, 0, sizeof(*Compressor.mOutput));
-  Compressor.mOutput->nTracks = Compressor.mMemory->nStoredTracks;
-  Compressor.mOutput->nAttachedClusters = Compressor.mMemory->nStoredAttachedClusters;
-  Compressor.mOutput->nUnattachedClusters = Compressor.mMemory->nStoredUnattachedClusters;
-  Compressor.mOutput->nAttachedClustersReduced = Compressor.mOutput->nAttachedClusters - Compressor.mOutput->nTracks;
-  Compressor.mOutput->nSliceRows = NSLICES * GPUCA_ROW_COUNT;
-  Compressor.mOutput->nComppressionModes = param().rec.tpcCompressionModes;
+  o2::tpc::CompressedClusters* O = Compressor.mOutput;
+  memset((void*)O, 0, sizeof(*O));
+  O->nTracks = Compressor.mMemory->nStoredTracks;
+  O->nAttachedClusters = Compressor.mMemory->nStoredAttachedClusters;
+  O->nUnattachedClusters = Compressor.mMemory->nStoredUnattachedClusters;
+  O->nAttachedClustersReduced = O->nAttachedClusters - O->nTracks;
+  O->nSliceRows = NSLICES * GPUCA_ROW_COUNT;
+  O->nComppressionModes = param().rec.tpcCompressionModes;
   AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, &mRec->OutputControl());
-  const GPUTPCCompression* outputSrc = nullptr;
+  const o2::tpc::CompressedClustersPtrsOnly* P = nullptr;
   if (DeviceProcessingSettings().tpcCompressionGatherMode == 2) {
     TransferMemoryResourcesToGPU(myStep, &Compressor, 0);
     runKernel<GPUTPCCompressionKernels, GPUTPCCompressionKernels::step2gather>(GetGridBlk(BlockCount(), 0), krnlRunRangeNone, krnlEventNone);
+    getKernelTimer<GPUTPCCompressionKernels, GPUTPCCompressionKernels::step2gather>(RecoStep::TPCCompression, 0,
+                                                                                    NSLICES * GPUCA_ROW_COUNT * sizeof(O->nSliceRowClusters[0]) +
+                                                                                      O->nTracks * sizeof(O->nTrackClusters[0]) +
+                                                                                      O->nUnattachedClusters * (sizeof(O->qTotU[0]) + sizeof(O->qMaxU[0]) + sizeof(O->flagsU[0]) + sizeof(O->padDiffU[0]) + sizeof(O->timeDiffU[0]) + sizeof(O->sigmaPadU[0]) + sizeof(O->sigmaTimeU[0])) +
+                                                                                      O->nAttachedClusters * (sizeof(O->qTotA[0]) + sizeof(O->qMaxA[0]) + sizeof(O->flagsA[0]) + sizeof(O->sigmaPadA[0]) + sizeof(O->sigmaTimeA[0])) +
+                                                                                      O->nAttachedClustersReduced * (sizeof(O->rowDiffA[0]) + sizeof(O->sliceLegDiffA[0]) + sizeof(O->padResA[0]) + sizeof(O->timeResA[0])) +
+                                                                                      O->nTracks * (sizeof(O->qPtA[0]) + sizeof(O->rowA[0]) + sizeof(O->sliceA[0]) + sizeof(O->timeA[0]) + sizeof(O->padA[0])));
   } else {
     char direction = 0;
     if (DeviceProcessingSettings().tpcCompressionGatherMode == 0) {
-      outputSrc = &CompressorShadow;
+      P = &CompressorShadow.mPtrs;
     } else if (DeviceProcessingSettings().tpcCompressionGatherMode == 1) {
-      outputSrc = &Compressor;
+      P = &Compressor.mPtrs;
       direction = -1;
     }
-    GPUMemCpyAlways(myStep, Compressor.mOutput->nSliceRowClusters, outputSrc->mPtrs.nSliceRowClusters, NSLICES * GPUCA_ROW_COUNT * sizeof(Compressor.mOutput->nSliceRowClusters[0]), 0, direction);
-    GPUMemCpyAlways(myStep, Compressor.mOutput->nTrackClusters, outputSrc->mPtrs.nTrackClusters, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->nTrackClusters[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->nSliceRowClusters, P->nSliceRowClusters, NSLICES * GPUCA_ROW_COUNT * sizeof(O->nSliceRowClusters[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->nTrackClusters, P->nTrackClusters, O->nTracks * sizeof(O->nTrackClusters[0]), 0, direction);
     SynchronizeGPU();
     unsigned int offset = 0;
     for (unsigned int i = 0; i < NSLICES; i++) {
       for (unsigned int j = 0; j < GPUCA_ROW_COUNT; j++) {
-        GPUMemCpyAlways(myStep, Compressor.mOutput->qTotU + offset, outputSrc->mPtrs.qTotU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->qTotU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->qMaxU + offset, outputSrc->mPtrs.qMaxU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->qMaxU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->flagsU + offset, outputSrc->mPtrs.flagsU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->flagsU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->padDiffU + offset, outputSrc->mPtrs.padDiffU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->padDiffU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->timeDiffU + offset, outputSrc->mPtrs.timeDiffU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->timeDiffU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->sigmaPadU + offset, outputSrc->mPtrs.sigmaPadU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->sigmaPadU[0]), 0, direction);
-        GPUMemCpyAlways(myStep, Compressor.mOutput->sigmaTimeU + offset, outputSrc->mPtrs.sigmaTimeU + mClusterNativeAccess->clusterOffset[i][j], Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(Compressor.mOutput->sigmaTimeU[0]), 0, direction);
-        offset += Compressor.mOutput->nSliceRowClusters[i * GPUCA_ROW_COUNT + j];
+        GPUMemCpyAlways(myStep, O->qTotU + offset, P->qTotU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->qTotU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->qMaxU + offset, P->qMaxU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->qMaxU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->flagsU + offset, P->flagsU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->flagsU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->padDiffU + offset, P->padDiffU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->padDiffU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->timeDiffU + offset, P->timeDiffU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->timeDiffU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->sigmaPadU + offset, P->sigmaPadU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->sigmaPadU[0]), 0, direction);
+        GPUMemCpyAlways(myStep, O->sigmaTimeU + offset, P->sigmaTimeU + mClusterNativeAccess->clusterOffset[i][j], O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j] * sizeof(O->sigmaTimeU[0]), 0, direction);
+        offset += O->nSliceRowClusters[i * GPUCA_ROW_COUNT + j];
       }
     }
     offset = 0;
-    for (unsigned int i = 0; i < Compressor.mOutput->nTracks; i++) {
-      GPUMemCpyAlways(myStep, Compressor.mOutput->qTotA + offset, outputSrc->mPtrs.qTotA + Compressor.mAttachedClusterFirstIndex[i], Compressor.mOutput->nTrackClusters[i] * sizeof(Compressor.mOutput->qTotA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->qMaxA + offset, outputSrc->mPtrs.qMaxA + Compressor.mAttachedClusterFirstIndex[i], Compressor.mOutput->nTrackClusters[i] * sizeof(Compressor.mOutput->qMaxA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->flagsA + offset, outputSrc->mPtrs.flagsA + Compressor.mAttachedClusterFirstIndex[i], Compressor.mOutput->nTrackClusters[i] * sizeof(Compressor.mOutput->flagsA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->sigmaPadA + offset, outputSrc->mPtrs.sigmaPadA + Compressor.mAttachedClusterFirstIndex[i], Compressor.mOutput->nTrackClusters[i] * sizeof(Compressor.mOutput->sigmaPadA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->sigmaTimeA + offset, outputSrc->mPtrs.sigmaTimeA + Compressor.mAttachedClusterFirstIndex[i], Compressor.mOutput->nTrackClusters[i] * sizeof(Compressor.mOutput->sigmaTimeA[0]), 0, direction);
+    for (unsigned int i = 0; i < O->nTracks; i++) {
+      GPUMemCpyAlways(myStep, O->qTotA + offset, P->qTotA + Compressor.mAttachedClusterFirstIndex[i], O->nTrackClusters[i] * sizeof(O->qTotA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->qMaxA + offset, P->qMaxA + Compressor.mAttachedClusterFirstIndex[i], O->nTrackClusters[i] * sizeof(O->qMaxA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->flagsA + offset, P->flagsA + Compressor.mAttachedClusterFirstIndex[i], O->nTrackClusters[i] * sizeof(O->flagsA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->sigmaPadA + offset, P->sigmaPadA + Compressor.mAttachedClusterFirstIndex[i], O->nTrackClusters[i] * sizeof(O->sigmaPadA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->sigmaTimeA + offset, P->sigmaTimeA + Compressor.mAttachedClusterFirstIndex[i], O->nTrackClusters[i] * sizeof(O->sigmaTimeA[0]), 0, direction);
 
       // First index stored with track
-      GPUMemCpyAlways(myStep, Compressor.mOutput->rowDiffA + offset - i, outputSrc->mPtrs.rowDiffA + Compressor.mAttachedClusterFirstIndex[i] + 1, (Compressor.mOutput->nTrackClusters[i] - 1) * sizeof(Compressor.mOutput->rowDiffA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->sliceLegDiffA + offset - i, outputSrc->mPtrs.sliceLegDiffA + Compressor.mAttachedClusterFirstIndex[i] + 1, (Compressor.mOutput->nTrackClusters[i] - 1) * sizeof(Compressor.mOutput->sliceLegDiffA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->padResA + offset - i, outputSrc->mPtrs.padResA + Compressor.mAttachedClusterFirstIndex[i] + 1, (Compressor.mOutput->nTrackClusters[i] - 1) * sizeof(Compressor.mOutput->padResA[0]), 0, direction);
-      GPUMemCpyAlways(myStep, Compressor.mOutput->timeResA + offset - i, outputSrc->mPtrs.timeResA + Compressor.mAttachedClusterFirstIndex[i] + 1, (Compressor.mOutput->nTrackClusters[i] - 1) * sizeof(Compressor.mOutput->timeResA[0]), 0, direction);
-      offset += Compressor.mOutput->nTrackClusters[i];
+      GPUMemCpyAlways(myStep, O->rowDiffA + offset - i, P->rowDiffA + Compressor.mAttachedClusterFirstIndex[i] + 1, (O->nTrackClusters[i] - 1) * sizeof(O->rowDiffA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->sliceLegDiffA + offset - i, P->sliceLegDiffA + Compressor.mAttachedClusterFirstIndex[i] + 1, (O->nTrackClusters[i] - 1) * sizeof(O->sliceLegDiffA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->padResA + offset - i, P->padResA + Compressor.mAttachedClusterFirstIndex[i] + 1, (O->nTrackClusters[i] - 1) * sizeof(O->padResA[0]), 0, direction);
+      GPUMemCpyAlways(myStep, O->timeResA + offset - i, P->timeResA + Compressor.mAttachedClusterFirstIndex[i] + 1, (O->nTrackClusters[i] - 1) * sizeof(O->timeResA[0]), 0, direction);
+      offset += O->nTrackClusters[i];
     }
-    GPUMemCpyAlways(myStep, Compressor.mOutput->qPtA, outputSrc->mPtrs.qPtA, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->qPtA[0]), 0, direction);
-    GPUMemCpyAlways(myStep, Compressor.mOutput->rowA, outputSrc->mPtrs.rowA, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->rowA[0]), 0, direction);
-    GPUMemCpyAlways(myStep, Compressor.mOutput->sliceA, outputSrc->mPtrs.sliceA, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->sliceA[0]), 0, direction);
-    GPUMemCpyAlways(myStep, Compressor.mOutput->timeA, outputSrc->mPtrs.timeA, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->timeA[0]), 0, direction);
-    GPUMemCpyAlways(myStep, Compressor.mOutput->padA, outputSrc->mPtrs.padA, Compressor.mOutput->nTracks * sizeof(Compressor.mOutput->padA[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->qPtA, P->qPtA, O->nTracks * sizeof(O->qPtA[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->rowA, P->rowA, O->nTracks * sizeof(O->rowA[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->sliceA, P->sliceA, O->nTracks * sizeof(O->sliceA[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->timeA, P->timeA, O->nTracks * sizeof(O->timeA[0]), 0, direction);
+    GPUMemCpyAlways(myStep, O->padA, P->padA, O->nTracks * sizeof(O->padA[0]), 0, direction);
   }
   SynchronizeGPU();
 
-  mIOPtrs.tpcCompressedClusters = Compressor.mOutput;
+  mIOPtrs.tpcCompressedClusters = O;
 #endif
   return 0;
 }

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1854,9 +1854,8 @@ int GPUChainTracking::RunChain()
     }
   }
   static HighResTimer timerTracking, timerMerger, timerQA, timerTransform, timerCompression, timerClusterer;
-  int nCount = mRec->getNEventsProcessed();
   if (GetDeviceProcessingSettings().debugLevel >= 6) {
-    mDebugFile << "\n\nProcessing event " << nCount << std::endl;
+    mDebugFile << "\n\nProcessing event " << mRec->getNEventsProcessed() << std::endl;
   }
   if (mRec->slavesExist() && mRec->IsGPU()) {
     const auto threadContext = GetThreadContext();
@@ -1930,6 +1929,7 @@ int GPUChainTracking::RunChain()
   }
 
   if (GetDeviceProcessingSettings().debugLevel >= 0) {
+    int nCount = mRec->getNEventsProcessedInStat();
     char nAverageInfo[16] = "";
     if (nCount > 1) {
       sprintf(nAverageInfo, " (%d)", nCount);

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -713,17 +713,12 @@ void GPUChainTracking::SetTRDGeometry(std::unique_ptr<o2::trd::TRDGeometryFlat>&
   processors()->calibObjects.trdGeometry = mTRDGeometryU.get();
 }
 
-int GPUChainTracking::ReadEvent(int iSlice, int threadId)
+int GPUChainTracking::ReadEvent(unsigned int iSlice, int threadId)
 {
   if (GetDeviceProcessingSettings().debugLevel >= 5) {
     GPUInfo("Running ReadEvent for slice %d on thread %d\n", iSlice, threadId);
   }
-  HighResTimer& timer = getTimer<GPUTPCSliceData>("ReadEvent", threadId);
-  timer.Start();
-  if (processors()->tpcTrackers[iSlice].ReadEvent()) {
-    return (1);
-  }
-  timer.Stop();
+  runKernel<GPUTPCCreateSliceData>({GetGridBlk(1, 0, GPUReconstruction::krnlDeviceType::CPU)}, {iSlice});
   if (GetDeviceProcessingSettings().debugLevel >= 5) {
     GPUInfo("Finished ReadEvent for slice %d on thread %d\n", iSlice, threadId);
   }

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -177,7 +177,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   GPUChainTracking(GPUReconstruction* rec, unsigned int maxTPCHits = GPUCA_MAX_CLUSTERS, unsigned int maxTRDTracklets = GPUCA_MAX_TRD_TRACKLETS);
 
-  int ReadEvent(int iSlice, int threadId);
+  int ReadEvent(unsigned int iSlice, int threadId);
   void WriteOutput(int iSlice, int threadId);
   int GlobalTracking(unsigned int iSlice, int threadId);
   void PrepareEventFromNative();

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -189,7 +189,7 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
       continue;
     }
     CA_DEBUGGER(refitCounters[nClusters - 4]++);
-    int trackId = CAMath::AtomicAdd(&Fitter.NumberOfTracks(), 1);
+    int trackId = CAMath::AtomicAdd(&Fitter.NumberOfTracks(), 1u);
     Fitter.tracks()[trackId] = temporaryTrack;
   }
 #ifdef CA_DEBUG

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -122,3 +122,13 @@ void GPUTPCO2Interface::GetClusterErrors2(int row, float z, float sinPhi, float 
   mRec->GetParam().GetClusterErrors2(row, z, sinPhi, DzDs, ErrY2, ErrZ2);
   mRec->GetParam().UpdateClusterError2ByState(clusterState, ErrY2, ErrZ2);
 }
+
+int GPUTPCO2Interface::registerMemoryForGPU(const void* ptr, size_t size)
+{
+  return mRec->registerMemoryForGPU(ptr, size);
+}
+
+int GPUTPCO2Interface::unregisterMemoryForGPU(const void* ptr)
+{
+  return mRec->unregisterMemoryForGPU(ptr);
+}

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -55,6 +55,9 @@ class GPUTPCO2Interface
   bool GetParamContinuous() { return (mContinuous); }
   void GetClusterErrors2(int row, float z, float sinPhi, float DzDs, short clusterState, float& ErrY2, float& ErrZ2) const;
 
+  int registerMemoryForGPU(const void* ptr, size_t size);
+  int unregisterMemoryForGPU(const void* ptr);
+
   const GPUO2InterfaceConfiguration& getConfig() const { return *mConfig; }
 
  private:

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -508,8 +508,8 @@ GPUd() void GPUTPCGMMerger::RefitSliceTracks(int nBlocks, int nThreads, int iBlo
     TrackIds[iSlice * mNMaxSingleSliceTracks + sliceTr->LocalTrackId()] = myTrack;
     mSliceTrackInfos[myTrack] = track;
   }
-  if (!Param().rec.mergerReadFromTrackerDirectly && nLocalTracks) {
-    mMemory->firstGlobalTracks[iSlice] = sliceTr->GetNextTrack();
+  if (!Param().rec.mergerReadFromTrackerDirectly) {
+    mMemory->firstGlobalTracks[iSlice] = nLocalTracks ? sliceTr->GetNextTrack() : mkSlices[iSlice]->GetFirstTrack();
   }
 }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1060,6 +1060,10 @@ GPUd() void GPUTPCGMMerger::MergeCE(int nBlocks, int nThreads, int iBlock, int i
 #else
         // TODO: proper overflow handling
 #endif
+        for (unsigned int k = newRef; k < mNMaxOutputTrackClusters; k++) {
+          mClusters[k].num = 0;
+          mClusters[k].state = 0;
+        }
         CAMath::AtomicExch(&mMemory->nOutputTrackClusters, mNMaxOutputTrackClusters);
         return;
       }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1052,6 +1052,10 @@ GPUd() void GPUTPCGMMerger::MergeCE(int nBlocks, int nThreads, int iBlock, int i
       if (!trk[1]->OK() || trk[1]->CCE()) {
         continue;
       }
+      bool looper = trk[0]->Looper() || trk[1]->Looper() || (trk[0]->GetParam().GetQPt() > 1 && trk[0]->GetParam().GetQPt() * trk[1]->GetParam().GetQPt() < 0);
+      if (!looper && trk[0]->GetParam().GetPar(3) * trk[1]->GetParam().GetPar(3) < 0) {
+        continue;
+      }
 
       unsigned int newRef = CAMath::AtomicAdd(&mMemory->nOutputTrackClusters, trk[0]->NClusters() + trk[1]->NClusters());
       if (newRef + trk[0]->NClusters() + trk[1]->NClusters() >= mNMaxOutputTrackClusters) {
@@ -1068,10 +1072,6 @@ GPUd() void GPUTPCGMMerger::MergeCE(int nBlocks, int nThreads, int iBlock, int i
         return;
       }
 
-      bool looper = trk[0]->Looper() || trk[1]->Looper() || (trk[0]->GetParam().GetQPt() > 1 && trk[0]->GetParam().GetQPt() * trk[1]->GetParam().GetQPt() < 0);
-      if (!looper && trk[0]->GetParam().GetPar(3) * trk[1]->GetParam().GetPar(3) < 0) {
-        continue;
-      }
       bool needswap = false;
       if (looper) {
         float z0max, z1max;

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -439,7 +439,7 @@ GPUd() void GPUTPCGMMerger::UnpackSliceGlobal(int nBlocks, int nThreads, int iBl
     if (localId == -1) {
       continue;
     }
-    unsigned int myTrack = CAMath::AtomicAdd(&mMemory->nUnpackedTracks, 1);
+    unsigned int myTrack = CAMath::AtomicAdd(&mMemory->nUnpackedTracks, 1u);
     GPUTPCGMSliceTrack& track = mSliceTrackInfos[myTrack];
     SetTrackClusterZT(track, iSlice, sliceTr);
     track.Set(this, sliceTr, alpha, iSlice);
@@ -504,7 +504,7 @@ GPUd() void GPUTPCGMMerger::RefitSliceTracks(int nBlocks, int nThreads, int iBlo
     track.SetPrevSegmentNeighbour(-1);
     track.SetGlobalTrackId(0, -1);
     track.SetGlobalTrackId(1, -1);
-    unsigned int myTrack = CAMath::AtomicAdd(&mMemory->nUnpackedTracks, 1);
+    unsigned int myTrack = CAMath::AtomicAdd(&mMemory->nUnpackedTracks, 1u);
     TrackIds[iSlice * mNMaxSingleSliceTracks + sliceTr->LocalTrackId()] = myTrack;
     mSliceTrackInfos[myTrack] = track;
   }
@@ -586,7 +586,7 @@ GPUd() void GPUTPCGMMerger::MakeBorderTracks(int nBlocks, int nThreads, int iBlo
       if (CAMath::Abs(b.Cov()[4]) >= 0.5) {
         b.SetCov(4, 0.5);
       }
-      unsigned int myTrack = CAMath::AtomicAdd(&nB[iSlice], 1);
+      unsigned int myTrack = CAMath::AtomicAdd(&nB[iSlice], 1u);
       B[iSlice][myTrack] = b;
     }
   }
@@ -807,7 +807,7 @@ GPUd() void GPUTPCGMMerger::MergeWithinSlicesPrepare(int nBlocks, int nThreads, 
       CADEBUG(
         printf("WITHIN SLICE %d Track %d - ", iSlice, itr); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Par()[i]); } printf(" - "); for (int i = 0; i < 5; i++) { printf("%8.3f ", b.Cov()[i]); } printf("\n"));
       b.SetNClusters(track.NClusters());
-      unsigned int myTrack = CAMath::AtomicAdd(&mTmpCounter[iSlice], 1);
+      unsigned int myTrack = CAMath::AtomicAdd(&mTmpCounter[iSlice], 1u);
       mBorder[iSlice][myTrack] = b;
     }
   }
@@ -1032,7 +1032,7 @@ GPUd() void GPUTPCGMMerger::MergeCEFill(const GPUTPCGMSliceTrack* track, const G
       }
       b.SetRow(cls.row);
       unsigned int id = slice + attempt * NSLICES;
-      unsigned int myTrack = CAMath::AtomicAdd(&mTmpCounter[id], 1);
+      unsigned int myTrack = CAMath::AtomicAdd(&mTmpCounter[id], 1u);
       mBorder[id][myTrack] = b;
       break;
     }
@@ -1524,7 +1524,7 @@ GPUd() void GPUTPCGMMerger::SortTracksPrepare(int nBlocks, int nThreads, int iBl
   for (unsigned int i = iBlock * nThreads + iThread; i < mMemory->nOutputTracks; i += nThreads * nBlocks) {
     const GPUTPCGMMergedTrack& trk = mOutputTracks[i];
     if (trk.CCE() || trk.Legs()) {
-      CAMath::AtomicAdd(&mMemory->nSlowTracks, 1);
+      CAMath::AtomicAdd(&mMemory->nSlowTracks, 1u);
     }
     mTrackOrderProcess[i] = i;
   }
@@ -1558,7 +1558,7 @@ GPUd() void GPUTPCGMMerger::PrepareClustersForFit1(int nBlocks, int nThreads, in
   }
   for (unsigned int i = iBlock * nThreads + iThread; i < mMemory->nOutputTrackClusters; i += nBlocks * nThreads) {
     mClusterAttachment[mClusters[i].num] = attachAttached | attachGood;
-    CAMath::AtomicAdd(&sharedCount[mClusters[i].num], 1);
+    CAMath::AtomicAdd(&sharedCount[mClusters[i].num], 1u);
   }
 }
 
@@ -1599,7 +1599,7 @@ GPUd() void GPUTPCGMMerger::Finalize1(int nBlocks, int nThreads, int iBlock, int
     char goodLeg = mClusters[trk.FirstClusterRef() + trk.NClusters() - 1].leg;
     for (unsigned int j = 0; j < trk.NClusters(); j++) {
       int id = mClusters[trk.FirstClusterRef() + j].num;
-      int weight = mTrackOrderAttach[i] | attachAttached;
+      unsigned int weight = mTrackOrderAttach[i] | attachAttached;
       unsigned char clusterState = mClusters[trk.FirstClusterRef() + j].state;
       if (!(clusterState & GPUTPCGMMergedTrackHit::flagReject)) {
         weight |= attachGood;

--- a/GPU/GPUTracking/Merger/GPUTPCGMMergerDump.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMergerDump.cxx
@@ -40,7 +40,7 @@ void GPUTPCGMMerger::DumpSliceTracks(std::ostream& out)
   out << std::setprecision(2);
   out << "\nTPC Merger Slice Tracks\n";
   for (int iSlice = 0; iSlice < NSLICES; iSlice++) {
-    out << "Slice Track Info Index" << mSliceTrackInfoIndex[iSlice] << " / " << mSliceTrackInfoIndex[NSLICES + iSlice] << "\n";
+    out << "Slice Track Info Index " << (mSliceTrackInfoIndex[iSlice + 1] - mSliceTrackInfoIndex[iSlice]) << " / " << (mSliceTrackInfoIndex[NSLICES + iSlice + 1] - mSliceTrackInfoIndex[NSLICES + iSlice]) << "\n";
     for (int iGlobal = 0; iGlobal < 2; iGlobal++) {
       out << "  Track type " << iGlobal << "\n";
       for (int j = mSliceTrackInfoIndex[iSlice + NSLICES * iGlobal]; j < mSliceTrackInfoIndex[iSlice + NSLICES * iGlobal + 1]; j++) {

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -545,9 +545,9 @@ GPUd() bool GPUTPCGMTrackParam::FollowCircleChk(float lrFactor, float toY, float
 
 GPUd() void GPUTPCGMTrackParam::StoreAttachMirror(const GPUTPCGMMerger* GPUrestrict() Merger, int slice, int iRow, int iTrack, bool goodLeg, float toAlpha, float toY, float toX, int toSlice, int toRow, bool inFlyDirection, float alpha)
 {
-  unsigned int nLoopData = CAMath::AtomicAdd(&Merger->Memory()->nLoopData, 1);
+  unsigned int nLoopData = CAMath::AtomicAdd(&Merger->Memory()->nLoopData, 1u);
   if (nLoopData >= Merger->NMaxTracks()) {
-    CAMath::AtomicExch(&Merger->Memory()->nLoopData, 0);
+    CAMath::AtomicExch(&Merger->Memory()->nLoopData, 0u);
     // TODO: GPUCA_ERROR_LOOPER_OVERFLOW
     return;
   }
@@ -962,7 +962,7 @@ GPUd() void GPUTPCGMTrackParam::RefitTrack(GPUTPCGMMergedTrack& GPUrestrict() tr
       Alpha = track.Alpha();
       ok = t.Fit(merger, iTrk, clusters + track.FirstClusterRef(), nTrackHits, NTolerated, Alpha, 1, GPUCA_MAX_SIN_PHI, &track.OuterParam(), merger->Param().dodEdx ? &track.dEdxInfo() : nullptr);
     } else {
-      unsigned int nRefit = CAMath::AtomicAdd(&merger->Memory()->nRetryRefit, 1);
+      unsigned int nRefit = CAMath::AtomicAdd(&merger->Memory()->nRetryRefit, 1u);
       merger->RetryRefitIds()[nRefit] = iTrk;
       return;
     }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.cxx
@@ -20,8 +20,5 @@ using namespace GPUCA_NAMESPACE::gpu;
 template <>
 GPUdii() void GPUTPCCreateSliceData::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() MEM_LOCAL(GPUSharedMemory) & GPUrestrict() s, processorType& GPUrestrict() tracker)
 {
-  if (iThread || iBlock) {
-    return;
-  }
-  tracker.Data().InitFromClusterData(nBlocks, nThreads, iBlock, iThread, tracker.GetConstantMem(), tracker.ISlice());
+  tracker.Data().InitFromClusterData(nBlocks, nThreads, iBlock, iThread, tracker.GetConstantMem(), tracker.ISlice(), s.tmp);
 }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.cxx
@@ -1,0 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCCreateSliceData.cxx
+/// \author David Rohr
+
+#include "GPUTPCCreateSliceData.h"
+#include "GPUTPCTracker.h"
+#include "GPUCommonMath.h"
+
+using namespace GPUCA_NAMESPACE::gpu;
+
+template <>
+GPUdii() void GPUTPCCreateSliceData::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() MEM_LOCAL(GPUSharedMemory) & GPUrestrict() s, processorType& GPUrestrict() tracker)
+{
+  if (iThread || iBlock) {
+    return;
+  }
+  tracker.Data().InitFromClusterData(nBlocks, nThreads, iBlock, iThread, tracker.GetConstantMem(), tracker.ISlice());
+}

--- a/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.h
@@ -28,6 +28,10 @@ class GPUTPCTracker;
 class GPUTPCCreateSliceData : public GPUKernelTemplate
 {
  public:
+  struct GPUSharedMemory {
+    float tmp[4];
+  };
+
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
   GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()

--- a/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCCreateSliceData.h
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCCreateSliceData.h
+/// \author David Rohr
+
+#ifndef GPUTPCCREATESLICEDATA_H
+#define GPUTPCCREATESLICEDATA_H
+
+#include "GPUTPCDef.h"
+#include "GPUTPCHitId.h"
+#include "GPUGeneralKernels.h"
+#include "GPUConstantMem.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+class GPUTPCTracker;
+
+class GPUTPCCreateSliceData : public GPUKernelTemplate
+{
+ public:
+  typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  MEM_TEMPLATE()
+  GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
+  {
+    return processors.tpcTrackers;
+  }
+  template <int iKernel = defaultKernel>
+  GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() MEM_LOCAL(GPUSharedMemory) & smem, processorType& tracker);
+};
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif // GPUTPCCREATESLICEDATA_H

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGlobalTracking.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGlobalTracking.cxx
@@ -72,13 +72,13 @@ GPUd() int GPUTPCGlobalTracking::PerformGlobalTrackingRun(GPUTPCTracker& tracker
   int nHits = GPUTPCTrackletConstructor::GPUTPCTrackletConstructorGlobalTracking(tracker, smem, tParam, rowIndex, direction, 0, rowHits);
   if (nHits >= GPUCA_GLOBAL_TRACKING_MIN_HITS) {
     // GPUInfo("%d hits found", nHits);
-    unsigned int hitId = CAMath::AtomicAdd(&tracker.CommonMemory()->nTrackHits, nHits);
+    unsigned int hitId = CAMath::AtomicAdd(&tracker.CommonMemory()->nTrackHits, (unsigned int)nHits);
     if (hitId + nHits > tracker.NMaxTrackHits()) {
       tracker.CommonMemory()->kernelError = GPUCA_ERROR_GLOBAL_TRACKING_TRACK_HIT_OVERFLOW;
       CAMath::AtomicExch(&tracker.CommonMemory()->nTrackHits, tracker.NMaxTrackHits());
       return (0);
     }
-    unsigned int trackId = CAMath::AtomicAdd(&tracker.CommonMemory()->nTracks, 1);
+    unsigned int trackId = CAMath::AtomicAdd(&tracker.CommonMemory()->nTracks, 1u);
     if (direction == 1) {
       int i = 0;
       while (i < nHits) {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
@@ -20,7 +20,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #endif
 
 MEM_CLASS_PRE()
-void MEM_LG(GPUTPCGrid)::CreateEmpty()
+GPUd() void MEM_LG(GPUTPCGrid)::CreateEmpty()
 {
   // Create an empty grid
   mYMin = 0.f;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
@@ -45,7 +45,7 @@ GPUd() void MEM_LG(GPUTPCGrid)::Create(float yMin, float yMax, float zMin, float
 
   float sy = CAMath::Max((yMax + 0.1f - yMin) / ny, GPUCA_MIN_BIN_SIZE);
   float sz = CAMath::Max((zMax + 0.1f - zMin) / nz, GPUCA_MIN_BIN_SIZE);
-  
+
   mStepYInv = 1.f / sy;
   mStepZInv = 1.f / sz;
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGrid.cxx
@@ -37,17 +37,20 @@ void MEM_LG(GPUTPCGrid)::CreateEmpty()
 }
 
 MEM_CLASS_PRE()
-GPUd() void MEM_LG(GPUTPCGrid)::Create(float yMin, float yMax, float zMin, float zMax, float sy, float sz)
+GPUd() void MEM_LG(GPUTPCGrid)::Create(float yMin, float yMax, float zMin, float zMax, int ny, int nz)
 {
   //* Create the grid
   mYMin = yMin;
   mZMin = zMin;
 
+  float sy = CAMath::Max((yMax + 0.1f - yMin) / ny, GPUCA_MIN_BIN_SIZE);
+  float sz = CAMath::Max((zMax + 0.1f - zMin) / nz, GPUCA_MIN_BIN_SIZE);
+  
   mStepYInv = 1.f / sy;
   mStepZInv = 1.f / sz;
 
-  mNy = static_cast<unsigned int>((yMax - mYMin) * mStepYInv + 1.f);
-  mNz = static_cast<unsigned int>((zMax - mZMin) * mStepZInv + 1.f);
+  mNy = ny;
+  mNz = nz;
 
   mN = mNy * mNz;
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGrid.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGrid.h
@@ -33,7 +33,7 @@ class GPUTPCGrid
 {
  public:
   void CreateEmpty();
-  GPUd() void Create(float yMin, float yMax, float zMin, float zMax, float sy, float sz);
+  GPUd() void Create(float yMin, float yMax, float zMin, float zMax, int ny, int nz);
 
   GPUd() int GetBin(float Y, float Z) const;
   /**

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGrid.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGrid.h
@@ -32,7 +32,7 @@ MEM_CLASS_PRE()
 class GPUTPCGrid
 {
  public:
-  void CreateEmpty();
+  GPUd() void CreateEmpty();
   GPUd() void Create(float yMin, float yMax, float zMin, float zMax, int ny, int nz);
 
   GPUd() int GetBin(float Y, float Z) const;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCRow.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCRow.cxx
@@ -15,7 +15,7 @@
 using namespace GPUCA_NAMESPACE::gpu;
 
 #if !defined(GPUCA_GPUCODE)
-GPUTPCRow::GPUTPCRow() : mNHits(0), mX(0), mMaxY(0), mGrid(), mHy0(0), mHz0(0), mHstepY(0), mHstepZ(0), mHstepYi(0), mHstepZi(0), mFullSize(0), mHitNumberOffset(0), mFirstHitInBinOffset(0)
+GPUTPCRow::GPUTPCRow() : mNHits(0), mX(0), mMaxY(0), mGrid(), mHy0(0), mHz0(0), mHstepY(0), mHstepZ(0), mHstepYi(0), mHstepZi(0), mHitNumberOffset(0), mFirstHitInBinOffset(0)
 {
   // dummy constructor
 }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCRow.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCRow.h
@@ -53,7 +53,6 @@ class GPUTPCRow
   GPUhd() float HstepZ() const { return mHstepZ; }
   GPUhd() float HstepYi() const { return mHstepYi; }
   GPUhd() float HstepZi() const { return mHstepZi; }
-  GPUhd() int FullSize() const { return mFullSize; }
   GPUhd() int HitNumberOffset() const { return mHitNumberOffset; }
   GPUhd() unsigned int FirstHitInBinOffset() const { return mFirstHitInBinOffset; }
 
@@ -75,7 +74,6 @@ class GPUTPCRow
   float mHstepYi; // inverse step size
   float mHstepZi; // inverse step size
 
-  int mFullSize;        // size of this row in Tracker::mRowData
   int mHitNumberOffset; // index of the first hit in the hit array, used as
   // offset in GPUTPCSliceData::LinkUp/DownData/HitDataY/...
   unsigned int mFirstHitInBinOffset; // offset in Tracker::mRowData to find the FirstHitInBin

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -44,7 +44,7 @@ class GPUTPCSliceData
   void* SetPointersRows(void* mem);
 #endif
 
-  GPUd() int InitFromClusterData(int nBlocks, int nThreads, int iBlock, int iThread, GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
+  GPUd() int InitFromClusterData(int nBlocks, int nThreads, int iBlock, int iThread, GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice, float* tmpMinMax);
 
   /**
  * Return the number of hits in this slice.
@@ -137,7 +137,7 @@ class GPUTPCSliceData
   GPUTPCSliceData& operator=(const GPUTPCSliceData&) CON_DELETE; // ROOT 5 tries to use this if it is not private
   GPUTPCSliceData(const GPUTPCSliceData&) CON_DELETE;            //
 #endif
-  GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, const float2* data, int ClusterDataHitNumberOffset, float yMin, float yMax, float zMin, float zMax);
+  GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, float yMin, float yMax, float zMin, float zMax);
   GPUd() static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, int& maxY, int& maxZ);
   GPUd() unsigned int GetGridSize(unsigned int nHits, unsigned int nRows);
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -139,7 +139,7 @@ class GPUTPCSliceData
 #endif
   GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, const float2* data, int ClusterDataHitNumberOffset, float yMin, float yMax, float zMin, float zMax);
   GPUd() static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, int& maxY, int& maxZ);
-  GPUd() unsigned int GetGridSize();
+  GPUd() unsigned int GetGridSize(unsigned int nHits, unsigned int nRows);
 
   friend class GPUTPCNeighboursFinder;
   friend class GPUTPCStartHitsFinder;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -137,7 +137,7 @@ class GPUTPCSliceData
   GPUTPCSliceData& operator=(const GPUTPCSliceData&) CON_DELETE; // ROOT 5 tries to use this if it is not private
   GPUTPCSliceData(const GPUTPCSliceData&) CON_DELETE;            //
 #endif
-  GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, const float2* data, int ClusterDataHitNumberOffset);
+  GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, const float2* data, int ClusterDataHitNumberOffset, float yMin, float yMax, float zMin, float zMax);
   GPUd() static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, int& maxY, int& maxZ);
   GPUd() unsigned int GetGridSize();
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -101,9 +101,9 @@ class GPUTPCSliceData
  * If the given weight is higher than what is currently stored replace with the new weight.
  */
   MEM_TEMPLATE()
-  GPUd() void MaximizeHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, int weight);
+  GPUd() void MaximizeHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, unsigned int weight);
   MEM_TEMPLATE()
-  GPUd() void SetHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, int weight);
+  GPUd() void SetHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, unsigned int weight);
 
   /**
  * Return the maximal weight the given hit got from one tracklet
@@ -210,14 +210,14 @@ GPUhdi() int MEM_LG(GPUTPCSliceData)::ClusterDataIndex(const MEM_TYPE(GPUTPCRow)
 
 MEM_CLASS_PRE()
 MEM_TEMPLATE()
-GPUdi() void MEM_LG(GPUTPCSliceData)::MaximizeHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, int weight)
+GPUdi() void MEM_LG(GPUTPCSliceData)::MaximizeHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, unsigned int weight)
 {
   CAMath::AtomicMax(&mHitWeights[row.mHitNumberOffset + hitIndex], weight);
 }
 
 MEM_CLASS_PRE()
 MEM_TEMPLATE()
-GPUdi() void MEM_LG(GPUTPCSliceData)::SetHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, int weight)
+GPUdi() void MEM_LG(GPUTPCSliceData)::SetHitWeight(const MEM_TYPE(GPUTPCRow) & row, unsigned int hitIndex, unsigned int weight)
 {
   mHitWeights[row.mHitNumberOffset + hitIndex] = weight;
 }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -37,6 +37,7 @@ class GPUTPCSliceData
   ~GPUTPCSliceData() CON_DEFAULT;
   void InitializeRows(const MEM_CONSTANT(GPUParam) & p);
   void SetMaxData();
+  unsigned int GetGridSize();
   void SetClusterData(const GPUTPCClusterData* data, int nClusters, int clusterIdOffset);
   void* SetPointersInput(void* mem, bool idsOnGPU);
   void* SetPointersScratch(GPUconstantref() const MEM_CONSTANT(GPUConstantMem)& cm, void* mem);
@@ -137,9 +138,11 @@ class GPUTPCSliceData
 #ifndef GPUCA_GPUCODE
   GPUTPCSliceData& operator=(const GPUTPCSliceData&) CON_DELETE; // ROOT 5 tries to use this if it is not private
   GPUTPCSliceData(const GPUTPCSliceData&) CON_DELETE;            //
-  void CreateGrid(GPUTPCRow* row, const float2* data, int ClusterDataHitNumberOffset);
-  int PackHitData(GPUTPCRow* row, const GPUTPCHit* binSortedHits);
 #endif
+  void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow)* row, const float2* data, int ClusterDataHitNumberOffset);
+  void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int& maxY, int& maxZ);
+  int PackHitData(MEM_GLOBAL(GPUTPCRow)* row, const GPUTPCHit* binSortedHits);
+
   friend class GPUTPCNeighboursFinder;
   friend class GPUTPCStartHitsFinder;
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -33,24 +33,16 @@ class GPUTPCSliceData
  public:
   GPUTPCSliceData() : mNumberOfHits(0), mNumberOfHitsPlusAlign(0), mClusterIdOffset(0), mMaxZ(0.f), mGPUTextureBase(nullptr), mRows(nullptr), mLinkUpData(nullptr), mLinkDownData(nullptr), mClusterData(nullptr) {}
 
-#ifndef GPUCA_GPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
   ~GPUTPCSliceData() CON_DEFAULT;
-#endif //! GPUCA_GPUCODE
-
-  MEM_CLASS_PRE2()
-  void InitializeRows(const MEM_LG2(GPUParam) & parameters);
-
-  /**
- * (Re)Create the data that is tuned for optimal performance of the algorithm from the cluster
- * data.
- */
-
+  void InitializeRows(const MEM_CONSTANT(GPUParam) & p);
   void SetMaxData();
   void SetClusterData(const GPUTPCClusterData* data, int nClusters, int clusterIdOffset);
   void* SetPointersInput(void* mem, bool idsOnGPU);
-  void* SetPointersScratch(void* mem);
+  void* SetPointersScratch(GPUconstantref() const MEM_CONSTANT(GPUConstantMem)& cm, void* mem);
   void* SetPointersScratchHost(void* mem, bool idsOnGPU);
   void* SetPointersRows(void* mem);
+#endif
 
   int InitFromClusterData(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
 
@@ -165,7 +157,9 @@ class GPUTPCSliceData
   GPUglobalref() calink* mLinkDownData;  // hit index in the row below which is linked to the given (global) hit index
   GPUglobalref() cahit2* mHitData;       // packed y,z coordinate of the given (global) hit index
   GPUglobalref() int* mClusterDataIndex; // see ClusterDataIndex()
-
+  
+  uint4* mTmpMem;
+  
   /*
  * The size of the array is row.Grid.N + row.Grid.Ny + 3. The row.Grid.Ny + 3 is an optimization
  * to remove the need for bounds checking. The last values are the same as the entry at [N - 1].

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -31,7 +31,7 @@ MEM_CLASS_PRE()
 class GPUTPCSliceData
 {
  public:
-  GPUTPCSliceData() : mNumberOfHits(0), mNumberOfHitsPlusAlign(0), mClusterIdOffset(0), mMaxZ(0.f), mGPUTextureBase(nullptr), mRows(nullptr), mLinkUpData(nullptr), mLinkDownData(nullptr), mClusterData(nullptr) {}
+  GPUTPCSliceData() : mNumberOfHits(0), mNumberOfHitsPlusAlign(0), mClusterIdOffset(0), mGPUTextureBase(nullptr), mRows(nullptr), mLinkUpData(nullptr), mLinkDownData(nullptr), mClusterData(nullptr) {}
 
 #ifndef GPUCA_GPUCODE_DEVICE
   ~GPUTPCSliceData() CON_DEFAULT;
@@ -44,7 +44,7 @@ class GPUTPCSliceData
   void* SetPointersRows(void* mem);
 #endif
 
-  GPUd() int InitFromClusterData(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
+  GPUd() int InitFromClusterData(int nBlocks, int nThreads, int iBlock, int iThread, GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
 
   /**
  * Return the number of hits in this slice.
@@ -131,7 +131,6 @@ class GPUTPCSliceData
   GPUhdi() char* GPUTextureBaseConst() const { return ((char*)mGPUTextureBase); }
 
   GPUhdi() GPUglobalref() const GPUTPCClusterData* ClusterData() const { return mClusterData; }
-  float MaxZ() const { return mMaxZ; }
 
  private:
 #ifndef GPUCA_GPUCODE
@@ -148,8 +147,6 @@ class GPUTPCSliceData
   int mNumberOfHits; // the number of hits in this slice
   int mNumberOfHitsPlusAlign;
   int mClusterIdOffset;
-
-  float mMaxZ;
 
   GPUglobalref() const void* mGPUTextureBase; // pointer to start of GPU texture
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -37,7 +37,6 @@ class GPUTPCSliceData
   ~GPUTPCSliceData() CON_DEFAULT;
   void InitializeRows(const MEM_CONSTANT(GPUParam) & p);
   void SetMaxData();
-  unsigned int GetGridSize();
   void SetClusterData(const GPUTPCClusterData* data, int nClusters, int clusterIdOffset);
   void* SetPointersInput(void* mem, bool idsOnGPU);
   void* SetPointersScratch(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) & cm, void* mem);
@@ -45,7 +44,7 @@ class GPUTPCSliceData
   void* SetPointersRows(void* mem);
 #endif
 
-  int InitFromClusterData(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
+  GPUd() int InitFromClusterData(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int iSlice);
 
   /**
  * Return the number of hits in this slice.
@@ -139,8 +138,9 @@ class GPUTPCSliceData
   GPUTPCSliceData& operator=(const GPUTPCSliceData&) CON_DELETE; // ROOT 5 tries to use this if it is not private
   GPUTPCSliceData(const GPUTPCSliceData&) CON_DELETE;            //
 #endif
-  void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * row, const float2* data, int ClusterDataHitNumberOffset);
-  static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, GPUTPCRow* GPUrestrict() row, int& maxY, int& maxZ);
+  GPUd() void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, const float2* data, int ClusterDataHitNumberOffset);
+  GPUd() static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * GPUrestrict() row, int& maxY, int& maxZ);
+  GPUd() unsigned int GetGridSize();
 
   friend class GPUTPCNeighboursFinder;
   friend class GPUTPCStartHitsFinder;
@@ -159,8 +159,6 @@ class GPUTPCSliceData
   GPUglobalref() calink* mLinkDownData;  // hit index in the row below which is linked to the given (global) hit index
   GPUglobalref() cahit2* mHitData;       // packed y,z coordinate of the given (global) hit index
   GPUglobalref() int* mClusterDataIndex; // see ClusterDataIndex()
-
-  uint4* mTmpMem;
 
   /*
  * The size of the array is row.Grid.N + row.Grid.Ny + 3. The row.Grid.Ny + 3 is an optimization

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -40,7 +40,7 @@ class GPUTPCSliceData
   unsigned int GetGridSize();
   void SetClusterData(const GPUTPCClusterData* data, int nClusters, int clusterIdOffset);
   void* SetPointersInput(void* mem, bool idsOnGPU);
-  void* SetPointersScratch(GPUconstantref() const MEM_CONSTANT(GPUConstantMem)& cm, void* mem);
+  void* SetPointersScratch(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) & cm, void* mem);
   void* SetPointersScratchHost(void* mem, bool idsOnGPU);
   void* SetPointersRows(void* mem);
 #endif
@@ -139,9 +139,8 @@ class GPUTPCSliceData
   GPUTPCSliceData& operator=(const GPUTPCSliceData&) CON_DELETE; // ROOT 5 tries to use this if it is not private
   GPUTPCSliceData(const GPUTPCSliceData&) CON_DELETE;            //
 #endif
-  void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow)* row, const float2* data, int ClusterDataHitNumberOffset);
-  void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, int& maxY, int& maxZ);
-  int PackHitData(MEM_GLOBAL(GPUTPCRow)* row, const GPUTPCHit* binSortedHits);
+  void CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, MEM_GLOBAL(GPUTPCRow) * row, const float2* data, int ClusterDataHitNumberOffset);
+  static void GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, GPUTPCRow* GPUrestrict() row, int& maxY, int& maxZ);
 
   friend class GPUTPCNeighboursFinder;
   friend class GPUTPCStartHitsFinder;
@@ -160,9 +159,9 @@ class GPUTPCSliceData
   GPUglobalref() calink* mLinkDownData;  // hit index in the row below which is linked to the given (global) hit index
   GPUglobalref() cahit2* mHitData;       // packed y,z coordinate of the given (global) hit index
   GPUglobalref() int* mClusterDataIndex; // see ClusterDataIndex()
-  
+
   uint4* mTmpMem;
-  
+
   /*
  * The size of the array is row.Grid.N + row.Grid.Ny + 3. The row.Grid.Ny + 3 is an optimization
  * to remove the need for bounds checking. The last values are the same as the entry at [N - 1].

--- a/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.cxx
@@ -42,18 +42,18 @@ GPUdii() void GPUTPCStartHitsFinder::Thread<0>(int /*nBlocks*/, int nThreads, in
     if (tracker.mData.mLinkDownData[lHitNumberOffset + ih] == CALINK_INVAL && linkUpData != CALINK_INVAL && tracker.mData.mLinkUpData[rowUp.mHitNumberOffset + linkUpData] != CALINK_INVAL) {
 #ifdef GPUCA_SORT_STARTHITS
       GPUglobalref() GPUTPCHitId* const GPUrestrict() startHits = tracker.mTrackletTmpStartHits + s.mIRow * tracker.mNMaxRowStartHits;
-      unsigned int nextRowStartHits = CAMath::AtomicAddShared(&s.mNRowStartHits, 1);
+      unsigned int nextRowStartHits = CAMath::AtomicAddShared(&s.mNRowStartHits, 1u);
       CONSTEXPR int errCode = GPUCA_ERROR_ROWSTARTHIT_OVERFLOW;
       if (nextRowStartHits >= tracker.mNMaxRowStartHits)
 #else
       GPUglobalref() GPUTPCHitId* const GPUrestrict() startHits = tracker.mTrackletStartHits;
-      unsigned int nextRowStartHits = CAMath::AtomicAdd(&tracker.mCommonMem->nStartHits, 1);
+      unsigned int nextRowStartHits = CAMath::AtomicAdd(&tracker.mCommonMem->nStartHits, 1u);
       CONSTEXPR int errCode = GPUCA_ERROR_STARTHIT_OVERFLOW;
       if (nextRowStartHits >= tracker.mNMaxStartHits)
 #endif
       {
         trackerX.CommonMemory()->kernelError = errCode;
-        CAMath::AtomicExch(&tracker.mCommonMem->nStartHits, 0);
+        CAMath::AtomicExch(&tracker.mCommonMem->nStartHits, 0u);
         break;
       }
       startHits[nextRowStartHits].Set(s.mIRow, ih);
@@ -67,7 +67,7 @@ GPUdii() void GPUTPCStartHitsFinder::Thread<0>(int /*nBlocks*/, int nThreads, in
     tracker.mRowStartHitCountOffset[s.mIRow] = s.mNRowStartHits;
     if (nOffset + s.mNRowStartHits > tracker.mNMaxStartHits) {
       trackerX.CommonMemory()->kernelError = GPUCA_ERROR_STARTHIT_OVERFLOW;
-      CAMath::AtomicExch(&tracker.mCommonMem->nStartHits, 0);
+      CAMath::AtomicExch(&tracker.mCommonMem->nStartHits, 0u);
     }
   }
 #endif

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
@@ -158,20 +158,6 @@ void GPUTPCTracker::UpdateMaxData()
 
 void GPUTPCTracker::SetupCommonMemory() { new (mCommonMem) commonMemoryStruct; }
 
-int GPUTPCTracker::ReadEvent()
-{
-  //* Convert input hits, create grids, etc.
-  if (mData.InitFromClusterData(mConstantMem, mISlice)) {
-    GPUError("Error initializing from cluster data");
-    return 1;
-  }
-  if (mData.MaxZ() > 300 && !Param().ContinuousTracking) {
-    GPUError("Need to set continuous tracking mode for data outside of the TPC volume!");
-    return 1;
-  }
-  return 0;
-}
-
 GPUh() int GPUTPCTracker::CheckEmptySlice()
 {
   // Check if the Slice is empty, if so set the output apropriate and tell the reconstuct procesdure to terminate

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
@@ -66,7 +66,7 @@ void GPUTPCTracker::InitializeProcessor()
 
 void* GPUTPCTracker::SetPointersDataInput(void* mem) { return mData.SetPointersInput(mem, mRec->GetRecoStepsGPU() & GPUReconstruction::RecoStep::TPCMerging); }
 
-void* GPUTPCTracker::SetPointersDataScratch(void* mem) { return mData.SetPointersScratch(mem); }
+void* GPUTPCTracker::SetPointersDataScratch(void* mem) { return mData.SetPointersScratch(mRec->GetConstantMem(), mem); }
 
 void* GPUTPCTracker::SetPointersDataRows(void* mem) { return mData.SetPointersRows(mem); }
 

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
@@ -58,7 +58,6 @@ class GPUTPCTracker : public GPUProcessor
   MEM_CLASS_PRE2()
   void InitializeRows(const MEM_CONSTANT(GPUParam) * param) { mData.InitializeRows(*param); }
 
-  int ReadEvent();
   int CheckEmptySlice();
   void WriteOutputPrepare();
   void WriteOutput();

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
@@ -50,6 +50,27 @@ class GPUTPCTracker : public GPUProcessor
   ~GPUTPCTracker();
   GPUTPCTracker(const GPUTPCTracker&) CON_DELETE;
   GPUTPCTracker& operator=(const GPUTPCTracker&) CON_DELETE;
+
+  MEM_CLASS_PRE2()
+  void SetSlice(int iSlice);
+  MEM_CLASS_PRE2()
+  void InitializeProcessor();
+  MEM_CLASS_PRE2()
+  void InitializeRows(const MEM_CONSTANT(GPUParam) * param) { mData.InitializeRows(*param); }
+
+  int ReadEvent();
+  int CheckEmptySlice();
+  void WriteOutputPrepare();
+  void WriteOutput();
+
+  // Debugging Stuff
+  void DumpSliceData(std::ostream& out);    // Dump Input Slice Data
+  void DumpLinks(std::ostream& out);        // Dump all links to file (for comparison after NeighboursFinder/Cleaner)
+  void DumpStartHits(std::ostream& out);    // Same for Start Hits
+  void DumpHitWeights(std::ostream& out);   //....
+  void DumpTrackHits(std::ostream& out);    // Same for Track Hits
+  void DumpTrackletHits(std::ostream& out); // Same for Track Hits
+  void DumpOutput(std::ostream& out);       // Similar for output
 #endif
 
   struct StructGPUParameters {
@@ -74,30 +95,6 @@ class GPUTPCTracker : public GPUProcessor
     StructGPUParameters gpuParameters;  // GPU parameters
   };
 
-  MEM_CLASS_PRE2()
-  void SetSlice(int iSlice);
-  MEM_CLASS_PRE2()
-  void InitializeProcessor();
-  MEM_CLASS_PRE2()
-  void InitializeRows(const MEM_CONSTANT(GPUParam) * param) { mData.InitializeRows(*param); }
-
-  int CheckEmptySlice();
-  void WriteOutputPrepare();
-  void WriteOutput();
-
-// GPU Tracker Interface
-#if !defined(GPUCA_GPUCODE_DEVICE)
-  // Debugging Stuff
-  void DumpSliceData(std::ostream& out);    // Dump Input Slice Data
-  void DumpLinks(std::ostream& out);        // Dump all links to file (for comparison after NeighboursFinder/Cleaner)
-  void DumpStartHits(std::ostream& out);    // Same for Start Hits
-  void DumpHitWeights(std::ostream& out);   //....
-  void DumpTrackHits(std::ostream& out);    // Same for Track Hits
-  void DumpTrackletHits(std::ostream& out); // Same for Track Hits
-  void DumpOutput(std::ostream& out);       // Similar for output
-
-  int ReadEvent();
-#endif
 
 #if !defined(__OPENCL__) || defined(__OPENCLCPP__)
   GPUhdi() GPUglobalref() const GPUTPCClusterData* ClusterData() const

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.cxx
@@ -65,12 +65,12 @@ GPUd() void GPUTPCTrackletConstructor::StoreTracklet(int /*nBlocks*/, int /*nThr
           tParam.Cov()[0], tParam.Cov()[1], tParam.Cov()[2], tParam.Cov()[3], tParam.Cov()[4], tParam.Cov()[5], tParam.Cov()[6], tParam.Cov()[7], tParam.Cov()[8], tParam.Cov()[9],
           tParam.Cov()[10], tParam.Cov()[11], tParam.Cov()[12], tParam.Cov()[13], tParam.Cov()[14]);*/
 
-  unsigned int itrout = CAMath::AtomicAdd(tracker.NTracklets(), 1);
+  unsigned int itrout = CAMath::AtomicAdd(tracker.NTracklets(), 1u);
   const unsigned int nHits = r.mLastRow + 1 - r.mFirstRow;
   unsigned int hitout = CAMath::AtomicAdd(tracker.NRowHits(), nHits);
   if (itrout >= tracker.NMaxTracklets() || hitout + nHits > tracker.NMaxRowHits()) {
     tracker.CommonMemory()->kernelError = itrout >= tracker.NMaxTracklets() ? GPUCA_ERROR_TRACKLET_OVERFLOW : GPUCA_ERROR_TRACKLET_HIT_OVERFLOW;
-    CAMath::AtomicExch(tracker.NTracklets(), 0);
+    CAMath::AtomicExch(tracker.NTracklets(), 0u);
     if (hitout + nHits > tracker.NMaxRowHits()) {
       CAMath::AtomicExch(tracker.NRowHits(), tracker.NMaxRowHits());
     }
@@ -488,7 +488,7 @@ GPUd() int GPUTPCTrackletConstructor::FetchTracklet(GPUconstantref() MEM_GLOBAL(
       sMem.mNextStartHitFirstRun = 0;
     } else {
       if (tracker.GPUParameters()->nextStartHit < nStartHit) {
-        firstStartHit = CAMath::AtomicAdd(&tracker.GPUParameters()->nextStartHit, GPUCA_GET_THREAD_COUNT(GPUCA_LB_GPUTPCTrackletConstructor));
+        firstStartHit = CAMath::AtomicAdd<unsigned int>(&tracker.GPUParameters()->nextStartHit, GPUCA_GET_THREAD_COUNT(GPUCA_LB_GPUTPCTrackletConstructor));
       }
     }
     sMem.mNextStartHitFirst = firstStartHit < (int)nStartHit ? firstStartHit : -2;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackletSelector.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackletSelector.cxx
@@ -84,11 +84,11 @@ GPUdii() void GPUTPCTrackletSelector::Thread<0>(int nBlocks, int nThreads, int i
 
       if (gap > kMaxRowGap || irow == lastRow) { // store
         if (nHits >= minHits) {
-          unsigned int itrout = CAMath::AtomicAdd(tracker.NTracks(), 1);
-          unsigned int nFirstTrackHit = CAMath::AtomicAdd(tracker.NTrackHits(), nHits);
+          unsigned int itrout = CAMath::AtomicAdd(tracker.NTracks(), 1u);
+          unsigned int nFirstTrackHit = CAMath::AtomicAdd(tracker.NTrackHits(), (unsigned int)nHits);
           if (itrout >= tracker.NMaxTracks() || nFirstTrackHit + nHits > tracker.NMaxTrackHits()) {
             tracker.CommonMemory()->kernelError = (itrout >= tracker.NMaxTracks()) ? GPUCA_ERROR_TRACK_OVERFLOW : GPUCA_ERROR_TRACK_HIT_OVERFLOW;
-            CAMath::AtomicExch(tracker.NTracks(), 0);
+            CAMath::AtomicExch(tracker.NTracks(), 0u);
             if (nFirstTrackHit + nHits > tracker.NMaxTrackHits()) {
               CAMath::AtomicExch(tracker.NTrackHits(), tracker.NMaxTrackHits());
             }

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -1551,9 +1551,9 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
 #endif
       for (int iSlice = 0; iSlice < NSLICES; iSlice++) {
         GPUTPCTracker& tracker = (GPUTPCTracker&)sliceTracker(iSlice);
-        tracker.Data().SetPointersScratch(tracker.LinkTmpMemory());
+        tracker.Data().SetPointersScratch(*tracker.GetConstantMem(), tracker.LinkTmpMemory());
         mGlDLLines[iSlice][tINITLINK] = DrawLinks(tracker, tINITLINK, true);
-        tracker.Data().SetPointersScratch(mChain->rec()->Res(tracker.MemoryResLinksScratch()).Ptr());
+        tracker.Data().SetPointersScratch(*tracker.GetConstantMem(), mChain->rec()->Res(tracker.MemoryResLinksScratch()).Ptr());
       }
       GPUTPCGMPropagator prop;
       const float kRho = 1.025e-3;  // 0.9e-3;

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -571,8 +571,6 @@ void GPUQA::RunQA(bool matchOnly)
     mcEffBuffer[mNEvents - 1].resize(GetNMCTracks(0));
     mcLabelBuffer[mNEvents - 1].resize(merger.NOutputTracks());
   }
-  std::vector<int>& effBuffer = mcEffBuffer[mNEvents - 1];
-  std::vector<int>& labelBuffer = mcLabelBuffer[mNEvents - 1];
 
   bool mcAvail = mcPresent();
 
@@ -836,6 +834,7 @@ void GPUQA::RunQA(bool matchOnly)
           mc2.eta = -std::log(std::tan(0.5 * mc2.theta));
         }
         if (mConfig.writeMCLabels) {
+          std::vector<int>& effBuffer = mcEffBuffer[mNEvents - 1];
           effBuffer[i] = mRecTracks[iCol][i] * 1000 + mFakeTracks[iCol][i];
         }
       }
@@ -933,6 +932,7 @@ void GPUQA::RunQA(bool matchOnly)
 
     for (int i = 0; i < merger.NOutputTracks(); i++) {
       if (mConfig.writeMCLabels) {
+        std::vector<int>& labelBuffer = mcLabelBuffer[mNEvents - 1];
         labelBuffer[i] = mTrackMCLabels[i].getTrackID();
       }
       if (mTrackMCLabels[i].isFake()) {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -701,6 +701,7 @@ int main(int argc, char** argv)
           rec->SetResetTimers(j1 < configStandalone.runsInit);
 
           if (configStandalone.testSyncAsync) {
+            recAsync->SetResetTimers(j1 < configStandalone.runsInit);
             printf("Running synchronous phase\n");
           }
           chainTracking->mIOPtrs = ioPtrSave;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.cxx
@@ -364,7 +364,7 @@ GPUd() void GPUTPCCFClusterizer::buildClusterNaive(
 
 GPUd() uint GPUTPCCFClusterizer::sortIntoBuckets(const tpc::ClusterNative& cluster, uint row, uint maxElemsPerBucket, uint* elemsInBucket, tpc::ClusterNative* buckets)
 {
-  uint index = CAMath::AtomicAdd(&elemsInBucket[row], 1);
+  uint index = CAMath::AtomicAdd(&elemsInBucket[row], 1u);
   if (index < maxElemsPerBucket) {
     buckets[maxElemsPerBucket * row + index] = cluster;
   }

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -104,7 +104,7 @@ GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUShared
         GPUbarrier();
         for (int n = iThread; n < nRowsUsed; n += nThreads) {
           const unsigned char* rowData = n == 0 ? pagePtr : (page + tbHdr->rowAddr1()[n - 1]);
-          s.RowClusterOffset[n] = CAMath::AtomicAddShared(&s.rowOffsetCounter, rowData[2 * *rowData]);
+          s.RowClusterOffset[n] = CAMath::AtomicAddShared<unsigned int>(&s.rowOffsetCounter, rowData[2 * *rowData]);
         }
         /*if (iThread < GPUCA_WARP_SIZE) { // TODO: Seems to miscompile with HIP, CUDA performance doesn't really change, for now sticking to the AtomicAdd
           GPUSharedMemory& smem = s;


### PR DESCRIPTION
Required significant changes to memory allocation and reusage of some already available buffers that are empty at that stage to avoid running out of GPU memory since the buffer size will multiply when running in parallel.
So far, can compile the code at least on GPU but not run it, runs faster and with less memory on the CPU yielding the same result.