### PR TITLE
Split workflow in multiple tasks and add validation plots

### DIFF
--- a/Analysis/DataModel/include/Analysis/RecoDecay.h
+++ b/Analysis/DataModel/include/Analysis/RecoDecay.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_ANALYSIS_RECODECAY_H_
+#define O2_ANALYSIS_RECODECAY_H_
+
+float energy(float px, float py, float pz, float mass)
+{
+  float en_ = sqrtf(mass * mass + px * px + py * py + pz * pz);
+  return en_;
+};
+
+float invmass2prongs2(float px0, float py0, float pz0, float mass0,
+                      float px1, float py1, float pz1, float mass1)
+{
+
+  float energy0_ = energy(px0, py0, pz0, mass0);
+  float energy1_ = energy(px1, py1, pz1, mass1);
+  float energytot = energy0_ + energy1_;
+
+  float psum2 = (px0 + px1) * (px0 + px1) +
+                (py0 + py1) * (py0 + py1) +
+                (pz0 + pz1) * (pz0 + pz1);
+  return energytot * energytot - psum2;
+};
+
+float invmass3prongs2(float px0, float py0, float pz0, float mass0,
+                      float px1, float py1, float pz1, float mass1,
+                      float px2, float py2, float pz2, float mass2)
+{
+  float energy0_ = energy(px0, py0, pz0, mass0);
+  float energy1_ = energy(px1, py1, pz1, mass1);
+  float energy2_ = energy(px2, py2, pz2, mass2);
+  float energytot = energy0_ + energy1_ + energy2_;
+
+  float psum2 = (px0 + px1 + px2) * (px0 + px1 + px2) +
+                (py0 + py1 + py2) * (py0 + py1 + py2) +
+                (pz0 + pz1 + pz2) * (pz0 + pz1 + pz2);
+  return energytot * energytot - psum2;
+};
+
+float invmass2prongs(float px0, float py0, float pz0, float mass0,
+                     float px1, float py1, float pz1, float mass1)
+{
+  return sqrt(invmass2prongs2(px0, py0, pz0, mass0,
+                              px1, py1, pz1, mass1));
+};
+
+float invmass3prongs(float px0, float py0, float pz0, float mass0,
+                     float px1, float py1, float pz1, float mass1,
+                     float px2, float py2, float pz2, float mass2)
+{
+  return sqrt(invmass3prongs2(px0, py0, pz0, mass0,
+                              px1, py1, pz1, mass1,
+                              px2, py2, pz2, mass2));
+};
+
+#endif // O2_ANALYSIS_RECODECAY_H_

--- a/Analysis/DataModel/include/Analysis/RecoDecay.h
+++ b/Analysis/DataModel/include/Analysis/RecoDecay.h
@@ -61,4 +61,24 @@ float invmass3prongs(float px0, float py0, float pz0, float mass0,
                               px2, py2, pz2, mass2));
 };
 
+float ptcand2prong(float px0, float py0, float px1, float py1)
+{
+  return sqrt((px0 + px1) * (px0 + px1) + (py0 + py1) * (py0 + py1));
+};
+
+float pttrack(float px, float py)
+{
+  return sqrt(px * px + py * py);
+};
+
+float declength(float xdecay, float ydecay, float zdecay, float xvtx, float yvtx, float zvtx)
+{
+  return sqrtf((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx) + (zdecay - zvtx) * (zdecay - zvtx));
+};
+
+float declengthxy(float xdecay, float ydecay, float xvtx, float yvtx)
+{
+  return sqrtf((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx));
+};
+
 #endif // O2_ANALYSIS_RECODECAY_H_

--- a/Analysis/DataModel/include/Analysis/SecondaryVertex.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertex.h
@@ -72,29 +72,4 @@ DECLARE_SOA_TABLE(Cand2Prong, "AOD", "CANDDZERO",
                   cand2prong::MassD0, cand2prong::MassD0bar);
 } // namespace o2::aod
 
-//FIXME: this functions will need to become dynamic columns
-//once we will be able to build dynamic columns starting from
-//columns that belongs to different tables
-
-float energy(float px, float py, float pz, float mass)
-{
-  float en_ = sqrtf(mass * mass + px * px + py * py + pz * pz);
-  return en_;
-};
-
-float invmass2prongs(float px0, float py0, float pz0, float mass0,
-                     float px1, float py1, float pz1, float mass1)
-{
-
-  float energy0_ = energy(px0, py0, pz0, mass0);
-  float energy1_ = energy(px1, py1, pz1, mass1);
-  float energytot = energy0_ + energy1_;
-
-  float psum2 = (px0 + px1) * (px0 + px1) +
-                (py0 + py1) * (py0 + py1) +
-                (pz0 + pz1) * (pz0 + pz1);
-  float mass = sqrtf(energytot * energytot - psum2);
-  return mass;
-};
-
 #endif // O2_ANALYSIS_SECONDARYVERTEX_H_

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -37,6 +37,13 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Index2, index2, int, BigTracks, "fIndex2");
 DECLARE_SOA_COLUMN(HFflag, hfflag, float);
 } // namespace hftrackindexprong3
 
+namespace hfcandprong2
+{
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_COLUMN(MassD0, massD0, float);
+DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float);
+} // namespace hfcandprong2
+
 DECLARE_SOA_TABLE(HfTrackIndexProng2, "AOD", "HFTRACKIDXP2",
                   hftrackindexprong2::CollisionId,
                   hftrackindexprong2::Index0Id,
@@ -49,6 +56,10 @@ DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
                   hftrackindexprong3::Index1Id,
                   hftrackindexprong3::Index2Id,
                   hftrackindexprong3::HFflag);
+
+DECLARE_SOA_TABLE(HfCandProng2, "AOD", "HFCANDPRONG2",
+                  //hfcandprong2::CollisionId,
+                  hfcandprong2::MassD0, hfcandprong2::MassD0bar);
 } // namespace o2::aod
 
 float energy(float px, float py, float pz, float mass)

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -68,8 +68,8 @@ float energy(float px, float py, float pz, float mass)
   return en_;
 };
 
-float invmass2prongs(float px0, float py0, float pz0, float mass0,
-                     float px1, float py1, float pz1, float mass1)
+float invmass2prongs2(float px0, float py0, float pz0, float mass0,
+                      float px1, float py1, float pz1, float mass1)
 {
 
   float energy0_ = energy(px0, py0, pz0, mass0);
@@ -79,8 +79,7 @@ float invmass2prongs(float px0, float py0, float pz0, float mass0,
   float psum2 = (px0 + px1) * (px0 + px1) +
                 (py0 + py1) * (py0 + py1) +
                 (pz0 + pz1) * (pz0 + pz1);
-  float mass = sqrtf(energytot * energytot - psum2);
-  return mass;
+  return energytot * energytot - psum2;
 };
 
 float invmass3prongs2(float px0, float py0, float pz0, float mass0,

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -22,7 +22,7 @@ using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra>;
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
-DECLARE_SOA_COLUMN(HFflag, hfflag, float);
+DECLARE_SOA_COLUMN(HFflag, hfflag, int);
 } // namespace hftrackindexprong2
 
 namespace hftrackindexprong3
@@ -34,7 +34,7 @@ DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
 DECLARE_SOA_INDEX_COLUMN_FULL(Index2, index2, int, BigTracks, "fIndex2");
-DECLARE_SOA_COLUMN(HFflag, hfflag, float);
+DECLARE_SOA_COLUMN(HFflag, hfflag, int);
 } // namespace hftrackindexprong3
 
 namespace hfcandprong2

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -24,8 +24,6 @@ DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
 DECLARE_SOA_COLUMN(HFflag, hfflag, int);
