### PR TITLE
MFT: introduce the decoder for the new data format.

### DIFF
--- a/Detectors/ITSMFT/MFT/simulation/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/simulation/CMakeLists.txt
@@ -18,3 +18,15 @@ o2_target_root_dictionary(MFTSimulation
 
 
 o2_data_file(COPY data  DESTINATION Detectors/MFT/simulation)
+
+o2_add_executable(digi2raw
+                  COMPONENT_NAME mft
+                  SOURCES src/digi2raw.cxx
+                  PUBLIC_LINK_LIBRARIES O2::ITSMFTReconstruction
+                                        O2::DataFormatsITSMFT
+                                        O2::ITSMFTBase
+                                        O2::ITSMFTSimulation
+                                        O2::DetectorsRaw
+                                        O2::DetectorsCommonDataFormats
+                                        O2::CommonUtils
+                                        Boost::program_options)

--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -1,0 +1,276 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file digi2raw.cxx
+/// \author ruben.shahoyan@cern.ch, bogdan.vulpescu@clermont.in2p3.fr
+
+#include <boost/program_options.hpp>
+#include <TTree.h>
+#include <TSystem.h>
+#include <TChain.h>
+#include <TFile.h>
+#include <TStopwatch.h>
+#include "Framework/Logger.h"
+#include <vector>
+#include <string>
+#include <iomanip>
+#include "ITSMFTReconstruction/ChipMappingMFT.h"
+#include "ITSMFTReconstruction/GBTWord.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsITSMFT/Digit.h"
+#include "ITSMFTSimulation/MC2RawEncoder.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "CommonUtils/StringUtils.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtils.h"
+
+/// MC->raw conversion with new (variable page size) format for MFT
+using MAP = o2::itsmft::ChipMappingMFT;
+namespace bpo = boost::program_options;
+
+void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, std::string_view outPrefix, bool filePerCRU);
+void digi2raw(std::string_view inpName, std::string_view outDir, bool filePerCRU, int verbosity, uint32_t rdhV = 4, bool noEmptyHBF = false,
+              int superPageSizeInB = 1024 * 1024);
+
+int main(int argc, char** argv)
+{
+  bpo::variables_map vm;
+  bpo::options_description opt_general("Usage:\n  " + std::string(argv[0]) +
+                                       "Convert MFT digits to CRU raw data\n");
+  bpo::options_description opt_hidden("");
+  bpo::options_description opt_all;
+  bpo::positional_options_description opt_pos;
+
+  try {
+    auto add_option = opt_general.add_options();
+    add_option("help,h", "Print this help message");
+    add_option("verbosity,v", bpo::value<uint32_t>()->default_value(0), "verbosity level [0 = no output]");
+    add_option("input-file,i", bpo::value<std::string>()->default_value("mftdigits.root"), "input MFT digits file");
+    add_option("file-per-cru,c", bpo::value<bool>()->default_value(false)->implicit_value(true), "create output file per CRU (default: per layer)");
+    add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
+    uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
+    add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
+    add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
+
+    opt_all.add(opt_general).add(opt_hidden);
+    bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
+
+    if (vm.count("help")) {
+      std::cout << opt_general << std::endl;
+      exit(0);
+    }
+
+    bpo::notify(vm);
+  } catch (bpo::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl
+              << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(1);
+  } catch (std::exception& e) {
+    std::cerr << e.what() << ", application will now exit" << std::endl;
+    exit(2);
+  }
+  o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
+  digi2raw(vm["input-file"].as<std::string>(),
+           vm["output-dir"].as<std::string>(),
+           vm["file-per-cru"].as<bool>(),
+           vm["verbosity"].as<uint32_t>(),
+           vm["rdh-version"].as<uint32_t>(),
+           vm["no-empty-hbf"].as<bool>());
+
+  return 0;
+}
+
+void digi2raw(std::string_view inpName, std::string_view outDir, bool filePerCRU, int verbosity, uint32_t rdhV, bool noEmptyHBF, int superPageSizeInB)
+{
+  TStopwatch swTot;
+  swTot.Start();
+  using ROFR = o2::itsmft::ROFRecord;
+  using ROFRVEC = std::vector<o2::itsmft::ROFRecord>;
+  const uint8_t ruSWMin = 0, ruSWMax = 0xff; // seq.ID of 1st and last RU (stave) to convert
+
+  LOG(INFO) << "HBFUtil settings:";
+  o2::raw::HBFUtils::Instance().print();
+
+  // if needed, create output directory
+  if (gSystem->AccessPathName(outDir.data())) {
+    if (gSystem->mkdir(outDir.data(), kTRUE)) {
+      LOG(FATAL) << "could not create output directory " << outDir;
+    } else {
+      LOG(INFO) << "created output directory " << outDir;
+    }
+  }
+  ///-------> input
+  std::string digTreeName{o2::base::NameConf::MCTTREENAME.data()};
+  TChain digTree(digTreeName.c_str());
+  digTree.AddFile(inpName.data());
+  digTree.SetBranchStatus("*MCTruth*", 0); // ignore MC info
+
+  std::vector<o2::itsmft::Digit> digiVec, *digiVecP = &digiVec;
+  std::string digBranchName = o2::utils::concat_string(MAP::getName(), "Digit");
+  if (!digTree.GetBranch(digBranchName.c_str())) {
+    LOG(FATAL) << "Failed to find the branch " << digBranchName << " in the tree " << digTreeName;
+  }
+  digTree.SetBranchAddress(digBranchName.c_str(), &digiVecP);
+
+  // ROF record entries in the digit tree
+  ROFRVEC rofRecVec, *rofRecVecP = &rofRecVec;
+  std::string rofRecName = o2::utils::concat_string(MAP::getName(), "DigitROF");
+  if (!digTree.GetBranch(rofRecName.c_str())) {
+    LOG(FATAL) << "Failed to find the branch " << rofRecName << " in the tree " << digTreeName;
+  }
+  digTree.SetBranchAddress(rofRecName.c_str(), &rofRecVecP);
+  ///-------< input
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+
+  o2::itsmft::MC2RawEncoder<MAP> m2r;
+  m2r.setVerbosity(verbosity);
+  m2r.setContinuousReadout(grp->isDetContinuousReadOut(MAP::getDetID())); // must be set explicitly
+  m2r.setDefaultSinkName(o2::utils::concat_string(MAP::getName(), ".raw"));
+  m2r.setMinMaxRUSW(ruSWMin, ruSWMax);
+  m2r.getWriter().setSuperPageSize(superPageSizeInB);
+  m2r.getWriter().useRDHVersion(rdhV);
+  m2r.getWriter().setDontFillEmptyHBF(noEmptyHBF);
+
+  m2r.setVerbosity(verbosity);
+  setupLinks(m2r, outDir, MAP::getName(), filePerCRU);
+  //-------------------------------------------------------------------------------<<<<
+  int lastTreeID = -1;
+  long offs = 0, nEntProc = 0;
+  for (int i = 0; i < digTree.GetEntries(); i++) {
+    digTree.GetEntry(i);
+    for (const auto& rofRec : rofRecVec) {
+      int nDigROF = rofRec.getNEntries();
+      if (verbosity) {
+        LOG(INFO) << "Processing ROF:" << rofRec.getROFrame() << " with " << nDigROF << " entries";
+        rofRec.print();
+      }
+      if (!nDigROF) {
+        if (verbosity) {
+          LOG(INFO) << "Frame is empty"; // ??
+        }
+        continue;
+      }
+      nEntProc++;
+      auto dgs = nDigROF ? gsl::span<const o2::itsmft::Digit>(&digiVec[rofRec.getFirstEntry()], nDigROF) : gsl::span<const o2::itsmft::Digit>();
+      m2r.digits2raw(dgs, rofRec.getBCData());
+    }
+  } // loop over multiple ROFvectors (in case of chaining)
+
+  m2r.getWriter().writeConfFile(MAP::getName(), "RAWDATA", o2::utils::concat_string(outDir, '/', MAP::getName(), "raw.cfg"));
+  m2r.finalize(); // finish TF and flush data
+  //
+  swTot.Stop();
+  swTot.Print();
+}
+
+void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, std::string_view outPrefix, bool filePerCRU)
+{
+  // see the same file from ITS
+
+  constexpr int MaxLinksPerCRU = 8;
+  const auto& mp = m2r.getMapping();
+
+  // MFT has 13 RU types (NRUTypes) and 1 link per RU:
+  int lnkAssign[13] = {7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 14};
+
+  std::vector<std::vector<int>> defRU{// number of RUs per CRU at each layer
+                                      {6, 6},
+                                      {8, 8},
+                                      {5, 5, 5, 5},
+                                      {12, 12},
+                                      {8, 7, 8, 7},
+                                      {11, 10, 11, 10},
+                                      {12, 12, 12, 12}};
+
+  // this is an arbitrary mapping
+  int nCRU = 0, nRUtot = 0, nRU = 0, nLinks = 0;
+  int linkID = 0, cruIDprev = -1, cruID = o2::detectors::DetID::MFT << 8; // this will be the lowest CRUID
+  std::string outFileLink;
+
+  int nruLr = mp.getNZonesPerLayer();
+  int ruHW = -1, ruSW = -1;
+
+  // loop over the lower half, then over the upper half
+  for (int h = 0; h < 2; h++) {
+    if (h > 0) {
+      cruID = (o2::detectors::DetID::MFT << 8) + 1;
+    }
+    for (int ilr = 0; ilr < mp.getNLayers(); ilr++) {
+
+      outFileLink = filePerCRU ? o2::utils::concat_string(outDir, "/", outPrefix, "_cru", std::to_string(nCRU), ".raw") : o2::utils::concat_string(outDir, "/", outPrefix, "_lr", std::to_string(ilr), ".raw");
+
+      for (int ir = 0; ir < nruLr; ir++) {
+
+        if (h != (ir / 4))
+          continue;
+
+        // RU software id
+        ruSW = nruLr * ilr + (nruLr / 2) * (ir / 4) + (ir % 4);
+
+        // RU hardware id
+        ruHW = 0;
+        ruHW += (ir / 4) << 6;
+        ruHW += (ilr / 2) << 3; // disk
+        ruHW += (ilr % 2) << 2; // plane (disk face)
+        ruHW += (ir % 4);
+
+        int ruType = mp.getRUType(ir, ilr);
+        int lnkAs = lnkAssign[ruType];
+
+        int ruID = nRUtot++;
+        bool accept = !(ruSW < m2r.getRUSWMin() || ruSW > m2r.getRUSWMax()); // ignored RUs ?
+        int accL = 0;
+        if (accept) {
+          m2r.getCreateRUDecode(ruSW); // create RU container
+          nRU++;
+          nLinks++;
+          auto& ru = *m2r.getRUDecode(ruSW);
+          uint32_t lanes = mp.getCablesOnRUType(ru.ruInfo->ruType); // lanes patter of this RU
+          ru.links[0] = m2r.addGBTLink();
+          auto link = m2r.getGBTLink(ru.links[0]);
+          link->lanes = lanes & ((0x1 << lnkAs) - 1) << (accL);
+          link->idInCRU = linkID;
+          link->cruID = cruID;
+          link->feeID = mp.RUSW2FEEId(ruSW);
+          link->endPointID = 0; // 0 or 1
+          accL += lnkAs;
+          // register the link in the writer, if not done here, its data will be dumped to common default file
+          //printf("Register link: FeeID 0x%02x , CRU ID 0x%x , link ID %2d \n", link->feeID, link->cruID, link->idInCRU);
+          //printf("RU SW: %2d   HW: 0x%02x   Type: %2d   %s \n", ruSW, ruHW, ruType, outFileLink.data());
+          //std::bitset<32> bv_lanes(link->lanes);
+          //LOG(INFO) << "with lanes " << bv_lanes;
+          m2r.getWriter().registerLink(link->feeID, link->cruID, link->idInCRU,
+                                       link->endPointID, outFileLink);
+
+          if (cruIDprev != cruID) { // just to count used CRUs
+            cruIDprev = cruID;
+            nCRU++;
+          }
+
+          if ((++linkID) >= MaxLinksPerCRU) {
+            linkID = 0;
+            cruID += 2;
+          }
+
+        } // end select RU SW ID range
+
+      } // end zone (RU) loop
+
+    } // end layer loop
+
+  } // end half loop
+
+  LOG(INFO) << "Distributed " << nLinks << " links on " << nRU << " RUs in " << nCRU << " CRUs";
+}

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -16,8 +16,10 @@ o2_add_library(MFTWorkflow
 	               src/ClusterWriterSpec.cxx
 		       src/ClusterReaderSpec.cxx
 		       src/TrackerSpec.cxx
-           src/TrackFitterSpec.cxx
+                       src/TrackFitterSpec.cxx
 		       src/TrackWriterSpec.cxx
+                       src/DigitWorkflow.cxx
+                       src/DigitWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
                                      O2::SimulationDataFormat
@@ -27,5 +29,10 @@ o2_add_library(MFTWorkflow
 
 o2_add_executable(reco-workflow
                   SOURCES src/mft-reco-workflow.cxx
+                  COMPONENT_NAME mft
+                  PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)
+
+o2_add_executable(digit-workflow
+                  SOURCES src/mft-digit-workflow.cxx
                   COMPONENT_NAME mft
                   PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/DigitWorkflow.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/DigitWorkflow.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MFT_DIGITWORKFLOW_H_
+#define O2_MFT_DIGITWORKFLOW_H_
+
+/// @file   DigitWorkflow.h
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace mft
+{
+
+namespace digit_workflow
+{
+framework::WorkflowSpec getWorkflow();
+}
+
+} // namespace mft
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/DigitWriterSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/DigitWriterSpec.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitWriterSpec.h
+
+#ifndef O2_MFT_DIGITWRITER_H_
+#define O2_MFT_DIGITWRITER_H_
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class DigitWriter : public o2::framework::Task
+{
+ public:
+  DigitWriter() = default;
+  ~DigitWriter() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  std::unique_ptr<TFile> mFile = nullptr;
+  std::unique_ptr<TTree> mTree = nullptr;
+};
+
+/// create a processor spec
+/// write MFT digits a root file
+framework::DataProcessorSpec getDigitWriterSpec();
+
+} // namespace mft
+} // namespace o2
+
+#endif /* O2_MFT_DIGITWRITER_H */

--- a/Detectors/ITSMFT/MFT/workflow/src/DigitWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/DigitWorkflow.cxx
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitWorkflow.cxx
+
+#include <TTree.h>
+#include "MFTWorkflow/DigitWorkflow.h"
+
+#include "MFTWorkflow/DigitWriterSpec.h"
+
+namespace o2
+{
+namespace mft
+{
+
+namespace digit_workflow
+{
+
+framework::WorkflowSpec getWorkflow()
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::mft::getDigitWriterSpec());
+
+  return specs;
+}
+
+} // namespace digit_workflow
+
+} // namespace mft
+} // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/DigitWriterSpec.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   DigitWriterSpec.cxx
+
+#include <vector>
+
+#include "MFTWorkflow/DigitWriterSpec.h"
+
+#include "TTree.h"
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "DataFormatsITSMFT/Digit.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "CommonUtils/StringUtils.h"
+
+using namespace o2::framework;
+using namespace o2::itsmft;
+
+namespace o2
+{
+namespace mft
+{
+
+template <typename T>
+TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
+{
+  if (auto br = tree->GetBranch(brname)) {
+    br->SetAddress(static_cast<void*>(ptr));
+    return br;
+  }
+  return tree->Branch(brname, ptr); // otherwise make it
+}
+
+void DigitWriter::init(InitContext& ic)
+{
+  auto filename = ic.options().get<std::string>("mft-digit-outfile");
+  mFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
+  if (!mFile->IsOpen()) {
+    throw std::runtime_error(o2::utils::concat_string("failed to open MFT digits output file ", filename));
+  }
+  mTree = std::make_unique<TTree>("o2sim", "Tree with decoded MFT digits");
+}
+
+void DigitWriter::run(ProcessingContext& pc)
+{
+  auto digits = pc.inputs().get<const std::vector<o2::itsmft::Digit>>("digits");
+  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+
+  auto digitsPtr = &digits;
+  getOrMakeBranch(mTree.get(), "MFTDigit", &digitsPtr);
+  auto rofsPtr = &rofs;
+  getOrMakeBranch(mTree.get(), "MFTDigitROF", &rofsPtr);
+
+  LOG(INFO) << "MFTDigitWriter read " << digits.size() << " digits, in " << rofs.size() << " RO frames";
+
+  mTree->Fill();
+}
+
+void DigitWriter::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  LOG(INFO) << "Finalizing MFT digit writing";
+  mTree->Write();
+  mTree.release()->Delete();
+  mFile->Close();
+}
+
+DataProcessorSpec getDigitWriterSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("digits", "MFT", "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "DigitROF", 0, Lifetime::Timeframe);
+  return DataProcessorSpec{
+    "mft-digit-writer",
+    inputs,
+    Outputs{},
+    AlgorithmSpec{adaptFromTask<DigitWriter>()},
+    Options{
+      {"mft-digit-outfile", VariantType::String, "mftdigitsdecode.root", {"Name of the input file"}}}};
+}
+
+} // namespace mft
+} // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-digit-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-digit-workflow.cxx
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MFTWorkflow/DigitWorkflow.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // write the configuration used for the digitizer workflow
+  o2::conf::ConfigurableParam::writeINI("o2mftdigitwriter_configuration.ini");
+
+  return std::move(o2::mft::digit_workflow::getWorkflow());
+}

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -90,7 +90,7 @@ class ChipMappingMFT
     uint16_t plane = (feeID >> 2) & 0x1;
     uint16_t zone = feeID & 0x3;
     layer = 2 * disk + plane;
