### PR TITLE
Fixes for combining reco workflows

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
@@ -74,7 +74,7 @@ void TOFMatchedWriter::run(ProcessingContext& pc)
     getOrMakeBranch(mTree.get(), "MatchTPCMCTruth", &labeltpcPtr);
     getOrMakeBranch(mTree.get(), "MatchITSMCTruth", &labelitsPtr);
   }
-  mTree->Write();
+  mTree->Fill();
 }
 
 void TOFMatchedWriter::endOfStream(EndOfStreamContext& ec)

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -53,6 +53,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
   workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
   workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
+  workflowOptions.push_back(ConfigParamSpec{"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
+  workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
 }
 
@@ -125,6 +127,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     rawinput = 1;
   }
 
+  auto useMC = !cfgc.options().get<bool>("disable-mc");
+  auto useCCDB = cfgc.options().get<bool>("use-ccdb");
+  auto useFIT = cfgc.options().get<bool>("use-fit");
+  bool disableRootInput = cfgc.options().get<bool>("disable-root-input") || rawinput;
+  bool disableRootOutput = cfgc.options().get<bool>("disable-root-output");
+
   LOG(INFO) << "TOF RECO WORKFLOW configuration";
   LOG(INFO) << "TOF input = " << cfgc.options().get<std::string>("input-type");
   LOG(INFO) << "TOF output = " << cfgc.options().get<std::string>("output-type");
@@ -133,10 +141,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   LOG(INFO) << "TOF lanes = " << cfgc.options().get<std::string>("tof-lanes");
   LOG(INFO) << "TOF use-ccdb = " << cfgc.options().get<std::string>("use-ccdb");
   LOG(INFO) << "TOF use-fit = " << cfgc.options().get<std::string>("use-fit");
