### PR TITLE
Support padded or unpadded TPC ZS pages

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -212,6 +212,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       config.configDeviceProcessing.runMC = processMC;       // Propagate MC labels
       config.configDeviceProcessing.eventDisplay = display;  // Ptr to event display backend, for running standalone OpenGL event display
       config.configDeviceProcessing.debugLevel = debugLevel; // Debug verbosity
+      config.configDeviceProcessing.forceMemoryPoolSize = 1; // Some memory auto-detection
 
       config.configEvent.solenoidBz = solenoidBz;
       int maxContTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * Constants::LHCBCPERTIMEBIN - 2) / Constants::LHCBCPERTIMEBIN;

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -518,7 +518,7 @@ inline std::unique_ptr<T> GPUReconstruction::ReadFlatObjectFromFile(const char* 
   if (r == 0 || size[0] != sizeof(T)) {
     fclose(fp);
     GPUError("ERROR reading %s, invalid size: %lld (%lld expected)", file, (long long int)size[0], (long long int)sizeof(T));
-    return nullptr;
+    throw std::runtime_error("invalid size");
   }
   std::unique_ptr<T> retVal(new T);
   char* buf = new char[size[1]]; // Not deleted as ownership is transferred to FlatObject
@@ -558,7 +558,8 @@ inline std::unique_ptr<T> GPUReconstruction::ReadStructFromFile(const char* file
   r = fread(&size, sizeof(size), 1, fp);
   if (r == 0 || size != sizeof(T)) {
     fclose(fp);
-    return nullptr;
+    GPUError("ERROR reading %s, invalid size: %lld (%lld expected)", file, (long long int)size, (long long int)sizeof(T));
+    throw std::runtime_error("invalid size");
   }
   std::unique_ptr<T> newObj(new T);
   r = fread(newObj.get(), 1, size, fp);

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -51,7 +51,7 @@ class GPUReconstructionConvert
   static void ConvertNativeToClusterData(o2::tpc::ClusterNativeAccess* native, std::unique_ptr<GPUTPCClusterData[]>* clusters, unsigned int* nClusters, const TPCFastTransform* transform, int continuousMaxTimeBin = 0);
   static void ConvertRun2RawToNative(o2::tpc::ClusterNativeAccess& native, std::unique_ptr<o2::tpc::ClusterNative[]>& nativeBuffer, const AliHLTTPCRawCluster** rawClusters, unsigned int* nRawClusters);
   template <class T, class S>
-  static void RunZSEncoder(const S& in, std::unique_ptr<unsigned long long int[]>* outBuffer, unsigned int* outSizes, o2::raw::RawFileWriter* raw, const o2::InteractionRecord* ir, const GPUParam& param, bool zs12bit, bool verify, float threshold = 0.f);
+  static void RunZSEncoder(const S& in, std::unique_ptr<unsigned long long int[]>* outBuffer, unsigned int* outSizes, o2::raw::RawFileWriter* raw, const o2::InteractionRecord* ir, const GPUParam& param, bool zs12bit, bool verify, float threshold = 0.f, bool padding = true);
   static void RunZSEncoderCreateMeta(const unsigned long long int* buffer, const unsigned int* sizes, void** ptrs, GPUTrackingInOutZS* out);
   static void RunZSFilter(std::unique_ptr<o2::tpc::Digit[]>* buffers, const o2::tpc::Digit* const* ptrs, size_t* nsb, const size_t* ns, const GPUParam& param, bool zs12bit);
   static int GetMaxTimeBin(const o2::tpc::ClusterNativeAccess& native);

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1381,7 +1381,7 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
 
     std::array<bool, NSLICES> transferRunning;
     transferRunning.fill(true);
-    if ((GetRecoStepsOutputs() & GPUDataTypes::InOutType::TPCSectorTracks) || (doGPU && !(GetRecoStepsGPU() & RecoStep::TRDTracking))) {
+    if ((GetRecoStepsOutputs() & GPUDataTypes::InOutType::TPCSectorTracks) || (doGPU && !(GetRecoStepsGPU() & RecoStep::TPCMerging))) {
       if (param().rec.GlobalTracking) {
         mWriteOutputDone.fill(0);
       }


### PR DESCRIPTION
@shahor02 : Add option --no-padding to TPC raw writer. Currently, the tpc-reco-workflow fails for me reading raw data:
```
o2-raw-file-reader-workflow --conf tpcrawzs.raw/tpcraw.cfg | o2-tpc-reco-workflow --ca-clusterer --input-type=zsraw --disable-m

Invalid workflow: No matching output found for <matcher query: (and origin:TPC (and startTime:$0  description:RAWDATA ))>. Candidates:
-TPC/CLUSREFS/0
-TPC/TRACKS/0
```