### PR TITLE
Alpide strobe is divisor of orbit, DEF=9 strobes/orbit

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -102,6 +102,13 @@ struct InteractionRecord {
     return (int64_t(orbit) * o2::constants::lhc::LHCMaxBunches) + bc;
   }
 
+  void setFromLong(int64_t l)
+  {
+    // set from long BC counter
+    bc = l % o2::constants::lhc::LHCMaxBunches;
+    orbit = l / o2::constants::lhc::LHCMaxBunches;
+  }
+
   bool operator>(const InteractionRecord& other) const
   {
     return (orbit == other.orbit) ? (bc > other.bc) : (orbit > other.orbit);
@@ -256,6 +263,11 @@ struct InteractionTimeRecord : public InteractionRecord {
   {
     InteractionRecord::clear();
     timeNS = 0.;
+  }
+
+  double getTimeOffsetWrtBC() const
+  {
+    return timeNS - bc2ns();
   }
 
   void print() const;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -314,6 +314,8 @@ class MatchTPCITS
 
   ///< set ITS ROFrame duration in microseconds
   void setITSROFrameLengthMUS(float fums) { mITSROFrameLengthMUS = fums; }
+  ///< set ITS ROFrame duration in BC (continuous mode only)
+  void setITSROFrameLengthInBC(int nbc);
 
   ///< set ITS 0-th ROFrame time start in \mus
   void setITSROFrameOffsetMUS(float v) { mITSROFrameOffsetMUS = v; }
@@ -550,6 +552,7 @@ class MatchTPCITS
   ///< assigned time0 and its track Z position (converted from mTPCTimeEdgeZSafeMargin)
   float mTPCTimeEdgeTSafeMargin = 0.f;
 
+  int mITSROFrameLengthInBC = 0;    ///< ITS RO frame in BC (for ITS cont. mode only)
   float mITSROFrameLengthMUS = -1.; ///< ITS RO frame in \mus
   float mITSROFrameOffsetMUS = 0;   ///< time in \mus corresponding to start of 1st ITS ROFrame,
                                     ///< i.e. t = ROFrameID*mITSROFrameLengthMUS - mITSROFrameOffsetMUS

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -339,7 +339,11 @@ void MatchTPCITS::init()
 
   assert(mITSROFrameLengthMUS > 0.0f);
   mITSROFramePhaseOffset = mITSROFrameOffsetMUS / mITSROFrameLengthMUS;
-  mITSROFrame2TPCBin = mITSROFrameLengthMUS / mTPCTBinMUS;
+  if (mITSTriggered) {
+    mITSROFrame2TPCBin = mITSROFrameLengthMUS / mTPCTBinMUS;
+  } else {
+    mITSROFrame2TPCBin = mITSROFrameLengthMUS / mTPCTBinMUS; // RSTODO use both ITS and TPC times BCs once will be available for TPC also
+  }
   mTPCBin2ITSROFrame = 1. / mITSROFrame2TPCBin;
   mTPCBin2Z = mTPCTBinMUS * mTPCVDrift0;
   mZ2TPCBin = 1. / mTPCBin2Z;
@@ -2572,6 +2576,13 @@ void MatchTPCITS::refitABTrack(int ibest) const
     }
     ibest = lnk.parentID;
   }
+}
+
+//______________________________________________
+void MatchTPCITS::setITSROFrameLengthInBC(int nbc)
+{
+  mITSROFrameLengthInBC = nbc;
+  mITSROFrameLengthMUS = nbc * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
 }
 
 //<<============================= AfterBurner for TPC-track / ITS cluster matching ===================<<

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -66,7 +66,9 @@ void ClustererDPL::init(InitContext& ic)
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
   const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance();
-  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + clParams.maxBCDiffToMaskBias);
+  auto nbc = clParams.maxBCDiffToMaskBias;
+  nbc += mClusterer->isContinuousReadOut() ? alpParams.roFrameLengthInBC : (alpParams.roFrameLengthTrig / o2::constants::lhc::LHCBunchSpacingNS);
+  mClusterer->setMaxBCSeparationToMask(nbc);
   mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
   std::string dictPath = ic.options().get<std::string>("its-dictionary-path");

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -69,7 +69,9 @@ void ClustererDPL::init(InitContext& ic)
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
   const auto& clParams = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance();
