### PR TITLE
Define default TPC time bin BCs

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/ParameterElectronics.h
+++ b/Detectors/TPC/base/include/TPCBase/ParameterElectronics.h
@@ -18,6 +18,7 @@
 #include <array>
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
+#include "CommonConstants/LHCConstants.h"
 
 namespace o2
 {
@@ -32,6 +33,7 @@ enum class DigitzationMode : char {
 };
 
 struct ParameterElectronics : public o2::conf::ConfigurableParamHelper<ParameterElectronics> {
+  static constexpr int TIMEBININBC = 8;
 
   int NShapedPoints = 8;                                        ///< Number of ADC samples which are taken into account for a given, shaped signal (should fit
                                                                 /// into SSE registers)
@@ -39,7 +41,7 @@ struct ParameterElectronics : public o2::conf::ConfigurableParamHelper<Parameter
   float ChipGain = 20.f;                                        ///< Gain of the SAMPA [mV/fC] - may be either 20 or 30
   float ADCdynamicRange = 2200.f;                               ///< Dynamic range of the ADC [mV]
   float ADCsaturation = 1024.f;                                 ///< ADC saturation [ADC counts]
-  float ZbinWidth = 0.2;                                        ///< Width of a z bin [us]
+  float ZbinWidth = TIMEBININBC * o2::constants::lhc::LHCBunchSpacingNS * 1e-3; ///< Width of a z bin [us]
   float ElectronCharge = 1.602e-19f;                            ///< Electron charge [C]
   DigitzationMode DigiMode = DigitzationMode::SubtractPedestal; ///< Digitization mode [full / ... ]
 

--- a/Detectors/TPC/base/test/testTPCParameters.cxx
+++ b/Detectors/TPC/base/test/testTPCParameters.cxx
@@ -28,6 +28,8 @@ namespace o2
 namespace tpc
 {
 
+constexpr float NominalTimeBin = 8 * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+
 /// \brief Trivial test of the default initialization of Parameter Detector
 /// Precision: 1E-3 %
 BOOST_AUTO_TEST_CASE(ParameterDetector_test1)
@@ -67,7 +69,7 @@ BOOST_AUTO_TEST_CASE(ParameterElectronics_test1)
   BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ChipGain, 20, 1e-3);
   BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ADCdynamicRange, 2200, 1e-3);
   BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ADCsaturation, 1024, 1e-3);
-  BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ZbinWidth, 0.2f, 1e-3);
+  BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ZbinWidth, NominalTimeBin, 1e-3);
   BOOST_CHECK_CLOSE(ParameterElectronics::Instance().ElectronCharge, 1.602e-19, 1e-3);
   BOOST_CHECK(ParameterElectronics::Instance().DigiMode == DigitzationMode::SubtractPedestal);
 
@@ -76,7 +78,7 @@ BOOST_AUTO_TEST_CASE(ParameterElectronics_test1)
   BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ChipGain"), 20, 1e-3);
   BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ADCdynamicRange"), 2200, 1e-3);
   BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ADCsaturation"), 1024, 1e-3);
-  BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ZbinWidth"), 0.2f, 1e-3);
+  BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ZbinWidth"), NominalTimeBin, 1e-3);
   BOOST_CHECK_CLOSE(o2::conf::ConfigurableParam::getValueAs<float>("TPCEleParam.ElectronCharge"), 1.602e-19, 1e-3);
 }
 


### PR DESCRIPTION
@davidrohr,  @wiechula I've changed the timebin definition to account for the real BC spacing.
This should solve the problem of de-synchronization between the ITS and TPC for TF>1.

I did a fast test with boxgen, comparing 1 "long TF" reconstruction with digits and the same data converted to 4 TFs of  64 HBFs, matching in TF>1 ( x>5700 on the attached plot showing the matched track times in \mus, red from digits, blue from raw) improved (before ~half of matches were lost) but is still not good, apparently I have problems also in the matching code.
In any case, the time now should be correct and the eventual change in time -> timebin mapping in digtization to avoid round-off errors should not affect the readability of digits So, David, I think you can generate a sample w/o much risk of its becoming obsolete in a couple of days (note that the ITS reconstruction from raw is at the moment broken, need https://github.com/AliceO2Group/AliceO2/pull/3756 to fix it).

![tf64_afterFix](https://user-images.githubusercontent.com/7382029/84332497-5f8c7380-ab8d-11ea-8de3-69969639ba08.gif)
