### PR TITLE
 Defining completion policy for the GlobalTrackingWorkflow processor specs and some cleanup

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
@@ -13,8 +13,6 @@
 #ifndef O2_MATCHING_TPCITS_SPEC
 #define O2_MATCHING_TPCITS_SPEC
 
-#include "TFile.h"
-
 #include "GlobalTracking/MatchTPCITS.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsTPC/Constants.h"
@@ -34,8 +32,8 @@ namespace globaltracking
 class TPCITSMatchingDPL : public Task
 {
  public:
-  TPCITSMatchingDPL(bool useMC, const std::vector<int>& tpcClusLanes)
-    : mUseMC(useMC), mTPCClusLanes(tpcClusLanes) {}
+  TPCITSMatchingDPL(bool useMC)
+    : mUseMC(useMC) {}
   ~TPCITSMatchingDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -44,7 +42,6 @@ class TPCITSMatchingDPL : public Task
  private:
   o2::globaltracking::MatchTPCITS mMatching; // matching engine
   o2::itsmft::TopologyDictionary mITSDict;   // cluster patterns dictionary
-  std::vector<int> mTPCClusLanes;
   std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters; // at the moment not used
   bool mUseMC = true;
   TStopwatch mTimer;

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
@@ -42,7 +42,6 @@ class TPCITSMatchingDPL : public Task
  private:
   o2::globaltracking::MatchTPCITS mMatching; // matching engine
   o2::itsmft::TopologyDictionary mITSDict;   // cluster patterns dictionary
-  std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters; // at the moment not used
   bool mUseMC = true;
   TStopwatch mTimer;
 };

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -126,12 +126,12 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     throw std::runtime_error("Did not receive TPC clusters data for all sectors");
   }
   //------------------------------------------------------------------------------
-  std::array<gsl::span<const char>, o2::tpc::Constants::MAXSECTOR> clustersTPC;
+  std::vector<gsl::span<const char>> clustersTPC;
 
   for (auto const& refentry : datarefs) {
     auto& sector = refentry.first;
     auto& ref = refentry.second;
-    clustersTPC[sector] = gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref));
+    clustersTPC.emplace_back(ref.payload, DataRefUtils::getPayloadSize(ref));
     printInputLog(ref, "received", sector);
   }
 
@@ -176,7 +176,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   o2::tpc::ClusterNativeAccess clusterIndex;
   std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC, [&validSectors](auto& index) { return validSectors.test(index); });
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC);
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   //

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -124,40 +124,15 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     // not all sectors available
     // Since we expect complete input, this should not happen (why does the bufferization considered for TPC CA tracker? Ask Matthias)
     throw std::runtime_error("Did not receive TPC clusters data for all sectors");
-    /*
-    for (auto const& refentry : datarefs) {
-      auto& sector = refentry.first;
-      auto& ref = refentry.second;
-      auto payploadSize = DataRefUtils::getPayloadSize(ref);
-      mBufferedTPCClusters[sector].resize(payploadSize);
-      std::copy(ref.payload, ref.payload + payploadSize, mBufferedTPCClusters[sector].begin());
-      
-      printInputLog(ref, "buffering", sector);
-    }
-    // not needed to send something, DPL will simply drop this timeslice, whenever the
-    // data for all sectors is available, the output is sent in that time slice
-    return;
-    */
   }
   //------------------------------------------------------------------------------
   std::array<gsl::span<const char>, o2::tpc::Constants::MAXSECTOR> clustersTPC;
-  auto sectorStatus = validSectors;
 
   for (auto const& refentry : datarefs) {
     auto& sector = refentry.first;
     auto& ref = refentry.second;
     clustersTPC[sector] = gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref));
-    sectorStatus.reset(sector);
     printInputLog(ref, "received", sector);
-  }
-  if (sectorStatus.any()) {
-    LOG(ERROR) << "Reading bufferized TPC clusters, this should not happen";
-    // some of the inputs have been buffered
-    for (size_t sector = 0; sector < sectorStatus.size(); ++sector) {
-      if (sectorStatus.test(sector)) {
-        clustersTPC[sector] = gsl::span(&mBufferedTPCClusters[sector].front(), mBufferedTPCClusters[sector].size());
-      }
-    }
   }
 
   // Just print TPC clusters status
@@ -255,12 +230,6 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   }
 
   mMatching.run();
