### PR TITLE
handle boost exceptions to print all details

### DIFF
--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -22,12 +22,15 @@
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <boost/exception/diagnostic_information.hpp>
 
 #include <unistd.h>
 #include <vector>
 #include <cstring>
 #include <exception>
+
+namespace boost{
+  class exception;
+}
 
 namespace o2
 {
@@ -106,6 +109,8 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::ConfigParamSpec> const& workflowOptions,
            o2::framework::ConfigContext& configContext);
 
+void doBoostException(boost::exception &e);
+
 int main(int argc, char** argv)
 {
   using namespace o2::framework;
@@ -143,7 +148,7 @@ int main(int argc, char** argv)
     overridePipeline(configContext, specs);
     result = doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, workflowOptions, configContext);
   } catch (boost::exception& e) {
-    LOG(ERROR) << "error while setting up workflow: \n" << boost::current_exception_diagnostic_information(true);
+    doBoostException(e);
   } catch (std::exception const& error) {
     LOG(ERROR) << "error while setting up workflow: " << error.what();
   } catch (...) {

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -22,6 +22,7 @@
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <boost/exception/diagnostic_information.hpp>
 
 #include <unistd.h>
 #include <vector>
@@ -141,6 +142,8 @@ int main(int argc, char** argv)
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     overridePipeline(configContext, specs);
     result = doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, workflowOptions, configContext);
+  } catch (boost::exception& e) {
+    LOG(ERROR) << "error while setting up workflow: \n" << boost::current_exception_diagnostic_information(true);
   } catch (std::exception const& error) {
     LOG(ERROR) << "error while setting up workflow: " << error.what();
   } catch (...) {

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -28,8 +28,9 @@
 #include <cstring>
 #include <exception>
 
-namespace boost{
-  class exception;
+namespace boost
+{
+class exception;
 }
 
 namespace o2
@@ -109,7 +110,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::ConfigParamSpec> const& workflowOptions,
            o2::framework::ConfigContext& configContext);
 
-void doBoostException(boost::exception &e);
+void doBoostException(boost::exception& e);
 
 int main(int argc, char** argv)
 {

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -64,6 +64,7 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <boost/exception/diagnostic_information.hpp>
 
 #include <cinttypes>
 #include <cstdint>
@@ -725,6 +726,10 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
 
     runner.AddHook<fair::mq::hooks::InstantiateDevice>(afterConfigParsingCallback);
     return runner.Run();
+  } catch (boost::exception& e) {
+    LOG(ERROR) << "Unhandled exception reached the top of main, device shutting down. Details follow: \n"
+      << boost::current_exception_diagnostic_information(true);
+    return 1;
   } catch (std::exception& e) {
     LOG(ERROR) << "Unhandled exception reached the top of main: " << e.what() << ", device shutting down.";
     return 1;

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -728,7 +728,7 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
     return runner.Run();
   } catch (boost::exception& e) {
     LOG(ERROR) << "Unhandled exception reached the top of main, device shutting down. Details follow: \n"
-      << boost::current_exception_diagnostic_information(true);
+               << boost::current_exception_diagnostic_information(true);
     return 1;
   } catch (std::exception& e) {
     LOG(ERROR) << "Unhandled exception reached the top of main: " << e.what() << ", device shutting down.";
@@ -1600,4 +1600,10 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
                          driverInfo,
                          gDeviceMetricsInfos,
                          frameworkId);
+}
+
+void doBoostException(boost::exception& e)
+{
+  LOG(ERROR) << "error while setting up workflow: \n"
+             << boost::current_exception_diagnostic_information(true);
 }


### PR DESCRIPTION
We are reviewing the way we create, populate, catch and rethrow exceptions in QC as they were implemented at a time when DPL did not exist and we had our own `main()`. 
The exceptions we use in QC and the other FLP repositories are based on `boost::exception`. I don't think that we should debate here and now whether it is good or not.

The fatal exceptions are left bubbling up, finally reaching the DPL main. The way  they are printed at the moment do not take advantage of the details we add to them.  

For example this is the current output of a configuration mistake that is not recoverable : 
```
[ERROR] error while setting up workflow: AliceO2::Common::Exception
[INFO] Process 19328 is exiting.
```
vs the one after this PR : 
```
[ERROR] error while setting up workflow: 
/Users/barth/alice/sw/SOURCES/QualityControl/better-handling-exceptions/0/Framework/src/TaskRunner.cxx(320): Throw in function void o2::quality_control::core::TaskRunner::populateConfig(std::string)
Dynamic exception type: boost::wrapexcept<AliceO2::Common::FatalException>
std::exception::what: AliceO2::Common::Exception
[AliceO2::Common::errinfo_details_*] = Configuration error : dataSource type unknown : dataSampliasdfngPolicy
[INFO] Process 5673 is exiting.
```
Would you mind adding this extra catch ? 