### PR TITLE
(O2-1203) [rANS] Coder Refactoring

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -155,6 +155,50 @@ struct Block {
     return alignSize((_ndict + _ndata) * sizeof(W));
   }
 
+  // store a dictionary in an empty block
+  void storeDict(int _ndict, const W* _dict)
+  {
+    if (nDict || nStored) {
+      throw std::runtime_error("trying to write in occupied block");
+    }
+    size_t sz = estimateSize(_ndict, 0);
+    assert(registry); // this method is valid only for flat version, which has a registry
+    assert(sz <= registry->getFreeSize());
+    assert((_ndict > 0) == (_dict != nullptr));
+    nDict = nStored = _ndict;
+    if (nDict) {
+      auto ptr = payload = reinterpret_cast<W*>(registry->getFreeBlockStart());
+      memcpy(ptr, _dict, _ndict * sizeof(W));
+      ptr += _ndict;
+    }
+  };
+
+  // store a dictionary to a block which can either be empty or contain a dict.
+  void storeData(int _ndata, const W* _data)
+  {
+    if (nStored > nDict) {
+      throw std::runtime_error("trying to write in occupied block");
+    }
+
+    size_t sz = estimateSize(0, _ndata);
+    assert(registry); // this method is valid only for flat version, which has a registry
+    assert(sz <= registry->getFreeSize());
+    assert((_ndata > 0) == (_data != nullptr));
+    nStored = nDict + _ndata;
+    if (_ndata) {
+      auto ptr = payload = reinterpret_cast<W*>(registry->getFreeBlockStart());
+      ptr += nDict;
+      memcpy(ptr, _data, _ndata * sizeof(W));
+    }
+  }
+
+  // resize block and free up unused buffer space.
+  void endBlock()
+  {
+    size_t sz = estimateSize(nStored, 0);
+    registry->shrinkFreeBlock(sz);
+  }
+
   /// store binary blob data (buffer filled from head to tail)
   void store(int _ndict, int _ndata, const W* _dict, const W* _data)
   {
@@ -186,7 +230,7 @@ struct Block {
   }
 
   ClassDefNV(Block, 1);
-};
+}; // namespace ctf
 
 ///<<======================== Auxiliary classes =======================<<
 
