### PR TITLE
Fix a bug in the event-generator trigger logic not clearing particles

### DIFF
--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -60,11 +60,11 @@ Bool_t
 {
   /** read event **/
 
-  /** clear particle vector **/
-  mParticles.clear();
-
   /** endless generate-and-trigger loop **/
   while (true) {
+
+    /** clear particle vector **/
+    mParticles.clear();
 
     /** generate event **/
     if (!generateEvent())


### PR DESCRIPTION
This PR fixes a bug in the logic of the event-generator trigger.
The particle vector was not cleared after a failed trigger.