### PR TITLE
GPU: Switch GPU code to RawDataHeaderV6

### DIFF
--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -27,6 +27,7 @@
 #include "GPUReconstructionConvert.h"
 #include "GPUHostDataTypes.h"
 #include "GPUParam.h"
+#include "GPURawData.h"
 
 #include "Framework/Logger.h"
 #include "DetectorsRaw/RawFileWriter.h"
@@ -227,7 +228,7 @@ int main(int argc, char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("sector"), "single file per: link,sector,all");
     add_option("stop-page,p", bpo::value<bool>()->default_value(false)->implicit_value(true), "HBF stop on separate CRU page");
     add_option("no-padding", bpo::value<bool>()->default_value(false)->implicit_value(true), "Don't pad pages to 8kb");
-    uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
+    uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include "GPUParam.h"
 #include "GPUReconstructionConvert.h"
+#include "GPURawData.h"
 #include "DetectorsRaw/RawFileWriter.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -150,7 +151,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
         const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
         o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
         writer.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)); // must be set explicitly
-        uint32_t rdhV = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
+        uint32_t rdhV = o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>();
         writer.useRDHVersion(rdhV);
         std::string outDir = "./";
         const unsigned int defaultLink = rdh_utils::UserLogicLinkID;

--- a/GPU/GPUTracking/Base/GPURawData.h
+++ b/GPU/GPUTracking/Base/GPURawData.h
@@ -39,15 +39,17 @@ namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
+typedef o2::header::RAWDataHeader RAWDataHeaderGPU;
+
 class GPURawDataUtils
 {
  public:
-  static GPUd() unsigned int getOrbit(const o2::header::RAWDataHeader* rdh);
-  static GPUd() unsigned int getBC(const o2::header::RAWDataHeader* rdh);
-  static GPUd() unsigned int getSize(const o2::header::RAWDataHeader* rdh);
+  static GPUd() unsigned int getOrbit(const RAWDataHeaderGPU* rdh);
+  static GPUd() unsigned int getBC(const RAWDataHeaderGPU* rdh);
+  static GPUd() unsigned int getSize(const RAWDataHeaderGPU* rdh);
 };
 
