### PR TITLE
TRD: trigger and pileup implementation 

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -87,6 +87,13 @@ class Digitizer
   int mEventID = 0;
   int mSrcID = 0;
 
+  enum EventType {
+    kFirstEvent,
+    kPileupEvent,
+    kTriggerFired,
+    kEmbeddingEvent
+  };
+
   // Trigger parameters
   bool mTriggeredEvent = false;
   static constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.
@@ -115,10 +122,12 @@ class Digitizer
   void setSimulationParameters();
 
   // Digitization chain methods
-  void triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
+  int triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void pileup();
+  SignalContainer addSignalsFromPileup();
+  void clearContainers();
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                // True if signal-to-ADC conversion is successful
+  bool convertSignalsToADC(const SignalContainer&, DigitContainer&, int thread = 0);          // True if signal-to-ADC conversion is successful
   void addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -40,7 +40,6 @@ class PadResponse;
 
 struct SignalArray {
   double firstTBtime;                     // first TB time
-  bool trigger;                           // true if signal comes from a trigger event, false otherwise (from pileup)
   std::array<float, kTimeBins> signals{}; // signals
   std::unordered_map<int, int> trackIds;  // tracks Ids associated to the signal
   std::vector<MCLabel> labels;            // labels associated to the signal

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -118,7 +118,7 @@ class Digitizer
   void triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void pileup();
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToADC(const int, SignalContainer&, DigitContainer&, int thread = 0);     // True if signal-to-ADC conversion is successful
+  bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                // True if signal-to-ADC conversion is successful
   void addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -12,15 +12,20 @@
 #define ALICEO2_TRD_DIGITIZER_H_
 
 #include "TRDSimulation/Detector.h"
+
+#include "TRDBase/Calibrations.h"
 #include "TRDBase/Digit.h"
 #include "TRDBase/MCLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
-
 #include "TRDBase/TRDCommonParam.h"
 #include "TRDBase/TRDDiffAndTimeStructEstimator.h"
-#include "TRDBase/Calibrations.h"
 
 #include "MathUtils/RandomRing.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+
+#include <array>
+#include <deque>
+#include <unordered_map>
+#include <vector>
 
 namespace o2
 {

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -81,16 +81,17 @@ class Digitizer
   std::vector<math_utils::RandomRing<>> mLogRandomRings;  // pre-generated exp distributed random number
   std::vector<TRDDiffusionAndTimeStructEstimator> mDriftEstimators;
 
-  double mTime = 0.;                   // time in nanoseconds
-  double mLastTime = 1.0e10;           // starts in the future
-  double mCurrentTriggerTime = 1.0e10; // starts in the future
+  double mTime = 0.;               // time in nanoseconds
+  double mLastTime = -1;           // negative, by default to flag the first event
+  double mCurrentTriggerTime = -1; // negative, by default to flag the first event
   int mEventID = 0;
   int mSrcID = 0;
 
   // Trigger parameters
   bool mTriggeredEvent = false;
-  static constexpr double READOUT_TIME = 3000;            // the time the readout takes, as 30 TB = 3 micro-s.
-  static constexpr double BUSY_TIME = READOUT_TIME + 200; // the time for which no new trigger can be received in nanoseconds
+  static constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.
+  static constexpr double DEAD_TIME = 200;                      // trigger deadtime, 2 micro-s
+  static constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no new trigger can be received in nanoseconds
 
   // Digitization parameters
   static constexpr float AmWidth = TRDGeometry::amThick(); // Width of the amplification region
@@ -108,11 +109,9 @@ class Digitizer
   std::vector<HitType> mHitContainer;                            // the container of hits in a given detector
   std::vector<MCLabel> mMergedLabels;                            // temporary label container
   std::array<SignalContainer, kNdet> mSignalsMapCollection;      // container for caching signals over a timeframe
-  std::array<DigitContainer, kNdet> mDigitsCollection;           // container for caching digits for paralellization
   std::deque<std::array<SignalContainer, kNdet>> mPileupSignals; // container for piled up signals
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
-  void clearCollections();
   void setSimulationParameters();
 
   // Digitization chain methods

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -34,8 +34,9 @@ class TRDArraySignal;
 class PadResponse;
 
 struct SignalArray {
-  std::array<float, kTimeBins> signals{}; // signals
   double firstTBtime;                     // first TB time
+  bool trigger;                           // true if signal comes from a trigger event, false otherwise (from pileup)
+  std::array<float, kTimeBins> signals{}; // signals
   std::unordered_map<int, int> trackIds;  // tracks Ids associated to the signal
   std::vector<MCLabel> labels;            // labels associated to the signal
 };
@@ -83,6 +84,7 @@ class Digitizer
   int mSrcID = 0;
 
   // Trigger parameters
+  bool mTriggeredEvent = false;
   static constexpr double READOUT_TIME = 3000;            // the time the readout takes, as 30 TB = 3 micro-s.
   static constexpr double BUSY_TIME = READOUT_TIME + 200; // the time for which no new trigger can be received in nanoseconds
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -201,8 +201,6 @@ void Digitizer::triggerEventProcessing(DigitContainer& digits, o2::dataformats::
   if ((mTime - mCurrentTriggerTime) < BUSY_TIME) {
     // do not change the current trigger time and add send the signal containers to the pileup container
     pileup();
-    mLastTime = mTime;
-    mTriggeredEvent = false;
   } else {
     // flush the digits: signals from the pileup container are converted to adcs
     // digits and labels are produced
@@ -210,7 +208,6 @@ void Digitizer::triggerEventProcessing(DigitContainer& digits, o2::dataformats::
     flush(digits, labels);
     mCurrentTriggerTime = mTime;
     mLastTime = mTime;
-    mTriggeredEvent = true;
   }
 }
 
@@ -445,7 +442,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
 
         const int key = calculateKey(det, rowE, colPos);
         auto& currentSignalData = signalMapCont[key]; // Get the old signal or make a new one if it doesn't exist
-        currentSignalData.trigger = mTriggeredEvent;  // keep record if the signals are from a trigger event or not
         auto& currentSignal = currentSignalData.signals;
         auto& trackIds = currentSignalData.trackIds;
         auto& labels = currentSignalData.labels;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -102,7 +102,6 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
           }
           // add only what's leftover from this signal
           int idx = (int)((mCurrentTriggerTime - signalArray.firstTBtime) * 0.01); // number of bins to add, from the tail
-//          LOG(INFO) << "(older) Start position: " << idx << "\t Current trigger time: " << mCurrentTriggerTime << "\t First TB time: " << signalArray.firstTBtime;
           auto it0 = signalArray.signals.begin() + idx;
           auto it1 = fullSignal[key].signals.begin();
           while (it0 < signalArray.signals.end()) {
@@ -113,7 +112,6 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
         } else {
           // the signal is from a triggered event
           int idx = (int)((signalArray.firstTBtime - mCurrentTriggerTime) * 0.01); // number of bins to add, on the tail of the final signal
-//          LOG(INFO) << "(newer) Start position: " << idx << "\t Current trigger time: " << mCurrentTriggerTime << "\t First TB time: " << signalArray.firstTBtime;
           auto it0 = signalArray.signals.begin();
           auto it1 = fullSignal[key].signals.begin() + idx;
           while (it1 < fullSignal[key].signals.end()) {
@@ -165,7 +163,10 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
 void Digitizer::pileup()
 {
   mPileupSignals.push_back(mSignalsMapCollection);
-  std::for_each(mSignalsMapCollection.begin(), mSignalsMapCollection.end(), [](SignalContainer& sc) { sc.clear(); });
+  // clear the signal map collection - always!
+  for (auto& sm : mSignalsMapCollection) {
+    sm.clear();
+  }
 }
 
 void Digitizer::triggerEventProcessing(DigitContainer& digits, o2::dataformats::MCTruthContainer<MCLabel>& labels)

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -188,31 +188,25 @@ int Digitizer::triggerEventProcessing(DigitContainer& digits, o2::dataformats::M
 {
   if (mCurrentTriggerTime < 0 && mLastTime < 0) {
     // very first event
-    LOG(INFO) << "First event recieved";
     mCurrentTriggerTime = mTime;
     mLastTime = mTime;
-    LOG(INFO) << "First event, current trigger time = " << mCurrentTriggerTime;
     return EventType::kFirstEvent;
   }
   if (mTime > mLastTime) {
     if ((mTime - mCurrentTriggerTime) < BUSY_TIME) {
       // send the signal containers to the pileup container, and do not change the current trigger time.
-      LOG(INFO) << "Pileup event, current trigger time = " << mCurrentTriggerTime;
       pileup();
       mLastTime = mTime;
       return EventType::kPileupEvent;
     } else {
       // flush the digits: signals from the pileup container are converted to adcs
       // digits and labels are produced, and the current trigger time is changed after the flush is completed
-      LOG(INFO) << "Separated event recieved, current trigger time = " << mCurrentTriggerTime;
       flush(digits, labels);
       mCurrentTriggerTime = mTime;
       mLastTime = mTime;
-      LOG(INFO) << "Separated event flushed, current trigger time = " << mCurrentTriggerTime;
       return EventType::kTriggerFired;
     }
   } else {
-    LOG(INFO) << "Embedding event recieved, keep going";
     return EventType::kEmbeddingEvent;
   }
 }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -126,10 +126,11 @@ SignalContainer Digitizer::addSignalsFromPileup()
         const SignalArray& signalArray = signal.second;
         // check if the signal is from a previous event
         if (signalArray.firstTBtime < mCurrentTriggerTime) {
-          if ((mCurrentTriggerTime - signalArray.firstTBtime) < (READOUT_TIME + BUSY_TIME)) {
+          if ((mCurrentTriggerTime - signalArray.firstTBtime) < BUSY_TIME) {
             continue; // ignore the signal if it  is too old.
           }
           // add only what's leftover from this signal
+          // 0.01 = samplingRate/1000, 1/1000 to go from ns to micro-s, the sampling rate is in 1/micro-s
           int idx = (int)((mCurrentTriggerTime - signalArray.firstTBtime) * 0.01); // number of bins to add, from the tail
           auto it0 = signalArray.signals.begin() + idx;
           auto it1 = addedSignalsMap[key].signals.begin();


### PR DESCRIPTION
Two things take place here:

- The implementation of signals pileup, and
- a basic trigger for the TRD, with dead time.

We may want to discuss where to keep the trigger. 

To do:

- Take the trigger information to the trigger records object, or
- omit the trigger records and use the digit time information instead, and
- map labels to digits by using and index in the MC label container (for another PR?)
