### PR TITLE
TPC workflow for zs from digits including MC

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Helpers.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Helpers.h
@@ -55,6 +55,11 @@ class ClusterHardwareContainerFixedSize
   static_assert(size >= sizeof(ClusterHardwareContainer), "Size must be at least sizeof(ClusterHardwareContainer)");
 };
 typedef ClusterHardwareContainerFixedSize<8192> ClusterHardwareContainer8kb;
+
+struct ZeroSuppressedContainer8kb {
+  char data[8192];
+};
+
 } // namespace tpc
 } // namespace o2
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -44,6 +44,15 @@ struct TPCZSTBHDR {
   GPUd() const unsigned short* rowAddr1() const { return (unsigned short*)((unsigned char*)this + sizeof(*this)); }
 };
 
+struct ZeroSuppressedContainer { // Struct for the TPC zero suppressed data format
+                                 // RDH 64 byte
+                                 // 6 byte header for the zero suppressed format ; 8 bit version, 8 bit number of timebins, 16 bit CRU ID, 16 bit time offset
+                                 // Time bin information
+  uint64_t rdh[8] = {};          //< 8 * 64 bit RDH (raw data header)
+  TPCZSHDR hdr;                  // ZS header
+  TPCZSTBHDR tbhdr;              // ZS timebin header
+};
+
 } // namespace tpc
 } // namespace o2
 #endif

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -48,7 +48,7 @@ struct ZeroSuppressedContainer { // Struct for the TPC zero suppressed data form
                                  // RDH 64 byte
                                  // 6 byte header for the zero suppressed format ; 8 bit version, 8 bit number of timebins, 16 bit CRU ID, 16 bit time offset
                                  // Time bin information
-  uint64_t rdh[8] = {};          //< 8 * 64 bit RDH (raw data header)
+  unsigned long int rdh[8] = {}; //< 8 * 64 bit RDH (raw data header)
   TPCZSHDR hdr;                  // ZS header
   TPCZSTBHDR tbhdr;              // ZS timebin header
 };

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -21,12 +21,14 @@
 #pragma link C++ class o2::tpc::ClusterHardwareContainerFixedSize < 8192> + ;
 #pragma link C++ class o2::tpc::ClusterNativeContainer + ;
 #pragma link C++ class o2::tpc::Digit + ;
+#pragma link C++ class o2::tpc::ZeroSuppressedContainer8kb + ;
 #pragma link C++ class std::vector < o2::tpc::ClusterNative> + ;
 #pragma link C++ class std::vector < o2::tpc::ClusterNativeContainer> + ;
 #pragma link C++ class std::vector < o2::tpc::ClusterHardware> + ;
 #pragma link C++ class std::vector < o2::tpc::ClusterHardwareContainerFixedSize < 8192>> + ;
 #pragma link C++ class std::vector < o2::tpc::ClusterHardwareContainer8kb> + ;
 #pragma link C++ class std::vector < o2::tpc::Digit> + ;
+#pragma link C++ class std::vector < o2::tpc::ZeroSuppressedContainer8kb > +;
 #pragma link C++ class o2::tpc::TrackTPC + ;
 #pragma link C++ class o2::tpc::LaserTrack + ;
 #pragma link C++ class o2::tpc::LaserTrackContainer + ;

--- a/Detectors/TPC/base/CMakeLists.txt
+++ b/Detectors/TPC/base/CMakeLists.txt
@@ -32,6 +32,7 @@ o2_add_library(TPCBase
                        src/ROC.cxx
                        src/Sector.cxx
                        src/Utils.cxx
+                       src/ZeroSuppress.cxx
                PUBLIC_LINK_LIBRARIES Vc::Vc Boost::boost O2::DataFormatsTPC
                                      O2::DetectorsRaw O2::CCDB FairRoot::Base)
 
@@ -58,6 +59,7 @@ o2_target_root_dictionary(TPCBase
                                   include/TPCBase/PartitionInfo.h
                                   include/TPCBase/ROC.h
                                   include/TPCBase/Sector.h
+                                  include/TPCBase/ZeroSuppress.h
                                   include/TPCBase/Utils.h)
 
 o2_add_test(Base

--- a/Detectors/TPC/base/include/TPCBase/ZeroSuppress.h
+++ b/Detectors/TPC/base/include/TPCBase/ZeroSuppress.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ZeroSuppressed.h
+/// \brief Class for the TPC zero suppressed data format
+/// \author Johannes Lehrbach
+
+#ifndef ALICEO2_DATAFORMATSTPC_ZEROSUPPRESS_H
+#define ALICEO2_DATAFORMATSTPC_ZEROSUPPRESS_H
+
+#include <math.h>
+#include <vector>
+#include <array>
+
+#include <iostream>
+
+#include "DataFormatsTPC/Digit.h"
+#include "TPCBase/Mapper.h"
+#include "TPCBase/CRU.h"
+#include "DataFormatsTPC/Defs.h"
+#include "DataFormatsTPC/Helpers.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace tpc
+{
+class ZeroSuppress
+{
+
+ private:
+  std::vector<std::vector<ZeroSuppressedContainer8kb>> z0Pages = {}; //vector of 8kb pages as zero suppressed output
+  Mapper& mapper;
+
+ public:
+  /// constructor
+  ZeroSuppress() : mapper(Mapper::instance()){};
+  /// destructor
+  virtual ~ZeroSuppress() = default;
+  ZeroSuppress(const ZeroSuppress&) = delete;
+
+  void process();
+  void DecodeZSPages(gsl::span<const ZeroSuppressedContainer8kb>* z0in, std::vector<Digit>* outDigits, int firstHBF);
+};
+
+} // namespace tpc
+} // namespace o2
+
+#endif // ALICEO2_DATAFORMATSTPC_ZEROSUPPRESS_H

