### PR TITLE
Add reading of tpc compressed clusters in TPC workflow

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -93,11 +93,13 @@ struct CompressedClustersROOT : public CompressedClusters {
 };
 
 struct CompressedClustersFlat : private CompressedClustersCounters, private CompressedClustersOffsets {
-  friend struct CompressedClusters;    // We don't want anyone to access the members directly, should only be used to construct a CompressedClusters struct
-  CompressedClustersFlat() CON_DELETE; // Must not be constructed, but just reinterpret_casted from void* array (void* to enforce alignment)
-  size_t totalDataSize = 0;
+  friend struct CompressedClusters;               // We don't want anyone to access the members directly, should only be used to construct a CompressedClusters struct
+  CompressedClustersFlat() CON_DELETE;            // Must not be constructed
+  size_t totalDataSize = 0;                       // Total data size of header + content
+  const CompressedClusters* ptrForward = nullptr; // Must be 0 if this object is really flat, or can be a ptr to a CompressedClusters struct (abusing the flat structure to forward a ptr to the e.g. root version)
 
   void set(size_t bufferSize, const CompressedClusters& v);
+  void setForward(const CompressedClusters* p);
 };
 
 } // namespace tpc

--- a/DataFormats/Detectors/TPC/src/CompressedClusters.cxx
+++ b/DataFormats/Detectors/TPC/src/CompressedClusters.cxx
@@ -13,6 +13,7 @@
 
 #include "DataFormatsTPC/CompressedClusters.h"
 
+#include <cstring>
 #ifndef GPUCA_STANDALONE
 #include "DataFormatsTPC/CompressedClustersHelpers.h"
 #include "TBuffer.h"
@@ -43,7 +44,14 @@ void CompressedClustersFlat::set(size_t bufferSize, const CompressedClusters& v)
   for (unsigned int i = 0; i < sizeof(offsets) / sizeof(size_t); i++) {
     reinterpret_cast<size_t*>(&offsets)[i] = (reinterpret_cast<const size_t*>(&ptrs)[i] - reinterpret_cast<size_t>(this)); // Compute offsets from beginning of structure
   }
+  ptrForward = nullptr;
   totalDataSize = bufferSize;
