### PR TITLE
DPL: add provenance information for ConfigParamSpec

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -34,6 +34,7 @@ o2_add_library(Framework
                        src/CompletionPolicyHelpers.cxx
                        src/ComputingResourceHelpers.cxx
                        src/DispatchPolicy.cxx
+                       src/ConfigParamStore.cxx
                        src/ConfigParamsHelper.cxx
                        src/DDSConfigHelpers.cxx
                        src/DataAllocator.cxx
@@ -142,6 +143,7 @@ foreach(t
         ChannelSpecHelpers
         CompletionPolicy
         ComputingResourceHelpers
+        ConfigParamStore
         ConfigParamRegistry
         ContextRegistry
         DataDescriptorMatcher

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -58,6 +58,7 @@ o2_add_library(Framework
                        src/DataSamplingPolicy.cxx
                        src/DataSamplingReadoutAdapter.cxx
                        src/DataSpecUtils.cxx
+                       src/DeviceConfigInfo.cxx
                        src/DeviceMetricsInfo.cxx
                        src/DeviceSpec.cxx
                        src/DeviceSpecHelpers.cxx
@@ -153,6 +154,7 @@ foreach(t
         DataSamplingCondition
         DataSamplingHeader
         DataSamplingPolicy
+        DeviceConfigInfo
         DeviceMetricsInfo
         DeviceSpec
         DeviceSpecHelpers

--- a/Framework/Core/include/Framework/BoostOptionsRetriever.h
+++ b/Framework/Core/include/Framework/BoostOptionsRetriever.h
@@ -13,14 +13,11 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ParamRetriever.h"
 
-#include <boost/program_options.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <string>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/program_options/options_description.hpp>
 #include <vector>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 /// This extracts the specified ConfigParams from (argc, argv) and makes them
@@ -28,25 +25,18 @@ namespace framework
 class BoostOptionsRetriever : public ParamRetriever
 {
  public:
-  BoostOptionsRetriever(std::vector<ConfigParamSpec> const& specs,
-                        bool ignoreUnknown,
-                        int& argc, char**& argv);
-
-  bool isSet(const char* name) const final;
-  int getInt(const char* name) const final;
-  int64_t getInt64(const char* name) const final;
-  float getFloat(const char* name) const final;
-  double getDouble(const char* name) const final;
-  bool getBool(const char* name) const final;
-  std::string getString(const char* name) const final;
-  boost::property_tree::ptree getPTree(const char* name) const final;
+  BoostOptionsRetriever(bool ignoreUnknown,
+                        int argc, char** argv);
+  void update(std::vector<ConfigParamSpec> const& specs,
+              boost::property_tree::ptree& store,
+              boost::property_tree::ptree& provenance) override;
 
  private:
-  boost::property_tree::ptree mStore;
   boost::program_options::options_description mDescription;
+  int mArgc;
+  char** mArgv;
   bool mIgnoreUnknown;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 #endif // FRAMEWORK_BOOSTOPTIONSRETRIEVER_H

--- a/Framework/Core/include/Framework/ConfigParamStore.h
+++ b/Framework/Core/include/Framework/ConfigParamStore.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_CONFIGPARAMSTORE_H_
+#define O2_FRAMEWORK_CONFIGPARAMSTORE_H_
+
+#include "Framework/ParamRetriever.h"
+#include "Framework/ConfigParamSpec.h"
+
+#include <boost/property_tree/ptree_fwd.hpp>
+
+namespace o2::framework
+{
+
+/// This provides unified store for the parameters specified in the
+/// ConfigParamSpecs. This provides only the store, not the actual
+/// API to access it. Notice how the loading of the data is done in
+/// to steps, to allow doing a diff between the old and the new
+/// configuration.
+class ConfigParamStore
+{
+ public:
+  ConfigParamStore(std::vector<ConfigParamSpec> const& specs,
+                   std::vector<std::unique_ptr<ParamRetriever>> retrievers);
+
+  /// Preload the next store with a new copy of
+  /// the configuration.
+  void preload();
+
+  /// Get the store
+  boost::property_tree::ptree& store() { return *mStore; };
+  boost::property_tree::ptree& provenanceTree() { return *mProvenance; };
+
+  /// Activate the next store
+  void activate();
+
+  std::string provenance(const char*) const;
+
+ private:
+  std::vector<ConfigParamSpec> const& mSpecs;
+  std::vector<std::unique_ptr<ParamRetriever>> mRetrievers;
+  std::unique_ptr<boost::property_tree::ptree> mStore;
+  std::unique_ptr<boost::property_tree::ptree> mProvenance;
+  std::unique_ptr<boost::property_tree::ptree> mNextStore;
+  std::unique_ptr<boost::property_tree::ptree> mNextProvenance;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_CONFIGPARAMREGISTRY_H_

--- a/Framework/Core/include/Framework/DeviceConfigInfo.h
+++ b/Framework/Core/include/Framework/DeviceConfigInfo.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+#ifndef O2_FRAMEWORK_DEVICECONFIGINFO_H_
+#define O2_FRAMEWORK_DEVICECONFIGINFO_H_
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <boost/property_tree/ptree.hpp>
+
+namespace o2::framework
+{
+
+struct DeviceInfo;
+
+/// Temporary struct to hold a configuration parameter.
+struct ParsedConfigMatch {
+  char const* beginKey;
+  char const* endKey;
+  char const* beginValue;
+  char const* endValue;
+  std::size_t timestamp;
+};
+
+struct DeviceConfigHelper {
+  /// Helper function to parse a metric string.
+  static bool parseConfig(std::string_view const s, ParsedConfigMatch& results);
+
+  /// Processes a parsed configuration and stores in the backend store.
+  ///
+  /// @matches is the regexp_matches from the metric identifying regex
+  /// @info is the DeviceInfo associated to the device posting the metric
+  /// @newMetricsCallback is a callback that will be invoked every time a new metric is added to the list.
+  static bool processConfig(ParsedConfigMatch& results,
+                            DeviceInfo& info);
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DEVICEMETRICSINFO_H_

--- a/Framework/Core/include/Framework/DeviceConfigInfo.h
+++ b/Framework/Core/include/Framework/DeviceConfigInfo.h
@@ -17,7 +17,6 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <boost/property_tree/ptree.hpp>
 
 namespace o2::framework
 {
@@ -30,18 +29,22 @@ struct ParsedConfigMatch {
   char const* endKey;
   char const* beginValue;
   char const* endValue;
+  char const* beginProvenance;
+  char const* endProvenance;
   std::size_t timestamp;
 };
 
 struct DeviceConfigHelper {
-  /// Helper function to parse a metric string.
+  /// Helper function to parse a configuration parameter reported by
+  /// a given device. The format is the following:
+  ///
+  /// [CONFIG]: key=value timestamp provenance
   static bool parseConfig(std::string_view const s, ParsedConfigMatch& results);
 
   /// Processes a parsed configuration and stores in the backend store.
   ///
   /// @matches is the regexp_matches from the metric identifying regex
   /// @info is the DeviceInfo associated to the device posting the metric
-  /// @newMetricsCallback is a callback that will be invoked every time a new metric is added to the list.
   static bool processConfig(ParsedConfigMatch& results,
                             DeviceInfo& info);
 };

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -65,6 +65,8 @@ struct DeviceInfo {
   Metric2DViewIndex queriesViewIndex;
   /// Current configuration for the device
   boost::property_tree::ptree currentConfig;
+  /// Current provenance for the configuration keys
+  boost::property_tree::ptree currentProvenance;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -21,6 +21,7 @@
 // For pid_t
 #include <unistd.h>
 #include <array>
+#include <boost/property_tree/ptree.hpp>
 
 namespace o2
 {
@@ -62,6 +63,8 @@ struct DeviceInfo {
   Metric2DViewIndex variablesViewIndex;
   /// Index for the queries of each input route.
   Metric2DViewIndex queriesViewIndex;
+  /// Current configuration for the device
+  boost::property_tree::ptree currentConfig;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/FairOptionsRetriever.h
+++ b/Framework/Core/include/Framework/FairOptionsRetriever.h
@@ -7,47 +7,32 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_BOOSTOPTIONSRETRIEVER_H
-#define FRAMEWORK_BOOSTOPTIONSRETRIEVER_H
+#ifndef O2_FRAMEWORK_FAIROPTIONSRETRIEVER_H_
+#define O2_FRAMEWORK_FAIROPTIONSRETRIEVER_H_
 
 #include "Framework/ParamRetriever.h"
 #include "Framework/ConfigParamSpec.h"
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <fairmq/ProgOptionsFwd.h>
 
-#include <string>
 #include <vector>
 
-#if __has_include(<fairmq/ProgOptionsFwd.h>)
-#include <fairmq/ProgOptionsFwd.h>
-#else
-class FairMQProgOptions;
-#endif
-
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 class FairOptionsRetriever : public ParamRetriever
 {
  public:
-  FairOptionsRetriever(std::vector<ConfigParamSpec> const& schema, const FairMQProgOptions* opts);
+  FairOptionsRetriever(const FairMQProgOptions* opts) : mOpts{opts} {}
 
-  bool isSet(const char* name) const final;
-  int getInt(const char* name) const final;
-  int64_t getInt64(const char* name) const final;
-  float getFloat(const char* name) const final;
-  double getDouble(const char* name) const final;
-  bool getBool(const char* name) const final;
-  std::string getString(const char* name) const final;
-  boost::property_tree::ptree getPTree(const char* name) const final;
+  void update(std::vector<ConfigParamSpec> const& schema,
+              boost::property_tree::ptree& store,
+              boost::property_tree::ptree& provenance) override;
 
  private:
   const FairMQProgOptions* mOpts;
-  boost::property_tree::ptree mStore;
 };
 
-} // namespace framework
-} // namespace o2
-#endif // FRAMEWORK_BOOSTOPTIONSRETRIEVER_H
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_FAIROPTIONSRETRIEVER_H_

--- a/Framework/Core/include/Framework/ParamRetriever.h
+++ b/Framework/Core/include/Framework/ParamRetriever.h
@@ -7,34 +7,27 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_PARAMETERRETRIEVER_H
-#define FRAMEWORK_PARAMETERRETRIEVER_H
+#ifndef O2_FRAMEWORK_PARAMRETRIEVER_H_
+#define O2_FRAMEWORK_PARAMRETRIEVER_H_
 
-#include <boost/property_tree/ptree.hpp>
+#include "Framework/ConfigParamSpec.h"
+
+#include <boost/property_tree/ptree_fwd.hpp>
 #include <string>
 #include <vector>
 
-namespace o2
+namespace o2::framework
 {
-namespace framework
-{
-
 /// Base class for extracting Configuration options from a given backend (e.g.
 /// command line options).
 class ParamRetriever
 {
  public:
-  virtual bool isSet(const char* name) const = 0;
-  virtual int getInt(const char* name) const = 0;
-  virtual int64_t getInt64(const char* name) const = 0;
-  virtual float getFloat(const char* name) const = 0;
-  virtual double getDouble(const char* name) const = 0;
-  virtual bool getBool(const char* name) const = 0;
-  virtual std::string getString(const char* name) const = 0;
-  virtual boost::property_tree::ptree getPTree(const char* name) const = 0;
+  virtual void update(std::vector<ConfigParamSpec> const& specs,
+                      boost::property_tree::ptree& store,
+                      boost::property_tree::ptree& provenance) = 0;
   virtual ~ParamRetriever() = default;
 };
 
-} // namespace framework
-} // namespace o2
-#endif // FRAMEWORK_PARAMETERRETRIEVER_H
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_PARAMRETRIEVER_H_

--- a/Framework/Core/include/Framework/SimpleOptionsRetriever.h
+++ b/Framework/Core/include/Framework/SimpleOptionsRetriever.h
@@ -11,6 +11,8 @@
 #define O2_FRAMEWORK_SIMPLEOPTIONSRETRIEVER_H_
 
 #include "Framework/ParamRetriever.h"
+#include <boost/property_tree/ptree.hpp>
+#include <string>
 
 namespace o2::framework
 {
@@ -20,25 +22,19 @@ namespace o2::framework
 class SimpleOptionsRetriever : public ParamRetriever
 {
  public:
-  bool isSet(const char* name) const final;
-  int getInt(const char* name) const final;
-  int64_t getInt64(const char* name) const final;
-  float getFloat(const char* name) const final;
-  double getDouble(const char* name) const final;
-  bool getBool(const char* name) const final;
-  std::string getString(const char* name) const final;
-  boost::property_tree::ptree getPTree(const char* name) const final;
+  SimpleOptionsRetriever(boost::property_tree::ptree& tree, std::string const& provenanceLabel)
+    : mTree{tree},
+      mProvenanceLabel{provenanceLabel}
+  {
+  }
 
-  void setInt(char const* name, int);
-  void setInt64(char const* name, int64_t);
-  void setFloat(char const* name, float);
-  void setDouble(char const* name, double);
-  void setBool(char const* name, bool);
-  void setString(char const* name, std::string const&);
-  void setPTree(char const* name, boost::property_tree::ptree const& tree);
+  virtual void update(std::vector<ConfigParamSpec> const& specs,
+                      boost::property_tree::ptree& store,
+                      boost::property_tree::ptree& provenance) override;
 
  private:
-  boost::property_tree::ptree mStore;
+  boost::property_tree::ptree mTree;
+  std::string mProvenanceLabel;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/SimpleOptionsRetriever.h
+++ b/Framework/Core/include/Framework/SimpleOptionsRetriever.h
@@ -28,9 +28,9 @@ class SimpleOptionsRetriever : public ParamRetriever
   {
   }
 
-  virtual void update(std::vector<ConfigParamSpec> const& specs,
-                      boost::property_tree::ptree& store,
-                      boost::property_tree::ptree& provenance) override;
+  void update(std::vector<ConfigParamSpec> const& specs,
+              boost::property_tree::ptree& store,
+              boost::property_tree::ptree& provenance) override;
 
  private:
   boost::property_tree::ptree mTree;

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -23,17 +23,21 @@
 using namespace o2::framework;
 namespace bpo = boost::program_options;
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
-BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> const& specs,
-                                             bool ignoreUnknown,
-                                             int& argc, char**& argv)
-  : mStore{},
-    mDescription{"ALICE O2 Framework - Available options"},
-    mIgnoreUnknown{ignoreUnknown}
+BoostOptionsRetriever::BoostOptionsRetriever(bool ignoreUnknown,
+                                             int argc, char** argv)
+  : mDescription{"ALICE O2 Framework - Available options"},
+    mIgnoreUnknown{ignoreUnknown},
+    mArgc{argc},
+    mArgv{argv}
+{
+}
+
+void BoostOptionsRetriever::update(std::vector<ConfigParamSpec> const& specs,
+                                   boost::property_tree::ptree& store,
+                                   boost::property_tree::ptree& provenance)
 {
   auto options = mDescription.add_options();
   for (auto& spec : specs) {
@@ -65,52 +69,11 @@ BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> const&
     };
   }
 
-  auto parsed = mIgnoreUnknown ? bpo::command_line_parser(argc, argv).options(mDescription).allow_unregistered().run()
-                               : bpo::parse_command_line(argc, argv, mDescription);
+  auto parsed = mIgnoreUnknown ? bpo::command_line_parser(mArgc, mArgv).options(mDescription).allow_unregistered().run()
+                               : bpo::parse_command_line(mArgc, mArgv, mDescription);
   bpo::variables_map vmap;
   bpo::store(parsed, vmap);
-  PropertyTreeHelpers::populate(specs, mStore, vmap);
+  PropertyTreeHelpers::populate(specs, store, vmap, provenance);
 }
 
-bool BoostOptionsRetriever::isSet(const char* key) const
-{
-  return (mStore.find(key) != mStore.not_found());
-}
-
-int BoostOptionsRetriever::getInt(const char* key) const
-{
-  return mStore.get<int>(key);
-}
-
-int64_t BoostOptionsRetriever::getInt64(const char* key) const
-{
-  return mStore.get<int64_t>(key);
-}
-
-float BoostOptionsRetriever::getFloat(const char* key) const
-{
-  return mStore.get<float>(key);
-}
-
-double BoostOptionsRetriever::getDouble(const char* key) const
-{
-  return mStore.get<double>(key);
-}
-
-bool BoostOptionsRetriever::getBool(const char* key) const
-{
-  return mStore.get<bool>(key);
-}
-
-std::string BoostOptionsRetriever::getString(const char* key) const
-{
-  return mStore.get<std::string>(key);
-}
-
-boost::property_tree::ptree BoostOptionsRetriever::getPTree(const char* key) const
-{
-  return mStore.get_child(key);
-}
-
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework

--- a/Framework/Core/src/ConfigParamStore.cxx
+++ b/Framework/Core/src/ConfigParamStore.cxx
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigParamStore.h"
+#include "Framework/ParamRetriever.h"
+#include "PropertyTreeHelpers.h"
+#include <boost/property_tree/ptree.hpp>
+
+namespace o2::framework
+{
+
+ConfigParamStore::ConfigParamStore(std::vector<ConfigParamSpec> const& specs,
+                                   std::vector<std::unique_ptr<ParamRetriever>> retrievers)
+  : mSpecs(specs),
+    mRetrievers{std::move(retrievers)},
+    mStore{new boost::property_tree::ptree{}},
+    mProvenance{new boost::property_tree::ptree{}},
+    mNextStore{new boost::property_tree::ptree{}},
+    mNextProvenance{new boost::property_tree::ptree{}}
+{
+}
+
+/// Preload the next store with a new copy of
+/// the configuration.
+void ConfigParamStore::preload()
+{
+  mNextStore->clear();
+  mNextProvenance->clear();
+  // By default we populate with code.
+  PropertyTreeHelpers::populateDefaults(mSpecs, *mNextStore, *mNextProvenance);
+  for (auto& retriever : mRetrievers) {
+    retriever->update(mSpecs, *mNextStore, *mNextProvenance);
+  }
+}
+
+/// Activate the next store
+void ConfigParamStore::activate()
+{
+  mStore->swap(*mNextStore);
+  mProvenance->swap(*mNextProvenance);
+}
+
+std::string ConfigParamStore::provenance(const char* key) const
+{
+  return mProvenance->get<std::string>(key);
+}
+} // namespace o2::framework

--- a/Framework/Core/src/ConfigurationOptionsRetriever.cxx
+++ b/Framework/Core/src/ConfigurationOptionsRetriever.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 #include "ConfigurationOptionsRetriever.h"
 
+#include "Configuration/ConfigurationInterface.h"
 #include "Framework/ConfigParamSpec.h"
 #include "PropertyTreeHelpers.h"
 
@@ -28,59 +29,24 @@ namespace bpt = boost::property_tree;
 namespace o2::framework
 {
 
-ConfigurationOptionsRetriever::ConfigurationOptionsRetriever(std::vector<ConfigParamSpec> const& schema,
-                                                             ConfigurationInterface* cfg,
+ConfigurationOptionsRetriever::ConfigurationOptionsRetriever(ConfigurationInterface* cfg,
                                                              std::string const& mainKey)
   : mCfg{cfg},
-    mStore{}
+    mMainKey{mainKey}
+{
+}
+
+void ConfigurationOptionsRetriever::update(std::vector<ConfigParamSpec> const& schema,
+                                           boost::property_tree::ptree& store,
+                                           boost::property_tree::ptree& provenance)
 {
   boost::property_tree::ptree in;
   try {
-    in = cfg->getRecursive(mainKey);
+    in = mCfg->getRecursive(mMainKey);
   } catch (...) {
     in.clear();
   }
-  PropertyTreeHelpers::populate(schema, mStore, in);
-}
-
-bool ConfigurationOptionsRetriever::isSet(const char* key) const
-{
-  return (mStore.count(key) > 0);
-}
-
-int ConfigurationOptionsRetriever::getInt(const char* key) const
-{
-  return mStore.get<int>(key);
-}
-
-int64_t ConfigurationOptionsRetriever::getInt64(const char* key) const
-{
-  return mStore.get<int64_t>(key);
-}
-
-float ConfigurationOptionsRetriever::getFloat(const char* key) const
-{
-  return mStore.get<float>(key);
-}
-
-double ConfigurationOptionsRetriever::getDouble(const char* key) const
-{
-  return mStore.get<double>(key);
-}
-
-bool ConfigurationOptionsRetriever::getBool(const char* key) const
-{
-  return mStore.get<bool>(key);
-}
-
-std::string ConfigurationOptionsRetriever::getString(const char* key) const
-{
-  return mStore.get<std::string>(key);
-}
-
-boost::property_tree::ptree ConfigurationOptionsRetriever::getPTree(const char* key) const
-{
-  return mStore.get_child(key);
+  PropertyTreeHelpers::populate(schema, store, in, provenance, "configuration:" + mMainKey);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/ConfigurationOptionsRetriever.h
+++ b/Framework/Core/src/ConfigurationOptionsRetriever.h
@@ -7,25 +7,21 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef O2_FRAMEWORK_BOOSTOPTIONSRETRIEVER_H_
-#define O2_FRAMEWORK_BOOSTOPTIONSRETRIEVER_H_
+#ifndef O2_FRAMEWORK_CONFIGURATIONOPTIONSRETRIEVER_H_
+#define O2_FRAMEWORK_CONFIGURATIONOPTIONSRETRIEVER_H_
 
 #include "Framework/ParamRetriever.h"
 #include "Framework/ConfigParamSpec.h"
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
 
 #include <string>
 #include <vector>
 
-#if __has_include(<Configuration/ConfigurationInterface.h>)
-#include <Configuration/ConfigurationInterface.h>
-#else
 namespace o2::configuration
 {
 class ConfigurationInterface;
 }
-#endif
 
 namespace o2::framework
 {
@@ -34,23 +30,16 @@ namespace o2::framework
 class ConfigurationOptionsRetriever : public ParamRetriever
 {
  public:
-  ConfigurationOptionsRetriever(std::vector<ConfigParamSpec> const& schema,
-                                configuration::ConfigurationInterface* cfg,
+  ConfigurationOptionsRetriever(configuration::ConfigurationInterface* cfg,
                                 std::string const& mainKey);
-
-  bool isSet(const char* name) const final;
-  int getInt(const char* name) const final;
-  int64_t getInt64(const char* name) const final;
-  float getFloat(const char* name) const final;
-  double getDouble(const char* name) const final;
-  bool getBool(const char* name) const final;
-  std::string getString(const char* name) const final;
-  boost::property_tree::ptree getPTree(const char* name) const final;
+  void update(std::vector<ConfigParamSpec> const& schema,
+              boost::property_tree::ptree& store,
+              boost::property_tree::ptree& provenance) override;
 
  private:
-  configuration::ConfigurationInterface const* mCfg;
-  boost::property_tree::ptree mStore;
+  configuration::ConfigurationInterface* mCfg;
+  std::string mMainKey;
 };
 
 } // namespace o2::framework
-#endif // O2_FRAMEWORK_BOOSTOPTIONSRETRIEVER_H_
+#endif // O2_FRAMEWORK_CONFIGURATIONOPTIONSRETRIEVER_H_

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -151,7 +151,7 @@ void DataProcessingDevice::Init()
   configStore->activate();
   /// Dump the configuration so that we can get it from the driver.
   for (auto& entry : configStore->store()) {
-    LOG(INFO) << "[CONFIG] " << entry.first << "=" << configStore->store().get<std::string>(entry.first) << " 1";
+    LOG(INFO) << "[CONFIG] " << entry.first << "=" << configStore->store().get<std::string>(entry.first) << " 1 " << configStore->provenance(entry.first.c_str());
   }
   mConfigRegistry = std::make_unique<ConfigParamRegistry>(std::move(configStore));
 

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -149,6 +149,10 @@ void DataProcessingDevice::Init()
   auto configStore = std::move(std::make_unique<ConfigParamStore>(mSpec.options, std::move(retrievers)));
   configStore->preload();
   configStore->activate();
+  /// Dump the configuration so that we can get it from the driver.
+  for (auto& entry : configStore->store()) {
+    LOG(INFO) << "[CONFIG] " << entry.first << "=" << configStore->store().get<std::string>(entry.first) << " 1";
+  }
   mConfigRegistry = std::make_unique<ConfigParamRegistry>(std::move(configStore));
 
   mExpirationHandlers.clear();

--- a/Framework/Core/src/DeviceConfigInfo.cxx
+++ b/Framework/Core/src/DeviceConfigInfo.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DeviceConfigInfo.h"
+#include "Framework/DeviceInfo.h"
+#include <cassert>
+#include <cinttypes>
+#include <cstdlib>
+
+#include <algorithm>
+#include <regex>
+#include <string_view>
+#include <tuple>
+#include <iostream>
+
+namespace o2::framework
+{
+
+// Parses a config entry in the form
+//
+// [CONFIG] <key>=<vaue> <timestamp>
+bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& match)
+{
+  const char* end = s.end();
+  if (s.size() > 17 && (strncmp("[CONFIG] ", s.data() + 17, 9) != 0)) {
+    return false;
+  }
+  match.beginKey = s.data() + 9 + 17;
+  match.endKey = (char const*)memchr(match.beginKey, '=', s.size() - 9);
+  if (match.endKey == 0) {
+    return false;
+  }
+  match.beginValue = match.endKey + 1;
+  match.endValue = (char const*)memchr(match.beginValue, ' ', end - match.beginValue);
+  if (match.endValue == 0) {
+    return false;
+  }
+  char* err = 0;
+  match.timestamp = strtoll(match.endValue, &err, 10);
+  if (err != s.end()) {
+    return false;
+  }
+
+  return true;
+}
+
+bool DeviceConfigHelper::processConfig(ParsedConfigMatch& match,
+                                       DeviceInfo& info)
+{
+  if (match.beginKey == nullptr || match.endKey == nullptr ||
+      match.beginValue == nullptr || match.endValue == nullptr) {
+    return false;
+  }
+  info.currentConfig.put(std::string(match.beginKey, match.endKey - match.beginKey),
+                         std::string(match.beginValue, match.endValue - match.beginValue));
+  return true;
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/FairOptionsRetriever.cxx
+++ b/Framework/Core/src/FairOptionsRetriever.cxx
@@ -21,57 +21,14 @@ using namespace o2::framework;
 namespace bpo = boost::program_options;
 namespace bpt = boost::property_tree;
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
-FairOptionsRetriever::FairOptionsRetriever(std::vector<ConfigParamSpec> const& schema, const FairMQProgOptions* opts)
-  : mOpts{opts},
-    mStore{}
+void FairOptionsRetriever::update(std::vector<ConfigParamSpec> const& schema,
+                                  boost::property_tree::ptree& store,
+                                  boost::property_tree::ptree& provenance)
 {
-  PropertyTreeHelpers::populate(schema, mStore, mOpts->GetVarMap());
+  PropertyTreeHelpers::populate(schema, store, mOpts->GetVarMap(), provenance);
 }
 
-bool FairOptionsRetriever::isSet(const char* key) const
-{
-  return (mOpts->Count(key) > 0);
-}
-
-int FairOptionsRetriever::getInt(const char* key) const
-{
-  return mStore.get<int>(key);
-}
-
-int64_t FairOptionsRetriever::getInt64(const char* key) const
-{
-  return mStore.get<int64_t>(key);
-}
-
-float FairOptionsRetriever::getFloat(const char* key) const
-{
-  return mStore.get<float>(key);
-}
-
-double FairOptionsRetriever::getDouble(const char* key) const
-{
-  return mStore.get<double>(key);
-}
-
-bool FairOptionsRetriever::getBool(const char* key) const
-{
-  return mStore.get<bool>(key);
-}
-
-std::string FairOptionsRetriever::getString(const char* key) const
-{
-  return mStore.get<std::string>(key);
-}
-
-boost::property_tree::ptree FairOptionsRetriever::getPTree(const char* key) const
-{
-  return mStore.get_child(key);
-}
-
-} // namespace framework
 } // namespace o2

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -162,7 +162,7 @@ void displayDeviceInspector(DeviceSpec const& spec,
   }
 
   deviceInfoTable(info, metrics);
-  optionsTable("Options", spec.options, control);
+  //optionsTable("Options", spec.options, control);
   optionsTable("Workflow Options", metadata.workflowOptions, control);
   if (ImGui::CollapsingHeader("Command line arguments", ImGuiTreeNodeFlags_DefaultOpen)) {
     for (auto& arg : metadata.cmdLineArgs) {

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -63,6 +63,33 @@ void deviceInfoTable(DeviceInfo const& info, DeviceMetricsInfo const& metrics)
   }
 }
 
+void configurationTable(boost::property_tree::ptree const& currentConfig)
+{
+  if (ImGui::CollapsingHeader("Current Config", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (currentConfig.empty()) {
+      return;
+    }
+    ImGui::Columns(2);
+    auto labels = {"Name", "Value"};
+    for (auto& label : labels) {
+      ImGui::TextUnformatted(label);
+      ImGui::NextColumn();
+    }
+    for (auto& option : currentConfig) {
+      ImGui::TextUnformatted(option.first.c_str());
+      if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::TextUnformatted(option.first.c_str());
+        ImGui::EndTooltip();
+      }
+      ImGui::NextColumn();
+      ImGui::TextUnformatted(option.second.data().c_str());
+      ImGui::NextColumn();
+    }
+    ImGui::Columns(1);
+  }
+}
+
 void optionsTable(const char* label, std::vector<ConfigParamSpec> const& options, const DeviceControl& control)
 {
   if (options.empty()) {
@@ -162,7 +189,10 @@ void displayDeviceInspector(DeviceSpec const& spec,
   }
 
   deviceInfoTable(info, metrics);
-  //optionsTable("Options", spec.options, control);
+  for (auto& option : info.currentConfig) {
+    ImGui::Text("%s: %s", option.first.c_str(), option.second.data().c_str());
+  }
+  configurationTable(info.currentConfig);
   optionsTable("Workflow Options", metadata.workflowOptions, control);
   if (ImGui::CollapsingHeader("Command line arguments", ImGuiTreeNodeFlags_DefaultOpen)) {
     for (auto& arg : metadata.cmdLineArgs) {

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -63,12 +63,13 @@ void deviceInfoTable(DeviceInfo const& info, DeviceMetricsInfo const& metrics)
   }
 }
 
-void configurationTable(boost::property_tree::ptree const& currentConfig)
+void configurationTable(boost::property_tree::ptree const& currentConfig,
+                        boost::property_tree::ptree const& currentProvenance)
 {
+  if (currentConfig.empty()) {
+    return;
+  }
   if (ImGui::CollapsingHeader("Current Config", ImGuiTreeNodeFlags_DefaultOpen)) {
-    if (currentConfig.empty()) {
-      return;
-    }
     ImGui::Columns(2);
     auto labels = {"Name", "Value"};
     for (auto& label : labels) {
@@ -83,7 +84,12 @@ void configurationTable(boost::property_tree::ptree const& currentConfig)
         ImGui::EndTooltip();
       }
       ImGui::NextColumn();
-      ImGui::TextUnformatted(option.second.data().c_str());
+      ImGui::Text("%s (%s)", option.second.data().c_str(), currentProvenance.get<std::string>(option.first).c_str());
+      if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::Text("%s (%s)", option.second.data().c_str(), currentProvenance.get<std::string>(option.first).c_str());
+        ImGui::EndTooltip();
+      }
       ImGui::NextColumn();
     }
     ImGui::Columns(1);
@@ -192,7 +198,7 @@ void displayDeviceInspector(DeviceSpec const& spec,
   for (auto& option : info.currentConfig) {
     ImGui::Text("%s: %s", option.first.c_str(), option.second.data().c_str());
   }
-  configurationTable(info.currentConfig);
+  configurationTable(info.currentConfig, info.currentProvenance);
   optionsTable("Workflow Options", metadata.workflowOptions, control);
   if (ImGui::CollapsingHeader("Command line arguments", ImGuiTreeNodeFlags_DefaultOpen)) {
     for (auto& arg : metadata.cmdLineArgs) {

--- a/Framework/Core/src/PropertyTreeHelpers.h
+++ b/Framework/Core/src/PropertyTreeHelpers.h
@@ -18,17 +18,34 @@
 namespace o2::framework
 {
 
-/// Helpers to manipulate property_trees
+/// Helpers to manipulate property_trees.
 struct PropertyTreeHelpers {
   /// For all the options specified in @a schama, this fills
   /// @a tree with the contents of @a vmap, which is populated via boost
-  /// program options.
-  static void populate(std::vector<ConfigParamSpec> const& schema, boost::property_tree::ptree& tree, boost::program_options::variables_map const& vmap);
+  /// program options. Any key in the @a schema will be marked as
+  /// "default" in the provenance ptree.
+  static void populateDefaults(std::vector<ConfigParamSpec> const& schema,
+                               boost::property_tree::ptree& tree,
+                               boost::property_tree::ptree& provenance);
+
+  /// For all the options specified in @a schama, this fills
+  /// @a tree with the contents of @a vmap, which is populated via boost
+  /// program options. Any key in the @a schema will be marked as
+  /// "fairmq" in the provenance ptree.
+  static void populate(std::vector<ConfigParamSpec> const& schema,
+                       boost::property_tree::ptree& tree,
+                       boost::program_options::variables_map const& vmap,
+                       boost::property_tree::ptree& provenance);
 
   /// For all the options specified in @a schama, this fills
   /// @a tree with the contents of @a in, which is another ptree
-  /// e.g. populated using ConfigurationInterface
-  static void populate(std::vector<ConfigParamSpec> const& schema, boost::property_tree::ptree& tree, boost::property_tree::ptree const& in);
+  /// e.g. populated using ConfigurationInterface.
+  /// Any key in the @a schema will be marked as "configuration" in the provenance ptree.
+  static void populate(std::vector<ConfigParamSpec> const& schema,
+                       boost::property_tree::ptree& tree,
+                       boost::property_tree::ptree const& in,
+                       boost::property_tree::ptree& provenance,
+                       std::string const& propertyLabel);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/PropertyTreeHelpers.h
+++ b/Framework/Core/src/PropertyTreeHelpers.h
@@ -14,6 +14,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <functional>
 
 namespace o2::framework
 {
@@ -46,6 +47,16 @@ struct PropertyTreeHelpers {
                        boost::property_tree::ptree const& in,
                        boost::property_tree::ptree& provenance,
                        std::string const& propertyLabel);
+
+  //using WalkerFunction = std::function<void(boost::property_tree::ptree const&, boost::property_tree::ptree::path_type, boost::property_tree::ptree const&)>;
+  using WalkerFunction = std::function<void(boost::property_tree::ptree const&, boost::property_tree::ptree::path_type, boost::property_tree::ptree const&)>;
+  /// Traverse the tree recursively calling @a WalkerFunction on each leaf.
+  static void traverse(boost::property_tree::ptree const& parent, WalkerFunction& method);
+
+  /// Merge @a source ptree into @a dest
+  static void merge(boost::property_tree::ptree& dest,
+                    boost::property_tree::ptree const& source,
+                    boost::property_tree::ptree::path_type const& mergePoint);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/SimpleOptionsRetriever.cxx
+++ b/Framework/Core/src/SimpleOptionsRetriever.cxx
@@ -13,7 +13,7 @@
 
 #include "PropertyTreeHelpers.h"
 
-#include <boost/program_options.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include <string>
 #include <vector>
@@ -26,79 +26,11 @@ namespace bpo = boost::program_options;
 namespace o2::framework
 {
 
-bool SimpleOptionsRetriever::isSet(const char* key) const
+void SimpleOptionsRetriever::update(std::vector<ConfigParamSpec> const& schema,
+                                    boost::property_tree::ptree& store,
+                                    boost::property_tree::ptree& provenance)
 {
-  return (mStore.find(key) != mStore.not_found());
-}
-
-int SimpleOptionsRetriever::getInt(char const* key) const
-{
-  return mStore.get<int>(key);
-}
-
-int64_t SimpleOptionsRetriever::getInt64(char const* key) const
-{
-  return mStore.get<int64_t>(key);
-}
-
-float SimpleOptionsRetriever::getFloat(char const* key) const
-{
-  return mStore.get<float>(key);
-}
-
-double SimpleOptionsRetriever::getDouble(char const* key) const
-{
-  return mStore.get<double>(key);
-}
-
-bool SimpleOptionsRetriever::getBool(char const* key) const
-{
-  return mStore.get<bool>(key);
-}
-
-std::string SimpleOptionsRetriever::getString(char const* key) const
-{
-  return mStore.get<std::string>(key);
-}
-
-boost::property_tree::ptree SimpleOptionsRetriever::getPTree(char const* key) const
-{
-  return mStore.get_child(key);
-}
-
-void SimpleOptionsRetriever::setInt(char const* key, int value)
-{
-  mStore.put<int>(key, value);
-}
-
-void SimpleOptionsRetriever::setInt64(char const* key, int64_t value)
-{
-  mStore.put<int64_t>(key, value);
-}
-
-void SimpleOptionsRetriever::setFloat(char const* key, float value)
-{
-  mStore.put<float>(key, value);
-}
-
-void SimpleOptionsRetriever::setDouble(char const* key, double value)
-{
-  mStore.put<double>(key, value);
-}
-
-void SimpleOptionsRetriever::setBool(char const* key, bool value)
-{
-  mStore.put<bool>(key, value);
-}
-
-void SimpleOptionsRetriever::setString(char const* key, std::string const& value)
-{
-  mStore.put<std::string>(key, value);
-}
-
-void SimpleOptionsRetriever::setPTree(char const* key, boost::property_tree::ptree const& value)
-{
-  mStore.put_child(key, value);
+  PropertyTreeHelpers::populate(schema, store, mTree, provenance, mProvenanceLabel);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -27,6 +27,7 @@
 #include "Framework/DeviceExecution.h"
 #include "Framework/DeviceInfo.h"
 #include "Framework/DeviceMetricsInfo.h"
+#include "Framework/DeviceConfigInfo.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceState.h"
 #include "Framework/FrameworkGUIDebugger.h"
@@ -469,6 +470,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
   assert(infos.size() == controls.size());
   std::smatch match;
   ParsedMetricMatch metricMatch;
+  ParsedConfigMatch configMatch;
   const std::string delimiter("\n");
   bool hasNewMetric = false;
   for (size_t di = 0, de = infos.size(); di < de; ++di) {
@@ -541,6 +543,8 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
           // FIXME: this should really be a policy...
           doToMatchingPid(info.pid, [](DeviceInfo& info) { info.streamingState = StreamingState::EndOfStreaming; });
         }
+      } else if (logLevel == LogParsingHelpers::LogLevel::Info && DeviceConfigHelper::parseConfig(token, configMatch)) {
+        DeviceConfigHelper::processConfig(configMatch, info);
       } else if (!control.quiet && (token.find(control.logFilter) != std::string::npos) &&
                  logLevel >= control.logLevel) {
         assert(info.historyPos >= 0);

--- a/Framework/Core/test/benchmark_WorkflowHelpers.cxx
+++ b/Framework/Core/test/benchmark_WorkflowHelpers.cxx
@@ -23,8 +23,12 @@ std::unique_ptr<ConfigContext> makeEmptyConfigContext()
 {
   // FIXME: Ugly... We need to fix ownership and make sure the ConfigContext
   //        either owns or shares ownership of the registry.
-  static std::unique_ptr<ParamRetriever> retriever(new SimpleOptionsRetriever);
-  static ConfigParamRegistry registry{std::move(retriever)};
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  static std::vector<ConfigParamSpec> specs;
+  auto store = std::make_unique<ConfigParamStore>(specs, std::move(retrievers));
+  store->preload();
+  store->activate();
+  static ConfigParamRegistry registry(std::move(store));
   auto context = std::make_unique<ConfigContext>(registry, 0, nullptr);
   return context;
 }

--- a/Framework/Core/test/test_DeviceConfigInfo.cxx
+++ b/Framework/Core/test/test_DeviceConfigInfo.cxx
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DeviceConfigInfo
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/DeviceConfigInfo.h"
+#include "Framework/DeviceInfo.h"
+#include <boost/test/unit_test.hpp>
+#include <string_view>
+
+BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo)
+{
+  using namespace o2::framework;
+  std::string configString;
+  bool result;
+  ParsedConfigMatch match;
+  DeviceInfo info;
+
+  // Something which does not match
+  configString = "foo[NOCONFIG] foo=bar 1789372894\n";
+  std::string_view config1{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config1, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Something which does not match
+  configString = "foo[CONFIG] foobar 1789372894\n";
+  std::string_view config2{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config2, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Something which does not match
+  configString = "foo[CONFIG] foo=bar1789372894\n";
+  std::string_view config3{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config3, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Something which does not match
+  configString = "foo[CONFIG] foo=bar\n";
+  std::string_view config4{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config4, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Something which does not match
+  configString = "foo[CONFIG] foo=bar 1789372894t\n";
+  std::string_view config5{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config5, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Parse a simple configuration bit
+  configString = "foo[CONFIG] foo=bar 1789372894\n";
+  std::string_view config{configString.data() + 3, configString.size() - 4};
+  BOOST_REQUIRE_EQUAL(config, std::string("[CONFIG] foo=bar 1789372894"));
+  result = DeviceConfigHelper::parseConfig(config, match);
+  BOOST_REQUIRE_EQUAL(result, true);
+  BOOST_CHECK(strncmp(match.beginKey, "foo", 3) == 0);
+  BOOST_CHECK_EQUAL(match.timestamp, 1789372894);
+  BOOST_CHECK(strncmp(match.beginValue, "bar", 3) == 0);
+
+  // Process a given config entry
+  result = DeviceConfigHelper::processConfig(match, info);
+  BOOST_CHECK_EQUAL(result, true);
+  BOOST_CHECK_EQUAL(info.currentConfig.get<std::string>("foo"), "bar");
+}

--- a/Framework/Core/test/test_DeviceConfigInfo.cxx
+++ b/Framework/Core/test/test_DeviceConfigInfo.cxx
@@ -31,41 +31,49 @@ BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo)
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[CONFIG] foobar 1789372894\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foobar 1789372894\n";
   std::string_view config2{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config2, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[CONFIG] foo=bar1789372894\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar1789372894\n";
   std::string_view config3{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config3, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[CONFIG] foo=bar\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar\n";
   std::string_view config4{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config4, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[CONFIG] foo=bar 1789372894t\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894t\n";
   std::string_view config5{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config5, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Parse a simple configuration bit
-  configString = "foo[CONFIG] foo=bar 1789372894\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894\n";
+  std::string_view config6{configString.data() + 3, configString.size() - 4};
+  result = DeviceConfigHelper::parseConfig(config6, match);
+  BOOST_REQUIRE_EQUAL(result, false);
+
+  // Parse a simple configuration bit
+  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov\n";
   std::string_view config{configString.data() + 3, configString.size() - 4};
-  BOOST_REQUIRE_EQUAL(config, std::string("[CONFIG] foo=bar 1789372894"));
+  BOOST_REQUIRE_EQUAL(config, std::string("[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov"));
   result = DeviceConfigHelper::parseConfig(config, match);
   BOOST_REQUIRE_EQUAL(result, true);
   BOOST_CHECK(strncmp(match.beginKey, "foo", 3) == 0);
   BOOST_CHECK_EQUAL(match.timestamp, 1789372894);
   BOOST_CHECK(strncmp(match.beginValue, "bar", 3) == 0);
+  BOOST_CHECK(strncmp(match.beginProvenance, "prov", 4) == 0);
 
   // Process a given config entry
   result = DeviceConfigHelper::processConfig(match, info);
   BOOST_CHECK_EQUAL(result, true);
   BOOST_CHECK_EQUAL(info.currentConfig.get<std::string>("foo"), "bar");
+  BOOST_CHECK_EQUAL(info.currentProvenance.get<std::string>("foo"), "prov");
 }

--- a/Framework/Core/test/test_FairMQOptionsRetriever.cxx
+++ b/Framework/Core/test/test_FairMQOptionsRetriever.cxx
@@ -14,7 +14,9 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/program_options.hpp>
 #include "Framework/FairOptionsRetriever.h"
+#include "Framework/ConfigParamStore.h"
 #include <fairmq/options/FairMQProgOptions.h>
+#include <boost/property_tree/ptree.hpp>
 
 namespace bpo = boost::program_options;
 using namespace o2::framework;
@@ -53,17 +55,24 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
     ConfigParamSpec{"aNested.int", VariantType::Int, 2, {"an int option, nested in an object"}},
     ConfigParamSpec{"aNested.float", VariantType::Float, 3.f, {"a float option, nested in an object"}},
   };
-  FairOptionsRetriever retriever(specs, options);
-  BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 1.0);
-  BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 2.0);
-  BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 10);
-  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), 50000000000000ll);
-  BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), true);
-  BOOST_CHECK_EQUAL(retriever.getString("aString"), "somethingelse");
-  BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 1);
-  BOOST_CHECK_EQUAL(retriever.getInt("aNested.float"), 2.f);
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  std::unique_ptr<ParamRetriever> fairmqRetriver{new FairOptionsRetriever(options)};
+  retrievers.emplace_back(std::move(fairmqRetriver));
+
+  ConfigParamStore store{specs, std::move(retrievers)};
+  store.preload();
+  store.activate();
+
+  BOOST_CHECK_EQUAL(store.store().get<float>("aFloat"), 1.0);
+  BOOST_CHECK_EQUAL(store.store().get<double>("aDouble"), 2.0);
+  BOOST_CHECK_EQUAL(store.store().get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(store.store().get<int64_t>("anInt64"), 50000000000000ll);
+  BOOST_CHECK_EQUAL(store.store().get<bool>("aBoolean"), true);
+  BOOST_CHECK_EQUAL(store.store().get<std::string>("aString"), "somethingelse");
+  BOOST_CHECK_EQUAL(store.store().get<int>("aNested.int"), 1);
+  BOOST_CHECK_EQUAL(store.store().get<float>("aNested.float"), 2.f);
   // We can get nested objects also via their top-level ptree.
-  auto pt = retriever.getPTree("aNested");
+  auto pt = store.store().get_child("aNested");
   BOOST_CHECK_EQUAL(pt.get<int>("int"), 1);
   BOOST_CHECK_EQUAL(pt.get<float>("float"), 2.f);
 }
@@ -93,14 +102,33 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
     ConfigParamSpec{"aBoolean", VariantType::Bool, true, {"a boolean option"}},
     ConfigParamSpec{"aNested.int", VariantType::Int, 2, {"an int option, nested in an object"}},
     ConfigParamSpec{"aNested.float", VariantType::Float, 3.f, {"a float option, nested in an object"}},
+    ConfigParamSpec{"aNested.double", VariantType::Double, 4., {"a float option, nested in an object"}},
   };
-  FairOptionsRetriever retriever(specs, options);
-  BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 10.f);
-  BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 20.);
-  BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 1);
-  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), -50000000000000ll);
-  BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), false);
-  BOOST_CHECK_EQUAL(retriever.getString("aString"), "something");
-  BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 2);
-  BOOST_CHECK_EQUAL(retriever.getInt("aNested.float"), 3.f);
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  std::unique_ptr<ParamRetriever> fairmqRetriver{new FairOptionsRetriever(options)};
+  retrievers.emplace_back(std::move(fairmqRetriver));
+
+  ConfigParamStore store{specs, std::move(retrievers)};
+  store.preload();
+  store.activate();
+
+  BOOST_CHECK_EQUAL(store.store().get<float>("aFloat"), 10.f);
+  BOOST_CHECK_EQUAL(store.store().get<double>("aDouble"), 20.);
+  BOOST_CHECK_EQUAL(store.store().get<int>("anInt"), 1);
+  BOOST_CHECK_EQUAL(store.store().get<int64_t>("anInt64"), -50000000000000ll);
+  BOOST_CHECK_EQUAL(store.store().get<bool>("aBoolean"), false);
+  BOOST_CHECK_EQUAL(store.store().get<std::string>("aString"), "something");
+  BOOST_CHECK_EQUAL(store.store().get<int>("aNested.int"), 2);
+  BOOST_CHECK_EQUAL(store.store().get<float>("aNested.float"), 3.f);
+
+  /// They come from FairMQ, not default in any case...
+  BOOST_CHECK_EQUAL(store.provenance("aFloat"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aDouble"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anInt"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anInt64"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aBoolean"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aString"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aNested.int"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aNested.float"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("aNested.double"), "default");
 }

--- a/Framework/Core/test/test_RootConfigParamHelpers.cxx
+++ b/Framework/Core/test/test_RootConfigParamHelpers.cxx
@@ -38,8 +38,14 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
 
   std::vector<ConfigParamSpec> specs = RootConfigParamHelpers::asConfigParamSpecs<o2::test::SimplePODClass>("foo");
 
-  auto retriever = std::make_unique<FairOptionsRetriever>(specs, options);
-  ConfigParamRegistry registry(std::move(retriever));
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  std::unique_ptr<ParamRetriever> fairmqRetriver{new FairOptionsRetriever(options)};
+  retrievers.emplace_back(std::move(fairmqRetriver));
+
+  auto store = std::make_unique<ConfigParamStore>(specs, std::move(retrievers));
+  store->preload();
+  store->activate();
+  ConfigParamRegistry registry(std::move(store));
 
   BOOST_CHECK_EQUAL(registry.get<int>("foo.x"), 1);
   BOOST_CHECK_EQUAL(registry.get<float>("foo.y"), 2.f);

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -28,8 +28,12 @@ std::unique_ptr<ConfigContext> makeEmptyConfigContext()
 {
   // FIXME: Ugly... We need to fix ownership and make sure the ConfigContext
   //        either owns or shares ownership of the registry.
-  static std::unique_ptr<ParamRetriever> retriever(new SimpleOptionsRetriever);
-  static ConfigParamRegistry registry{std::move(retriever)};
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  static std::vector<ConfigParamSpec> specs;
+  auto store = std::make_unique<ConfigParamStore>(specs, std::move(retrievers));
+  store->preload();
+  store->activate();
+  static ConfigParamRegistry registry(std::move(store));
   auto context = std::make_unique<ConfigContext>(registry, 0, nullptr);
   return context;
 }

--- a/Framework/Core/test/unittest_SimpleOptionsRetriever.cxx
+++ b/Framework/Core/test/unittest_SimpleOptionsRetriever.cxx
@@ -14,11 +14,24 @@
 
 #include "Framework/SimpleOptionsRetriever.h"
 #include <boost/test/unit_test.hpp>
+#include "Framework/ParamRetriever.h"
+#include "Framework/ConfigParamStore.h"
+
+using namespace o2::framework;
 
 BOOST_AUTO_TEST_CASE(TestInsertion)
 {
-  o2::framework::SimpleOptionsRetriever options{};
+  std::vector<ConfigParamSpec> specs{
+    ConfigParamSpec{"foo", VariantType::Int, 1, {"foo"}}};
+  boost::property_tree::ptree opt;
+  opt.put<int>("foo", 123);
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  std::unique_ptr<ParamRetriever> retriever{new SimpleOptionsRetriever(opt, "simple")};
+  retrievers.emplace_back(std::move(retriever));
 
-  options.setInt("foo", 123);
-  BOOST_CHECK_EQUAL(options.getInt("foo"), 123);
+  ConfigParamStore store{specs, std::move(retrievers)};
+  store.preload();
+  store.activate();
+
+  BOOST_CHECK_EQUAL(store.store().get<int>("foo"), 123);
 }


### PR DESCRIPTION
This also include framework support for multiple, nested,
ParamRetriever. To be integrated by the driver / GUI.