### PR TITLE
InteractionTimeRecord will store time in BC instead of abs. time

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -240,34 +240,42 @@ struct InteractionRecord {
 };
 
 struct InteractionTimeRecord : public InteractionRecord {
-  double timeNS = 0.; ///< time in NANOSECONDS from start of run (orbit=0)
+  double timeInBCNS = 0.; ///< time in NANOSECONDS relative to orbit/bc
 
   InteractionTimeRecord() = default;
 
-  InteractionTimeRecord(const InteractionRecord& ir, double tNS) : InteractionRecord(ir), timeNS(tNS)
+  InteractionTimeRecord(const InteractionRecord& ir, double timeInBCNS) : InteractionRecord(ir), timeInBCNS(timeInBCNS)
   {
   }
 
-  InteractionTimeRecord(double tNS)
+  /// create from the abs. (since orbit=0/bc=0) time in NS
+  InteractionTimeRecord(double tNS) : InteractionRecord(tNS)
   {
-    setFromNS(tNS);
+    timeInBCNS = tNS - bc2ns();
   }
 
-  void setFromNS(double ns)
+  /// set the from the abs. (since orbit=0/bc=0) time in NS
+  void setFromNS(double tNS)
   {
-    timeNS = ns;
-    InteractionRecord::setFromNS(ns);
+    InteractionRecord::setFromNS(tNS);
+    timeInBCNS = tNS - bc2ns();
   }
 
   void clear()
   {
     InteractionRecord::clear();
-    timeNS = 0.;
+    timeInBCNS = 0.;
   }
 
   double getTimeOffsetWrtBC() const
   {
-    return timeNS - bc2ns();
+    return timeInBCNS;
+  }
+
+  /// get time in ns from orbit=0/bc=0
+  double getTimeNS() const
+  {
+    return timeInBCNS + bc2ns();
   }
 
   void print() const;

--- a/DataFormats/common/src/InteractionRecord.cxx
+++ b/DataFormats/common/src/InteractionRecord.cxx
@@ -23,7 +23,7 @@ std::ostream& operator<<(std::ostream& stream, o2::InteractionRecord const& ir)
 
 std::ostream& operator<<(std::ostream& stream, o2::InteractionTimeRecord const& ir)
 {
-  stream << "BCid: " << ir.bc << " Orbit: " << ir.orbit << " T(ns): " << ir.timeNS;
+  stream << "BCid: " << ir.bc << " Orbit: " << ir.orbit << " T in BC(ns): " << ir.timeInBCNS;
   return stream;
 }
 

--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -28,7 +28,7 @@ void DigitizationContext::printCollisionSummary() const
   }
   std::cout << "Number of Collisions " << mEventRecords.size() << "\n";
   for (int i = 0; i < mEventRecords.size(); ++i) {
-    std::cout << "Collision " << i << " TIME " << mEventRecords[i].timeNS;
+    std::cout << "Collision " << i << " TIME " << mEventRecords[i];
     for (auto& e : mEventParts[i]) {
       std::cout << " (" << e.sourceID << " , " << e.entryID << ")";
     }

--- a/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
@@ -64,7 +64,7 @@ void Digitizer::process(const std::vector<o2::fdd::Hit>& hits,
     double timeHit = delayScintillator + hit.GetTime();
 
     timeHit -= getTOFCorrection(int(iChannel / 4)); // account for TOF to detector
-    timeHit += mIntRecord.timeNS;
+    timeHit += mIntRecord.getTimeNS();
     o2::InteractionRecord irHit(timeHit); // BC in which the hit appears (might be different from interaction BC for slow particles)
 
     int nCachedIR = 0;

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -68,7 +68,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     auto& irecords = context->getEventRecords();
 
     for (auto& record : irecords) {
-      LOG(INFO) << "TRD TIME RECEIVED " << record.timeNS;
+      LOG(INFO) << "TRD TIME RECEIVED " << record.getTimeNS();
     }
 
     auto& eventParts = context->getEventParts();
@@ -85,7 +85,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
-      mDigitizer.setEventTime(irecords[collID].timeNS);
+      mDigitizer.setEventTime(irecords[collID].getTimeNS());
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -73,7 +73,7 @@ void Digitizer::process(const std::vector<o2::zdc::Hit>& hits,
     }
 
     double hTime = hit.GetTime() - getTOFCorrection(detID); // account for TOF to detector
-    hTime += mIR.timeNS;
+    hTime += mIR.getTimeNS();
     //
     o2::InteractionRecord irHit(hTime); // BC in which the hit appears (might be different from interaction BC for slow particles)
 

--- a/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
@@ -109,7 +109,7 @@ void DigitizerSpec::run(framework::ProcessingContext& pc)
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
-    mDigitizer.setEventTime(timesview[collID].timeNS);
+    mDigitizer.setEventTime(timesview[collID].getTimeNS());
 
     // for each collision, loop over the constituents event and source IDs
     // (background signal merging is basically taking place here)

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -76,7 +76,7 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
-    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive(timesview[collID].timeNS))) {
+    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive(timesview[collID].getTimeNS()))) {
       // copy digits into accumulator
       mDigits.clear();
       mLabels.clear();
@@ -90,7 +90,7 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
       mLabels.clear();
     }
 