--- a/Detectors/TPC/base/include/TPCBase/ZeroSuppress.h
+++ b/Detectors/TPC/base/include/TPCBase/ZeroSuppress.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_DATAFORMATSTPC_ZEROSUPPRESS_H
 #define ALICEO2_DATAFORMATSTPC_ZEROSUPPRESS_H
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <array>
 

--- a/Detectors/TPC/base/src/ZeroSuppress.cxx
+++ b/Detectors/TPC/base/src/ZeroSuppress.cxx
@@ -1,0 +1,131 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ZeroSuppress.cxx
+/// \brief Class for the TPC zero suppressed data format
+
+#include <math.h>
+#include <iostream>
+#include <array>
+
+#include "TPCBase/ZeroSuppress.h"
+#include "CommonConstants/LHCConstants.h"
+#include "DetectorsRaw/RDHUtils.h"
+
+#include "DataFormatsTPC/Digit.h"
+#include "TPCBase/Mapper.h"
+#include "TPCBase/CRU.h"
+
+#include "DataFormatsTPC/Defs.h"
+#include "DataFormatsTPC/Helpers.h"
+
+using namespace o2::tpc;
+
+void ZeroSuppress::process()
+{
+  std::cout << "Zero Suppress process call" << std::endl;
+}
+
+void ZeroSuppress::DecodeZSPages(gsl::span<const ZeroSuppressedContainer8kb>* z0in, std::vector<Digit>* outDigits, int firstHBF)
+{
+  std::vector<Digit>& digits = *outDigits;
+  std::vector<unsigned int> _ADC = {};
+  _ADC.resize(TPCZSHDR::MAX_DIGITS_IN_PAGE);
+  gsl::span<const ZeroSuppressedContainer8kb>& z0input = *z0in;
+
+  for (auto inputPage : z0input) {
+    unsigned char* pageStart = reinterpret_cast<unsigned char*>(&inputPage);
+    unsigned char* startPtr = pageStart;
+    unsigned char* nextPage = pageStart + TPCZSHDR::TPC_ZS_PAGE_SIZE;
+
+    ZeroSuppressedContainer* z0Container = reinterpret_cast<ZeroSuppressedContainer*>(startPtr);
+    unsigned int _adcBits = (z0Container->hdr.version == 1) ? 10 : ((z0Container->hdr.version == 2) ? 12 : 0);
+    if (!_adcBits) {
+      if ((int)z0Container->hdr.nADCsamples) {
+        std::cout << "unsupported zero suppressed version" << std::endl;
+        break;
+      } else {
+        continue;
+      }
+    }
+    uint16_t _CRUID = z0Container->hdr.cruID;
+    uint16_t _timeOffset = z0Container->hdr.timeOffset;
+    unsigned int mask = static_cast<unsigned int>(pow(2, _adcBits)) - 1;
+    float decodeFactor = 1.0 / (1 << _adcBits - 10);
+
+    const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)&inputPage;
+    auto orbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdh);
+    int timeBin = (_timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
+
+    unsigned int ct = 0;
+    startPtr += (sizeof(z0Container->rdh) + sizeof(z0Container->hdr)); // move to first time bin
+    // iterate through all time bins indicated in the z0 header
+    for (int tb = 0; tb < z0Container->hdr.nTimeBins; tb++) {
+      startPtr += (startPtr - pageStart) % 2;
+      TPCZSTBHDR* tbHdr = reinterpret_cast<TPCZSTBHDR*>(startPtr);
+      unsigned int numberRows = __builtin_popcount((tbHdr->rowMask & 0x7FFF)); // number of ones, excluding upper/lower bit
+      if (startPtr > nextPage) {
+        throw std::runtime_error("pointer for time bin outside current zs page");
+      }
+      unsigned int rowUpperOffset = (tbHdr->rowMask & (1 << 15)) ? (mapper.getNumberOfRowsRegion(_CRUID % 10) / 2) : 0;
+      unsigned int _timeBin = timeBin + tb;
+
+      //if rows in timebin
+      if ((numberRows != 0)) {
+        startPtr += 2 * numberRows;
+        for (unsigned int pos = 0; pos < 15; pos++) { // TODO: end iterations at max number of rows for that endpoint
+          if (tbHdr->rowMask & (1 << pos)) {          //row bit set decode row
+            unsigned int _row = pos + rowUpperOffset;
+            uint8_t numberSequences = *startPtr;
+            uint8_t numberADCs = *(startPtr + (2 * numberSequences));
+
+            unsigned char* _adcstart = startPtr + 2 * numberSequences + 1;
+            unsigned int length = (numberADCs * _adcBits + 7) / 8;
+            unsigned int temp = 0;
+            unsigned int t = 0;
+            unsigned int shift = 0;
+            unsigned int a1 = 0;
+            unsigned int count = 0;
+            if (_adcstart + length > nextPage) {
+              throw std::runtime_error("pointer for current sequence outside current zs page");
+            }
+            for (unsigned int a = 0; a < length; a++) {
+              temp = (*_adcstart) << shift;
+              _adcstart++;
+              t |= temp;
+              shift += 8;
+              while (shift >= _adcBits) {
+                a1 = t & mask;
+                _ADC[count] = a1;
+                count++;
+                shift -= _adcBits;
+                t >>= _adcBits;
+              }
+            }
+            for (unsigned int nADC = 0; nADC < numberADCs; nADC++) {
+              for (unsigned int seq = 0; seq < numberSequences; seq++) {
+                unsigned int seqLength = seq ? startPtr[2 * (seq + 1)] - startPtr[2 * seq] : startPtr[2];
+                for (unsigned int s = 0; s < seqLength; s++) {
+                  digits.emplace_back(Digit((int)_CRUID, (float)(_ADC[nADC] * decodeFactor), (int)(_row + mapper.getGlobalRowOffsetRegion(_CRUID % 10)), (int)(*(startPtr + 2 * seq + 1) + s), _timeBin));
+                  nADC++;
+                }
+              }
+            }
+            startPtr += (numberSequences * 2) + length + 1;
+          }
+        }
+
+      } else { // pointer + empty tb hdr
+        startPtr += 2;
+        continue;
+      }
+    }
+  }
+}

