### PR TITLE
DPL: consider nullptr in payload a valid message when forwarding O2-1489

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -46,7 +46,7 @@ std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
@@ -57,7 +57,7 @@ std::string ChannelSpecHelpers::channelUrl(InputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -685,7 +685,7 @@ bool DataProcessingDevice::tryDispatchComputation()
       // we forward it, because of a custom completion policy.
       // this means that we need to skip the empty entries in the
       // record for being forwarded.
-      if (input.header == nullptr || input.payload == nullptr) {
+      if (input.header == nullptr) {
         continue;
       }
       auto sih = o2::header::get<SourceInfoHeader*>(input.header);


### PR DESCRIPTION
In the case of shmem backend, a nullptr in the payload is actually a valid message, so we need to forward it, if requested. Analogous to 99c816d27f6960af9ccb6428bba27ffbae032e51.