### PR TITLE
DPL Analysis: Expression-based column for soa::Table

### DIFF
--- a/Analysis/Tasks/correlationsCollection.cxx
+++ b/Analysis/Tasks/correlationsCollection.cxx
@@ -25,12 +25,12 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta2, eta2, float);
-DECLARE_SOA_COLUMN(Phi2, phi2, float);
-DECLARE_SOA_COLUMN(Pt2, pt2, float);
+DECLARE_SOA_COLUMN(Etam, etam, float);
+DECLARE_SOA_COLUMN(Phim, phim, float);
+DECLARE_SOA_COLUMN(Ptm, ptm, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
-                  etaphi::Eta2, etaphi::Phi2, etaphi::Pt2);
+                  etaphi::Etam, etaphi::Phim, etaphi::Ptm);
 } // namespace o2::aod
 
 using namespace o2;
@@ -59,7 +59,7 @@ struct CorrelationTask {
   // Filters and input definitions
 #define MYFILTER
 #ifdef MYFILTER
-  Filter trackFilter = (aod::etaphi::eta2 > -0.8f) && (aod::etaphi::eta2 < 0.8f) && (aod::etaphi::pt2 > 1.0f);
+  Filter trackFilter = (aod::etaphi::etam > -0.8f) && (aod::etaphi::etam < 0.8f) && (aod::etaphi::ptm > 1.0f);
   using myTracks = soa::Filtered<soa::Join<aod::Tracks, aod::EtaPhi>>;
 #else
   using myTracks = soa::Join<aod::Tracks, aod::EtaPhi>;
@@ -194,12 +194,12 @@ struct CorrelationTask {
 
         double values[6] = {0};
 
-        values[0] = track1.eta2() - track2.eta2();
+        values[0] = track1.etam() - track2.etam();
         values[1] = track1.pt2();
         values[2] = track2.pt2();
         values[3] = collision.centV0M();
 
-        values[4] = track1.phi2() - track2.phi2();
+        values[4] = track1.phim() - track2.phim();
         if (values[4] > 1.5 * TMath::Pi())
           values[4] -= TMath::TwoPi();
         if (values[4] < -0.5 * TMath::Pi())
@@ -254,12 +254,12 @@ struct CorrelationTask {
 
       double values[6] = {0};
 
-      values[0] = track1.eta2() - track2.eta2();
+      values[0] = track1.etam() - track2.etam();
       values[1] = track1.pt2();
       values[2] = track2.pt2();
       values[3] = 0; // collision.v0mult();
 
-      values[4] = track1.phi2() - track2.phi2();
+      values[4] = track1.phim() - track2.phim();
       if (values[4] > 1.5 * TMath::Pi())
         values[4] -= TMath::TwoPi();
       if (values[4] < -0.5 * TMath::Pi())
@@ -361,21 +361,21 @@ struct CorrelationTask {
 
     float tantheta1 = 1e10;
 
-    if (track1.eta2() < -1e-10 || track1.eta2() > 1e-10) {
-      float expTmp = TMath::Exp(-track1.eta2());
+    if (track1.etam() < -1e-10 || track1.etam() > 1e-10) {
+      float expTmp = TMath::Exp(-track1.etam());
       tantheta1 = 2.0 * expTmp / (1.0 - expTmp * expTmp);
     }
 
     float tantheta2 = 1e10;
-    if (track2.eta2() < -1e-10 || track2.eta2() > 1e-10) {
-      float expTmp = TMath::Exp(-track2.eta2());
+    if (track2.etam() < -1e-10 || track2.etam() > 1e-10) {
+      float expTmp = TMath::Exp(-track2.etam());
       tantheta2 = 2.0 * expTmp / (1.0 - expTmp * expTmp);
     }
 
     float e1squ = m0_1 * m0_1 + track1.pt2() * track1.pt2() * (1.0 + 1.0 / tantheta1 / tantheta1);
     float e2squ = m0_2 * m0_2 + track2.pt2() * track2.pt2() * (1.0 + 1.0 / tantheta2 / tantheta2);
 
-    float mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (track1.pt2() * track2.pt2() * (TMath::Cos(track1.phi2() - track2.phi2()) + 1.0 / tantheta1 / tantheta2)));
+    float mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (track1.ptm() * track2.ptm() * (TMath::Cos(track1.phim() - track2.phim()) + 1.0 / tantheta1 / tantheta2)));
 
     // Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi2, m0_1, m0_2, mass2));
 
@@ -387,12 +387,12 @@ struct CorrelationTask {
   {
     // calculate inv mass squared approximately
 
-    const float eta1 = track1.eta2();
-    const float eta2 = track2.eta2();
-    const float phi1 = track1.phi2();
-    const float phi2 = track2.phi2();
-    const float pt1 = track1.pt2();
-    const float pt2 = track2.pt2();
+    const float eta1 = track1.etam();
+    const float eta2 = track2.etam();
+    const float phi1 = track1.phim();
+    const float phi2 = track2.phim();
+    const float pt1 = track1.ptm();
+    const float pt2 = track2.ptm();
 
     float tantheta1 = 1e10;
 
@@ -438,7 +438,7 @@ struct CorrelationTask {
     // the variables & cuthave been developed by the HBT group
     // see e.g. https://indico.cern.ch/materialDisplay.py?contribId=36&sessionId=6&materialId=slides&confId=142700
 
-    auto deta = track1.eta2() - track2.eta2();
+    auto deta = track1.etam() - track2.etam();
 
     // optimization
     if (TMath::Abs(deta) < cfgTwoTrackCut * 2.5 * 3) {
@@ -483,12 +483,12 @@ struct CorrelationTask {
     // calculates dphistar
     //
 
-    auto phi1 = track1.phi2();
-    auto pt1 = track1.pt2();
+    auto phi1 = track1.phim();
+    auto pt1 = track1.ptm();
     auto charge1 = track1.charge();
 
-    auto phi2 = track2.phi2();
-    auto pt2 = track2.pt2();
+    auto phi2 = track2.phim();
+    auto pt2 = track2.ptm();
     auto charge2 = track2.charge();
 
     float dphistar = phi1 - phi2 - charge1 * bSign * TMath::ASin(0.075 * radius / pt1) + charge2 * bSign * TMath::ASin(0.075 * radius / pt2);

--- a/Analysis/Tasks/correlationsMixed.cxx
+++ b/Analysis/Tasks/correlationsMixed.cxx
@@ -26,12 +26,12 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta2, eta2, float);
-DECLARE_SOA_COLUMN(Phi2, phi2, float);
-DECLARE_SOA_COLUMN(Pt2, pt2, float);
+DECLARE_SOA_COLUMN(Etam, etam, float);
+DECLARE_SOA_COLUMN(Phim, phim, float);
+DECLARE_SOA_COLUMN(Ptm, ptm, float);
 } // namespace etaphi
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
-                  etaphi::Eta2, etaphi::Phi2, etaphi::Pt2);
+                  etaphi::Etam, etaphi::Phim, etaphi::Ptm);
 } // namespace o2::aod
 
 namespace o2::aod
@@ -109,7 +109,7 @@ struct CorrelationTask {
   using myTracks = soa::Filtered<soa::Join<aod::Tracks, aod::EtaPhi>>;
 
   // Filters
-  Filter trackFilter = (aod::etaphi::eta2 > -0.8f) && (aod::etaphi::eta2 < 0.8f) && (aod::etaphi::pt2 > 1.0f);
+  Filter trackFilter = (aod::etaphi::etam > -0.8f) && (aod::etaphi::etam < 0.8f) && (aod::etaphi::ptm > 1.0f);
 
   // Output definitions
   OutputObj<CorrelationContainer> same{"sameEvent"};
@@ -224,10 +224,10 @@ struct CorrelationTask {
         if (cfgTriggerCharge != 0 && cfgTriggerCharge * track1.charge() < 0)
           continue;
 
-        //LOGF(info, "TRACK %f %f | %f %f | %f %f", track1.eta(), track1.eta2(), track1.phi(), track1.phi2(), track1.pt(), track1.pt2());
+        //LOGF(info, "TRACK %f %f | %f %f | %f %f", track1.eta(), track1.etam(), track1.phi(), track1.phim(), track1.pt(), track1.ptm());
 
         double eventValues[3];
-        eventValues[0] = track1.pt2();
+        eventValues[0] = track1.ptm();
         eventValues[1] = collision1.centV0M();
         eventValues[2] = collision1.posZ();
 
@@ -248,12 +248,12 @@ struct CorrelationTask {
 
           double values[6] = {0};
 
-          values[0] = track1.eta2() - track2.eta2();
-          values[1] = track1.pt2();
-          values[2] = track2.pt2();
+          values[0] = track1.etam() - track2.etam();
+          values[1] = track1.ptm();
+          values[2] = track2.ptm();
           values[3] = collision1.centV0M();
 
-          values[4] = track1.phi2() - track2.phi2();
+          values[4] = track1.phim() - track2.phim();
           if (values[4] > 1.5 * TMath::Pi())
             values[4] -= TMath::TwoPi();
           if (values[4] < -0.5 * TMath::Pi())
@@ -295,7 +295,7 @@ struct CorrelationTask {
   template <typename T>
   bool conversionCut(T const& track1, T const& track2, PairCuts conv, double cut)
   {
-    //LOGF(info, "pt is %f %f", track1.pt2(), track2.pt2());
+    //LOGF(info, "pt is %f %f", track1.ptm(), track2.ptm());
 
     if (cut < 0)
       return false;
@@ -356,21 +356,21 @@ struct CorrelationTask {
 
     float tantheta1 = 1e10;
 
-    if (track1.eta2() < -1e-10 || track1.eta2() > 1e-10) {
-      float expTmp = TMath::Exp(-track1.eta2());
+    if (track1.etam() < -1e-10 || track1.etam() > 1e-10) {
+      float expTmp = TMath::Exp(-track1.etam());
       tantheta1 = 2.0 * expTmp / (1.0 - expTmp * expTmp);
     }
 
     float tantheta2 = 1e10;
-    if (track2.eta2() < -1e-10 || track2.eta2() > 1e-10) {
-      float expTmp = TMath::Exp(-track2.eta2());
+    if (track2.etam() < -1e-10 || track2.etam() > 1e-10) {
+      float expTmp = TMath::Exp(-track2.etam());
       tantheta2 = 2.0 * expTmp / (1.0 - expTmp * expTmp);
     }
 
-    float e1squ = m0_1 * m0_1 + track1.pt2() * track1.pt2() * (1.0 + 1.0 / tantheta1 / tantheta1);
-    float e2squ = m0_2 * m0_2 + track2.pt2() * track2.pt2() * (1.0 + 1.0 / tantheta2 / tantheta2);
+    float e1squ = m0_1 * m0_1 + track1.ptm() * track1.ptm() * (1.0 + 1.0 / tantheta1 / tantheta1);
+    float e2squ = m0_2 * m0_2 + track2.ptm() * track2.ptm() * (1.0 + 1.0 / tantheta2 / tantheta2);
 
-    float mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (track1.pt2() * track2.pt2() * (TMath::Cos(track1.phi2() - track2.phi2()) + 1.0 / tantheta1 / tantheta2)));
+    float mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (track1.ptm() * track2.ptm() * (TMath::Cos(track1.phim() - track2.phim()) + 1.0 / tantheta1 / tantheta2)));
 
     // Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi2, m0_1, m0_2, mass2));
 
@@ -382,12 +382,12 @@ struct CorrelationTask {
   {
     // calculate inv mass squared approximately
 
-    const float eta1 = track1.eta2();
-    const float eta2 = track2.eta2();
-    const float phi1 = track1.phi2();
-    const float phi2 = track2.phi2();
-    const float pt1 = track1.pt2();
-    const float pt2 = track2.pt2();
+    const float eta1 = track1.etam();
+    const float eta2 = track2.etam();
+    const float phi1 = track1.phim();
+    const float phi2 = track2.phim();
+    const float pt1 = track1.ptm();
+    const float pt2 = track2.ptm();
 
     float tantheta1 = 1e10;
 
@@ -422,7 +422,7 @@ struct CorrelationTask {
 
     double mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (pt1 * pt2 * (cosDeltaPhi + 1.0 / tantheta1 / tantheta2)));
 
-    //   Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi2, m0_1, m0_2, mass2));
+    //   Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi1, m0_1, m0_2, mass2));
 
     return mass2;
   }
@@ -433,7 +433,7 @@ struct CorrelationTask {
     // the variables & cuthave been developed by the HBT group
     // see e.g. https://indico.cern.ch/materialDisplay.py?contribId=36&sessionId=6&materialId=slides&confId=142700
 
-    auto deta = track1.eta2() - track2.eta2();
+    auto deta = track1.etam() - track2.etam();
 
     // optimization
     if (TMath::Abs(deta) < cfgTwoTrackCut * 2.5 * 3) {
@@ -457,14 +457,14 @@ struct CorrelationTask {
           }
         }
 
-        qa.mTwoTrackDistancePt[0]->Fill(deta, dphistarmin, TMath::Abs(track1.pt2() - track2.pt2()));
+        qa.mTwoTrackDistancePt[0]->Fill(deta, dphistarmin, TMath::Abs(track1.ptm() - track2.ptm()));
 
         if (dphistarminabs < cfgTwoTrackCut && TMath::Abs(deta) < cfgTwoTrackCut) {
-          //Printf("Removed track pair %ld %ld with %f %f %f %f %d %f %f %d %d", track1.index(), track2.index(), deta, dphistarminabs, track1.phi2(), track1.pt2(), track1.charge(), track2.phi2(), track2.pt2(), track2.charge(), bSign);
+          //Printf("Removed track pair %ld %ld with %f %f %f %f %d %f %f %d %d", track1.index(), track2.index(), deta, dphistarminabs, track1.phim(), track1.ptm(), track1.charge(), track2.phim(), track2.ptm(), track2.charge(), bSign);
           return true;
         }
 
-        qa.mTwoTrackDistancePt[1]->Fill(deta, dphistarmin, TMath::Abs(track1.pt2() - track2.pt2()));
+        qa.mTwoTrackDistancePt[1]->Fill(deta, dphistarmin, TMath::Abs(track1.ptm() - track2.ptm()));
       }
     }
 
@@ -478,12 +478,12 @@ struct CorrelationTask {
     // calculates dphistar
     //
 
-    auto phi1 = track1.phi2();
-    auto pt1 = track1.pt2();
+    auto phi1 = track1.phim();
+    auto pt1 = track1.ptm();
     auto charge1 = track1.charge();
 
-    auto phi2 = track2.phi2();
-    auto pt2 = track2.pt2();
+    auto phi2 = track2.phim();
+    auto pt2 = track2.ptm();
     auto charge2 = track2.charge();
 
     float dphistar = phi1 - phi2 - charge1 * bSign * TMath::ASin(0.075 * radius / pt1) + charge2 * bSign * TMath::ASin(0.075 * radius / pt2);
@@ -507,7 +507,7 @@ struct CorrelationTask {
   //       static_assert("Need to pass aod::track");
   //
   //
-  // //     LOGF(info, "pt %f", track1.pt2());
+  // //     LOGF(info, "pt %f", track1.ptm());
   //     return false;
   //   }
 

--- a/Analysis/Tasks/correlationsMixed.cxx
+++ b/Analysis/Tasks/correlationsMixed.cxx
@@ -422,7 +422,7 @@ struct CorrelationTask {
 
     double mass2 = m0_1 * m0_1 + m0_2 * m0_2 + 2 * (TMath::Sqrt(e1squ * e2squ) - (pt1 * pt2 * (cosDeltaPhi + 1.0 / tantheta1 / tantheta2)));
 
-    //   Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi1, m0_1, m0_2, mass2));
+    //   Printf(Form("%f %f %f %f %f %f %f %f %f", pt1, eta1, phi1, pt2, eta2, phi2, m0_1, m0_2, mass2));
 
     return mass2;
   }

--- a/Analysis/Tutorials/src/associatedExample.cxx
+++ b/Analysis/Tutorials/src/associatedExample.cxx
@@ -19,6 +19,7 @@ DECLARE_SOA_COLUMN(Eta, etas, float);
 DECLARE_SOA_COLUMN(Phi, phis, float);
 DECLARE_SOA_COLUMN(Pt, pts, float);
 } // namespace etaphi
+
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);
 DECLARE_SOA_TABLE(EtaPhiPt, "AOD", "ETAPHIPT",
@@ -59,7 +60,7 @@ struct ATask {
 struct MTask {
   Produces<aod::CollisionsExtra> colextra;
 
-  void process(aod::Collision const& collision, aod::Tracks const& tracks)
+  void process(aod::Collision const&, aod::Tracks const& tracks)
   {
     colextra(tracks.size());
   }

--- a/Analysis/Tutorials/src/filters.cxx
+++ b/Analysis/Tutorials/src/filters.cxx
@@ -45,7 +45,10 @@ struct BTask {
   float fPI = static_cast<float>(M_PI);
   float ptlow = 0.5f;
   float ptup = 2.0f;
-  Filter ptFilter = ((aod::track::signed1Pt < 1.0f / ptlow) && (aod::track::signed1Pt > 1.0f / ptup)) || ((aod::track::signed1Pt < -1.0f / ptup) && (aod::track::signed1Pt < -1.0f / ptlow));
+  Filter ptFilter_a = aod::track::pt2 > (ptlow * ptlow);
+  Filter ptFilter_b = aod::track::pt2 < (ptup * ptup);
+
+  //  Filter ptFilter = ((aod::track::signed1Pt < 1.0f / ptlow) && (aod::track::signed1Pt > 1.0f / ptup)) || ((aod::track::signed1Pt < -1.0f / ptup) && (aod::track::signed1Pt < -1.0f / ptlow));
   float etalow = -1.0f;
   float etaup = 1.0f;
   Filter etafilter = (aod::etaphi::eta2 < etaup) && (aod::etaphi::eta2 > etalow);

--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -23,6 +23,7 @@ namespace readers
 
 struct AODReaderHelpers {
   static AlgorithmSpec rootFileReaderCallback();
+  static AlgorithmSpec aodSpawnerCallback(std::vector<InputSpec> requested);
 };
 
 } // namespace readers

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1058,36 +1058,36 @@ using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
   DECLARE_SOA_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_)
 
 /// An 'expression' column. i.e. a column that can be calculated from other
-/// columns with gandiva. Consists of 'normal' soa::Colunm definition and a
-/// Generator template that can be used to calculate it from a supplied arrow
-/// Table. By default it is not restricted to an soa::Table type, however the
-/// supplied expression determines compatible schemas.
-#define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Label_, _Expression_) \
-  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                    \
-    static constexpr const char* mLabel = _Label_;                                     \
-    using base = o2::soa::Column<_Type_, _Name_>;                                      \
-    using type = _Type_;                                                               \
-    using column_t = _Name_;                                                           \
-    _Name_(arrow::ChunkedArray const* column)                                          \
-      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))         \
-    {                                                                                  \
-    }                                                                                  \
-                                                                                       \
-    _Name_() = default;                                                                \
-    _Name_(_Name_ const& other) = default;                                             \
-    _Name_& operator=(_Name_ const& other) = default;                                  \
-                                                                                       \
-    decltype(auto) _Getter_() const                                                    \
-    {                                                                                  \
-      return *mColumnIterator;                                                         \
-    }                                                                                  \
-    static o2::framework::expressions::Projector Projector()                           \
-    {                                                                                  \
-      return _Expression_;                                                             \
-    }                                                                                  \
-  };                                                                                   \
-  static const o2::framework::expressions::BindingNode _Getter_ { _Label_,             \
+/// columns with gandiva based on supplied C++ expression.
+#define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_) \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                         \
+    static constexpr const char* mLabel = _Label_;                                          \
+    using base = o2::soa::Column<_Type_, _Name_>;                                           \
+    using type = _Type_;                                                                    \
+    using column_t = _Name_;                                                                \
+    _Name_(arrow::ChunkedArray const* column)                                               \
+      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))              \
+    {                                                                                       \
+    }                                                                                       \
+                                                                                            \
+    _Name_() = default;                                                                     \
+    _Name_(_Name_ const& other) = default;                                                  \
+    _Name_& operator=(_Name_ const& other) = default;                                       \
+                                                                                            \
+    decltype(auto) _Getter_() const                                                         \
+    {                                                                                       \
+      return *mColumnIterator;                                                              \
+    }                                                                                       \
+    static o2::framework::expressions::Projector Projector()                                \
+    {                                                                                       \
+      return _Expression_;                                                                  \
+    }                                                                                       \
+  };                                                                                        \
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_,                  \
                                                                   o2::framework::expressions::selectArrowType<_Type_>() }
+
+#define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Expression_) \
+  DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_, _Expression_);
 
 /// An index column is a column of indices to elements / of another table named
 /// _Name_##s. The column name will be _Name_##Id and will always be stored in

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -25,10 +25,15 @@
 #include <arrow/compute/kernel.h>
 #include <gandiva/selection_vector.h>
 #include <cassert>
+#include <fmt/format.h>
 
 namespace o2::soa
 {
-
+template <typename... C>
+auto createSchemaFromColumns(framework::pack<C...>)
+{
+  return std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>{C::asArrowField()...});
+}
 using SelectionVector = std::vector<int64_t>;
 
 template <typename, typename = void>
@@ -267,6 +272,12 @@ struct Column {
   {
     return mColumnIterator;
   }
+
+  static auto asArrowField()
+  {
+    return std::make_shared<arrow::Field>(inherited_t::mLabel, framework::expressions::concreteArrowType(framework::expressions::selectArrowType<type>()));
+  }
+
   /// FIXME: rather than keeping this public we should have a protected
   /// non-const getter and mark this private.
   ColumnIterator<T> mColumnIterator;
@@ -982,10 +993,35 @@ template <typename INHERIT>
 class TableMetadata
 {
  public:
-  static constexpr char const* const tableLabel() { return INHERIT::mLabel; }
+  static constexpr char const* tableLabel() { return INHERIT::mLabel; }
   static constexpr char const (&origin())[4] { return INHERIT::mOrigin; }
   static constexpr char const (&description())[16] { return INHERIT::mDescription; }
 };
+
+template <typename... C1, typename... C2>
+constexpr auto join(o2::soa::Table<C1...> const& t1, o2::soa::Table<C2...> const& t2)
+{
+  return o2::soa::Table<C1..., C2...>(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename T1, typename T2, typename... Ts>
+constexpr auto join(T1 const& t1, T2 const& t2, Ts const&... ts)
+{
+  return join(t1, join(t2, ts...));
+}
+
+template <typename T1, typename T2>
+constexpr auto concat(T1&& t1, T2&& t2)
+{
+  using table_t = typename PackToTable<framework::intersected_pack_t<typename T1::columns, typename T2::columns>>::table;
+  return table_t(ArrowHelpers::concatTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename... Ts>
+using JoinBase = decltype(join(std::declval<Ts>()...));
+
+template <typename T1, typename T2>
+using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
 
 } // namespace o2::soa
 
@@ -1020,6 +1056,38 @@ class TableMetadata
 
 #define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_) \
   DECLARE_SOA_COLUMN_FULL(_Name_, _Getter_, _Type_, "f" #_Name_)
+
+/// An 'expression' column. i.e. a column that can be calculated from other
+/// columns with gandiva. Consists of 'normal' soa::Colunm definition and a
+/// Generator template that can be used to calculate it from a supplied arrow
+/// Table. By default it is not restricted to an soa::Table type, however the
+/// supplied expression determines compatible schemas.
+#define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Label_, _Expression_) \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                    \
+    static constexpr const char* mLabel = _Label_;                                     \
+    using base = o2::soa::Column<_Type_, _Name_>;                                      \
+    using type = _Type_;                                                               \
+    using column_t = _Name_;                                                           \
+    _Name_(arrow::ChunkedArray const* column)                                          \
+      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))         \
+    {                                                                                  \
+    }                                                                                  \
+                                                                                       \
+    _Name_() = default;                                                                \
+    _Name_(_Name_ const& other) = default;                                             \
+    _Name_& operator=(_Name_ const& other) = default;                                  \
+                                                                                       \
+    decltype(auto) _Getter_() const                                                    \
+    {                                                                                  \
+      return *mColumnIterator;                                                         \
+    }                                                                                  \
+    static o2::framework::expressions::Projector Projector()                           \
+    {                                                                                  \
+      return _Expression_;                                                             \
+    }                                                                                  \
+  };                                                                                   \
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_,             \
+                                                                  o2::framework::expressions::selectArrowType<_Type_>() }
 
 /// An index column is a column of indices to elements / of another table named
 /// _Name_##s. The column name will be _Name_##Id and will always be stored in
@@ -1147,54 +1215,53 @@ class TableMetadata
     std::tuple<o2::soa::ColumnIterator<typename Bindings::type> const*...> boundIterators;                                 \
   }
 
-#define DECLARE_SOA_TABLE(_Name_, _Origin_, _Description_, ...)        \
-  using _Name_ = o2::soa::Table<__VA_ARGS__>;                          \
-                                                                       \
-  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> { \
-    using table_t = _Name_;                                            \
-    static constexpr char const* mLabel = #_Name_;                     \
-    static constexpr char const mOrigin[4] = _Origin_;                 \
-    static constexpr char const mDescription[16] = _Description_;      \
-  };                                                                   \
-                                                                       \
-  template <>                                                          \
-  struct MetadataTrait<_Name_> {                                       \
-    using metadata = _Name_##Metadata;                                 \
-  };                                                                   \
-                                                                       \
-  template <>                                                          \
-  struct MetadataTrait<_Name_::unfiltered_iterator> {                  \
-    using metadata = _Name_##Metadata;                                 \
+#define DECLARE_SOA_TABLE_FULL(_Name_, _Label_, _Origin_, _Description_, ...) \
+  using _Name_ = o2::soa::Table<__VA_ARGS__>;                                 \
+                                                                              \
+  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> {        \
+    using table_t = _Name_;                                                   \
+    static constexpr char const* mLabel = _Label_;                            \
+    static constexpr char const mOrigin[4] = _Origin_;                        \
+    static constexpr char const mDescription[16] = _Description_;             \
+  };                                                                          \
+                                                                              \
+  template <>                                                                 \
+  struct MetadataTrait<_Name_> {                                              \
+    using metadata = _Name_##Metadata;                                        \
+  };                                                                          \
+                                                                              \
+  template <>                                                                 \
+  struct MetadataTrait<_Name_::unfiltered_iterator> {                         \
+    using metadata = _Name_##Metadata;                                        \
+  };
+
+#define DECLARE_SOA_TABLE(_Name_, _Origin_, _Description_, ...) \
+  DECLARE_SOA_TABLE_FULL(_Name_, #_Name_, _Origin_, _Description_, __VA_ARGS__);
+
+#define DECLARE_SOA_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...)   \
+  using _Name_ = o2::soa::JoinBase<_Table_, o2::soa::Table<__VA_ARGS__>>; \
+                                                                          \
+  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> {    \
+    using table_t = _Name_;                                               \
+    using base_table_t = _Table_;                                         \
+    using expression_pack_t = framework::pack<__VA_ARGS__>;               \
+    static constexpr char const* mLabel = #_Name_;                        \
+    static constexpr char const mOrigin[4] = "DYN";                       \
+    static constexpr char const mDescription[16] = _Description_;         \
+  };                                                                      \
+                                                                          \
+  template <>                                                             \
+  struct MetadataTrait<_Name_> {                                          \
+    using metadata = _Name_##Metadata;                                    \
+  };                                                                      \
+                                                                          \
+  template <>                                                             \
+  struct MetadataTrait<_Name_::unfiltered_iterator> {                     \
+    using metadata = _Name_##Metadata;                                    \
   };
 
 namespace o2::soa
 {
-
-template <typename... C1, typename... C2>
-constexpr auto join(o2::soa::Table<C1...> const& t1, o2::soa::Table<C2...> const& t2)
-{
-  return o2::soa::Table<C1..., C2...>(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
-}
-
-template <typename T1, typename T2, typename... Ts>
-constexpr auto join(T1 const& t1, T2 const& t2, Ts const&... ts)
-{
-  return join(t1, join(t2, ts...));
-}
-
-template <typename T1, typename T2>
-constexpr auto concat(T1&& t1, T2&& t2)
-{
-  using table_t = typename PackToTable<framework::intersected_pack_t<typename T1::columns, typename T2::columns>>::table;
-  return table_t(ArrowHelpers::concatTables({t1.asArrowTable(), t2.asArrowTable()}));
-}
-
-template <typename... Ts>
-using JoinBase = decltype(join(std::declval<Ts>()...));
-
-template <typename T1, typename T2>
-using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
-
 template <typename... Ts>
 struct Join : JoinBase<Ts...> {
   Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
@@ -1291,7 +1358,7 @@ class Filtered : public T
     : T{std::move(tables), offset},
       mSelectedRows{copySelection(framework::expressions::createSelection(this->asArrowTable(),
                                                                           framework::expressions::createFilter(this->asArrowTable()->schema(),
-                                                                                                               framework::expressions::createCondition(tree))))},
+                                                                                                               framework::expressions::makeCondition(tree))))},
       mFilteredBegin{table_t::filtered_begin(mSelectedRows)},
       mFilteredEnd{mSelectedRows.size()}
   {

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -105,7 +105,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(P2, p2, [](float signed1Pt, float tgl) -> float {
   return (1.f + tgl * tgl) / (signed1Pt * signed1Pt);
 });
 
-DECLARE_SOA_EXPRESSION_COLUMN(Pt2, pt2, float, "fPt2", (1.f / aod::track::signed1Pt) * (1.f / aod::track::signed1Pt));
+DECLARE_SOA_EXPRESSION_COLUMN(Pt2, pt2, float, (1.f / aod::track::signed1Pt) * (1.f / aod::track::signed1Pt));
 
 // TRACKPARCOV TABLE definition
 DECLARE_SOA_COLUMN(CYY, cYY, float);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -105,6 +105,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(P2, p2, [](float signed1Pt, float tgl) -> float {
   return (1.f + tgl * tgl) / (signed1Pt * signed1Pt);
 });
 
+DECLARE_SOA_EXPRESSION_COLUMN(Pt2, pt2, float, "fPt2", (1.f / aod::track::signed1Pt) * (1.f / aod::track::signed1Pt));
+
 // TRACKPARCOV TABLE definition
 DECLARE_SOA_COLUMN(CYY, cYY, float);
 DECLARE_SOA_COLUMN(CZY, cZY, float);
@@ -165,20 +167,22 @@ DECLARE_SOA_DYNAMIC_COLUMN(TPCFractionSharedCls, tpcFractionSharedCls, [](uint8_
 });
 } // namespace track
 
-DECLARE_SOA_TABLE(Tracks, "AOD", "TRACKPAR",
-                  o2::soa::Index<>, track::CollisionId, track::TrackType,
-                  track::X, track::Alpha,
-                  track::Y, track::Z, track::Snp, track::Tgl,
-                  track::Signed1Pt,
-                  track::Phi<track::Snp, track::Alpha>,
-                  track::Eta<track::Tgl>,
-                  track::Pt<track::Signed1Pt>,
-                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>,
-                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>,
-                  track::Pz<track::Signed1Pt, track::Tgl>,
-                  track::P<track::Signed1Pt, track::Tgl>,
-                  track::P2<track::Signed1Pt, track::Tgl>,
-                  track::Charge<track::Signed1Pt>);
+DECLARE_SOA_TABLE_FULL(StoredTracks, "Tracks", "AOD", "TRACKPAR",
+                       o2::soa::Index<>, track::CollisionId, track::TrackType,
+                       track::X, track::Alpha,
+                       track::Y, track::Z, track::Snp, track::Tgl,
+                       track::Signed1Pt,
+                       track::Phi<track::Snp, track::Alpha>,
+                       track::Eta<track::Tgl>,
+                       track::Pt<track::Signed1Pt>,
+                       track::Px<track::Signed1Pt, track::Snp, track::Alpha>,
+                       track::Py<track::Signed1Pt, track::Snp, track::Alpha>,
+                       track::Pz<track::Signed1Pt, track::Tgl>,
+                       track::P<track::Signed1Pt, track::Tgl>,
+                       track::P2<track::Signed1Pt, track::Tgl>,
+                       track::Charge<track::Signed1Pt>);
+
+DECLARE_SOA_EXTENDED_TABLE(Tracks, StoredTracks, "TRACKPAR", aod::track::Pt2);
 
 DECLARE_SOA_TABLE(TracksCov, "AOD", "TRACKPARCOV",
                   track::CYY, track::CZY, track::CZZ, track::CSnpY,

--- a/Framework/Core/include/Framework/BasicOps.h
+++ b/Framework/Core/include/Framework/BasicOps.h
@@ -25,6 +25,7 @@ enum BasicOp : unsigned int {
   GreaterThanOrEqual,
   Equal,
   NotEqual,
+  Power,
   Exp,
   Log,
   Log10,

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -45,6 +45,7 @@ class FairMQMessage;
 namespace arrow
 {
 class Schema;
+class Table;
 
 namespace ipc
 {
@@ -198,6 +199,10 @@ class DataAllocator
   /// it as an Arrow table to all consumers of @a spec once done
   void
     adopt(const Output& spec, struct TreeToTable*);
+
+  /// Adopt an Arrow table and send it to all consumers of @a spec
+  void
+    adopt(const Output& spec, std::shared_ptr<class arrow::Table>);
 
   /// Adopt a raw buffer in the framework and serialize / send
   /// it to the consumers of @a spec once done.

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -23,6 +23,8 @@
 #include <gandiva/selection_vector.h>
 #include <gandiva/node.h>
 #include <gandiva/filter.h>
+#include <gandiva/projector.h>
+#include <fmt/format.h>
 #else
 namespace gandiva
 {
@@ -62,6 +64,10 @@ constexpr auto selectArrowType()
     return atype::FLOAT;
   } else if constexpr (std::is_same_v<T, double>) {
     return atype::DOUBLE;
+  } else if constexpr (std::is_same_v<T, uint8_t>) {
+    return atype::INT8;
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    return atype::INT16;
   } else {
     return atype::NA;
   }
@@ -209,11 +215,48 @@ inline Node operator||(Node left, Node right)
   return Node{OpNode{BasicOp::LogicalOr}, std::move(left), std::move(right)};
 }
 
+/// arithmetical operations between nodes
+inline Node operator*(Node left, Node right)
+{
+  return Node{OpNode{BasicOp::Multiplication}, std::move(left), std::move(right)};
+}
+
+inline Node operator*(BindingNode left, BindingNode right)
+{
+  return Node{OpNode{BasicOp::Multiplication}, left, right};
+}
+
+inline Node operator*(BindingNode left, Node right)
+{
+  return Node{OpNode{BasicOp::Multiplication}, left, std::move(right)};
+}
+
+inline Node operator/(Node left, Node right)
+{
+  return Node{OpNode{BasicOp::Division}, std::move(left), std::move(right)};
+}
+
+inline Node operator+(Node left, Node right)
+{
+  return Node{OpNode{BasicOp::Addition}, std::move(left), std::move(right)};
+}
+
+inline Node operator-(Node left, Node right)
+{
+  return Node{OpNode{BasicOp::Subtraction}, std::move(left), std::move(right)};
+}
+
 /// arithmetical operations between node and literal
 template <typename T>
 inline Node operator*(Node left, T right)
 {
   return Node{OpNode{BasicOp::Multiplication}, std::move(left), LiteralNode{right}};
+}
+
+template <typename T>
+inline Node operator*(T left, Node right)
+{
+  return Node{OpNode{BasicOp::Multiplication}, LiteralNode{left}, std::move(right)};
 }
 
 template <typename T>
@@ -238,6 +281,12 @@ template <typename T>
 inline Node operator-(Node left, T right)
 {
   return Node{OpNode{BasicOp::Subtraction}, std::move(left), LiteralNode{right}};
+}
+/// semi-binary
+template <typename T>
+inline Node npow(Node left, T right)
+{
+  return Node{OpNode{BasicOp::Power}, std::move(left), LiteralNode{right}};
 }
 
 /// unary operations on nodes
@@ -264,27 +313,49 @@ inline Node nabs(Node left)
 /// A struct, containing the root of the expression tree
 struct Filter {
   Filter(Node&& node_) : node{std::make_unique<Node>(std::move(node_))} {}
-
+  Filter(Filter&& other) : node{std::move(other.node)} {}
   std::unique_ptr<Node> node;
 };
 
+using Projector = Filter;
+
 using Selection = std::shared_ptr<gandiva::SelectionVector>;
-Selection createSelection(std::shared_ptr<arrow::Table> table, Filter const& expression);
+/// Function for creating gandiva selection from our internal filter tree
+Selection createSelection(std::shared_ptr<arrow::Table> table, Filter&& expression);
+/// Function for creating gandiva selection from prepared gandiva expressions tree
 Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<gandiva::Filter> gfilter);
 
 struct ColumnOperationSpec;
 using Operations = std::vector<ColumnOperationSpec>;
 
+/// Function to create an internal operation sequence from a filter tree
 Operations createOperations(Filter const& expression);
+
+/// Function to check compatibility of a given arrow schema with operation sequence
 bool isSchemaCompatible(gandiva::SchemaPtr const& Schema, Operations const& opSpecs);
+/// Function to create gandiva expression tree from operation sequence
 gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
                                       gandiva::SchemaPtr const& Schema);
+/// Function to create gandiva filter from gandiva condition
 std::shared_ptr<gandiva::Filter> createFilter(gandiva::SchemaPtr const& Schema,
                                               gandiva::ConditionPtr condition);
+/// Function to create gandiva filter from operation sequence
 std::shared_ptr<gandiva::Filter> createFilter(gandiva::SchemaPtr const& Schema,
                                               Operations const& opSpecs);
+/// Function to create gandiva projector from operation sequence
+std::shared_ptr<gandiva::Projector> createProjector(gandiva::SchemaPtr const& Schema,
+                                                    Operations const& opSpecs,
+                                                    gandiva::FieldPtr result);
+/// Function to create gandiva projector directly from expression
+std::shared_ptr<gandiva::Projector> createProjector(gandiva::SchemaPtr const& Schema,
+                                                    Projector&& p,
+                                                    gandiva::FieldPtr result);
+/// Function for attaching gandiva filters to to compatible task inputs
 void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos);
-gandiva::ConditionPtr createCondition(gandiva::NodePtr node);
+/// Function to create gandiva condition expression from generic gandiva expression tree
+gandiva::ConditionPtr makeCondition(gandiva::NodePtr node);
+/// Function to create gandiva projecting expression from generic gandiva expression tree
+gandiva::ExpressionPtr makeExpression(gandiva::NodePtr node, gandiva::FieldPtr result);
 } // namespace o2::framework::expressions
 
 #endif // O2_FRAMEWORK_EXPRESSIONS_H_

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -321,7 +321,7 @@ using Projector = Filter;
 
 using Selection = std::shared_ptr<gandiva::SelectionVector>;
 /// Function for creating gandiva selection from our internal filter tree
-Selection createSelection(std::shared_ptr<arrow::Table> table, Filter&& expression);
+Selection createSelection(std::shared_ptr<arrow::Table> table, Filter const& expression);
 /// Function for creating gandiva selection from prepared gandiva expressions tree
 Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<gandiva::Filter> gfilter);
 

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -12,10 +12,13 @@
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "DataProcessingHelpers.h"
+#include "ExpressionHelpers.h"
 #include "Framework/RootTableBuilderHelpers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
+#include "Framework/CallbackService.h"
+#include "Framework/EndOfStreamContext.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/DataSpecUtils.h"
@@ -38,6 +41,24 @@
 
 namespace o2::framework::readers
 {
+
+namespace
+{
+auto tableTypeFromInput(InputSpec const& spec)
+{
+  auto description = std::visit(
+    overloaded{
+      [](ConcreteDataMatcher const& matcher) { return matcher.description; },
+      [](auto&&) { return header::DataDescription{""}; }},
+    spec.matcher);
+
+  if (description == header::DataDescription{"TRACKPAR"}) {
+    return o2::aod::TracksMetadata{};
+  } else {
+    throw std::runtime_error("Not an extended table");
+  }
+}
+} // namespace
 
 enum AODTypeMask : uint64_t {
   None = 0,
@@ -138,6 +159,78 @@ std::vector<OutputRoute> getListOfUnknown(std::vector<OutputRoute> const& routes
   return unknows;
 }
 
+/// Expression-based column generator to materialize columns
+template <typename... C>
+auto spawner(framework::pack<C...> columns, arrow::Table* atable)
+{
+  arrow::TableBatchReader reader(*atable);
+  std::shared_ptr<arrow::RecordBatch> batch;
+  arrow::ArrayVector v;
+  std::vector<arrow::ArrayVector> chunks(sizeof...(C));
+
+  auto projectors = framework::expressions::createProjectors(columns, atable->schema());
+  while (true) {
+    auto s = reader.ReadNext(&batch);
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s));
+    }
+    if (batch == nullptr) {
+      break;
+    }
+    s = projectors->Evaluate(*batch, arrow::default_memory_pool(), &v);
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot apply projector {}", s));
+    }
+    for (auto i = 0u; i < sizeof...(C); ++i) {
+      chunks[i].emplace_back(v.at(i));
+    }
+  }
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> results(sizeof...(C));
+  for (auto i = 0u; i < sizeof...(C); ++i) {
+    results[i] = std::make_shared<arrow::ChunkedArray>(chunks[i]);
+  }
+  return results;
+}
+
+template <typename T>
+auto extractTable(ProcessingContext& pc)
+{
+  return pc.inputs().get<TableConsumer>(aod::MetadataTrait<T>::metadata::tableLabel())->asArrowTable();
+}
+
+AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> requested)
+{
+  return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
+    auto& callbacks = ic.services().get<CallbackService>();
+    auto endofdatacb = [](EndOfStreamContext& eosc) {
+      auto& control = eosc.services().get<ControlService>();
+      control.endOfStream();
+      control.readyToQuit(QuitRequest::Me);
+    };
+    callbacks.set(CallbackService::Id::EndOfStream, endofdatacb);
+
+    return [requested](ProcessingContext& pc) {
+      auto outputs = pc.outputs();
+      // spawn tables
+      for (auto& input : requested) {
+        using metadata = decltype(tableTypeFromInput(input));
+        using table_t = metadata::table_t;
+        using base_t = metadata::base_table_t;
+        using expressions = metadata::expression_pack_t;
+        auto schema = o2::soa::createSchemaFromColumns(table_t::persistent_columns_t{});
+        auto original_table = extractTable<base_t>(pc);
+        auto arrays = spawner(expressions{}, original_table.get());
+        std::vector<std::shared_ptr<arrow::ChunkedArray>> columns = original_table->columns();
+        for (auto i = 0u; i < framework::pack_size(expressions{}); ++i) {
+          columns.push_back(arrays[i]);
+        }
+        auto new_table = arrow::Table::Make(schema, columns);
+        outputs.adopt(Output{metadata::origin(), metadata::description()}, new_table);
+      }
+    };
+  }};
+}
+
 AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
 {
   auto callback = AlgorithmSpec{adaptStateful([](ConfigParamRegistry const& options,
@@ -195,7 +288,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         }
       };
       tableMaker(o2::aod::CollisionsMetadata{}, AODTypeMask::Collision, "O2collision");
-      tableMaker(o2::aod::TracksMetadata{}, AODTypeMask::Track, "O2track");
+      tableMaker(o2::aod::StoredTracksMetadata{}, AODTypeMask::Track, "O2track");
       tableMaker(o2::aod::TracksCovMetadata{}, AODTypeMask::TrackCov, "O2track");
       tableMaker(o2::aod::TracksExtraMetadata{}, AODTypeMask::TrackExtra, "O2track");
       tableMaker(o2::aod::CalosMetadata{}, AODTypeMask::Calo, "O2calo");

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -172,14 +172,14 @@ auto spawner(framework::pack<C...> columns, arrow::Table* atable)
   while (true) {
     auto s = reader.ReadNext(&batch);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s));
+      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s.ToString()));
     }
     if (batch == nullptr) {
       break;
     }
     s = projectors->Evaluate(*batch, arrow::default_memory_pool(), &v);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot apply projector {}", s));
