### PR TITLE
Speed-up of TPC-ITS matching

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -563,6 +563,8 @@ class MatchTPCITS
   float mNTPCBinsFullDrift = 0.;    ///< max time bin for full drift
   float mTPCZMax = 0.;              ///< max drift length
 
+  float mMinTPCTrackPtInv = 999.; ///< cutoff on TPC track inverse pT
+  float mMinITSTrackPtInv = 999.; ///< cutoff on ITS track inverse pT
 
   std::unique_ptr<TPCTransform> mTPCTransform;         ///< TPC cluster transformation
   std::unique_ptr<o2::gpu::GPUParam> mTPCClusterParam; ///< TPC clusters error param

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -29,7 +29,8 @@ struct MatchITSTPCParams : public o2::conf::ConfigurableParamHelper<MatchITSTPCP
   float crudeAbsDiffCut[o2::track::kNParams] = {2.f, 2.f, 0.2f, 0.2f, 4.f};
   float crudeNSigma2Cut[o2::track::kNParams] = {49.f, 49.f, 49.f, 49.f, 49.f};
 
-  float minTPCPt = 0.04;   ///< cut on minimal pT of TPC tracks to consider for matching
+  float minTPCTrackR = 26.6; ///< cut on minimal TPC tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
+  float minITSTrackR = 26.6; ///< cut on minimal ITS tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   int minTPCClusters = 25; ///< minimum number of clusters to consider
   int askMinTPCRow = 15;   ///< disregard tracks starting above this row
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -631,6 +631,7 @@ bool MatchTPCITS::prepareITSTracks()
   }
   mTimer[SWPrepITS].Start(false);
   mITSWork.clear();
+  mITSWork.reserve(mITSTracksArray.size());
   mITSROFTimes.clear();
   // number of records might be actually more than N tracks!
   mMatchRecordsITS.clear(); // RS TODO reserve(mMatchRecordsITS.size() + mParams->maxMatchCandidates*ntr);
@@ -752,25 +753,6 @@ bool MatchTPCITS::prepareITSTracks()
       }
       return trackA.getTgl() < trackB.getTgl();
     });
-
-    /* TOREMOVE?
-    // build array of 1st entries with of each ITS ROFrame
-    int nbins = 1 + mITSWork[indexCache.back()].roFrame;
-    auto& tbinStart = mITSTimeBinStart[sec];
-    tbinStart.resize(nbins > 1 ? nbins : 1, -1);
-    tbinStart[0] = 0;
-    for (int itr = 0; itr < (int)indexCache.size(); itr++) {
-      auto& trc = mITSWork[indexCache[itr]];
-      if (tbinStart[trc.roFrame] == -1) {
-        tbinStart[trc.roFrame] = itr;
-      }
-    }
-    for (int i = 1; i < nbins; i++) {
-      if (tbinStart[i] == -1) { // fill gaps with preceding indices. TODO ? Shall we do this for cont.readout in ITS only?
-        tbinStart[i] = tbinStart[i - 1];
-      }
-    }
-    */
   } // loop over tracks of single sector
   mMatchRecordsITS.reserve(mITSWork.size() * mParams->maxMatchCandidates);
   mTimer[SWPrepITS].Stop();
@@ -1159,10 +1141,9 @@ float MatchTPCITS::getPredictedChi2NoZ(const o2::track::TrackParCov& tr1, const 
 //______________________________________________
 void MatchTPCITS::addLastTrackCloneForNeighbourSector(int sector)
 {
-  // add clone of the src ITS track cashe, propagate it to ref.X in requested sector
+  // add clone of the src ITS track cache, propagate it to ref.X in requested sector
   // and register its index in the sector cache. Used for ITS tracks which are so close
   // to their setctor edge that their matching should be checked also in the neighbouring sector
-  mITSWork.reserve(mITSWork.size() + 100);
   mITSWork.push_back(mITSWork.back()); // clone the last track defined in given sector
   auto& trc = mITSWork.back();
   if (trc.rotate(o2::utils::Sector2Angle(sector)) &&


### PR DESCRIPTION
* Eliminate vector expansion hotspot
* Option of 1/pT cutoff for ITS and TPC tracks
