### PR TITLE
Options to set 1st orbit/bc for sampling in digitization

### DIFF
--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -29,7 +29,6 @@ class InteractionSampler
 {
  public:
   static constexpr float Sec2NanoSec = 1.e9; // s->ns conversion
-  static constexpr int FirstOrbit = 1;       // start from orbit > 0 to avoid problems with negative BCs
   const o2::InteractionTimeRecord& generateCollisionTime();
   void generateCollisionTimes(std::vector<o2::InteractionTimeRecord>& dest);
 
@@ -37,6 +36,7 @@ class InteractionSampler
 
   void setInteractionRate(float rateHz) { mIntRate = rateHz; }
   float getInteractionRate() const { return mIntRate; }
+  void setFirstIR(const o2::InteractionRecord& ir) { mIR.InteractionRecord::operator=(ir); }
   void setMuPerBC(float mu) { mMuBC = mu; }
   float getMuPerBC() const { return mMuBC; }
   void setBCTimeRMS(float tNS = 0.2) { mBCTimeRMS = tNS; }
@@ -56,7 +56,7 @@ class InteractionSampler
   void nextCollidingBC();
   void warnOrbitWrapped() const;
 
-  o2::InteractionTimeRecord mIR{{0, FirstOrbit}, 0.};
+  o2::InteractionTimeRecord mIR{{0, 0}, 0.};
   int mIntBCCache = 0;         ///< N interactions left for current BC
   int mBCMin = 0;              ///< 1st filled BCID
   int mBCMax = -1;             ///< last filled BCID

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -54,7 +54,7 @@ void InteractionSampler::init()
   mProbInteraction = 1. - muexp;
   mMuBCZTRed = mMuBC * muexp / mProbInteraction;
   mIntBCCache = 0;
-  mIR.bc = mBCMin;
+  mIR.bc = std::max(uint16_t(mBCMin), mIR.bc);
 }
 
 //_________________________________________________


### PR DESCRIPTION
o2-sim-digitizer-workflow --firstOrbit <orb> --firstBC <bc>
will enforce sampling starting from given orbit/bc (if bc exceeds LHCMaxBunches,
the firstOrbit will be incremented by bc/LHCMaxBunches and bc%LHCMaxBunches will
be used as a 1st bc.
Default behaviour is unchanged: firstOrbit = 1, firstBC = 0.

@davidrohr with ``o2-sim-digitizer-workflow --firstOrbit 0`` you can avoid a gap between default ``HBFUtil.getFirstIR()`` and 1st sampled orbit, in case the ZDC is not in the game. Even with ZDC in the  ``o2-sim-digitizer-workflow --firstOrbit 0 --firstBC 4`` should be absolutely safe, it will just skip 1st 4 BCs.