-  mClusterer->setMaxBCSeparationToMask(alpParams.roFrameLength / o2::constants::lhc::LHCBunchSpacingNS + clParams.maxBCDiffToMaskBias);
+  auto nbc = clParams.maxBCDiffToMaskBias;
+  nbc += mClusterer->isContinuousReadOut() ? alpParams.roFrameLengthInBC : (alpParams.roFrameLengthTrig / o2::constants::lhc::LHCBunchSpacingNS);
+  mClusterer->setMaxBCSeparationToMask(nbc);
   mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
   std::string dictPath = ic.options().get<std::string>("mft-dictionary-path");

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
@@ -21,21 +21,24 @@ namespace o2
 {
 namespace itsmft
 {
-
-constexpr float DEFROFLength = o2::constants::lhc::LHCOrbitNS / 15;         // ROF length, divisor of the orbit
+/// allowed values: 1,2,3,4,6,9,11,12,18
+constexpr int DEFROFLengthBC = o2::constants::lhc::LHCMaxBunches / 9;       // default ROF length in BC for continuos mode
 constexpr float DEFStrobeDelay = o2::constants::lhc::LHCBunchSpacingNS * 4; // ~100 ns delay
 
 template <int N>
 struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<N>> {
   static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");
+  static_assert(o2::constants::lhc::LHCMaxBunches % DEFROFLengthBC == 0); // make sure ROF length is divisor of the orbit
 
   static constexpr std::string_view getParamName()
   {
     return N == o2::detectors::DetID::ITS ? ParamName[0] : ParamName[1];
   }
-  float roFrameLength = DEFROFLength;                 ///< length of RO frame in ns
+  int roFrameLengthInBC = DEFROFLengthBC;             ///< ROF length in BC for continuos mode
+  float roFrameLengthTrig = 6000.;                    ///< length of RO frame in ns for triggered mode
   float strobeDelay = DEFStrobeDelay;                 ///< strobe start (in ns) wrt ROF start
-  float strobeLength = DEFROFLength - DEFStrobeDelay; ///< length of the strobe in ns (sig. over threshold checked in this window only)
+  float strobeLengthCont = -1.;                       ///< if < 0, full ROF length - delay
+  float strobeLengthTrig = 100.;                      ///< length of the strobe in ns (sig. over threshold checked in this window only)
 
   // boilerplate stuff + make principal key
   O2ParamDef(DPLAlpideParam, getParamName().data());

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
@@ -50,6 +50,9 @@ class DigiParams
   void setContinuous(bool v) { mIsContinuous = v; }
   bool isContinuous() const { return mIsContinuous; }
 
+  int getROFrameLengthInBC() const { return mROFrameLengthInBC; }
+  void setROFrameLengthInBC(int n) { mROFrameLengthInBC = n; }
+
   void setROFrameLength(float ns);
   float getROFrameLength() const { return mROFrameLength; }
   float getROFrameLengthInv() const { return mROFrameLengthInv; }
@@ -87,9 +90,10 @@ class DigiParams
   static constexpr double infTime = 1e99;
   bool mIsContinuous = false;        ///< flag for continuous simulation
   float mNoisePerPixel = 1.e-7;      ///< ALPIDE Noise per chip
-  float mROFrameLength = DEFROFLength;                 ///< length of RO frame in ns
-  float mStrobeDelay = DEFStrobeDelay;                 ///< strobe start (in ns) wrt ROF start
-  float mStrobeLength = DEFROFLength - DEFStrobeDelay; ///< length of the strobe in ns (sig. over threshold checked in this window only)
+  int mROFrameLengthInBC = 0;        ///< ROF length in BC for continuos mode
+  float mROFrameLength = 0;          ///< length of RO frame in ns
+  float mStrobeDelay = 0.;           ///< strobe start (in ns) wrt ROF start
+  float mStrobeLength = 0;           ///< length of the strobe in ns (sig. over threshold checked in this window only)
   double mTimeOffset = -2 * infTime; ///< time offset (in seconds!) to calculate ROFrame from hit time
 
   int mChargeThreshold = 150;              ///< charge threshold in Nelectrons
@@ -105,7 +109,7 @@ class DigiParams
   float mROFrameLengthInv = 0; ///< inverse length of RO frame in ns
   float mNSimStepsInv = 0;     ///< its inverse
 
-  ClassDefNV(DigiParams, 1);
+  ClassDefNV(DigiParams, 2);
 };
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -27,6 +27,7 @@
 #include "ITSMFTBase/GeometryTGeo.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include "CommonDataFormat/InteractionRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 namespace o2
@@ -61,8 +62,7 @@ class Digitizer : public TObject
 
   /// Steer conversion of hits to digits
   void process(const std::vector<Hit>* hits, int evID, int srcID);
-  void setEventTime(double t);
-  double getEventTime() const { return mEventTime; }
+  void setEventTime(const o2::InteractionTimeRecord& irt);
   double getEndTimeOfROFMax() const
   {
     ///< return the time corresponding to end of the last reserved ROFrame : mROFrameMax
@@ -107,8 +107,8 @@ class Digitizer : public TObject
   static constexpr float sec2ns = 1e9;
 
   o2::itsmft::DigiParams mParams; ///< digitization parameters
-  double mEventTime = 0;          ///< global event time
-  bool mContinuous = false;       ///< flag for continuous simulation
+  o2::InteractionTimeRecord mEventTime; ///< global event time and interaction record
+  double mCollisionTimeWrtROF;
   UInt_t mROFrameMin = 0;         ///< lowest RO frame of current digits
   UInt_t mROFrameMax = 0;         ///< highest RO frame of current digits
   UInt_t mNewROFrame = 0;         ///< ROFrame corresponding to provided time

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -52,8 +52,7 @@ void Digitizer::process(const std::vector<Hit>* hits, int evID, int srcID)
   // digitize single event, the time must have been set beforehand
 
   LOG(INFO) << "Digitizing " << mGeometry->getName() << " hits of entry " << evID << " from source "
-            << srcID << " at time " << mEventTime + mParams.getTimeOffset() << " (TOff.= "
-            << mParams.getTimeOffset() << " ROFrame= " << mNewROFrame << ")"
+            << srcID << " at time " << mEventTime << " ROFrame= " << mNewROFrame << ")"
             << " cont.mode: " << isContinuous()
             << " Min/Max ROFrames " << mROFrameMin << "/" << mROFrameMax;
 
@@ -82,33 +81,29 @@ void Digitizer::process(const std::vector<Hit>* hits, int evID, int srcID)
 }
 
 //_______________________________________________________________________
-void Digitizer::setEventTime(double t)
+void Digitizer::setEventTime(const o2::InteractionTimeRecord& irt)
 {
   // assign event time in ns
-  mEventTime = t;
-  // to randomize the RO phase wrt the event time we use a random offset
-  if (mParams.isContinuous()) {       // in continuous mode we set the offset only in the very beginning
-    if (!mParams.isTimeOffsetSet()) { // offset is initially at -inf
-      mParams.setTimeOffset(0);       ///*mEventTime + */ mParams.getROFrameLength() * (gRandom->Rndm() - 0.5));
-    }
-  } else {                             // in the triggered mode we start from 0 ROFrame in every event, is this correct?
-    mParams.setTimeOffset(mEventTime); // + mParams.getROFrameLength() * (gRandom->Rndm() - 0.5));
-    mROFrameMin = 0;                   // so we reset the frame counters
+  mEventTime = irt;
+  if (!mParams.isContinuous()) {
+    mROFrameMin = 0; // in triggered mode reset the frame counters
     mROFrameMax = 0;
   }
-
-  mEventTime -= mParams.getTimeOffset(); // subtract common offset
-  if (mEventTime < 0.) {
-    mEventTime = 0.;
-  } else if (mEventTime > UINT_MAX * mParams.getROFrameLength()) {
-    LOG(FATAL) << "ROFrame for event time " << t << " exceeds allowe maximum " << UINT_MAX;
+  // RO frame corresponding to provided time
+  mCollisionTimeWrtROF = mEventTime.getTimeOffsetWrtBC();
+  if (mParams.isContinuous()) {
+    auto nbc = mEventTime.toLong();
+    if (mCollisionTimeWrtROF < 0 && nbc > 0) {
+      nbc--;
+    }
+    mNewROFrame = nbc / mParams.getROFrameLengthInBC();
+    mCollisionTimeWrtROF = mEventTime.timeNS - mNewROFrame * mParams.getROFrameLength();
+  } else {
+    mNewROFrame = 0;
   }
 
-  // RO frame corresponding to provided time
-  mNewROFrame = static_cast<UInt_t>(mEventTime * mParams.getROFrameLengthInv());
-
   if (mNewROFrame < mROFrameMin) {
-    LOG(FATAL) << "New ROFrame (time=" << t << ") precedes currently cashed " << mROFrameMin;
+    LOG(FATAL) << "New ROFrame (time=" << irt.timeNS << ") precedes currently cashed " << mROFrameMin;
   }
 
   if (mParams.isContinuous() && mROFrameMax < mNewROFrame) {
@@ -166,7 +161,11 @@ void Digitizer::fillOutputContainer(UInt_t frameLast)
     }
     // finalize ROF record
     rcROF.setNEntries(mDigits->size() - rcROF.getFirstEntry()); // number of digits
-    rcROF.getBCData().setFromNS(mROFrameMin * mParams.getROFrameLength() + mParams.getTimeOffset());
+    if (isContinuous()) {
+      rcROF.getBCData().setFromLong(mROFrameMin * mParams.getROFrameLengthInBC());
+    } else {
+      rcROF.getBCData() = mEventTime; // RSTODO do we need to add trigger delay?
+    }
     if (mROFRecords) {
       mROFRecords->push_back(rcROF);
     }
@@ -181,33 +180,33 @@ void Digitizer::fillOutputContainer(UInt_t frameLast)
 void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, int srcID)
 {
   // convert single hit to digits
-  double hTime0 = hit.GetTime() * sec2ns;
-  if (hTime0 > 20e3) {
+  float timeInROF = hit.GetTime() * sec2ns;
+  if (timeInROF > 20e3) {
     const int maxWarn = 10;
     static int warnNo = 0;
     if (warnNo < maxWarn) {
-      LOG(WARNING) << "Ignoring hit with time_in_event = " << hTime0 << " ns"
+      LOG(WARNING) << "Ignoring hit with time_in_event = " << timeInROF << " ns"
                    << ((++warnNo < maxWarn) ? "" : " (suppressing further warnings)");
     }
     return;
   }
-  hTime0 += mEventTime; // time from the RO start, in ns
-
+  if (isContinuous()) {
+    timeInROF += mCollisionTimeWrtROF;
+  }
   // calculate RO Frame for this hit
-  if (hTime0 < 0) {
-    hTime0 = 0.;
+  if (timeInROF < 0) {
+    timeInROF = 0.;
   }
   float tTot = mParams.getSignalShape().getMaxDuration();
-  // frame of the hit signal start
-  UInt_t roFrame = UInt_t(hTime0 * mParams.getROFrameLengthInv());
-  // frame of the hit signal end: in the triggered mode we read just 1 frame
-  UInt_t roFrameMax = mParams.isContinuous() ? UInt_t((hTime0 + tTot) * mParams.getROFrameLengthInv()) : roFrame;
-  int nFrames = roFrameMax + 1 - roFrame;
+  // frame of the hit signal start wrt event ROFrame
+  int roFrameRel = int(timeInROF * mParams.getROFrameLengthInv());
+  // frame of the hit signal end  wrt event ROFrame: in the triggered mode we read just 1 frame
+  UInt_t roFrameRelMax = mParams.isContinuous() ? (timeInROF + tTot) * mParams.getROFrameLengthInv() : roFrameRel;
+  int nFrames = roFrameRelMax + 1 - roFrameRel;
+  UInt_t roFrameMax = mNewROFrame + roFrameRelMax;
   if (roFrameMax > maxFr) {
     maxFr = roFrameMax; // if signal extends beyond current maxFrame, increase the latter
   }
-  // delay of the signal start wrt 1st ROF start
-  float timeInROF = float(hTime0 - (roFrame * mParams.getROFrameLength()));
 
   // here we start stepping in the depth of the sensor to generate charge diffision
   float nStepsInv = mParams.getNSimStepsInv();
@@ -322,7 +321,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, 
   // fire the pixels assuming Poisson(n_response_electrons)
   o2::MCCompLabel lbl(hit.GetTrackID(), evID, srcID, false);
   auto& chip = mChips[hit.GetDetectorID()];
-
+  auto roFrameAbs = mNewROFrame + roFrameRel;
   for (int irow = rowSpan; irow--;) {
     UShort_t rowIS = irow + rowS;
     for (int icol = colSpan; icol--;) {
@@ -337,7 +336,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, 
       }
       UShort_t colIS = icol + colS;
       //
-      registerDigits(chip, roFrame, timeInROF, nFrames, rowIS, colIS, nEle, lbl);
+      registerDigits(chip, roFrameAbs, timeInROF, nFrames, rowIS, colIS, nEle, lbl);
     }
   }
 }

--- a/macro/run_clus_itsSA.C
+++ b/macro/run_clus_itsSA.C
@@ -25,7 +25,7 @@
 void run_clus_itsSA(std::string inputfile = "rawits.bin", // input file name
                     std::string outputfile = "clr.root",  // output file name (root or raw)
                     bool raw = true,                      // flag if this is raw data
-                    float strobe = -1.,                   // strobe length in ns of ALPIDE readout, if <0, get automatically
+                    int strobeBC = -1,                    // strobe length in BC for masking, if <0, get automatically (assume cont. readout)
                     bool withFullClusters = true,
                     std::string dictionaryfile = "",
                     bool withPatterns = true)
@@ -56,11 +56,11 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // input file name
 
   // Mask fired pixels separated by <= this number of BCs (for overflow pixels).
   // In continuos mode strobe lenght should be used, in triggered one: signal shaping time (~7mus)
-  if (strobe < 0) {
+  if (strobeBC < 0) {
     const auto& dgParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-    strobe = dgParams.roFrameLength;
+    strobeBC = dgParams.roFrameLengthInBC;
   }
-  clus->getClusterer().setMaxBCSeparationToMask(strobe / o2::constants::lhc::LHCBunchSpacingNS + 10);
+  clus->getClusterer().setMaxBCSeparationToMask(strobeBC + 10);
   clus->getClusterer().setWantFullClusters(withFullClusters);
 
   clus->getClusterer().print();

--- a/macro/run_clus_mftSA.C
+++ b/macro/run_clus_mftSA.C
@@ -21,7 +21,7 @@
 void run_clus_mftSA(std::string outputfile, // output file name
                     std::string inputfile,  // input file name (root or raw)
                     bool raw = false,       // flag if this is raw data
-                    float strobe = 6000.)   // strobe length of ALPIDE readout
+                    int strobeBC = -1)      // strobe length in BC for masking, if <0, get automatically), get automatically (assume cont. readout)
 {
   // Initialize logger
   FairLogger* logger = FairLogger::GetLogger();
@@ -37,7 +37,11 @@ void run_clus_mftSA(std::string outputfile, // output file name
 
   // Mask fired pixels separated by <= this number of BCs (for overflow pixels).
   // In continuos mode strobe lenght should be used, in triggered one: signal shaping time (~7mus)
-  clus->getClusterer().setMaxBCSeparationToMask(strobe / o2::constants::lhc::LHCBunchSpacingNS + 10);
+  if (strobeBC < 0) {
+    const auto& dgParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
+    strobeBC = dgParams.roFrameLengthInBC;
+  }
+  clus->getClusterer().setMaxBCSeparationToMask(strobeBC + 10);
   clus->getClusterer().setWantFullClusters(true);    // require clusters with coordinates and full pattern
   clus->getClusterer().setWantCompactClusters(true); // require compact clusters with patternID
 


### PR DESCRIPTION
To avoid ROF calculation slippage due to the float errors operate, in continuous mode use ROF length
explicitly expressed in number of BCs (must be also divisor of orbit).

## Default ROF duration in cont. mode is set to 9 strobes per orbit.

@sawenzel, @rohr, @iouribelikov, @noferini,  @bovulpes @rpezzi : due to the change of the default Alpide strobe (old one was not respecting requirement of being divisor of the orbit) this PR will invalidate old simulated data (for what concerns the reconstruction tests involving ITS or MFT).

Similar correction will be needed for TPC (yet to be produced).