### PR TITLE
Extended table for the modified cov. matrix

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -116,21 +116,37 @@ DECLARE_SOA_DYNAMIC_COLUMN(P2, p2, [](float signed1Pt, float tgl) -> float {
 DECLARE_SOA_EXPRESSION_COLUMN(Pt2, pt2, float, (1.f / aod::track::signed1Pt) * (1.f / aod::track::signed1Pt));
 
 // TRACKPARCOV TABLE definition
-DECLARE_SOA_COLUMN(CYY, cYY, float);
-DECLARE_SOA_COLUMN(CZY, cZY, float);
-DECLARE_SOA_COLUMN(CZZ, cZZ, float);
-DECLARE_SOA_COLUMN(CSnpY, cSnpY, float);
-DECLARE_SOA_COLUMN(CSnpZ, cSnpZ, float);
-DECLARE_SOA_COLUMN(CSnpSnp, cSnpSnp, float);
-DECLARE_SOA_COLUMN(CTglY, cTglY, float);
-DECLARE_SOA_COLUMN(CTglZ, cTglZ, float);
-DECLARE_SOA_COLUMN(CTglSnp, cTglSnp, float);
-DECLARE_SOA_COLUMN(CTglTgl, cTglTgl, float);
-DECLARE_SOA_COLUMN(C1PtY, c1PtY, float);
-DECLARE_SOA_COLUMN(C1PtZ, c1PtZ, float);
-DECLARE_SOA_COLUMN(C1PtSnp, c1PtSnp, float);
-DECLARE_SOA_COLUMN(C1PtTgl, c1PtTgl, float);
-DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float);
+DECLARE_SOA_COLUMN(SigmaY, sigmaY, float);
+DECLARE_SOA_COLUMN(SigmaZ, sigmaZ, float);
+DECLARE_SOA_COLUMN(SigmaSnp, sigmaSnp, float);
+DECLARE_SOA_COLUMN(SigmaTgl, sigmaTgl, float);
+DECLARE_SOA_COLUMN(Sigma1Pt, sigma1Pt, float);
+DECLARE_SOA_COLUMN(RhoZY, rhoZY, int8_t);
+DECLARE_SOA_COLUMN(RhoSnpY, rhoSnpY, int8_t);
+DECLARE_SOA_COLUMN(RhoSnpZ, rhoSnpZ, int8_t);
+DECLARE_SOA_COLUMN(RhoTglY, rhoTglY, int8_t);
+DECLARE_SOA_COLUMN(RhoTglZ, rhoTglZ, int8_t);
+DECLARE_SOA_COLUMN(RhoTglSnp, rhoTglSnp, int8_t);
+DECLARE_SOA_COLUMN(Rho1PtY, rho1PtY, int8_t);
+DECLARE_SOA_COLUMN(Rho1PtZ, rho1PtZ, int8_t);
+DECLARE_SOA_COLUMN(Rho1PtSnp, rho1PtSnp, int8_t);
+DECLARE_SOA_COLUMN(Rho1PtTgl, rho1PtTgl, int8_t);
+ 
+DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, aod::track::sigmaY*aod::track::sigmaY);
+DECLARE_SOA_EXPRESSION_COLUMN(CZY, cZY, float, (aod::track::rhoZY/128.f)*(aod::track::sigmaZ*aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CZZ, cZZ, float, aod::track::sigmaZ*aod::track::sigmaZ);
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpY, cSnpY, float, (aod::track::rhoSnpY/128.f)*(aod::track::sigmaSnp*aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpZ, cSnpZ, float, (aod::track::rhoSnpZ/128.f)*(aod::track::sigmaSnp*aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpSnp, cSnpSnp, float, aod::track::sigmaSnp*aod::track::sigmaSnp);
+DECLARE_SOA_EXPRESSION_COLUMN(CTglY, cTglY, float, (aod::track::rhoTglY/128.f)*(aod::track::sigmaTgl*aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglZ, cTglZ, float, (aod::track::rhoTglZ/128.f)*(aod::track::sigmaTgl*aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglSnp, cTglSnp, float, (aod::track::rhoTglSnp/128.f)*(aod::track::sigmaTgl*aod::track::sigmaSnp));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglTgl, cTglTgl, float, aod::track::sigmaTgl*aod::track::sigmaTgl);
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtY, c1PtY, float, (aod::track::rho1PtY/128.f)*(aod::track::sigma1Pt*aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtZ, c1PtZ, float, (aod::track::rho1PtZ/128.f)*(aod::track::sigma1Pt*aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtSnp, c1PtSnp, float, (aod::track::rho1PtSnp/128.f)*(aod::track::sigma1Pt*aod::track::sigmaSnp));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, (aod::track::rho1PtTgl/128.f)*(aod::track::sigma1Pt*aod::track::sigmaTgl));
+DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::track::sigma1Pt*aod::track::sigma1Pt);
 
 // TRACKEXTRA TABLE definition
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);
@@ -192,12 +208,29 @@ DECLARE_SOA_TABLE_FULL(StoredTracks, "Tracks", "AOD", "TRACKPAR",
 
 DECLARE_SOA_EXTENDED_TABLE(Tracks, StoredTracks, "TRACKPAR", aod::track::Pt2);
 
-DECLARE_SOA_TABLE(TracksCov, "AOD", "TRACKPARCOV",
-                  track::CYY, track::CZY, track::CZZ, track::CSnpY,
-                  track::CSnpZ, track::CSnpSnp, track::CTglY,
-                  track::CTglZ, track::CTglSnp, track::CTglTgl,
-                  track::C1PtY, track::C1PtZ, track::C1PtSnp, track::C1PtTgl,
-                  track::C1Pt21Pt2);
+DECLARE_SOA_TABLE_FULL(StoredTracksCov, "TracksCov", "AOD", "TRACKPARCOV",
+                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
+		  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,
+                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl
+                  );
+
+DECLARE_SOA_EXTENDED_TABLE(TracksCov, StoredTracksCov, "TRACKPARCOV",
+			   aod::track::CYY,
+			   aod::track::CZY,
+			   aod::track::CZZ,
+			   aod::track::CSnpY,
+			   aod::track::CSnpZ,
+			   aod::track::CSnpSnp,
+			   aod::track::CTglY,
+			   aod::track::CTglZ,
+			   aod::track::CTglSnp,
+			   aod::track::CTglTgl,
+			   aod::track::C1PtY,
+			   aod::track::C1PtZ,
+			   aod::track::C1PtSnp,
+			   aod::track::C1PtTgl,
+			   aod::track::C1Pt21Pt2
+			   );
 
 DECLARE_SOA_TABLE(TracksExtra, "AOD", "TRACKEXTRA",
                   track::TPCInnerParam, track::Flags, track::ITSClusterMap,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -131,22 +131,22 @@ DECLARE_SOA_COLUMN(Rho1PtY, rho1PtY, int8_t);
 DECLARE_SOA_COLUMN(Rho1PtZ, rho1PtZ, int8_t);
 DECLARE_SOA_COLUMN(Rho1PtSnp, rho1PtSnp, int8_t);
 DECLARE_SOA_COLUMN(Rho1PtTgl, rho1PtTgl, int8_t);
- 
-DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, aod::track::sigmaY*aod::track::sigmaY);
-DECLARE_SOA_EXPRESSION_COLUMN(CZY, cZY, float, (aod::track::rhoZY/128.f)*(aod::track::sigmaZ*aod::track::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CZZ, cZZ, float, aod::track::sigmaZ*aod::track::sigmaZ);
-DECLARE_SOA_EXPRESSION_COLUMN(CSnpY, cSnpY, float, (aod::track::rhoSnpY/128.f)*(aod::track::sigmaSnp*aod::track::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CSnpZ, cSnpZ, float, (aod::track::rhoSnpZ/128.f)*(aod::track::sigmaSnp*aod::track::sigmaZ));
-DECLARE_SOA_EXPRESSION_COLUMN(CSnpSnp, cSnpSnp, float, aod::track::sigmaSnp*aod::track::sigmaSnp);
-DECLARE_SOA_EXPRESSION_COLUMN(CTglY, cTglY, float, (aod::track::rhoTglY/128.f)*(aod::track::sigmaTgl*aod::track::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglZ, cTglZ, float, (aod::track::rhoTglZ/128.f)*(aod::track::sigmaTgl*aod::track::sigmaZ));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglSnp, cTglSnp, float, (aod::track::rhoTglSnp/128.f)*(aod::track::sigmaTgl*aod::track::sigmaSnp));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglTgl, cTglTgl, float, aod::track::sigmaTgl*aod::track::sigmaTgl);
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtY, c1PtY, float, (aod::track::rho1PtY/128.f)*(aod::track::sigma1Pt*aod::track::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtZ, c1PtZ, float, (aod::track::rho1PtZ/128.f)*(aod::track::sigma1Pt*aod::track::sigmaZ));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtSnp, c1PtSnp, float, (aod::track::rho1PtSnp/128.f)*(aod::track::sigma1Pt*aod::track::sigmaSnp));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, (aod::track::rho1PtTgl/128.f)*(aod::track::sigma1Pt*aod::track::sigmaTgl));
-DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::track::sigma1Pt*aod::track::sigma1Pt);
+
+DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, aod::track::sigmaY* aod::track::sigmaY);
+DECLARE_SOA_EXPRESSION_COLUMN(CZY, cZY, float, (aod::track::rhoZY / 128.f) * (aod::track::sigmaZ * aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CZZ, cZZ, float, aod::track::sigmaZ* aod::track::sigmaZ);
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpY, cSnpY, float, (aod::track::rhoSnpY / 128.f) * (aod::track::sigmaSnp * aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpZ, cSnpZ, float, (aod::track::rhoSnpZ / 128.f) * (aod::track::sigmaSnp * aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(CSnpSnp, cSnpSnp, float, aod::track::sigmaSnp* aod::track::sigmaSnp);
+DECLARE_SOA_EXPRESSION_COLUMN(CTglY, cTglY, float, (aod::track::rhoTglY / 128.f) * (aod::track::sigmaTgl * aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglZ, cTglZ, float, (aod::track::rhoTglZ / 128.f) * (aod::track::sigmaTgl * aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglSnp, cTglSnp, float, (aod::track::rhoTglSnp / 128.f) * (aod::track::sigmaTgl * aod::track::sigmaSnp));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglTgl, cTglTgl, float, aod::track::sigmaTgl* aod::track::sigmaTgl);
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtY, c1PtY, float, (aod::track::rho1PtY / 128.f) * (aod::track::sigma1Pt * aod::track::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtZ, c1PtZ, float, (aod::track::rho1PtZ / 128.f) * (aod::track::sigma1Pt * aod::track::sigmaZ));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtSnp, c1PtSnp, float, (aod::track::rho1PtSnp / 128.f) * (aod::track::sigma1Pt * aod::track::sigmaSnp));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, (aod::track::rho1PtTgl / 128.f) * (aod::track::sigma1Pt * aod::track::sigmaTgl));
+DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::track::sigma1Pt* aod::track::sigma1Pt);
 
 // TRACKEXTRA TABLE definition
 DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float);