--- a/Detectors/TPC/base/src/ZeroSuppress.cxx
+++ b/Detectors/TPC/base/src/ZeroSuppress.cxx
@@ -11,7 +11,7 @@
 /// \file ZeroSuppress.cxx
 /// \brief Class for the TPC zero suppressed data format
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <array>
 

--- a/Detectors/TPC/base/src/ZeroSuppress.cxx
+++ b/Detectors/TPC/base/src/ZeroSuppress.cxx
@@ -58,7 +58,7 @@ void ZeroSuppress::DecodeZSPages(gsl::span<const ZeroSuppressedContainer8kb>* z0
     uint16_t _CRUID = z0Container->hdr.cruID;
     uint16_t _timeOffset = z0Container->hdr.timeOffset;
     unsigned int mask = static_cast<unsigned int>(pow(2, _adcBits)) - 1;
-    float decodeFactor = 1.0 / (1 << _adcBits - 10);
+    float decodeFactor = 1.0 / (1 << (_adcBits - 10));
 
     const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)&inputPage;
     auto orbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdh);

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -7,6 +7,7 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
+                     
 
 # FIXME: do we really need a library here ? Is the exe not enough ?
 o2_add_library(TPCWorkflow
@@ -20,6 +21,7 @@ o2_add_library(TPCWorkflow
                        src/RawToDigitsSpec.cxx
                        src/LinkZSToDigitsSpec.cxx
                        src/TPCSectorCompletionPolicy.cxx
+                       src/ZSSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -33,6 +33,7 @@ namespace ca
 enum struct Operation {
   CAClusterer,            // run the CA clusterer
   ZSDecoder,              // run the ZS raw data decoder
+  ZSOnTheFly,             // use zs on the fly
   OutputTracks,           // publish tracks
   OutputCAClusters,       // publish the clusters produced by CA clusterer
   OutputCompClusters,     // publish CompClusters container
@@ -61,6 +62,9 @@ struct Config {
       case Operation::ZSDecoder:
         zsDecoder = true;
         break;
+      case Operation::ZSOnTheFly:
+        zsOnTheFly = true;
+        break;
       case Operation::OutputTracks:
         outputTracks = true;
         break;
@@ -88,6 +92,7 @@ struct Config {
 
   bool caClusterer = false;
   bool zsDecoder = false;
+  bool zsOnTheFly = false;
   bool outputTracks = false;
   bool outputCompClusters = false;
   bool outputCompClustersFlat = false;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -44,6 +44,7 @@ enum struct InputType { Digitizer,        // directly read digits from channel {
 /// - Tracks           tracks
 /// - CompClusters     compressed clusters, CompClusters container
 /// - EncodedClusters  the encoded CompClusters container
+/// - ZSRaw            TPC zero-suppressed raw data
 enum struct OutputType { Digits,
                          ClustersHardware,
                          Clusters,
@@ -51,6 +52,7 @@ enum struct OutputType { Digits,
                          CompClusters,
                          EncodedClusters,
                          DisableWriter,
+                         ZSRaw,
 };
 
 /// create the workflow for TPC reconstruction
@@ -59,32 +61,38 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,         
                                     bool propagateMC = true, unsigned nLanes = 1, //
                                     std::string const& cfgInput = "digitizer",    //
                                     std::string const& cfgOutput = "tracks",      //
-                                    int caClusterer = 0                           //
-);
+                                    int caClusterer = 0,                          //
+                                    int zsOnTheFly = 0,
+                                    int zs10bit = 0,
+                                    float zsThreshold = 2.0f);
 
 static inline framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,           //
                                                   bool propagateMC = true, unsigned nLanes = 1, //
                                                   std::string const& cfgInput = "digitizer",    //
                                                   std::string const& cfgOutput = "tracks",      //
-                                                  int caClusterer = 0                           //
-)
+                                                  int caClusterer = 0,                          //
+                                                  int zsOnTheFly = 0,
+                                                  int zs10bit = 0,
+                                                  float zsThreshold = 2.0f)
 {
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer);
+  return getWorkflow(tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
 }
 
 static inline framework::WorkflowSpec getWorkflow(bool propagateMC = true, unsigned nLanes = 1, //
                                                   std::string const& cfgInput = "digitizer",    //
                                                   std::string const& cfgOutput = "tracks",      //
-                                                  int caClusterer = 0                           //
-)
+                                                  int caClusterer = 0,                          //
+                                                  int zsOnTheFly = 0,
+                                                  int zs10bit = 0,
+                                                  float zsThreshold = 2.0f)
 {
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow({}, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer);
+  return getWorkflow({}, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
 }
 
 } // end namespace reco_workflow

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
@@ -1,0 +1,24 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs12bit, float threshold, bool outRaw);
+
+framework::DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds);
+
+} // end namespace tpc
+} // end namespace o2

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -54,6 +54,8 @@
 #include <vector>
 #include <iomanip>
 #include <stdexcept>
+#include <regex>
+#include "GPUReconstructionConvert.h"
 
 using namespace o2::framework;
 using namespace o2::header;
