### PR TITLE
(O2-1203) [rANS] Codebase Hardening + Diagnostics

### DIFF
--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -10,8 +10,8 @@
 
 o2_add_library(rANS  
                SOURCES src/SymbolStatistics.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonUtils)
-             
+               PUBLIC_LINK_LIBRARIES O2::CommonUtils FairLogger::FairLogger)
+
 o2_add_test(EncodeDecode
             NAME EncodeDecode
             SOURCES test/test_ransEncodeDecode.cxx

--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 o2_add_library(rANS  
                SOURCES src/SymbolStatistics.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonUtils FairLogger::FairLogger)
+               PUBLIC_LINK_LIBRARIES FairLogger::FairLogger)
 
 o2_add_test(EncodeDecode
             NAME EncodeDecode

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -20,6 +20,8 @@
 #include <type_traits>
 #include <iostream>
 
+#include <fairlogger/Logger.h>
+
 #include "SymbolTable.h"
 #include "DecoderSymbol.h"
 #include "ReverseSymbolLookupTable.h"
@@ -86,6 +88,8 @@ template <typename coder_T, typename stream_T, typename source_T>
 template <typename stream_IT, typename source_IT>
 void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputBegin, size_t numSymbols) const
 {
+  LOG(trace) << "start decoding";
+
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
@@ -118,6 +122,8 @@ void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, 
     ransDecoder::decAdvanceSymbol(&rans0, &ptr, &(*mSymbolTable)[s0],
                                   mProbabilityBits);
   }
+
+  LOG(trace) << "done decoding";
 }
 } // namespace rans
 } // namespace o2

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -101,9 +101,17 @@ void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, 
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
+  if (numSymbols == 0) {
+    LOG(warning) << "Empty message passed to decoder, skipping decode process";
+    return;
+  }
+
   State<coder_T> rans0, rans1;
   const stream_T* ptr = &(*inputBegin);
   source_IT it = outputBegin;
+
+  assert(ptr != nullptr);
+
   ransDecoder::decInit(&rans0, &ptr);
   ransDecoder::decInit(&rans1, &ptr);
 

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -80,8 +80,15 @@ Decoder<coder_T, stream_T, source_T>& Decoder<coder_T, stream_T, source_T>::oper
 template <typename coder_T, typename stream_T, typename source_T>
 Decoder<coder_T, stream_T, source_T>::Decoder(const SymbolStatistics& stats, size_t probabilityBits) : mSymbolTable(nullptr), mReverseLUT(nullptr), mProbabilityBits(probabilityBits)
 {
+  RANSTimer t;
+  t.start();
   mSymbolTable = std::make_unique<decoderSymbol_t>(stats, probabilityBits);
+  t.stop();
+  LOG(debug1) << "Decoder SymbolTable inclusive time (ms): " << t.getDurationMS();
+  t.start();
   mReverseLUT = std::make_unique<reverseSymbolLookupTable_t>(probabilityBits, stats);
+  t.stop();
+  LOG(debug1) << "ReverseSymbolLookupTable inclusive time (ms): " << t.getDurationMS();
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
@@ -89,7 +96,8 @@ template <typename stream_IT, typename source_IT>
 void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputBegin, size_t numSymbols) const
 {
   LOG(trace) << "start decoding";
-
+  RANSTimer t;
+  t.start();
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
@@ -122,6 +130,8 @@ void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, 
     ransDecoder::decAdvanceSymbol(&rans0, &ptr, &(*mSymbolTable)[s0],
                                   mProbabilityBits);
   }
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
 
   LOG(trace) << "done decoding";
 }

