### PR TITLE
Fix copy/paste typo in starting point definition

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/DCAFitterN.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/DCAFitterN.h
@@ -270,7 +270,7 @@ int DCAFitterN<N, Args...>::process(const Tr&... args)
     if (dst2 < mMaxDist2ToMergeSeeds) {
       mCrossings.nDCA = 1;
       mCrossings.xDCA[0] = 0.5 * (mCrossings.xDCA[0] + mCrossings.xDCA[1]);
-      mCrossings.xDCA[0] = 0.5 * (mCrossings.xDCA[0] + mCrossings.xDCA[1]);
+      mCrossings.yDCA[0] = 0.5 * (mCrossings.yDCA[0] + mCrossings.yDCA[1]);
     }
   }
   // check all crossings


### PR DESCRIPTION
Hi @shahor02 ,

while working on the hypertriton 3 body decay @galocco spotted this typo. I corrected it as it seems to me appropriate, please check it is fine.
We are checking what is the effect.

Cheers,
Max