### PR TITLE
Using the RootTreeWriter as writer for TPC digits in the digitization workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -16,12 +16,10 @@
 #include "TPCDigitRootWriterSpec.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "CommonDataFormat/RangeReference.h"
-#include "Framework/CallbackService.h"
-#include "Framework/ConfigParamRegistry.h"
-#include "Framework/ControlService.h"
 #include "Framework/InputRecord.h"
 #include "Framework/InputRecordWalker.h"
 #include "Framework/WorkflowSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TPCBase/Sector.h"
 #include "DataFormatsTPC/Digit.h"
 #include "TPCSimulation/CommonMode.h"
@@ -32,11 +30,9 @@
 #include <TBranch.h>
 #include <memory> // for make_shared, make_unique, unique_ptr
 #include <stdexcept>
-#include <sstream>
 #include <string>
 #include <vector>
 #include <utility>
-#include <gsl/gsl>
 
 using namespace o2::framework;
 using namespace o2::header;
@@ -45,265 +41,239 @@ using DigiGroupRef = o2::dataformats::RangeReference<int, int>;
 
 namespace o2
 {
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
 namespace tpc
 {
-
-template <typename T>
-TBranch* getOrMakeBranch(TTree& tree, std::string basename, int sector, T* ptr)
-{
-  std::stringstream stream;
-  stream << basename << "_" << sector;
-  const auto brname = stream.str();
-  if (auto br = tree.GetBranch(brname.c_str())) {
-    br->SetAddress(static_cast<void*>(&ptr));
-    return br;
-  }
-  // otherwise make it
-  return tree.Branch(brname.c_str(), ptr);
-}
 
 /// create the processor spec
 /// describing a processor aggregating digits for various TPC sectors and writing them to file
 /// MC truth information is also aggregated and written out
 DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfiguration, bool mctruth)
 {
-  auto initFunction = [](InitContext& ic) {
-    // get the option from the init context
-    auto filename = ic.options().get<std::string>("tpc-digit-outfile");
-    auto treename = ic.options().get<std::string>("treename");
+  // the callback to be set as hook for custom action when the writer is closed
+  auto finishWriting = [](TFile* outputfile, TTree* outputtree) {
+    // check/verify number of entries (it should be same in all branches)
 
-    auto outputfile = std::make_shared<TFile>(filename.c_str(), "RECREATE");
-    auto outputtree = std::make_shared<TTree>(treename.c_str(), treename.c_str());
+    // will return a TObjArray
+    const auto brlist = outputtree->GetListOfBranches();
+    int entries = -1; // init to -1 (as unitialized)
+    for (TObject* entry : *brlist) {
+      auto br = static_cast<TBranch*>(entry);
+      int brentries = br->GetEntries();
+      if (entries == -1) {
+        entries = brentries;
+      } else {
+        if (brentries != entries && !TString(br->GetName()).Contains("CommonMode")) {
+          LOG(WARNING) << "INCONSISTENT NUMBER OF ENTRIES IN BRANCH " << br->GetName() << ": " << entries << " vs " << brentries;
+        }
+      }
+    }
+    if (entries > 0) {
+      outputtree->SetEntries(entries);
+    }
+    outputtree->Write();
+    outputfile->Close();
+  };
 
-    // container for cached grouping of digits
-    // TODO: once InputRecord::ReturnType helper has been merged
-    // using DigitGroupRefInputContainer = InputRecord::ReturnType<std::vector<DigiGroupRef>>;
-    using DigitGroupRefInputContainer = decltype(std::declval<InputRecord>().get<std::vector<DigiGroupRef>>(DataRef{nullptr, nullptr, nullptr}));
-    auto trigP2Sect = std::make_shared<std::array<DigitGroupRefInputContainer, 36>>();
+  //branch definitions for RootTreeWriter spec
+  using DigitsOutputType = std::vector<o2::tpc::Digit>;
+  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using CommonModeOutputType = std::vector<o2::tpc::CommonMode>;
 
-    // the callback to be set as hook at stop of processing for the framework
-    auto finishWriting = [outputfile, outputtree]() {
-      // check/verify number of entries (it should be same in all branches)
+  // extracts the sector from header of an input
+  auto extractSector = [](auto const& ref) {
+    auto sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+    if (!sectorHeader) {
+      throw std::runtime_error("Missing sector header in TPC data");
+    }
+    // the TPCSectorHeader now allows to transport information for more than one sector,
+    // e.g. for transporting clusters in one single data block. The digitization is however
+    // only on sector level
+    if (sectorHeader->sector() >= TPCSectorHeader::NSectors) {
+      throw std::runtime_error("Digitizer can only work on single sectors");
+    }
+    return sectorHeader->sector();
+  };
 
-      // will return a TObjArray
-      const auto brlist = outputtree->GetListOfBranches();
-      int entries = -1; // init to -1 (as unitialized)
-      for (TObject* entry : *brlist) {
-        auto br = static_cast<TBranch*>(entry);
-        int brentries = br->GetEntries();
-        if (entries == -1) {
-          entries = brentries;
+  // The generic writer needs a way to associate incoming data with the individual branches for
+  // the TPC sectors. The sector number is transmitted as part of the sector header, the callback
+  // finds the corresponding index in the vector of configured sectors
+  auto getIndex = [laneConfiguration, extractSector](o2::framework::DataRef const& ref) -> size_t {
+    auto sector = extractSector(ref);
+    if (sector < 0) {
+      // special data sets, don't write
+      return ~(size_t)0;
+    }
+    size_t index = 0;
+    for (auto const& s : laneConfiguration) {
+      if (sector == s) {
+        return index;
+      }
+      ++index;
+    }
+    throw std::runtime_error("sector " + std::to_string(sector) + " not configured for writing");
+  };
+
+  // callback to create branch name
+  auto getName = [laneConfiguration](std::string base, size_t index) -> std::string {
+    return base + "_" + std::to_string(laneConfiguration.at(index));
+  };
+
+  // container for cached grouping of digits
+  auto trigP2Sect = std::make_shared<std::array<std::vector<DigiGroupRef>, 36>>();
+
+  // preprocessor callback
+  // read the trigger data first and store in the trigP2Sect shared pointer
+  auto preprocessor = [extractSector, trigP2Sect](ProcessingContext& pc) {
+    for (auto& cont : *trigP2Sect) {
+      cont.clear();
+    }
+    std::vector<InputSpec> filter = {
+      {"check", ConcreteDataTypeMatcher{"TPC", "DIGTRIGGERS"}, Lifetime::Timeframe},
+    };
+    for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+      auto sector = extractSector(ref);
+      auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
+      LOG(INFO) << "HAVE TRIGGER DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
+      if (sector >= 0) {
+        // extract the trigger information and make it available for the other handlers
+        auto triggers = pc.inputs().get<std::vector<DigiGroupRef>>(ref);
+        (*trigP2Sect)[sector].assign(triggers.begin(), triggers.end());
+        const auto& trigS = (*trigP2Sect)[sector];
+        LOG(INFO) << "GOT Triggers of sector " << sector << " | SIZE " << trigS.size();
+      }
+    }
+  };
+
+  // handler to fill the digit branch, this handles filling based on the trigger information, each trigger
+  // will be a new entry
+  auto fillDigits = [extractSector, trigP2Sect](TBranch& branch, DigitsOutputType const& digiData, DataRef const& ref) {
+    auto sector = extractSector(ref);
+    auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
+    LOG(INFO) << "HAVE DIGIT DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
+    if (sector >= 0) {
+      LOG(INFO) << "DIGIT SIZE " << digiData.size();
+      const auto& trigS = (*trigP2Sect.get())[sector];
+      if (!trigS.size()) {
+        std::runtime_error("Digits for sector " + std::to_string(sector) + " are received w/o info on grouping in triggers");
+      } else { // check consistency of Ndigits with that of expected from the trigger
+        int nExp = trigS.back().getFirstEntry() + trigS.back().getEntries() - trigS.front().getFirstEntry();
+        if (nExp != digiData.size()) {
+          LOG(ERROR) << "Number of digits " << digiData.size() << " is inconsistent with expectation " << nExp
+                     << " from digits grouping for sector " << sector;
+        }
+      }
+
+      {
+        if (trigS.size() == 1) { // just 1 entry (continous mode?), use digits directly
+          auto ptr = &digiData;
+          branch.SetAddress(&ptr);
+          branch.Fill();
+          branch.ResetAddress();
+        } else {                                // triggered mode (>1 entries will be written)
+          std::vector<o2::tpc::Digit> digGroup; // group of digits related to single trigger
+          auto ptr = &digGroup;
+          branch.SetAddress(&ptr);
+          for (auto const& group : trigS) {
+            digGroup.clear();
+            for (int i = 0; i < group.getEntries(); i++) {
+              digGroup.emplace_back(digiData[group.getFirstEntry() + i]); // fetch digits of given trigger
+            }
+            branch.Fill();
+          }
+          branch.ResetAddress();
+        }
+      }
+    }
+  };
+
+  // handler for labels
+  // TODO: this is almost a copy of the above, reduce to a single methods with amends
+  auto fillLabels = [extractSector, trigP2Sect](TBranch& branch, MCLabelContainer const& labeldata, DataRef const& ref) {
+    auto sector = extractSector(ref);
+    auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
+    LOG(INFO) << "HAVE LABEL DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
+    if (sector >= 0) {
+      LOG(INFO) << "MCTRUTH ELEMENTS " << labeldata.getIndexedSize()
+                << " WITH " << labeldata.getNElements() << " LABELS";
+      const auto& trigS = (*trigP2Sect.get())[sector];
+      if (!trigS.size()) {
+        throw std::runtime_error("MCTruth for sector " + std::to_string(sector) + " are received w/o info on grouping in triggers");
+      } else {
+        int nExp = trigS.back().getFirstEntry() + trigS.back().getEntries() - trigS.front().getFirstEntry();
+        if (nExp != labeldata.getIndexedSize()) {
+          LOG(ERROR) << "Number of indexed (label) slots " << labeldata.getIndexedSize()
+                     << " is inconsistent with expectation " << nExp
+                     << " from digits grouping for sector " << sector;
+        }
+      }
+      {
+        if (trigS.size() == 1) { // just 1 entry (continous mode?), use labels directly
+          auto ptr = &labeldata;
+          branch.SetAddress(&ptr);
+          branch.Fill();
+          branch.ResetAddress();
         } else {
-          if (brentries != entries && !TString(br->GetName()).Contains("CommonMode")) {
-            LOG(WARNING) << "INCONSISTENT NUMBER OF ENTRIES IN BRANCH " << br->GetName() << ": " << entries << " vs " << brentries;
+          o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblGroup; // labels for group of digits related to single trigger
+          auto ptr = &lblGroup;
+          branch.SetAddress(&ptr);
+          for (auto const& group : trigS) {
+            lblGroup.clear();
+            for (int i = 0; i < group.getEntries(); i++) {
+              auto lbls = labeldata.getLabels(group.getFirstEntry() + i);
+              lblGroup.addElements(i, lbls);
+            }
+            branch.Fill();
           }
+          branch.ResetAddress();
         }
       }
-      if (entries > 0) {
-        outputtree->SetEntries(entries);
-      }
-      outputtree->Write();
-      outputfile->Close();
-    };
-    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishWriting);
-
-    // set up the processing function
-    // using by-copy capture of the worker instance shared pointer
-    // the shared pointer makes sure to clean up the instance when the processing
-    // function gets out of scope
-    auto processingFct = [outputfile, outputtree, trigP2Sect](ProcessingContext& pc) {
-      // extracts the sector from header of an input
-      auto extractSector = [&pc](auto const& ref) {
-        auto sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
-        if (!sectorHeader) {
-          throw std::runtime_error("Missing sector header in TPC data");
-        }
-        // the TPCSectorHeader now allows to transport information for more than one sector,
-        // e.g. for transporting clusters in one single data block. The digitization is however
-        // only on sector level
-        if (sectorHeader->sector() >= TPCSectorHeader::NSectors) {
-          throw std::runtime_error("Digitizer can only work on single sectors");
-        }
-        return sectorHeader->sector();
-      };
-
-      // read the trigger data first
-      {
-        std::vector<InputSpec> filter = {
-          {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGTRIGGERS"}, Lifetime::Timeframe},
-        };
-        for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
-          auto sector = extractSector(ref);
-          auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
-          LOG(INFO) << "HAVE TRIGGER DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
-          if (sector >= 0) {
-            auto triggers = pc.inputs().get<std::vector<DigiGroupRef>>(ref);
-            (*trigP2Sect.get())[sector] = std::move(triggers);
-            const auto& trigS = (*trigP2Sect.get())[sector];
-            LOG(INFO) << "GOT Triggers of sector " << sector << " | SIZE " << trigS.size();
-          }
-        }
-      }
-
-      {
-        // probe which channel has data and of what kind
-        // a) probe for digits:
-        std::vector<InputSpec> filter = {
-          {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe},
-        };
-        for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
-          auto sector = extractSector(ref);
-          auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
-          LOG(INFO) << "HAVE DIGIT DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
-          if (sector >= 0) {
-            // the digits
-            auto digiData = pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref);
-            LOG(INFO) << "DIGIT SIZE " << digiData.size();
-            const auto& trigS = (*trigP2Sect.get())[sector];
-            if (!trigS.size()) {
-              LOG(FATAL) << "Digits for sector " << sector << " are received w/o info on grouping in triggers";
-            } else { // check consistency of Ndigits with that of expected from the trigger
-              int nExp = trigS.back().getFirstEntry() + trigS.back().getEntries() - trigS.front().getFirstEntry();
-              if (nExp != digiData.size()) {
-                LOG(ERROR) << "Number of digits " << digiData.size() << " is inconsistent with expectation " << nExp
-                           << " from digits grouping for sector " << sector;
-              }
-            }
-
-            {
-              if (trigS.size() == 1) { // just 1 entry (continous mode?), use digits directly
-                // connect this to a particular branch
-                // the input data span is directly using the raw buffer, we need to copy to
-                // the object we want to write, maybe we can avoid this with some tricks
-                std::vector<o2::tpc::Digit> writeObj(digiData.begin(), digiData.end());
-                auto digP = &writeObj;
-                auto br = getOrMakeBranch(*outputtree.get(), "TPCDigit", sector, digP);
-                br->Fill();
-                br->ResetAddress();
-              } else {                                // triggered mode (>1 entries will be written)
-                std::vector<o2::tpc::Digit> digGroup; // group of digits related to single trigger
-                auto digGroupPtr = &digGroup;
-                auto br = getOrMakeBranch(*outputtree.get(), "TPCDigit", sector, digGroupPtr);
-                for (auto grp : trigS) {
-                  digGroup.clear();
-                  for (int i = 0; i < grp.getEntries(); i++) {
-                    digGroup.emplace_back(digiData[grp.getFirstEntry() + i]); // fetch digits of given trigger
-                  }
-                  br->Fill();
-                }
-                br->ResetAddress();
-              }
-            }
-          }
-        } // end digit case
-      }
-
-      {
-        // b) probe for labels
-        std::vector<InputSpec> filter = {
-          {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITSMCTR"}, Lifetime::Timeframe},
-        };
-        for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
-          auto sector = extractSector(ref);
-          auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
-          LOG(INFO) << "HAVE LABEL DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
-          if (sector >= 0) {
-            // the labels
-            auto labeldata = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>(ref);
-            auto labeldataRaw = labeldata.get();
-            LOG(INFO) << "MCTRUTH ELEMENTS " << labeldataRaw->getIndexedSize()
-                      << " WITH " << labeldataRaw->getNElements() << " LABELS";
-            const auto& trigS = (*trigP2Sect.get())[sector];
-            if (!trigS.size()) {
-              LOG(FATAL) << "MCTruth for sector " << sector << " are received w/o info on grouping in triggers";
-            } else {
-              int nExp = trigS.back().getFirstEntry() + trigS.back().getEntries() - trigS.front().getFirstEntry();
-              if (nExp != labeldataRaw->getIndexedSize()) {
-                LOG(ERROR) << "Number of indexed (label) slots " << labeldataRaw->getIndexedSize()
-                           << " is inconsistent with expectation " << nExp
-                           << " from digits grouping for sector " << sector;
-              }
-            }
-            {
-              if (trigS.size() == 1) { // just 1 entry (continous mode?), use labels directly
-                auto br = getOrMakeBranch(*outputtree.get(), "TPCDigitMCTruth", sector, &labeldataRaw);
-                br->Fill();
-                br->ResetAddress();
-              } else {
-                o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblGroup; // labels for group of digits related to single trigger
-                auto lblGroupPtr = &lblGroup;
-                auto br = getOrMakeBranch(*outputtree.get(), "TPCDigitMCTruth", sector, &lblGroupPtr);
-                for (auto grp : trigS) {
-                  lblGroup.clear();
-                  for (int i = 0; i < grp.getEntries(); i++) {
-                    auto lbls = labeldataRaw->getLabels(grp.getFirstEntry() + i);
-                    lblGroup.addElements(i, lbls);
-                  }
-                  br->Fill();
-                }
-              }
-            }
-          }
-        } // end label case
-      }
-
-      {
-        // c) probe for common mode:
-        std::vector<InputSpec> filter = {
-          {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "COMMONMODE"}, Lifetime::Timeframe},
-        };
-        for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
-          auto sector = extractSector(ref);
-          auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
-          LOG(INFO) << "HAVE COMMON MODE DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
-          const auto& trigS = (*trigP2Sect.get())[sector];
-          if (sector >= 0) {
-            auto commonModeData = pc.inputs().get<std::vector<o2::tpc::CommonMode>>(ref);
-            LOG(INFO) << "COMMON MODE SIZE " << commonModeData.size();
-
-            if (!trigS.size()) {
-              LOG(FATAL) << "CommonMode for sector " << sector << " are received w/o info on grouping in triggers";
-            }
-            {
-              auto digC = &commonModeData;
-              auto br = getOrMakeBranch(*outputtree.get(), "TPCCommonMode", sector, digC);
-              br->Fill();
-              br->ResetAddress();
-            }
-          }
-        } // end common mode case
-      }
-    };
-
-    // return the actual processing function as a lambda function using variables
-    // of the init function
-    return processingFct;
+    }
   };
 