--- a/Utilities/rANS/include/rANS/DecoderSymbol.h
+++ b/Utilities/rANS/include/rANS/DecoderSymbol.h
@@ -29,10 +29,9 @@ struct DecoderSymbol {
   DecoderSymbol(uint32_t start, uint32_t freq, uint32_t probabilityBits)
     : start(start), freq(freq)
   {
-    (void)probabilityBits; // silence compiler warning.
-    // TODO(lettrich): a check should be definitely done here.
-    //		RansAssert(start <= (1 << 16));
-    //		RansAssert(freq <= (1 << 16) - start);
+    (void)probabilityBits; // silence compiler warnings if assert not compiled.
+    assert(start <= (1 << probabilityBits));
+    assert(freq <= (1 << probabilityBits) - start);
   };
 
   uint32_t start; // Start of range.

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -25,6 +25,7 @@
 #include "EncoderSymbol.h"
 #include "Coder.h"
 #include "CommonUtils/StringUtils.h"
+#include "helper.h"
 
 namespace o2
 {
@@ -90,7 +91,11 @@ template <typename coder_T, typename stream_T, typename source_T>
 Encoder<coder_T, stream_T, source_T>::Encoder(const SymbolStatistics& stats,
                                               size_t probabilityBits) : mSymbolTable(nullptr), mProbabilityBits(probabilityBits)
 {
+  RANSTimer t;
+  t.start();
   mSymbolTable = std::make_unique<encoderSymbolTable_t>(stats, probabilityBits);
+  t.stop();
+  LOG(debug1) << "Encoder SymbolTable inclusive time (ms): " << t.getDurationMS();
 }
 
 template <typename coder_T, typename stream_T, typename source_T>
@@ -99,6 +104,8 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
   const stream_IT outputBegin, const stream_IT outputEnd, const source_IT inputBegin, const source_IT inputEnd) const
 {
   LOG(trace) << "start encoding";
+  RANSTimer t;
+  t.start();
 
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
@@ -141,6 +148,9 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
     std::cerr << "Exception is thrown: " << e.what() << '\n';
     throw;
   }
+
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
 
 // advanced diagnostics for debug builds
 #if !defined(NDEBUG)

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -24,7 +24,6 @@
 #include "SymbolTable.h"
 #include "EncoderSymbol.h"
 #include "Coder.h"
-#include "CommonUtils/StringUtils.h"
 #include "helper.h"
 
 namespace o2
@@ -110,12 +109,25 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
+  if (inputBegin == inputEnd) {
+    LOG(warning) << "passed empty message to encoder, skip encoding";
+    return outputEnd;
+  }
+
+  if (outputBegin == outputEnd) {
+    const std::string errorMessage("Unallocated encode buffer passed to encoder. Aborting");
+    LOG(error) << errorMessage;
+    throw std::runtime_error(errorMessage);
+  }
+
   State<coder_T> rans0, rans1;
   ransCoder::encInit(&rans0);
   ransCoder::encInit(&rans1);
 
   stream_T* ptr = &(*outputEnd);
   source_IT inputIT = inputEnd;
+
+  assert(ptr != nullptr);
 
   const auto inputBufferSize = std::distance(inputBegin, inputEnd);
 
@@ -124,6 +136,7 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
     const coder_T s = *(--inputIT);
     ransCoder::encPutSymbol(&rans0, &ptr, &(*mSymbolTable)[s],
                             mProbabilityBits);
+    assert(&(*outputBegin) < ptr);
   }
 
   while (inputIT > inputBegin) { // NB: working in reverse!
@@ -133,20 +146,23 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
                             mProbabilityBits);
     ransCoder::encPutSymbol(&rans0, &ptr, &(*mSymbolTable)[s0],
                             mProbabilityBits);
+    assert(&(*outputBegin) < ptr);
   }
   ransCoder::encFlush(&rans1, &ptr);
   ransCoder::encFlush(&rans0, &ptr);
 
