### PR TITLE
Fix memory corruption in TPC tracker when DPL provides unaligned input buffer

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -729,10 +729,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
 
       if (ptrs.compressedClusters != nullptr) {
         if (specconfig.outputCompClustersFlat) {
+          bufferCompressedClusters->resize(outputRegions.compressedClusters.size);
           if ((void*)ptrs.compressedClusters != (void*)bufferCompressedClusters->data()) {
             throw std::runtime_error("compressed cluster output ptrs out of sync"); // sanity check
           }
-          bufferCompressedClusters->resize(outputRegions.compressedClusters.size);
         }
         if (specconfig.outputCompClusters) {
           CompressedClustersROOT compressedClusters = *ptrs.compressedClusters;
@@ -749,10 +749,10 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       // previously, clusters have been published individually for the enabled sectors
       // clusters are now published as one block, subspec is NSectors
       if (clusterOutput != nullptr) {
+        clusterOutput->resize(sizeof(ClusterCountIndex) + outputRegions.clustersNative.size);
         if ((void*)ptrs.clusters->clustersLinear != (void*)((char*)clusterOutput->data() + sizeof(ClusterCountIndex))) {
           throw std::runtime_error("cluster native output ptrs out of sync"); // sanity check
         }
-        clusterOutput->resize(sizeof(ClusterCountIndex) + outputRegions.clustersNative.size);
 
         o2::header::DataHeader::SubSpecificationType subspec = NSectors;
         // doing a copy for now, in the future the tracker uses the output buffer directly

--- a/GPU/GPUTracking/Base/GPUProcessor.h
+++ b/GPU/GPUTracking/Base/GPUProcessor.h
@@ -125,6 +125,9 @@ class GPUProcessor
   template <class T, class S>
   static inline void computePointerWithoutAlignment(T*& basePtr, S*& objPtr, size_t nEntries = 1)
   {
+    if ((size_t)basePtr < GPUCA_BUFFER_ALIGNMENT) {
+      reinterpret_cast<size_t&>(basePtr) = GPUCA_BUFFER_ALIGNMENT;
+    }
     objPtr = reinterpret_cast<S*>(getPointerWithAlignment<1, char>(reinterpret_cast<size_t&>(basePtr), nEntries * sizeof(S)));
   }
 #endif

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -10,6 +10,8 @@
 
 set(MODULE GPUTracking)
 
+#set(CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE} "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}} -O0") # to uncomment if needed, tired of typing this...
+
 if(ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
   if(ENABLE_CUDA OR ENABLE_OPENCL1 OR ENABLE_OPENCL2 OR ENABLE_HIP)
     cmake_minimum_required(VERSION 3.13 FATAL_ERROR)


### PR DESCRIPTION
Weird fun fact:
Using `basePtr = (T*)GPUCA_BUFFER_ALIGNMENT;` instead of `reinterpret_cast<size_t&>(basePtr) = GPUCA_BUFFER_ALIGNMENT;` doesn't work (if you use -O2 or -O3, -O0 works)!

I first thought it is a miscompilation and took me a while to understand that the compiler behaviour is totally legit. I'll buy a beer for everyone who can explain it to me properly :)