### PR TITLE
Add 3 prong case in the skim + code reorganization

### DIFF
--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -1,0 +1,90 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_ANALYSIS_SECONDARYVERTEXHF_H_
+#define O2_ANALYSIS_SECONDARYVERTEXHF_H_
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+namespace hftrackindexprong2
+{
+// FIXME: this is a workaround until we get the index columns to work with joins.
+using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra>;
+
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
+DECLARE_SOA_COLUMN(HFflag, hfflag, float);
+} // namespace hftrackindexprong2
+
+namespace hftrackindexprong3
+{
+// FIXME: this is a workaround until we get the index columns to work with joins.
+using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra>;
+
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
+DECLARE_SOA_INDEX_COLUMN_FULL(Index2, index2, int, BigTracks, "fIndex2");
+DECLARE_SOA_COLUMN(HFflag, hfflag, float);
+} // namespace hftrackindexprong3
+
+DECLARE_SOA_TABLE(HfTrackIndexProng2, "AOD", "HFTRACKIDXP2",
+		  hftrackindexprong2::CollisionId,
+		  hftrackindexprong2::Index0Id,
+		  hftrackindexprong2::Index1Id,
+		  hftrackindexprong2::HFflag);
+
+DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
+		  hftrackindexprong3::CollisionId,
+		  hftrackindexprong3::Index0Id,
+		  hftrackindexprong3::Index1Id,
+		  hftrackindexprong3::Index2Id,
+		  hftrackindexprong3::HFflag);
+} // namespace o2::aod
+
+float energy(float px, float py, float pz, float mass)
+{
+  float en_ = sqrtf(mass * mass + px * px + py * py + pz * pz);
+  return en_;
+};
+
+float invmass2prongs(float px0, float py0, float pz0, float mass0,
+                     float px1, float py1, float pz1, float mass1)
+{
+
+  float energy0_ = energy(px0, py0, pz0, mass0);
+  float energy1_ = energy(px1, py1, pz1, mass1);
+  float energytot = energy0_ + energy1_;
+
+  float psum2 = (px0 + px1) * (px0 + px1) +
+                (py0 + py1) * (py0 + py1) +
+                (pz0 + pz1) * (pz0 + pz1);
+  float mass = sqrtf(energytot * energytot - psum2);
+  return mass;
+};
+
+float invmass3prongs2(float px0, float py0, float pz0, float mass0,
+                     float px1, float py1, float pz1, float mass1,
+                     float px2, float py2, float pz2, float mass2)
+{
+  float energy0_ = energy(px0, py0, pz0, mass0);
+  float energy1_ = energy(px1, py1, pz1, mass1);
+  float energy2_ = energy(px2, py2, pz2, mass2);
+  float energytot = energy0_ + energy1_ + energy2_;
+
+  float psum2 = (px0 + px1 + px2) * (px0 + px1 + px2) +
+                (py0 + py1 + py2) * (py0 + py1 + py2) +
+                (pz0 + pz1 + pz2) * (pz0 + pz1 + pz2);
+  return energytot * energytot - psum2;
+};
+
+#endif // O2_ANALYSIS_SECONDARYVERTEXHF_H_

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -38,17 +38,17 @@ DECLARE_SOA_COLUMN(HFflag, hfflag, float);
 } // namespace hftrackindexprong3
 
 DECLARE_SOA_TABLE(HfTrackIndexProng2, "AOD", "HFTRACKIDXP2",
-		  hftrackindexprong2::CollisionId,
-		  hftrackindexprong2::Index0Id,
-		  hftrackindexprong2::Index1Id,
-		  hftrackindexprong2::HFflag);
+                  hftrackindexprong2::CollisionId,
+                  hftrackindexprong2::Index0Id,
+                  hftrackindexprong2::Index1Id,
+                  hftrackindexprong2::HFflag);
 
 DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
