### PR TITLE
Update AliRoot_Hijing example to run with o2-sim

### DIFF
--- a/run/SimExamples/AliRoot_Hijing/run.sh
+++ b/run/SimExamples/AliRoot_Hijing/run.sh
@@ -15,6 +15,8 @@
 # To run this example you need to load an AliRoot package compatible with the O2.
 # for more details, https://alice.its.cern.ch/jira/browse/AOGM-246
 #
+# AliRoot needs to be loaded **after** O2 in the following sense:
+# `alienv enter O2/latest,AliRoot/latest`
 #
 
 set -x
@@ -23,6 +25,6 @@ NEV=5
 ENERGY=5020.
 BMIN=0
 BMAX=20.
-o2-sim-serial -j 20 -n ${NEV} -g extgen -m PIPE ITS TPC -o sim \
-	      --extGenFile "aliroot_hijing.macro" --extGenFunc "hijing(${ENERGY}, ${BMIN}, ${BMAX})" \
-	      --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
+o2-sim -j 20 -n ${NEV} -g extgen -m PIPE ITS TPC -o sim \
+       --extGenFile "aliroot_hijing.macro" --extGenFunc "hijing(${ENERGY}, ${BMIN}, ${BMAX})" \
+       --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"


### PR DESCRIPTION
Updating this example to run with `o2-sim` executable, now that we understood how to make it work like that.