-    ruOnLayer = 2 * half + zone;
+    ruOnLayer = 4 * half + zone;
   }
 
   ///< get info on sw RU
@@ -118,13 +118,13 @@ class ChipMappingMFT
   ///< convert HW id of chip in the module to SW ID (sequential ID on the module)
   int chipModuleIDHW2SW(int ruType, int hwIDinMod) const
   {
-    return hwIDinMod;
+    return (8 - hwIDinMod);
   }
 
   ///< convert SW id of chip in the module to HW ID
   int chipModuleIDSW2HW(int ruType, int swIDinMod) const
   {
-    return swIDinMod;
+    return (8 - swIDinMod);
   }
 
   static constexpr Int_t getNChips() { return NChips; }
@@ -216,14 +216,19 @@ class ChipMappingMFT
     return sid + ruOnLayer;
   }
 
+  const int getNZonesPerLayer() const { return NZonesPerLayer; }
+  const int getNLayers() const { return NLayers; }
+
+  ///< convert zone number [0...8] and layer number [0...10] to RU type
+  int getRUType(int zone, int layer) const { return ZoneRUType[zone % 4][layer / 2]; }
+
+  static constexpr int NLayers = 10, NZonesPerLayer = 2 * 4, NRUTypes = 13;
+
  private:
   Int_t invalid() const;
