### PR TITLE
Fixes in EMCal workflow

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/ClusterizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/ClusterizerSpec.h
@@ -16,6 +16,7 @@
 #include "EMCALReconstruction/Clusterizer.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
+#include "TStopwatch.h"
 
 namespace o2
 {
@@ -60,6 +61,7 @@ class ClusterizerSpec : public framework::Task
   /// Output clusters: {"clusters", "CLUSTERS", 0, Lifetime::Timeframe}
   /// Output indices: {"clusterDigitIndices", "CLUSTERDIGITINDICES", 0, Lifetime::Timeframe}
   void run(framework::ProcessingContext& ctx) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
 
  private:
   o2::emcal::Clusterizer<InputType> mClusterizer;                               ///< Clusterizer object
@@ -68,6 +70,7 @@ class ClusterizerSpec : public framework::Task
   std::vector<o2::emcal::ClusterIndex>* mOutputCellDigitIndices = nullptr;      ///< Container with indices of cluster digits (pointer)
   std::vector<o2::emcal::TriggerRecord>* mOutputTriggerRecord = nullptr;        ///< Container with Trigger records for clusters
   std::vector<o2::emcal::TriggerRecord>* mOutputTriggerRecordIndices = nullptr; ///< Container with Trigger records for indices
+  TStopwatch mTimer;
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Clusterizer Spec

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -27,14 +27,6 @@ void CellConverterSpec::init(framework::InitContext& ctx)
 void CellConverterSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(DEBUG) << "[EMCALCellConverter - run] called";
-  auto dataref = ctx.inputs().get("digits");
-  auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
-  if (!emcheader->mHasPayload) {
-    LOG(DEBUG) << "[EMCALCellConverter - run] No more digits" << std::endl;
-    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
-    // ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
-    return;
-  }
   mOutputCells.clear();
   mOutputTriggers.clear();
   auto digitsAll = ctx.inputs().get<gsl::span<o2::emcal::Digit>>("digits");

--- a/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
@@ -44,13 +44,15 @@ void ClusterizerSpec<InputType>::init(framework::InitContext& ctx)
   mOutputCellDigitIndices = new std::vector<o2::emcal::ClusterIndex>();
   mOutputTriggerRecord = new std::vector<o2::emcal::TriggerRecord>();
   mOutputTriggerRecordIndices = new std::vector<o2::emcal::TriggerRecord>();
+  mTimer.Stop();
+  mTimer.Reset();
 }
 
 template <class InputType>
 void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
 {
   LOG(DEBUG) << "[EMCALClusterizer - run] called";
-
+  mTimer.Start(false);
   std::string inputname;
   std::string TrigName;
 
@@ -62,15 +64,6 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
     TrigName = "cellstrgr";
   }
 
-  auto dataref = ctx.inputs().get(inputname.c_str());
-  auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
-
-  if (!emcheader->mHasPayload) {
-    LOG(DEBUG) << "[EMCALClusterizer - run] No more cells/digits" << std::endl;
-    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
-    //ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
-    return;
-  }
   auto Inputs = ctx.inputs().get<gsl::span<InputType>>(inputname.c_str());
   LOG(DEBUG) << "[EMCALClusterizer - run]  Received " << Inputs.size() << " Cells/digits, running clusterizer ...";
 
@@ -84,7 +77,6 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
 
   int currentStartClusters = mOutputClusters->size();
   int currentStartIndices = mOutputCellDigitIndices->size();
-
   for (auto iTrgRcrd : InputTriggerRecord) {
 
     mClusterizer.findClusters(gsl::span<const InputType>(&Inputs[iTrgRcrd.getFirstEntry()], iTrgRcrd.getNumberOfObjects())); // Find clusters on cells/digits (pass by ref)
@@ -105,13 +97,19 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
     currentStartClusters = mOutputClusters->size();
     currentStartIndices = mOutputCellDigitIndices->size();
   }
-
   LOG(DEBUG) << "[EMCALClusterizer - run] Writing " << mOutputClusters->size() << " clusters ...";
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, *mOutputClusters);
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICES", 0, o2::framework::Lifetime::Timeframe}, *mOutputCellDigitIndices);
 
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CLUSTERSTRGR", 0, o2::framework::Lifetime::Timeframe}, *mOutputTriggerRecord);
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "INDICESTRGR", 0, o2::framework::Lifetime::Timeframe}, *mOutputTriggerRecordIndices);
+  mTimer.Stop();
+}
+
+template <class InputType>
+void ClusterizerSpec<InputType>::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  LOG(INFO) << "EMCALClusterizer timing: CPU: " << mTimer.CpuTime() << " Real: " << mTimer.RealTime() << " in " << mTimer.Counter() - 1 << " TFs";
 }
 
 o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getClusterizerSpec(bool useDigits)