-  std::vector<InputSpec> inputs = {
-    {"digitinput", "TPC", "DIGITS", 0, Lifetime::Timeframe},        // digit input
-    {"triggerinput", "TPC", "DIGTRIGGERS", 0, Lifetime::Timeframe}, // groupping in triggers
-    {"commonmodeinput", "TPC", "COMMONMODE", 0, Lifetime::Timeframe},
+  // A spectator to print logging for the common mode data
+  auto commonModeSpectator = [extractSector](CommonModeOutputType const& commonModeData, DataRef const& ref) {
+    auto sector = extractSector(ref);
+    auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
+    LOG(INFO) << "HAVE COMMON MODE DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
+    LOG(INFO) << "COMMON MODE SIZE " << commonModeData.size();
   };
-  if (mctruth) {
-    inputs.emplace_back("labelinput", "TPC", "DIGITSMCTR", 0, Lifetime::Timeframe);
-  }
 
-  auto amendInput = [&laneConfiguration](InputSpec& spec, size_t index) {
-    spec.binding += std::to_string(laneConfiguration[index]);
-    DataSpecUtils::updateMatchingSubspec(spec, laneConfiguration[index]);
-  };
-  inputs = mergeInputs(inputs, laneConfiguration.size(), amendInput);
+  auto digitsdef = BranchDefinition<DigitsOutputType>{InputSpec{"digits", ConcreteDataTypeMatcher{"TPC", "DIGITS"}},
+                                                      "TPCDigit", "digits-branch-name",
+                                                      laneConfiguration.size(),
+                                                      fillDigits,
+                                                      getIndex,
+                                                      getName};
 
-  return DataProcessorSpec{
-    "TPCDigitWriter",
-    inputs,
-    {}, // no output
-    AlgorithmSpec(initFunction),
-    Options{
-      {"tpc-digit-outfile", VariantType::String, "tpcdigits.root", {"Name of the input file"}},
-      {"treename", VariantType::String, "o2sim", {"Name of tree for tracks"}},
-    }};
+  auto labelsdef = BranchDefinition<MCLabelContainer>{InputSpec{"labelinput", ConcreteDataTypeMatcher{"TPC", "DIGITSMCTR"}},
+                                                      "TPCDigitMCTruth", "labels-branch-name",
+                                                      // this branch definition is disabled if MC labels are not processed
+                                                      (mctruth ? laneConfiguration.size() : 0),
+                                                      fillLabels,
+                                                      getIndex,
+                                                      getName};
+
+  auto commddef = BranchDefinition<CommonModeOutputType>{InputSpec{"commonmode", ConcreteDataTypeMatcher{"TPC", "COMMONMODE"}},
+                                                         "TPCCommonMode", "common-mode-branch-name",
+                                                         laneConfiguration.size(),
+                                                         commonModeSpectator,
+                                                         getIndex,
+                                                         getName};
+
+  return MakeRootTreeWriterSpec("TPCDigitWriter", "tpcdigits.root", "o2sim",
+                                // the preprocessor reads the trigger info object and makes it available
+                                // to the Fill handlers
+                                MakeRootTreeWriterSpec::Preprocessor{preprocessor},
+                                // defining the input for the trigger object, as an auxiliary input it is
+                                // not written to any branch
+                                MakeRootTreeWriterSpec::AuxInputRoute{{"triggerinput", ConcreteDataTypeMatcher{"TPC", "DIGTRIGGERS"}}},
+                                // setting a custom callback for closing the writer
+                                MakeRootTreeWriterSpec::CustomClose(finishWriting),
+                                // passing the branch configuration as argument pack
+                                std::move(digitsdef), std::move(labelsdef), std::move(commddef))();
 }
 } // end namespace tpc
 } // end namespace o2


### PR DESCRIPTION
The implementation of digitization of triggered TPC data makes the corresponding
writer special, because the entries are split based on a trigger info object.
This is handled using specific branch callbacks for writing portions of digits and
labels.