-  try {                            //TODO Michael may want to generate exception message in different way
-    assert(&(*outputBegin) < ptr); // for some reason assert does not work in test, apparently BOOST modifies its handling
-    if (ptr < &(*outputBegin)) {   // RS: this exception is thrown with default calculateMaxBufferSize when running o2-test-ctf-io
-      throw std::runtime_error(o2::utils::concat_string("output buffer too short: provided ",
-                                                        std::to_string(&(*outputEnd) - &(*outputBegin)),
-                                                        " filled ", std::to_string(&(*outputEnd) - ptr), " slots"));
-    }
-  } catch (std::exception& e) {
-    std::cerr << "Exception is thrown: " << e.what() << '\n';
-    throw;
+  assert(&(*outputBegin) < ptr);
+
+  // deal with overflow
+  if (ptr < &(*outputBegin)) {
+    const std::string exceptionText = [&]() {
+      std::stringstream ss;
+      ss << __func__ << " detected overflow in encode buffer: allocated:" << std::distance(inputBegin, inputEnd) << ", used:" << std::distance(ptr, &(*outputEnd));
+      return ss.str();
+    }();
+
+    LOG(error) << exceptionText;
+    throw std::runtime_error(exceptionText);
   }
 
   t.stop();

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <algorithm>
 
+#include <fairlogger/Logger.h>
+
 #include "SymbolTable.h"
 #include "EncoderSymbol.h"
 #include "Coder.h"
@@ -96,6 +98,8 @@ template <typename stream_IT, typename source_IT>
 const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
   const stream_IT outputBegin, const stream_IT outputEnd, const source_IT inputBegin, const source_IT inputEnd) const
 {
+  LOG(trace) << "start encoding";
+
   static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
   static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
@@ -106,7 +110,7 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
   stream_T* ptr = &(*outputEnd);
   source_IT inputIT = inputEnd;
 
-  const auto inputBufferSize = inputEnd - inputBegin;
+  const auto inputBufferSize = std::distance(inputBegin, inputEnd);
 
   // odd number of bytes?
   if (inputBufferSize & 1) {
@@ -137,6 +141,19 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
     std::cerr << "Exception is thrown: " << e.what() << '\n';
     throw;
   }
+
+// advanced diagnostics for debug builds
+#if !defined(NDEBUG)
+  LOG(debug2) << "EncoderProperties: {"
+              << "sourceTypeB: " << sizeof(source_T) << ", "
+              << "streamTypeB: " << sizeof(stream_T) << ", "
+              << "coderTypeB: " << sizeof(coder_T) << ", "
+              << "probabilityBits: " << mProbabilityBits << ", "
+              << "inputBufferSizeB: " << inputBufferSize * sizeof(source_T) << ", "
+              << "outputBufferSizeB: " << std::distance(ptr, &(*outputEnd)) * sizeof(stream_T) << "}";
+#endif
+
+  LOG(trace) << "done encoding";
 
   return outputBegin + std::distance(&(*outputBegin), ptr);
 };

