### PR TITLE
Tracklet error parameterization is loaded based on B-field, not per compiler flag anymore

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDDef.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDDef.h
@@ -28,10 +28,10 @@ class AliTrackerBase;
 #else
 namespace o2
 {
-namespace track
+namespace dataformats
 {
-class TrackParCov;
-} // namespace track
+class TrackTPCITS;
+} // namespace dataformats
 namespace base
 {
 class Propagator;
@@ -56,7 +56,7 @@ typedef AliExternalTrackParam TRDBaseTrackGPU;
 // class GPUTPCGMTrackParam;
 // typedef GPUTPCGMTrackParam TRDBaseTrack;
 #elif defined(TRD_TRACK_TYPE_O2)
-typedef o2::track::TrackParCov TRDBaseTrack;
+typedef o2::dataformats::TrackTPCITS TRDBaseTrack;
 class GPUTPCGMTrackParam;
 typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #endif

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -128,7 +128,7 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
 
 #if (defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE)) && !defined(GPUCA_GPUCODE) // Interface for O2, build only with O2
 
-#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
 #include "DetectorsBase/Propagator.h"
 
 namespace GPUCA_NAMESPACE
@@ -138,13 +138,13 @@ namespace gpu
 {
 
 template <>
-class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
+class trackInterface<o2::dataformats::TrackTPCITS> : public o2::dataformats::TrackTPCITS
 {
  public:
-  trackInterface<o2::track::TrackParCov>() = default;
-  trackInterface<o2::track::TrackParCov>(const trackInterface<o2::track::TrackParCov>& param) = default;
-  trackInterface<o2::track::TrackParCov>(const o2::track::TrackParCov& param) = delete;
-  trackInterface<o2::track::TrackParCov>(const GPUTPCGMMergedTrack& trk)
+  trackInterface<o2::dataformats::TrackTPCITS>() = default;
+  trackInterface<o2::dataformats::TrackTPCITS>(const trackInterface<o2::dataformats::TrackTPCITS>& param) = default;
+  trackInterface<o2::dataformats::TrackTPCITS>(const o2::dataformats::TrackTPCITS& param) = delete;
+  trackInterface<o2::dataformats::TrackTPCITS>(const GPUTPCGMMergedTrack& trk)
   {
     setX(trk.OuterParam().X);
     setAlpha(trk.OuterParam().alpha);
@@ -155,7 +155,7 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
       setCov(trk.OuterParam().C[i], i);
     }
   }
-  trackInterface<o2::track::TrackParCov>(const GPUTPCGMTrackParam::GPUTPCOuterParam& param)
+  trackInterface<o2::dataformats::TrackTPCITS>(const GPUTPCGMTrackParam::GPUTPCOuterParam& param)
   {
     setX(param.X);
     setAlpha(param.alpha);
@@ -183,7 +183,7 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
 
   bool CheckNumericalQuality() const { return true; }
 
-  typedef o2::track::TrackParCov baseClass;
+  typedef o2::dataformats::TrackTPCITS baseClass;
 };
 
 template <>
@@ -197,7 +197,7 @@ class propagatorInterface<o2::base::Propagator>
   bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep); }
   int getPropagatedYZ(My_Float x, My_Float& projY, My_Float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
 
-  void setTrack(trackInterface<o2::track::TrackParCov>* trk) { mParam = trk; }
+  void setTrack(trackInterface<o2::dataformats::TrackTPCITS>* trk) { mParam = trk; }
   void setFitInProjections(bool flag) {}
 
   float getAlpha() { return (mParam) ? mParam->getAlpha() : 99999.f; }
@@ -223,7 +223,7 @@ class propagatorInterface<o2::base::Propagator>
   }
   bool rotate(float alpha) { return (mParam) ? mParam->rotate(alpha) : false; }
 
-  trackInterface<o2::track::TrackParCov>* mParam{nullptr};
+  trackInterface<o2::dataformats::TrackTPCITS>* mParam{nullptr};
   o2::base::Propagator* mProp{o2::base::Propagator::Instance()};
 };
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
@@ -213,7 +213,7 @@ namespace gpu
 template class GPUTRDTrack_t<trackInterface<AliExternalTrackParam>>;
 #endif
 #ifdef GPUCA_O2_LIB // Instantiate O2 track version