@@ -596,53 +640,79 @@ void EncodedBlocks<H, N, W>::encode(const S* const srcBegin, // begin of source 
                                     Metadata::OptStore opt,  // option for data compression
                                     VB* buffer)              // optional buffer (vector) providing memory for encoded blocks
 {
-
-  // symbol statistics and encoding
+  // fill a new block
   assert(slot == mRegistry.nFilledBlocks);
   mRegistry.nFilledBlocks++;
   using stream_t = typename o2::rans::Encoder64<S>::stream_t;
+
+  // cover three cases:
+  // * empty source message: no entropy coding
+  // * source message to pass through without any entropy coding
+  // * source message where entropy coding should be applied
+
+  // case 1: empty source message
   if (srcBegin == srcEnd) {
     mMetadata[slot] = Metadata{0, sizeof(uint64_t), sizeof(stream_t), probabilityBits, Metadata::OptStore::NODATA, 0, 0, 0, 0};
     return;
   }
-  std::vector<stream_t> encoderBuffer;
   static_assert(std::is_same<W, stream_t>());
-  const stream_t* dictStart = nullptr;
-  int dictSize = 0, dataSize = 0;
-  o2::rans::SymbolStatistics stats{srcBegin, srcEnd}; // need to create it, even if not used
-  if (opt == Metadata::OptStore::EENCODE) {
-    stats.rescaleToNBits(probabilityBits);
-    const auto buffSize = o2::rans::calculateMaxBufferSize(stats.getMessageLength(),
-                                                           stats.getAlphabetRangeBits(),
-                                                           sizeof(S));
-    encoderBuffer.resize(buffSize);
-    const o2::rans::Encoder64<S> encoder{stats, probabilityBits};
-    const auto encodedMessageEnd = encoder.process(encoderBuffer.begin(), encoderBuffer.end(), srcBegin, srcEnd);
-    dictStart = stats.getFrequencyTable().data();
-    dictSize = stats.getFrequencyTable().size();
-    dataSize = std::distance(encoderBuffer.begin(), encodedMessageEnd); // number of elements to store
-  } else {                                                              // store original data w/o EEncoding
-    auto szb = (srcEnd - srcBegin) * sizeof(S);
-    dataSize = szb / sizeof(stream_t) + (sizeof(S) < sizeof(stream_t));
-    encoderBuffer.resize(dataSize);
-    memcpy(encoderBuffer.data(), srcBegin, szb);
-  }
-  auto szNeed = estimateBlockSize(dictSize, dataSize); // size in bytes!!!
+  std::unique_ptr<rans::SymbolStatistics> stats = nullptr;
+
+  Metadata md;
   auto* bl = &mBlocks[slot];
   auto* meta = &mMetadata[slot];
-  if (szNeed >= getFreeSize()) {
-    LOG(INFO) << "Slot " << slot << ": free size: " << getFreeSize() << ", need " << szNeed;
-    if (buffer) {
-      expand(*buffer, size() + (szNeed - getFreeSize()));
-      meta = &(get(buffer->data())->mMetadata[slot]);
-      bl = &(get(buffer->data())->mBlocks[slot]); // in case of resizing this and any this.xxx becomes invalid
-    } else {
-      throw std::runtime_error("no room for encoded block in provided container");
+
+  // resize underlying buffer of block if necessary and update all pointers.
+  auto expandStorage = [&](int dictElems, int encodeBufferElems) {
+    auto szNeed = estimateBlockSize(dictElems, encodeBufferElems); // size in bytes!!!
+    if (szNeed >= getFreeSize()) {
+      LOG(INFO) << "Slot " << slot << ": free size: " << getFreeSize() << ", need " << szNeed;
+      if (buffer) {
+        expand(*buffer, size() + (szNeed - getFreeSize()));
+        meta = &(get(buffer->data())->mMetadata[slot]);
+        bl = &(get(buffer->data())->mBlocks[slot]); // in case of resizing this and any this.xxx becomes invalid
+      } else {
+        throw std::runtime_error("no room for encoded block in provided container");
+      }
     }
+  };
+
+  // case 3: message where entropy coding should be applied
+  if (opt == Metadata::OptStore::EENCODE) {
+    // build symbol statistics
+    stats = std::make_unique<rans::SymbolStatistics>(srcBegin, srcEnd);
+    stats->rescaleToNBits(probabilityBits);
+    const o2::rans::Encoder64<S> encoder{*stats, probabilityBits};
+    const int dictSize = stats->getFrequencyTable().size();
+
+    // estimate size of encode buffer
+    int dataSize = rans::calculateMaxBufferSize(stats->getMessageLength(),
+                                                stats->getAlphabetRangeBits(),
+                                                sizeof(S));
+    // preliminary expansion of storage based on dict size + estimated size of encode buffer
+    expandStorage(dictSize, dataSize);
+    //store dictionary first
+    bl->storeDict(dictSize, stats->getFrequencyTable().data());
+    // directly encode source message into block buffer.
+    const auto encodedMessageEnd = encoder.process(bl->getData(), bl->getData() + dataSize, srcBegin, srcEnd);
+    dataSize = encodedMessageEnd - bl->getData();
+    // update the size claimed by encode message directly inside the block
+    bl->nStored = bl->nDict + dataSize;
+    *meta = Metadata{stats->getMessageLength(), sizeof(uint64_t), sizeof(stream_t), probabilityBits, opt,
+                     stats->getMinSymbol(), stats->getMaxSymbol(), dictSize, dataSize};
+
+  } else { // store original data w/o EEncoding
+    const size_t messageLength = (srcEnd - srcBegin);
+    const size_t szb = messageLength * sizeof(S);
+    const int dataSize = szb / sizeof(stream_t) + (sizeof(S) < sizeof(stream_t));
+    // no dictionary needed
+    expandStorage(0, dataSize);
+    *meta = Metadata{messageLength, sizeof(uint64_t), sizeof(stream_t), probabilityBits, opt,
+                     0, 0, 0, dataSize};
+    bl->storeData(meta->nDataWords, reinterpret_cast<const W*>(srcBegin));
   }
-  *meta = Metadata{stats.getMessageLength(), sizeof(uint64_t), sizeof(stream_t), probabilityBits, opt,
-                   stats.getMinSymbol(), stats.getMaxSymbol(), dictSize, dataSize};
-  bl->store(dictSize, dataSize, dictStart, encoderBuffer.data());
+  // resize block if necessary
+  bl->endBlock();
 }
 
 } // namespace ctf

--- a/Utilities/rANS/include/rANS/Coder.h
+++ b/Utilities/rANS/include/rANS/Coder.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include <cstdint>
 #include <cassert>
+#include <type_traits>
 
 #include "DecoderSymbol.h"
 #include "EncoderSymbol.h"
@@ -28,11 +29,6 @@ namespace o2
 {
 namespace rans
 {
-
-// State for a rANS encoder. Yep, that's all there is to it.
-template <typename T>
-using State = T;
-
 __extension__ typedef unsigned __int128 uint128;
 
 // READ ME FIRST:
@@ -63,24 +59,21 @@ __extension__ typedef unsigned __int128 uint128;
 //    argument instead of just storing it in some context struct.
 
 // --------------------------------------------------------------------------
-template <typename Coder_t, typename Stream_t>
+template <typename State_T, typename Stream_T>
 class Coder
 {
   // the Coder works either with a 64Bit state and 32 bit streaming or
   //a 32 Bit state and 8 Bit streaming We need to make sure it gets initialized with
   //the right template arguments at compile time.
-  static_assert((sizeof(Coder_t) == sizeof(uint32_t) && sizeof(Stream_t) == sizeof(uint8_t)) ||
-                  (sizeof(Coder_t) == sizeof(uint64_t) && sizeof(Stream_t) == sizeof(uint32_t)),
+  static_assert((sizeof(State_T) == sizeof(uint32_t) && sizeof(Stream_T) == sizeof(uint8_t)) ||
+                  (sizeof(State_T) == sizeof(uint64_t) && sizeof(Stream_T) == sizeof(uint32_t)),
                 "Coder can either be 32Bit with 8 Bit stream type or 64 Bit Type with 32 Bit stream type");
 
  public:
-  Coder() = delete;
+  Coder();
 
-  // Initialize a rANS encoder.
-  static void encInit(State<Coder_t>* r)
-  {
-    *r = LOWER_BOUND;
-  };
+  // Initializes the encoder
+  void encInit();
 
   // Encodes a single symbol with range start "start" and frequency "freq".
   // All frequencies are assumed to sum to "1 << scale_bits", and the
@@ -89,184 +82,293 @@ class Coder
   // NOTE: With rANS, you need to encode symbols in *reverse order*, i.e. from
   // beginning to end! Likewise, the output bytestream is written *backwards*:
   // ptr starts pointing at the end of the output buffer and keeps decrementing.
-  static void encPut(State<Coder_t>* r, Stream_t** pptr, uint32_t start, uint32_t freq, uint32_t scale_bits)
-  {
-    // renormalize
-    State<Coder_t> x = encRenorm(*r, pptr, freq, scale_bits);
-
-    // x = C(s,x)
-    *r = ((x / freq) << scale_bits) + (x % freq) + start;
-  };
+  template <typename Stream_IT>
+  Stream_IT encPut(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits);
 
   // Flushes the rANS encoder.
-  static void encFlush(State<Coder_t>* r, Stream_t** pptr)
-  {
-    Coder_t x = *r;
-    Stream_t* ptr = *pptr;
-
-    if constexpr (needs64Bit<Coder_t>()) {
-      ptr -= 2;
-      ptr[0] = static_cast<Stream_t>(x >> 0);
-      ptr[1] = static_cast<Stream_t>(x >> 32);
-    } else {
-      ptr -= 4;
-      ptr[0] = static_cast<Stream_t>(x >> 0);
-      ptr[1] = static_cast<Stream_t>(x >> 8);
-      ptr[2] = static_cast<Stream_t>(x >> 16);
-      ptr[3] = static_cast<Stream_t>(x >> 24);
-    }
-
-    *pptr = ptr;
-  };
+  template <typename Stream_IT>
+  Stream_IT encFlush(Stream_IT iter);
 
   // Initializes a rANS decoder.
   // Unlike the encoder, the decoder works forwards as you'd expect.
-  static void decInit(State<Coder_t>* r, const Stream_t** pptr)
-  {
-    Coder_t x;
-    const Stream_t* ptr = *pptr;
-
-    if constexpr (needs64Bit<Coder_t>()) {
-      x = static_cast<Coder_t>(ptr[0]) << 0;
-      x |= static_cast<Coder_t>(ptr[1]) << 32;
-      ptr += 2;
-    } else {
-      x = ptr[0] << 0;
-      x |= ptr[1] << 8;
-      x |= ptr[2] << 16;
-      x |= ptr[3] << 24;
-      ptr += 4;
-    }
-
-    *pptr = ptr;
-    *r = x;
-  };
+  template <typename Stream_IT>
+  Stream_IT decInit(Stream_IT iter);
 
   // Returns the current cumulative frequency (map it to a symbol yourself!)
-  static uint32_t decGet(State<Coder_t>* r, uint32_t scale_bits)
-  {
-    return *r & ((1u << scale_bits) - 1);
-  };
+  uint32_t decGet(uint32_t scale_bits);
 
   // Advances in the bit stream by "popping" a single symbol with range start
   // "start" and frequency "freq". All frequencies are assumed to sum to "1 << scale_bits",
   // and the resulting bytes get written to ptr (which is updated).
-  static void decAdvance(State<Coder_t>* r, const Stream_t** pptr, uint32_t start, uint32_t freq, uint32_t scale_bits)
-  {
-    Coder_t mask = (1ull << scale_bits) - 1;
-
-    // s, x = D(x)
-    Coder_t x = *r;
-    x = freq * (x >> scale_bits) + (x & mask) - start;
-
-    // renormalize
-    decRenorm(&x, pptr);
-
-    *r = x;
-  };
+  template <typename Stream_IT>
+  Stream_IT decAdvance(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits);
 
   // Encodes a given symbol. This is faster than straight RansEnc since we can do
   // multiplications instead of a divide.
   //
   // See Rans32EncSymbolInit for a description of how this works.
-  static void encPutSymbol(State<Coder_t>* r, Stream_t** pptr, EncoderSymbol<Coder_t> const* sym, uint32_t scale_bits)
-  {
-    assert(sym->freq != 0); // can't encode symbol with freq=0
-
-    // renormalize
-    Coder_t x = encRenorm(*r, pptr, sym->freq, scale_bits);
-
-    // x = C(s,x)
-    Coder_t q;
-
-    if constexpr (needs64Bit<Coder_t>()) {
-      // This code needs support for 64-bit long multiplies with 128-bit result
-      // (or more precisely, the top 64 bits of a 128-bit result).
-      q = static_cast<Coder_t>((static_cast<uint128>(x) * sym->rcp_freq) >> 64);
-    } else {
-      q = static_cast<Coder_t>((static_cast<uint64_t>(x) * sym->rcp_freq) >> 32);
-    }
-    q = q >> sym->rcp_shift;
-
-    *r = x + sym->bias + q * sym->cmpl_freq;
-  };
+  template <typename Stream_IT>
+  Stream_IT encPutSymbol(Stream_IT iter, const EncoderSymbol<State_T>& sym, uint32_t scale_bits);
 
   // Equivalent to Rans32DecAdvance that takes a symbol.
-  static void decAdvanceSymbol(State<Coder_t>* r, const Stream_t** pptr, DecoderSymbol const* sym, uint32_t scale_bits)
-  {
-    decAdvance(r, pptr, sym->start, sym->freq, scale_bits);
-  };
+  template <typename Stream_IT>
+  Stream_IT decAdvanceSymbol(Stream_IT iter, const DecoderSymbol& sym, uint32_t scale_bits);
 
   // Advances in the bit stream by "popping" a single symbol with range start
   // "start" and frequency "freq". All frequencies are assumed to sum to "1 << scale_bits".
   // No renormalization or output happens.
-  static void decAdvanceStep(State<Coder_t>* r, uint32_t start, uint32_t freq, uint32_t scale_bits)
-  {
-    Coder_t mask = (1u << scale_bits) - 1;
-
-    // s, x = D(x)
-    Coder_t x = *r;
-    *r = freq * (x >> scale_bits) + (x & mask) - start;
-  };
+  void decAdvanceStep(uint32_t start, uint32_t freq, uint32_t scale_bits);
 
   // Equivalent to Rans32DecAdvanceStep that takes a symbol.
-  static void decAdvanceSymbolStep(State<Coder_t>* r, DecoderSymbol const* sym, uint32_t scale_bits)
-  {
-    decAdvanceStep(r, sym->start, sym->freq, scale_bits);
-  };
+  void decAdvanceSymbolStep(const DecoderSymbol& sym, uint32_t scale_bits);
 
   // Renormalize.
-  static inline void decRenorm(State<Coder_t>* r, const Stream_t** pptr)
-  {
-    // renormalize
-    Coder_t x = *r;
-    if (x < LOWER_BOUND) {
-      if constexpr (needs64Bit<Coder_t>()) {
-        x = (x << STREAM_BITS) | **pptr;
-        *pptr += 1;
-        assert(x >= LOWER_BOUND);
-      } else {
-        const Stream_t* ptr = *pptr;
-        do
-          x = (x << STREAM_BITS) | *ptr++;
-        while (x < LOWER_BOUND);
-        *pptr = ptr;
-      }
-    }
-    *r = x;
-  }
+  template <typename Stream_IT>
+  Stream_IT decRenorm(Stream_IT iter);
 
  private:
+  State_T mState;
+
   // Renormalize the encoder.
-  static inline State<Coder_t> encRenorm(State<Coder_t> x, Stream_t** pptr, uint32_t freq, uint32_t scale_bits)
-  {
-    Coder_t x_max = ((LOWER_BOUND >> scale_bits) << STREAM_BITS) * freq; // this turns into a shift.
-    if (x >= x_max) {
-      if constexpr (needs64Bit<Coder_t>()) {
-        *pptr -= 1;
-        **pptr = static_cast<Stream_t>(x);
-        x >>= STREAM_BITS;
-        assert(x < x_max);
-      } else {
-        Stream_t* ptr = *pptr;
-        do {
-          *--ptr = static_cast<Stream_t>(x & 0xff);
-          x >>= STREAM_BITS;
-        } while (x >= x_max);
-        *pptr = ptr;
-      }
-    }
-    return x;
-  };
+  template <typename Stream_IT>
+  std::tuple<State_T, Stream_IT> encRenorm(State_T x, Stream_IT iter, uint32_t freq, uint32_t scale_bits);
+
+  // Renormalize.
+  template <typename Stream_IT>
+  std::tuple<State_T, Stream_IT> decRenorm(State_T x, Stream_IT iter);
 
   // L ('l' in the paper) is the lower bound of our normalization interval.
   // Between this and our byte-aligned emission, we use 31 (not 32!) bits.
   // This is done intentionally because exact reciprocals for 31-bit uints
   // fit in 32-bit uints: this permits some optimizations during encoding.
-  inline static constexpr Coder_t LOWER_BOUND = needs64Bit<Coder_t>() ? (1u << 31) : (1u << 23); // lower bound of our normalization interval
+  inline static constexpr State_T LOWER_BOUND = needs64Bit<State_T>() ? (1u << 31) : (1u << 23); // lower bound of our normalization interval
 
-  inline static constexpr Coder_t STREAM_BITS = sizeof(Stream_t) * 8; // lower bound of our normalization interval
+  inline static constexpr State_T STREAM_BITS = sizeof(Stream_T) * 8; // lower bound of our normalization interval
 };
+
+template <typename State_T, typename Stream_T>
+Coder<State_T, Stream_T>::Coder() : mState(){};
+
+template <typename State_T, typename Stream_T>
+void Coder<State_T, Stream_T>::encInit()
+{
+  mState = LOWER_BOUND;
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::encPut(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+  // renormalize
+  Stream_IT streamPos;
+  State_T x;
+  std::tie(x, streamPos) = encRenorm(mState, iter, freq, scale_bits);
+
+  // x = C(s,x)
+  mState = ((x / freq) << scale_bits) + (x % freq) + start;
+  return streamPos;
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::encFlush(Stream_IT iter)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  Stream_IT streamPos = iter;
+
+  if constexpr (needs64Bit<State_T>()) {
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 32);
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 0);
+    assert(std::distance(streamPos, iter) == 2);
+  } else {
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 24);
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 16);
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 8);
+    --streamPos;
+    *streamPos = static_cast<Stream_T>(mState >> 0);
+    assert(std::distance(streamPos, iter) == 4);
+  }
+
+  mState = 0;
+  return streamPos;
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::decInit(Stream_IT iter)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  State_T x = 0;
+  Stream_IT streamPos = iter;
+
+  if constexpr (needs64Bit<State_T>()) {
+    x = static_cast<State_T>(*streamPos) << 0;
+    ++streamPos;
+    x |= static_cast<State_T>(*streamPos) << 32;
+    ++streamPos;
+  } else {
+    x = static_cast<State_T>(*streamPos) << 0;
+    ++streamPos;
+    x |= static_cast<State_T>(*streamPos) << 8;
+    ++streamPos;
+    x |= static_cast<State_T>(*streamPos) << 16;
+    ++streamPos;
+    x |= static_cast<State_T>(*streamPos) << 24;
+    ++streamPos;
+  }
+
+  mState = x;
+  return streamPos;
+};
+
+template <typename State_T, typename Stream_T>
+uint32_t Coder<State_T, Stream_T>::decGet(uint32_t scale_bits)
+{
+  return mState & ((1u << scale_bits) - 1);
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::decAdvance(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  State_T mask = (1ull << scale_bits) - 1;
+
+  // s, x = D(x)
+  State_T x = mState;
+  x = freq * (x >> scale_bits) + (x & mask) - start;
+
+  // renormalize
+  Stream_IT streamPos;
+  std::tie(mState, streamPos) = this->decRenorm(x, iter);
+  return streamPos;
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::encPutSymbol(Stream_IT iter, const EncoderSymbol<State_T>& sym, uint32_t scale_bits)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  assert(sym.freq != 0); // can't encode symbol with freq=0
+
+  // renormalize
+  Stream_IT streamPos;
+  State_T x;
+  std::tie(x, streamPos) = encRenorm(mState, iter, sym.freq, scale_bits);
+
+  // x = C(s,x)
+  State_T q;
+
+  if constexpr (needs64Bit<State_T>()) {
+    // This code needs support for 64-bit long multiplies with 128-bit result
+    // (or more precisely, the top 64 bits of a 128-bit result).
+    q = static_cast<State_T>((static_cast<uint128>(x) * sym.rcp_freq) >> 64);
+  } else {
+    q = static_cast<State_T>((static_cast<uint64_t>(x) * sym.rcp_freq) >> 32);
+  }
+  q = q >> sym.rcp_shift;
+
+  mState = x + sym.bias + q * sym.cmpl_freq;
+  return streamPos;
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::decAdvanceSymbol(Stream_IT iter, const DecoderSymbol& sym, uint32_t scale_bits)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  return decAdvance(iter, sym.start, sym.freq, scale_bits);
+};
+
+template <typename State_T, typename Stream_T>
+void Coder<State_T, Stream_T>::decAdvanceStep(uint32_t start, uint32_t freq, uint32_t scale_bits)
+{
+  State_T mask = (1u << scale_bits) - 1;
+
+  // s, x = D(x)
+  State_T x = mState;
+  mState = freq * (x >> scale_bits) + (x & mask) - start;
+};
+
+template <typename State_T, typename Stream_T>
+void Coder<State_T, Stream_T>::decAdvanceSymbolStep(const DecoderSymbol& sym, uint32_t scale_bits)
+{
+  decAdvanceStep(sym.start, sym.freq, scale_bits);
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+Stream_IT Coder<State_T, Stream_T>::decRenorm(Stream_IT iter)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  Stream_IT streamPos;
+  std::tie(mState, streamPos) = this->decRenorm(mState, iter);
+  return streamPos;
+}
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+inline std::tuple<State_T, Stream_IT> Coder<State_T, Stream_T>::encRenorm(State_T x, Stream_IT iter, uint32_t freq, uint32_t scale_bits)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  Stream_IT streamPos = iter;
+
+  State_T x_max = ((LOWER_BOUND >> scale_bits) << STREAM_BITS) * freq; // this turns into a shift.
+  if (x >= x_max) {
+    if constexpr (needs64Bit<State_T>()) {
+      --streamPos;
+      *streamPos = static_cast<Stream_T>(x);
+      x >>= STREAM_BITS;
+      assert(x < x_max);
+    } else {
+      do {
+        --streamPos;
+        *streamPos = static_cast<Stream_T>(x & 0xff);
+        x >>= STREAM_BITS;
+      } while (x >= x_max);
+    }
+  }
+  return std::make_tuple(x, streamPos);
+};
+
+template <typename State_T, typename Stream_T>
+template <typename Stream_IT>
+inline std::tuple<State_T, Stream_IT> Coder<State_T, Stream_T>::decRenorm(State_T x, Stream_IT iter)
+{
+  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
+
+  Stream_IT streamPos = iter;
+
+  // renormalize
+  if (x < LOWER_BOUND) {
+    if constexpr (needs64Bit<State_T>()) {
+      x = (x << STREAM_BITS) | *streamPos;
+      streamPos++;
+      assert(x >= LOWER_BOUND);
+    } else {
+
+      do {
+        x = (x << STREAM_BITS) | *streamPos;
+        streamPos++;
+      } while (x < LOWER_BOUND);
+    }
+  }
+  return std::make_tuple(x, streamPos);
+}
+
 } // namespace rans
 } // namespace o2
 