+}
+
+void CompressedClustersFlat::setForward(const CompressedClusters* p)
+{
+  memset((void*)this, 0, sizeof(*this));
+  ptrForward = p;
 }
 
 #ifndef GPUCA_STANDALONE

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -61,7 +61,7 @@ void GPUCATracking::deinitialize()
 
 int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* outputs)
 {
-  if ((int)(data->tpcZS != nullptr) + (int)(data->o2Digits != nullptr) + (int)(data->clusters != nullptr) != 1) {
+  if ((int)(data->tpcZS != nullptr) + (int)(data->o2Digits != nullptr) + (int)(data->clusters != nullptr) + (int)(data->compressedClusters != nullptr) != 1) {
     return 0;
   }
 
@@ -86,7 +86,9 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
   GPUTPCDigitsMCInput gpuDigitsMC;
   GPUTrackingInOutPointers ptrs;
 
-  if (data->tpcZS) {
+  if (data->compressedClusters) {
+    ptrs.tpcCompressedClusters = data->compressedClusters;
+  } else if (data->tpcZS) {
     ptrs.tpcZS = data->tpcZS;
   } else if (data->o2Digits) {
     ptrs.clustersNative = nullptr;
@@ -119,7 +121,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
     ptrs.tpcPackedDigits = nullptr;
   }
   int retVal = mTrackingCAO2Interface->RunTracking(&ptrs, outputs);
-  if (data->o2Digits || data->tpcZS) {
+  if (data->o2Digits || data->tpcZS || data->compressedClusters) {
     clusters = ptrs.clustersNative;
   }
   const GPUTPCGMMergedTrack* tracks = ptrs.mergedTracks;
@@ -283,10 +285,10 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
     int lastSector = trackClusters[tracks[i].FirstClusterRef() + tracks[i].NClusters() - 1].slice;
   }
   outClusRefs->resize(clBuff); // remove overhead
-  data->compressedClusters = ptrs.tpcCompressedClusters;
-  if (data->o2Digits || data->tpcZS) {
+  if (data->o2Digits || data->tpcZS || data->compressedClusters) {
     data->clusters = ptrs.clustersNative;
   }
+  data->compressedClusters = ptrs.tpcCompressedClusters;
   mTrackingCAO2Interface->Clear(false);
 
   return (retVal);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -31,6 +31,7 @@ namespace ca
 // The CA tracker is now a wrapper to not only the actual tracking on GPU but
 // also the decoding of the zero-suppressed raw format and the clusterer.
 enum struct Operation {
+  DecompressTPC,          // run cluster decompressor
   CAClusterer,            // run the CA clusterer
   ZSDecoder,              // run the ZS raw data decoder
   ZSOnTheFly,             // use zs on the fly
@@ -57,6 +58,9 @@ struct Config {
   void init(Operation const& op, Args&&... args)
   {
     switch (op) {
+      case Operation::DecompressTPC:
+        decompressTPC = true;
+        break;
       case Operation::CAClusterer:
         caClusterer = true;
         break;
@@ -94,6 +98,7 @@ struct Config {
   // Cannot specialize constructor to create proper copy constructor directly --> must overload init
   void init(const Config& x) { *this = x; }
 
+  bool decompressTPC = false;
   bool caClusterer = false;
   bool zsDecoder = false;
   bool zsOnTheFly = false;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -32,6 +32,7 @@ namespace ca
 // also the decoding of the zero-suppressed raw format and the clusterer.
 enum struct Operation {
   DecompressTPC,          // run cluster decompressor
+  DecompressTPCFromROOT,  // the cluster decompressor input is a root object not flat
   CAClusterer,            // run the CA clusterer
   ZSDecoder,              // run the ZS raw data decoder
   ZSOnTheFly,             // use zs on the fly
@@ -60,6 +61,9 @@ struct Config {
     switch (op) {
       case Operation::DecompressTPC:
         decompressTPC = true;
+        break;
+      case Operation::DecompressTPCFromROOT:
+        decompressTPCFromROOT = true;
         break;
       case Operation::CAClusterer:
         caClusterer = true;
@@ -99,6 +103,7 @@ struct Config {
   void init(const Config& x) { *this = x; }
 
   bool decompressTPC = false;
+  bool decompressTPCFromROOT = false;
   bool caClusterer = false;
   bool zsDecoder = false;
   bool zsOnTheFly = false;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -33,6 +33,7 @@ enum struct InputType { Digitizer,        // directly read digits from channel {
                         ClustersHardware, // read hardware clusters in raw page format from file
                         Clusters,         // read native clusters from file
                         CompClusters,     // read compressed cluster container
+                        CompClustersCTF,  // compressed clusters from CTF, as flat format
                         EncodedClusters,  // read encoded clusters
                         ZSRaw,
 };

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -120,6 +120,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       char tpcTransformationFileName[1024] = ""; // A file with the TPC transformation
       char matBudFileName[1024] = "";            // Material budget file name
       char dEdxSplinesFile[1024] = "";           // File containing dEdx splines
+      int tpcRejectionMode = GPUSettings::RejectionStrategyA;
 
       const auto grp = o2::parameters::GRPObject::loadFrom("o2sim_grp.root");
       if (grp) {
@@ -173,6 +174,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
           } else if (optLen > 8 && strncmp(optPtr, "threads=", 8) == 0) {
             sscanf(optPtr + 8, "%d", &nThreads);
             printf("Using %d threads\n", nThreads);
+          } else if (optLen > 21 && strncmp(optPtr, "tpcRejectionStrategy=", 21) == 0) {
+            sscanf(optPtr + 21, "%d", &tpcRejectionMode);
+            tpcRejectionMode = tpcRejectionMode == 0 ? GPUSettings::RejectionNone : tpcRejectionMode == 1 ? GPUSettings::RejectionStrategyA : GPUSettings::RejectionStrategyB;
+            printf("TPC Rejection Mode: %d\n", tpcRejectionMode);
           } else if (optLen > 8 && strncmp(optPtr, "gpuType=", 8) == 0) {
             int len = std::min(optLen - 8, 1023);
             memcpy(gpuType, optPtr + 8, len);
@@ -229,7 +234,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       config.configReconstruction.TrackReferenceX = refX;
 
       // Settings for TPC Compression:
-      config.configReconstruction.tpcRejectionMode = GPUSettings::RejectionStrategyA; // Implement TPC Strategy A
+      config.configReconstruction.tpcRejectionMode = tpcRejectionMode;                // Implement TPC Strategy A
       config.configReconstruction.tpcRejectQPt = 1.f / 0.05f;                         // Reject clusters of tracks < 50 MeV
       config.configReconstruction.tpcCompressionModes = GPUSettings::CompressionFull; // Activate all compression steps
       config.configReconstruction.tpcCompressionSortOrder = GPUSettings::SortPad;     // Sort order for differences compression

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -123,6 +123,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       char matBudFileName[1024] = "";            // Material budget file name
       char dEdxSplinesFile[1024] = "";           // File containing dEdx splines
       int tpcRejectionMode = GPUSettings::RejectionStrategyA;
+      size_t memoryPoolSize = 1;
 
       const auto grp = o2::parameters::GRPObject::loadFrom("o2sim_grp.root");
       if (grp) {
@@ -193,6 +194,9 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
           } else if (optLen > 8 && strncmp(optPtr, "gpuNum=", 7) == 0) {
             sscanf(optPtr + 7, "%d", &gpuDevice);
             printf("Using GPU device %d\n", gpuDevice);
+          } else if (optLen > 8 && strncmp(optPtr, "gpuMemorySize=", 14) == 0) {
+            sscanf(optPtr + 14, "%llu", (unsigned long long int*)&memoryPoolSize);
+            printf("GPU memory pool size set to %llu\n", (unsigned long long int)memoryPoolSize);
           } else if (optLen > 8 && strncmp(optPtr, "dEdxFile=", 9) == 0) {
             int len = std::min(optLen - 9, 1023);
             memcpy(dEdxSplinesFile, optPtr + 9, len);
@@ -230,11 +234,11 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       }
       config.configDeviceProcessing.deviceNum = gpuDevice;
       config.configDeviceProcessing.nThreads = nThreads;
-      config.configDeviceProcessing.runQA = qa;                   // Run QA after tracking
-      config.configDeviceProcessing.runMC = specconfig.processMC; // Propagate MC labels
-      config.configDeviceProcessing.eventDisplay = display;       // Ptr to event display backend, for running standalone OpenGL event display
-      config.configDeviceProcessing.debugLevel = debugLevel;      // Debug verbosity
-      config.configDeviceProcessing.forceMemoryPoolSize = 1;      // Some memory auto-detection
+      config.configDeviceProcessing.runQA = qa;                           // Run QA after tracking
+      config.configDeviceProcessing.runMC = specconfig.processMC;         // Propagate MC labels
+      config.configDeviceProcessing.eventDisplay = display;               // Ptr to event display backend, for running standalone OpenGL event display
+      config.configDeviceProcessing.debugLevel = debugLevel;              // Debug verbosity
+      config.configDeviceProcessing.forceMemoryPoolSize = memoryPoolSize; // Memory pool size, default = 1 = auto-detect
 
       config.configEvent.solenoidBz = solenoidBz;
       int maxContTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * Constants::LHCBCPERTIMEBIN - 2) / Constants::LHCBCPERTIMEBIN;

--- a/GPU/GPUTracking/Base/GPUDataTypes.cxx
+++ b/GPU/GPUTracking/Base/GPUDataTypes.cxx
@@ -17,5 +17,6 @@
 using namespace GPUCA_NAMESPACE::gpu;
 
 constexpr const char* const GPUDataTypes::RECO_STEP_NAMES[];
+constexpr const char* const GPUDataTypes::GENERAL_STEP_NAMES[];
 
 GPUDataTypes::DeviceType GPUDataTypes::GetDeviceType(const char* type) { return GPUReconstruction::GetDeviceType(type); }

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -113,6 +113,7 @@ class GPUDataTypes
                              ITSTracking = 32,
                              TPCdEdx = 64,
                              TPCClusterFinding = 128,
+                             TPCDecompression = 256,
                              AllRecoSteps = 0x7FFFFFFF,
                              NoRecoStep = 0 };
   enum ENUM_CLASS InOutType { TPCClusters = 1,
@@ -124,7 +125,7 @@ class GPUDataTypes
                               TPCRaw = 64 };
 
 #ifdef GPUCA_NOCOMPAT_ALLOPENCL
-  static constexpr const char* const RECO_STEP_NAMES[] = {"TPC Transformation", "TPC Sector Tracking", "TPC Track Merging and Fit", "TPC Compression", "TRD Tracking", "ITS Tracking", "TPC dEdx Computation", "TPC Cluster Finding"};
+  static constexpr const char* const RECO_STEP_NAMES[] = {"TPC Transformation", "TPC Sector Tracking", "TPC Track Merging and Fit", "TPC Compression", "TRD Tracking", "ITS Tracking", "TPC dEdx Computation", "TPC Cluster Finding", "TPC Decompression"};
   typedef bitfield<RecoStep, unsigned int> RecoStepField;
   typedef bitfield<InOutType, unsigned int> InOutTypeField;
 #endif

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -105,6 +105,9 @@ class GPUDataTypes
                               HIP = 3,
                               OCL = 4,
                               OCL2 = 5 };
+  enum ENUM_CLASS GeneralStep { Prepare = 1,
+                                QA = 2 };
+
   enum ENUM_CLASS RecoStep { TPCConversion = 1,
                              TPCSliceTracking = 2,
                              TPCMerging = 4,
@@ -126,6 +129,7 @@ class GPUDataTypes
 
 #ifdef GPUCA_NOCOMPAT_ALLOPENCL
   static constexpr const char* const RECO_STEP_NAMES[] = {"TPC Transformation", "TPC Sector Tracking", "TPC Track Merging and Fit", "TPC Compression", "TRD Tracking", "ITS Tracking", "TPC dEdx Computation", "TPC Cluster Finding", "TPC Decompression"};
+  static constexpr const char* const GENERAL_STEP_NAMES[] = {"Prepare", "QA"};
   typedef bitfield<RecoStep, unsigned int> RecoStepField;
   typedef bitfield<InOutType, unsigned int> InOutTypeField;
 #endif

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -71,6 +71,7 @@ class GPUReconstruction
   using GeometryType = GPUDataTypes::GeometryType;
   using DeviceType = GPUDataTypes::DeviceType;
   using RecoStep = GPUDataTypes::RecoStep;
+  using GeneralStep = GPUDataTypes::GeneralStep;
   using RecoStepField = GPUDataTypes::RecoStepField;
   using InOutTypeField = GPUDataTypes::InOutTypeField;
 

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -180,17 +180,22 @@ int GPUReconstructionCPU::ExitDevice()
   return 0;
 }
 
-int GPUReconstructionCPU::getRecoStepNum(RecoStep step, bool validCheck)
+template <class T>
+static inline int getStepNum(T step, bool validCheck, int N, const char* err)
 {
+  static_assert(sizeof(step) == sizeof(unsigned int), "Invalid step enum size");
   int retVal = 8 * sizeof(unsigned int) - 1 - CAMath::Clz((unsigned int)step);
-  if ((unsigned int)step == 0 || retVal >= N_RECO_STEPS) {
+  if ((unsigned int)step == 0 || retVal >= N) {
     if (!validCheck) {
       return -1;
     }
-    throw std::runtime_error("Invalid Reco Step");
+    throw std::runtime_error("Invalid General Step");
   }
   return retVal;
 }
+
+int GPUReconstructionCPU::getRecoStepNum(RecoStep step, bool validCheck) { return getStepNum(step, validCheck, N_RECO_STEPS, "Invalid Reco Step"); }
+int GPUReconstructionCPU::getGeneralStepNum(GeneralStep step, bool validCheck) { return getStepNum(step, validCheck, N_GENERAL_STEPS, "Invalid General Step"); }
 
 int GPUReconstructionCPU::RunChains()
 {
@@ -253,7 +258,7 @@ int GPUReconstructionCPU::RunChains()
     }
     for (int i = 0; i < N_RECO_STEPS; i++) {
       if (kernelStepTimes[i] != 0.) {
-        printf("Execution Time: Step              : %50s Time: %'10d us\n", GPUDataTypes::RECO_STEP_NAMES[i], (int)(kernelStepTimes[i] * 1000000 / mStatNEvents));
+        printf("Execution Time: Step              : %11s %38s Time: %'10d us (Total Time: %'10d us)\n", "Tasks", GPUDataTypes::RECO_STEP_NAMES[i], (int)(kernelStepTimes[i] * 1000000 / mStatNEvents), (int)(mTimersRecoSteps[i].timerTotal.GetElapsedTime() * 1000000 / mStatNEvents));
       }
       if (mTimersRecoSteps[i].bytesToGPU) {
         printf("Execution Time: Step (D %8ux): %11s %38s Time: %'10d us (%6.3f GB/s - %'14lu bytes - %'14lu per call)\n", mTimersRecoSteps[i].countToGPU, "DMA to GPU", GPUDataTypes::RECO_STEP_NAMES[i], (int)(mTimersRecoSteps[i].timerToGPU.GetElapsedTime() * 1000000 / mStatNEvents),
@@ -267,9 +272,14 @@ int GPUReconstructionCPU::RunChains()
         mTimersRecoSteps[i].bytesToGPU = mTimersRecoSteps[i].bytesToHost = 0;
         mTimersRecoSteps[i].timerToGPU.Reset();
         mTimersRecoSteps[i].timerToHost.Reset();
-        mTimersRecoSteps[i].timer.Reset();
+        mTimersRecoSteps[i].timerTotal.Reset();
         mTimersRecoSteps[i].countToGPU = 0;
         mTimersRecoSteps[i].countToHost = 0;
+      }
+    }
+    for (int i = 0; i < N_GENERAL_STEPS; i++) {
+      if (mTimersGeneralSteps[i].GetElapsedTime() != 0.) {
+        printf("Execution Time: General Step      : %50s Time: %'10d us\n", GPUDataTypes::GENERAL_STEP_NAMES[i], (int)(mTimersGeneralSteps[i].GetElapsedTime() * 1000000 / mStatNEvents));
       }
     }
     mStatKernelTime = kernelTotal * 1000000 / mStatNEvents;

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -142,6 +142,9 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
 
   int RunChains() override;
 
+  HighResTimer& getRecoStepTimer(RecoStep step) { return mTimersRecoSteps[getRecoStepNum(step)].timerTotal; }
+  HighResTimer& getGeneralStepTimer(GeneralStep step) { return mTimersGeneralSteps[getGeneralStepNum(step)]; }
+
  protected:
   struct GPUProcessorProcessors : public GPUProcessor {
     GPUConstantMem* mProcessorsProc = nullptr;
@@ -203,9 +206,9 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
   };
 
   struct RecoStepTimerMeta {
-    HighResTimer timer;
     HighResTimer timerToGPU;
     HighResTimer timerToHost;
+    HighResTimer timerTotal;
     size_t bytesToGPU = 0;
     size_t bytesToHost = 0;
     unsigned int countToGPU = 0;
@@ -213,6 +216,9 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
   };
 
   constexpr static int N_RECO_STEPS = sizeof(GPUDataTypes::RECO_STEP_NAMES) / sizeof(GPUDataTypes::RECO_STEP_NAMES[0]);
+  constexpr static int N_GENERAL_STEPS = sizeof(GPUDataTypes::GENERAL_STEP_NAMES) / sizeof(GPUDataTypes::GENERAL_STEP_NAMES[0]);
+  HighResTimer mTimersGeneralSteps[N_GENERAL_STEPS];
+
   std::vector<std::unique_ptr<timerMeta>> mTimers;
   RecoStepTimerMeta mTimersRecoSteps[N_RECO_STEPS];
   HighResTimer timerTotal;
@@ -221,6 +227,7 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
   template <class T, int J = -1>
   HighResTimer& getTimer(const char* name, int num = -1);
   int getRecoStepNum(RecoStep step, bool validCheck = true);
+  int getGeneralStepNum(GeneralStep step, bool validCheck = true);
 
   std::vector<std::vector<deviceEvent*>> mEvents;
 

--- a/GPU/GPUTracking/DataCompression/GPUTPCClusterStatistics.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCClusterStatistics.cxx
@@ -108,7 +108,8 @@ void GPUTPCClusterStatistics::RunStatistics(const o2::tpc::ClusterNativeAccess* 
   o2::tpc::ClusterNativeAccess clustersNativeDecoded;
   std::vector<o2::tpc::ClusterNative> clusterBuffer;
   GPUInfo("Compression statistics, decoding: %d attached (%d tracks), %d unattached", clustersCompressed->nAttachedClusters, clustersCompressed->nTracks, clustersCompressed->nUnattachedClusters);
-  mDecoder.decompress(clustersCompressed, clustersNativeDecoded, clusterBuffer, param);
+  mDecoder.decompress(
+    clustersCompressed, clustersNativeDecoded, [&clusterBuffer](size_t size) {clusterBuffer.resize(size); return clusterBuffer.data(); }, param);
   std::vector<o2::tpc::ClusterNative> tmpClusters;
   if (param.rec.tpcRejectionMode == GPUSettings::RejectionNone) { // verification does not make sense if we reject clusters during compression
     for (unsigned int i = 0; i < NSLICES; i++) {

--- a/GPU/GPUTracking/DataCompression/GPUTPCClusterStatistics.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCClusterStatistics.cxx
@@ -108,8 +108,8 @@ void GPUTPCClusterStatistics::RunStatistics(const o2::tpc::ClusterNativeAccess* 
   o2::tpc::ClusterNativeAccess clustersNativeDecoded;
   std::vector<o2::tpc::ClusterNative> clusterBuffer;
   GPUInfo("Compression statistics, decoding: %d attached (%d tracks), %d unattached", clustersCompressed->nAttachedClusters, clustersCompressed->nTracks, clustersCompressed->nUnattachedClusters);
-  mDecoder.decompress(
-    clustersCompressed, clustersNativeDecoded, [&clusterBuffer](size_t size) {clusterBuffer.resize(size); return clusterBuffer.data(); }, param);
+  auto allocator = [&clusterBuffer](size_t size) {clusterBuffer.resize(size); return clusterBuffer.data(); };
+  mDecoder.decompress(clustersCompressed, clustersNativeDecoded, allocator, param);
   std::vector<o2::tpc::ClusterNative> tmpClusters;
   if (param.rec.tpcRejectionMode == GPUSettings::RejectionNone) { // verification does not make sense if we reject clusters during compression
     for (unsigned int i = 0; i < NSLICES; i++) {

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -264,18 +264,23 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step1un
         const ClusterNative& GPUrestrict() orgCl = clusters->clusters[iSlice][iRow][sortBuffer[j]];
         unsigned int lastTime = 0;
         unsigned int lastPad = 0;
-        if (j != 0) {
-          const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][sortBuffer[j - 1]];
-          lastPad = orgClPre.padPacked;
-          lastTime = orgClPre.getTimePacked();
-        } else if (totalCount != 0) {
-          const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][smem.step1.lastIndex];
-          lastPad = orgClPre.padPacked;
-          lastTime = orgClPre.getTimePacked();
-        }
+        if (param.rec.tpcCompressionModes & GPUSettings::CompressionDifferences) {
+          if (j != 0) {
+            const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][sortBuffer[j - 1]];
+            lastPad = orgClPre.padPacked;
+            lastTime = orgClPre.getTimePacked();
+          } else if (totalCount != 0) {
+            const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][smem.step1.lastIndex];
+            lastPad = orgClPre.padPacked;
+            lastTime = orgClPre.getTimePacked();
+          }
 
-        c.padDiffU[outidx] = orgCl.padPacked - lastPad;
-        c.timeDiffU[outidx] = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
+          c.padDiffU[outidx] = orgCl.padPacked - lastPad;
+          c.timeDiffU[outidx] = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
+        } else {
+          c.padDiffU[outidx] = orgCl.padPacked;
+          c.timeDiffU[outidx] = orgCl.getTimePacked();
+        }
 
         unsigned short qtot = orgCl.qTot, qmax = orgCl.qMax;
         unsigned char sigmapad = orgCl.sigmaPadPacked, sigmatime = orgCl.sigmaTimePacked;

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
@@ -23,8 +23,15 @@ using namespace o2::tpc;
 
 int TPCClusterDecompressor::decompress(const CompressedClustersFlat* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::function<o2::tpc::ClusterNative*(size_t)> allocator, const GPUParam& param)
 {
-  CompressedClusters c = *clustersCompressed;
-  return decompress(&c, clustersNative, allocator, param);
+  CompressedClusters c;
+  const CompressedClusters* p;
+  if (clustersCompressed->ptrForward) {
+    p = clustersCompressed->ptrForward;
+  } else {
+    c = *clustersCompressed;
+    p = &c;
+  }
+  return decompress(p, clustersNative, allocator, param);
 }
 
 int TPCClusterDecompressor::decompress(const CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::function<o2::tpc::ClusterNative*(size_t)> allocator, const GPUParam& param)

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.h
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.h
@@ -16,6 +16,7 @@
 
 #include "GPUTPCCompression.h"
 #include <vector>
+#include <functional>
 
 namespace o2
 {
@@ -36,8 +37,8 @@ class TPCClusterDecompressor
 {
  public:
   static constexpr unsigned int NSLICES = GPUCA_NSLICES;
-  int decompress(const o2::tpc::CompressedClustersFlat* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param);
-  int decompress(const o2::tpc::CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::vector<o2::tpc::ClusterNative>& clusterBuffer, const GPUParam& param);
+  int decompress(const o2::tpc::CompressedClustersFlat* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::function<o2::tpc::ClusterNative*(size_t)> allocator, const GPUParam& param);
+  int decompress(const o2::tpc::CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::function<o2::tpc::ClusterNative*(size_t)> allocator, const GPUParam& param);
 
  protected:
 };

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -131,7 +131,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   // Processing functions
   int RunTPCClusterizer(bool synchronizeOutput = true);
-  void ForwardTPCDigits();
+  int ForwardTPCDigits();
   int RunTPCTrackingSlices();
   int RunTPCTrackingMerger(bool synchronizeOutput = true);
   int RunTRDTracking();

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -137,6 +137,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   int RunTRDTracking();
   int DoTRDGPUTracking();
   int RunTPCCompression();
+  int RunTPCDecompression();
 
   // Getters / setters for parameters
   const TPCFastTransform* GetTPCTransform() const { return processors()->calibObjects.fastTransform; }

--- a/GPU/GPUTracking/Global/GPUTrackingInputProvider.cxx
+++ b/GPU/GPUTracking/Global/GPUTrackingInputProvider.cxx
@@ -64,6 +64,6 @@ void GPUTrackingInputProvider::RegisterMemoryAllocation()
 void GPUTrackingInputProvider::SetMaxData(const GPUTrackingInOutPointers& io)
 {
   mHoldTPCZS = io.tpcZS && (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding);
-  mHoldTPCClusterNative = (io.tpcZS || io.tpcPackedDigits || io.clustersNative) && mRec->IsGPU();
-  mHoldTPCClusterNativeOutput = (io.tpcZS || io.tpcPackedDigits);
+  mHoldTPCClusterNative = (io.tpcZS || io.tpcPackedDigits || io.clustersNative || io.tpcCompressedClusters) && mRec->IsGPU();
+  mHoldTPCClusterNativeOutput = (io.tpcZS || io.tpcPackedDigits || io.tpcCompressedClusters);
 }

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -112,7 +112,7 @@ struct GPUO2InterfaceIOPtrs {
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr;
 
   // Output for entropy-reduced clusters of TPC compression
-  const o2::tpc::CompressedClustersFlat* compressedClusters;
+  const o2::tpc::CompressedClustersFlat* compressedClusters = nullptr;
 
   // Hint for GPUCATracking to place its output in this buffer if possible.
   // This enables to create the output directly in a shared memory segment of the framework.

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -102,7 +102,6 @@ void GPUTPCGMMerger::CheckMergedTracks()
     }
     int leg = 0;
     GPUTPCGMSliceTrack *trbase = &track, *tr = &track;
-    tr->SetPrevSegmentNeighbour(1000000000);
     while (true) {
       int iTrk = tr - mSliceTrackInfos;
       if (trkUsed[iTrk]) {
@@ -113,7 +112,6 @@ void GPUTPCGMMerger::CheckMergedTracks()
       int jtr = tr->NextSegmentNeighbour();
       if (jtr >= 0) {
         tr = &(mSliceTrackInfos[jtr]);
-        tr->SetPrevSegmentNeighbour(1000000002);
         continue;
       }
       jtr = trbase->NextNeighbour();
@@ -123,7 +121,6 @@ void GPUTPCGMMerger::CheckMergedTracks()
         if (tr->PrevSegmentNeighbour() >= 0) {
           break;
         }
-        tr->SetPrevSegmentNeighbour(1000000001);
         leg++;
         continue;
       }

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -711,7 +711,6 @@ int main(int argc, char** argv)
           rec->SetResetTimers(j1 < configStandalone.runsInit);
 
           if (configStandalone.testSyncAsync) {
-            recAsync->SetResetTimers(j1 < configStandalone.runsInit);
             printf("Running synchronous phase\n");
           }
           chainTracking->mIOPtrs = ioPtrSave;
@@ -757,13 +756,8 @@ int main(int argc, char** argv)
               chainTrackingAsync->mIOPtrs.nRawClusters[i] = 0;
             }
             chainTrackingAsync->mIOPtrs.clustersNative = nullptr;
-            if (configStandalone.controlProfiler && j1 == configStandalone.runs - 1) {
-              rec->startGPUProfiling();
-            }
+            recAsync->SetResetTimers(j1 < configStandalone.runsInit);
             tmpRetVal = recAsync->RunChains();
-            if (configStandalone.controlProfiler && j1 == configStandalone.runs - 1) {
-              rec->endGPUProfiling();
-            }
             if (tmpRetVal == 0 || tmpRetVal == 2) {
               OutputStat(chainTrackingAsync, nullptr, nullptr);
               if (configStandalone.memoryStat) {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -391,6 +391,8 @@ int SetupReconstruction()
   steps.steps = GPUDataTypes::RecoStep::AllRecoSteps;
   if (configStandalone.configRec.runTRD != -1) {
     steps.steps.setBits(GPUDataTypes::RecoStep::TRDTracking, configStandalone.configRec.runTRD > 0);
+  } else if (chainTracking->GetTRDGeometry() == nullptr) {
+    steps.steps.setBits(GPUDataTypes::RecoStep::TRDTracking, false);
   }
   if (configStandalone.configRec.rundEdx != -1) {
     steps.steps.setBits(GPUDataTypes::RecoStep::TPCdEdx, configStandalone.configRec.rundEdx > 0);


### PR DESCRIPTION
@shahor02 : This adds the reading of tpc compressed clusters in the tpc workflow.
It is not properly rebased, basically it is the last 2 commits and depends on #3685.
As soon as #3685 is merged, I'll rebase this.
Also, I found a bug in the track model compression, which currently doesn't decompress correctly.
I'll try to fix that in the meantime and push on top of this.
But for just testing the passing of the ctf to the tpc-workflow, cherry picking the last two commits here should do.

I used the command line
```
o2-ctf-reader-workflow  --ctf-input o2_ctf_0000000000.root  | o2-its-reco-workflow --trackerCA --clusters-from-upstream --disable-mc | o2-tpc-reco-workflow --input-type compressed-clusters-ctf --output-type tracks,clusters --disable-mc
```

I added a new input-type `compressed-clusters-ctf` to get data in the flat format and not read it from the root file. Cluster and tracks output works. In principle, recompressing the clusters would also work, but that would break DPL because it matches only the data type. But anyhow, I don't think we need that.