### PR TITLE
GPU: Compute TPC page and digits offsets for all fragments in one loop over raw pages header

### DIFF
--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -183,7 +183,8 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR CONFIG_O2_EXTENSIONS)
                      TPCClusterFinder/ChargePos.h
                      TPCClusterFinder/clusterFinderDefs.h
                      TPCClusterFinder/GPUTPCClusterFinderKernels.h
-                     TPCClusterFinder/PackedCharge.h)
+                     TPCClusterFinder/PackedCharge.h
+                     TPCClusterFinder/GPUTPCCFChainContext.h)
 endif()
 
 # Sources only for AliRoot

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -60,6 +60,7 @@ class TPCFastTransform;
 class TPCdEdxCalibrationSplines;
 class GPUTrackingInputProvider;
 class GPUChainTrackingFinalContext;
+struct GPUTPCCFChainContext;
 
 class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelegateBase
 {
@@ -238,11 +239,11 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   GPUOutputControl* mOutputClustersNative = nullptr;
   GPUOutputControl* mOutputTPCTracks = nullptr;
 
+  std::unique_ptr<GPUTPCCFChainContext> mCFContext;
+
   // Upper bounds for memory allocation
   unsigned int mMaxTPCHits = 0;
   unsigned int mMaxTRDTracklets = 0;
-
-  unsigned int mTPCMaxTimeBin = 0;
 
   // Debug
   std::unique_ptr<std::ofstream> mDebugFile;
@@ -257,9 +258,10 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
  private:
   int RunChainFinalize();
   int RunTPCTrackingSlices_internal();
-  std::pair<unsigned int, unsigned int> RunTPCClusterizer_transferZS(int iSlice, unsigned int start, unsigned int end, int lane);
+  std::pair<unsigned int, unsigned int> RunTPCClusterizer_transferZS(int iSlice, const CfFragment& fragment, int lane);
   void RunTPCClusterizer_compactPeaks(GPUTPCClusterFinder& clusterer, GPUTPCClusterFinder& clustererShadow, int stage, bool doGPU, int lane);
-  std::pair<unsigned int, unsigned int> TPCClusterizerDecodeZSCount(unsigned int iSlice, unsigned int minTime, unsigned int maxTime);
+  std::pair<unsigned int, unsigned int> TPCClusterizerDecodeZSCount(unsigned int iSlice, const CfFragment& fragment);
+  std::pair<unsigned int, unsigned int> TPCClusterizerDecodeZSCountUpdate(unsigned int iSlice, const CfFragment& fragment);
   void RunTPCTrackingMerger_MergeBorderTracks(char withinSlice, char mergeMode, GPUReconstruction::krnlDeviceType deviceType);
   void RunTPCTrackingMerger_Resolve(char useOrigTrackParam, char mergeAll, GPUReconstruction::krnlDeviceType deviceType);
 

--- a/GPU/GPUTracking/TPCClusterFinder/CfFragment.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfFragment.h
@@ -39,6 +39,8 @@ struct CfFragment {
 
   bool hasBacklog = false;
   bool hasFuture = false;
+  tpccf::TPCTime totalSliceLength = 0;
+  tpccf::TPCFragmentTime maxSubSliceLength = 0;
 
   GPUdDefault() CfFragment() CON_DEFAULT;
 
@@ -46,9 +48,9 @@ struct CfFragment {
 
   GPUdi() bool isEnd() const { return length == 0; }
 
-  GPUdi() CfFragment next(tpccf::TPCTime totalSliceLen, tpccf::TPCFragmentTime maxSubSliceLen) const
+  GPUdi() CfFragment next() const
   {
-    return CfFragment{index + 1, hasFuture, tpccf::TPCTime(start + length - (hasFuture ? 2 * OverlapTimebins : 0)), totalSliceLen, maxSubSliceLen};
+    return CfFragment{index + 1, hasFuture, tpccf::TPCTime(start + length - (hasFuture ? 2 * OverlapTimebins : 0)), totalSliceLength, maxSubSliceLength};
   }
 
   GPUdi() tpccf::TPCTime first() const
@@ -88,10 +90,11 @@ struct CfFragment {
     this->index = index_;
     this->hasBacklog = hasBacklog_;
     this->start = start_;
-
     tpccf::TPCTime remainder = totalSliceLen - start;
     this->hasFuture = remainder > tpccf::TPCTime(maxSubSliceLen);
     this->length = hasFuture ? maxSubSliceLen : remainder;
+    this->totalSliceLength = totalSliceLen;
+    this->maxSubSliceLength = maxSubSliceLen;
   }
 };
 

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChainContext.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChainContext.h
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCCFChainContext.h
+/// \author David Rohr
+
+#ifndef O2_GPU_TPCCFCHAINCONTEXT_H
+#define O2_GPU_TPCCFCHAINCONTEXT_H
+
+#include "clusterFinderDefs.h"
+#include "GPUDataTypes.h"
+#include "GPUTPCClusterFinder.h"
+#include <vector>
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+struct GPUTPCCFChainContext {
+  struct FragmentData {
+    unsigned int nDigits[GPUCA_NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+    unsigned int nPages[GPUCA_NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+    std::vector<unsigned short> pageDigits[GPUCA_NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+    GPUTPCClusterFinder::MinMaxCN minMaxCN[GPUCA_NSLICES][GPUTrackingInOutZS::NENDPOINTS];
+  };
+
+  std::vector<FragmentData> fragmentData;
+  unsigned int nPagesTotal;
+  unsigned int nPagesSectorMax;
+  unsigned int nPagesSector[GPUCA_NSLICES];
+  unsigned int tpcMaxTimeBin;
+
+  void prepare(bool tpcZS, const CfFragment& fragmentMax)
+  {
+    nPagesTotal = nPagesSectorMax = tpcMaxTimeBin = 0;
+    for (unsigned int i = 0; i < GPUCA_NSLICES; i++) {
+      nPagesSector[i] = 0;
+    }
+
+    if (tpcZS) {
+      tpcMaxTimeBin = 0;
+      CfFragment f = fragmentMax;
+      while (!f.isEnd()) {
+        f = f.next();
+      }
+      if (fragmentData.size() < f.index) {
+        fragmentData.resize(f.index);
+      }
+
+      for (unsigned int i = 0; i < f.index; i++) {
+        for (unsigned int j = 0; j < GPUCA_NSLICES; j++) {
+          for (unsigned int k = 0; k < GPUTrackingInOutZS::NENDPOINTS; k++) {
+            fragmentData[i].nDigits[j][k] = fragmentData[i].nPages[j][k] = 0;
+            fragmentData[i].pageDigits[j][k].clear();
+          }
+        }
+      }
+    }
+  }
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif


### PR DESCRIPTION
This PR avoids scanning the tpc raw pages multiple times for precomputing pointers for decoded adc values.
It is slightly faster than before and in particular reduces the stress on the CPU cache and the host memory.
Also, this is needed for some further optimizations that are planed.