--- a/Utilities/rANS/include/rANS/Coder.h
+++ b/Utilities/rANS/include/rANS/Coder.h
@@ -179,21 +179,21 @@ Stream_IT Coder<State_T, Stream_T>::encFlush(Stream_IT iter)
   Stream_IT streamPos = iter;
 
   if constexpr (needs64Bit<State_T>()) {
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 32);
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 0);
-    assert(std::distance(streamPos, iter) == 2);
+    assert(std::distance(iter, streamPos) == 2);
   } else {
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 24);
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 16);
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 8);
-    --streamPos;
+    ++streamPos;
     *streamPos = static_cast<Stream_T>(mState >> 0);
-    assert(std::distance(streamPos, iter) == 4);
+    assert(std::distance(iter, streamPos) == 4);
   }
 
   mState = 0;
@@ -211,18 +211,20 @@ Stream_IT Coder<State_T, Stream_T>::decInit(Stream_IT iter)
 
   if constexpr (needs64Bit<State_T>()) {
     x = static_cast<State_T>(*streamPos) << 0;
-    ++streamPos;
+    --streamPos;
     x |= static_cast<State_T>(*streamPos) << 32;
-    ++streamPos;
+    --streamPos;
+    assert(std::distance(streamPos, iter) == 2);
   } else {
     x = static_cast<State_T>(*streamPos) << 0;
-    ++streamPos;
+    --streamPos;
     x |= static_cast<State_T>(*streamPos) << 8;
-    ++streamPos;
+    --streamPos;
     x |= static_cast<State_T>(*streamPos) << 16;
-    ++streamPos;
+    --streamPos;
     x |= static_cast<State_T>(*streamPos) << 24;
-    ++streamPos;
+    --streamPos;
+    assert(std::distance(streamPos, iter) == 4);
   }
 
   mState = x;