@@ -70,10 +72,13 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
   auto& processMC = specconfig.processMC;
   auto& caClusterer = specconfig.caClusterer;
   auto& zsDecoder = specconfig.zsDecoder;
+  auto& zsOnTheFly = specconfig.zsOnTheFly;
   if (specconfig.outputCAClusters && !specconfig.caClusterer) {
     throw std::runtime_error("inconsistent configuration: cluster output is only possible if CA clusterer is activated");
   }
+
   constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
+  constexpr static size_t NEndpoints = 20; //TODO: get from mapper?
   using ClusterGroupParser = o2::algorithm::ForwardParser<o2::tpc::ClusterGroupHeader>;
   struct ProcessAttributes {
     std::bitset<NSectors> validInputs = 0;
@@ -89,9 +94,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
   };
 
   auto processAttributes = std::make_shared<ProcessAttributes>();
-  auto initFunction = [processAttributes, processMC, caClusterer, zsDecoder](InitContext& ic) {
+  auto initFunction = [processAttributes, processMC, caClusterer, zsDecoder, zsOnTheFly](InitContext& ic) {
     auto options = ic.options().get<std::string>("tracker-options");
-
     {
       auto& parser = processAttributes->parser;
       auto& tracker = processAttributes->tracker;
@@ -295,7 +299,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       }
     });
 
