### PR TITLE
Fix: check for initDone was blocking next TF input

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -84,8 +84,8 @@ class MatchTOF
   ///< perform all initializations
   void init();
 
-  ///< perform all initializations
-  void initWorkflow(const gsl::span<const o2::dataformats::TrackTPCITS>& trackArray, const gsl::span<const Cluster>& clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& toflab, const gsl::span<const o2::MCCompLabel>& itslab, const gsl::span<const o2::MCCompLabel>& tpclab);
+  ///< attach DPL data and run
+  void run(const gsl::span<const o2::dataformats::TrackTPCITS>& trackArray, const gsl::span<const Cluster>& clusterArray, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& toflab, const gsl::span<const o2::MCCompLabel>& itslab, const gsl::span<const o2::MCCompLabel>& tpclab);
 
   ///< set tree/chain containing tracks
   void setInputTreeTracks(TTree* tree) { mInputTreeTracks = tree; }
@@ -211,7 +211,8 @@ class MatchTOF
 
   // Data members
 
-  bool mInitDone = false; ///< flag init already done
+  bool mSAInitDone = false;      ///< flag that standalone init already done
+  bool mWFInputAttached = false; ///< flag that the standalone input is attached
 
   float mXRef = Geo::RMIN; ///< reference radius to propage tracks for matching
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -100,8 +100,7 @@ class TOFDPLRecoWorkflowTask
       toflab = std::move(*toflabel);
     }
 
-    mMatcher.initWorkflow(tracksRO, clustersRO, toflab, itslab, tpclab);
-    mMatcher.run();
+    mMatcher.run(tracksRO, clustersRO, toflab, itslab, tpclab);
 
     // in run_match_tof aggiugnere esplicitamente la chiamata a fill del tree (nella classe MatchTOF) e il metodo per leggere i vettori di output
 


### PR DESCRIPTION
The mInitDone flag (legacy of macro-steered mode), set during 1st TF processeing, was preventing setting the input of following TFs. Therefore, after the 1st TF the matching was running over potentially invalid old input from 1st TF.
Introduced separate flag for DPL data attachment, in the DPL mode process directly with overloaded run method w/o wrong check for init.