### PR TITLE
ConfParam: minor improvements

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -274,6 +274,7 @@ class ConfigurableParam
   static EnumRegistry* sEnumRegistry;
 
   void setRegisterMode(bool b) { sRegisterMode = b; }
+  bool isInitialized() const { return sIsFullyInitialized; }
 
  private:
   // static registry for implementations of this type

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -33,7 +33,7 @@ struct ParamDataMember {
   std::string value;
   std::string provenance;
 
-  std::string toString(bool showProv) const;
+  std::string toString(std::string const& prefix, bool showProv) const;
 };
 
 // ----------------------------------------------------------------
@@ -43,20 +43,20 @@ struct ParamDataMember {
 class _ParamHelper
 {
  private:
-  static std::vector<ParamDataMember>* getDataMembersImpl(std::string mainkey, TClass* cl, void*,
+  static std::vector<ParamDataMember>* getDataMembersImpl(std::string const& mainkey, TClass* cl, void*,
                                                           std::map<std::string, ConfigurableParam::EParamProvenance> const* provmap);
 
-  static void fillKeyValuesImpl(std::string mainkey, TClass* cl, void*, boost::property_tree::ptree*,
+  static void fillKeyValuesImpl(std::string const& mainkey, TClass* cl, void*, boost::property_tree::ptree*,
                                 std::map<std::string, std::pair<std::type_info const&, void*>>*,
                                 EnumRegistry*);
 
   static void printWarning(std::type_info const&);
 
-  static void assignmentImpl(std::string mainkey, TClass* cl, void* to, void* from,
+  static void assignmentImpl(std::string const& mainkey, TClass* cl, void* to, void* from,
                              std::map<std::string, ConfigurableParam::EParamProvenance>* provmap);
 
-  static void outputMembersImpl(std::ostream& out, std::vector<ParamDataMember> const* members, bool showProv);
-  static void printMembersImpl(std::vector<ParamDataMember> const* members, bool showProv);
+  static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
+  static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
 
   template <typename P>
   friend class ConfigurableParamHelper;
@@ -85,10 +85,13 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   // ----------------------------------------------------------------
 
   // one of the key methods, using introspection to print itself
-  void printKeyValues(bool showProv) const final
+  void printKeyValues(bool showProv = true) const final
   {
+    if (!isInitialized()) {
+      initialize();
+    }
     auto members = getDataMembers();
-    _ParamHelper::printMembersImpl(members, showProv);
+    _ParamHelper::printMembersImpl(getName(), members, showProv);
   }
 
   // ----------------------------------------------------------------
@@ -96,7 +99,7 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   void output(std::ostream& out) const final
   {
     auto members = getDataMembers();
-    _ParamHelper::outputMembersImpl(out, members, true);
+    _ParamHelper::outputMembersImpl(out, getName(), members, true);
   }
 
   // ----------------------------------------------------------------

--- a/Common/Utils/src/ConfigurableParamHelper.cxx
+++ b/Common/Utils/src/ConfigurableParamHelper.cxx
@@ -33,12 +33,12 @@ using namespace o2::conf;
 
 // ----------------------------------------------------------------------
 
-std::string ParamDataMember::toString(bool showProv) const
+std::string ParamDataMember::toString(std::string const& prefix, bool showProv) const
 {
   std::string nil = "<null>";
 
   std::ostringstream out;
-  out << name << " : " << value;
+  out << prefix << "." << name << " : " << value;
 
   if (showProv) {
     std::string prov = (provenance.compare("") == 0 ? nil : provenance);
@@ -51,7 +51,7 @@ std::string ParamDataMember::toString(bool showProv) const
 
 std::ostream& operator<<(std::ostream& out, const ParamDataMember& pdm)
 {
-  out << pdm.toString(false);
+  out << pdm.toString("", false);
   return out;
 }
 
@@ -159,7 +159,7 @@ const char* asString(TDataMember const& dm, char* pointer)
 
 // ----------------------------------------------------------------------
 
-std::vector<ParamDataMember>* _ParamHelper::getDataMembersImpl(std::string mainkey, TClass* cl, void* obj,
+std::vector<ParamDataMember>* _ParamHelper::getDataMembersImpl(std::string const& mainkey, TClass* cl, void* obj,
                                                                std::map<std::string, ConfigurableParam::EParamProvenance> const* provmap)
 {
   std::vector<ParamDataMember>* members = new std::vector<ParamDataMember>;
@@ -251,7 +251,7 @@ std::type_info const& nameToTypeInfo(const char* tname, TDataType const* dt)
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::fillKeyValuesImpl(std::string mainkey, TClass* cl, void* obj, boost::property_tree::ptree* tree,
+void _ParamHelper::fillKeyValuesImpl(std::string const& mainkey, TClass* cl, void* obj, boost::property_tree::ptree* tree,
                                      std::map<std::string, std::pair<std::type_info const&, void*>>* keytostoragemap,
                                      EnumRegistry* enumRegistry)
 {
@@ -281,19 +281,19 @@ void _ParamHelper::fillKeyValuesImpl(std::string mainkey, TClass* cl, void* obj,
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::printMembersImpl(std::vector<ParamDataMember> const* members, bool showProv)
+void _ParamHelper::printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv)
 {
-  _ParamHelper::outputMembersImpl(std::cout, members, showProv);
+  _ParamHelper::outputMembersImpl(std::cout, mainkey, members, showProv);
 }
 
-void _ParamHelper::outputMembersImpl(std::ostream& out, std::vector<ParamDataMember> const* members, bool showProv)
+void _ParamHelper::outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv)
 {
   if (members == nullptr) {
     return;
   }
 
   for (auto& member : *members) {
-    out << member.toString(showProv);
+    out << member.toString(mainkey, showProv);
   }
 }
 
@@ -312,7 +312,7 @@ bool isMemblockDifferent(char const* block1, char const* block2, int sizeinbytes
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::assignmentImpl(std::string mainkey, TClass* cl, void* to, void* from,
+void _ParamHelper::assignmentImpl(std::string const& mainkey, TClass* cl, void* to, void* from,
                                   std::map<std::string, ConfigurableParam::EParamProvenance>* provmap)
 {
   auto assignifchanged = [to, from, &mainkey, provmap](const TDataMember* dm, int index, int size) {


### PR DESCRIPTION
- make sure provenance information is available before
  printing parameter
- use std::string const& instead of std::string
- print main parameter key in printouts