### PR TITLE
Rdev external decayer

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -33,7 +33,6 @@ struct SimConfigData {
   std::string mExtTrgFileName;               // file name containing the external trigger configuration
   std::string mExtTrgFuncName;               // function call to retrieve the external trigger configuration
   std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
-  std::string mDecayConfig;                  // filename containing the external decayer configuration
   unsigned int mStartEvent;                  // index of first event to be taken
   float mBMax;                               // maximum for impact parameter sampling
   bool mIsMT;                                // chosen MT mode (Geant4 only)
@@ -108,7 +107,6 @@ class SimConfig
   std::string getExtTriggerFileName() const { return mConfigData.mExtTrgFileName; }
   std::string getExtTriggerFuncName() const { return mConfigData.mExtTrgFuncName; }
   std::string getEmbedIntoFileName() const { return mConfigData.mEmbedIntoFileName; }
-  std::string getDecayConfig() const { return mConfigData.mDecayConfig; }
   unsigned int getStartEvent() const { return mConfigData.mStartEvent; }
   float getBMax() const { return mConfigData.mBMax; }
   bool getIsMT() const { return mConfigData.mIsMT; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -43,8 +43,6 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "function call to load the definition of external event generator trigger")(
     "embedIntoFile", bpo::value<std::string>()->default_value(""),
     "filename containing the reference events to be used for the embedding")(
-    "decayConfig", bpo::value<std::string>()->default_value(""),
-    "filename containing the external decayer configuration")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
@@ -102,7 +100,6 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mExtTrgFileName = vm["extTrgFile"].as<std::string>();
   mConfigData.mExtTrgFuncName = vm["extTrgFunc"].as<std::string>();
   mConfigData.mEmbedIntoFileName = vm["embedIntoFile"].as<std::string>();
-  mConfigData.mDecayConfig = vm["decayConfig"].as<std::string>();
   mConfigData.mStartEvent = vm["startEvent"].as<unsigned int>();
   mConfigData.mBMax = vm["bMax"].as<float>();
   mConfigData.mIsMT = vm["isMT"].as<bool>();

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(SimSetup
                                      MC::Geant4
                                      O2::SimulationDataFormat
                                      O2::DetectorsPassive
+				     O2::Generators
                                      MC::Pythia6 # this is needed by Geant3 and
                                                  # EGPythia6
                                      ROOT::EGPythia6 # this is needed by Geant4

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -4,6 +4,8 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "SimulationDataFormat/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
+#include "TVirtualMC.h"
+#include "Generators/DecayerPythia8.h"
 #endif
 
 template <typename T, typename R>
@@ -39,4 +41,11 @@ void stackSetup(T* vmc, R* run)
     }
   }
 */
+}
+
+void decayerSetup(TVirtualMC* vmc)
+{
+  auto decayer = new o2::eventgen::DecayerPythia8;
+  decayer->Init();
+  vmc->SetExternalDecayer(decayer);
 }

--- a/Detectors/gconfig/g3Config.C
+++ b/Detectors/gconfig/g3Config.C
@@ -32,6 +32,9 @@ void Config()
   }
   stackSetup(geant3, run);
 
+  // setup decayer
+  decayerSetup(geant3);
+
   // ******* GEANT3  specific configuration for simulated Runs  *******
   geant3->SetTRIG(1); // Number of events to be processed
   geant3->SetSWIT(4, 100);

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -10,7 +10,6 @@
 #include <iostream>
 #include "TGeant4.h"
 #include "TString.h"
-#include "TPythia6Decayer.h"
 #include "FairRunSim.h"
 #include "TSystem.h"
 #include "TG4RunConfiguration.h"
@@ -69,10 +68,7 @@ void Config()
   stackSetup(geant4, FairRunSim::Instance());
 
   // setup decayer
-  if (FairRunSim::Instance()->IsExtDecayer()) {
-    TVirtualMCDecayer* decayer = TPythia6Decayer::Instance();
-    geant4->SetExternalDecayer(decayer);
-  }
+  decayerSetup(geant4);
 
   TString configm(gSystem->Getenv("VMCWORKDIR"));
   auto configm1 = configm + "/Detectors/gconfig/g4config.in";

