### PR TITLE
DPL: distinctly named *label() methods for soa::Column and Table

### DIFF
--- a/Analysis/DataModel/src/dumpDataModel.cxx
+++ b/Analysis/DataModel/src/dumpDataModel.cxx
@@ -23,7 +23,7 @@ template <typename C>
 void printColumn(char const* fg, char const* bg)
 {
   if constexpr (!is_index_column_v<C>) {
-    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::label());
+    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
   }
 }
 
@@ -31,7 +31,7 @@ template <typename C>
 void printIndexColumn(char const* fg, char const* bg)
 {
   if constexpr (is_index_column_v<C>) {
-    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::label());
+    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
   }
 }
 
@@ -39,13 +39,13 @@ template <typename C, typename T>
 void printIndex()
 {
   if constexpr (!is_type_with_originals_v<typename C::binding_t>) {
-    auto a = MetadataTrait<typename C::binding_t>::metadata::label();
-    auto b = MetadataTrait<T>::metadata::label();
+    auto a = MetadataTrait<typename C::binding_t>::metadata::tableLabel();
+    auto b = MetadataTrait<T>::metadata::tableLabel();
     fmt::printf("%s -> %s []\n", a, b);
   } else {
     using main_original = pack_element_t<0, typename C::binding_t::originals>;
-    auto a = MetadataTrait<main_original>::metadata::label();
-    auto b = MetadataTrait<T>::metadata::label();
+    auto a = MetadataTrait<main_original>::metadata::tableLabel();
+    auto b = MetadataTrait<T>::metadata::tableLabel();
     fmt::printf("%s -> %s []\n", a, b);
   }
 }
