### PR TITLE
MCH: added number-of-samples parameter to the Digit structure

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -47,12 +47,15 @@ class Digit
 
   Digit() = default;
 
-  Digit(int detid, int pad, unsigned long adc, Time time);
+  Digit(int detid, int pad, unsigned long adc, Time time, uint16_t nSamples = 1);
   ~Digit() = default;
 
   bool operator==(const Digit&) const;
 
   Time getTime() const { return mTime; }
+
+  uint16_t getNSamples() const { return mNSamples; }
+  void setNSamples(uint16_t n) { mNSamples = n; }
 
   int getDetID() const { return mDetID; }
 
@@ -64,6 +67,7 @@ class Digit
 
  private:
   Time mTime;
+  uint16_t mNSamples; /// number of samples in the signal
   int mDetID;
   int mPadID;         /// PadIndex to which the digit corresponds to
   unsigned long mADC; /// Amplitude of signal

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -54,8 +54,8 @@ class Digit
 
   Time getTime() const { return mTime; }
 
-  uint16_t getNSamples() const { return mNSamples; }
-  void setNSamples(uint16_t n) { mNSamples = n; }
+  uint16_t nofSamples() const { return mNofSamples; }
+  void setNofSamples(uint16_t n) { mNofSamples = n; }
 
   int getDetID() const { return mDetID; }
 
@@ -67,7 +67,7 @@ class Digit
 
  private:
   Time mTime;
-  uint16_t mNSamples; /// number of samples in the signal
+  uint16_t mNofSamples; /// number of samples in the signal
   int mDetID;
   int mPadID;         /// PadIndex to which the digit corresponds to
   unsigned long mADC; /// Amplitude of signal

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -72,7 +72,7 @@ class Digit
   int mPadID;         /// PadIndex to which the digit corresponds to
   unsigned long mADC; /// Amplitude of signal
 
-  ClassDefNV(Digit, 1);
+  ClassDefNV(Digit, 2);
 }; //class Digit
 
 } //namespace mch

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -19,8 +19,8 @@ bool closeEnough(double x, double y, double eps = 1E-6)
   return std::fabs(x - y) <= eps * std::max(1.0, std::max(std::fabs(x), std::fabs(y)));
 }
 
-Digit::Digit(int detid, int pad, unsigned long adc, Time time)
-  : mDetID(detid), mPadID(pad), mADC(adc), mTime(time)
+Digit::Digit(int detid, int pad, unsigned long adc, Time time, uint16_t nSamples)
+  : mDetID(detid), mPadID(pad), mADC(adc), mTime(time), mNSamples(nSamples)
 {
 }
 
@@ -29,7 +29,8 @@ bool Digit::operator==(const Digit& other) const
   return mDetID == other.mDetID &&
          mPadID == other.mPadID &&
          mADC == other.mADC &&
-         mTime.time == other.mTime.time;
+         mTime.time == other.mTime.time &&
+         mNSamples == other.mNSamples;
 }
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -20,7 +20,7 @@ bool closeEnough(double x, double y, double eps = 1E-6)
 }
 
 Digit::Digit(int detid, int pad, unsigned long adc, Time time, uint16_t nSamples)
-  : mDetID(detid), mPadID(pad), mADC(adc), mTime(time), mNSamples(nSamples)
+  : mDetID(detid), mPadID(pad), mADC(adc), mTime(time), mNofSamples(nSamples)
 {
 }
 
@@ -30,7 +30,7 @@ bool Digit::operator==(const Digit& other) const
          mPadID == other.mPadID &&
          mADC == other.mADC &&
          mTime.time == other.mTime.time &&
-         mNSamples == other.mNSamples;
+         mNofSamples == other.mNofSamples;
 }
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 ///
+///
 /// \file    DatDecoderSpec.cxx
 /// \author  Andrea Ferrero
 ///

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -124,7 +124,7 @@ class DataDecoderTask
       time.bunchCrossing = sc.bunchCrossing;
       time.orbit = orbit;
 
-      digits.emplace_back(o2::mch::Digit(deId, padId, digitadc, time));
+      digits.emplace_back(o2::mch::Digit(deId, padId, digitadc, time, sc.nofSamples()));
 
       if (mPrint)
         std::cout << "DIGIT STORED:\nADC " << digits.back().getADC() << " DE# " << digits.back().getDetID() << " PadId " << digits.back().getPadID() << " time " << digits.back().getTime().sampaTime << std::endl;

--- a/Detectors/MUON/MCH/Workflow/src/file-to-digits-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/file-to-digits-workflow.cxx
@@ -148,7 +148,7 @@ class FileReaderTask
 
       o2::mch::Digit::Time time;
 
-      digits.emplace_back(o2::mch::Digit(deId, padId, digitadc, time));
+      digits.emplace_back(o2::mch::Digit(deId, padId, digitadc, time, sc.nofSamples()));
       //o2::mch::Digit& mchdigit = digits.back();
       //mchdigit.setDetID(deId);
       //mchdigit.setPadID(padId);


### PR DESCRIPTION
The information on the number of samples in the detected signal is needed in order to perform digits merging in continuous data taking mode, and might be exploited to distinguish real signals from noise hits.