-DECLARE_SOA_DYNAMIC_COLUMN(Value, value,
-                           [](int val) { return val; });
 } // namespace hftrackindexprong2
 
 namespace hftrackindexprong3
@@ -43,16 +41,35 @@ DECLARE_SOA_COLUMN(HFflag, hfflag, int);
 namespace hfcandprong2
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_COLUMN(PxProng0, pxprong0, float);
+DECLARE_SOA_COLUMN(PyProng0, pyprong0, float);
+DECLARE_SOA_COLUMN(PzProng0, pzprong0, float);
+DECLARE_SOA_COLUMN(PxProng1, pxprong1, float);
+DECLARE_SOA_COLUMN(PyProng1, pyprong1, float);
+DECLARE_SOA_COLUMN(PzProng1, pzprong1, float);
+DECLARE_SOA_COLUMN(DecayVtxX, decayvtxx, float);
+DECLARE_SOA_COLUMN(DecayVtxY, decayvtxy, float);
+DECLARE_SOA_COLUMN(DecayVtxZ, decayvtxz, float);
 DECLARE_SOA_COLUMN(MassD0, massD0, float);
 DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float);
+DECLARE_SOA_DYNAMIC_COLUMN(PtProng0, ptprong0,
+                           [](float px0, float py0) { return pttrack(px0, py0); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtProng1, ptprong1,
+                           [](float px1, float py1) { return pttrack(px1, py1); });
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt,
+                           [](float px0, float py0, float px1, float py1) { return ptcand2prong(px0, py0, px1, py1); });
+DECLARE_SOA_DYNAMIC_COLUMN(DecaylengthXY, decaylengthxy,
+                           [](float xvtxd, float yvtxd, float xvtxp, float yvtxp) { return declengthxy(xvtxd, yvtxd, xvtxp, yvtxp); });
+DECLARE_SOA_DYNAMIC_COLUMN(Decaylength, decaylength,
+                           [](float xvtxd, float yvtxd, float zvtxd, float xvtxp,
+                              float yvtxp, float zvtxp) { return declength(xvtxd, yvtxd, zvtxd, xvtxp, yvtxp, zvtxp); });
 } // namespace hfcandprong2
 
 DECLARE_SOA_TABLE(HfTrackIndexProng2, "AOD", "HFTRACKIDXP2",
                   hftrackindexprong2::CollisionId,
                   hftrackindexprong2::Index0Id,
                   hftrackindexprong2::Index1Id,
-                  hftrackindexprong2::HFflag,
-                  hftrackindexprong2::Value<hftrackindexprong2::Index0Id>);
+                  hftrackindexprong2::HFflag);
 
 DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
                   hftrackindexprong3::CollisionId,
@@ -62,8 +79,20 @@ DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
                   hftrackindexprong3::HFflag);
 
 DECLARE_SOA_TABLE(HfCandProng2, "AOD", "HFCANDPRONG2",
-                  //hfcandprong2::CollisionId,
-                  hfcandprong2::MassD0, hfcandprong2::MassD0bar);
+                  collision::PosX, collision::PosY, collision::PosZ,
+                  hfcandprong2::PxProng0, hfcandprong2::PyProng0, hfcandprong2::PzProng0,
+                  hfcandprong2::PxProng1, hfcandprong2::PyProng1, hfcandprong2::PzProng1,
+                  hfcandprong2::DecayVtxX, hfcandprong2::DecayVtxY, hfcandprong2::DecayVtxZ,
+                  hfcandprong2::MassD0, hfcandprong2::MassD0bar,
+                  hfcandprong2::PtProng0<hfcandprong2::PxProng0, hfcandprong2::PyProng0>,
+                  hfcandprong2::PtProng1<hfcandprong2::PxProng1, hfcandprong2::PyProng1>,
+                  hfcandprong2::Pt<hfcandprong2::PxProng0, hfcandprong2::PyProng0,
+                                   hfcandprong2::PxProng1, hfcandprong2::PyProng1>,
+                  hfcandprong2::DecaylengthXY<hfcandprong2::DecayVtxX, hfcandprong2::DecayVtxY,
+                                              collision::PosX, collision::PosY>,
+                  hfcandprong2::Decaylength<hfcandprong2::DecayVtxX, hfcandprong2::DecayVtxY,
+                                            hfcandprong2::DecayVtxZ, collision::PosX,
+                                            collision::PosY, collision::PosZ>);
 } // namespace o2::aod
 
 

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -95,5 +95,4 @@ DECLARE_SOA_TABLE(HfCandProng2, "AOD", "HFCANDPRONG2",
                                             collision::PosY, collision::PosZ>);
 } // namespace o2::aod
 
-
 #endif // O2_ANALYSIS_SECONDARYVERTEXHF_H_

--- a/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
+++ b/Analysis/DataModel/include/Analysis/SecondaryVertexHF.h
@@ -11,6 +11,7 @@
 #define O2_ANALYSIS_SECONDARYVERTEXHF_H_
 
 #include "Framework/AnalysisDataModel.h"
+#include "Analysis/RecoDecay.h"
 
 namespace o2::aod
 {
@@ -23,6 +24,8 @@ DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, BigTracks, "fIndex0");
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, BigTracks, "fIndex1");
 DECLARE_SOA_COLUMN(HFflag, hfflag, int);
+DECLARE_SOA_DYNAMIC_COLUMN(Value, value,
+                           [](int val) { return val; });
 } // namespace hftrackindexprong2
 
 namespace hftrackindexprong3
@@ -48,7 +51,8 @@ DECLARE_SOA_TABLE(HfTrackIndexProng2, "AOD", "HFTRACKIDXP2",
                   hftrackindexprong2::CollisionId,
                   hftrackindexprong2::Index0Id,
                   hftrackindexprong2::Index1Id,
-                  hftrackindexprong2::HFflag);
+                  hftrackindexprong2::HFflag,
+                  hftrackindexprong2::Value<hftrackindexprong2::Index0Id>);
 
 DECLARE_SOA_TABLE(HfTrackIndexProng3, "AOD", "HFTRACKIDXP3",
                   hftrackindexprong3::CollisionId,
@@ -62,39 +66,5 @@ DECLARE_SOA_TABLE(HfCandProng2, "AOD", "HFCANDPRONG2",
                   hfcandprong2::MassD0, hfcandprong2::MassD0bar);
 } // namespace o2::aod
 
-float energy(float px, float py, float pz, float mass)
-{
-  float en_ = sqrtf(mass * mass + px * px + py * py + pz * pz);
-  return en_;
-};
-
-float invmass2prongs2(float px0, float py0, float pz0, float mass0,
-                      float px1, float py1, float pz1, float mass1)
-{
-
-  float energy0_ = energy(px0, py0, pz0, mass0);
-  float energy1_ = energy(px1, py1, pz1, mass1);
-  float energytot = energy0_ + energy1_;
-
-  float psum2 = (px0 + px1) * (px0 + px1) +
-                (py0 + py1) * (py0 + py1) +
-                (pz0 + pz1) * (pz0 + pz1);
-  return energytot * energytot - psum2;
-};
-
-float invmass3prongs2(float px0, float py0, float pz0, float mass0,
-                      float px1, float py1, float pz1, float mass1,
-                      float px2, float py2, float pz2, float mass2)
-{
-  float energy0_ = energy(px0, py0, pz0, mass0);
-  float energy1_ = energy(px1, py1, pz1, mass1);
-  float energy2_ = energy(px2, py2, pz2, mass2);
-  float energytot = energy0_ + energy1_ + energy2_;
-
-  float psum2 = (px0 + px1 + px2) * (px0 + px1 + px2) +
-                (py0 + py1 + py2) * (py0 + py1 + py2) +
-                (pz0 + pz1 + pz2) * (pz0 + pz1 + pz2);
-  return energytot * energytot - psum2;
-};
 
 #endif // O2_ANALYSIS_SECONDARYVERTEXHF_H_

