### PR TITLE
Correcting the TPC CA tracker completion policy and reactivating it

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(TPCWorkflow
                        src/TrackReaderSpec.cxx
                        src/RawToDigitsSpec.cxx
                        src/LinkZSToDigitsSpec.cxx
+                       src/TPCSectorCompletionPolicy.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
@@ -1,0 +1,165 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_TPCSECTORCOMPLETIONPOLICY_H
+#define O2_TPC_TPCSECTORCOMPLETIONPOLICY_H
+/// @file   TPCSectorCompletionPolicy.h
+/// @author Matthias Richter
+/// @since  2020-05-20
+/// @brief  DPL completion policy helper for TPC scetor data
+
+#include "Framework/CompletionPolicy.h"
+#include "Framework/InputSpec.h"
+#include "Framework/DeviceSpec.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "TPCBase/Sector.h"
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <sstream>
+#include <regex>
+
+namespace o2
+{
+using namespace framework;
+namespace tpc
+{
+
+/// @class TPCSectorCompletionPolicy
+/// A helper class providing a DPL completion policy definition for the TPC sector data
+///
+/// The class can be used as a functor creating the CompletionPolicy object based on the parameters
+/// provided to the constructor.
+///
+/// TPC data is split on the level of sectors. For processors requiring the full data set like e.g.
+/// the tracker, DPL will synchronize complete data sets from the input routes. Multiple O2 messages
+/// can be received on one input route, a custom completion policy is needed to define the complete
+/// data set. All TPC data except raw data is sent with a specific TPCSectorHeader on the header
+/// stack describing the current sector and defining the active sectors in the setup. The completion
+/// policy callback will wait until there is data for all active sectors.
+///
+/// Parameters:
+///   processor name   rexexp to match a name of the processor for which the policy should be applied
+///   input matchers   provided as an argument pack
+///                    Note: it is important to use ConcreteDataTypeMatcher to define input spec with
+///                          wildcard on subSpecification
+/// Usage:
+///   TPCSectorCompletionPolicy("processor-name-regexp", InputSpec{"", ConcreteDataTypeMatcher{"DET", "RAWDATA"}}, ...)();
+///
+class TPCSectorCompletionPolicy
+{
+ public:
+  TPCSectorCompletionPolicy() = delete;
+  template <typename... Args>
+  TPCSectorCompletionPolicy(const char* processorName, Args&&... args)
+    : mProcessorName(processorName), mInputMatchers()
+  {
+    init(std::forward<Args>(args)...);
+  }
+
+  o2::framework::CompletionPolicy operator()()
+  {
+    constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
+
+    auto matcher = [expression = mProcessorName](DeviceSpec const& device) -> bool {
+      return std::regex_match(device.name.begin(), device.name.end(), std::regex(expression.c_str()));
+    };
+
+    auto callback = [inputMatchers = mInputMatchers](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
+      auto op = CompletionPolicy::CompletionOp::Wait;
+      std::bitset<NSectors> validSectors = 0;
+      bool haveMatchedInput = false;
+      uint64_t activeSectors = 0;
+      size_t nActiveInputRoutes = 0;
+      size_t nMaxPartsPerRoute = 0;
+      int inputType = -1;
+      for (auto it = inputs.begin(), end = inputs.end(); it != end; ++it) {
+        nMaxPartsPerRoute = it.size() > nMaxPartsPerRoute ? it.size() : nMaxPartsPerRoute;
+        bool haveActivePart = false;
+        for (auto const& ref : it) {
+          if (!DataRefUtils::isValid(ref)) {
+            continue;
+          }
+          haveActivePart = true;
+          auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+          // check if the O2 message matches on of the input specs to be matched and
+          // if it matches, check for the sector header, retrieve the active sector information
+          // and mark the sector as valid
+          for (size_t idx = 0, end = inputMatchers.size(); idx < end; idx++) {
+            auto const& spec = inputMatchers[idx];
+            if (DataRefUtils::match(ref, spec)) {
+              haveMatchedInput = true;
+              if (inputType == -1) {
+                // we bind to the index of the first match and require all other inputs to match the same spec
+                inputType = idx;
+              } else if (inputType != idx) {
+                std::stringstream error;
+                error << "routing error, input messages must all be of the same type previously bound to "
+                      << inputMatchers[inputType]
+                      << dh->dataOrigin.as<std::string>() + "/"
+                      << dh->dataDescription.as<std::string>() + "/" + dh->subSpecification;
+                throw std::runtime_error(error.str());
+              }
+              auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+              if (sectorHeader == nullptr) {
+                // FIXME: think about error policy
+                throw std::runtime_error("TPC sector header missing on header stack");
+              }
+              activeSectors |= sectorHeader->activeSectors;
+              validSectors.set(sectorHeader->sector);
+              break;
+            }
+          }
+        }
+        if (haveActivePart) {
+          ++nActiveInputRoutes;
+        }
+      }
+
+      if (haveMatchedInput && activeSectors == validSectors.to_ulong()) {
+        // we can process if there is input for all sectors, the required sectors are
+        // transported as part of the sector header
+        op = CompletionPolicy::CompletionOp::Process;
+      } else if (activeSectors == 0 && nActiveInputRoutes == inputs.size()) {
+        // no sector header is transmitted, this is the case for e.g. the ZS raw data
+        // we simply require input on all routes, this is also the default of DPL DataRelayer
+        // Because DPL can not do more without knowing how many parts are required for a complete
+        // data set, the workflow should be such that exactly one O2 message arrives per input route.
+        // Currently, the workflow has multiple O2 messages per input route, but they all come in
+        // a single multipart message. So it works fine, and we disable the warning below, but there
+        // is a potential problem. Need to fix this on the level of the workflow.
+        //if (nMaxPartsPerRoute > 1) {
+        //  LOG(WARNING) << "No sector information is provided with the data, data set is complete with data on all input routes. But there are multiple parts on at least one route and this policy might not be complete, no check possible if other parts on some routes are still missing. It is adviced to add a custom policy.";
+        //}
+        op = CompletionPolicy::CompletionOp::Process;
+      }
+
+      return op;
+    };
+    return CompletionPolicy{"TPCSectorCompletionPolicy", matcher, callback};
+  }
+
+ private:
+  /// recursively init list of input routes from parameter pack
+  template <typename... Args>
+  void init(InputSpec&& spec, Args&&... args)
+  {
+    mInputMatchers.emplace_back(std::move(spec));
+    if constexpr (sizeof...(args) > 0) {
+      init(std::forward<Args>(args)...);
+    }
+  }
+
+  std::string mProcessorName;
+  std::vector<InputSpec> mInputMatchers;
+};
+} // namespace tpc
+} // namespace o2
+#endif // O2_TPC_TPCSECTORCOMPLETIONPOLICY_H

--- a/Detectors/TPC/workflow/src/TPCSectorCompletionPolicy.cxx
+++ b/Detectors/TPC/workflow/src/TPCSectorCompletionPolicy.cxx
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TPCSectorCompletionPolicy.cxx
+/// @author Matthias Richter
+/// @since  2020-05-20
+/// @brief  DPL completion policy helper for TPC scetor data
+
+#include "TPCWorkflow/TPCSectorCompletionPolicy.h"
+#include "Framework/CompletionPolicy.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -80,7 +80,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
-  //  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
+  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
 }
 
 #include "Framework/runDataProcessing.h" // the main driver

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -19,8 +19,9 @@
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/PartRef.h"
+#include "Framework/ConcreteDataMatcher.h"
 #include "TPCWorkflow/RecoWorkflow.h"
