### PR TITLE
DPL: do not skip messages with nullptr payload

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -662,7 +662,7 @@ bool DataProcessingDevice::tryDispatchComputation()
       if (input.spec->lifetime != Lifetime::Timer) {
         continue;
       }
-      if (input.header == nullptr || input.payload == nullptr) {
+      if (input.header == nullptr) {
         continue;
       }
       // This will hopefully delete the message.


### PR DESCRIPTION
Messages with empty (nullptr) payload are nevertheless valid when running on
shmem transport and soon also for FairMQ.