### PR TITLE
overlap corrections in passive components

### DIFF
--- a/Detectors/Passive/src/Cave.cxx
+++ b/Detectors/Passive/src/Cave.cxx
@@ -92,7 +92,7 @@ void Cave::ConstructGeometry()
   cavevol->AddNode(voBarrel, 1, new TGeoTranslation(0., -30., 0.));
 
   // mother volune for RB24 side (FDD, Compensator)
-  const Float_t kRB24CL = 2. * 598.74752;
+  const Float_t kRB24CL = 2. * 597.9;
   auto shCaveRB24 = new TGeoPcon(0., 360., 6);
   Float_t z0 = kRB24CL / 2 + 714.6;
   shCaveRB24->DefineSection(0, -kRB24CL / 2., 0., 105.);

--- a/Detectors/Passive/src/FrameStructure.cxx
+++ b/Detectors/Passive/src/FrameStructure.cxx
@@ -429,15 +429,19 @@ void FrameStructure::ConstructGeometry()
   //
   TGeoPgon* shB77A = new TGeoPgon(0., 360., 18, 2);
   shB77A->SetName("shB77A");
-  shB77A->DefineSection(0, -zE, 280., 423.7);
-  shB77A->DefineSection(1, zE, 280., 423.7);
+  shB77A->DefineSection(0, -zE, 280., 422.15);
+  shB77A->DefineSection(1, zE, 280., 422.15);
   TGeoBBox* shB77B = new TGeoBBox(3.42, 2., 375.5);
   shB77B->SetName("shB77B");
   TGeoTranslation* trB77A = new TGeoTranslation("trB77A", +283.32, 0., 0.);
   TGeoTranslation* trB77B = new TGeoTranslation("trB77B", -283.32, 0., 0.);
   trB77A->RegisterYourself();
   trB77B->RegisterYourself();
-  TGeoCompositeShape* shB77 = new TGeoCompositeShape("shB77", "shB77A+shB77B:trB77A+shB77B:trB77B");
+  TGeoPgon* shB77C = new TGeoPgon(60., 360., 18, 2);
+  shB77C->SetName("shB77C");
+  shB77C->DefineSection(0, -zE, 422.15, 423.70);
+  shB77C->DefineSection(1, zE, 422.15, 423.70);
+  TGeoCompositeShape* shB77 = new TGeoCompositeShape("shB77", "shB77A+shB77B:trB77A+shB77B:trB77B+shB77C");
   TGeoVolume* voB77 = new TGeoVolume("B077", shB77, gGeoManager->GetMedium("FRAME_Air"));
   voB77->SetName("B077"); // just to avoid a warning
   vmc->Gspos("B077", 1, TOPNAME, 0., 30., 0., 0, "ONLY");
