### PR TITLE
Multiplicity estimator and ev. selection for ITS sync. processing

### DIFF
--- a/Detectors/ITSMFT/ITS/README.md
+++ b/Detectors/ITSMFT/ITS/README.md
@@ -29,3 +29,20 @@ o2-raw-file-reader-workflow --loop 5 --delay 3 --conf ITSraw.cfg | o2-itsmft-stf
 o2-raw-file-reader-workflow --loop 5 --delay 3 --conf ITSraw.cfg | o2-itsmft-stf-decoder-workflow --digits  | o2-its-reco-workflow --disable-mc --digits-from-upstream --clusters-from-upstream
 ```
 
+## Tracking
+
+```bash
+# main tracking workflow, by default run CookedSeed Tracker, with --trackerCA uses CA-tracker
+o2-its-reco-workflow
+```
+
+For the synchronous mode one can apply selection on the ROF multiplicity either in therms of signal clusters and/or number of contributing tracklets in seeding vertices
+`FastMultEst` implements the fast estimator of signal clusters multiplicity either via free noise + signal fit or via signal fit with noise level imposed (via `FastMultEstConfig.imposedNoisePerChip`).
+Multiplicity is provided as Ncl. per layer modulo acceptance correction from the FastMultEstConfig.
+The latter provides the settings for the estimator as well as the low/high cuts on the estimate mult. and (if these cuts are passed) eventual cuts on the vertices multiplicity used to seed the ITS tracks. 
+For example, the command:
+```cpp
+o2-its-reco-workflow --configKeyValues "fastMultConfig.cutMultClusLow=50;fastMultConfig.cutMultClusHigh=4000;fastMultConfig.cutMultVtxHigh=1000"
+```
+will track only ROFs with N signal clusters between 50 and 4000 and will consider seeding vertices with multiplicity below 1000 tracklets.
+

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -11,10 +11,15 @@
 o2_add_library(
   ITSReconstruction
   SOURCES src/ClustererTask.cxx src/CookedTracker.cxx src/RecoGeomHelper.cxx
-  PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTReconstruction O2::DataFormatsITS)
+          src/FastMultEstConfig.cxx src/FastMultEst.cxx
+  PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTReconstruction O2::DataFormatsITS
+                        O2::CommonUtils)
 
 o2_target_root_dictionary(
   ITSReconstruction
   HEADERS include/ITSReconstruction/ClustererTask.h
           include/ITSReconstruction/CookedTracker.h
-          include/ITSReconstruction/RecoGeomHelper.h)
+          include/ITSReconstruction/RecoGeomHelper.h
+          include/ITSReconstruction/FastMultEst.h
+          include/ITSReconstruction/FastMultEstConfig.h
+          )

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEst.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEst.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  FastMultEst.h
+/// \brief Fast multiplicity estimator for ITS
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_ITS_FASTMULTEST_
+#define ALICEO2_ITS_FASTMULTEST_
+
+#include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "ITSReconstruction/FastMultEstConfig.h"
+#include <gsl/span>
+#include <array>
+
+namespace o2
+{
+namespace its
+{
+
+struct FastMultEst {
+
+  static constexpr int NLayers = o2::itsmft::ChipMappingITS::NLayers;
+
+  float mult = 0.;                         /// estimated signal clusters multipliciy at reference (1st?) layer
+  float noisePerChip = 0.;                 /// estimated or imposed noise per chip
+  float cov[3] = {0.};                     /// covariance matrix of estimation
+  float chi2 = 0.;                         /// chi2
+  int nLayersUsed = 0;                     /// number of layers actually used
+  std::array<int, NLayers> nClPerLayer{0}; // measured N Cl per layer
+
+  void fillNClPerLayer(const gsl::span<const o2::itsmft::CompClusterExt>& clusters);
+  float process(const std::array<int, NLayers> ncl)
+  {
+    return FastMultEstConfig::Instance().imposeNoisePerChip > 0 ? processNoiseImposed(ncl) : processNoiseFree(ncl);
+  }
+  float processNoiseFree(const std::array<int, NLayers> ncl);
+  float processNoiseImposed(const std::array<int, NLayers> ncl);
+  float process(const gsl::span<const o2::itsmft::CompClusterExt>& clusters)
+  {
+    fillNClPerLayer(clusters);
+    return process(nClPerLayer);
+  }
+
+  ClassDefNV(FastMultEst, 1);
+};
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  FastMultEstConfig.h
+/// \brief Configuration parameters for ITS fast multiplicity estimator
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_ITS_FASTMULTESTCONF_H_
+#define ALICEO2_ITS_FASTMULTESTCONF_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include "ITSMFTReconstruction/ChipMappingITS.h"
+
+namespace o2
+{
+namespace its
+{
+struct FastMultEstConfig : public o2::conf::ConfigurableParamHelper<FastMultEstConfig> {
+  static constexpr int NLayers = o2::itsmft::ChipMappingITS::NLayers;
+
+  /// acceptance correction per layer (relative to 1st one)
+  float accCorr[NLayers] = {1.f, 0.895, 0.825, 0.803, 0.720, 0.962, 0.911};
+  int firstLayer = 3;                            /// 1st layer to account
+  int lastLayer = 6;                             /// last layer to account
+  float imposeNoisePerChip = 1.e-7 * 1024 * 512; // assumed noise, free parameter if<0
+
+  // cuts to reject to low or too high mult events
+  float cutMultClusLow = 0;   /// reject ROF with estimated cluster mult. below this value (no cut if <0)
+  float cutMultClusHigh = -1; /// reject ROF with estimated cluster mult. above this value (no cut if <0)
+  float cutMultVtxLow = -1;   /// reject seed vertex if its multiplicity below this value (no cut if <0)
+  float cutMultVtxHigh = -1;  /// reject seed vertex if its multiplicity above this value (no cut if <0)
+
+  O2ParamDef(FastMultEstConfig, "fastMultConfig");
+};
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEst.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEst.cxx
@@ -1,0 +1,129 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  FastMultEst.h
+/// \brief Fast multiplicity estimator for ITS
+/// \author ruben.shahoyan@cern.ch
+
+#include "ITSReconstruction/FastMultEst.h"
+#include <cstring>
+
+using namespace o2::its;
+
+///______________________________________________________
+/// find multiplicity for given set of clusters
+void FastMultEst::fillNClPerLayer(const gsl::span<const o2::itsmft::CompClusterExt>& clusters)
+{
+  int lr = FastMultEst::NLayers - 1, nchAcc = o2::itsmft::ChipMappingITS::getNChips() - o2::itsmft::ChipMappingITS::getNChipsPerLr(lr);
+  std::memset(&nClPerLayer[0], 0, sizeof(int) * FastMultEst::NLayers);
+  for (int i = clusters.size(); i--;) { // profit from clusters being ordered in chip increasing order
+    while (clusters[i].getSensorID() < nchAcc) {
+      assert(lr >= 0);
+      nchAcc -= o2::itsmft::ChipMappingITS::getNChipsPerLr(--lr);
+    }
+    nClPerLayer[lr]++;
+  }
+}
+
+///______________________________________________________
+/// find multiplicity for given number of clusters per layer
+float FastMultEst::processNoiseFree(const std::array<int, NLayers> ncl)
+{
+  // we assume that on the used layers the observed number of clusters is defined by the
+  // the noise ~ nu * Nchips and contribution from the signal tracks Ntr*mAccCorr
+  const auto& conf = FastMultEstConfig::Instance();
+
+  float mat[3] = {0}, b[2] = {0};
+  nLayersUsed = 0;
+  for (int il = conf.firstLayer; il <= conf.lastLayer; il++) {
+    if (ncl[il] > 0) {
+      int nch = o2::itsmft::ChipMappingITS::getNChipsPerLr(il);
+      float err2i = 1. / ncl[il];
+      float m2n = nch * err2i;
+      mat[0] += err2i * conf.accCorr[il] * conf.accCorr[il];
+      mat[2] += nch * m2n;
+      mat[1] += conf.accCorr[il] * m2n; // non-diagonal element
+      b[0] += conf.accCorr[il];
+      b[1] += nch;
+      nLayersUsed++;
+    }
+  }
+  mult = noisePerChip = chi2 = -1;
+  float det = mat[0] * mat[2] - mat[1] * mat[1];
+  if (nLayersUsed < 2 || std::abs(det) < 1e-15) {
+    return -1;
+  }
+  float detI = 1. / det;
+  mult = detI * (b[0] * mat[2] - b[1] * mat[1]);
+  noisePerChip = detI * (b[1] * mat[0] - b[0] * mat[1]);
+  cov[0] = mat[2] * detI;
+  cov[2] = mat[0] * detI;
+  cov[1] = -mat[1] * detI;
+  chi2 = 0.;
+  for (int il = conf.firstLayer; il <= conf.lastLayer; il++) {
+    if (ncl[il] > 0) {
+      int nch = o2::itsmft::ChipMappingITS::getNChipsPerLr(il);
+      float err2i = 1. / ncl[il];
+      float diff = mult * conf.accCorr[il] + nch * noisePerChip - ncl[il];
+      chi2 += diff * diff / ncl[il];
+    }
+  }
+  chi2 = nLayersUsed > 2 ? chi2 / (nLayersUsed - 2) : 0.;
+  return mult;
+}
+
+///______________________________________________________
+/// find multiplicity for given number of clusters per layer with mean noise imposed
+float FastMultEst::processNoiseImposed(const std::array<int, NLayers> ncl)
+{
+  // we assume that on the used layers the observed number of clusters is defined by the
+  // the noise ~ nu * Nchips and contribution from the signal tracks Ntr*conf.accCorr
+  //
+  // minimize the form sum_lr (noise_i - mu nchips_i)^2 / (mu nchips_i) + lambda_i * (noise_i + mult*acc_i - ncl_i)
+  // whith noise_i being estimate of the noise clusters in nchips_i of layer i, mu is the mean noise per chip,
+  // mult is the number of signal clusters on the ref. (1st) layer and the acc_i is the acceptance of layer i wrt 1st.
+  // The lambda_i is hust a Lagrange multiplier.
+
+  const auto& conf = FastMultEstConfig::Instance();
+  float w2sum = 0., wnsum = 0., wsum = 0.;
+  nLayersUsed = 0;
+  for (int il = conf.firstLayer; il <= conf.lastLayer; il++) {
+    if (ncl[il] > 0) {
+      float nchInv = 1. / o2::itsmft::ChipMappingITS::getNChipsPerLr(il);
+      w2sum += conf.accCorr[il] * conf.accCorr[il] * nchInv;
+      wnsum += ncl[il] * nchInv * conf.accCorr[il];
+      wsum += conf.accCorr[il];
+      nLayersUsed++;
+    }
+  }
+  mult = 0;
+  chi2 = -1;
+  noisePerChip = conf.imposeNoisePerChip;
+  if (nLayersUsed < 1) {
+    return -1;
+  }
+  auto w2sumI = 1. / w2sum;
+  mult = (wnsum - noisePerChip * wsum) * w2sumI;
+  cov[0] = wnsum * w2sumI;
+  cov[2] = 0.;
+  cov[1] = 0.;
+
+  chi2 = 0.;
+  for (int il = conf.firstLayer; il <= conf.lastLayer; il++) {
+    if (ncl[il] > 0) {
+      int nch = o2::itsmft::ChipMappingITS::getNChipsPerLr(il);
+      float noise = ncl[il] - mult * conf.accCorr[il], estNoise = o2::itsmft::ChipMappingITS::getNChipsPerLr(il) * noisePerChip;
+      float diff = noise - estNoise;
+      chi2 += diff * diff / estNoise;
+    }
+  }
+  chi2 = nLayersUsed > 2 ? chi2 / (nLayersUsed - 2) : 0.;
+  return mult;
+}

--- a/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEstConfig.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEstConfig.cxx
@@ -8,19 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#include "ITSReconstruction/FastMultEstConfig.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::its::ClustererTask + ;
-#pragma link C++ class o2::its::CookedTracker + ;
-
-#pragma link C++ class o2::its::RecoGeomHelper + ;
-
-#pragma link C++ class o2::its::FastMultEst + ;
-#pragma link C++ class o2::its::FastMultEstConfig + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::FastMultEstConfig> + ;
-
-#endif
+O2ParamImpl(o2::its::FastMultEstConfig);


### PR DESCRIPTION
* Fast mult.estimator and its config for ITS selective reconstruction:
implements fast estimator of signal clusters multiplicity either via free noise + signal fit
or via signal fit with noise level imposed. Multiplicity is provided as Ncl. per layer modulo acceptance
correction from the FastMultEstConfig. The latter provides the settings for the estimator as well as 
the low/high cuts on the estimate mult. and (if these cuts are passed) eventual cuts on the vertices multiplicity used to seed the ITS tracks.

* FastMultEst and cuts from FastMultEstConfig are deployed in ITS tracking workflows to avoid tracking ROF with too high or too low number of signal clusters (or vertices with too many contributors. The following command will track only ROFs with N signal clusters between 50 and 4000 and will  consider seeding vertices with multiplicity below 1000 tracklets
````
o2-its-reco-workflow --configKeyValues "fastMultConfig.cutMultClusLow=50;fastMultConfig.cutMultClusHigh=4000;fastMultConfig.cutMultVtxHigh=1000"
````