### PR TITLE
Allow to set GEANT UserDecay via configurable params

### DIFF
--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -11,6 +11,7 @@
 o2_add_library(SimConfig
                SOURCES src/SimConfig.cxx 
                        src/SimCutParams.cxx		       
+                       src/SimUserDecay.cxx		       
                        src/DigiParams.cxx src/G4Params.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
@@ -20,6 +21,7 @@ o2_add_library(SimConfig
 o2_target_root_dictionary(SimConfig
                           HEADERS include/SimConfig/SimConfig.h
                                   include/SimConfig/SimCutParams.h
+                                  include/SimConfig/SimUserDecay.h
 				  include/SimConfig/DigiParams.h
                                   include/SimConfig/G4Params.h)
 

--- a/Common/SimConfig/include/SimConfig/SimUserDecay.h
+++ b/Common/SimConfig/include/SimConfig/SimUserDecay.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_SIMCONFIG_SIMUSERDECAY_H_
+#define O2_SIMCONFIG_SIMUSERDECAY_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace conf
+{
+struct SimUserDecay : public o2::conf::ConfigurableParamHelper<SimUserDecay> {
+  std::string pdglist = "";
+
+  O2ParamDef(SimUserDecay, "SimUserDecay");
+};
+} // namespace conf
+} // namespace o2
+
+#endif /* O2_SIMCONFIG_SIMUSERDECAY_H_ */

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -19,6 +19,9 @@
 #pragma link C++ class o2::conf::SimCutParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimCutParams> + ;
 
+#pragma link C++ class o2::conf::SimUserDecay + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimUserDecay> + ;
+
 #pragma link C++ class o2::conf::DigiParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::DigiParams> + ;
 

--- a/Common/SimConfig/src/SimUserDecay.cxx
+++ b/Common/SimConfig/src/SimUserDecay.cxx
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * SimUserDecay.cxx
+ *
+ *  Created on: Jun 16, 2020
+ *      Author: r+preghenella
+ */
+
+#include "SimConfig/SimUserDecay.h"
+O2ParamImpl(o2::conf::SimUserDecay);

--- a/Generators/include/Generators/DecayerPythia8.h
+++ b/Generators/include/Generators/DecayerPythia8.h
@@ -54,6 +54,9 @@ class DecayerPythia8 : public TVirtualMCDecayer
   /** Pythia8 **/
   ::Pythia8::Pythia mPythia; //!
 
+  /** flags **/
+  bool mVerbose = false;
+
   ClassDefOverride(DecayerPythia8, 1);
 
 }; /** class Decayer **/

--- a/Generators/include/Generators/DecayerPythia8Param.h
+++ b/Generators/include/Generators/DecayerPythia8Param.h
@@ -30,6 +30,7 @@ namespace eventgen
 
 struct DecayerPythia8Param : public o2::conf::ConfigurableParamHelper<DecayerPythia8Param> {
   std::string config = "${O2_ROOT}/share/Generators/pythia8/decays/base.cfg";
+  bool verbose = false;
   O2ParamDef(DecayerPythia8Param, "DecayerPythia8");
 };
 

--- a/Generators/src/DecayerPythia8.cxx
+++ b/Generators/src/DecayerPythia8.cxx
@@ -51,6 +51,9 @@ void DecayerPythia8::Init()
     }
   }
 
+  /** verbose flag **/
+  mVerbose = param.verbose;
+
   /** initialise **/
   if (!mPythia.init()) {
     LOG(FATAL) << "Failed to init \'DecayerPythia8\': init returned with error";
@@ -68,6 +71,8 @@ void DecayerPythia8::Decay(Int_t pdg, TLorentzVector* lv)
   mPythia.event.clear();
   mPythia.event.append(pdg, 11, 0, 0, lv->Px(), lv->Py(), lv->Pz(), lv->E(), lv->M());
   mPythia.moreDecays();
+  if (mVerbose)
+    mPythia.event.list();
 
   mPythia.particleData.mayDecay(pdg, mayDecay); // restore mayDecay status
 }

--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -48,6 +48,7 @@ class O2MCApplicationBase : public FairMCApplication
   void ConstructGeometry() override;
   void InitGeometry() override;
   bool MisalignGeometry() override;
+  void AddParticles() override;
 
   // specific implementation of our hard geometry limits
   double TrackingRmax() const override { return mCutParams.maxRTracking; }

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -26,7 +26,6 @@
 #include <FairVolume.h>
 #include <DetectorsCommonDataFormats/NameConf.h>
 #include "SimConfig/SimUserDecay.h"