--- a/Analysis/Tasks/CMakeLists.txt
+++ b/Analysis/Tasks/CMakeLists.txt
@@ -38,6 +38,16 @@ o2_add_dpl_workflow(hftrackindexskimscreator
 		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsVertexing
 	          COMPONENT_NAME Analysis)
 
+o2_add_dpl_workflow(hfcandidatecreator2prong
+                  SOURCES hfcandidatecreator2prong.cxx
+		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsVertexing
+	          COMPONENT_NAME Analysis)
+
+o2_add_dpl_workflow(taskdzero
+                  SOURCES taskdzero.cxx
+		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsVertexing
+	          COMPONENT_NAME Analysis)
+
 o2_add_dpl_workflow(validation
 	  	  SOURCES validation.cxx
 		  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -28,6 +28,11 @@ using std::array;
 
 struct HFCandidateCreator2Prong {
   Produces<aod::HfCandProng2> hfcandprong2;
+  Configurable<bool> b_dovalplots{"b_dovalplots", true, "do validation plots"};
+  OutputObj<TH1F> hvtx_x_out{TH1F("hvtx_x", "2-track vtx", 100, -0.1, 0.1)};
+  OutputObj<TH1F> hvtx_y_out{TH1F("hvtx_y", "2-track vtx", 100, -0.1, 0.1)};
+  OutputObj<TH1F> hvtx_z_out{TH1F("hvtx_z", "2-track vtx", 100, -0.1, 0.1)};
+  OutputObj<TH1F> hmass2{TH1F("hmass2", "2-track inv mass", 500, 0, 5.0)};
   Configurable<double> d_bz{"d_bz", 5.0, "bz field"};
   Configurable<bool> b_propdca{"b_propdca", true,
                                "create tracks version propagated to PCA"};
@@ -97,6 +102,14 @@ struct HFCandidateCreator2Prong {
                                      pvec1[2], masspion);
       LOGF(info, "mass x %f %f", mass_, masssw_);
       hfcandprong2(mass_, masssw_);
+      if (b_dovalplots == true) {
+        hvtx_x_out->Fill(vtx[0]);
+        hvtx_y_out->Fill(vtx[1]);
+        hvtx_z_out->Fill(vtx[2]);
+        hmass2->Fill(mass_);
+        hmass2->Fill(masssw_);
+
+      }
     }
   }
 };

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -92,12 +92,12 @@ struct HFCandidateCreator2Prong {
       df.getTrack(1).getPxPyPzGlo(pvec1);
       float masspion = 0.140;
       float masskaon = 0.494;
-      float mass_ = invmass2prongs(pvec0[0], pvec0[1],
-		                   pvec0[2], masspion,
+      float mass_ = invmass2prongs(pvec0[0], pvec0[1]
+                                   pvec0[2], masspion,
                                    pvec1[0], pvec1[1],
                                    pvec1[2], masskaon);
       float masssw_ = invmass2prongs(pvec0[0], pvec0[1],
-		                     pvec0[2], masskaon,
+                                     pvec0[2], masskaon,
                                      pvec1[0], pvec1[1],
                                      pvec1[2], masspion);
       LOGF(info, "mass x %f %f", mass_, masssw_);
@@ -108,7 +108,6 @@ struct HFCandidateCreator2Prong {
         hvtx_z_out->Fill(vtx[2]);
         hmass2->Fill(mass_);
         hmass2->Fill(masssw_);
-
       }
     }
   }

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -55,8 +55,6 @@ struct HFCandidateCreator2Prong {
     df.setMinRelChi2Change(d_minrelchi2change);
 
     for (auto& hfpr2 : hftrackindexprong2s) {
-      LOGF(INFO, "test %f", hfpr2.hfflag());
-
       float x_p1 = hfpr2.index0().x();
       float alpha_p1 = hfpr2.index0().alpha();
       std::array<float, 5> arraypar_p1 = {hfpr2.index0().y(), hfpr2.index0().z(), hfpr2.index0().snp(),
@@ -85,22 +83,20 @@ struct HFCandidateCreator2Prong {
       if (nCand == 0)
         continue;
       const auto& vtx = df.getPCACandidate();
-      LOGF(info, "vertex x %f", vtx[0]);
       std::array<float, 3> pvec0;
       std::array<float, 3> pvec1;
       df.getTrack(0).getPxPyPzGlo(pvec0);
       df.getTrack(1).getPxPyPzGlo(pvec1);
       float masspion = 0.140;
       float masskaon = 0.494;
-      float mass_ = invmass2prongs(pvec0[0], pvec0[1],
-                                   pvec0[2], masspion,
-                                   pvec1[0], pvec1[1],
-                                   pvec1[2], masskaon);
-      float masssw_ = invmass2prongs(pvec0[0], pvec0[1],
-                                     pvec0[2], masskaon,
-                                     pvec1[0], pvec1[1],
-                                     pvec1[2], masspion);
-      LOGF(info, "mass x %f %f", mass_, masssw_);
+      float mass_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
+                                         pvec0[2], masspion,
+                                         pvec1[0], pvec1[1],
+                                         pvec1[2], masskaon));
+      float masssw_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
+                                           pvec0[2], masskaon,
+                                           pvec1[0], pvec1[1],
+                                           pvec1[2], masspion));
       hfcandprong2(mass_, masssw_);
       if (b_dovalplots == true) {
         hvtx_x_out->Fill(vtx[0]);

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Analysis/SecondaryVertexHF.h"
+#include "DetectorsVertexing/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+
+#include <TFile.h>
+#include <TH1F.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+struct HFCandidateCreator2Prong {
+  Produces<aod::HfCandProng2> hfcandprong2;
+  Configurable<double> d_bz{"d_bz", 5.0, "bz field"};
+  Configurable<bool> b_propdca{"b_propdca", true,
+                               "create tracks version propagated to PCA"};
+  Configurable<double> d_maxr{"d_maxr", 200, "reject PCA's above this radius"};
+  Configurable<double> d_maxdzini{"d_maxdzini", 4,
+                                  "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> d_minparamchange{"d_minparamchange", 1e-3,
+                                        "stop iterations if largest change of any X is smaller than this"};
+  Configurable<double> d_minrelchi2change{"d_minrelchi2change", 0.9,
+                                          "stop iterations is chi2/chi2old > this"};
+  void process(aod::HfTrackIndexProng2 const& hftrackindexprong2s,
+               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
+  {
+    o2::vertexing::DCAFitterN<2> df;
+    df.setBz(d_bz);
+    df.setPropagateToPCA(b_propdca);
+    df.setMaxR(d_maxr);
+    df.setMaxDZIni(d_maxdzini);
+    df.setMinParamChange(d_minparamchange);
+    df.setMinRelChi2Change(d_minrelchi2change);
+
+    for (auto& hfpr2 : hftrackindexprong2s) {
+      LOGF(INFO, "test %f", hfpr2.hfflag());
+
+      float x_p1 = hfpr2.index0().x();
+      float alpha_p1 = hfpr2.index0().alpha();
+      std::array<float, 5> arraypar_p1 = {hfpr2.index0().y(), hfpr2.index0().z(), hfpr2.index0().snp(),
+                                          hfpr2.index0().tgl(), hfpr2.index0().signed1Pt()};
+      std::array<float, 15> covpar_p1 = {hfpr2.index0().cYY(), hfpr2.index0().cZY(), hfpr2.index0().cZZ(),
+                                         hfpr2.index0().cSnpY(), hfpr2.index0().cSnpZ(),
+                                         hfpr2.index0().cSnpSnp(), hfpr2.index0().cTglY(), hfpr2.index0().cTglZ(),
+                                         hfpr2.index0().cTglSnp(), hfpr2.index0().cTglTgl(),
+                                         hfpr2.index0().c1PtY(), hfpr2.index0().c1PtZ(), hfpr2.index0().c1PtSnp(),
+                                         hfpr2.index0().c1PtTgl(), hfpr2.index0().c1Pt21Pt2()};
+      o2::track::TrackParCov trackparvar_p1(x_p1, alpha_p1, arraypar_p1, covpar_p1);
+
+      float x_n1 = hfpr2.index1().x();
+      float alpha_n1 = hfpr2.index1().alpha();
+      std::array<float, 5> arraypar_n1 = {hfpr2.index1().y(), hfpr2.index1().z(), hfpr2.index1().snp(),
+                                          hfpr2.index1().tgl(), hfpr2.index1().signed1Pt()};
+      std::array<float, 15> covpar_n1 = {hfpr2.index1().cYY(), hfpr2.index1().cZY(), hfpr2.index1().cZZ(),
+                                         hfpr2.index1().cSnpY(), hfpr2.index1().cSnpZ(),
+                                         hfpr2.index1().cSnpSnp(), hfpr2.index1().cTglY(), hfpr2.index1().cTglZ(),
+                                         hfpr2.index1().cTglSnp(), hfpr2.index1().cTglTgl(),
+                                         hfpr2.index1().c1PtY(), hfpr2.index1().c1PtZ(), hfpr2.index1().c1PtSnp(),
+                                         hfpr2.index1().c1PtTgl(), hfpr2.index1().c1Pt21Pt2()};
+      o2::track::TrackParCov trackparvar_n1(x_n1, alpha_n1, arraypar_n1, covpar_n1);
+      df.setUseAbsDCA(true);
+      int nCand = df.process(trackparvar_p1, trackparvar_n1);
+      if (nCand == 0)
+        continue;
+      const auto& vtx = df.getPCACandidate();
+      LOGF(info, "vertex x %f", vtx[0]);
+      std::array<float, 3> pvec0;
+      std::array<float, 3> pvec1;
+      df.getTrack(0).getPxPyPzGlo(pvec0);
+      df.getTrack(1).getPxPyPzGlo(pvec1);
+      float masspion = 0.140;
+      float masskaon = 0.494;
+      float mass_ = invmass2prongs(pvec0[0], pvec0[1],
+		                   pvec0[2], masspion,
+                                   pvec1[0], pvec1[1],
+                                   pvec1[2], masskaon);
+      float masssw_ = invmass2prongs(pvec0[0], pvec0[1],
+		                     pvec0[2], masskaon,
+                                     pvec1[0], pvec1[1],
+                                     pvec1[2], masspion);
+      LOGF(info, "mass x %f %f", mass_, masssw_);
+      hfcandprong2(mass_, masssw_);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HFCandidateCreator2Prong>("vertexerhf-hfcandcreator2prong")};
+}

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -44,7 +44,8 @@ struct HFCandidateCreator2Prong {
                                         "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> d_minrelchi2change{"d_minrelchi2change", 0.9,
                                           "stop iterations is chi2/chi2old > this"};
-  void process(aod::HfTrackIndexProng2 const& hftrackindexprong2s,
+  void process(aod::Collision const& collision,
+               aod::HfTrackIndexProng2 const& hftrackindexprong2s,
                soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
   {
     o2::vertexing::DCAFitterN<2> df;
@@ -98,7 +99,9 @@ struct HFCandidateCreator2Prong {
                                            pvec0[2], masskaon,
                                            pvec1[0], pvec1[1],
                                            pvec1[2], masspion));
-      hfcandprong2(mass_, masssw_);
+      hfcandprong2(collision.posX(), collision.posY(), collision.posZ(),
+                   pvec0[0], pvec0[1], pvec0[2], pvec1[0], pvec1[1], pvec1[2],
+                   vtx[0], vtx[1], vtx[2], mass_, masssw_);
       if (b_dovalplots == true) {
         hvtx_x_out->Fill(vtx[0]);
         hvtx_y_out->Fill(vtx[1]);

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -92,7 +92,7 @@ struct HFCandidateCreator2Prong {
       df.getTrack(1).getPxPyPzGlo(pvec1);
       float masspion = 0.140;
       float masskaon = 0.494;
-      float mass_ = invmass2prongs(pvec0[0], pvec0[1]
+      float mass_ = invmass2prongs(pvec0[0], pvec0[1],
                                    pvec0[2], masspion,
                                    pvec1[0], pvec1[1],
                                    pvec1[2], masskaon);

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -14,6 +14,7 @@
 #include "Analysis/SecondaryVertexHF.h"
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "ReconstructionDataFormats/Track.h"
+#include "Analysis/RecoDecay.h"
 
 #include <TFile.h>
 #include <TH1F.h>

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -41,13 +41,13 @@ DECLARE_SOA_TABLE(SelTrack, "AOD", "SELTRACK", seltrack::IsSel, seltrack::DCAPri
 struct SelectTracks {
   Produces<aod::SelTrack> seltrack;
   Configurable<double> ptmintrack{"ptmintrack", -1, "ptmin single track"};
-  Configurable<double> dcatrackmin{"dcatrackmin", 0, "dca single track min"};
+  Configurable<double> dcatoprimxymin{"dcatoprimxymin", 0, "dca xy to prim vtx min"};
   Configurable<int> d_tpcnclsfound{"d_tpcnclsfound", 70, "min number of tpc cls >="};
   Configurable<double> d_bz{"d_bz", 5.0, "bz field"};
   Configurable<bool> b_dovalplots{"b_dovalplots", true, "do validation plots"};
   OutputObj<TH1F> hpt_nocuts{TH1F("hpt_nocuts", "pt tracks (#GeV)", 100, 0., 10.)};
   OutputObj<TH1F> hpt_cuts{TH1F("hpt_cuts", "pt tracks (#GeV)", 100, 0., 10.)};
-  OutputObj<TH1F> hdca_cuts{TH1F("hdca_cuts", "dca to prim. vertex (cm)", 100, 0., 10.)};
+  OutputObj<TH1F> hdcatoprimxy_cuts{TH1F("hdcatoprimxy_cuts", "dca xy to prim. vertex (cm)", 100, -1.0, 1.0)};
 
   void process(aod::Collision const& collision,
                soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
@@ -78,12 +78,12 @@ struct SelectTracks {
                                        track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
       o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
       trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
-      if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
+      if (abs(dca[0]) < dcatoprimxymin)
         status = 0;
       if (b_dovalplots == true) {
         if (status == 1) {
           hpt_cuts->Fill(track_0.pt());
-          hdca_cuts->Fill(sqrt(dca[0] * dca[0] + dca[1] * dca[1]));
+          hdcatoprimxy_cuts->Fill(dca[0]);
         }
       }
       seltrack(status, dca[0], dca[1]);

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -60,7 +60,6 @@ struct SelectTracks {
         hpt_nocuts->Fill(track_0.pt());
       if (track_0.pt() < ptmintrack)
         status = 0;
-        LOGF(info, "pt %f flag %d", abs(track_0.signed1Pt()), status);
       UChar_t clustermap_0 = track_0.itsClusterMap();
       bool isselected_0 = track_0.tpcNClsFound() >= d_tpcnclsfound && track_0.flags() & 0x4;
       isselected_0 = isselected_0 && (TESTBIT(clustermap_0, 0) || TESTBIT(clustermap_0, 1));
@@ -82,9 +81,9 @@ struct SelectTracks {
       //if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
       //  status = 0;
       if (b_dovalplots == true) {
-        if (status == 1){
+        if (status == 1) {
           hpt_cuts->Fill(track_0.pt());
-	  //hdca_cuts->Fill(sqrt(dca[0] * dca[0] + dca[1] * dca[1]));
+          //hdca_cuts->Fill(sqrt(dca[0] * dca[0] + dca[1] * dca[1]));
         }
       }
       seltrack(status, dca[0], dca[1]);

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -47,7 +47,7 @@ struct SelectTracks {
   Configurable<bool> b_dovalplots{"b_dovalplots", true, "do validation plots"};
   OutputObj<TH1F> hpt_nocuts{TH1F("hpt_nocuts", "pt tracks (#GeV)", 100, 0., 10.)};
   OutputObj<TH1F> hpt_cuts{TH1F("hpt_cuts", "pt tracks (#GeV)", 100, 0., 10.)};
-  OutputObj<TH1F> hdca_cuts{TH1F("hdca_cuts", "dca (cm)", 100, 0., 10.)};
+  OutputObj<TH1F> hdca_cuts{TH1F("hdca_cuts", "dca to prim. vertex (cm)", 100, 0., 10.)};
 
   void process(aod::Collision const& collision,
                soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
@@ -94,8 +94,8 @@ struct SelectTracks {
 struct HFTrackIndexSkimsCreator {
   float masspion = 0.140;
   float masskaon = 0.494;
-  OutputObj<TH1F> hmass2pre{TH1F("hmass2pre", "; Inv Mass (GeV/c^{2})", 500, 0, 5.0)};
-  OutputObj<TH1F> hmass3pre{TH1F("hmass3pre", "; Inv Mass (GeV/c^{2})", 500, 0, 5.0)};
+  OutputObj<TH1F> hmass2{TH1F("hmass2", "; Inv Mass (GeV/c^{2})", 500, 0, 5.0)};
+  OutputObj<TH1F> hmass3{TH1F("hmass3", "; Inv Mass (GeV/c^{2})", 500, 0, 5.0)};
   Produces<aod::HfTrackIndexProng2> hftrackindexprong2;
   Produces<aod::HfTrackIndexProng3> hftrackindexprong3;
   Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
@@ -193,12 +193,12 @@ struct HFTrackIndexSkimsCreator {
                                              pvec1[0], pvec1[1],
                                              pvec1[2], masspion));
         if (b_dovalplots == true) {
-          hmass2pre->Fill(mass_);
-          hmass2pre->Fill(masssw_);
+          hmass2->Fill(mass_);
+          hmass2->Fill(masssw_);
         }
         hftrackindexprong2(track_p1.collisionId(),
                            track_p1.globalIndex(),
-                           track_n1.globalIndex(), 1.);
+                           track_n1.globalIndex(), 1);
         if (do3prong == 1) {
           //second loop on positive tracks
           for (auto i_p2 = i_p1 + 1; i_p2 != tracks.end(); ++i_p2) {
@@ -213,7 +213,7 @@ struct HFTrackIndexSkimsCreator {
             if (mass3prong2 < d_minmassDp * d_minmassDp || mass3prong2 > d_maxmassDp * d_maxmassDp)
               continue;
             if (b_dovalplots == true)
-              hmass3pre->Fill(sqrt(mass3prong2));
+              hmass3->Fill(sqrt(mass3prong2));
             std::array<float, 5> arraypar_p2 = {track_p2.y(), track_p2.z(), track_p2.snp(),
                                                 track_p2.tgl(), track_p2.signed1Pt()};
             std::array<float, 15> covpar_p2 = {track_p2.cYY(), track_p2.cZY(), track_p2.cZZ(),
@@ -241,12 +241,12 @@ struct HFTrackIndexSkimsCreator {
                                                pvec2[0], pvec2[1],
                                                pvec2[2], masspion));
             if (b_dovalplots == true) {
-              hmass3pre->Fill(mass_);
+              hmass3->Fill(mass_);
             }
             hftrackindexprong3(track_p1.collisionId(),
                                track_p1.globalIndex(),
                                track_n1.globalIndex(),
-                               track_p1.globalIndex(), 2.);
+                               track_p1.globalIndex(), 2);
           }
           //second loop on negative tracks
           for (auto i_n2 = i_n1 + 1; i_n2 != tracks.end(); ++i_n2) {
@@ -260,7 +260,7 @@ struct HFTrackIndexSkimsCreator {
                                                  track_n2.px(), track_n2.py(), track_n2.pz(), masspion);
             if (mass3prong2 < d_minmassDp * d_minmassDp || mass3prong2 > d_maxmassDp * d_maxmassDp)
               continue;
-            hmass3pre->Fill(sqrt(mass3prong2));
+            hmass3->Fill(sqrt(mass3prong2));
             std::array<float, 5> arraypar_n2 = {track_n2.y(), track_n2.z(), track_n2.snp(),
                                                 track_n2.tgl(), track_n2.signed1Pt()};
             std::array<float, 15> covpar_n2 = {track_n2.cYY(), track_n2.cZY(), track_n2.cZZ(),
@@ -288,7 +288,7 @@ struct HFTrackIndexSkimsCreator {
                                                pvec2[0], pvec2[1],
                                                pvec2[2], masspion));
             if (b_dovalplots == true) {
-              hmass3pre->Fill(mass_);
+              hmass3->Fill(mass_);
             }
             hftrackindexprong3(track_n1.collisionId(),
                                track_n1.globalIndex(),

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -100,7 +100,8 @@ struct HFTrackIndexSkimsCreator {
                                         "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> d_minrelchi2change{"d_minrelchi2change", 0.9,
                                           "stop iterations is chi2/chi2old > this"};
-
+  Configurable<double> d_minmassDp{"d_minmassDp", 1.5, "min mass dplus presel"};
+  Configurable<double> d_maxmassDp{"d_maxmassDp", 2.1, "max mass dplus presel"};
   Filter seltrack = (aod::seltrack::issel == 1);
 
   void process(aod::Collision const& collision,
@@ -133,90 +134,119 @@ struct HFTrackIndexSkimsCreator {
     df3.setMinParamChange(d_minparamchange);
     df3.setMinRelChi2Change(d_minrelchi2change);
 
-    for (auto it0 = tracks.begin(); it0 != tracks.end(); ++it0) {
-      auto& track_0 = *it0;
-      float x0_ = track_0.x();
-      float alpha0_ = track_0.alpha();
-      std::array<float, 5> arraypar0 = {track_0.y(), track_0.z(), track_0.snp(),
-                                        track_0.tgl(), track_0.signed1Pt()};
-      std::array<float, 15> covpar0 = {track_0.cYY(), track_0.cZY(), track_0.cZZ(),
-                                       track_0.cSnpY(), track_0.cSnpZ(),
-                                       track_0.cSnpSnp(), track_0.cTglY(), track_0.cTglZ(),
-                                       track_0.cTglSnp(), track_0.cTglTgl(),
-                                       track_0.c1PtY(), track_0.c1PtZ(), track_0.c1PtSnp(),
-                                       track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
-      o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
-      for (auto it1 = it0 + 1; it1 != tracks.end(); ++it1) {
-        auto& track_1 = *it1;
-        if (track_0.signed1Pt() * track_1.signed1Pt() > 0)
+    for (auto i_p1 = tracks.begin(); i_p1 != tracks.end(); ++i_p1) {
+      auto& track_p1 = *i_p1;
+      float x_p1 = track_p1.x();
+      float alpha_p1 = track_p1.alpha();
+      std::array<float, 5> arraypar_p1 = {track_p1.y(), track_p1.z(), track_p1.snp(),
+                                          track_p1.tgl(), track_p1.signed1Pt()};
+      std::array<float, 15> covpar_p1 = {track_p1.cYY(), track_p1.cZY(), track_p1.cZZ(),
+                                         track_p1.cSnpY(), track_p1.cSnpZ(),
+                                         track_p1.cSnpSnp(), track_p1.cTglY(), track_p1.cTglZ(),
+                                         track_p1.cTglSnp(), track_p1.cTglTgl(),
+                                         track_p1.c1PtY(), track_p1.c1PtZ(), track_p1.c1PtSnp(),
+                                         track_p1.c1PtTgl(), track_p1.c1Pt21Pt2()};
+      o2::track::TrackParCov trackparvar_p1(x_p1, alpha_p1, arraypar_p1, covpar_p1);
+      for (auto i_n1 = tracks.begin(); i_n1 != tracks.end(); ++i_n1) {
+        auto& track_n1 = *i_n1;
+        if (track_n1.signed1Pt() > 0)
           continue;
-        float x1_ = track_1.x();
-        float alpha1_ = track_1.alpha();
-        std::array<float, 5> arraypar1 = {track_1.y(), track_1.z(), track_1.snp(),
-                                          track_1.tgl(), track_1.signed1Pt()};
-        std::array<float, 15> covpar1 = {track_1.cYY(), track_1.cZY(), track_1.cZZ(),
-                                         track_1.cSnpY(), track_1.cSnpZ(),
-                                         track_1.cSnpSnp(), track_1.cTglY(), track_1.cTglZ(),
-                                         track_1.cTglSnp(), track_1.cTglTgl(),
-                                         track_1.c1PtY(), track_1.c1PtZ(), track_1.c1PtSnp(),
-                                         track_1.c1PtTgl(), track_1.c1Pt21Pt2()};
-        o2::track::TrackParCov trackparvar1(x1_, alpha1_, arraypar1, covpar1);
+        float x_n1 = track_n1.x();
+        float alpha_n1 = track_n1.alpha();
+        std::array<float, 5> arraypar_n1 = {track_n1.y(), track_n1.z(), track_n1.snp(),
+                                            track_n1.tgl(), track_n1.signed1Pt()};
+        std::array<float, 15> covpar_n1 = {track_n1.cYY(), track_n1.cZY(), track_n1.cZZ(),
+                                           track_n1.cSnpY(), track_n1.cSnpZ(),
+                                           track_n1.cSnpSnp(), track_n1.cTglY(), track_n1.cTglZ(),
+                                           track_n1.cTglSnp(), track_n1.cTglTgl(),
+                                           track_n1.c1PtY(), track_n1.c1PtZ(), track_n1.c1PtSnp(),
+                                           track_n1.c1PtTgl(), track_n1.c1Pt21Pt2()};
+        o2::track::TrackParCov trackparvar_n1(x_n1, alpha_n1, arraypar_n1, covpar_n1);
         df.setUseAbsDCA(true);
-        int nCand = df.process(trackparvar0, trackparvar1);
+        int nCand = df.process(trackparvar_p1, trackparvar_n1);
         if (nCand == 0)
           continue;
         const auto& vtx = df.getPCACandidate();
         //LOGF(info, "vertex x %f", vtx[0]);
-        std::array<float, 3> pvec0;
-        std::array<float, 3> pvec1;
-        df.getTrack(0).getPxPyPzGlo(pvec0);
-        df.getTrack(1).getPxPyPzGlo(pvec1);
-        float mass_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masspion,
-                                     pvec1[0], pvec1[1], pvec1[2], masskaon);
-        float masssw_ = invmass2prongs(pvec0[0], pvec0[1], pvec0[2], masskaon,
-                                       pvec1[0], pvec1[1], pvec1[2], masspion);
-        hftrackindexprong2(track_0.collisionId(),
-                           track_0.globalIndex(),
-                           track_1.globalIndex(), 1.);
+        //std::array<float, 3> pvec0;
+        //std::array<float, 3> pvec1;
+        //df.getTrack(0).getPxPyPzGlo(pvec0);
+        //df.getTrack(1).getPxPyPzGlo(pvec1);
+
+        hftrackindexprong2(track_p1.collisionId(),
+                           track_p1.globalIndex(),
+                           track_n1.globalIndex(), 1.);
         if (do3prong == 1) {
-          for (auto it2 = it0 + 1; it2 != tracks.end(); ++it2) {
-            if (it2 == it0 || it2 == it1)
+          //second loop on positive tracks
+          for (auto i_p2 = i_p1 + 1; i_p2 != tracks.end(); ++i_p2) {
+            auto& track_p2 = *i_p2;
+            if (track_p2.signed1Pt() < 0)
               continue;
-            auto& track_2 = *it2;
-            if (track_1.signed1Pt() * track_2.signed1Pt() > 0)
-              continue;
-            float x2_ = track_2.x();
-            float alpha2_ = track_2.alpha();
-            double mass3prong2 = invmass3prongs2(track_0.px(), track_0.py(), track_0.pz(), masspion,
-                                                 track_1.px(), track_1.py(), track_1.pz(), masspion,
-                                                 track_2.px(), track_2.py(), track_2.pz(), masspion);
-            if (mass3prong2 < 1.5 * 1.5 || mass3prong2 > 2.5 * 2.5)
+            float x_p2 = track_p2.x();
+            float alpha_p2 = track_p2.alpha();
+            double mass3prong2 = invmass3prongs2(track_p1.px(), track_p1.py(), track_p1.pz(), masspion,
+                                                 track_n1.px(), track_n1.py(), track_n1.pz(), masskaon,
+                                                 track_p2.px(), track_p2.py(), track_p2.pz(), masspion);
+            if (mass3prong2 < d_minmassDp * d_minmassDp || mass3prong2 > d_maxmassDp * d_maxmassDp)
               continue;
 
-            std::array<float, 5> arraypar2 = {track_2.y(), track_2.z(), track_2.snp(),
-                                              track_2.tgl(), track_2.signed1Pt()};
-            std::array<float, 15> covpar2 = {track_2.cYY(), track_2.cZY(), track_2.cZZ(),
-                                             track_2.cSnpY(), track_2.cSnpZ(),
-                                             track_2.cSnpSnp(), track_2.cTglY(), track_2.cTglZ(),
-                                             track_2.cTglSnp(), track_2.cTglTgl(),
-                                             track_2.c1PtY(), track_2.c1PtZ(), track_2.c1PtSnp(),
-                                             track_2.c1PtTgl(), track_2.c1Pt21Pt2()};
-            o2::track::TrackParCov trackparvar2(x2_, alpha2_, arraypar2, covpar2);
+            std::array<float, 5> arraypar_p2 = {track_p2.y(), track_p2.z(), track_p2.snp(),
+                                                track_p2.tgl(), track_p2.signed1Pt()};
+            std::array<float, 15> covpar_p2 = {track_p2.cYY(), track_p2.cZY(), track_p2.cZZ(),
+                                               track_p2.cSnpY(), track_p2.cSnpZ(),
+                                               track_p2.cSnpSnp(), track_p2.cTglY(), track_p2.cTglZ(),
+                                               track_p2.cTglSnp(), track_p2.cTglTgl(),
+                                               track_p2.c1PtY(), track_p2.c1PtZ(), track_p2.c1PtSnp(),
+                                               track_p2.c1PtTgl(), track_p2.c1Pt21Pt2()};
+            o2::track::TrackParCov trackparvar_p2(x_p2, alpha_p2, arraypar_p2, covpar_p2);
             df3.setUseAbsDCA(true);
-            int nCand3 = df3.process(trackparvar0, trackparvar1, trackparvar2);
+            int nCand3 = df3.process(trackparvar_p1, trackparvar_n1, trackparvar_p2);
             if (nCand3 == 0)
               continue;
             const auto& vtx3 = df3.getPCACandidate();
-            std::array<float, 3> pvec0_3p;
-            std::array<float, 3> pvec1_3p;
-            std::array<float, 3> pvec2_3p;
-            df3.getTrack(0).getPxPyPzGlo(pvec0_3p);
-            df3.getTrack(1).getPxPyPzGlo(pvec1_3p);
-            df3.getTrack(2).getPxPyPzGlo(pvec2_3p);
-            hftrackindexprong3(track_0.collisionId(),
-                               track_0.globalIndex(),
-                               track_1.globalIndex(),
-                               track_2.globalIndex(), 1.);
+            hftrackindexprong3(track_p1.collisionId(),
+                               track_p1.globalIndex(),
+                               track_n1.globalIndex(),
+                               track_p1.globalIndex(), 2.);
+          }
+          //second loop on negative tracks
+          for (auto i_n2 = i_n1 + 1; i_n2 != tracks.end(); ++i_n2) {
+            auto& track_n2 = *i_n2;
+            if (track_n2.signed1Pt() > 0)
+              continue;
+            float x_n2 = track_n2.x();
+            float alpha_n2 = track_n2.alpha();
+            double mass3prong2 = invmass3prongs2(track_n1.px(), track_n1.py(), track_n1.pz(), masspion,
+                                                 track_p1.px(), track_p1.py(), track_p1.pz(), masskaon,
+                                                 track_n2.px(), track_n2.py(), track_n2.pz(), masspion);
+            if (mass3prong2 < d_minmassDp * d_minmassDp || mass3prong2 > d_maxmassDp * d_maxmassDp)
+              continue;
+
+            std::array<float, 5> arraypar_n2 = {track_n2.y(), track_n2.z(), track_n2.snp(),
+                                                track_n2.tgl(), track_n2.signed1Pt()};
+            std::array<float, 15> covpar_n2 = {track_n2.cYY(), track_n2.cZY(), track_n2.cZZ(),
+                                               track_n2.cSnpY(), track_n2.cSnpZ(),
+                                               track_n2.cSnpSnp(), track_n2.cTglY(), track_n2.cTglZ(),
+                                               track_n2.cTglSnp(), track_n2.cTglTgl(),
+                                               track_n2.c1PtY(), track_n2.c1PtZ(), track_n2.c1PtSnp(),
+                                               track_n2.c1PtTgl(), track_n2.c1Pt21Pt2()};
+            o2::track::TrackParCov trackparvar_n2(x_n2, alpha_n2, arraypar_n2, covpar_n2);
+            df3.setUseAbsDCA(true);
+            int nCand3 = df3.process(trackparvar_n1, trackparvar_p1, trackparvar_n2);
+            if (nCand3 == 0)
+              continue;
+            const auto& vtx3 = df3.getPCACandidate();
+            //std::array<float, 3> pvec0_3p;
+            //std::array<float, 3> pvec1_3p;
+            //std::array<float, 3> pvec2_3p;
+            //df3.getTrack(0).getPxPyPzGlo(pvec0_3p);
+            //df3.getTrack(1).getPxPyPzGlo(pvec1_3p);
+            //df3.getTrack(2).getPxPyPzGlo(pvec2_3p);
+
+            hftrackindexprong3(track_n1.collisionId(),
+                               track_n1.globalIndex(),
+                               track_p1.globalIndex(),
+                               track_n1.globalIndex(), 2.);
           }
         }
       }

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -148,6 +148,8 @@ struct HFTrackIndexSkimsCreator {
 
     for (auto i_p1 = tracks.begin(); i_p1 != tracks.end(); ++i_p1) {
       auto& track_p1 = *i_p1;
+      if (track_p1.signed1Pt() < 0)
+        continue;
       float x_p1 = track_p1.x();
       float alpha_p1 = track_p1.alpha();
       std::array<float, 5> arraypar_p1 = {track_p1.y(), track_p1.z(), track_p1.snp(),

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -76,14 +76,14 @@ struct SelectTracks {
                                        track_0.cTglSnp(), track_0.cTglTgl(),
                                        track_0.c1PtY(), track_0.c1PtZ(), track_0.c1PtSnp(),
                                        track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
-      //o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
-      //trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
-      //if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
-      //  status = 0;
+      o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
+      trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
+      if (dca[0] * dca[0] + dca[1] * dca[1] < dcatrackmin * dcatrackmin)
+        status = 0;
       if (b_dovalplots == true) {
         if (status == 1) {
           hpt_cuts->Fill(track_0.pt());
-          //hdca_cuts->Fill(sqrt(dca[0] * dca[0] + dca[1] * dca[1]));
+          hdca_cuts->Fill(sqrt(dca[0] * dca[0] + dca[1] * dca[1]));
         }
       }
       seltrack(status, dca[0], dca[1]);
@@ -184,15 +184,14 @@ struct HFTrackIndexSkimsCreator {
         std::array<float, 3> pvec1;
         df.getTrack(0).getPxPyPzGlo(pvec0);
         df.getTrack(1).getPxPyPzGlo(pvec1);
-        float mass_ = invmass2prongs(pvec0[0], pvec0[1],
-                                     pvec0[2], masspion,
-                                     pvec1[0], pvec1[1],
-                                     pvec1[2], masskaon);
-        float masssw_ = invmass2prongs(pvec0[0], pvec0[1],
-                                       pvec0[2], masskaon,
-                                       pvec1[0], pvec1[1],
-                                       pvec1[2], masspion);
-        LOGF(info, "mass x %f %f", mass_, masssw_);
+        float mass_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
+                                           pvec0[2], masspion,
+                                           pvec1[0], pvec1[1],
+                                           pvec1[2], masskaon));
+        float masssw_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
+                                             pvec0[2], masskaon,
+                                             pvec1[0], pvec1[1],
+                                             pvec1[2], masspion));
         if (b_dovalplots == true) {
           hmass2pre->Fill(mass_);
           hmass2pre->Fill(masssw_);
@@ -229,6 +228,21 @@ struct HFTrackIndexSkimsCreator {
             if (nCand3 == 0)
               continue;
             const auto& vtx3 = df3.getPCACandidate();
+            std::array<float, 3> pvec0;
+            std::array<float, 3> pvec1;
+            std::array<float, 3> pvec2;
+            df.getTrack(0).getPxPyPzGlo(pvec0);
+            df.getTrack(1).getPxPyPzGlo(pvec1);
+            df.getTrack(2).getPxPyPzGlo(pvec2);
+            float mass_ = sqrt(invmass3prongs2(pvec0[0], pvec0[1],
+                                               pvec0[2], masspion,
+                                               pvec1[0], pvec1[1],
+                                               pvec1[2], masskaon,
+                                               pvec2[0], pvec2[1],
+                                               pvec2[2], masspion));
+            if (b_dovalplots == true) {
+              hmass3pre->Fill(mass_);
+            }
             hftrackindexprong3(track_p1.collisionId(),
                                track_p1.globalIndex(),
                                track_n1.globalIndex(),
@@ -261,12 +275,21 @@ struct HFTrackIndexSkimsCreator {
             if (nCand3 == 0)
               continue;
             const auto& vtx3 = df3.getPCACandidate();
-            //std::array<float, 3> pvec0_3p;
-            //std::array<float, 3> pvec1_3p;
-            //std::array<float, 3> pvec2_3p;
-            //df3.getTrack(0).getPxPyPzGlo(pvec0_3p);
-            //df3.getTrack(1).getPxPyPzGlo(pvec1_3p);
-            //df3.getTrack(2).getPxPyPzGlo(pvec2_3p);
+            std::array<float, 3> pvec0;
+            std::array<float, 3> pvec1;
+            std::array<float, 3> pvec2;
+            df.getTrack(0).getPxPyPzGlo(pvec0);
+            df.getTrack(1).getPxPyPzGlo(pvec1);
+            df.getTrack(2).getPxPyPzGlo(pvec2);
+            float mass_ = sqrt(invmass3prongs2(pvec0[0], pvec0[1],
+                                               pvec0[2], masspion,
+                                               pvec1[0], pvec1[1],
+                                               pvec1[2], masskaon,
+                                               pvec2[0], pvec2[1],
+                                               pvec2[2], masspion));
+            if (b_dovalplots == true) {
+              hmass3pre->Fill(mass_);
+            }
             hftrackindexprong3(track_n1.collisionId(),
                                track_n1.globalIndex(),
                                track_p1.globalIndex(),

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -167,11 +167,19 @@ struct HFTrackIndexSkimsCreator {
         if (nCand == 0)
           continue;
         const auto& vtx = df.getPCACandidate();
-        //LOGF(info, "vertex x %f", vtx[0]);
-        //std::array<float, 3> pvec0;
-        //std::array<float, 3> pvec1;
-        //df.getTrack(0).getPxPyPzGlo(pvec0);
-        //df.getTrack(1).getPxPyPzGlo(pvec1);
+        std::array<float, 3> pvec0;
+        std::array<float, 3> pvec1;
+        df.getTrack(0).getPxPyPzGlo(pvec0);
+        df.getTrack(1).getPxPyPzGlo(pvec1);
+        float mass_ = invmass2prongs(pvec0[0], pvec0[1],
+                                     pvec0[2], masspion,
+                                     pvec1[0], pvec1[1],
+                                     pvec1[2], masskaon);
+        float masssw_ = invmass2prongs(pvec0[0], pvec0[1],
+                                       pvec0[2], masskaon,
+                                       pvec1[0], pvec1[1],
+                                       pvec1[2], masspion);
+        LOGF(info, "mass x %f %f", mass_, masssw_);
 
         hftrackindexprong2(track_p1.collisionId(),
                            track_p1.globalIndex(),

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -14,6 +14,7 @@
 #include "Analysis/SecondaryVertexHF.h"
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "ReconstructionDataFormats/Track.h"
+#include "Analysis/RecoDecay.h"
 
 #include <TFile.h>
 #include <TH1F.h>

--- a/Analysis/Tasks/taskdzero.cxx
+++ b/Analysis/Tasks/taskdzero.cxx
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Analysis/SecondaryVertexHF.h"
+#include "DetectorsVertexing/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+
+#include <TFile.h>
+#include <TH1F.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+struct TaskDzero {
+  OutputObj<TH1F> hmass{TH1F("hmass", "2-track inv mass", 500, 0, 5.0)};
+  void process(aod::HfCandProng2 const& hfcandprong2s)
+  {
+    for (auto& hfcandprong2 : hfcandprong2s) {
+      hmass->Fill(hfcandprong2.massD0());
+      hmass->Fill(hfcandprong2.massD0bar());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<TaskDzero>("hf-taskdzero")};
+}
+

--- a/Analysis/Tasks/taskdzero.cxx
+++ b/Analysis/Tasks/taskdzero.cxx
@@ -42,4 +42,3 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   return WorkflowSpec{
     adaptAnalysisTask<TaskDzero>("hf-taskdzero")};
 }
-

--- a/Analysis/Tasks/taskdzero.cxx
+++ b/Analysis/Tasks/taskdzero.cxx
@@ -28,11 +28,22 @@ using std::array;
 
 struct TaskDzero {
   OutputObj<TH1F> hmass{TH1F("hmass", "2-track inv mass", 500, 0, 5.0)};
+  OutputObj<TH1F> hptcand{TH1F("hptcand", "pt candidate", 100, 0, 10.0)};
+  OutputObj<TH1F> hptprong0{TH1F("hptprong0", "pt prong0", 100, 0, 10.0)};
+  OutputObj<TH1F> hptprong1{TH1F("hptprong1", "pt prong1", 100, 0, 10.0)};
+  OutputObj<TH1F> hdeclength{TH1F("declength", "decay length", 100, 0., 1.0)};
+  OutputObj<TH1F> hdeclengthxy{TH1F("declengthxy", "decay length xy", 100, 0., 1.0)};
+
   void process(aod::HfCandProng2 const& hfcandprong2s)
   {
     for (auto& hfcandprong2 : hfcandprong2s) {
       hmass->Fill(hfcandprong2.massD0());
       hmass->Fill(hfcandprong2.massD0bar());
+      hptprong0->Fill(hfcandprong2.ptprong0());
+      hptprong1->Fill(hfcandprong2.ptprong1());
+      hptcand->Fill(hfcandprong2.pt());
+      hdeclength->Fill(hfcandprong2.decaylength());
+      hdeclengthxy->Fill(hfcandprong2.decaylengthxy());
     }
   }
 };

--- a/Analysis/Tasks/vertexerhf.cxx
+++ b/Analysis/Tasks/vertexerhf.cxx
@@ -12,6 +12,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "Analysis/SecondaryVertex.h"
+#include "Analysis/RecoDecay.h"
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "ReconstructionDataFormats/Track.h"
 


### PR DESCRIPTION
Dear @jgrosseo this PR is ready to be merged. Please squash it before merging. A complete description of the modifications is provided below. 

- split the workflow in track finder, candidate building and task
- loop reorganized per charge, following the Run2 schema
- dca selection on single track included (being compared to Run2) 
- add validation plots inside the different tasks (to be replaced by corresponding QA). Validation plots production can be activated using a flag.
- Add a RecoDecay.h header to store the definition of decay variables
- Add more selection and kinematic variables for D0 decays