### PR TITLE
Update for arrow 0.17 stream writing

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -481,7 +481,7 @@ struct BaseHeader {
 /// use like this:
 /// HeaderType* h = get<HeaderType*>(buffer)
 template <typename HeaderType, typename std::enable_if_t<std::is_pointer<HeaderType>::value, int> = 0>
-auto get(const o2::byte* buffer, size_t /*len*/ = 0)
+auto get(const o2::byte* buffer, std::size_t /*len*/ = 0)
 {
   using HeaderConstPtrType = const typename std::remove_pointer<HeaderType>::type*;
   using HeaderValueType = typename std::remove_pointer<HeaderType>::type;
@@ -499,7 +499,7 @@ auto get(const o2::byte* buffer, size_t /*len*/ = 0)
 }
 
 template <typename HeaderType, typename std::enable_if_t<std::is_pointer<HeaderType>::value, int> = 0>
-auto get(const void* buffer, size_t len = 0)
+auto get(const void* buffer, std::size_t len = 0)
 {
   return get<HeaderType>(reinterpret_cast<const byte*>(buffer), len);
 }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -285,7 +285,7 @@ struct AnalysisDataProcessorBuilder {
     (doAppendInputWithMetadata<Args>(inputs), ...);
   }
 
-  template <typename T, size_t At>
+  template <typename T, std::size_t At>
   static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
   {
     using dT = std::decay_t<T>;
@@ -355,7 +355,7 @@ struct AnalysisDataProcessorBuilder {
     }
   }
 
-  template <typename T, size_t At>
+  template <typename T, std::size_t At>
   static auto extractSomethingFromRecord(InputRecord& record, std::vector<ExpressionInfo> const infos)
   {
     using decayed = std::decay_t<T>;
@@ -534,7 +534,7 @@ struct AnalysisDataProcessorBuilder {
             return typedTable;
           } else {
             auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[position]).value);
-            std::decay_t<A1> typedTable{{groupedElementsTable}, (offsets[index])[position]};
+            A1 typedTable{{groupedElementsTable}, (offsets[index])[position]};
             return typedTable;
           }
         } else {

--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -46,7 +46,7 @@ class ContextRegistry
   T* get() const
   {
     void* instance = nullptr;
-    for (size_t i = 0; i < mRegistryCount; ++i) {
+    for (std::size_t i = 0; i < mRegistryCount; ++i) {
       if (mRegistryKey[i] == typeid(T*).hash_code()) {
         return reinterpret_cast<T*>(mRegistryValue[i]);
       }
@@ -65,7 +65,7 @@ class ContextRegistry
   void set(T* instance)
   {
     static_assert(std::is_void<T>::value == false, "can not register a void object");
-    size_t i = 0;
+    std::size_t i = 0;
     for (i = 0; i < mRegistryCount; ++i) {
       if (typeid(T*).hash_code() == mRegistryKey[i]) {
         return;
@@ -80,9 +80,9 @@ class ContextRegistry
   }
 
  private:
-  static constexpr size_t MAX_REGISTRY_SIZE = 8;
-  size_t mRegistryCount = 0;
-  std::array<size_t, MAX_REGISTRY_SIZE> mRegistryKey;
+  static constexpr std::size_t MAX_REGISTRY_SIZE = 8;
+  std::size_t mRegistryCount = 0;
+  std::array<std::size_t, MAX_REGISTRY_SIZE> mRegistryKey;
   std::array<void*, MAX_REGISTRY_SIZE> mRegistryValue;
 };
 

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -83,11 +83,11 @@ class DataAllocator
                 ContextRegistry* contextes,
                 const AllowedOutputRoutes& routes);
 
-  DataChunk& newChunk(const Output&, size_t);
+  DataChunk& newChunk(const Output&, std::size_t);
 
-  inline DataChunk& newChunk(OutputRef&& ref, size_t size) { return newChunk(getOutputByBind(std::move(ref)), size); }
+  inline DataChunk& newChunk(OutputRef&& ref, std::size_t size) { return newChunk(getOutputByBind(std::move(ref)), size); }
 
-  void adoptChunk(const Output&, char*, size_t, fairmq_free_fn*, void*);
+  void adoptChunk(const Output&, char*, std::size_t, fairmq_free_fn*, void*);
 
   /// Generic helper to create an object which is owned by the framework and
   /// returned as a reference to the own object.
@@ -348,7 +348,7 @@ class DataAllocator
   /// Take a snapshot of a raw data array which can be either POD or may contain a serialized
   /// object (in such case the serialization method should be specified accordingly). Changes
   /// to the data after the call will not be sent.
-  void snapshot(const Output& spec, const char* payload, size_t payloadSize,
+  void snapshot(const Output& spec, const char* payload, std::size_t payloadSize,
                 o2::header::SerializationMethod serializationMethod = o2::header::gSerializationMethodNone);
 
   /// make an object of type T and route to output specified by OutputRef
@@ -429,21 +429,16 @@ class DataAllocator
   TimingInfo* mTimingInfo;
   ContextRegistry* mContextRegistry;
 
-  std::string const& matchDataHeader(const Output& spec, size_t timeframeId);
+  std::string const& matchDataHeader(const Output& spec, std::size_t timeframeId);
   FairMQMessagePtr headerMessageFromOutput(Output const& spec,                                  //
                                            std::string const& channel,                          //
                                            o2::header::SerializationMethod serializationMethod, //
-                                           size_t payloadSize);                                 //
+                                           std::size_t payloadSize);                            //
 
   Output getOutputByBind(OutputRef&& ref);
   void addPartToContext(FairMQMessagePtr&& payload,
                         const Output& spec,
                         o2::header::SerializationMethod serializationMethod);
-
-  /// Fills the passed arrow::ipc::BatchRecordWriter in the framework and
-  /// have it serialise / send data as RecordBatches to all consumers
-  /// of @a spec once done.
-  void create(const Output& spec, std::shared_ptr<arrow::ipc::RecordBatchWriter>*, std::shared_ptr<arrow::Schema>);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -84,10 +84,10 @@ class DataRelayer
   const std::vector<int>& forwardingMask();
 
   /// Returns how many timeslices we can handle in parallel
-  size_t getParallelTimeslices() const;
+  std::size_t getParallelTimeslices() const;
 
   /// Tune the maximum number of in flight timeslices this can handle.
-  void setPipelineLength(size_t s);
+  void setPipelineLength(std::size_t s);
 
   /// @return the current stats about the data relaying process
   DataRelayerStats const& getStats() const;
@@ -113,7 +113,7 @@ class DataRelayer
   TimesliceIndex& mTimesliceIndex;
 
   CompletionPolicy mCompletionPolicy;
-  std::vector<size_t> mDistinctRoutesIndex;
+  std::vector<std::size_t> mDistinctRoutesIndex;
   std::vector<data_matcher::DataDescriptorMatcher> mInputMatchers;
   std::vector<data_matcher::VariableContext> mVariableContextes;
   std::vector<int> mCachedStateMetrics;

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -42,7 +42,7 @@ class FairMQDeviceProxy
   FairMQTransportFactory* getTransport();
   FairMQTransportFactory* getTransport(const std::string& channel, int index = 0);
   std::unique_ptr<FairMQMessage> createMessage() const;
-  std::unique_ptr<FairMQMessage> createMessage(const size_t size) const;
+  std::unique_ptr<FairMQMessage> createMessage(const std::size_t size) const;
 
  private:
   FairMQDevice* mDevice;

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -181,7 +181,7 @@ class InputRecord
     return ref;
   }
 
-  size_t getNofParts(int pos) const
+  std::size_t getNofParts(int pos) const
   {
     if (pos < 0 || pos >= mSpan.size()) {
       return 0;
@@ -440,7 +440,7 @@ class InputRecord
   bool isValid(char const* s) const;
   bool isValid(int pos) const;
 
-  size_t size() const
+  std::size_t size() const
   {
     return mSpan.size();
   }
@@ -461,7 +461,7 @@ class InputRecord
 
     Iterator() = delete;
 
-    Iterator(ParentType const* parent, size_t position = 0, size_t size = 0)
+    Iterator(ParentType const* parent, std::size_t position = 0, std::size_t size = 0)
       : mParent(parent), mPosition(position), mSize(size > position ? size : position), mElement{nullptr, nullptr, nullptr}
     {
       if (mPosition < mSize) {
@@ -546,14 +546,14 @@ class InputRecord
       return mParent;
     }
 
-    size_t position() const
+    std::size_t position() const
     {
       return mPosition;
     }
 
    private:
-    size_t mPosition;
-    size_t mSize;
+    std::size_t mPosition;
+    std::size_t mSize;
     ParentType const* mParent;
     ElementType mElement;
   };
@@ -574,19 +574,19 @@ class InputRecord
     using iterator = Iterator<SelfType, T>;
     using const_iterator = Iterator<SelfType, const T>;
 
-    InputRecordIterator(InputRecord const* parent, size_t position = 0, size_t size = 0)
+    InputRecordIterator(InputRecord const* parent, std::size_t position = 0, std::size_t size = 0)
       : BaseType(parent, position, size)
     {
     }
 
     /// Get element at {slotindex, partindex}
-    ElementType getByPos(size_t pos) const
+    ElementType getByPos(std::size_t pos) const
     {
       return this->parent()->getByPos(this->position(), pos);
     }
 
     /// Check if slot is valid, index of part is not used
-    bool isValid(size_t = 0) const
+    bool isValid(std::size_t = 0) const
     {
       if (this->position() < this->parent()->size()) {
         return this->parent()->isValid(this->position());
@@ -595,7 +595,7 @@ class InputRecord
     }
 
     /// Get number of parts in input slot
-    size_t size() const
+    std::size_t size() const
     {
       return this->parent()->getNofParts(this->position());
     }

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -127,7 +127,7 @@ struct BuilderUtils {
   }
 
   template <typename BuilderType, typename PTR>
-  static arrow::Status bulkAppend(BuilderType& builder, size_t bulkSize, const PTR ptr)
+  static arrow::Status bulkAppend(BuilderType& builder, std::size_t bulkSize, const PTR ptr)
   {
     return builder->AppendValues(ptr, bulkSize, nullptr);
   }
@@ -298,7 +298,7 @@ struct TableBuilderHelpers {
   {
     std::vector<std::shared_ptr<arrow::DataType>> types{BuilderMaker<ARGS>::make_datatype()...};
     std::vector<std::shared_ptr<arrow::Field>> result;
-    for (size_t i = 0; i < names.size(); ++i) {
+    for (std::size_t i = 0; i < names.size(); ++i) {
       result.emplace_back(std::make_shared<arrow::Field>(names[i], types[i], true, nullptr));
     }
     return std::move(result);
@@ -321,7 +321,7 @@ struct TableBuilderHelpers {
   }
 
   template <std::size_t... Is, typename BUILDERS, typename PTRS>
-  static bool bulkAppend(BUILDERS& builders, size_t bulkSize, std::index_sequence<Is...>, PTRS ptrs)
+  static bool bulkAppend(BUILDERS& builders, std::size_t bulkSize, std::index_sequence<Is...>, PTRS ptrs)
   {
     return (BuilderUtils::bulkAppend(std::get<Is>(builders), bulkSize, std::get<Is>(ptrs)).ok() && ...);
   }
@@ -334,7 +334,7 @@ struct TableBuilderHelpers {
   }
 
   template <typename BUILDERS, std::size_t... Is>
-  static bool reserveAll(BUILDERS& builders, size_t s, std::index_sequence<Is...>)
+  static bool reserveAll(BUILDERS& builders, std::size_t s, std::index_sequence<Is...>)
   {
     return (std::get<Is>(builders)->Reserve(s).ok() && ...);
   }
@@ -390,7 +390,7 @@ class TableBuilder
   }
 
   template <typename... ARGS>
-  auto makeBuilders(std::vector<std::string> const& columnNames, size_t nRows)
+  auto makeBuilders(std::vector<std::string> const& columnNames, std::size_t nRows)
   {
     mSchema = std::make_shared<arrow::Schema>(TableBuilderHelpers::makeFields<ARGS...>(columnNames));
 
@@ -512,7 +512,7 @@ class TableBuilder
   }
 
   template <typename... ARGS>
-  auto bulkPersist(std::vector<std::string> const& columnNames, size_t nRows)
+  auto bulkPersist(std::vector<std::string> const& columnNames, std::size_t nRows)
   {
     constexpr int nColumns = sizeof...(ARGS);
     validate<ARGS...>(columnNames);
@@ -520,7 +520,7 @@ class TableBuilder
     makeBuilders<ARGS...>(columnNames, nRows);
     makeFinalizer<ARGS...>();
 
-    return [builders = (BuildersTuple<ARGS...>*)mBuilders](unsigned int slot, size_t batchSize, typename BuilderMaker<ARGS>::FillType const*... args) -> void {
+    return [builders = (BuildersTuple<ARGS...>*)mBuilders](unsigned int slot, std::size_t batchSize, typename BuilderMaker<ARGS>::FillType const*... args) -> void {
       TableBuilderHelpers::bulkAppend(*builders, batchSize, std::index_sequence_for<ARGS...>{}, std::forward_as_tuple(args...));
     };
   }
@@ -548,14 +548,14 @@ class TableBuilder
   /// Helper which actually creates the insertion cursor. Notice that the
   /// template argument T is a o2::soa::Table which contains only the
   /// persistent columns.
-  template <typename T, size_t... Is>
+  template <typename T, std::size_t... Is>
   auto cursorHelper(std::index_sequence<Is...> s)
   {
     std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::label()...};
     return this->template persist<typename pack_element_t<Is, typename T::columns>::type...>(columnNames);
   }
 
-  template <typename T, typename E, size_t... Is>
+  template <typename T, typename E, std::size_t... Is>
   auto cursorHelper(std::index_sequence<Is...> s)
   {
     std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::label()...};

--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -24,14 +24,14 @@ namespace framework
 
 struct TimesliceId {
   static constexpr uint64_t INVALID = -1;
-  size_t value;
+  std::size_t value;
   static bool isValid(TimesliceId const& timeslice);
 };
 
 struct TimesliceSlot {
   static constexpr uint64_t INVALID = -1;
   static constexpr uint64_t ANY = -2;
-  size_t index;
+  std::size_t index;
   static bool isValid(TimesliceSlot const& slot);
   bool operator==(const TimesliceSlot that) const;
   bool operator!=(const TimesliceSlot that) const;
@@ -54,8 +54,8 @@ class TimesliceIndex
     DropObsolete     /// An obsolete context is not inserted in the index and dropped
   };
 
-  inline void resize(size_t s);
-  inline size_t size() const;
+  inline void resize(std::size_t s);
+  inline std::size_t size() const;
   inline bool isValid(TimesliceSlot const& slot) const;
   inline bool isDirty(TimesliceSlot const& slot) const;
   inline void markAsDirty(TimesliceSlot slot, bool value);

--- a/Framework/Core/include/Framework/TimingInfo.h
+++ b/Framework/Core/include/Framework/TimingInfo.h
@@ -16,7 +16,7 @@
 /// This class holds the information about timing
 /// of the messages being processed.
 struct TimingInfo {
-  size_t timeslice; /// the timeslice associated to current processing
+  std::size_t timeslice; /// the timeslice associated to current processing
 };
 
 #endif // Timing information for the current computation

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -71,6 +71,7 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
     mStatelessProcess{spec.algorithm.onProcess},
     mError{spec.algorithm.onError},
     mConfigRegistry{nullptr},
+    mServiceRegistry{registry},
     mFairMQContext{FairMQDeviceProxy{this}},
     mStringContext{FairMQDeviceProxy{this}},
     mDataFrameContext{FairMQDeviceProxy{this}},
@@ -81,7 +82,6 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
              spec.inputs,
              registry.get<Monitoring>(),
              registry.get<TimesliceIndex>()},
-    mServiceRegistry{registry},
     mErrorCount{0},
     mProcessingCount{0}
 {
@@ -120,7 +120,7 @@ void DataProcessingDevice::Init()
     }
   }
   auto optionsRetriever(std::make_unique<FairOptionsRetriever>(mSpec.options, GetConfig()));
-  mConfigRegistry = std::move(std::make_unique<ConfigParamRegistry>(std::move(optionsRetriever)));
+  mConfigRegistry = std::make_unique<ConfigParamRegistry>(std::move(optionsRetriever));
 
   mExpirationHandlers.clear();
 
@@ -155,7 +155,7 @@ void DataProcessingDevice::Init()
   /// Internal channels which will never create an actual message
   /// should be considered as in "Pull" mode, since we do not
   /// expect them to create any data.
-  for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
+  for (std::size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
     auto& name = mSpec.inputChannels[ci].name;
     if (name.find("from_internal-dpl-clock") == 0) {
       mState.inputChannelInfos[ci].state = InputChannelState::Pull;
@@ -217,7 +217,7 @@ bool DataProcessingDevice::ConditionalRun()
   };
 
   /// This will flush metrics only once every second.
-  auto flushMetrics = [& stats = mStats,
+  auto flushMetrics = [&stats = mStats,
                        &relayer = mRelayer,
                        &lastFlushed = mLastMetricFlushedTimestamp,
                        &currentTime = mBeginIterationTimestamp,
@@ -231,7 +231,7 @@ bool DataProcessingDevice::ConditionalRun()
     // Send all the relevant metrics for the relayer to update the GUI
     // FIXME: do a delta with the previous version if too many metrics are still
     // sent...
-    for (size_t si = 0; si < stats.relayerState.size(); ++si) {
+    for (std::size_t si = 0; si < stats.relayerState.size(); ++si) {
       auto state = stats.relayerState[si];
       monitoring.send({state, "data_relayer/" + std::to_string(si)});
     }
@@ -241,7 +241,7 @@ bool DataProcessingDevice::ConditionalRun()
     O2_SIGNPOST_END(MonitoringStatus::ID, MonitoringStatus::FLUSH, 0, 0, O2_SIGNPOST_RED);
   };
 
-  auto switchState = [& control = mServiceRegistry.get<ControlService>(),
+  auto switchState = [&control = mServiceRegistry.get<ControlService>(),
                       &state = mState.streaming](StreamingState newState) {
     state = newState;
     control.notifyStreamingState(state);
@@ -262,7 +262,7 @@ bool DataProcessingDevice::ConditionalRun()
     return info.state != InputChannelState::Pull;
   });
   // Whether or not all the channels are completed
-  for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
+  for (std::size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
     auto& channel = mSpec.inputChannels[ci];
     auto& info = mState.inputChannelInfos[ci];
 
@@ -381,7 +381,7 @@ bool DataProcessingDevice::handleData(FairMQParts& parts, InputChannelInfo& info
   // and we do a few stats. We bind parts as a lambda captured variable, rather
   // than an input, because we do not want the outer loop actually be exposed
   // to the implementation details of the messaging layer.
-  auto getInputTypes = [& stats = mStats, &parts, &info]() -> std::optional<std::vector<InputType>> {
+  auto getInputTypes = [&stats = mStats, &parts, &info]() -> std::optional<std::vector<InputType>> {
     stats.inputParts = parts.Size();
 
     if (parts.Size() % 2) {
@@ -389,7 +389,7 @@ bool DataProcessingDevice::handleData(FairMQParts& parts, InputChannelInfo& info
     }
     std::vector<InputType> results(parts.Size() / 2, InputType::Invalid);
 
-    for (size_t hi = 0; hi < parts.Size() / 2; ++hi) {
+    for (std::size_t hi = 0; hi < parts.Size() / 2; ++hi) {
       auto pi = hi * 2;
       auto sih = o2::header::get<SourceInfoHeader*>(parts.At(pi)->GetData());
       if (sih) {
@@ -419,14 +419,14 @@ bool DataProcessingDevice::handleData(FairMQParts& parts, InputChannelInfo& info
     return results;
   };
 
-  auto reportError = [& device = *this](const char* message) {
+  auto reportError = [&device = *this](const char* message) {
     device.error(message);
   };
 
   auto handleValidMessages = [&parts, &relayer = mRelayer, &reportError](std::vector<InputType> const& types) {
     // We relay execution to make sure we have a complete set of parts
     // available.
-    for (size_t pi = 0; pi < (parts.Size() / 2); ++pi) {
+    for (std::size_t pi = 0; pi < (parts.Size() / 2); ++pi) {
       switch (types[pi]) {
         case InputType::Data: {
           auto headerIndex = 2 * pi;
@@ -530,7 +530,7 @@ bool DataProcessingDevice::tryDispatchComputation()
   // the execution.
   auto fillInputs = [&relayer, &inputsSchema, &currentSetOfInputs](TimesliceSlot slot) -> InputRecord {
     currentSetOfInputs = std::move(relayer.getInputsForTimeslice(slot));
-    auto getter = [&currentSetOfInputs](size_t i, size_t partindex) -> DataRef {
+    auto getter = [&currentSetOfInputs](std::size_t i, std::size_t partindex) -> DataRef {
       if (currentSetOfInputs[i].size() > partindex) {
         return DataRef{nullptr,
                        static_cast<char const*>(currentSetOfInputs[i].at(partindex).header->GetData()),
@@ -538,7 +538,7 @@ bool DataProcessingDevice::tryDispatchComputation()
       }
       return DataRef{nullptr, nullptr, nullptr};
     };
-    auto nofPartsGetter = [&currentSetOfInputs](size_t i) -> size_t {
+    auto nofPartsGetter = [&currentSetOfInputs](std::size_t i) -> std::size_t {
       return currentSetOfInputs[i].size();
     };
     InputSpan span{getter, nofPartsGetter, currentSetOfInputs.size()};
@@ -603,7 +603,7 @@ bool DataProcessingDevice::tryDispatchComputation()
   // O2-646.
   auto cleanTimers = [&currentSetOfInputs](TimesliceSlot slot, InputRecord& record) {
     assert(record.size() == currentSetOfInputs.size());
-    for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
+    for (std::size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
       DataRef input = record.getByPos(ii);
       if (input.spec->lifetime != Lifetime::Timer) {
         continue;
@@ -626,7 +626,7 @@ bool DataProcessingDevice::tryDispatchComputation()
     // because the forwards are stable during this function, we use the pointer
     // to channel string as key to avoid string allocation in the map
     std::unordered_map<const std::string*, FairMQParts> forwardedParts;
-    for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
+    for (std::size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
       DataRef input = record.getByPos(ii);
 
       // If is now possible that the record is not complete when
@@ -710,7 +710,7 @@ bool DataProcessingDevice::tryDispatchComputation()
   };
 
   auto calculateTotalInputRecordSize = [](InputRecord const& record) -> int {
-    size_t totalInputSize = 0;
+    std::size_t totalInputSize = 0;
     for (auto& item : record) {
       auto* header = o2::header::get<DataHeader*>(item.header);
       if (header == nullptr) {
@@ -721,7 +721,7 @@ bool DataProcessingDevice::tryDispatchComputation()
     return totalInputSize;
   };
 
-  auto switchState = [& control = mServiceRegistry.get<ControlService>(),
+  auto switchState = [&control = mServiceRegistry.get<ControlService>(),
                       &state = mState.streaming](StreamingState newState) {
     state = newState;
     control.notifyStreamingState(state);
@@ -745,7 +745,7 @@ bool DataProcessingDevice::tryDispatchComputation()
       }
     }
     auto tStart = std::chrono::high_resolution_clock::now();
-    for (size_t ai = 0; ai != record.size(); ai++) {
+    for (auto ai = 0u; ai != record.size(); ai++) {
       auto cacheId = action.slot.index * record.size() + ai;
       auto state = record.isValid(ai) ? 2 : 0;
       mStats.relayerState.resize(std::max(cacheId + 1, mStats.relayerState.size()), 0);
@@ -758,7 +758,7 @@ bool DataProcessingDevice::tryDispatchComputation()
     } catch (std::exception& e) {
       errorHandling(e, record);
     }
-    for (size_t ai = 0; ai != record.size(); ai++) {
+    for (auto ai = 0u; ai != record.size(); ai++) {
       auto cacheId = action.slot.index * record.size() + ai;
       auto state = record.isValid(ai) ? 3 : 0;
       mStats.relayerState.resize(std::max(cacheId + 1, mStats.relayerState.size()), 0);

--- a/Framework/Core/src/FairMQResizableBuffer.cxx
+++ b/Framework/Core/src/FairMQResizableBuffer.cxx
@@ -33,26 +33,26 @@ FairMQResizableBuffer::FairMQResizableBuffer(Creator creator)
   this->size_ = 0;
 }
 
-arrow::Status FairMQResizableBuffer::Resize(const int64_t newSize, bool shrink_to_fit)
+arrow::Status FairMQResizableBuffer::Resize(const int64_t new_size, bool shrink_to_fit)
 {
-  if (newSize < this->capacity_ && shrink_to_fit == true) {
-    auto newMessage = mCreator(newSize);
-    memcpy(newMessage->GetData(), mMessage->GetData(), newSize);
+  if (new_size < this->capacity_ && shrink_to_fit == true) {
+    auto newMessage = mCreator(new_size);
+    memcpy(newMessage->GetData(), mMessage->GetData(), new_size);
     mMessage = std::move(newMessage);
     this->mutable_data_ = reinterpret_cast<uint8_t*>(mMessage->GetData());
     this->data_ = this->mutable_data_;
     assert(this->data_);
     this->capacity_ = static_cast<int64_t>(mMessage->GetSize());
-    assert(newSize == this->capacity_);
-  } else if (newSize > this->capacity_) {
-    auto status = this->Reserve(newSize);
+    assert(new_size == this->capacity_);
+  } else if (new_size > this->capacity_) {
+    auto status = this->Reserve(new_size);
     if (status.ok() == false) {
       return status;
     }
   }
-  assert(newSize <= this->capacity_);
+  assert(new_size <= this->capacity_);
 
-  this->size_ = newSize;
+  this->size_ = new_size;
   assert(this->size_ <= mMessage->GetSize());
   return arrow::Status::OK();
 }

--- a/Framework/Core/src/FairMQResizableBuffer.h
+++ b/Framework/Core/src/FairMQResizableBuffer.h
@@ -29,7 +29,7 @@ namespace framework
 class FairMQResizableBuffer : public ::arrow::ResizableBuffer
 {
  public:
-  using Creator = std::function<std::unique_ptr<FairMQMessage>(size_t)>;
+  using Creator = std::function<std::unique_ptr<FairMQMessage>(std::size_t)>;
 
   FairMQResizableBuffer(Creator);
   ~FairMQResizableBuffer() override;

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -35,7 +35,7 @@ template <typename TYPE, typename C_TYPE>
 void ArrayFromVector(const std::vector<C_TYPE>& values, std::shared_ptr<arrow::Array>* out)
 {
   typename arrow::TypeTraits<TYPE>::BuilderType builder;
-  for (size_t i = 0; i < values.size(); ++i) {
+  for (std::size_t i = 0; i < values.size(); ++i) {
     auto status = builder.Append(values[i]);
     assert(status.ok());
   }
@@ -54,7 +54,7 @@ std::shared_ptr<arrow::Table>
   mFinalizer();
   std::vector<std::shared_ptr<BackendColumnType>> columns;
   columns.reserve(mArrays.size());
-  for (size_t i = 0; i < mSchema->num_fields(); ++i) {
+  for (std::size_t i = 0; i < mSchema->num_fields(); ++i) {
     auto column = makeBackendColumn<BackendColumnType>(mSchema->field(i), mArrays[i]);
     columns.emplace_back(column);
   }

--- a/Framework/Core/test/test_FairMQResizableBuffer.cxx
+++ b/Framework/Core/test/test_FairMQResizableBuffer.cxx
@@ -30,7 +30,7 @@ template class std::unique_ptr<FairMQMessage>;
 BOOST_AUTO_TEST_CASE(TestCreation)
 {
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  FairMQResizableBuffer buffer{[&transport](size_t size) -> std::unique_ptr<FairMQMessage> {
+  FairMQResizableBuffer buffer{[&transport](std::size_t size) -> std::unique_ptr<FairMQMessage> {
     return std::move(transport->CreateMessage(size));
   }};
 }
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(TestCreation)
 BOOST_AUTO_TEST_CASE(TestInvariants)
 {
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  FairMQResizableBuffer buffer{[&transport](size_t size) -> std::unique_ptr<FairMQMessage> {
+  FairMQResizableBuffer buffer{[&transport](std::size_t size) -> std::unique_ptr<FairMQMessage> {
     return std::move(transport->CreateMessage(size));
   }};
 
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(TestInvariants)
 BOOST_AUTO_TEST_CASE(TestContents)
 {
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  FairMQResizableBuffer buffer{[&transport](size_t size) -> std::unique_ptr<FairMQMessage> {
+  FairMQResizableBuffer buffer{[&transport](std::size_t size) -> std::unique_ptr<FairMQMessage> {
     return std::move(transport->CreateMessage(size));
   }};
 
@@ -130,15 +130,14 @@ BOOST_AUTO_TEST_CASE(TestStreaming)
 
   auto table = builder.finalize();
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  auto creator = [&transport](size_t size) -> std::unique_ptr<FairMQMessage> {
+  auto creator = [&transport](std::size_t size) -> std::unique_ptr<FairMQMessage> {
     return std::move(transport->CreateMessage(size));
   };
   auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
   /// Writing to a stream
   auto stream = std::make_shared<arrow::io::BufferOutputStream>(buffer);
-  std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
-  auto outBatch = arrow::ipc::RecordBatchStreamWriter::Open(stream.get(), table->schema(), &writer);
-  auto outStatus = writer->WriteTable(*table);
+  auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
+  auto outStatus = outBatch.ValueOrDie()->WriteTable(*table);
   if (outStatus.ok() == false) {
     throw std::runtime_error("Unable to Write table");
   }


### PR DESCRIPTION
Main changes are in `DataAllocator`: now uses new arrow interface for stream writing.

* replace `size_t` with `std::size_t` - not really necessary now, but helps with static analysis and will be needed for gcc10
* minor fixes - inconsistent naming and redundant std::move

@ktf `DataAllocator::create` is not used anywhere, but the comment on it suggests otherwise. However it cannot be used in a present stay with arrow 0.17 where it seems writer is not supposed to be used directly. Can you please confirm that it is not needed or if that is not the case point me to where it is used?