-  static constexpr Int_t NZonesPerLayer = 2 * 4;
-  static constexpr Int_t NLayers = 10;
   static constexpr Int_t NRUs = NLayers * NZonesPerLayer;
   static constexpr Int_t NModules = 280;
   static constexpr Int_t NChips = 936;
-  static constexpr Int_t NRUTypes = 13;
   static constexpr Int_t NChipsInfo = 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 16 + 17 + 18 + 19 + 14;
   static constexpr Int_t NChipsPerCable = 1;
   static constexpr Int_t NLinks = 1;

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
@@ -1638,6 +1638,7 @@ ChipMappingMFT::ChipMappingMFT()
       auto layer = ModuleMappingData[module].layer;
       auto zone = ModuleMappingData[module].zone;
       auto half = ModuleMappingData[module].half;
+      auto connector = ModuleMappingData[module].connector;
       auto ruType = ZoneRUType[zone][layer / 2];
 
       if (ruType != iRU || chipsOnRUType[iRU] == NChipsOnRUType[iRU]) {
@@ -1659,19 +1660,23 @@ ChipMappingMFT::ChipMappingMFT()
       }
 
       auto& chInfo = mChipsInfo[mChipInfoEntryRU[iRU] + chipOnRU];
-      ++ctrChip;
 
       chInfo.id = chipOnRU;
 
