### PR TITLE
Fixes for ITSTPC matching at TF>0 or ITS data with gaps

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -338,7 +338,6 @@ void MatchTPCITS::init()
   mTPCZMax = detParam.TPClength;
 
   assert(mITSROFrameLengthMUS > 0.0f);
-  mITSROFramePhaseOffset = mITSROFrameOffsetMUS / mITSROFrameLengthMUS;
   if (mITSTriggered) {
     mITSROFrame2TPCBin = mITSROFrameLengthMUS / mTPCTBinMUS;
   } else {
@@ -643,9 +642,22 @@ bool MatchTPCITS::prepareITSTracks()
     mITSTimeBinStart[sec].clear();
     mITSTimeBinStart[sec].resize(nROFs, -1); // start of ITS work tracks in every sector
   }
-  setStartIR(mITSTrackROFRec[0].getBCData());
+
+  mITSTrackROFContMapping.clear(); // there might be gaps in the non-empty rofs, this will map continuous ROFs index to non empty ones
+
+  setStartIR(mITSTrackROFRec[0].getBCData()); //// TODO: this should be set from external info
+
   for (int irof = 0; irof < nROFs; irof++) {
     const auto& rofRec = mITSTrackROFRec[irof];
+
+    if (!mITSTriggered) {
+      auto irofCont = (rofRec.getBCData().toLong() - mStartIR.toLong()) / mITSROFrameLengthInBC;
+      if (mITSTrackROFContMapping.size() <= irofCont) {
+        mITSTrackROFContMapping.resize((1 + irofCont / 128) * 128, 0);
+      }
+      mITSTrackROFContMapping[irofCont] = irof;
+    }
+
     int cluROFOffset = mITSClusterROFRec[irof].getFirstEntry(); // clusters of this ROF start at this offset
     float tmn = intRecord2TPCTimeBin(rofRec.getBCData());     // ITS track min time in TPC time-bins
     mITSROFTimes.emplace_back(tmn, tmn + mITSROFrame2TPCBin); // ITS track min/max time in TPC time-bins
@@ -703,6 +715,15 @@ bool MatchTPCITS::prepareITSTracks()
       float dy2Dn = (YMaxAtXMatchingRef + trcY) / (tgp - Tan70);
       if ((dy2Dn * dy2Dn * Cos70I2) < mSectEdgeMargin2) { // need to check this track for matching in sector down
         addLastTrackCloneForNeighbourSector(sector > 1 ? sector - 1 : o2::constants::math::NSectors - 1);
+      }
+    }
+  }
+
+  if (!mITSTriggered) { // fill the gaps;
+    int nr = mITSTrackROFContMapping.size();
+    for (int i = 1; i < nr; i++) {
+      if (mITSTrackROFContMapping[i] < mITSTrackROFContMapping[i - 1]) {
+        mITSTrackROFContMapping[i] = mITSTrackROFContMapping[i - 1];
       }
     }
   }
@@ -793,6 +814,7 @@ void MatchTPCITS::doMatching(int sec)
     // estimate ITS 1st ROframe bin this track may match to: TPC track are sorted according to their
     // timeMax, hence the timeMax - MaxmNTPCBinsFullDrift are non-decreasing
     int itsROBin = tpcTimeBin2ITSROFrame(trefTPC.timeBins.max() - maxTDriftSafe);
+
     if (itsROBin >= int(tbinStartITS.size())) { // time of TPC track exceeds the max time of ITS in the cache
       break;
     }


### PR DESCRIPTION
#### Use extra mapping from gap-less continuos ROF index to supplied ITS ROFs
Since the ITS data may contain gaps even in continuous mode and the TPC time-bin
is mapped to ideal ITS ROFrame, we need an extra mapping ideal frames to closest
real frame.

At the moment set the 1st orbit of TF from 1 IR of the supplied ITS data, which assumes all ITS ROFs are complete and w/o gaps, otherwise it will fail. Robust solution is to set the 1st IR of TF externally.

#### Fix in TPCITS matching aux. arrays sorting 