+      throw std::runtime_error(fmt::format("Cannot apply projector {}", s.ToString()));
     }
     for (auto i = 0u; i < sizeof...(C); ++i) {
       chunks[i].emplace_back(v.at(i));

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -50,15 +50,22 @@ struct OpNodeHelper {
 
 std::shared_ptr<arrow::DataType> concreteArrowType(atype::type type)
 {
-  if (type == atype::INT32)
-    return arrow::int32();
-  if (type == atype::FLOAT)
-    return arrow::float32();
-  if (type == atype::DOUBLE)
-    return arrow::float64();
-  if (type == atype::BOOL)
-    return arrow::boolean();
-  return nullptr;
+  switch (type) {
+    case atype::INT8:
+      return arrow::int8();
+    case atype::INT16:
+      return arrow::int16();
+    case atype::INT32:
+      return arrow::int32();
+    case atype::FLOAT:
+      return arrow::float32();
+    case atype::DOUBLE:
+      return arrow::float64();
+    case atype::BOOL:
+      return arrow::boolean();
+    default:
+      return nullptr;
+  }
 }
 
 bool operator==(DatumSpec const& lhs, DatumSpec const& rhs)
@@ -225,9 +232,14 @@ Operations createOperations(Filter const& expression)
   return OperationSpecs;
 }
 
-gandiva::ConditionPtr createCondition(gandiva::NodePtr node)
+gandiva::ConditionPtr makeCondition(gandiva::NodePtr node)
 {
   return gandiva::TreeExprBuilder::MakeCondition(node);
+}
+
+gandiva::ExpressionPtr makeExpression(gandiva::NodePtr node, gandiva::FieldPtr result)
+{
+  return gandiva::TreeExprBuilder::MakeExpression(node, result);
 }
 
 std::shared_ptr<gandiva::Filter>
@@ -235,11 +247,13 @@ std::shared_ptr<gandiva::Filter>
 {
   std::shared_ptr<gandiva::Filter> filter;
   auto s = gandiva::Filter::Make(Schema,
-                                 createCondition(createExpressionTree(opSpecs, Schema)),
+                                 makeCondition(createExpressionTree(opSpecs, Schema)),
                                  &filter);
-  if (s.ok())
+  if (s.ok()) {
     return filter;
-  throw std::runtime_error(fmt::format("Failed to create filter: {}", s));
+  } else {
+    throw std::runtime_error(fmt::format("Failed to create filter: {}", s.ToString()));
+  }
 }
 
 std::shared_ptr<gandiva::Filter>
@@ -249,9 +263,31 @@ std::shared_ptr<gandiva::Filter>
   auto s = gandiva::Filter::Make(Schema,
                                  condition,
                                  &filter);
-  if (s.ok())
+  if (s.ok()) {
     return filter;
-  throw std::runtime_error(fmt::format("Failed to create filter: {}", s));
+  } else {
+    throw std::runtime_error(fmt::format("Failed to create filter: {}", s.ToString()));
+  }
+}
+
+std::shared_ptr<gandiva::Projector>
+  createProjector(gandiva::SchemaPtr const& Schema, Operations const& opSpecs, gandiva::FieldPtr result)
+{
+  std::shared_ptr<gandiva::Projector> projector;
+  auto s = gandiva::Projector::Make(Schema,
+                                    {makeExpression(createExpressionTree(opSpecs, Schema), result)},
+                                    &projector);
+  if (s.ok()) {
+    return projector;
+  } else {
+    throw std::runtime_error(fmt::format("Failed to create projector: {}", s.ToString()));
+  }
+}
+
+std::shared_ptr<gandiva::Projector>
+  createProjector(gandiva::SchemaPtr const& Schema, Projector&& p, gandiva::FieldPtr result)
+{
+  return createProjector(std::move(Schema), createOperations(std::move(p)), std::move(result));
 }
 
 Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<gandiva::Filter> gfilter)
