### PR TITLE
Updated format for transport of TPCNativeCluster

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -76,6 +76,43 @@ struct ClusterNativeBuffer : public ClusterGroupHeader {
   value_type clusters[0];
 };
 
+// @struct ClusterCountIndex
+// Index of cluster counts per {sector,padrow} for the full TPC
+//
+// This is the header for the transport format of TPC ClusterNative data,
+// followed by a linear buffer of clusters.
+struct alignas(64) ClusterCountIndex {
+  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+};
+
+// @struct ClusterCountIndex
+// Index of cluster counts per {sector,padrow} coordinate
+// TODO: remove or merge with the above
+struct alignas(64) ClusterIndexBuffer {
+  using value_type = ClusterNative;
+
+  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+
+  size_t getNClusters() const
+  {
+    size_t count = 0;
+    for (auto sector = 0; sector < Constants::MAXSECTOR; sector++) {
+      for (auto row = 0; row < Constants::MAXGLOBALPADROW; row++) {
+        count += nClusters[sector][row];
+      }
+    }
+    return count;
+  }
+
+  size_t getFlatSize() const { return sizeof(this) + getNClusters() * sizeof(value_type); }
+
+  const value_type* data() const { return clusters; }
+
+  value_type* data() { return clusters; }
+
+  value_type clusters[0];
+};
+
 /// @class ClusterNativeHelper utility class for TPC native clusters
 /// This class supports the following utility functionality for handling of
 /// TPC ClusterNative data:
@@ -185,9 +222,9 @@ class ClusterNativeHelper
       ClusterNativeAccess& clusterIndex, std::unique_ptr<ClusterNative[]>& clusterBuffer,
       DataArrayType& inputs, CheckFct checkFct = [](auto const&) { return true; })
     {
-      // just use a dummy parameter with empty vectors, the ugly double vector will be removed
-      // soon. TODO: maybe do in one function with conditional template parameter
-      std::vector<std::vector<MCLabelContainer>> dummy(inputs.size());
+      // just use a dummy parameter with empty vectors
+      // TODO: maybe do in one function with conditional template parameter
+      std::vector<std::unique_ptr<MCLabelContainer>> dummy;
       // another default, nothing will be added to the container
       MCLabelContainer mcBuffer;
       return fillIndex(clusterIndex, clusterBuffer, mcBuffer, inputs, dummy, checkFct);
@@ -196,10 +233,10 @@ class ClusterNativeHelper
     // Process data for one sector.
     // This function does not copy any data but sets the corresponding poiters in the index.
     // Cluster data are provided as a raw buffer of consecutive ClusterNative arrays preceded by ClusterGroupHeader
-    // MC labels are provided as a span of MCLabelContainers, one per pad row.
+    // MC labels are provided as a span of MCLabelContainers, one per sector.
     static int parseSector(const char* buffer, size_t size, gsl::span<MCLabelContainer const> const& mcinput, //
                            ClusterNativeAccess& clusterIndex,                                                 //
-                           const MCLabelContainer* (&clustersMCTruth)[NSectors][NPadRows]);                   //
+                           const MCLabelContainer* (&clustersMCTruth)[NSectors]);                             //
 
     // Process data for one sector
     // Helper method receiving raw buffer provided as container
