### PR TITLE
DataInputDirector constructor with a vector of data files and input

### DIFF
--- a/Analysis/Tutorials/src/aodwriter.cxx
+++ b/Analysis/Tutorials/src/aodwriter.cxx
@@ -139,7 +139,7 @@ struct ATask {
       table_uno(phi, eta, mom);
       table_due(ok, phi, eta, mom, pt);
       table_tre(phi, eta, mom, id);
-      LOGF(INFO, "Values (%i): (%i %f, %f, %f, %f, %i)", cnt, ok, eta, phi, mom, pt, id);
+      //LOGF(INFO, "Values (%i): (%i %f, %f, %f, %f, %i)", cnt, ok, eta, phi, mom, pt, id);
       cnt++;
     }
 

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -75,6 +75,7 @@ struct DataInputDirector {
 
   DataInputDirector();
   DataInputDirector(std::string inputFile);
+  DataInputDirector(std::vector<std::string> inputFiles);
 
   void reset();
   void createDefaultDataInputDescriptor();

--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -144,6 +144,15 @@ DataInputDirector::DataInputDirector(std::string inputFile)
   createDefaultDataInputDescriptor();
 }
 
+DataInputDirector::DataInputDirector(std::vector<std::string> inputFiles)
+{
+  for (auto inputFile : inputFiles) {
+    mdefaultInputFiles.emplace_back(inputFile);
+  }
+
+  createDefaultDataInputDescriptor();
+}
+
 void DataInputDirector::reset()
 {
   mdataInputDescriptors.clear();

--- a/Framework/Core/test/test_DataInputDirector.cxx
+++ b/Framework/Core/test/test_DataInputDirector.cxx
@@ -48,18 +48,56 @@ BOOST_AUTO_TEST_CASE(TestDatainputDirector)
   jf << R"(})" << std::endl;
   jf.close();
 
-  DataInputDirector didir;
-  BOOST_CHECK(didir.readJson(jsonFile));
-  //didir.printOut(); printf("\n\n");
+  DataInputDirector didir1;
+  BOOST_CHECK(didir1.readJson(jsonFile));
+  //didir1.printOut(); printf("\n\n");
 
-  BOOST_CHECK_EQUAL(didir.getNumberInputDescriptors(), 2);
+  BOOST_CHECK_EQUAL(didir1.getNumberInputDescriptors(), 2);
 
   auto dh = DataHeader(DataDescription{"DUE"},
                        DataOrigin{"AOD"},
                        DataHeader::SubSpecificationType{0});
-  BOOST_CHECK_EQUAL(didir.getInputFilename(dh, 1), "Bresults_1.root");
+  BOOST_CHECK_EQUAL(didir1.getInputFilename(dh, 1), "Bresults_1.root");
 
-  auto didesc = didir.getDataInputDescriptor(dh);
+  auto didesc = didir1.getDataInputDescriptor(dh);
   BOOST_CHECK(didesc);
   BOOST_CHECK_EQUAL(didesc->getNumberInputfiles(), 2);
+
+  // test initialization with "std::vector<std::string> inputFiles"
+  // in this case "resfile" of the InputDataDirector in the json file must be
+  // empty, otherwise files specified in the json file will be added to the
+  // list of input files
+  jf.open("testO2config.json", std::ofstream::out);
+  jf << R"({)" << std::endl;
+  jf << R"(  "InputDirector": {)" << std::endl;
+  jf << R"delimiter(    "fileregex": "(Ares)(.*)",)delimiter" << std::endl;
+  jf << R"(    "InputDescriptors": [)" << std::endl;
+  jf << R"(      {)" << std::endl;
+  jf << R"(        "table": "AOD/UNO/0",)" << std::endl;
+  jf << R"(        "treename": "uno")" << std::endl;
+  jf << R"(      },)" << std::endl;
+  jf << R"(      {)" << std::endl;
+  jf << R"(        "table": "AOD/DUE/0",)" << std::endl;
+  jf << R"(        "treename": "due",)" << std::endl;
+  jf << R"delimiter(        "fileregex": "(Bres)(.*)")delimiter" << std::endl;
+  jf << R"(      })" << std::endl;
+  jf << R"(    ])" << std::endl;
+  jf << R"(  })" << std::endl;
+  jf << R"(})" << std::endl;
+  jf.close();
+
+  std::vector<std::string> inputFiles = {"Aresults_0.root",
+                                         "Aresults_1.root",
+                                         "Bresults_0.root",
+                                         "Aresults_2.root",
+                                         "Bresults_1.root",
+                                         "Bresults_2.root"};
+  DataInputDirector didir2(inputFiles);
+  BOOST_CHECK(didir2.readJson(jsonFile));
+
+  BOOST_CHECK_EQUAL(didir2.getInputFilename(dh, 1), "Bresults_1.root");
+
+  didesc = didir2.getDataInputDescriptor(dh);
+  BOOST_CHECK(didesc);
+  BOOST_CHECK_EQUAL(didesc->getNumberInputfiles(), 3);
 }


### PR DESCRIPTION
. a std::vector<std::string> is used to provide the list of input data files
. ATTENTION if this is used together with the internal-dpl-aod-reader command line option json-file:
 the data files specified as item "resfiles" in the json file will be added to the list of input data files