### PR TITLE
Replace #pragma omp atomic with GCC/clang builtins

### DIFF
--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -73,6 +73,13 @@ class GPUCommonMath
   {
     return GPUCommonMath::AtomicExchInt(addr, val);
   }
+
+  template <class T>
+  GPUdi() static T AtomicCAS(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T cmp, T val)
+  {
+    return GPUCommonMath::AtomicCASInt(addr, cmp, val);
+  }
+
   template <class T>
   GPUdi() static T AtomicAdd(GPUglobalref() GPUgeneric() GPUAtomic(T) * addr, T val)
   {
@@ -137,6 +144,8 @@ class GPUCommonMath
  private:
   template <class S, class T>
   GPUd() static unsigned int AtomicExchInt(S* addr, T val);
+  template <class S, class T>
+  GPUd() static T AtomicCASInt(S* addr, T cmp, T val);
   template <class S, class T>
   GPUd() static unsigned int AtomicAddInt(S* addr, T val);
   template <class S, class T>
@@ -383,6 +392,25 @@ GPUdi() unsigned int GPUCommonMath::AtomicExchInt(S* addr, T val)
 #else
   unsigned int old = *addr;
   *addr = val;
+  return old;
+#endif
+}
+
+template <class S, class T>
+GPUdi() T GPUCommonMath::AtomicCASInt(S* addr, T cmp, T val)
+{
+#if defined(GPUCA_GPUCODE) && defined(__OPENCLCPP__) && (!defined(__clang__) || defined(GPUCA_OPENCL_CPP_CLANG_C11_ATOMICS))
+  return ::atomic_compare_exchange(addr, cmp, val);
+#elif defined(GPUCA_GPUCODE) && defined(__OPENCL__)
+  return ::atomic_cmpxchg(addr, cmp, val);
+#elif defined(GPUCA_GPUCODE) && (defined(__CUDACC__) || defined(__HIPCC__))
+  return ::atomicCAS(addr, cmp, val);
+#elif defined(WITH_OPENMP)
+  __atomic_compare_exchange(addr, &cmp, &val, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+  return cmp;
+#else
+  T old = *addr;
+  *addr = (old == cmp) ? val : old;
   return old;
 #endif
 }


### PR DESCRIPTION
OpenMP atomics with capture are poorly supported in compilers and it seems in particular CAS is not always compiled correctly. Instead, we just use the GCC/clang builtins which map directly to the x86 atomic CPU instructions.