-      chInfo.moduleHW = ModuleMappingData[module].connector;
-      chInfo.moduleSW = ChipMappingData[iChip].module;
+      chInfo.moduleHW = connector;
+      chInfo.moduleSW = module;
 
-      chInfo.chipOnModuleSW = ChipMappingData[iChip].chipOnModule;
-      chInfo.chipOnModuleHW = chInfo.chipOnModuleSW;
+      chInfo.chipOnModuleSW = chipOnModule;
+      // SW          HW
+      // 0 1 2 3 4 = 8 7 6 5 4
+      // 0 1 2 3   = 8 7 6 5
+      // 0 1 2     = 8 7 6
+      // 0 1       = 8 7
+      chInfo.chipOnModuleHW = 8 - chInfo.chipOnModuleSW;
 
-      chInfo.cableHW = ChipConnectorCable[chInfo.moduleHW][chInfo.chipOnModuleHW];
-      chInfo.cableSW = ChipMappingData[iChip].chipOnRU;
-      chInfo.cableHWPos = ChipMappingData[iChip].chipOnRU;
+      chInfo.cableHW = ChipConnectorCable[chInfo.moduleHW][chInfo.chipOnModuleSW];
+      chInfo.cableSW = chipOnRU;
+      chInfo.cableHWPos = chipOnRU;
 
       chInfo.chipOnCable = 0;
 
