### PR TITLE
DPL: Base validity check for InputRecord route on header message only

### DIFF
--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -63,7 +63,7 @@ int InputRecord::getPos(std::string const& binding) const
 bool InputRecord::isValid(char const* s) const
 {
   DataRef ref = get(s);
-  if (ref.header == nullptr || ref.payload == nullptr) {
+  if (ref.header == nullptr) {
     return false;
   }
   return true;
@@ -75,7 +75,7 @@ bool InputRecord::isValid(int s) const
     return false;
   }
   DataRef ref = getByPos(s);
-  if (ref.header == nullptr || ref.payload == nullptr) {
+  if (ref.header == nullptr) {
     return false;
   }
   return true;


### PR DESCRIPTION
FairMQ shared memory transport gives a nullptr for a zero-length message,
while zmq transport returns a valid pointer. Validity check did require
both valid header and payload message pointers. That makes zero length
shared memory messages to be masked out.

In principle it's enough to check for the header message pointer because
the DataRelayer logic makes sure that the message pair has arrived. To
check for the payload message pointer we would need to check the payload
size and her it would mean to get DataHeader and check. Some overhead
we probably do not want.