### PR TITLE
Using DPL RootTreeWriter for ITS and MFT workflows

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
@@ -13,34 +13,15 @@
 #ifndef O2_ITS_CLUSTERWRITER
 #define O2_ITS_CLUSTERWRITER
 
-#include "TFile.h"
-#include "TTree.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
 
 namespace o2
 {
 namespace its
 {
 
-class ClusterWriter : public o2::framework::Task
-{
- public:
-  ClusterWriter(bool useMC) : mUseMC(useMC) {}
-  ~ClusterWriter() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
-
- private:
-  bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-};
-
 /// create a processor spec
-/// write ITS clusters a root file
+/// write ITS clusters to ROOT file
 framework::DataProcessorSpec getClusterWriterSpec(bool useMC);
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
@@ -13,33 +13,15 @@
 #ifndef O2_ITS_TRACKWRITER
 #define O2_ITS_TRACKWRITER
 
-#include "TFile.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
 
 namespace o2
 {
 namespace its
 {
 
-class TrackWriter : public o2::framework::Task
-{
- public:
-  TrackWriter(bool useMC) : mUseMC(useMC) {}
-  ~TrackWriter() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
-
- private:
-  bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-};
-
 /// create a processor spec
-/// write ITS tracks a root file
+/// write ITS tracks to ROOT file
 o2::framework::DataProcessorSpec getTrackWriterSpec(bool useMC);
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -12,15 +12,13 @@
 
 #include <vector>
 
-#include "Framework/ControlService.h"
-#include "Framework/ConfigParamRegistry.h"
 #include "ITSWorkflow/ClusterWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/Cluster.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
-#include "DataFormatsITSMFT/ROFRecord.h"
-#include "CommonUtils/StringUtils.h"
 
 using namespace o2::framework;
 
@@ -30,90 +28,49 @@ namespace its
 {
 
 template <typename T>
-TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
-{
-  if (auto br = tree->GetBranch(brname)) {
-    br->SetAddress(static_cast<void*>(ptr));
-    return br;
-  }
-  return tree->Branch(brname, ptr); // otherwise make it
-}
-
-void ClusterWriter::init(InitContext& ic)
-{
-  auto filename = ic.options().get<std::string>("its-cluster-outfile");
-  mFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
-  if (!mFile->IsOpen()) {
-    throw std::runtime_error(o2::utils::concat_string("failed to open ITS clusters output file ", filename));
-  }
-  mTree = std::make_unique<TTree>("o2sim", "Tree with ITS clusters");
-}
-
-void ClusterWriter::run(ProcessingContext& pc)
-{
-  auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto pspan = pc.inputs().get<gsl::span<unsigned char>>("patterns");
-  auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
-  std::vector<unsigned char> patterns(pspan.begin(), pspan.end());
-
-  LOG(INFO) << "ITSClusterWriter pulled " << compClusters.size() << " clusters, in " << rofs.size() << " RO frames";
-  auto compClustersPtr = &compClusters;
-  getOrMakeBranch(mTree.get(), "ITSClusterComp", &compClustersPtr);
-  auto patternsPtr = &patterns;
-  getOrMakeBranch(mTree.get(), "ITSClusterPatt", &patternsPtr);
-  auto clustersPtr = &clusters;
-  getOrMakeBranch(mTree.get(), "ITSCluster", &clustersPtr); // RSTODO being eliminated
-  auto rofsPtr = &rofs;
-  getOrMakeBranch(mTree.get(), "ITSClustersROF", &rofsPtr);
-
-  if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    plabels = labels.get();
-    getOrMakeBranch(mTree.get(), "ITSClusterMCTruth", &plabels);
-
-    // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    mc2rofs.reserve(m2rvec.size());
-    for (const auto& m2rv : m2rvec) {
-      mc2rofs.push_back(m2rv);
-    }
-    getOrMakeBranch(mTree.get(), "ITSClustersMC2ROF", &mc2rofsPtr);
-  }
-  mTree->Fill();
-}
-
-void ClusterWriter::endOfStream(o2::framework::EndOfStreamContext& ec)
-{
-  LOG(INFO) << "Finalizing ITS cluster writing";
-  mTree->Write();
-  mTree.release()->Delete();
-  mFile->Close();
-}
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using CompClusType = std::vector<o2::itsmft::CompClusterExt>;
+using PatternsType = std::vector<unsigned char>;
+using ClustersType = std::vector<o2::itsmft::Cluster>;
+using ROFrameRType = std::vector<o2::itsmft::ROFRecord>;
+using LabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
+using namespace o2::header;
 
 DataProcessorSpec getClusterWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
-  if (useMC) {
-    inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe);
-  }
-
-  return DataProcessorSpec{
-    "its-cluster-writer",
-    inputs,
-    Outputs{},
-    AlgorithmSpec{adaptFromTask<ClusterWriter>(useMC)},
-    Options{
-      {"its-cluster-outfile", VariantType::String, "o2clus_its.root", {"Name of the output file"}}}};
+  // Spectators for logging
+  // this is only to restore the original behavior
+  auto compClustersSize = std::make_shared<int>(0);
+  auto compClustersSizeGetter = [compClustersSize](CompClusType const& compClusters) {
+    *compClustersSize = compClusters.size();
+  };
+  auto logger = [compClustersSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
+    LOG(INFO) << "ITSClusterWriter pulled " << *compClustersSize << " clusters, in " << rofs.size() << " RO frames";
+  };
+  return MakeRootTreeWriterSpec("its-cluster-writer",
+                                "o2clus_its.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with ITS clusters"},
+                                BranchDefinition<CompClusType>{InputSpec{"compclus", "ITS", "COMPCLUSTERS", 0},
+                                                               "ITSClusterComp",
+                                                               compClustersSizeGetter},
+                                BranchDefinition<PatternsType>{InputSpec{"patterns", "ITS", "PATTERNS", 0},
+                                                               "ITSClusterPatt"},
+                                // this has been marked to be removed in the original implementation
+                                // RSTODO being eliminated
+                                BranchDefinition<ClustersType>{InputSpec{"clusters", "ITS", "CLUSTERS", 0},
+                                                               "ITSCluster"},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "ITSClusterROF", 0},
+                                                               "ITSClustersROF",
+                                                               logger},
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "CLUSTERSMCTR", 0},
+                                                             "ITSClusterMCTruth",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSClusterMC2ROF", 0},
+                                                             "ITSClustersMC2ROF",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""})();
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -12,17 +12,13 @@
 
 #include <vector>
 
