### PR TITLE
Detector may chose if HBF end is signaled by RDH.stop on new page

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -154,6 +154,9 @@ writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ), preformat
 In this case provided span is interpretted as a fully formatted CRU page payload (i.e. it lacks the RDH which will be added by the writer) of the maximum size `8192-sizeof(RDH) = 8128` bytes.
 The writer will create a new CRU page with provided payload equipping it with the proper RDH: copying already stored RDH of the current HBF, if the interaction record `ir` belongs to the same HBF or generating new RDH for new HBF otherwise (and filling all missing HBFs in-between). In case the payload size exceeds maximum, an exception will be thrown w/o any attempt to split the page.
 
+Some detectors signal the end of the HBF by adding an empty CRU page containing just a header with ``RDH.stop=1`` while others may simply set the ``RDH.stop=1`` in the last CRU page of the HBF (it may appear to be also the 1st and the only page of the HBF and may or may not contain the payload).
+This behaviour is steered by ``writer.setAddSeparateHBFStopPage(bool v)`` switch. By default end of the HBF is signaled on separate page.
+
 For further details see  ``ITSMFT/common/simulation/MC2RawEncoder`` class and the macro
 `Detectors/ITSMFT/ITS/macros/test/run_digi2rawVarPage_its.C` to steer the MC to raw data conversion.
 
@@ -289,7 +292,7 @@ o2-raw-file-reader-workflow
   # to suppress various error checks / reporting
   --nocheck-packet-increment            ignore /Wrong RDH.packetCounter increment/
   --nocheck-page-increment              ignore /Wrong RDH.pageCnt increment/
-  --nocheck-stop-on-page0               ignore /RDH.stop set of 1st HBF page/
+  --check-stop-on-page0                 check  /RDH.stop set of 1st HBF page/
   --nocheck-missing-stop                ignore /New HBF starts w/o closing old one/
   --nocheck-starts-with-tf              ignore /Data does not start with TF/HBF/
   --nocheck-hbf-per-tf                  ignore /Number of HBFs per TF not as expected/
@@ -329,7 +332,7 @@ Options:
   -t [ --hbfpertf ]  arg (=256)     nominal number of HBFs per TF
   --nocheck-packet-increment        ignore /Wrong RDH.packetCounter increment/
   --nocheck-page-increment          ignore /Wrong RDH.pageCnt increment/
-  --nocheck-stop-on-page0           ignore /RDH.stop set of 1st HBF page/
+  --check-stop-on-page0             check  /RDH.stop set of 1st HBF page/
   --nocheck-missing-stop            ignore /New HBF starts w/o closing old one/
   --nocheck-starts-with-tf          ignore /Data does not start with TF/HBF/
   --nocheck-hbf-per-tf              ignore /Number of HBFs per TF not as expected/

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -63,16 +63,30 @@ class RawFileReader
     "Wrong HBF orbit increment",             // ErrHBFJump
     "TF does not start by new superpage"     // ErrNoSuperPageForTF
   };
-  static constexpr std::string_view ErrNamesShort[] = { // short names for error codes
-    "packet-increment",
-    "page-increment",
-    "stop-on-page0",
-    "missing-stop",
-    "starts-with-tf",
-    "hbf-per-tf",
-    "tf-per-link",
-    "hbf-jump",
-    "no-spage-for-tf"};
+  static constexpr std::string_view ErrNamesShort[] = {
+    // short names for error codes
+    "packet-increment", // ErrWrongPacketCounterIncrement
+    "page-increment",   // ErrWrongPageCounterIncrement
+    "stop-on-page0",    // ErrHBFStopOnFirstPage
+    "missing-stop",     // ErrHBFNoStop
+    "starts-with-tf",   // ErrWrongFirstPage
+    "hbf-per-tf",       // ErrWrongHBFsPerTF
+    "tf-per-link",      // ErrWrongNumberOfTF
+    "hbf-jump",         // ErrHBFJump
+    "no-spage-for-tf"   // ErrNoSuperPageForTF
+  };
+  static constexpr bool ErrCheckDefaults[] = {
+    true,  // ErrWrongPacketCounterIncrement
+    true,  // ErrWrongPageCounterIncrement
+    false, // ErrHBFStopOnFirstPage
+    true,  // ErrHBFNoStop
+    true,  // ErrWrongFirstPage
+    true,  // ErrWrongHBFsPerTF
+    true,  // ErrWrongNumberOfTF
+    true,  // ErrHBFJump
+    true   // ErrNoSuperPageForTF
+  };
+
   //================================================================================
 
   //=====================================================================================

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -288,6 +288,9 @@ class RawFileWriter
   bool getDontFillEmptyHBF() const { return mDontFillEmptyHBF; }
   void setDontFillEmptyHBF(bool v) { mDontFillEmptyHBF = v; }
 
