### PR TITLE
Add structure for upgrades

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@
 /DataFormats/Detectors/TOF                     @noferini 
 /DataFormats/Detectors/TPC                     @davidrohr @wiechula @shahor02
 /DataFormats/Detectors/TRD                     @jolopezl @bazinski @tdietel
+/DataFormats/Detectors/Upgrades                @qgp @marcovanleeuwen
 /DataFormats/Detectors/ZDC                     @coppedis
 
 #/DataFormats/Headers
@@ -66,6 +67,7 @@
 /Detectors/TOF                     @noferini 
 /Detectors/TPC                     @davidrohr @wiechula @shahor02
 /Detectors/TRD                     @jolopezl @bazinski @tdietel
+/Detectors/Upgrades                @qgp @marcovanleeuwen
 /Detectors/ZDC                     @coppedis
 
 /EventVisualisation  @jmyrcha @AliceO2Group/framework-admins

--- a/DataFormats/Detectors/Upgrades/CMakeLists.txt
+++ b/DataFormats/Detectors/Upgrades/CMakeLists.txt
@@ -7,21 +7,3 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
-
-# @brief  cmake setup for the DataFormats module of AliceO2
-
-add_subdirectory(Common)
-add_subdirectory(TPC)
-add_subdirectory(ITSMFT)
-add_subdirectory(MUON)
-add_subdirectory(TOF)
-add_subdirectory(FIT)
-add_subdirectory(EMCAL)
-add_subdirectory(ZDC)
-add_subdirectory(TRD)
-add_subdirectory(PHOS)
-add_subdirectory(CPV)
-
-if(ENABLE_UPGRADES)
-  add_subdirectory(Upgrades)
-endif()

--- a/DataFormats/Detectors/Upgrades/CMakeLists.txt
+++ b/DataFormats/Detectors/Upgrades/CMakeLists.txt
@@ -7,3 +7,5 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
+
+message(STATUS "Building dataformats for upgrades")

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -40,3 +40,7 @@ if(BUILD_SIMULATION)
 endif()
 
 o2_data_file(COPY Geometry DESTINATION Detectors)
+
+if(ENABLE_UPGRADES)
+  add_subdirectory(Upgrades)
+endif()

--- a/Detectors/Upgrades/CMakeLists.txt
+++ b/Detectors/Upgrades/CMakeLists.txt
@@ -7,3 +7,5 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
+
+message(STATUS "Building detectors for upgrades")

--- a/Detectors/Upgrades/CMakeLists.txt
+++ b/Detectors/Upgrades/CMakeLists.txt
@@ -7,21 +7,3 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
-
-# @brief  cmake setup for the DataFormats module of AliceO2
-
-add_subdirectory(Common)
-add_subdirectory(TPC)
-add_subdirectory(ITSMFT)
-add_subdirectory(MUON)
-add_subdirectory(TOF)
-add_subdirectory(FIT)
-add_subdirectory(EMCAL)
-add_subdirectory(ZDC)
-add_subdirectory(TRD)
-add_subdirectory(PHOS)
-add_subdirectory(CPV)
-
-if(ENABLE_UPGRADES)
-  add_subdirectory(Upgrades)
-endif()

--- a/cmake/O2DefineOptions.cmake
+++ b/cmake/O2DefineOptions.cmake
@@ -28,5 +28,5 @@ function(o2_define_options)
   # for the complete picture of how BUILD_SIMULATION is handled see
   # ../dependencies/O2SimulationDependencies.cmake
 
-  option(ENABLE_UPGRADES "Enable detectros for upgrades" ON)
+  option(ENABLE_UPGRADES "Enable detectors for upgrades" OFF)
 endfunction()

--- a/cmake/O2DefineOptions.cmake
+++ b/cmake/O2DefineOptions.cmake
@@ -28,4 +28,5 @@ function(o2_define_options)
   # for the complete picture of how BUILD_SIMULATION is handled see
   # ../dependencies/O2SimulationDependencies.cmake
 
+  option(ENABLE_UPGRADES "Enable detectros for upgrades" ON)
 endfunction()


### PR DESCRIPTION
@ktf @davidrohr @mconcas @mpuccio @marcovanleeuwen

As discussed some time ago, introduction of `Upgrades` directory to contain evolving detectors for future upgrades (s.a. ITS3, FoCal, post-LS4, ...). Please comment if this looks fine to you or if you'd prefer to handle this differently