### PR TITLE
EMCal wokflow: fix in completion policy

### DIFF
--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -31,10 +31,10 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
   if (!emcheader->mHasPayload) {
     LOG(DEBUG) << "[EMCALCellConverter - run] No more digits" << std::endl;
-    ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
+    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
+    // ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
     return;
   }
-
   mOutputCells.clear();
   mOutputTriggers.clear();
   auto digitsAll = ctx.inputs().get<gsl::span<o2::emcal::Digit>>("digits");

--- a/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
@@ -64,12 +64,13 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
 
   auto dataref = ctx.inputs().get(inputname.c_str());
   auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
+
   if (!emcheader->mHasPayload) {
     LOG(DEBUG) << "[EMCALClusterizer - run] No more cells/digits" << std::endl;
-    ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
+    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
+    //ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
     return;
   }
-
   auto Inputs = ctx.inputs().get<gsl::span<InputType>>(inputname.c_str());
   LOG(DEBUG) << "[EMCALClusterizer - run]  Received " << Inputs.size() << " Cells/digits, running clusterizer ...";
 

--- a/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
@@ -48,7 +48,8 @@ void DigitsPrinterSpec<InputType>::run(framework::ProcessingContext& pc)
   auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
   if (!emcheader->mHasPayload) {
     LOG(DEBUG) << "[EMCALDigitsPrinter - process] No more digits" << std::endl;
-    pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
+    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
+    // pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
     return;
   }
 

--- a/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
@@ -86,6 +86,7 @@ o2::framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config
         }
       }
       if ((processAttributes->finished = (active == false)) && processAttributes->terminateOnEod) {
+        pc.services().get<o2::framework::ControlService>().endOfStream();
         pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
       }
     };


### PR DESCRIPTION
@mfasDa this fixes the hunging of the workflow: the publisher should declare end of stream once data is over. Still, I am not sure why the processing devices can get data with ``emcheader->mHasPayload==0``? Could you recheck the publisher, perhaps it does 1 empty cycle in the end?