--- a/Detectors/gconfig/src/G3Config.cxx
+++ b/Detectors/gconfig/src/G3Config.cxx
@@ -19,6 +19,7 @@
 #include <DetectorsPassive/Cave.h>
 #include "DetectorsBase/MaterialManager.h"
 #include "SimSetup/GlobalProcessCutSimParam.h"
+#include "Generators/DecayerPythia8.h"
 
 //using declarations here since SetCuts.C and g3Config.C are included within namespace
 // these are needed for SetCuts.C inclusion
@@ -29,6 +30,8 @@ using o2::base::MaterialManager;
 // these are used in g3Config.C
 using std::cout;
 using std::endl;
+// these are used in commonConfig.C
+using o2::eventgen::DecayerPythia8;
 #include <SimSetup/SimSetup.h>
 
 namespace o2

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -21,6 +21,7 @@
 #include "DetectorsBase/MaterialManager.h"
 #include "SimSetup/GlobalProcessCutSimParam.h"
 #include "SimConfig/G4Params.h"
+#include "Generators/DecayerPythia8.h"
 
 //using declarations here since SetCuts.C and g4Config.C are included within namespace
 // these are needed for SetCuts.C inclusion
@@ -31,6 +32,8 @@ using o2::base::MaterialManager;
 // these are used in g4Config.C
 using std::cout;
 using std::endl;
