### PR TITLE
GPU: Obtain valid device-version of host pointer for HIP

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -177,6 +177,7 @@ class GPUReconstruction
   unsigned int getNEventsProcessedInStat() { return mStatNEvents; }
   virtual int registerMemoryForGPU(const void* ptr, size_t size) = 0;
   virtual int unregisterMemoryForGPU(const void* ptr) = 0;
+  virtual void* getGPUPointer(void* ptr) { return ptr; }
   virtual void startGPUProfiling() {}
   virtual void endGPUProfiling() {}
   int CheckErrorCodes();

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
@@ -48,6 +48,7 @@ class GPUReconstructionHIPBackend : public GPUReconstructionDeviceBase
   bool IsEventDone(deviceEvent* evList, int nEvents = 1) override;
   int registerMemoryForGPU(const void* ptr, size_t size) override;
   int unregisterMemoryForGPU(const void* ptr) override;
+  void* getGPUPointer(void* ptr) override;
 
   size_t WriteToConstantMemory(size_t offset, const void* src, size_t size, int stream = -1, deviceEvent* ev = nullptr) override;
   size_t TransferMemoryInternal(GPUMemoryResource* res, int stream, deviceEvent* ev, deviceEvent* evList, int nEvents, bool toGPU, const void* src, void* dst) override;

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -572,6 +572,13 @@ int GPUReconstructionHIPBackend::unregisterMemoryForGPU(const void* ptr)
   return GPUFailedMsgI(hipHostUnregister((void*)ptr));
 }
 
+void* GPUReconstructionHIPBackend::getGPUPointer(void* ptr)
+{
+  void* retVal = nullptr;
+  GPUFailedMsg(hipHostGetDevicePointer(&retVal, ptr, 0));
+  return retVal;
+}
+
 void GPUReconstructionHIPBackend::PrintKernelOccupancies()
 {
   unsigned int maxBlocks, threads, suggestedBlocks;


### PR DESCRIPTION
It seems with hip memory registered with hipHostRegister is not in the unified address space, so we have to do some magic with the host pointers to enable zero-copy dma access from GPU kernels.