-GPUdi() unsigned int GPURawDataUtils::getOrbit(const o2::header::RAWDataHeader* rdh)
+GPUdi() unsigned int GPURawDataUtils::getOrbit(const RAWDataHeaderGPU* rdh)
 {
 #ifndef __OPENCL__
   return o2::raw::RDHUtils::getHeartBeatOrbit(*rdh);
@@ -56,16 +58,16 @@ GPUdi() unsigned int GPURawDataUtils::getOrbit(const o2::header::RAWDataHeader* 
 #endif
 }
 
-GPUdi() unsigned int GPURawDataUtils::getBC(const o2::header::RAWDataHeader* rdh)
+GPUdi() unsigned int GPURawDataUtils::getBC(const RAWDataHeaderGPU* rdh)
 {
 #ifndef __OPENCL__
   return o2::raw::RDHUtils::getHeartBeatBC(*rdh);
 #else
-  return ((rdh->words[4] >> 48) & 0xFFF); // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
+  return (rdh->words[2] & 0xFFF);         // TODO: Ad-hoc implementation for OpenCL, RDHV4, to be moved to RDHUtils
 #endif
 }
 
-GPUdi() unsigned int GPURawDataUtils::getSize(const o2::header::RAWDataHeader* rdh)
+GPUdi() unsigned int GPURawDataUtils::getSize(const RAWDataHeaderGPU* rdh)
 {
 #ifndef __OPENCL__
   return o2::raw::RDHUtils::getMemorySize(*rdh);

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -153,13 +153,13 @@ int GPUReconstructionConvert::GetMaxTimeBin(const GPUTrackingInOutZS& zspages)
 #ifdef HAVE_O2HEADERS
   float retVal = 0;
   for (unsigned int i = 0; i < NSLICES; i++) {
-    int firstHBF = zspages.slice[i].count[0] ? o2::raw::RDHUtils::getHeartBeatOrbit(*(const o2::header::RAWDataHeader*)zspages.slice[i].zsPtr[0][0]) : 0;
+    int firstHBF = zspages.slice[i].count[0] ? o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)zspages.slice[i].zsPtr[0][0]) : 0;
     for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
       for (unsigned int k = 0; k < zspages.slice[i].count[j]; k++) {
         const char* page = (const char*)zspages.slice[i].zsPtr[j][k];
         for (unsigned int l = 0; l < zspages.slice[i].nZSPtr[j][k]; l++) {
-          o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE);
-          TPCZSHDR* hdr = (TPCZSHDR*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE + sizeof(o2::header::RAWDataHeader));
+          RAWDataHeaderGPU* rdh = (RAWDataHeaderGPU*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE);
+          TPCZSHDR* hdr = (TPCZSHDR*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE + sizeof(RAWDataHeaderGPU));
           unsigned int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN + hdr->nTimeBins;
           if (timeBin > retVal) {
             retVal = timeBin;
@@ -194,12 +194,14 @@ void GPUReconstructionConvert::ZSstreamOut(unsigned short* bufIn, unsigned int& 
 }
 
 #ifdef HAVE_O2HEADERS
-void GPUReconstructionConvert::ZSfillEmpty(void* ptr, int shift)
+void GPUReconstructionConvert::ZSfillEmpty(void* ptr, int shift, unsigned int feeId)
 {
-  o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)ptr;
+  RAWDataHeaderGPU* rdh = (RAWDataHeaderGPU*)ptr;
   o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, 0);
   o2::raw::RDHUtils::setHeartBeatBC(*rdh, shift);
-  o2::raw::RDHUtils::setMemorySize(*rdh, sizeof(o2::header::RAWDataHeader));
+  o2::raw::RDHUtils::setMemorySize(*rdh, sizeof(RAWDataHeaderGPU));
+  o2::raw::RDHUtils::setVersion(*rdh, o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>());
+  o2::raw::RDHUtils::setFEEID(*rdh, feeId);
 }
 
 static inline auto ZSEncoderGetDigits(const GPUTrackingInOutDigits& in, int i) { return in.tpcDigits[i]; }
@@ -240,6 +242,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
     int rawlnk = rdh_utils::UserLogicLinkID;
     int bcShiftInFirstHBF = ir ? ir->bc : 0;
 #else
+    int rawlnk = 15;
     int bcShiftInFirstHBF = 0;
 #endif
     int rawcru = 0;
@@ -342,19 +345,21 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           }
         }
         if (page && (k >= tmpBuffer.size() || endpoint != lastEndpoint)) {
+          const rdh_utils::FEEIDType rawfeeid = rdh_utils::getFEEID(rawcru, rawendpoint, rawlnk);
 #ifdef GPUCA_O2_LIB
           if (raw) {
-            const rdh_utils::FEEIDType rawfeeid = rdh_utils::getFEEID(rawcru, rawendpoint, rawlnk);
             size_t size = (padding || lastEndpoint == -1) ? TPCZSHDR::TPC_ZS_PAGE_SIZE : (pagePtr - (unsigned char*)page);
             size = CAMath::nextMultipleOf<o2::raw::RDHUtils::GBTWord>(size);
-            raw->addData(rawfeeid, rawcru, rawlnk, rawendpoint, *ir + hbf * o2::constants::lhc::LHCMaxBunches, gsl::span<char>((char*)page + sizeof(o2::header::RAWDataHeader), (char*)page + size), true);
+            raw->addData(rawfeeid, rawcru, rawlnk, rawendpoint, *ir + hbf * o2::constants::lhc::LHCMaxBunches, gsl::span<char>((char*)page + sizeof(RAWDataHeaderGPU), (char*)page + size), true);
           } else
 #endif
           {
-            o2::header::RAWDataHeader* rdh = (o2::header::RAWDataHeader*)page;
+            RAWDataHeaderGPU* rdh = (RAWDataHeaderGPU*)page;
             o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, hbf);
             o2::raw::RDHUtils::setHeartBeatBC(*rdh, bcShiftInFirstHBF);
             o2::raw::RDHUtils::setMemorySize(*rdh, TPCZSHDR::TPC_ZS_PAGE_SIZE);
+            o2::raw::RDHUtils::setVersion(*rdh, o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>());
+            o2::raw::RDHUtils::setFEEID(*rdh, rawfeeid);
           }
         }
         if (k >= tmpBuffer.size()) {
@@ -368,7 +373,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           if (buffer[i][endpoint].size() == 0 && nexthbf != 0) {
             // Emplace empty page with RDH containing beginning of TFgpuDigitsMap
             buffer[i][endpoint].emplace_back();
-            ZSfillEmpty(&buffer[i][endpoint].back(), bcShiftInFirstHBF);
+            ZSfillEmpty(&buffer[i][endpoint].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + endpoint / 2, endpoint & 1, rawlnk));
             totalPages++;
           }
           buffer[i][endpoint].emplace_back();
