### PR TITLE
TRD: Fix bug due to changes in #3758

### DIFF
--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -2561,6 +2561,8 @@ void TRDGeometry::fillMatrixCache(int mask)
   }
 
   std::string volPath;
+  // keep in mind that changing this path can affect behaviour in Detector.cxx
+  // see: https://github.com/AliceO2Group/AliceO2/pull/3890
   const std::string vpStr{"ALIC_1/barrel_1/B077_1/BSEGMO"};
   const std::string vpApp1{"_1/BTRD"};
   const std::string vpApp2{"_1"};

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -126,12 +126,12 @@ bool Detector::ProcessHits(FairVolume* v)
   cIdSector[1] = cIdPath[5];
   cIdSector[2] = 0;
   sector = atoi(cIdSector);
-  if (sector < 0 || sector > 17) {
+  if (sector < 0 || sector >= kNsector) {
     LOG(FATAL) << "Sector out of bounds";
   }
   // The detector number (0 - 539)
   det = mGeom->getDetector(mGeom->getLayer(idChamber), mGeom->getStack(idChamber), sector);
-  if (det < 0 || det > 539) {
+  if (det < 0 || det >= kNdet) {
     LOG(FATAL) << "Detector number out of bounds";
   }
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -8,18 +8,23 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <TGeoManager.h>
-#include <TVirtualMC.h>
-#include <vector>
-#include <stdexcept>
-#include "FairVolume.h"
-#include "FairRootManager.h"
-#include "SimulationDataFormat/Stack.h"
-#include "CommonUtils/ShmAllocator.h"
+#include "TRDSimulation/Detector.h"
+
 #include "TRDBase/TRDCommonParam.h"
 #include "TRDBase/TRDGeometry.h"
-#include "TRDSimulation/Detector.h"
 #include "TRDSimulation/TRsim.h"
+
+#include "CommonUtils/ShmAllocator.h"
+#include "SimulationDataFormat/Stack.h"
+#include "FairVolume.h"
+#include "FairRootManager.h"
+
+#include <TGeoManager.h>
+#include <TVirtualMC.h>
+
+#include <vector>
+#include <stdexcept>
+#include <string>
 
 using namespace o2::trd;
 
@@ -102,24 +107,33 @@ bool Detector::ProcessHits(FairVolume* v)
     return false;
   }
 
-  // Determine the dectector number
+  // Determine the detector number
   int sector, det;
   // The plane number and chamber number
   char cIdChamber[3];
   cIdChamber[0] = cIdCurrent[2];
   cIdChamber[1] = cIdCurrent[3];
   cIdChamber[2] = 0;
-  // The det-sec number (0 – 29)
+  // The det-sec number (0 - 29)
   const int idChamber = mGeom->getDetectorSec(atoi(cIdChamber));
+  if (idChamber < 0 || idChamber > 29) {
+    LOG(FATAL) << "Chamber ID out of bounds";
+  }
   // The sector number (0 - 17), according to the standard coordinate system
-  TString cIdPath = fMC->CurrentVolPath();
+  TString cIdPath = fMC->CurrentVolOffName(7); // will return BTRD0....BTRD17
   char cIdSector[3];
-  cIdSector[0] = cIdPath[30];
-  cIdSector[1] = cIdPath[31];
+  cIdSector[0] = cIdPath[4];
+  cIdSector[1] = cIdPath[5];
   cIdSector[2] = 0;
   sector = atoi(cIdSector);
-  // The detector number (0 – 539)
+  if (sector < 0 || sector > 17) {
+    LOG(FATAL) << "Sector out of bounds";
+  }
+  // The detector number (0 - 539)
   det = mGeom->getDetector(mGeom->getLayer(idChamber), mGeom->getStack(idChamber), sector);
+  if (det < 0 || det > 539) {
+    LOG(FATAL) << "Detector number out of bounds";
+  }
 
   // 0: InFlight 1: Entering 2: Exiting
   int trkStat = 0;

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -114,8 +114,8 @@ bool Detector::ProcessHits(FairVolume* v)
   // The sector number (0 - 17), according to the standard coordinate system
   TString cIdPath = fMC->CurrentVolPath();
   char cIdSector[3];
-  cIdSector[0] = cIdPath[21];
-  cIdSector[1] = cIdPath[22];
+  cIdSector[0] = cIdPath[30];
+  cIdSector[1] = cIdPath[31];
   cIdSector[2] = 0;
   sector = atoi(cIdSector);
   // The detector number (0 – 539)


### PR DESCRIPTION
Fix bug due to changes in #3758.

The following change:
```
  std::string vpStr{"ALIC_1/B077_1/BSEGMO"};
  std::string vpStr{"ALIC_1/barrel_1/B077_1/BSEGMO"};
```
affected one string that is used to compute detector geometry.