### PR TITLE
GPU: Disable TPC fast inverse transform for AliRoot

### DIFF
--- a/GPU/TPCFastTransformation/TPCFastTransformManager.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransformManager.cxx
@@ -326,7 +326,9 @@ int TPCFastTransformManager::updateCalibration(TPCFastTransform& fastTransform,
     } // row
   }   // slice
 
+#ifndef GPUCA_ALIROOT_LIB // Disable in AliRoot case temporarily, since it crashes, and is not used anyway
   correction.initInverse();
+#endif
 
   // set back the time-of-flight correction;
 


### PR DESCRIPTION
@sgorbuno : Disabling this temporarily since it crashes. Just disabled it again once fixed.