### PR TITLE
Optionally disable root I/O in TPC calib interpolation workflow

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationWorkflow.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace tpc
 {
 
-framework::WorkflowSpec getTPCInterpolationWorkflow(bool useMC);
+framework::WorkflowSpec getTPCInterpolationWorkflow(bool disableRootInp, bool disableRootOut);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -20,8 +20,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   workflowOptions.push_back(ConfigParamSpec{
-    "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
-
+    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
 }
@@ -36,7 +37,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   // write the configuration used for the workflow
   o2::conf::ConfigurableParam::writeINI("o2tpcinterpolation-workflow_configuration.ini");
-
-  auto useMC = !configcontext.options().get<bool>("disable-mc");
-  return std::move(o2::tpc::getTPCInterpolationWorkflow(useMC));
+  auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
+  auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
+  return std::move(o2::tpc::getTPCInterpolationWorkflow(disableRootInp, disableRootOut));
 }


### PR DESCRIPTION
Needed for clean merging of workflows.
Also, removed ``disable-mc`` option since the MC is anyway not supported in this flow