@@ -207,7 +244,7 @@ class ClusterNativeHelper
     template <typename ContainerT>
     static int parseSector(ContainerT const cont, gsl::span<MCLabelContainer const> const& mcinput, //
                            ClusterNativeAccess& clusterIndex,                                       //
-                           const MCLabelContainer* (&clustersMCTruth)[NSectors][NPadRows])          //
+                           const MCLabelContainer* (&clustersMCTruth)[NSectors])                    //
     {
       using T = typename std::remove_pointer<ContainerT>::type;
       static_assert(sizeof(typename T::value_type) == 1, "raw container must be byte-type");
@@ -316,13 +353,37 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
     std::runtime_error("inconsistent size of MC label array " + std::to_string(mcinputs.size()) + ", expected " + std::to_string(inputs.size()));
   }
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  const MCLabelContainer* clustersMCTruth[NSectors][NPadRows] = {};
+  if (inputs.size() == 1) {
+    if (inputs[0].size() >= sizeof(o2::tpc::ClusterCountIndex)) {
+      // there is only one data block and we can set the index directly from it
+      const o2::tpc::ClusterCountIndex* hdr = reinterpret_cast<o2::tpc::ClusterCountIndex const*>(inputs[0].data());
+      memcpy((void*)&clusterIndex.nClusters[0][0], hdr, sizeof(*hdr));
+      clusterIndex.clustersLinear = reinterpret_cast<const o2::tpc::ClusterNative*>(inputs[0].data() + sizeof(*hdr));
+      clusterIndex.setOffsetPtrs();
+      if (mcinputs.size() > 0) {
+        clusterIndex.clustersMCTruth = mcinputs[0].get();
+      }
+    }
+    if (sizeof(ClusterCountIndex) + clusterIndex.nClustersTotal * sizeof(ClusterNative) > inputs[0].size()) {
+      throw std::runtime_error("inconsistent input buffer, expecting size " + std::to_string(sizeof(ClusterCountIndex) + clusterIndex.nClustersTotal * sizeof(ClusterNative)) + " got " + std::to_string(inputs[0].size()));
+    }
+    return clusterIndex.nClustersTotal;
+  }
+
+  // multiple data blocks need to be merged into the single block
+  const MCLabelContainer* clustersMCTruth[NSectors] = {nullptr};
   int result = 0;
   for (size_t index = 0, end = inputs.size(); index < end; index++) {
     if (!checkFct(index)) {
       continue;
     }
-    int locres = parseSector(inputs[index], mcinputs[index], clusterIndex, clustersMCTruth);
+    MCLabelContainer const* labelsptr = nullptr;
+    int extent = 0;
+    if (index < mcinputs.size()) {
+      labelsptr = mcinputs[index].get();
+      extent = 1;
+    }
+    int locres = parseSector(inputs[index], {labelsptr, extent}, clusterIndex, clustersMCTruth);
     if (locres < 0) {
       return locres;
     }
@@ -337,12 +398,13 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
   clusterIndex.clustersLinear = clusterBuffer.get();
   clusterIndex.setOffsetPtrs();
   for (unsigned int i = 0; i < NSectors; i++) {
+    int sectorLabelId = 0;
     for (unsigned int j = 0; j < NPadRows; j++) {
       memcpy(&clusterBuffer[clusterIndex.clusterOffset[i][j]], old.clusters[i][j], sizeof(*old.clusters[i][j]) * old.nClusters[i][j]);
-      if (clustersMCTruth[i][j]) {
+      if (clustersMCTruth[i]) {
         mcPresent = true;
-        for (unsigned int k = 0; k < old.nClusters[i][j]; k++) {
-          for (auto const& label : clustersMCTruth[i][j]->getLabels(k)) {
+        for (unsigned int k = 0; k < old.nClusters[i][j]; k++, sectorLabelId++) {
+          for (auto const& label : clustersMCTruth[i]->getLabels(sectorLabelId)) {
             mcBuffer.addElement(clusterIndex.clusterOffset[i][j] + k, label);
           }
         }

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -92,22 +92,17 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
       LOG(ERROR) << "sector header missing on header stack";
       throw std::runtime_error("sector header missing on header stack");
     }
-    const int& sector = sectorHeader->sector();
-    // the TPCSectorHeader now allows to transport information for more than one sector,
-    // e.g. for transporting clusters in one single data block. For the moment, the
-    // implemenation here requires single sectors
-    if (sector >= o2::tpc::TPCSectorHeader::NSectors) {
-      throw std::runtime_error("Expecting data for single sectors");
-    }
-    LOG(INFO) << "Reading cluster data for sector " << sector;
-    if (validSectors.test(sector)) {
+    int sector = sectorHeader->sector();
+    std::bitset<o2::tpc::Constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
+    if ((validSectors & sectorMask).any()) {
       // have already data for this sector, this should not happen in the current
       // sequential implementation, for parallel path merged at the tracker stage
       // multiple buffers need to be handled
       throw std::runtime_error("can only have one data set per sector");
     }
     activeSectors |= sectorHeader->activeSectors;
-    validSectors.set(sector);
+    validSectors |= sectorMask;
     datarefs[sector] = ref;
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -67,21 +67,16 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
       throw std::runtime_error("sector header missing on header stack");
     }
     const int& sector = sectorHeader->sector();
-    // the TPCSectorHeader now allows to transport information for more than one sector,
-    // e.g. for transporting clusters in one single data block. For the moment, the
-    // implemenation here requires single sectors
-    if (sector >= o2::tpc::TPCSectorHeader::NSectors) {
-      throw std::runtime_error("Expecting data for single sectors");
-    }
-    LOG(INFO) << "Reading cluster data for sector " << sector;
-    if (validSectors.test(sector)) {
+    std::bitset<o2::tpc::Constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
+    if ((validSectors & sectorMask).any()) {
       // have already data for this sector, this should not happen in the current
       // sequential implementation, for parallel path merged at the tracker stage
       // multiple buffers need to be handled
       throw std::runtime_error("can only have one data set per sector");
     }
     activeSectors |= sectorHeader->activeSectors;
-    validSectors.set(sector);
+    validSectors |= sectorMask;
     datarefs[sector] = ref;
   }
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -77,7 +77,7 @@ class HardwareClusterDecoder
   int decodeClusters(std::vector<std::pair<const o2::tpc::ClusterHardwareContainer*, std::size_t>>& inputClusters,
                      OutputAllocator outputAllocator,
                      const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr,
-                     std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
+                     o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outMCLabels = nullptr);
 
   /// @brief Sort clusters and MC labels in place
   /// ClusterNative defines the smaller-than relation used in the sorting, with time being the more significant

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -35,14 +35,21 @@ using namespace o2::dataformats;
 int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>>& inputClusters,
                                            HardwareClusterDecoder::OutputAllocator outputAllocator,
                                            const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels,
-                                           std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels)
+                                           o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outMCLabels)
 {
   if (mIntegrator == nullptr)
     mIntegrator.reset(new DigitalCurrentClusterIntegrator);
-  if (!inMCLabels)
+  // MCLabelContainer does only allow appending new labels, so we need to write to separate
+  // containers per {sector,padrow} and merge at the end;
+  std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>> outMCLabelContainers;
+  if (!inMCLabels) {
     outMCLabels = nullptr;
-  std::vector<ClusterNativeBuffer*> outputBufferMap;
+  }
+  ClusterNative* outputClusterBuffer = nullptr;
+  // the number of clusters in a {sector,row}
   int nRowClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
+  // offset of first cluster of {sector,row} in the output buffer
+  size_t clusterOffsets[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
   int containerRowCluster[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
   Mapper& mapper = Mapper::instance();
   int numberOfOutputContainers = 0;
@@ -62,13 +69,16 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
         const PadRegionInfo& region = mapper.getPadRegionInfo(cru.region());
         const int rowOffset = region.getGlobalRowOffset();
 
+        // TODO: make sure that input clusters are sorted in ascending row, so we
+        // can write the MCLabels directly in consecutive order following the cluster sequence
+        // Note: also the sorting below would need to be adjusted.
         for (int k = 0; k < cont.numberOfClusters; k++) {
           const int padRowGlobal = rowOffset + cont.clusters[k].getRow();
           int& nCls = nRowClusters[sector][padRowGlobal];
           if (loop == 1) {
             //Fill cluster in the respective output buffer
             const ClusterHardware& cIn = cont.clusters[k];
-            ClusterNative& cOut = outputBufferMap[containerRowCluster[sector][padRowGlobal]]->clusters[nCls];
+            ClusterNative& cOut = outputClusterBuffer[clusterOffsets[sector][padRowGlobal] + nCls];
             float pad = cIn.getPad();
             cOut.setPad(pad);
             cOut.setTimeFlags(cIn.getTimeLocal() + cont.timeBinOffset, cIn.getFlags());
@@ -78,7 +88,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
             cOut.qTot = cIn.getQTot();
             mIntegrator->integrateCluster(sector, padRowGlobal, pad, cIn.getQTot());
             if (outMCLabels) {
-              auto& mcOut = (*outMCLabels)[containerRowCluster[sector][padRowGlobal]];
+              auto& mcOut = outMCLabelContainers[containerRowCluster[sector][padRowGlobal]];
               for (const auto& element : (*inMCLabels)[i].getLabels(k)) {
                 mcOut.addElement(nCls, element);
               }
@@ -95,38 +105,63 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
     }
     if (loop == 1) {
       //We are done with filling the buffers, sort all output buffers
-      for (int i = 0; i < outputBufferMap.size(); i++) {
-        if (outMCLabels) {
-          sortClustersAndMC(outputBufferMap[i]->clusters, outputBufferMap[i]->nClusters, (*outMCLabels)[i]);
-        } else {
-          auto* cl = outputBufferMap[i]->clusters;
-          std::sort(cl, cl + outputBufferMap[i]->nClusters);
+      for (int i = 0; i < Constants::MAXSECTOR; i++) {
+        for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+          if (nRowClusters[i][j] == 0) {
+            continue;
+          }
+          if (outMCLabels) {
+            sortClustersAndMC(outputClusterBuffer + clusterOffsets[i][j], nRowClusters[i][j], outMCLabelContainers[containerRowCluster[i][j]]);
+          } else {
+            auto* cl = outputClusterBuffer + clusterOffsets[i][j];
+            std::sort(cl, cl + nRowClusters[i][j]);
+          }
         }
       }
     } else {
       //Now we know the size of all output buffers, allocate them
-      if (outMCLabels)
-        outMCLabels->resize(numberOfOutputContainers);
-      size_t rawOutputBufferSize = numberOfOutputContainers * sizeof(ClusterNativeBuffer) + nTotalClusters * sizeof(ClusterNative);
+      if (outMCLabels) {
+        outMCLabelContainers.resize(numberOfOutputContainers);
+      }
+      size_t rawOutputBufferSize = sizeof(ClusterCountIndex) + nTotalClusters * sizeof(ClusterNative);
       char* rawOutputBuffer = outputAllocator(rawOutputBufferSize);
-      char* rawOutputBufferIterator = rawOutputBuffer;
+      auto& clusterCounts = *(reinterpret_cast<ClusterCountIndex*>(rawOutputBuffer));
+      outputClusterBuffer = reinterpret_cast<ClusterNative*>(rawOutputBuffer + sizeof(ClusterCountIndex));
+      nTotalClusters = 0;
       numberOfOutputContainers = 0;
       for (int i = 0; i < Constants::MAXSECTOR; i++) {
         for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
-          if (nRowClusters[i][j] == 0)
+          clusterCounts.nClusters[i][j] = nRowClusters[i][j];
+          if (nRowClusters[i][j] == 0) {
             continue;
-          outputBufferMap.push_back(reinterpret_cast<ClusterNativeBuffer*>(rawOutputBufferIterator));
-          ClusterNativeBuffer& container = *outputBufferMap.back();
-          container.sector = i;
-          container.globalPadRow = j;
-          container.nClusters = nRowClusters[i][j];
+          }
           containerRowCluster[i][j] = numberOfOutputContainers++;
-          rawOutputBufferIterator += container.getFlatSize();
+          clusterOffsets[i][j] = nTotalClusters;
+          nTotalClusters += nRowClusters[i][j];
           mIntegrator->initRow(i, j);
         }
       }
-      assert(rawOutputBufferIterator == rawOutputBuffer + rawOutputBufferSize);
       memset(nRowClusters, 0, sizeof(nRowClusters));
+    }
+  }
+  // Finally merge MC label containers into one container following the cluster sequence in the
+  // output buffer
+  if (outMCLabels) {
+    auto& labels = *outMCLabels;
+    int nCls = 0;
+    for (int i = 0; i < Constants::MAXSECTOR; i++) {
+      for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+        if (nRowClusters[i][j] == 0) {
+          continue;
+        }
+        for (int k = 0, end = outMCLabelContainers[containerRowCluster[i][j]].getIndexedSize(); k < end; k++, nCls++) {
+          assert(end == nRowClusters[i][j]);
+          assert(clusterOffsets[i][j] + k == nCls);
+          for (const auto& element : outMCLabelContainers[containerRowCluster[i][j]].getLabels(k)) {
+            labels.addElement(nCls, element);
+          }
+        }
+      }
     }
   }
   return (0);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCSectorCompletionPolicy.h
@@ -125,7 +125,8 @@ class TPCSectorCompletionPolicy
                 throw std::runtime_error("TPC sector header missing on header stack");
               }
               activeSectors |= sectorHeader->activeSectors;
-              validSectors.set(sectorHeader->sector());
+              std::bitset<NSectors> sectorMask(sectorHeader->sectorBits);
+              validSectors |= sectorMask;
               break;
             }
           }

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -309,7 +309,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       auto& verbosity = processAttributes->verbosity;
       // FIXME cleanup almost duplicated code
       auto& validMcInputs = processAttributes->validMcInputs;
-      using CachedMCLabelContainer = decltype(std::declval<InputRecord>().get<std::vector<MCLabelContainer>>(DataRef{nullptr, nullptr, nullptr}));
+      using CachedMCLabelContainer = decltype(std::declval<InputRecord>().get<MCLabelContainer*>(DataRef{nullptr, nullptr, nullptr}));
       std::array<CachedMCLabelContainer, NSectors> mcInputs;
       std::array<gsl::span<const char>, NSectors> inputs;
       o2::gpu::GPUTrackingInOutZS tpcZS;
@@ -354,7 +354,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
           if (caClusterer) {
             inputDigitsMC[sector] = std::move(pc.inputs().get<const MCLabelContainer*>(ref));
           } else {
-            mcInputs[sector] = std::move(pc.inputs().get<std::vector<MCLabelContainer>>(ref));
+            mcInputs[sector] = std::move(pc.inputs().get<const MCLabelContainer*>(ref));
           }
           validMcInputs.set(sector);
           activeSectors |= sectorHeader->activeSectors;
@@ -696,7 +696,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       if (processMC) {
         validMcInputs.reset();
         for (auto& mcInput : mcInputs) {
-          mcInput.clear();
+          mcInput.reset();
         }
       }
     };

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -165,8 +165,8 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         outputBuffer = pc.outputs().newChunk(Output{gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack)}, size).data();
         return outputBuffer;
       };
-      std::vector<MCLabelContainer> mcoutList;
-      decoder->decodeClusters(inputList, outputAllocator, (mcin ? &mcinCopies : nullptr), &mcoutList);
+      MCLabelContainer mcout;
+      decoder->decodeClusters(inputList, outputAllocator, (mcin ? &mcinCopies : nullptr), &mcout);
 
       // TODO: reestablish the logging messages on the raw buffer
       // if (verbosity > 1) {
@@ -177,12 +177,11 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
 
       if (DataRefUtils::isValid(mclabelref)) {
         if (verbosity > 0) {
-          LOG(INFO) << "sending " << mcoutList.size() << " MC label container(s) with in total "
-                    << std::accumulate(mcoutList.begin(), mcoutList.end(), size_t(0), [](size_t l, auto const& r) { return l + r.getIndexedSize(); })
+          LOG(INFO) << "sending " << mcout.getIndexedSize()
                     << " label object(s)" << std::endl;
         }
         // serialize the complete list of MC label containers
-        pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, Lifetime::Timeframe, std::move(mcHeaderStack)}, mcoutList);
+        pc.outputs().snapshot(Output{gDataOriginTPC, DataDescription("CLNATIVEMCLBL"), fanSpec, Lifetime::Timeframe, std::move(mcHeaderStack)}, mcout);
       }
     };
 


### PR DESCRIPTION
This PR is sketching the work for moving to an updated transport format as it is produced by the CAclusterer. The format consists of a header with the index of cluster counts for the full TPC and one monolithic buffer for all cluster objects. The cluster offsets per {sector,row} coordinates corresponds to the accumulated cluster counts. The preliminary version seems to work when MC labels are disabled.

The main changes are:
- the ClusterDecoderRaw directly writes the updated format
- ClusterNativeHelper can read the updated format

- [x] handling of the MC labels, this is a bit convoluted with multiple copies, needs to be sorted out
- [x] set ClusterNativeAccess from monolithic buffer without copy
- [x] publish the CA clusterer output in the updated format
- [x] test with subsequent workflows (ITS-TPC matching, TPC interpolation)
- [x] make the writing and reading of ClusterNative files working for all cases
