### PR TITLE
MFT: do the standalone tracking using the compressed clusters

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
@@ -22,7 +22,10 @@
 #include <gsl/gsl>
 
 #include "MFTTracking/ROframe.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "ReconstructionDataFormats/BaseCluster.h"
 
 namespace o2
 {
@@ -38,17 +41,29 @@ class MCTruthContainer;
 namespace itsmft
 {
 class Cluster;
-}
+class CompClusterExt;
+class TopologyDictionary;
+} // namespace itsmft
 
 namespace mft
 {
 
 namespace ioutils
 {
+constexpr float DefClusErrorRow = o2::itsmft::SegmentationAlpide::PitchRow * 0.5;
+constexpr float DefClusErrorCol = o2::itsmft::SegmentationAlpide::PitchCol * 0.5;
+constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
+constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
+
 Int_t loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<itsmft::Cluster const> const& clusters, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
+
+int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
+                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+
 void loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* clusters,
                    const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
-} // namespace IOUtils
+} // namespace ioutils
 } // namespace mft
 } // namespace o2
 

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -36,7 +36,7 @@ class Tracker
 {
 
  public:
-  Tracker() = default;
+  Tracker(bool useMC);
   ~Tracker() = default;
 
   Tracker(const Tracker&) = delete;
@@ -84,6 +84,8 @@ class Tracker
   o2::dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;
 
   Int_t mMaxCellLevel = 0;
+
+  bool mUseMC = false;
 };
 
 inline std::vector<TrackMFT>& Tracker::getTracks()

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -26,6 +26,8 @@ namespace o2
 namespace mft
 {
 
+Tracker::Tracker(bool useMC) : mUseMC{useMC} {}
+
 void Tracker::clustersToTracks(ROframe& event, std::ostream& timeBenchmarkOutputStream)
 {
   mTracks.clear();
@@ -165,7 +167,7 @@ void Tracker::findTracksLTF(ROframe& event)
             event.addTrackLTF();
 
             // add the first seed-point
-            mcCompLabel = event.getClusterLabels(layer1, cluster1.clusterId);
+            mcCompLabel = mUseMC ? event.getClusterLabels(layer1, cluster1.clusterId) : MCCompLabel();
             newPoint = kTRUE;
             event.getCurrentTrackLTF().setPoint(cluster1.xCoordinate, cluster1.yCoordinate, cluster1.zCoordinate, layer1, clsLayer1, mcCompLabel, newPoint);
 
@@ -206,7 +208,7 @@ void Tracker::findTracksLTF(ROframe& event)
                     dRmin = dR;
 
                     hasDisk[layer / 2] = kTRUE;
-                    mcCompLabel = event.getClusterLabels(layer, cluster.clusterId);
+                    mcCompLabel = mUseMC ? event.getClusterLabels(layer, cluster.clusterId) : MCCompLabel();
                     event.getCurrentTrackLTF().setPoint(cluster.xCoordinate, cluster.yCoordinate, cluster.zCoordinate, layer, clsLayer, mcCompLabel, newPoint);
                   } // end clusters bin intermediate layer
                 }   // end intermediate layers
@@ -214,7 +216,7 @@ void Tracker::findTracksLTF(ROframe& event)
             }       // end binR
 
             // add the second seed-point
-            mcCompLabel = event.getClusterLabels(layer2, cluster2.clusterId);
+            mcCompLabel = mUseMC ? event.getClusterLabels(layer2, cluster2.clusterId) : MCCompLabel();
             newPoint = kTRUE;
             event.getCurrentTrackLTF().setPoint(cluster2.xCoordinate, cluster2.yCoordinate, cluster2.zCoordinate, layer2, clsLayer2, mcCompLabel, newPoint);
 
@@ -326,7 +328,7 @@ void Tracker::findTracksCA(ROframe& event)
               event.addRoad();
 
               // add the 1st/2nd road points
-              mcCompLabel = event.getClusterLabels(layer1, cluster1.clusterId);
+              mcCompLabel = mUseMC ? event.getClusterLabels(layer1, cluster1.clusterId) : MCCompLabel();
               newPoint = kTRUE;
               event.getCurrentRoad().setPoint(cluster1.xCoordinate, cluster1.yCoordinate, cluster1.zCoordinate, layer1, clsLayer1, mcCompLabel, newPoint);
 
@@ -363,7 +365,7 @@ void Tracker::findTracksCA(ROframe& event)
                       }
 
                       hasDisk[layer / 2] = kTRUE;
-                      mcCompLabel = event.getClusterLabels(layer, cluster.clusterId);
+                      mcCompLabel = mUseMC ? event.getClusterLabels(layer, cluster.clusterId) : MCCompLabel();
                       newPoint = kTRUE;
                       event.getCurrentRoad().setPoint(cluster.xCoordinate, cluster.yCoordinate, cluster.zCoordinate, layer, clsLayer, mcCompLabel, newPoint);
 
@@ -373,7 +375,7 @@ void Tracker::findTracksCA(ROframe& event)
               }       // end binR
 
               // add the second seed-point
-              mcCompLabel = event.getClusterLabels(layer2, cluster2.clusterId);
+              mcCompLabel = mUseMC ? event.getClusterLabels(layer2, cluster2.clusterId) : MCCompLabel();
               newPoint = kTRUE;
               event.getCurrentRoad().setPoint(cluster2.xCoordinate, cluster2.yCoordinate, cluster2.zCoordinate, layer2, clsLayer2, mcCompLabel, newPoint);
 
@@ -720,8 +722,8 @@ const Bool_t Tracker::addCellToCurrentTrackCA(const Int_t layer1, const Int_t ce
     }
   }
 