@@ -209,28 +209,26 @@ DECLARE_SOA_TABLE_FULL(StoredTracks, "Tracks", "AOD", "TRACKPAR",
 DECLARE_SOA_EXTENDED_TABLE(Tracks, StoredTracks, "TRACKPAR", aod::track::Pt2);
 
 DECLARE_SOA_TABLE_FULL(StoredTracksCov, "TracksCov", "AOD", "TRACKPARCOV",
-                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
-		  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,
-                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl
-                  );
+                       track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
+                       track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,
+                       track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksCov, StoredTracksCov, "TRACKPARCOV",
-			   aod::track::CYY,
-			   aod::track::CZY,
-			   aod::track::CZZ,
-			   aod::track::CSnpY,
-			   aod::track::CSnpZ,
-			   aod::track::CSnpSnp,
-			   aod::track::CTglY,
-			   aod::track::CTglZ,
-			   aod::track::CTglSnp,
-			   aod::track::CTglTgl,
-			   aod::track::C1PtY,
-			   aod::track::C1PtZ,
-			   aod::track::C1PtSnp,
-			   aod::track::C1PtTgl,
-			   aod::track::C1Pt21Pt2
-			   );
+                           aod::track::CYY,
+                           aod::track::CZY,
+                           aod::track::CZZ,
+                           aod::track::CSnpY,
+                           aod::track::CSnpZ,
+                           aod::track::CSnpSnp,
+                           aod::track::CTglY,
+                           aod::track::CTglZ,
+                           aod::track::CTglSnp,
+                           aod::track::CTglTgl,
+                           aod::track::C1PtY,
+                           aod::track::C1PtZ,
+                           aod::track::C1PtSnp,
+                           aod::track::C1PtTgl,
+                           aod::track::C1Pt21Pt2);
 
 DECLARE_SOA_TABLE(TracksExtra, "AOD", "TRACKEXTRA",
                   track::TPCInnerParam, track::Flags, track::ITSClusterMap,

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -221,7 +221,13 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> reques
         if (description == header::DataDescription{"TRACKPAR"}) {
           outputs.adopt(Output{origin, description}, maker(o2::aod::TracksMetadata{}));
         } else {
-          throw std::runtime_error("Not an extended table");
+          throw std::runtime_error("TRACKPAR: Not an extended table");
+        }
+	
+        if (description == header::DataDescription{"TRACKPARCOV"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::TracksCovMetadata{}));
+        } else {
+          throw std::runtime_error("TRACLPARCOV: Not an extended table");
         }
       }
     };