-template class GPUTRDTrack_t<trackInterface<o2::track::TrackParCov>>;
+template class GPUTRDTrack_t<trackInterface<o2::dataformats::TrackTPCITS>>;
 #endif
 #endif
 template class GPUTRDTrack_t<trackInterface<GPUTPCGMTrackParam>>; // Always instatiate GM track version

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -655,7 +655,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         // first propagate track to x of tracklet
         for (int iTrklt = 0; iTrklt < mNTrackletsInChamber[currDet]; ++iTrklt) {
           int trkltIdx = mTrackletIndexArray[currDet] + iTrklt;
-          if (CAMath::Abs(trkWork->getY() - mSpacePoints[trkltIdx].mX[0]) > roadY && CAMath::Abs(trkWork->getZ() - mSpacePoints[trkltIdx].mX[1]) > roadZ) {
+          if (CAMath::Abs(trkWork->getY() - mSpacePoints[trkltIdx].mX[0]) > roadY || CAMath::Abs(trkWork->getZ() - mSpacePoints[trkltIdx].mX[1]) > roadZ) {
             // skip tracklets which are too far away
             // although the radii of space points and tracks may differ by ~ few mm the roads are large enough to allow no efficiency loss by this cut
             continue;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -106,8 +106,7 @@ void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracks(void* base)
 }
 
 template <class TRDTRK, class PROP>
-GPUTRDTracker_t<TRDTRK, PROP>::GPUTRDTracker_t()
-  : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mDebugOutput(false), mRadialOffset(-0.1), mMinPt(2.f), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug<TRDTRK>())
+GPUTRDTracker_t<TRDTRK, PROP>::GPUTRDTracker_t() : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mRPhiA2(0), mRPhiB(0), mRPhiC2(0), mDyA2(0), mDyB(0), mDyC2(0), mAngleToDyA(0), mAngleToDyB(0), mAngleToDyC(0), mDebugOutput(false), mRadialOffset(-0.1), mMinPt(2.f), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug<TRDTRK>())
 {
   //--------------------------------------------------------------------
   // Default constructor
@@ -132,6 +131,39 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
   mGeo = (TRD_GEOMETRY_CONST GPUTRDGeometry*)GetConstantMem()->calibObjects.trdGeometry;
   if (!mGeo) {
     Error("Init", "TRD geometry must be provided externally");
+  }
+
+  float Bz = Param().BzkG;
+  GPUInfo("Initializing with B-field: %f kG", Bz);
+  if (abs(abs(Bz) - 2) < 0.1) {
+    // magnetic field +-0.2 T
+    if (Bz > 0) {
+      GPUInfo("Loading error parameterization for Bz = +2 kG");
+      mRPhiA2 = 1.6e-3f, mRPhiB = -1.43e-2f, mRPhiC2 = 4.55e-2f;
+      mDyA2 = 1.225e-3f, mDyB = -9.8e-3f, mDyC2 = 3.88e-2f;
+      mAngleToDyA = -0.1f, mAngleToDyB = 1.89f, mAngleToDyC = -0.4f;
+    } else {
+      GPUInfo("Loading error parameterization for Bz = -2 kG");
+      mRPhiA2 = 1.6e-3f, mRPhiB = 1.43e-2f, mRPhiC2 = 4.55e-2f;
+      mDyA2 = 1.225e-3f, mDyB = 9.8e-3f, mDyC2 = 3.88e-2f;
+      mAngleToDyA = 0.1f, mAngleToDyB = 1.89f, mAngleToDyC = 0.4f;
+    }
+  } else if (abs(abs(Bz) - 5) < 0.1) {
+    // magnetic field +-0.5 T
+    if (Bz > 0) {
+      GPUInfo("Loading error parameterization for Bz = +5 kG");
+      mRPhiA2 = 1.6e-3f, mRPhiB = 0.125f, mRPhiC2 = 0.0961f;
+      mDyA2 = 1.681e-3f, mDyB = 0.15f, mDyC2 = 0.1849f;
+      mAngleToDyA = 0.13f, mAngleToDyB = 2.43f, mAngleToDyC = -0.58f;
+    } else {
+      GPUInfo("Loading error parameterization for Bz = -5 kG");
+      mRPhiA2 = 1.6e-3f, mRPhiB = -0.14f, mRPhiC2 = 0.1156f;
+      mDyA2 = 2.209e-3f, mDyB = -0.15f, mDyC2 = 0.2025f;
+      mAngleToDyA = -0.15f, mAngleToDyB = 2.34f, mAngleToDyC = 0.56f;
+    }
+  } else {
+    // magnetic field 0 T or another value which is not covered by the error parameterizations
+    GPUError("No error parameterization available for Bz = %.2f kG", Bz);
   }
 
 #ifdef GPUCA_ALIROOT_LIB
@@ -248,7 +280,7 @@ void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking(GPUChainTracking* chainTracking)
   std::cout << " nTracklets: " << mNTracklets;
   std::cout << std::endl;
   */
-  DumpTracks();
+  //DumpTracks();
   mNEvents++;
 }
 
