### PR TITLE
Fix bugs in the encoding of MID raw data

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <gsl/gsl>
 #include "DataFormatsMID/ColumnData.h"
+#include "MIDBase/Mapping.h"
 #include "MIDRaw/CrateMapper.h"
 #include "MIDRaw/LocalBoardRO.h"
 
@@ -38,6 +39,7 @@ class ColumnDataToLocalBoard
   std::unordered_map<uint16_t, LocalBoardRO> mLocalBoardsMap{};      /// Map of data per board
   std::unordered_map<uint16_t, std::vector<LocalBoardRO>> mGBTMap{}; /// Map of data per GBT link
   CrateMapper mCrateMapper{};                                        /// Crate mapper
+  Mapping mMapping{};                                                /// Segmentation
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
+++ b/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
@@ -32,18 +32,17 @@ void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data)
   // First fill the map with the active local boards.
   // Each local board gets a unique id.
   for (auto& col : data) {
-    for (int iline = 0; iline < 4; ++iline) {
-      if (col.getBendPattern(iline) == 0) {
-        continue;
+    for (int iline = mMapping.getFirstBoardBP(col.columnId, col.deId); iline <= mMapping.getLastBoardBP(col.columnId, col.deId); ++iline) {
+      if (col.getBendPattern(iline) || col.getNonBendPattern()) {
+        auto uniqueLocId = mCrateMapper.deLocalBoardToRO(col.deId, col.columnId, iline);
+        auto& roData = mLocalBoardsMap[uniqueLocId];
+        roData.statusWord = raw::sSTARTBIT | raw::sCARDTYPE;
+        roData.boardId = crateparams::getLocId(uniqueLocId);
+        int ich = detparams::getChamber(col.deId);
+        roData.firedChambers |= (1 << ich);
+        roData.patternsBP[ich] = col.getBendPattern(iline);
+        roData.patternsNBP[ich] = col.getNonBendPattern();
       }
-      auto uniqueLocId = mCrateMapper.deLocalBoardToRO(col.deId, col.columnId, iline);
-      auto& roData = mLocalBoardsMap[uniqueLocId];
-      roData.statusWord = raw::sSTARTBIT | raw::sCARDTYPE;
-      roData.boardId = crateparams::getLocId(uniqueLocId);
-      int ich = detparams::getChamber(col.deId);
-      roData.firedChambers |= (1 << ich);
-      roData.patternsBP[ich] = col.getBendPattern(iline);
-      roData.patternsNBP[ich] = col.getNonBendPattern();
     }
   }
 


### PR DESCRIPTION
This PR fixes two issues:
- the answer of the local boards to the HB trigger was incorrectly encoded, resulting in errors in the decoding of data
- the case where only the anode or cathode was fired was not correctly treated
The PR also includes some additional tests to spot these two cases.

The commits are meant to be atomic: please do not squash them.