### PR TITLE
TPC QC tasks on Tracks and PID: fix phi range

### DIFF
--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -33,13 +33,13 @@ void PID::initializeHistograms()
   mHist1D.emplace_back("hNClusters", "; # of clusters; counts", 160, 0, 1600); //| mHist1D[0]
   mHist1D.emplace_back("hdEdxTot", "; dEdxTot (a.u.); counts", 200, 0, 200);   //| mHist1D[1]
   mHist1D.emplace_back("hdEdxMax", "; dEdxMax (a.u.); counts", 200, 0, 200);   //| mHist1D[2]
-  mHist1D.emplace_back("hPhi", "; #phi (rad); counts", 180, 0., 2*M_PI);       //| mHist1D[3]
+  mHist1D.emplace_back("hPhi", "; #phi (rad); counts", 180, 0., 2 * M_PI);     //| mHist1D[3]
   mHist1D.emplace_back("hTgl", "; tan#lambda; counts", 60, -2, 2);             //| mHist1D[4]
   mHist1D.emplace_back("hSnp", "; sin p; counts", 60, -2, 2);                  //| mHist1D[5]
 
-  mHist2D.emplace_back("hdEdxVsPhi", "dEdx (a.u.) vs #phi (rad); #phi (rad); dEdx (a.u.)", 180, 0., 2*M_PI, 300, 0, 300);  //| mHist2D[0]
-  mHist2D.emplace_back("hdEdxVsTgl", "dEdx (a.u.) vs tan#lambda; tan#lambda; dEdx (a.u.)", 60, -2, 2, 300, 0, 300);        //| mHist2D[1]
-  mHist2D.emplace_back("hdEdxVsncls", "dEdx (a.u.) vs ncls; ncls; dEdx (a.u.)", 80, 0, 160, 300, 0, 300);                  //| mHist2D[2]
+  mHist2D.emplace_back("hdEdxVsPhi", "dEdx (a.u.) vs #phi (rad); #phi (rad); dEdx (a.u.)", 180, 0., 2 * M_PI, 300, 0, 300); //| mHist2D[0]
+  mHist2D.emplace_back("hdEdxVsTgl", "dEdx (a.u.) vs tan#lambda; tan#lambda; dEdx (a.u.)", 60, -2, 2, 300, 0, 300);         //| mHist2D[1]
+  mHist2D.emplace_back("hdEdxVsncls", "dEdx (a.u.) vs ncls; ncls; dEdx (a.u.)", 80, 0, 160, 300, 0, 300);                   //| mHist2D[2]
 
   const auto logPtBinning = helpers::makeLogBinning(30, 0.1, 10);
   if (logPtBinning.size() > 0) {

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -33,11 +33,11 @@ void PID::initializeHistograms()
   mHist1D.emplace_back("hNClusters", "; # of clusters; counts", 160, 0, 1600); //| mHist1D[0]
   mHist1D.emplace_back("hdEdxTot", "; dEdxTot (a.u.); counts", 200, 0, 200);   //| mHist1D[1]
   mHist1D.emplace_back("hdEdxMax", "; dEdxMax (a.u.); counts", 200, 0, 200);   //| mHist1D[2]
-  mHist1D.emplace_back("hPhi", "; #phi (rad); counts", 180, -M_PI, M_PI);      //| mHist1D[3]
+  mHist1D.emplace_back("hPhi", "; #phi (rad); counts", 180, 0., 2*M_PI);       //| mHist1D[3]
   mHist1D.emplace_back("hTgl", "; tan#lambda; counts", 60, -2, 2);             //| mHist1D[4]
   mHist1D.emplace_back("hSnp", "; sin p; counts", 60, -2, 2);                  //| mHist1D[5]
 
-  mHist2D.emplace_back("hdEdxVsPhi", "dEdx (a.u.) vs #phi (rad); #phi (rad); dEdx (a.u.)", 180, -M_PI, M_PI, 300, 0, 300); //| mHist2D[0]
+  mHist2D.emplace_back("hdEdxVsPhi", "dEdx (a.u.) vs #phi (rad); #phi (rad); dEdx (a.u.)", 180, 0., 2*M_PI, 300, 0, 300);  //| mHist2D[0]
   mHist2D.emplace_back("hdEdxVsTgl", "dEdx (a.u.) vs tan#lambda; tan#lambda; dEdx (a.u.)", 60, -2, 2, 300, 0, 300);        //| mHist2D[1]
   mHist2D.emplace_back("hdEdxVsncls", "dEdx (a.u.) vs ncls; ncls; dEdx (a.u.)", 80, 0, 160, 300, 0, 300);                  //| mHist2D[2]
 
@@ -45,8 +45,8 @@ void PID::initializeHistograms()
   if (logPtBinning.size() > 0) {
     mHist2D.emplace_back("hdEdxVsp", "dEdx (a.u.) vs p (G#it{e}V/#it{c}); p (G#it{e}V/#it{c}); dEdx (a.u.)", logPtBinning.size() - 1, logPtBinning.data(), 300, 0, 300); //| mHist2D[3]
   }
-  //mHist2D.emplace_back("hdedxVsphiMIPA","; #phi (rad); dedx (a.u.)", 180,-M_PI,M_PI,25,35,60);  //| mHist2D[4]
-  //mHist2D.emplace_back("hdedxVsphiMIPC","; #phi (rad); dedx (a.u.)", 180,-M_PI,M_PI,25,35,60);  //| mHist2D[5]
+  //mHist2D.emplace_back("hdedxVsphiMIPA","; #phi (rad); dedx (a.u.)", 180,0.,2*M_PI,25,35,60);  //| mHist2D[4]
+  //mHist2D.emplace_back("hdedxVsphiMIPC","; #phi (rad); dedx (a.u.)", 180,0.,2*M_PI,25,35,60);  //| mHist2D[5]
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/qc/src/Tracks.cxx
+++ b/Detectors/TPC/qc/src/Tracks.cxx
@@ -30,18 +30,18 @@ void Tracks::initializeHistograms()
   mHist1D.emplace_back("hNClustersBeforeCuts", "Number of clusters before cuts;# TPC clusters", 160, -0.5, 159.5);
   mHist1D.emplace_back("hNClustersAfterCuts", "Number of clusters after cuts;# TPC clusters", 160, -0.5, 159.5);
   mHist1D.emplace_back("hEta", "Pseudorapidity;eta", 400, -2., 2.);
-  mHist1D.emplace_back("hPhiAside", "Azimuthal angle, A side;phi", 360, 0., 2*M_PI);
-  mHist1D.emplace_back("hPhiCside", "Azimuthal angle, C side;phi", 360, 0., 2*M_PI);
+  mHist1D.emplace_back("hPhiAside", "Azimuthal angle, A side;phi", 360, 0., 2 * M_PI);
+  mHist1D.emplace_back("hPhiCside", "Azimuthal angle, C side;phi", 360, 0., 2 * M_PI);
   mHist1D.emplace_back("hPt", "Transverse momentum;p_T", 200, 0., 10.);
   mHist1D.emplace_back("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
 
   mHist2D.emplace_back("h2DNClustersEta", "Number of clusters vs. eta;eta;# TPC clusters", 400, -2., 2., 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DNClustersPhiAside", "Number of clusters vs. phi, A side ;phi;# TPC clusters", 360, 0., 2*M_PI, 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DNClustersPhiCside", "Number of clusters vs. phi, C side ;phi;# TPC clusters", 360, 0., 2*M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiAside", "Number of clusters vs. phi, A side ;phi;# TPC clusters", 360, 0., 2 * M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiCside", "Number of clusters vs. phi, C side ;phi;# TPC clusters", 360, 0., 2 * M_PI, 160, -0.5, 159.5);
   mHist2D.emplace_back("h2DNClustersPt", "Number of clusters vs. p_T;p_T;# TPC clusters", 200, 0., 10., 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DEtaPhi", "Tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
-  mHist2D.emplace_back("h2DEtaPhiNeg", "Negative tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
-  mHist2D.emplace_back("h2DEtaPhiPos", "Positive tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhi", "Tracks in eta vs. phi;phi;eta", 360, 0., 2 * M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiNeg", "Negative tracks in eta vs. phi;phi;eta", 360, 0., 2 * M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiPos", "Positive tracks in eta vs. phi;phi;eta", 360, 0., 2 * M_PI, 400, -2., 2.);
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/qc/src/Tracks.cxx
+++ b/Detectors/TPC/qc/src/Tracks.cxx
@@ -30,18 +30,18 @@ void Tracks::initializeHistograms()
   mHist1D.emplace_back("hNClustersBeforeCuts", "Number of clusters before cuts;# TPC clusters", 160, -0.5, 159.5);
   mHist1D.emplace_back("hNClustersAfterCuts", "Number of clusters after cuts;# TPC clusters", 160, -0.5, 159.5);
   mHist1D.emplace_back("hEta", "Pseudorapidity;eta", 400, -2., 2.);
-  mHist1D.emplace_back("hPhiAside", "Azimuthal angle, A side;phi", 360, -M_PI, M_PI);
-  mHist1D.emplace_back("hPhiCside", "Azimuthal angle, C side;phi", 360, -M_PI, M_PI);
+  mHist1D.emplace_back("hPhiAside", "Azimuthal angle, A side;phi", 360, 0., 2*M_PI);
+  mHist1D.emplace_back("hPhiCside", "Azimuthal angle, C side;phi", 360, 0., 2*M_PI);
   mHist1D.emplace_back("hPt", "Transverse momentum;p_T", 200, 0., 10.);
   mHist1D.emplace_back("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
 
   mHist2D.emplace_back("h2DNClustersEta", "Number of clusters vs. eta;eta;# TPC clusters", 400, -2., 2., 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DNClustersPhiAside", "Number of clusters vs. phi, A side ;phi;# TPC clusters", 360, -M_PI, M_PI, 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DNClustersPhiCside", "Number of clusters vs. phi, C side ;phi;# TPC clusters", 360, -M_PI, M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiAside", "Number of clusters vs. phi, A side ;phi;# TPC clusters", 360, 0., 2*M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiCside", "Number of clusters vs. phi, C side ;phi;# TPC clusters", 360, 0., 2*M_PI, 160, -0.5, 159.5);
   mHist2D.emplace_back("h2DNClustersPt", "Number of clusters vs. p_T;p_T;# TPC clusters", 200, 0., 10., 160, -0.5, 159.5);
-  mHist2D.emplace_back("h2DEtaPhi", "Tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
-  mHist2D.emplace_back("h2DEtaPhiNeg", "Negative tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
-  mHist2D.emplace_back("h2DEtaPhiPos", "Positive tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhi", "Tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiNeg", "Negative tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiPos", "Positive tracks in eta vs. phi;phi;eta", 360, 0., 2*M_PI, 400, -2., 2.);
 }
 
 //______________________________________________________________________________
@@ -70,9 +70,9 @@ bool Tracks::processTrack(const o2::tpc::TrackTPC& track)
 
   // ===| cuts |===
   // hard coded cuts. Should be more configural in future
-  if (nCls < 20) {
-    return false;
-  }
+  //if (nCls < 20) {
+  //  return false;
+  //}
 
   // ===| 1D histogram filling |===
   mHist1D[1].Fill(nCls);


### PR DESCRIPTION
o Phi range has been changed from -pi to +pi now to 0 to 2pi
o This is changed here in the TPC O2 QC tasks
o In addition, the hard coded cut on TPC clusters in the tracks task
  is switched off for the tests during TPC pre-commissioning