### PR TITLE
Bug fix RootTreeWriter: Argument parsing of the constructor

### DIFF
--- a/Framework/Utils/include/DPLUtils/RootTreeWriter.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeWriter.h
@@ -707,7 +707,7 @@ class RootTreeWriter
       mTreeStructure = createTreeStructure<0, TreeStructureInterface>(std::forward<Arg>(arg), std::forward<Args>(args)...);
       return;
     }
-    if constexpr (sizeof...(Args) > 1) {
+    if constexpr (sizeof...(Args) > 0) {
       parseConstructorArgs(std::forward<Args>(args)...);
     }
   }


### PR DESCRIPTION
The argument pack was not correctly forwarded when only one branch definition was
in use.