@@ -1372,6 +1376,8 @@ void FrameStructure::ConstructGeometry()
   asTOFS01->SetVisibility(1);
 
   for (i = 0; i < 18; i++) {
+    if (i >= 4 && i <= 8)
+      continue;
     float phi1 = i * 20.;
     float phi2 = 270. + phi1;
     rot1 = new TGeoRotation(Form("TOFS_R1_%d", i), 90.0, phi1, 90., phi2, 0., 0.);
@@ -1561,8 +1567,8 @@ void FrameStructure::ConstructGeometry()
   vmc->Gspos("BRS2", 1, "BRS1", 0., -27.5 + 3.75, 0., 0, "ONLY");
   vmc->Gspos("BRS2", 2, "BRS1", 0., 27.5 - 3.75, 0., 0, "ONLY");
   vmc->Gspos("BRS3", 1, "BRS1", 0., 0., 0., 0, "ONLY");
-  vmc->Gspos("BRS1", 1, TOPNAME, -430. - 3. + 30., -190., 0., 0, "ONLY");
-  vmc->Gspos("BRS1", 2, TOPNAME, 430. + 3. + 30., -190., 0., 0, "ONLY");
+  vmc->Gspos("BRS1", 1, TOPNAME, -430. - 3.1 + 30., -190., 0., 0, "ONLY");
+  vmc->Gspos("BRS1", 2, TOPNAME, 430. + 3.1 + 30., -190., 0., 0, "ONLY");
 
   rbox[0] = 3.0;
   rbox[1] = 145. / 4.;

--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -16,6 +16,7 @@
 #include <TGeoPcon.h>
 #include <TGeoTorus.h>
 #include <TGeoTube.h>
+#include <TGeoEltu.h>
 #include <TVirtualMC.h>
 #include "TGeoManager.h"  // for TGeoManager, gGeoManager
 #include "TGeoMaterial.h" // for TGeoMaterial
@@ -629,14 +630,14 @@ void Pipe::ConstructGeometry()
   //
 
   // Copper Tube RB24/1
-  const Float_t kRB24CuTubeL = 393.5;
-  const Float_t kRB24cCuTubeL = 167.775;
-  const Float_t kRB24bCuTubeL = 393.5 - kRB24cCuTubeL;
+  const Float_t kRB24CuTubeL = 381.5;
+  const Float_t kRB24cCuTubeL = 155.775;
+  const Float_t kRB24bCuTubeL = kRB24CuTubeL - kRB24cCuTubeL;
   const Float_t kRB24CuTubeRi = 8.0 / 2.;
   const Float_t kRB24CuTubeRo = 8.4 / 2.;
   const Float_t kRB24CuTubeFRo = 7.6;
   const Float_t kRB24CuTubeFL = 1.86;
-  const Float_t kRB24CL = 2. * 598.74752;
+  const Float_t kRB24CL = 2. * 597.9;
   //
   // introduce cut at end of barrel 714.6m
   //
@@ -1466,28 +1467,62 @@ void Pipe::ConstructGeometry()
   //
   // Copper Tube RB24/2
   // mainly inside the compensator magnet
-  const Float_t kRB242CuTubeL = 330.0;
-
+  const Float_t kRB242CuTubeL = 350.0;
+  // 20 cm straight - 20 cm transition to final oval - 270 oval - 20 cm transition to final oval - 20 cm straight
+  //
+  // mother volume for transition region
+  TGeoVolume* voRB242CuOvTransMo = new TGeoVolume("voRB24CuOvTransMo", new TGeoTube(0., 4.75, 10.), kMedAir);
+  TGeoVolume* voRB242CuOvTransV[8];
+  TGeoVolume* voRB242CuOvTransI[8];
+  Float_t dovX = 4.;
+  Float_t dovY = 4.;
+  Float_t dovZ = -9.0;
+  for (Int_t i = 0; i < 10; i++) {
+    dovX -= 0.0625;
+    dovY += 0.075;
+    char vname[20];
+    sprintf(vname, "voRB242CuOvTransV%d", i);
+    voRB242CuOvTransV[i] = new TGeoVolume(vname, new TGeoEltu(dovX, dovY, 1.0), kMedCuHC);
+    sprintf(vname, "voRB242CuOvTransI%d", i);
+    voRB242CuOvTransI[i] = new TGeoVolume(vname, new TGeoEltu(dovX - 0.2, dovY - 0.2, 1.0), kMedVacHC);
+    voRB242CuOvTransV[i]->AddNode(voRB242CuOvTransI[i], 1, gGeoIdentity);
+    voRB242CuOvTransMo->AddNode(voRB242CuOvTransV[i], 1, new TGeoTranslation(0., 0., dovZ));
+    dovZ += 2.;
+  }
+  //
   TGeoVolume* voRB242CuTubeM =
-    new TGeoVolume("voRB242CuTubeM", new TGeoTube(0., kRB24CuTubeRo, kRB242CuTubeL / 2.), kMedVacHC);
-  voRB24CuTubeM->SetVisibility(0);
+    new TGeoVolume("voRB242CuTubeM", new TGeoTube(0., kRB24CuTubeRo, 10.), kMedVacHC);
   TGeoVolume* voRB242CuTube =
-    new TGeoVolume("voRB242CuTube", new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB242CuTubeL / 2.), kMedCuHC);
+    new TGeoVolume("voRB242CuTube", new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, 10.), kMedCuHC);
   voRB242CuTubeM->AddNode(voRB242CuTube, 1, gGeoIdentity);
-
+  TGeoVolume* voRB242CuOvalM =
+    new TGeoVolume("voRB242CuOvalM", new TGeoEltu(3.375, 4.75, 135.), kMedCuHC);
+  TGeoVolume* voRB242CuOval =
+    new TGeoVolume("voRB242CuOval", new TGeoEltu(3.175, 4.55, 135.), kMedVacHC);
+  voRB242CuOvalM->AddNode(voRB242CuOval, 1, gGeoIdentity);
+  //
   TGeoVolumeAssembly* voRB242 = new TGeoVolumeAssembly("RB242");
