### PR TITLE
Flat trivially-messageable output path for tpc clusters from gputracker to tpc-its-matcher

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -156,11 +156,11 @@ struct ClusterNative {
 // the data inside a buffer.
 struct ClusterNativeAccess {
   const ClusterNative* clustersLinear;
-  const ClusterNative* clusters[o2::tpc::Constants::MAXSECTOR][o2::tpc::Constants::MAXGLOBALPADROW];
+  const ClusterNative* clusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth;
-  unsigned int nClusters[o2::tpc::Constants::MAXSECTOR][o2::tpc::Constants::MAXGLOBALPADROW];
-  unsigned int nClustersSector[o2::tpc::Constants::MAXSECTOR];
-  unsigned int clusterOffset[o2::tpc::Constants::MAXSECTOR][o2::tpc::Constants::MAXGLOBALPADROW];
+  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  unsigned int nClustersSector[Constants::MAXSECTOR];
+  unsigned int clusterOffset[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
   unsigned int nClustersTotal;
 
   void setOffsetPtrs();
@@ -169,9 +169,9 @@ struct ClusterNativeAccess {
 inline void ClusterNativeAccess::setOffsetPtrs()
 {
   int offset = 0;
-  for (unsigned int i = 0; i < o2::tpc::Constants::MAXSECTOR; i++) {
+  for (unsigned int i = 0; i < Constants::MAXSECTOR; i++) {
     nClustersSector[i] = 0;
-    for (unsigned int j = 0; j < o2::tpc::Constants::MAXGLOBALPADROW; j++) {
+    for (unsigned int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
       clusterOffset[i][j] = offset;
       clusters[i][j] = &clustersLinear[offset];
       nClustersSector[i] += nClusters[i][j];

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -135,8 +135,8 @@ class ClusterNativeHelper
   ClusterNativeHelper() = default;
   ~ClusterNativeHelper() = default;
 
-  constexpr static unsigned int NSectors = o2::tpc::Constants::MAXSECTOR;
-  constexpr static unsigned int NPadRows = o2::tpc::Constants::MAXGLOBALPADROW;
+  constexpr static unsigned int NSectors = Constants::MAXSECTOR;
+  constexpr static unsigned int NPadRows = Constants::MAXGLOBALPADROW;
 
   /// convert clusters stored in binary cluster native format to a tree and write to root file
   /// the cluster parameters are stored in the tree together with sector and padrow numbers.
@@ -354,11 +354,11 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
   }
   memset(&clusterIndex, 0, sizeof(clusterIndex));
   if (inputs.size() == 1) {
-    if (inputs[0].size() >= sizeof(o2::tpc::ClusterCountIndex)) {
+    if (inputs[0].size() >= sizeof(ClusterCountIndex)) {
       // there is only one data block and we can set the index directly from it
-      const o2::tpc::ClusterCountIndex* hdr = reinterpret_cast<o2::tpc::ClusterCountIndex const*>(inputs[0].data());
+      const ClusterCountIndex* hdr = reinterpret_cast<ClusterCountIndex const*>(inputs[0].data());
       memcpy((void*)&clusterIndex.nClusters[0][0], hdr, sizeof(*hdr));
-      clusterIndex.clustersLinear = reinterpret_cast<const o2::tpc::ClusterNative*>(inputs[0].data() + sizeof(*hdr));
+      clusterIndex.clustersLinear = reinterpret_cast<const ClusterNative*>(inputs[0].data() + sizeof(*hdr));
       clusterIndex.setOffsetPtrs();
       if (mcinputs.size() > 0) {
         clusterIndex.clustersMCTruth = mcinputs[0].get();

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -46,6 +46,7 @@ enum struct Operation {
 /// the processor spec. The struct is initialized by a variable list of
 /// constructor arguments.
 struct Config {
+  Config(const Config&) = default;
   template <typename... Args>
   Config(Args&&... args)
   {
@@ -89,6 +90,9 @@ struct Config {
       init(std::forward<Args>(args)...);
     }
   }
+
+  // Cannot specialize constructor to create proper copy constructor directly --> must overload init
+  void init(const Config& x) { *this = x; }
 
   bool caClusterer = false;
   bool zsDecoder = false;

--- a/GPU/GPUTracking/Base/GPUOutputControl.h
+++ b/GPU/GPUTracking/Base/GPUOutputControl.h
@@ -15,10 +15,9 @@
 #define GPUOUTPUTCONTROL_H
 
 #include "GPUCommonDef.h"
-#ifndef GPUCA_GPUCODE_DEVICE
 #include <cstddef>
+#include <functional>
 #include <new>
-#endif
 
 namespace GPUCA_NAMESPACE
 {
@@ -27,7 +26,6 @@ namespace gpu
 struct GPUOutputControl {
   enum OutputTypeStruct { AllocateInternal = 0,
                           UseExternalBuffer = 1 };
-#ifndef GPUCA_GPUCODE_DEVICE
   GPUOutputControl() = default;
   void set(void* ptr, size_t size)
   {
@@ -36,17 +34,23 @@ struct GPUOutputControl {
     OutputBase = OutputPtr = (char*)ptr;
     OutputMaxSize = size;
   }
+  void set(const std::function<void*(size_t)>& allocator)
+  {
+    new (this) GPUOutputControl;
+    OutputType = GPUOutputControl::UseExternalBuffer;
+    OutputAllocator = allocator;
+  }
   void reset()
   {
     new (this) GPUOutputControl;
   }
-#endif
 
-  void* OutputBase = nullptr;                     // Base ptr to memory pool, occupied size is OutputPtr - OutputBase
-  void* OutputPtr = nullptr;                      // Pointer to Output Space
-  size_t OutputMaxSize = 0;                       // Max Size of Output Data if Pointer to output space is given
-  OutputTypeStruct OutputType = AllocateInternal; // How to perform the output
-  char EndOfSpace = 0;                            // end of space flag
+  void* OutputBase = nullptr;                             // Base ptr to memory pool, occupied size is OutputPtr - OutputBase
+  void* OutputPtr = nullptr;                              // Pointer to Output Space
+  size_t OutputMaxSize = 0;                               // Max Size of Output Data if Pointer to output space is given
+  std::function<void*(size_t)> OutputAllocator = nullptr; // Allocator callback
+  OutputTypeStruct OutputType = AllocateInternal;         // How to perform the output
+  char EndOfSpace = 0;                                    // end of space flag
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -450,7 +450,13 @@ size_t GPUReconstruction::AllocateRegisteredMemory(short ires, GPUOutputControl*
     }
     if ((!IsGPU() || (res->mType & GPUMemoryResource::MEMORY_HOST) || mDeviceProcessingSettings.keepDisplayMemory) && !(res->mType & GPUMemoryResource::MEMORY_EXTERNAL)) { // keepAllMemory --> keepDisplayMemory
       if (control && control->OutputType == GPUOutputControl::UseExternalBuffer) {
-        res->mSize = AllocateRegisteredMemoryHelper(res, res->mPtr, control->OutputPtr, control->OutputBase, control->OutputMaxSize, &GPUMemoryResource::SetPointers);
+        if (control->OutputAllocator) {
+          res->mSize = std::max((size_t)res->SetPointers((void*)1) - 1, res->mOverrideSize);
+          res->mPtr = control->OutputAllocator(res->mSize);
+          res->SetPointers(res->mPtr);
+        } else {
+          res->mSize = AllocateRegisteredMemoryHelper(res, res->mPtr, control->OutputPtr, control->OutputBase, control->OutputMaxSize, &GPUMemoryResource::SetPointers);
+        }
       } else {
         res->mSize = AllocateRegisteredMemoryHelper(res, res->mPtr, mHostMemoryPool, mHostMemoryBase, mHostMemorySize, &GPUMemoryResource::SetPointers);
       }

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -291,6 +291,9 @@ int GPUChainTracking::Init()
   if (mOutputCompressedClusters == nullptr) {
     mOutputCompressedClusters = &mRec->OutputControl();
   }
+  if (mOutputClustersNative == nullptr) {
+    mOutputClustersNative = &mRec->OutputControl();
+  }
 
   if (mRec->IsGPU()) {
     if (processors()->calibObjects.fastTransform) {
@@ -962,7 +965,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
     buildNativeGPU = true;
   }
   if (mRec->GetRecoStepsOutputs() & GPUDataTypes::InOutType::TPCClusters) { // TODO: Should do this also when clusters are needed for later steps on the host but not requested as output
-    AllocateRegisteredMemory(mInputsHost->mResourceClusterNativeOutput);
+    AllocateRegisteredMemory(mInputsHost->mResourceClusterNativeOutput, mOutputClustersNative);
     buildNativeHost = true;
   }
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -154,6 +154,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetTRDGeometry(const o2::trd::TRDGeometryFlat* geo) { processors()->calibObjects.trdGeometry = geo; }
   void LoadClusterErrors();
   void SetOutputControlCompressedClusters(GPUOutputControl* v) { mOutputCompressedClusters = v; }
+  void SetOutputControlClustersNative(GPUOutputControl* v) { mOutputClustersNative = v; }
 
   const void* mConfigDisplay = nullptr; // Abstract pointer to Standalone Display Configuration Structure
   const void* mConfigQA = nullptr;      // Abstract pointer to Standalone QA Configuration Structure
@@ -227,6 +228,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   std::unique_ptr<GPUTrackingInOutZS> mTPCZS;                         // TPC ZS Data Structure
 
   GPUOutputControl* mOutputCompressedClusters = nullptr;
+  GPUOutputControl* mOutputClustersNative = nullptr;
 
   // Upper bounds for memory allocation
   unsigned int mMaxTPCHits = 0;

--- a/GPU/GPUTracking/Global/GPUTrackingInputProvider.cxx
+++ b/GPU/GPUTracking/Global/GPUTrackingInputProvider.cxx
@@ -48,7 +48,7 @@ void* GPUTrackingInputProvider::SetPointersInputClusterNativeBuffer(void* mem)
 void* GPUTrackingInputProvider::SetPointersInputClusterNativeOutput(void* mem)
 {
   if (mHoldTPCClusterNativeOutput) {
-    computePointerWithAlignment(mem, mPclusterNativeOutput, mNClusterNative);
+    computePointerWithoutAlignment(mem, mPclusterNativeOutput, mNClusterNative); // TODO: Should decide based on some settings whether with or without alignment. Without only needed for output to unaligned shared memory in workflow.
   }
   return mem;
 }

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -103,12 +103,16 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
 
   mChain->mIOPtrs = *data;
   if (mConfig->configInterface.outputToExternalBuffers) {
-    if (outputs->compressedClusters.ptr) {
+    if (outputs->compressedClusters.allocator) {
+      mOutputCompressedClusters->set(outputs->compressedClusters.allocator);
+    } else if (outputs->compressedClusters.ptr) {
       mOutputCompressedClusters->set(outputs->compressedClusters.ptr, outputs->compressedClusters.size);
     } else {
       mOutputCompressedClusters->reset();
     }
-    if (outputs->clustersNative.ptr) {
+    if (outputs->clustersNative.allocator) {
+      mOutputClustersNative->set(outputs->clustersNative.allocator);
+    } else if (outputs->clustersNative.ptr) {
       mOutputClustersNative->set(outputs->clustersNative.ptr, outputs->clustersNative.size);
     } else {
       mOutputClustersNative->reset();

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -73,6 +73,7 @@ class GPUTPCO2Interface
   GPUChainTracking* mChain = nullptr;
   std::unique_ptr<GPUO2InterfaceConfiguration> mConfig;
   std::unique_ptr<GPUOutputControl> mOutputCompressedClusters;
+  std::unique_ptr<GPUOutputControl> mOutputClustersNative;
 };
 } // namespace o2::gpu
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -57,6 +57,7 @@ struct GPUInterfaceOutputRegion {
 
 struct GPUInterfaceOutputs {
   GPUInterfaceOutputRegion compressedClusters;
+  GPUInterfaceOutputRegion clustersNative;
 };
 
 // Full configuration structure with all available settings of GPU...
@@ -68,7 +69,7 @@ struct GPUO2InterfaceConfiguration {
   // Settings for the Interface class
   struct GPUInterfaceSettings {
     bool dumpEvents = false;
-    bool outputToPreallocatedBuffers = false;
+    bool outputToExternalBuffers = false;
     // These constants affect GPU memory allocation and do not limit the CPU processing
     unsigned int maxTPCHits = 1024 * 1024 * 1024;
     unsigned int maxTRDTracklets = 128 * 1024;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <array>
 #include <vector>
+#include <functional>
 #include <gsl/gsl>
 #include "GPUSettings.h"
 #include "GPUDisplayConfig.h"
@@ -50,9 +51,11 @@ class TPCFastTransform;
 // Since DPL does not respect the alignment of data types, we do not impose anything specic but just use a char data type, but it should be >= 64 bytes ideally.
 // The size defines the maximum possible buffer size when GPUReconstruction is called, and returns the number of filled bytes when it returns.
 // If ptr == nullptr, there is no region defined and GPUReconstruction will write its output to an internal buffer.
+// If allocator is set, it is called as a callback to provide a ptr to the memory.
 struct GPUInterfaceOutputRegion {
   void* ptr = nullptr;
   size_t size = 0;
+  std::function<void*(size_t)> allocator = nullptr;
 };
 
 struct GPUInterfaceOutputs {


### PR DESCRIPTION
This should basically be only the last commit, but it depends on #3546 and #3547.
This adds writing of the TPC clusters during GPU reconstruction to a preallocated flat buffer and shipping that without serialization and without any copy.

I figured we'll run into the same ROOT TBuffer problems as with the compressed clusters, so we should not store the data to a root file in this way but, until we have a workaround to split the entries, keep storing the clusters per tpc sector.

Thus, this adds a new data type `CLSNATIVEFLAT` for messagint the ClusterNative in a flat format.
The `o2-tpc-reco-workflow` sends in this format when the `disable-writer` option is set, and the `o2-tpcits-match-workflow` receives in this format when the `--disable-root-input` is set. Otherwise, both keep using the old `CLUSTERNATIVE` data type per sector.

This yielded the problem that the `o2-tpc-reco-workflow` failed when the `--ca-clusterer` option is not set but the `disable-writer` option is set, because in that case the clusters are already an input for the GPU tracking. Thus, I added an on-the-fly conversion to create the `CLSNATIVEFLAT` in addition. This is quite inefficient but shouldn't matter since the old clusterizer will not be used in the long run anyway.

Finally, this will need in other workflows (besides `o2-tpcits-matching-workflow`) that read the tpc ClusterNative directly from the `o2-tpc-reco-workflow` without intermediate ROOT IO. I don't know how many are affected, but the changes are rather small for the reading (lines 83 - 91 in `TPCITSMatchingSpec.cxx`).

@shahor02  @matthiasrichter Could you have a look?