### PR TITLE
Decoupling TPC digitizer workflow from reco workflow

### DIFF
--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -115,13 +115,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::vector<int> laneConfiguration;
   auto nLanes = cfgc.options().get<int>("tpc-lanes");
   auto inputType = cfgc.options().get<std::string>("input-type");
-  if (inputType == "digitizer") {
-    // the digitizer is using a different lane setup so we have to force this for the moment
-    laneConfiguration.resize(nLanes);
-    std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  } else {
-    laneConfiguration = tpcSectors;
-  }
+  laneConfiguration = tpcSectors;
 
   // depending on whether to dispatch early (prompt) and on the input type, we
   // set the matcher. Note that this has to be in accordance with the OutputSpecs

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -46,11 +46,10 @@ o2_add_executable(digitizer-workflow
                                         O2::PHOSSimulation
                                         O2::CPVSimulation
                                         O2::TOFSimulation
-					                    O2::TOFCalibration
+                                        O2::TOFCalibration
                                         O2::TOFReconstruction
                                         O2::TOFWorkflowUtils
                                         O2::TPCSimulation
-                                        O2::TPCWorkflow
                                         O2::TRDSimulation
                                         O2::TRDWorkflow
                                         O2::DataFormatsTRD

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -28,7 +28,6 @@
 #include "TPCDigitRootWriterSpec.h"
 #include "TPCBase/Sector.h"
 #include "TPCBase/CDBInterface.h"
-#include "TPCWorkflow/RecoWorkflow.h"
 // needed in order to init the **SHARED** polyadist file (to be done before the digitizers initialize)
 #include "TPCSimulation/GEMAmplification.h"
 
@@ -142,7 +141,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"skipDet", VariantType::String, "none", {skiphelp}});
 
   // we support only output type 'tracks' for the moment
-  std::string tpcrthelp("Run TPC reco workflow to specified output type, currently supported: 'tracks'");
+  std::string tpcrthelp("deprecated option, please connect workflows on the command line by pipe");
   workflowOptions.push_back(
     ConfigParamSpec{"tpc-reco-type", VariantType::String, "", {tpcrthelp}});
 
@@ -439,15 +438,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     WorkflowSpec tpcPipelines = o2::tpc::getTPCDigitizerSpec(lanes, tpcsectors, mctruth);
     specs.insert(specs.end(), tpcPipelines.begin(), tpcPipelines.end());
 
-    auto tpcRecoOutputType = configcontext.options().get<std::string>("tpc-reco-type");
-    if (tpcRecoOutputType.empty()) {
-      // for writing digits to disc
-      specs.emplace_back(o2::tpc::getTPCDigitRootWriterSpec(tpcsectors, mctruth));
-    } else {
-      // attach the TPC reco workflow
-      auto tpcRecoWorkflow = o2::tpc::reco_workflow::getWorkflow(tpcsectors, tpcsectors, true, lanes, "digitizer", tpcRecoOutputType.c_str());
-      specs.insert(specs.end(), tpcRecoWorkflow.begin(), tpcRecoWorkflow.end());
+    if (configcontext.options().get<std::string>("tpc-reco-type").empty() == false) {
+      throw std::runtime_error("option 'tpc-reco-type' is deprecated, please connect workflows on the command line by pipe");
     }
+    // for writing digits to disc
+    specs.emplace_back(o2::tpc::getTPCDigitRootWriterSpec(tpcsectors, mctruth));
   }
 
   // first 36 channels are reserved for the TPC


### PR DESCRIPTION
Workflows can be combined on the command line by using pipe. Removing
the early implementation of combining the two workflows.

Example usage:
```
o2-sim-digitizer-workflow --onlyDet TPC | o2-tpc-reco-workflow --input-type digitizer --tpc-lanes 4
```