### PR TITLE
Updating version of TPCSectorHeader

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
@@ -24,15 +24,28 @@ namespace tpc
 struct TPCSectorHeader : public o2::header::BaseHeader {
   // Required to do the lookup
   constexpr static const o2::header::HeaderType sHeaderType = "TPCSectH";
-  static const uint32_t sVersion = 1;
+  static const uint32_t sVersion = 2;
+  static constexpr int NSectors = o2::tpc::Constants::MAXSECTOR;
 
   TPCSectorHeader(int s)
-    : BaseHeader(sizeof(TPCSectorHeader), sHeaderType, o2::header::gSerializationMethodNone, sVersion), sector(s)
+    : BaseHeader(sizeof(TPCSectorHeader), sHeaderType, o2::header::gSerializationMethodNone, sVersion), sectorBits(((uint64_t)0x1) << s)
   {
   }
 
-  static constexpr int NSectors = o2::tpc::Constants::MAXSECTOR;
-  int sector;
+  int sector() const
+  {
+    for (int s = 0; s < NSectors; s++) {
+      if ((sectorBits >> s) == 0x1) {
+        return s;
+      }
+    }
+    if (sectorBits != 0) {
+      return NSectors;
+    }
+    return -1;
+  }
+
+  uint64_t sectorBits;
   union {
     uint64_t activeSectorsFlags = 0;
     struct {

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -96,19 +96,6 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
       throw std::runtime_error("sector header missing on header stack");
     }
     const int& sector = sectorHeader->sector();
-    // check the current operation, this is used to either signal eod or noop
-    // FIXME: the noop is not needed any more once the lane configuration with one
-    // channel per sector is used
-    if (sector < 0) {
-      if (operation < 0 && operation != sector) {
-        // we expect the same operation on all inputs
-        LOG(ERROR) << "inconsistent lane operation, got " << sector << ", expecting " << operation;
-      } else if (operation == 0) {
-        // store the operation
-        operation = sector;
-      }
-      continue;
-    }
     // the TPCSectorHeader now allows to transport information for more than one sector,
     // e.g. for transporting clusters in one single data block. For the moment, the
     // implemenation here requires single sectors
@@ -124,11 +111,6 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     activeSectors |= sectorHeader->activeSectors;
     validSectors.set(sector);
     datarefs[sector] = ref;
-  }
-
-  if (operation == -1) {
-    // EOD is transmitted in the sectorHeader with sector number equal to -1
-    LOG(WARNING) << "operation = " << operation;
   }
 
   auto printInputLog = [&validSectors, &activeSectors](auto& r, const char* comment, auto& s) {

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -95,7 +95,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
       LOG(ERROR) << "sector header missing on header stack";
       throw std::runtime_error("sector header missing on header stack");
     }
-    const int& sector = sectorHeader->sector;
+    const int& sector = sectorHeader->sector();
     // check the current operation, this is used to either signal eod or noop
     // FIXME: the noop is not needed any more once the lane configuration with one
     // channel per sector is used
@@ -108,6 +108,12 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
         operation = sector;
       }
       continue;
+    }
+    // the TPCSectorHeader now allows to transport information for more than one sector,
+    // e.g. for transporting clusters in one single data block. For the moment, the
+    // implemenation here requires single sectors
+    if (sector >= o2::tpc::TPCSectorHeader::NSectors) {
+      throw std::runtime_error("Expecting data for single sectors");
     }
     if (validSectors.test(sector)) {
       // have already data for this sector, this should not happen in the current

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -66,7 +66,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
       LOG(ERROR) << "sector header missing on header stack";
       throw std::runtime_error("sector header missing on header stack");
     }
-    const int& sector = sectorHeader->sector;
+    const int& sector = sectorHeader->sector();
     // check the current operation, this is used to either signal eod or noop
     // FIXME: the noop is not needed any more once the lane configuration with one
     // channel per sector is used
@@ -79,6 +79,12 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
         operation = sector;
       }
       continue;
