### PR TITLE
MCH: bare elink decoder bugfixes (obsolete)

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/BareElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/BareElinkDecoder.h
@@ -301,7 +301,7 @@ void BareElinkDecoder<CHARGESUM>::handleReadSample()
   }
   oneLess10BitWord();
   if (mNofSamples) {
-    handleReadData();
+    changeToReadingData();
   } else {
     sendCluster();
     if (mNof10BitsWordsToRead) {


### PR DESCRIPTION
The number of 10-bit words was erroneously decremented by 2 instead of 1 when reading individual ADC samples.