### PR TITLE
bug correction for current particle during stepping 

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -238,6 +238,7 @@ class Stack : public FairGenericStack
   std::vector<int> mTrackIDtoParticlesEntry; //! an O(1) mapping of trackID to the entry of mParticles
   // the current TParticle object
   TParticle mCurrentParticle;
+  TParticle mCurrentParticle0;
 
   // keep primary particles in its original form
   // (mainly for the PopPrimaryParticleInterface

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -206,7 +206,7 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
       p.SetBit(ParticleStatus::kToBeDone, 0);
     }
     mParticles.emplace_back(p);
-    mCurrentParticle = p;
+    mCurrentParticle0 = p;
   }
   mStack.push(p);
 }
@@ -241,6 +241,8 @@ void Stack::SetCurrentTrack(Int_t iTrack)
     auto& p = mPrimaryParticles[iTrack];
     mCurrentParticle = p;
     mIndexOfCurrentPrimary = mCurrentParticle.GetStatusCode();
+  } else {
+    mCurrentParticle = mCurrentParticle0;
   }
 }
 


### PR DESCRIPTION
- For Geant3 the current particle has to be updated when a new particle is taken from the stack
- For Geant4 the current particle has to be updated when a new particle is put on the stack (in SetCurrentParticle which is always called after PushTrack)