### PR TITLE
Make sure digi->raw converters set SOX trigger bits in the very 1st RDH

### DIFF
--- a/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
+++ b/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
@@ -23,6 +23,7 @@
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "FT0Simulation/Digits2Raw.h"
+#include "DataFormatsParameters/GRPObject.h"
 
 /// MC->raw conversion for FT0
 
@@ -90,6 +91,9 @@ void digi2raw(const std::string& inpName, const std::string& outDir, int verbosi
   m2r.setFilePerLink(filePerLink);
   m2r.setVerbosity(verbosity);
   auto& wr = m2r.getWriter();
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+  wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::FT0)); // must be set explicitly
   wr.setSuperPageSize(superPageSizeInB);
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -30,6 +30,7 @@
 #include "Algorithm/RangeTokenizer.h"
 #include "FairLogger.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 // GRP
 #include "DataFormatsParameters/GRPObject.h"
@@ -80,16 +81,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec specs;
 
-  o2::base::Propagator::initFieldFromGRP("o2sim_grp.root");
-  auto grp = o2::parameters::GRPObject::loadFrom("o2sim_grp.root");
-
-  if (!grp) {
-    LOG(ERROR) << "This workflow needs a valid GRP file to start";
-    return specs;
+  if (!cfgc.helpOnCommandLine()) {
+    std::string inputGRP = o2::base::NameConf::getGRPFileName();
+    o2::base::Propagator::initFieldFromGRP(inputGRP);
+    const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+    if (!grp) {
+      LOG(ERROR) << "This workflow needs a valid GRP file to start";
+      return specs;
+    }
+    o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+    //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
   }
-  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
-
   // the lane configuration defines the subspecification ids to be distributed among the lanes.
   // auto tofSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tof-sectors"));
   // std::vector<int> laneConfiguration = tofSectors;

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/MC2RawEncoder.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/MC2RawEncoder.h
@@ -71,8 +71,8 @@ class MC2RawEncoder
   int getRUSWMin() const { return mRUSWMin; }
   int getRUSWMax() const { return mRUSWMax; }
 
-  void setContinuousReadout(bool v) { mROMode = v ? Continuous : Triggered; }
-  bool isContinuousReadout() const { return mROMode == Continuous; }
+  void setContinuousReadout(bool v) { mWriter.setContinuousReadout(v); }
+  bool isContinuousReadout() const { return mWriter.isContinuousReadout(); }
 
   o2::raw::RawFileWriter& getWriter() { return mWriter; }
 
@@ -120,7 +120,6 @@ class MC2RawEncoder
   std::array<RUDecodeData, Mapping::getNRUs()> mRUDecodeVec; /// decoding buffers for all active RUs
   std::array<int, Mapping::getNRUs()> mRUEntry;              /// entry of the RU with given SW ID in the mRUDecodeVec
   std::vector<GBTLink> mGBTLinks;
-  RoMode_t mROMode = NotSet;
 
   ClassDefNV(MC2RawEncoder, 1);
 };

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -21,9 +21,7 @@ using RDHUtils = o2::raw::RDHUtils;
 template <class Mapping>
 void MC2RawEncoder<Mapping>::init()
 {
-  if (mROMode == NotSet) {
-    LOG(FATAL) << "Readout Mode must be set explicitly via setContinuousReadout(bool)";
-  }
+  assert(mWriter.isReadOutModeSet());
   mWriter.setCarryOverCallBack(this);
 
   // limit RUs to convert to existing ones

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -42,11 +42,13 @@ class Encoder
 
   void finalize(bool closeFile = true);
 
+  auto& getWriter() { return mRawWriter; }
+
  private:
   void flush(uint16_t feeId, const InteractionRecord& ir);
   void hbTrigger(const InteractionRecord& ir);
 
-  o2::raw::RawFileWriter mRawWriter{};        /// Raw file writer
+  o2::raw::RawFileWriter mRawWriter{o2::header::gDataOriginMID}; /// Raw file writer
   std::map<uint16_t, LocalBoardRO> mROData{}; /// Map of data per board
   ColumnDataToLocalBoard mConverter{};        /// ColumnData to LocalBoardRO converter
   FEEIdConfig mFEEIdConfig{};                 /// Crate FEEId mapper

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -30,6 +30,7 @@ void Encoder::init(const char* filename, int verbosity)
 
   CrateMasks masks;
   auto gbtIds = mFEEIdConfig.getConfiguredGBTIds();
+
   mRawWriter.setVerbosity(verbosity);
   for (auto& gbtId : gbtIds) {
     auto feeId = mFEEIdConfig.getFeeId(gbtId);

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -180,6 +180,7 @@ class RawFileWriter
 
   void setContinuousReadout() { mROMode = Continuous; }
   void setTriggeredReadout() { mROMode = Triggered; }
+  void setContinuousReadout(bool v) { mROMode = v ? Continuous : Triggered; }
   bool isContinuousReadout() const { return mROMode == Continuous; }
   bool isTriggeredReadout() const { return mROMode == Triggered; }
   bool isReadOutModeSet() const { return mROMode != NotSet; }

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Encoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Encoder.h
@@ -58,6 +58,8 @@ class Encoder
   void setContinuous(bool value) { mIsContinuous = value; }
   bool isContinuous() const { return mIsContinuous; }
 
+  auto& getWriter() { return mFileWriter; };
+
   static int getNCRU() { return NCRU; }
 
  protected:

--- a/Detectors/TOF/reconstruction/src/Encoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Encoder.cxx
@@ -17,6 +17,9 @@
 #include "CommonConstants/Triggers.h"
 #include "TString.h"
 #include "FairLogger.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+
 #include <array>
 #define VERBOSE
 
@@ -70,6 +73,10 @@ bool Encoder::open(const std::string name, std::string path)
     if (mCrateOn[feeid])
       mFileWriter.registerLink(rdh, Form("%s/cru%02d%s", path.c_str(), rdh.cruID, name.c_str()));
   }
+
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+  mFileWriter.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TOF)); // must be set explicitly
 
   return status;
 }

