### PR TITLE
Fix: data caching for ITS SA clustering with old reader

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
@@ -136,6 +136,8 @@ void CheckTopologies(std::string clusfile = "o2clus_its.root", std::string hitfi
       }
     } // << build min and max MC events used by each ROF
 
+    auto pattIdx = patternsPtr->cbegin();
+
     for (int irof = 0; irof < nROFRec; irof++) {
       const auto& rofRec = rofRecVec[irof];
       rofRec.print();
@@ -155,7 +157,6 @@ void CheckTopologies(std::string clusfile = "o2clus_its.root", std::string hitfi
         }
       } // << cache MC events contributing to this ROF
 
-      auto pattIdx = patternsPtr->cbegin();
       for (int icl = 0; icl < rofRec.getNEntries(); icl++) {
         int clEntry = rofRec.getFirstEntry() + icl; // entry of icl-th cluster of this ROF in the vector of clusters
         // do we read MC data?

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -121,11 +121,6 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
     }
     LOG(INFO) << Class()->GetName() << " | MCTruth: " << (mUseMCTruth ? "ON" : "OFF");
 
-    // loop over entries of the input tree
-    while (mReaderMC->readNextEntry()) {
-      mClusterer.process(1, *mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
-    }
-
     outTree.Branch("ITSClusterPatt", &mPatterns);
 
     std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
@@ -136,6 +131,11 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
         mc2rof.push_back(m2r);
       }
       outTree.Branch("ITSClustersMC2ROF", mc2rofPtr);