-
-  auto useMC = !cfgc.options().get<bool>("disable-mc");
-  auto useCCDB = cfgc.options().get<bool>("use-ccdb");
-  auto useFIT = cfgc.options().get<bool>("use-fit");
+  LOG(INFO) << "TOF disable-root-input = " << disableRootInput;
+  LOG(INFO) << "TOF disable-root-output = " << disableRootOutput;
 
   if (clusterinput) {
     LOG(INFO) << "Insert TOF Cluster Reader";
@@ -156,7 +162,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     specs.emplace_back(o2::tof::getCompressedDecodingSpec(inputDesc));
     useMC = 0;
 
-    if (writedigit) {
+    if (writedigit && !disableRootOutput) {
       // add TOF digit writer without mc labels
       LOG(INFO) << "Insert TOF Digit Writer";
       specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0));
@@ -166,7 +172,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (!clusterinput && writecluster) {
     LOG(INFO) << "Insert TOF Clusterizer";
     specs.emplace_back(o2::tof::getTOFClusterizerSpec(useMC, useCCDB));
-    if (writecluster) {
+    if (writecluster && !disableRootOutput) {
       LOG(INFO) << "Insert TOF Cluster Writer";
       specs.emplace_back(o2::tof::getTOFClusterWriterSpec(useMC));
     }
@@ -177,12 +183,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   if (writematching || writecalib) {
-    LOG(INFO) << "Insert ITS-TPC Track Reader";
-    specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    if (!disableRootInput) {
+      LOG(INFO) << "Insert ITS-TPC Track Reader";
+      specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    }
     LOG(INFO) << "Insert TOF Matching";
     specs.emplace_back(o2::tof::getTOFRecoWorkflowSpec(useMC, useFIT));
 
-    if (writematching) {
+    if (writematching && !disableRootOutput) {
       LOG(INFO) << "Insert TOF Matched Info Writer";
       specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC));
     }

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -533,7 +533,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       if (pc.outputs().isAllowed({gDataOriginTPC, "TRACKS", 0})) {
         pc.outputs().snapshot(OutputRef{"outTracks"}, tracks);
         pc.outputs().snapshot(OutputRef{"outClusRefs"}, clusRefs);
-        if (pc.outputs().isAllowed({gDataOriginTPC, "TRACKMCLBL", 0})) {
+        if (pc.outputs().isAllowed({gDataOriginTPC, "TRACKSMCLBL", 0})) {
           LOG(INFO) << "sending " << tracksMCTruth.getIndexedSize() << " track label(s)";
           pc.outputs().snapshot(OutputRef{"mclblout"}, tracksMCTruth);
         }
@@ -641,7 +641,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
     }
     if (specconfig.processMC && specconfig.outputTracks) {
       OutputLabel label{"mclblout"};
-      constexpr o2::header::DataDescription datadesc("TRACKMCLBL");
+      constexpr o2::header::DataDescription datadesc("TRACKSMCLBL");
       outputSpecs.emplace_back(label, gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
     }
     if (specconfig.outputCompClusters) {

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -431,7 +431,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
                                                        "TPCTracks", "track-branch-name"};              //
     auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", "CLUSREFS"}, //
                                                          "ClusRefs", "trackclusref-branch-name"};      //
-    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKMCLBL"},         //
+    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKSMCLBL"},        //
                                                     "TPCTracksMCTruth", "trackmc-branch-name"};        //
 
     // depending on the MC propagation flag, the RootTreeWriter spec is created with 3 or 2


### PR DESCRIPTION
* TPC::TRACKMCLBL make outputSpec names consistent
Depending on the device the Tracks MC labels were called either TRACKMCLBL or TRACSKMCLBL

* TOF workflow: allow disabling root I/O for w-flows merging
In the ``raw`` mode the input from the root files (e.g. TPCITS tracks) should be disabled in favor of direct DPL input from TPC/ITS matcher. Explicitly add option to disable root input and output to be able to merge different workflows.
Fix in tree filling.

--------------------------
Instructions to run (just for the record) combined w-flow:

In ``raw`` data mode:
````
o2-raw-file-reader-workflow --loop 1 --conf raw/rawAll.cfg | o2-itsmft-stf-decoder-workflow |  o2-its-reco-workflow --disable-mc --clusters-from-upstream --disable-root-output  | o2-tpc-reco-workflow --ca-clusterer --input-type=zsraw --disable-mc  --output-type tracks,clusters,disable-writer |  o2-tpcits-match-workflow  --disable-root-input --disable-mc | o2-tof-compressor  | o2-tof-reco-workflow --input-type raw --disable-mc  --run
````

In ``digits`` mode:
````
o2-its-reco-workflow | o2-tpc-reco-workflow  --tpc-digit-reader '--infile tpcdigits.root' --input-type digits --output-type clusters,tracks | o2-tpcits-match-workflow  --disable-root-input --disable-root-output | o2-tof-reco-workflow --disable-root-input --run
````

Preparing raw data:
````
o2-sim -n 10 -m PIPE ITS TPC TOF -g pythia8
o2-sim-digitizer-workflow
mkdir raw
o2-tpc-digits-to-rawzs -i tpcdigits.root -o raw/TPC/
o2-its-digi2raw -c -o raw/ITS/
o2-tof-reco-workflow -b --output-type raw
mkdir raw/TOF
mv cru*rawtof.bin  raw/TOF/

# create a config file, e.g. raw/TOF/TOFraw.cfg (at the moment needs manual intervention)
[input-TOF-0]
dataOrigin = TOF
dataDescription = RAWDATA
filePath = raw/TOF/cru00rawtof.bin
[input-TOF-1]
dataOrigin = TOF
dataDescription = RAWDATA
filePath = raw/TOF/cru01rawtof.bin

[input-TOF-2]
dataOrigin = TOF
dataDescription = RAWDATA
filePath = /home/shahoian/tmp/digfl/pbpb100/raw/TOF/cru02rawtof.bin

[input-TOF-3]
dataOrigin = TOF
dataDescription = RAWDATA
filePath = /home/shahoian/tmp/digfl/pbpb100/raw/TOF/cru03rawtof.bin
#---------------------

# create combined raw data config file:
cat raw/*/*.cfg > raw/rawAll.cfg
````