-    auto processingFct = [processAttributes, processMC, caClusterer, zsDecoder](ProcessingContext& pc) {
+    auto processingFct = [processAttributes, processMC, caClusterer, zsDecoder, zsOnTheFly](ProcessingContext& pc) {
       if (processAttributes->readyToQuit) {
         return;
       }
@@ -303,7 +307,6 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       auto& tracker = processAttributes->tracker;
       uint64_t activeSectors = 0;
       auto& verbosity = processAttributes->verbosity;
-
       // FIXME cleanup almost duplicated code
       auto& validMcInputs = processAttributes->validMcInputs;
       using CachedMCLabelContainer = decltype(std::declval<InputRecord>().get<std::vector<MCLabelContainer>>(DataRef{nullptr, nullptr, nullptr}));
@@ -316,6 +319,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       const unsigned int* tpcZSmetaSizes2[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
       std::array<gsl::span<const o2::tpc::Digit>, NSectors> inputDigits;
       std::array<std::unique_ptr<const MCLabelContainer>, NSectors> inputDigitsMC;
+      std::array<unsigned int, NEndpoints * NSectors> sizes;
+      gsl::span<const ZeroSuppressedContainer8kb> inputZS;
+
+      // unsigned int totalZSPages = 0;
       if (processMC) {
         std::vector<InputSpec> filter = {
           {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITSMCTR"}, Lifetime::Timeframe},
@@ -363,6 +370,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
         {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe},
         {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERNATIVE"}, Lifetime::Timeframe},
       };
+
       for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
         auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
         if (sectorHeader == nullptr) {
@@ -382,12 +390,45 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
         activeSectors |= sectorHeader->activeSectors;
         validInputs.set(sector);
         datarefs[sector] = ref;
-        if (caClusterer) {
+        if (caClusterer && !zsOnTheFly) {
           inputDigits[sector] = pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref);
           LOG(INFO) << "GOT SPAN FOR SECTOR " << sector << " -> " << inputDigits[sector].size();
         }
       }
+      if (zsOnTheFly) {
+        sizes = {0};
+        // sizes: #zs pages per endpoint:
+        std::vector<InputSpec> filter = {{"check", ConcreteDataTypeMatcher{gDataOriginTPC, "ZSSIZES"}, Lifetime::Timeframe}};
+        for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+          sizes = pc.inputs().get<std::array<unsigned int, NEndpoints * NSectors>>(ref);
+        }
+        // zs pages
+        std::vector<InputSpec> filter2 = {{"check", ConcreteDataTypeMatcher{gDataOriginTPC, "TPCZS"}, Lifetime::Timeframe}};
+        for (auto const& ref : InputRecordWalker(pc.inputs(), filter2)) {
+          inputZS = pc.inputs().get<gsl::span<ZeroSuppressedContainer8kb>>(ref);
+        }
+        //set all sectors as active and as valid inputs
+        for (int s = 0; s < NSectors; s++) {
+          activeSectors |= 1 << s;
+          validInputs.set(s);
+        }
+        for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
+          for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
+            tpcZSmetaPointers[i][j].clear();
+            tpcZSmetaSizes[i][j].clear();
+          }
+        }
 
+        unsigned int offset = 0;
+        for (unsigned int i = 0; i < NSectors; i++) {
+          unsigned int pageSector = 0;
+          for (unsigned int j = 0; j < NEndpoints; j++) {
+            pageSector += sizes[i * NEndpoints + j];
+            offset += sizes[i * NEndpoints + j];
+          }
+          LOG(INFO) << "GOT ZS pages FOR SECTOR " << i << " ->  pages: " << pageSector;
+        }
+      }
       if (zsDecoder) {
         for (unsigned int i = 0; i < GPUTrackingInOutZS::NSLICES; i++) {
           for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
@@ -416,9 +457,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
                 tpcZSmetaSizes[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].emplace_back(count);
               }
               count = 0;
-              lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
-              rawcru = rdh_utils::getCRU(lastFEE);
-              rawendpoint = rdh_utils::getEndPoint(lastFEE);
+              //lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
+              lastFEE = int(rdh->feeId);
+              rawcru = int(rdh->cruID);
+              rawendpoint = int(rdh->endPointID);
               if (it.size() == 0 && tpcZSmetaPointers[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].size()) {
                 ptr = nullptr;
                 continue;
@@ -459,8 +501,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
           unsigned long subspec = dh->subSpecification;
           printf("Test: rdh %p, raw %p, payload %p, payloadSize %lld, offset %lld, %s %s %lld\n", rdh, raw, payload, (long long int)payloadSize, (long long int)offset, dh->dataOrigin.as<std::string>().c_str(), dh->dataDescription.as<std::string>().c_str(), (long long int)dh->subSpecification);
         }*/
-
-      } else {
+      } else if (!zsOnTheFly) {
         // FIXME: We can have digits input in zs decoder mode for MC labels
         // This code path should run optionally also for the zs decoder version
         auto printInputLog = [&verbosity, &validInputs, &activeSectors](auto& r, const char* comment, auto& s) {
@@ -539,11 +580,21 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       ClusterNativeAccess clusterIndex;
       std::unique_ptr<ClusterNative[]> clusterBuffer;
       MCLabelContainer clustersMCBuffer;
+      void* ptrEp[NSectors * NEndpoints] = {};
       ptrs.outputTracks = &tracks;
       ptrs.outputClusRefs = &clusRefs;
       ptrs.outputTracksMCTruth = (processMC ? &tracksMCTruth : nullptr);
       if (caClusterer) {
-        if (zsDecoder) {
+        if (zsOnTheFly) {
+          std::cout << "inputZS size: " << inputZS.size() << std::endl;
+          const unsigned long long int* buffer = reinterpret_cast<const unsigned long long int*>(&inputZS[0]);
+          o2::gpu::GPUReconstructionConvert::RunZSEncoderCreateMeta(buffer, sizes.data(), *&ptrEp, &tpcZS);
+          ptrs.tpcZS = &tpcZS;
+          if (processMC) {
+            throw std::runtime_error("Currently unable to process MC information, tpc-tracker crashing when MC propagated");
+            ptrs.o2DigitsMC = &inputDigitsMC;
+          }
+        } else if (zsDecoder) {
           ptrs.tpcZS = &tpcZS;
           if (processMC) {
             throw std::runtime_error("Cannot process MC information, none available"); // In fact, passing in MC data with ZS TPC Raw is not yet available
@@ -554,6 +605,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
             ptrs.o2DigitsMC = &inputDigitsMC;
           }
         }
+
       } else {
         memset(&clusterIndex, 0, sizeof(clusterIndex));
         ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersMCBuffer, inputs, mcInputs, [&validInputs](auto& index) { return validInputs.test(index); });
@@ -648,14 +700,14 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
     Inputs inputs;
     if (specconfig.caClusterer) {
       // We accept digits and MC labels also if we run on ZS Raw data, since they are needed for MC label propagation
-      if (!specconfig.zsDecoder) { // FIXME: We can have digits input in zs decoder mode for MC labels, to be made optional
+      if (!specconfig.zsOnTheFly && !specconfig.zsDecoder) { // FIXME: We can have digits input in zs decoder mode for MC labels, to be made optional
         inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe});
       }
     } else {
       inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERNATIVE"}, Lifetime::Timeframe});
     }
     if (specconfig.processMC) {
-      if (specconfig.caClusterer) {
+      if (!specconfig.zsOnTheFly && specconfig.caClusterer) {
         constexpr o2::header::DataDescription datadesc("DIGITSMCTR");
         if (!specconfig.zsDecoder) { // FIXME: We can have digits input in zs decoder mode for MC labels, to be made optional
           inputs.emplace_back(InputSpec{"mclblin", ConcreteDataTypeMatcher{gDataOriginTPC, datadesc}, Lifetime::Timeframe});
@@ -669,6 +721,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       // All ZS raw data is published with subspec 0 by the o2-raw-file-reader-workflow and DataDistribution
       // creates subspec fom CRU and endpoint id, we create one single input route subscribing to all TPC/RAWDATA
       inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Timeframe});
+    }
+    if (specconfig.zsOnTheFly) {
+      inputs.emplace_back(InputSpec{"zsinput", ConcreteDataTypeMatcher{"TPC", "TPCZS"}, Lifetime::Timeframe});
+      inputs.emplace_back(InputSpec{"zsinputsizes", ConcreteDataTypeMatcher{"TPC", "ZSSIZES"}, Lifetime::Timeframe});
     }
     return inputs;
   };

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -1,0 +1,343 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCWorkflow/ZSSpec.h"
+#include "Headers/DataHeader.h"
+#include "Framework/WorkflowSpec.h" // o2::framework::mergeInputs
+#include "Framework/DataRefUtils.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/InputRecordWalker.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
+#include "DataFormatsTPC/Helpers.h"
+#include "TPCReconstruction/GPUCATracking.h"
+#include "DataFormatsTPC/Digit.h"
+#include "GPUDataTypes.h"
+#include "GPUHostDataTypes.h"
+#include "GPUO2InterfaceConfiguration.h"
+#include "TPCBase/Sector.h"
+#include "Algorithm/Parser.h"
+#include <FairMQLogger.h>
+#include <memory> // for make_shared
+#include <vector>
+#include <iomanip>
+#include <stdexcept>
+#include <array>
+#include <unistd.h>
+#include "GPUParam.h"
+#include "GPUReconstructionConvert.h"
+#include "DetectorsRaw/RawFileWriter.h"
+#include "DetectorsRaw/HBFUtils.h"
+#include "DetectorsRaw/RDHUtils.h"
+#include "TPCBase/RDHUtils.h"
+#include "TPCBase/ZeroSuppress.h"
+#include "DPLUtils/DPLRawParser.h"
+
+using namespace o2::framework;
+using namespace o2::header;
+using namespace o2::gpu;
+using namespace o2::base;
+
+namespace o2
+{
+namespace tpc
+{
+
+DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bit, float threshold = 2.f, bool outRaw = false)
+{
+  std::string processorName = "tpc-zsEncoder";
+  constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
+  constexpr static size_t NEndpoints = o2::gpu::GPUTrackingInOutZS::NENDPOINTS;
+  using DigitArray = std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::Sector::MAXSECTOR>;
+
+  struct ProcessAttributes {
+    std::unique_ptr<unsigned long long int[]> zsoutput;
+    std::vector<unsigned int> sizes;
+    std::unique_ptr<o2::gpu::GPUReconstructionConvert> zsEncoder;
+    std::vector<int> inputIds;
+    bool verify = false;
+    int verbosity = 1;
+    bool finished = false;
+  };
+
+  auto initFunction = [inputIds, zs10bit, threshold, outRaw](InitContext& ic) {
+    auto processAttributes = std::make_shared<ProcessAttributes>();
+    auto& zsEncoder = processAttributes->zsEncoder;
+    auto& zsoutput = processAttributes->zsoutput;
+    processAttributes->inputIds = inputIds;
+    auto& verify = processAttributes->verify;
+    auto& sizes = processAttributes->sizes;
+    auto& verbosity = processAttributes->verbosity;
+
+    auto processingFct = [processAttributes, zs10bit, threshold, outRaw](
+                           ProcessingContext& pc) {
+      if (processAttributes->finished) {
+        return;
+      }
+
+      auto& zsEncoder = processAttributes->zsEncoder;
+      auto& zsoutput = processAttributes->zsoutput;
+      auto& verify = processAttributes->verify;
+      auto& sizes = processAttributes->sizes;
+      auto& verbosity = processAttributes->verbosity;
+
+      std::array<gsl::span<const o2::tpc::Digit>, NSectors> inputDigits;
+      GPUTrackingInOutDigits inDigitsGPU;
+
+      GPUParam _GPUParam;
+      _GPUParam.SetDefaults(5.00668);
+      const GPUParam mGPUParam = _GPUParam;
+
+      int operation = 0;
+      std::vector<InputSpec> filter = {{"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe}};
+      for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+        auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+        if (sectorHeader == nullptr) {
+          // FIXME: think about error policy
+          LOG(ERROR) << "sector header missing on header stack";
+          return;
+        }
+        const int& sector = sectorHeader->sector;
+        // check the current operation, this is used to either signal eod or noop
+        // FIXME: the noop is not needed any more once the lane configuration with one
+        // channel per sector is used
+        if (sector < 0) {
+          if (operation < 0 && operation != sector) {
+            // we expect the same operation on all inputs
+            LOG(ERROR) << "inconsistent lane operation, got "
+                       << sector << ", expecting " << operation;
+          } else if (operation == 0) {
+            // store the operation
+            operation = sector;
+          }
+          continue;
+        }
+
+        inputDigits[sector] = pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref);
+        LOG(INFO) << "GOT SPAN FOR SECTOR " << sector << " -> "
+                  << inputDigits[sector].size();
+      }
+      if (operation == -1) {
+        pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+        processAttributes->finished = true;
+        return;
+      }
+      for (int i = 0; i < NSectors; i++) {
+        inDigitsGPU.tpcDigits[i] = inputDigits[i].data();
+        inDigitsGPU.nTPCDigits[i] = inputDigits[i].size();
+      }
+      sizes.resize(NSectors * NEndpoints);
+      bool zs12bit = !zs10bit;
+      o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
+      zsEncoder->RunZSEncoder<o2::tpc::Digit, DigitArray>(inputDigits, &zsoutput, sizes.data(), nullptr, &ir, mGPUParam, zs12bit, verify, threshold);
+      ZeroSuppressedContainer8kb* page = reinterpret_cast<ZeroSuppressedContainer8kb*>(zsoutput.get());
+      unsigned int offset = 0;
+      for (unsigned int i = 0; i < NSectors; i++) {
+        unsigned int pageSector = 0;
+        for (unsigned int j = 0; j < NEndpoints; j++) {
+          if (sizes[i * NEndpoints + j] != 0) {
+            pageSector += sizes[i * NEndpoints + j];
+          }
+        }
+        offset += pageSector;
+      }
+      o2::tpc::TPCSectorHeader sh{0};
+      gsl::span<ZeroSuppressedContainer8kb> outp(&page[0], offset);
+      pc.outputs().snapshot(Output{gDataOriginTPC, "TPCZS", 0, Lifetime::Timeframe, sh}, outp);
+      pc.outputs().snapshot(Output{gDataOriginTPC, "ZSSIZES", 0, Lifetime::Timeframe, sh}, sizes);
+
+      if (outRaw) {
+        // ===| set up raw writer |===================================================
+        o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
+        uint32_t rdhV = 4;
+        writer.useRDHVersion(rdhV);
+        std::string outDir = "./";
+        const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
+
+        for (unsigned int i = 0; i < NSectors; i++) {
+          for (unsigned int j = 0; j < NEndpoints; j++) {
+            const unsigned int cruInSector = j / 2;
+            const unsigned int cruID = i * 10 + cruInSector;
+            const rdh_utils::FEEIDType feeid = rdh_utils::getFEEID(cruID, j & 1, defaultLink);
+            writer.registerLink(feeid, cruID, defaultLink, j & 1, fmt::format("{}cru{}_{}.raw", outDir, cruID, j & 1));
+          }
+        }
+        zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, threshold);
+        writer.writeConfFile("TPC", "RAWDATA", fmt::format("{}tpcraw.cfg", outDir));
+      }
+      zsoutput.reset(nullptr);
+      sizes = {};
+      inputDigits = {};
+    };
+    return processingFct;
+  };
+
+  auto createInputSpecs = [inputIds]() {
+    Inputs inputs;
+    //    inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe});
+    inputs.emplace_back(InputSpec{"input", gDataOriginTPC, "DIGITS", 0, Lifetime::Timeframe});
+    return std::move(mergeInputs(inputs, inputIds.size(),
+                                 [inputIds](InputSpec& input, size_t index) {
+                                   // using unique input names for the moment but want to find
+                                   // an input-multiplicity-agnostic way of processing
+                                   input.binding += std::to_string(inputIds[index]);
+                                   DataSpecUtils::updateMatchingSubspec(input, inputIds[index]);
+                                 }));
+    return inputs;
+  };
+
+  auto createOutputSpecs = []() {
+    std::vector<OutputSpec> outputSpecs = {};
+    OutputLabel label{"TPCZS"};
+    constexpr o2::header::DataDescription datadesc("TPCZS");
+    OutputLabel label2{"sizes"};
+    constexpr o2::header::DataDescription datadesc2("ZSSIZES");
+    outputSpecs.emplace_back(label, gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
+    outputSpecs.emplace_back(label2, gDataOriginTPC, datadesc2, 0, Lifetime::Timeframe);
+    return std::move(outputSpecs);
+  };
+
+  return DataProcessorSpec{"tpc-zsEncoder",
+                           {createInputSpecs()},
+                           {createOutputSpecs()},
+                           AlgorithmSpec(initFunction)};
+} //spec end
+
+DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
+{
+  std::string processorName = "tpc-zs-to-Digits";
+  constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
+  constexpr static size_t NEndpoints = o2::gpu::GPUTrackingInOutZS::NENDPOINTS;
+
+  struct ProcessAttributes {
+    std::array<std::vector<Digit>, NSectors> outDigits;
+    std::unique_ptr<unsigned long long int[]> zsinput;
+    std::vector<unsigned int> sizes;
+    std::unique_ptr<o2::tpc::ZeroSuppress> decoder;
+    std::vector<int> inputIds;
+    bool verify = false;
+    int verbosity = 1;
+    bool finished = false;
+
+    /// Digit sorting according to expected output from simulation
+    void sortDigits()
+    {
+      // sort digits
+      for (auto& digits : outDigits) {
+        std::sort(digits.begin(), digits.end(), [](const auto& a, const auto& b) {
+          if (a.getTimeStamp() < b.getTimeStamp())
+            return true;
+          if ((a.getTimeStamp() == b.getTimeStamp()) && (a.getRow() < b.getRow()))
+            return true;
+          return false;
+        });
+      }
+    }
+  };
+
+  auto initFunction = [inputIds](InitContext& ic) {
+    auto processAttributes = std::make_shared<ProcessAttributes>();
+    processAttributes->inputIds = inputIds;
+    auto& outDigits = processAttributes->outDigits;
+    auto& decoder = processAttributes->decoder;
+    decoder = std::make_unique<o2::tpc::ZeroSuppress>();
+    auto& verbosity = processAttributes->verbosity;
+
+    auto processingFct = [processAttributes](
+                           ProcessingContext& pc) {
+      if (processAttributes->finished) {
+        return;
+      }
+      std::array<unsigned int, NEndpoints * NSectors> sizes;
+      gsl::span<const ZeroSuppressedContainer8kb> inputZS;
+      std::array<gsl::span<const ZeroSuppressedContainer8kb>, NSectors> inputZSSector;
+      auto& outDigits = processAttributes->outDigits;
+      auto& decoder = processAttributes->decoder;
+      auto& verbosity = processAttributes->verbosity;
+      unsigned int firstOrbit = 0;
+
+      for (unsigned int i = 0; i < NSectors; i++) {
+        outDigits[i].clear();
+      }
+      o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
+      firstOrbit = ir.orbit;
+      std::vector<InputSpec> filter = {{"check", ConcreteDataTypeMatcher{gDataOriginTPC, "RAWDATA"}, Lifetime::Timeframe}};
+      for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+        const o2::header::DataHeader* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+        const gsl::span<const char> raw = pc.inputs().get<gsl::span<char>>(ref);
+        o2::framework::RawParser parser(raw.data(), raw.size());
+
+        const unsigned char* ptr = nullptr;
+        int count = 0;
+        int cruID = 0;
+        rdh_utils::FEEIDType lastFEE = -1;
+        size_t totalSize = 0;
+        for (auto it = parser.begin(); it != parser.end(); it++) {
+          const unsigned char* current = it.raw();
+          const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)current;
+          if (current == nullptr || it.size() == 0 || (current - ptr) % TPCZSHDR::TPC_ZS_PAGE_SIZE || o2::raw::RDHUtils::getFEEID(*rdh) != lastFEE) {
+            if (count) {
+              unsigned int sector = cruID / 10;
+              gsl::span<const ZeroSuppressedContainer8kb> z0in(reinterpret_cast<const ZeroSuppressedContainer8kb*>(ptr), count);
+              decoder->DecodeZSPages(&z0in, &outDigits[sector], firstOrbit);
+            }
+            count = 0;
+            lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
+            cruID = int(rdh->cruID);
+            if (it.size() == 0) {
+              ptr = nullptr;
+              continue;
+            }
+            ptr = current;
+          }
+          count++;
+        }
+        if (count) {
+          unsigned int sector = cruID / 10;
+          gsl::span<const ZeroSuppressedContainer8kb> z0in(reinterpret_cast<const ZeroSuppressedContainer8kb*>(ptr), count);
+          decoder->DecodeZSPages(&z0in, &outDigits[sector], firstOrbit);
+        }
+      }
+      for (int i = 0; i < NSectors; i++) {
+        LOG(INFO) << "digits in sector " << i << " : " << outDigits[i].size();
+        o2::tpc::TPCSectorHeader sh{i};
+        pc.outputs().snapshot(Output{gDataOriginTPC, "DIGITS", i, Lifetime::Timeframe, sh}, outDigits[i]);
+      }
+    };
+    return processingFct;
+  };
+
+  auto createInputSpecs = []() {
+    Inputs inputs;
+    inputs.emplace_back(InputSpec{"zsraw", ConcreteDataTypeMatcher{"TPC", "RAWDATA"}, Lifetime::Timeframe});
+
+    return std::move(inputs);
+  };
+
+  auto createOutputSpecs = []() {
+    std::vector<OutputSpec> outputSpecs = {};
+    OutputLabel label{"tpcdigits"};
+    constexpr o2::header::DataDescription datadesc("DIGITS");
+    for (int i = 0; i < NSectors; i++) {
+      outputSpecs.emplace_back(gDataOriginTPC, "DIGITS", i, Lifetime::Timeframe);
+    }
+    return std::move(outputSpecs);
+  };
+
+  return DataProcessorSpec{"decode-zs-to-digits",
+                           {createInputSpecs()},
+                           {createOutputSpecs()},
+                           AlgorithmSpec(initFunction)};
+} // spec end
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -310,7 +310,7 @@ DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
       for (int i = 0; i < NSectors; i++) {
         LOG(INFO) << "digits in sector " << i << " : " << outDigits[i].size();
         o2::tpc::TPCSectorHeader sh{i};
-        pc.outputs().snapshot(Output{gDataOriginTPC, "DIGITS", i, Lifetime::Timeframe, sh}, outDigits[i]);
+        pc.outputs().snapshot(Output{gDataOriginTPC, "DIGITS", (unsigned int)i, Lifetime::Timeframe, sh}, outDigits[i]);
       }
     };
     return processingFct;

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -43,12 +43,15 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   std::vector<ConfigParamSpec> options{
     {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters"}},
-    {"output-type", VariantType::String, "tracks", {"digits, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer"}},
+    {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer"}},
     {"ca-clusterer", VariantType::Bool, false, {"Use clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     {"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},
     {"tpc-lanes", VariantType::Int, 1, {"number of parallel lanes up to the tracker"}},
     {"dispatching-mode", VariantType::String, "prompt", {"determines when to dispatch: prompt, complete"}},
+    {"tpc-zs", VariantType::Bool, false, {"use TPC zero suppression, true/false"}},
+    {"zs-threshold", VariantType::Float, 2.0f, {"zero suppression threshold"}},
+    {"zs-10bit", VariantType::Bool, false, {"use 10 bit ADCs for TPC zero suppression, true/false, default/false = 12 bit ADC"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCHwClusterer.peakChargeThreshold=4;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}}};
 
@@ -148,6 +151,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                              nLanes,                                         //
                                              inputType,                                      //
                                              cfgc.options().get<std::string>("output-type"), //
-                                             cfgc.options().get<bool>("ca-clusterer")        //
+                                             cfgc.options().get<bool>("ca-clusterer"),       //
+                                             cfgc.options().get<bool>("tpc-zs"),             //
+                                             cfgc.options().get<bool>("zs-10bit"),           //
+                                             cfgc.options().get<float>("zs-threshold")       //
   );
 }

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -222,7 +222,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
 {
   // Pass in either outBuffer / outSizes, to fill standalone output buffers, or raw / ir to use RawFileWriter
   // ir is the interaction record for time bin 0
-  if (((outBuffer == nullptr) ^ (outSizes == nullptr)) || ((raw == nullptr) ^ (ir == nullptr)) || !((outBuffer == nullptr) ^ (raw == nullptr)) || (raw && verify) || (threshold > 0.f && verify)) {
+  if (((outBuffer == nullptr) ^ (outSizes == nullptr)) || ((raw != nullptr) ^ (ir == nullptr)) || !((outBuffer == nullptr) ^ (raw == nullptr)) || (raw && verify) || (threshold > 0.f && verify)) {
     throw std::runtime_error("Invalid parameters");
   }
 #ifdef GPUCA_TPC_GEOMETRY_O2

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -222,7 +222,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
 {
   // Pass in either outBuffer / outSizes, to fill standalone output buffers, or raw / ir to use RawFileWriter
   // ir is the interaction record for time bin 0
-  if (((outBuffer == nullptr) ^ (outSizes == nullptr)) || ((raw != nullptr) ^ (ir == nullptr)) || !((outBuffer == nullptr) ^ (raw == nullptr)) || (raw && verify) || (threshold > 0.f && verify)) {
+  if (((outBuffer == nullptr) ^ (outSizes == nullptr)) || ((raw != nullptr) && (ir == nullptr)) || !((outBuffer == nullptr) ^ (raw == nullptr)) || (raw && verify) || (threshold > 0.f && verify)) {
     throw std::runtime_error("Invalid parameters");
   }
 #ifdef GPUCA_TPC_GEOMETRY_O2


### PR DESCRIPTION
new options for the o2-tpc-reco-workflow for the usage with the ca-clusterer, to use zero suppression with digits from simulation:
-tpc-zs  : convert input tpc digits to zero suppressed raw pages and feed them into the ca-tracker
-zs-threshold : set zero suppression threshold, default 2.0
--zs-10bit  : use 10 bit ADC values for the zero suppression, default (false) use 12 bit ADC 

sample usage:
o2-tpc-reco-workflow --infile tpcdigits.root --ca-clusterer --tpc-zs --disable-mc 

option --disable-mc is still mandatory, tpc-tracker segfaults when forwarding MC from digits is enabled 