--- a/Detectors/TOF/simulation/CMakeLists.txt
+++ b/Detectors/TOF/simulation/CMakeLists.txt
@@ -18,3 +18,9 @@ o2_target_root_dictionary(TOFSimulation
                           HEADERS include/TOFSimulation/Detector.h
                                   include/TOFSimulation/Digitizer.h
                                   include/TOFSimulation/DigitizerTask.h)
+
+o2_add_executable(digi2raw
+                  COMPONENT_NAME tof
+                  SOURCES src/digi2raw.cxx
+                  PUBLIC_LINK_LIBRARIES O2::CommonUtils
+                                        Boost::program_options)

--- a/Detectors/TOF/simulation/src/digi2raw.cxx
+++ b/Detectors/TOF/simulation/src/digi2raw.cxx
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file digi2raw.cxx
+/// \breif an alias to o2-tof-reco-workflow -b --output-type raw --tof-raw-outdir <outdir>
+/// \author ruben.shahoyan@cern.ch
+
+#include <boost/program_options.hpp>
+#include <iostream>
+#include "CommonUtils/StringUtils.h"
+
+namespace bpo = boost::program_options;
+
+int main(int argc, char** argv)
+{
+  bpo::variables_map vm;
+  bpo::options_description opt_general("Usage:\n" + std::string(argv[0]) +
+                                       "Convert TOF digits to CRU raw data\n");
+  bpo::options_description opt_hidden("");
+  bpo::options_description opt_all;
+  bpo::positional_options_description opt_pos;
+
+  try {
+    auto add_option = opt_general.add_options();
+    add_option("help,h", "Print this help message");
+    add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
+    add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
+    opt_all.add(opt_general).add(opt_hidden);
+    bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
+
+    if (vm.count("help")) {
+      std::cout << opt_general << std::endl;
+      exit(0);
+    }
+
+    bpo::notify(vm);
+  } catch (bpo::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl
+              << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(1);
+  } catch (std::exception& e) {
+    std::cerr << e.what() << ", application will now exit" << std::endl;
+    exit(2);
+  }
+
+  auto cmd = o2::utils::concat_string("o2-tof-reco-workflow -b --output-type raw --tof-raw-outdir ", vm["output-dir"].as<std::string>(),
+                                      R"( --configKeyValues ")", vm["configKeyValues"].as<std::string>(), '"');
+  return system(cmd.c_str());
+}

