### PR TITLE
Fix in ray tracing and use material LUT in TPC-ITS matching

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
@@ -67,6 +67,9 @@ class NameConf
   // Filename to for decoding dictionaries
   static std::string getDictionaryFileName(DId det, const std::string_view prefix = "", const std::string_view ext = "");
 
+  // Filename to store material LUT file
+  static std::string getMatLUTFileName(const std::string_view prefix = "");
+
   // Filename to store summary about simulation processes and cut values
   static std::string getCutProcFileName(const std::string_view prefix = "");
 
@@ -101,6 +104,7 @@ class NameConf
   static constexpr std::string_view CUT_FILE_STRING = "proc-cut";
 
   static constexpr std::string_view DICTFILENAME = "dictionary";
+  static constexpr std::string_view MATBUDLUT = "matbud";
 };
 
 } // namespace base

--- a/DataFormats/Detectors/Common/src/NameConf.cxx
+++ b/DataFormats/Detectors/Common/src/NameConf.cxx
@@ -61,7 +61,7 @@ std::string NameConf::getCutProcFileName(std::string_view prefix)
   return o2::utils::concat_string(prefix.empty() ? STANDARDSIMPREFIX : prefix, "_", CUT_FILE_STRING, ".dat");
 }
 
-// Filename to store geometry file
+// Filename to store ITSMFT dictionary
 std::string NameConf::getDictionaryFileName(DId det, const std::string_view prefix, const std::string_view ext)
 {
   // check if the prefix is an existing path
@@ -71,6 +71,18 @@ std::string NameConf::getDictionaryFileName(DId det, const std::string_view pref
     return std::string(prefix); // it is a full file
   }
   return o2::utils::concat_string(prefix, det.getName(), DICTFILENAME, ext);
+}
+
+// Filename to store material LUT file
+std::string NameConf::getMatLUTFileName(const std::string_view prefix)
+{
+  // check if the prefix is an existing path
+  if (pathIsDirectory(prefix)) {
+    return o2::utils::concat_string(prefix, "/", MATBUDLUT, ".root");
+  } else if (pathExists(prefix)) {
+    return std::string(prefix); // it is a full file
+  }
+  return o2::utils::concat_string(prefix, MATBUDLUT, ".root");
 }
 
 std::string NameConf::getCTFFileName(long id, const std::string_view prefix)

--- a/Detectors/Base/src/Ray.cxx
+++ b/Detectors/Base/src/Ray.cxx
@@ -60,7 +60,7 @@ GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
 
   if (tCross1Min > -0.f) {
     mCrossParams1[nCross] = tCross1Min < 1.f ? tCross1Min : 1.f;
-    mCrossParams1[nCross] = tCross0Min > 0.f ? tCross0Min : 0.f;
+    mCrossParams2[nCross] = tCross0Min > 0.f ? tCross0Min : 0.f;
     if (validateZRange(mCrossParams1[nCross], mCrossParams2[nCross], lr)) {
       nCross++;
     }

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -16,6 +16,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
 #include "ReconstructionDataFormats/Track.h"
+#include "DetectorsBase/Propagator.h"
 
 namespace o2
 {
@@ -45,6 +46,8 @@ struct MatchITSTPCParams : public o2::conf::ConfigurableParamHelper<MatchITSTPCP
   float TPCTimeEdgeZSafeMargin = 20.f; ///< safety margin in cm when estimating TPC track tMin and tMax from assigned time0 and its track Z position
 
   float TimeBinTolerance = 10.f; ///<tolerance in time-bin for ITS-TPC time bracket matching (not used ? TODO)
+
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT; /// Material correction type
 
   O2ParamDef(MatchITSTPCParams, "tpcitsMatch");
 };

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -325,6 +325,12 @@ void MatchTPCITS::init()
     mTimer[i].Reset();
   }
   mParams = &Params::Instance();
+  setUseMatCorrFlag(mParams->matCorr);
+  auto* prop = o2::base::Propagator::Instance();
+  if (!prop->getMatLUT() && mParams->matCorr == o2::base::Propagator::MatCorrType::USEMatCorrLUT) {
+    LOG(WARNING) << "Requested material LUT is not loaded, switching to TGeo usage";
+    setUseMatCorrFlag(o2::base::Propagator::MatCorrType::USEMatCorrTGeo);
+  }
 
   // make sure T2GRot matrices are loaded into ITS geometry helper
   o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2GRot));

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -67,6 +67,17 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   } else {
     LOG(INFO) << "Dictionary " << dictFile << " is absent, Matching expects ITS cluster patterns";
   }
+
+  // this is a hack to provide Mat.LUT from the local file, in general will be provided by the framework from CCDB
+  std::string matLUTPath = ic.options().get<std::string>("material-lut-path");
+  std::string matLUTFile = o2::base::NameConf::getMatLUTFileName(matLUTPath);
+  if (o2::base::NameConf::pathExists(matLUTFile)) {
+    auto* lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
+    o2::base::Propagator::Instance()->setMatLUT(lut);
+    LOG(INFO) << "Loaded material LUT from " << matLUTFile;
+  } else {
+    LOG(INFO) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
+  }
   mMatching.init();
   //
 }
@@ -282,7 +293,9 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcC
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<TPCITSMatchingDPL>(useMC)},
-    Options{{"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}}}};
+    Options{
+      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
+      {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};
 }
 
 } // namespace globaltracking


### PR DESCRIPTION
* Fix in ray-tracing for material lookup
* Retrieve material LUT filename from NameConf
* Can set material query method from MatchTPCITSParams
Default method in MatchTPCITSParams is set to USEMatCorrLUT, it will be automatically overridden to USEMatCorrTGeo if the material LUT file is not available in the current directory.
This is a hack until the material LUT will be provided by the framework as CCDB object.