--- a/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
@@ -44,14 +44,6 @@ void DigitsPrinterSpec<InputType>::run(framework::ProcessingContext& pc)
     LOG(ERROR) << "Unsupported input type ... ";
     return;
   }
-  auto dataref = pc.inputs().get(objectbranch);
-  auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
-  if (!emcheader->mHasPayload) {
-    LOG(DEBUG) << "[EMCALDigitsPrinter - process] No more digits" << std::endl;
-    // RS: QuitRequest on the end of data should be determined by the input supplier, not the processor
-    // pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
-    return;
-  }
 
   auto objects = pc.inputs().get<gsl::span<InputType>>(objectbranch);
   auto triggerrecords = pc.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggerrecord");

--- a/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
@@ -74,18 +74,7 @@ o2::framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config
         return true;
       };
 
-      bool active(true);
       if (!publish()) {
-        active = false;
-        // Send dummy header with no payload option
-        o2::emcal::EMCALBlockHeader dummyheader(false);
-        pc.outputs().snapshot(o2::framework::OutputRef{"output", 0, {dummyheader}}, 0);
-        pc.outputs().snapshot(o2::framework::OutputRef{"outputTRG", 0, {dummyheader}}, 0);
-        if (propagateMC) {
-          pc.outputs().snapshot(o2::framework::OutputRef{"outputMC", 0, {dummyheader}}, 0);
-        }
-      }
-      if ((processAttributes->finished = (active == false)) && processAttributes->terminateOnEod) {
         pc.services().get<o2::framework::ControlService>().endOfStream();
         pc.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
       }
@@ -101,7 +90,9 @@ o2::framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config
     auto mco = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.mcoutput);
     outputSpecs.emplace_back(o2::framework::OutputSpec{{"output"}, dto.origin, dto.description, 0, o2::framework::Lifetime::Timeframe});
     outputSpecs.emplace_back(o2::framework::OutputSpec{{"outputTRG"}, tro.origin, tro.description, 0, o2::framework::Lifetime::Timeframe});
-    outputSpecs.emplace_back(o2::framework::OutputSpec{{"outputMC"}, mco.origin, mco.description, 0, o2::framework::Lifetime::Timeframe});
+    if (propagateMC) {
+      outputSpecs.emplace_back(o2::framework::OutputSpec{{"outputMC"}, mco.origin, mco.description, 0, o2::framework::Lifetime::Timeframe});
+    }
     return std::move(outputSpecs);
   };
 


### PR DESCRIPTION
* eliminate dummy data sendning cycle in the end of publisher processing and
the protection against processing these empty data in all processor devices.
* do not create MC outputSpec in the publisher if MC was disabled.
* add timer for the Clusterizer

@mfasDa there was indeed an empty cycle in the of the publisher lifetime (apparently in the original TPC code it served to inform the downstream devices about the end of data, not needed anymore sine endOfStream() is available).
Benchmarking the data you provided I see (fixed to 2.4 GHz) 0.062s per your Run2 "TF". If it indeed contains 300 EMC triggers, than we are completely safe. 
But this looks too good and is certainly not compatible with 0.02s per single pp triggers. Perhaps you should rerun pp again. 
In my test I see ~ 320 clusters per pbpb trigger, is this reasonable?
````
[16080:EMCALClusterizerSpec]: Real time 0:00:00, CP time 0.070, 2 slices
[16080:EMCALClusterizerSpec]: [00:04:06][INFO] [EMCALClusterizer - run] Writing 97892 clusters ...
[16080:EMCALClusterizerSpec]: Real time 0:00:00, CP time 0.140, 3 slices
[16080:EMCALClusterizerSpec]: [00:04:06][INFO] [EMCALClusterizer - run] Writing 96575 clusters ...
[16080:EMCALClusterizerSpec]: Real time 0:00:00, CP time 0.210, 4 slices
[16080:EMCALClusterizerSpec]: [00:04:07][INFO] [EMCALClusterizer - run] Writing 97261 clusters ...
[16080:EMCALClusterizerSpec]: Real time 0:00:00, CP time 0.280, 5 slices
[16080:EMCALClusterizerSpec]: [00:04:07][INFO] [EMCALClusterizer - run] Writing 96102 clusters ...
[16080:EMCALClusterizerSpec]: Real time 0:00:00, CP time 0.340, 6 slices
...
[16080:EMCALClusterizerSpec]: Real time 0:00:01, CP time 1.480, 25 slices
[16080:EMCALClusterizerSpec]: [00:04:09][INFO] [EMCALClusterizer - run] Writing 22917 clusters ...
[16080:EMCALClusterizerSpec]: [00:04:09][INFO] EMCALClusterizer timing: CPU: 1.48 Real: 1.46645 in 24 TFs
````