-#include "TTree.h"
-
-#include "Framework/ControlService.h"
-#include "Framework/ConfigParamRegistry.h"
 #include "ITSWorkflow/TrackWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITS/TrackITS.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "ReconstructionDataFormats/Vertex.h"
-#include "CommonUtils/StringUtils.h"
 
 using namespace o2::framework;
 
@@ -33,94 +29,45 @@ namespace its
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
 template <typename T>
-TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
-{
-  if (auto br = tree->GetBranch(brname)) {
-    br->SetAddress(static_cast<void*>(ptr));
-    return br;
-  }
-  return tree->Branch(brname, ptr); // otherwise make it
-}
-
-void TrackWriter::init(InitContext& ic)
-{
-  auto filename = ic.options().get<std::string>("its-track-outfile");
-  mFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
-  if (!mFile->IsOpen()) {
-    throw std::runtime_error(o2::utils::concat_string("failed to open ITS tracks output file ", filename));
-  }
-  mTree = std::make_unique<TTree>("o2sim", "Tree with ITS tracks");
-}
-
-void TrackWriter::run(ProcessingContext& pc)
-{
-  auto tracks = pc.inputs().get<const std::vector<o2::its::TrackITS>>("tracks");
-  auto clusIdx = pc.inputs().get<gsl::span<int>>("trackClIdx");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-  auto vertices = pc.inputs().get<const std::vector<Vertex>>("vertices");
-  auto verticesROF = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("verticesROF");
-
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
-  std::vector<int> clusIdxOut;
-  clusIdxOut.reserve(clusIdx.size());
-  std::copy(clusIdx.begin(), clusIdx.end(), std::back_inserter(clusIdxOut));
-
-  LOG(INFO) << "ITSTrackWriter pulled " << tracks.size() << " tracks, in " << rofs.size() << " RO frames";
-
-  auto tracksPtr = &tracks;
-  getOrMakeBranch(mTree.get(), "ITSTrack", &tracksPtr);
-  auto clusIdxOutPtr = &clusIdxOut;
-  getOrMakeBranch(mTree.get(), "ITSTrackClusIdx", &clusIdxOutPtr);
-  auto verticesPtr = &vertices;
-  getOrMakeBranch(mTree.get(), "Vertices", &verticesPtr);
-  auto verticesROFPtr = &verticesROF;
-  getOrMakeBranch(mTree.get(), "VerticesROF", &verticesROFPtr);
-  auto rofsPtr = &rofs;
-  getOrMakeBranch(mTree.get(), "ITSTracksROF", &rofsPtr); // write ROFrecords vector to a tree
-
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
-  if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    plabels = labels.get();
-    getOrMakeBranch(mTree.get(), "ITSTrackMCTruth", &plabels);
-
-    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    mc2rofs.reserve(m2rvec.size());
-    std::copy(m2rvec.begin(), m2rvec.end(), std::back_inserter(mc2rofs));
-    getOrMakeBranch(mTree.get(), "ITSTracksMC2ROF", &mc2rofsPtr);
-  }
-  mTree->Fill();
-}
-
-void TrackWriter::endOfStream(EndOfStreamContext& ec)
-{
-  LOG(INFO) << "Finalizing ITS tracks writing";
-  mTree->Write();
-  mTree.release()->Delete();
-  mFile->Close();
-}
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using LabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
+using namespace o2::header;
 
 DataProcessorSpec getTrackWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("tracks", "ITS", "TRACKS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("trackClIdx", "ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
-  inputs.emplace_back("vertices", "ITS", "VERTICES", 0, Lifetime::Timeframe);
-  inputs.emplace_back("verticesROF", "ITS", "VERTICESROF", 0, Lifetime::Timeframe);
-  if (useMC) {
-    inputs.emplace_back("labels", "ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
-  }
-
-  return DataProcessorSpec{
-    "its-track-writer",
-    inputs,
-    Outputs{},
-    AlgorithmSpec{adaptFromTask<TrackWriter>(useMC)},
-    Options{
-      {"its-track-outfile", VariantType::String, "o2trac_its.root", {"Name of the output file"}}}};
+  // Spectators for logging
+  // this is only to restore the original behavior
+  auto tracksSize = std::make_shared<int>(0);
+  auto tracksSizeGetter = [tracksSize](std::vector<o2::its::TrackITS> const& tracks) {
+    *tracksSize = tracks.size();
+  };
+  auto logger = [tracksSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
+    LOG(INFO) << "ITSTrackWriter pulled " << *tracksSize << " tracks, in " << rofs.size() << " RO frames";
+  };
+  return MakeRootTreeWriterSpec("its-track-writer",
+                                "o2trac_its.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with ITS tracks"},
+                                BranchDefinition<std::vector<o2::its::TrackITS>>{InputSpec{"tracks", "ITS", "TRACKS", 0},
+                                                                                 "ITSTrack",
+                                                                                 tracksSizeGetter},
+                                BranchDefinition<std::vector<int>>{InputSpec{"trackClIdx", "ITS", "TRACKCLSID", 0},
+                                                                   "ITSTrackClusIdx"},
+                                BranchDefinition<std::vector<Vertex>>{InputSpec{"vertices", "ITS", "VERTICES", 0},
+                                                                      "Vertices"},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"vtxROF", "ITS", "VERTICESROF", 0},
+                                                                                     "VerticesROF"},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "ITS", "ITSTrackROF", 0},
+                                                                                     "ITSTracksROF",
+                                                                                     logger},
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "TRACKSMCTR", 0},
+                                                             "ITSTrackMCTruth",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSTrackMC2ROF", 0},
+                                                             "ITSTracksMC2ROF",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""})();
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClusterWriterSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClusterWriterSpec.h
@@ -13,30 +13,12 @@
 #ifndef O2_MFT_CLUSTERWRITER_H_
 #define O2_MFT_CLUSTERWRITER_H_
 