--- a/Utilities/rANS/include/rANS/EncoderSymbol.h
+++ b/Utilities/rANS/include/rANS/EncoderSymbol.h
@@ -34,7 +34,6 @@ template <typename T>
 struct EncoderSymbol {
   EncoderSymbol(uint32_t start, uint32_t freq, uint32_t scale_bits)
   {
-    //TODO(lettrich): a check should be definitely done here.
     //		RansAssert(scale_bits <= 16);
     assert(start <= (1u << scale_bits));
     assert(freq <= (1u << scale_bits) - start);

--- a/Utilities/rANS/include/rANS/ReverseSymbolLookupTable.h
+++ b/Utilities/rANS/include/rANS/ReverseSymbolLookupTable.h
@@ -17,6 +17,8 @@
 #define RANS_REVERSESYMBOLLOOKUPTABLE_H
 
 #include <vector>
+#include <type_traits>
+#include <fairlogger/Logger.h>
 
 #include "SymbolStatistics.h"
 #include "helper.h"
@@ -32,6 +34,8 @@ class ReverseSymbolLookupTable
   ReverseSymbolLookupTable(size_t probabilityBits,
                            const SymbolStatistics& stats)
   {
+    LOG(trace) << "start building reverse symbol lookup table";
+
     mLut.resize(bitsToRange(probabilityBits));
     // go over all symbols
     for (int symbol = stats.getMinSymbol(); symbol < stats.getMaxSymbol() + 1;
@@ -43,6 +47,15 @@ class ReverseSymbolLookupTable
         //      << symbol;
       }
     }
+
+// advanced diagnostics for debug builds
+#if !defined(NDEBUG)
+    LOG(debug2) << "reverseSymbolLookupTableProperties: {"
+                << "elements: " << mLut.size() << ", "
+                << "sizeB: " << mLut.size() * sizeof(typename std::decay_t<decltype(mLut)>::value_type) << "}";
+#endif
+
+    LOG(trace) << "done building reverse symbol lookup table";
   };
 
   inline source_t operator[](size_t cummulative) const

--- a/Utilities/rANS/include/rANS/ReverseSymbolLookupTable.h
+++ b/Utilities/rANS/include/rANS/ReverseSymbolLookupTable.h
@@ -32,19 +32,22 @@ class ReverseSymbolLookupTable
 {
  public:
   ReverseSymbolLookupTable(size_t probabilityBits,
-                           const SymbolStatistics& stats)
+                           const SymbolStatistics& stats) : mLut()
   {
     LOG(trace) << "start building reverse symbol lookup table";
 
+    if (stats.getAlphabetSize() == 0) {
+      LOG(warning) << "SymbolStatistics of empty message passed to " << __func__;
+      return;
+    }
+
     mLut.resize(bitsToRange(probabilityBits));
     // go over all symbols
-    for (int symbol = stats.getMinSymbol(); symbol < stats.getMaxSymbol() + 1;
+    for (int symbol = stats.getMinSymbol(); symbol <= stats.getMaxSymbol();
          symbol++) {
       for (uint32_t cumulative = stats[symbol].second;
-           cumulative < stats[symbol + 1].second; cumulative++) {
+           cumulative < stats[symbol].second + stats[symbol].first; cumulative++) {
         mLut[cumulative] = symbol;
-        //      std::cout << "ReverseSymbolLookupTable[" << cumulative << "]: "
-        //      << symbol;
       }
     }
 

--- a/Utilities/rANS/include/rANS/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/SymbolStatistics.h
@@ -26,6 +26,8 @@
 
 #include <fairlogger/Logger.h>
 
+#include "helper.h"
+
 namespace o2
 {
 namespace rans
@@ -101,6 +103,9 @@ template <typename IT>
 SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range) : mMin(0), mMax(0), mNUsedAlphabetSymbols(0), mMessageLength(0), mFrequencyTable(), mCumulativeFrequencyTable()
 {
   LOG(trace) << "start building symbol statistics";
+  RANSTimer t;
+  t.start();
+
   buildFrequencyTable(begin, end, range);
 
   for (auto i : mFrequencyTable) {
@@ -112,6 +117,9 @@ SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range) :
   buildCumulativeFrequencyTable();
 
   mMessageLength = mCumulativeFrequencyTable.back();
+
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
 
 // advanced diagnostics in debug builds
 #if !defined(NDEBUG)

--- a/Utilities/rANS/include/rANS/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/SymbolStatistics.h
@@ -21,6 +21,10 @@
 #include <iostream>
 #include <numeric>
 #include <vector>
+#include <cmath>
+#include <iterator>
+
+#include <fairlogger/Logger.h>
 
 namespace o2
 {
@@ -91,9 +95,12 @@ class SymbolStatistics
   std::vector<uint32_t> mCumulativeFrequencyTable;
 };
 
+std::ostream& operator<<(std::ostream& strm, const SymbolStatistics& a);
+
 template <typename IT>
-SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range)
+SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range) : mMin(0), mMax(0), mNUsedAlphabetSymbols(0), mMessageLength(0), mFrequencyTable(), mCumulativeFrequencyTable()
 {
+  LOG(trace) << "start building symbol statistics";
   buildFrequencyTable(begin, end, range);
 
   for (auto i : mFrequencyTable) {
@@ -105,11 +112,52 @@ SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range)
   buildCumulativeFrequencyTable();
 
   mMessageLength = mCumulativeFrequencyTable.back();
+
+// advanced diagnostics in debug builds
+#if !defined(NDEBUG)
+  [&]() {
+    const uint messageRange = [&]() -> uint {
+      if (range > 0) {
+        return range;
+      } else if (mMax - mMin == 0) {
+        return 1;
+      } else {
+        return std::ceil(std::log2(mMax - mMin));
+      } }();
+
+    double entropy = 0;
+    for (auto frequency : mFrequencyTable) {
+      if (frequency > 0) {
+        const double p = (frequency * 1.0) / mMessageLength;
+        entropy -= p * std::log2(p);
+      }
+    }
+
+    LOG(debug2) << "messageProperties: {"
+                << "numSymbols: " << mMessageLength << ", "
+                << "alphabetRange: " << messageRange << ", "
+                << "alphabetSize: " << mNUsedAlphabetSymbols << ", "
+                << "minSymbol: " << mMin << ", "
+                << "maxSymbol: " << mMax << ", "
+                << "entropy: " << entropy << ", "
+                << "bufferSizeB: " << mMessageLength * sizeof(typename std::iterator_traits<IT>::value_type) << ", "
+                << "actualSizeB: " << static_cast<int>(mMessageLength * messageRange / 8) << ", "
+                << "entropyMessageB: " << static_cast<int>(std::ceil(entropy * mMessageLength / 8)) << "}";
+
+    LOG(debug2) << "SymbolStatistics: {"
+                << "entries: " << mFrequencyTable.size() << ", "
+                << "frequencyTableSizeB: " << mFrequencyTable.size() * sizeof(std::decay_t<decltype(mFrequencyTable)>::value_type) << ", "
+                << "CumulativeFrequencyTableSizeB: " << mCumulativeFrequencyTable.size() * sizeof(std::decay_t<decltype(mCumulativeFrequencyTable)>::value_type) << "}";
+  }();
+#endif
+
+  LOG(trace) << "done building symbol statistics";
 }
 
 template <typename IT>
 SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t min, size_t max, size_t messageLength) : mMin(min), mMax(max), mNUsedAlphabetSymbols(0), mMessageLength(messageLength), mFrequencyTable(begin, end), mCumulativeFrequencyTable()
 {
+  LOG(trace) << "start loading external symbol statistics";
   for (auto i : mFrequencyTable) {
     if (i > 0) {
       mNUsedAlphabetSymbols++;
@@ -117,12 +165,15 @@ SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t min, siz
   }
 
   buildCumulativeFrequencyTable();
+
+  LOG(trace) << "done loading external symbol statistics";
 }
 
 template <typename IT>
 void SymbolStatistics::buildFrequencyTable(const IT begin, const IT end,
                                            size_t range)
 {
+  LOG(trace) << "start building frequency table";
   // find min_ and max_
   const auto minmax = std::minmax_element(begin, end);
 
@@ -148,8 +199,8 @@ void SymbolStatistics::buildFrequencyTable(const IT begin, const IT end,
   for (IT it = begin; it != end; it++) {
     mFrequencyTable[*it - mMin]++;
   }
+  LOG(trace) << "done building frequency table";
 }
-
 } // namespace rans
 } // namespace o2
 

--- a/Utilities/rANS/include/rANS/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/SymbolStatistics.h
@@ -105,6 +105,10 @@ SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range) :
   LOG(trace) << "start building symbol statistics";
   RANSTimer t;
   t.start();
