### PR TITLE
[WIP] MCH: time clustering

### DIFF
--- a/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
@@ -8,13 +8,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Contour)
-add_subdirectory(Mapping)
-add_subdirectory(PreClustering)
-add_subdirectory(TimeClustering)
-add_subdirectory(Clustering)
-add_subdirectory(Simulation)
-add_subdirectory(Tracking)
-add_subdirectory(Raw)
-add_subdirectory(Workflow)
+o2_add_library(MCHTimeClustering
+        SOURCES src/TimeClusterFinder.cxx
+        PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl3 O2::MCHBase O2::Framework)

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinder.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinder.h
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimeClusterFinder.h
+/// \brief Class to group the fired pads according to their time stamp
+///
+/// \author Andrea Ferrero, CEA
+
+#ifndef ALICEO2_MCH_TIMECLUSTERFINDER_H_
+#define ALICEO2_MCH_TIMECLUSTERFINDER_H_
+
+#include <cassert>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <gsl/span>
+
+#include "MCHBase/Digit.h"
+#include "MCHBase/PreCluster.h"
+
+namespace o2
+{
+namespace mch
+{
+
+class TimeClusterFinder
+{
+ public:
+  TimeClusterFinder();
+  ~TimeClusterFinder();
+
+  TimeClusterFinder(const TimeClusterFinder&) = delete;
+  TimeClusterFinder& operator=(const TimeClusterFinder&) = delete;
+  TimeClusterFinder(TimeClusterFinder&&) = delete;
+  TimeClusterFinder& operator=(TimeClusterFinder&&) = delete;
+
+  void init();
+  void deinit();
+  void reset();
+
+  void loadDigits(gsl::span<const Digit> digits);
+
+  int run();
+
+  void getTimeClusters(gsl::span<PreCluster>& preClusters, gsl::span<Digit>& digits);
+
+ private:
+  struct DetectionElement;
+
+  void storeCluster(std::vector<const Digit*>& digits);
+
+  void createMapping();
+
+  static constexpr int SNDEs = 156; ///< number of DEs
+
+  std::vector<std::unique_ptr<DetectionElement>> mDEs; ///< internal mapping
+  std::unordered_map<int, int> mDEIndices{};           ///< maps DE indices from DE IDs
+
+  gsl::span<Digit> mOutputDigits{};           ///< array of output digits
+  gsl::span<PreCluster> mOutputPreclusters{}; ///< array of output preclusters
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif // ALICEO2_MCH_TIMECLUSTERFINDER_H_

--- a/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinder.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinder.cxx
@@ -1,0 +1,375 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHTimeClustering/TimeClusterFinder.h"
+
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <fmt/format.h>
+
+#include <fairmq/Tools.h>
+#include <FairMQLogger.h>
+
+#include "MCHMappingInterface/Segmentation.h"
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+
+static bool sPrint = false;
+
+ostream& operator<<(ostream& ostr, const Digit& d)
+{
+  ostr << fmt::format("PAD ({:04d} {:04d})\tADC {:04d}\tTIME ({} {} {})",
+                      d.getDetID(), d.getPadID(), d.getADC(), d.getTime().orbit, d.getTime().bunchCrossing, d.getTime().sampaTime);
+  return ostr;
+}
+
+struct CompareDigitTime final {
+  bool operator()(const Digit& left, const Digit& right) const
+  {
+    return (left.getTime().getBXTime() < right.getTime().getBXTime());
+  }
+};
+
+struct TimeClusterFinder::DetectionElement {
+  using DigitsMap = std::multimap<Digit, bool, CompareDigitTime>;
+  DigitsMap mDigits[2];
+  int orbit[2] = {-1, -1};
+  int currentBufId = {1};
+  int previousBufId = {0};
+
+  std::function<void(std::vector<const Digit*>&)> sendTimeCluster;
+
+  DetectionElement(std::function<void(std::vector<const Digit*>&)> f) : sendTimeCluster(f)
+  {
+  }
+
+  int getCurrentOrbit() { return orbit[currentBufId]; }
+
+  void mergeAndSendTimeClusters();
+
+  void storeDigit(const Digit& d);
+};
+
+void TimeClusterFinder::DetectionElement::storeDigit(const Digit& d)
+{
+  if (d.getTime().orbit != getCurrentOrbit()) {
+    mergeAndSendTimeClusters();
+
+    currentBufId = 1 - currentBufId;
+    previousBufId = 1 - previousBufId;
+    mDigits[currentBufId].clear();
+    orbit[currentBufId] = d.getTime().orbit;
+  }
+
+  mDigits[currentBufId].insert(std::make_pair(d, false));
+}
+
+static bool compareDigits(const Digit& lhs, const Digit& rhs)
+{
+  return (lhs.getTime().getBXTime() < rhs.getTime().getBXTime());
+}
+
+static int64_t getTimeDiff(Digit& d1, Digit& d2)
+{
+  return (static_cast<int64_t>(d2.getTime().getBXTime()) - static_cast<int64_t>(d1.getTime().getBXTime()));
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::DetectionElement::mergeAndSendTimeClusters()
+{
+  if (sPrint) {
+    std::cout << "\n[mergeAndSendTimeClusters] list of digits:\n";
+    for (auto& d : mDigits[previousBufId])
+      std::cout << d.first << " [prev]" << std::endl;
+    for (auto& d : mDigits[currentBufId])
+      std::cout << d.first << " [cur]" << std::endl;
+  }
+
+  // collect the time clusters
+  // step 1: find index of first non-merged digit in previous orbit
+  DigitsMap::iterator iStart, iEnd, iDigit;
+  uint64_t tStart = 0, tEnd = 0;
+  for (iStart = mDigits[previousBufId].begin(); iStart != mDigits[previousBufId].end(); iStart++) {
+    if (iStart->second == false) {
+      break;
+    }
+  }
+  if (iStart == mDigits[previousBufId].end())
+    return;
+
+  // the first non-merged digit is used as seed to search for the next time cluster
+  while (iStart != mDigits[previousBufId].end()) {
+
+    iEnd = iStart;
+
+    if (sPrint) {
+      std::cout << "[mergeAndSendTimeClusters] previousBufId: " << previousBufId << "  iStart: " << iStart->first << std::endl;
+    }
+    const Digit* d1 = &(iStart->first);
+
+    // we add the seed digit to the next time cluster
+    if (sPrint) {
+      std::cout << "[mergeAndSendTimeClusters] adding digit to cluster [0]: " << *d1 << std::endl;
+    }
+    std::vector<const Digit*> timeClusterDigits;
+    timeClusterDigits.push_back(d1);
+
+    // the added digit is marked as merged
+    iStart->second = true;
+
+    // initialize the time bounds of the current cluster
+    tStart = d1->getTime().getBXTime();
+    tEnd = tStart;
+
+    // step 2: loop on digits from previous orbit, starting from the one after the seed
+    iDigit = iStart;
+    iDigit++;
+    for (; iDigit != mDigits[previousBufId].end(); iDigit++) {
+
+      // skip digits that have already been merged to a time cluster
+      if (iDigit->second) {
+        continue;
+      }
+
+      // we check the time difference between the current digit and the previous one, in
+      // units of bunch crossings
+      const Digit* d2 = &(iDigit->first);
+      uint64_t td2 = d2->getTime().getBXTime();
+
+      // the cluster is ended if the time difference with respect to the last digit
+      // is larger than 10 ADC samples, or equivalently 40 bunch crossings
+      if (td2 > (tEnd + 40)) {
+        break;
+      }
+
+      // the digit is added to the time cluster and marked as merged
+      if (sPrint) {
+        std::cout << "[mergeAndSendTimeClusters] adding digit to cluster [1]: " << *d2 << std::endl;
+      }
+      timeClusterDigits.push_back(d2);
+      iDigit->second = true;
+
+      // update of the time bounds
+      if (td2 > tEnd) {
+        tEnd = td2;
+      }
+
+      // we update the pointer and index to the last digit in the cluster
+      d1 = d2;
+      iEnd = iDigit;
+    }
+
+    // step 3: loop on digits from current orbit, stop when no more digits can be added to the current cluster
+    for (iDigit = mDigits[currentBufId].begin(); iDigit != mDigits[currentBufId].end(); iDigit++) {
+
+      // skip digits that have already been merged to a time cluster
+      if (iDigit->second) {
+        continue;
+      }
+
+      // we check the time difference between the current digit and the last one in the cluster,
+      // in units of bunch crossings
+      const Digit* d2 = &(iDigit->first);
+      uint64_t td2 = d2->getTime().getBXTime();
+
+      // the cluster is ended if the digit is outside of the time bounds by more than 10 ADC samples,
+      // or equivalently 40 bunch crossings.
+      if (((td2 + 40) < tStart) || (td2 > (tEnd + 40))) {
+        break;
+      }
+
+      // the digit is added to the time cluster and marked as merged
+      if (sPrint) {
+        std::cout << "[mergeAndSendTimeClusters] adding digit to cluster [2]: " << *d2 << std::endl;
+      }
+      timeClusterDigits.push_back(d2);
+      iDigit->second = true;
+
+      // update of the time bounds
+      if (td2 > tEnd) {
+        tEnd = td2;
+      } else if (td2 < tStart) {
+        tStart = td2;
+      }
+
+      // we update the pointer to the last digit in the cluster
+      // the index is not updated because it refers to the vector of digits
+      // in the previous orbit
+      d1 = d2;
+    }
+
+    if (!timeClusterDigits.empty()) {
+      sendTimeCluster(timeClusterDigits);
+    }
+
+    // we set the new seed to the digit immediately following the last one in the current cluster
+    iStart = iEnd;
+    iStart++;
+  }
+}
+
+//_________________________________________________________________________________________________
+TimeClusterFinder::TimeClusterFinder() : mDEs{}
+{
+  /// default constructor: prepare the internal mapping structures
+  const auto clusterHandler = [&](std::vector<const Digit*>& digits) {
+    storeCluster(digits);
+  };
+  for (auto i = 0; i < SNDEs; i++) {
+    mDEs.emplace_back(new DetectionElement(clusterHandler));
+  }
+}
+
+//_________________________________________________________________________________________________
+TimeClusterFinder::~TimeClusterFinder() = default;
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::init()
+{
+  /// load the mapping and fill the internal structures
+
+  createMapping();
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::deinit()
+{
+  /// clear the internal structure
+  reset();
+  mDEIndices.clear();
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::reset()
+{
+  /// reset digits and precluster arrays. The allocated memory must be free'd by the calling function.
+  size_t size = 0;
+  mOutputDigits = gsl::span<Digit>(static_cast<Digit*>(nullptr), size_t{0});
+  mOutputPreclusters = gsl::span<PreCluster>(static_cast<PreCluster*>(nullptr), size_t{0});
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::loadDigits(gsl::span<const Digit> digits)
+{
+  /// fill the Mapping::MpDE structure with fired pads
+
+  for (const auto& digit : digits) {
+
+    int deIndex = mDEIndices[digit.getDetID()];
+    assert(deIndex >= 0 && deIndex < SNDEs);
+
+    DetectionElement& de(*(mDEs[deIndex]));
+    de.storeDigit(digit);
+  }
+}
+
+//_________________________________________________________________________________________________
+template <typename T>
+bool expandArray(gsl::span<T>& array, size_t newSize)
+{
+  void* oldPtr = array.data();
+  size_t newSizeBytes = newSize * sizeof(T);
+  T* newPtr = reinterpret_cast<T*>(realloc(oldPtr, newSizeBytes));
+  if (!newPtr) {
+    return false;
+  }
+  array = gsl::span<T>(newPtr, newSize);
+  return true;
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::storeCluster(std::vector<const Digit*>& digits)
+{
+  if (sPrint) {
+    std::cout << "\n[storeCluster]:\n";
+    for (auto& d : digits) {
+      std::cout << *d << std::endl;
+    }
+  }
+
+  size_t oldSize = mOutputDigits.size();
+  size_t newSize = oldSize + digits.size();
+  if (!expandArray(mOutputDigits, newSize)) {
+    return;
+  }
+  if (sPrint) {
+    std::cout << "[storeCluster] new digits size: " << mOutputDigits.size() << std::endl;
+  }
+
+  // append digits
+  for (size_t i = 0; i < digits.size(); i++) {
+    memcpy(&(mOutputDigits[i + oldSize]), digits[i], sizeof(Digit));
+  }
+
+  PreCluster precluster;
+  precluster.firstDigit = oldSize;
+  precluster.nDigits = digits.size();
+
+  // append precluster
+  oldSize = mOutputPreclusters.size();
+  newSize = oldSize + 1;
+  if (!expandArray(mOutputPreclusters, newSize)) {
+    return;
+  }
+  if (sPrint) {
+    std::cout << "[storeCluster] new preclusters size: " << mOutputPreclusters.size() << std::endl;
+  }
+  memcpy(&(mOutputPreclusters[oldSize]), &precluster, sizeof(PreCluster));
+}
+
+//_________________________________________________________________________________________________
+int TimeClusterFinder::run()
+{
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::getTimeClusters(gsl::span<PreCluster>& preClusters, gsl::span<Digit>& digits)
+{
+  preClusters = mOutputPreclusters;
+  digits = mOutputDigits;
+}
+
+//_________________________________________________________________________________________________
+void TimeClusterFinder::createMapping()
+{
+  /// Fill the internal mapping structures
+
+  auto tStart = std::chrono::high_resolution_clock::now();
+
+  int iDE = 0;
+  mDEIndices.reserve(SNDEs);
+
+  std::unordered_map<int, int>& deIDs = mDEIndices;
+
+  // create the internal mapping for each DE
+  mapping::forEachDetectionElement([&deIDs, &iDE](int deID) {
+    deIDs.emplace(deID, iDE);
+    iDE += 1;
+  });
+
+  if (mDEIndices.size() != SNDEs) {
+    throw runtime_error("invalid mapping");
+  }
+
+  auto tEnd = std::chrono::high_resolution_clock::now();
+  LOG(INFO) << "create mapping in: " << std::chrono::duration<double, std::milli>(tEnd - tStart).count() << " ms";
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -9,10 +9,10 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(MCHWorkflow
-               SOURCES src/DataDecoderSpec.cxx src/PreClusterFinderSpec.cxx src/ClusterFinderOriginalSpec.cxx
+               SOURCES src/DataDecoderSpec.cxx src/TimePreClusterFinderSpec.cxx src/TimeClusterFinderSpec.cxx src/PreClusterFinderSpec.cxx src/ClusterFinderOriginalSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHRawDecoder Boost::program_options
-                                     O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface O2::MCHPreClustering
+                                     O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface O2::MCHPreClustering O2::MCHTimeClustering
                                      O2::MCHMappingImpl3 O2::MCHRawElecMap O2::MCHBase O2::MCHClustering)
 
 o2_add_executable(
@@ -38,6 +38,18 @@ o2_add_executable(
 o2_add_executable(
         raw-to-digits-workflow
         SOURCES src/raw-to-digits-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+
+o2_add_executable(
+        digits-to-timeclusters-workflow
+        SOURCES src/digits-to-timeclusters-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+
+o2_add_executable(
+        timeclusters-to-preclusters-workflow
+        SOURCES src/timeclusters-to-preclusters-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimeClusterFinderSpec.h
+/// \brief Definition of a data processor to run the time clusterizer
+///
+/// \author Andrea Ferrero, CEA
+
+#ifndef O2_MCH_TIMECLUSTERFINDERSPEC_H_
+#define O2_MCH_TIMECLUSTERFINDERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mch
+{
+
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec();
+
+} // end namespace mch
+} // end namespace o2
+
+#endif // O2_MCH_TIMECLUSTERFINDERSPEC_H_

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimePreClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimePreClusterFinderSpec.h
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimePreClusterFinderSpec.h
+/// \brief Definition of a data processor to run the preclusterizer after the time clusterizer
+///
+/// \author Andrea Ferrero, CEA
+/// \author Philippe Pillot, Subatech
+
+#ifndef O2_MCH_TIMEPRECLUSTERFINDERSPEC_H_
+#define O2_MCH_TIMEPRECLUSTERFINDERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mch
+{
+
+o2::framework::DataProcessorSpec getTimePreClusterFinderSpec();
+
+} // end namespace mch
+} // end namespace o2
+
+#endif // O2_MCH_TIMEPRECLUSTERFINDERSPEC_H_

--- a/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
@@ -1,0 +1,135 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimeClusterFinderSpec.cxx
+/// \brief Implementation of a data processor to run the time clusterizer
+///
+/// \author Andrea Ferrero, CEA
+
+#include "MCHWorkflow/TimeClusterFinderSpec.h"
+
+#include <iostream>
+#include <fstream>
+#include <chrono>
+#include <vector>
+
+#include <stdexcept>
+
+#include <fmt/core.h>
+
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+
+#include "MCHBase/Digit.h"
+#include "MCHBase/PreCluster.h"
+#include "MCHTimeClustering/TimeClusterFinder.h"
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+using namespace o2::framework;
+
+class TimeClusterFinderTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  void init(framework::InitContext& ic)
+  {
+    /// Prepare the preclusterizer
+    LOG(INFO) << "initializing preclusterizer";
+
+    mTimeClusterFinder.init();
+
+    auto stop = [this]() {
+      LOG(INFO) << "reset precluster finder duration = " << mTimeResetTimeClusterFinder.count() << " ms";
+      LOG(INFO) << "load digits duration = " << mTimeLoadDigits.count() << " ms";
+      LOG(INFO) << "precluster finder duration = " << mTimeTimeClusterFinder.count() << " ms";
+      LOG(INFO) << "store precluster duration = " << mTimeStorePreClusters.count() << " ms";
+      /// Clear the preclusterizer
+      auto tStart = std::chrono::high_resolution_clock::now();
+      this->mTimeClusterFinder.deinit();
+      auto tEnd = std::chrono::high_resolution_clock::now();
+      LOG(INFO) << "deinitializing preclusterizer in: "
+                << std::chrono::duration<double, std::milli>(tEnd - tStart).count() << " ms";
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    /// read the digits, preclusterize and send the preclusters
+
+    // prepare to receive new data
+    auto tStart = std::chrono::high_resolution_clock::now();
+    mTimeClusterFinder.reset();
+    mPreClusters.clear();
+    mUsedDigits.clear();
+    auto tEnd = std::chrono::high_resolution_clock::now();
+    mTimeResetTimeClusterFinder += tEnd - tStart;
+
+    // get the input digits
+    auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
+
+    //std::cout<<"digits size: "<<digits.size()<<std::endl;
+
+    // load the digits to get the fired pads
+    tStart = std::chrono::high_resolution_clock::now();
+    mTimeClusterFinder.loadDigits(digits);
+    tEnd = std::chrono::high_resolution_clock::now();
+    mTimeLoadDigits += tEnd - tStart;
+
+    gsl::span<Digit> outputDigits;
+    gsl::span<PreCluster> outputPreclusters;
+    mTimeClusterFinder.getTimeClusters(outputPreclusters, outputDigits);
+
+    //std::cout<<"output preclusters size: "<<outputPreclusters.size()<<std::endl;
+    //std::cout<<"output digits size: "<<outputDigits.size()<<std::endl;
+    // send the output messages
+    auto freefct = [](void* data, void* /*hint*/) { free(data); };
+    pc.outputs().adoptChunk(Output{"MCH", "TCLUSTERS", 0, Lifetime::Timeframe},
+                            reinterpret_cast<char*>(outputPreclusters.data()), outputPreclusters.size_bytes(), freefct, nullptr);
+    pc.outputs().adoptChunk(Output{"MCH", "TCLUSTERDIGITS", 0, Lifetime::Timeframe},
+                            reinterpret_cast<char*>(outputDigits.data()), outputDigits.size_bytes(), freefct, nullptr);
+  }
+
+ private:
+  TimeClusterFinder mTimeClusterFinder{}; ///< preclusterizer
+  std::vector<PreCluster> mPreClusters{}; ///< vector of preclusters
+  std::vector<Digit> mUsedDigits{};       ///< vector of digits in the preclusters
+
+  std::chrono::duration<double, std::milli> mTimeResetTimeClusterFinder{}; ///< timer
+  std::chrono::duration<double, std::milli> mTimeLoadDigits{};             ///< timer
+  std::chrono::duration<double, std::milli> mTimeTimeClusterFinder{};      ///< timer
+  std::chrono::duration<double, std::milli> mTimeStorePreClusters{};       ///< timer
+};
+
+//_________________________________________________________________________________________________
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec()
+{
+  return DataProcessorSpec{
+    "TimeClusterFinder",
+    Inputs{InputSpec{"digits", "MCH", "DIGITS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{"MCH", "TCLUSTERS", 0, Lifetime::Timeframe},
+            OutputSpec{"MCH", "TCLUSTERDIGITS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TimeClusterFinderTask>()},
+    Options{}};
+}
+
+} // end namespace mch
+} // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TimePreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TimePreClusterFinderSpec.cxx
@@ -1,0 +1,158 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimePreClusterFinderSpec.cxx
+/// \brief Implementation of a data processor to run the preclusterizer after the time clusterizer
+///
+/// \author Andrea Ferrero, CEA
+/// \author Philippe Pillot, Subatech
+
+#include "MCHWorkflow/TimePreClusterFinderSpec.h"
+
+#include <iostream>
+#include <fstream>
+#include <chrono>
+#include <vector>
+
+#include <stdexcept>
+
+#include <fmt/core.h>
+
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+
+#include "MCHBase/Digit.h"
+#include "MCHBase/PreCluster.h"
+#include "MCHPreClustering/PreClusterFinder.h"
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+using namespace o2::framework;
+
+class TimePreClusterFinderTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  void init(framework::InitContext& ic)
+  {
+    /// Prepare the preclusterizer
+    LOG(INFO) << "initializing preclusterizer";
+
+    mPreClusterFinder.init();
+
+    auto stop = [this]() {
+      LOG(INFO) << "reset precluster finder duration = " << mTimeResetPreClusterFinder.count() << " ms";
+      LOG(INFO) << "load digits duration = " << mTimeLoadDigits.count() << " ms";
+      LOG(INFO) << "precluster finder duration = " << mTimePreClusterFinder.count() << " ms";
+      LOG(INFO) << "store precluster duration = " << mTimeStorePreClusters.count() << " ms";
+      /// Clear the preclusterizer
+      auto tStart = std::chrono::high_resolution_clock::now();
+      this->mPreClusterFinder.deinit();
+      auto tEnd = std::chrono::high_resolution_clock::now();
+      LOG(INFO) << "deinitializing preclusterizer in: "
+                << std::chrono::duration<double, std::milli>(tEnd - tStart).count() << " ms";
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    // get the input buffers
+    auto preClusters = pc.inputs().get<gsl::span<PreCluster>>("preclusters");
+    auto digits = pc.inputs().get<gsl::span<Digit>>("preclusterdigits");
+
+    //if (mPrint) {
+    //  std::cout << "Number of pre-clusters: " << preClusters.size() << std::endl;
+    //}
+    mPreClusters.clear();
+    mUsedDigits.clear();
+
+    /// read the time clusters, preclusterize and send the preclusters
+    for (auto& preCluster : preClusters) {
+      // get the digits of this precluster
+      auto preClusterDigits = digits.subspan(preCluster.firstDigit, preCluster.nDigits);
+
+      // prepare to receive new data
+      auto tStart = std::chrono::high_resolution_clock::now();
+      mPreClusterFinder.reset();
+      auto tEnd = std::chrono::high_resolution_clock::now();
+      mTimeResetPreClusterFinder += tEnd - tStart;
+
+      // load the digits to get the fired pads
+      tStart = std::chrono::high_resolution_clock::now();
+      mPreClusterFinder.loadDigits(preClusterDigits);
+      tEnd = std::chrono::high_resolution_clock::now();
+      mTimeLoadDigits += tEnd - tStart;
+
+      // preclusterize
+      tStart = std::chrono::high_resolution_clock::now();
+      int nPreClusters = mPreClusterFinder.run();
+      tEnd = std::chrono::high_resolution_clock::now();
+      mTimePreClusterFinder += tEnd - tStart;
+
+      // get the preclusters and associated digits
+      tStart = std::chrono::high_resolution_clock::now();
+      mPreClusters.reserve(mPreClusters.size() + nPreClusters); // to avoid reallocation if
+      mUsedDigits.reserve(mUsedDigits.size() + digits.size());  // the capacity is exceeded
+      mPreClusterFinder.getPreClusters(mPreClusters, mUsedDigits);
+      //if (mUsedDigits.size() != digits.size()) {
+      //std::cout<<"some digits have been lost during the preclustering"<<std::endl;
+      //for (auto& d : digits) {
+      //  std::cout << fmt::format("  DE {:4d}  PAD {:5d}  ADC {:6d}  TIME {}-{:4d}",
+      //      d.getDetID(), d.getPadID(), d.getADC(), d.getTime().bunchCrossing, d.getTimeStamp());
+      //  std::cout << std::endl;
+      //}
+      //throw runtime_error("some digits have been lost during the preclustering");
+      //}
+      tEnd = std::chrono::high_resolution_clock::now();
+      mTimeStorePreClusters += tEnd - tStart;
+    }
+
+    // send the output messages
+    pc.outputs().snapshot(Output{"MCH", "PRECLUSTERS", 0, Lifetime::Timeframe}, mPreClusters);
+    pc.outputs().snapshot(Output{"MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}, mUsedDigits);
+  }
+
+ private:
+  PreClusterFinder mPreClusterFinder{};   ///< preclusterizer
+  std::vector<PreCluster> mPreClusters{}; ///< vector of preclusters
+  std::vector<Digit> mUsedDigits{};       ///< vector of digits in the preclusters
+
+  std::chrono::duration<double, std::milli> mTimeResetPreClusterFinder{}; ///< timer
+  std::chrono::duration<double, std::milli> mTimeLoadDigits{};            ///< timer
+  std::chrono::duration<double, std::milli> mTimePreClusterFinder{};      ///< timer
+  std::chrono::duration<double, std::milli> mTimeStorePreClusters{};      ///< timer
+};
+
+//_________________________________________________________________________________________________
+o2::framework::DataProcessorSpec getTimePreClusterFinderSpec()
+{
+  return DataProcessorSpec{
+    "TimePreClusterFinder",
+    Inputs{InputSpec{"preclusters", "MCH", "TCLUSTERS", 0, Lifetime::Timeframe},
+           InputSpec{"preclusterdigits", "MCH", "TCLUSTERDIGITS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{"MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
+            OutputSpec{"MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TimePreClusterFinderTask>()},
+    Options{}};
+}
+
+} // end namespace mch
+} // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file digits-to-timeclusters-workflow.cxx
+/// \brief This is an executable that runs the time clusterization via DPL.
+///
+/// This is an executable that takes digits from the Data Processing Layer, runs the time clusterization and sends the time clusters via the Data Processing Layer.
+///
+/// \author Andrea Ferrero, CEA
+
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Task.h"
+#include "Framework/runDataProcessing.h"
+#include "MCHWorkflow/TimeClusterFinderSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  WorkflowSpec specs;
+
+  DataProcessorSpec producer = o2::mch::getTimeClusterFinderSpec();
+  specs.push_back(producer);
+
+  return specs;
+}

--- a/Detectors/MUON/MCH/Workflow/src/timeclusters-to-preclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/timeclusters-to-preclusters-workflow.cxx
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file preclusters-to-clusters-workflow.cxx
+/// \brief This is an executable that runs the cluster fitting via DPL.
+///
+/// This is an executable that takes preclusters from the Data Processing Layer, runs the cluster finding and fitting algorithm, and sends the clusters via the Data Processing Layer.
+///
+/// \author Philippe Pillot, Subatech
+/// \author Andrea Ferrero, CEA
+
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Task.h"
+#include "Framework/runDataProcessing.h"
+#include "MCHWorkflow/TimePreClusterFinderSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  WorkflowSpec specs;
+
+  DataProcessorSpec producer = o2::mch::getTimePreClusterFinderSpec();
+  specs.push_back(producer);
+
+  return specs;
+}


### PR DESCRIPTION
This PR introduces a time-based clustering of MCH digits, that should be executed before the standard pre-clustering.

The code is still work in progress, and depends on #3618 for the new digit time definition.

The additional sources are the following:
* [the time clustering algorithm](https://github.com/AliceMCH/AliceO2/tree/mch-time-clustering/Detectors/MUON/MCH/TimeClustering)
* two new workflows, [digits-to-timeclusters](https://github.com/AliceMCH/AliceO2/blob/mch-time-clustering/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx) and [timeclusters-to-preclusters](https://github.com/AliceMCH/AliceO2/blob/mch-time-clustering/Detectors/MUON/MCH/Workflow/src/timeclusters-to-preclusters-workflow.cxx) and the corresponding specs, [TimeClusterFinderSpec.](https://github.com/AliceMCH/AliceO2/blob/mch-time-clustering/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx) and (TimePreClusterFinderSpec)[https://github.com/AliceMCH/AliceO2/blob/mch-time-clustering/Detectors/MUON/MCH/Workflow/src/TimePreClusterFinderSpec.cxx] (I am not very happy about this last file name).