### PR TITLE
FT0::HitType: provide all template types to generate dict.

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/HitType.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/HitType.h
@@ -22,10 +22,11 @@ namespace o2
 {
 namespace ft0
 {
-class HitType : public o2::BasicXYZEHit<float>
+class HitType : public o2::BasicXYZEHit<float, float, float>
 {
  public:
-  using BasicXYZEHit<float>::BasicXYZEHit;
+  using BasicXYZEHit<float, float, float>::BasicXYZEHit;
+  ClassDefNV(HitType, 1);
 };
 
 } // namespace ft0


### PR DESCRIPTION
ClassDefNV was missing, even with it the dictionary complains of template ambiguities when loading
Hits tree interactively