### PR TITLE
Fix in ITS CAtracker cluster indexing 

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
@@ -121,9 +121,10 @@ template <class T>
 std::ostream& operator<<(std::ostream& os, const BaseCluster<T>& c)
 {
   // stream itself
-  os << "SId" << std::setw(5) << c.getSensorID() << " (" << std::showpos << std::scientific << c.getX() << ","
-     << std::scientific << c.getY() << "," << std::scientific << c.getZ() << ") cnt:" << std::setw(4) << +c.getCount()
-     << " bits:" << std::bitset<8>(c.getBits());
+  os << "SId" << std::setw(5) << c.getSensorID() << " (" << std::showpos << std::scientific
+     << c.getX() << "," << c.getY() << "," << c.getZ() << ")/("
+     << c.getSigmaY2() << "," << c.getSigmaYZ() << "," << c.getSigmaZ2()
+     << ") cnt:" << std::setw(4) << +c.getCount() << " bits:" << std::bitset<8>(c.getBits());
   return os;
 }
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -82,6 +82,7 @@ class Tracker
   void traverseCellsTree(const int, const int);
   void computeRoadsMClabels(const ROframe&);
   void computeTracksMClabels(const ROframe&);
+  void rectifyClusterIndices(const ROframe& event);
 
   template <typename... T>
   float evaluateTask(void (Tracker::*)(T...), const char*, std::ostream& ostream, T&&... args);

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -31,6 +31,7 @@
 #include "MathUtils/Utils.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "Framework/Logger.h"
 
 namespace
 {
@@ -75,8 +76,8 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
       o2::itsmft::ClusterPattern patt(pattIt);
       locXYZ = dict.getClusterCoordinates(c, patt);
     }
-    auto cl3d = output.emplace_back(c.getSensorID(), geom->getMatrixT2L(c.getSensorID()) ^ locXYZ); // local --> tracking
-    cl3d.setErrors(sigmaY2, sigmaYZ, sigmaZ2);
+    auto& cl3d = output.emplace_back(c.getSensorID(), geom->getMatrixT2L(c.getSensorID()) ^ locXYZ); // local --> tracking
+    cl3d.setErrors(sigmaY2, sigmaZ2, sigmaYZ);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -74,7 +74,11 @@ void Tracker::clustersToTracks(const ROframe& event, std::ostream& timeBenchmark
       timeBenchmarkOutputStream << std::setw(2) << " - "
                                 << "Vertex processing completed in: " << total << "ms" << std::endl;
   }
-  computeTracksMClabels(event);
+  if (event.hasMCinformation()) {
+    computeTracksMClabels(event);
+  } else {
+    rectifyClusterIndices(event);
+  }
 }
 
 void Tracker::computeTracklets()
@@ -558,7 +562,6 @@ void Tracker::computeTracksMClabels(const ROframe& event)
           count = 1;
         }
       }
-
       track.setExternalClusterIndex(iCluster, event.getClusterExternalIndex(iCluster, index));
     }
 
@@ -566,6 +569,19 @@ void Tracker::computeTracksMClabels(const ROframe& event)
       maxOccurrencesValue.setFakeFlag();
     }
     mTrackLabels.addElement(mTrackLabels.getIndexedSize(), maxOccurrencesValue);
+  }
+}
+
+void Tracker::rectifyClusterIndices(const ROframe& event)
+{
+  int tracksNum{static_cast<int>(mTracks.size())};
+  for (auto& track : mTracks) {
+    for (int iCluster = 0; iCluster < TrackITSExt::MaxClusters; ++iCluster) {
+      const int index = track.getClusterIndex(iCluster);
+      if (index != constants::its::UnusedIndex) {
+        track.setExternalClusterIndex(iCluster, event.getClusterExternalIndex(iCluster, index));
+      }
+    }
   }
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -133,7 +133,7 @@ void TrackerDPL::run(ProcessingContext& pc)
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
       int ncl = trc.getNumberOfClusters();
-      for (int ic = 0; ic < ncl; ic++) {
+      for (int ic = ncl; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
         allClusIdx.push_back(trc.getClusterIndex(ic) + offset);
       }
       allTracks.emplace_back(trc);
@@ -194,7 +194,8 @@ void TrackerDPL::run(ProcessingContext& pc)
         LOG(INFO) << "Found tracks: " << tracks.size();
         int number = tracks.size();
         trackLabels = mTracker->getTrackLabels(); /// FIXME: assignment ctor is not optimal.
-        int shiftIdx = -rof.getFirstEntry();
+        int shiftIdx = -rof.getFirstEntry();      // cluster entry!!!
+        rof.setFirstEntry(first);
         rof.setNEntries(number);
         copyTracks(tracks, allTracks, allClusIdx, shiftIdx);
         allTrackLabels.mergeAtBack(trackLabels);


### PR DESCRIPTION
The cluster indices were registered wrt ROF start only in MCLabels mode while in raw mode they were kept wrt TF start.
Indices must be stored in out->in order