### PR TITLE
Add Pythia8 HI impact parameter to event header + example

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -84,6 +84,9 @@ class Generator : public FairGenerator
   virtual Bool_t generateEvent() = 0;
   virtual Bool_t importParticles() = 0;
 
+  /** methods that can be overridded **/
+  virtual void updateHeader(FairMCEventHeader* eventHeader){};
+
   /** internal methods **/
   Bool_t addTracks(FairPrimaryGenerator* primGen);
   Bool_t boostEvent();

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -57,6 +57,9 @@ class GeneratorPythia8 : public Generator
   Bool_t generateEvent() override;
   Bool_t importParticles() override;
 
+  /** methods that can be overridded **/
+  void updateHeader(FairMCEventHeader* eventHeader) override;
+
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!
 

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -83,6 +83,9 @@ Bool_t
   if (!addTracks(primGen))
     return kFALSE;
 
+  /** update header **/
+  updateHeader(primGen->GetEvent());
+
   /** success **/
   return kTRUE;
 }

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -14,6 +14,8 @@
 #include "Generators/ConfigurationMacroHelper.h"
 #include "FairLogger.h"
 #include "TParticle.h"
+#include "FairMCEventHeader.h"
+#include "Pythia8/HIUserHooks.h"
 
 namespace o2
 {
@@ -146,6 +148,18 @@ Bool_t
 
   /** success **/
   return kTRUE;
+}
+
+/*****************************************************************/
+
+void GeneratorPythia8::updateHeader(FairMCEventHeader* eventHeader)
+{
+  /** update header **/
+
+  /** set impact parameter if in heavy-ion mode **/
+  auto hiinfo = mPythia.info.hiinfo;
+  if (hiinfo)
+    eventHeader->SetB(mPythia.info.hiinfo->b());
 }
 
 /*****************************************************************/

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -452,6 +452,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | --------------------- | -------------------------------------------------------------------------------------- |
 | [AliRoot_Hijing](../run/SimExamples/AliRoot_Hijing) | Example showing how to use Hijing from AliRoot for event generation |
 | [Adaptive_Pythia8](../run/SimExamples/Adaptive_Pythia8) | Complex example showing **generator configuration for embedding** that cat adapt the response based on the background event |
+| [Signal_ImpactB](../run/SimExamples/Signal_ImpactB) | Example showing **generator configuration for embedding** that cat adapt to the impact parameter of the background event |
 | [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -5,6 +5,7 @@
 # Simulation Examples
 
 <!-- doxy
+* \subpage refrunSimExamplesSignal_ImpactB
 * \subpage refrunSimExamplesAdaptive_Pythia8
 * \subpage refrunSimExamplesAliRoot_Hijing
 * \subpage refrunSimExamplesHepMC_STARlight

--- a/run/SimExamples/Signal_ImpactB/README.md
+++ b/run/SimExamples/Signal_ImpactB/README.md
@@ -1,0 +1,16 @@
+<!-- doxy
+\page refrunSimExamplesSignal_ImpactB Example Signal_ImpactB
+/doxy -->
+
+This is a simulation example showing the following things
+
+a) how to run a simple background event simulation with some parameter customization
+b) how to setup and run an event generator that produces signal events based on the impact parameter of the backround event where it will be embetted into
+
+Custom signal events generated according to the configuration given in a file 'signal_impactb.macro'.
+The custom event generator receives and react to a notification that signals the embedding status of the simulation, giving the header of the background event for determination of subsequent actions.
+In this case, the impact paramereter from the background event is used to calculate the number of particles to be generated as signal
+
+The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieve the configuration and define the formula is specified via the argument of `--extGenFunc`.
+
+The event generator for the background embedding needs to be capable of providing an impact parameter. In this case, Pythia8 heavy-ion model provides such value.

--- a/run/SimExamples/Signal_ImpactB/run.sh
+++ b/run/SimExamples/Signal_ImpactB/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# This is a simulation example showing the following things
+#
+
+# a) how to run a simple background event simulation with some parameter customization
+# b) how to setup and run an event generator that produces signal events based on the 
+#    impact parameter of the backround event where it will be embetted into
+
+set -x
+
+# PART a)
+NBGR=5
+o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValue \
+       "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
+
+# PART b)
+# produce signal events generated according to the configuration given in a file 'signal_impactb.macro'.
+# the custom event generator receives and react to a notification that signals
+# the embedding status of the simulation, giving the header of the background event for determination
+# of subsequent actions. In this case, the impact paramereter from the backgorund event
+# is used to calculate the number of particles to be generated as signal
+NSGN=10
+o2-sim -j 20 -n ${NSGN} extgen -m PIPE ITS \
+       -g extgen --extGenFile signal_impactb.macro --extGenFunc "signal_impactb(333, \"20. / (x + 1.)\")" \
+       --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1