@@ -260,30 +296,53 @@ Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<g
   auto s = gandiva::SelectionVector::MakeInt64(table->num_rows(),
                                                arrow::default_memory_pool(),
                                                &selection);
-  if (!s.ok())
-    throw std::runtime_error(fmt::format("Cannot allocate selection vector {}", s));
+  if (!s.ok()) {
+    throw std::runtime_error(fmt::format("Cannot allocate selection vector {}", s.ToString()));
+  }
   arrow::TableBatchReader reader(*table);
   std::shared_ptr<arrow::RecordBatch> batch;
   while (true) {
     s = reader.ReadNext(&batch);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s));
+      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s.ToString()));
     }
     if (batch == nullptr) {
       break;
     }
     s = gfilter->Evaluate(*batch, selection);
-    if (!s.ok())
-      throw std::runtime_error(fmt::format("Cannot apply filter {}", s));
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot apply filter {}", s.ToString()));
+    }
   }
 
   return selection;
 }
 
 Selection createSelection(std::shared_ptr<arrow::Table> table,
-                          Filter const& expression)
+                          Filter&& expression)
 {
-  return createSelection(table, createFilter(table->schema(), createOperations(expression)));
+  return createSelection(table, createFilter(table->schema(), createOperations(std::move(expression))));
+}
+
+auto createProjection(std::shared_ptr<arrow::Table> table, std::shared_ptr<gandiva::Projector> gprojector)
+{
+  arrow::TableBatchReader reader(*table);
+  std::shared_ptr<arrow::RecordBatch> batch;
+  std::shared_ptr<arrow::ArrayVector> v;
+  while (true) {
+    auto s = reader.ReadNext(&batch);
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s.ToString()));
+    }
+    if (batch == nullptr) {
+      break;
+    }
+    s = gprojector->Evaluate(*batch, arrow::default_memory_pool(), v.get());
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot apply projector {}", s.ToString()));
+    }
+  }
+  return v;
 }
 
 gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