@@ -286,7 +292,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
       };
       tableMaker(o2::aod::CollisionsMetadata{}, AODTypeMask::Collision, "O2collision");
       tableMaker(o2::aod::StoredTracksMetadata{}, AODTypeMask::Track, "O2track");
-      tableMaker(o2::aod::TracksCovMetadata{}, AODTypeMask::TrackCov, "O2track");
+      tableMaker(o2::aod::StoredTracksCovMetadata{}, AODTypeMask::TrackCov, "O2track");
       tableMaker(o2::aod::TracksExtraMetadata{}, AODTypeMask::TrackExtra, "O2track");
       tableMaker(o2::aod::CalosMetadata{}, AODTypeMask::Calo, "O2calo");
       tableMaker(o2::aod::CaloTriggersMetadata{}, AODTypeMask::Calo, "O2calotrigger");

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -220,14 +220,10 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> reques
 
         if (description == header::DataDescription{"TRACKPAR"}) {
           outputs.adopt(Output{origin, description}, maker(o2::aod::TracksMetadata{}));
-        } else {
-          throw std::runtime_error("TRACKPAR: Not an extended table");
-        }
-	
-        if (description == header::DataDescription{"TRACKPARCOV"}) {
+        } else if (description == header::DataDescription{"TRACKPARCOV"}) {
           outputs.adopt(Output{origin, description}, maker(o2::aod::TracksCovMetadata{}));
         } else {
-          throw std::runtime_error("TRACLPARCOV: Not an extended table");
+          throw std::runtime_error("Not an extended table");
         }
       }
     };

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -33,8 +33,8 @@ BOOST_AUTO_TEST_CASE(TestJoinedTables)
   auto tracks = trackBuilder.finalize();
 
   TableBuilder trackParCovBuilder;
-  auto trackParCovWriter = trackParCovBuilder.cursor<TracksCov>();
-  trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  auto trackParCovWriter = trackParCovBuilder.cursor<StoredTracksCov>();
+  trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4);
   auto covs = trackParCovBuilder.finalize();
 
   using Test = Join<StoredTracks, TracksCov>;

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(TestJoinedTables)
 
   TableBuilder trackParCovBuilder;
   auto trackParCovWriter = trackParCovBuilder.cursor<TracksCov>();
-  trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4);
+  trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
   auto covs = trackParCovBuilder.finalize();
 
   using Test = Join<StoredTracks, TracksCov>;


### PR DESCRIPTION
@aalkin The current version compiles, but the extended table is not recognised in the exection, for example in:

o2-analysistutorial-mc-histograms -b --aod-file AO2D.root

and I get exception
[26594:internal-dpl-aod-spawner]: [12:39:28][ERROR] Exception caught: TRACLPARCOV: Not an extended table