### PR TITLE
Improve ITS clusterizer multi-threading

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -52,7 +52,7 @@ void ClustererDPL::init(InitContext& ic)
   }
 
   mPatterns = !ic.options().get<bool>("no-patterns");
-  mNThreads = ic.options().get<int>("nthreads");
+  mNThreads = std::max(1, ic.options().get<int>("nthreads"));
 
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
@@ -152,7 +152,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
       {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
-      {"nthreads", VariantType::Int, 0, {"Number of clustering threads (<1: rely on openMP default)"}}}};
+      {"nthreads", VariantType::Int, 1, {"Number of clustering threads"}}}};
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -58,7 +58,7 @@ void ClustererDPL::init(InitContext& ic)
   }
 
   mPatterns = !ic.options().get<bool>("no-patterns");
-  mNThreads = ic.options().get<int>("nthreads");
+  mNThreads = std::max(1, ic.options().get<int>("nthreads"));
 
   // settings for the fired pixel overflow masking
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
@@ -158,7 +158,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
       {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
-      {"nthreads", VariantType::Int, 0, {"Number of clustering threads (<1: rely on openMP default)"}}}};
+      {"nthreads", VariantType::Int, 1, {"Number of clustering threads"}}}};
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -68,6 +68,16 @@ class Clusterer
   static constexpr int MaxLabels = 10;
   //=========================================================
   /// methods and transient data used within a thread
+  struct ThreadStat {
+    uint16_t firstChip = 0;
+    uint16_t nChips = 0;
+    uint32_t firstClus = 0;
+    uint32_t firstPatt = 0;
+    uint32_t nClus = 0;
+    uint32_t nPatt = 0;
+    ThreadStat() = default;
+  };
+
   struct ClustererThread {
 
     Clusterer* parent = nullptr; // parent clusterer
@@ -91,6 +101,7 @@ class Clusterer
     CompClusCont compClusters;
     PatternCont patterns;
     MCTruth labels;
+    std::vector<ThreadStat> stats; // statistics for each thread results, used at merging
     ///
     ///< reset column buffer, for the performance reasons we use memset
     void resetColumn(int* buff) { std::memset(buff, -1, sizeof(int) * SegmentationAlpide::NRows); }
@@ -125,7 +136,7 @@ class Clusterer
                     const MCTruth* labelsDig, MCTruth* labelsClus);
     void finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, CompClusCont* compClusPtr,
                                  PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr);
-    void process(gsl::span<ChipPixelData*> chipPtrs, CompClusCont* compClusPtr, PatternCont* patternsPtr,
+    void process(uint16_t chip, uint16_t nChips, CompClusCont* compClusPtr, PatternCont* patternsPtr,
                  const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr);
 
     ClustererThread(Clusterer* par = nullptr) : parent(par), curr(column2 + 1), prev(column1 + 1)

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -70,12 +70,7 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
   mInteractionRecord.clear();
   int nLinksWithData = 0, nru = mRUDecodeVec.size();
 #ifdef WITH_OPENMP
-  if (mNThreads > 0) { // otherwhise, rely on default
-    omp_set_num_threads(mNThreads);
-  } else {
-    mNThreads = omp_get_num_threads();
-    LOG(INFO) << mSelfName << " will use " << mNThreads << " threads";
-  }
+  omp_set_num_threads(mNThreads);
 #pragma omp parallel for schedule(dynamic) reduction(+ \
                                                      : nLinksWithData, mNChipsFiredROF, mNPixelsFiredROF)
 #endif
@@ -289,7 +284,7 @@ template <class Mapping>
 void RawPixelDecoder<Mapping>::setNThreads(int n)
 {
 #ifdef WITH_OPENMP
-  mNThreads = n;
+  mNThreads = n > 0 ? n : 1;
 #else
   LOG(WARNING) << mSelfName << " Multithreading is not supported, imposing single thread";
   mNThreads = 1;

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -56,7 +56,7 @@ void STFDecoder<Mapping>::init(InitContext& ic)
   mDecoder->init();
 
   auto detID = Mapping::getDetID();
-  mNThreads = ic.options().get<int>("nthreads");
+  mNThreads = std::max(1, ic.options().get<int>("nthreads"));
   mDecoder->setNThreads(mNThreads);
   mDecoder->setFormat(ic.options().get<bool>("old-format") ? GBTLink::OldFormat : GBTLink::NewFormat);
   mDecoder->setVerbosity(ic.options().get<int>("decoder-verbosity"));
@@ -170,7 +170,7 @@ DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool do
     outputs,
     AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(doClusters, doPatterns, doDigits, dict)},
     Options{
-      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}},
+      {"nthreads", VariantType::Int, 1, {"Number of decoding/clustering threads"}},
       {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},
       {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data)"}}}};
 }
@@ -198,7 +198,7 @@ DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool do
     outputs,
     AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingMFT>>(doClusters, doPatterns, doDigits, dict)},
     Options{
-      {"nthreads", VariantType::Int, 0, {"Number of decoding/clustering threads (<1: rely on openMP default)"}},
+      {"nthreads", VariantType::Int, 1, {"Number of decoding/clustering threads"}},
       {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},
       {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data)"}}}};
 }


### PR DESCRIPTION
Following patch from Gvozden switched to more conventional OMP parallel for cycle.

The OMP dynamic chunk size and number of chips per thread is tuned for AMD ROME single workflow MT processing with
export GOMP_CPU_AFFINITY=0-63
numactl -N 0 --membind 0 ./benchmark.sh