### PR TITLE
RawWriter will discard data with IR<HBFUtils.getFirstIR()

### DIFF
--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -132,6 +132,10 @@ void RawFileWriter::addData(uint16_t feeid, uint16_t cru, uint8_t lnk, uint8_t e
   }
   auto sspec = RDHUtils::getSubSpec(cru, lnk, endpoint, feeid);
   auto& link = getLinkWithSubSpec(sspec);
+  if (ir < mHBFUtils.getFirstIR()) {
+    LOG(WARNING) << "provided " << ir << " precedes first TF " << mHBFUtils.getFirstIR() << " | discarding data for " << link.describe();
+    return;
+  }
   if (ir < mFirstIRAdded) {
     mFirstIRAdded = ir;
   }

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -180,7 +180,8 @@ void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::
   _GPUParam.SetDefaults(5.00668);
   const GPUParam mGPUParam = _GPUParam;
 
-  o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
+  //o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
+  o2::InteractionRecord ir(0, 0); // we start with the time registered in ditigs, w/o extra offset
   zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, zsThreshold, processAttributes->padding);
 }
 


### PR DESCRIPTION
@davidrohr: with this PR the ``o2-tpc-digits-to-rawzs --configKeyValues "HBFUtils.orbitFirst=1"`` will discard all data of (dummy) HBFs preceding the desired 1st TF start.
This works for all converters, since the modification is on the RawWriter level. 
But for the TPC I had to remove the biasing of the digits time by the ``HBFUtils::getFirstIR()`` since in this way it would always add ``HBFUtils.orbitFirst`` empty orbits in front of the 1st digitized one.
If you want to be able to shift the TF to the future, the shift should be provided by an additional option, independent from the ``HBFUtils::getFirstIR()``.