### PR TITLE
Fix stack construction from BaseHeader references

### DIFF
--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -116,6 +116,7 @@ struct Stack {
   template <typename T>
   constexpr static size_t calculateSize(T&& h) noexcept
   {
+    //if it's a pointer (to a stack) traverse it
     if constexpr (std::is_convertible_v<T, o2::byte*>) {
       const BaseHeader* next = BaseHeader::get(std::forward<T>(h));
       if (!next) {
@@ -126,6 +127,7 @@ struct Stack {
         size += next->size();
       }
       return size;
+      //otherwise get the size directly
     } else {
       return h.size();
     }
@@ -156,6 +158,10 @@ struct Stack {
       if (!last)
         return here;
       last->flagsNextHeader = more;
+      return here + h.size();
+    } else if constexpr (std::is_same_v<BaseHeader, headerType>) {
+      std::copy(h.data(), h.data() + h.size(), here);
+      reinterpret_cast<BaseHeader*>(here)->flagsNextHeader = more;
       return here + h.size();
     } else if constexpr (std::is_base_of_v<BaseHeader, headerType>) {
       ::new (static_cast<void*>(here)) headerType(std::forward<T>(h));

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -274,6 +274,14 @@ BOOST_AUTO_TEST_CASE(headerStack_test)
   Stack s2{s1, meta};
   BOOST_CHECK(s2.size() == s1.size() + sizeof(decltype(meta)));
 
+  //check dynamic construction - where we don't have the type information and need to
+  //work with BaseHeader pointers
+  const test::MetaHeader thead{2};
+  o2::header::BaseHeader const* bname = reinterpret_cast<BaseHeader const*>(&thead);
+  Stack ds2(s1, *bname);
+  BOOST_CHECK(ds2.size() == s1.size() + sizeof(thead));
+  BOOST_CHECK(std::memcmp(get<test::MetaHeader*>(ds2.data()), &thead, sizeof(thead)) == 0);
+
   auto* h3 = get<test::MetaHeader*>(s1.data());
   BOOST_CHECK(h3 == nullptr);
   h3 = get<test::MetaHeader*>(s2.data());


### PR DESCRIPTION
at runtime we don't always know the type of the header but it should be enough to construct a stack anyway from whatever get<> gives back.