### PR TITLE
DPL IO: Make extracted ROOT collections owning to avoid memory leak

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -113,6 +113,14 @@ struct DataRefUtils {
              << " is actually stored which cannot be casted to the requested one.";
           throw std::runtime_error(ss.str());
         }
+        // collections in ROOT can be non-owning or owning and the proper cleanup depends on
+        // this flag. Be it a bug or a feature in ROOT, but the owning flag of the extracted
+        // object only depends on the state at serialization of the original object. However,
+        // all objects created during deserialization are new and must be owned by the collection
+        // to avoid memory leak. So we call SetOwner if it is available for the type.
+        if constexpr (has_root_setowner<T>::value) {
+          result->SetOwner(true);
+        }
       });
 
       return std::move(result);
@@ -148,6 +156,10 @@ struct DataRefUtils {
             ss << cl->GetName();
           }
           throw std::runtime_error(ss.str());
+        }
+        // workaround for ROOT feature, see above
+        if constexpr (has_root_setowner<T>::value) {
+          result->SetOwner(true);
         }
       });
       return std::move(result);

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -139,6 +139,23 @@ class has_root_dictionary<T, typename std::enable_if<is_container<T>::value>::ty
 {
 };
 
+// Detect whether a class is a ROOT class implementing SetOwner
+// This member detector idiom is implemented using SFINAE idiom to look for
+// a 'SetOwner()' method.
+template <typename T, typename _ = void>
+struct has_root_setowner : std::false_type {
+};
+
+template <typename T>
+struct has_root_setowner<
+  T,
+  std::conditional_t<
+    false,
+    class_member_checker<
+      decltype(std::declval<T>().SetOwner(true))>,
+    void>> : public std::true_type {
+};
+
 /// Helper class to deal with the case we are creating the first instance of a
 /// (possibly) shared resource.
 ///


### PR DESCRIPTION
Collections in ROOT can be non-owning or owning and the proper cleanup depends on
this flag. Be it a bug or a feature in ROOT, but the owning flag of the extracted
object only depends on the state at serialization of the original object. However,
all objects created during deserialization are new and must be owned by the collection
to avoid memory leak. So we call SetOwner if available for the type.