### PR TITLE
Simplifying writer specs in the GlobalTracking workflows

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TrackWriterTPCITSSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TrackWriterTPCITSSpec.h
@@ -13,12 +13,7 @@
 #ifndef O2_TRACKWRITER_TPCITS
 #define O2_TRACKWRITER_TPCITS
 
-#include "TFile.h"
-#include "TTree.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-#include <string>
 
 using namespace o2::framework;
 
@@ -26,26 +21,6 @@ namespace o2
 {
 namespace globaltracking
 {
-
-class TrackWriterTPCITS : public Task
-{
- public:
-  TrackWriterTPCITS(bool useMC = true) : mUseMC(useMC) {}
-  ~TrackWriterTPCITS() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-  void endOfStream(EndOfStreamContext& ec) final;
-
- private:
-  bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-  std::string mOutFileName = "o2match_itstpc.root";
-  std::string mTreeName = "matchTPCITS";
-  std::string mOutTPCITSTracksBranchName = "TPCITS";        ///< name of branch containing output matched tracks
-  std::string mOutTPCMCTruthBranchName = "MatchTPCMCTruth"; ///< name of branch for output matched tracks TPC MC
-  std::string mOutITSMCTruthBranchName = "MatchITSMCTruth"; ///< name of branch for output matched tracks ITS MC
-};
 
 /// create a processor spec
 /// write ITS tracks a root file

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
@@ -13,36 +13,12 @@
 
 /// @file   TPCResidualWriterSpec.h
 
-#include "TFile.h"
-#include "TTree.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-#include <string>
 
 namespace o2
 {
 namespace tpc
 {
-
-class ResidualWriterTPC : public o2::framework::Task
-{
- public:
-  ResidualWriterTPC(bool useMC = false) : mUseMC(useMC) {}
-  ~ResidualWriterTPC() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
-
- private:
-  bool mUseMC = false;                               ///< MC flag
-  std::string mOutFileName = "o2residuals_tpc.root"; ///< name of output file
-  std::string mTreeName = "residualsTPC";            ///< name of tree containing output
-  std::string mOutTracksBranchName = "tracks";       ///< name of branch containing output used tracks
-  std::string mOutResidualsBranchName = "residuals"; ///< name of branch containing output used residuals
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-};
 
 /// create a processor spec
 framework::DataProcessorSpec getTPCResidualWriterSpec(bool useMC);


### PR DESCRIPTION
Replacing duplicated boiler plate code by DPL RootTreeWriter.