### PR TITLE
GPU: Add double-pipeline mode to hide latencies of input / output

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <string>
 #include <memory>
-#include <fstream>
+#include <iosfwd>
 #include <vector>
 #include <unordered_map>
 
@@ -48,6 +48,7 @@ namespace gpu
 {
 class GPUChain;
 class GPUMemorySizeScalers;
+struct GPUReconstructionPipelineContext;
 
 class GPUReconstruction
 {
@@ -179,6 +180,8 @@ class GPUReconstruction
   virtual void startGPUProfiling() {}
   virtual void endGPUProfiling() {}
   int CheckErrorCodes();
+  void RunPipelineWorker();
+  void TerminatePipelineWorker();
 
   // Helpers for memory allocation
   GPUMemoryResource& Res(short num) { return mMemoryResources[num]; }
@@ -258,6 +261,8 @@ class GPUReconstruction
   virtual int ExitDevice() = 0;
   virtual size_t WriteToConstantMemory(size_t offset, const void* src, size_t size, int stream = -1, deviceEvent* ev = nullptr) = 0;
   void UpdateMaxMemoryUsed();
+  int EnqueuePipeline(bool terminate = false);
+  GPUChain* GetNextChainInQueue();
 
   // Management for GPU thread contexts
   class GPUThreadContext
@@ -364,6 +369,8 @@ class GPUReconstruction
   };
   std::unordered_map<GPUMemoryReuse::ID, MemoryReuseMeta> mMemoryReuse1to1;
   std::vector<std::pair<void*, void*>> mNonPersistentMemoryStack;
+
+  std::unique_ptr<GPUReconstructionPipelineContext> mPipelineContext;
 
   // Helpers for loading device library via dlopen
   class LibraryLoader

--- a/GPU/GPUTracking/Base/GPUSettings.cxx
+++ b/GPU/GPUTracking/Base/GPUSettings.cxx
@@ -105,10 +105,11 @@ void GPUSettingsDeviceProcessing::SetDefaults()
   mergerSortTracks = -1;
   runMC = false;
   memoryScalingFactor = 1.f;
-  disableMemoryReuse = true;
+  disableMemoryReuse = false;
   fullMergerOnGPU = true;
   alternateBorderSort = -1;
   delayedOutput = true;
   tpccfGatherKernel = true;
   prefetchTPCpageScan = false;
+  doublePipeline = false;
 }

--- a/GPU/GPUTracking/Base/GPUSettings.h
+++ b/GPU/GPUTracking/Base/GPUSettings.h
@@ -172,6 +172,7 @@ struct GPUSettingsDeviceProcessing {
   bool delayedOutput;                 // Delay output to be parallel to track fit
   bool tpccfGatherKernel;             // Use a kernel instead of the DMA engine to gather the clusters
   bool prefetchTPCpageScan;           // Prefetch headers during TPC page scan
+  bool doublePipeline;                // Use a double-pipeline driven by 2 threads
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -47,6 +47,7 @@ class GPUChain
   virtual void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) = 0;
   virtual void PrintMemoryStatistics(){};
   virtual int CheckErrorCodes() { return 0; }
+  virtual bool SupportsDoublePipeline() { return false; }
 
   constexpr static int NSLICES = GPUReconstruction::NSLICES;
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -74,6 +74,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   int RunChain() override;
   void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) override;
   int CheckErrorCodes() override;
+  bool SupportsDoublePipeline() override { return true; }
   void ClearErrorCodes();
 
   // Structures for input and output data
@@ -239,7 +240,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   unsigned int mTPCMaxTimeBin = 0;
 
   // Debug
-  std::ofstream mDebugFile;
+  std::unique_ptr<std::ofstream> mDebugFile;
 
   // Synchronization and Locks
   eventStruct* mEvents = nullptr;

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -99,6 +99,7 @@ AddOption(recoStepsGPU, int, -1, "recoStepsGPU", 0, "Bitmask for RecoSteps")
 AddOption(tpcCompressionGatherMode, int, -1, "tpcCompressionGatherMode", 0, "TPC Compressed Clusters Gather Mode")
 AddOption(runMC, bool, false, "runMC", 0, "Process MC labels")
 AddOption(ompKernels, bool, false, "ompKernels", 0, "Parallelize with OMP inside kernels instead of over slices")
+AddOption(doublePipeline, bool, false, "doublePipeline", 0, "Double pipeline mode")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Standalone/utils/bitfield.h
+++ b/GPU/GPUTracking/Standalone/utils/bitfield.h
@@ -68,6 +68,28 @@ class bitfield
   operator S() const { return bits; }
   bool isSet(const bitfield& v) const { return *this & v; }
   bool isSet(const S v) const { return bits & v; }
+  template <typename... Args>
+  bool isSetAll(Args... args)
+  {
+    return (bits & lor(args...).bits) == lor(args...).bits;
+  }
+  template <typename... Args>
+  bool isSetAny(Args... args)
+  {
+    return (bits & lor(args...).bits) != 0;
+  }
+  template <typename... Args>
+  bool isOnlySet(Args... args)
+  {
+    return (bits & ~lor(args...).bits) == 0;
+  }
+  template <typename... Args>
+  static bitfield lor(const Args&... args)
+  {
+    bitfield retVal;
+    retVal.set(args...);
+    return retVal;
+  }
 
 #ifdef GPUCA_NOCOMPAT_ALLOPENCL
   static_assert(std::is_integral<S>::value, "Storage type non integral");


### PR DESCRIPTION
This is just some framework code to support overlapping input / output of consecutive time frames, actual implementation of the pipeline will follow.
+ some cleanup off fstream headers.