--- a/Detectors/TOF/workflow/include/TOFWorkflow/TOFRawWriterSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/TOFRawWriterSpec.h
@@ -36,7 +36,6 @@ class RawWriter : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  bool mFinished = false;
   std::string mOutFileName; // read from workflow
   std::string mOutDirName;  // read from workflow
 };

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -40,6 +40,8 @@
 #include "TPCBase/RDHUtils.h"
 #include "DataFormatsTPC/Digit.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace bpo = boost::program_options;
 
@@ -105,9 +107,13 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   }
 
   // ===| set up raw writer |===================================================
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+
   o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
   writer.useRDHVersion(rdhV);
   writer.setAddSeparateHBFStopPage(stopPage);
+  writer.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)); // must be set explicitly
   const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
 
   for (unsigned int i = 0; i < NSectors; i++) {
@@ -200,7 +206,7 @@ int main(int argc, char** argv)
     auto add_option = opt_general.add_options();
     add_option("help,h", "Print this help message");
     add_option("verbose,v", bpo::value<uint32_t>()->default_value(0), "Select verbosity level [0 = no output]");
-    add_option("input-file,i", bpo::value<std::string>()->required(), "Specifies input file.");
+    add_option("input-file,i", bpo::value<std::string>()->default_value("tpcdigits.root"), "Specifies input file.");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "Specify output directory");
     add_option("no-parent-directories,n", "Do not create parent directories recursively");
     add_option("sector-by-sector,s", bpo::value<bool>()->default_value(false)->implicit_value(true), "Run one TPC sector after another");

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -41,6 +41,8 @@
 #include "TPCBase/RDHUtils.h"
 #include "TPCBase/ZeroSuppress.h"
 #include "DPLUtils/DPLRawParser.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 using namespace o2::framework;
 using namespace o2::header;
@@ -144,7 +146,10 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
 
       if (outRaw) {
         // ===| set up raw writer |===================================================
+        std::string inputGRP = o2::base::NameConf::getGRPFileName();
+        const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
         o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
+        writer.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)); // must be set explicitly
         uint32_t rdhV = 4;
         writer.useRDHVersion(rdhV);
         std::string outDir = "./";


### PR DESCRIPTION
All detectors data must start with SOX (X = continuous or triggered) trigger bits set in the RDH.
This PR ensures that this info from the GRP (updated during digitization) is transferred from the converter to the RawFileWriter, which takes care of setting the trigger bits.
Also, a other modifications are introduced to uniformize (more or less) the conventions the different converters.

####  TOF digit2raw: add executable, ensure SOX written
add o2-tof-digi2raw executable aliased to the tof workflow with output-type=raw and supporting the same options as other converters. Also, the config file is brought to same conventions as for other detectors. The output names a modified to cruxxxtof.raw

#### TPC digit2raw: ensure SOX written, add default input digits filename 

#### FT0 digit2raw: ensure SOX written 

#### ITS/MFT digit2raw: ensure SOX written 

#### MCH digit2raw: ensure SOX written, set default input digits filename 

#### MID digit2raw: ensure SOX written, set optional output directory
Also, change default output filename to <det>.raw. The config file writing is delegated to RawFileWriter, will be stored in the same format as for other detectors in <outdir>/MIDraw.cfg 
(failed to add @dstocco to reviewers)