@@ -295,6 +354,9 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
   std::unordered_map<std::string, gandiva::NodePtr> fieldNodes;
 
   auto datumNode = [Schema, &opNodes, &fieldNodes](DatumSpec const& spec) {
+    if (spec.datum.index() == 0) {
+      return gandiva::NodePtr(nullptr);
+    }
     if (spec.datum.index() == 1) {
       return opNodes[std::get<size_t>(spec.datum)];
     }
@@ -315,8 +377,9 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
     if (spec.datum.index() == 3) {
       auto name = std::get<std::string>(spec.datum);
       auto lookup = fieldNodes.find(name);
-      if (lookup != fieldNodes.end())
+      if (lookup != fieldNodes.end()) {
         return lookup->second;
+      }
       auto node = gandiva::TreeExprBuilder::MakeField(Schema->GetFieldByName(name));
       fieldNodes.insert({name, node});
       return node;
@@ -336,7 +399,7 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
         tree = gandiva::TreeExprBuilder::MakeAnd({leftNode, rightNode});
         break;
       default:
-        if (it->op <= BasicOp::Exp) {
+        if (it->op < BasicOp::Exp) {
           tree = gandiva::TreeExprBuilder::MakeFunction(binaryOperationsMap[it->op], {leftNode, rightNode}, concreteArrowType(it->type));
         } else {
           tree = gandiva::TreeExprBuilder::MakeFunction(binaryOperationsMap[it->op], {leftNode}, concreteArrowType(it->type));

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -319,7 +319,7 @@ Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<g
 }
 
 Selection createSelection(std::shared_ptr<arrow::Table> table,
-                          Filter&& expression)
+                          const Filter& expression)
 {
   return createSelection(table, createFilter(table->schema(), createOperations(std::move(expression))));
 }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -144,6 +144,18 @@ void addMissingOutputsToReader(std::vector<OutputSpec> const& providedOutputs,
   }
 }
 
+void addMissingOutputsToSpawner(std::vector<InputSpec>&& requestedDYNs,
+                                std::vector<InputSpec>& requestedAODs,
+                                DataProcessorSpec& publisher)
+{
+  for (auto& input : requestedDYNs) {
+    publisher.inputs.emplace_back(InputSpec{input.binding, header::DataOrigin{"AOD"}, DataSpecUtils::asConcreteDataMatcher(input).description});
+    requestedAODs.emplace_back(InputSpec{input.binding, header::DataOrigin{"AOD"}, DataSpecUtils::asConcreteDataMatcher(input).description});
+    auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
+    publisher.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec});
+  }
+}
+
 void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext const& ctx)
 {
   auto fakeCallback = AlgorithmSpec{[](InitContext& ic) {
@@ -199,6 +211,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   std::vector<InputSpec> requestedAODs;
   std::vector<OutputSpec> providedAODs;
+  std::vector<InputSpec> requestedDYNs;
+
   std::vector<InputSpec> requestedCCDBs;
   std::vector<OutputSpec> providedCCDBs;
   std::vector<OutputSpec> providedOutputObj;
@@ -256,6 +270,9 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"AOD"})) {
         requestedAODs.emplace_back(input);
       }
