### PR TITLE
set of methods for calculation of DCA to vertex 

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -72,6 +72,11 @@ inline void sincosf(float ang, float& s, float& c)
   o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
 
+inline void sincos(float ang, float& s, float& c)
+{
+  o2::gpu::GPUCommonMath::SinCos(ang, s, c);
+}
+
 inline void sincos(double ang, double& s, double& c)
 {
   o2::gpu::GPUCommonMath::SinCos(ang, s, c);

--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(ReconstructionDataFormats
                        src/MatchInfoTOF.cxx
                        src/TrackLTIntegral.cxx
                        src/PID.cxx
+                       src/DCA.cxx
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                      O2::DetectorsCommonDataFormats
                                      O2::CommonDataFormat)
@@ -28,7 +29,8 @@ o2_target_root_dictionary(
           include/ReconstructionDataFormats/Vertex.h
           include/ReconstructionDataFormats/MatchInfoTOF.h
           include/ReconstructionDataFormats/TrackLTIntegral.h
-          include/ReconstructionDataFormats/PID.h)
+          include/ReconstructionDataFormats/PID.h
+          include/ReconstructionDataFormats/DCA.h)
 
 o2_add_test(Vertex
             SOURCES test/testVertex.cxx

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DCA_H
+#define ALICEO2_DCA_H
+
+#include "GPUCommonRtypes.h"
+
+#ifndef __OPENCL__
+#include <array>
+#endif
+#ifndef ALIGPU_GPUCODE
+#include <iosfwd>
+#endif
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief  class for distance of closest approach to vertex
+
+namespace o2
+{
+namespace dataformats
+{
+
+class DCA
+{
+
+ public:
+  DCA() = default;
+
+  DCA(float y, float z, float syy = 0.f, float syz = 0.f, float szz = 0.f)
+  {
+    set(y, z, syy, syz, szz);
+  }
+
+  void set(float y, float z, float syy, float syz, float szz)
+  {
+    mY = y;
+    mZ = z;
+    mCov[0] = syy;
+    mCov[1] = syz;
+    mCov[2] = szz;
+  }
+
+  void set(float y, float z)
+  {
+    mY = y;
+    mZ = z;
+  }
+
+  auto getY() const { return mY; }
+  auto getZ() const { return mZ; }
+  auto getSigmaY2() const { return mCov[0]; }
+  auto getSigmaYZ() const { return mCov[1]; }
+  auto getSigmaZ2() const { return mCov[2]; }
+  const auto& getCovariance() const { return mCov; }
+
+  void print() const;
+
+ private:
+  float mY = 0.f;
+  float mZ = 0.f;
+  std::array<float, 3> mCov; ///< s2y, syz, s2z
+
+  ClassDefNV(DCA, 1);
+};
+
+std::ostream& operator<<(std::ostream& os, const DCA& d);
+
+} // namespace dataformats
+} // namespace o2
+
+#endif //ALICEO2_DCA_H

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -27,33 +27,26 @@ namespace o2
 namespace dataformats
 {
 
-// Base primary vertex class, with position, error, N candidates and flags field
-// The Stamp template parameter allows to define vertex (time)stamp in different
-// formats (ITS ROFrame ID, real time + error etc)
-
-template <typename Stamp = o2::dataformats::TimeStamp<int>>
-class Vertex
+// Base primary vertex class, with position, error
+class VertexBase
 {
-  using ushort = unsigned short;
-
  public:
   enum CovElems : int { kCovXX,
                         kCovXY,
                         kCovYY,
                         kCovXZ,
                         kCovYZ,
-                        kCovZZ,
-                        kNCov };
-  static ushort constexpr FlagsMask = 0xffff;
-
-  Vertex() = default;
-  ~Vertex() = default;
-  Vertex(const Point3D<float>& pos, const std::array<float, kNCov>& cov, ushort nCont, float chi2)
-    : mPos(pos), mCov(cov), mNContributors(nCont), mChi2(chi2)
+                        kCovZZ };
+  static constexpr int kNCov = 6;
+  VertexBase() = default;
+  ~VertexBase() = default;
+  VertexBase(const Point3D<float>& pos, const std::array<float, kNCov>& cov) : mPos(pos), mCov(cov)
   {
   }
 
+#ifndef ALIGPU_GPUCODE
   void print() const;
+#endif
 
   // getting the cartesian coordinates and errors
   float getX() const { return mPos.X(); }
@@ -99,6 +92,35 @@ class Vertex
   }
   void setCov(const std::array<float, kNCov>& cov) { mCov = cov; }
 
+ protected:
+  Point3D<float> mPos{0., 0., 0.}; ///< cartesian position
+  std::array<float, kNCov> mCov{}; ///< errors, see CovElems enum
+
+  ClassDefNV(VertexBase, 1);
+};
+
+// Base primary vertex class, with position, error, N candidates and flags field
+// The Stamp template parameter allows to define vertex (time)stamp in different
+// formats (ITS ROFrame ID, real time + error etc)
+
+template <typename Stamp = o2::dataformats::TimeStamp<int>>
+class Vertex : public VertexBase
+{
+ public:
+  using ushort = unsigned short;
+  static ushort constexpr FlagsMask = 0xffff;
+
+  Vertex() = default;
+  ~Vertex() = default;
+  Vertex(const Point3D<float>& pos, const std::array<float, kNCov>& cov, ushort nCont, float chi2)
+    : VertexBase(pos, cov), mNContributors(nCont), mChi2(chi2)
+  {
+  }
+
+#ifndef ALIGPU_GPUCODE
+  void print() const;
+#endif
+
   ushort getNContributors() const { return mNContributors; }
   void setNContributors(ushort v) { mNContributors = v; }
 
@@ -116,27 +138,22 @@ class Vertex
   void setTimeStamp(const Stamp& v) { mTimeStamp = v; }
 
  private:
-  Point3D<float> mPos;           ///< cartesian position
-  std::array<float, kNCov> mCov; ///< errors, see CovElems enum
   float mChi2 = 0;               ///< chi2 or quality of tracks to vertex attachment
   ushort mNContributors = 0;     ///< N contributors
   ushort mBits = 0;              ///< bit field for flags
   Stamp mTimeStamp;              ///< vertex time-stamp
 
-  ClassDefNV(Vertex, 1);
+  ClassDefNV(Vertex, 2);
 };
 
 #ifndef ALIGPU_GPUCODE
