### PR TITLE
Separate cable HW_ID position and ordering mappings

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -153,7 +153,10 @@ class ChipMappingITS
   ///< get number of chips served by single cable on given RU type
   uint8_t getGBTHeaderRUType(int ruType, int cableHW) { return GBTHeaderFlagSB[ruType] + (cableHW & 0x1f); }
 
-  ///< convert HW cable ID to SW ID for give RU type
+  ///< convert HW cable ID to its position on the ActiveLanes word in the GBT.header for given RU type
+  uint8_t cableHW2Pos(uint8_t ruType, uint8_t hwid) const { return mCableHW2Pos[ruType][hwid]; }
+
+  ///< convert HW cable ID to SW ID for given RU type (see ChipOnRUInfo.cableSW explanation)
   uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
   ///< get number of chips served by single cable on given RU type
@@ -282,6 +285,7 @@ class ChipMappingITS
   int mChipInfoEntrySB[NSubB] = {0};
 
   std::vector<uint8_t> mCableHW2SW[NSubB];       ///< table of cables HW to SW conversion for each RU type
+  std::vector<uint8_t> mCableHW2Pos[NSubB];      ///< table of cables positions in the ActiveLanes mask for each RU type
   std::vector<uint8_t> mCableHWFirstChip[NSubB]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
 
   ClassDefNV(ChipMappingITS, 1);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -102,6 +102,9 @@ class ChipMappingMFT
     return (cableHW & 0x1f);
   }
 
+  ///< convert HW cable ID to its position on the ActiveLanes word in the GBT.header for given RU type
+  uint8_t cableHW2Pos(uint8_t ruType, uint8_t hwid) const { return mCableHW2Pos[ruType][hwid]; }
+
   ///< convert HW cable ID to SW ID for give RU type
   uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
@@ -267,6 +270,7 @@ class ChipMappingMFT
   std::vector<uint8_t> mFEEId2RUSW; // HW RU ID -> SW ID conversion
 
   std::vector<uint8_t> mCableHW2SW[NRUs];       ///< table of cables HW to SW conversion for each RU type