+    }
+    // the TPCSectorHeader now allows to transport information for more than one sector,
+    // e.g. for transporting clusters in one single data block. For the moment, the
+    // implemenation here requires single sectors
+    if (sector >= o2::tpc::TPCSectorHeader::NSectors) {
+      throw std::runtime_error("Expecting data for single sectors");
     }
     if (validSectors.test(sector)) {
       // have already data for this sector, this should not happen in the current

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -67,19 +67,6 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
       throw std::runtime_error("sector header missing on header stack");
     }
     const int& sector = sectorHeader->sector();
-    // check the current operation, this is used to either signal eod or noop
-    // FIXME: the noop is not needed any more once the lane configuration with one
-    // channel per sector is used
-    if (sector < 0) {
-      if (operation < 0 && operation != sector) {
-        // we expect the same operation on all inputs
-        LOG(ERROR) << "inconsistent lane operation, got " << sector << ", expecting " << operation;
-      } else if (operation == 0) {
-        // store the operation
-        operation = sector;
-      }
-      continue;
-    }
     // the TPCSectorHeader now allows to transport information for more than one sector,
     // e.g. for transporting clusters in one single data block. For the moment, the
     // implemenation here requires single sectors
@@ -95,11 +82,6 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     activeSectors |= sectorHeader->activeSectors;
     validSectors.set(sector);
     datarefs[sector] = ref;
-  }
-
-  if (operation == -1) {
-    // EOD is transmitted in the sectorHeader with sector number equal to -1
-    LOG(WARNING) << "operation = " << operation;
   }
 
   auto printInputLog = [&validSectors, &activeSectors](auto& r, const char* comment, auto& s) {

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
@@ -113,7 +113,7 @@ class TPCSectorCompletionPolicy
                 throw std::runtime_error("TPC sector header missing on header stack");
               }
               activeSectors |= sectorHeader->activeSectors;
-              validSectors.set(sectorHeader->sector);
+              validSectors.set(sectorHeader->sector());
               break;
             }
           }

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -335,9 +335,15 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
             LOG(ERROR) << "sector header missing on header stack";
             return;
           }
-          const int sector = sectorHeader->sector;
+          const int sector = sectorHeader->sector();
           if (sector < 0) {
             continue;
+          }
+          // the TPCSectorHeader now allows to transport information for more than one sector,
+          // e.g. for transporting clusters in one single data block. For the moment, the
+          // implemenation here requires single sectors
+          if (sector >= TPCSectorHeader::NSectors) {
+            throw std::runtime_error("Expecting data for single sectors");
           }
           if (validMcInputs.test(sector)) {
             // have already data for this sector, this should not happen in the current
@@ -376,10 +382,16 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
         if (sectorHeader == nullptr) {
           throw std::runtime_error("sector header missing on header stack");
         }
-        const int sector = sectorHeader->sector;
+        const int sector = sectorHeader->sector();
         if (sector < 0) {
           //throw std::runtime_error("lagacy input, custom eos is not expected anymore")
           continue;
+        }
+        // the TPCSectorHeader now allows to transport information for more than one sector,
+        // e.g. for transporting clusters in one single data block. For the moment, the
+        // implemenation here requires single sectors
+        if (sector >= TPCSectorHeader::NSectors) {
+          throw std::runtime_error("Expecting data for single sectors");
         }
         if (validInputs.test(sector)) {
           // have already data for this sector, this should not happen in the current

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -87,7 +87,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         if (sectorHeaderMC) {
           o2::header::Stack actual{*sectorHeaderMC};
           std::swap(mcHeaderStack, actual);
-          if (sectorHeaderMC->sector < 0) {
+          if (sectorHeaderMC->sector() < 0) {
             pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, Lifetime::Timeframe, std::move(mcHeaderStack)}, fanSpec);
           }
         }
@@ -96,12 +96,12 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       if (sectorHeader) {
         o2::header::Stack actual{*sectorHeader};
         std::swap(rawHeaderStack, actual);
-        if (sectorHeader->sector < 0) {
+        if (sectorHeader->sector() < 0) {
           pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack)}, fanSpec);
           return;
         }
       }
