### PR TITLE
bug fixes related to TrackReferences

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -311,6 +311,7 @@ class Stack : public FairGenericStack
   ClassDefOverride(Stack, 1);
 };
 
+
 inline void Stack::addTrackReference(const o2::TrackReference& ref)
 {
   if (mIndexOfCurrentTrack >= mNumberOfPrimaryParticles) {

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -311,7 +311,6 @@ class Stack : public FairGenericStack
   ClassDefOverride(Stack, 1);
 };
 
-
 inline void Stack::addTrackReference(const o2::TrackReference& ref)
 {
   if (mIndexOfCurrentTrack >= mNumberOfPrimaryParticles) {

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -318,6 +318,7 @@ inline void Stack::addTrackReference(const o2::TrackReference& ref)
     auto& part = mParticles[iTrack];
     part.setStore(true);
   }
+  mTrackRefs->push_back(ref);
 }
 
 inline int Stack::getCurrentPrimaryIndex() const { return mPrimaryParticles.size() - 1 - mPrimariesDone; }

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -21,7 +21,6 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "SimulationDataFormat/MCEventStats.h"
-
 #include "Rtypes.h"
 #include "TParticle.h"
 
@@ -312,7 +311,14 @@ class Stack : public FairGenericStack
   ClassDefOverride(Stack, 1);
 };
 
-inline void Stack::addTrackReference(const o2::TrackReference& ref) { mTrackRefs->push_back(ref); }
+inline void Stack::addTrackReference(const o2::TrackReference& ref)
+{
+  if (mIndexOfCurrentTrack >= mNumberOfPrimaryParticles) {
+    Int_t iTrack = mTrackIDtoParticlesEntry[mIndexOfCurrentTrack];
+    auto& part = mParticles[iTrack];
+    part.setStore(true);
+  }
+}
 
 inline int Stack::getCurrentPrimaryIndex() const { return mPrimaryParticles.size() - 1 - mPrimariesDone; }
 

--- a/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
@@ -49,11 +49,15 @@ struct SimTrackStatus {
       mStatus |= kTrackOut;
     }
     if (vmc.IsTrackStop()) {
-      mStatus |= kTrackAlive;
+      mStatus |= kTrackStopped;
     }
     if (vmc.IsNewTrack()) {
       mStatus |= kTrackNew;
     }
+    if (vmc.IsTrackAlive()) {
+      mStatus |= kTrackAlive;
+    }
+
   }
   bool isEntering() const { return mStatus & kTrackEntering; }
   bool isInside() const { return mStatus & kTrackInside; }
@@ -211,6 +215,7 @@ inline TrackReference::TrackReference(TVirtualMC const& vmc, int detlabel) : mSt
   mTrackLength = vmc.TrackLength();
   mTof = vmc.TrackTime();
   mDetectorId = detlabel;
+  mTrackNumber = vmc.GetStack()->GetCurrentTrackNumber(); 
 }
 
 inline std::ostream& operator<<(std::ostream& os, const TrackReference& a)

--- a/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/TrackReference.h
@@ -57,7 +57,6 @@ struct SimTrackStatus {
     if (vmc.IsTrackAlive()) {
       mStatus |= kTrackAlive;
     }
-
   }
   bool isEntering() const { return mStatus & kTrackEntering; }
   bool isInside() const { return mStatus & kTrackInside; }
@@ -215,7 +214,7 @@ inline TrackReference::TrackReference(TVirtualMC const& vmc, int detlabel) : mSt
   mTrackLength = vmc.TrackLength();
   mTof = vmc.TrackTime();
   mDetectorId = detlabel;
-  mTrackNumber = vmc.GetStack()->GetCurrentTrackNumber(); 
+  mTrackNumber = vmc.GetStack()->GetCurrentTrackNumber();
 }
 
 inline std::ostream& operator<<(std::ostream& os, const TrackReference& a)

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -671,6 +671,8 @@ bool Stack::selectTracks()
         }
       }
     }
+
+    store = store || thisPart.getStore();
     thisPart.setStore(store);
   }
 


### PR DESCRIPTION
- missing initialisation of mTrackNumber in one of the constructors
- corrected "alive" and "stopped" conditions
- particles producing a TrackReference are kept on the stack
(avoids also "Invalid trackref ... needs to be removed" messages.)