-		  hftrackindexprong3::CollisionId,
-		  hftrackindexprong3::Index0Id,
-		  hftrackindexprong3::Index1Id,
-		  hftrackindexprong3::Index2Id,
-		  hftrackindexprong3::HFflag);
+                  hftrackindexprong3::CollisionId,
+                  hftrackindexprong3::Index0Id,
+                  hftrackindexprong3::Index1Id,
+                  hftrackindexprong3::Index2Id,
+                  hftrackindexprong3::HFflag);
 } // namespace o2::aod
 
 float energy(float px, float py, float pz, float mass)
@@ -73,8 +73,8 @@ float invmass2prongs(float px0, float py0, float pz0, float mass0,
 };
 
 float invmass3prongs2(float px0, float py0, float pz0, float mass0,
-                     float px1, float py1, float pz1, float mass1,
-                     float px2, float py2, float pz2, float mass2)
+                      float px1, float py1, float pz1, float mass1,
+                      float px2, float py2, float pz2, float mass2)
 {
   float energy0_ = energy(px0, py0, pz0, mass0);
   float energy1_ = energy(px1, py1, pz1, mass1);

--- a/Analysis/Tasks/CMakeLists.txt
+++ b/Analysis/Tasks/CMakeLists.txt
@@ -33,6 +33,11 @@ o2_add_dpl_workflow(vertexing-hf
 		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsVertexing
 	          COMPONENT_NAME Analysis)
 
+o2_add_dpl_workflow(hftrackindexskimscreator
+                  SOURCES hftrackindexskimscreator.cxx
+		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsVertexing
+	          COMPONENT_NAME Analysis)
+
 o2_add_dpl_workflow(validation
 	  	  SOURCES validation.cxx
 		  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -167,12 +167,10 @@ struct HFTrackIndexSkimsCreator {
           continue;
         const auto& vtx = df.getPCACandidate();
         //LOGF(info, "vertex x %f", vtx[0]);
-        o2::track::TrackParCov trackdec0 = df.getTrack(0);
-        o2::track::TrackParCov trackdec1 = df.getTrack(1);
         std::array<float, 3> pvec0;
         std::array<float, 3> pvec1;
-        trackdec0.getPxPyPzGlo(pvec0);
-        trackdec1.getPxPyPzGlo(pvec1);
+        df.getTrack(0).getPxPyPzGlo(pvec0);
+        df.getTrack(1).getPxPyPzGlo(pvec1);
         float mass_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masspion,
                                      pvec1[0], pvec1[1], pvec1[2], masskaon);
         float masssw_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masskaon,
@@ -209,15 +207,12 @@ struct HFTrackIndexSkimsCreator {
             if (nCand3 == 0)
               continue;
             const auto& vtx3 = df3.getPCACandidate();
-            o2::track::TrackParCov trackdec0_3p = df3.getTrack(0);
-            o2::track::TrackParCov trackdec1_3p = df3.getTrack(1);
-            o2::track::TrackParCov trackdec2_3p = df3.getTrack(2);
             std::array<float, 3> pvec0_3p;
             std::array<float, 3> pvec1_3p;
             std::array<float, 3> pvec2_3p;
-            trackdec0_3p.getPxPyPzGlo(pvec0_3p);
-            trackdec1_3p.getPxPyPzGlo(pvec1_3p);
-            trackdec2_3p.getPxPyPzGlo(pvec2_3p);
+            df3.getTrack(0).getPxPyPzGlo(pvec0_3p);
+            df3.getTrack(1).getPxPyPzGlo(pvec1_3p);
+            df3.getTrack(2).getPxPyPzGlo(pvec2_3p);
             hftrackindexprong3(track_0.collisionId(),
                                track_0.globalIndex(),
                                track_1.globalIndex(),

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -76,8 +76,8 @@ struct SelectTracks {
       trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
       if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
         status = 0;
-      seltrack(status, dca[0], dca[1]);
       //hdca->Fill(sqrt(dca[0]*dca[0] + dca[1]*dca[1]));
+      seltrack(status, dca[0], dca[1]);
     }  
   }
 };

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -1,0 +1,231 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Analysis/SecondaryVertexHF.h"
+#include "DetectorsVertexing/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+
+#include <TFile.h>
+#include <TH1F.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+namespace o2::aod
+{
+namespace seltrack
+{
+DECLARE_SOA_COLUMN(IsSel, issel, int);
+} // namespace etaphi
+DECLARE_SOA_TABLE(SelTrack, "AOD", "SELTRACK", seltrack::IsSel);
+} // namespace o2::aod
+
+
+struct SelectTracks {
+  Produces<aod::SelTrack> seltrack;
+  Configurable<double> ptmintrack{"ptmintrack", -1, "ptmin single track"};
+  Configurable<int> d_tpcnclsfound {"d_tpcnclsfound", 70, "min number of tpc cls >="};
+
+  void process(aod::Collision const& collision,
+               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
+  {
+    Point3D<float> vtxXYZ(collision.posX(), collision.posY(), collision.posZ());
+    for (auto it0 = tracks.begin(); it0 != tracks.end(); ++it0) {
+      auto& track_0 = *it0;
+      int status = 1;
+      if (abs(track_0.signed1Pt())<ptmintrack)
+        status = 0;
+       UChar_t clustermap_0 = track_0.itsClusterMap();
+       bool isselected_0 = track_0.tpcNClsFound() >= d_tpcnclsfound && track_0.flags() & 0x4;
+       isselected_0 = isselected_0 && (TESTBIT(clustermap_0, 0) || TESTBIT(clustermap_0, 1));
+       if (!isselected_0)
+         status = 0;
+       seltrack(status);
+
+      array<float,2> dca;
+      float x0_ = track_0.x();
+      float alpha0_ = track_0.alpha();
+      std::array<float, 5> arraypar0 = {track_0.y(), track_0.z(), track_0.snp(),
+                                        track_0.tgl(), track_0.signed1Pt()};
+      std::array<float, 15> covpar0 = {track_0.cYY(), track_0.cZY(), track_0.cZZ(),
+                                       track_0.cSnpY(), track_0.cSnpZ(),
+                                       track_0.cSnpSnp(), track_0.cTglY(), track_0.cTglZ(),
+                                       track_0.cTglSnp(), track_0.cTglTgl(),
+                                       track_0.c1PtY(), track_0.c1PtZ(), track_0.c1PtSnp(),
+                                       track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
+      o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
+      trackparvar0.propagateParamToDCA(vtxXYZ, 5., &dca);
+      LOGF(info, "dca values %f %f", dca[0], dca[1]);
+    }  
+  }
+};
+
+struct HFTrackIndexSkimsCreator {
+  float masspion = 0.140;
+  float masskaon = 0.494;
+
+  Produces<aod::HfTrackIndexProng2> hftrackindexprong2;
+  Produces<aod::HfTrackIndexProng3> hftrackindexprong3;
+  Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
+  Configurable<int> do3prong{"do3prong", 0, "do 3 prong"};
+  Configurable<double> d_bz{"d_bz", 5.0, "bz field"};
+  Configurable<bool> b_propdca{"b_propdca", true, \
+                "create tracks version propagated to PCA"};
+  Configurable<double> d_maxr{"d_maxr", 200, "reject PCA's above this radius"};
+  Configurable<double> d_maxdzini{"d_maxdzini", 4, \
+                "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> d_minparamchange{"d_minparamchange", 1e-3, \
+                "stop iterations if largest change of any X is smaller than this"};
+  Configurable<double> d_minrelchi2change {"d_minrelchi2change", 0.9, \
+                "stop iterations is chi2/chi2old > this"};
+
+  Filter seltrack = (aod::seltrack::issel == 1);
+
+  void process(aod::Collision const& collision,
+               aod::BCs const& bcs,
+               soa::Filtered<soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::SelTrack>> const& tracks)
+  {
+    int trigindex = int{triggerindex};
+    if (trigindex != -1) {
+      //LOGF(info, "Selecting on trigger bit %d", trigindex);
+      uint64_t triggerMask = collision.bc().triggerMask();
+      bool isTriggerClassFired = triggerMask & 1ul << (trigindex - 1);
+      if (!isTriggerClassFired)
+        return;
+    }
+
+    LOGF(info, "N. of Tracks for collision: %d", tracks.size());
+    o2::vertexing::DCAFitterN<2> df;
+    df.setBz(d_bz);
+    df.setPropagateToPCA(b_propdca);
+    df.setMaxR(d_maxr);
+    df.setMaxDZIni(d_maxdzini);
+    df.setMinParamChange(d_minparamchange);
+    df.setMinRelChi2Change(d_minrelchi2change);
+
+    o2::vertexing::DCAFitterN<3> df3;
+    df3.setBz(d_bz);
+    df3.setPropagateToPCA(b_propdca);
+    df3.setMaxR(d_maxr);
+    df3.setMaxDZIni(d_maxdzini);
+    df3.setMinParamChange(d_minparamchange);
+    df3.setMinRelChi2Change(d_minrelchi2change);
+
+
+    for (auto it0 = tracks.begin(); it0 != tracks.end(); ++it0) {
+      auto& track_0 = *it0;
+      float x0_ = track_0.x();
+      float alpha0_ = track_0.alpha();
+      std::array<float, 5> arraypar0 = {track_0.y(), track_0.z(), track_0.snp(),
+                                        track_0.tgl(), track_0.signed1Pt()};
+      std::array<float, 15> covpar0 = {track_0.cYY(), track_0.cZY(), track_0.cZZ(),
+                                       track_0.cSnpY(), track_0.cSnpZ(),
+                                       track_0.cSnpSnp(), track_0.cTglY(), track_0.cTglZ(),
+                                       track_0.cTglSnp(), track_0.cTglTgl(),
+                                       track_0.c1PtY(), track_0.c1PtZ(), track_0.c1PtSnp(),
+                                       track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
+      o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
+      for (auto it1 = it0 + 1; it1 != tracks.end(); ++it1) {
+        auto& track_1 = *it1;
+        if (track_0.signed1Pt() * track_1.signed1Pt() > 0)
+          continue;
+        float x1_ = track_1.x();
+        float alpha1_ = track_1.alpha();
+        std::array<float, 5> arraypar1 = {track_1.y(), track_1.z(), track_1.snp(),
+                                          track_1.tgl(), track_1.signed1Pt()};
+        std::array<float, 15> covpar1 = {track_1.cYY(), track_1.cZY(), track_1.cZZ(),
+                                         track_1.cSnpY(), track_1.cSnpZ(),
+                                         track_1.cSnpSnp(), track_1.cTglY(), track_1.cTglZ(),
+                                         track_1.cTglSnp(), track_1.cTglTgl(),
+                                         track_1.c1PtY(), track_1.c1PtZ(), track_1.c1PtSnp(),
+                                         track_1.c1PtTgl(), track_1.c1Pt21Pt2()};
+        o2::track::TrackParCov trackparvar1(x1_, alpha1_, arraypar1, covpar1);
+        df.setUseAbsDCA(true);
+        int nCand = df.process(trackparvar0, trackparvar1);
+        if (nCand == 0)
+          continue;
+        const auto& vtx = df.getPCACandidate();
+        //LOGF(info, "vertex x %f", vtx[0]);
+        o2::track::TrackParCov trackdec0 = df.getTrack(0);
+        o2::track::TrackParCov trackdec1 = df.getTrack(1);
+        std::array<float, 3> pvec0;
+        std::array<float, 3> pvec1;
+        trackdec0.getPxPyPzGlo(pvec0);
+        trackdec1.getPxPyPzGlo(pvec1);
+        float mass_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masspion,
+                                     pvec1[0], pvec1[1], pvec1[2], masskaon);
+        float masssw_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masskaon,
+                                       pvec1[0], pvec1[1], pvec1[2], masspion);
+        hftrackindexprong2(track_0.collisionId(),
+                           track_0.globalIndex(),
+                           track_1.globalIndex(), 1.);
+        if (do3prong == 1) {
+          for (auto it2 = it0 + 1; it2 != tracks.end(); ++it2) {
+            if(it2 == it0 || it2 == it1)
+              continue;
+            auto& track_2 = *it2;
+            if (track_1.signed1Pt() * track_2.signed1Pt() > 0)
+              continue;
+            float x2_ = track_2.x();
+            float alpha2_ = track_2.alpha();
+            double mass3prong2 = invmass3prongs2(track_0.px(), track_0.py(), track_0.pz(), masspion,
+                                               track_1.px(), track_1.py(), track_1.pz(), masspion,
+                                               track_2.px(), track_2.py(), track_2.pz(), masspion);
+            if (mass3prong2 < 1.5*1.5 || mass3prong2 > 2.5*2.5) continue;
+
+            std::array<float, 5> arraypar2 = {track_2.y(), track_2.z(), track_2.snp(),
+                                              track_2.tgl(), track_2.signed1Pt()};
+            std::array<float, 15> covpar2 = {track_2.cYY(), track_2.cZY(), track_2.cZZ(),
+                                             track_2.cSnpY(), track_2.cSnpZ(),
+                                             track_2.cSnpSnp(), track_2.cTglY(), track_2.cTglZ(),
+                                             track_2.cTglSnp(), track_2.cTglTgl(),
+                                             track_2.c1PtY(), track_2.c1PtZ(), track_2.c1PtSnp(),
+                                             track_2.c1PtTgl(), track_2.c1Pt21Pt2()};
+            o2::track::TrackParCov trackparvar2(x2_, alpha2_, arraypar2, covpar2);
+            df3.setUseAbsDCA(true);
+            int nCand3 = df3.process(trackparvar0, trackparvar1, trackparvar2);
+            if (nCand3 == 0)
+              continue;
+            const auto& vtx3 = df3.getPCACandidate();
+            o2::track::TrackParCov trackdec0_3p = df3.getTrack(0);
+            o2::track::TrackParCov trackdec1_3p = df3.getTrack(1);
+            o2::track::TrackParCov trackdec2_3p = df3.getTrack(2);
+            std::array<float, 3> pvec0_3p;
+            std::array<float, 3> pvec1_3p;
+            std::array<float, 3> pvec2_3p;
+            trackdec0_3p.getPxPyPzGlo(pvec0_3p);
+            trackdec1_3p.getPxPyPzGlo(pvec1_3p);
+            trackdec2_3p.getPxPyPzGlo(pvec2_3p);
+            hftrackindexprong3(track_0.collisionId(),
+                               track_0.globalIndex(),
+			       track_1.globalIndex(),
+			       track_2.globalIndex(), 1.);
+          }
+        }
+      }
+    }
+  }
+};
+
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<SelectTracks>("produce-sel-track"),
+    adaptAnalysisTask<HFTrackIndexSkimsCreator>("vertexerhf-hftrackindexskimscreator")};
+}

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -98,8 +98,8 @@ struct HFTrackIndexSkimsCreator {
                                   "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> d_minparamchange{"d_minparamchange", 1e-3,
                                         "stop iterations if largest change of any X is smaller than this"};
-  Configurable<double> d_minrelchi2change {"d_minrelchi2change", 0.9,
-                                           "stop iterations is chi2/chi2old > this"};
+  Configurable<double> d_minrelchi2change{"d_minrelchi2change", 0.9,
+                                          "stop iterations is chi2/chi2old > this"};
 
   Filter seltrack = (aod::seltrack::issel == 1);
 

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -33,9 +33,9 @@ namespace seltrack
 DECLARE_SOA_COLUMN(IsSel, issel, int);
 DECLARE_SOA_COLUMN(DCAPrim0, dcaprim0, float);
 DECLARE_SOA_COLUMN(DCAPrim1, dcaprim1, float);
-} // namespace etaphi
+} // namespace seltrack
 DECLARE_SOA_TABLE(SelTrack, "AOD", "SELTRACK", seltrack::IsSel, seltrack::DCAPrim0,
-                                               seltrack::DCAPrim1);
+                  seltrack::DCAPrim1);
 } // namespace o2::aod
 
 struct SelectTracks {
@@ -74,7 +74,7 @@ struct SelectTracks {
                                        track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
       o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
       trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
-      if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin*dcatrackmin)
+      if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
         status = 0;
       seltrack(status, dca[0], dca[1]);
       //hdca->Fill(sqrt(dca[0]*dca[0] + dca[1]*dca[1]));
@@ -91,14 +91,14 @@ struct HFTrackIndexSkimsCreator {
   Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
   Configurable<int> do3prong{"do3prong", 0, "do 3 prong"};
   Configurable<double> d_bz{"d_bz", 5.0, "bz field"};
-  Configurable<bool> b_propdca{"b_propdca", true, \
+  Configurable<bool> b_propdca{"b_propdca", true,
                                "create tracks version propagated to PCA"};
   Configurable<double> d_maxr{"d_maxr", 200, "reject PCA's above this radius"};
-  Configurable<double> d_maxdzini{"d_maxdzini", 4, \
+  Configurable<double> d_maxdzini{"d_maxdzini", 4,
                                   "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
-  Configurable<double> d_minparamchange{"d_minparamchange", 1e-3, \
+  Configurable<double> d_minparamchange{"d_minparamchange", 1e-3,
                                         "stop iterations if largest change of any X is smaller than this"};
-  Configurable<double> d_minrelchi2change {"d_minrelchi2change", 0.9, \
+  Configurable<double> d_minrelchi2change {"d_minrelchi2change", 0.9,
                                            "stop iterations is chi2/chi2old > this"};
 
   Filter seltrack = (aod::seltrack::issel == 1);
@@ -132,7 +132,6 @@ struct HFTrackIndexSkimsCreator {
     df3.setMaxDZIni(d_maxdzini);
     df3.setMinParamChange(d_minparamchange);
     df3.setMinRelChi2Change(d_minrelchi2change);
-
 
     for (auto it0 = tracks.begin(); it0 != tracks.end(); ++it0) {
       auto& track_0 = *it0;
@@ -193,7 +192,8 @@ struct HFTrackIndexSkimsCreator {
             double mass3prong2 = invmass3prongs2(track_0.px(), track_0.py(), track_0.pz(), masspion,
                                                  track_1.px(), track_1.py(), track_1.pz(), masspion,
                                                  track_2.px(), track_2.py(), track_2.pz(), masspion);
-            if (mass3prong2 < 1.5*1.5 || mass3prong2 > 2.5*2.5) continue;
+            if (mass3prong2 < 1.5 * 1.5 || mass3prong2 > 2.5 * 2.5)
+              continue;
 
             std::array<float, 5> arraypar2 = {track_2.y(), track_2.z(), track_2.snp(),
                                               track_2.tgl(), track_2.signed1Pt()};
@@ -228,7 +228,6 @@ struct HFTrackIndexSkimsCreator {
     }
   }
 };
-
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -78,7 +78,7 @@ struct SelectTracks {
         status = 0;
       //hdca->Fill(sqrt(dca[0]*dca[0] + dca[1]*dca[1]));
       seltrack(status, dca[0], dca[1]);
-    }  
+    }
   }
 };
 


### PR DESCRIPTION
- First step for the final structure: the vertexinghf.cxx task will be split in partial steps to facilitate the code development
- The task hftrackindexskimscreator.cxx will include the creation of the track index derived tables.
- Added options to include/exclude 3 prong and a selection on the single track min pT to perform CPU timing/performance tests
- the vertexerhf.cxx code will be kept for the moment cause it provides useful comparison with Run2 code. It will be removed once the full chain and the corresponding validation tools will be in place.