@@ -329,13 +331,13 @@ inline std::tuple<State_T, Stream_IT> Coder<State_T, Stream_T>::encRenorm(State_
   State_T x_max = ((LOWER_BOUND >> scale_bits) << STREAM_BITS) * freq; // this turns into a shift.
   if (x >= x_max) {
     if constexpr (needs64Bit<State_T>()) {
-      --streamPos;
+      ++streamPos;
       *streamPos = static_cast<Stream_T>(x);
       x >>= STREAM_BITS;
       assert(x < x_max);
     } else {
       do {
-        --streamPos;
+        ++streamPos;
         *streamPos = static_cast<Stream_T>(x & 0xff);
         x >>= STREAM_BITS;
       } while (x >= x_max);
@@ -356,13 +358,13 @@ inline std::tuple<State_T, Stream_IT> Coder<State_T, Stream_T>::decRenorm(State_
   if (x < LOWER_BOUND) {
     if constexpr (needs64Bit<State_T>()) {
       x = (x << STREAM_BITS) | *streamPos;
-      streamPos++;
+      --streamPos;
       assert(x >= LOWER_BOUND);
     } else {
 
       do {
         x = (x << STREAM_BITS) | *streamPos;
-        streamPos++;
+        --streamPos;
       } while (x < LOWER_BOUND);
     }
   }

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -106,37 +106,32 @@ void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, 
     return;
   }
 
-  State<coder_T> rans0, rans1;
-  const stream_T* ptr = &(*inputBegin);
+  ransDecoder rans0, rans1;
+  stream_IT inputIter = inputBegin;
   source_IT it = outputBegin;
 
-  assert(ptr != nullptr);
-
-  ransDecoder::decInit(&rans0, &ptr);
-  ransDecoder::decInit(&rans1, &ptr);
+  inputIter = rans0.decInit(inputIter);
+  inputIter = rans1.decInit(inputIter);
 
   for (size_t i = 0; i < (numSymbols & ~1); i += 2) {
     const stream_T s0 =
-      (*mReverseLUT)[ransDecoder::decGet(&rans0, mProbabilityBits)];
+      (*mReverseLUT)[rans0.decGet(mProbabilityBits)];
     const stream_T s1 =
-      (*mReverseLUT)[ransDecoder::decGet(&rans1, mProbabilityBits)];
+      (*mReverseLUT)[rans1.decGet(mProbabilityBits)];
     *it++ = s0;
     *it++ = s1;
-    ransDecoder::decAdvanceSymbolStep(&rans0, &(*mSymbolTable)[s0],
-                                      mProbabilityBits);
-    ransDecoder::decAdvanceSymbolStep(&rans1, &(*mSymbolTable)[s1],
-                                      mProbabilityBits);
-    ransDecoder::decRenorm(&rans0, &ptr);
-    ransDecoder::decRenorm(&rans1, &ptr);
+    rans0.decAdvanceSymbolStep((*mSymbolTable)[s0], mProbabilityBits);
+    rans1.decAdvanceSymbolStep((*mSymbolTable)[s1], mProbabilityBits);
+    inputIter = rans0.decRenorm(inputIter);
+    inputIter = rans1.decRenorm(inputIter);
   }
 
   // last byte, if number of bytes was odd
   if (numSymbols & 1) {
     const stream_T s0 =
-      (*mReverseLUT)[ransDecoder::decGet(&rans0, mProbabilityBits)];
+      (*mReverseLUT)[rans0.decGet(mProbabilityBits)];
     *it = s0;
-    ransDecoder::decAdvanceSymbol(&rans0, &ptr, &(*mSymbolTable)[s0],
-                                  mProbabilityBits);
+    inputIter = rans0.decAdvanceSymbol(inputIter, (*mSymbolTable)[s0], mProbabilityBits);
   }
   t.stop();
   LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -49,7 +49,7 @@ class Decoder
   Decoder(const SymbolStatistics& stats, size_t probabilityBits);
 
   template <typename stream_IT, typename source_IT>
-  void process(const source_IT outputBegin, const stream_IT inputBegin, size_t numSymbols) const;
+  void process(const source_IT outputBegin, const stream_IT inputEnd, size_t numSymbols) const;
 
   using coder_t = coder_T;
   using stream_t = stream_T;
@@ -93,7 +93,7 @@ Decoder<coder_T, stream_T, source_T>::Decoder(const SymbolStatistics& stats, siz
 
 template <typename coder_T, typename stream_T, typename source_T>
 template <typename stream_IT, typename source_IT>
-void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputBegin, size_t numSymbols) const
+void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputEnd, size_t numSymbols) const
 {
   LOG(trace) << "start decoding";
   RANSTimer t;
@@ -107,8 +107,11 @@ void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, 
   }
 
   ransDecoder rans0, rans1;
-  stream_IT inputIter = inputBegin;
+  stream_IT inputIter = inputEnd;
   source_IT it = outputBegin;
+
+  // make Iter point to the last last element
+  --inputIter;
 
   inputIter = rans0.decInit(inputIter);
   inputIter = rans1.decInit(inputIter);

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -120,44 +120,39 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
     throw std::runtime_error(errorMessage);
   }
 
-  State<coder_T> rans0, rans1;
-  ransCoder::encInit(&rans0);
-  ransCoder::encInit(&rans1);
+  ransCoder rans0, rans1;
+  rans0.encInit();
+  rans1.encInit();
 
-  stream_T* ptr = &(*outputEnd);
+  stream_IT outputIter = outputEnd;
   source_IT inputIT = inputEnd;
-
-  assert(ptr != nullptr);
 
   const auto inputBufferSize = std::distance(inputBegin, inputEnd);
 
   // odd number of bytes?
   if (inputBufferSize & 1) {
     const coder_T s = *(--inputIT);
-    ransCoder::encPutSymbol(&rans0, &ptr, &(*mSymbolTable)[s],
-                            mProbabilityBits);
-    assert(&(*outputBegin) < ptr);
+    outputIter = rans0.encPutSymbol(outputIter, (*mSymbolTable)[s], mProbabilityBits);
+    assert(outputBegin < outputIter);
   }
 
   while (inputIT > inputBegin) { // NB: working in reverse!
     const coder_T s1 = *(--inputIT);
     const coder_T s0 = *(--inputIT);
-    ransCoder::encPutSymbol(&rans1, &ptr, &(*mSymbolTable)[s1],
-                            mProbabilityBits);
-    ransCoder::encPutSymbol(&rans0, &ptr, &(*mSymbolTable)[s0],
-                            mProbabilityBits);
-    assert(&(*outputBegin) < ptr);
+    outputIter = rans1.encPutSymbol(outputIter, (*mSymbolTable)[s1], mProbabilityBits);
+    outputIter = rans0.encPutSymbol(outputIter, (*mSymbolTable)[s0], mProbabilityBits);
+    assert(outputBegin < outputIter);
   }
-  ransCoder::encFlush(&rans1, &ptr);
-  ransCoder::encFlush(&rans0, &ptr);
+  outputIter = rans1.encFlush(outputIter);
+  outputIter = rans0.encFlush(outputIter);
 
-  assert(&(*outputBegin) < ptr);
+  assert(outputBegin < outputIter);
 
   // deal with overflow
-  if (ptr < &(*outputBegin)) {
+  if (outputIter < outputBegin) {
     const std::string exceptionText = [&]() {
       std::stringstream ss;
-      ss << __func__ << " detected overflow in encode buffer: allocated:" << std::distance(inputBegin, inputEnd) << ", used:" << std::distance(ptr, &(*outputEnd));
+      ss << __func__ << " detected overflow in encode buffer: allocated:" << std::distance(inputBegin, inputEnd) << ", used:" << std::distance(outputIter, outputEnd);
       return ss.str();
     }();
 
@@ -176,12 +171,12 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(
               << "coderTypeB: " << sizeof(coder_T) << ", "
               << "probabilityBits: " << mProbabilityBits << ", "
               << "inputBufferSizeB: " << inputBufferSize * sizeof(source_T) << ", "
-              << "outputBufferSizeB: " << std::distance(ptr, &(*outputEnd)) * sizeof(stream_T) << "}";
+              << "outputBufferSizeB: " << std::distance(outputIter, outputEnd) * sizeof(stream_T) << "}";
 #endif
 
   LOG(trace) << "done encoding";
 
-  return outputBegin + std::distance(&(*outputBegin), ptr);
+  return outputBegin + std::distance(outputBegin, outputIter);
 };
 
 } // namespace rans

--- a/Utilities/rANS/include/rANS/SymbolTable.h
+++ b/Utilities/rANS/include/rANS/SymbolTable.h
@@ -17,6 +17,7 @@
 #define RANS_SYMBOLTABLE_H
 
 #include <vector>
+#include <cstdint>
 
 #include <fairlogger/Logger.h>
 


### PR DESCRIPTION
Refactors the rANS Coder class used by encoder decoder:

* Coder is now stateful i.e. it keeps the rANS state internally to simplify code and declutter interface
* Coder methods refactored to be compliant with std::iterator_traits.
* Coder/Encoder writes output to encode buffer from the beginning of the buffer (instead of the end) to simplify handling of the encode buffer. The return value is an iterator to the first element past the encoded message (stl complient).  
* The decoder starts from the end of the stream (i.e. iterator to first element past the message) and decodes the message.
* adapt common detector entropy coding interfaces in EncodedBlocks.
