### PR TITLE
Multi-threaded ping-pong pipeline for the GPU tracking + required features + some fixes

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -708,6 +708,13 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
           outputRegions.clustersNative.size = clusterOutput->size() * sizeof(*clusterOutput->data()) - sizeof(ClusterCountIndex);
         }
       }
+      auto* bufferTPCTracks = !processAttributes->allocateOutputOnTheFly ? &pc.outputs().make<std::vector<char>>(Output{gDataOriginTPC, "TRACKSGPU", 0}, bufferSize) : nullptr;
+      if (processAttributes->allocateOutputOnTheFly) {
+        outputRegions.tpcTracks.allocator = [&bufferTPCTracks, &pc](size_t size) -> void* {bufferTPCTracks = &pc.outputs().make<std::vector<char>>(Output{gDataOriginTPC, "TRACKSGPU", 0}, size); return bufferTPCTracks->data(); };
+      } else {
+        outputRegions.tpcTracks.ptr = bufferTPCTracks->data();
+        outputRegions.tpcTracks.size = bufferTPCTracks->size();
+      }
 
       int retVal = tracker->runTracking(&ptrs, &outputRegions);
       if (processAttributes->suppressOutput) {
@@ -821,6 +828,11 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
     std::vector<OutputSpec> outputSpecs{
       OutputSpec{{"outTracks"}, gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe},
       OutputSpec{{"outClusRefs"}, gDataOriginTPC, "CLUSREFS", 0, Lifetime::Timeframe},
+      // This is not really used as an output, but merely to allocate a GPU-registered memory where the GPU can write the track output.
+      // Right now, the tracks are still reformatted, and copied in the above buffers.
+      // This one will not have any consumer and just be dropped.
+      // But we need something to provide to the GPU as external buffer to test direct writing of tracks in the shared memory.
+      OutputSpec{{"outTracksGPUBuffer"}, gDataOriginTPC, "TRACKSGPU", 0, Lifetime::Timeframe},
     };
     if (!specconfig.outputTracks) {
       // this case is the less unlikely one, that's why the logic this way

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -42,7 +42,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   using namespace o2::framework;
 
   std::vector<ConfigParamSpec> options{
-    {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters"}},
+    {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters, compressed-clusters-ctf"}},
     {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer"}},
     {"ca-clusterer", VariantType::Bool, false, {"Use clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},

--- a/GPU/Common/GPUCommonAlgorithm.h
+++ b/GPU/Common/GPUCommonAlgorithm.h
@@ -16,7 +16,7 @@
 
 #include "GPUCommonDef.h"
 
-#if !defined(GPUCA_GPUCODE_DEVICE)
+#if !defined(GPUCA_GPUCODE)
 //&& (!defined __cplusplus || __cplusplus < 201402L) // This would enable to custom search also on the CPU if available by the compiler, but it is not always faster, so we stick to std::sort
 #include <algorithm>
 #define GPUCA_ALGORITHM_STD
@@ -226,7 +226,7 @@ namespace gpu
 template <class T>
 GPUdi() void GPUCommonAlgorithm::sortDeviceDynamic(T* begin, T* end)
 {
-#ifndef GPUCA_GPUCODE_DEVICE
+#ifndef GPUCA_GPUCODE
   GPUCommonAlgorithm::sort(begin, end);
 #else
   GPUCommonAlgorithm::sortDeviceDynamic(begin, end, [](auto&& x, auto&& y) { return x < y; });
@@ -236,7 +236,7 @@ GPUdi() void GPUCommonAlgorithm::sortDeviceDynamic(T* begin, T* end)
 template <class T, class S>
 GPUdi() void GPUCommonAlgorithm::sortDeviceDynamic(T* begin, T* end, const S& comp)
 {
-#ifndef GPUCA_GPUCODE_DEVICE
+#ifndef GPUCA_GPUCODE
   GPUCommonAlgorithm::sort(begin, end, comp);
 #else
   GPUCommonAlgorithm::sortInBlock(begin, end, comp);
@@ -277,7 +277,7 @@ GPUdi() void GPUCommonAlgorithm::sort(T* begin, T* end, const S& comp)
 template <class T>
 GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end)
 {
-#ifndef GPUCA_GPUCODE_DEVICE
+#ifndef GPUCA_GPUCODE
   GPUCommonAlgorithm::sort(begin, end);
 #else
   GPUCommonAlgorithm::sortInBlock(begin, end, [](auto&& x, auto&& y) { return x < y; });
@@ -287,7 +287,7 @@ GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end)
 template <class T, class S>
 GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end, const S& comp)
 {
-#ifndef GPUCA_GPUCODE_DEVICE
+#ifndef GPUCA_GPUCODE
   GPUCommonAlgorithm::sort(begin, end, comp);
 #else
   int n = end - begin;
@@ -308,7 +308,7 @@ GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end, const S& comp)
 #endif
 }
 
-#ifdef GPUCA_GPUCODE_DEVICE
+#ifdef GPUCA_GPUCODE
 template <class T>
 GPUdi() void GPUCommonAlgorithm::swap(T& a, T& b)
 {

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -132,6 +132,8 @@ class GPUDataTypes
   static constexpr const char* const GENERAL_STEP_NAMES[] = {"Prepare", "QA"};
   typedef bitfield<RecoStep, unsigned int> RecoStepField;
   typedef bitfield<InOutType, unsigned int> InOutTypeField;
+  constexpr static int N_RECO_STEPS = sizeof(GPUDataTypes::RECO_STEP_NAMES) / sizeof(GPUDataTypes::RECO_STEP_NAMES[0]);
+  constexpr static int N_GENERAL_STEPS = sizeof(GPUDataTypes::GENERAL_STEP_NAMES) / sizeof(GPUDataTypes::GENERAL_STEP_NAMES[0]);
 #endif
 #ifdef GPUCA_NOCOMPAT
   static constexpr unsigned int NSLICES = 36;

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -220,6 +220,7 @@ struct GPUTrackingInOutPointers {
   unsigned int nMergedTracks = 0;
   const GPUTPCGMMergedTrackHit* mergedTrackHits = nullptr;
   unsigned int nMergedTrackHits = 0;
+  unsigned int* mergedTrackHitAttachment = nullptr;
   const o2::tpc::CompressedClustersFlat* tpcCompressedClusters = nullptr;
   const GPUTRDTrackletWord* trdTracklets = nullptr;
   unsigned int nTRDTracklets = 0;

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -758,7 +758,7 @@ int GPUReconstruction::EnqueuePipeline(bool terminate)
   }
   rec->mPipelineContext->cond.notify_one();
   q->c.wait(lkdone, [&q]() { return q->done; });
-  return 0;
+  return q->retVal;
 }
 
 GPUChain* GPUReconstruction::GetNextChainInQueue()

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -197,7 +197,7 @@ class GPUReconstruction
   void ClearAllocatedMemory(bool clearOutputs = true);
   void ReturnVolatileDeviceMemory();
   void PushNonPersistentMemory();
-  void PopNonPersistentMemory();
+  void PopNonPersistentMemory(RecoStep step);
   void ResetRegisteredMemoryPointers(GPUProcessor* proc);
   void ResetRegisteredMemoryPointers(short res);
   void ComputeReuseMax(GPUProcessor* proc);
@@ -236,6 +236,8 @@ class GPUReconstruction
   RecoStepField GetRecoStepsGPU() const { return mRecoStepsGPU; }
   InOutTypeField GetRecoStepsInputs() const { return mRecoStepsInputs; }
   InOutTypeField GetRecoStepsOutputs() const { return mRecoStepsOutputs; }
+  int getRecoStepNum(RecoStep step, bool validCheck = true);
+  int getGeneralStepNum(GeneralStep step, bool validCheck = true);
 
   // Registration of GPU Processors
   template <class T>

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -198,6 +198,8 @@ class GPUReconstruction
   void ReturnVolatileDeviceMemory();
   void PushNonPersistentMemory();
   void PopNonPersistentMemory(RecoStep step);
+  void BlockStackedMemory(GPUReconstruction* rec);
+  void UnblockStackedMemory();
   void ResetRegisteredMemoryPointers(GPUProcessor* proc);
   void ResetRegisteredMemoryPointers(short res);
   void ComputeReuseMax(GPUProcessor* proc);
@@ -325,19 +327,21 @@ class GPUReconstruction
   std::string mDeviceName = "CPU";
 
   // Ptrs to host and device memory;
-  void* mHostMemoryBase = nullptr;        // Ptr to begin of large host memory buffer
-  void* mHostMemoryPermanent = nullptr;   // Ptr to large host memory buffer offset by permanently allocated memory
-  void* mHostMemoryPool = nullptr;        // Ptr to next free location in host memory buffer
-  void* mHostMemoryPoolEnd = nullptr;     // Ptr to end of pool
-  size_t mHostMemorySize = 0;             // Size of host memory buffer
-  size_t mHostMemoryUsedMax = 0;          // Maximum host memory size used over time
-  void* mDeviceMemoryBase = nullptr;      //
-  void* mDeviceMemoryPermanent = nullptr; //
-  void* mDeviceMemoryPool = nullptr;      //
-  void* mDeviceMemoryPoolEnd = nullptr;   //
-  size_t mDeviceMemorySize = 0;           //
-  void* mVolatileMemoryStart = nullptr;   // Ptr to beginning of temporary volatile memory allocation, nullptr if uninitialized
-  size_t mDeviceMemoryUsedMax = 0;        //
+  void* mHostMemoryBase = nullptr;          // Ptr to begin of large host memory buffer
+  void* mHostMemoryPermanent = nullptr;     // Ptr to large host memory buffer offset by permanently allocated memory
+  void* mHostMemoryPool = nullptr;          // Ptr to next free location in host memory buffer
+  void* mHostMemoryPoolEnd = nullptr;       // Ptr to end of pool
+  void* mHostMemoryPoolBlocked = nullptr;   // Ptr to end of pool
+  size_t mHostMemorySize = 0;               // Size of host memory buffer
+  size_t mHostMemoryUsedMax = 0;            // Maximum host memory size used over time
+  void* mDeviceMemoryBase = nullptr;        //
+  void* mDeviceMemoryPermanent = nullptr;   //
+  void* mDeviceMemoryPool = nullptr;        //
+  void* mDeviceMemoryPoolEnd = nullptr;     //
+  void* mDeviceMemoryPoolBlocked = nullptr; //
+  size_t mDeviceMemorySize = 0;             //
+  void* mVolatileMemoryStart = nullptr;     // Ptr to beginning of temporary volatile memory allocation, nullptr if uninitialized
+  size_t mDeviceMemoryUsedMax = 0;          //
 
   GPUReconstruction* mMaster = nullptr;    // Ptr to a GPUReconstruction object serving as master, sharing GPU memory, events, etc.
   std::vector<GPUReconstruction*> mSlaves; // Ptr to slave GPUReconstructions

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -180,23 +180,6 @@ int GPUReconstructionCPU::ExitDevice()
   return 0;
 }
 
-template <class T>
-static inline int getStepNum(T step, bool validCheck, int N, const char* err)
-{
-  static_assert(sizeof(step) == sizeof(unsigned int), "Invalid step enum size");
-  int retVal = 8 * sizeof(unsigned int) - 1 - CAMath::Clz((unsigned int)step);
-  if ((unsigned int)step == 0 || retVal >= N) {
-    if (!validCheck) {
-      return -1;
-    }
-    throw std::runtime_error("Invalid General Step");
-  }
-  return retVal;
-}
-
-int GPUReconstructionCPU::getRecoStepNum(RecoStep step, bool validCheck) { return getStepNum(step, validCheck, N_RECO_STEPS, "Invalid Reco Step"); }
-int GPUReconstructionCPU::getGeneralStepNum(GeneralStep step, bool validCheck) { return getStepNum(step, validCheck, N_GENERAL_STEPS, "Invalid General Step"); }
-
 int GPUReconstructionCPU::RunChains()
 {
   mStatNEvents++;
@@ -229,7 +212,7 @@ int GPUReconstructionCPU::RunChains()
   mStatWallTime = (timerTotal.GetElapsedTime() * 1000000. / mStatNEvents);
   if (GetDeviceProcessingSettings().debugLevel >= 1) {
     double kernelTotal = 0;
-    std::vector<double> kernelStepTimes(N_RECO_STEPS);
+    std::vector<double> kernelStepTimes(GPUDataTypes::N_RECO_STEPS);
 
     for (unsigned int i = 0; i < mTimers.size(); i++) {
       double time = 0;
@@ -261,7 +244,7 @@ int GPUReconstructionCPU::RunChains()
         mTimers[i]->memSize = 0;
       }
     }
-    for (int i = 0; i < N_RECO_STEPS; i++) {
+    for (int i = 0; i < GPUDataTypes::N_RECO_STEPS; i++) {
       if (kernelStepTimes[i] != 0.) {
         printf("Execution Time: Step              : %11s %38s Time: %'10d us (Total Time: %'10d us)\n", "Tasks", GPUDataTypes::RECO_STEP_NAMES[i], (int)(kernelStepTimes[i] * 1000000 / mStatNEvents), (int)(mTimersRecoSteps[i].timerTotal.GetElapsedTime() * 1000000 / mStatNEvents));
       }
@@ -282,7 +265,7 @@ int GPUReconstructionCPU::RunChains()
         mTimersRecoSteps[i].countToHost = 0;
       }
     }
-    for (int i = 0; i < N_GENERAL_STEPS; i++) {
+    for (int i = 0; i < GPUDataTypes::N_GENERAL_STEPS; i++) {
       if (mTimersGeneralSteps[i].GetElapsedTime() != 0.) {
         printf("Execution Time: General Step      : %50s Time: %'10d us\n", GPUDataTypes::GENERAL_STEP_NAMES[i], (int)(mTimersGeneralSteps[i].GetElapsedTime() * 1000000 / mStatNEvents));
       }

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -245,8 +245,8 @@ int GPUReconstructionCPU::RunChains()
       }
     }
     for (int i = 0; i < GPUDataTypes::N_RECO_STEPS; i++) {
-      if (kernelStepTimes[i] != 0.) {
-        printf("Execution Time: Step              : %11s %38s Time: %'10d us (Total Time: %'10d us)\n", "Tasks", GPUDataTypes::RECO_STEP_NAMES[i], (int)(kernelStepTimes[i] * 1000000 / mStatNEvents), (int)(mTimersRecoSteps[i].timerTotal.GetElapsedTime() * 1000000 / mStatNEvents));
+      if (kernelStepTimes[i] != 0. || mTimersRecoSteps[i].timerTotal.GetElapsedTime() != 0.) {
+        printf("Execution Time: Step              : %11s %38s Time: %'10d us ( Total Time : %'14d us)\n", "Tasks", GPUDataTypes::RECO_STEP_NAMES[i], (int)(kernelStepTimes[i] * 1000000 / mStatNEvents), (int)(mTimersRecoSteps[i].timerTotal.GetElapsedTime() * 1000000 / mStatNEvents));
       }
       if (mTimersRecoSteps[i].bytesToGPU) {
         printf("Execution Time: Step (D %8ux): %11s %38s Time: %'10d us (%6.3f GB/s - %'14lu bytes - %'14lu per call)\n", mTimersRecoSteps[i].countToGPU, "DMA to GPU", GPUDataTypes::RECO_STEP_NAMES[i], (int)(mTimersRecoSteps[i].timerToGPU.GetElapsedTime() * 1000000 / mStatNEvents),

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -217,19 +217,15 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
     unsigned int countToHost = 0;
   };
 
-  constexpr static int N_RECO_STEPS = sizeof(GPUDataTypes::RECO_STEP_NAMES) / sizeof(GPUDataTypes::RECO_STEP_NAMES[0]);
-  constexpr static int N_GENERAL_STEPS = sizeof(GPUDataTypes::GENERAL_STEP_NAMES) / sizeof(GPUDataTypes::GENERAL_STEP_NAMES[0]);
-  HighResTimer mTimersGeneralSteps[N_GENERAL_STEPS];
+  HighResTimer mTimersGeneralSteps[GPUDataTypes::N_GENERAL_STEPS];
 
   std::vector<std::unique_ptr<timerMeta>> mTimers;
-  RecoStepTimerMeta mTimersRecoSteps[N_RECO_STEPS];
+  RecoStepTimerMeta mTimersRecoSteps[GPUDataTypes::N_RECO_STEPS];
   HighResTimer timerTotal;
   template <class T, int I = 0, int J = -1>
   HighResTimer& getKernelTimer(RecoStep step, int num = 0, size_t addMemorySize = 0);
   template <class T, int J = -1>
   HighResTimer& getTimer(const char* name, int num = -1);
-  int getRecoStepNum(RecoStep step, bool validCheck = true);
-  int getGeneralStepNum(GeneralStep step, bool validCheck = true);
 
   std::vector<std::vector<deviceEvent*>> mEvents;
 

--- a/GPU/GPUTracking/Base/GPUSettings.cxx
+++ b/GPU/GPUTracking/Base/GPUSettings.cxx
@@ -83,6 +83,7 @@ void GPUSettingsDeviceProcessing::SetDefaults()
   gpuDeviceOnly = false;
   nDeviceHelperThreads = 2;
   debugLevel = -1;
+  allocDebugLevel = 0;
   deviceTimers = true;
   debugMask = -1;
   comparableDebutOutput = true;

--- a/GPU/GPUTracking/Base/GPUSettings.h
+++ b/GPU/GPUTracking/Base/GPUSettings.h
@@ -144,6 +144,7 @@ struct GPUSettingsDeviceProcessing {
   bool gpuDeviceOnly;                 // Use only GPU as device (i.e. no CPU for OpenCL)
   int nDeviceHelperThreads;           // Additional CPU helper-threads for CPU parts of processing with accelerator
   int debugLevel;                     // Level of debug output (-1 = silent)
+  int allocDebugLevel;                // Some debug output for memory allocations (without messing with normal debug level)
   int debugMask;                      // Mask for debug output dumps to file
   bool comparableDebutOutput;         // Make CPU and GPU debug output comparable (sort / skip concurrent parts)
   int resetTimers;                    // Reset timers every event

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAInternals.h
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDAInternals.h
@@ -24,6 +24,7 @@ namespace gpu
 {
 struct GPUReconstructionCUDAInternals {
   CUcontext CudaContext;                       // Pointer to CUDA context
+  unsigned int cudaContextObtained = 0;        // If multiple instances of GPUThreadContextCUDA are obtained, we count them and return the context only after all are destroyed
   cudaStream_t Streams[GPUCA_MAX_STREAMS];     // Pointer to array of CUDA Streams
 };
 

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -48,6 +48,7 @@ class GPUChain
   virtual void PrintMemoryStatistics(){};
   virtual int CheckErrorCodes() { return 0; }
   virtual bool SupportsDoublePipeline() { return false; }
+  virtual int FinalizePipelinedProcessing() { return 0; }
 
   constexpr static int NSLICES = GPUReconstruction::NSLICES;
 
@@ -209,6 +210,8 @@ class GPUChain
   {
     mRec->SetupGPUProcessor<T>(proc, allocate);
   }
+
+  inline GPUChain* GetNextChainInQueue() { return mRec->GetNextChainInQueue(); }
 
   virtual int PrepareTextures() { return 0; }
   virtual int DoStuckProtection(int stream, void* event) { return 0; }

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1975,10 +1975,13 @@ int GPUChainTracking::RunTPCDecompression()
     this->AllocateRegisteredMemory(this->mInputsHost->mResourceClusterNativeOutput, this->mOutputClustersNative);
     return this->mInputsHost->mPclusterNativeOutput;
   };
+  auto& gatherTimer = getTimer<TPCClusterDecompressor>("TPCDecompression", 0);
+  gatherTimer.Start();
   if (decomp.decompress(mIOPtrs.tpcCompressedClusters, *mClusterNativeAccess, allocator, param())) {
     GPUError("Error decompressing clusters");
     return 1;
   }
+  gatherTimer.Stop();
   mIOPtrs.clustersNative = mClusterNativeAccess.get();
   if (mRec->IsGPU()) {
     AllocateRegisteredMemory(mInputsHost->mResourceClusterNativeBuffer);

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -304,6 +304,9 @@ int GPUChainTracking::Init()
   if (mOutputClustersNative == nullptr) {
     mOutputClustersNative = &mRec->OutputControl();
   }
+  if (mOutputTPCTracks == nullptr) {
+    mOutputTPCTracks = &mRec->OutputControl();
+  }
   processors()->errorCodes.setMemory(mInputsHost->mErrorCodes);
   processors()->errorCodes.clear();
 
@@ -1710,6 +1713,7 @@ int GPUChainTracking::RunTPCTrackingMerger(bool synchronizeOutput)
   const auto& threadContext = GetThreadContext();
 
   SetupGPUProcessor(&Merger, true);
+  AllocateRegisteredMemory(Merger.MemoryResOutput(), mOutputTPCTracks);
 
   if (Merger.CheckSlices()) {
     return 1;

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -2129,6 +2129,7 @@ int GPUChainTracking::DoTRDGPUTracking()
 
 int GPUChainTracking::RunChain()
 {
+  const auto threadContext = GetThreadContext();
   if (GetDeviceProcessingSettings().runCompressionStatistics && mCompressionStatistics == nullptr) {
     mCompressionStatistics.reset(new GPUTPCClusterStatistics);
   }
@@ -2142,7 +2143,6 @@ int GPUChainTracking::RunChain()
     *mDebugFile << "\n\nProcessing event " << mRec->getNEventsProcessed() << std::endl;
   }
   if (mRec->slavesExist() && mRec->IsGPU()) {
-    const auto threadContext = GetThreadContext();
     WriteToConstantMemory(RecoStep::NoRecoStep, (char*)&processors()->calibObjects - (char*)processors(), &mFlatObjectsDevice.mCalibObjects, sizeof(mFlatObjectsDevice.mCalibObjects), 0); // Reinitialize
   }
 
@@ -2161,10 +2161,7 @@ int GPUChainTracking::RunChain()
 
   PrepareDebugOutput();
 
-  {
-    const auto threadContext = GetThreadContext();
-    SynchronizeStream(0); // Synchronize all init copies that might be ongoing
-  }
+  SynchronizeStream(0); // Synchronize all init copies that might be ongoing
 
   if (mIOPtrs.tpcCompressedClusters) {
     if (runRecoStep(RecoStep::TPCDecompression, &GPUChainTracking::RunTPCDecompression)) {
@@ -2219,7 +2216,6 @@ int GPUChainTracking::RunChain()
   }
 
   if (!GetDeviceProcessingSettings().doublePipeline) { // Synchronize with output copies running asynchronously
-    const auto& threadContext = GetThreadContext();
     SynchronizeStream(mRec->NStreams() - 2);
   }
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -556,7 +556,7 @@ int GPUChainTracking::ConvertNativeToClusterData()
     mIOPtrs.nClusterData[i] = (i == NSLICES - 1 ? mIOPtrs.clustersNative->nClustersTotal : mIOPtrs.clustersNative->clusterOffset[i + 1][0]) - mIOPtrs.clustersNative->clusterOffset[i][0];
     mIOPtrs.clusterData[i] = convert.mClusters + mIOPtrs.clustersNative->clusterOffset[i][0];
   }
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TPCConversion);
 #endif
   return 0;
 }
@@ -1206,7 +1206,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
     }
   }
   mRec->MemoryScalers()->nTPCHits = nClsTotal;
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TPCClusterFinding);
 
 #endif
   return 0;
@@ -1617,7 +1617,7 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
   if (GetDeviceProcessingSettings().debugLevel >= 2) {
     GPUInfo("TPC Slice Tracker finished");
   }
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TPCSliceTracking);
   return 0;
 }
 
@@ -1858,7 +1858,7 @@ int GPUChainTracking::RunTPCTrackingMerger(bool synchronizeOutput)
   if (GetDeviceProcessingSettings().debugLevel >= 2) {
     GPUInfo("TPC Merger Finished (output clusters %d / input clusters %d)", Merger.NOutputTrackClusters(), Merger.NClusters());
   }
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TPCMerging);
   return 0;
 }
 
@@ -1960,7 +1960,7 @@ int GPUChainTracking::RunTPCCompression()
   }
 
   mIOPtrs.tpcCompressedClusters = Compressor.mOutputFlat;
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TPCCompression);
 #endif
   return 0;
 }
@@ -2045,7 +2045,7 @@ int GPUChainTracking::RunTRDTracking()
 
   mIOPtrs.nTRDTracks = Tracker.NTracks();
   mIOPtrs.trdTracks = Tracker.Tracks();
-  mRec->PopNonPersistentMemory();
+  mRec->PopNonPersistentMemory(RecoStep::TRDTracking);
 
   return 0;
 }