@@ -276,6 +308,12 @@ void GPUTRDTracker_t<TRDTRK, PROP>::PrintSettings() const
   GPUInfo(" mMaxChi2(%.2f), mChi2Penalty(%.2f), nCandidates(%i), maxMissingLayers(%i)", mMaxChi2, mChi2Penalty, mNCandidates, mMaxMissingLy);
   GPUInfo(" ptCut = %.2f GeV, abs(eta) < %.2f", mMinPt, mMaxEta);
   GPUInfo("##############################################################");
+}
+
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::StartDebugging()
+{
+  mDebug->CreateStreamer();
 }
 
 template <class TRDTRK, class PROP>
@@ -513,7 +551,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
   // -> returns false if prolongation could not be executed fully
   //    or track does not fullfill threshold conditions
   //--------------------------------------------------------------------
-  GPUInfo("Start track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
+  //GPUInfo("Start track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
   mDebug->Reset();
   int iTrack = t->GetTPCtrackId();
   t->SetChi2(0.f);
@@ -586,9 +624,9 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
 
       // propagate track to average radius of TRD layer iLayer (sector 0, stack 2 is chosen as a reference)
       if (!prop->propagateToX(mR[2 * kNLayers + iLayer], .8f, 2.f)) {
-        //if (ENABLE_INFO) {
-        GPUInfo("Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
-        //}
+        if (ENABLE_INFO) {
+          GPUInfo("Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
+        }
         GPUInfo("Propagation failed");
         continue;
       }
@@ -934,8 +972,8 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
     mDebug->SetUpdates(update);
     mDebug->Output();
   }
-  GPUInfo("Ended track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
-  GPUInfo("Attached %i tracklets", t->GetNtracklets());
+  //GPUInfo("Ended track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
+  //GPUInfo("Attached %i tracklets", t->GetNtracklets());
   return true;
 }
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -239,7 +239,7 @@ void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking(GPUChainTracking* chainTracking)
         trkltIndexArray[iDet] = trkltCounter;
       }
       currDet = nextDet;
-     }
+    }
     ++trkltCounter;
   }
   for (int iDet = currDet; iDet <= kNChambers; ++iDet) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -45,7 +45,7 @@ namespace gpu
 class GPUTRDTrackletWord;
 class GPUTRDGeometry;
 class GPUChainTracking;
-template<class T>
+template <class T>
 class GPUTRDTrackerDebug;
 
 //-------------------------------------------------------------------------

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -16,13 +16,11 @@
 #ifndef GPUTRDTRACKER_H
 #define GPUTRDTRACKER_H
 
-#define POSITIVE_B_FIELD_5KG
 
 #include "GPUCommonDef.h"
 #include "GPUProcessor.h"
 #include "GPUTRDDef.h"
 #include "GPUDef.h"
-#include "GPUTRDTrackerDebug.h"
 #include "GPUTRDTrack.h"
 #include "GPULogging.h"
 
@@ -47,6 +45,8 @@ namespace gpu
 class GPUTRDTrackletWord;
 class GPUTRDGeometry;
 class GPUChainTracking;
+template<class T>
+class GPUTRDTrackerDebug;
 
 //-------------------------------------------------------------------------
 template <class TRDTRK, class PROP>
@@ -71,7 +71,7 @@ class GPUTRDTracker_t : public GPUProcessor
   void SetNCandidates(int n);
   void PrintSettings() const;
   bool IsInitialized() const { return mIsInitialized; }
