### PR TITLE
Move to RAWDataHeaderV6 as default header

### DIFF
--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -424,7 +424,7 @@ struct RAWDataHeaderV2 {
   };
 };
 
-using RAWDataHeader = RAWDataHeaderV4; // default version
+using RAWDataHeader = RAWDataHeaderV6; // default version
 using RDHLowest = RAWDataHeaderV4;     // link this to lowest version
 using RDHHighest = RAWDataHeaderV6;    // link this to highest version
 

--- a/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(FT0Reconstruction
   PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::Framework
   O2::FT0Base
   O2::DataFormatsFT0
+  O2::DetectorsRaw
   O2::Headers)
 
 o2_target_root_dictionary(  

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/ReadRaw.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/ReadRaw.h
@@ -66,25 +66,6 @@ class ReadRaw
 
     return o2::ft0::LookUpTable{lut_data};
   }
-  void printRDH(const o2::header::RAWDataHeader* h)
-  {
-    {
-      if (!h) {
-        printf("Provided RDH pointer is null\n");
-        return;
-      }
-      printf("RDH| Ver:%2u Hsz:%2u Blgt:%4u FEEId:0x%04x PBit:%u\n",
-             uint32_t(h->version), uint32_t(h->headerSize), uint32_t(h->blockLength), uint32_t(h->feeId), uint32_t(h->priority));
-      printf("RDH|[CRU: Offs:%5u Msz:%4u LnkId:0x%02x Packet:%3u CRUId:0x%04x]\n",
-             uint32_t(h->offsetToNext), uint32_t(h->memorySize), uint32_t(h->linkID), uint32_t(h->packetCounter), uint32_t(h->cruID));
-      printf("RDH| TrgOrb:%9u HBOrb:%9u TrgBC:%4u HBBC:%4u TrgType:%u\n",
-             uint32_t(h->triggerOrbit), uint32_t(h->heartbeatOrbit), uint32_t(h->triggerBC), uint32_t(h->heartbeatBC),
-
-             uint32_t(h->triggerType));
-      printf("RDH| DetField:0x%05x Par:0x%04x Stop:0x%04x PageCnt:%5u\n",
-             uint32_t(h->detectorField), uint32_t(h->par), uint32_t(h->stop), uint32_t(h->pageCnt));
-    }
-  }
 
  private:
   std::ifstream mFileDest;

--- a/Detectors/FIT/FT0/reconstruction/src/ReadRaw.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/ReadRaw.cxx
@@ -59,8 +59,10 @@ Continueous mode  :   for only bunches with data at least in 1 channel.
 #include "TTree.h"
 #include "TBranch.h"
 #include "CommonConstants/LHCConstants.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 using namespace o2::ft0;
+using RDHUtils = o2::raw::RDHUtils;
 
 ClassImp(ReadRaw);
 