@@ -107,7 +107,7 @@ void dumpTable(bool index = true, enum StyleType styleId = StyleType::DEFAULT)
 {
   auto style = styles[static_cast<int>(styleId)];
   //  nodes.push_back({MetadataTrait<T>::metadata::label(), nodeCount});
-  auto label = MetadataTrait<T>::metadata::label();
+  auto label = MetadataTrait<T>::metadata::tableLabel();
   fmt::printf(R"(%s[color="%s" cellpadding="0" fillcolor="%s" fontcolor="%s" label = <
 <TABLE cellpadding='2' cellspacing='0' cellborder='0' ><TH cellpadding='0' bgcolor="black"><TD bgcolor="%s"><font color="%s">%s</font></TD></TH>)",
               label, style.color, style.background, style.fontcolor, style.headerbgcolor, style.headerfontcolor, label);

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -254,7 +254,7 @@ struct Column {
 
   using persistent = std::true_type;
   using type = T;
-  static constexpr const char* const& label() { return INHERIT::mLabel; }
+  static constexpr const char* const& columnLabel() { return INHERIT::mLabel; }
   ColumnIterator<T> const& getIterator() const
   {
     return mColumnIterator;
@@ -271,7 +271,7 @@ struct DynamicColumn {
   using inherited_t = INHERIT;
 
   using persistent = std::false_type;
-  static constexpr const char* const& label() { return INHERIT::mLabel; }
+  static constexpr const char* const& columnLabel() { return INHERIT::mLabel; }
 };
 
 template <typename INHERIT>
@@ -279,7 +279,7 @@ struct IndexColumn {
   using inherited_t = INHERIT;
 
   using persistent = std::false_type;
-  static constexpr const char* const& label() { return INHERIT::mLabel; }
+  static constexpr const char* const& columnLabel() { return INHERIT::mLabel; }
 };
 
 template <int64_t START = 0, int64_t END = -1>
@@ -913,7 +913,7 @@ class Table
   BackendColumnType* lookupColumn()
   {
     if constexpr (T::persistent::value) {
-      auto label = T::label();
+      auto label = T::columnLabel();
       auto index = mTable->schema()->GetFieldIndex(label);
       if (index == -1) {
         throw std::runtime_error(std::string("Unable to find column with label ") + label);
@@ -963,7 +963,7 @@ template <typename INHERIT>
 class TableMetadata
 {
  public:
-  static constexpr char const* const label() { return INHERIT::mLabel; }
+  static constexpr char const* const tableLabel() { return INHERIT::mLabel; }
   static constexpr char const (&origin())[4] { return INHERIT::mOrigin; }
   static constexpr char const (&description())[16] { return INHERIT::mDescription; }
 };

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -136,12 +136,12 @@ struct Produces<soa::Table<C...>> : WritingCursor<typename soa::FilterPersistent
   // @return the associated OutputSpec
   OutputSpec const spec()
   {
-    return OutputSpec{OutputLabel{metadata::label()}, metadata::origin(), metadata::description()};
+    return OutputSpec{OutputLabel{metadata::tableLabel()}, metadata::origin(), metadata::description()};
   }
 
   OutputRef ref()
   {
-    return OutputRef{metadata::label(), 0};
+    return OutputRef{metadata::tableLabel(), 0};
   }
 };
 
@@ -280,7 +280,7 @@ struct AnalysisDataProcessorBuilder {
     using metadata = typename aod::MetadataTrait<std::decay_t<Arg>>::metadata;
     static_assert(std::is_same_v<metadata, void> == false,
                   "Could not find metadata. Did you register your type?");
-    inputs.push_back({metadata::label(), "AOD", metadata::description()});
+    inputs.push_back({metadata::tableLabel(), "AOD", metadata::description()});
   }
 
   template <typename... Args>
@@ -332,7 +332,7 @@ struct AnalysisDataProcessorBuilder {
   static auto extractTableFromRecord(InputRecord& record)
   {
     if constexpr (soa::is_type_with_metadata_v<aod::MetadataTrait<T>>) {
-      return record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::label())->asArrowTable();
+      return record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::tableLabel())->asArrowTable();
     } else if constexpr (soa::is_type_with_originals_v<T>) {
       return extractFromRecord<T>(record, typename T::originals{});
     }
@@ -427,10 +427,10 @@ struct AnalysisDataProcessorBuilder {
         if constexpr (soa::is_type_with_originals_v<std::decay_t<G>>) {
           using T = typename framework::pack_element_t<0, typename std::decay_t<G>::originals>;
           using groupingMetadata = typename aod::MetadataTrait<T>::metadata;
-          return std::string("f") + groupingMetadata::label() + "ID";
+          return std::string("f") + groupingMetadata::tableLabel() + "ID";
         } else {
           using groupingMetadata = typename aod::MetadataTrait<std::decay_t<G>>::metadata;
-          return std::string("f") + groupingMetadata::label() + "ID";
+          return std::string("f") + groupingMetadata::tableLabel() + "ID";
         }
       }
 

--- a/Framework/Core/include/Framework/RootTableBuilderHelpers.h
+++ b/Framework/Core/include/Framework/RootTableBuilderHelpers.h
@@ -149,7 +149,7 @@ template <typename C>
 struct ColumnReaderTrait {
   static auto createReader(TTreeReader& reader)
   {
-    return std::move(HolderMaker<Remap64Bit_t<typename C::type>>::make(reader, C::base::label()));
+    return std::move(HolderMaker<Remap64Bit_t<typename C::type>>::make(reader, C::base::columnLabel()));
   }
 };
 

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -552,14 +552,14 @@ class TableBuilder
   template <typename T, size_t... Is>
   auto cursorHelper(std::index_sequence<Is...> s)
   {
-    std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::label()...};
+    std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::columnLabel()...};
     return this->template persist<typename pack_element_t<Is, typename T::columns>::type...>(columnNames);
   }
 
   template <typename T, typename E, size_t... Is>
   auto cursorHelper(std::index_sequence<Is...> s)
   {
-    std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::label()...};
+    std::vector<std::string> columnNames{pack_element_t<Is, typename T::columns>::columnLabel()...};
     return this->template persist<E>(columnNames);
   }
 

--- a/Framework/Core/src/verifyAODFile.cxx
+++ b/Framework/Core/src/verifyAODFile.cxx
@@ -22,7 +22,7 @@ using namespace o2::soa;
 template <typename T>
 void verifyTable(TFile* infile, const char* branchName)
 {
-  std::cout << "Table: " << o2::aod::MetadataTrait<T>::metadata::label() << std::endl;
+  std::cout << "Table: " << o2::aod::MetadataTrait<T>::metadata::tableLabel() << std::endl;
   std::unique_ptr<TTreeReader> reader = std::make_unique<TTreeReader>(branchName, infile);
   TableBuilder builder;
   RootTableBuilderHelpers::convertASoA<T>(builder, *reader);


### PR DESCRIPTION
* Replace `soa::Column::label()` with `soa::Column::columnLabel()` so that one can have `label()` as a getter for a column. 
* Replace `aod::TableMetadata::label()` with `tableLabel` for consistency