-    mDigitizer.setEventTime(timesview[collID].timeNS);
+    mDigitizer.setEventTime(timesview[collID].getTimeNS());
 
     if (!mDigitizer.isLive())
       continue;

--- a/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
@@ -67,7 +67,7 @@ class FDDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     context->initSimChains(o2::detectors::DetID::FDD, mSimChains);
     mDigitizer.setEventTime(context->getGRP().getTimeStart());
     for (auto& record : irecords) {
-      LOG(INFO) << "FDD TIME RECEIVED " << record.timeNS;
+      LOG(INFO) << "FDD TIME RECEIVED " << record.getTimeNS();
     }
 
     auto& eventParts = context->getEventParts();

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -63,7 +63,7 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     auto& irecords = context->getEventRecords();
 
     for (auto& record : irecords) {
-      LOG(INFO) << "HMPID TIME RECEIVED " << record.timeNS;
+      LOG(INFO) << "HMPID TIME RECEIVED " << record.getTimeNS();
     }
 
     auto& eventParts = context->getEventParts();
@@ -86,12 +86,12 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     for (int collID = 0; collID < irecords.size(); ++collID) {
 
       // try to start new readout cycle by setting the trigger time
-      auto triggeraccepted = mDigitizer.setTriggerTime(irecords[collID].timeNS);
+      auto triggeraccepted = mDigitizer.setTriggerTime(irecords[collID].getTimeNS());
       if (triggeraccepted) {
         flushDigitsAndLabels(); // flush previous readout cycle
       }
 
-      auto withinactivetime = mDigitizer.setEventTime(irecords[collID].timeNS);
+      auto withinactivetime = mDigitizer.setEventTime(irecords[collID].getTimeNS());
       if (withinactivetime) {
         // for each collision, loop over the constituents event and source IDs
         // (background signal merging is basically taking place here)

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -165,10 +165,10 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   void processQED(const o2::InteractionTimeRecord& irt)
   {
 
-    auto tQEDNext = mLastQEDTime.timeNS + mQEDEntryTimeBinNS; // timeslice to retrieve
+    auto tQEDNext = mLastQEDTime.getTimeNS() + mQEDEntryTimeBinNS; // timeslice to retrieve
     std::string detStr = mID.getName();
     auto br = mQEDChain.GetBranch((detStr + "Hit").c_str());
-    while (tQEDNext < irt.timeNS) {
+    while (tQEDNext < irt.getTimeNS()) {
       mLastQEDTime.setFromNS(tQEDNext); // time used for current QED slot
       tQEDNext += mQEDEntryTimeBinNS; // prepare time for next QED slot
       if (++mLastQEDEntry >= mQEDChain.GetEntries()) {

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -59,7 +59,7 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     auto& irecords = context->getEventRecords();
 
     for (auto& record : irecords) {
-      LOG(DEBUG) << "MCH TIME RECEIVED " << record.timeNS;
+      LOG(DEBUG) << "MCH TIME RECEIVED " << record.getTimeNS();
     }
 
     auto& eventParts = context->getEventParts();
@@ -69,7 +69,7 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
-      mDigitizer.setEventTime(irecords[collID].timeNS);
+      mDigitizer.setEventTime(irecords[collID].getTimeNS());
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)
       for (auto& part : eventParts[collID]) {

--- a/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
@@ -103,7 +103,7 @@ void DigitizerSpec::run(framework::ProcessingContext& pc)
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
-    mDigitizer.setEventTime(timesview[collID].timeNS);
+    mDigitizer.setEventTime(timesview[collID].getTimeNS());
 
     // for each collision, loop over the constituents event and source IDs
     // (background signal merging is basically taking place here)

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -125,7 +125,7 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < timesview.size(); ++collID) {
-      mDigitizer->setEventTime(timesview[collID].timeNS);
+      mDigitizer->setEventTime(timesview[collID].getTimeNS());
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -275,7 +275,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     };
 
     static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
-    mDigitizer.setStartTime(sampaProcessing.getTimeBinFromTime(irecords[0].timeNS / 1000.f));
+    mDigitizer.setStartTime(sampaProcessing.getTimeBinFromTime(irecords[0].getTimeNS() / 1000.f));
 
     TStopwatch timer;
     timer.Start();
@@ -283,7 +283,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
-      const float eventTime = irecords[collID].timeNS / 1000.f;
+      const float eventTime = irecords[collID].getTimeNS() / 1000.f;
       LOG(INFO) << "TPC: Event time " << eventTime << " us";
       mDigitizer.setEventTime(eventTime);
       if (!isContinuous) {

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -80,7 +80,7 @@ const o2::InteractionTimeRecord& InteractionSampler::generateCollisionTime()
   if (mIntBCCache < 1) {                   // do we still have interaction in current BC?
     mIntBCCache = simulateInteractingBC(); // decide which BC interacts and N collisions
   }
-  mIR.timeNS = mTimeInBC.back() + mIR.bc2ns();
+  mIR.timeInBCNS = mTimeInBC.back();
   mTimeInBC.pop_back();
   mIntBCCache--;
 

--- a/Steer/test/testInteractionSampler.cxx
+++ b/Steer/test/testInteractionSampler.cxx
@@ -33,8 +33,8 @@ BOOST_AUTO_TEST_CASE(InteractionSampler)
   defSampler.generateCollisionTimes(records);
   double t = -1.;
   for (const auto& rec : records) {
-    BOOST_CHECK(rec.timeNS >= t); // make sure time is non-decreasing
-    t = rec.timeNS;
+    BOOST_CHECK(rec.getTimeNS() >= t); // make sure time is non-decreasing
+    t = rec.getTimeNS();
   }
 
   printf("\nTesting sampler with custom bunch filling and low mu\n");
@@ -55,14 +55,14 @@ BOOST_AUTO_TEST_CASE(InteractionSampler)
   sampler1.generateCollisionTimes(records);
   t = -1.;
   for (const auto& rec : records) {
-    BOOST_CHECK(rec.timeNS >= t); // make sure time is non-decreasing
-    t = rec.timeNS;
+    BOOST_CHECK(rec.getTimeNS() >= t); // make sure time is non-decreasing
+    t = rec.getTimeNS();
   }
 
   // make sure the IR corresponds to declared one
   records.reserve((int)sampler1.getInteractionRate());
   sampler1.generateCollisionTimes(records);
-  double dt = (records.back().timeNS - records.front().timeNS) * 1.e-9;
+  double dt = (records.back().getTimeNS() - records.front().getTimeNS()) * 1.e-9;
   printf("\nGenerated %d collisions with time span %.3fs at IR=%e\n",
          (int)records.size(), dt, sampler1.getInteractionRate());
   BOOST_CHECK(std::abs(dt - 1.) < 0.1);
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(InteractionSampler)
     auto rec = sampler1.generateCollisionTime();
     rec.print();
     // make sure time is non-decreasing and the BC is interacting
-    BOOST_CHECK(rec.timeNS >= t && sampler1.getBunchFilling().testBC(rec.bc));
-    t = rec.timeNS;
+    BOOST_CHECK(rec.getTimeNS() >= t && sampler1.getBunchFilling().testBC(rec.bc));
+    t = rec.getTimeNS();
   }
   sampler1.print();
   sampler1.getBunchFilling().print();


### PR DESCRIPTION
To avoid round-off  errors the InteractionTimeRecord produced by the InteractionSampler in the digitization will store the time in ns wrt the BC/orbit it indicates (i.e. it is the time of the interaction within the bunch) rather than the time from BC=0/orbit=0 stored before. The latter can be obtained as ``InteractionTimeRecord::getTimeNS()``.

The detectors digitization code was updated correspondingly, so the change is transparent for them.