@@ -1679,6 +1684,7 @@ ChipMappingMFT::ChipMappingMFT()
       mCableHW2SW[iRU][chInfo.cableHW] = chInfo.cableSW;
       mCableHWFirstChip[iRU][chInfo.cableHW] = 0;
 
+      ++ctrChip;
       ++chipsOnRUType[iRU];
     }
   }
@@ -1715,7 +1721,6 @@ ChipMappingMFT::ChipMappingMFT()
             mRUGlobalChipID[ruInfo.idSW].resize(NChipsOnRUType[ruType]);
             ruInfo.firstChipIDSW = iChip;
           }
-          //auto& chInfo = mChipsInfo[mChipInfoEntryRU[ruType] + chipOnRU];
           mRUGlobalChipID[(int)(ruInfo.idSW)].at((int)(chipOnRU)) = iChip;
         }
       }


### PR DESCRIPTION
I add also a device to read the piped decoded digits and write them into a file in ROOT format. This is the full chain to check the encoding / decoding:

o2-sim -j 4 -m MFT -e TGeant3 -n 10 -g boxgen --configKeyValues 'BoxGun.pdg=13; BoxGun.eta[0]=-3.8; BoxGun.eta[1]=-2.1; BoxGun.prange[0]=5.0; BoxGun.prange[1]=10.; BoxGun.number=10'

o2-sim-digitizer-workflow -b 

o2-mft-digi2raw -b

o2-raw-file-reader-workflow -b --nocheck-missing-stop --max-tf 100 --input-conf MFTraw.cfg | o2-itsmft-stf-decoder-workflow -b --mft --digits --dict-file ITSdictionary.bin | o2-mft-digit-workflow -b

and at the end compare the digits from the two files:

mftdigits.root

and

mftdigitsdecode.root