### PR TITLE
Revert "DPL I/O API: adding support for spectator vector"

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -42,9 +42,6 @@ namespace framework
 
 struct InputSpec;
 
-template <typename T>
-using SpectatorMemoryResource = o2::pmr::SpectatorMemoryResource<T>;
-
 /// @class InputRecord
 /// @brief The input API of the Data Processing Layer
 /// This class holds the inputs which are valid for processing. The user can get an
@@ -316,11 +313,11 @@ class InputRecord
         auto header = o2::header::get<const DataHeader*>(ref.header);
         auto method = header->payloadSerializationMethod;
         if (method == o2::header::gSerializationMethodNone) {
-          std::unique_ptr<char, Deleter<char>> resourcebuffer((char*)ref.payload, Deleter<char>(false));
-          std::unique_ptr<boost::container::pmr::memory_resource> resource(new SpectatorMemoryResource<decltype(resourcebuffer)>(std::move(resourcebuffer), header->payloadSize));
-          const_cast<InputRecord*>(this)->mSpectatorResources.push_back(std::unique_ptr<boost::container::pmr::memory_resource>(resource.release()));
-          size_t size = header->payloadSize / sizeof(typename T::value_type);
-          std::vector<typename T::value_type const, o2::pmr::SpectatorAllocator<typename T::value_type const>> result(size, o2::pmr::SpectatorAllocator<typename T::value_type const>(mSpectatorResources.back().get()));
+          // TODO: construct a vector spectator
+          // this is a quick solution now which makes a copy of the plain vector data
+          auto* start = reinterpret_cast<typename T::value_type const*>(ref.payload);
+          auto* end = start + header->payloadSize / sizeof(typename T::value_type);
+          T result(start, end);
           return result;
         } else if (method == o2::header::gSerializationMethodROOT) {
           /// substitution for container of non-messageable objects with ROOT dictionary
@@ -333,10 +330,10 @@ class InputRecord
             // we expect the unique_ptr to hold an object, exception should have been thrown
             // otherwise
             auto object = DataRefUtils::as<NonConstT>(ref);
-            size_t nElements = object->size();
-            std::unique_ptr<boost::container::pmr::memory_resource> resource(new SpectatorMemoryResource<decltype(object)>(std::move(object)));
-            const_cast<InputRecord*>(this)->mSpectatorResources.push_back(std::unique_ptr<boost::container::pmr::memory_resource>(resource.release()));
-            std::vector<typename T::value_type const, o2::pmr::SpectatorAllocator<typename T::value_type const>> container(nElements, o2::pmr::SpectatorAllocator<typename T::value_type const>(mSpectatorResources.back().get()));
+            // need to swap the content of the deserialized container to a local variable to force return
+            // value optimization
+            T container;
+            std::swap(const_cast<NonConstT&>(container), *object);
             return container;
           } else {
             throw std::runtime_error("No supported conversion function for ROOT serialized message");
@@ -642,7 +639,6 @@ class InputRecord
  private:
   std::vector<InputRoute> const& mInputsSchema;
   InputSpan mSpan;
-  std::vector<std::unique_ptr<boost::container::pmr::memory_resource>> mSpectatorResources;
 };
 
 } // namespace framework

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -303,11 +303,6 @@ DataProcessorSpec getSinkSpec()
     // forward the read-only span on a different route
     pc.outputs().snapshot(Output{"TST", "MSGABLVECTORCPY", 0, Lifetime::Timeframe}, object12);
 
-    // extract the trivially copyable vector by std::vector object which will return vector
-    // with special allocator and the underlting pointer is the original input data
-    auto vector12 = pc.inputs().get<std::vector<o2::test::TriviallyCopyable>>("input12");
-    ASSERT_ERROR((object12.data() == vector12.data()) && (object12.size() == vector12.size()));
-
     LOG(INFO) << "extracting TNamed object from input13";
     auto object13 = pc.inputs().get<TNamed*>("input13");
     ASSERT_ERROR(strcmp(object13->GetName(), "a_name") == 0);


### PR DESCRIPTION
This reverts commit 64d00d964f42092d5b992de3e4d8f9e569e08a49.

Newer versions of stl do not allow const type as value type, this
is checked by static assert in stl_vector.h.
Need to return a const vector object instead, but some changes seem
to be necessary first to allow the assignment without copy.