-#include "TFile.h"
-
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
 
 namespace o2
 {
 namespace mft
 {
-
-class ClusterWriter : public o2::framework::Task
-{
- public:
-  ClusterWriter(bool useMC) : mUseMC(useMC) {}
-  ~ClusterWriter() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
-
- private:
-  bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-  std::unique_ptr<TTree> mTree = nullptr;
-};
 
 /// create a processor spec
 /// write MFT clusters a root file

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackWriterSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackWriterSpec.h
@@ -23,20 +23,6 @@ namespace o2
 namespace mft
 {
 
-class TrackWriter : public o2::framework::Task
-{
- public:
-  TrackWriter(bool useMC) : mUseMC(useMC) {}
-  ~TrackWriter() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-
- private:
-  int mState = 0;
-  bool mUseMC = true;
-  std::unique_ptr<TFile> mFile = nullptr;
-};
-
 /// create a processor spec
 /// write MFT tracks a root file
 o2::framework::DataProcessorSpec getTrackWriterSpec(bool useMC);

--- a/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
@@ -12,17 +12,13 @@
 
 #include <vector>
 
-#include "TTree.h"
-
-#include "Framework/ControlService.h"
-#include "Framework/ConfigParamRegistry.h"
 #include "MFTWorkflow/ClusterWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
-#include "CommonUtils/StringUtils.h"
 
 using namespace o2::framework;
 
@@ -32,92 +28,49 @@ namespace mft
 {
 
 template <typename T>
-TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
-{
-  if (auto br = tree->GetBranch(brname)) {
-    br->SetAddress(static_cast<void*>(ptr));
-    return br;
-  }
-  return tree->Branch(brname, ptr); // otherwise make it
-}
-
-void ClusterWriter::init(InitContext& ic)
-{
-  auto filename = ic.options().get<std::string>("mft-cluster-outfile");
-  mFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
-  if (!mFile->IsOpen()) {
-    throw std::runtime_error(o2::utils::concat_string("failed to open MFT clusters output file ", filename));
-  }
-  mTree = std::make_unique<TTree>("o2sim", "Tree with MFT clusters");
-}
-
-void ClusterWriter::run(ProcessingContext& pc)
-{
-  auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto pspan = pc.inputs().get<gsl::span<unsigned char>>("patterns");
-  auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
-  std::vector<unsigned char> patterns(pspan.begin(), pspan.end());
-
-  LOG(INFO) << "MFTClusterWriter pulled " << clusters.size() << " clusters, in " << rofs.size() << " RO frames";
-
-  auto compClustersPtr = &compClusters;
-  getOrMakeBranch(mTree.get(), "MFTClusterComp", &compClustersPtr);
-  auto patternsPtr = &patterns;
-  getOrMakeBranch(mTree.get(), "MFTClusterPatt", &patternsPtr);
-  auto clustersPtr = &clusters;
-  getOrMakeBranch(mTree.get(), "MFTCluster", &clustersPtr); // RSTODO being eliminated
-  auto rofsPtr = &rofs;
-  getOrMakeBranch(mTree.get(), "MFTClustersROF", &rofsPtr);
-
-  if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    plabels = labels.get();
-    getOrMakeBranch(mTree.get(), "MFTClusterMCTruth", &plabels);
-
-    // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    mc2rofs.reserve(m2rvec.size());
-    for (const auto& m2rv : m2rvec) {
-      mc2rofs.push_back(m2rv);
-    }
-    getOrMakeBranch(mTree.get(), "MFTClustersMC2ROF", &mc2rofsPtr);
-  }
-
-  mTree->Fill();
-}
-
-void ClusterWriter::endOfStream(o2::framework::EndOfStreamContext& ec)
-{
-  LOG(INFO) << "Finalizing MFT cluster writing";
-  mTree->Write();
-  mTree.release()->Delete();
-  mFile->Close();
-}
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using CompClusType = std::vector<o2::itsmft::CompClusterExt>;
+using PatternsType = std::vector<unsigned char>;
+using ClustersType = std::vector<o2::itsmft::Cluster>;
+using ROFrameRType = std::vector<o2::itsmft::ROFRecord>;
+using LabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
+using namespace o2::header;
 
 DataProcessorSpec getClusterWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("compClusters", "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("patterns", "MFT", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("clusters", "MFT", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "MFTClusterROF", 0, Lifetime::Timeframe);
-  if (useMC) {
-    inputs.emplace_back("labels", "MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe);
-  }
-
-  return DataProcessorSpec{
-    "mft-cluster-writer",
-    inputs,
-    Outputs{},
-    AlgorithmSpec{adaptFromTask<ClusterWriter>(useMC)},
-    Options{
-      {"mft-cluster-outfile", VariantType::String, "mftclusters.root", {"Name of the output file"}}}};
+  // Spectators for logging
+  // this is only to restore the original behavior
+  auto clustersSize = std::make_shared<int>(0);
+  auto clustersSizeGetter = [clustersSize](ClustersType const& clusters) {
+    *clustersSize = clusters.size();
+  };
+  auto logger = [clustersSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
+    LOG(INFO) << "MFTClusterWriter pulled " << *clustersSize << " clusters, in " << rofs.size() << " RO frames";
+  };
+  return MakeRootTreeWriterSpec("mft-cluster-writer",
+                                "mftclusters.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with MFT clusters"},
+                                BranchDefinition<CompClusType>{InputSpec{"compclus", "MFT", "COMPCLUSTERS", 0},
+                                                               "MFTClusterComp"},
+                                BranchDefinition<PatternsType>{InputSpec{"patterns", "MFT", "PATTERNS", 0},
+                                                               "MFTClusterPatt"},
+                                // this has been marked to be removed in the original implementation
+                                // RSTODO being eliminated
+                                BranchDefinition<ClustersType>{InputSpec{"clusters", "MFT", "CLUSTERS", 0},
+                                                               "MFTCluster",
+                                                               clustersSizeGetter},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "MFT", "MFTClusterROF", 0},
+                                                               "MFTClustersROF",
+                                                               logger},
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "MFT", "CLUSTERSMCTR", 0},
+                                                             "MFTClusterMCTruth",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "MFTClusterMC2ROF", 0},
+                                                             "MFTClustersMC2ROF",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""})();
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -12,13 +12,10 @@
 
 #include <vector>
 
