### PR TITLE
run time watchdog

### DIFF
--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -21,6 +21,48 @@ namespace framework
 namespace readers
 {
 
+struct RuntimeWatchdog {
+  int numberOfCycles;
+  clock_t startTime;
+  clock_t lastTime;
+  double runTime;
+  Long64_t runTimeLimit;
+
+  RuntimeWatchdog(Long64_t limit)
+  {
+    numberOfCycles = -1;
+    startTime = clock();
+    lastTime = startTime;
+    runTime = 0.;
+    runTimeLimit = limit;
+  }
+
+  bool update()
+  {
+    numberOfCycles++;
+    if (runTimeLimit <= 0) {
+      return true;
+    }
+
+    auto nowTime = clock();
+
+    // time spent to process the time frame
+    double time_spent = ((numberOfCycles > 1) ? 1. : 0.) * (double)(nowTime - lastTime) / CLOCKS_PER_SEC;
+    runTime += time_spent;
+    lastTime = nowTime;
+
+    return ((lastTime - startTime) / CLOCKS_PER_SEC + runTime / (numberOfCycles + 1)) < runTimeLimit;
+  }
+
+  void printOut()
+  {
+    LOGP(INFO, "RuntimeWatchdog");
+    LOGP(INFO, "  run time limit: {}", runTimeLimit);
+    LOGP(INFO, "  number of Cycles: {}", numberOfCycles);
+    LOGP(INFO, "  total runTime: {}", (lastTime - startTime) / CLOCKS_PER_SEC + ((numberOfCycles >= 0) ? runTime / (numberOfCycles + 1) : 0.));
+  }
+};
+
 struct AODReaderHelpers {
   static AlgorithmSpec rootFileReaderCallback();
   static AlgorithmSpec aodSpawnerCallback(std::vector<InputSpec> requested);

--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -22,7 +22,7 @@ namespace readers
 {
 
 struct RuntimeWatchdog {
-  int numberOfCycles;
+  int numberTimeFrames;
   clock_t startTime;
   clock_t lastTime;
   double runTime;
@@ -30,7 +30,7 @@ struct RuntimeWatchdog {
 
   RuntimeWatchdog(Long64_t limit)
   {
-    numberOfCycles = -1;
+    numberTimeFrames = -1;
     startTime = clock();
     lastTime = startTime;
     runTime = 0.;
@@ -39,7 +39,7 @@ struct RuntimeWatchdog {
 
   bool update()
   {
-    numberOfCycles++;
+    numberTimeFrames++;
     if (runTimeLimit <= 0) {
       return true;
     }
@@ -47,19 +47,20 @@ struct RuntimeWatchdog {
     auto nowTime = clock();
 
     // time spent to process the time frame
-    double time_spent = ((numberOfCycles > 1) ? 1. : 0.) * (double)(nowTime - lastTime) / CLOCKS_PER_SEC;
+    double time_spent = numberTimeFrames < 1 ? (double)(nowTime - lastTime) / CLOCKS_PER_SEC : 0.;
     runTime += time_spent;
     lastTime = nowTime;
 
-    return ((lastTime - startTime) / CLOCKS_PER_SEC + runTime / (numberOfCycles + 1)) < runTimeLimit;
+    return ((double)(lastTime - startTime) / CLOCKS_PER_SEC + runTime / (numberTimeFrames + 1)) < runTimeLimit;
   }
 
   void printOut()
   {
     LOGP(INFO, "RuntimeWatchdog");
     LOGP(INFO, "  run time limit: {}", runTimeLimit);
-    LOGP(INFO, "  number of Cycles: {}", numberOfCycles);
-    LOGP(INFO, "  total runTime: {}", (lastTime - startTime) / CLOCKS_PER_SEC + ((numberOfCycles >= 0) ? runTime / (numberOfCycles + 1) : 0.));
+    LOGP(INFO, "  number of time frames: {}", numberTimeFrames);
+    LOGP(INFO, "  estimated run time per time frame: {}", (numberTimeFrames >= 0) ? runTime / (numberTimeFrames + 1) : 0.);
+    LOGP(INFO, "  estimated total run time: {}", (double)(lastTime - startTime) / CLOCKS_PER_SEC + ((numberTimeFrames >= 0) ? runTime / (numberTimeFrames + 1) : 0.));
   }
 };
 

--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -13,6 +13,7 @@
 
 #include "Framework/TableBuilder.h"
 #include "Framework/AlgorithmSpec.h"
+#include <uv.h>
 
 namespace o2
 {
@@ -23,15 +24,15 @@ namespace readers
 
 struct RuntimeWatchdog {
   int numberTimeFrames;
-  clock_t startTime;
-  clock_t lastTime;
+  uint64_t startTime;
+  uint64_t lastTime;
   double runTime;
-  Long64_t runTimeLimit;
+  uint64_t runTimeLimit;
 
   RuntimeWatchdog(Long64_t limit)
   {
     numberTimeFrames = -1;
-    startTime = clock();
+    startTime = uv_hrtime();
     lastTime = startTime;
     runTime = 0.;
     runTimeLimit = limit;
@@ -44,14 +45,14 @@ struct RuntimeWatchdog {
       return true;
     }
 
-    auto nowTime = clock();
+    auto nowTime = uv_hrtime();
 
     // time spent to process the time frame
-    double time_spent = numberTimeFrames < 1 ? (double)(nowTime - lastTime) / CLOCKS_PER_SEC : 0.;
+    double time_spent = numberTimeFrames < 1 ? (double)(nowTime - lastTime) / 1.E9 : 0.;
     runTime += time_spent;
     lastTime = nowTime;
 
-    return ((double)(lastTime - startTime) / CLOCKS_PER_SEC + runTime / (numberTimeFrames + 1)) < runTimeLimit;
+    return ((double)(lastTime - startTime) / 1.E9 + runTime / (numberTimeFrames + 1)) < runTimeLimit;
   }
 
   void printOut()
@@ -60,7 +61,7 @@ struct RuntimeWatchdog {
     LOGP(INFO, "  run time limit: {}", runTimeLimit);
     LOGP(INFO, "  number of time frames: {}", numberTimeFrames);
     LOGP(INFO, "  estimated run time per time frame: {}", (numberTimeFrames >= 0) ? runTime / (numberTimeFrames + 1) : 0.);
-    LOGP(INFO, "  estimated total run time: {}", (double)(lastTime - startTime) / CLOCKS_PER_SEC + ((numberTimeFrames >= 0) ? runTime / (numberTimeFrames + 1) : 0.));
+    LOGP(INFO, "  estimated total run time: {}", (double)(lastTime - startTime) / 1.E9 + ((numberTimeFrames >= 0) ? runTime / (numberTimeFrames + 1) : 0.));
   }
 };
 

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -38,7 +38,6 @@
 #include <arrow/util/key_value_metadata.h>
 
 #include <thread>
-#include <time.h>
 
 namespace o2::framework::readers
 {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -205,6 +205,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     readers::AODReaderHelpers::rootFileReaderCallback(),
     {ConfigParamSpec{"aod-file", VariantType::String, "aod.root", {"Input AOD file"}},
      ConfigParamSpec{"json-file", VariantType::String, {"json configuration file"}},
+     ConfigParamSpec{"time-limit", VariantType::Int64, 0ll, {"Maximum run time limit in seconds"}},
      ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
      ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
      ConfigParamSpec{"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}}}};


### PR DESCRIPTION
a run time watchdog is introduced which stops execution when runtime exceeds a given limit.
. use command line optino --time-limit to specify run time limit in seconds
. stops only at time frame boundaries, thus before data for next time frame is to be read