--- a/run/SimExamples/Signal_ImpactB/signal_impactb.macro
+++ b/run/SimExamples/Signal_ImpactB/signal_impactb.macro
@@ -1,0 +1,82 @@
+/// \author R+Preghenella - May 2020
+
+// Example of an implementation of an external event generator
+// that is used and adapts it behavior in an embedding scenario.
+//
+//   usage: o2sim -g extgen --extGenFile signal_impactb.C
+// options:                 --extGenFunc "signal_impactb(\"20. / (x + 1.)\")
+
+using namespace o2::eventgen;
+
+class Signal_ImpactB : public Generator
+{
+public:
+  Signal_ImpactB(int pdg = 333, const char *formula = "20. / (x + 1.)") :
+    Generator(), mNSignals(1), mPDG(pdg), mMass(0.), mFormula("formula", formula) {};
+  ~Signal_ImpactB() = default;
+
+  // override init to get mass from PDG
+  Bool_t Init() override {
+    Generator::Init();
+    if (!TDatabasePDG::Instance()->GetParticle(mPDG)) {
+      std::cout << " --- unknown PDG: " << mPDG << std::endl;
+      return false;
+    }
+    mMass = TDatabasePDG::Instance()->GetParticle(mPDG)->Mass();
+    std::cout << " --- initialised Signal_ImpactB: pdg = " << mPDG << ", mass = " << mMass << std::endl;
+    return true;
+  }
+  
+  // update the number of particles to be generated
+  // according to impact parameter and formula
+  void notifyEmbedding(const FairMCEventHeader *bkgHeader) override {
+    auto b = bkgHeader->GetB();
+    mNSignals = mFormula.Eval(b);
+    std::cout << " --- notify embedding: b = " << b << ", nparticles = " << mNSignals << std::endl;
+  };
+  
+  // generate event must be overridden but does nothing
+  Bool_t generateEvent() override { return true; };
+
+  // import particles will add the particles
+  Bool_t importParticles() override {
+    int st = 1; // status
+    int m1 = -1, m2 = -1; // mothers
+    int d1 = -1, d2 = -1; // daughters
+    double vx = 0., vy = 0., vz = 0., vt = 0.; // vertex
+
+    // generated uniform pt, eta, phi
+    double pt  = gRandom->Uniform(0., 10.);
+    double eta = gRandom->Uniform(-1., 1.);
+    double phi = gRandom->Uniform(-M_PI, M_PI);
+
+    // tranform to px, py, pz
+    double px = pt * cos(phi);
+    double py = pt * sin(phi);
+    double pz = pt * sinh(eta);
+
+    // calculate energy
+    double et = sqrt(px * px + py * py + pz * pz + mMass * mMass);
+
+    // add particles
+    for (int ipart = 0; ipart < mNSignals; ++ipart)
+      mParticles.push_back(TParticle(mPDG, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt));
+    return true;
+  }
+
+private:
+
+  int mNSignals = 1;
+  int mPDG = 0;
+  double mMass = 0.;
+  TFormula mFormula;
+  
+};
+
+FairGenerator*
+signal_impactb(int pdg = 333, const char *formula = "20. / (x + 1.)")
+{
+  std::cout << " --- signal_impactb initialising with pdg / formula: " << pdg << " / " << formula << std::endl;
+  auto gen = new Signal_ImpactB(pdg, formula);
+  return gen;
+}


### PR DESCRIPTION
This PR implements the `updateHeader` virtual method of the `o2::eventgen::Generator` class.
The method is called in the generation loop and can be overridden by a concrete `Generator`.
This allows generators to update the `MCEventHeader` with extra information.
In this case, `Pythia8` updates the impact parameter information in the `MCEventHeader` in case it is sunning the heavy-ion model.

The extra information can be used by event generators of signal events in an embedding scenario, to allow them to tune the generation on the background event to be embedded into.

This PR also brings an example of the use of the impact parameter in embedding simulation.
The simulation example show the following things

a) how to run a simple background event simulation with some parameter customization
b) how to setup and run an event generator that produces signal events based on the impact parameter of the backround event where it will be embetted into

Custom signal events generated according to the configuration given in a file 'signal_impactb.macro'.
The custom event generator receives and react to a notification that signals the embedding status of the simulation, giving the header of the background event for determination of subsequent actions.
In this case, the impact paramereter from the background event is used to calculate the number of particles to be generated as signal

The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieve the configuration and define the formula is specified via the argument of `--extGenFunc`.

The event generator for the background embedding needs to be capable of providing an impact parameter. In this case, Pythia8 heavy-ion model provides such value.
