### PR TITLE
Compute particle energy is negative value passed to AddTrack

### DIFF
--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -128,7 +128,8 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   vz += fVertex.Z();
 
   /** check if particle to be tracked exists in PDG database **/
-  if (wanttracking && !TDatabasePDG::Instance()->GetParticle(pdgid)) {
+  auto particlePDG = TDatabasePDG::Instance()->GetParticle(pdgid);
+  if (wanttracking && !particlePDG) {
     LOG(WARN) << "Particle to be tracked is not defined in PDG: pdg = " << pdgid;
     wanttracking = false;
   }
@@ -160,6 +161,12 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   if (abs(pdgid) == 311 && doTracking) {
     LOG(WARN) << "K0/antiK0 requested for tracking: converting into K0s/K0L";
     pdgid = gRandom->Uniform() < 0.5 ? 310 : 130;
+  }
+
+  /** compute particle energy if negative **/
+  if (e < 0) {
+    double mass = particlePDG ? particlePDG->Mass() : 0.;
+    e = sqrt(mass * mass + px * px + py * py + pz * pz);
   }
 
   /** add track to stack **/

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -166,7 +166,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   /** compute particle energy if negative **/
   if (e < 0) {
     double mass = particlePDG ? particlePDG->Mass() : 0.;
-    e = sqrt(mass * mass + px * px + py * py + pz * pz);
+    e = std::sqrt(mass * mass + px * px + py * py + pz * pz);
   }
 
   /** add track to stack **/


### PR DESCRIPTION
This commit fixes a issue that could happen in case of user-defined event generators that attempt to directly add tracks via the 
```
virtual void AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t pz,
                        Double_t vx, Double_t vy, Double_t vz,
                        Int_t parent = -1, Bool_t wanttracking = true,
                        Double_t e = -9e9, Double_t tof = 0.,
                        Double_t weight = 0., TMCProcess proc = kPPrimary);
```
method and do not specify a valid energy, that is they use the default.

For the cases where a negative energy is passed, a protection must be taken in the method to convert the negative value to a reasonable value. If the particle PDG id is known, than the mass is retrieved and the energy computed. Otherwise zero mass is assumed.

