### PR TITLE
Get ready for Pythia8 upgrade to 8.302

### DIFF
--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -66,11 +66,24 @@ Bool_t GeneratorPythia8::Init()
     auto hooks = GetFromMacro<Pythia8::UserHooks*>(mHooksFileName, mHooksFuncName, "Pythia8::UserHooks*", "pythia8_user_hooks");
     if (!hooks)
       LOG(FATAL) << "Failed to init \'Pythia8\': problem with user hooks configuration ";
+#if PYTHIA_VERSION_INTEGER < 8300
     mPythia.setUserHooksPtr(hooks);
+#else
+    mPythia.setUserHooksPtr(std::shared_ptr<Pythia8::UserHooks>(hooks));
+#endif
   }
+
+#if PYTHIA_VERSION_INTEGER < 8300
+  /** [NOTE] The issue with large particle production vertex when running 
+      Pythia8 heavy-ion model (Angantyr) is solved in Pythia 8.3 series.
+      For discussions about this issue, please refer to this JIRA ticket
+      https://alice.its.cern.ch/jira/browse/O2-1382.
+      The code remains within preprocessor directives, both for reference
+      and in case future use demands to roll back to Pythia 8.2 series. **/
 
   /** inhibit hadron decays **/
   mPythia.readString("HadronLevel:Decay off");
+#endif
 
   /** initialise **/
   if (!mPythia.init()) {
@@ -89,15 +102,23 @@ Bool_t
 {
   /** generate event **/
 
+  /** generate event **/
+  if (!mPythia.next())
+    return false;
+
+#if PYTHIA_VERSION_INTEGER < 8300
+  /** [NOTE] The issue with large particle production vertex when running 
+      Pythia8 heavy-ion model (Angantyr) is solved in Pythia 8.3 series.
+      For discussions about this issue, please refer to this JIRA ticket
+      https://alice.its.cern.ch/jira/browse/O2-1382.
+      The code remains within preprocessor directives, both for reference
+      and in case future use demands to roll back to Pythia 8.2 series. **/
+
   /** As we have inhibited all hadron decays before init,
       the event generation stops after hadronisation.
       We then pick all particles from here and force their
       production vertex to be (0,0,0,0).
       Afterwards we process the decays. **/
-
-  /** generate event **/
-  if (!mPythia.next())
-    return false;
 
   /** force production vertices to (0,0,0,0) **/
   auto nParticles = mPythia.event.size();
@@ -112,6 +133,7 @@ Bool_t
   /** proceed with decays **/
   if (!mPythia.moreDecays())
     return false;
+#endif
 
   /** success **/
   return true;
@@ -156,10 +178,15 @@ void GeneratorPythia8::updateHeader(FairMCEventHeader* eventHeader)
 {
   /** update header **/
 
-  /** set impact parameter if in heavy-ion mode **/
+#if PYTHIA_VERSION_INTEGER < 8300
   auto hiinfo = mPythia.info.hiinfo;
+#else
+  auto hiinfo = mPythia.info.hiInfo;
+#endif
+
+  /** set impact parameter if in heavy-ion mode **/
   if (hiinfo)
-    eventHeader->SetB(mPythia.info.hiinfo->b());
+    eventHeader->SetB(hiinfo->b());
 }
 
 /*****************************************************************/


### PR DESCRIPTION
This PR prepares a few pieces of the O2 for the upgrade of Pythia8 to version 8.302.
Given that a few details have changed in the API, corresponding pre-processor directives have been put in place to allow the code to be built safely with both the current Pythia8 version and the upcoming one.

Also, the patch to set the vertices at (0,0,0) as discussed in #3446 is not needed anymore in the upcoming Pythia8.302 version.