### PR TITLE
Added new aliases, AD timing decisions

### DIFF
--- a/Analysis/DataModel/include/Analysis/EventSelection.h
+++ b/Analysis/DataModel/include/Analysis/EventSelection.h
@@ -14,8 +14,8 @@
 
 // TODO read nAliases from the alias map?
 #define nAliases 10
-enum triggerAliases{
-  kINT7=0,
+enum triggerAliases {
+  kINT7 = 0,
   kEMC7,
   kINT7inMUON,
   kMuonSingleLowPt7,

--- a/Analysis/DataModel/include/Analysis/EventSelection.h
+++ b/Analysis/DataModel/include/Analysis/EventSelection.h
@@ -13,7 +13,19 @@
 #include "Framework/AnalysisDataModel.h"
 
 // TODO read nAliases from the alias map?
-#define nAliases 2
+#define nAliases 10
+enum triggerAliases{
+  kINT7=0,
+  kEMC7,
+  kINT7inMUON,
+  kMuonSingleLowPt7,
+  kMuonUnlikeLowPt7,
+  kMuonLikeLowPt7,
+  kCUP8,
+  kCUP9,
+  kMUP10,
+  kMUP11
+};
 
 namespace o2::aod
 {
@@ -27,11 +39,16 @@ DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool); // beam-gas time in V0A
 DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool); // beam-gas time in V0C
 DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool); // beam-beam time in ZNA
 DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool); // beam-beam time in ZNC
+DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool); // beam-beam time in FDA
+DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool); // beam-beam time in FDC
+DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool); // beam-gas time in FDA
+DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool); // beam-gas time in FDC
 DECLARE_SOA_DYNAMIC_COLUMN(SEL7, sel7, [](bool bbV0A, bool bbV0C, bool bbZNA, bool bbZNC) -> bool { return bbV0A && bbV0C && bbZNA && bbZNC; });
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL",
                   evsel::Alias,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C, evsel::BBZNA, evsel::BBZNC,
+                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::SEL7<evsel::BBV0A, evsel::BBV0C, evsel::BBZNA, evsel::BBZNC>);
 using EvSel = EvSels::iterator;
 } // namespace o2::aod

--- a/Analysis/Tasks/centralityQa.cxx
+++ b/Analysis/Tasks/centralityQa.cxx
@@ -21,12 +21,12 @@ struct CentralityQaTask {
   OutputObj<TH1F> hCentV0M{TH1F("hCentV0M", "", 21, 0, 105.)};
   void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& col)
   {
-    if (!col.alias()[0])
+    if (!col.alias()[kINT7])
       return;
     if (!col.sel7())
       return;
 
-    LOGF(info, "centV0M=%.0f", col.centV0M());
+    LOGF(debug, "centV0M=%.0f", col.centV0M());
     // fill centrality histos
     hCentV0M->Fill(col.centV0M());
   }