-  voRB242->AddNode(voRB242CuTube, 1, gGeoIdentity);
+  voRB242->AddNode(voRB242CuOvalM, 1, gGeoIdentity);
   z = -kRB242CuTubeL / 2 + kRB24CuTubeFL / 2.;
   voRB242->AddNode(voRB24CuTubeF, 3, new TGeoTranslation(0., 0., z));
   z = +kRB242CuTubeL / 2 - kRB24CuTubeFL / 2.;
   voRB242->AddNode(voRB24CuTubeF, 4, new TGeoTranslation(0., 0., z));
-  z = -kRB24cCuTubeL / 2 - kRB24VMABCL - kRB242CuTubeL / 2.;
+  z = 135. + 10.;
+  voRB242->AddNode(voRB242CuOvTransMo, 1, new TGeoCombiTrans(0., 0., z, rot180));
+  z = -135. - 10.;
+  voRB242->AddNode(voRB242CuOvTransMo, 2, new TGeoTranslation(0., 0., z));
+  z = -135. - 30.;
+  voRB242->AddNode(voRB242CuTubeM, 1, new TGeoTranslation(0., 0., z));
+  z = 135. + 30.;
+  voRB242->AddNode(voRB242CuTubeM, 2, new TGeoTranslation(0., 0., z));
+  z = -kRB24cCuTubeL / 2 - kRB24VMABCL - kRB242CuTubeL / 2. - 1.2;
   voRB24C->AddNode(voRB242, 1, new TGeoTranslation(0., 0., z));
   //
   //   RB24/3
   //
   // Copper Tube RB24/3
-  const Float_t kRB243CuTubeL = 303.35;
+  // the lenth of the tube is 296.85 on the drawing but this is inconsistent with the total length tube + bellow
+  const Float_t kRB243CuTubeL = 297.85;
 
   TGeoVolume* voRB243CuTubeM =
     new TGeoVolume("voRB243CuTubeM", new TGeoTube(0., kRB24CuTubeRo, kRB243CuTubeL / 2.), kMedVacNF);
@@ -1515,7 +1550,7 @@ void Pipe::ConstructGeometry()
   z = -2. * (kRB243CuTubeL + kRB24B1L) - (kRB24VMABCL - kRB24VMABCRBT1L / 2) + 1.;
   voRB243->AddNode(voRB24VMABCRB, 3, new TGeoTranslation(0., 0., z));
 
-  z = -kRB24cCuTubeL / 2 - kRB24VMABCL - kRB242CuTubeL;
+  z = -kRB24cCuTubeL / 2 - kRB24VMABCL - kRB242CuTubeL - 1.2;
   voRB24C->AddNode(voRB243, 1, new TGeoTranslation(0., 0., z));
 
   //

--- a/Detectors/Passive/src/Pipe.cxx
+++ b/Detectors/Passive/src/Pipe.cxx
@@ -1472,12 +1472,13 @@ void Pipe::ConstructGeometry()
   //
   // mother volume for transition region
   TGeoVolume* voRB242CuOvTransMo = new TGeoVolume("voRB24CuOvTransMo", new TGeoTube(0., 4.75, 10.), kMedAir);
-  TGeoVolume* voRB242CuOvTransV[8];
-  TGeoVolume* voRB242CuOvTransI[8];
+  const Int_t nTrans = 10;
+  TGeoVolume* voRB242CuOvTransV[nTrans];
+  TGeoVolume* voRB242CuOvTransI[nTrans];
   Float_t dovX = 4.;
   Float_t dovY = 4.;
   Float_t dovZ = -9.0;
-  for (Int_t i = 0; i < 10; i++) {
+  for (Int_t i = 0; i < nTrans; i++) {
     dovX -= 0.0625;
     dovY += 0.075;
     char vname[20];

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -637,7 +637,7 @@ void Detector::createAsideBeamLine()
   Double_t tubspar[5] = {0., 0., 0., 0., 0.};
   Double_t conpar[15] = {0.}; // all elements will be 0
 
-  Float_t zA = 1910.2;
+  Float_t zA = 1910.4;
 
   conpar[0] = 0.;
   conpar[1] = 360.;


### PR DESCRIPTION
corrected
- overlaps between HMP cradle and Frame
- small overlap inside frame
- overlap between RB24 pipe and ZDC (beam pipe)
- overlap between PIPE and COMP
For this a more realistic geometry of the pipe inside COMP has been implemented:
transition round to oval and oval beam.pipe inside the compensator magnet.  
Implementation needs to be reconsidered in case there is a performance penalty.