+// these are used in commonConfig.C
+using o2::eventgen::DecayerPythia8;
 
 namespace o2
 {

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -36,7 +36,9 @@ o2_add_library(Generators
                        $<$<BOOL:${pythia6_FOUND}>:src/GeneratorPythia6.cxx>
                        $<$<BOOL:${pythia6_FOUND}>:src/GeneratorPythia6Param.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8.cxx>
+                       $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8Param.cxx>
+                       $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8Param.cxx>
                        $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils
                                      O2::SimulationDataFormat ${pythia6Target} ${pythiaTarget} ${hepmcTarget}
@@ -75,8 +77,11 @@ if (pythia6_FOUND)
 endif()
 
 if(pythia_FOUND)
-  list(APPEND headers include/Generators/GeneratorPythia8.h
+  list(APPEND headers 
+              include/Generators/GeneratorPythia8.h
+              include/Generators/DecayerPythia8.h
               include/Generators/GeneratorPythia8Param.h
+              include/Generators/DecayerPythia8Param.h
               include/Generators/GeneratorFactory.h)
 endif()
 
@@ -131,3 +136,9 @@ install(FILES share/egconfig/pythia8_inel.cfg
 	      share/egconfig/pythia8_hi.cfg
 	      share/egconfig/pythia8_userhooks_charm.C
         DESTINATION share/Generators/egconfig/)
+
+install(FILES share/pythia8/decays/base.cfg
+              share/pythia8/decays/bjpsidimuon.cfg
+        DESTINATION share/Generators/pythia8/decays/)
+
+      

--- a/Generators/include/Generators/DecayerPythia8.h
+++ b/Generators/include/Generators/DecayerPythia8.h
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2020
+
+#ifndef ALICEO2_EVENTGEN_DECAYERPYTHIA8_H_
+#define ALICEO2_EVENTGEN_DECAYERPYTHIA8_H_
+
+#include "TVirtualMCDecayer.h"
+#include "Pythia8/Pythia.h"
+
+#include <iostream>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+class DecayerPythia8 : public TVirtualMCDecayer
+{
+
+ public:
+  /** default constructor **/
+  DecayerPythia8() = default;
+  /** destructor **/
+  ~DecayerPythia8() override = default;
+
+  /** methods to override **/
+  void Init() override;
+  void Decay(Int_t pdg, TLorentzVector* lv) override;
+  Int_t ImportParticles(TClonesArray* particles) override;
+  void SetForceDecay(Int_t type) override{};
+  void ForceDecay() override{};
+  Float_t GetPartialBranchingRatio(Int_t ipart) override { return 0.; };
+  Float_t GetLifetime(Int_t kf) override { return 0.; };
+  void ReadDecayTable() override{};
+
+ protected:
+  /** copy constructor **/
+  DecayerPythia8(const DecayerPythia8&);
+  /** operator= **/
+  DecayerPythia8& operator=(const DecayerPythia8&);
+
+  /** Pythia8 **/
+  ::Pythia8::Pythia mPythia; //!
+
+  ClassDefOverride(DecayerPythia8, 1);
+
+}; /** class Decayer **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_DECAYER_H_ */

--- a/Generators/include/Generators/DecayerPythia8Param.h
+++ b/Generators/include/Generators/DecayerPythia8Param.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2020
+
+#ifndef ALICEO2_EVENTGEN_DECAYERPYTHIA8PARAM_H_
+#define ALICEO2_EVENTGEN_DECAYERPYTHIA8PARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include <string>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the Pythia8 decayer and
+ ** allow the user to modify them 
+ **/
+
+struct DecayerPythia8Param : public o2::conf::ConfigurableParamHelper<DecayerPythia8Param> {
+  std::string config = "${O2_ROOT}/share/Generators/pythia8/decays/base.cfg";
+  O2ParamDef(DecayerPythia8Param, "DecayerPythia8");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_DECAYERPYTHIA8PARAM_H_

--- a/Generators/share/pythia8/decays/base.cfg
+++ b/Generators/share/pythia8/decays/base.cfg
@@ -1,0 +1,34 @@
+### do not show changed particle data
+
+Init:showChangedParticleData off
+
+### switch off decays of long-lived particles
+### including particles that decay electromagnetically
+
+13:mayDecay   off	# mu-
+15:mayDecay   off	# tau-
+111:mayDecay  off	# pi0
+130:mayDecay  off	# K_0L
+211:mayDecay  off	# pi+
+221:mayDecay  off	# eta
+310:mayDecay  off	# K_S0
+321:mayDecay  off	# K+
+411:mayDecay  off	# D+
+421:mayDecay  off	# D0
+431:mayDecay  off	# D_s+
+511:mayDecay  off	# B0
+521:mayDecay  off	# B+
+531:mayDecay  off	# B_s0
+541:mayDecay  off	# B_c+
+3112:mayDecay off	# Sigma-
+3122:mayDecay off	# Lambda0
+3212:mayDecay off	# Sigma0
+3222:mayDecay off	# Sigma+
+3312:mayDecay off	# Xi-
+3322:mayDecay off	# Xi0
+3334:mayDecay off	# Omega-
+4122:mayDecay off	# Lambda_c+
+4132:mayDecay off	# Xi_c0
+4232:mayDecay off	# Xi_c+
+4332:mayDecay off	# Omega_c0
+5122:mayDecay off	# Lambda_b0

--- a/Generators/share/pythia8/decays/bjpsidimuon.cfg
+++ b/Generators/share/pythia8/decays/bjpsidimuon.cfg
@@ -1,0 +1,23 @@
+### B0 -> J/psi (psi') + X
+511:onMode = off		# switch off all decay channels
+511:onIfAny = 443 100443	# switch on J/psi (psi') decay channels
+
+### B+ -> J/psi (psi') + X
+521:onMode = off		# switch off all decay channels
+521:onIfAny = 443 100443	# switch on J/psi (psi') decay channels
+
+### B_s -> J/psi (psi') + X
+531:onMode = off		# switch off all decay channels
+531:onIfAny = 443 100443	# switch on J/psi (psi') decay channels
+
+### Lambda_b -> J/psi (psi') + X
+5122:onMode = off		# switch off all decay channels
+5122:onIfAny = 443 100443	# switch on J/psi (psi') decay channels
+
+### psi' -> J/psi + X
+100443:onMode = off		# switch off all decay channels
+100443:onIfAny = 443		# switch on J/psi decay channels
+
+### J/psi -> mu+ mu-
+443:onMode = off		# switch off all decay channels
+443:onIfAll = 13 -13		# switch on mu+ mu- decay channel

--- a/Generators/src/DecayerPythia8.cxx
+++ b/Generators/src/DecayerPythia8.cxx
@@ -1,0 +1,112 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2020
+
+#include "Generators/DecayerPythia8.h"
+#include "Generators/DecayerPythia8Param.h"
+#include "FairLogger.h"
+#include "TLorentzVector.h"
+#include "TClonesArray.h"
+#include "TParticle.h"
+#include "TSystem.h"
+
+#include <iostream>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+void DecayerPythia8::Init()
+{
+
+  /** switch off process level **/
+  mPythia.readString("ProcessLevel:all off");
+
+  /** config **/
+  auto& param = DecayerPythia8Param::Instance();
+  LOG(INFO) << "Init \'DecayerPythia8\' with following parameters";
+  LOG(INFO) << param;
+  if (!param.config.empty()) {
+    std::stringstream ss(param.config);
+    std::string config;
+    while (getline(ss, config, ' ')) {
+      config = gSystem->ExpandPathName(config.c_str());
+      if (!mPythia.readFile(config, true)) {
+        LOG(FATAL) << "Failed to init \'DecayerPythia8\': problems with configuration file "
+                   << config;
+        return;
+      }
+    }
+  }
+
+  /** initialise **/
+  if (!mPythia.init()) {
+    LOG(FATAL) << "Failed to init \'DecayerPythia8\': init returned with error";
+    return;
+  }
+}
+
+/*****************************************************************/
+
+void DecayerPythia8::Decay(Int_t pdg, TLorentzVector* lv)
+{
+  auto mayDecay = mPythia.particleData.mayDecay(pdg); // save mayDecay status
+  mPythia.particleData.mayDecay(pdg, true);           // force decay
+
+  mPythia.event.clear();
+  mPythia.event.append(pdg, 11, 0, 0, lv->Px(), lv->Py(), lv->Pz(), lv->E(), lv->M());
+  mPythia.moreDecays();
+
+  mPythia.particleData.mayDecay(pdg, mayDecay); // restore mayDecay status
+}
+
+/*****************************************************************/
+
+Int_t DecayerPythia8::ImportParticles(TClonesArray* particles)
+{
+  TClonesArray& ca = *particles;
+  ca.Clear();
+
+  auto nParticles = mPythia.event.size();
+  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
+    auto particle = mPythia.event[iparticle];
+    auto pdg = particle.id();
+    auto st = particle.statusHepMC();
+    auto px = particle.px();
+    auto py = particle.py();
+    auto pz = particle.pz();
+    auto et = particle.e();
+    auto vx = particle.xProd() * 0.1;
+    auto vy = particle.yProd() * 0.1;
+    auto vz = particle.zProd() * 0.1;
+    auto vt = particle.tProd() * 3.3356410e-12;
+    auto m1 = particle.mother1();
+    auto m2 = particle.mother2();
+    auto d1 = particle.daughter1();
+    auto d2 = particle.daughter2();
+
+    new (ca[iparticle]) TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt);
+  }
+
+  return ca.GetEntries();
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+ClassImp(o2::eventgen::DecayerPythia8);

--- a/Generators/src/DecayerPythia8Param.cxx
+++ b/Generators/src/DecayerPythia8Param.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2020
+
+#include "Generators/DecayerPythia8Param.h"
+O2ParamImpl(o2::eventgen::DecayerPythia8Param);

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -37,8 +37,11 @@
 #endif
 #ifdef GENERATORS_WITH_PYTHIA8
 #pragma link C++ class o2::eventgen::GeneratorPythia8 + ;
+#pragma link C++ class o2::eventgen::DecayerPythia8 + ;
 #pragma link C++ class o2::eventgen::GeneratorPythia8Param + ;
+#pragma link C++ class o2::eventgen::DecayerPythia8Param + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorPythia8Param > +;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::DecayerPythia8Param> + ;
 #pragma link C++ class o2::eventgen::GeneratorFactory + ;
 #endif
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -84,9 +84,6 @@ FairRunSim* o2sim_init(bool asservice)
   run->SetName(confref.getMCEngine().c_str()); // Transport engine
   run->SetIsMT(confref.getIsMT());             // MT mode
 
-  /** set external decayer **/
-  run->SetPythiaDecayer(TString(confref.getDecayConfig()));
-
   /** set event header **/
   auto header = new o2::dataformats::MCEventHeader();
   run->SetMCEventHeader(header);


### PR DESCRIPTION
This PR implements a dedicated `o2` external decayer for G3 and G4.
The current implementation makes use of Pythia8 to deal with particle decays and is defined in the `DecayerPythia8` class.

The settings of the decayer can be modified by passing via configurable parameters the filename containing the settings
```
--configKeyValues 'DecayerPythia8.config=path_to_config_file'
```
The default points to 
```
${O2_ROOT}/share/Generators/pythia8/decays/base.cfg
```
Multiple files can be used, to allow the user to add custom settings on top of the defaults ones
```
--configKeyValues 'DecayerPythia8.config=path_to_default_file path_to_user_file'
```
An example of user custom setting is given in
```
${O2_ROOT}/share/Generators/pythia8/decays/bjpsidimuon.cfg
```