--- a/Analysis/Tasks/centralityTable.cxx
+++ b/Analysis/Tasks/centralityTable.cxx
@@ -35,7 +35,7 @@ struct CentralityTableTask {
   void process(aod::Mult const& mult)
   {
     float centV0M = hCumMultV0M->GetBinContent(hCumMultV0M->FindFixBin(mult.multV0M()));
-    LOGF(info, "centV0M=%.0f", centV0M);
+    LOGF(debug, "centV0M=%.0f", centV0M);
     // fill centrality columns
     cent(centV0M);
   }

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -21,12 +21,47 @@ using std::string;
 using namespace o2;
 using namespace o2::framework;
 
+struct EvSelParameters{
+  // time-of-flight offset
+  float fV0ADist = 329.00/TMath::Ccgs()*1e9;            // ns
+  float fV0CDist =  87.15/TMath::Ccgs()*1e9;            // ns
+  
+  float fFDADist = (1695.30+1698.04)/TMath::Ccgs()*1e9; // ns
+  float fFDCDist = (1952.90+1955.90)/TMath::Ccgs()*1e9; // ns
+  
+  // beam-beam and beam-gas windows
+  float fV0ABBlower = +fV0ADist -9.5; // ns
+  float fV0ABBupper = +fV0ADist+22.5; // ns
+  float fV0ABGlower = -fV0ADist -2.5; // ns
+  float fV0ABGupper = -fV0ADist +5.0; // ns
+  float fV0CBBlower = +fV0CDist -2.5; // ns
+  float fV0CBBupper = +fV0CDist+22.5; // ns
+  float fV0CBGlower = -fV0CDist -2.5; // ns
+  float fV0CBGupper = -fV0CDist +2.5; // ns
+  
+  float fFDABBlower = +fFDADist -2.5; // ns
+  float fFDABBupper = +fFDADist +2.5; // ns
+  float fFDABGlower = -fFDADist -4.0; // ns
+  float fFDABGupper = -fFDADist +4.0; // ns
+
+  float fFDCBBlower = +fFDCDist -1.5; // ns
+  float fFDCBBupper = +fFDCDist +1.5; // ns
+  float fFDCBGlower = -fFDCDist -2.0; // ns
+  float fFDCBGupper = -fFDCDist +2.0; // ns
+  
+  float fZNABBlower = -2.0; // ns
+  float fZNABBupper =  2.0; // ns
+  float fZNCBBlower = -2.0; // ns
+  float fZNCBBupper =  2.0; // ns
+};
+
 struct EventSelectionTask {
   Produces<aod::EvSels> evsel;
   map<string, int> mClasses;
   map<int, string> mAliases;
   map<int, vector<int>> mAliasToClassIds;
-
+  EvSelParameters par;
+  
   aod::Run2V0 getVZero(aod::BC const& bc, aod::Run2V0s const& vzeros)
   {
     for (auto& vzero : vzeros)
@@ -45,11 +80,28 @@ struct EventSelectionTask {
     return dummy;
   }
 
+  aod::FDD getFDD(aod::BC const& bc, aod::FDDs const& fdds)
+  {
+    for (auto& fdd : fdds)
+      if (fdd.bc() == bc)
+        return fdd;
+    aod::FDD dummy;
+    return dummy;
+  }
+  
   // TODO create aliases elsewhere (like BrowseAndFill macro)
   void createAliases()
   {
-    mAliases[0] = "CINT7-B-NOPF-CENT";
-    mAliases[1] = "CEMC7-B-NOPF-CENTNOPMD,CDMC7-B-NOPF-CENTNOPMD";
+    mAliases[kINT7]             = "CINT7-B-NOPF-CENT,CINT7-B-NOPF-CENTNOTRD";
+    mAliases[kEMC7]             = "CEMC7-B-NOPF-CENTNOPMD,CDMC7-B-NOPF-CENTNOPMD";
+    mAliases[kINT7inMUON]       = "CINT7-B-NOPF-MUFAST";
+    mAliases[kMuonSingleLowPt7] = "CMSL7-B-NOPF-MUFAST";
+    mAliases[kMuonUnlikeLowPt7] = "CMUL7-B-NOPF-MUFAST";
+    mAliases[kMuonLikeLowPt7]   = "CMLL7-B-NOPF-MUFAST";
+    mAliases[kCUP8]             = "CCUP8-B-NOPF-CENTNOTRD";
+    mAliases[kCUP9]             = "CCUP9-B-NOPF-CENTNOTRD";
+    mAliases[kMUP10]            = "CMUP10-B-NOPF-MUFAST";
+    mAliases[kMUP11]            = "CMUP11-B-NOPF-MUFAST";
   }
 
   void init(InitContext&)
@@ -67,7 +119,7 @@ struct EventSelectionTask {
     t->GetEntryWithIndex(244918);
     LOGF(debug, "List of trigger classes");
     for (auto& cl : mClasses) {
-      LOGF(debug, "class %d %s", cl.second, cl.first);
+      LOGF(debug, "class %02d %s", cl.second, cl.first);
     }
 
     LOGF(debug, "Fill map of alias-to-class-indices");
@@ -77,15 +129,17 @@ struct EventSelectionTask {
       for (int iClasses = 0; iClasses < tokens->GetEntriesFast(); iClasses++) {
         string className = tokens->At(iClasses)->GetName();
         int index = mClasses[className] - 1;
-        if (index < 0 || index > 49)
+        if (index < 0 || index > 63)
           continue;
         mAliasToClassIds[al.first].push_back(index);
       }
       delete tokens;
     }
+    
+    // TODO Fill EvSelParameters with configurable cuts from CCDB
   }
 
-  void process(aod::Collision const& collision, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::Run2V0s const& vzeros)
+  void process(aod::Collision const& collision, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::Run2V0s const& vzeros, aod::FDDs const& fdds)
   {
     LOGF(debug, "Starting new event");
     // CTP info
@@ -95,25 +149,43 @@ struct EventSelectionTask {
     int32_t alias[nAliases] = {0};
     for (auto& al : mAliasToClassIds) {
       for (auto& classIndex : al.second) {
-        alias[al.first] |= triggerMask & (1ul << classIndex);
+        alias[al.first] |= (triggerMask & (1ull << classIndex))>0;
       }
     }
+    
+    // for (int i=0;i<64;i++) printf("%i",(triggerMask & (1ull << i)) > 0); printf("\n");
+    // for (int i=0;i<nAliases;i++) printf("%i ",alias[i]); printf("\n");
+    
     // ZDC info
     auto zdc = getZdc(collision.bc(), zdcs);
-    bool bbZNA = zdc.timeZNA() > -2. && zdc.timeZNA() < 2.;
-    bool bbZNC = zdc.timeZNC() > -2. && zdc.timeZNC() < 2.;
+    float timeZNA = zdc.timeZNA();
+    float timeZNC = zdc.timeZNC();
     // VZERO info
     auto vzero = getVZero(collision.bc(), vzeros);
     float timeV0A = vzero.timeA();
     float timeV0C = vzero.timeC();
-    // TODO replace it with configurable cuts from CCDB
-    bool bbV0A = timeV0A > 0. && timeV0A < 25.;  // ns
-    bool bbV0C = timeV0C > 0. && timeV0C < 25.;  // ns
-    bool bgV0A = timeV0A > -25. && timeV0A < 0.; // ns
-    bool bgV0C = timeV0C > -25. && timeV0C < 0.; // ns
-
+    // FDD info
+    auto fdd = getFDD(collision.bc(), fdds);
+    float timeFDA = fdd.timeA();
+    float timeFDC = fdd.timeC();
+    
+    LOGF(debug, "timeZNA=%f timeZNC=%f", timeZNA, timeZNC);
+    LOGF(debug, "timeV0A=%f timeV0C=%f", timeV0A, timeV0C);
+    LOGF(debug, "timeFDA=%f timeFDC=%f", timeFDA, timeFDC);
+    
+    bool bbZNA = timeZNA > par.fZNABBlower && timeZNA < par.fZNABBupper;
+    bool bbZNC = timeZNC > par.fZNCBBlower && timeZNC < par.fZNCBBupper;
+    bool bbV0A = timeV0A > par.fV0ABBlower && timeV0A < par.fV0ABBupper;
+    bool bbV0C = timeV0C > par.fV0CBBlower && timeV0C < par.fV0CBBupper;
+    bool bgV0A = timeV0A > par.fV0ABGlower && timeV0A < par.fV0ABGupper;
+    bool bgV0C = timeV0C > par.fV0CBGlower && timeV0C < par.fV0CBGupper;
+    bool bbFDA = timeFDA > par.fFDABBlower && timeFDA < par.fFDABBupper;
+    bool bbFDC = timeFDC > par.fFDCBBlower && timeFDC < par.fFDCBBupper;
+    bool bgFDA = timeFDA > par.fFDABGlower && timeFDA < par.fFDABGupper;
+    bool bgFDC = timeFDC > par.fFDCBGlower && timeFDC < par.fFDCBGupper;
+    
     // Fill event selection columns
-    evsel(alias, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC);
+    evsel(alias, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC);
   }
 };
 

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -21,38 +21,38 @@ using std::string;
 using namespace o2;
 using namespace o2::framework;
 
-struct EvSelParameters{
+struct EvSelParameters {
   // time-of-flight offset
-  float fV0ADist = 329.00/TMath::Ccgs()*1e9;            // ns
-  float fV0CDist =  87.15/TMath::Ccgs()*1e9;            // ns
-  
-  float fFDADist = (1695.30+1698.04)/TMath::Ccgs()*1e9; // ns
-  float fFDCDist = (1952.90+1955.90)/TMath::Ccgs()*1e9; // ns
-  
-  // beam-beam and beam-gas windows
-  float fV0ABBlower = +fV0ADist -9.5; // ns
-  float fV0ABBupper = +fV0ADist+22.5; // ns
-  float fV0ABGlower = -fV0ADist -2.5; // ns
-  float fV0ABGupper = -fV0ADist +5.0; // ns
-  float fV0CBBlower = +fV0CDist -2.5; // ns
-  float fV0CBBupper = +fV0CDist+22.5; // ns
-  float fV0CBGlower = -fV0CDist -2.5; // ns
-  float fV0CBGupper = -fV0CDist +2.5; // ns
-  
-  float fFDABBlower = +fFDADist -2.5; // ns
-  float fFDABBupper = +fFDADist +2.5; // ns
-  float fFDABGlower = -fFDADist -4.0; // ns
-  float fFDABGupper = -fFDADist +4.0; // ns
+  float fV0ADist = 329.00 / TMath::Ccgs() * 1e9; // ns
+  float fV0CDist = 87.15 / TMath::Ccgs() * 1e9;  // ns
 
-  float fFDCBBlower = +fFDCDist -1.5; // ns
-  float fFDCBBupper = +fFDCDist +1.5; // ns
-  float fFDCBGlower = -fFDCDist -2.0; // ns
-  float fFDCBGupper = -fFDCDist +2.0; // ns
-  
+  float fFDADist = (1695.30 + 1698.04) / TMath::Ccgs() * 1e9; // ns
+  float fFDCDist = (1952.90 + 1955.90) / TMath::Ccgs() * 1e9; // ns
+
+  // beam-beam and beam-gas windows
+  float fV0ABBlower = +fV0ADist - 9.5;  // ns
+  float fV0ABBupper = +fV0ADist + 22.5; // ns
+  float fV0ABGlower = -fV0ADist - 2.5;  // ns
+  float fV0ABGupper = -fV0ADist + 5.0;  // ns
+  float fV0CBBlower = +fV0CDist - 2.5;  // ns
+  float fV0CBBupper = +fV0CDist + 22.5; // ns
+  float fV0CBGlower = -fV0CDist - 2.5;  // ns
+  float fV0CBGupper = -fV0CDist + 2.5;  // ns
+
+  float fFDABBlower = +fFDADist - 2.5; // ns
+  float fFDABBupper = +fFDADist + 2.5; // ns
+  float fFDABGlower = -fFDADist - 4.0; // ns
+  float fFDABGupper = -fFDADist + 4.0; // ns
+
+  float fFDCBBlower = +fFDCDist - 1.5; // ns
+  float fFDCBBupper = +fFDCDist + 1.5; // ns
+  float fFDCBGlower = -fFDCDist - 2.0; // ns
+  float fFDCBGupper = -fFDCDist + 2.0; // ns
+
   float fZNABBlower = -2.0; // ns
-  float fZNABBupper =  2.0; // ns
+  float fZNABBupper = 2.0;  // ns
   float fZNCBBlower = -2.0; // ns
-  float fZNCBBupper =  2.0; // ns
+  float fZNCBBupper = 2.0;  // ns
 };
 
 struct EventSelectionTask {
@@ -61,7 +61,7 @@ struct EventSelectionTask {
   map<int, string> mAliases;
   map<int, vector<int>> mAliasToClassIds;
   EvSelParameters par;
-  
+
   aod::Run2V0 getVZero(aod::BC const& bc, aod::Run2V0s const& vzeros)
   {
     for (auto& vzero : vzeros)
@@ -88,20 +88,20 @@ struct EventSelectionTask {
     aod::FDD dummy;
     return dummy;
   }
-  
+
   // TODO create aliases elsewhere (like BrowseAndFill macro)
   void createAliases()
   {
-    mAliases[kINT7]             = "CINT7-B-NOPF-CENT,CINT7-B-NOPF-CENTNOTRD";
-    mAliases[kEMC7]             = "CEMC7-B-NOPF-CENTNOPMD,CDMC7-B-NOPF-CENTNOPMD";
-    mAliases[kINT7inMUON]       = "CINT7-B-NOPF-MUFAST";
+    mAliases[kINT7] = "CINT7-B-NOPF-CENT,CINT7-B-NOPF-CENTNOTRD";
+    mAliases[kEMC7] = "CEMC7-B-NOPF-CENTNOPMD,CDMC7-B-NOPF-CENTNOPMD";
+    mAliases[kINT7inMUON] = "CINT7-B-NOPF-MUFAST";
     mAliases[kMuonSingleLowPt7] = "CMSL7-B-NOPF-MUFAST";
     mAliases[kMuonUnlikeLowPt7] = "CMUL7-B-NOPF-MUFAST";
-    mAliases[kMuonLikeLowPt7]   = "CMLL7-B-NOPF-MUFAST";
-    mAliases[kCUP8]             = "CCUP8-B-NOPF-CENTNOTRD";
-    mAliases[kCUP9]             = "CCUP9-B-NOPF-CENTNOTRD";
-    mAliases[kMUP10]            = "CMUP10-B-NOPF-MUFAST";
-    mAliases[kMUP11]            = "CMUP11-B-NOPF-MUFAST";
+    mAliases[kMuonLikeLowPt7] = "CMLL7-B-NOPF-MUFAST";
+    mAliases[kCUP8] = "CCUP8-B-NOPF-CENTNOTRD";
+    mAliases[kCUP9] = "CCUP9-B-NOPF-CENTNOTRD";
+    mAliases[kMUP10] = "CMUP10-B-NOPF-MUFAST";
+    mAliases[kMUP11] = "CMUP11-B-NOPF-MUFAST";
   }
 
   void init(InitContext&)
@@ -135,7 +135,7 @@ struct EventSelectionTask {
       }
       delete tokens;
     }
-    
+
     // TODO Fill EvSelParameters with configurable cuts from CCDB
   }
 
@@ -149,13 +149,13 @@ struct EventSelectionTask {
     int32_t alias[nAliases] = {0};
     for (auto& al : mAliasToClassIds) {
       for (auto& classIndex : al.second) {
-        alias[al.first] |= (triggerMask & (1ull << classIndex))>0;
+        alias[al.first] |= (triggerMask & (1ull << classIndex)) > 0;
       }
     }
-    
+
     // for (int i=0;i<64;i++) printf("%i",(triggerMask & (1ull << i)) > 0); printf("\n");
     // for (int i=0;i<nAliases;i++) printf("%i ",alias[i]); printf("\n");
-    
+
     // ZDC info
     auto zdc = getZdc(collision.bc(), zdcs);
     float timeZNA = zdc.timeZNA();
@@ -168,11 +168,11 @@ struct EventSelectionTask {
     auto fdd = getFDD(collision.bc(), fdds);
     float timeFDA = fdd.timeA();
     float timeFDC = fdd.timeC();
-    
+
     LOGF(debug, "timeZNA=%f timeZNC=%f", timeZNA, timeZNC);
     LOGF(debug, "timeV0A=%f timeV0C=%f", timeV0A, timeV0C);
     LOGF(debug, "timeFDA=%f timeFDC=%f", timeFDA, timeFDC);
-    
+
     bool bbZNA = timeZNA > par.fZNABBlower && timeZNA < par.fZNABBupper;
     bool bbZNC = timeZNC > par.fZNCBBlower && timeZNC < par.fZNCBBupper;
     bool bbV0A = timeV0A > par.fV0ABBlower && timeV0A < par.fV0ABBupper;
@@ -183,7 +183,7 @@ struct EventSelectionTask {
     bool bbFDC = timeFDC > par.fFDCBBlower && timeFDC < par.fFDCBBupper;
     bool bgFDA = timeFDA > par.fFDABGlower && timeFDA < par.fFDABGupper;
     bool bgFDC = timeFDC > par.fFDCBGlower && timeFDC < par.fFDCBGupper;
-    
+
     // Fill event selection columns
     evsel(alias, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC);
   }

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -34,18 +34,31 @@ struct EventSelectionTask {
     return dummy;
   }
 
+  aod::FDD getFDD(aod::BC const& bc, aod::FDDs const& fdds)
+  {
+    for (auto& fdd : fdds)
+      if (fdd.bc() == bc)
+        return fdd;
+    aod::FDD dummy;
+    return dummy;
+  }
+  
   OutputObj<TH1F> hTimeV0Aall{TH1F("hTimeV0Aall", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeV0Call{TH1F("hTimeV0Call", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeZNAall{TH1F("hTimeZNAall", "", 250, -25., 25.)};
   OutputObj<TH1F> hTimeZNCall{TH1F("hTimeZNCall", "", 250, -25., 25.)};
+  OutputObj<TH1F> hTimeFDAall{TH1F("hTimeFDAall", "", 1000, -100., 100.)};
+  OutputObj<TH1F> hTimeFDCall{TH1F("hTimeFDCall", "", 1000, -100., 100.)};
   OutputObj<TH1F> hTimeV0Aacc{TH1F("hTimeV0Aacc", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeV0Cacc{TH1F("hTimeV0Cacc", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeZNAacc{TH1F("hTimeZNAacc", "", 250, -25., 25.)};
   OutputObj<TH1F> hTimeZNCacc{TH1F("hTimeZNCacc", "", 250, -25., 25.)};
+  OutputObj<TH1F> hTimeFDAacc{TH1F("hTimeFDAacc", "", 1000, -100., 100.)};
+  OutputObj<TH1F> hTimeFDCacc{TH1F("hTimeFDCacc", "", 1000, -100., 100.)};
 
-  void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& col, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::Run2V0s const& vzeros)
+  void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& col, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::Run2V0s const& vzeros, aod::FDDs fdds)
   {
-    if (!col.alias()[0])
+    if (!col.alias()[kINT7])
       return;
 
     auto vzero = getVZero(col.bc(), vzeros);
@@ -56,6 +69,10 @@ struct EventSelectionTask {
     hTimeZNAall->Fill(zdc.timeZNA());
     hTimeZNCall->Fill(zdc.timeZNC());
 
+    auto fdd = getFDD(col.bc(), fdds);
+    hTimeFDAall->Fill(fdd.timeA());
+    hTimeFDCall->Fill(fdd.timeC());
+    
     if (!col.sel7())
       return;
 
@@ -63,6 +80,8 @@ struct EventSelectionTask {
     hTimeV0Cacc->Fill(vzero.timeC());
     hTimeZNAacc->Fill(zdc.timeZNA());
     hTimeZNCacc->Fill(zdc.timeZNC());
+    hTimeFDAacc->Fill(fdd.timeA());
+    hTimeFDCacc->Fill(fdd.timeC());
   }
 };
 

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -42,7 +42,7 @@ struct EventSelectionTask {
     aod::FDD dummy;
     return dummy;
   }
-  
+
   OutputObj<TH1F> hTimeV0Aall{TH1F("hTimeV0Aall", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeV0Call{TH1F("hTimeV0Call", "", 200, -50., 50.)};
   OutputObj<TH1F> hTimeZNAall{TH1F("hTimeZNAall", "", 250, -25., 25.)};
@@ -72,7 +72,7 @@ struct EventSelectionTask {
     auto fdd = getFDD(col.bc(), fdds);
     hTimeFDAall->Fill(fdd.timeA());
     hTimeFDCall->Fill(fdd.timeC());
-    
+
     if (!col.sel7())
       return;
 

--- a/Analysis/Tasks/multiplicityQa.cxx
+++ b/Analysis/Tasks/multiplicityQa.cxx
@@ -24,12 +24,12 @@ struct MultiplicityQaTask {
 
   void process(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& col)
   {
-    if (!col.alias()[0])
+    if (!col.alias()[kINT7])
       return;
     if (!col.sel7())
       return;
 
-    LOGF(info, "multV0A=%5.0f multV0C=%5.0f multV0M=%5.0f", col.multV0A(), col.multV0C(), col.multV0M());
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multV0M=%5.0f", col.multV0A(), col.multV0C(), col.multV0M());
     // fill calibration histos
     hMultV0M->Fill(col.multV0M());
     hMultZNA->Fill(col.multZNA());

--- a/Analysis/Tasks/multiplicityTable.cxx
+++ b/Analysis/Tasks/multiplicityTable.cxx
@@ -46,7 +46,7 @@ struct MultiplicityTableTask {
     float multZNA = zdc.energyCommonZNA();
     float multZNC = zdc.energyCommonZNC();
 
-    LOGF(info, "multV0A=%5.0f multV0C=%5.0f multZNA=%6.0f multZNC=%6.0f", multV0A, multV0C, multZNA, multZNC);
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multZNA=%6.0f multZNC=%6.0f", multV0A, multV0C, multZNA, multZNC);
     // fill multiplicity columns
     mult(multV0A, multV0C, multZNA, multZNC);
   }


### PR DESCRIPTION
Changes:
* Added new aliases corresponding to muon and UPC classes
* Added AD timing decisions in the event selection table
* Added AD timing QA in the event selection QA
* Isolated configurable cut parameters in EvSelParameters structure
* Introduced alias names similar to Run2 (kINT7 etc)
* replaced alias[0] to alias[kINT7] for minimum bias selection
* Suppressed debug messages
