### PR TITLE
options to disable root I/O in fit workflow

### DIFF
--- a/Detectors/FIT/workflow/include/FITWorkflow/RecoWorkflow.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/RecoWorkflow.h
@@ -19,7 +19,7 @@ namespace o2
 {
 namespace fit
 {
-framework::WorkflowSpec getRecoWorkflow(bool useMC);
+framework::WorkflowSpec getRecoWorkflow(bool useMC, bool disableRootInp, bool disableRootOut);
 } // namespace fit
 } // namespace o2
 #endif

--- a/Detectors/FIT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/FIT/workflow/src/RecoWorkflow.cxx
@@ -21,13 +21,16 @@ namespace o2
 namespace fit
 {
 
-framework::WorkflowSpec getRecoWorkflow(bool useMC)
+framework::WorkflowSpec getRecoWorkflow(bool useMC, bool disableRootInp, bool disableRootOut)
 {
   framework::WorkflowSpec specs;
-  specs.emplace_back(o2::ft0::getFT0DigitReaderSpec(useMC));
+  if (!disableRootInp) {
+    specs.emplace_back(o2::ft0::getFT0DigitReaderSpec(useMC));
+  }
   specs.emplace_back(o2::ft0::getFT0ReconstructorSpec(useMC));
-  specs.emplace_back(o2::ft0::getFT0RecPointWriterSpec(useMC));
-
+  if (!disableRootOut) {
+    specs.emplace_back(o2::ft0::getFT0RecPointWriterSpec(useMC));
+  }
   return specs;
 }
 

--- a/Detectors/FIT/workflow/src/fit-reco-workflow.cxx
+++ b/Detectors/FIT/workflow/src/fit-reco-workflow.cxx
@@ -21,7 +21,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   workflowOptions.push_back(ConfigParamSpec{
     "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
-
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
 }
@@ -39,6 +42,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::writeINI("o2tpcits-match-recoflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
+  auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
+  auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
+
   LOG(INFO) << "WorkflowSpec getRecoWorkflow useMC " << useMC;
-  return std::move(o2::fit::getRecoWorkflow(useMC));
+  return std::move(o2::fit::getRecoWorkflow(useMC, disableRootInp, disableRootOut));
 }

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -21,8 +21,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
-    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
-    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);


### PR DESCRIPTION
Hi @AllaMaevskaya 
As far as I can see, there is no yet decoded device to convert the T0 raw stream to digits which can be used for the reconstruction. 
Could you prepare one, please? The aim is to have ``o2-ft0-decoderaw`` device to be able to run:
````
# create raw data from digits 
o2-ft0-digi2raw  -o raw/FT0
o2-raw-file-reader-workflow --conf raw/FT0/FT0raw.cfg | o2-ft0-decoderaw | o2-fit-reco-workflow --disable-mc --disable-root-input
````
i.e. ``o2-fit-reco-workflow`` getting the input not from the digits file using reader but from the DPL