### PR TITLE
Fix IO warning

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 using namespace o2::trd;
+class TRootIOCtor;
 
 namespace o2
 {
@@ -30,6 +31,8 @@ class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCache
 {
  public:
   ~TRDGeometry() override = default;
+  // A ROOT IO constructor (to silence warnings about missing default constructor)
+  TRDGeometry(TRootIOCtor*) {}
 
   static TRDGeometry* instance()
   {


### PR DESCRIPTION
Fixes
Warning in <TBufferFile::WriteObjectAny>: since o2::trd::TRDGeometry has no public constructor

that appeared in simulation