### PR TITLE
DPL: enable shmem (O2-1434)

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -46,7 +46,7 @@ std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
@@ -57,7 +57,7 @@ std::string ChannelSpecHelpers::channelUrl(InputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -744,6 +744,34 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workf
   }
 }
 
+void DeviceSpecHelpers::reworkShmSegmentSize(std::vector<DataProcessorInfo>& infos)
+{
+  int64_t segmentSize = 0;
+  for (auto& info : infos) {
+    auto it = std::find(info.cmdLineArgs.begin(), info.cmdLineArgs.end(), "--shm-segment-size");
+    if (it == info.cmdLineArgs.end()) {
+      continue;
+    }
+    auto value = it + 1;
+    if (value == info.cmdLineArgs.end()) {
+      throw std::runtime_error("--shm-segment-size requires an argument");
+    }
+    char* err = nullptr;
+    int64_t size = strtoll(value->c_str(), &err, 10);
+    if (size > segmentSize) {
+      segmentSize = size;
+    }
+    info.cmdLineArgs.erase(it, it + 2);
+  }
+  if (segmentSize == 0) {
+    segmentSize = 2000000000LL;
+  }
+  for (auto& info : infos) {
+    info.cmdLineArgs.push_back("--shm-segment-size");
+    info.cmdLineArgs.push_back(std::to_string(segmentSize));
+  }
+}
+
 void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
                                          std::vector<DataProcessorInfo> const& processorInfos,
                                          std::vector<DeviceSpec> const& deviceSpecs,

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -68,6 +68,9 @@ struct DeviceSpecHelpers {
   /// Helper to provide the channel configuration string for an output channel
   static std::string outputChannel2String(const OutputChannelSpec& channel);
 
+  /// Rework the infos so that they have a consisten --shm-section-size
+  /// which is the maximum of the specified value.
+  static void reworkShmSegmentSize(std::vector<DataProcessorInfo>& infos);
   /// Helper to prepare the arguments which will be used to
   /// start the various devices.
   static void prepareArguments(

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -977,6 +977,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
         controls.resize(deviceSpecs.size());
         deviceExecutions.resize(deviceSpecs.size());
 
+        DeviceSpecHelpers::reworkShmSegmentSize(dataProcessorInfos);
         DeviceSpecHelpers::prepareArguments(driverControl.defaultQuiet,
                                             driverControl.defaultStopped,
                                             dataProcessorInfos,


### PR DESCRIPTION
This enables shared memory when on the same host and makes sure that the `--shm-segment-size` option is the same and the largest specified value for every device. If no device requires a special size, the default of 2GB is used.