### PR TITLE
Move ITS/MFT digitwriter to ITSMFT/common/workflow and make it workflow

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -256,7 +256,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcC
   inputs.emplace_back("trackITSROF", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITS", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITSPatt", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("clusITSROF", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clusITSROF", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -60,14 +60,14 @@ DataProcessorSpec getClusterWriterSpec(bool useMC)
                                 // RSTODO being eliminated
                                 BranchDefinition<ClustersType>{InputSpec{"clusters", "ITS", "CLUSTERS", 0},
                                                                "ITSCluster"},
-                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "ClusterROF", 0},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "ITS", "CLUSTERSROF", 0},
                                                                "ITSClustersROF",
                                                                logger},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", "ITS", "CLUSTERSMCTR", 0},
                                                              "ITSClusterMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ClusterMC2ROF", 0},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0},
                                                              "ITSClustersMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -118,7 +118,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   mClusterer->process(mNThreads, reader, mFullClusters ? &clusVec : nullptr, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
   pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "ClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
   pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec);
   pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
 
@@ -128,7 +128,7 @@ void ClustererDPL::run(ProcessingContext& pc)
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "ClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
@@ -140,19 +140,19 @@ DataProcessorSpec getClustererSpec(bool useMC)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "ITS", "DIGITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "DigitROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "DIGITSROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "PATTERNS", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("ITS", "ClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "DigitMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -202,7 +202,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
@@ -213,7 +213,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
@@ -70,10 +70,10 @@ void DigitReader::run(ProcessingContext& pc)
               << profs->size() << " RO frames";
 
     pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(Output{"ITS", "DigitROF", 0, Lifetime::Timeframe}, *profs);