-#include <iostream>
 
 namespace o2
 {

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -25,6 +25,8 @@
 #include <fstream>
 #include <FairVolume.h>
 #include <DetectorsCommonDataFormats/NameConf.h>
+#include "SimConfig/SimUserDecay.h"
+#include <iostream>
 
 namespace o2
 {
@@ -170,6 +172,28 @@ void O2MCApplicationBase::BeginEvent()
   static_cast<o2::data::Stack*>(GetStack())->setMCEventStats(&header->getMCEventStats());
 
   mStepCounter = 0;
+}
+
+void O2MCApplicationBase::AddParticles()
+{
+  // dispatch first to function in FairRoot
+  FairMCApplication::AddParticles();
+
+  auto& param = o2::conf::SimUserDecay::Instance();
+  LOG(INFO) << "Printing \'SimUserDecay\' parameters";
+  LOG(INFO) << param;
+
+  // check if there are PDG codes requested for user decay
+  if (param.pdglist.empty())
+    return;
+
+  // loop over PDG codes in the string
+  std::stringstream ss(param.pdglist);
+  int pdg;
+  while (ss >> pdg) {
+    LOG(INFO) << "Setting user decay for PDG " << pdg;
+    TVirtualMC::GetMC()->SetUserDecay(pdg);
+  }
 }
 
 void O2MCApplication::initLate()

--- a/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/README.md
+++ b/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/README.md
@@ -1,0 +1,28 @@
+<!-- doxy
+\page refrunSimExamplesForceDecay_Lambda_Neutron_Dalitz Example ForceDecay_Lambda_Neutron_Dalitz
+/doxy -->
+
+This is a simple simulation example showing how to force a specific particle decay chain.
+To simplify the example, we will use a Box generator to inject Lambda0 particles in the simulation.
+
+What we want to achieve is a forced decay chain of the Lambda0
+```
+Lambda0 --> n pi0 --> n e+ e- gamma
+```
+Given that both the Lambda0 and the pi0 are by default decayed by Geant, we have to turn on the external decayer for these particles.
+This can be done with
+```
+--configKeyValues 'SimUserDecay.pdg=3122 111'
+```
+
+On top of that we have to setup the external decayer to perform the decay forcing the channels we desire.
+The default external decayer configuration is loaded from
+```
+${O2_ROOT}/share/Generators/pythia8/decays/base.cfg
+```
+What we want to do is to add on top of the default configuration some extra settings that are provided in the `decay_lambda_neutron_dalitz.cfg` file.
+This can be done with
+```
+--configKeyValues 'DecayerPythia8.config=${O2_ROOT}/share/Generators/pythia8/decays/base.cfg decay_lambda_neutron_dalitz.cfg'
+```
+

--- a/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/decay_lambda_neutron_dalitz.cfg
+++ b/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/decay_lambda_neutron_dalitz.cfg
@@ -1,0 +1,7 @@
+### force Lambda0 -> n pi0
+3122:onMode = off
+3122:onIfAll = 2112 111
+
+### force pi0 Dalitz
+111:onMode = off
+111:onIfAny = 11

--- a/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/run.sh
+++ b/run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+
+# This is a simple simulation example showing how to force a specific particle decay chain.
+# To simplify the example, we will use a Box generator to inject Lambda0 particles in the simulation.
+#
+# What we want to achieve is a forced decay chain of the Lambda0
+# Lambda0 --> n pi0 --> n e+ e- gamma
+#
+# Given that both the Lambda0 and the pi0 are by default decayed by Geant, we have to turn on the external decayer for these particles.
+# This can be done with
+# --configKeyValues 'SimUserDecay.pdg=3122 111'
+#
+# On top of that we have to setup the external decayer to perform the decay forcing the channels we desire.
+# The default external decayer configuration is loaded from
+# ${O2_ROOT}/share/Generators/pythia8/decays/base.cfg
+#
+# What we want to do is to add on top of the default configuration some extra settings that are provided in the `decay_lambda_neutron_dalitz.cfg` file.
+# This can be done with
+# --configKeyValues 'DecayerPythia8.config=${O2_ROOT}/share/Generators/pythia8/decays/base.cfg decay_lambda_neutron_dalitz.cfg'
+#
+
+set -x
+
+NEV=10
+o2-sim -j 20 -n ${NEV} -g boxgen -m PIPE ITS TPC --configKeyValues 'BoxGun.pdg=3122;BoxGun.number=1;SimUserDecay.pdglist=3122 111;DecayerPythia8.config=${O2_ROOT}/share/Generators/pythia8/decays/base.cfg decay_lambda_neutron_dalitz.cfg;DecayerPythia8.verbose=true'

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -12,4 +12,5 @@
 * \subpage refrunSimExamplesHepMC_STARlight
 * \subpage refrunSimExamplesJet_Embedding_Pythia8
 * \subpage refrunSimExamplesStepMonitoringSimple1
+* \subpage refrunSimExamplesForceDecay_Lambda_Neutron_Dalitz
 /doxy -->


### PR DESCRIPTION
This PR allows the user to switch on Geant user decay for any given particle.
It is technically done via configurable parameters at command line.
As an example
```
--configKeyValues 'SimUserDecay.pdg=3122 111;
```
will turn on user decay for Lambda0 (3122) and pi0 (111) which will be in turn be decayed by the external decayer. 

The feature will be useful for users that need productions with force decays and/or decay chains.
An example of use is given in
```
run/SimExamples/ForceDecay_Lambda_Neutron_Dalitz/
```

The PR also adds the `DecayerPythia8.verbose` parameter to have a verbose logging.

*****
This is the README.md of the sim example.

This is a simple simulation example showing how to force a specific particle decay chain.
To simplify the example, we will use a Box generator to inject Lambda0 particles in the simulation.

What we want to achieve is a forced decay chain of the Lambda0
```
Lambda0 --> n pi0 --> n e+ e- gamma
```
Given that both the Lambda0 and the pi0 are by default decayed by Geant, we have to turn on the external decayer for these particles.
This can be done with
```
--configKeyValues 'SimUserDecay.pdg=3122 111'
```

On top of that we have to setup the external decayer to perform the decay forcing the channels we desire.
The default external decayer configuration is loaded from
```
${O2_ROOT}/share/Generators/pythia8/decays/base.cfg
```
What we want to do is to add on top of the default configuration some extra settings that are provided in the `decay_lambda_neutron_dalitz.cfg` file.
This can be done with
```
--configKeyValues 'DecayerPythia8.config=${O2_ROOT}/share/Generators/pythia8/decays/base.cfg decay_lambda_neutron_dalitz.cfg'
```

