### PR TITLE
Label renamed to Lbl, MC information in dumpDataModel

### DIFF
--- a/Analysis/DataModel/src/dumpDataModel.cxx
+++ b/Analysis/DataModel/src/dumpDataModel.cxx
@@ -165,5 +165,8 @@ edge[dir=back, arrowtail=empty]
   dumpTable<Jets>(true, StyleType::BLUE);
   dumpTable<JetConstituents>(true, StyleType::BLUE);
   dumpTable<UnassignedTracks>();
+  dumpTable<McCollisions>();
+  dumpTable<McLabels>();
+  dumpTable<McParticles>();
   fmt::printf("%s\n", R"(})");
 }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -420,8 +420,8 @@ using McCollision = McCollisions::iterator;
 
 namespace mclabel
 {
-DECLARE_SOA_COLUMN(Label, label, int);
-DECLARE_SOA_COLUMN(LabelMask, labelMask, uint16_t);
+DECLARE_SOA_COLUMN(Lbl, lbl, int);
+DECLARE_SOA_COLUMN(LblMask, lblMask, uint16_t);
 /// Bit mask to indicate detector mismatches (bit ON means mismatch)
 /// Bit 0-6: mismatch at ITS layer
 /// Bit 7-9: # of TPC mismatches in the ranges 0, 1, 2-3, 4-7, 8-15, 16-31, 32-63, >64
@@ -429,7 +429,7 @@ DECLARE_SOA_COLUMN(LabelMask, labelMask, uint16_t);
 } // namespace mclabel
 
 DECLARE_SOA_TABLE(McLabels, "AOD", "MCLABEL", o2::soa::Index<>,
-                  mclabel::Label, mclabel::LabelMask);
+                  mclabel::Lbl, mclabel::LblMask);
 using McLabel = McLabels::iterator;
 
 namespace mcparticle


### PR DESCRIPTION
Rename Label to Lbl since label in O2 is used in different scope. 
Add the MC information to dumpDataModel