-#include "TTree.h"
-
 #include "MFTWorkflow/TrackWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "MFTTracking/TrackCA.h"
 
-#include "Framework/ControlService.h"
-#include "Framework/ConfigParamRegistry.h"
 #include "DataFormatsMFT/TrackMFT.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -31,88 +28,42 @@ namespace o2
 namespace mft
 {
 
-void TrackWriter::init(InitContext& ic)
-{
-  auto filename = ic.options().get<std::string>("mft-track-outfile");
-  mFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
-  if (!mFile->IsOpen()) {
-    LOG(ERROR) << "Cannot open the " << filename.c_str() << " file !";
-    mState = 0;
-    return;
-  }
-  mState = 1;
-}
-
-void TrackWriter::run(ProcessingContext& pc)
-{
-  if (mState != 1)
-    return;
-
-  auto tracks = pc.inputs().get<const std::vector<o2::mft::TrackMFT>>("tracks");
-  auto tracksltf = pc.inputs().get<const std::vector<o2::mft::TrackLTF>>("tracksltf");
-  auto tracksca = pc.inputs().get<const std::vector<o2::mft::TrackCA>>("tracksca");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
-
-  LOG(INFO) << "MFTTrackWriter pulled "
-            << tracks.size() << " tracks, "
-            << tracksltf.size() << " tracks LTF, "
-            << tracksca.size() << " tracks CA, in "
-            << rofs.size() << " RO frames";
-
-  TTree tree("o2sim", "Tree with MFT tracks");
-  tree.Branch("MFTTrack", &tracks);
-  tree.Branch("MFTTrackLTF", &tracksltf);
-  tree.Branch("MFTTrackCA", &tracksca);
-  if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    plabels = labels.get();
-    tree.Branch("MFTTrackMCTruth", &plabels);
-  }
-  // write ROFrecords vector to a tree
-  auto* rofsPtr = &rofs;
-  tree.Branch("MFTTracksROF", &rofsPtr);
-
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
-  if (mUseMC) {
-    // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    mc2rofs.reserve(m2rvec.size());
-    for (const auto& m2rv : m2rvec) {
-      mc2rofs.push_back(m2rv);
-    }
-    tree.Branch("MFTTracksMC2ROF", &mc2rofsPtr);
-  }
-
-  tree.Fill();
-  tree.Write();
-  mFile->Close();
-
-  mState = 2;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-}
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using namespace o2::header;
 
 DataProcessorSpec getTrackWriterSpec(bool useMC)
 {
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("tracks", "MFT", "TRACKS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("tracksltf", "MFT", "TRACKSLTF", 0, Lifetime::Timeframe);
-  inputs.emplace_back("tracksca", "MFT", "TRACKSCA", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "MFTTrackROF", 0, Lifetime::Timeframe);
-  if (useMC) {
-    inputs.emplace_back("labels", "MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "MFTTrackMC2ROF", 0, Lifetime::Timeframe);
-  }
-
-  return DataProcessorSpec{
-    "mft-track-writer",
-    inputs,
-    Outputs{},
-    AlgorithmSpec{adaptFromTask<TrackWriter>(useMC)},
-    Options{
-      {"mft-track-outfile", VariantType::String, "mfttracks.root", {"Name of the output file"}}}};
+  // Spectators for logging
+  // this is only to restore the original behavior
+  auto tracksSize = std::make_shared<int>(0);
+  auto tracksSizeGetter = [tracksSize](std::vector<o2::mft::TrackMFT> const& tracks) {
+    *tracksSize = tracks.size();
+  };
+  auto logger = [tracksSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
+    LOG(INFO) << "MFTTrackWriter pulled " << *tracksSize << " tracks, in " << rofs.size() << " RO frames";
+  };
+  return MakeRootTreeWriterSpec("mft-track-writer",
+                                "mfttracks.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with MFT tracks"},
+                                BranchDefinition<std::vector<o2::mft::TrackMFT>>{InputSpec{"tracks", "MFT", "TRACKS", 0},
+                                                                                 "MFTTrack",
+                                                                                 tracksSizeGetter},
+                                BranchDefinition<std::vector<o2::mft::TrackLTF>>{InputSpec{"tracksltf", "MFT", "TRACKSLTF", 0},
+                                                                                 "MFTTrackLTF"},
+                                BranchDefinition<std::vector<o2::mft::TrackCA>>{InputSpec{"tracksca", "MFT", "TRACKSCA", 0},
+                                                                                "MFTTrackCA"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"labels", "MFT", "TRACKSMCTR", 0},
+                                                                                                     "MFTTrackMCTruth",
+                                                                                                     (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                                                                     ""},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "MFTTrackROF", 0},
+                                                                                     "MFTTracksROF",
+                                                                                     logger},
+                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "MFTTrackMC2ROF", 0},
+                                                                                        "MFTTracksMC2ROF",
+                                                                                        (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                                                        ""})();
 }
 
 } // namespace mft

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.cxx
@@ -11,20 +11,13 @@
 /// @brief  Processor spec for a ROOT file writer for ITSMFT digits
 
 #include "ITSMFTDigitWriterSpec.h"
