### PR TITLE
DPL: proper Services API

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(Framework
                        src/ChannelConfigurationPolicyHelpers.cxx
                        src/ChannelSpecHelpers.cxx
                        src/CommonDataProcessors.cxx
+                       src/CommonServices.cxx
                        src/CompletionPolicy.cxx
                        src/CompletionPolicyHelpers.cxx
                        src/ComputingResourceHelpers.cxx

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_COMMONSERVICES_H_
+#define O2_FRAMEWORK_COMMONSERVICES_H_
+
+#include "Framework/ServiceSpec.h"
+#include "Framework/TypeIdHelpers.h"
+
+namespace o2::framework
+{
+
+/// A few ServiceSpecs for services we know about and that / are needed by
+/// everyone.
+struct CommonServices {
+  /// An helper for services which do not need any / much special initialization or
+  /// configuration.
+  template <typename I, typename T>
+  static ServiceInit simpleServiceInit()
+  {
+    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      return ServiceHandle{TypeIdHelpers::uniqueId<I>(), new T};
+    };
+  }
+
+  /// An helper to transform Singletons in to services, optionally configuring them
+  template <typename I, typename T>
+  static ServiceInit singletonServiceInit()
+  {
+    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      return ServiceHandle{TypeIdHelpers::uniqueId<I>(), T::instance()};
+    };
+  }
+
+  static ServiceConfigure noConfiguration()
+  {
+    return [](InitContext&, void* service) -> void* { return service; };
+  }
+
+  static ServiceSpec monitoringSpec();
+  static ServiceSpec infologgerContextSpec();
+  static ServiceSpec infologgerSpec();
+  static ServiceSpec configurationSpec();
+  static ServiceSpec controlSpec();
+  static ServiceSpec rootFileSpec();
+  static ServiceSpec parallelSpec();
+  static ServiceSpec rawDeviceSpec();
+  static ServiceSpec callbacksSpec();
+  static ServiceSpec timesliceIndex();
+  static ServiceSpec dataRelayer();
+
+  static std::vector<ServiceSpec> defaultServices();
+  static std::vector<ServiceSpec> requiredServices();
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_COMMONSERVICES_H_

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -79,7 +79,7 @@ class DataProcessingDevice : public FairMQDevice
   RawBufferContext mRawBufferContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
-  DataRelayer mRelayer;
+  DataRelayer* mRelayer = nullptr;
   std::vector<ExpirationHandler> mExpirationHandlers;
   std::vector<DataRelayer::RecordAction> mCompleted;
 

--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -16,6 +16,7 @@
 #include "Framework/DataRef.h"
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
+#include "Framework/CommonServices.h"
 
 #include <string>
 #include <vector>
@@ -37,8 +38,13 @@ struct DataProcessorSpec {
   AlgorithmSpec algorithm;
 
   Options options = {};
-  // FIXME: not used for now...
-  std::vector<std::string> requiredServices = {};
+  /// A set of services which are required to run
+  /// this data processor spec. Defaults to the old
+  /// list of hardcoded services. If you want
+  /// to override them, make sure you request at least
+  /// CommonServices::requiredServices() otherwise things
+  /// will go horribly wrong.
+  std::vector<ServiceSpec> requiredServices = CommonServices::defaultServices();
   /// Labels associated to the DataProcessor. These can
   /// be used to group different DataProcessor together
   /// and they can allow to filter different groups, e.g.

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -23,6 +23,7 @@
 #include "Framework/OutputRoute.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/DispatchPolicy.h"
+#include "Framework/ServiceSpec.h"
 
 #include <vector>
 #include <string>
@@ -43,6 +44,7 @@ struct DeviceSpec {
   std::vector<OutputChannelSpec> outputChannels;
   std::vector<std::string> arguments;
   std::vector<ConfigParamSpec> options;
+  std::vector<ServiceSpec> services;
 
   AlgorithmSpec algorithm;
 

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_SERVICESPEC_H_
+#define O2_FRAMEWORK_SERVICESPEC_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace fair::mq
+{
+struct ProgOptions;
+}
+
+namespace o2::framework
+{
+
+struct InitContext;
+struct DeviceSpec;
+struct ServiceRegistry;
+struct DeviceState;
+
+/// Handle to the service hash must be calculated
+/// using TypeIdHelper::uniqueId<BaseClass>() so that
+/// we can retrieve the service by its baseclass.
+struct ServiceHandle {
+  uint32_t hash;
+  void* instance;
+};
+
+/// A callback to create a given Service.
+using ServiceInit = std::function<ServiceHandle(ServiceRegistry&, DeviceState&, fair::mq::ProgOptions&)>;
+
+/// A callback to configure a given Service. Notice that the
+/// service itself is type erased and it's responsibility of
+/// the configuration itself to cast it to the correct value
+using ServiceConfigure = std::function<void*(InitContext&, void*)>;
+
+/// The kind of service we are asking for
+enum struct ServiceKind {
+  /// A Service which is not thread safe, therefore all accesses to it must be mutexed.
+  Serial,
+  /// A Service which is thread safe and therefore can be used by many threads the same time without risk
+  Global,
+  /// A Service which is specific to a given thread in a thread pool
+  Stream
+};
+
+/// A declaration of a service to be used by the associated DataProcessor
+struct ServiceSpec {
+  std::string name;
+  ServiceInit init;
+  ServiceConfigure configure;
+  ServiceKind kind;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_SERVICESPEC_H_

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -19,6 +19,7 @@
 #include "Framework/ConfigContext.h"
 #include "Framework/BoostOptionsRetriever.h"
 #include "Framework/CustomWorkflowTerminationHook.h"
+#include "Framework/CommonServices.h"
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
@@ -33,16 +34,12 @@ namespace boost
 class exception;
 }
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 using Inputs = std::vector<InputSpec>;
 using Outputs = std::vector<OutputSpec>;
 using Options = std::vector<ConfigParamSpec>;
-
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
 /// To be implemented by the user to specify one or more DataProcessorSpec.
 ///
@@ -75,6 +72,11 @@ void defaultConfiguration(std::vector<o2::framework::ChannelConfigurationPolicy>
 void defaultConfiguration(std::vector<o2::framework::ConfigParamSpec>& globalWorkflowOptions) {}
 void defaultConfiguration(std::vector<o2::framework::CompletionPolicy>& completionPolicies) {}
 void defaultConfiguration(std::vector<o2::framework::DispatchPolicy>& dispatchPolicies) {}
+void defaultConfiguration(std::vector<o2::framework::ServiceSpec>& services)
+{
+  services = o2::framework::CommonServices::defaultServices();
+}
+
 void defaultConfiguration(o2::framework::OnWorkflowTerminationHook& hook)
 {
   hook = [](const char*) {};
@@ -152,6 +154,9 @@ int main(int argc, char** argv)
     ConfigContext configContext(workflowOptionsRegistry, argc, argv);
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     overridePipeline(configContext, specs);
+    for (auto& spec : specs) {
+      UserCustomizationsHelper::userDefinedCustomization(spec.requiredServices, 0);
+    }
     result = doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, workflowOptions, configContext);
   } catch (boost::exception& e) {
     doBoostException(e);

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -1,0 +1,230 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/CommonServices.h"
+#include "Framework/ParallelContext.h"
+#include "Framework/TextControlService.h"
+#include "Framework/CallbackService.h"
+#include "Framework/TimesliceIndex.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/LocalRootFileService.h"
+#include "Framework/DataRelayer.h"
+
+#include <Configuration/ConfigurationInterface.h>
+#include <Configuration/ConfigurationFactory.h>
+#include <Monitoring/MonitoringFactory.h>
+#include <InfoLogger/InfoLogger.hxx>
+
+#include <options/FairMQProgOptions.h>
+
+using AliceO2::InfoLogger::InfoLogger;
+using AliceO2::InfoLogger::InfoLoggerContext;
+using o2::configuration::ConfigurationFactory;
+using o2::configuration::ConfigurationInterface;
+using o2::monitoring::Monitoring;
+using o2::monitoring::MonitoringFactory;
+
+namespace o2::framework
+{
+o2::framework::ServiceSpec CommonServices::monitoringSpec()
+{
+  return ServiceSpec{"monitoring",
+                     [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+                       void* service = MonitoringFactory::Get(options.GetPropertyAsString("monitoring-backend")).release();
+                       return ServiceHandle{TypeIdHelpers::uniqueId<Monitoring>(), service};
+                     },
+                     noConfiguration(),
+                     ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::infologgerContextSpec()
+{
+  return ServiceSpec{"infologger-contex",
+                     simpleServiceInit<InfoLoggerContext, InfoLoggerContext>(),
+                     noConfiguration(),
+                     ServiceKind::Serial};
+}
+
+// Creates the sink for FairLogger / InfoLogger integration
+auto createInfoLoggerSinkHelper(InfoLogger* logger, InfoLoggerContext* ctx)
+{
+  return [logger,
+          ctx](const std::string& content, const fair::LogMetaData& metadata) {
+    // translate FMQ metadata
+    InfoLogger::InfoLogger::Severity severity = InfoLogger::Severity::Undefined;
+    int level = InfoLogger::undefinedMessageOption.level;
+
+    if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::nolog)) {
+      // discard
+      return;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::fatal)) {
+      severity = InfoLogger::Severity::Fatal;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::error)) {
+      severity = InfoLogger::Severity::Error;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::warn)) {
+      severity = InfoLogger::Severity::Warning;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::state)) {
+      severity = InfoLogger::Severity::Info;
+      level = 10;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::info)) {
+      severity = InfoLogger::Severity::Info;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug)) {
+      severity = InfoLogger::Severity::Debug;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug1)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 10;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug2)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 20;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug3)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 30;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug4)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 40;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::trace)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 50;
+    }
+
+    InfoLogger::InfoLoggerMessageOption opt = {
+      severity,
+      level,
+      InfoLogger::undefinedMessageOption.errorCode,
+      metadata.file.c_str(),
+      atoi(metadata.line.c_str())};
+
+    if (logger) {
+      logger->log(opt, *ctx, "DPL: %s", content.c_str());
+    }
+  };
+};
+
+o2::framework::ServiceSpec CommonServices::infologgerSpec()
+{
+  return ServiceSpec{"infologger",
+                     [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+                       auto infoLoggerMode = options.GetPropertyAsString("infologger-mode");
+                       if (infoLoggerMode != "") {
+                         setenv("INFOLOGGER_MODE", infoLoggerMode.c_str(), 1);
+                       }
+                       auto infoLoggerService = new InfoLogger;
+                       auto infoLoggerContext = &services.get<InfoLoggerContext>();
+
+                       auto infoLoggerSeverity = options.GetPropertyAsString("infologger-severity");
+                       if (infoLoggerSeverity != "") {
+                         fair::Logger::AddCustomSink("infologger", infoLoggerSeverity, createInfoLoggerSinkHelper(infoLoggerService, infoLoggerContext));
+                       }
+                       return ServiceHandle{TypeIdHelpers::uniqueId<InfoLogger>(), infoLoggerService};
+                     },
+                     noConfiguration(),
+                     ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::configurationSpec()
+{
+  return ServiceSpec{
+    "configuration",
+    [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      auto backend = options.GetPropertyAsString("configuration");
+      if (backend == "command-line") {
+        return ServiceHandle{0, nullptr};
+      }
+      return ServiceHandle{TypeIdHelpers::uniqueId<ConfigurationInterface>(),
+                           ConfigurationFactory::getConfiguration(backend).release()};
+    },
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::controlSpec()
+{
+  return ServiceSpec{
+    "control",
+    [](ServiceRegistry& services, DeviceState& state, fair::mq::ProgOptions& options) -> ServiceHandle {
+      return ServiceHandle{TypeIdHelpers::uniqueId<ControlService>(),
+                           new TextControlService(services, state)};
+    },
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::rootFileSpec()
+{
+  return ServiceSpec{
+    "localrootfile",
+    simpleServiceInit<LocalRootFileService, LocalRootFileService>(),
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::parallelSpec()
+{
+  return ServiceSpec{
+    "parallel",
+    [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      auto& spec = services.get<DeviceSpec const>();
+      return ServiceHandle{TypeIdHelpers::uniqueId<ParallelContext>(),
+                           new ParallelContext(spec.rank, spec.nSlots)};
+    },
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::timesliceIndex()
+{
+  return ServiceSpec{
+    "timesliceindex",
+    simpleServiceInit<TimesliceIndex, TimesliceIndex>(),
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::callbacksSpec()
+{
+  return ServiceSpec{
+    "callbacks",
+    simpleServiceInit<CallbackService, CallbackService>(),
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+o2::framework::ServiceSpec CommonServices::dataRelayer()
+{
+  return ServiceSpec{
+    "datarelayer",
+    [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      auto& spec = services.get<DeviceSpec const>();
+      return ServiceHandle{TypeIdHelpers::uniqueId<DataRelayer>(),
+                           new DataRelayer(spec.completionPolicy,
+                                           spec.inputs,
+                                           services.get<Monitoring>(),
+                                           services.get<TimesliceIndex>())};
+    },
+    noConfiguration(),
+    ServiceKind::Serial};
+}
+
+std::vector<ServiceSpec> CommonServices::defaultServices()
+{
+  return {
+    timesliceIndex(),
+    monitoringSpec(),
+    infologgerContextSpec(),
+    infologgerSpec(),
+    configurationSpec(),
+    controlSpec(),
+    rootFileSpec(),
+    parallelSpec(),
+    callbacksSpec(),
+    dataRelayer()};
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -266,6 +266,7 @@ void DeviceSpecHelpers::processOutEdgeActions(std::vector<DeviceSpec>& devices,
       device.id = processor.name + "_t" + std::to_string(edge.producerTimeIndex);
     }
     device.algorithm = processor.algorithm;
+    device.services = processor.requiredServices;
     device.options = processor.options;
     device.rank = processor.rank;
     device.nSlots = processor.nSlots;
@@ -470,6 +471,7 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
       device.id += "_t" + std::to_string(edge.timeIndex);
     }
     device.algorithm = processor.algorithm;
+    device.services = processor.requiredServices;
     device.options = processor.options;
     device.rank = processor.rank;
     device.nSlots = processor.nSlots;

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -81,7 +81,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       tpcSummary.at(0).inputCount = ctx.inputs().size();
     }},
     {ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}},
-    {"CPUTimer"}};
+  };
 
   DataProcessorSpec itsClusterSummary{
     "its-cluster-summary",
@@ -94,7 +94,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       itsSummary.at(0).inputCount = ctx.inputs().size();
     }},
     {ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}},
-    {"CPUTimer"}};
+  };
 
   DataProcessorSpec merger{
     "merger",


### PR DESCRIPTION
This finally implements Services as originally conceived:

* Each dataprocessor has a list of required services specification.
  The specification will allow creating the service and (optionally)
  configuring it, attaching them to the provided Context.
* Required services are instanciated before running, without having to
  hardcode the list.

Eventually this will be extended to support transitions in a multithreaded
environment (e.g. some services might have to be created on a per thread
basis).

By default the old list of hardcoded services is provided. Users can override
that via the usual customise mecanism.