### PR TITLE
[WIP] headers: TimeFrameMetadata: TimeFrame global information

### DIFF
--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -8,12 +8,33 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/Headers/TimeFrameMetadata.h
+  COMMAND $<TARGET_FILE:flatbuffers::flatc> --cpp --gen-mutable --scoped-enums --gen-name-strings
+        --reflect-types --reflect-names --force-defaults --gen-object-api
+        -o ${CMAKE_CURRENT_BINARY_DIR}
+        include/Headers/TimeFrameMetadata.fbs
+  COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/TimeFrameMetadata_generated.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/Headers/TimeFrameMetadata.h
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/Headers/TimeFrameMetadata.fbs
+)
+
+# Prefer the static library
+set(flatbuffers_lib flatbuffers::flatbuffers)
+if(NOT TARGET flatbuffers::flatbuffers AND TARGET flatbuffers::flatbuffers_shared)
+  set(flatbuffers_lib flatbuffers::flatbuffers_shared)
+endif()
+
 o2_add_library(Headers
                SOURCES src/DataHeader.cxx src/NameHeader.cxx
                        src/HeartbeatFrame.cxx src/TimeStamp.cxx
                        src/DAQID.cxx src/RDHAny.cxx
+                       include/Headers/TimeFrameMetadata.h include/Headers/TimeFrameMetadata.fbs
                PUBLIC_LINK_LIBRARIES O2::MemoryResources
-                                     O2::GPUCommon)
+                                     O2::GPUCommon
+                                     flatbuffers::flatbuffers)
 
 o2_add_test(DataHeader
             SOURCES test/testDataHeader.cxx
@@ -41,6 +62,12 @@ o2_add_test(RAWDataHeader
 
 o2_add_test(DAQID
             SOURCES test/testDAQID.cxx
+            PUBLIC_LINK_LIBRARIES O2::Headers
+            COMPONENT_NAME Headers
+            LABELS dataformats)
+
+o2_add_test(TimeFrameMetadata
+            SOURCES test/test_TimeFrameMetadata.cxx
             PUBLIC_LINK_LIBRARIES O2::Headers
             COMPONENT_NAME Headers
             LABELS dataformats)

--- a/DataFormats/Headers/include/Headers/.gitignore
+++ b/DataFormats/Headers/include/Headers/.gitignore
@@ -1,0 +1,1 @@
+TimeFrameMetadata.h

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -645,6 +645,7 @@ constexpr o2::header::DataDescription gDataDescriptionTracks{"TRACKS"};
 constexpr o2::header::DataDescription gDataDescriptionConfig{"CONFIGURATION"};
 constexpr o2::header::DataDescription gDataDescriptionInfo{"INFORMATION"};
 constexpr o2::header::DataDescription gDataDescriptionROOTStreamers{"ROOT STREAMERS"};
+constexpr o2::header::DataDescription gDataDescriptionTimeFrameMetadata{"TIMEFRAME META"};
 /// @} // end of doxygen group
 
 //__________________________________________________________________________________________________

--- a/DataFormats/Headers/include/Headers/TimeFrameMetadata.fbs
+++ b/DataFormats/Headers/include/Headers/TimeFrameMetadata.fbs
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief O2 (Sub)TimeFrame metadata information
+
+namespace o2.header;
+
+enum TimeFrameSource : byte {
+    TF = 1,                     // Raw TimeFrame (input for synchronous reconstruction)
+    CTF,                        // CTF data (input for asynchronous reconstruction)
+    MC_DIGITS,
+    AOD
+}
+
+table TimeFrameMetadata {
+    /// General TimeFrame information
+    tfID : uint64 = 0;
+    firstTfOrbit : uint32 = 0;
+    firstTfBc : uint16 = 0;
+    runNumber : uint64 = 0;
+    tfSource : TimeFrameSource = TF;
+}
+
+root_type TimeFrameMetadata;

--- a/DataFormats/Headers/test/test_TimeFrameMetadata.cxx
+++ b/DataFormats/Headers/test/test_TimeFrameMetadata.cxx
@@ -1,0 +1,100 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TimeFrameMetadata
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <iomanip>
+#include "Headers/DataHeader.h"
+#include "Headers/TimeFrameMetadata.h"
+
+using TimeFrameMetadata = o2::header::TimeFrameMetadata;
+using TimeFrameMetadataT = o2::header::TimeFrameMetadataT;
+using TimeFrameMetadataBuilder = o2::header::TimeFrameMetadataBuilder;
+
+BOOST_AUTO_TEST_CASE(test_timeframemetadata)
+{
+  flatbuffers::FlatBufferBuilder builder(512);
+
+  TimeFrameMetadataBuilder tfm_builder(builder);
+  tfm_builder.add_runNumber(5);
+  tfm_builder.add_firstTfOrbit(128);
+  tfm_builder.add_tfID(6);
+  auto meta_off = tfm_builder.Finish();
+
+  // !!! finish the buffer before accessing the serialized data
+  builder.Finish(meta_off);
+
+  // get data
+  void *ptr = builder.GetBufferPointer();
+  // get size
+  size_t size = builder.GetSize();
+
+  // fake a message
+  auto buffer = std::make_unique<uint8_t[]>(size);
+  std::memcpy(buffer.get(), ptr, size);
+  // clear the original data
+  builder.Clear();
+
+  std::cout << "Buffer size: " << size << std::endl;
+
+
+  {
+    // recreate the object
+    const TimeFrameMetadata *rec_tfm = o2::header::GetTimeFrameMetadata(buffer.get());
+
+    // check the fields
+    flatbuffers::Verifier tfm_verifier(buffer.get(), size);
+
+    BOOST_CHECK( o2::header::VerifyTimeFrameMetadataBuffer(tfm_verifier) );
+    BOOST_CHECK(rec_tfm->runNumber() == 5);
+    BOOST_CHECK(rec_tfm->tfID() == 6);
+    BOOST_CHECK(rec_tfm->firstTfOrbit() == 128);
+    BOOST_CHECK(rec_tfm->firstTfBc() == 0); // default value
+    BOOST_CHECK(rec_tfm->tfSource() == o2::header::TimeFrameSource::TF); // default value
+  }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_timeframemetadataT)
+{
+  TimeFrameMetadataT tfmd;
+  tfmd.runNumber = 1;
+  tfmd.tfSource = o2::header::TimeFrameSource::CTF;
+
+  flatbuffers::FlatBufferBuilder builder(512);
+  auto meta_off = o2::header::CreateTimeFrameMetadata(builder, &tfmd);
+  // !!! finish the buffer before accessing the serialized data
+  builder.Finish(meta_off);
+
+  // get data
+  void *ptr = builder.GetBufferPointer();
+  // get size
+  size_t size = builder.GetSize();
+
+  // fake a message
+  auto buffer = std::make_unique<uint8_t[]>(size);
+  std::memcpy(buffer.get(), ptr, size);
+  // clear the original data
+  builder.Clear();
+
+  std::cout << "Buffer size: " << size << std::endl;
+
+  {
+    TimeFrameMetadataT rcvd_tfmd;
+    o2::header::GetTimeFrameMetadata(buffer.get())->UnPackTo(&rcvd_tfmd);
+
+    BOOST_CHECK(rcvd_tfmd.runNumber == 1);
+    BOOST_CHECK(rcvd_tfmd.firstTfBc == 0); // default value
+    BOOST_CHECK(rcvd_tfmd.tfSource == o2::header::TimeFrameSource::CTF);
+  }
+}

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -48,6 +48,9 @@ set_package_properties(ROOT PROPERTIES TYPE REQUIRED)
 find_package(fmt)
 set_package_properties(fmt PROPERTIES TYPE REQUIRED)
 
+find_package(Flatbuffers)
+set_package_properties(Flatbuffers PROPERTIES TYPE REQUIRED)
+
 find_package(Boost 1.70
              COMPONENTS container
                         thread


### PR DESCRIPTION
TimeFrameMetadata is a flatbuffer serialized structure holding global TF information.
A single copy of the structure will be injected into DPL using the { "TIMEFRAME META" }
data description, positioned as the first O2 message of the complete TF multipart message.

The payload is serialized using the flatbuffer library. To access the fields, defined
in TimeFrameMetadata.fbs, perform the following :
```c++
const TimeFrameMetadata tfm = o2::header::GetTimeFrameMetadata(fmqmessage->GetData());
const auto myHBF = tfm->firstTfOrbit();
```