+    pc.outputs().snapshot(Output{"ITS", "DIGITSROF", 0, Lifetime::Timeframe}, *profs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"ITS", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"ITS", "DigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
+      pc.outputs().snapshot(Output{"ITS", "DIGITSMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the ITS digits !";
@@ -88,10 +88,10 @@ DataProcessorSpec getDigitReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "DIGITS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("ITS", "DigitROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "DIGITSROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("ITS", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("ITS", "DigitMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -239,7 +239,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, o2::gpu::GPUDataTypes::DeviceType d
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "ClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
@@ -250,7 +250,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, o2::gpu::GPUDataTypes::DeviceType d
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/MFT/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClusterReaderSpec.cxx
@@ -73,10 +73,10 @@ void ClusterReader::run(ProcessingContext& pc)
 
     pc.outputs().snapshot(Output{"MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe}, compClusters);
     pc.outputs().snapshot(Output{"MFT", "CLUSTERS", 0, Lifetime::Timeframe}, clusters);
-    pc.outputs().snapshot(Output{"MFT", "ClusterROF", 0, Lifetime::Timeframe}, rofs);
+    pc.outputs().snapshot(Output{"MFT", "CLUSTERSROF", 0, Lifetime::Timeframe}, rofs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+      pc.outputs().snapshot(Output{"MFT", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the MFT clusters !";
@@ -91,10 +91,10 @@ DataProcessorSpec getClusterReaderSpec(bool useMC)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "CLUSTERSROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClusterWriterSpec.cxx
@@ -60,14 +60,14 @@ DataProcessorSpec getClusterWriterSpec(bool useMC)
                                 BranchDefinition<ClustersType>{InputSpec{"clusters", "MFT", "CLUSTERS", 0},
                                                                "MFTCluster",
                                                                clustersSizeGetter},
-                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "MFT", "ClusterROF", 0},
+                                BranchDefinition<ROFrameRType>{InputSpec{"ROframes", "MFT", "CLUSTERSROF", 0},
                                                                "MFTClustersROF",
                                                                logger},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", "MFT", "CLUSTERSMCTR", 0},
                                                              "MFTClusterMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "ClusterMC2ROF", 0},
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "CLUSTERSMC2ROF", 0},
                                                              "MFTClustersMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""})();

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -121,7 +121,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   mClusterer->process(mNThreads, reader, mFullClusters ? &clusVec : nullptr, &clusCompVec, mPatterns ? &clusPattVec : nullptr, &clusROFVec, clusterLabels.get());
   pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
-  pc.outputs().snapshot(Output{orig, "ClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+  pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
   pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec);
   pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
 
@@ -131,7 +131,7 @@ void ClustererDPL::run(ProcessingContext& pc)
     for (int i = mc2rofs.size(); i--;) {
       clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
     }
-    pc.outputs().snapshot(Output{orig, "ClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
@@ -144,19 +144,19 @@ DataProcessorSpec getClustererSpec(bool useMC)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "MFT", "DIGITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "DigitROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "DIGITSROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "PATTERNS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "MFT", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "DigitMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "MFT", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/MFT/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/DigitReaderSpec.cxx
@@ -69,10 +69,10 @@ void DigitReader::run(ProcessingContext& pc)
               << profs->size() << " RO frames";
 
     pc.outputs().snapshot(Output{"MFT", "DIGITS", 0, Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(Output{"MFT", "DigitROF", 0, Lifetime::Timeframe}, *profs);
+    pc.outputs().snapshot(Output{"MFT", "DIGITSROF", 0, Lifetime::Timeframe}, *profs);
     if (mUseMC) {
       pc.outputs().snapshot(Output{"MFT", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
-      pc.outputs().snapshot(Output{"MFT", "DigitMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
+      pc.outputs().snapshot(Output{"MFT", "DIGITSMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
     }
   } else {
     LOG(ERROR) << "Cannot read the MFT digits !";
@@ -87,10 +87,10 @@ DataProcessorSpec getDigitReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "DIGITS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "DigitROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "DIGITSROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back("MFT", "DIGITSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "DigitMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "DIGITSMC2ROF", 0, Lifetime::Timeframe);
   }
   return DataProcessorSpec{
     "mft-digit-reader",

--- a/Detectors/ITSMFT/MFT/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/DigitWriterSpec.cxx
@@ -77,7 +77,7 @@ DataProcessorSpec getDigitWriterSpec()
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "MFT", "DIGITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "DigitROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "DIGITSROF", 0, Lifetime::Timeframe);
   return DataProcessorSpec{
     "mft-digit-writer",
     inputs,

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -57,10 +57,10 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                                                                      "MFTTrackMCTruth",
                                                                                                      (useMC ? 1 : 0), // one branch if mc labels enabled
                                                                                                      ""},
-                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "TrackROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "TRACKSROF", 0},
                                                                                      "MFTTracksROF",
                                                                                      logger},
-                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "TrackMC2ROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "TRACKSMC2ROF", 0},
                                                                                         "MFTTracksMC2ROF",
                                                                                         (useMC ? 1 : 0), // one branch if mc labels enabled
                                                                                         ""})();

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -84,7 +84,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   // the output vector however is created directly inside the message memory thus avoiding copy by
   // snapshot
   auto rofsinput = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "TrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "TRACKSROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
 
   LOG(INFO) << "MFTTracker pulled " << clusters.size() << " full clusters in "
             << rofs.size() << " RO frames";
@@ -159,7 +159,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   LOG(INFO) << "MFTTracker pushed " << allTracksCA.size() << " tracks CA";
   if (mUseMC) {
     pc.outputs().snapshot(Output{"MFT", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
-    pc.outputs().snapshot(Output{"MFT", "TrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
+    pc.outputs().snapshot(Output{"MFT", "TRACKSMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
   }
 }
 
@@ -169,18 +169,18 @@ DataProcessorSpec getTrackerSpec(bool useMC)
   inputs.emplace_back("compClusters", "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "MFT", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "MFT", "ClusterROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "MFT", "CLUSTERSROF", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "TRACKSLTF", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "TRACKSCA", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "TrackROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "TRACKSROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    inputs.emplace_back("MC2ROframes", "MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "MFT", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
-    outputs.emplace_back("MFT", "TrackMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("MFT", "TRACKSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/common/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/workflow/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 o2_add_library(ITSMFTWorkflow
                SOURCES src/ClusterReaderSpec.cxx
+                       src/DigitWriterSpec.cxx
                        src/STFDecoderSpec.cxx
                        src/EntropyEncoderSpec.cxx
                        src/EntropyDecoderSpec.cxx
@@ -25,5 +26,10 @@ o2_add_library(ITSMFTWorkflow
 
 o2_add_executable(stf-decoder-workflow
                   SOURCES src/stf-decoder-workflow.cxx
+                  COMPONENT_NAME itsmft
+                  PUBLIC_LINK_LIBRARIES O2::ITSMFTWorkflow)
+
+o2_add_executable(digit-writer-workflow
+                  SOURCES src/digit-writer-workflow.cxx
                   COMPONENT_NAME itsmft
                   PUBLIC_LINK_LIBRARIES O2::ITSMFTWorkflow)

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitWriterSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitWriterSpec.h
@@ -8,8 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef STEER_DIGITIZERWORKFLOW_ITSMFTDIGITWRITER_H_
-#define STEER_DIGITIZERWORKFLOW_ITSMFTDIGITWRITER_H_
+#ifndef STEER_ITSMFTDIGITWRITER_H_
+#define STEER_ITSMFTDIGITWRITER_H_
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -24,4 +24,4 @@ o2::framework::DataProcessorSpec getMFTDigitWriterSpec(bool mctruth = true);
 } // end namespace itsmft
 } // end namespace o2
 
-#endif /* STEER_DIGITIZERWORKFLOW_ITSMFTDIGITWRITER_H_ */
+#endif /* STEER_ITSMFTDIGITWRITER_H_ */

--- a/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/ClusterReaderSpec.cxx
@@ -55,7 +55,7 @@ void ClusterReader::run(ProcessingContext& pc)
 
   // This is a very ugly way of providing DataDescription, which anyway does not need to contain detector name.
   // To be fixed once the names-definition class is ready
-  pc.outputs().snapshot(Output{mOrigin, "ClusterROF", 0, Lifetime::Timeframe}, mClusROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "CLUSTERSROF", 0, Lifetime::Timeframe}, mClusROFRec);
   if (mUseClFull) {
     pc.outputs().snapshot(Output{mOrigin, "CLUSTERS", 0, Lifetime::Timeframe}, mClusterArray);
   }
@@ -67,7 +67,7 @@ void ClusterReader::run(ProcessingContext& pc)
   }
   if (mUseMC) {
     pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMCTR", 0, Lifetime::Timeframe}, mClusterMCTruth);
-    pc.outputs().snapshot(Output{mOrigin, "ClusterMC2ROF", 0, Lifetime::Timeframe}, mClusMC2ROFs);
+    pc.outputs().snapshot(Output{mOrigin, "CLUSTERSMC2ROF", 0, Lifetime::Timeframe}, mClusMC2ROFs);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
@@ -110,7 +110,7 @@ void ClusterReader::connectTree(const std::string& filename)
 DataProcessorSpec getITSClusterReaderSpec(bool useMC, bool useClFull, bool useClComp, bool usePatterns)
 {
   std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("ITS", "ClusterROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
   if (useClFull) {
     outputSpec.emplace_back("ITS", "CLUSTERS", 0, Lifetime::Timeframe);
   }
@@ -122,7 +122,7 @@ DataProcessorSpec getITSClusterReaderSpec(bool useMC, bool useClFull, bool useCl
   }
   if (useMC) {
     outputSpec.emplace_back("ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputSpec.emplace_back("ITS", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputSpec.emplace_back("ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{
@@ -137,7 +137,7 @@ DataProcessorSpec getITSClusterReaderSpec(bool useMC, bool useClFull, bool useCl
 DataProcessorSpec getMFTClusterReaderSpec(bool useMC, bool useClFull, bool useClComp, bool usePatterns)
 {
   std::vector<OutputSpec> outputSpec;
-  outputSpec.emplace_back("MFT", "ClusterROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("MFT", "CLUSTERSROF", 0, Lifetime::Timeframe);
   if (useClFull) {
     outputSpec.emplace_back("MFT", "CLUSTERS", 0, Lifetime::Timeframe);
   }
@@ -149,7 +149,7 @@ DataProcessorSpec getMFTClusterReaderSpec(bool useMC, bool useClFull, bool useCl
   }
   if (useMC) {
     outputSpec.emplace_back("MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
-    outputSpec.emplace_back("MFT", "ClusterMC2ROF", 0, Lifetime::Timeframe);
+    outputSpec.emplace_back("MFT", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
@@ -10,7 +10,7 @@
 
 /// @brief  Processor spec for a ROOT file writer for ITSMFT digits
 
-#include "ITSMFTDigitWriterSpec.h"
+#include "ITSMFTWorkflow/DigitWriterSpec.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "Headers/DataHeader.h"
@@ -36,7 +36,7 @@ using MCCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 /// create the processor spec
 /// describing a processor receiving digits for ITS/MFT and writing them to file
-DataProcessorSpec getITSMFTDigitWriterSpec(bool mctruth, o2::header::DataOrigin detOrig, o2::detectors::DetID detId)
+DataProcessorSpec getDigitWriterSpec(bool mctruth, o2::header::DataOrigin detOrig, o2::detectors::DetID detId)
 {
   std::string detStr = o2::detectors::DetID::getName(detId);
   std::string detStrL = detStr;
@@ -62,12 +62,12 @@ DataProcessorSpec getITSMFTDigitWriterSpec(bool mctruth, o2::header::DataOrigin 
 
 DataProcessorSpec getITSDigitWriterSpec(bool mctruth)
 {
-  return getITSMFTDigitWriterSpec(mctruth, o2::header::gDataOriginITS, o2::detectors::DetID::ITS);
+  return getDigitWriterSpec(mctruth, o2::header::gDataOriginITS, o2::detectors::DetID::ITS);
 }
 
 DataProcessorSpec getMFTDigitWriterSpec(bool mctruth)
 {
-  return getITSMFTDigitWriterSpec(mctruth, o2::header::gDataOriginMFT, o2::detectors::DetID::MFT);
+  return getDigitWriterSpec(mctruth, o2::header::gDataOriginMFT, o2::detectors::DetID::MFT);
 }
 
 } // end namespace itsmft

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -64,7 +64,7 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig)
   std::vector<OutputSpec> outputs{
     OutputSpec{{"compClusters"}, orig, "COMPCLUSTERS", 0, Lifetime::Timeframe},
     OutputSpec{{"patterns"}, orig, "PATTERNS", 0, Lifetime::Timeframe},
-    OutputSpec{{"ROframes"}, orig, "ClusterROF", 0, Lifetime::Timeframe},
+    OutputSpec{{"ROframes"}, orig, "CLUSTERSROF", 0, Lifetime::Timeframe},
     OutputSpec{{"fullclusters"}, orig, "CLUSTERS", 0, Lifetime::Timeframe} // RS DUMMY, being outphased
   };
 

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -132,13 +132,13 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
 
   if (mDoDigits) {
     pc.outputs().snapshot(Output{orig, "DIGITS", 0, Lifetime::Timeframe}, digVec);
-    pc.outputs().snapshot(Output{orig, "DigitROF", 0, Lifetime::Timeframe}, digROFVec);
+    pc.outputs().snapshot(Output{orig, "DIGITSROF", 0, Lifetime::Timeframe}, digROFVec);
   }
   if (mDoClusters) {                                                                  // we are not obliged to create vectors which are not requested, but other devices might not know the options of this one
     pc.outputs().snapshot(Output{orig, "CLUSTERS", 0, Lifetime::Timeframe}, clusVec); // DUMMY!!!
     pc.outputs().snapshot(Output{orig, "COMPCLUSTERS", 0, Lifetime::Timeframe}, clusCompVec);
     pc.outputs().snapshot(Output{orig, "PATTERNS", 0, Lifetime::Timeframe}, clusPattVec);
-    pc.outputs().snapshot(Output{orig, "ClusterROF", 0, Lifetime::Timeframe}, clusROFVec);
+    pc.outputs().snapshot(Output{orig, "CLUSTERSROF", 0, Lifetime::Timeframe}, clusROFVec);
   }
 
   if (mDoClusters) {
@@ -174,11 +174,11 @@ DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool do
 
   if (doDigits) {
     outputs.emplace_back(orig, "DIGITS", 0, Lifetime::Timeframe);
-    outputs.emplace_back(orig, "DigitROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back(orig, "DIGITSROF", 0, Lifetime::Timeframe);
   }
   if (doClusters) {
     outputs.emplace_back(orig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
-    outputs.emplace_back(orig, "ClusterROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back(orig, "CLUSTERSROF", 0, Lifetime::Timeframe);
     // in principle, we don't need to open this input if we don't need to send real data,
     // but other devices expecting it do not know about options of this device: problem?
     // if (doClusters && doPatterns)
@@ -204,11 +204,11 @@ DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool do
   auto orig = o2::header::gDataOriginMFT;
   if (doDigits) {
     outputs.emplace_back(orig, "DIGITS", 0, Lifetime::Timeframe);
-    outputs.emplace_back(orig, "DigitROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back(orig, "DIGITSROF", 0, Lifetime::Timeframe);
   }
   if (doClusters) {
     outputs.emplace_back(orig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
-    outputs.emplace_back(orig, "ClusterROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back(orig, "CLUSTERSROF", 0, Lifetime::Timeframe);
     // in principle, we don't need to open this input if we don't need to send real data,
     // but other devices expecting it do not know about options of this device: problem?
     // if (doClusters && doPatterns)

--- a/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSMFTWorkflow/DigitWriterSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"disable-mc", VariantType::Bool, false, {"disable mc truth"}},
+    ConfigParamSpec{"mft", VariantType::Bool, false, {"expect MFT data"}},
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  bool useMC = !cfgc.options().get<bool>("disable-mc");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
+  if (cfgc.options().get<bool>("mft")) {
+    wf.emplace_back(o2::itsmft::getMFTDigitWriterSpec(useMC));
+  } else {
+    wf.emplace_back(o2::itsmft::getITSDigitWriterSpec(useMC));
+  }
+  return wf;
+}

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -18,7 +18,6 @@ o2_add_executable(digitizer-workflow
                           src/FDDDigitizerSpec.cxx
                           src/GRPUpdaterSpec.cxx
                           src/HMPIDDigitizerSpec.cxx
-                          src/ITSMFTDigitWriterSpec.cxx
                           src/ITSMFTDigitizerSpec.cxx
                           src/MCHDigitizerSpec.cxx
                           src/MIDDigitizerSpec.cxx
@@ -39,6 +38,7 @@ o2_add_executable(digitizer-workflow
                                         O2::HMPIDSimulation
                                         O2::ITSMFTSimulation
                                         O2::ITSSimulation
+                                        O2::ITSMFTWorkflow
                                         O2::MCHSimulation
                                         O2::MCHBase
                                         O2::MFTSimulation
@@ -46,7 +46,7 @@ o2_add_executable(digitizer-workflow
                                         O2::PHOSSimulation
                                         O2::CPVSimulation
                                         O2::TOFSimulation
-					                    O2::TOFCalibration
+                                        O2::TOFCalibration
                                         O2::TOFReconstruction
                                         O2::TOFWorkflowUtils
                                         O2::TPCSimulation

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -34,7 +34,7 @@
 
 // for ITSMFT
 #include "ITSMFTDigitizerSpec.h"
-#include "ITSMFTDigitWriterSpec.h"
+#include "ITSMFTWorkflow/DigitWriterSpec.h"
 
 // for TOF
 #include "TOFDigitizerSpec.h"
@@ -398,7 +398,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
         return f.accept(id);
       }
     }
-
     // accept all if neither onlyDet/skipDet are provided
     return true;
   };


### PR DESCRIPTION
DigitsWriter is extracted to separated workflow to allow writing root digits avoiding whole ITS of MFT reconstruction chain. 
The raw data can be converted to digits by
````
o2-raw-file-reader-workflow --input-conf ITSraw.cfg  | o2-itsmft-stf-decoder-workflow --digits --no-clusters | o2-itsmft-digit-writer-workflow --disable-mc --shm-segment-size 4000000000
````

The same can be used for the MFT as 
````
o2-raw-file-reader-workflow --input-conf MFTraw.cfg  | o2-itsmft-stf-decoder-workflow --digits --no-clusters --mft | o2-itsmft-digit-writer-workflow --disable-mc --mft --shm-segment-size 4000000000
````
Also fixed some non-uniformities between the DataDescriptions in ITS and MFT worflow, now all is in capital.

@bovulpes I saw that you've added separate writer for the MFT digits, in principle, it is now redudant.