-  MCCompLabel mcCompLabel1 = event.getClusterLabels(layer1, cluster1.clusterId);
-  MCCompLabel mcCompLabel2 = event.getClusterLabels(layer2, cluster2.clusterId);
+  MCCompLabel mcCompLabel1 = mUseMC ? event.getClusterLabels(layer1, cluster1.clusterId) : MCCompLabel();
+  MCCompLabel mcCompLabel2 = mUseMC ? event.getClusterLabels(layer2, cluster2.clusterId) : MCCompLabel();
 
   Bool_t newPoint;
 

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
@@ -22,7 +22,7 @@ namespace mft
 
 namespace reco_workflow
 {
-framework::WorkflowSpec getWorkflow(bool useMC);
+framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput);
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -18,6 +18,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 
 namespace o2
 {
@@ -33,8 +34,8 @@ class TrackerDPL : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
 
  private:
-  int mState = 0;
   bool mUseMC = false;
+  o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<o2::mft::Tracker> mTracker = nullptr;
 };

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -136,7 +136,8 @@ void ClustererDPL::run(ProcessingContext& pc)
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
   // -> consider recalculationg maxROF
-  LOG(INFO) << "MFTClusterer pushed " << clusCompVec.size() << " clusters, in " << clusROFVec.size() << " RO frames";
+  LOG(INFO) << "MFTClusterer pushed " << clusCompVec.size() << " compressed clusters, in " << clusROFVec.size() << " RO frames";
+  LOG(INFO) << "MFTClusterer pushed " << clusVec.size() << " full clusters, in " << clusROFVec.size() << " RO frames";
 }
 
 DataProcessorSpec getClustererSpec(bool useMC)
@@ -146,9 +147,9 @@ DataProcessorSpec getClustererSpec(bool useMC)
   inputs.emplace_back("ROframes", "MFT", "DigitROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
+  outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "PATTERNS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
@@ -166,7 +167,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
     Options{
       {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
-      {"full-clusters", o2::framework::VariantType::Bool, true, {"Produce full clusters"}}, // RSTODO temporary set to true
+      {"full-clusters", o2::framework::VariantType::Bool, false, {"Produce full clusters"}}, // RSTODO temporary set to true
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
       {"nthreads", VariantType::Int, 0, {"Number of clustering threads (<1: rely on openMP default)"}}}};
 }

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -29,22 +29,29 @@ namespace mft
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC)
+framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput)
 {
   framework::WorkflowSpec specs;
 
-  specs.emplace_back(o2::mft::getDigitReaderSpec(useMC));
-  specs.emplace_back(o2::mft::getClustererSpec(useMC));
-  specs.emplace_back(o2::mft::getClusterWriterSpec(useMC));
-
+  if (!(upstreamDigits || upstreamClusters)) {
+    specs.emplace_back(o2::mft::getDigitReaderSpec(useMC));
+  }
+  if (!upstreamClusters) {
+    specs.emplace_back(o2::mft::getClustererSpec(useMC));
+  }
+  if (!disableRootOutput) {
+    specs.emplace_back(o2::mft::getClusterWriterSpec(useMC));
+  }
   specs.emplace_back(o2::mft::getTrackerSpec(useMC));
   specs.emplace_back(o2::mft::getTrackFitterSpec(useMC));
-  specs.emplace_back(o2::mft::getTrackWriterSpec(useMC));
+  if (!disableRootOutput) {
+    specs.emplace_back(o2::mft::getTrackWriterSpec(useMC));
+  }
 
   return specs;
 }
 
-} // namespace RecoWorkflow
+} // namespace reco_workflow
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -57,10 +57,10 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                                                                      "MFTTrackMCTruth",
                                                                                                      (useMC ? 1 : 0), // one branch if mc labels enabled
                                                                                                      ""},
-                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "MFTTrackROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "TrackROF", 0},
                                                                                      "MFTTracksROF",
                                                                                      logger},
-                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "MFTTrackMC2ROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "TrackMC2ROF", 0},
                                                                                         "MFTTracksMC2ROF",
                                                                                         (useMC ? 1 : 0), // one branch if mc labels enabled
                                                                                         ""})();

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-digit-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-digit-workflow.cxx
@@ -21,7 +21,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
-  // write the configuration used for the digitizer workflow
+  // write the configuration
   o2::conf::ConfigurableParam::writeINI("o2mftdigitwriter_configuration.ini");
 
   return std::move(o2::mft::digit_workflow::getWorkflow());

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
@@ -18,6 +18,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
+    {"digits-from-upstream", o2::framework::VariantType::Bool, false, {"digits will be provided from upstream, skip digits reader"}},
+    {"clusters-from-upstream", o2::framework::VariantType::Bool, false, {"clusters will be provided from upstream, skip clusterizer"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}}};
 
   std::swap(workflowOptions, options);
@@ -33,10 +36,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  // write the configuration used for the digitizer workflow
+  // write the configuration
   o2::conf::ConfigurableParam::writeINI("o2mftrecoflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
+  auto extDigits = configcontext.options().get<bool>("digits-from-upstream");
+  auto extClusters = configcontext.options().get<bool>("clusters-from-upstream");
+  auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
 
-  return std::move(o2::mft::reco_workflow::getWorkflow(useMC));
+  return std::move(o2::mft::reco_workflow::getWorkflow(useMC, extDigits, extClusters, disableRootOutput));
 }


### PR DESCRIPTION
MFT was still using the full clusters for the track finding, with this PR the compressed clusters are used instead. The default for the MFT clusterer is now to produce only the compressed clusters. The dictionary for the cluster patterns is the one produced separately from an ITS simulation.