+      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"DYN"})) {
+        requestedDYNs.emplace_back(input);
+      }
     }
     std::stable_sort(timer.outputs.begin(), timer.outputs.end(), [](OutputSpec const& a, OutputSpec const& b) { return *DataSpecUtils::getOptionalSubSpec(a) < *DataSpecUtils::getOptionalSubSpec(b); });
 
@@ -263,7 +280,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       auto& output = processor.outputs[oi];
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
-
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         providedOutputObj.emplace_back(output);
         auto it = std::find_if(outObjMap.begin(), outObjMap.end(), [&](auto&& x) { return x.first == hash; });
@@ -279,6 +295,17 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     }
   }
 
+  auto last = std::unique(requestedDYNs.begin(), requestedDYNs.end());
+  requestedDYNs.erase(last, requestedDYNs.end());
+
+  DataProcessorSpec aodSpawner{
+    "internal-dpl-aod-spawner",
+    {},
+    {},
+    readers::AODReaderHelpers::aodSpawnerCallback(requestedDYNs),
+    {}};
+
+  addMissingOutputsToSpawner(std::move(requestedDYNs), requestedAODs, aodSpawner);
   addMissingOutputsToReader(providedAODs, requestedAODs, aodReader);
   addMissingOutputsToReader(providedCCDBs, requestedCCDBs, ccdbBackend);
 
