### PR TITLE
Update of DPL RootTreeWriter

### DIFF
--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -219,5 +219,39 @@ template <class Type>
 struct is_boost_serializable<Type, boost::archive::binary_oarchive, std::void_t<typename Type::value_type>>
   : is_boost_serializable<typename Type::value_type, boost::archive::binary_oarchive> {
 };
+
+/// Helper to get the corresponding std::function type for a callable object
+/// the default is void
+template <typename T>
+struct get_function {
+  using type = void;
+};
+
+/// the matching specialization builds the function type from the return type
+/// and types in the argument pack
+template <typename Ret, typename Class, typename... Args>
+struct get_function<Ret (Class::*)(Args...) const> {
+  using type = std::function<Ret(Args...)>;
+};
+
+/// check if a lambda can be assigned to concrete std::function
+/// default is false
+template <typename From, typename To, typename _ = void>
+struct can_assign : public std::false_type {
+};
+
+/// specialize for callable types, i.e. having operator(), the 'From' type can be
+/// assigned if its corresponding function type is the same as 'To' type
+/// a direct comparison is not possible because lambdas are their own type
+template <typename From, typename To>
+struct can_assign<
+  From, To,
+  std::conditional_t<
+    false,
+    class_member_checker<
+      decltype(&From::operator())>,
+    void>> : public std::is_same<typename get_function<decltype(&From::operator())>::type, To> {
+};
+
 } // namespace o2::framework
 #endif // FRAMEWORK_TYPETRAITS_H

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -141,3 +141,20 @@ BOOST_AUTO_TEST_CASE(TestIsSpan)
   BOOST_REQUIRE_EQUAL(is_span<decltype(b)>::value, false);
   BOOST_REQUIRE_EQUAL(is_span<decltype(c)>::value, false);
 }
+
+BOOST_AUTO_TEST_CASE(TestCanAssign)
+{
+  using Callback = std::function<bool(int, float)>;
+  auto matching = [](int, float) -> bool {
+    return true;
+  };
+  auto otherReturn = [](int, float) -> int {
+    return 0;
+  };
+  auto otherParam = [](int, int) -> bool {
+    return true;
+  };
+  BOOST_REQUIRE((can_assign<decltype(matching), Callback>::value == true));
+  BOOST_REQUIRE((can_assign<decltype(otherReturn), Callback>::value == false));
+  BOOST_REQUIRE((can_assign<decltype(otherParam), Callback>::value == false));
+}

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -102,23 +102,34 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   // first definition is for a single input and simple type written to one branch
   // second branch handles two inputs of the same data type, the mapping of the
   // input data to the target branch is taken from the sub specification
-  auto getIndex = [](o2::framework::DataRef const& ref) {
+  auto getIndex = [](o2::framework::DataRef const& ref) -> size_t {
     auto const* dataHeader = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     return dataHeader->subSpecification;
   };
-  auto getName = [](std::string base, size_t i) {
+  auto getName = [](std::string base, size_t i) -> std::string {
     return base + "_" + std::to_string(i);
   };
+  auto customClose = [](TFile* file, TTree* tree) {
+    // branches are filled independently of the tree, so the tree state needs to be
+    // synchronized with the branch states
+    tree->SetEntries();
+    std::cout << "Custom close, tree has " << tree->GetEntries() << " entries" << std::endl;
+    // there was one write cycle and each branch should have one entry
+    BOOST_CHECK(tree->GetEntries() == 1);
+    tree->Write();
+    file->Close();
+  };
   RootTreeWriter writer(filename.c_str(), treename, // file and tree name
+                        customClose,
                         RootTreeWriter::BranchDef<int>{"input1", "intbranch"},
                         RootTreeWriter::BranchDef<Container>{
                           std::vector<std::string>({"input2", "input3"}), "containerbranch",
                           // define two target branches (this matches the input list)
                           2,
                           // the callback extracts the sub specification from the DataHeader as index
-                          RootTreeWriter::IndexExtractor(getIndex),
+                          getIndex,
                           // the branch names are simply built by adding the index
-                          RootTreeWriter::BranchNameMapper(getName)},
+                          getName},
                         RootTreeWriter::BranchDef<const char*>{"input4", "binarybranch"},
                         RootTreeWriter::BranchDef<o2::test::TriviallyCopyable>{"input6", "msgablebranch"},
                         RootTreeWriter::BranchDef<std::vector<int>>{"input6", "intvecbranch"},
@@ -234,7 +245,9 @@ BOOST_AUTO_TEST_CASE(test_MakeRootTreeWriterSpec)
   struct Printer {
     Printer()
     {
-      std::cout << "setting up" << std::endl;
+      // TODO: to be fully correct we need to check at exit if we have been here instead
+      // of a thumb log message
+      std::cout << "Setting up a spectator" << std::endl;
     }
   };
   auto logger = [printer = std::make_shared<Printer>()](float const&) {
@@ -243,7 +256,7 @@ BOOST_AUTO_TEST_CASE(test_MakeRootTreeWriterSpec)
                          BranchDefinition<int>{InputSpec{"input1", "TST", "INTDATA"}, "intbranch"}, //
                          BranchDefinition<float>{InputSpec{"input2", "TST", "FLOATDATA"},           //
                                                  "floatbranch", "floatbranchname",                  //
-                                                 1, BranchDefinition<float>::Spectator(logger)}     //
+                                                 1, logger}                                         //
                          )();
 }
 


### PR DESCRIPTION
- More flexible API for passing handlers to RootTreeWriter
- Supporting DataRef const& as optional callback parameter in the branch
callbacks.
- Introducing a custom close handler.
- Adding support for auxiliary inputs, i.e. inputs which are not connected to
  a branch definition. Auxiliary inputs can be accessed in the preprocessor callback
