### PR TITLE
Further cleanup of workflow writers for TOF and FIT

### DIFF
--- a/Detectors/FIT/FDD/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FDD/workflow/CMakeLists.txt
@@ -12,7 +12,7 @@ o2_add_library(FDDWorkflow
                SOURCES src/RecoWorkflow.cxx src/DigitReaderSpec.cxx
                        src/ReconstructorSpec.cxx src/RecPointWriterSpec.cxx
                        src/RecPointReaderSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::FDDReconstruction O2::Framework)
+               PUBLIC_LINK_LIBRARIES O2::FDDReconstruction O2::Framework O2::DPLUtils)
 
 o2_add_executable(reco-workflow
                   COMPONENT_NAME fdd

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointWriterSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RecPointWriterSpec.h
@@ -13,10 +13,8 @@
 #ifndef O2_FDD_RECPOINTWRITER_H
 #define O2_FDD_RECPOINTWRITER_H
 
-#include "TFile.h"
 
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
 
 using namespace o2::framework;
 
@@ -24,24 +22,6 @@ namespace o2
 {
 namespace fdd
 {
-
-class FDDRecPointWriter : public Task
-{
- public:
-  FDDRecPointWriter(bool useMC = true) : mUseMC(useMC) {}
-  ~FDDRecPointWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-
- private:
-  bool mFinished = false;
-  bool mUseMC = true;
-
-  std::string mOutputFileName = "o2reco_fdd.root";
-  std::string mOutputTreeName = "o2sim";
-  std::string mRPOutputBranchName = "FDDCluster";
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginFDD;
-};
 
 /// create a processor spec
 /// write ITS clusters a root file

--- a/Detectors/FIT/FDD/workflow/src/RecPointWriterSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/RecPointWriterSpec.cxx
@@ -12,10 +12,8 @@
 
 #include <vector>
 
-#include "TTree.h"
-
-#include "Framework/ControlService.h"
 #include "FDDWorkflow/RecPointWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsFDD/RecPoint.h"
 
 using namespace o2::framework;
@@ -25,47 +23,23 @@ namespace o2
 namespace fdd
 {
 
-void FDDRecPointWriter::init(InitContext& ic)
-{
-}
-
-void FDDRecPointWriter::run(ProcessingContext& pc)
-{
-  if (mFinished) {
-    return;
-  }
-  // no MC infor treatment at the moment
-  auto recPoints = pc.inputs().get<const std::vector<o2::fdd::RecPoint>>("recpoints");
-  auto recPointsPtr = &recPoints;
-  LOG(INFO) << "FDDRecPointWriter pulled " << recPoints.size() << " RecPoints";
-
-  TFile flOut(mOutputFileName.c_str(), "recreate");
-  if (flOut.IsZombie()) {
-    LOG(FATAL) << "Failed to create FDD RecPoints output file " << mOutputFileName;
-  }
-  TTree tree(mOutputTreeName.c_str(), "Tree with FDD RecPoints");
-  tree.Branch(mRPOutputBranchName.c_str(), &recPointsPtr);
-  tree.Fill();
-  tree.Write();
-
-  mFinished = true;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-}
-
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 DataProcessorSpec getFDDRecPointWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputSpec;
-  inputSpec.emplace_back("recpoints", o2::header::gDataOriginFDD, "RECPOINTS", 0, Lifetime::Timeframe);
-  return DataProcessorSpec{
-    "fdd-recpoint-writer",
-    inputSpec,
-    Outputs{},
-    AlgorithmSpec{adaptFromTask<FDDRecPointWriter>(useMC)},
-    Options{
-      {"fdd-recpoint-outfile", VariantType::String, "o2reco_fdd.root", {"Name of the output file"}},
-      {"fdd-recpoint-tree-name", VariantType::String, "o2sim", {"Name of the FDD recpoints tree"}},
-      {"fdd-recpoint-branch-name", VariantType::String, "FDDCluster", {"Name of the FDD recpoints branch"}},
-    }};
+  using RecPointsType = std::vector<o2::fdd::RecPoint>;
+  // Spectators for logging
+  auto logger = [](RecPointsType const& recPoints) {
+    LOG(INFO) << "FDDRecPointWriter pulled " << recPoints.size() << " RecPoints";
+  };
+  return MakeRootTreeWriterSpec("fdd-recpoint-writer",
+                                "o2reco_fdd.root",
+                                "o2sim",
+                                BranchDefinition<RecPointsType>{InputSpec{"recPoints", "FDD", "RECPOINTS", 0},
+                                                                "FDDCluster",
+                                                                "fdd-recpoint-branch-name",
+                                                                1,
+                                                                logger})();
 }
 
 } // namespace fdd

--- a/Detectors/FIT/workflow/CMakeLists.txt
+++ b/Detectors/FIT/workflow/CMakeLists.txt
@@ -12,7 +12,7 @@ o2_add_library(FITWorkflow
                SOURCES src/RecoWorkflow.cxx src/FT0DigitReaderSpec.cxx
                        src/FT0ReconstructorSpec.cxx src/FT0RecPointWriterSpec.cxx
                        src/FT0RecPointReaderSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::FT0Reconstruction O2::Framework)
+               PUBLIC_LINK_LIBRARIES O2::FT0Reconstruction O2::Framework O2::DPLUtils)
 
 o2_add_executable(reco-workflow
                   COMPONENT_NAME fit

--- a/Detectors/FIT/workflow/include/FITWorkflow/FT0RecPointWriterSpec.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/FT0RecPointWriterSpec.h
@@ -13,10 +13,8 @@
 #ifndef O2_FT0RECPOINTWRITER_H
 #define O2_FT0RECPOINTWRITER_H
 
-#include "TFile.h"
 
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
 
 using namespace o2::framework;
 
@@ -25,27 +23,7 @@ namespace o2
 namespace ft0
 {
 
-class FT0RecPointWriter : public Task
-{
- public:
-  FT0RecPointWriter(bool useMC = true) : mUseMC(useMC) {}
-  ~FT0RecPointWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-
- private:
-  bool mFinished = false;
-  bool mUseMC = true;
-
-  std::string mOutputFileName = "o2reco_ft0.root";
-  std::string mOutputTreeName = "o2sim";
-  std::string mRPOutputBranchName = "FT0Cluster";
-  std::string mRPOutputChBranchName = "FT0RecChData";
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginFT0;
-};
-
 /// create a processor spec
-/// write ITS clusters a root file
 framework::DataProcessorSpec getFT0RecPointWriterSpec(bool useMC);
 
 } // namespace ft0

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFCalibWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFCalibWriterSpec.h
@@ -13,11 +13,7 @@
 #ifndef TOFWORKFLOW_TOFCALIBWRITER_H_
 #define TOFWORKFLOW_TOFCALIBWRITER_H_
 
-#include "TFile.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-#include <string>
 
 using namespace o2::framework;
 
@@ -25,20 +21,6 @@ namespace o2
 {
 namespace tof
 {
-
-class TOFCalibWriter : public Task
-{
- public:
-  TOFCalibWriter() = default;
-  ~TOFCalibWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-
- private:
-  bool mFinished = false;
-  std::string mOutFileName; // read from workflow
-  std::string mOutTreeName; // read from workflow
-};
 
 /// create a processor spec
 /// write TOF calbi info in a root file

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedWriterSpec.h
@@ -13,11 +13,7 @@
 #ifndef TOFWORKFLOW_TOFMATCHEDWRITER_H_
 #define TOFWORKFLOW_TOFMATCHEDWRITER_H_
 
-#include "TTree.h"
-#include "TFile.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-#include <string>
 
 using namespace o2::framework;
 
@@ -25,23 +21,6 @@ namespace o2
 {
 namespace tof
 {
-
-class TOFMatchedWriter : public Task
-{
- public:
-  TOFMatchedWriter(bool useMC = true) : mUseMC(useMC) {}
-  ~TOFMatchedWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-  void endOfStream(EndOfStreamContext& ec) final;
-
- private:
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-  bool mUseMC = true;
-  std::string mOutFileName; // read from workflow
-  std::string mOutTreeName; // read from workflow
-};
 
 /// create a processor spec
 /// write TOF matching info in a root file

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
@@ -13,6 +13,7 @@
 #include "TOFWorkflow/TOFMatchedWriterSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Headers/DataHeader.h"
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>
@@ -27,83 +28,54 @@ namespace o2
 {
 namespace tof
 {
-using evIdx = o2::dataformats::EvIndex<int, int>;
-using MatchOutputType = std::vector<o2::dataformats::MatchInfoTOF>;
 
 template <typename T>
-TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
-{
-  if (auto br = tree->GetBranch(brname)) {
-    br->SetAddress(static_cast<void*>(&ptr));
-    return br;
-  }
-  // otherwise make it
-  return tree->Branch(brname, ptr);
-}
-
-void TOFMatchedWriter::init(InitContext& ic)
-{
-  // get the option from the init context
-  mOutFileName = ic.options().get<std::string>("tof-matched-outfile");
-  mOutTreeName = ic.options().get<std::string>("treename");
-  mFile = std::make_unique<TFile>(mOutFileName.c_str(), "RECREATE");
-  if (!mFile->IsOpen()) {
-    throw std::runtime_error(o2::utils::concat_string("failed to open TOF macthes output file ", mOutFileName));
-  }
-  mTree = std::make_unique<TTree>(mOutTreeName.c_str(), "Tree of TOF matching infos");
-}
-
-void TOFMatchedWriter::run(ProcessingContext& pc)
-{
-  auto indata = pc.inputs().get<MatchOutputType>("tofmatching");
-  LOG(INFO) << "RECEIVED MATCHED SIZE " << indata.size();
-  auto indataPtr = &indata;
-  getOrMakeBranch(mTree.get(), "TOFMatchInfo", &indataPtr);
-  std::vector<o2::MCCompLabel> labeltof, *labeltofPtr = &labeltof;
-  std::vector<o2::MCCompLabel> labeltpc, *labeltpcPtr = &labeltpc;
-  std::vector<o2::MCCompLabel> labelits, *labelitsPtr = &labelits;
-  if (mUseMC) {
-    labeltof = std::move(pc.inputs().get<std::vector<o2::MCCompLabel>>("matchtoflabels"));
-    labeltpc = std::move(pc.inputs().get<std::vector<o2::MCCompLabel>>("matchtpclabels")); // RS why do we need to repead ITS/TPC labels ?
-    labelits = std::move(pc.inputs().get<std::vector<o2::MCCompLabel>>("matchitslabels")); // They can be extracted from TPC-ITS matches
-    LOG(INFO) << "TOF LABELS GOT " << labeltof.size() << " LABELS ";
-    LOG(INFO) << "TPC LABELS GOT " << labeltpc.size() << " LABELS ";
-    LOG(INFO) << "ITS LABELS GOT " << labelits.size() << " LABELS ";
-    // connect this to particular branches
-    getOrMakeBranch(mTree.get(), "MatchTOFMCTruth", &labeltofPtr);
-    getOrMakeBranch(mTree.get(), "MatchTPCMCTruth", &labeltpcPtr);
-    getOrMakeBranch(mTree.get(), "MatchITSMCTruth", &labelitsPtr);
-  }
-  mTree->Fill();
-}
-
-void TOFMatchedWriter::endOfStream(EndOfStreamContext& ec)
-{
-  LOG(INFO) << "Finalizing TOF matching info writing";
-  mTree->Write();
-  mTree.release()->Delete();
-  mFile->Close();
-}
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using OutputType = std::vector<o2::dataformats::MatchInfoTOF>;
+using LabelsType = std::vector<o2::MCCompLabel>;
+using namespace o2::header;
 
 DataProcessorSpec getTOFMatchedWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("tofmatching", o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
-  if (useMC) {
-    inputs.emplace_back("matchtoflabels", o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchtpclabels", o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchitslabels", o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
-  }
-
-  return DataProcessorSpec{
-    "TOFMatchedWriter",
-    inputs,
-    {}, // no output
-    AlgorithmSpec{adaptFromTask<TOFMatchedWriter>(useMC)},
-    Options{
-      {"tof-matched-outfile", VariantType::String, "o2match_tof.root", {"Name of the input file"}},
-      {"treename", VariantType::String, "matchTOF", {"Name of top-level TTree"}},
-    }};
+  // spectators for logging
+  auto loggerMatched = [](OutputType const& indata) {
+    LOG(INFO) << "RECEIVED MATCHED SIZE " << indata.size();
+  };
+  auto loggerTofLabels = [](LabelsType const& labeltof) {
+    LOG(INFO) << "TOF LABELS GOT " << labeltof.size() << " LABELS ";
+  };
+  auto loggerTpcLabels = [](LabelsType const& labeltpc) {
+    LOG(INFO) << "TPC LABELS GOT " << labeltpc.size() << " LABELS ";
+  };
+  auto loggerItsLabels = [](LabelsType const& labelits) {
+    LOG(INFO) << "ITS LABELS GOT " << labelits.size() << " LABELS ";
+  };
+  // TODO: there was a comment in the original implementation:
+  // RS why do we need to repead ITS/TPC labels ?
+  // They can be extracted from TPC-ITS matches
+  return MakeRootTreeWriterSpec("TOFMatchedWriter",
+                                "o2match_tof.root",
+                                "matchTOF",
+                                BranchDefinition<OutputType>{InputSpec{"tofmatching", gDataOriginTOF, "MATCHINFOS", 0},
+                                                             "TOFMatchInfo",
+                                                             "TOFMatchInfo-branch-name",
+                                                             1,
+                                                             loggerMatched},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtoflabels", gDataOriginTOF, "MATCHTOFINFOSMC", 0},
+                                                             "MatchTOFMCTruth",
+                                                             "MatchTOFMCTruth-branch-name",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             loggerTofLabels},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", gDataOriginTOF, "MATCHTPCINFOSMC", 0},
+                                                             "MatchTPCMCTruth",
+                                                             "MatchTPCMCTruth-branch-name",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             loggerTpcLabels},
+                                BranchDefinition<LabelsType>{InputSpec{"matchitslabels", gDataOriginTOF, "MATCHITSINFOSMC", 0},
+                                                             "MatchITSMCTruth",
+                                                             "MatchITSMCTruth-branch-name",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             loggerItsLabels})();
 }
 } // namespace tof
 } // namespace o2

--- a/Detectors/TOF/workflow/CMakeLists.txt
+++ b/Detectors/TOF/workflow/CMakeLists.txt
@@ -17,5 +17,5 @@ o2_add_library(TOFWorkflowUtils
                        src/TOFRawWriterSpec.cxx
                        src/CompressedDecodingTask.cxx
                        src/CompressedInspectorTask.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::TOFBase O2::DataFormatsTOF
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::TOFBase O2::DataFormatsTOF
                                      O2::TOFReconstruction)

--- a/Detectors/TOF/workflow/include/TOFWorkflow/TOFClusterWriterSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/TOFClusterWriterSpec.h
@@ -13,12 +13,7 @@
 #ifndef STEER_DIGITIZERWORKFLOW_TOFCLUSTERWRITER_H_
 #define STEER_DIGITIZERWORKFLOW_TOFCLUSTERWRITER_H_
 
-#include "TFile.h"
-
-#include "Framework/RootSerializationSupport.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-#include <string>
 
 using namespace o2::framework;
 
@@ -26,21 +21,6 @@ namespace o2
 {
 namespace tof
 {
-
-class ClusterWriter : public Task
-{
- public:
-  ClusterWriter(bool useMC = true) : mUseMC(useMC) {}
-  ~ClusterWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
-
- private:
-  bool mFinished = false;
-  bool mUseMC = true;
-  std::string mOutFileName; // read from workflow
-  std::string mOutTreeName; // read from workflow
-};
 
 /// create a processor spec
 /// write ITS tracks a root file


### PR DESCRIPTION
Using DPL utility RootTreeWriter and the MakeRootTreeWriterSpec generator and removing duplicated boiler-plate code in the TOF and FIT workflows

Have been checking the following workflow tests:
- [x] full workflow of ITS, TPC, TOF reconstruction, matching, and interpolation
```
o2-its-reco-workflow --disable-root-output | o2-tpc-reco-workflow --tpc-digit-reader '--infile tpcdigits.root' --ca-clusterer --input-type digits --output-type clusters,tracks | o2-tpcits-match-workflow --disable-root-input | o2-tof-reco-workflow --disable-root-input --disable-root-output | o2-tpc-scdcalib-interpolation-workflow --disable-root-input
```

- [x] FT0 reco workflow
```
o2-fit-reco-workflow
```

- [ ] FDD reco workflow
```
o2-fdd-reco-workflow
```
here there is a crash independent of this PR
```
===========================================================
#6  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local (this=0x0) at /usr/include/c++/7/bits/basic_string.h:211
#7  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator= (__str=..., this=0x0) at /usr/include/c++/7/bits/basic_string.h:725
#8  boost::property_tree::basic_ptree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::clear (this=0x0) at /src/src/alisw/sw/ubuntu1804_x86-64/boost/v1.72.0-alice1-1/include/boost/property_tree/detail/ptree_implementation.hpp:565
#9  o2::conf::ConfigurableParam::initPropertyTree () at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/Common/Utils/src/ConfigurableParam.cxx:293
#10 0x00007f43da02faa3 in o2::conf::ConfigurableParam::initialize () at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/Common/Utils/src/ConfigurableParam.cxx:373
#11 0x00007f43da033b0d in o2::conf::ConfigurableParam::updateFromString (configString="") at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/Common/Utils/src/ConfigurableParam.cxx:441
#12 0x000056083208623c in defineDataProcessing (configcontext=...) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/Detectors/FIT/FDD/workflow/src/fdd-reco-workflow.cxx:40
#13 0x0000560832084cde in main (argc=1, argv=0x7ffff25051f8) at /home/richter/src/alisw/sw/SOURCES/O2/v1.2.0/0/Framework/Core/include/Framework/runDataProcessing.h:153
===========================================================
```