### PR TITLE
[MCH] Add extra rotation to Station3 when put into the dipole

### DIFF
--- a/Detectors/MUON/MCH/Simulation/src/Station345Geometry.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Station345Geometry.cxx
@@ -683,10 +683,17 @@ void buildHalfChambers(TGeoVolume& topVolume)
 
     Double_t zpos = halfCh["position"][2].GetDouble();
 
+    Double_t xExtraTheta = 0.0;
+    Double_t zExtraTheta = 0.0;
+
     // change the mother volume if the Dipole and/or 'YOUT2' are present in the geometry
     if ((nCh == 5 || nCh == 6) && gGeoManager->GetVolume("Dipole")) {
       motherVolume = gGeoManager->GetVolume("DDIP");
       zpos *= -1.; // z > 0 convention for dipole volumes
+      // the dipole passive volume will be rotated 180 around y
+      // when put into cave, so have to compensate for that here
+      xExtraTheta = 180.0;
+      zExtraTheta = 180;
     }
 
     if (nCh > 6 && gGeoManager->GetVolume("YOUT2")) {
@@ -697,10 +704,11 @@ void buildHalfChambers(TGeoVolume& topVolume)
     motherVolume->AddNode(
       halfChVol, moduleID,
       new TGeoCombiTrans(halfCh["position"][0].GetDouble(), halfCh["position"][1].GetDouble(), zpos,
-                         new TGeoRotation(Form("%srotation", name.data()), halfCh["rotation"][0].GetDouble(),
-                                          halfCh["rotation"][1].GetDouble(), halfCh["rotation"][2].GetDouble(),
-                                          halfCh["rotation"][3].GetDouble(), halfCh["rotation"][4].GetDouble(),
-                                          halfCh["rotation"][5].GetDouble())));
+                         new TGeoRotation(
+                           Form("%srotation", name.data()),
+                           halfCh["rotation"][0].GetDouble() + xExtraTheta, halfCh["rotation"][1].GetDouble(),
+                           halfCh["rotation"][2].GetDouble(), halfCh["rotation"][3].GetDouble(),
+                           halfCh["rotation"][4].GetDouble() + zExtraTheta, halfCh["rotation"][5].GetDouble())));
 
   } // end of the half-chambers loop
 }

--- a/Detectors/MUON/MCH/Simulation/test/testGeometry.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/testGeometry.cxx
@@ -173,13 +173,12 @@ bool operator==(const CoarseLocation& a, const CoarseLocation& b)
 CoarseLocation getDetElemCoarseLocation(int detElemId)
 {
   auto t = o2::mch::getTransformation(detElemId, *gGeoManager);
-  Point3D<double> localTestPos{35.0, -19.75, 0.0};
-  // knowing that the smallest slat is 80cm wide
-  // and that all slats are 40cm tall
+  Point3D<double> localTestPos{0.0, 0.0, 0.0}; // slat center
 
   if (detElemId < 500) {
-    localTestPos.SetXYZ(60, 60, 0); // in the rough ballpark of the center
-    // of the quadrant
+    // in the rough ballpark of the center
+    // of the quadrants
+    localTestPos.SetXYZ(60, 60, 0);
   }
 
   // for slats around the middle (y closest to 0) we have to be a bit


### PR DESCRIPTION
The dipole volume is rotated 180 degrees when placed in its mother volume, a fact which was not correctly taken into account when placing the MCH Station 3 within it. As a result that station (and only this one) ended up wrongly flipped left-right in the final geometry. 
This PR fixes that (and add a corresponding unit test)