### PR TITLE
Do not ovewrite status code of primaries.

### DIFF
--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -75,17 +75,8 @@ class O2MCApplication : public O2MCApplicationBase
   void GeneratePrimaries() override
   {
     // ordinarily we would call the event generator ...
-
-    // correct status code
-    int i = 0;
-    for (auto& p : mPrimaries) {
-      p.SetStatusCode(i);
-      i++;
-    }
-
     LOG(INFO) << "Generate primaries " << mPrimaries.size() << "\n";
     GetStack()->Reset();
-
     // but here we init the stack from
     // a vector of particles that someone sets externally
     static_cast<o2::data::Stack*>(GetStack())->initFromPrimaries(mPrimaries);


### PR DESCRIPTION
Avoid overwriting of the status code of primary particles from the event generator.
In the previous version of the code the status code is used to store the trackID of primary particles. This is not needed since Geant4 passes the trackID in SetCurrentTrack(...) and for Geant3 the trackID is equal to the size of the stack at the moment when the particle is read back from the stack.

Currently the status code is not stored in MCTrack. However, we should keep this option open for the future.