+    }
+
+    // loop over entries of the input tree
+    while (mReaderMC->readNextEntry()) {
+      mClusterer.process(1, *mReaderMC.get(), &mFullClus, &mCompClus, &mPatterns, &mROFRecVec, &mClsLabels);
     }
 
     outTree.Fill();

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -133,7 +133,7 @@ class Clusterer
     void finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, FullClusCont* fullClusPtr, CompClusCont* compClusPtr,
                                  PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr);
     void process(gsl::span<ChipPixelData*> chipPtrs, FullClusCont* fullClusPtr, CompClusCont* compClusPtr, PatternCont* patternsPtr,
-                 const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord* rofPtr);
+                 const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr);
 
     ClustererThread(Clusterer* par = nullptr) : parent(par), curr(column2 + 1), prev(column1 + 1)
     {
@@ -168,12 +168,8 @@ class Clusterer
   bool getWantFullClusters() const { return mWantFullClusters; }
   bool getWantCompactClusters() const { return mWantCompactClusters; }
 
-  uint32_t getCurrROF() const { return mROFRef.getROFrame(); }
-
   void print() const;
   void clear();
-
-  void setOutputTree(TTree* tr) { mClusTree = tr; }
 
   void setNChips(int n)
   {
@@ -225,10 +221,6 @@ class Clusterer
   const o2::itsmft::GeometryTGeo* mGeometry = nullptr; //! ITS OR MFT upgrade geometry
 
   LookUp mPattIdConverter; //! Convert the cluster topology to the corresponding entry in the dictionary.
-
-  // this makes sense only for single-threaded execution with autosaving of the tree: legacy, TOREM
-  o2::itsmft::ROFRecord mROFRef; // ROF reference
-  TTree* mClusTree = nullptr;    //! externally provided tree to write clusters output (if needed)
 
   TStopwatch mTimer;
   TStopwatch mTimerMerge;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -204,7 +204,7 @@ class ChipPixelData
           continue;
         } else {
           pix0.setMask();
-          if (mFirstUnmasked == itC) { // mFirstUnmasked should flag 1st unmasked pixel entry
+          if (int(mFirstUnmasked) == itC) { // mFirstUnmasked should flag 1st unmasked pixel entry
             mFirstUnmasked = itC + 1;
           }
           break;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -615,7 +615,10 @@ class RawPixelReader : public PixelReader
   {
     // Decode next trigger from the cached links data and decrease cached triggers counter, return N links decoded
     if (mMinTriggersCached < 1) {
-      return 0;
+      cacheLinksData(mRawBuffer);
+      if (mMinTriggersCached < 1) {
+        return 0;
+      }
     }
     int nlinks = 0;
     for (int ir = mNRUs; ir--;) {

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -34,7 +34,6 @@ void Clusterer::process(int nThreads, PixelReader& reader, FullClusCont* fullClu
 
   constexpr int LoopPerThread = 4; // in MT mode run so many times more loops than the threads allowed
   auto autoDecode = reader.getDecodeNextAuto();
-  o2::itsmft::ROFRecord* rof = nullptr;
   do {
     if (autoDecode) {
       reader.setDecodeNextAuto(false); // internally do not autodecode
@@ -50,12 +49,17 @@ void Clusterer::process(int nThreads, PixelReader& reader, FullClusCont* fullClu
       mFiredChipsPtr.push_back(curChipData);
       nPix += curChipData->getData().size();
     }
+
+    auto& rof = vecROFRec->emplace_back(reader.getInteractionRecord(), 0, compClus->size(), 0); // create new ROF
+
     int nFired = mFiredChipsPtr.size();
     if (!nFired) {
-      break;
+      if (autoDecode) {
+        continue;
+      }
+      break; // just 1 ROF was asked to be processed
     }
-    auto clustersCount = compClus->size();                                                                                        // RSTODO: in principle, the compClus is never supposed to be 0
-    rof = &vecROFRec->emplace_back(mFiredChipsPtr[0]->getInteractionRecord(), mFiredChipsPtr[0]->getROFrame(), clustersCount, 0); // create new ROF
+
     if (nFired < nThreads) {
       nThreads = nFired;
     }
@@ -154,15 +158,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, FullClusCont* fullClu
       mTimerMerge.Stop();
 #endif
     }
-    // finalize last ROF
-    if (rof) {
-      auto cntUpd = compClus->size();
-      rof->setNEntries(cntUpd - clustersCount); // update
-      if (mClusTree) {                          // if necessary, flush existing data, legacy code, to remove
-        mROFRef = *rof;
-        flushClusters(fullClus, compClus, labelsCl);
-      }
-    }
+    rof.setNEntries(compClus->size() - rof.getFirstEntry()); // update
   } while (autoDecode);
 
   reader.setDecodeNextAuto(autoDecode); // restore setting
@@ -173,14 +169,14 @@ void Clusterer::process(int nThreads, PixelReader& reader, FullClusCont* fullClu
 
 //__________________________________________________
 void Clusterer::ClustererThread::process(gsl::span<ChipPixelData*> chipPtrs, FullClusCont* fullClusPtr, CompClusCont* compClusPtr, PatternCont* patternsPtr,
-                                         const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord* rofPtr)
+                                         const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr)
 {
   int nch = chipPtrs.size();
   for (auto curChipData : chipPtrs) {
     auto chipID = curChipData->getChipID();
     if (parent->mMaxBCSeparationToMask > 0) { // mask pixels fired from the previous ROF
       const auto& chipInPrevROF = parent->mChipsOld[chipID];
-      if (std::abs(rofPtr->getBCData().differenceInBC(chipInPrevROF.getInteractionRecord())) < parent->mMaxBCSeparationToMask) {
+      if (std::abs(rofPtr.getBCData().differenceInBC(chipInPrevROF.getInteractionRecord())) < parent->mMaxBCSeparationToMask) {
         parent->mMaxRowColDiffToMask ? curChipData->maskFiredInSample(parent->mChipsOld[chipID], parent->mMaxRowColDiffToMask) : curChipData->maskFiredInSample(parent->mChipsOld[chipID]);
       }
     }
@@ -387,7 +383,6 @@ void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixel
 //__________________________________________________
 Clusterer::Clusterer() : mPattIdConverter()
 {
-  mROFRef.clear();
 #ifdef _ClusterTopology_
   LOG(INFO) << "*********************************************************************";
   LOG(INFO) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN";
@@ -501,36 +496,12 @@ void Clusterer::ClustererThread::fetchMCLabels(int digID, const MCTruth* labelsD
 void Clusterer::clear()
 {
   // reset
-  mClusTree = nullptr;
-  mROFRef.clear();
 #ifdef _PERFORM_TIMING_
   mTimer.Stop();
   mTimer.Reset();
   mTimerMerge.Stop();
   mTimerMerge.Reset();
 #endif
-}
-
-///< flush cluster data accumulated so far into the tree, this method should be NEVER used in MT-mode
-//__________________________________________________
-void Clusterer::flushClusters(FullClusCont* fullClus, CompClusCont* compClus, MCTruth* labels)
-{
-#ifdef _PERFORM_TIMING_
-  mTimer.Stop();
-#endif
-  mClusTree->Fill();
-#ifdef _PERFORM_TIMING_
-  mTimer.Start(kFALSE);
-#endif
-  if (fullClus) {
-    fullClus->clear();
-  }
-  if (compClus) {
-    compClus->clear();
-  }
-  if (labels) {
-    labels->clear();
-  }
 }
 
 //__________________________________________________


### PR DESCRIPTION
Since the loop over the ROFs in updated clusterization is managed by the clusterizer rather than
the reader (even in autoRead mode), the reader should try to cache its data at decodeNextTrigger call.

Eliminate the internal tree in the cluster: we anyway do not store per ROF.