### PR TITLE
Fix: disable TPC CAtracker completion policy customization

### DIFF
--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -80,7 +80,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
-  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
+  //  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
 }
 
 #include "Framework/runDataProcessing.h" // the main driver


### PR DESCRIPTION
As it triggers throwing exception after suppressing bufferization

@matthiasrichter The commented line triggers processing data of different sectors as they arrive instead of waiting for the complete TF, which triggers the exception mentioned in private emails.