@@ -2137,7 +2137,7 @@ int GPUChainTracking::RunChain()
   if (runRecoStep(RecoStep::TPCMerging, &GPUChainTracking::RunTPCTrackingMerger, false)) {
     return 1;
   }
-  mRec->PopNonPersistentMemory(); // Release 1st stack level, TPC slice data not needed after merger
+  mRec->PopNonPersistentMemory(RecoStep::TPCSliceTracking); // Release 1st stack level, TPC slice data not needed after merger
 
   if (mIOPtrs.clustersNative) {
     if (runRecoStep(RecoStep::TPCCompression, &GPUChainTracking::RunTPCCompression)) {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -2208,8 +2208,9 @@ int GPUChainTracking::RunChain()
     if (runRecoStep(RecoStep::TPCCompression, &GPUChainTracking::RunTPCCompression)) {
       return 1;
     }
-    if (GetDeviceProcessingSettings().runCompressionStatistics) { // TODO: move to standalone.cxx
-      mCompressionStatistics->RunStatistics(mIOPtrs.clustersNative, processors()->tpcCompressor.mOutput, param());
+    if (GetDeviceProcessingSettings().runCompressionStatistics) {
+      CompressedClusters c = *mIOPtrs.tpcCompressedClusters;
+      mCompressionStatistics->RunStatistics(mIOPtrs.clustersNative, &c, param());
     }
   }
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -158,6 +158,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void LoadClusterErrors();
   void SetOutputControlCompressedClusters(GPUOutputControl* v) { mOutputCompressedClusters = v; }
   void SetOutputControlClustersNative(GPUOutputControl* v) { mOutputClustersNative = v; }
+  void SetOutputControlTPCTracks(GPUOutputControl* v) { mOutputTPCTracks = v; }
 
   const void* mConfigDisplay = nullptr; // Abstract pointer to Standalone Display Configuration Structure
   const void* mConfigQA = nullptr;      // Abstract pointer to Standalone QA Configuration Structure
@@ -232,6 +233,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   GPUOutputControl* mOutputCompressedClusters = nullptr;
   GPUOutputControl* mOutputClustersNative = nullptr;
+  GPUOutputControl* mOutputTPCTracks = nullptr;
 
   // Upper bounds for memory allocation
   unsigned int mMaxTPCHits = 0;

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -59,6 +59,7 @@ class GPUTRDGeometry;
 class TPCFastTransform;
 class TPCdEdxCalibrationSplines;
 class GPUTrackingInputProvider;
+class GPUChainTrackingFinalContext;
 
 class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelegateBase
 {
@@ -75,6 +76,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) override;
   int CheckErrorCodes() override;
   bool SupportsDoublePipeline() override { return true; }
+  int FinalizePipelinedProcessing() override;
   void ClearErrorCodes();
 
   // Structures for input and output data
@@ -260,6 +262,8 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void RunTPCTrackingMerger_Resolve(char useOrigTrackParam, char mergeAll, GPUReconstruction::krnlDeviceType deviceType);
 
   std::atomic_flag mLockAtomic = ATOMIC_FLAG_INIT;
+  std::unique_ptr<GPUChainTrackingFinalContext> mPipelineFinalizationCtx;
+  GPUChainTrackingFinalContext* mPipelineNotifyCtx = nullptr;
 
   int HelperReadEvent(int iSlice, int threadId, GPUReconstructionHelpers::helperParam* par);
   int HelperOutput(int iSlice, int threadId, GPUReconstructionHelpers::helperParam* par);

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -254,6 +254,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   std::vector<outputQueueEntry> mOutputQueue;
 
  private:
+  int RunChainFinalize();
   int RunTPCTrackingSlices_internal();
   std::pair<unsigned int, unsigned int> RunTPCClusterizer_transferZS(int iSlice, unsigned int start, unsigned int end, int lane);
   void RunTPCClusterizer_compactPeaks(GPUTPCClusterFinder& clusterer, GPUTPCClusterFinder& clustererShadow, int stage, bool doGPU, int lane);

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -60,6 +60,8 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
     mChain->SetOutputControlCompressedClusters(mOutputCompressedClusters.get());
     mOutputClustersNative.reset(new GPUOutputControl);
     mChain->SetOutputControlClustersNative(mOutputClustersNative.get());
+    mOutputTPCTracks.reset(new GPUOutputControl);
+    mChain->SetOutputControlTPCTracks(mOutputTPCTracks.get());
   }
 
   if (mRec->Init()) {
@@ -120,6 +122,13 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
     } else {
       mOutputClustersNative->reset();
     }
+    if (outputs->tpcTracks.allocator) {
+      mOutputTPCTracks->set(outputs->tpcTracks.allocator);
+    } else if (outputs->tpcTracks.ptr) {
+      mOutputTPCTracks->set(outputs->tpcTracks.ptr, outputs->tpcTracks.size);
+    } else {
+      mOutputTPCTracks->reset();
+    }
   }
   int retVal = mRec->RunChains();
   if (retVal == 2) {
@@ -132,6 +141,7 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
   if (mConfig->configInterface.outputToExternalBuffers) {
     outputs->compressedClusters.size = mOutputCompressedClusters->EndOfSpace ? 0 : mChain->mIOPtrs.tpcCompressedClusters->totalDataSize;
     outputs->clustersNative.size = mOutputClustersNative->EndOfSpace ? 0 : (mChain->mIOPtrs.clustersNative->nClustersTotal * sizeof(*mChain->mIOPtrs.clustersNative->clustersLinear));
+    outputs->tpcTracks.size = mOutputCompressedClusters->EndOfSpace ? 0 : (size_t)((char*)mOutputCompressedClusters->OutputPtr - (char*)mOutputCompressedClusters->OutputBase);
   }
   *data = mChain->mIOPtrs;
 

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -74,6 +74,7 @@ class GPUTPCO2Interface
   std::unique_ptr<GPUO2InterfaceConfiguration> mConfig;
   std::unique_ptr<GPUOutputControl> mOutputCompressedClusters;
   std::unique_ptr<GPUOutputControl> mOutputClustersNative;
+  std::unique_ptr<GPUOutputControl> mOutputTPCTracks;
 };
 } // namespace o2::gpu
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -61,6 +61,7 @@ struct GPUInterfaceOutputRegion {
 struct GPUInterfaceOutputs {
   GPUInterfaceOutputRegion compressedClusters;
   GPUInterfaceOutputRegion clustersNative;
+  GPUInterfaceOutputRegion tpcTracks;
 };
 
 // Full configuration structure with all available settings of GPU...

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -283,7 +283,7 @@ void GPUTPCGMMerger::RegisterMemoryAllocation()
   AllocateAndInitializeLate();
   mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersMerger, (mRec->GetDeviceProcessingSettings().fullMergerOnGPU ? 0 : GPUMemoryResource::MEMORY_HOST) | GPUMemoryResource::MEMORY_SCRATCH | GPUMemoryResource::MEMORY_STACK, "TPCMerger");
   mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersRefitScratch, GPUMemoryResource::MEMORY_SCRATCH | GPUMemoryResource::MEMORY_STACK, "TPCMergerRefitScratch");
