### PR TITLE
Material LUT treats as 0 lenght distances < 1micron, always return full length

### DIFF
--- a/Detectors/Base/src/MatLayerCylSet.cxx
+++ b/Detectors/Base/src/MatLayerCylSet.cxx
@@ -245,7 +245,8 @@ GPUd() MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, floa
   MatBudget rval;
   Ray ray(x0, y0, z0, x1, y1, z1);
   short lmin, lmax; // get innermost and outermost relevant layer
-  if (!getLayersRange(ray, lmin, lmax)) {
+  if (ray.isTooShort() || !getLayersRange(ray, lmin, lmax)) {
+    rval.length = ray.getDist();
     return rval;
   }
   short lrID = lmax;

--- a/Detectors/Base/src/MatLayerCylSet.cxx
+++ b/Detectors/Base/src/MatLayerCylSet.cxx
@@ -354,8 +354,9 @@ GPUd() MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, floa
     rval.meanRho /= rval.length;                                       // average
     float norm = (rval.length < 0.f) ? -ray.getDist() : ray.getDist(); // normalize
     rval.meanX2X0 *= norm;
-    rval.length *= norm;
   }
+  rval.length = ray.getDist();
+
 #ifdef _DBG_LOC_
   printf("<rho> = %e, x2X0 = %e  | step = %e\n", rval.meanRho, rval.meanX2X0, rval.length);
 #endif


### PR DESCRIPTION
* If queried points are separated by less than threshold (1\mum), 0 material budget will be returned, with the length set.

* Material LUT will return full distance, even if outside of the acceptance
Change in the definition of the MatBudget.length: it will always correspond to full straight distance between start and end points. 
In opposite, the meanX2X0 and meanXRho are calculated only for the segments which are parametrized by the LUT (i.e. detectors acceptance).