+  bool getAddSeparateHBFStopPage() const { return mAddSeparateHBFStopPage; }
+  void setAddSeparateHBFStopPage(bool v) { mAddSeparateHBFStopPage = v; }
+
  private:
   enum RoMode_t { NotSet,
                   Continuous,
@@ -307,6 +310,7 @@ class RawFileWriter
   int mSuperPageSize = 1024 * 1024; // super page size
   bool mStartTFOnNewSPage = true;   // every TF must start on a new SPage
   bool mDontFillEmptyHBF = false;   // skipp adding empty HBFs (uness it must have TF flag)
+  bool mAddSeparateHBFStopPage = true; // HBF stop is added on a separate CRU page
   RoMode_t mROMode = NotSet;
   IR mFirstIRAdded; // 1st IR seen
   ClassDefNV(RawFileWriter, 1);

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -568,7 +568,7 @@ bool RawFileReader::init()
     counts << "Lnk" << std::setw(4) << std::left << i << "| ";
     link.print(mVerbosity, counts.str());
     if (msp > mNominalSPageSize) {
-      LOGF(WARNING, "       Attention: largest superpage %zu B exceeds expected %d B",
+      LOGF(DEBUG, "       Attention: largest superpage %zu B exceeds expected %d B",
            msp, mNominalSPageSize);
     }
     // min max orbits
@@ -709,12 +709,12 @@ RawFileReader::InputsMap RawFileReader::parseInput(const std::string& confUri)
 
 std::string RawFileReader::nochk_opt(RawFileReader::ErrTypes e)
 {
-  std::string ignore = "nocheck-";
-  return ignore + RawFileReader::ErrNamesShort[e].data();
+  std::string opt = ErrCheckDefaults[e] ? "nocheck-" : "check-";
+  return opt + RawFileReader::ErrNamesShort[e].data();
 }
 
 std::string RawFileReader::nochk_expl(RawFileReader::ErrTypes e)
 {
-  std::string ignore = "ignore /";
-  return ignore + RawFileReader::ErrNames[e].data() + '/';
+  std::string opt = ErrCheckDefaults[e] ? "ignore /" : "check  /";
+  return opt + RawFileReader::ErrNames[e].data() + '/';
 }

--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -284,7 +284,6 @@ void RawFileWriter::LinkData::addHBFPage(bool stop)
 {
   /// Add new page (RDH) to existing one for the link (possibly stop page)
 
-  // check if the superpage reached the size where it hase to be flushed
   if (lastRDHoffset < 0) {
     return; // no page was open
   }
@@ -303,25 +302,33 @@ void RawFileWriter::LinkData::addHBFPage(bool stop)
   RDHUtils::setOffsetToNext(lastRDH, psize);
   RDHUtils::setMemorySize(lastRDH, psize);
 
+  rdhCopy = lastRDH;
+  bool add = true;
+  if (stop && !writer->mAddSeparateHBFStopPage) {
+    RDHUtils::setStop(lastRDH, stop);
+    add = false;
+  }
   if (writer->mVerbosity > 2) {
     RDHUtils::printRDH(lastRDH);
   }
-  rdhCopy = lastRDH;
-  int left = writer->mSuperPageSize - buffer.size();
-  if (left <= MarginToFlush) {
-    flushSuperPage();
+  if (add) { // if we are in stopping HBF and new page is needed, add it
+    // check if the superpage reached the size where it hase to be flushed
+    int left = writer->mSuperPageSize - buffer.size();
+    if (left <= MarginToFlush) {
+      flushSuperPage();
+    }
+    RDHUtils::setPacketCounter(rdhCopy, packetCounter++);
+    RDHUtils::setPageCounter(rdhCopy, pageCnt++);
+    RDHUtils::setStop(rdhCopy, stop);
+    RDHUtils::setOffsetToNext(rdhCopy, sizeof(RDHAny));
+    RDHUtils::setMemorySize(rdhCopy, sizeof(RDHAny));
+    lastRDHoffset = pushBack(rdhCopy); // entry of the new RDH
   }
-  RDHUtils::setPacketCounter(rdhCopy, packetCounter++);
-  RDHUtils::setPageCounter(rdhCopy, pageCnt++);
-  RDHUtils::setStop(rdhCopy, stop);
-  RDHUtils::setOffsetToNext(rdhCopy, sizeof(RDHAny));
-  RDHUtils::setMemorySize(rdhCopy, sizeof(RDHAny));
-  lastRDHoffset = pushBack(rdhCopy); // entry of the new RDH
   if (stop) {
     if (RDHUtils::getTriggerType(rdhCopy) & o2::trigger::TF) {
       nTFWritten++;
     }
-    if (writer->mVerbosity > 2) {
+    if (writer->mVerbosity > 2 && add) {
       RDHUtils::printRDH(rdhCopy);
     }
     lastRDHoffset = -1; // after closing, the previous RDH is not valid anymore

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -13,6 +13,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/Logger.h"
 #include <string>
+#include <bitset>
 
 using namespace o2::framework;
 using namespace o2::raw;
@@ -32,15 +33,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"buffer-size", o2::framework::VariantType::Int64, 1024L * 1024L, {"buffer size for files preprocessing"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongPacketCounterIncrement), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongPacketCounterIncrement)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongPageCounterIncrement), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongPageCounterIncrement)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFStopOnFirstPage), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFStopOnFirstPage)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFNoStop), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFNoStop)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongFirstPage), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongFirstPage)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongHBFsPerTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongHBFsPerTF)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrWrongNumberOfTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrWrongNumberOfTF)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrHBFJump), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrHBFJump)}});
-  options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(RawFileReader::ErrNoSuperPageForTF), VariantType::Bool, false, {RawFileReader::nochk_expl(RawFileReader::ErrNoSuperPageForTF)}});
+  for (int i = 0; i < RawFileReader::NErrorsDefined; i++) {
+    auto ei = RawFileReader::ErrTypes(i);
+    options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(ei), VariantType::Bool, RawFileReader::ErrCheckDefaults[i], {RawFileReader::nochk_expl(ei)}});
+  }
   std::swap(workflowOptions, options);
 }
 