@@ -377,7 +382,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         hbf = nexthbf;
         pagePtr = reinterpret_cast<unsigned char*>(page);
         std::fill(page->begin(), page->end(), 0);
-        pagePtr += sizeof(o2::header::RAWDataHeader);
+        pagePtr += sizeof(RAWDataHeaderGPU);
         hdr = reinterpret_cast<TPCZSHDR*>(pagePtr);
         pagePtr += sizeof(*hdr);
         hdr->version = zs12bit ? 2 : 1;
@@ -429,7 +434,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
       for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
         if (buffer[i][j].size() == 0) {
           buffer[i][j].emplace_back();
-          ZSfillEmpty(&buffer[i][j].back(), bcShiftInFirstHBF);
+          ZSfillEmpty(&buffer[i][j].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + j / 2, j & 1, rawlnk));
           totalPages++;
         }
       }
@@ -440,15 +445,15 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
       std::vector<o2::tpc::Digit> compareBuffer;
       compareBuffer.reserve(tmpBuffer.size());
       for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
-        unsigned int firstOrbit = o2::raw::RDHUtils::getHeartBeatOrbit(*(const o2::header::RAWDataHeader*)buffer[i][j].data());
+        unsigned int firstOrbit = o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)buffer[i][j].data());
         for (unsigned int k = 0; k < buffer[i][j].size(); k++) {
           page = &buffer[i][j][k];
           pagePtr = reinterpret_cast<unsigned char*>(page);
-          const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)pagePtr;
-          if (o2::raw::RDHUtils::getMemorySize(*rdh) == sizeof(o2::header::RAWDataHeader)) {
+          const RAWDataHeaderGPU* rdh = (const RAWDataHeaderGPU*)pagePtr;
+          if (o2::raw::RDHUtils::getMemorySize(*rdh) == sizeof(RAWDataHeaderGPU)) {
             continue;
           }
-          pagePtr += sizeof(o2::header::RAWDataHeader);
+          pagePtr += sizeof(RAWDataHeaderGPU);
           hdr = reinterpret_cast<TPCZSHDR*>(pagePtr);
           pagePtr += sizeof(*hdr);
           if (hdr->version != 1 && hdr->version != 2) {

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -60,7 +60,7 @@ class GPUReconstructionConvert
 
  private:
   static void ZSstreamOut(unsigned short* bufIn, unsigned int& lenIn, unsigned char* bufOut, unsigned int& lenOut, unsigned int nBits);
-  static void ZSfillEmpty(void* ptr, int shift);
+  static void ZSfillEmpty(void* ptr, int shift, unsigned int feeId);
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -41,7 +41,6 @@
 #ifdef HAVE_O2HEADERS
 #include "GPUTPCClusterStatistics.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
-#include "Headers/RAWDataHeader.h"
 #include "GPUHostDataTypes.h"
 #include "DataFormatsTPC/Digit.h"
 #include "TPCdEdxCalibrationSplines.h"

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -72,15 +72,15 @@ GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUShared
       CA_SHARED_CACHE_REF(&s.ZSPage[0], pageSrc, TPCZSHDR::TPC_ZS_PAGE_SIZE, unsigned int, pageCache);
       GPUbarrier();
       const unsigned char* page = (const unsigned char*)pageCache;
-      const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)page;
-      if (GPURawDataUtils::getSize(rdh) == sizeof(o2::header::RAWDataHeader)) {
+      const RAWDataHeaderGPU* rdh = (const RAWDataHeaderGPU*)page;
+      if (GPURawDataUtils::getSize(rdh) == sizeof(RAWDataHeaderGPU)) {
 #ifdef GPUCA_GPUCODE
         return;
 #else
         continue;
 #endif
       }
-      const unsigned char* pagePtr = page + sizeof(o2::header::RAWDataHeader);
+      const unsigned char* pagePtr = page + sizeof(RAWDataHeaderGPU);
       const TPCZSHDR* hdr = reinterpret_cast<const TPCZSHDR*>(pagePtr);
       pagePtr += sizeof(*hdr);
       const bool decode12bit = hdr->version == 2;


### PR DESCRIPTION
@shahor02 @wiechula @ironMann : This moves the GPU and TPC ZS code to RDH version 6. It is not backward-compatible, so all Raw files created with the o2-tpc-digits-to-rawzs tool will not be readable anymore. Should give a readable error though. This cannot be avoided without making the RDHAny gpu-compatible and doing the arbitration on the GPU during ZS decoding. I hope we are still in a situation where we can do such a change.