-
-  /* // at the moment we don't assume need for bufferization, no nead to clear
-  for (auto& secClBuf : mBufferedTPCClusters) {
-    secClBuf.clear();
-  }
-  */
 
   pc.outputs().snapshot(Output{"GLO", "TPCITS", 0, Lifetime::Timeframe}, mMatching.getMatchedTracks());
   if (mUseMC) {

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -10,6 +10,8 @@
 
 #include "GlobalTrackingWorkflow/MatchTPCITSWorkflow.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "TPCWorkflow/TPCSectorCompletionPolicy.h"
 
 using namespace o2::framework;
 
@@ -26,6 +28,17 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);
+}
+
+// the matcher process requires the TPC sector completion to trigger and data on
+// all defined routes
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // the TPC sector completion policy checks when the set of TPC/CLUSTERNATIVE data is complete
+  // in addition we require to have input from all other routes
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("itstpc-track-matcher",
+                                                        o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
+                                                        InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -36,7 +36,6 @@ class TPCInterpolationDPL : public Task
 
  private:
   o2::tpc::TrackInterpolation mInterpolation; // track interpolation engine
-  std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters;
   bool mUseMC{false}; ///< MC flag
   TStopwatch mTimer;
 };

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -28,7 +28,7 @@ namespace tpc
 class TPCInterpolationDPL : public Task
 {
  public:
-  TPCInterpolationDPL(bool useMC, const std::vector<int>& tpcClusLanes) : mUseMC(useMC), mTPCClusLanes(tpcClusLanes) {}
+  TPCInterpolationDPL(bool useMC) : mUseMC(useMC) {}
   ~TPCInterpolationDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -36,7 +36,6 @@ class TPCInterpolationDPL : public Task
 
  private:
   o2::tpc::TrackInterpolation mInterpolation; // track interpolation engine
-  std::vector<int> mTPCClusLanes;
   std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters;
   bool mUseMC{false}; ///< MC flag
   TStopwatch mTimer;

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-#include "Framework/ControlService.h"
+#include "Framework/InputRecordWalker.h"
 #include "DataFormatsITS/TrackITS.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
 #include "DataFormatsTPC/TrackTPC.h"
@@ -56,10 +56,10 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   uint64_t activeSectors = 0;
   std::bitset<o2::tpc::Constants::MAXSECTOR> validSectors = 0;
   std::map<int, DataRef> datarefs;
-  for (auto const& lane : mTPCClusLanes) {
-    std::string inputLabel = "clusTPC" + std::to_string(lane);
-    LOG(INFO) << "Reading lane " << lane << " " << inputLabel;
-    auto ref = pc.inputs().get(inputLabel);
+  std::vector<InputSpec> filter = {
+    {"check", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe},
+  };
+  for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
     auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
     if (sectorHeader == nullptr) {
       // FIXME: think about error policy
@@ -73,6 +73,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     if (sector >= o2::tpc::TPCSectorHeader::NSectors) {
       throw std::runtime_error("Expecting data for single sectors");
     }
+    LOG(INFO) << "Reading cluster data for sector " << sector;
     if (validSectors.test(sector)) {
       // have already data for this sector, this should not happen in the current
       // sequential implementation, for parallel path merged at the tracker stage
@@ -113,7 +114,6 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     */
   }
   //------------------------------------------------------------------------------
-  std::array<std::vector<MCLabelContainer>, o2::tpc::Constants::MAXSECTOR> mcInputs; // DUMMY
   std::array<gsl::span<const char>, o2::tpc::Constants::MAXSECTOR> clustersTPC;
   auto sectorStatus = validSectors;
 
@@ -174,9 +174,8 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
 
   o2::tpc::ClusterNativeAccess clusterIndex;
   std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
-  o2::tpc::MCLabelContainer clusterMCBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clusterMCBuffer, clustersTPC, mcInputs, [&validSectors](auto& index) { return validSectors.test(index); });
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC, [&validSectors](auto& index) { return validSectors.test(index); });
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   // pass input data to TrackInterpolation object
@@ -217,10 +216,7 @@ DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tp
   inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
 
-  for (auto lane : tpcClusLanes) {
-    std::string clusBind = "clusTPC" + std::to_string(lane);
-    inputs.emplace_back(clusBind.c_str(), "TPC", "CLUSTERNATIVE", lane, Lifetime::Timeframe);
-  }
+  inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
 
   inputs.emplace_back("match", "GLO", "TPCITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("matchTOF", "TOF", "MATCHINFOS", 0, Lifetime::Timeframe);
@@ -243,7 +239,7 @@ DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tp
     "tpc-track-interpolation",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(useMC, tpcClusLanes)},
+    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(useMC)},
     Options{}};
 }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -100,12 +100,12 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     throw std::runtime_error("Did not receive TPC clusters data for all sectors");
   }
   //------------------------------------------------------------------------------
-  std::array<gsl::span<const char>, o2::tpc::Constants::MAXSECTOR> clustersTPC;
+  std::vector<gsl::span<const char>> clustersTPC;
 
   for (auto const& refentry : datarefs) {
     auto& sector = refentry.first;
     auto& ref = refentry.second;
-    clustersTPC[sector] = gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref));
+    clustersTPC.emplace_back(ref.payload, DataRefUtils::getPayloadSize(ref));
     printInputLog(ref, "received", sector);
   }
 
@@ -150,7 +150,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   o2::tpc::ClusterNativeAccess clusterIndex;
   std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC, [&validSectors](auto& index) { return validSectors.test(index); });
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC);
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   // pass input data to TrackInterpolation object

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -10,6 +10,8 @@
 
 #include "TPCInterpolationWorkflow/TrackInterpolationWorkflow.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "TPCWorkflow/TPCSectorCompletionPolicy.h"
 
 using namespace o2::framework;
 
@@ -25,6 +27,17 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+}
+
+// the matcher process requires the TPC sector completion to trigger and data on
+// all defined routes
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // the TPC sector completion policy checks when the set of TPC/CLUSTERNATIVE data is complete
+  // in addition we require to have input from all other routes
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-track-interpolation",
+                                                        o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
+                                                        InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
 }
 
 // ------------------------------------------------------------------


### PR DESCRIPTION
The matcher process requires the TPC sector completion to trigger and data on
all defined routes.

@davidrohr , @shahor02 this is an example for a custom completion policy. We could implement it in a dedicated class for the global matching workflows.