+  if (begin == end) {
+    LOG(warning) << "Passed empty message to " << __func__;
+    return;
+  }
 
   buildFrequencyTable(begin, end, range);
 
@@ -117,6 +121,10 @@ SymbolStatistics::SymbolStatistics(const IT begin, const IT end, size_t range) :
   buildCumulativeFrequencyTable();
 
   mMessageLength = mCumulativeFrequencyTable.back();
+
+  assert(mFrequencyTable.size() > 0);
+  assert(mCumulativeFrequencyTable.size() > 1);
+  assert(mCumulativeFrequencyTable.size() - mFrequencyTable.size() == 1);
 
   t.stop();
   LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
@@ -191,16 +199,17 @@ void SymbolStatistics::buildFrequencyTable(const IT begin, const IT end,
 
     // do checks
     if (static_cast<unsigned int>(mMin) > *minmax.first) {
-      throw std::runtime_error("min of data too small for given minimum");
+      throw std::runtime_error("min of data too small for specified range");
     }
 
     if (static_cast<unsigned int>(mMax) < *minmax.second) {
-      throw std::runtime_error("max of data too big for given maximum");
+      throw std::runtime_error("max of data too big for specified range");
     }
   } else {
     mMin = *minmax.first;
     mMax = *minmax.second;
   }
+  assert(mMax >= mMin);
 
   mFrequencyTable.resize(std::abs(mMax - mMin) + 1, 0);
 

--- a/Utilities/rANS/include/rANS/SymbolTable.h
+++ b/Utilities/rANS/include/rANS/SymbolTable.h
@@ -18,6 +18,8 @@
 
 #include <vector>
 
+#include <fairlogger/Logger.h>
+
 #include "SymbolStatistics.h"
 
 namespace o2
