### PR TITLE
[Steer] Remove unwanted/unneeded depencency on TPCSimulation

### DIFF
--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -14,8 +14,7 @@ o2_add_library(Steer
 		       PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
 		                     O2::CommonConstants
                                      O2::SimulationDataFormat
-                                     O2::DetectorsCommonDataFormats
-                                     O2::TPCSimulation)
+                                     O2::DetectorsCommonDataFormats)
 
 o2_target_root_dictionary(Steer
                           HEADERS include/Steer/InteractionSampler.h

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -13,7 +13,6 @@
 #include <FairMQMessage.h>
 #include <FairMQDevice.h>
 #include <FairMQParts.h>
-#include <TPCSimulation/Point.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
 #include <TMessage.h>
 #include <sstream>


### PR DESCRIPTION
For the record, I found this one when trying to compile only Mch-related targets using : 

```
cmake --build . --target $(ninja -t targets | grep -i "^O2" | grep -i mch | cut -d ':' -f 1 | tr "\n" " ")
```

and still getting TPC libs built...