-  mMemoryResOutput = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersOutput, mRec->GetDeviceProcessingSettings().fullMergerOnGPU ? GPUMemoryResource::MEMORY_OUTPUT : GPUMemoryResource::MEMORY_INOUT, "TPCMergerOutput");
+  mMemoryResOutput = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersOutput, (mRec->GetDeviceProcessingSettings().fullMergerOnGPU ? GPUMemoryResource::MEMORY_OUTPUT : GPUMemoryResource::MEMORY_INOUT) | GPUMemoryResource::MEMORY_CUSTOM, "TPCMergerOutput");
   mMemoryResMemory = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersMemory, GPUMemoryResource::MEMORY_PERMANENT, "TPCMergerMemory");
 }
 

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -128,6 +128,7 @@ AddOption(helperThreads, int, 1, "helperThreads", 0, "Number of CPU helper threa
 AddOption(noprompt, bool, true, "prompt", 0, "Do prompt for keypress before exiting", def(false))
 AddOption(continueOnError, bool, false, "continue", 0, "Continue processing after an error")
 AddOption(DebugLevel, int, 0, "debug", 'd', "Set debug level")
+AddOption(allocDebugLevel, int, 0, "allocDebug", 0, "Set alloc debug level")
 AddOption(DeviceTiming, bool, true, "deviceTiming", 0, "Use device timers instead of host-based time measurement")
 AddOption(seed, int, -1, "seed", 0, "Set srand seed (-1: random)")
 AddOption(cleardebugout, bool, false, "clearDebugFile", 0, "Clear debug output file when processing next event")

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -29,6 +29,8 @@
 #include <tuple>
 #include <algorithm>
 #include <thread>
+#include <future>
+#include <atomic>
 #ifdef WITH_OPENMP
 #include <omp.h>
 #endif
@@ -78,10 +80,11 @@ GPUChainTracking *chainTracking, *chainTrackingAsync, *chainTrackingPipeline;
 #ifdef HAVE_O2HEADERS
 GPUChainITS *chainITS, *chainITSAsync, *chainITSPipeline;
 #endif
-std::unique_ptr<char[]> outputmemory;
+std::unique_ptr<char[]> outputmemory, outputmemoryPipeline;
 std::unique_ptr<GPUDisplayBackend> eventDisplay;
 std::unique_ptr<GPUReconstructionTimeframe> tf;
 int nEventsInDirectory = 0;
+std::atomic<unsigned int> nIteration, nIterationEnd;
 
 void SetCPUAndOSSettings()
 {
@@ -232,6 +235,9 @@ int ReadConfiguration(int argc, char** argv)
 #endif
   if (configStandalone.outputcontrolmem) {
     outputmemory.reset(new char[configStandalone.outputcontrolmem]);
+    if (configStandalone.configProc.doublePipeline) {
+      outputmemoryPipeline.reset(new char[configStandalone.outputcontrolmem]);
+    }
   }
 
 #if !(defined(CUDA_ENABLED) || defined(OPENCL1_ENABLED) || defined(HIP_ENABLED))
@@ -481,13 +487,23 @@ int SetupReconstruction()
     recSet.useMatLUT = true;
     recAsync->SetSettings(&ev, &recSet, &devProc, &steps);
   }
+
+  if (configStandalone.outputcontrolmem) {
+    rec->SetOutputControl(outputmemory.get(), configStandalone.outputcontrolmem);
+    if (configStandalone.configProc.doublePipeline) {
+      recPipeline->SetOutputControl(outputmemoryPipeline.get(), configStandalone.outputcontrolmem);
+    }
+  }
+
   if (rec->Init()) {
     printf("Error initializing GPUReconstruction!\n");
     return 1;
   }
-  if (configStandalone.outputcontrolmem && rec->IsGPU() && rec->registerMemoryForGPU(outputmemory.get(), configStandalone.outputcontrolmem)) {
-    printf("ERROR registering memory for the GPU!!!\n");
-    return 1;
+  if (configStandalone.outputcontrolmem && rec->IsGPU()) {
+    if (rec->registerMemoryForGPU(outputmemory.get(), configStandalone.outputcontrolmem) || (configStandalone.configProc.doublePipeline && recPipeline->registerMemoryForGPU(outputmemoryPipeline.get(), configStandalone.outputcontrolmem))) {
+      printf("ERROR registering memory for the GPU!!!\n");
+      return 1;
+    }
   }
   if (configStandalone.DebugLevel >= 4) {
     rec->PrintKernelOccupancies();
@@ -545,6 +561,102 @@ void OutputStat(GPUChainTracking* t, long long int* nTracksTotal = nullptr, long
     snprintf(trdText, 1024, " - TRD Tracker reconstructed %d tracks (%d tracklets)", t->GetTRDTracker()->NTracks(), nTracklets);
   }
   printf("Output Tracks: %d (%d / %d / %d / %d clusters (fitted / attached / adjacent / total))%s\n", nTracks, nAttachedClustersFitted, nAttachedClusters, nAdjacentClusters, t->GetTPCMerger().NMaxClusters(), trdText);
+}
+
+int RunBenchmark(GPUReconstruction* recUse, GPUChainTracking* chainTrackingUse, int runs, const GPUTrackingInOutPointers& ioPtrs, long long int* nTracksTotal, long long int* nClustersTotal, int threadId = 0, HighResTimer* timerPipeline = nullptr)
+{
+  int iRun = 0, iteration = 0;
+  while ((iteration = nIteration.fetch_add(1)) < runs) {
+    if (configStandalone.runs > 1) {
+      printf("Run %d (thread %d)\n", iteration + 1, threadId);
+    }
+    recUse->SetResetTimers(iRun < configStandalone.runsInit);
+    if (configStandalone.outputcontrolmem) {
+      recUse->SetOutputControl(threadId ? outputmemoryPipeline.get() : outputmemory.get(), configStandalone.outputcontrolmem);
+    }
+
+    if (configStandalone.testSyncAsync) {
+      printf("Running synchronous phase\n");
+    }
+    chainTrackingUse->mIOPtrs = ioPtrs;
+    if (iteration == (configStandalone.configProc.doublePipeline ? 1 : (configStandalone.runs - 1))) {
+      if (configStandalone.configProc.doublePipeline) {
+        timerPipeline->Start();
+      }
+      if (configStandalone.controlProfiler) {
+        rec->startGPUProfiling();
+      }
+    }
+    int tmpRetVal = recUse->RunChains();
+    int iterationEnd = nIterationEnd.fetch_add(1);
+    if (iterationEnd == configStandalone.runs - 1) {
+      if (configStandalone.configProc.doublePipeline) {
+        timerPipeline->Stop();
+      }
+      if (configStandalone.controlProfiler) {
+        rec->endGPUProfiling();
+      }
+    }
+
+    if (tmpRetVal == 0 || tmpRetVal == 2) {
+      OutputStat(chainTrackingUse, iRun == 0 ? nTracksTotal : nullptr, iRun == 0 ? nClustersTotal : nullptr);
+      if (configStandalone.memoryStat) {
+        recUse->PrintMemoryStatistics();
+      } else if (configStandalone.DebugLevel >= 2) {
+        recUse->PrintMemoryOverview();
+      }
+    }
+
+#ifdef HAVE_O2HEADERS
+    if (tmpRetVal == 0 && configStandalone.testSyncAsync) {
+      if (configStandalone.testSyncAsync) {
+        printf("Running asynchronous phase\n");
+      }
+
+      vecpod<char> compressedTmpMem(chainTracking->mIOPtrs.tpcCompressedClusters->totalDataSize);
+      memcpy(compressedTmpMem.data(), (const void*)chainTracking->mIOPtrs.tpcCompressedClusters, chainTracking->mIOPtrs.tpcCompressedClusters->totalDataSize);
+
+      chainTrackingAsync->mIOPtrs = ioPtrs;
+      chainTrackingAsync->mIOPtrs.tpcCompressedClusters = (o2::tpc::CompressedClustersFlat*)compressedTmpMem.data();
+      chainTrackingAsync->mIOPtrs.tpcZS = nullptr;
+      chainTrackingAsync->mIOPtrs.tpcPackedDigits = nullptr;
+      chainTrackingAsync->mIOPtrs.mcInfosTPC = nullptr;
+      chainTrackingAsync->mIOPtrs.nMCInfosTPC = 0;
+      chainTrackingAsync->mIOPtrs.mcLabelsTPC = nullptr;
+      chainTrackingAsync->mIOPtrs.nMCLabelsTPC = 0;
+      for (int i = 0; i < chainTracking->NSLICES; i++) {
+        chainTrackingAsync->mIOPtrs.clusterData[i] = nullptr;
+        chainTrackingAsync->mIOPtrs.nClusterData[i] = 0;
+        chainTrackingAsync->mIOPtrs.rawClusters[i] = nullptr;
+        chainTrackingAsync->mIOPtrs.nRawClusters[i] = 0;
+      }
+      chainTrackingAsync->mIOPtrs.clustersNative = nullptr;
+      recAsync->SetResetTimers(iRun < configStandalone.runsInit);
+      tmpRetVal = recAsync->RunChains();
+      if (tmpRetVal == 0 || tmpRetVal == 2) {
+        OutputStat(chainTrackingAsync, nullptr, nullptr);
+        if (configStandalone.memoryStat) {
+          recAsync->PrintMemoryStatistics();
+        }
+      }
+      recAsync->ClearAllocatedMemory();
+    }
+#endif
+    recUse->ClearAllocatedMemory();
+
+    if (tmpRetVal == 2) {
+      configStandalone.continueOnError = 0; // Forced exit from event display loop
+      configStandalone.noprompt = 1;
+    }
+    if (tmpRetVal && !configStandalone.continueOnError) {
+      if (tmpRetVal != 2) {
+        printf("Error occured\n");
+      }
+      return 1;
+    }
+    iRun++;
+  }
+  return 0;
 }
 
 int main(int argc, char** argv)
@@ -647,13 +759,13 @@ int main(int argc, char** argv)
       }
     }
 
