### PR TITLE
GPU: Revert size back to size_t in clusterizer

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.h
@@ -37,7 +37,7 @@ class GPUTPCCFPeakFinder : public GPUKernelTemplate
     PackedCharge buf[SCRATCH_PAD_WORK_GROUP_SIZE * SCRATCH_PAD_SEARCH_N];
   };
 
-  static GPUd() void findPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const ChargePos*, uint, uchar*, Array2D<uchar>&);
+  static GPUd() void findPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const ChargePos*, tpccf::SizeT, uchar*, Array2D<uchar>&);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;

--- a/GPU/GPUTracking/TPCClusterFinder/clusterFinderDefs.h
+++ b/GPU/GPUTracking/TPCClusterFinder/clusterFinderDefs.h
@@ -74,7 +74,7 @@ namespace gpu
 namespace tpccf
 {
 
-using SizeT = uint;
+using SizeT = size_t;
 using TPCTime = int;
 using TPCFragmentTime = short;
 using Pad = unsigned char;


### PR DESCRIPTION
This fixes a problem introduced in #3691 
@fweig : Could you have a look, I didn't dig deeper, but the change to uint seems to segfault on large events. This revert only that change, but leaves your cleanup in, which seems to be ok.