### PR TITLE
More detailed timing for TPC/ITS matching

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -646,10 +646,17 @@ class MatchTPCITS
   static constexpr float MaxTgp = 2.064;               // max tg corresponting to MaxSnp = MaxSnp/std::sqrt(1.-MaxSnp^2)
   static constexpr float MinTBToCleanCache = 600.;     // keep in AB ITS cluster refs cache at most this number of TPC bins
 
-  TStopwatch mTimerTot;
-  TStopwatch mTimerIO;
-  TStopwatch mTimerDBG;
-  TStopwatch mTimerRefit;
+  enum TimerIDs { SWTot,
+                  SWPrepITS,
+                  SWPrepTPC,
+                  SWDoMatching,
+                  SWSelectBest,
+                  SWRefit,
+                  SWIO,
+                  SWDBG,
+                  NStopWatches };
+  static constexpr std::string_view TimerName[] = {"Total", "PrepareITS", "PrepareTPC", "DoMatching", "SelectBest", "Refit", "IO", "Debug"};
+  TStopwatch mTimer[NStopWatches];
 
   ClassDefNV(MatchTPCITS, 1);
 };


### PR DESCRIPTION
For the record: matching of low-mult. preselected ITS data to TPC is slower than the naive ITS multiplicity scaling because 100% of TPC tracks are prepared for matching (and only ~1% is used).
Given that matching in sync. reco is done having in mind further matching in TRD and TOF, one could apply a low pT cut-off of 0.4 GeV (at least)  w/o any loss of efficiency. Only this speeds up the matching by factor of 2.
````
 o2-tpcits-match-workflow --configKeyValues "tpcitsMatch.minTPCPt=0.4" ...
````