### PR TITLE
Digitization: Optional MCTruth propagation TPC/ITS/MFT

### DIFF
--- a/Common/SimConfig/include/SimConfig/DigiParams.h
+++ b/Common/SimConfig/include/SimConfig/DigiParams.h
@@ -28,6 +28,7 @@ struct DigiParams : public o2::conf::ConfigurableParamHelper<DigiParams> {
   std::string ccdb = "http://ccdb-test.cern.ch:8080"; // URL for CCDB acces
   std::string digitizationgeometry = "";              // with with geometry file to digitize -> leave empty as this needs to be filled by the digitizer workflow
   std::string grpfile = "";                           // which GRP file to use --> leave empty as this needs to be filled by the digitizer workflow
+  bool mctruth = true;                                // whether to create labels
 
   O2ParamDef(DigiParams, "DigiParams");
 };

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.h
@@ -18,8 +18,8 @@ namespace o2
 namespace itsmft
 {
 
-o2::framework::DataProcessorSpec getITSDigitWriterSpec();
-o2::framework::DataProcessorSpec getMFTDigitWriterSpec();
+o2::framework::DataProcessorSpec getITSDigitWriterSpec(bool mctruth = true);
+o2::framework::DataProcessorSpec getMFTDigitWriterSpec(bool mctruth = true);
 
 } // end namespace itsmft
 } // end namespace o2

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.h
@@ -18,8 +18,8 @@ namespace o2
 namespace itsmft
 {
 
-o2::framework::DataProcessorSpec getITSDigitizerSpec(int channel);
-o2::framework::DataProcessorSpec getMFTDigitizerSpec(int channel);
+o2::framework::DataProcessorSpec getITSDigitizerSpec(int channel, bool mctruth = true);
+o2::framework::DataProcessorSpec getMFTDigitizerSpec(int channel, bool mctruth = true);
 
 } // end namespace itsmft
 } // end namespace o2

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -65,7 +65,7 @@ TBranch* getOrMakeBranch(TTree& tree, std::string basename, int sector, T* ptr)
 /// create the processor spec
 /// describing a processor aggregating digits for various TPC sectors and writing them to file
 /// MC truth information is also aggregated and written out
-DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfiguration)
+DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfiguration, bool mctruth)
 {
   auto initFunction = [](InitContext& ic) {
     // get the option from the init context
@@ -277,9 +277,12 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
   std::vector<InputSpec> inputs = {
     {"digitinput", "TPC", "DIGITS", 0, Lifetime::Timeframe},        // digit input
     {"triggerinput", "TPC", "DIGTRIGGERS", 0, Lifetime::Timeframe}, // groupping in triggers
-    {"labelinput", "TPC", "DIGITSMCTR", 0, Lifetime::Timeframe},
     {"commonmodeinput", "TPC", "COMMONMODE", 0, Lifetime::Timeframe},
   };
+  if (mctruth) {
+    inputs.emplace_back("labelinput", "TPC", "DIGITSMCTR", 0, Lifetime::Timeframe);
+  }
+
   auto amendInput = [&laneConfiguration](InputSpec& spec, size_t index) {
     spec.binding += std::to_string(laneConfiguration[index]);
     DataSpecUtils::updateMatchingSubspec(spec, laneConfiguration[index]);

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.h
@@ -21,14 +21,14 @@ namespace tpc
 {
 /// get the processor spec
 /// the laneConfiguration is a vector of subspecs which the processor subscribes to
-o2::framework::DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfiguration);
+o2::framework::DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfiguration, bool mctruth);
 
 // numberofsourcedevices is the number of devices we receive digits from
 inline o2::framework::DataProcessorSpec getTPCDigitRootWriterSpec(int numberofsourcedevices = 1)
 {
   std::vector<int> defaultConfiguration(numberofsourcedevices);
   std::iota(defaultConfiguration.begin(), defaultConfiguration.end(), 0);
-  return getTPCDigitRootWriterSpec(defaultConfiguration);
+  return getTPCDigitRootWriterSpec(defaultConfiguration, true);
 }
 
 } // namespace tpc

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
@@ -19,9 +19,9 @@ namespace o2
 namespace tpc
 {
 
-o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP);
+o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth);
 
-o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors);
+o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth);
 
 } // end namespace tpc
 } // end namespace o2


### PR DESCRIPTION
Allow to disable MC labels in TPC/ITS/MFT digitization.
Add mctruth flag to DigiParams.

This commit allows to reach a timeframe with >= 500PbPb.

In a future commit, the actual creation of labels within
the digit process function can be disabled in addition.
For the moment, merely the messaging and IO part has been disabled.