### PR TITLE
DPL GUI: avoid misbehavior when % is passed in string

### DIFF
--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -145,7 +145,11 @@ void displayHistory(const DeviceInfo& info, DeviceControl& control)
       // stream, a second time at display time, to avoid
       // showing unrelevant messages from past.
       if (logLevel >= control.logLevel) {
-        ImGui::TextColored(color, line.c_str(), line.c_str() + line.size());
+        if (line.find('%', 0) == std::string::npos) {
+          ImGui::TextUnformatted(line.c_str(), line.c_str() + line.size());
+        } else {
+          ImGui::TextColored(color, line.c_str(), line.c_str() + line.size());
+        }
       }
     }
     ji = (ji + 1) % historySize;


### PR DESCRIPTION
Render it unformatted in case that's the case.