+std::ostream& operator<<(std::ostream& os, const o2::dataformats::VertexBase& v);
+
 template <typename Stamp>
-std::ostream& operator<<(std::ostream& os, const Vertex<Stamp>& v)
+inline std::ostream& operator<<(std::ostream& os, const o2::dataformats::Vertex<Stamp>& v)
 {
   // stream itself
-  os << std::scientific << "Vertex X: " << v.getX() << " Y: " << v.getY() << " Z: " << v.getZ()
-     << " NCont: " << v.getNContributors() << " Chi2: " << v.getChi2() << "\nCov.mat:\n"
-     << v.getSigmaX2() << '\n'
-     << v.getSigmaXY() << ' ' << v.getSigmaY2() << '\n'
-     << v.getSigmaXZ() << ' ' << v.getSigmaYZ() << ' ' << v.getSigmaZ2() << '\n'
-     << "TimeStamp: " << v.getTimeStamp();
+  os << (const VertexBase&)v << "\n NCont: " << v.getNContributors() << " Chi2: " << v.getChi2() << " TimeStamp: " << v.getTimeStamp();
   return os;
 }
 
@@ -146,6 +163,7 @@ void Vertex<Stamp>::print() const
   std::cout << *this << std::endl;
 }
 #endif
+
 } // namespace dataformats
 } // namespace o2
 #endif

