### PR TITLE
Fix serach path for libUV

### DIFF
--- a/dependencies/FindLibUV.cmake
+++ b/dependencies/FindLibUV.cmake
@@ -50,11 +50,13 @@ They may be set by end users to point at libuv components.
 #-----------------------------------------------------------------------------
 find_library(LibUV_LIBRARY
   NAMES uv libuv
+  PATHS $ENV{LIBUV_ROOT}/lib
   )
 mark_as_advanced(LibUV_LIBRARY)
 
 find_path(LibUV_INCLUDE_DIR
   NAMES uv.h
+  PATHS $ENV{LIBUV_ROOT}/include
   )
 mark_as_advanced(LibUV_INCLUDE_DIR)
 


### PR DESCRIPTION
With the current implementation the dependencies are not correctly exported.
So, for packages that depend on O2, the cmake fails in finding the libUV installed via aliBuild.
This PR should be complemented later on with a modification of o2.sh and libuv.sh inside alidist.