### PR TITLE
Removing duplicated short option, probably a simple c&p typo

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1440,7 +1440,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     ("port-range,pr", bpo::value<unsigned short>()->default_value(1000), "ports in range")                              //
     ("completion-policy,c", bpo::value<TerminationPolicy>(&policy)->default_value(TerminationPolicy::QUIT),             //
      "what to do when processing is finished: quit, wait")                                                              //
-    ("error-policy,c", bpo::value<TerminationPolicy>(&errorPolicy)->default_value(TerminationPolicy::QUIT),             //
+    ("error-policy", bpo::value<TerminationPolicy>(&errorPolicy)->default_value(TerminationPolicy::QUIT),             //
      "what to do when a device has an error: quit, wait")                                                               //
     ("graphviz,g", bpo::value<bool>()->zero_tokens()->default_value(false), "produce graph output")                     //
     ("timeout,t", bpo::value<double>()->default_value(0), "timeout after which to exit")                                //


### PR DESCRIPTION
Short option `-c` is already used by option `--completion-policy`