-#include "Framework/CallbackService.h"
-#include "Framework/ConfigParamRegistry.h"
-#include "Framework/ControlService.h"
-#include "Framework/Task.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "Headers/DataHeader.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include <TTree.h>
-#include <TBranch.h>
-#include <TFile.h>
-#include <memory> // for make_shared, make_unique, unique_ptr
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -37,185 +30,44 @@ namespace o2
 namespace itsmft
 {
 
-class ITSMFTDPLDigitWriter
-{
-
-  using MCCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-
- public:
-  void init(framework::InitContext& ic)
-  {
-    //    std::string detStr = mID.getName();
-    std::string detStrL = mID.getName();
-    std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-
-    mFileName = ic.options().get<std::string>((detStrL + "-digit-outfile").c_str());
-    mTreeNameDig = ic.options().get<std::string>("treename");
-
-    LOG(INFO) << "Will store in " << mFileName << ":";
-    LOG(INFO) << "Tree " << mTreeNameDig << " with " << mID.getName() << " digits";
-
-    mOutFile = std::make_unique<TFile>(mFileName.c_str(), "RECREATE");
-    if (!mOutFile || mOutFile->IsZombie()) {
-      LOG(ERROR) << "Failed to open " << mFileName << " output file";
-    } else {
-      LOG(INFO) << "Opened " << mFileName << " output file";
-    }
-    mOutTreeDig = std::make_unique<TTree>(mTreeNameDig.c_str(), "Digits tree");
-  }
-
-  void run(framework::ProcessingContext& pc)
-  {
-    if (mFinished) {
-      return;
-    }
-    std::string detStr = mID.getName();
-    std::string detStrL = mID.getName();
-    std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-
-    // retrieve the digits from the input
-    auto inDigits = pc.inputs().get<std::vector<o2::itsmft::Digit>>((detStr + "digits").c_str());
-    auto inROFs = pc.inputs().get<std::vector<o2::itsmft::ROFRecord>>((detStr + "digitsROF").c_str());
-
-    if (mWithMCTruth) {
-      auto inLabels = pc.inputs().get<MCCont*>((detStr + "digitsMCTR").c_str());
-      auto labelsRaw = inLabels.get();
-
-      auto inMC2ROFs = pc.inputs().get<std::vector<o2::itsmft::MC2ROFRecord>>((detStr + "digitsMC2ROF").c_str());
-      auto mc2rofP = &inMC2ROFs;
-      fillBranch(*mOutTreeDig.get(), (detStr + "DigitMCTruth").c_str(), &labelsRaw);
-      fillBranch(*mOutTreeDig.get(), (detStr + "DigitMC2ROF").c_str(), &mc2rofP);
-    }
-    LOG(INFO) << "RECEIVED DIGITS SIZE " << inDigits.size();
-
-    auto digitsP = &inDigits;
-    auto rofP = &inROFs;
-    fillBranch(*mOutTreeDig.get(), (detStr + "Digit").c_str(), &digitsP);
-    fillBranch(*mOutTreeDig.get(), (detStr + "DigitROF").c_str(), &rofP);
-
-    mOutTreeDig->SetEntries(mOutTreeDig->GetEntries() + 1);
-
-    mOutTreeDig->Write();
-    mOutTreeDig.reset(); // delete the trees before closing the file
-
-    mOutFile->Close();
-    mFinished = true;
-    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-  }
-
- protected:
-  ITSMFTDPLDigitWriter(bool mctruth = true) : mWithMCTruth(mctruth) {}
-  template <typename T>
-  void fillBranch(TTree& tree, std::string brname, T* ptr)
-  {
-    auto br = tree.GetBranch(brname.c_str());
-    if (br) {
-      br->SetAddress(static_cast<void*>(ptr));
-    } else {
-      // otherwise make it
-      br = tree.Branch(brname.c_str(), ptr);
-    }
-    // fill data and reset
-    br->Fill();
-    br->ResetAddress();
-  }
-
-  std::string mFileName = "ditigs.root";  // output file name
-  std::string mTreeNameDig = "o2sim";     // tree name for digits
-
-  bool mFinished = false;
-  o2::detectors::DetID mID;
-  o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
-  std::vector<o2::itsmft::Digit> mDigits; // input digits
-  std::unique_ptr<TFile> mOutFile;
-  std::unique_ptr<TTree> mOutTreeDig;    // output tree with digits
-  bool mWithMCTruth = true;
-};
-
-//_______________________________________________
-class ITSDPLDigitWriter : public ITSMFTDPLDigitWriter
-{
- public:
-  // FIXME: origina should be extractable from the DetID, the problem is 3d party header dependencies
-  static constexpr o2::detectors::DetID::ID DETID = o2::detectors::DetID::ITS;
-  static constexpr o2::header::DataOrigin DETOR = o2::header::gDataOriginITS;
-  ITSDPLDigitWriter(bool mctruth = true) : ITSMFTDPLDigitWriter(mctruth)
-  {
-    mID = DETID;
-    mOrigin = DETOR;
-    mFileName = "itsdigits.root"; // should be eventually set via config param
-  }
-};
-
-constexpr o2::detectors::DetID::ID ITSDPLDigitWriter::DETID;
-constexpr o2::header::DataOrigin ITSDPLDigitWriter::DETOR;
-
-//_______________________________________________
-class MFTDPLDigitWriter : public ITSMFTDPLDigitWriter
-{
- public:
-  // FIXME: origina should be extractable from the DetID, the problem is 3d party header dependencies
-  static constexpr o2::detectors::DetID::ID DETID = o2::detectors::DetID::MFT;
-  static constexpr o2::header::DataOrigin DETOR = o2::header::gDataOriginMFT;
-  MFTDPLDigitWriter(bool mctruth = true) : ITSMFTDPLDigitWriter(mctruth)
-  {
-    mID = DETID;
-    mOrigin = DETOR;
-    mFileName = "mftdigits.root"; // should be eventually set via config param
-  }
-};
-
-constexpr o2::detectors::DetID::ID MFTDPLDigitWriter::DETID;
-constexpr o2::header::DataOrigin MFTDPLDigitWriter::DETOR;
-
-std::vector<InputSpec> makeInputs(std::string const& detStr, o2::header::DataOrigin detOrig, bool mctruth)
-{
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back(InputSpec{(detStr + "digits").c_str(), detOrig, "DIGITS", 0, Lifetime::Timeframe});
-  inputs.emplace_back(InputSpec{(detStr + "digitsROF").c_str(), detOrig, "DIGITSROF", 0, Lifetime::Timeframe});
-  if (mctruth) {
-    inputs.emplace_back(InputSpec{(detStr + "digitsMCTR").c_str(), detOrig, "DIGITSMCTR", 0, Lifetime::Timeframe});
-    inputs.emplace_back(InputSpec{(detStr + "digitsMC2ROF").c_str(), detOrig, "DIGITSMC2ROF", 0, Lifetime::Timeframe});
-  }
-  return inputs;
-}
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using MCCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 /// create the processor spec
 /// describing a processor receiving digits for ITS/MFT and writing them to file
-DataProcessorSpec getITSDigitWriterSpec(bool mctruth)
+DataProcessorSpec getITSMFTDigitWriterSpec(bool mctruth, o2::header::DataOrigin detOrig, o2::detectors::DetID detId)
 {
-  std::string detStr = o2::detectors::DetID::getName(ITSDPLDigitWriter::DETID);
+  std::string detStr = o2::detectors::DetID::getName(detId);
   std::string detStrL = detStr;
   std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-  auto detOrig = ITSDPLDigitWriter::DETOR;
+  auto logger = [](std::vector<o2::itsmft::Digit> const& inDigits) {
+    LOG(INFO) << "RECEIVED DIGITS SIZE " << inDigits.size();
+  };
+  return MakeRootTreeWriterSpec((detStr + "DigitWriter").c_str(),
+                                (detStrL + "digits.root").c_str(),
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Digits tree"},
+                                BranchDefinition<MCCont>{InputSpec{"digitsMCTR", detOrig, "DIGITSMCTR", 0},
+                                                         (detStr + "DigitMCTruth").c_str(),
+                                                         (mctruth ? 1 : 0)},
+                                BranchDefinition<std::vector<itsmft::MC2ROFRecord>>{InputSpec{"digitsMC2ROF", detOrig, "DIGITSMC2ROF", 0},
+                                                                                    (detStr + "DigitMC2ROF").c_str(),
+                                                                                    (mctruth ? 1 : 0)},
+                                BranchDefinition<std::vector<itsmft::Digit>>{InputSpec{"digits", detOrig, "DIGITS", 0},
+                                                                             (detStr + "Digit").c_str(),
+                                                                             logger},
+                                BranchDefinition<std::vector<itsmft::ROFRecord>>{InputSpec{"digitsROF", detOrig, "DIGITSROF", 0},
+                                                                                 (detStr + "DigitROF").c_str()})();
+}
 
-  return DataProcessorSpec{
-    (detStr + "DigitWriter").c_str(),
-    makeInputs(detStr, detOrig, mctruth),
-    {}, // no output
-    AlgorithmSpec(adaptFromTask<ITSDPLDigitWriter>(mctruth)),
-    Options{
-      {(detStrL + "-digit-outfile").c_str(), VariantType::String, (detStrL + "digits.root").c_str(), {"Name of the input file"}},
-      {"treename", VariantType::String, "o2sim", {"Name of top-level TTree"}},
-    }};
+DataProcessorSpec getITSDigitWriterSpec(bool mctruth)
+{
+  return getITSMFTDigitWriterSpec(mctruth, o2::header::gDataOriginITS, o2::detectors::DetID::ITS);
 }
 
 DataProcessorSpec getMFTDigitWriterSpec(bool mctruth)
 {
-  std::string detStr = o2::detectors::DetID::getName(MFTDPLDigitWriter::DETID);
-  std::string detStrL = detStr;
-  std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-  auto detOrig = MFTDPLDigitWriter::DETOR;
-
-  return DataProcessorSpec{
-    (detStr + "DigitWriter").c_str(),
-    makeInputs(detStr, detOrig, mctruth),
-    {}, // no output
-    AlgorithmSpec(adaptFromTask<MFTDPLDigitWriter>(mctruth)),
-    Options{
-      {(detStrL + "-digit-outfile").c_str(), VariantType::String, (detStrL + "digits.root").c_str(), {"Name of the input file"}},
-      {"treename", VariantType::String, "o2sim", {"Name of top-level TTree"}},
-    }};
+  return getITSMFTDigitWriterSpec(mctruth, o2::header::gDataOriginMFT, o2::detectors::DetID::MFT);
 }
 
 } // end namespace itsmft


### PR DESCRIPTION
Duplicate boiler plate code is replaced with standard RootTreeWriter.