--- a/DataFormats/Reconstruction/src/DCA.cxx
+++ b/DataFormats/Reconstruction/src/DCA.cxx
@@ -8,8 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ReconstructionDataFormats/Vertex.h"
+#include "ReconstructionDataFormats/DCA.h"
 #include <iostream>
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief  class for distance of closest approach to vertex
 
 namespace o2
 {
@@ -17,22 +20,20 @@ namespace dataformats
 {
 
 #ifndef ALIGPU_GPUCODE
-std::ostream& operator<<(std::ostream& os, const o2::dataformats::VertexBase& v)
+std::ostream& operator<<(std::ostream& os, const o2::dataformats::DCA& d)
 {
   // stream itself
-  os << std::scientific << "Vertex X: " << v.getX() << " Y: " << v.getY() << " Z: " << v.getZ()
-     << " Cov.mat:\n"
-     << v.getSigmaX2() << '\n'
-     << v.getSigmaXY() << ' ' << v.getSigmaY2() << '\n'
-     << v.getSigmaXZ() << ' ' << v.getSigmaYZ() << ' ' << v.getSigmaZ2() << '\n';
+  os << "DCA YZ {" << d.getY() << ", " << d.getZ() << "} Cov {" << d.getSigmaY2() << ", " << d.getSigmaYZ() << ", " << d.getSigmaZ2() << "}";
   return os;
 }
-
-void VertexBase::print() const
-{
-  std::cout << *this << std::endl;
-}
 #endif
+
+void DCA::print() const
+{
+#ifndef ALIGPU_GPUCODE
+  std::cout << *this << '\n';
+#endif
+}
 
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -29,9 +29,12 @@
 #pragma link C++ class std::vector < std::pair < int, float>> + ;
 #pragma link C++ class std::vector < int> + ;
 
+#pragma link C++ class o2::dataformats::VertexBase + ;
 #pragma link C++ class o2::dataformats::Vertex < int> + ;
 #pragma link C++ class o2::dataformats::Vertex < o2::dataformats::TimeStamp < int>> + ;
 #pragma link C++ class o2::dataformats::Vertex < o2::dataformats::TimeStampWithError < double, double>> + ;
 #pragma link C++ class std::vector < o2::dataformats::Vertex < o2::dataformats::TimeStamp < int>>> + ;
+
+#pragma link C++ class o2::dataformats::DCA + ;
 
 #endif

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -259,6 +259,7 @@ class MatchTPCITS
   using TPCTransform = o2::gpu::TPCFastTransform;
   using BracketF = o2::utils::Bracket<float>;
   using Params = o2::globaltracking::MatchITSTPCParams;
+  using MatCorrType = o2::base::Propagator::MatCorrType;
 
  public:
   MatchTPCITS(); // std::unique_ptr to forward declared type needs constructor / destructor in .cxx
@@ -409,8 +410,8 @@ class MatchTPCITS
   std::vector<o2::MCCompLabel>& getMatchedTPCLabels() { return mOutTPCLabels; }
 
   //>>> ====================== options =============================>>>
-  void setUseMatCorrFlag(int f);
-  int getUseMatCorrFlag() const { return mUseMatCorrFlag; }
+  void setUseMatCorrFlag(MatCorrType f) { mUseMatCorrFlag = f; }
+  auto getUseMatCorrFlag() const { return mUseMatCorrFlag; }
 
   //<<< ====================== options =============================<<<
 
@@ -537,7 +538,7 @@ class MatchTPCITS
   ///========== Parameters to be set externally, e.g. from CCDB ====================
   const Params* mParams = nullptr;
 
-  int mUseMatCorrFlag = o2::base::Propagator::USEMatCorrTGeo;
+  MatCorrType mUseMatCorrFlag = MatCorrType::USEMatCorrTGeo;
 
   bool mITSTriggered = false; ///< ITS readout is triggered
 

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -944,7 +944,7 @@ void MatchTOF::selectBestMatches()
 bool MatchTOF::propagateToRefX(o2::track::TrackParCov& trc, float xRef, float stepInCm, o2::track::TrackLTIntegral& intLT)
 {
   // propagate track to matching reference X
-  const int matCorr = 1; // material correction method
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrTGeo; // material correction method
   const float tanHalfSector = tan(o2::constants::math::SectorSpanRad / 2);
   bool refReached = false;
   float xStart = trc.getX();

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -29,6 +29,7 @@
 #include "DataFormatsTOF/Cluster.h"
 #include "SpacePoints/SpacePointsCalibParam.h"
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
+#include "DetectorsBase/Propagator.h"
 
 class TTree;
 
@@ -81,6 +82,8 @@ struct TrackData {
 class TrackInterpolation
 {
  public:
+  using MatCorrType = o2::base::Propagator::MatCorrType;
+
   /// Default constructor
   TrackInterpolation() = default;
 
@@ -145,7 +148,7 @@ class TrackInterpolation
   /// Sets the maximum step length for track extrapolation
   void setMaxStep(float step) { mMaxStep = step; }
   /// Sets the flag if material correction should be applied when extrapolating the tracks
-  void setMatCorr(int matCorr) { mMatCorr = matCorr; }
+  void setMatCorr(MatCorrType matCorr) { mMatCorr = matCorr; }
   /// Sets whether ITS tracks without match in TRD or TOF should be processed as well
   void setDoITSOnlyTracks(bool flag) { mDoITSOnlyTracks = flag; }
 
@@ -176,7 +179,7 @@ class TrackInterpolation
   float mSigYZ2TOF{.75f};    ///< for now assume cluster error for TOF equal for all clusters in both Y and Z
   float mMaxSnp{.85f};          ///< max snp when propagating ITS tracks
   float mMaxStep{2.f};          ///< maximum step for propagation
-  int mMatCorr{0};              ///< if material correction should be done
+  MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   bool mDoITSOnlyTracks{false}; ///< if ITS only tracks should be processed or not
 
   // input

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -17,7 +17,6 @@
 #include "SpacePoints/TrackInterpolation.h"
 #include "TPCBase/ParameterElectronics.h"
 #include "DataFormatsTPC/TrackTPC.h"
-#include "DetectorsBase/Propagator.h"
 
 #include <fairlogger/Logger.h>
 


### PR DESCRIPTION
@ginnocen in the end I've added these methods in 2 versions:
in the TrackPar / TrackParCov classes:
````
bool TrackPar::propagateParamToDCA(const Point3D<float>& vtx, float b, std::array<float, 2>* dca=nullptr, float maxD=999);
bool TrackParCov::propagateToDCA(const o2::dataformats::VertexBase& vtx, float b, o2::dataformats::DCA* dca=nullptr, float maxD=999)
````
you can use them (almost) exactly like in the AliExternalTrackParam::PropagateToDCA, the method for TrackPar allows to avoid track cov.matrix propagation propagation (i.e. if you just need to know the dca of the track w/o errors rather than to propagate it to vertex, use 
````
o2::dataformats::VertexBase vtx; // ...
o2::track::TrackParCov tr;
//....
o2::track::TrackPar tp(track);
array<float,2> dca;
tp.propagateParamToDCA(vtx.getXYZ(), bz, &dca);

/// instead of full fledged
o2::dataformats::DCA dcaWithErr;
track.propagateToDCA(vtx, bz, &dcaWithErr);
````

Then there is a set of new methods ``propagateToDCA....`` in the Propagator class which offer the same but with possibility to propagate the full track or ist parameters only accounting for the materials corrections, 3D field, calculation of the track length integral etc. As all methods in the Propagator, they reqiure magnetic field and geometry loaded.