### PR TITLE
An example to run Pythia8 heavy-ion with impact-parameter trigger

### DIFF
--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -6,6 +6,7 @@
 
 <!-- doxy
 * \subpage refrunSimExamplesSignal_ImpactB
+* \subpage refrunSimExamplesTrigger_ImpactB_Pythia8
 * \subpage refrunSimExamplesAdaptive_Pythia8
 * \subpage refrunSimExamplesAliRoot_Hijing
 * \subpage refrunSimExamplesHepMC_STARlight

--- a/run/SimExamples/Trigger_ImpactB_Pythia8/README.md
+++ b/run/SimExamples/Trigger_ImpactB_Pythia8/README.md
@@ -1,0 +1,18 @@
+<!-- doxy
+\page refrunSimExamplesTrigger_ImpactB_Pythia8 Example Trigger_ImpactB_Pythia8
+/doxy -->
+
+This is a simple simulation example showing how to run event simulation using the Pythia8 event generator in heavy-ion mode and use an external custom trigger.
+The external trigger makes use of the `DeepTrigger` functionality to allow the user to access the internals of the event generator to define the trigger.
+In this example, information about the impact parameter of the currently-generated Pythia8 heavy-ion event is used.
+The trigger selection defines impact parameters to be accepted according to a min-max range that can be adjusted from the command line.
+
+The definition and configuration of the external `DeepTrigger` is performed by the function `trigger_impactb_pythia8(double bMin = 0., double bMax = 20.)` defined in the macro `trigger_impactb_pythia8.macro`.
+
+The macro file is specified via the argument of `--extTrgFile` whereas the specific function call to retrieve the configuration is specified via the argument of `--extTrgFunc`.
+
+# WARNING
+Using a trigger is not always the most efficient way to deal with event generation.
+It is always advisable to find a way to bias the event-geneator process to save CPU time.
+In this case, the selection of a specific impact-parameter range in Pythia8 can lead to
+a large time spent in the event generation rather than in the simulation.

--- a/run/SimExamples/Trigger_ImpactB_Pythia8/run.sh
+++ b/run/SimExamples/Trigger_ImpactB_Pythia8/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# This is a simple simulation example showing how to run event simulation using
+# the Pythia8 event generator in heavy-ion mode and use an external custom trigger.
+# The external trigger makes use of the `DeepTrigger` functionality to allow the
+# user to access the internals of the event generator to define the trigger.
+#
+# In this example, information about the impact parameter of the currently-generated
+# Pythia8 heavy-ion event is used.
+# The trigger selection defines impact parameters to be accepted according to a
+# min-max range that can be adjusted from the command line.
+
+# The definition and configuration of the external `DeepTrigger` is performed by
+# the function `trigger_impactb_pythia8(double bMin = 0., double bMax = 20.)`
+# defined in the macro `trigger_impactb_pythia8.macro`.
+
+# The macro file is specified via the argument of `--extTrgFile` whereas the specific
+# function call to retrieve the configuration is specified via the argument of `--extTrgFunc`.
+ 
+set -x
+
+NEV=10
+BMIN=15.
+BMAX=20.
+o2-sim -j 20 -n ${NEV} -g pythia8hi -m PIPE ITS TPC --trigger external --extTrgFile trigger_impactb_pythia8.macro --extTrgFunc "trigger_impactb_pythia8(${BMIN}, ${BMAX})"

--- a/run/SimExamples/Trigger_ImpactB_Pythia8/trigger_impactb_pythia8.macro
+++ b/run/SimExamples/Trigger_ImpactB_Pythia8/trigger_impactb_pythia8.macro
@@ -1,0 +1,31 @@
+/// \author R+Preghenella - May 2020
+
+#include "Generators/Trigger.h"
+#include "Pythia8/Pythia.h"
+#include "Pythia8/HIUserHooks.h"
+#include "FairLogger.h"
+
+o2::eventgen::DeepTrigger
+  trigger_impactb_pythia8(double bmin = 5., double bmax = 10.)
+{
+  return [bmin, bmax](void* interface, std::string name) -> bool {
+    if (!name.compare("pythia8")) {
+      auto py8 = reinterpret_cast<Pythia8::Pythia*>(interface);
+#if PYTHIA_VERSION_INTEGER < 8300
+      auto hiinfo = py8->info.hiinfo;
+#else
+      auto hiinfo = py8->info.hiInfo;
+#endif
+      if (!hiinfo) {
+        LOG(FATAL) << "Cannot define impact parameter: is \'pythia8\' running in heavy-ion mode?";
+      }
+      auto b = hiinfo->b();
+      auto selected = (b > bmin && b < bmax);
+      LOG(INFO) << "Impact parameter = " << b << " fm: " << (selected ? "selected" : "rejected");
+      return selected;
+    } else {
+      LOG(FATAL) << "Cannot define impact parameter for generator interface \'" << name << "\'";
+    }
+    return false;
+  };
+}


### PR DESCRIPTION
This is a simple simulation example showing how to run event simulation using the Pythia8 event generator in heavy-ion mode and use an external custom trigger.
The external trigger makes use of the `DeepTrigger` functionality to allow the user to access the internals of the event generator to define the trigger.
In this example, information about the impact parameter of the currently-generated Pythia8 heavy-ion event is used.
The trigger selection defines impact parameters to be accepted according to a min-max range that can be adjusted from the command line.

The definition and configuration of the external `DeepTrigger` is performed by the function `trigger_impactb_pythia8(double bMin = 0., double bMax = 20.)` defined in the macro `trigger_impactb_pythia8.macro`.

The macro file is specified via the argument of `--extTrgFile` whereas the specific function call to retrieve the configuration is specified via the argument of `--extTrgFunc`.

# WARNING
Using a trigger is not always the most efficient way to deal with event generation.
It is always advisable to find a way to bias the event-geneator process to save CPU time.
In this case, the selection of a specific impact-parameter range in Pythia8 can lead to
a large time spent in the event generation rather than in the simulation.