-      assert(sectorHeaderMC == nullptr || sectorHeader->sector == sectorHeaderMC->sector);
+      assert(sectorHeaderMC == nullptr || sectorHeader->sector() == sectorHeaderMC->sector());
 
       // input to the decoder is a vector of raw pages description ClusterHardwareContainer,
       // each specified as a pair of pointer to ClusterHardwareContainer and the number
@@ -110,7 +110,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       size_t nPages = size / 8192;
       std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>> inputList;
       if (verbosity > 0 && !DataRefUtils::isValid(mclabelref)) {
-        LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages for sector " << sectorHeader->sector;
+        LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages for sector " << sectorHeader->sector();
       }
 
       // MC labels are received as one container of labels in the sequence matching clusters
@@ -121,7 +121,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         mcin = std::move(pc.inputs().get<MCLabelContainer*>(mclabelref));
         mcinCopies.resize(nPages);
         if (verbosity > 0) {
-          LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages, " << mcin->getIndexedSize() << " MC label sets for sector " << sectorHeader->sector;
+          LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages, " << mcin->getIndexedSize() << " MC label sets for sector " << sectorHeader->sector();
         }
       }
 
@@ -170,7 +170,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
 
       // TODO: reestablish the logging messages on the raw buffer
       // if (verbosity > 1) {
-      //   LOG(INFO) << "decoder " << std::setw(2) << sectorHeader->sector                             //
+      //   LOG(INFO) << "decoder " << std::setw(2) << sectorHeader->sector()                             //
       //             << ": decoded " << std::setw(4) << coll.clusters.size() << " clusters on sector " //
       //             << std::setw(2) << (int)coll.sector << "[" << (int)coll.globalPadRow << "]";      //
       // }
@@ -204,7 +204,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
           LOG(ERROR) << "sector header missing on header stack for input on " << inputRef.spec->binding;
           continue;
         }
-        const int sector = sectorHeader->sector;
+        const int sector = sectorHeader->sector();
         if (DataRefUtils::match(inputRef, {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERHW"}})) {
           inputs[sector].dataref = inputRef;
         }

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -76,7 +76,7 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       auto const* dataHeader = DataRefUtils::getHeader<o2::header::DataHeader*>(dataref);
       o2::header::DataHeader::SubSpecificationType fanSpec = dataHeader->subSpecification;
 
-      const auto sector = sectorHeader->sector;
+      const auto sector = sectorHeader->sector();
       if (sector < 0) {
         // forward the control information
         // FIXME define and use flags in TPCSectorHeader
@@ -107,7 +107,7 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       auto& clusterer = clusterers[sector];
 
       if (verbosity > 0) {
-        LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector
+        LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector()
                   << " input size " << DataRefUtils::getPayloadSize(dataref);
       }
       // process the digits and MC labels, the bool parameter controls whether to clear all
@@ -122,10 +122,10 @@ DataProcessorSpec getClustererSpec(bool sendMC)
         LOG(INFO) << "clusterer produced "
                   << std::accumulate(clusterArray.begin(), clusterArray.end(), size_t(0), [](size_t l, auto const& r) { return l + r.getContainer()->numberOfClusters; })
                   << " cluster(s)"
-                  << " for sector " << sectorHeader->sector
+                  << " for sector " << sectorHeader->sector()
                   << " total size " << sizeof(ClusterHardwareContainer8kb) * clusterArray.size();
         if (DataRefUtils::isValid(mclabelref)) {
-          LOG(INFO) << "clusterer produced " << mctruthArray.getIndexedSize() << " MC label object(s) for sector " << sectorHeader->sector;
+          LOG(INFO) << "clusterer produced " << mctruthArray.getIndexedSize() << " MC label object(s) for sector " << sectorHeader->sector();
         }
       }
       // FIXME: that should be a case for pmr, want to send the content of the vector as a binary
@@ -155,7 +155,7 @@ DataProcessorSpec getClustererSpec(bool sendMC)
           LOG(ERROR) << "sector header missing on header stack for input on " << inputRef.spec->binding;
           continue;
         }
-        const int sector = sectorHeader->sector;
+        const int sector = sectorHeader->sector();
         if (DataRefUtils::match(inputRef, {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}})) {
           inputs[sector].dataref = inputRef;
         }

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -265,18 +265,18 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
     if (!tpcSectorHeader) {
       throw std::runtime_error("TPC sector header missing in header stack");
     }