-  void StartDebugging() { mDebug->CreateStreamer(); }
+  void StartDebugging();
 #endif
 
   enum EGPUTRDTracker { kNLayers = 6,
@@ -153,18 +153,9 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() bool AdjustSector(PROP* prop, TRDTRK* t, const int layer) const;
   GPUd() int GetSector(float alpha) const;
   GPUd() float GetAlphaOfSector(const int sec) const;
-  // TODO all parametrizations depend on B-field -> need to find correct description.. To be put in CCDB in the future?
-#ifdef POSITIVE_B_FIELD_5KG
-  // B = +5kG for Run 244340 and 245353
-  GPUd() float GetRPhiRes(float snp) const { return (0.04f * 0.04f + 0.31f * 0.31f * (snp - 0.125f) * (snp - 0.125f)); } // parametrization obtained from track-tracklet residuals
-  GPUd() float GetAngularResolution(float snp) const { return 0.041f * 0.041f + 0.43f * 0.43f * (snp - 0.15f) * (snp - 0.15f); }
-  GPUd() float ConvertAngleToDy(float snp) const { return 0.13f + 2.43f * snp - 0.58f * snp * snp; } // more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
-#else
-  // B = -5kG for Run 246390
-  GPUd() float GetRPhiRes(float snp) const { return (0.04f * 0.04f + 0.34f * 0.34f * (snp + 0.14f) * (snp + 0.14f)); }
-  GPUd() float GetAngularResolution(float snp) const { return 0.047f * 0.047f + 0.45f * 0.45f * (snp + 0.15f) * (snp + 0.15f); }
-  GPUd() float ConvertAngleToDy(float snp) const { return -0.15f + 2.34f * snp + 0.56f * snp * snp; } // more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
-#endif
+  GPUd() float GetRPhiRes(float snp) const { return (mRPhiA2 + mRPhiC2 * (snp - mRPhiB) * (snp - mRPhiB)); }           // parametrization obtained from track-tracklet residuals:
+  GPUd() float GetAngularResolution(float snp) const { return mDyA2 + mDyC2 * (snp - mDyB) * (snp - mDyB); }           // a^2 + c^2 * (snp - b)^2
+  GPUd() float ConvertAngleToDy(float snp) const { return mAngleToDyA + mAngleToDyB * snp + mAngleToDyC * snp * snp; } // a + b*snp + c*snp^2 is more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
   GPUd() float GetAngularPull(float dYtracklet, float snp) const;
   GPUd() void RecalcTrkltCov(const float tilt, const float snp, const float rowSize, My_Float (&cov)[3]);
   GPUd() void CheckTrackRefs(const int trackID, bool* findableMC) const;
@@ -227,6 +218,17 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUTRDSpacePointInternal* mSpacePoints;  // array with tracklet coordinates in global tracking frame
   int* mTrackletLabels;                    // array with MC tracklet labels
   TRD_GEOMETRY_CONST GPUTRDGeometry* mGeo; // TRD geometry
+  /// ---- error parametrization depending on magnetic field ----
+  float mRPhiA2;     // parameterization for tracklet position resolution
+  float mRPhiB;      // parameterization for tracklet position resolution
+  float mRPhiC2;     // parameterization for tracklet position resolution
+  float mDyA2;       // parameterization for tracklet angular resolution
+  float mDyB;        // parameterization for tracklet angular resolution
+  float mDyC2;       // parameterization for tracklet angular resolution
+  float mAngleToDyA; // parameterization for conversion track angle -> tracklet deflection
+  float mAngleToDyB; // parameterization for conversion track angle -> tracklet deflection
+  float mAngleToDyC; // parameterization for conversion track angle -> tracklet deflection
+  /// ---- end error parametrization ----
   bool mDebugOutput;                       // store debug output
   float mRadialOffset;                     // due to mis-calibration of t0
   float mMinPt;                            // min pt of TPC tracks for tracking

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -211,8 +211,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUTRDTrackletWord* mTracklets;          // array of all tracklets, later sorted by HCId
   int mMaxThreads;                         // maximum number of supported threads
   int mNTracklets;                         // total number of tracklets in event
-  int* mNTrackletsInChamber;               // number of tracklets in each chamber
-  int* mTrackletIndexArray;                // index of first tracklet for each chamber
+  int* mTrackletIndexArray;                // index of first tracklet for each chamber, last entry is the total amount of tracklets
   Hypothesis* mHypothesis;                 // array with multiple track hypothesis
   TRDTRK* mCandidates;                     // array of tracks for multiple hypothesis tracking
   GPUTRDSpacePointInternal* mSpacePoints;  // array with tracklet coordinates in global tracking frame


### PR DESCRIPTION
- If the tracklets are out of the search road **either** in Y **or** Z they are ignored
- Some additions to the debugging macro