### PR TITLE
InteractionTimeRecord must override comparison operators

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -279,6 +279,36 @@ struct InteractionTimeRecord : public InteractionRecord {
     return timeInBCNS + bc2ns();
   }
 
+  bool operator==(const InteractionTimeRecord& other) const
+  {
+    return this->InteractionRecord::operator==(other) && (timeInBCNS == other.timeInBCNS);
+  }
+
+  bool operator!=(const InteractionTimeRecord& other) const
+  {
+    return this->InteractionRecord::operator!=(other) || (timeInBCNS != other.timeInBCNS);
+  }
+
+  bool operator>(const InteractionTimeRecord& other) const
+  {
+    return (this->InteractionRecord::operator>(other)) || (this->InteractionRecord::operator==(other) && (timeInBCNS > other.timeInBCNS));
+  }
+
+  bool operator>=(const InteractionTimeRecord& other) const
+  {
+    return !((*this) < other);
+  }
+
+  bool operator<(const InteractionTimeRecord& other) const
+  {
+    return (this->InteractionRecord::operator<(other)) || (this->InteractionRecord::operator==(other) && (timeInBCNS < other.timeInBCNS));
+  }
+
+  bool operator<=(const InteractionTimeRecord& other) const
+  {
+    return !((*this) > other);
+  }
+
   void print() const;
 
   friend std::ostream& operator<<(std::ostream& stream, InteractionTimeRecord const& ir);


### PR DESCRIPTION
Since the hadronic and QED event records need to be merged in a sorted way, the InteractionTimeRecord must implement its own comparison operators, accounting for the timeInBunch rather than inheriting them from the InteractionRecord