@@ -101,14 +103,14 @@ void ReadRaw::readData(const std::string fileRaw, const o2::ft0::LookUpTable& lu
     int pos = 0;
     mFileDest.seekg(posInFile);
     mFileDest.read(reinterpret_cast<char*>(&mRDH), sizeof(mRDH));
-    printRDH(&mRDH);
-    int nwords = mRDH.memorySize;
-    int npackages = mRDH.packetCounter;
-    int numPage = mRDH.pageCnt;
-    int offset = mRDH.offsetToNext;
-    int link = mRDH.linkID;
+    RDHUtils::printRDH(mRDH);
+    int nwords = RDHUtils::getMemorySize(mRDH);
+    int npackages = RDHUtils::getPacketCounter(mRDH);
+    int numPage = RDHUtils::getPageCounter(mRDH);
+    int offset = RDHUtils::getOffsetToNext(mRDH);
+    int link = RDHUtils::getLinkID(mRDH);
     if (nwords <= sizeof(mRDH)) {
-      posInFile += mRDH.offsetToNext;
+      posInFile += RDHUtils::getOffsetToNext(mRDH);
       LOG(INFO) << " next RDH";
       pos = 0;
     } else {

--- a/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
@@ -16,11 +16,13 @@
 #include "MIDRaw/CRUBareDecoder.h"
 
 #include "RawInfo.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 namespace o2
 {
 namespace mid
 {
+using RDHUtils = o2::raw::RDHUtils;
 
 void CRUBareDecoder::reset()
 {
@@ -110,7 +112,7 @@ void CRUBareDecoder::addBoard(size_t ilink)
     eventType = EventType::Dead;
   }
   auto firstEntry = mData.size();
-  InteractionRecord intRec(localClock - sDelayBCToLocal, mBuffer.getRDH()->triggerOrbit);
+  InteractionRecord intRec(localClock - sDelayBCToLocal, RDHUtils::getTriggerOrbit(*mBuffer.getRDH()));
   mData.push_back({mELinkDecoders[ilink].getStatusWord(), mELinkDecoders[ilink].getTriggerWord(), crateparams::makeUniqueLocID(mCrateId, mELinkDecoders[ilink].getId()), mELinkDecoders[ilink].getInputs()});
   mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
 }

--- a/Detectors/MUON/MID/Raw/src/RawBuffer.cxx
+++ b/Detectors/MUON/MID/Raw/src/RawBuffer.cxx
@@ -17,11 +17,13 @@
 
 #include "MIDRaw/RawUnit.h"
 #include "RawInfo.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 namespace o2
 {
 namespace mid
 {
+using RDHUtils = o2::raw::RDHUtils;
 
 template <typename T>
 unsigned int RawBuffer<T>::next(unsigned int nBits)
@@ -73,10 +75,10 @@ bool RawBuffer<T>::nextHeader()
   }
   mHeaderIndex = mNextHeaderIndex;
   mRDH = reinterpret_cast<const header::RAWDataHeader*>(&mBytes[mHeaderIndex]);
-  mEndOfPayloadIndex = mHeaderIndex + (mRDH->memorySize / mElementSizeInBytes);
+  mEndOfPayloadIndex = mHeaderIndex + (RDHUtils::getMemorySize(*mRDH) / mElementSizeInBytes);
   // Go to end of header, i.e. beginning of payload
-  mElementIndex = mHeaderIndex + (mRDH->headerSize / mElementSizeInBytes);
-  mNextHeaderIndex = mHeaderIndex + mRDH->offsetToNext / mElementSizeInBytes;
+  mElementIndex = mHeaderIndex + (RDHUtils::getHeaderSize(*mRDH) / mElementSizeInBytes);
+  mNextHeaderIndex = mHeaderIndex + RDHUtils::getOffsetToNext(*mRDH) / mElementSizeInBytes;
   mBitIndex = 0;
 
   return true;
@@ -134,7 +136,7 @@ bool RawBuffer<T>::isHBClosed()
   if (!mRDH) {
     return false;
   }
-  return mRDH->stop;
+  return RDHUtils::getStop(*mRDH);
 }
 
 template <typename T>

--- a/Detectors/TOF/compression/include/TOFCompression/Compressor.h
+++ b/Detectors/TOF/compression/include/TOFCompression/Compressor.h
@@ -28,7 +28,7 @@ namespace o2
 namespace tof
 {
 
-template <typename RAWDataHeader, bool verbose>
+template <typename RDH, bool verbose>
 class Compressor
 {
 
@@ -108,7 +108,7 @@ class Compressor
   const uint32_t* mDecoderPointerNext = nullptr;
   uint8_t mDecoderNextWord = 1;
   uint8_t mDecoderNextWordStep = 2;
-  const RAWDataHeader* mDecoderRDH;
+  const RDH* mDecoderRDH;
   bool mDecoderCONET = false;
   bool mDecoderVerbose = false;
   bool mDecoderError = false;
@@ -130,7 +130,7 @@ class Compressor
   uint32_t* mEncoderPointerMax = nullptr;
   uint32_t* mEncoderPointerStart = nullptr;
   uint8_t mEncoderNextWord = 1;
-  RAWDataHeader* mEncoderRDH;
+  RDH* mEncoderRDH;
   bool mEncoderVerbose = false;
 
   /** checker private functions and data members **/

--- a/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
+++ b/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
@@ -28,7 +28,7 @@ namespace o2
 namespace tof
 {
 
-template <typename RAWDataHeader, bool verbose>
+template <typename RDH, bool verbose>
 class CompressorTask : public Task
 {
  public:
@@ -38,7 +38,7 @@ class CompressorTask : public Task
   void run(ProcessingContext& pc) final;
 
  private:
-  Compressor<RAWDataHeader, verbose> mCompressor;
+  Compressor<RDH, verbose> mCompressor;
 };
 
 } // namespace tof

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -96,8 +96,8 @@ namespace o2
 namespace tof
 {
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::processHBF()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::processHBF()
 {
 
   if (verbose && mDecoderVerbose) {
@@ -107,8 +107,8 @@ bool Compressor<RAWDataHeader, verbose>::processHBF()
               << std::endl;
   }
 
-  mDecoderRDH = reinterpret_cast<const RAWDataHeader*>(mDecoderPointer);
-  mEncoderRDH = reinterpret_cast<RAWDataHeader*>(mEncoderPointer);
+  mDecoderRDH = reinterpret_cast<const RDH*>(mDecoderPointer);
+  mEncoderRDH = reinterpret_cast<RDH*>(mEncoderPointer);
   auto rdh = mDecoderRDH;
 
   /** loop until RDH close **/
@@ -132,7 +132,7 @@ bool Compressor<RAWDataHeader, verbose>::processHBF()
     mDecoderSaveBufferDataSize += drmPayload;
 
     /** move to next RDH **/
-    rdh = reinterpret_cast<const RAWDataHeader*>(reinterpret_cast<const char*>(rdh) + offsetToNext);
+    rdh = reinterpret_cast<const RDH*>(reinterpret_cast<const char*>(rdh) + offsetToNext);
 
     /** check next RDH is within buffer **/
     if (reinterpret_cast<const char*>(rdh) < mDecoderBuffer + mDecoderBufferSize)
@@ -181,7 +181,7 @@ bool Compressor<RAWDataHeader, verbose>::processHBF()
 
   /** copy RDH close to encoder buffer **/
   /** CAREFUL WITH THE PAGE COUNTER **/
-  mEncoderRDH = reinterpret_cast<RAWDataHeader*>(mEncoderPointer);
+  mEncoderRDH = reinterpret_cast<RDH*>(mEncoderPointer);
   std::memcpy(mEncoderRDH, rdh, rdh->headerSize);
   mEncoderRDH->memorySize = rdh->headerSize;
   mEncoderRDH->offsetToNext = mEncoderRDH->memorySize;
@@ -205,8 +205,8 @@ bool Compressor<RAWDataHeader, verbose>::processHBF()
   return true;
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::processDRM()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::processDRM()
 {
 
   if (verbose && mDecoderVerbose) {
@@ -501,8 +501,8 @@ bool Compressor<RAWDataHeader, verbose>::processDRM()
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::processLTM()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::processLTM()
 {
   /** process LTM **/
 
@@ -544,8 +544,8 @@ bool Compressor<RAWDataHeader, verbose>::processLTM()
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::processTRM()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::processTRM()
 {
   /** process TRM **/
 
@@ -633,8 +633,8 @@ bool Compressor<RAWDataHeader, verbose>::processTRM()
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::processTRMchain(int itrm, int ichain)
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::processTRMchain(int itrm, int ichain)
 {
   /** process TRM chain **/
 
@@ -730,8 +730,8 @@ bool Compressor<RAWDataHeader, verbose>::processTRMchain(int itrm, int ichain)
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::decoderParanoid()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::decoderParanoid()
 {
   /** decoder paranoid **/
 
@@ -743,8 +743,8 @@ bool Compressor<RAWDataHeader, verbose>::decoderParanoid()
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-void Compressor<RAWDataHeader, verbose>::encoderSpider(int itrm)
+template <typename RDH, bool verbose>
+void Compressor<RDH, verbose>::encoderSpider(int itrm)
 {
   /** encoder spider **/
 
@@ -850,8 +850,8 @@ void Compressor<RAWDataHeader, verbose>::encoderSpider(int itrm)
   }
 }
 
-template <typename RAWDataHeader, bool verbose>
-bool Compressor<RAWDataHeader, verbose>::checkerCheck()
+template <typename RDH, bool verbose>
+bool Compressor<RDH, verbose>::checkerCheck()
 {
   /** checker check **/
 
@@ -1220,8 +1220,8 @@ bool Compressor<RAWDataHeader, verbose>::checkerCheck()
   return false;
 }
 
-template <typename RAWDataHeader, bool verbose>
-void Compressor<RAWDataHeader, verbose>::checkerCheckRDH()
+template <typename RDH, bool verbose>
+void Compressor<RDH, verbose>::checkerCheckRDH()
 {
 }
 
@@ -1319,8 +1319,8 @@ void Compressor<o2::header::RAWDataHeaderV6, false>::checkerCheckRDH()
   }
 }
 
-template <typename RAWDataHeader, bool verbose>
-void Compressor<RAWDataHeader, verbose>::resetCounters()
+template <typename RDH, bool verbose>
+void Compressor<RDH, verbose>::resetCounters()
 {
   mEventCounter = 0;
   mFatalCounter = 0;
@@ -1334,8 +1334,8 @@ void Compressor<RAWDataHeader, verbose>::resetCounters()
   }
 }
 
-template <typename RAWDataHeader, bool verbose>
-void Compressor<RAWDataHeader, verbose>::checkSummary()
+template <typename RDH, bool verbose>
+void Compressor<RDH, verbose>::checkSummary()
 {
   char chname[2] = {'a', 'b'};
 

--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -29,8 +29,8 @@ namespace o2
 namespace tof
 {
 
-template <typename RAWDataHeader, bool verbose>
-void CompressorTask<RAWDataHeader, verbose>::init(InitContext& ic)
+template <typename RDH, bool verbose>
+void CompressorTask<RDH, verbose>::init(InitContext& ic)
 {
   LOG(INFO) << "Compressor init";
 
@@ -51,8 +51,8 @@ void CompressorTask<RAWDataHeader, verbose>::init(InitContext& ic)
   ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
 }
 
-template <typename RAWDataHeader, bool verbose>
-void CompressorTask<RAWDataHeader, verbose>::run(ProcessingContext& pc)
+template <typename RDH, bool verbose>
+void CompressorTask<RDH, verbose>::run(ProcessingContext& pc)
 {
   LOG(DEBUG) << "Compressor run";
 

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/DecoderBase.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/DecoderBase.h
@@ -30,7 +30,7 @@ namespace tof
 namespace compressed
 {
 
-template <typename RAWDataHeader>
+template <typename RDH>
 class DecoderBaseT
 {
 
@@ -58,7 +58,7 @@ class DecoderBaseT
  private:
   /** handlers **/
 
-  virtual void rdhHandler(const RAWDataHeader* rdh){};
+  virtual void rdhHandler(const RDH* rdh){};
   virtual void headerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit){};
 
   virtual void frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
@@ -84,7 +84,7 @@ class DecoderBaseT
   const uint32_t* mDecoderPointer = nullptr;
   const uint32_t* mDecoderPointerMax = nullptr;
   const uint32_t* mDecoderPointerNext = nullptr;
-  const RAWDataHeader* mDecoderRDH;
+  const RDH* mDecoderRDH;
   bool mDecoderVerbose = false;
   bool mDecoderError = false;
   bool mDecoderFatal = false;
@@ -95,7 +95,7 @@ class DecoderBaseT
 
 typedef DecoderBaseT<o2::header::RAWDataHeaderV4> DecoderBaseV4;
 typedef DecoderBaseT<o2::header::RAWDataHeaderV6> DecoderBaseV6;
-using DecoderBase = DecoderBaseV4;
+using DecoderBase = DecoderBaseT<o2::header::RAWDataHeader>;
 
 } // namespace compressed
 } // namespace tof

--- a/Detectors/TOF/workflow/include/TOFWorkflow/CompressedInspectorTask.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/CompressedInspectorTask.h
@@ -35,8 +35,8 @@ namespace tof
 
 using namespace compressed;
 
-template <typename RAWDataHeader>
-class CompressedInspectorTask : public DecoderBaseT<RAWDataHeader>, public Task
+template <typename RDH>
+class CompressedInspectorTask : public DecoderBaseT<RDH>, public Task
 {
  public:
   CompressedInspectorTask() = default;

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -23,6 +23,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/Logger.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 using namespace o2::framework;
 
@@ -30,6 +31,8 @@ namespace o2
 {
 namespace tof
 {
+
+using RDHUtils = o2::raw::RDHUtils;
 
 void CompressedDecodingTask::init(InitContext& ic)
 {
@@ -118,16 +121,17 @@ void CompressedDecodingTask::rdhHandler(const o2::header::RAWDataHeader* rdh)
 {
 
   // rdh close
-  if (rdh->stop && rdh->heartbeatOrbit == o2::raw::HBFUtils::Instance().getNOrbitsPerTF() - 1 + mInitOrbit) {
+  const auto& rdhr = *rdh;
+  if (RDHUtils::getStop(rdhr) && RDHUtils::getHeartBeatOrbit(rdhr) == o2::raw::HBFUtils::Instance().getNOrbitsPerTF() - 1 + mInitOrbit) {
     mNCrateCloseTF++;
     //    printf("New TF close RDH %d\n", int(rdh->feeId));
     return;
   }
 
   // rdh open
-  if ((rdh->pageCnt == 0) && (rdh->triggerType & o2::trigger::TF)) {
+  if ((RDHUtils::getPageCounter(rdhr) == 0) && (RDHUtils::getTriggerType(rdhr) & o2::trigger::TF)) {
     mNCrateOpenTF++;
-    mInitOrbit = rdh->heartbeatOrbit;
+    mInitOrbit = RDHUtils::getHeartBeatOrbit(rdhr);
     //    printf("New TF open RDH %d\n", int(rdh->feeId));
   }
 };

--- a/Detectors/TOF/workflow/src/CompressedInspectorTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedInspectorTask.cxx
@@ -31,8 +31,8 @@ namespace o2
 namespace tof
 {
 
-template <typename RAWDataHeader>
-void CompressedInspectorTask<RAWDataHeader>::init(InitContext& ic)
+template <typename RDH>
+void CompressedInspectorTask<RDH>::init(InitContext& ic)
 {
   LOG(INFO) << "CompressedInspector init";
   auto filename = ic.options().get<std::string>("tof-compressed-inspector-filename");
@@ -74,8 +74,8 @@ void CompressedInspectorTask<RAWDataHeader>::init(InitContext& ic)
   ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
 }
 
-template <typename RAWDataHeader>
-void CompressedInspectorTask<RAWDataHeader>::run(ProcessingContext& pc)
+template <typename RDH>
+void CompressedInspectorTask<RDH>::run(ProcessingContext& pc)
 {
   LOG(DEBUG) << "CompressedInspector run";
 
@@ -97,24 +97,24 @@ void CompressedInspectorTask<RAWDataHeader>::run(ProcessingContext& pc)
       auto payloadIn = ref.payload;
       auto payloadInSize = headerIn->payloadSize;
 
-      DecoderBaseT<RAWDataHeader>::setDecoderBuffer(payloadIn);
-      DecoderBaseT<RAWDataHeader>::setDecoderBufferSize(payloadInSize);
-      DecoderBaseT<RAWDataHeader>::run();
+      DecoderBaseT<RDH>::setDecoderBuffer(payloadIn);
+      DecoderBaseT<RDH>::setDecoderBufferSize(payloadInSize);
+      DecoderBaseT<RDH>::run();
     }
   }
 }
 
-template <typename RAWDataHeader>
-void CompressedInspectorTask<RAWDataHeader>::headerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit)
+template <typename RDH>
+void CompressedInspectorTask<RDH>::headerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit)
 {
   for (int ibit = 0; ibit < 11; ++ibit)
     if (crateHeader->slotPartMask & (1 << ibit))
       mHistos2D["slotPartMask"]->Fill(crateHeader->drmID, ibit + 2);
 };
 
-template <typename RAWDataHeader>
-void CompressedInspectorTask<RAWDataHeader>::frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
-                                                          const FrameHeader_t* frameHeader, const PackedHit_t* packedHits)
+template <typename RDH>
+void CompressedInspectorTask<RDH>::frameHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
+                                                const FrameHeader_t* frameHeader, const PackedHit_t* packedHits)
 {
   mHistos1D["hHisto"]->Fill(frameHeader->numberOfHits);
   for (int i = 0; i < frameHeader->numberOfHits; ++i) {
@@ -135,10 +135,10 @@ void CompressedInspectorTask<RAWDataHeader>::frameHandler(const CrateHeader_t* c
   }
 };
 
-template <typename RAWDataHeader>
-void CompressedInspectorTask<RAWDataHeader>::trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
-                                                            const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
-                                                            const Error_t* errors)
+template <typename RDH>
+void CompressedInspectorTask<RDH>::trailerHandler(const CrateHeader_t* crateHeader, const CrateOrbit_t* crateOrbit,
+                                                  const CrateTrailer_t* crateTrailer, const Diagnostic_t* diagnostics,
+                                                  const Error_t* errors)
 {
   mHistos2D["diagnostic"]->Fill(crateHeader->drmID, 0);
   for (int i = 0; i < crateTrailer->numberOfDiagnostics; ++i) {

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReaderCRU.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReaderCRU.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <functional>
 #include <gsl/span>
+#include "DetectorsRaw/RDHUtils.h"
 
 #include "MemoryResources/Types.h"
 #include "TPCBase/CRU.h"
@@ -43,6 +44,8 @@ namespace tpc
 {
 namespace rawreader
 {
+
+using RDHUtils = o2::raw::RDHUtils;
 
 /// debug level bits
 enum DebugLevel : uint8_t {
@@ -386,10 +389,10 @@ class RawReaderCRUEventSync
     // check if event is already registered. If not create a new one.
     auto& event = createEvent(rdh, dataType);
 
-    const auto dataWrapperID = rdh.endPointID;
-    const auto linkID = rdh.linkID;
+    const auto dataWrapperID = RDHUtils::getEndPointID(rdh);
+    const auto linkID = RDHUtils::getLinkID(rdh);
     const auto globalLinkID = linkID + dataWrapperID * 12;
-    return event.CRUInfoArray[rdh.cruID].LinkInformation[globalLinkID];
+    return event.CRUInfoArray[RDHUtils::getCRUID(rdh)].LinkInformation[globalLinkID];
   }
 
   /// get array with all link informaiton for a specific event number and cru

--- a/Detectors/TPC/reconstruction/src/RawReaderCRU.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReaderCRU.cxx
@@ -20,11 +20,13 @@
 #include "TPCReconstruction/RawReaderCRU.h"
 #include "TPCBase/Mapper.h"
 #include "Framework/Logger.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 #define CHECK_BIT(var, pos) ((var) & (1 << (pos)))
 using RDH = o2::header::RAWDataHeader;
 //using namespace o2::tpc;
 using namespace o2::tpc::rawreader;
+using RDHUtils = o2::raw::RDHUtils;
 
 std::ostream& operator<<(std::ostream& output, const RDH& rdh);
 std::istream& operator>>(std::istream& input, RDH& rdh);
@@ -43,7 +45,7 @@ RawReaderCRUEventSync::LinkInfo& RawReaderCRUEventSync::getLinkInfo(uint32_t hea
 
 RawReaderCRUEventSync::EventInfo& RawReaderCRUEventSync::createEvent(const RDH& rdh, DataType dataType)
 {
-  const auto heartbeatOrbit = rdh.heartbeatOrbit;
+  const auto heartbeatOrbit = RDHUtils::getHeartBeatOrbit(rdh);
 
   for (auto& ev : mEventInformation) {
     const auto hbMatch = ev.hasHearbeatOrbit(heartbeatOrbit);
@@ -186,7 +188,7 @@ int RawReaderCRU::scanFile()
   // std::vector<PacketDescriptor> mPacketDescriptorMap;
   //const uint64_t RDH_HEADERWORD0 = 0x1ea04003;
   //const uint64_t RDH_HEADERWORD0 = 0x00004003;
-  const uint64_t RDH_HEADERWORD0 = 0x00004004;
+  const uint64_t RDH_HEADERWORD0 = 0x00004000 + RDHUtils::getVersion<o2::header::RAWDataHeader>();
 
   std::ifstream file;
   file.open(mInputFileName, std::ifstream::binary);
@@ -214,8 +216,8 @@ int RawReaderCRU::scanFile()
     // ===| read in the RawDataHeader at the current position |=================
     file >> rdh;
 
-    const size_t packetSize = rdh.offsetToNext;
-    const size_t offset = packetSize - rdh.headerSize;
+    const size_t packetSize = RDHUtils::getOffsetToNext(rdh);
+    const size_t offset = packetSize - RDHUtils::getHeaderSize(rdh);
 
     // ===| try to detect data type if not already set |========================
     //
@@ -227,8 +229,8 @@ int RawReaderCRU::scanFile()
     if (mManager) {
       if (mManager->mDataType == DataType::TryToDetect) {
         const uint64_t triggerTypeForTriggeredData = 0x10;
-        const uint64_t triggerType = rdh.triggerType;
-        const uint64_t pageCnt = rdh.pageCnt;
+        const uint64_t triggerType = RDHUtils::getTriggerType(rdh);
+        const uint64_t pageCnt = RDHUtils::getPageCounter(rdh);
 
         if (pageCnt == 1) {
           if (triggerType == triggerTypeForTriggeredData) {
@@ -244,19 +246,19 @@ int RawReaderCRU::scanFile()
 
     // ===| get relavant data information |=====================================
     //const auto heartbeatOrbit = rdh.heartbeatOrbit;
-    const auto dataWrapperID = rdh.endPointID;
-    const auto linkID = rdh.linkID;
+    const auto dataWrapperID = RDHUtils::getEndPointID(rdh);
+    const auto linkID = RDHUtils::getLinkID(rdh);
     const auto globalLinkID = linkID + dataWrapperID * 12;
     //const auto blockLength = rdh.blockLength;
-    const auto memorySize = rdh.memorySize;
-    const auto payloadSize = rdh.memorySize - rdh.headerSize;
+    const auto memorySize = RDHUtils::getMemorySize(rdh);
+    const auto payloadSize = memorySize - RDHUtils::getHeaderSize(rdh);
 
     // ===| check if cru should be forced |=====================================
     if (!mForceCRU) {
-      mCRU = rdh.cruID;
+      mCRU = RDHUtils::getCRUID(rdh);
     } else {
       //overwrite cru id in rdh for further processing
-      rdh.cruID = mCRU;
+      RDHUtils::setCRUID(rdh, mCRU);
     }
 
     // ===| find evnet info or create a new one |===============================
@@ -276,7 +278,7 @@ int RawReaderCRU::scanFile()
     //
     if ((rdh.word0 & 0x0000FFFF) == RDH_HEADERWORD0) {
       // non 0 stop bit means data with payload
-      if (rdh.stop == 0) {
+      if (RDHUtils::getStop(rdh) == 0) {
         mPacketDescriptorMaps[globalLinkID].emplace_back(currentPos, mCRU, linkID, dataWrapperID, memorySize, packetSize);
         mLinkPresent[globalLinkID] = true;
         mPacketsPerLink[globalLinkID]++;
@@ -285,14 +287,14 @@ int RawReaderCRU::scanFile()
           linkInfo->IsPresent = true;
           linkInfo->PayloadSize += payloadSize;
         }
-      } else if (rdh.stop == 1) {
+      } else if (RDHUtils::getStop(rdh) == 1) {
         // stop bit 1 means we hit the HB end frame without payload.
         // This marks the end of an "event" in HB scaling mode.
         if (linkInfo) {
           linkInfo->HBEndSeen = true;
         }
       } else {
-        O2ERROR("Unknown stop code: %lu", (unsigned long)rdh.stop);
+        O2ERROR("Unknown stop code: %lu", (unsigned long)RDHUtils::getStop(rdh));
       }
       //std::cout << dataWrapperID << "." << linkID << " (" << globalLinkID << ")\n";
     } else {
@@ -304,7 +306,7 @@ int RawReaderCRU::scanFile()
       //std::cout << "Packet " << std::setw(5) << currentPacket << " - Link " << int(linkID) << "\n";
       //std::cout << rdh;
       printHorizontal(rdh);
-      if (rdh.stop) {
+      if (RDHUtils::getStop(rdh)) {
         std::cout << "\n";
         printHeader();
       }
@@ -859,29 +861,30 @@ std::ostream& operator<<(std::ostream& output, const RDH& rdh)
 {
   output << "word0            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word0 << "\n"
          << std::dec;
-  output << "  version        : " << rdh.version << "\n";
-  output << "  headerSize     : " << rdh.headerSize << "\n";
-  output << "  blockLength    : " << rdh.blockLength << "\n";
-  output << "  feeId          : " << rdh.feeId << "\n";
-  output << "  priority       : " << rdh.priority << "\n";
-  output << "  zero0          : " << rdh.zero0 << "\n";
+  output << "  version        : " << RDHUtils::getVersion(rdh) << "\n";
+  output << "  headerSize     : " << RDHUtils::getHeaderSize(rdh) << "\n";
+  if (RDHUtils::getVersion(rdh) == 4) {
+    output << "  blockLength    : " << RDHUtils::getBlockLength(rdh) << "\n";
+  }
+  output << "  feeId          : " << RDHUtils::getFEEID(rdh) << "\n";
+  output << "  priority       : " << RDHUtils::getPriorityBit(rdh) << "\n";
   output << "\n";
 
   output << "word1            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word1 << "\n"
          << std::dec;
-  output << "  Offset to next : " << int(rdh.offsetToNext) << "\n";
-  output << "  Memory size    : " << int(rdh.memorySize) << "\n";
-  output << "  LinkID         : " << int(rdh.linkID) << "\n";
-  output << "  Global LinkID  : " << int(rdh.linkID) + (((rdh.word1 >> 32) >> 28) * 12) << "\n";
-  output << "  CRUid          : " << rdh.cruID << "\n";
-  output << "  Packet Counter : " << rdh.packetCounter << "\n";
+  output << "  Offset to next : " << int(RDHUtils::getOffsetToNext(rdh)) << "\n";
+  output << "  Memory size    : " << int(RDHUtils::getMemorySize(rdh)) << "\n";
+  output << "  LinkID         : " << int(RDHUtils::getLinkID(rdh)) << "\n";
+  output << "  Global LinkID  : " << int(RDHUtils::getLinkID(rdh)) + (((rdh.word1 >> 32) >> 28) * 12) << "\n";
+  output << "  CRUid          : " << RDHUtils::getCRUID(rdh) << "\n";
+  output << "  Packet Counter : " << RDHUtils::getPacketCounter(rdh) << "\n";
   output << "  DataWrapper-ID : " << (((rdh.word1 >> 32) >> 28) & 0x01) << "\n";
   output << "\n";
 
   output << "word2            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word2 << "\n"
          << std::dec;
-  output << "  triggerOrbit   : " << rdh.triggerOrbit << "\n";
-  output << "  heartbeatOrbit : " << rdh.heartbeatOrbit << "\n";
+  output << "  triggerOrbit   : " << RDHUtils::getTriggerOrbit(rdh) << "\n";
+  output << "  heartbeatOrbit : " << RDHUtils::getHeartBeatOrbit(rdh) << "\n";
   output << "\n";
 
   output << "word3            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word3 << "\n"
@@ -890,11 +893,9 @@ std::ostream& operator<<(std::ostream& output, const RDH& rdh)
 
   output << "word4            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word4 << "\n"
          << std::dec;
-  output << "  triggerBC      : " << rdh.triggerBC << "\n";
-  output << "  zero41         : " << rdh.zero41 << "\n";
-  output << "  heartbeatBC    : " << rdh.heartbeatBC << "\n";
-  output << "  zero42         : " << rdh.zero42 << "\n";
-  output << "  triggerType    : " << rdh.triggerType << "\n";
+  output << "  triggerBC      : " << RDHUtils::getTriggerBC(rdh) << "\n";
+  output << "  heartbeatBC    : " << RDHUtils::getHeartBeatBC(rdh) << "\n";
+  output << "  triggerType    : " << RDHUtils::getTriggerType(rdh) << "\n";
   output << "\n";
 
   output << "word5            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word5 << "\n"
@@ -903,11 +904,10 @@ std::ostream& operator<<(std::ostream& output, const RDH& rdh)
 
   output << "word6            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word6 << "\n"
          << std::dec;
-  output << "  detectorField  : " << rdh.detectorField << "\n";
-  output << "  par            : " << rdh.par << "\n";
-  output << "  stop           : " << rdh.stop << "\n";
-  output << "  pageCnt        : " << rdh.pageCnt << "\n";
-  output << "  zero6          : " << rdh.zero6 << "\n";
+  output << "  detectorField  : " << RDHUtils::getDetectorField(rdh) << "\n";
+  output << "  par            : " << RDHUtils::getDetectorPAR(rdh) << "\n";
+  output << "  stop           : " << RDHUtils::getStop(rdh) << "\n";
+  output << "  pageCnt        : " << RDHUtils::getPageCounter(rdh) << "\n";
   output << "\n";
 
   output << "word7            : 0x" << std::setfill('0') << std::setw(16) << std::hex << rdh.word7 << "\n"
@@ -925,20 +925,20 @@ void printHeader()
 
 void printHorizontal(const RDH& rdh)
 {
-  const int globalLinkID = int(rdh.linkID) + (((rdh.word1 >> 32) >> 28) * 12);
+  const int globalLinkID = int(RDHUtils::getLinkID(rdh)) + (((rdh.word1 >> 32) >> 28) * 12);
 
   fmt::print("{:>5} {:>4} {:>4} {:>4} {:>6} {:>4} {:>3} {:>4} {:>10} {:>5} {:>1}\n",
-             (uint64_t)rdh.packetCounter,
-             (uint64_t)rdh.pageCnt,
-             (uint64_t)rdh.triggerType,
-             (uint64_t)rdh.feeId,
-             (uint64_t)rdh.offsetToNext,
-             (uint64_t)rdh.memorySize,
-             (uint64_t)rdh.cruID,
+             (uint64_t)RDHUtils::getPacketCounter(rdh),
+             (uint64_t)RDHUtils::getPageCounter(rdh),
+             (uint64_t)RDHUtils::getTriggerType(rdh),
+             (uint64_t)RDHUtils::getFEEID(rdh),
+             (uint64_t)RDHUtils::getOffsetToNext(rdh),
+             (uint64_t)RDHUtils::getMemorySize(rdh),
+             (uint64_t)RDHUtils::getCRUID(rdh),
              (uint64_t)globalLinkID,
-             (uint64_t)rdh.heartbeatOrbit,
-             (uint64_t)rdh.heartbeatBC,
-             (uint64_t)rdh.stop);
+             (uint64_t)RDHUtils::getHeartBeatOrbit(rdh),
+             (uint64_t)RDHUtils::getHeartBeatBC(rdh),
+             (uint64_t)RDHUtils::getStop(rdh));
 }
 
 std::istream& operator>>(std::istream& input, RDH& rdh)

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -57,6 +57,7 @@
 #include <stdexcept>
 #include <regex>
 #include "GPUReconstructionConvert.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 using namespace o2::framework;
 using namespace o2::header;
@@ -498,10 +499,12 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
                 tpcZSmetaSizes[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].emplace_back(count);
               }
               count = 0;
-              //lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
-              lastFEE = int(rdh->feeId);
-              rawcru = int(rdh->cruID);
-              rawendpoint = int(rdh->endPointID);
+              lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
+              rawcru = o2::raw::RDHUtils::getCRUID(*rdh);
+              rawendpoint = o2::raw::RDHUtils::getEndPointID(*rdh);
+              //lastFEE = int(rdh->feeId);
+              //rawcru = int(rdh->cruID);
+              //rawendpoint = int(rdh->endPointID);
               if (it.size() == 0 && tpcZSmetaPointers[rawcru / 10][(rawcru % 10) * 2 + rawendpoint].size()) {
                 ptr = nullptr;
                 continue;

--- a/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
@@ -28,6 +28,7 @@
 #include "TPCWorkflow/LinkZSToDigitsSpec.h"
 #include <vector>
 #include <string>
+#include "DetectorsRaw/RDHUtils.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -145,7 +146,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
           o2::framework::RawParser parser(input.payload, dh->payloadSize);
 
           for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-            auto* rdhPtr = it.get_if<o2::header::RAWDataHeaderV4>();
+            auto* rdhPtr = it.get_if<o2::header::RAWDataHeader>();
             if (!rdhPtr) {
               break;
             }
@@ -153,7 +154,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
             const auto& rdh = *rdhPtr;
 
             // ===| only accept physics triggers |===
-            if (rdh.triggerType != 0x10) {
+            if (o2::raw::RDHUtils::getTriggerType(rdhPtr) != 0x10) {
               continue;
             }
 
@@ -162,13 +163,13 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
             // really ugly, better treatment required extension in DPL
             // events are are detected by close by orbit numbers
             //
-            const auto hbOrbit = rdh.heartbeatOrbit;
+            const auto hbOrbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdhPtr);
             const auto lastOrbit = processAttributes->lastOrbit;
 
             if (!processAttributes->firstOrbit) {
               processAttributes->firstOrbit = hbOrbit;
               if (!processAttributes->isContinuous) {
-                processAttributes->firstBC = rdh.heartbeatBC;
+                processAttributes->firstBC = o2::raw::RDHUtils::getHeartBeatBC(rdhPtr);
               }
             }
 

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -150,7 +150,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
         const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
         o2::raw::RawFileWriter writer{"TPC"}; // to set the RDHv6.sourceID if V6 is used
         writer.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)); // must be set explicitly
-        uint32_t rdhV = 4;
+        uint32_t rdhV = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
         writer.useRDHVersion(rdhV);
         std::string outDir = "./";
         const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
@@ -299,7 +299,7 @@ DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
             }
             count = 0;
             lastFEE = o2::raw::RDHUtils::getFEEID(*rdh);
-            cruID = int(rdh->cruID);
+            cruID = int(o2::raw::RDHUtils::getCRUID(*rdh));
             if (it.size() == 0) {
               ptr = nullptr;
               continue;


### PR DESCRIPTION
* TOF: fixes: use RDHUtils to access RDH fields, dont use RAWDataHeader as template typename
* FT0: fixes: use RDHUtils to access RDH fields
* TPC: fixes: use RDHUtils to access RDH fields
* MID: fixes: use RDHUtils to access RDH fields
* Link RAWDataHeader to RAWDataHeaderV6

I've fixed compilation conflicts + hardcoded particular RDH version + obvious cases of direct access to RDH fields for detectors above.
@wiechula, @noferini, @preghenella, @AllaMaevskaya, @dstocco, could you please check if these fixes are ok?
Will merge this on Fri. if there are no blockers.

@JohannesLb I see that in 0422b5cdb35adbbc714795f70b73851068deb29a you have reverted usiage of some RDHUtils getters to direct access to RDH fields. Was there any reason for that? In this PR I've reverted to RDHUtils usage.