### PR TITLE
flatten compressed cluster output

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -84,6 +84,7 @@ struct CompressedClusters : public CompressedClustersCounters, public Compressed
 struct CompressedClustersROOT : public CompressedClusters {
   CompressedClustersROOT() CON_DEFAULT;
   CompressedClustersROOT(const CompressedClustersFlat& v) : CompressedClusters(v) {}
+  CompressedClustersROOT(const CompressedClusters& v) : CompressedClusters(v) {}
   // flatbuffer used for streaming
   int flatdataSize = 0;
   char* flatdata = nullptr; //[flatdataSize]

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -15,6 +15,7 @@
 #ifndef ALICEO2_DATAFORMATSTPC_COMPRESSED_CLUSTERS_H
 #define ALICEO2_DATAFORMATSTPC_COMPRESSED_CLUSTERS_H
 
+#include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 
 namespace o2
@@ -29,52 +30,75 @@ struct CompressedClustersCounters {
   unsigned int nSliceRows = 36 * 152;
   unsigned char nComppressionModes = 0;
 
-  ClassDefNV(CompressedClustersCounters, 1);
+  ClassDefNV(CompressedClustersCounters, 2);
 };
 
-template <class T>
-struct CompressedClustersPtrs_helper : public T {
-  unsigned short* qTotA = nullptr;        //! [nAttachedClusters]
-  unsigned short* qMaxA = nullptr;        //! [nAttachedClusters]
-  unsigned char* flagsA = nullptr;        //! [nAttachedClusters]
-  unsigned char* rowDiffA = nullptr;      //! [nAttachedClustersReduced]
-  unsigned char* sliceLegDiffA = nullptr; //! [nAttachedClustersReduced]
-  unsigned short* padResA = nullptr;      //! [nAttachedClustersReduced]
-  unsigned int* timeResA = nullptr;       //! [nAttachedClustersReduced]
-  unsigned char* sigmaPadA = nullptr;     //! [nAttachedClusters]
-  unsigned char* sigmaTimeA = nullptr;    //! [nAttachedClusters]
+template <class TCHAR, class TSHORT, class TINT>
+struct CompressedClustersPtrs_x {
+  TSHORT qTotA = 0;        //!
+  TSHORT qMaxA = 0;        //!
+  TCHAR flagsA = 0;        //!
+  TCHAR rowDiffA = 0;      //!
+  TCHAR sliceLegDiffA = 0; //!
+  TSHORT padResA = 0;      //!
+  TINT timeResA = 0;       //!
+  TCHAR sigmaPadA = 0;     //!
+  TCHAR sigmaTimeA = 0;    //!
 
-  unsigned char* qPtA = nullptr;   //! [nTracks]
-  unsigned char* rowA = nullptr;   //! [nTracks]
-  unsigned char* sliceA = nullptr; //! [nTracks]
-  unsigned int* timeA = nullptr;   //! [nTracks]
-  unsigned short* padA = nullptr;  //! [nTracks]
+  TCHAR qPtA = 0;   //!
+  TCHAR rowA = 0;   //!
+  TCHAR sliceA = 0; //!
+  TINT timeA = 0;   //!
+  TSHORT padA = 0;  //!
 
-  unsigned short* qTotU = nullptr;     //! [nUnattachedClusters]
-  unsigned short* qMaxU = nullptr;     //! [nUnattachedClusters]
-  unsigned char* flagsU = nullptr;     //! [nUnattachedClusters]
-  unsigned short* padDiffU = nullptr;  //! [nUnattachedClusters]
-  unsigned int* timeDiffU = nullptr;   //! [nUnattachedClusters]
-  unsigned char* sigmaPadU = nullptr;  //! [nUnattachedClusters]
-  unsigned char* sigmaTimeU = nullptr; //! [nUnattachedClusters]
+  TSHORT qTotU = 0;     //!
+  TSHORT qMaxU = 0;     //!
+  TCHAR flagsU = 0;     //!
+  TSHORT padDiffU = 0;  //!
+  TINT timeDiffU = 0;   //!
+  TCHAR sigmaPadU = 0;  //!
+  TCHAR sigmaTimeU = 0; //!
 
-  unsigned short* nTrackClusters = nullptr;  //! [nTracks]
-  unsigned int* nSliceRowClusters = nullptr; //! [nSliceRows]
+  TSHORT nTrackClusters = 0;  //!
+  TINT nSliceRowClusters = 0; //!
 
+  ClassDefNV(CompressedClustersPtrs_x, 2);
+};
+
+struct CompressedClustersPtrs : public CompressedClustersPtrs_x<unsigned char*, unsigned short*, unsigned int*> {
+};
+
+struct CompressedClustersOffsets : public CompressedClustersPtrs_x<size_t, size_t, size_t> {
+};
+
+struct CompressedClustersFlat;
+
+struct CompressedClusters : public CompressedClustersCounters, public CompressedClustersPtrs {
+  CompressedClusters() CON_DEFAULT;
+  ~CompressedClusters() CON_DEFAULT;
+  CompressedClusters(const CompressedClustersFlat& c);
+
+  ClassDefNV(CompressedClusters, 2);
+};
+
+struct CompressedClustersROOT : public CompressedClusters {
+  CompressedClustersROOT() CON_DEFAULT;
+  CompressedClustersROOT(const CompressedClustersFlat& v) : CompressedClusters(v) {}
   // flatbuffer used for streaming
   int flatdataSize = 0;
   char* flatdata = nullptr; //[flatdataSize]
 
-  ClassDefNV(CompressedClustersPtrs_helper, 2);
+  ClassDefNV(CompressedClustersROOT, 2);
 };
 
-struct CompressedClustersDummy_helper {
+struct CompressedClustersFlat : private CompressedClustersCounters, private CompressedClustersOffsets {
+  friend struct CompressedClusters;    // We don't want anyone to access the members directly, should only be used to construct a CompressedClusters struct
+  CompressedClustersFlat() CON_DELETE; // Must not be constructed, but just reinterpret_casted from void* array (void* to enforce alignment)
+  size_t totalDataSize = 0;
+
+  void set(size_t bufferSize, const CompressedClusters& v);
 };
 
-//Version with valid ROOT streamers for storage
-using CompressedClusters = CompressedClustersPtrs_helper<CompressedClustersCounters>;
-//Slightly smaller version with pointers only for GPU constant cache
-using CompressedClustersPtrsOnly = CompressedClustersPtrs_helper<CompressedClustersDummy_helper>;
 } // namespace tpc
 } // namespace o2
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClustersHelpers.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClustersHelpers.h
@@ -35,7 +35,7 @@ struct CompressedClustersHelpers {
   /// @param ptr      buffer pointer, passed onto to operation
   /// @param counters the counters object CompressedClustersCounters
   template <typename Op, typename BufferType>
-  static size_t apply(Op op, BufferType& ptr, CompressedClusters& c)
+  static size_t apply(Op op, BufferType& ptr, CompressedClustersROOT& c)
   {
     size_t size = 0;
     size += op(ptr, c.nAttachedClusters, c.qTotA, c.qMaxA, c.flagsA, c.sigmaPadA, c.sigmaTimeA);
@@ -49,7 +49,7 @@ struct CompressedClustersHelpers {
   /// Create a flat copy of the class
   /// The target container is resized accordingly
   template <typename ContainerType>
-  static size_t flattenTo(ContainerType& container, CompressedClusters& clusters)
+  static size_t flattenTo(ContainerType& container, CompressedClustersROOT& clusters)
   {
     static_assert(sizeof(typename ContainerType::value_type) == 1);
     char* dummyptr = nullptr;
@@ -65,7 +65,7 @@ struct CompressedClustersHelpers {
 
   /// Restore the array pointers from the data in the container
   template <typename ContainerType>
-  static size_t restoreFrom(ContainerType& container, CompressedClusters& clusters)
+  static size_t restoreFrom(ContainerType& container, CompressedClustersROOT& clusters)
   {
     static_assert(sizeof(typename ContainerType::value_type) == 1);
     char* dummyptr = nullptr;

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -37,8 +37,10 @@
 #pragma link C++ class std::vector < o2::tpc::ClusterNativeHelper::TreeWriter::BranchData> + ;
 #pragma link C++ class o2::tpc::dEdxInfo + ;
 #pragma link C++ class o2::tpc::CompressedClustersCounters + ;
-#pragma link C++ class o2::tpc::CompressedClustersPtrs_helper < o2::tpc::CompressedClustersCounters> - ;
-#pragma link C++ class o2::tpc::CompressedClusters - ;
+#pragma link C++ class o2::tpc::CompressedClustersPtrs_x < unsigned char*, unsigned short*, unsigned int*> + ;
+#pragma link C++ class o2::tpc::CompressedClustersPtrs + ;
+#pragma link C++ class o2::tpc::CompressedClusters + ;
+#pragma link C++ class o2::tpc::CompressedClustersROOT - ;
 #pragma link C++ enum o2::tpc::StatisticsType;
 
 #endif

--- a/DataFormats/Detectors/TPC/test/testCompressedClusters.cxx
+++ b/DataFormats/Detectors/TPC/test/testCompressedClusters.cxx
@@ -64,7 +64,7 @@ struct ClustersData {
   std::vector<unsigned int> nSliceRowClusters; //! [nSliceRows]
 };
 
-void fillClusters(CompressedClusters& clusters, ClustersData& data)
+void fillClusters(CompressedClustersROOT& clusters, ClustersData& data)
 {
   clusters.nAttachedClusters = rand() % 32;
   fillRandom(data.qTotA, clusters.nAttachedClusters);
@@ -125,12 +125,14 @@ void fillClusters(CompressedClusters& clusters, ClustersData& data)
 
 BOOST_AUTO_TEST_CASE(test_tpc_compressedclusters)
 {
-  CompressedClusters clusters;
+  CompressedClustersROOT clusters;
   ClustersData data;
   fillClusters(clusters, data);
   std::vector<char> buffer;
   CompressedClustersHelpers::flattenTo(buffer, clusters);
-  CompressedClusters restored{static_cast<CompressedClustersCounters&>(clusters)};
+  CompressedClustersROOT restored;
+  CompressedClustersCounters& x = restored;
+  x = static_cast<CompressedClustersCounters&>(clusters);
   BOOST_REQUIRE(restored.qTotA == nullptr);
   CompressedClustersHelpers::restoreFrom(buffer, restored);
 
@@ -147,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_tpc_compressedclusters)
 
 BOOST_AUTO_TEST_CASE(test_tpc_compressedclusters_root_streaming)
 {
-  CompressedClusters clusters;
+  CompressedClustersROOT clusters;
   ClustersData data;
   fillClusters(clusters, data);
 
@@ -172,12 +174,12 @@ BOOST_AUTO_TEST_CASE(test_tpc_compressedclusters_root_streaming)
     BOOST_REQUIRE(tree != nullptr);
     TBranch* branch = tree->GetBranch("compclusters");
     BOOST_REQUIRE(branch != nullptr);
-    CompressedClusters* readback = nullptr;
+    CompressedClustersROOT* readback = nullptr;
     branch->SetAddress(&readback);
     branch->GetEntry(0);
     BOOST_REQUIRE(readback != nullptr);
 
-    CompressedClusters& restored = *readback;
+    CompressedClustersROOT& restored = *readback;
     // check one entry from each category
     BOOST_CHECK(restored.nAttachedClusters == data.qMaxA.size());
     BOOST_CHECK(memcmp(restored.qMaxA, data.qMaxA.data(), restored.nAttachedClusters * sizeof(decltype(data.qMaxA)::value_type)) == 0);

--- a/Detectors/TPC/entropyCoding/run/decoder-standalone.cxx
+++ b/Detectors/TPC/entropyCoding/run/decoder-standalone.cxx
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
   if (!comparisonFileName.empty()) {
     // read compressed clusters from ROOT file:
     TFile file{comparisonFileName.c_str()};
-    o2::tpc::CompressedClusters* c;
+    o2::tpc::CompressedClustersROOT* c;
     file.GetObject("TPCCompressedClusters", c);
 
     size_t numErrors = 0;

--- a/Detectors/TPC/entropyCoding/run/encoder-standalone.cxx
+++ b/Detectors/TPC/entropyCoding/run/encoder-standalone.cxx
@@ -60,10 +60,13 @@ int main(int argc, char** argv)
   // read compressed clusters from ROOT file:
   auto clusters = [&]() {
     TFile srcFile{inputFileName.c_str()};
-    o2::tpc::CompressedClusters* c;
+    o2::tpc::CompressedClustersROOT* c;
     srcFile.GetObject("TPCCompressedClusters", c);
     srcFile.Close();
-    return std::unique_ptr<o2::tpc::CompressedClusters>(c);
+    if (c == nullptr) {
+      throw std::runtime_error("Cannot read clusters from root file");
+    }
+    return std::unique_ptr<o2::tpc::CompressedClustersROOT>(c);
   }();
 
   std::cout << "nAttachedClusters: " << clusters->nAttachedClusters << std::endl;

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GPUCATracking.h
@@ -24,6 +24,7 @@ namespace gpu
 {
 struct GPUO2InterfaceConfiguration;
 struct GPUO2InterfaceIOPtrs;
+struct GPUInterfaceOutputs;
 class GPUTPCO2Interface;
 } // namespace gpu
 } // namespace o2
@@ -55,7 +56,7 @@ class GPUCATracking
   void deinitialize();
 
   //Input: cluster structure, possibly including MC labels, pointers to std::vectors for tracks and track MC labels. outputTracksMCTruth may be nullptr to indicate missing cluster MC labels. Otherwise, cluster MC labels are assumed to be present.
-  int runTracking(o2::gpu::GPUO2InterfaceIOPtrs* data);
+  int runTracking(o2::gpu::GPUO2InterfaceIOPtrs* data, o2::gpu::GPUInterfaceOutputs* outputs = nullptr);
 
   float getPseudoVDrift();                                              //Return artificial VDrift used to convert time to Z
   int getNTracksASide() { return mNTracksASide; }

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -59,7 +59,7 @@ void GPUCATracking::deinitialize()
   mTrackingCAO2Interface.reset();
 }
 
-int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
+int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* outputs)
 {
   if ((int)(data->tpcZS != nullptr) + (int)(data->o2Digits != nullptr) + (int)(data->clusters != nullptr) != 1) {
     return 0;
@@ -118,7 +118,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
     ptrs.clustersNative = clusters;
     ptrs.tpcPackedDigits = nullptr;
   }
-  int retVal = mTrackingCAO2Interface->RunTracking(&ptrs);
+  int retVal = mTrackingCAO2Interface->RunTracking(&ptrs, outputs);
   if (data->o2Digits || data->tpcZS) {
     clusters = ptrs.clustersNative;
   }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -31,13 +31,14 @@ namespace ca
 // The CA tracker is now a wrapper to not only the actual tracking on GPU but
 // also the decoding of the zero-suppressed raw format and the clusterer.
 enum struct Operation {
-  CAClusterer,        // run the CA clusterer
-  ZSDecoder,          // run the ZS raw data decoder
-  OutputTracks,       // publish tracks
-  OutputCAClusters,   // publish the clusters produced by CA clusterer
-  OutputCompClusters, // publish CompClusters container
-  ProcessMC,          // process MC labels
-  Noop,               // skip argument on the constructor
+  CAClusterer,            // run the CA clusterer
+  ZSDecoder,              // run the ZS raw data decoder
+  OutputTracks,           // publish tracks
+  OutputCAClusters,       // publish the clusters produced by CA clusterer
+  OutputCompClusters,     // publish CompClusters container
+  OutputCompClustersFlat, // publish CompClusters container
+  ProcessMC,              // process MC labels
+  Noop,                   // skip argument on the constructor
 };
 
 /// Helper struct to pass the individual ca::Operation flags to
@@ -66,6 +67,9 @@ struct Config {
       case Operation::OutputCompClusters:
         outputCompClusters = true;
         break;
+      case Operation::OutputCompClustersFlat:
+        outputCompClustersFlat = true;
+        break;
       case Operation::OutputCAClusters:
         outputCAClusters = true;
         break;
@@ -86,6 +90,7 @@ struct Config {
   bool zsDecoder = false;
   bool outputTracks = false;
   bool outputCompClusters = false;
+  bool outputCompClustersFlat = false;
   bool outputCAClusters = false;
   bool processMC = false;
 };

--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
@@ -23,7 +23,7 @@ namespace tpc
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getEntropyEncoderSpec();
+framework::DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -561,9 +561,9 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       //std::vector<o2::tpc::ClusterNative> clusterBuffer; // std::vector that will hold the actual clusters, clustersNativeDecoded will point inside here
       //mDecoder.decompress(clustersCompressed, clustersNativeDecoded, clusterBuffer, param); // Run decompressor
       if (pc.outputs().isAllowed({gDataOriginTPC, "COMPCLUSTERS", 0})) {
-        const o2::tpc::CompressedClusters* compressedClusters = ptrs.compressedClusters;
-        if (compressedClusters != nullptr) {
-          pc.outputs().snapshot(Output{gDataOriginTPC, "COMPCLUSTERS", 0}, ROOTSerialized<o2::tpc::CompressedClusters const>(*compressedClusters));
+        if (ptrs.compressedClusters != nullptr) {
+          o2::tpc::CompressedClustersROOT compressedClusters = *ptrs.compressedClusters;
+          pc.outputs().snapshot(Output{gDataOriginTPC, "COMPCLUSTERS", 0}, ROOTSerialized<o2::tpc::CompressedClustersROOT const>(compressedClusters));
         } else {
           LOG(ERROR) << "unable to get compressed cluster info from track";
         }

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -52,7 +52,7 @@ DataProcessorSpec getEntropyEncoderSpec()
     auto processAttributes = std::make_shared<ProcessAttributes>();
 
     auto processingFct = [processAttributes](ProcessingContext& pc) {
-      auto clusters = pc.inputs().get<CompressedClusters*>("input");
+      auto clusters = pc.inputs().get<CompressedClustersROOT*>("input");
       if (clusters == nullptr) {
         LOG(ERROR) << "invalid input";
         return;

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -52,13 +52,14 @@ DataProcessorSpec getEntropyEncoderSpec()
     auto processAttributes = std::make_shared<ProcessAttributes>();
 
     auto processingFct = [processAttributes](ProcessingContext& pc) {
-      auto clusters = pc.inputs().get<CompressedClustersROOT*>("input");
-      if (clusters == nullptr) {
+      auto tmp = pc.inputs().get<CompressedClustersFlat*>("input");
+      if (tmp == nullptr) {
         LOG(ERROR) << "invalid input";
         return;
       }
+      CompressedClusters clusters(*tmp);
 
-      auto encodedClusters = o2::tpc::TPCEntropyEncoder::encode(*clusters);
+      auto encodedClusters = o2::tpc::TPCEntropyEncoder::encode(clusters);
 
       const char* outFileName = "tpc-encoded-clusters.root";
 

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -194,7 +194,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // output matrix
   // Note: the ClusterHardware format is probably a deprecated legacy format and also the
   // ClusterDecoderRawSpec
-  bool produceCompClusters = isEnabled(OutputType::CompClusters) || isEnabled(OutputType::EncodedClusters);
+  bool produceCompClusters = isEnabled(OutputType::CompClusters);
   bool produceTracks = isEnabled(OutputType::Tracks);
   bool runTracker = produceTracks || produceCompClusters;
   bool runHWDecoder = !caClusterer && (runTracker || isEnabled(OutputType::Clusters));
@@ -394,6 +394,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
                                                    zsDecoder ? ca::Operation::ZSDecoder : ca::Operation::Noop,
                                                    produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
                                                    produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
+                                                   runClusterEncoder ? ca::Operation::OutputCompClustersFlat : ca::Operation::Noop,
                                                    isEnabled(OutputType::Clusters) && caClusterer ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
                                                  },
                                                  laneConfiguration));
@@ -405,7 +406,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   //
   // selected by output type 'encoded-clusters'
   if (runClusterEncoder) {
-    specs.emplace_back(o2::tpc::getEntropyEncoderSpec());
+    specs.emplace_back(o2::tpc::getEntropyEncoderSpec(!runTracker));
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -464,7 +464,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
     const char* defaultTreeName = "tpcrec";
 
     //branch definitions for RootTreeWriter spec
-    using CCluSerializedType = ROOTSerialized<CompressedClusters>;
+    using CCluSerializedType = ROOTSerialized<CompressedClustersROOT>;
     auto ccldef = BranchDefinition<CCluSerializedType>{InputSpec{"inputCompCl", "TPC", "COMPCLUSTERS"}, //
                                                        "TPCCompClusters_0", "compcluster-branch-name"}; //
 

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -41,8 +41,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   using namespace o2::framework;
 
   std::vector<ConfigParamSpec> options{
-    {"input-type", VariantType::String, "digits", {"digitizer, digits, clustershw, clustersnative, zsraw"}},
-    {"output-type", VariantType::String, "tracks", {"digits, clustershw, clustersnative, tracks, disable-writer"}},
+    {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters"}},
+    {"output-type", VariantType::String, "tracks", {"digits, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer"}},
     {"ca-clusterer", VariantType::Bool, false, {"Use clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     {"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -34,10 +34,7 @@ namespace o2
 namespace tpc
 {
 struct ClusterNativeAccess;
-template <class T>
-struct CompressedClustersPtrs_helper;
-struct CompressedClustersCounters;
-using CompressedClusters = CompressedClustersPtrs_helper<CompressedClustersCounters>;
+struct CompressedClustersFlat;
 class Digit;
 } // namespace tpc
 } // namespace o2
@@ -216,7 +213,7 @@ struct GPUTrackingInOutPointers {
   unsigned int nMergedTracks = 0;
   const GPUTPCGMMergedTrackHit* mergedTrackHits = nullptr;
   unsigned int nMergedTrackHits = 0;
-  const o2::tpc::CompressedClusters* tpcCompressedClusters = nullptr;
+  const o2::tpc::CompressedClustersFlat* tpcCompressedClusters = nullptr;
   const GPUTRDTrackletWord* trdTracklets = nullptr;
   unsigned int nTRDTracklets = 0;
   const GPUTRDTrackletLabels* trdTrackletsMC = nullptr;

--- a/GPU/GPUTracking/Base/GPUO2FakeClasses.h
+++ b/GPU/GPUTracking/Base/GPUO2FakeClasses.h
@@ -91,7 +91,7 @@ class GPUTPCConvert
 class GPUTPCCompression
 {
  public:
-  GPUFakeEmpty mOutput;
+  GPUFakeEmpty* mOutput;
 };
 class GPUTPCClusterFinder
 {

--- a/GPU/GPUTracking/Base/GPUOutputControl.h
+++ b/GPU/GPUTracking/Base/GPUOutputControl.h
@@ -15,8 +15,9 @@
 #define GPUOUTPUTCONTROL_H
 
 #include "GPUCommonDef.h"
-#ifndef GPUCA_GPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <cstddef>
+#include <new>
 #endif
 
 namespace GPUCA_NAMESPACE
@@ -28,6 +29,13 @@ struct GPUOutputControl {
                           UseExternalBuffer = 1 };
 #ifndef GPUCA_GPUCODE_DEVICE
   GPUOutputControl() = default;
+  void set(void* ptr, size_t size)
+  {
+    new (this) GPUOutputControl;
+    OutputType = GPUOutputControl::UseExternalBuffer;
+    OutputBase = OutputPtr = (char*)ptr;
+    OutputMaxSize = size;
+  }
 #endif
 
   void* OutputBase = nullptr;                     // Base ptr to memory pool, occupied size is OutputPtr - OutputBase

--- a/GPU/GPUTracking/Base/GPUOutputControl.h
+++ b/GPU/GPUTracking/Base/GPUOutputControl.h
@@ -36,6 +36,10 @@ struct GPUOutputControl {
     OutputBase = OutputPtr = (char*)ptr;
     OutputMaxSize = size;
   }
+  void reset()
+  {
+    new (this) GPUOutputControl;
+  }
 #endif
 
   void* OutputBase = nullptr;                     // Base ptr to memory pool, occupied size is OutputPtr - OutputBase

--- a/GPU/GPUTracking/Base/GPUProcessor.h
+++ b/GPU/GPUTracking/Base/GPUProcessor.h
@@ -99,6 +99,7 @@ class GPUProcessor
     basePtr += nEntries * sizeof(S);
     return retVal;
   }
+
   template <size_t alignment = GPUCA_BUFFER_ALIGNMENT, class S>
   static inline S* getPointerWithAlignment(void*& basePtr, size_t nEntries = 1)
   {
@@ -109,6 +110,12 @@ class GPUProcessor
   static inline void computePointerWithAlignment(T*& basePtr, S*& objPtr, size_t nEntries = 1)
   {
     objPtr = getPointerWithAlignment<alignment, S>(reinterpret_cast<size_t&>(basePtr), nEntries);
+  }
+
+  template <class T, class S>
+  static inline void computePointerWithoutAlignment(T*& basePtr, S*& objPtr, size_t nEntries = 1)
+  {
+    objPtr = reinterpret_cast<S*>(getPointerWithAlignment<1, char>(reinterpret_cast<size_t&>(basePtr), nEntries * sizeof(S)));
   }
 #endif
 

--- a/GPU/GPUTracking/Base/GPUProcessor.h
+++ b/GPU/GPUTracking/Base/GPUProcessor.h
@@ -106,14 +106,9 @@ class GPUProcessor
   }
 
   template <size_t alignment = GPUCA_BUFFER_ALIGNMENT, class T, class S>
-  static inline void computePointerWithAlignment(T*& basePtr, S*& objPtr, size_t nEntries = 1, bool runConstructor = false)
+  static inline void computePointerWithAlignment(T*& basePtr, S*& objPtr, size_t nEntries = 1)
   {
     objPtr = getPointerWithAlignment<alignment, S>(reinterpret_cast<size_t&>(basePtr), nEntries);
-    if (runConstructor) {
-      for (size_t i = 0; i < nEntries; i++) {
-        new (objPtr + i) S;
-      }
-    }
   }
 #endif
 

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -651,9 +651,7 @@ void GPUReconstruction::SetSettings(const GPUSettingsEvent* settings, const GPUS
 void GPUReconstruction::SetOutputControl(void* ptr, size_t size)
 {
   GPUOutputControl outputControl;
-  outputControl.OutputType = GPUOutputControl::UseExternalBuffer;
-  outputControl.OutputBase = outputControl.OutputPtr = (char*)ptr;
-  outputControl.OutputMaxSize = size;
+  outputControl.set(ptr, size);
   SetOutputControl(outputControl);
 }
 

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompression.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompression.cxx
@@ -21,7 +21,7 @@ void GPUTPCCompression::InitializeProcessor() {}
 
 void* GPUTPCCompression::SetPointersOutputHost(void* mem)
 {
-  computePointerWithAlignment(mem, mOutputFlat);
+  computePointerWithoutAlignment(mem, mOutputFlat);
   SetPointersCompressedClusters(mem, *mOutput, mOutput->nAttachedClusters, mOutput->nTracks, mOutput->nUnattachedClusters, true);
   return mem;
 }

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompression.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompression.cxx
@@ -21,6 +21,7 @@ void GPUTPCCompression::InitializeProcessor() {}
 
 void* GPUTPCCompression::SetPointersOutputHost(void* mem)
 {
+  computePointerWithAlignment(mem, mOutputFlat);
   SetPointersCompressedClusters(mem, *mOutput, mOutput->nAttachedClusters, mOutput->nTracks, mOutput->nUnattachedClusters, true);
   return mem;
 }

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompression.h
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompression.h
@@ -26,13 +26,11 @@ namespace o2
 {
 namespace tpc
 {
-template <class T>
-struct CompressedClustersPtrs_helper {
+struct CompressedClustersPtrs {
 };
-struct CompressedClustersCounters {
+struct CompressedClusters {
 };
-using CompressedClusters = CompressedClustersPtrs_helper<CompressedClustersCounters>;
-struct CompressedClustersPtrsOnly {
+struct CompressedClustersFlat {
 };
 } // namespace tpc
 } // namespace o2
@@ -83,8 +81,9 @@ class GPUTPCCompression : public GPUProcessor
 
   constexpr static unsigned int NSLICES = GPUCA_NSLICES;
 
-  o2::tpc::CompressedClustersPtrsOnly mPtrs;
+  o2::tpc::CompressedClustersPtrs mPtrs;
   o2::tpc::CompressedClusters* mOutput = nullptr;
+  o2::tpc::CompressedClustersFlat* mOutputFlat = nullptr;
   const GPUTPCGMMerger* mMerger = nullptr;
 
   memory* mMemory = nullptr;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -40,7 +40,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
     }
     bool rejectTrk = CAMath::Abs(trk.GetParam().GetQPt()) > processors.param.rec.tpcRejectQPt;
     unsigned int nClustersStored = 0;
-    CompressedClustersPtrsOnly& GPUrestrict() c = compressor.mPtrs;
+    CompressedClustersPtrs& GPUrestrict() c = compressor.mPtrs;
     unsigned int lastRow = 0, lastSlice = 0; // BUG: These should be unsigned char, but then CUDA breaks
     GPUTPCCompressionTrackModel track;
     for (int k = trk.NClusters() - 1; k >= 0; k--) {
@@ -190,7 +190,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step1un
     unsigned int totalCount = 0;
     GPUbarrier();
 
-    CompressedClustersPtrsOnly& GPUrestrict() c = compressor.mPtrs;
+    CompressedClustersPtrs& GPUrestrict() c = compressor.mPtrs;
 
     const unsigned int nn = GPUCommonMath::nextMultipleOf<GPUCA_GET_THREAD_COUNT(GPUCA_LB_GPUTPCCompressionKernels_step1unattached)>(clusters->nClusters[iSlice][iRow]);
     for (unsigned int i = iThread; i < nn + nThreads; i += nThreads) {

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
@@ -21,6 +21,12 @@
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
 
+int TPCClusterDecompressor::decompress(const CompressedClustersFlat* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param)
+{
+  CompressedClusters c = *clustersCompressed;
+  return decompress(&c, clustersNative, clusterBuffer, param);
+}
+
 int TPCClusterDecompressor::decompress(const CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param)
 {
   std::vector<ClusterNative> clusters[NSLICES][GPUCA_ROW_COUNT];

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.h
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.h
@@ -30,14 +30,14 @@ namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
-using CompressedClusters = o2::tpc::CompressedClusters;
 struct GPUParam;
 
 class TPCClusterDecompressor
 {
  public:
   static constexpr unsigned int NSLICES = GPUCA_NSLICES;
-  int decompress(const CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param);
+  int decompress(const o2::tpc::CompressedClustersFlat* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param);
+  int decompress(const o2::tpc::CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param);
 
  protected:
 };

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -283,6 +283,10 @@ int GPUChainTracking::Init()
     mEventDisplay.reset(new GPUDisplay(GetDeviceProcessingSettings().eventDisplay, this, mQA.get()));
   }
 
+  if (mOutputCompressedClusters == nullptr) {
+    mOutputCompressedClusters = &mRec->OutputControl();
+  }
+
   if (mRec->IsGPU()) {
     if (processors()->calibObjects.fastTransform) {
       memcpy((void*)mFlatObjectsShadow.mCalibObjects.fastTransform, (const void*)processors()->calibObjects.fastTransform, sizeof(*processors()->calibObjects.fastTransform));
@@ -1697,7 +1701,7 @@ int GPUChainTracking::RunTPCCompression()
   O->nAttachedClustersReduced = O->nAttachedClusters - O->nTracks;
   O->nSliceRows = NSLICES * GPUCA_ROW_COUNT;
   O->nComppressionModes = param().rec.tpcCompressionModes;
-  size_t outputSize = AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, &mRec->OutputControl());
+  size_t outputSize = AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, mOutputCompressedClusters);
   Compressor.mOutputFlat->set(outputSize, *Compressor.mOutput);
   const o2::tpc::CompressedClustersPtrs* P = nullptr;
   if (DeviceProcessingSettings().tpcCompressionGatherMode == 2) {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1697,8 +1697,9 @@ int GPUChainTracking::RunTPCCompression()
   O->nAttachedClustersReduced = O->nAttachedClusters - O->nTracks;
   O->nSliceRows = NSLICES * GPUCA_ROW_COUNT;
   O->nComppressionModes = param().rec.tpcCompressionModes;
-  AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, &mRec->OutputControl());
-  const o2::tpc::CompressedClustersPtrsOnly* P = nullptr;
+  size_t outputSize = AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, &mRec->OutputControl());
+  Compressor.mOutputFlat->set(outputSize, *Compressor.mOutput);
+  const o2::tpc::CompressedClustersPtrs* P = nullptr;
   if (DeviceProcessingSettings().tpcCompressionGatherMode == 2) {
     TransferMemoryResourcesToGPU(myStep, &Compressor, 0);
     runKernel<GPUTPCCompressionKernels, GPUTPCCompressionKernels::step2gather>(GetGridBlk(BlockCount(), 0), krnlRunRangeNone, krnlEventNone);
@@ -1756,7 +1757,7 @@ int GPUChainTracking::RunTPCCompression()
   }
   SynchronizeGPU();
 
-  mIOPtrs.tpcCompressedClusters = O;
+  mIOPtrs.tpcCompressedClusters = Compressor.mOutputFlat;
 #endif
   return 0;
 }

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -152,6 +152,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetMatLUT(const o2::base::MatLayerCylSet* lut) { processors()->calibObjects.matLUT = lut; }
   void SetTRDGeometry(const o2::trd::TRDGeometryFlat* geo) { processors()->calibObjects.trdGeometry = geo; }
   void LoadClusterErrors();
+  void SetOutputControlCompressedClusters(GPUOutputControl* v) { mOutputCompressedClusters = v; }
 
   const void* mConfigDisplay = nullptr; // Abstract pointer to Standalone Display Configuration Structure
   const void* mConfigQA = nullptr;      // Abstract pointer to Standalone QA Configuration Structure
@@ -216,6 +217,8 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   std::unique_ptr<unsigned int[]> mTPCZSSizes;                        // Array with TPC ZS numbers of pages
   std::unique_ptr<void*[]> mTPCZSPtrs;                                // Array with pointers to TPC ZS pages
   std::unique_ptr<GPUTrackingInOutZS> mTPCZS;                         // TPC ZS Data Structure
+
+  GPUOutputControl* mOutputCompressedClusters = nullptr;
 
   // Upper bounds for memory allocation
   unsigned int mMaxTPCHits = 0;

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -101,7 +101,11 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
 
   mChain->mIOPtrs = *data;
   if (mConfig->configInterface.outputToPreallocatedBuffers) {
-    mOutputCompressedClusters->set(outputs->compressedClusters.ptr, outputs->compressedClusters.size);
+    if (outputs->compressedClusters.ptr) {
+      mOutputCompressedClusters->set(outputs->compressedClusters.ptr, outputs->compressedClusters.size);
+    } else {
+      mOutputCompressedClusters->reset();
+    }
   }
   int retVal = mRec->RunChains();
   if (retVal == 2) {

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -39,6 +39,8 @@ namespace o2::gpu
 class GPUReconstruction;
 class GPUChainTracking;
 struct GPUO2InterfaceConfiguration;
+struct GPUInterfaceOutputs;
+struct GPUOutputControl;
 
 class GPUTPCO2Interface
 {
@@ -49,7 +51,7 @@ class GPUTPCO2Interface
   int Initialize(const GPUO2InterfaceConfiguration& config);
   void Deinitialize();
 
-  int RunTracking(GPUTrackingInOutPointers* data);
+  int RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceOutputs* outputs = nullptr);
   void Clear(bool clearOutputs);
 
   bool GetParamContinuous() { return (mContinuous); }
@@ -65,12 +67,12 @@ class GPUTPCO2Interface
   GPUTPCO2Interface& operator=(const GPUTPCO2Interface&);
 
   bool mInitialized = false;
-  bool mDumpEvents = false;
   bool mContinuous = false;
 
   std::unique_ptr<GPUReconstruction> mRec;
   GPUChainTracking* mChain = nullptr;
   std::unique_ptr<GPUO2InterfaceConfiguration> mConfig;
+  std::unique_ptr<GPUOutputControl> mOutputCompressedClusters;
 };
 } // namespace o2::gpu
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -93,7 +93,7 @@ struct GPUO2InterfaceIOPtrs {
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr;
 
   // Output for entropy-reduced clusters of TPC compression
-  const o2::tpc::CompressedClusters* compressedClusters;
+  const o2::tpc::CompressedClustersFlat* compressedClusters;
 
   // Hint for GPUCATracking to place its output in this buffer if possible.
   // This enables to create the output directly in a shared memory segment of the framework.

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -45,15 +45,35 @@ class Digit;
 namespace gpu
 {
 class TPCFastTransform;
+
+// This defines an output region. Ptr points to a memory buffer, which should have a proper alignment of at least BUFFER_ALIGNMENT bytes.
+// The size defines the maximum possible buffer size when GPUReconstruction is called, and returns the number of filled bytes when it returns.
+// If ptr == nullptr, there is no region defined and GPUReconstruction will write its output to an internal buffer.
+struct GPUInterfaceOutputRegion {
+  void* ptr = nullptr;
+  size_t size = 0;
+};
+
+struct GPUInterfaceOutputs {
+  GPUInterfaceOutputRegion compressedClusters;
+};
+
 // Full configuration structure with all available settings of GPU...
 struct GPUO2InterfaceConfiguration {
   GPUO2InterfaceConfiguration() = default;
   ~GPUO2InterfaceConfiguration() = default;
   GPUO2InterfaceConfiguration(const GPUO2InterfaceConfiguration&) = default;
 
+  static constexpr size_t BUFFER_ALIGNMENT = 64;
+  class alignas(BUFFER_ALIGNMENT) bufferType
+  {
+    char x[BUFFER_ALIGNMENT];
+  };
+
   // Settings for the Interface class
   struct GPUInterfaceSettings {
     bool dumpEvents = false;
+    bool outputToPreallocatedBuffers = false;
     // These constants affect GPU memory allocation and do not limit the CPU processing
     unsigned int maxTPCHits = 1024 * 1024 * 1024;
     unsigned int maxTRDTracklets = 128 * 1024;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -46,7 +46,8 @@ namespace gpu
 {
 class TPCFastTransform;
 
-// This defines an output region. Ptr points to a memory buffer, which should have a proper alignment of at least BUFFER_ALIGNMENT bytes.
+// This defines an output region. Ptr points to a memory buffer, which should have a proper alignment.
+// Since DPL does not respect the alignment of data types, we do not impose anything specic but just use a char data type, but it should be >= 64 bytes ideally.
 // The size defines the maximum possible buffer size when GPUReconstruction is called, and returns the number of filled bytes when it returns.
 // If ptr == nullptr, there is no region defined and GPUReconstruction will write its output to an internal buffer.
 struct GPUInterfaceOutputRegion {
@@ -63,12 +64,6 @@ struct GPUO2InterfaceConfiguration {
   GPUO2InterfaceConfiguration() = default;
   ~GPUO2InterfaceConfiguration() = default;
   GPUO2InterfaceConfiguration(const GPUO2InterfaceConfiguration&) = default;
-
-  static constexpr size_t BUFFER_ALIGNMENT = 64;
-  class alignas(BUFFER_ALIGNMENT) bufferType
-  {
-    char x[BUFFER_ALIGNMENT];
-  };
 
   // Settings for the Interface class
   struct GPUInterfaceSettings {

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -157,6 +157,7 @@ target_compile_definitions(standalone_support PUBLIC $<TARGET_PROPERTY:O2::GPUTr
 # Add all sources and dependencies to to support based on Config File
 if(CONFIG_O2_EXTENSIONS)
   target_sources(standalone_support PRIVATE
+               ../../..//DataFormats/Detectors/TPC/src/CompressedClusters.cxx
                ../../..//DataFormats/simulation/src/MCCompLabel.cxx
                ../../..//Detectors/TRD/base/src/TRDGeometryBase.cxx
                ../../..//Detectors/Base/src/MatLayerCylSet.cxx


### PR DESCRIPTION
@ktf @matthiasrichter @shahor02 : This is an attempt to flatten the compressed cluster output from the source. It is huge because it also includes #3499, will clean up once the other one is merged.
The flat structure itself and writing to it seems to be working, but I am having trouble sending it via DPL.
The output buffer is allocated as
```
size_t bufferSize = 2048ul * 1024 * 1024; // TODO: Just allocated some large buffer for now, should estimate this correctly;
auto bufferCompressedClusters = pc.outputs().make<std::vector<char>>(Output{gDataOriginTPC, "COMPCLUSTERS", 0}, bufferSize);
```
in line 550, CATrackerSpec.cxx, and retrieved as
```
auto tmp2 = pc.inputs().get<gsl::span<char>>("input");
```
in line 51, EntropyEncoderSpec.cxx.

I have 2 problems:
- The receiver receives always the buffer with the size as originally allocated. Using `bufferCompressedClusters.resize(...)` or `bufferCompressedClusters.push_back(...)` or `bufferCompressedClusters.emplace_back(...)` works and modifies the buffer on the sender side, but the receiver always receives a buffer of size `bufferSize`.
- The receiver receives only zeroes, irrespective of what I write into the buffer on the sender side.

I added some debug output:
On the sender:
```
CompressedClustersFlat* tmp = (CompressedClustersFlat*) bufferCompressedClusters.data();
printf("XXXXXXX Test %d %lld\n", (int) tmp->totalDataSize, (long long int) bufferCompressedClusters.size());
```
and on the receive:
```
CompressedClustersFlat* tmp = (CompressedClustersFlat*) tmp2.data();
printf("XXXXXXX Test %d %lld\n", (int) tmp->totalDataSize, (long long int) tmp2.size());
CompressedClusters compressed(*tmp);
LOG(INFO) << "CCCCC input data with " << compressed.nTracks << " track(s) and " << compressed.nAttachedClusters << " attached clusters";
```
But the printouts I see are:
```
[4686:tpc-tracker]: XXXXXXX Test 22128 22128
[4720:tpc-entropy-encoder]: XXXXXXX Test 0 2147483648
[4720:tpc-entropy-encoder]: [12:45:08][INFO] CCCCC input data with 0 track(s) and 0 attached clusters
```
So the XXXXXXX... outputs are not the same. I am sorry but I don't manage to understand what I am doing wrong. Could you have a look, or advise how I should allocate / send / receive the buffer.