+  std::vector<uint8_t> mCableHW2Pos[NRUs];      ///< table of cables positions in the ActiveLanes mask for each RU type
   std::vector<uint8_t> mCableHWFirstChip[NRUs]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
 
   std::array<std::vector<uint16_t>, NRUs> mRUGlobalChipID;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -198,7 +198,7 @@ struct GBTLink {
   ErrorType checkErrorsTriggerWord(const GBTTrigger* gbtTrg) const { return NoError; }
   ErrorType checkErrorsHeaderWord(const GBTDataHeader* gbtH) const { return NoError; }
   ErrorType checkErrorsActiveLanes(int cables) const { return NoError; }
-  ErrorType checkErrorsGBTData(int cableHW, int cableSW) const { return NoError; }
+  ErrorType checkErrorsGBTData(int cablePos) const { return NoError; }
   ErrorType checkErrorsTrailerWord(const GBTDataTrailer* gbtT) const { return NoError; }
   ErrorType checkErrorsPacketDoneMissing(const GBTDataTrailer* gbtT, bool notEnd) const { return NoError; }
   ErrorType checkErrorsLanesStops() const { return NoError; }
@@ -209,7 +209,7 @@ struct GBTLink {
   ErrorType checkErrorsTriggerWord(const GBTTrigger* gbtTrg);
   ErrorType checkErrorsHeaderWord(const GBTDataHeader* gbtH);
   ErrorType checkErrorsActiveLanes(int cables);
-  ErrorType checkErrorsGBTData(int cableHW, int cableSW);
+  ErrorType checkErrorsGBTData(int cablePos);
   ErrorType checkErrorsTrailerWord(const GBTDataTrailer* gbtT);
   ErrorType checkErrorsPacketDoneMissing(const GBTDataTrailer* gbtT, bool notEnd);
   ErrorType checkErrorsLanesStops();
@@ -284,7 +284,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
       if (verbosity >= VerboseData) {
         gbtD->printX();
       }
-      GBTLINK_DECODE_ERRORCHECK(checkErrorsGBTData(cableHW, cableSW));
+      GBTLINK_DECODE_ERRORCHECK(checkErrorsGBTData(chmap.cableHW2Pos(ruPtr->ruInfo->ruType, cableHW)));
       ruPtr->cableData[cableSW].add(gbtD->getW8(), 9);
       ruPtr->cableHWID[cableSW] = cableHW;
       ruPtr->cableLinkID[cableSW] = idInRU;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -68,7 +68,7 @@ int RUDecodeData::decodeROF(const Mapping& mp)
   lastChipChecked = 0;
   int ntot = 0;
   auto* chipData = &chipsData[0];
-  for (int icab = 0; icab < nCables; icab++) {
+  for (int icab = 0; icab < nCables; icab++) { // cableData is ordered in such a way to have chipIDs in increasing order
     if (!cableData[icab].getSize()) {
       continue;
     }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUInfo.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUInfo.h
@@ -42,8 +42,9 @@ struct ChipOnRUInfo {
   std::uint8_t moduleHW = DUMMY8;       // HW ID of the chip's module on stave
   std::uint8_t chipOnModuleSW = DUMMY8; // sequential ID of the chip on the module
   std::uint8_t chipOnModuleHW = DUMMY8; // sequential ID of the chip on the module
-  std::uint8_t cableSW = DUMMY8;        // cable SW ID
+  std::uint8_t cableSW = DUMMY8;        // order in which data of the cable is queried at decoding (to have chips SW IDs sorted)
   std::uint8_t cableHW = DUMMY8;        // cable HW ID
+  std::uint8_t cableHWPos = DUMMY8;     // position of the bit of this cable in the activeLanes
   std::uint8_t chipOnCable = DUMMY8;    // chip within the cable (0 = master)
 
   void print() const;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -101,6 +101,7 @@ class RawPixelDecoder : public PixelReader
   std::array<int, Mapping::getNRUs()> mRUEntry; // entry of the RU with given SW ID in the mRUDecodeVec
   std::string mSelfName;                        // self name
   uint16_t mCurRUDecodeID = NORUDECODED;        // index of currently processed RUDecode container
+  int mLastReadChipID = -1;                     // chip ID returned by previous getNextChipData call, used for ordering checks
   Mapping mMAP;                                 // chip mapping
   int mVerbosity = 0;
   int mNThreads = 1; // number of decoding threads

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
@@ -73,6 +73,7 @@ ChipMappingITS::ChipMappingITS()
   int ctrChip = 0;
   mChipInfoEntrySB[IB] = ctrChip;
   mCableHW2SW[IB].resize(NChipsPerStaveSB[IB], 0xff);
+  mCableHW2Pos[IB].resize(NChipsPerStaveSB[IB], 0xff);
   mCableHWFirstChip[IB].resize(NChipsPerStaveSB[IB], 0xff);
   for (int i = 0; i < NChipsPerStaveSB[IB]; i++) {
     auto& cInfo = mChipsInfo[ctrChip++];
@@ -81,10 +82,12 @@ ChipMappingITS::ChipMappingITS()
     cInfo.moduleSW = 0;
     cInfo.chipOnModuleSW = i;
     cInfo.chipOnModuleHW = i;
-    cInfo.cableHW = i;
-    cInfo.cableSW = i;
+    cInfo.cableHW = i;                              //1-to-1 mapping
+    cInfo.cableHWPos = i;                           //1-to-1 mapping
+    cInfo.cableSW = i;                              //1-to-1 mapping
     cInfo.chipOnCable = 0;                          // every chip is master
-    mCableHW2SW[IB][cInfo.cableHW] = cInfo.cableSW; //1-to-1 mapping
+    mCableHW2SW[IB][cInfo.cableHW] = cInfo.cableSW;
+    mCableHW2Pos[IB][cInfo.cableHW] = cInfo.cableHWPos;
     mCableHWFirstChip[IB][i] = 0;                   // stave and module are the same
   }
 
@@ -92,6 +95,7 @@ ChipMappingITS::ChipMappingITS()
   for (int bid = MB; bid <= OB; bid++) { // MB and OB staves have similar layout
     mChipInfoEntrySB[bid] = ctrChip;
     mCableHW2SW[bid].resize(0xff, 0xff);
+    mCableHW2Pos[bid].resize(0xff, 0xff);
     mCableHWFirstChip[bid].resize(0xff, 0xff);
 
     for (int i = 0; i < NChipsPerStaveSB[bid]; i++) {
@@ -106,9 +110,11 @@ ChipMappingITS::ChipMappingITS()
 
       uint8_t connector = (hstave << 1) + (cInfo.chipOnModuleSW < (NChipsPerModuleSB[bid] / 2) ? 0 : 1);
       cInfo.cableHW = (connector << 3) + (cInfo.moduleHW - 1);
-      cInfo.cableSW = i / chipsOnCable;                                        // (cInfo.moduleHW - 1) + connector * (NModulesPerStaveSB[bid] / 2);
+      cInfo.cableSW = i / chipsOnCable;
+      cInfo.cableHWPos = (cInfo.moduleHW - 1) + connector * (NModulesPerStaveSB[bid] / 2);
       cInfo.chipOnCable = cInfo.chipOnModuleSW % (NChipsPerModuleSB[bid] / 2); // each cable serves half module
       mCableHW2SW[bid][cInfo.cableHW] = cInfo.cableSW;
+      mCableHW2Pos[bid][cInfo.cableHW] = cInfo.cableHWPos;
       if (cInfo.chipOnCable == 0) {
         mCableHWFirstChip[bid][cInfo.cableHW] = cInfo.moduleSW * NChipsPerModuleSB[bid];
       }

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
@@ -1650,6 +1650,7 @@ ChipMappingMFT::ChipMappingMFT()
         curHalf = half;
         mChipInfoEntryRU[iRU] = ctrChip;
         mCableHW2SW[iRU].resize(NRUCables, 0xff);
+        mCableHW2Pos[iRU].resize(NRUCables, 0xff);
         mCableHWFirstChip[iRU].resize(NRUCables, 0xff);
       } else {
         if ((layer != curLayer) || (zone != curZone) || (half != curHalf)) {
@@ -1670,9 +1671,11 @@ ChipMappingMFT::ChipMappingMFT()
 
       chInfo.cableHW = ChipConnectorCable[chInfo.moduleHW][chInfo.chipOnModuleHW];
       chInfo.cableSW = ChipMappingData[iChip].chipOnRU;
+      chInfo.cableHWPos = ChipMappingData[iChip].chipOnRU;
 
       chInfo.chipOnCable = 0;
 
+      mCableHW2Pos[iRU][chInfo.cableHW] = chInfo.cableHWPos;
       mCableHW2SW[iRU][chInfo.cableHW] = chInfo.cableSW;
       mCableHWFirstChip[iRU][chInfo.cableHW] = 0;
 

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -269,14 +269,14 @@ GBTLink::ErrorType GBTLink::checkErrorsActiveLanes(int cbl)
 
 ///_________________________________________________________________
 /// Check GBT Data word
-GBTLink::ErrorType GBTLink::checkErrorsGBTData(int cableHW, int cableSW)
+GBTLink::ErrorType GBTLink::checkErrorsGBTData(int cablePos)
 {
-  lanesWithData |= 0x1 << cableSW;    // flag that the data was seen on this lane
-  if (lanesStop & (0x1 << cableSW)) { // make sure stopped lanes do not transmit the data
+  lanesWithData |= 0x1 << cablePos;    // flag that the data was seen on this lane
+  if (lanesStop & (0x1 << cablePos)) { // make sure stopped lanes do not transmit the data
     statistics.errorCounts[GBTS::ErrDataForStoppedLane]++;
     if (verbosity >= VerboseErrors) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTS::ErrDataForStoppedLane]
-                 << cableHW << " (sw:" << cableSW << ")";
+                 << cablePos;
     }
     errorBits |= 0x1 << int(GBTS::ErrDataForStoppedLane);
     return Warning;

--- a/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
@@ -11,22 +11,17 @@
 // \file RUInfo.cxx
 // \brief Transient structures for ITS and MFT HW -> SW mapping
 
-#include <ITSMFTReconstruction/RUInfo.h>
+#include "ITSMFTReconstruction/RUInfo.h"
+#include <bitset>
 
 using namespace o2::itsmft;
 
 void ChipOnRUInfo::print() const
 {
-  printf("ChonRu:%3d ModSW:%2d ChOnModSW:%2d CabSW:%3d| ChOnCab:%d | CabHW: ",
-         id, moduleSW, chipOnModuleSW, cableSW, chipOnCable);
-  for (int i = 8; i--;) {
-    printf("%d", (cableHW & (0x1 << i)) ? 1 : 0);
-  }
-  printf(" | ModHW ");
-  for (int i = 8; i--;) {
-    printf("%d", (moduleHW & (0x1 << i)) ? 1 : 0);
-  }
-  printf(" | ChOnModHW: %2d\n", chipOnModuleHW);
+  std::bitset<8> chw(cableHW), mhw(moduleHW);
+  printf("ChonRu:%3d ModSW:%2d ChOnModSW:%2d CabSW:%3d| ChOnCab:%d | CabHW: %8s (%2d) | ModHW: %8s | ChOnModHW: %2d\n",
+         id, moduleSW, chipOnModuleSW, cableSW, chipOnCable, chw.to_string().c_str(), cableHWPos,
+         mhw.to_string().c_str(), chipOnModuleHW);
 }
 
 void ChipInfo::print() const

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -130,14 +130,14 @@ void MC2RawEncoder<Mapping>::convertChip(ChipPixelData& chipData, RUDecodeData& 
 {
   ///< convert digits of single chip to Alpide format.
   const auto& chip = *mMAP.getChipOnRUInfo(ru.ruInfo->ruType, chipData.getChipID());
-  ru.cableHWID[chip.cableSW] = chip.cableHW; // register the cable HW ID
+  ru.cableHWID[chip.cableHWPos] = chip.cableHW; // register the cable HW ID
   auto& pixels = chipData.getData();
   std::sort(pixels.begin(), pixels.end(),
             [](auto lhs, auto rhs) {
               return (lhs.getRow() < rhs.getRow()) ? true : ((lhs.getRow() > rhs.getRow()) ? false : (lhs.getCol() < rhs.getCol()));
             });
-  ru.cableData[chip.cableSW].ensureFreeCapacity(40 * (2 + pixels.size())); // make sure buffer has enough capacity
-  mCoder.encodeChip(ru.cableData[chip.cableSW], chipData, chip.chipOnModuleHW, mCurrIR.bc);
+  ru.cableData[chip.cableHWPos].ensureFreeCapacity(40 * (2 + pixels.size())); // make sure buffer has enough capacity
+  mCoder.encodeChip(ru.cableData[chip.cableHWPos], chipData, chip.chipOnModuleHW, mCurrIR.bc);
 }
 
 //______________________________________________________
@@ -147,9 +147,9 @@ void MC2RawEncoder<Mapping>::convertEmptyChips(int fromChip, int uptoChip, RUDec
   // add empty chip words to respective cable's buffers for all chips of the current RU container
   for (int chipIDSW = fromChip; chipIDSW < uptoChip; chipIDSW++) { // flag chips w/o data
     const auto& chip = *mMAP.getChipOnRUInfo(ru.ruInfo->ruType, chipIDSW);
-    ru.cableHWID[chip.cableSW] = chip.cableHW; // register the cable HW ID
-    ru.cableData[chip.cableSW].ensureFreeCapacity(100);
-    mCoder.addEmptyChip(ru.cableData[chip.cableSW], chip.chipOnModuleHW, mCurrIR.bc);
+    ru.cableHWID[chip.cableHWPos] = chip.cableHW; // register the cable HW ID
+    ru.cableData[chip.cableHWPos].ensureFreeCapacity(100);
+    mCoder.addEmptyChip(ru.cableData[chip.cableHWPos], chip.chipOnModuleHW, mCurrIR.bc);
   }
 }
 


### PR DESCRIPTION
Before the Alpide cableHW ID was mapped to cableSW ID which was corresponding both to the
1) position of the cable in the ActiveLanes mask shipped in the GBTHeader
2) the order in which cached cables data was decoded.

To make decoding more flexible and guarantee that the cables are decoded in such order
that leads to decoded chips ordered in their SW ID, an extra mapping cableHW -> cableHWPos
is introduced for (1), while the cableSW is redefined to be used for (2) only.

@bovulpes you may need to change the ChipMappingMFT, I will add some details in https://alice.its.cern.ch/jira/browse/O2-1475