@@ -31,11 +33,21 @@ class SymbolTable
  public:
   SymbolTable(const SymbolStatistics& symbolStats, uint64_t probabiltyBits) : mMin(symbolStats.getMinSymbol())
   {
+    LOG(trace) << "start building symbol table";
     mSymbolTable.reserve(symbolStats.getAlphabetSize());
 
     for (const auto& entry : symbolStats) {
       mSymbolTable.emplace_back(entry.second, entry.first, probabiltyBits);
     }
+
+// advanced diagnostics for debug builds
+#if !defined(NDEBUG)
+    LOG(debug2) << "SymbolTableProperties: {"
+                << "entries:" << mSymbolTable.size() << ", "
+                << "sizeB: " << mSymbolTable.size() * sizeof(T) << "}";
+#endif
+
+    LOG(trace) << "done building symbol table";
   }
 
   const T& operator[](int index) const

--- a/Utilities/rANS/include/rANS/SymbolTable.h
+++ b/Utilities/rANS/include/rANS/SymbolTable.h
@@ -52,8 +52,10 @@ class SymbolTable
 
   const T& operator[](int index) const
   {
-
-    return mSymbolTable[index - mMin];
+    auto idx = index - mMin;
+    assert(idx >= 0);
+    assert(idx < mSymbolTable.size());
+    return mSymbolTable[idx];
   }
 
  private:

--- a/Utilities/rANS/include/rANS/helper.h
+++ b/Utilities/rANS/include/rANS/helper.h
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cmath>
+#include <chrono>
 
 namespace o2
 {
@@ -46,6 +47,22 @@ inline size_t calculateMaxBufferSize(size_t num, size_t rangeBits, size_t sizeof
 constexpr size_t ProbabilityBits8Bit = 10;
 constexpr size_t ProbabilityBits16Bit = 22;
 constexpr size_t ProbabilityBits25Bit = 25;
+
+class RANSTimer
+{
+ public:
+  void start() { mStart = std::chrono::high_resolution_clock::now(); };
+  void stop() { mStop = std::chrono::high_resolution_clock::now(); };
+  double getDurationMS()
+  {
+    std::chrono::duration<double, std::milli> duration = mStop - mStart;
+    return duration.count();
+  }
+
+ private:
+  std::chrono::time_point<std::chrono::high_resolution_clock> mStart;
+  std::chrono::time_point<std::chrono::high_resolution_clock> mStop;
+};
 
 } // namespace rans
 } // namespace o2

--- a/Utilities/rANS/src/SymbolStatistics.cxx
+++ b/Utilities/rANS/src/SymbolStatistics.cxx
@@ -25,7 +25,9 @@ namespace rans
 
 void SymbolStatistics::rescaleToNBits(size_t bits)
 {
-  LOG(trace) << "rescaling frequency table";
+  LOG(trace) << "start rescaling frequency table";
+  RANSTimer t;
+  t.start();
 
   const size_t newCumulatedFrequency = bitsToRange(bits);
   assert(newCumulatedFrequency >= mFrequencyTable.size());
@@ -93,7 +95,10 @@ void SymbolStatistics::rescaleToNBits(size_t bits)
   //	    }
   //	    std::cout <<  cummulatedFrequencies_.back() << std::endl;
 
-  LOG(trace) << "rescaled frequency table";
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
+
+  LOG(trace) << "done rescaling frequency table";
 }
 
 int SymbolStatistics::getMinSymbol() const { return mMin; }
@@ -129,14 +134,14 @@ std::pair<uint32_t, uint32_t> SymbolStatistics::operator[](size_t index) const
 
 void SymbolStatistics::buildCumulativeFrequencyTable()
 {
-  LOG(trace) << "building cumulative frequency table";
+  LOG(trace) << "start building cumulative frequency table";
 
   mCumulativeFrequencyTable.resize(mFrequencyTable.size() + 1);
   mCumulativeFrequencyTable[0] = 0;
   std::partial_sum(mFrequencyTable.begin(), mFrequencyTable.end(),
                    mCumulativeFrequencyTable.begin() + 1);
 
-  LOG(trace) << "built cumulative frequency table";
+  LOG(trace) << "done building cumulative frequency table";
 }
 
 SymbolStatistics::Iterator SymbolStatistics::begin() const

