### PR TITLE
Sanity check for O2 headers on the header stack

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -467,14 +467,27 @@ struct BaseHeader {
   /// get the next header if any (const version)
   inline const BaseHeader* next() const noexcept
   {
-    return (flagsNextHeader) ? reinterpret_cast<const BaseHeader*>(reinterpret_cast<const o2::byte*>(this) + headerSize) : nullptr;
+    // BaseHeader::get checks that next header starts with the BaseHeader information at the
+    // offset given by the size of the current header.
+    return (flagsNextHeader) ? BaseHeader::get(reinterpret_cast<const o2::byte*>(this) + headerSize) : nullptr;
   }
 
   /// get the next header if any (non-const version)
   inline BaseHeader* next() noexcept
   {
-    return (flagsNextHeader) ? reinterpret_cast<BaseHeader*>(reinterpret_cast<o2::byte*>(this) + headerSize) : nullptr;
+    return (flagsNextHeader) ? BaseHeader::get(reinterpret_cast<o2::byte*>(this) + headerSize) : nullptr;
   }
+
+  /// check if the header matches expected version
+  /// throws runtime error if not matching
+  /// we might change this behavior if we want to support multiple version of a particular header
+  /// but until we have this support we need to be strict to catch a problem early and with
+  /// meaningful error message
+  bool sanityCheck(uint32_t expectedVersion) const;
+
+  /// throw runtime error to report inconsistent header stack when the next-header flag is set
+  /// but no next header is found; implemented only once, no template overloads
+  void throwInconsistentStackError() const;
 };
 
 /// find a header of type HeaderType in a buffer
@@ -487,13 +500,34 @@ auto get(const o2::byte* buffer, size_t /*len*/ = 0)
   using HeaderValueType = typename std::remove_pointer<HeaderType>::type;
 
   const BaseHeader* current = BaseHeader::get(buffer);
-  if (!current)
+  if (!current) {
     return HeaderConstPtrType{nullptr};
-  if (current->description == HeaderValueType::sHeaderType)
-    return reinterpret_cast<HeaderConstPtrType>(current);
-  while ((current = current->next())) {
-    if (current->description == HeaderValueType::sHeaderType)
+  }
+  if (current->description == HeaderValueType::sHeaderType) {
+    // FIXME: We need to think how to handle multiple versions.
+    // For the moment we require the version to exactly match the expected version, which
+    // is part of the header definition. The check function 'sanityCheck' will throw
+    // otherwise, we keep the code related to the exception outside the header file.
+    // Note: Can not check on size because the O2 data model requires variable size headers
+    // to be supported.
+    if (current->sanityCheck(HeaderValueType::sVersion)) {
       return reinterpret_cast<HeaderConstPtrType>(current);
+    }
+  }
+  auto* prev = current;
+  while ((current = current->next())) {
+    prev = current;
+    if (current->description == HeaderValueType::sHeaderType) {
+      if (current->sanityCheck(HeaderValueType::sVersion)) {
+        return reinterpret_cast<HeaderConstPtrType>(current);
+      }
+    }
+  }
+  // if a next header was expected but not found, the header stack is inconsistent
+  // either the flag is wrongly set, or the size of the current header is wrong so
+  // that the BaseHeader information is not found at the expected offset.
+  if (prev->flagsNextHeader) {
+    prev->throwInconsistentStackError();
   }
   return HeaderConstPtrType{nullptr};
 }

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -32,6 +32,26 @@ const o2::header::SerializationMethod o2::header::BaseHeader::sSerializationMeth
 using namespace o2::header;
 
 //__________________________________________________________________________________________________
+bool o2::header::BaseHeader::sanityCheck(uint32_t expectedVersion) const
+{
+  if (this->headerVersion != expectedVersion) {
+    std::string errmsg = "header of type " + this->description.as<std::string>() + " with invalid ";
+    errmsg += "version: " + std::to_string(this->headerVersion) + " (expected " + std::to_string(expectedVersion) + ")";
+    // for the moment we throw, there is no support for multiple versions of a particular header
+    // so we better spot non matching header stacks early, we migh change this later
+    throw std::runtime_error(errmsg);
+    return false;
+  }
+  return true;
+}
+
+//__________________________________________________________________________________________________
+void o2::header::BaseHeader::throwInconsistentStackError() const
+{
+  throw std::runtime_error("inconsistent header stack, no O2 header at expected offset " + std::to_string(this->headerSize) + "for header of type " + this->description.as<std::string>());
+}
+
+//__________________________________________________________________________________________________
 void o2::header::DataHeader::print() const
 {
   printf("Data header version %i, flags: %i\n", headerVersion, flags);


### PR DESCRIPTION
This is a follow up of the recent change of the `DataHeader`, #3475 

Checking if the header version and size matches the implementation.
There is no support for multiple versions of a particular header at
the moment. The minimum is to require the size and version to match
the current implementation.

TODO
- [x] make the exception message more descriptive
- [x] at the moment there is a problem with the header message created by the DPL DataAllocator, this I have to debug first