### PR TITLE
Fix inconsistencies in ITS/MFT message DataDescription names

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -256,7 +256,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcC
   inputs.emplace_back("trackITSROF", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITS", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITSPatt", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("clusITSROF", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clusITSROF", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -60,14 +60,14 @@ DataProcessorSpec getClusterWriterSpec(bool useMC)
                                 // RSTODO being eliminated
                                 BranchDefinition<ClustersType>{InputSpec{"clusters", "ITS", "CLUSTERS", 0},
                                                                "ITSCluster"},
-                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "ITSClusterROF", 0},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "ClusterROF", 0},
                                                                "ITSClustersROF",
                                                                logger},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "CLUSTERSMCTR", 0},
                                                              "ITSClusterMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSClusterMC2ROF", 0},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ClusterMC2ROF", 0},
                                                              "ITSClustersMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -118,7 +118,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   mClusterer->process(mNThreads, reader, mFullClusters ? &clusVec : nullptr, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
   pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "ITSClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "ClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
   pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec);
   pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
 
@@ -128,7 +128,7 @@ void ClustererDPL::run(ProcessingContext& pc)
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "ITSClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "ClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
@@ -140,19 +140,19 @@ DataProcessorSpec getClustererSpec(bool useMC)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "ITS", "DIGITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ITSDigitROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "DigitROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "PATTERNS", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "ClusterROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ITSDigitMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "DigitMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -202,7 +202,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
@@ -213,7 +213,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
@@ -70,10 +70,10 @@ void DigitReader::run(ProcessingContext& pc)
               << profs->size() << " RO frames";
 
     pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(Output{"ITS", "ITSDigitROF", 0, Lifetime::Timeframe}, *profs);
