### PR TITLE
Fix RawReader options, --input-conf instead of --conf

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -316,7 +316,7 @@ by using option `--output-per-link`.
 
 The standard use case of this workflow is to provide the input for other worfklows using the piping, e.g.
 ```cpp
-o2-raw-file-reader-workflow --conf myConf.cfg | o2-dpl-raw-parser
+o2-raw-file-reader-workflow --input-conf myConf.cfg | o2-dpl-raw-parser
 ```
 
 ## Raw data file checker (standalone executable)
@@ -325,7 +325,7 @@ o2-raw-file-reader-workflow --conf myConf.cfg | o2-dpl-raw-parser
 Usage:   o2-raw-file-check [options] file0 [... fileN]
 Options:
   -h [ --help ]                     print this help message.
-  -c [ --conf ] arg                 read input from configuration file
+  -c [ --input-conf ] arg           read input from configuration file
   -m [ --max-tf] arg (=0xffffffff)  max. TF ID to read (counts from 0)
   -v [ --verbosity ] arg (=0)    1: long report, 2 or 3: print or dump all RDH
   -s [ --spsize ]    arg (=1048576) nominal super-page size in bytes

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -530,7 +530,7 @@ bool RawFileReader::init()
 
   for (int i = 0; i < NErrorsDefined; i++) {
     if (mCheckErrors & (0x1 << i))
-      LOGF(INFO, "perform check for /%s/", ErrNames[i].data());
+      LOGF(INFO, "%s check for /%s/", (mCheckErrors & (0x1 << i)) ? "perform" : "ignore ", ErrNames[i].data());
   }
   if (mMaxTFToRead < 0xffffffff) {
     LOGF(INFO, "at most %u TF will be processed", mMaxTFToRead);

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -23,19 +23,20 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options;
-  options.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
-  options.push_back(ConfigParamSpec{"min-tf", o2::framework::VariantType::Int64, 0L, {"min TF ID to process"}});
-  options.push_back(ConfigParamSpec{"max-tf", o2::framework::VariantType::Int64, 0xffffffffL, {"max TF ID to process"}});
-  options.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
-  options.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
-  options.push_back(ConfigParamSpec{"output-per-link", o2::framework::VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
-  options.push_back(ConfigParamSpec{"delay", o2::framework::VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
-  options.push_back(ConfigParamSpec{"buffer-size", o2::framework::VariantType::Int64, 1024L * 1024L, {"buffer size for files preprocessing"}});
+  options.push_back(ConfigParamSpec{"input-conf", VariantType::String, "", {"configuration file with input (obligatory)"}});
+  options.push_back(ConfigParamSpec{"min-tf", VariantType::Int64, 0L, {"min TF ID to process"}});
+  options.push_back(ConfigParamSpec{"max-tf", VariantType::Int64, 0xffffffffL, {"max TF ID to process"}});
+  options.push_back(ConfigParamSpec{"loop", VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
+  options.push_back(ConfigParamSpec{"message-per-tf", VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
+  options.push_back(ConfigParamSpec{"output-per-link", VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
+  options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
+  options.push_back(ConfigParamSpec{"buffer-size", VariantType::Int64, 1024L * 1024L, {"buffer size for files preprocessing"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
+
   for (int i = 0; i < RawFileReader::NErrorsDefined; i++) {
     auto ei = RawFileReader::ErrTypes(i);
-    options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(ei), VariantType::Bool, RawFileReader::ErrCheckDefaults[i], {RawFileReader::nochk_expl(ei)}});
+    options.push_back(ConfigParamSpec{RawFileReader::nochk_opt(ei), VariantType::Bool, false, {RawFileReader::nochk_expl(ei)}});
   }
   std::swap(workflowOptions, options);
 }
@@ -46,24 +47,24 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
-  auto inifile = configcontext.options().get<std::string>("conf");
+  auto inifile = configcontext.options().get<std::string>("input-conf");
   auto loop = configcontext.options().get<int>("loop");
   uint32_t maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
   uint32_t minTF = uint32_t(configcontext.options().get<int64_t>("min-tf"));
   uint64_t buffSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
   auto tfAsMessage = configcontext.options().get<bool>("message-per-tf");
   auto outPerRoute = !configcontext.options().get<bool>("output-per-link");
-  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
   uint32_t errmap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     auto ei = RawFileReader::ErrTypes(i);
-    if (configcontext.options().get<bool>(RawFileReader::nochk_opt(ei).c_str())) {
+    bool defOpt = RawFileReader::ErrCheckDefaults[i];
+    if (configcontext.options().get<bool>(RawFileReader::nochk_opt(ei).c_str()) ? !defOpt : defOpt) { // cmdl option inverts default!
       errmap |= 0x1 << i;
     }
-    LOG(INFO) << ((errmap & (0x1 << i)) ? "apply " : "ignore") << " check for " << RawFileReader::ErrNames[i].data();
   }
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
   return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap, minTF, maxTF, buffSize));
 }

--- a/Detectors/Raw/src/rawfileCheck.cxx
+++ b/Detectors/Raw/src/rawfileCheck.cxx
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
   bpo::options_description descOpt("Options");
   auto desc_add_option = descOpt.add_options();
   desc_add_option("help,h", "print this help message.");
-  desc_add_option("conf,c", bpo::value(&config)->default_value(""), "read input from configuration file");
+  desc_add_option("input-conf,c", bpo::value(&config)->default_value(""), "read input from configuration file");
   desc_add_option("max-tf,m", bpo::value<uint32_t>()->default_value(0xffffffff), " ID to read (counts from 0)");
   desc_add_option("verbosity,v", bpo::value<int>()->default_value(reader.getVerbosity()), "1: long report, 2 or 3: print or dump all RDH");
   desc_add_option("spsize,s", bpo::value<int>()->default_value(reader.getNominalSPageSize()), "nominal super-page size in bytes");


### PR DESCRIPTION
To avoid clash with global framework options the configuration file with raw data should be
provided via --input-conf options.

Fix in the error-checking optional requests processing