@@ -60,12 +56,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
-  uint32_t errmap = 0xffffffff;
+  uint32_t errmap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
-    if (configcontext.options().get<bool>(RawFileReader::nochk_opt(RawFileReader::ErrTypes(i)).c_str())) {
-      errmap ^= 0x1 << i;
-      LOGF(INFO, "ignore  check for /%s/", RawFileReader::ErrNames[i].data());
+    auto ei = RawFileReader::ErrTypes(i);
+    if (configcontext.options().get<bool>(RawFileReader::nochk_opt(ei).c_str())) {
+      errmap |= 0x1 << i;
     }
+    LOG(INFO) << ((errmap & (0x1 << i)) ? "apply " : "ignore") << " check for " << RawFileReader::ErrNames[i].data();
   }
 
   return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap, minTF, maxTF, buffSize));

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -65,7 +65,7 @@ struct ProcessAttributes {
 
 void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::raw::RawFileWriter& writer);
 #include "DetectorsRaw/HBFUtils.h"
-void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view outputPath, bool sectorBySector, uint32_t rdhV, bool createParentDir)
+void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view outputPath, bool sectorBySector, uint32_t rdhV, bool stopPage, bool createParentDir)
 {
 
   // ===| open file and get tree |==============================================
@@ -106,7 +106,7 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   // ===| set up raw writer |===================================================
   o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
   writer.useRDHVersion(rdhV);
-
+  writer.setAddSeparateHBFStopPage(stopPage);
   const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
 
   for (unsigned int i = 0; i < NSectors; i++) {
@@ -200,7 +200,8 @@ int main(int argc, char** argv)
     add_option("input-file,i", bpo::value<std::string>()->required(), "Specifies input file.");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "Specify output directory");
     add_option("no-parent-directories,n", "Do not create parent directories recursively");
-    add_option("sector-by-sector,s", bpo::value<bool>()->default_value(false), "Run one TPC sector after another");
+    add_option("sector-by-sector,s", bpo::value<bool>()->default_value(false)->implicit_value(true), "Run one TPC sector after another");
+    add_option("stop-page,p", bpo::value<bool>()->default_value(false)->implicit_value(true), "HBF stop on separate CRU page");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
@@ -229,6 +230,7 @@ int main(int argc, char** argv)
     vm["output-dir"].as<std::string>(),
     vm["sector-by-sector"].as<bool>(),
     vm["rdh-version"].as<uint32_t>(),
+    vm["stop-page"].as<bool>(),
     !vm.count("no-parent-directories"));
 
   return 0;


### PR DESCRIPTION
* Detector may chose if HBF end is signaled by RDH.stop on new page
Some detectors signal the end of the HBF by adding an empty CRU page containing
just a header with RDH.stop=1 while others may simply set the RDH.stop in the last
page of the HBF (it may appear to be also the 1st and the page of the HBF and may or
may not  contain the payload). This behaviour is steered by call
writer.setAddSeparateHBFStopPage(bool v). By default end of the HBF is signaled on separate page.

* By default don't treat as error RDH.stop on 1st HBF page (need to be requested specially)

* TPC ZS data converter does not add empty page to signal HBF end.
 The RDH.stop=1 will be set at the last CRU page of the HBF, w/o adding separate page for that.
This behaviour can be inverted using option -p [ --stop-page ]