+    pc.outputs().snapshot(Output{"ITS", "DigitROF", 0, Lifetime::Timeframe}, *profs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"ITS", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"ITS", "ITSDigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
+      pc.outputs().snapshot(Output{"ITS", "DigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the ITS digits !";
@@ -88,10 +88,10 @@ DataProcessorSpec getDigitReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "DIGITS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("ITS", "ITSDigitROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "DigitROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("ITS", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("ITS", "ITSDigitMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "DigitMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -239,7 +239,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, o2::gpu::GPUDataTypes::DeviceType d
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
@@ -250,7 +250,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, o2::gpu::GPUDataTypes::DeviceType d
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/MFT/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClusterReaderSpec.cxx
@@ -73,10 +73,10 @@ void ClusterReader::run(ProcessingContext& pc)
 
     pc.outputs().snapshot(Output{"MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe}, compClusters);
     pc.outputs().snapshot(Output{"MFT", "CLUSTERS", 0, Lifetime::Timeframe}, clusters);
-    pc.outputs().snapshot(Output{"MFT", "MFTClusterROF", 0, Lifetime::Timeframe}, rofs);
+    pc.outputs().snapshot(Output{"MFT", "ClusterROF", 0, Lifetime::Timeframe}, rofs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+      pc.outputs().snapshot(Output{"MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the MFT clusters !";
@@ -91,10 +91,10 @@ DataProcessorSpec getClusterReaderSpec(bool useMC)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "MFTClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
@@ -60,14 +60,14 @@ DataProcessorSpec getClusterWriterSpec(bool useMC)
                                 BranchDefinition<ClustersType>{InputSpec{"clusters", "MFT", "CLUSTERS", 0},
                                                                "MFTCluster",
                                                                clustersSizeGetter},
-                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "MFT", "MFTClusterROF", 0},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "MFT", "ClusterROF", 0},
                                                                "MFTClustersROF",
                                                                logger},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", "MFT", "CLUSTERSMCTR", 0},
                                                              "MFTClusterMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "MFTClusterMC2ROF", 0},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "ClusterMC2ROF", 0},
                                                              "MFTClustersMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -121,7 +121,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   mClusterer->process(mNThreads, reader, mFullClusters ? &clusVec : nullptr, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
   pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "MFTClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "ClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
   pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec);
   pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
 
@@ -131,7 +131,7 @@ void ClustererDPL::run(ProcessingContext& pc)
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "MFTClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "ClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
@@ -143,19 +143,19 @@ DataProcessorSpec getClustererSpec(bool useMC)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "MFT", "DIGITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "MFTDigitROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "DigitROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "PATTERNS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "MFTClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "MFT", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "MFTDigitMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "MFT", "DigitMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/MFT/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/DigitReaderSpec.cxx
@@ -69,10 +69,10 @@ void DigitReader::run(ProcessingContext& pc)
               << profs->size() << " RO frames";
 
     pc.outputs().snapshot(Output{"MFT", "DIGITS", 0, Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(Output{"MFT", "MFTDigitROF", 0, Lifetime::Timeframe}, *profs);
+    pc.outputs().snapshot(Output{"MFT", "DigitROF", 0, Lifetime::Timeframe}, *profs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"MFT", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"MFT", "MFTDigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
+      pc.outputs().snapshot(Output{"MFT", "DigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the MFT digits !";
@@ -87,10 +87,10 @@ DataProcessorSpec getDigitReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "DIGITS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "MFTDigitROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "DigitROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("MFT", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "MFTDigitMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "DigitMC2ROF", 0, Lifetime::Timeframe);
   }
   return DataProcessorSpec{
     "mft-digit-reader",

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -162,7 +162,7 @@ DataProcessorSpec getTrackerSpec(bool useMC)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("compClusters", "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "MFT", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "MFTClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "ClusterROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "TRACKSLTF", 0, Lifetime::Timeframe);
@@ -171,7 +171,7 @@ DataProcessorSpec getTrackerSpec(bool useMC)
 
   if (useMC) {
     inputs.emplace_back("labels", "MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("MFT", "MFTTrackMC2ROF", 0, Lifetime::Timeframe);
   }

--- a/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
@@ -55,9 +55,7 @@ void ClusterReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, mOrigin == o2::header::gDataOriginITS ? "ITSClusterROF" : "MFTClusterROF",
-                               0, Lifetime::Timeframe},
-                        mClusROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "ClusterROF", 0, Lifetime::Timeframe}, mClusROFRec);
   if (mUseClFull) {
     pc.outputs().snapshot(Output{mOrigin, "CLUSTERS", 0, Lifetime::Timeframe}, mClusterArray);
   }
@@ -112,7 +110,7 @@ void ClusterReader::connectTree(const std::string& filename)
 DataProcessorSpec getITSClusterReaderSpec(bool useMC, bool useClFull, bool useClComp, bool usePatterns)
 {
   std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "ClusterROF", 0, Lifetime::Timeframe);
   if (useClFull) {
     outputSpec.emplace_back("ITS", "CLUSTERS", 0, Lifetime::Timeframe);
   }
@@ -139,7 +137,7 @@ DataProcessorSpec getITSClusterReaderSpec(bool useMC, bool useClFull, bool useCl
 DataProcessorSpec getMFTClusterReaderSpec(bool useMC, bool useClFull, bool useClComp, bool usePatterns)
 {
   std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("MFT", "MFTClusterROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
   if (useClFull) {
     outputSpec.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   }

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -64,7 +64,7 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig)
   std::vector<OutputSpec> outputs{
     OutputSpec{{"compClusters"}, orig, "COMPCLUSTERS", 0, Lifetime::Timeframe},
     OutputSpec{{"patterns"}, orig, "PATTERNS", 0, Lifetime::Timeframe},
-    OutputSpec{{"ROframes"}, orig, orig == o2::header::gDataOriginITS ? "ITSClusterROF" : "MFTClusterROF", 0, Lifetime::Timeframe},
+    OutputSpec{{"ROframes"}, orig, "ClusterROF", 0, Lifetime::Timeframe},
     OutputSpec{{"fullclusters"}, orig, "CLUSTERS", 0, Lifetime::Timeframe} // RS DUMMY, being outphased
   };
 

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -61,7 +61,7 @@ DataProcessorSpec getEntropyEncoderSpec(o2::header::DataOrigin orig)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("compClusters", orig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", orig, "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", orig, orig == o2::header::gDataOriginITS ? "ITSClusterROF" : "MFTClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", orig, "ClusterROF", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     orig == o2::header::gDataOriginITS ? "its-entropy-encoder" : "mft-entropy-encoder",

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -74,15 +74,15 @@ void STFDecoder<Mapping>::init(InitContext& ic)
       geom = o2::mft::GeometryTGeo::Instance();
       geom->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L));
     }
+    mClusterer = std::make_unique<Clusterer>();
+    mClusterer->setGeometry(geom);
+    mClusterer->setNChips(Mapping::getNChips());
     const auto grp = o2::parameters::GRPObject::loadFrom(o2::base::NameConf::getGRPFileName());
     if (grp) {
       mClusterer->setContinuousReadOut(grp->isDetContinuousReadOut(detID));
     } else {
       throw std::runtime_error("failed to retrieve GRP");
     }
-    mClusterer = std::make_unique<Clusterer>();
-    mClusterer->setGeometry(geom);
-    mClusterer->setNChips(Mapping::getNChips());
 
     // settings for the fired pixel overflow masking
     const auto& alpParams = DPLAlpideParam<Mapping::getDetID()>::Instance();


### PR DESCRIPTION
@bovulpes some DataDescription names were not changed all devices using then in the https://github.com/AliceO2Group/AliceO2/pull/3688.
I've fixed both the ITS and MFT part but I am not familiar with MFT workflows to test, please check.