### PR TITLE
Revert "GPU: Add option to TPC workflow to just dump binary events

### DIFF
--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -99,9 +99,6 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
     if (nEvent == 0) {
       mRec->DumpSettings();
     }
-    if (mConfig->configInterface.dumpEvents >= 2) {
-      return 0;
-    }
   }
 
   mChain->mIOPtrs = *data;
@@ -142,7 +139,7 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
   }
 
   nEvent++;
-  return 0;
+  return (0);
 }
 
 void GPUTPCO2Interface::Clear(bool clearOutputs) { mRec->ClearAllocatedMemory(clearOutputs); }

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -71,7 +71,7 @@ struct GPUO2InterfaceConfiguration {
 
   // Settings for the Interface class
   struct GPUInterfaceSettings {
-    int dumpEvents = 0;
+    bool dumpEvents = false;
     bool outputToExternalBuffers = false;
     // These constants affect GPU memory allocation and do not limit the CPU processing
     unsigned int maxTPCHits = 1024 * 1024 * 1024;


### PR DESCRIPTION
Maybe it can be fixed easily, but I need to revert  commit 272059a7960624d4d02cd0c59425b289f9e14726. to avoid a crash in the TPC tracking, Actually, this commit seems to activate something which has been in the code already.

Running
```
o2-tpc-reco-workflow --infile tpcdigits.root --output-type tracks,clusters --tracker-options "cont refX=83 bz=-5.0068597793 qa"
```

There is a crash
```
[16722:tpc-tracker]: ===========================================================
[16722:tpc-tracker]: #6  o2::gpu::FlatObject::getFlatBufferSize (this=0x555b0000000c) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/GPU/Utils/FlatObject.h:250
[16722:tpc-tracker]: #7  o2::gpu::GPUChainTracking::GPUTrackingFlatObjects::SetPointersFlatObjects (this=0x555b1eb6a590, mem=<optimized out>) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Global/GPUChainTracking.cxx:546
[16722:tpc-tracker]: #8  0x00007f84f99e1769 in o2::gpu::GPUMemoryResource::SetPointers (ptr=0x1, this=0x555b1eacbe60) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Base/GPUMemoryResource.h:88
[16722:tpc-tracker]: #9  o2::gpu::GPUReconstruction::AllocateRegisteredMemory (this=this
[16722:tpc-tracker]: entry=0x555b1eb7b230, ires=ires
[16722:tpc-tracker]: entry=0, control=control
[16722:tpc-tracker]: entry=0x0) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Base/GPUReconstruction.cxx:430
[16722:tpc-tracker]: #10 0x00007f84f99e246e in o2::gpu::GPUReconstruction::AllocateRegisteredPermanentMemory (this=this
[16722:tpc-tracker]: entry=0x555b1eb7b230) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Base/GPUReconstruction.cxx:371
```