-#include "TPCWorkflow/CATrackerSpec.h"
+#include "TPCWorkflow/TPCSectorCompletionPolicy.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "CommonUtils/ConfigurableParam.h"
@@ -80,7 +81,10 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
-  policies.push_back(o2::tpc::getCATrackerCompletionPolicy());
+  // the custom completion policy for the tracker
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-tracker.*",
+                                                        o2::framework::InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}},
+                                                        o2::framework::InputSpec{"digits", o2::framework::ConcreteDataTypeMatcher{"TPC", "DIGITS"}})());
 }
 
 #include "Framework/runDataProcessing.h" // the main driver


### PR DESCRIPTION
Background: the DPL completion policy defines when a data set is complete for
computation. The default policy is true if there is data on all input routes.
The TPC data is split into parts per sector, and currently the workflow defines
one route per sector. Also the CA tracker spec defines one input route per sector.

In order to support multiple parts(sectors) on the same input route, e.g. by a
generalized matcher with a wildcard om the subSpec, a custom policy needs to be
added to tell DPL when the data set is complete

Fixing the logic of the completion policy
- correcting the check for mixed cluster and digit input which is not allowed,
  but the tracker spec needs to be adjusted to support either the one or the other,
  the this temporary check can be removed
- for digit or cluster input the active sector information is required to be shipped
  as part of the sector header, the policy checks if data is availabel for all
  specified sectors
- there is no check on the MC labels in the completion policy, labels are required to
  be always together with corresponding sectors data in one multi-message
- if the active sector information is not shipped with the input data, e.g. for the
  ZS raw data, the DPL default policy is applied, i.e. when there is data on all input
  routes

Reverting "Fix: disable TPC CAtracker completion policy customization" to reenable the
custom policy

This reverts commit f73876917a1a46bda5367bfdd3ac2e5ad7452a0a.