### PR TITLE
Simplifying creation of writers in the TPC reco workflow

### DIFF
--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -406,16 +406,16 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
     auto logger = BranchDefinition<TrackOutputType>::Spectator([](TrackOutputType const& tracks) {
       LOG(INFO) << "writing " << tracks.size() << " track(s)";
     });
-    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", "TRACKS"},      //
-                                                       "TPCTracks", "track-branch-name",               //
-                                                       1,                                              //
-                                                       logger};                                        //
-    auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", "CLUSREFS"}, //
-                                                         "ClusRefs", "trackclusref-branch-name"};      //
-    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKSMCLBL"},        //
-                                                    "TPCTracksMCTruth",                                //
-                                                    (propagateMC ? 1 : 0),                             //
-                                                    "trackmc-branch-name"};                            //
+    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", "TRACKS", 0},      //
+                                                       "TPCTracks", "track-branch-name",                  //
+                                                       1,                                                 //
+                                                       logger};                                           //
+    auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", "CLUSREFS", 0}, //
+                                                         "ClusRefs", "trackclusref-branch-name"};         //
+    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKSMCLBL", 0},        //
+                                                    "TPCTracksMCTruth",                                   //
+                                                    (propagateMC ? 1 : 0),                                //
+                                                    "trackmc-branch-name"};                               //
 
     // depending on the MC propagation flag, branch definition for MC labels is disabled
     specs.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,


### PR DESCRIPTION
- removing remnants of custom end-of-stream handling
  The checkReady callback is not necessary anymore to steer termination of the
  workflow, eos is handled inside DPL
- MC label branches are optionally disabled at runtime using a new feature of
  the RootTreeWriter. The definition of branches can now be done completely
  at compile time, separate code branches for the different can be avoided