### PR TITLE
TF counter in the DataHeader

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -666,9 +666,10 @@ struct DataHeader : public BaseHeader {
   using SplitPayloadPartsType = uint32_t;
   using PayloadSizeType = uint64_t;
   using TForbitType = uint32_t;
+  using TFCounterType = uint32_t;
 
   //static data for this header type/version
-  static constexpr uint32_t sVersion{2};
+  static constexpr uint32_t sVersion{3};
   static constexpr o2::header::HeaderType sHeaderType{String2<uint64_t>("DataHead")};
   static constexpr o2::header::SerializationMethod sSerializationMethod{gSerializationMethodNone};
 
@@ -711,9 +712,14 @@ struct DataHeader : public BaseHeader {
   //___NEW STUFF GOES BELOW
 
   ///
-  /// first orbit of time frame as unique identifier within the run
+  /// first orbit of time frame as unique identifier within the run (unless the TF is replayed), since v2
   ///
   TForbitType firstTForbit;
+
+  ///
+  /// ever incrementing TF counter, allows to disentangle even TFs with same firstTForbit in case of replay, since v3
+  ///
+  TFCounterType tfCounter;
 
   //___the functions:
   //__________________________________________________________________________________________________
@@ -726,7 +732,8 @@ struct DataHeader : public BaseHeader {
       subSpecification(0),
       splitPayloadIndex(0),
       payloadSize(0),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0)
   {
   }
 
@@ -740,7 +747,8 @@ struct DataHeader : public BaseHeader {
       subSpecification(subspec),
       splitPayloadIndex(0),
       payloadSize(size),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0)
   {
   }
 
@@ -754,7 +762,8 @@ struct DataHeader : public BaseHeader {
       subSpecification(subspec),
       splitPayloadIndex(partIndex),
       payloadSize(size),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0)
   {
   }
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -40,6 +40,7 @@ class CTFReaderSpec : public o2::framework::Task
  private:
   DetID::mask_t mDets;             // detectors
   std::vector<std::string> mInput; // input files
+  uint32_t mTFCounter = 0;
   size_t mNextToProcess = 0;
   TStopwatch mTimer;
 };

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -94,6 +94,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
       throw std::runtime_error(o2::utils::concat_string("failed to find output message header for ", label));
     }
     hd->firstTForbit = ctfHeader.firstTForbit;
+    hd->tfCounter = mTFCounter;
   };
 
   // send CTF Header
@@ -133,6 +134,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
     LOGF(INFO, "CTF reading total timing: Cpu: %.3e Real: %.3e s in %d slots",
          mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   }
+  mTFCounter++;
 }
 
 ///_______________________________________


### PR DESCRIPTION
* Add ever-incrementing TF counter to DataHeader
The DataHeader::firstTForbit will not be unique when the same TFs are replayed in loop, this counter will resolve the ambiguity.

* Set the tfCounter in RawDataReader and CTFReader 

@ironMann this would need to be set also in the STFbuilder