### PR TITLE
Fix trd trackletplots

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Tracklet.h
+++ b/Detectors/TRD/base/include/TRDBase/Tracklet.h
@@ -69,7 +69,7 @@ class Tracklet
 
   // ----- Getters for contents of tracklet word -----
   int getYbin() const;                                          // in units of 160 um
-  int getdY() const;                                            // in units of 140 um
+  float getdY() const;                                          // in units of 140 um
   int getZbin() const { return ((mROB >> 1) << 2) | (mMCM >> 2); }
 
   int getPID() const { return mPID; }

--- a/Detectors/TRD/base/src/Tracklet.cxx
+++ b/Detectors/TRD/base/src/Tracklet.cxx
@@ -81,7 +81,7 @@ int Tracklet::getYbin() const
   return mY;
 }
 
-int Tracklet::getdY() const
+float Tracklet::getdY() const
 {
   return mdY;
 }

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -671,7 +671,7 @@ void TrapSimulator::draw(int choice, int index)
   if (!checkInitialized())
     return;
   TFile* rootfile = new TFile("trdtrackletplots.root", "UPDATE");
-  TCanvas* c1 = new TCanvas(Form("canvas_%i_%i:%i:%i_%i", index, mDetector, mRobPos, mMcmPos, mTrackletArray.size()));
+  TCanvas* c1 = new TCanvas(Form("canvas_%i_%i:%i:%i_%i", index, mDetector, mRobPos, mMcmPos, (int)mTrackletArray.size()));
   TH2F* hist = new TH2F(Form("mcmdata_%i", index),
                         Form("Data of MCM %i on ROB %i in detector %i ", mMcmPos, mRobPos, mDetector),
                         FeeParam::getNadcMcm(),


### PR DESCRIPTION
1. put all tracklet plots in 1 file, no more hundreds of files.
2. correctly plot graphs for COLZ option and actually working.
3. output corresponding text for each plot to cross reference the plots with the tracklet parameters 
4. something wrong with the calcuation of offsets as the tracklet line is often off the axises, fixed later.