### PR TITLE
DPL Analysis: Final fixes for block combinations, edge cases for basic combinations

### DIFF
--- a/Framework/Core/ANALYSIS.md
+++ b/Framework/Core/ANALYSIS.md
@@ -337,7 +337,7 @@ To get combinations of distinct tracks, helper functions from `ASoAHelpers.h` ca
 
 ```cpp
 combinations(tracks, tracks); // equivalent to combinations(CombinationsStrictlyUpperIndexPolicy(tracks, tracks));
-combinations(filter, tracks, covs); // equivalent to combinations(CombinationsFullIndexPolicy(tracks, covs), filter, tracks, covs);
+combinations(filter, tracks, covs); // equivalent to combinations(CombinationsUpperIndexPolicy(tracks, covs), filter, tracks, covs);
 ```
 
 The number of elements in a combination is deduced from the number of arguments passed to `combinations()` call. For example, to get pairs of tracks from the same source, one must specify `tracks` table twice:
@@ -367,11 +367,11 @@ struct MyTask : AnalysisTask {
 };
 ```
 
-One can get combinations of elements with the same value in a given column. Input tables do not need to be the same but each table must contain the column used for categorizing. Additionally, you can specify a value to be skipped for grouping as well as upper limit on number of combinations per category. Again, full, strictly upper and upper policies are available:
+One can get combinations of elements with the same value in a given column. Input tables do not need to be the same but each table must contain the column used for categorizing. Additionally, you can specify a value to be skipped for grouping as well as the number of elements to be matched with first element in a combination. Again, full, strictly upper and upper policies are available:
 
 ```cpp
 for (auto& [c0, c1] : combinations(CombinationsBlockStrictlyUpperIndexPolicy("fRunNumber", 3, -1, collisions, collisions))) {
-  // Pairs of collisions with same fRunNumber, max 3 pairs for each fRunNumber. Entries with fRunNumber == -1 are skipped.
+  // Pairs of collisions with same fRunNumber, max 3 pairs for each element in a given "fRunNumber" bin. Entries with fRunNumber == -1 are skipped.
 }
 for (auto& [c0, t1] : combinations(CombinationsBlockFullIndexPolicy("fX", 200, -1, collisions, tracks)));
 ```

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -281,28 +281,25 @@ struct CombinationsFullIndexPolicy : public CombinationsIndexPolicyBase<Ts...> {
   }
 };
 
+// For upper and full only
 template <typename T, typename... Ts>
 struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts...> {
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, int minWindowSize, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1)
+  CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1)
   {
     constexpr auto k = sizeof...(Ts);
     if (this->mIsEnd) {
       return;
     }
-    if (mSlidingWindowSize < minWindowSize) {
-      this->mIsEnd = true;
-      return;
-    }
-    if (((tables.size() < mSlidingWindowSize) || ...)) {
+    if (mSlidingWindowSize < 1) {
       this->mIsEnd = true;
       return;
     }
 
     int tableIndex = 0;
-    ((this->mGroupedIndices[tableIndex++] = groupTable(tables, categoryColumnName, mSlidingWindowSize, outsider)), ...);
+    ((this->mGroupedIndices[tableIndex++] = groupTable(tables, categoryColumnName, 1, outsider)), ...);
 
     // Synchronize categories across tables
     syncCategories(this->mGroupedIndices);
@@ -321,6 +318,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
 
   std::array<std::vector<std::pair<uint64_t, uint64_t>>, sizeof...(Ts)> mGroupedIndices;
   IndicesType mCurrentIndices;
+  IndicesType mBeginIndices;
   uint64_t mSlidingWindowSize;
 };
 
@@ -328,7 +326,7 @@ template <typename T, typename... Ts>
 struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBase<T, Ts...> {
   using CombinationType = typename CombinationsBlockIndexPolicyBase<T, Ts...>::CombinationType;
 
-  CombinationsBlockUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, tables...)
+  CombinationsBlockUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, tables...)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -341,8 +339,9 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
     for_<k>([&, this](auto i) {
       auto catBegin = this->mGroupedIndices[i.value].begin() + std::get<i.value>(this->mCurrentIndices);
       auto range = std::equal_range(catBegin, this->mGroupedIndices[i.value].end(), *catBegin, sameCategory);
+      std::get<i.value>(this->mBeginIndices) = std::distance(this->mGroupedIndices[i.value].begin(), range.first);
       std::get<i.value>(this->mCurrent).setCursor(range.first->second);
-      std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second - this->mSlidingWindowSize + 1);
+      std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second);
     });
   }
 
@@ -357,17 +356,21 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
         std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
-        uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
+        uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
+        if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          modify = false;
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
-            std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
-            uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
-            std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+            if (std::get<curJ - 1>(this->mCurrentIndices) < std::get<curJ>(this->mMaxOffset)) {
+              std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
+              uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
+              std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+            } else {
+              modify = true;
+            }
           });
-          modify = false;
         }
       }
     });
@@ -375,122 +378,33 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
     // First iterator processed separately
     if (modify) {
       std::get<0>(this->mCurrentIndices)++;
+      std::get<0>(this->mBeginIndices)++;
       uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
       std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
 
       // If we remain within the same category - slide window
       if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
+        modify = false;
         for_<k - 1>([&, this](auto j) {
           constexpr auto curJ = j.value + 1;
-          std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
-          uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
-          std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
-        });
-        modify = false;
-      } else {
-        // Move to the end of this category
-        for_<k>([&, this](auto j) {
-          std::get<j.value>(this->mCurrentIndices) = std::get<j.value>(this->mMaxOffset) + this->mSlidingWindowSize - 1;
-        });
-      }
-    }
-
-    // No more combinations within this category - move to the next category, if possible
-    if (modify) {
-      for_<k>([&, this](auto m) {
-        if (std::get<m.value>(this->mCurrentIndices) == this->mGroupedIndices[m.value].size()) {
-          nextCatAvailable = false;
-        }
-      });
-      if (nextCatAvailable) {
-        setRanges();
-      }
-    }
-
-    this->mIsEnd = modify && !nextCatAvailable;
-  }
-};
-
-template <typename T, typename... Ts>
-struct CombinationsBlockStrictlyUpperIndexPolicy : public CombinationsBlockIndexPolicyBase<T, Ts...> {
-  using CombinationType = typename CombinationsBlockIndexPolicyBase<T, Ts...>::CombinationType;
-
-  CombinationsBlockStrictlyUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts), tables...)
-  {
-    if (this->mIsEnd) {
-      return;
-    }
-
-    constexpr auto k = sizeof...(Ts);
-    for_<k>([this](auto i) {
-      std::get<i.value>(this->mCurrentIndices) = i.value;
-    });
-
-    setRanges();
-  }
-
-  void setRanges()
-  {
-    constexpr auto k = sizeof...(Ts);
-    for_<k>([&, this](auto i) {
-      auto catBegin = this->mGroupedIndices[i.value].begin() + std::get<i.value>(this->mCurrentIndices);
-      auto range = std::equal_range(catBegin, this->mGroupedIndices[i.value].end(), *catBegin, sameCategory);
-      std::get<i.value>(this->mCurrent).setCursor(range.first->second);
-      std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second - this->mSlidingWindowSize + i.value + 1);
-    });
-  }
-
-  void addOne()
-  {
-    constexpr auto k = sizeof...(Ts);
-    bool modify = true;
-    bool nextCatAvailable = true;
-    for_<k - 1>([&, this](auto i) {
-      if (modify) {
-        constexpr auto curInd = k - i.value - 1;
-        std::get<curInd>(this->mCurrentIndices)++;
-        uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
-        uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize - i.value;
-
-        // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
-          for_<i.value>([&, this](auto j) {
-            constexpr auto curJ = k - i.value + j.value;
-            std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices) + 1;
+          std::get<curJ>(this->mBeginIndices)++;
+          if (std::get<curJ>(this->mBeginIndices) < std::get<curJ>(this->mMaxOffset)) {
+            std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
             uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
             std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
-          });
-          modify = false;
-        }
-      }
-    });
-
-    // First iterator processed separately
-    if (modify) {
-      std::get<0>(this->mCurrentIndices)++;
-      uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
-
-      // If we remain within the same category - slide window
-      if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
-        for_<k - 1>([&, this](auto j) {
-          constexpr auto curJ = j.value + 1;
-          std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices) + 1;
-          uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
-          std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+          } else {
+            modify = true;
+          }
         });
-        modify = false;
       }
     }
 
     // No more combinations within this category - move to the next category, if possible
     if (modify) {
       for_<k>([&, this](auto m) {
+        std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset);
         if (std::get<m.value>(this->mCurrentIndices) == this->mGroupedIndices[m.value].size()) {
           nextCatAvailable = false;
-        } else {
-          std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset) + this->mSlidingWindowSize - 1;
         }
       });
       if (nextCatAvailable) {
@@ -507,7 +421,7 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
   using CombinationType = typename CombinationsBlockIndexPolicyBase<T, Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  CombinationsBlockFullIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, tables...)
+  CombinationsBlockFullIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, tables...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -521,7 +435,7 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
       auto catBegin = this->mGroupedIndices[i.value].begin() + std::get<i.value>(this->mCurrentIndices);
       auto range = std::equal_range(catBegin, this->mGroupedIndices[i.value].end(), *catBegin, sameCategory);
       std::get<i.value>(this->mBeginIndices) = std::distance(this->mGroupedIndices[i.value].begin(), range.first);
-      std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second - this->mSlidingWindowSize + 1);
+      std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second);
       std::get<i.value>(this->mCurrent).setCursor(range.first->second);
     });
   }
@@ -531,19 +445,24 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
     constexpr auto k = sizeof...(Ts);
     bool modify = true;
     bool nextCatAvailable = true;
-    for_<k - 1>([&, this](auto i) {
+    for_<k>([&, this](auto i) {
       if (modify) {
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
         std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
-        uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
+        uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
+        uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + windowOffset;
 
-        // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
+        // If we remain within the same sliding window and fixed index
+        if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
-            std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
+            if (curJ < this->mCurrentlyFixed) { // To assure no repetitions
+              std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices) + 1;
+            } else {
+              std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
+            }
             uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
             std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
           });
@@ -552,33 +471,50 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
       }
     });
 
-    // First iterator processed separately
+    // Currently fixed iterator processed separately
     if (modify) {
-      std::get<0>(this->mCurrentIndices)++;
-      uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
-
-      // If we remain within the same category - slide window
-      if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
-        for_<k - 1>([&, this](auto j) {
-          constexpr auto curJ = j.value + 1;
-          std::get<curJ>(this->mBeginIndices) = std::get<0>(this->mCurrentIndices);
-          std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
-          uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
-          std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+      // If we haven't finished with window starting element
+      if (this->mCurrentlyFixed < k - 1 && std::get<0>(this->mBeginIndices) < std::get<0>(this->mMaxOffset) - 1) {
+        this->mCurrentlyFixed++;
+        for_<k>([&, this](auto s) {
+          if (s.value < this->mCurrentlyFixed) { // To assure no repetitions
+            std::get<s.value>(this->mCurrentIndices) = std::get<s.value>(this->mBeginIndices) + 1;
+          } else {
+            std::get<s.value>(this->mCurrentIndices) = std::get<s.value>(this->mBeginIndices);
+          }
+          uint64_t curGroupedI = std::get<s.value>(this->mCurrentIndices);
+          std::get<s.value>(this->mCurrent).setCursor(this->mGroupedIndices[s.value][curGroupedI].second);
         });
         modify = false;
       } else {
-        // Move to the end of this category
-        for_<k>([&, this](auto j) {
-          std::get<j.value>(this->mCurrentIndices) = std::get<j.value>(this->mMaxOffset) + this->mSlidingWindowSize - 1;
-        });
+        this->mCurrentlyFixed = 0;
+        std::get<0>(this->mBeginIndices)++;
+        std::get<0>(this->mCurrentIndices) = std::get<0>(this->mBeginIndices);
+        uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
+        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
+
+        // If we remain within the same category - slide window
+        if (std::get<0>(this->mBeginIndices) < std::get<0>(this->mMaxOffset)) {
+          modify = false;
+          for_<k - 1>([&, this](auto j) {
+            constexpr auto curJ = j.value + 1;
+            std::get<curJ>(this->mBeginIndices)++;
+            if (std::get<curJ>(this->mBeginIndices) < std::get<curJ>(this->mMaxOffset)) {
+              std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
+              uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
+              std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+            } else {
+              modify = true;
+            }
+          });
+        }
       }
     }
 
     // No more combinations within this category - move to the next category, if possible
     if (modify) {
       for_<k>([&, this](auto m) {
+        std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset);
         if (std::get<m.value>(this->mCurrentIndices) == this->mGroupedIndices[m.value].size()) {
           nextCatAvailable = false;
         }
@@ -591,7 +527,7 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
     this->mIsEnd = modify && !nextCatAvailable;
   }
 
-  IndicesType mBeginIndices;
+  uint64_t mCurrentlyFixed;
 };
 
 template <typename T1, typename T, typename... Ts>
@@ -602,12 +538,13 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
   CombinationsBlockSameIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, int minWindowSize, const T& table, const Ts&... tables) : CombinationsIndexPolicyBase<T, Ts...>(table, tables...), mSlidingWindowSize(categoryNeighbours + 1)
   {
     constexpr auto k = sizeof...(Ts) + 1;
-    if (mSlidingWindowSize < minWindowSize || table.size() < mSlidingWindowSize) {
+    // minWindowSize == 1 for upper and full, and k for strictly upper k-combination
+    if (mSlidingWindowSize < minWindowSize) {
       this->mIsEnd = true;
       return;
     }
 
-    this->mGroupedIndices = groupTable(table, categoryColumnName, mSlidingWindowSize, outsider);
+    this->mGroupedIndices = groupTable(table, categoryColumnName, minWindowSize, outsider);
 
     if (this->mGroupedIndices.size() == 0) {
       this->mIsEnd = true;
@@ -638,7 +575,7 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
     constexpr auto k = sizeof...(Ts) + 1;
     auto catBegin = this->mGroupedIndices.begin() + std::get<0>(this->mCurrentIndices);
     auto range = std::equal_range(catBegin, this->mGroupedIndices.end(), *catBegin, sameCategory);
-    uint64_t offset = std::distance(this->mGroupedIndices.begin(), range.second) - this->mSlidingWindowSize + 1;
+    uint64_t offset = std::distance(this->mGroupedIndices.begin(), range.second);
 
     for_<k>([&, this](auto i) {
       std::get<i.value>(this->mCurrentIndices) = std::get<0>(this->mCurrentIndices);
@@ -660,7 +597,7 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
+        if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
@@ -687,9 +624,6 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
           std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedJ].second);
         });
         modify = false;
-      } else {
-        // Move to the end of this category
-        std::get<0>(this->mCurrentIndices) += this->mSlidingWindowSize - 1;
       }
     }
 
@@ -724,7 +658,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     for_<k>([&, this](auto i) {
       std::get<i.value>(this->mCurrentIndices) = std::get<0>(this->mCurrentIndices) + i.value;
       std::get<i.value>(this->mCurrent).setCursor(this->mGroupedIndices[std::get<i.value>(this->mCurrentIndices)].second);
-      std::get<i.value>(this->mMaxOffset) = lastOffset - this->mSlidingWindowSize + i.value + 1;
+      std::get<i.value>(this->mMaxOffset) = lastOffset - k + i.value + 1;
     });
   }
 
@@ -741,7 +675,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize - i.value;
 
         // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
+        if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices) + 1;
@@ -774,7 +708,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     // No more combinations within this category - move to the next category, if possible
     if (modify && std::get<k - 1>(this->mCurrentIndices) < this->mGroupedIndices.size()) {
       for_<k>([&, this](auto m) {
-        std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset) + this->mSlidingWindowSize - 1;
+        std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset) + k - 1;
       });
       setRanges();
       return;
@@ -788,7 +722,7 @@ template <typename T1, typename T, typename... Ts>
 struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, T, Ts...> {
   using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>::CombinationType;
 
-  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const T& table, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, table, tables...)
+  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const T& table, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, table, tables...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -801,7 +735,7 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
     auto catBegin = this->mGroupedIndices.begin() + std::get<0>(this->mCurrentIndices);
     auto range = std::equal_range(catBegin, this->mGroupedIndices.end(), *catBegin, sameCategory);
     this->mBeginIndex = std::get<0>(this->mCurrentIndices);
-    uint64_t offset = std::distance(this->mGroupedIndices.begin(), range.second) - this->mSlidingWindowSize + 1;
+    uint64_t offset = std::distance(this->mGroupedIndices.begin(), range.second);
 
     for_<k>([&, this](auto i) {
       std::get<i.value>(this->mMaxOffset) = offset;
@@ -814,19 +748,24 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
   {
     constexpr auto k = sizeof...(Ts) + 1;
     bool modify = true;
-    for_<k - 1>([&, this](auto i) {
+    for_<k>([&, this](auto i) {
       if (modify) {
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
         std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
-        uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
+        uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
+        uint64_t maxForWindow = this->mBeginIndex + windowOffset;
 
-        // If we remain within the same sliding window
-        if (curGroupedInd < maxForWindow) {
+        // If we remain within the same sliding window and fixed index
+        if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
-            std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex;
+            if (curJ < this->mCurrentlyFixed) { // To assure no repetitions
+              std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex + 1;
+            } else {
+              std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex;
+            }
             uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
             std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedJ].second);
           });
@@ -835,25 +774,42 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
       }
     });
 
-    // First iterator processed separately
+    // Currently fixed iterator processed separately
     if (modify) {
-      std::get<0>(this->mCurrentIndices)++;
-      uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
-      this->mBeginIndex = std::get<0>(this->mCurrentIndices);
-
-      // If we remain within the same category - slide window
-      if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
-        for_<k - 1>([&, this](auto j) {
-          constexpr auto curJ = j.value + 1;
-          std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex;
-          uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
-          std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedJ].second);
+      // If we haven't finished with window starting element
+      if (this->mCurrentlyFixed < k - 1 && this->mBeginIndex < std::get<0>(this->mMaxOffset) - 1) {
+        this->mCurrentlyFixed++;
+        for_<k>([&, this](auto s) {
+          if (s.value < this->mCurrentlyFixed) { // To assure no repetitions
+            std::get<s.value>(this->mCurrentIndices) = this->mBeginIndex + 1;
+          } else {
+            std::get<s.value>(this->mCurrentIndices) = this->mBeginIndex;
+          }
+          uint64_t curGroupedI = std::get<s.value>(this->mCurrentIndices);
+          std::get<s.value>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedI].second);
         });
         modify = false;
       } else {
-        // Move to the end of this category
-        std::get<0>(this->mCurrentIndices) += this->mSlidingWindowSize - 1;
+        this->mCurrentlyFixed = 0;
+        this->mBeginIndex++;
+        std::get<0>(this->mCurrentIndices) = this->mBeginIndex;
+        uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
+        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+
+        // If we remain within the same category - slide window
+        if (this->mBeginIndex < std::get<0>(this->mMaxOffset)) {
+          for_<k - 1>([&, this](auto j) {
+            constexpr auto curJ = j.value + 1;
+            std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex;
+            uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
+            std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedJ].second);
+          });
+          modify = false;
+        } else {
+          for_<k>([&, this](auto j) {
+            std::get<j.value>(this->mCurrentIndices) = std::get<j.value>(this->mMaxOffset);
+          });
+        }
       }
     }
 
@@ -867,6 +823,7 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
   }
 
   uint64_t mBeginIndex;
+  uint64_t mCurrentlyFixed;
 };
 
 /// @return next combination of rows of tables.
@@ -964,9 +921,9 @@ template <typename T1, typename T2, typename... T2s>
 auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2& table, const T2s&... tables)
 {
   if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsBlockStrictlyUpperIndexPolicy<T1, T2, T2s...>>(CombinationsBlockStrictlyUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
+    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2s...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
   } else {
-    return CombinationsGenerator<CombinationsBlockFullIndexPolicy<T1, T2, T2s...>>(CombinationsBlockFullIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
+    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, T2, T2s...>>(CombinationsBlockUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
   }
 }
 
@@ -974,9 +931,9 @@ template <typename T1, typename T2, typename... T2s>
 auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const o2::framework::expressions::Filter& filter, const T2& table, const T2s&... tables)
 {
   if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsBlockStrictlyUpperIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockStrictlyUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, Filtered<T2>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)}, Filtered<T2s>{{tables.asArrowTable()}, o2::framework::expressions::createSelection(tables.asArrowTable(), filter)}...));
+    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, Filtered<T2>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)}, Filtered<T2s>{{tables.asArrowTable()}, o2::framework::expressions::createSelection(tables.asArrowTable(), filter)}...));
   } else {
-    return CombinationsGenerator<CombinationsBlockFullIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockFullIndexPolicy(categoryColumnName, categoryNeighbours, outsider, Filtered<T2>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)}, Filtered<T2s>{{tables.asArrowTable()}, o2::framework::expressions::createSelection(tables.asArrowTable(), filter)}...));
+    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, Filtered<T2>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)}, Filtered<T2s>{{tables.asArrowTable()}, o2::framework::expressions::createSelection(tables.asArrowTable(), filter)}...));
   }
 }
 

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -462,7 +462,7 @@ static void BM_ASoAHelpersCombGenSimplePairsSameCategories(benchmark::State& sta
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : selfCombinations("x", 2, -1, tests, tests)) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("x", 2, -1, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -494,7 +494,7 @@ static void BM_ASoAHelpersCombGenSimpleFivesSameCategories(benchmark::State& sta
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : selfCombinations("x", 5, -1, tests, tests, tests, tests, tests)) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("x", 5, -1, tests, tests, tests, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -526,7 +526,7 @@ static void BM_ASoAHelpersCombGenSimplePairsCategories(benchmark::State& state)
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations("x", 2, -1, tests, tests)) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("x", 2, -1, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -558,7 +558,7 @@ static void BM_ASoAHelpersCombGenSimpleFivesCategories(benchmark::State& state)
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations("x", 5, -1, tests, tests, tests, tests, tests)) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("x", 2, -1, tests, tests, tests, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -595,7 +595,7 @@ static void BM_ASoAHelpersCombGenCollisionsPairsSameCategories(benchmark::State&
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : selfCombinations("fNumContrib", 2, -1, collisions, collisions)) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("fNumContrib", 2, -1, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -632,7 +632,7 @@ static void BM_ASoAHelpersCombGenCollisionsFivesSameCategories(benchmark::State&
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : selfCombinations("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions)) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -669,7 +669,7 @@ static void BM_ASoAHelpersCombGenCollisionsPairsCategories(benchmark::State& sta
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations("fNumContrib", 2, -1, collisions, collisions)) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("fNumContrib", 2, -1, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -706,7 +706,7 @@ static void BM_ASoAHelpersCombGenCollisionsFivesCategories(benchmark::State& sta
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions)) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -788,24 +788,35 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   BOOST_REQUIRE_EQUAL(10, testA.size());
 
   // Grouped data:
-  // [3, 5] [0, 4, 7], [1, 6], [2]
+  // [3, 5] [0, 4, 7], [1, 6], [2, 8, 9]
   // Assuming bins intervals: [ , )
   std::vector<uint32_t> yBins{0, 5, 10, 20, 30, 40, 50, 101};
   std::vector<float> zBins{-7.0f, -5.0f, -3.0f, -1.0f, 1.0f, 3.0f, 5.0f, 7.0f};
 
   TableBuilder builderAux;
+  TableBuilder builderAuxHalf;
   auto rowWriterAux = builderAux.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriterAuxHalf = builderAuxHalf.persist<int32_t, int32_t>({"x", "y"});
+  int size = 0;
   for (auto it = testA.begin(); it != testA.end(); it++) {
     auto& elem = *it;
     rowWriterAux(0, elem.x(), getHash(yBins, zBins, elem.y(), elem.floatZ()));
+    if (size < 5) {
+      rowWriterAuxHalf(0, elem.x(), getHash(yBins, zBins, elem.y(), elem.floatZ()));
+    }
+    size++;
   }
   auto tableAux = builderAux.finalize();
+  auto tableAuxHalf = builderAuxHalf.finalize();
   BOOST_REQUIRE_EQUAL(tableAux->num_rows(), 10);
+  BOOST_REQUIRE_EQUAL(tableAuxHalf->num_rows(), 5);
 
   // Auxiliary table: testsAux with id and hash, hash is the category for grouping
   using TestsAux = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
   TestsAux testAux{tableAux};
+  TestsAux testAuxHalf{tableAuxHalf};
   BOOST_REQUIRE_EQUAL(10, testAux.size());
+  BOOST_REQUIRE_EQUAL(5, testAuxHalf.size());
 
   // Omitting values outside bins
   TableBuilder builderAuxNoOverflows;
@@ -822,7 +833,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
 
   // 2, 3, 5, 8, 9 have overflows in testA
   std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsNoOverflows{
-    {0, 0}, {0, 4}, {4, 4}, {4, 7}, {1, 1}, {1, 6}};
+    {0, 0}, {0, 4}, {4, 0}, {4, 4}, {4, 7}, {7, 4}, {7, 7}, {1, 1}, {1, 6}, {6, 1}, {6, 6}};
   int count = 0;
   for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy("y", 1, -1, testAuxNoOverflows, testAuxNoOverflows))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairsNoOverflows[count]));
@@ -831,12 +842,8 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   }
   BOOST_CHECK_EQUAL(count, expectedFullPairsNoOverflows.size());
 
-  // TODO: What about repetitions for full? ((4, 4) and (8, 8) here)
-  //std::vector<std::tuple<int32_t, int32_t>> expectedFullPairs{
-  //  {0, 0}, {0, 4}, {4, 0}, {4, 4}, {4, 4}, {4, 7}, {7, 4}, {7, 7}, {1, 1}, {1, 6}, {6, 1}, {6, 6}, {3, 3}, {3, 5}, {5, 3}, {5, 5}, {2, 2}, {2, 8}, {8, 2}, {8, 8}, {8, 8}, {8, 9}, {9, 8}, {9, 9}};
-  // TODO: Or should it be equivalent to upper? (Then possibly not implemented at all)
   std::vector<std::tuple<int32_t, int32_t>> expectedFullPairs{
-    {0, 0}, {0, 4}, {0, 7}, {2, 2}, {2, 8}, {2, 9}};
+    {0, 0}, {0, 4}, {0, 7}, {4, 0}, {7, 0}, {4, 4}, {4, 7}, {7, 4}, {7, 7}, {1, 1}, {1, 6}, {6, 1}, {6, 6}, {3, 3}, {3, 5}, {5, 3}, {5, 5}, {2, 2}, {2, 8}, {2, 9}, {8, 2}, {9, 2}, {8, 8}, {8, 9}, {9, 8}, {9, 9}};
   count = 0;
   for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy("y", 2, -1, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairs[count]));
@@ -846,7 +853,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   BOOST_CHECK_EQUAL(count, expectedFullPairs.size());
 
   std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedFullTriples{
-    {0, 0, 0}, {0, 0, 4}, {0, 0, 7}, {0, 4, 0}, {0, 4, 4}, {0, 4, 7}, {0, 7, 0}, {0, 7, 4}, {0, 7, 7}, {2, 2, 2}, {2, 2, 8}, {2, 2, 9}, {2, 8, 2}, {2, 8, 8}, {2, 8, 9}, {2, 9, 2}, {2, 9, 8}, {2, 9, 9}};
+    {0, 0, 0}, {0, 0, 4}, {0, 0, 7}, {0, 4, 0}, {0, 4, 4}, {0, 4, 7}, {0, 7, 0}, {0, 7, 4}, {0, 7, 7}, {4, 0, 0}, {4, 0, 4}, {4, 0, 7}, {7, 0, 0}, {7, 0, 4}, {7, 0, 7}, {4, 4, 0}, {4, 7, 0}, {7, 4, 0}, {7, 7, 0}, {4, 4, 4}, {4, 4, 7}, {4, 7, 4}, {4, 7, 7}, {7, 4, 4}, {7, 4, 7}, {7, 7, 4}, {7, 7, 7}, {1, 1, 1}, {1, 1, 6}, {1, 6, 1}, {1, 6, 6}, {6, 1, 1}, {6, 1, 6}, {6, 6, 1}, {6, 6, 6}, {3, 3, 3}, {3, 3, 5}, {3, 5, 3}, {3, 5, 5}, {5, 3, 3}, {5, 3, 5}, {5, 5, 3}, {5, 5, 5}, {2, 2, 2}, {2, 2, 8}, {2, 2, 9}, {2, 8, 2}, {2, 8, 8}, {2, 8, 9}, {2, 9, 2}, {2, 9, 8}, {2, 9, 9}, {8, 2, 2}, {8, 2, 8}, {8, 2, 9}, {9, 2, 2}, {9, 2, 8}, {9, 2, 9}, {8, 8, 2}, {8, 9, 2}, {9, 8, 2}, {9, 9, 2}, {8, 8, 8}, {8, 8, 9}, {8, 9, 8}, {8, 9, 9}, {9, 8, 8}, {9, 8, 9}, {9, 9, 8}, {9, 9, 9}};
   count = 0;
   for (auto& [c0, c1, c2] : combinations(CombinationsBlockFullIndexPolicy("y", 2, -1, testAux, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullTriples[count]));
@@ -857,7 +864,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   BOOST_CHECK_EQUAL(count, expectedFullTriples.size());
 
   std::vector<std::tuple<int32_t, int32_t>> expectedUpperPairs{
-    {0, 0}, {0, 4}, {0, 7}, {2, 2}, {2, 8}, {2, 9}};
+    {0, 0}, {0, 4}, {0, 7}, {4, 4}, {4, 7}, {7, 7}, {1, 1}, {1, 6}, {6, 6}, {3, 3}, {3, 5}, {5, 5}, {2, 2}, {2, 8}, {2, 9}, {8, 8}, {8, 9}, {9, 9}};
   count = 0;
   for (auto& [c0, c1] : combinations(CombinationsBlockUpperIndexPolicy("y", 2, -1, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedUpperPairs[count]));
@@ -867,7 +874,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   BOOST_CHECK_EQUAL(count, expectedUpperPairs.size());
 
   std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedUpperTriples{
-    {0, 0, 0}, {0, 0, 4}, {0, 4, 4}, {4, 4, 4}, {4, 4, 7}, {4, 7, 7}, {1, 1, 1}, {1, 1, 6}, {1, 6, 6}, {3, 3, 3}, {3, 3, 5}, {3, 5, 5}, {2, 2, 2}, {2, 2, 8}, {2, 8, 8}, {8, 8, 8}, {8, 8, 9}, {8, 9, 9}};
+    {0, 0, 0}, {0, 0, 4}, {0, 4, 4}, {4, 4, 4}, {4, 4, 7}, {4, 7, 7}, {7, 7, 7}, {1, 1, 1}, {1, 1, 6}, {1, 6, 6}, {6, 6, 6}, {3, 3, 3}, {3, 3, 5}, {3, 5, 5}, {5, 5, 5}, {2, 2, 2}, {2, 2, 8}, {2, 8, 8}, {8, 8, 8}, {8, 8, 9}, {8, 9, 9}, {9, 9, 9}};
   count = 0;
   for (auto& [c0, c1, c2] : combinations(CombinationsBlockUpperIndexPolicy("y", 1, -1, testAux, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedUpperTriples[count]));
@@ -877,7 +884,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   }
   BOOST_CHECK_EQUAL(count, expectedUpperTriples.size());
 
-  std::vector<std::tuple<int32_t, int32_t, int32_t, int32_t, int32_t>> expectedUpperFives{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 4}, {0, 0, 0, 0, 7}, {0, 0, 0, 4, 4}, {0, 0, 0, 4, 7}, {0, 0, 0, 7, 7}, {0, 0, 4, 4, 4}, {0, 0, 4, 4, 7}, {0, 0, 4, 7, 7}, {0, 0, 7, 7, 7}, {0, 4, 4, 4, 4}, {0, 4, 4, 4, 7}, {0, 4, 4, 7, 7}, {0, 4, 7, 7, 7}, {0, 7, 7, 7, 7}, {2, 2, 2, 2, 2}, {2, 2, 2, 2, 8}, {2, 2, 2, 2, 9}, {2, 2, 2, 8, 8}, {2, 2, 2, 8, 9}, {2, 2, 2, 9, 9}, {2, 2, 8, 8, 8}, {2, 2, 8, 8, 9}, {2, 2, 8, 9, 9}, {2, 2, 9, 9, 9}, {2, 8, 8, 8, 8}, {2, 8, 8, 8, 9}, {2, 8, 8, 9, 9}, {2, 8, 9, 9, 9}, {2, 9, 9, 9, 9}};
+  std::vector<std::tuple<int32_t, int32_t, int32_t, int32_t, int32_t>> expectedUpperFives{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 4}, {0, 0, 0, 0, 7}, {0, 0, 0, 4, 4}, {0, 0, 0, 4, 7}, {0, 0, 0, 7, 7}, {0, 0, 4, 4, 4}, {0, 0, 4, 4, 7}, {0, 0, 4, 7, 7}, {0, 0, 7, 7, 7}, {0, 4, 4, 4, 4}, {0, 4, 4, 4, 7}, {0, 4, 4, 7, 7}, {0, 4, 7, 7, 7}, {0, 7, 7, 7, 7}, {4, 4, 4, 4, 4}, {4, 4, 4, 4, 7}, {4, 4, 4, 7, 7}, {4, 4, 7, 7, 7}, {4, 7, 7, 7, 7}, {7, 7, 7, 7, 7}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 6}, {1, 1, 1, 6, 6}, {1, 1, 6, 6, 6}, {1, 6, 6, 6, 6}, {6, 6, 6, 6, 6}, {3, 3, 3, 3, 3}, {3, 3, 3, 3, 5}, {3, 3, 3, 5, 5}, {3, 3, 5, 5, 5}, {3, 5, 5, 5, 5}, {5, 5, 5, 5, 5}, {2, 2, 2, 2, 2}, {2, 2, 2, 2, 8}, {2, 2, 2, 2, 9}, {2, 2, 2, 8, 8}, {2, 2, 2, 8, 9}, {2, 2, 2, 9, 9}, {2, 2, 8, 8, 8}, {2, 2, 8, 8, 9}, {2, 2, 8, 9, 9}, {2, 2, 9, 9, 9}, {2, 8, 8, 8, 8}, {2, 8, 8, 8, 9}, {2, 8, 8, 9, 9}, {2, 8, 9, 9, 9}, {2, 9, 9, 9, 9}, {8, 8, 8, 8, 8}, {8, 8, 8, 8, 9}, {8, 8, 8, 9, 9}, {8, 8, 9, 9, 9}, {8, 9, 9, 9, 9}, {9, 9, 9, 9, 9}};
   count = 0;
   for (auto& [c0, c1, c2, c3, c4] : combinations(CombinationsBlockUpperIndexPolicy("y", 2, -1, testAux, testAux, testAux, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedUpperFives[count]));
@@ -889,10 +896,20 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   }
   BOOST_CHECK_EQUAL(count, expectedUpperFives.size());
 
-  std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{
-    {0, 4}, {0, 7}, {2, 8}, {2, 9}};
+  std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairsSmaller{
+    {0, 4}, {4, 7}, {1, 6}, {3, 5}, {2, 8}, {8, 9}};
   count = 0;
-  for (auto& [c0, c1] : combinations(CombinationsBlockStrictlyUpperIndexPolicy("y", 2, -1, testAux, testAux))) {
+  for (auto& [c0, c1] : combinations(CombinationsBlockStrictlyUpperSameIndexPolicy("y", 1, -1, testAux, testAux))) {
+    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperPairsSmaller[count]));
+    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperPairsSmaller[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperPairsSmaller.size());
+
+  std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{
+    {0, 4}, {0, 7}, {4, 7}, {1, 6}, {3, 5}, {2, 8}, {2, 9}, {8, 9}};
+  count = 0;
+  for (auto& [c0, c1] : combinations(CombinationsBlockStrictlyUpperSameIndexPolicy("y", 2, -1, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperPairs[count]));
     BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperPairs[count]));
     count++;
@@ -902,7 +919,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedStrictlyUpperTriples{
     {0, 4, 7}, {2, 8, 9}};
   count = 0;
-  for (auto& [c0, c1, c2] : combinations(CombinationsBlockStrictlyUpperIndexPolicy("y", 2, -1, testAux, testAux, testAux))) {
+  for (auto& [c0, c1, c2] : combinations(CombinationsBlockStrictlyUpperSameIndexPolicy("y", 2, -1, testAux, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperTriples[count]));
     BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperTriples[count]));
     BOOST_CHECK_EQUAL(c2.x(), std::get<2>(expectedStrictlyUpperTriples[count]));
@@ -911,104 +928,55 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   BOOST_CHECK_EQUAL(count, expectedStrictlyUpperTriples.size());
 
   count = 0;
-  for (auto& [c0, c1, c2, c3, c4] : combinations(CombinationsBlockStrictlyUpperIndexPolicy("y", 1, -1, testAux, testAux, testAux, testAux, testAux))) {
+  for (auto& [c0, c1, c2, c3, c4] : combinations(CombinationsBlockStrictlyUpperSameIndexPolicy("y", 1, -1, testAux, testAux, testAux, testAux, testAux))) {
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);
 
-  TableBuilder builderCollisions;
-  auto rowWriterCol = builderCollisions.cursor<o2::aod::Collisions>();
-  rowWriterCol(0, 0,
-               0, 0, -6.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 25 /*uint32_t NumContrib*/,
-               0, 0, 0);
-  rowWriterCol(1, 0,
-               1.0f, 0, 0.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 18 /*uint32_t NumContrib*/,
-               0, 0, 1);
-  rowWriterCol(2, 0,
-               3.0f, 0, 8.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 48 /*uint32_t NumContrib*/,
-               0, 0, 2);
-  rowWriterCol(3, 0,
-               2.0f, 0, 2.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 103 /*uint32_t NumContrib*/,
-               0, 0, 3);
-  rowWriterCol(4, 0,
-               0.0f, 0, -6.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 28 /*uint32_t NumContrib*/,
-               0, 0, 4);
-  rowWriterCol(5, 0,
-               2.0f, 0, 2.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 102 /*uint32_t NumContrib*/,
-               0, 0, 5);
-  rowWriterCol(6, 0,
-               1.0f, 0, 0.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 12 /*uint32_t NumContrib*/,
-               0, 0, 6);
-  rowWriterCol(7, 0,
-               0.0f, 0, -7.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 24 /*uint32_t NumContrib*/,
-               0, 0, 7);
-  rowWriterCol(8, 0,
-               3.0f, 0, 8.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 41 /*uint32_t NumContrib*/,
-               0, 0, 8);
-  rowWriterCol(9, 0,
-               3.0f, 0, 8.0f /*float PosZ*/,
-               0, 0, 0, 0, 0, 0, 0, 49 /*uint32_t NumContrib*/,
-               0, 0, 9);
-  auto tableCol = builderCollisions.finalize();
-  BOOST_REQUIRE_EQUAL(tableCol->num_rows(), 10);
-
-  o2::aod::Collisions collisions{tableCol};
-  BOOST_REQUIRE_EQUAL(10, collisions.size());
-
-  TableBuilder builderColAux;
-  auto rowWriterColAux = builderColAux.persist<int32_t, int32_t>({"x", "y"});
-  int ind = 0;
-  for (auto it = collisions.begin(); it != collisions.end(); it++) {
-    auto& collision = *it;
-    rowWriterColAux(0, ind, getHash(yBins, zBins, collision.numContrib(), collision.posZ()));
-    ind++;
-  }
-  auto tableColAux = builderColAux.finalize();
-  BOOST_REQUIRE_EQUAL(tableColAux->num_rows(), 10);
-
-  // Auxiliary table: testAux with id and hash, hash is the category for grouping
-  TestsAux colAux{tableColAux};
-  BOOST_REQUIRE_EQUAL(10, colAux.size());
-
+  // Different tables of different size
+  std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsFirstSmaller{
+    {0, 0}, {0, 4}, {4, 0}, {4, 4}, {4, 7}, {1, 1}, {1, 6}, {3, 3}, {3, 5}, {2, 2}, {2, 8}};
   count = 0;
-  for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy("y", 2, -1, colAux, colAux))) {
-    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairs[count]));
-    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedFullPairs[count]));
-    // Corresponding collisions: collisions.begin() + c0.x(), collisions.begin() + c1.x()
+  for (auto& [x0, x1] : combinations(CombinationsBlockFullIndexPolicy("y", 1, -1, testAuxHalf, testAux))) {
+    BOOST_CHECK_EQUAL(x0.x(), std::get<0>(expectedFullPairsFirstSmaller[count]));
+    BOOST_CHECK_EQUAL(x1.x(), std::get<1>(expectedFullPairsFirstSmaller[count]));
     count++;
   }
-  BOOST_CHECK_EQUAL(count, expectedFullPairs.size());
+  BOOST_CHECK_EQUAL(count, expectedFullPairsFirstSmaller.size());
 
-  // Without hashing, taking a single column from the original table as a category
   count = 0;
-  for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy("fPosX", 2, -1.0f, collisions, collisions))) {
-    BOOST_CHECK_EQUAL(c0.index(), std::get<0>(expectedFullPairs[count]));
-    BOOST_CHECK_EQUAL(c1.index(), std::get<1>(expectedFullPairs[count]));
+  std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsSecondSmaller{
+    {0, 0}, {0, 4}, {4, 0}, {4, 4}, {7, 4}, {1, 1}, {6, 1}, {3, 3}, {5, 3}, {2, 2}, {8, 2}};
+  for (auto& [x0, x1] : combinations(CombinationsBlockFullIndexPolicy("y", 1, -1, testAux, testAuxHalf))) {
+    BOOST_CHECK_EQUAL(x0.x(), std::get<0>(expectedFullPairsSecondSmaller[count]));
+    BOOST_CHECK_EQUAL(x1.x(), std::get<1>(expectedFullPairsSecondSmaller[count]));
     count++;
   }
-  BOOST_CHECK_EQUAL(count, expectedFullPairs.size());
+  BOOST_CHECK_EQUAL(count, expectedFullPairsSecondSmaller.size());
 
-  // Different tables that have the same column name
+  std::vector<std::tuple<int32_t, int32_t>> expectedUpperPairsFirstSmaller{
+    {0, 0}, {0, 4}, {4, 4}, {4, 7}, {1, 1}, {1, 6}, {3, 3}, {3, 5}, {2, 2}, {2, 8}};
   count = 0;
-  for (auto& [x0, x1] : combinations(CombinationsBlockFullIndexPolicy("x", 0, -1, testA, testAux))) {
-    BOOST_CHECK_EQUAL(x0.x(), count);
-    BOOST_CHECK_EQUAL(x1.x(), count);
+  for (auto& [x0, x1] : combinations(CombinationsBlockUpperIndexPolicy("y", 1, -1, testAuxHalf, testAux))) {
+    BOOST_CHECK_EQUAL(x0.x(), std::get<0>(expectedUpperPairsFirstSmaller[count]));
+    BOOST_CHECK_EQUAL(x1.x(), std::get<1>(expectedUpperPairsFirstSmaller[count]));
     count++;
   }
-  BOOST_CHECK_EQUAL(count, testA.size());
+  BOOST_CHECK_EQUAL(count, expectedUpperPairsFirstSmaller.size());
+
+  count = 0;
+  std::vector<std::tuple<int32_t, int32_t>> expectedUpperPairsSecondSmaller{
+    {0, 0}, {0, 4}, {4, 4}, {1, 1}, {3, 3}, {2, 2}};
+  for (auto& [x0, x1] : combinations(CombinationsBlockUpperIndexPolicy("y", 1, -1, testAux, testAuxHalf))) {
+    BOOST_CHECK_EQUAL(x0.x(), std::get<0>(expectedUpperPairsSecondSmaller[count]));
+    BOOST_CHECK_EQUAL(x1.x(), std::get<1>(expectedUpperPairsSecondSmaller[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedUpperPairsSecondSmaller.size());
 
   // Using same index combinations for better performance
   count = 0;
-  for (auto& [c0, c1] : combinations(CombinationsBlockFullSameIndexPolicy("y", 2, -1, colAux, colAux))) {
+  for (auto& [c0, c1] : combinations(CombinationsBlockFullSameIndexPolicy("y", 2, -1, testAux, testAux))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairs[count]));
     BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedFullPairs[count]));
     count++;
@@ -1023,29 +991,6 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
     count++;
   }
   BOOST_CHECK_EQUAL(count, expectedFullTriples.size());
-
-  count = 0;
-  for (auto& [c0, c1] : selfCombinations("y", 2, -1, testAux, testAux)) {
-    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperPairs[count]));
-    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperPairs[count]));
-    count++;
-  }
-  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperPairs.size());
-
-  count = 0;
-  for (auto& [c0, c1, c2] : selfCombinations("y", 2, -1, testAux, testAux, testAux)) {
-    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperTriples[count]));
-    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperTriples[count]));
-    BOOST_CHECK_EQUAL(c2.x(), std::get<2>(expectedStrictlyUpperTriples[count]));
-    count++;
-  }
-  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperTriples.size());
-
-  count = 0;
-  for (auto& [c0, c1, c2, c3, c4] : selfCombinations("y", 2, -1, testAux, testAux, testAux, testAux, testAux)) {
-    count++;
-  }
-  BOOST_CHECK_EQUAL(count, 0);
 
   count = 0;
   for (auto& [c0, c1] : combinations(CombinationsBlockUpperSameIndexPolicy("y", 2, -1, testAux, testAux))) {
@@ -1074,4 +1019,27 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
     count++;
   }
   BOOST_CHECK_EQUAL(count, expectedUpperFives.size());
+
+  count = 0;
+  for (auto& [c0, c1] : selfCombinations("y", 2, -1, testAux, testAux)) {
+    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperPairs[count]));
+    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperPairs[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperPairs.size());
+
+  count = 0;
+  for (auto& [c0, c1, c2] : selfCombinations("y", 2, -1, testAux, testAux, testAux)) {
+    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedStrictlyUpperTriples[count]));
+    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedStrictlyUpperTriples[count]));
+    BOOST_CHECK_EQUAL(c2.x(), std::get<2>(expectedStrictlyUpperTriples[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperTriples.size());
+
+  count = 0;
+  for (auto& [c0, c1, c2, c3, c4] : selfCombinations("y", 2, -1, testAux, testAux, testAux, testAux, testAux)) {
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 0);
 }

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -403,10 +403,12 @@ BOOST_AUTO_TEST_CASE(Combinations)
   ConcatTest concatTests{tableA, tableB};
 
   BOOST_REQUIRE_EQUAL(8, testsA.size());
-  int nA = testsA.size();
   BOOST_REQUIRE_EQUAL(4, testsB.size());
   BOOST_REQUIRE_EQUAL(4, testsC.size());
   BOOST_REQUIRE_EQUAL(12, concatTests.size());
+  int nA = testsA.size();
+  int nB = testsB.size();
+  int nC = testsC.size();
 
   int count = 0;
   int i = 0;
@@ -558,63 +560,9 @@ BOOST_AUTO_TEST_CASE(Combinations)
       m = l + 1;
     }
   }
-
   BOOST_CHECK_EQUAL(count, 56);
 
-  int nB = testsB.size();
-  count = 0;
-  i = 0;
-  j = 0 + nA;
-  for (auto& [t0, t1] : combinations(CombinationsFullIndexPolicy(testsA, testsB))) {
-    BOOST_CHECK_EQUAL(t0.x(), i);
-    BOOST_CHECK_EQUAL(t1.x(), j);
-    count++;
-    j++;
-    if (j == nA + nB) {
-      i++;
-      j = 0 + nA;
-    }
-  }
-  BOOST_CHECK_EQUAL(count, 32);
-
-  int nC = testsC.size();
-  count = 0;
-  i = 0;
-  j = 0 + nA;
-  k = 0 + nA + nB;
-  for (auto& [t0, t1, t2] : combinations(CombinationsFullIndexPolicy(testsA, testsB, testsC))) {
-    BOOST_CHECK_EQUAL(t0.x(), i);
-    BOOST_CHECK_EQUAL(t1.x(), j);
-    BOOST_CHECK_EQUAL(t2.x(), k);
-    count++;
-    k++;
-    if (k == nA + nB + nC) {
-      if (j == nA + nB - 1) {
-        i++;
-        j = 0 + nA;
-      } else {
-        j++;
-      }
-      k = 0 + nA + nB;
-    }
-  }
-  BOOST_CHECK_EQUAL(count, 128);
-
-  count = 0;
-  i = 0;
-  j = 0 + nA;
-  for (auto& [t0, t1] : combinations(testsA, testsB)) {
-    BOOST_CHECK_EQUAL(t0.x(), i);
-    BOOST_CHECK_EQUAL(t1.x(), j);
-    count++;
-    j++;
-    if (j == nA + nB) {
-      i++;
-      j = 0 + nA;
-    }
-  }
-  BOOST_CHECK_EQUAL(count, 32);
-
+  // Combinations shortcut
   count = 0;
   i = 0;
   j = 1;
@@ -644,6 +592,244 @@ BOOST_AUTO_TEST_CASE(Combinations)
     }
   }
   BOOST_CHECK_EQUAL(count, 6);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA;
+  for (auto& [t0, t1] : combinations(testsA, testsB)) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == nA + nB) {
+      i++;
+      j = nA + i;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 10);
+
+  // Different tables of different size
+  count = 0;
+  i = 0;
+  j = 0 + nA;
+  for (auto& [t0, t1] : combinations(CombinationsFullIndexPolicy(testsA, testsB))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA + nB) {
+      i++;
+      j = 0 + nA;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 32);
+
+  count = 0;
+  i = 0 + nA;
+  j = 0;
+  for (auto& [t0, t1] : combinations(CombinationsFullIndexPolicy(testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA) {
+      i++;
+      j = 0;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 32);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA;
+  k = 0 + nA + nB;
+  for (auto& [t0, t1, t2] : combinations(CombinationsFullIndexPolicy(testsA, testsB, testsC))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA + nB + nC) {
+      if (j == nA + nB - 1) {
+        i++;
+        j = 0 + nA;
+      } else {
+        j++;
+      }
+      k = 0 + nA + nB;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 128);
+
+  count = 0;
+  i = 0 + nA + nB;
+  j = 0 + nA;
+  k = 0;
+  for (auto& [t0, t1, t2] : combinations(CombinationsFullIndexPolicy(testsC, testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA) {
+      if (j == nA + nB - 1) {
+        i++;
+        j = 0 + nA;
+      } else {
+        j++;
+      }
+      k = 0;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 128);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA;
+  for (auto& [t0, t1] : combinations(CombinationsUpperIndexPolicy(testsA, testsB))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA + nB) {
+      i++;
+      j = nA + i;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 10);
+
+  count = 0;
+  i = 0 + nA;
+  j = 0;
+  for (auto& [t0, t1] : combinations(CombinationsUpperIndexPolicy(testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA) {
+      i++;
+      j = -nA + i;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 26);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA;
+  k = 0 + nA + nB;
+  for (auto& [t0, t1, t2] : combinations(CombinationsUpperIndexPolicy(testsA, testsB, testsC))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA + nB + nC) {
+      if (j == nA + nB - 1) {
+        i++;
+        j = nA + i;
+      } else {
+        j++;
+      }
+      k = nB + j;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 20);
+
+  count = 0;
+  i = 0 + nA + nB;
+  j = 0 + nA;
+  k = 0;
+  for (auto& [t0, t1, t2] : combinations(CombinationsUpperIndexPolicy(testsC, testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA) {
+      if (j == nA + nB - 1) {
+        i++;
+        j = -nB + i;
+      } else {
+        j++;
+      }
+      k = -nA + j;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 60);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA + 1;
+  for (auto& [t0, t1] : combinations(CombinationsStrictlyUpperIndexPolicy(testsA, testsB))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA + nB) {
+      i++;
+      j = nA + i + 1;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 6);
+
+  count = 0;
+  i = 0 + nA;
+  j = 1;
+  for (auto& [t0, t1] : combinations(CombinationsStrictlyUpperIndexPolicy(testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    count++;
+    j++;
+    if (j == 0 + nA) {
+      i++;
+      j = -nA + i + 1;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 18);
+
+  count = 0;
+  i = 0;
+  j = 0 + nA + 1;
+  k = 0 + nA + nB + 2;
+  for (auto& [t0, t1, t2] : combinations(CombinationsStrictlyUpperIndexPolicy(testsA, testsB, testsC))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA + nB + nC) {
+      if (j == nA + nB - 2) {
+        i++;
+        j = nA + i + 1;
+      } else {
+        j++;
+      }
+      k = nB + j + 1;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 4);
+
+  count = 0;
+  i = 0 + nA + nB;
+  j = 0 + nA + 1;
+  k = 2;
+  for (auto& [t0, t1, t2] : combinations(CombinationsStrictlyUpperIndexPolicy(testsC, testsB, testsA))) {
+    BOOST_CHECK_EQUAL(t0.x(), i);
+    BOOST_CHECK_EQUAL(t1.x(), j);
+    BOOST_CHECK_EQUAL(t2.x(), k);
+    count++;
+    k++;
+    if (k == nA) {
+      if (j == nA + nB - 2) {
+        i++;
+        j = -nB + i + 1;
+      } else {
+        j++;
+      }
+      k = -nA + j + 1;
+    }
+  }
+  BOOST_CHECK_EQUAL(count, 16);
 }
 
 BOOST_AUTO_TEST_CASE(BreakingCombinations)


### PR DESCRIPTION
- loosened constraints on sliding window
- fixed all combinations for the case of different tables of different size
- all combinations on different tables are upper by default, not full