### PR TITLE
A  fix for importing decay products:

### DIFF
--- a/Generators/src/DecayerPythia8.cxx
+++ b/Generators/src/DecayerPythia8.cxx
@@ -74,17 +74,19 @@ void DecayerPythia8::Decay(Int_t pdg, TLorentzVector* lv)
 
 /*****************************************************************/
 
+#include <iostream>
+
 Int_t DecayerPythia8::ImportParticles(TClonesArray* particles)
 {
   TClonesArray& ca = *particles;
   ca.Clear();
 
   auto nParticles = mPythia.event.size();
-  for (Int_t iparticle = 1; iparticle < nParticles; iparticle++) {
+  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
     //  Do not import the decayed particle - start loop from 1
     auto particle = mPythia.event[iparticle];
     auto pdg = particle.id();
-    auto st = particle.statusHepMC();
+    auto st = particle.isFinal();
     auto px = particle.px();
     auto py = particle.py();
     auto pz = particle.pz();
@@ -98,7 +100,7 @@ Int_t DecayerPythia8::ImportParticles(TClonesArray* particles)
     auto d1 = particle.daughter1();
     auto d2 = particle.daughter2();
 
-    new (ca[iparticle - 1]) TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt);
+    new (ca[iparticle]) TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt);
   }
 
   return ca.GetEntries();

--- a/Generators/src/DecayerPythia8.cxx
+++ b/Generators/src/DecayerPythia8.cxx
@@ -74,8 +74,6 @@ void DecayerPythia8::Decay(Int_t pdg, TLorentzVector* lv)
 
 /*****************************************************************/
 
-#include <iostream>
-
 Int_t DecayerPythia8::ImportParticles(TClonesArray* particles)
 {
   TClonesArray& ca = *particles;


### PR DESCRIPTION
- Return isFinal() as the particle status code (instead of statusHepMC()), to be consistent with
  the decayer implementation in AliRoot.
- Revert back the changes in commit  b3e825ecc3 (not needed anymore).
This should fix the problem with the explosion of the log file in Geant4 O2 production tests.