### PR TITLE
Fix of test for trackable primaries

### DIFF
--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -107,9 +107,9 @@ Bool_t GeneratorFromFile::ReadEvent(FairPrimaryGenerator* primGen)
     // filter the particles from Kinematics.root originally put by a generator
     // and which are trackable
     auto isFirstTrackableDescendant = [](TParticle const& p) {
-      const int kDoneBit = 4;
+      const int kTransportBit = BIT(14);
       // The particle should have not set kDone bit and its status should not exceed 1
-      if (p.GetStatusCode() > 1 || p.TestBit(kDoneBit)) {
+      if (p.GetUniqueID() > 0 || !p.TestBit(kTransportBit)) {
         return false;
       }
       return true;
@@ -117,7 +117,6 @@ Bool_t GeneratorFromFile::ReadEvent(FairPrimaryGenerator* primGen)
 
     for (int i = 0; i < branch->GetEntries(); ++i) {
       auto& p = particles[i];
-
       if (!isFirstTrackableDescendant(p)) {
         continue;
       }


### PR DESCRIPTION
A particle is primary, if its UniqueID() == 0, and trackable, if TestBit(BIT(14)) == 1.
In a future update we can also put the untrackable primaries (parents) on the stacks. For this
one needs to calculate the daughter and mother IDs from the information in the Kinematics.tree