@@ -293,6 +320,11 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   if (qaStore.outputs.empty() == false) {
     extraSpecs.push_back(qaStore);
   }
+
+  if (aodSpawner.outputs.empty() == false) {
+    extraSpecs.push_back(aodSpawner);
+  }
+
   if (aodReader.outputs.empty() == false) {
     extraSpecs.push_back(timePipeline(aodReader, ctx.options().get<int64_t>("readers")));
     auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -318,7 +318,7 @@ static void BM_ASoAGettersPhi(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -350,7 +350,7 @@ static void BM_ASoAWholeTrackForLoop(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -378,7 +378,7 @@ static void BM_ASoADynamicColumnPhi(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -162,7 +162,7 @@ static void BM_ASoAHelpersNaiveTracksPairs(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -197,7 +197,7 @@ static void BM_ASoAHelpersNaiveTracksFives(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -300,7 +300,7 @@ static void BM_ASoAHelpersCombGenTracksPairs(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -332,7 +332,7 @@ static void BM_ASoAHelpersCombGenTracksFives(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -405,7 +405,7 @@ static void BM_ASoAHelpersCombGenTracksFivesMultipleChunks(benchmark::State& sta
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builderA;
-  auto rowWriterA = builderA.cursor<o2::aod::Tracks>();
+  auto rowWriterA = builderA.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriterA(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
                uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
@@ -414,7 +414,7 @@ static void BM_ASoAHelpersCombGenTracksFivesMultipleChunks(benchmark::State& sta
   auto tableA = builderA.finalize();
 
   TableBuilder builderB;
-  auto rowWriterB = builderB.cursor<o2::aod::Tracks>();
+  auto rowWriterB = builderB.cursor<o2::aod::StoredTracks>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriterB(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
                uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -488,3 +488,11 @@ BOOST_AUTO_TEST_CASE(TestDereference)
   BOOST_CHECK_EQUAL(se.pointB().y(), 4);
   BOOST_CHECK_EQUAL(se.thickness(), 1);
 }
+
+BOOST_AUTO_TEST_CASE(TestSchemaCreation)
+{
+  auto schema = createSchemaFromColumns(Points::persistent_columns_t{});
+  BOOST_CHECK_EQUAL(schema->num_fields(), 2);
+  BOOST_CHECK_EQUAL(schema->field(0)->name(), "x");
+  BOOST_CHECK_EQUAL(schema->field(1)->name(), "y");
+}

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -28,7 +28,7 @@ using namespace o2::aod;
 BOOST_AUTO_TEST_CASE(TestJoinedTables)
 {
   TableBuilder trackBuilder;
-  auto trackWriter = trackBuilder.cursor<Tracks>();
+  auto trackWriter = trackBuilder.cursor<StoredTracks>();
   trackWriter(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
   auto tracks = trackBuilder.finalize();
 

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -37,13 +37,13 @@ BOOST_AUTO_TEST_CASE(TestJoinedTables)
   trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4);
   auto covs = trackParCovBuilder.finalize();
 
-  using Test = Join<Tracks, TracksCov>;
+  using Test = Join<StoredTracks, TracksCov>;
 
   Test tests{0, tracks, covs};
   BOOST_REQUIRE(tests.asArrowTable()->num_columns() != 0);
   BOOST_REQUIRE_EQUAL(tests.asArrowTable()->num_columns(),
                       tracks->num_columns() + covs->num_columns());
-  auto tests2 = join(Tracks{tracks}, TracksCov{covs});
+  auto tests2 = join(StoredTracks{tracks}, TracksCov{covs});
   static_assert(std::is_same_v<Test::table_t, decltype(tests2)>,
                 "Joined tables should have the same type, regardless how we construct them");
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -13,6 +13,8 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "../src/ExpressionHelpers.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AODReaderHelpers.h"
 #include <boost/test/unit_test.hpp>
 
 using namespace o2::framework;
@@ -23,12 +25,20 @@ namespace nodes
 static BindingNode pt{"pt", atype::FLOAT};
 static BindingNode phi{"phi", atype::FLOAT};
 static BindingNode eta{"eta", atype::FLOAT};
+
+static BindingNode tgl{"tgl", atype::FLOAT};
+static BindingNode signed1Pt{"signed1Pt", atype::FLOAT};
 } // namespace nodes
+
+namespace o2::aod::track
+{
+DECLARE_SOA_EXPRESSION_COLUMN(Pze, pz, float, "fPz", o2::aod::track::tgl*(1.f / o2::aod::track::signed1Pt));
+}
 
 BOOST_AUTO_TEST_CASE(TestTreeParsing)
 {
   expressions::Filter f = ((nodes::phi > 1) && (nodes::phi < 2)) && (nodes::eta < 1);
-  auto specs = createOperations(f);
+  auto specs = createOperations(std::move(f));
   BOOST_REQUIRE_EQUAL(specs[0].left, (DatumSpec{1u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(specs[0].right, (DatumSpec{2u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(specs[0].result, (DatumSpec{0u, atype::BOOL}));
@@ -50,7 +60,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(specs[4].result, (DatumSpec{3u, atype::BOOL}));
 
   expressions::Filter g = ((nodes::eta + 2.f) > 0.5) || ((nodes::phi - M_PI) < 3);
-  auto gspecs = createOperations(g);
+  auto gspecs = createOperations(std::move(g));
   BOOST_REQUIRE_EQUAL(gspecs[0].left, (DatumSpec{1u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(gspecs[0].right, (DatumSpec{2u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(gspecs[0].result, (DatumSpec{0u, atype::BOOL}));
@@ -72,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(gspecs[4].result, (DatumSpec{4u, atype::FLOAT}));
 
   expressions::Filter h = (nodes::phi == 0) || (nodes::phi == 3);
-  auto hspecs = createOperations(h);
+  auto hspecs = createOperations(std::move(h));
 
   BOOST_REQUIRE_EQUAL(hspecs[0].left, (DatumSpec{1u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(hspecs[0].right, (DatumSpec{2u, atype::BOOL}));
@@ -87,7 +97,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(hspecs[2].result, (DatumSpec{1u, atype::BOOL}));
 
   expressions::Filter u = nabs(nodes::eta) < 1.0 && nexp(nodes::phi + 2.0 * M_PI) > 3.0;
-  auto uspecs = createOperations(u);
+  auto uspecs = createOperations(std::move(u));
   BOOST_REQUIRE_EQUAL(uspecs[0].left, (DatumSpec{1u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(uspecs[0].right, (DatumSpec{2u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(uspecs[0].result, (DatumSpec{0u, atype::BOOL}));
@@ -111,4 +121,52 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(uspecs[5].left, (DatumSpec{std::string{"eta"}, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(uspecs[5].right, (DatumSpec{}));
   BOOST_REQUIRE_EQUAL(uspecs[5].result, (DatumSpec{5u, atype::FLOAT}));
+}
+
+BOOST_AUTO_TEST_CASE(TestGandivaTreeCreation)
+{
+  Projector pze = o2::aod::track::Pze::Projector();
+  auto pzspecs = createOperations(std::move(pze));
+  BOOST_REQUIRE_EQUAL(pzspecs[0].left, (DatumSpec{std::string{"fTgl"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[0].right, (DatumSpec{1u, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[0].result, (DatumSpec{0u, atype::FLOAT}));
+
+  BOOST_REQUIRE_EQUAL(pzspecs[1].left, (DatumSpec{LiteralNode::var_t{1.f}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[1].result, (DatumSpec{1u, atype::FLOAT}));
+  auto infield1 = o2::aod::track::Signed1Pt::asArrowField();
+  auto infield2 = o2::aod::track::Tgl::asArrowField();
+  auto resfield = o2::aod::track::Pze::asArrowField();
+  auto schema = std::make_shared<arrow::Schema>(std::vector{infield1, infield2, resfield});
+  auto gandiva_tree = createExpressionTree(pzspecs, schema);
+
+  auto gandiva_expression = makeExpression(gandiva_tree, resfield);
+  BOOST_CHECK_EQUAL(gandiva_expression->ToString(), "float multiply((float) fTgl, float divide((const float) 1 raw(3f800000), (float) fSigned1Pt))");
+  auto projector = createProjector(schema, pzspecs, resfield);
+
+  Projector pte = o2::aod::track::Pt2::Projector();
+  auto ptespecs = createOperations(std::move(pte));
+  BOOST_REQUIRE_EQUAL(ptespecs[0].left, (DatumSpec{1u, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[0].right, (DatumSpec{2u, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[0].result, (DatumSpec{0u, atype::FLOAT}));
+
+  BOOST_REQUIRE_EQUAL(ptespecs[1].left, (DatumSpec{LiteralNode::var_t{1.f}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[1].result, (DatumSpec{2u, atype::FLOAT}));
+
+  BOOST_REQUIRE_EQUAL(ptespecs[2].left, (DatumSpec{LiteralNode::var_t{1.f}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[2].right, (DatumSpec{std::string{"fSigned1Pt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[2].result, (DatumSpec{1u, atype::FLOAT}));
+
+  auto infield3 = o2::aod::track::Signed1Pt::asArrowField();
+  auto resfield2 = o2::aod::track::Pt2::asArrowField();
+  auto schema2 = std::make_shared<arrow::Schema>(std::vector{infield3, resfield2});
+  auto gandiva_tree2 = createExpressionTree(ptespecs, schema2);
+
+  auto gandiva_expression2 = makeExpression(gandiva_tree2, resfield2);
+  BOOST_CHECK_EQUAL(gandiva_expression2->ToString(), "float multiply(float divide((const float) 1 raw(3f800000), (float) fSigned1Pt), float divide((const float) 1 raw(3f800000), (float) fSigned1Pt))");
+
+  auto projector_b = createProjector(schema2, ptespecs, resfield2);
+  auto schema_p = o2::soa::createSchemaFromColumns(o2::aod::Tracks::persistent_columns_t{});
+  auto projector_alt = o2::framework::expressions::createProjectors(o2::framework::pack<o2::aod::track::Pt2>{}, schema_p);
 }

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -32,7 +32,7 @@ static BindingNode signed1Pt{"signed1Pt", atype::FLOAT};
 
 namespace o2::aod::track
 {
-DECLARE_SOA_EXPRESSION_COLUMN(Pze, pz, float, "fPz", o2::aod::track::tgl*(1.f / o2::aod::track::signed1Pt));
+DECLARE_SOA_EXPRESSION_COLUMN(Pze, pz, float, o2::aod::track::tgl*(1.f / o2::aod::track::signed1Pt));
 }
 
 BOOST_AUTO_TEST_CASE(TestTreeParsing)

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(TestWithSOATables)
 {
   using namespace o2;
   TableBuilder builder2;
-  auto tracksCursor = builder2.cursor<aod::Tracks>();
+  auto tracksCursor = builder2.cursor<aod::StoredTracks>();
   tracksCursor(0, 0, 2, 3, 4, 5, 6, 7, 8, 9);
   tracksCursor(0, 0, 2, 3, 4, 5, 6, 7, 8, 9);
   tracksCursor(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);


### PR DESCRIPTION
@ktf @jgrosseo thank you for patience.

This introduces an "expression column" defined by the same sort of expression used in filters. Such columns are added to a pre-existing soa::Table with a `DECLARE_SOA_EXTENDED_TABLE` macro, specifying the base table and the list of columns, declared with `DECLARE_SOA_EXPRESSION_COLUMN`. Extended tables have special origin 'DYN' to distinguish them from normal AOD tables and allow framework to spawn a device that would run the expressions to create new columns in memory and send the table further. 

I've added an example column "Pt2" (pt-squared) and extended the `Tracks` table with it, renaming the original table to `StoredTracks`. The change should be completely transparent for user tasks, requesting `Tracks` (see example in filters.cxx) and this column can be used in filters directly. 

WARNING: there is a caveat that I use my own translation between C types and arrow types, which is not extended for arrays - I'm working on it - so extending tables with array columns in them will lead to problems now.