### PR TITLE
Enable Pythia6 external decayer + add cmdl parameter for custom Decay…

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -33,6 +33,7 @@ struct SimConfigData {
   std::string mExtTrgFileName;               // file name containing the external trigger configuration
   std::string mExtTrgFuncName;               // function call to retrieve the external trigger configuration
   std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
+  std::string mDecayConfig;                  // filename containing the external decayer configuration
   unsigned int mStartEvent;                  // index of first event to be taken
   float mBMax;                               // maximum for impact parameter sampling
   bool mIsMT;                                // chosen MT mode (Geant4 only)
@@ -107,6 +108,7 @@ class SimConfig
   std::string getExtTriggerFileName() const { return mConfigData.mExtTrgFileName; }
   std::string getExtTriggerFuncName() const { return mConfigData.mExtTrgFuncName; }
   std::string getEmbedIntoFileName() const { return mConfigData.mEmbedIntoFileName; }
+  std::string getDecayConfig() const { return mConfigData.mDecayConfig; }
   unsigned int getStartEvent() const { return mConfigData.mStartEvent; }
   float getBMax() const { return mConfigData.mBMax; }
   bool getIsMT() const { return mConfigData.mIsMT; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -43,6 +43,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "function call to load the definition of external event generator trigger")(
     "embedIntoFile", bpo::value<std::string>()->default_value(""),
     "filename containing the reference events to be used for the embedding")(
+    "decayConfig", bpo::value<std::string>()->default_value(""),
+    "filename containing the external decayer configuration")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
@@ -100,6 +102,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mExtTrgFileName = vm["extTrgFile"].as<std::string>();
   mConfigData.mExtTrgFuncName = vm["extTrgFunc"].as<std::string>();
   mConfigData.mEmbedIntoFileName = vm["embedIntoFile"].as<std::string>();
+  mConfigData.mDecayConfig = vm["decayConfig"].as<std::string>();
   mConfigData.mStartEvent = vm["startEvent"].as<unsigned int>();
   mConfigData.mBMax = vm["bMax"].as<float>();
   mConfigData.mIsMT = vm["isMT"].as<bool>();

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -84,6 +84,9 @@ FairRunSim* o2sim_init(bool asservice)
   run->SetName(confref.getMCEngine().c_str()); // Transport engine
   run->SetIsMT(confref.getIsMT());             // MT mode
 
+  /** set external decayer **/
+  run->SetPythiaDecayer(TString(confref.getDecayConfig()));
+
   /** set event header **/
   auto header = new o2::dataformats::MCEventHeader();
   run->SetMCEventHeader(header);


### PR DESCRIPTION
This PR switches on the use of the Pythia6 external decayer for Geant.
This allows Geant to perform decays of particles whose decays are not defined.
For instance, D and B mesons injected by Pyhtia8 generator are currently not being decayed.

The default configuration is taken from
```
$VMCWORKDIR/Detectors/gconfig/DecayConfig.C
```
The file is part of the `O2` and is located in 
```
Detectors/gconfig/DecayConfig.C
```
Tuning of this will be needed to achieve the desired default configuration.
This is not attempted for the time being.

The PR also adds to the `o2-sim` executable a command line parameter to allow the user to specify an alternative file via 
```
--decayConfig [filename]
```