-    if (tpcSectorHeader->sector < 0) {
+    if (tpcSectorHeader->sector() < 0) {
       // special data sets, don't write
       return ~(size_t)0;
     }
     size_t index = 0;
     for (auto const& sector : tpcSectors) {
-      if (sector == tpcSectorHeader->sector) {
+      if (sector == tpcSectorHeader->sector()) {
         return index;
       }
       ++index;
     }
-    throw std::runtime_error("sector " + std::to_string(tpcSectorHeader->sector) + " not configured for writing");
+    throw std::runtime_error("sector " + std::to_string(tpcSectorHeader->sector()) + " not configured for writing");
   };
   auto getName = [tpcSectors](std::string base, size_t index) {
     return base + "_" + std::to_string(tpcSectors.at(index));

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -107,20 +107,6 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
           return;
         }
         const int& sector = sectorHeader->sector();
-        // check the current operation, this is used to either signal eod or noop
-        // FIXME: the noop is not needed any more once the lane configuration with one
-        // channel per sector is used
-        if (sector < 0) {
-          if (operation < 0 && operation != sector) {
-            // we expect the same operation on all inputs
-            LOG(ERROR) << "inconsistent lane operation, got "
-                       << sector << ", expecting " << operation;
-          } else if (operation == 0) {
-            // store the operation
-            operation = sector;
-          }
-          continue;
-        }
         // the TPCSectorHeader now allows to transport information for more than one sector,
         // e.g. for transporting clusters in one single data block. Digits are however grouped
         // on sector level
@@ -131,11 +117,6 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
         inputDigits[sector] = pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref);
         LOG(INFO) << "GOT SPAN FOR SECTOR " << sector << " -> "
                   << inputDigits[sector].size();
-      }
-      if (operation == -1) {
-        pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-        processAttributes->finished = true;
-        return;
       }
       for (int i = 0; i < NSectors; i++) {
         inDigitsGPU.tpcDigits[i] = inputDigits[i].data();

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -106,7 +106,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
           LOG(ERROR) << "sector header missing on header stack";
           return;
         }
-        const int& sector = sectorHeader->sector;
+        const int& sector = sectorHeader->sector();
         // check the current operation, this is used to either signal eod or noop
         // FIXME: the noop is not needed any more once the lane configuration with one
         // channel per sector is used
@@ -120,6 +120,12 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
             operation = sector;
           }
           continue;
+        }
+        // the TPCSectorHeader now allows to transport information for more than one sector,
+        // e.g. for transporting clusters in one single data block. Digits are however grouped
+        // on sector level
+        if (sectorHeader->sector() >= TPCSectorHeader::NSectors) {
+          throw std::runtime_error("Expecting data for single sectors");
         }
 
         inputDigits[sector] = pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref);

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -118,7 +118,13 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
         if (!sectorHeader) {
           throw std::runtime_error("Missing sector header in TPC data");
         }
-        return sectorHeader->sector;
+        // the TPCSectorHeader now allows to transport information for more than one sector,
+        // e.g. for transporting clusters in one single data block. The digitization is however
+        // only on sector level
+        if (sectorHeader->sector() >= TPCSectorHeader::NSectors) {
+          throw std::runtime_error("Digitizer can only work on single sectors");
+        }
+        return sectorHeader->sector();
       };
 
       // read the trigger data first


### PR DESCRIPTION
TPCSectorHeader has been used to transport information for single TPC sectors.
For future extensions it will be needed to mark multiple sectors, the new
version uses one bit for each sector which will be set if data is present for
the sector.

We will need this to be more flexible with the exchange of TPC data, like e.g. #3552.