### PR TITLE
speed up FT0 simulation

### DIFF
--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
@@ -148,7 +148,11 @@ class Detector : public o2::base::DetImpl<Detector>
 
   template <typename Det>
   friend class o2::base::DetImpl;
-  ClassDefOverride(Detector, 1);
+
+  int mTrackIdTop;
+  int mTrackIdMCPtop; //TEMPORARY
+
+  ClassDefOverride(Detector, 2);
 };
 
 // Input and output function for standard C++ input/output.

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -232,7 +232,7 @@ void Detector::SetOneMCP(TGeoVolume* ins)
   Float_t pmcpbase[3] = {2.949, 2.949, 0.1};
   Float_t pmcptopglass[3] = {2.949, 2.949, 0.1}; // MCP top glass optical
 
-  Float_t preg[3] = {1.324, 1.324, 0.05}; // Photcathode
+  Float_t preg[3] = {1.324, 1.324, 0.005}; // Photcathode
   Double_t pal[3] = {2.648, 2.648, 0.25}; // 5mm Al on top of each radiator
   // Entry window (glass)
   TVirtualMC::GetMC()->Gsvolu("0TOP", "BOX", getMediumID(kOpGlass), ptop, 3); // Glass radiator


### PR DESCRIPTION
- increased min step size in thick radiator and front quartz MCP window;
- added radiator (0TOP) and front quartz MCP window (0MOP) as sensitive volumes;
- when photons just appeared we check QE and stop transport of photon if not;
- stop writing Cherenkov photons in Kine tree.  

CPU time was dropped down

- for pp from 0.43 to 0.25 s / event;
- for Pb-Pb  from 29 to 17s / event.