--- a/Utilities/rANS/src/SymbolStatistics.cxx
+++ b/Utilities/rANS/src/SymbolStatistics.cxx
@@ -25,6 +25,8 @@ namespace rans
 
 void SymbolStatistics::rescaleToNBits(size_t bits)
 {
+  LOG(trace) << "rescaling frequency table";
+
   const size_t newCumulatedFrequency = bitsToRange(bits);
   assert(newCumulatedFrequency >= mFrequencyTable.size());
 
@@ -90,6 +92,8 @@ void SymbolStatistics::rescaleToNBits(size_t bits)
   // cummulatedFrequencies_[i] << std::endl;
   //	    }
   //	    std::cout <<  cummulatedFrequencies_.back() << std::endl;
+
+  LOG(trace) << "rescaled frequency table";
 }
 
 int SymbolStatistics::getMinSymbol() const { return mMin; }
@@ -125,10 +129,14 @@ std::pair<uint32_t, uint32_t> SymbolStatistics::operator[](size_t index) const
 
 void SymbolStatistics::buildCumulativeFrequencyTable()
 {
+  LOG(trace) << "building cumulative frequency table";
+
   mCumulativeFrequencyTable.resize(mFrequencyTable.size() + 1);
   mCumulativeFrequencyTable[0] = 0;
   std::partial_sum(mFrequencyTable.begin(), mFrequencyTable.end(),
                    mCumulativeFrequencyTable.begin() + 1);
+
+  LOG(trace) << "built cumulative frequency table";
 }
 
 SymbolStatistics::Iterator SymbolStatistics::begin() const

--- a/Utilities/rANS/test/test_ransEncodeDecode.cxx
+++ b/Utilities/rANS/test/test_ransEncodeDecode.cxx
@@ -49,21 +49,25 @@ struct Fixture {
   // 25Bits for 25Bit alphabets
   const uint probabilityBits = P;
 
-  const std::string source =
-    R"(Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium 
-doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis 
-et quasi architecto beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem, 
-quia voluptas sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores 
-eos, qui ratione voluptatem sequi nesciunt, neque porro quisquam est, qui dolorem ipsum, 
-quia dolor sit, amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora 
-incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. ut enim ad minima veniam, 
-quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea 
-commodi consequatur? quis autem vel eum iure reprehenderit, qui in ea voluptate velit 
-esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, 
-quo voluptas nulla pariatur?)";
+  const std::string source = "";
 };
 
-typedef boost::mpl::vector<Fixture<uint32_t, uint8_t, 14>, Fixture<uint64_t, uint32_t, 18>> Fixtures;
+template <typename CODER_T, typename STREAM_T, uint P>
+struct FixtureFull : public Fixture<CODER_T, STREAM_T, P> {
+  const std::string source = R"(Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium
+			  doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis
+			  et quasi architecto beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem,
+			  quia voluptas sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+			  eos, qui ratione voluptatem sequi nesciunt, neque porro quisquam est, qui dolorem ipsum,
+			  quia dolor sit, amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora
+			  incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. ut enim ad minima veniam,
+			  quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+			  commodi consequatur? quis autem vel eum iure reprehenderit, qui in ea voluptate velit
+			  esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat,
+			  quo voluptas nulla pariatur?)";
+};
+
+typedef boost::mpl::vector<Fixture<uint32_t, uint8_t, 14>, Fixture<uint64_t, uint32_t, 18>, FixtureFull<uint32_t, uint8_t, 14>, FixtureFull<uint64_t, uint32_t, 18>> Fixtures;
 
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(test_EncodeDecode, T, Fixtures, T)
 {


### PR DESCRIPTION
Improvements in robustness of the codebase and advanced diagnostics 

* add logging on info, warning, error, debug, and tracing level.
* timers for inclusive time of key components (building of statistics, dictionaries, encoding/decoding)
* diagnostics if build in cmake debug mode (i.e. assertions enabled): 
  * source message and symbol statistics (entropy, number of symbols, size of source alphabet)
  * dictionary sizes
  * encoder/decoder compression
* assertions in debug mode to ease debugging of underflows/ overflows
* improved unit-testing
* hardening of public API (checks for empty messages, unallocated buffers etc) (O2-1488)
* small bugfixes