-    for (int j2 = 0; j2 < configStandalone.runs2; j2++) {
+    for (int iRun = 0; iRun < configStandalone.runs2; iRun++) {
       if (configStandalone.configQA.inputHistogramsOnly) {
         chainTracking->ForceInitQA();
         break;
       }
       if (configStandalone.runs2 > 1) {
-        printf("RUN2: %d\n", j2);
+        printf("RUN2: %d\n", iRun);
       }
       long long int nTracksTotal = 0;
       long long int nClustersTotal = 0;
@@ -739,102 +851,36 @@ int main(int argc, char** argv)
 
         printf("Processing Event %d\n", iEvent);
         GPUTrackingInOutPointers ioPtrSave = chainTracking->mIOPtrs;
-        HighResTimer timerPipeline;
-        for (int j1 = 0; j1 < configStandalone.runs; j1++) {
-          GPUReconstruction* recUse = configStandalone.configProc.doublePipeline && j1 && (j1 & 1) == 0 ? recPipeline : rec;
-          GPUChainTracking* chainTrackingUse = configStandalone.configProc.doublePipeline && j1 && (j1 & 1) == 0 ? chainTrackingPipeline : chainTracking;
-          if (configStandalone.runs > 1) {
-            printf("Run %d\n", j1 + 1);
-          }
-          if (configStandalone.outputcontrolmem) {
-            recUse->SetOutputControl(outputmemory.get(), configStandalone.outputcontrolmem);
-          }
-          recUse->SetResetTimers(j1 < configStandalone.runsInit);
 
-          if (configStandalone.testSyncAsync) {
-            printf("Running synchronous phase\n");
+        nIteration.store(0);
+        nIterationEnd.store(0);
+        double pipelineWalltime = 1.;
+        if (configStandalone.configProc.doublePipeline) {
+          HighResTimer timerPipeline;
+          if (RunBenchmark(rec, chainTracking, 1, ioPtrSave, &nTracksTotal, &nClustersTotal)) {
+            goto breakrun;
           }
-          chainTrackingUse->mIOPtrs = ioPtrSave;
-          if (j1 == (configStandalone.configProc.doublePipeline ? 1 : (configStandalone.runs - 1))) {
-            timerPipeline.Start();
-            if (configStandalone.controlProfiler) {
-              rec->startGPUProfiling();
-            }
+          nIteration.store(1);
+          nIterationEnd.store(1);
+          auto pipeline1 = std::async(std::launch::async, RunBenchmark, rec, chainTracking, configStandalone.runs, ioPtrSave, &nTracksTotal, &nClustersTotal, 0, &timerPipeline);
+          auto pipeline2 = std::async(std::launch::async, RunBenchmark, recPipeline, chainTrackingPipeline, configStandalone.runs, ioPtrSave, &nTracksTotal, &nClustersTotal, 1, &timerPipeline);
+          if (pipeline1.get() || pipeline2.get()) {
+            goto breakrun;
           }
-          int tmpRetVal = recUse->RunChains();
-          if (j1 == configStandalone.runs - 1) {
-            timerPipeline.Stop();
-            if (configStandalone.controlProfiler) {
-              rec->endGPUProfiling();
-            }
-          }
-          nEventsProcessed += (j1 == 0);
-
-          if (tmpRetVal == 0 || tmpRetVal == 2) {
-            OutputStat(chainTrackingUse, j1 == 0 ? &nTracksTotal : nullptr, j1 == 0 ? &nClustersTotal : nullptr);
-            if (configStandalone.memoryStat) {
-              recUse->PrintMemoryStatistics();
-            } else if (configStandalone.DebugLevel >= 2) {
-              recUse->PrintMemoryOverview();
-            }
-          }
-
-#ifdef HAVE_O2HEADERS
-          if (tmpRetVal == 0 && configStandalone.testSyncAsync) {
-            if (configStandalone.testSyncAsync) {
-              printf("Running asynchronous phase\n");
-            }
-
-            vecpod<char> compressedTmpMem(chainTracking->mIOPtrs.tpcCompressedClusters->totalDataSize);
-            memcpy(compressedTmpMem.data(), (const void*)chainTracking->mIOPtrs.tpcCompressedClusters, chainTracking->mIOPtrs.tpcCompressedClusters->totalDataSize);
-
-            chainTrackingAsync->mIOPtrs = ioPtrSave;
-            chainTrackingAsync->mIOPtrs.tpcCompressedClusters = (o2::tpc::CompressedClustersFlat*)compressedTmpMem.data();
-            chainTrackingAsync->mIOPtrs.tpcZS = nullptr;
-            chainTrackingAsync->mIOPtrs.tpcPackedDigits = nullptr;
-            chainTrackingAsync->mIOPtrs.mcInfosTPC = nullptr;
-            chainTrackingAsync->mIOPtrs.nMCInfosTPC = 0;
-            chainTrackingAsync->mIOPtrs.mcLabelsTPC = nullptr;
-            chainTrackingAsync->mIOPtrs.nMCLabelsTPC = 0;
-            for (int i = 0; i < chainTracking->NSLICES; i++) {
-              chainTrackingAsync->mIOPtrs.clusterData[i] = nullptr;
-              chainTrackingAsync->mIOPtrs.nClusterData[i] = 0;
-              chainTrackingAsync->mIOPtrs.rawClusters[i] = nullptr;
-              chainTrackingAsync->mIOPtrs.nRawClusters[i] = 0;
-            }
-            chainTrackingAsync->mIOPtrs.clustersNative = nullptr;
-            recAsync->SetResetTimers(j1 < configStandalone.runsInit);
-            tmpRetVal = recAsync->RunChains();
-            if (tmpRetVal == 0 || tmpRetVal == 2) {
-              OutputStat(chainTrackingAsync, nullptr, nullptr);
-              if (configStandalone.memoryStat) {
-                recAsync->PrintMemoryStatistics();
-              }
-            }
-            recAsync->ClearAllocatedMemory();
-          }
-#endif
-          recUse->ClearAllocatedMemory();
-
-          if (tmpRetVal == 2) {
-            configStandalone.continueOnError = 0; // Forced exit from event display loop
-            configStandalone.noprompt = 1;
-          }
-          if (tmpRetVal && !configStandalone.continueOnError) {
-            if (tmpRetVal != 2) {
-              printf("Error occured\n");
-            }
+          pipelineWalltime = timerPipeline.GetElapsedTime() / (configStandalone.runs - 1);
+          printf("Pipeline wall time: %f, %d iterations, %f per event\n", timerPipeline.GetElapsedTime(), configStandalone.runs - 1, pipelineWalltime);
+        } else {
+          if (RunBenchmark(rec, chainTracking, configStandalone.runs, ioPtrSave, &nTracksTotal, &nClustersTotal)) {
             goto breakrun;
           }
         }
-        if (configStandalone.configProc.doublePipeline) {
-          printf("Pipeline wall time: %f, %d iterations, %f per event\n", timerPipeline.GetElapsedTime(), configStandalone.runs - 1, timerPipeline.GetElapsedTime() / (configStandalone.runs - 1));
-        }
+        nEventsProcessed++;
+
         if (configStandalone.timeFrameTime) {
           double nClusters = chainTracking->GetTPCMerger().NMaxClusters();
           if (nClusters > 0) {
             double nClsPerTF = 550000. * 1138.3;
-            double timePerTF = (configStandalone.configProc.doublePipeline ? (timerPipeline.GetCurrentElapsedTime() / (configStandalone.runs - 1)) : ((configStandalone.DebugLevel ? rec->GetStatKernelTime() : rec->GetStatWallTime()) / 1000000.)) * nClsPerTF / nClusters;
+            double timePerTF = (configStandalone.configProc.doublePipeline ? pipelineWalltime : ((configStandalone.DebugLevel ? rec->GetStatKernelTime() : rec->GetStatWallTime()) / 1000000.)) * nClsPerTF / nClusters;
             double nGPUsReq = timePerTF / 0.02277;
             char stat[1024];
             snprintf(stat, 1024, "Sync phase: %.2f sec per 256 orbit TF, %.1f GPUs required", timePerTF, nGPUsReq);
@@ -870,7 +916,7 @@ breakrun:
 
   rec->Finalize();
   if (configStandalone.outputcontrolmem && rec->IsGPU()) {
-    if (rec->unregisterMemoryForGPU(outputmemory.get())) {
+    if (rec->unregisterMemoryForGPU(outputmemory.get()) || (configStandalone.configProc.doublePipeline && recPipeline->unregisterMemoryForGPU(outputmemoryPipeline.get()))) {
       printf("Error unregistering memory\n");
     }
   }

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -234,9 +234,17 @@ int ReadConfiguration(int argc, char** argv)
   configStandalone.OMPThreads = 1;
 #endif
   if (configStandalone.outputcontrolmem) {
+    bool forceEmptyMemory = getenv("LD_PRELOAD") && strstr(getenv("LD_PRELOAD"), "valgrind") != nullptr;
     outputmemory.reset(new char[configStandalone.outputcontrolmem]);
+    if (forceEmptyMemory) {
+      printf("Valgrind detected, emptying GPU output memory to avoid false positive undefined reads");
+      memset(outputmemory.get(), 0, configStandalone.outputcontrolmem);
+    }
     if (configStandalone.configProc.doublePipeline) {
       outputmemoryPipeline.reset(new char[configStandalone.outputcontrolmem]);
+      if (forceEmptyMemory) {
+        memset(outputmemoryPipeline.get(), 0, configStandalone.outputcontrolmem);
+      }
     }
   }
 

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -346,6 +346,7 @@ int SetupReconstruction()
   devProc.deviceNum = configStandalone.cudaDevice;
   devProc.forceMemoryPoolSize = (configStandalone.forceMemorySize == 1 && configStandalone.eventDisplay) ? 2 : configStandalone.forceMemorySize;
   devProc.debugLevel = configStandalone.DebugLevel;
+  devProc.allocDebugLevel = configStandalone.allocDebugLevel;
   devProc.deviceTimers = configStandalone.DeviceTiming;
   devProc.runQA = configStandalone.qa;
   devProc.runMC = configStandalone.configProc.runMC;

--- a/GPU/GPUTracking/Standalone/utils/timer.cxx
+++ b/GPU/GPUTracking/Standalone/utils/timer.cxx
@@ -102,7 +102,9 @@ double HighResTimer::GetCurrentElapsedTime(bool reset)
 {
   if (running == 0) {
     double retVal = GetElapsedTime();
-    Reset();
+    if (reset) {
+      Reset();
+    }
     return (retVal);
   }
   double CurrentTime = GetTime();


### PR DESCRIPTION
This PR finally implements the pipeline fed by 2 threads in a ping-pong way.
Required several additional features and improvements.
Average processing time on the RTX 2080 Ti improves from 1250 GPUs to 1175 GPUs.