### PR TITLE
TF counter and runNumber in the DataHeader

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -666,9 +666,11 @@ struct DataHeader : public BaseHeader {
   using SplitPayloadPartsType = uint32_t;
   using PayloadSizeType = uint64_t;
   using TForbitType = uint32_t;
+  using TFCounterType = uint32_t;
+  using RunNumberType = uint32_t;
 
   //static data for this header type/version
-  static constexpr uint32_t sVersion{2};
+  static constexpr uint32_t sVersion{3};
   static constexpr o2::header::HeaderType sHeaderType{String2<uint64_t>("DataHead")};
   static constexpr o2::header::SerializationMethod sSerializationMethod{gSerializationMethodNone};
 
@@ -711,9 +713,19 @@ struct DataHeader : public BaseHeader {
   //___NEW STUFF GOES BELOW
 
   ///
-  /// first orbit of time frame as unique identifier within the run
+  /// first orbit of time frame, since v2
   ///
   TForbitType firstTForbit;
+
+  ///
+  /// ever incrementing TF counter, allows to disentangle even TFs with same firstTForbit in case of replay, since v3
+  ///
+  TFCounterType tfCounter;
+
+  ///
+  /// run number TF belongs to, since v3
+  ///
+  RunNumberType runNumber;
 
   //___the functions:
   //__________________________________________________________________________________________________
@@ -726,7 +738,9 @@ struct DataHeader : public BaseHeader {
       subSpecification(0),
       splitPayloadIndex(0),
       payloadSize(0),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0),
+      runNumber(0)
   {
   }
 
@@ -740,7 +754,9 @@ struct DataHeader : public BaseHeader {
       subSpecification(subspec),
       splitPayloadIndex(0),
       payloadSize(size),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0),
+      runNumber(0)
   {
   }
 
@@ -754,7 +770,9 @@ struct DataHeader : public BaseHeader {
       subSpecification(subspec),
       splitPayloadIndex(partIndex),
       payloadSize(size),
-      firstTForbit{0}
+      firstTForbit{0},
+      tfCounter(0),
+      runNumber(0)
   {
   }
 
@@ -808,8 +826,8 @@ static_assert(sizeof(BaseHeader) == 32,
               "BaseHeader struct must be of size 32");
 static_assert(sizeof(DataOrigin) == 4,
               "DataOrigin struct must be of size 4");
-static_assert(sizeof(DataHeader) == 88,
-              "DataHeader struct must be of size 88");
+static_assert(sizeof(DataHeader) == 96,
+              "DataHeader struct must be of size 96");
 static_assert(gSizeMagicString == sizeof(BaseHeader::magicStringInt),
               "Size mismatch in magic string union");
 static_assert(sizeof(BaseHeader::sMagicString) == sizeof(BaseHeader::magicStringInt),

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -54,13 +54,16 @@ void o2::header::BaseHeader::throwInconsistentStackError() const
 //__________________________________________________________________________________________________
 void o2::header::DataHeader::print() const
 {
-  printf("Data header version %i, flags: %i\n", headerVersion, flags);
+  printf("Data header version %u, flags: %u\n", headerVersion, flags);
   printf("  origin       : %s\n", dataOrigin.str);
   printf("  serialization: %s\n", payloadSerializationMethod.str);
   printf("  description  : %s\n", dataDescription.str);
   printf("  sub spec.    : %llu\n", (long long unsigned int)subSpecification);
-  printf("  header size  : %i\n", headerSize);
+  printf("  header size  : %d\n", headerSize);
   printf("  payloadSize  : %llu\n", (long long unsigned int)payloadSize);
+  printf("  firstTFOrbit : %u\n", firstTForbit);
+  printf("  tfCounter    : %u\n", tfCounter);
+  printf("  runNumber    : %u\n", runNumber);
 }
 
 //__________________________________________________________________________________________________

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -236,9 +236,9 @@ BOOST_AUTO_TEST_CASE(DataHeader_test)
               << "size " << std::setw(2) << sizeof(dh.payloadSize) << " at " << (char*)(&dh.payloadSize) - (char*)(&dh) << std::endl;
   }
 
-  // DataHeader must have size 88
-  static_assert(sizeof(DataHeader) == 88,
-                "DataHeader struct must be of size 88");
+  // DataHeader must have size 96
+  static_assert(sizeof(DataHeader) == 96,
+                "DataHeader struct must be of size 96");
   DataHeader dh2;
   BOOST_CHECK(dh == dh2);
   DataHeader dh3{gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{0}, 0};

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -40,6 +40,7 @@ class CTFReaderSpec : public o2::framework::Task
  private:
   DetID::mask_t mDets;             // detectors
   std::vector<std::string> mInput; // input files
+  uint32_t mTFCounter = 0;
   size_t mNextToProcess = 0;
   TStopwatch mTimer;
 };

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -94,6 +94,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
       throw std::runtime_error(o2::utils::concat_string("failed to find output message header for ", label));
     }
     hd->firstTForbit = ctfHeader.firstTForbit;
+    hd->tfCounter = mTFCounter;
   };
 
   // send CTF Header
@@ -133,6 +134,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
     LOGF(INFO, "CTF reading total timing: Cpu: %.3e Real: %.3e s in %d slots",
          mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   }
+  mTFCounter++;
 }
 
 ///_______________________________________

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -107,7 +107,7 @@ class RawReaderSpecs : public o2f::Task
         tfID = 0;
         LOG(INFO) << "Starting new loop " << loopsDone << " from the beginning of data";
       } else {
-        LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", sentSize, sentMessages, mTFIDaccum);
+        LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", sentSize, sentMessages, mTFCounter);
         ctx.services().get<o2f::ControlService>().endOfStream();
         ctx.services().get<o2f::ControlService>().readyToQuit(o2f::QuitRequest::Me);
         mDone = true;
@@ -125,12 +125,12 @@ class RawReaderSpecs : public o2f::Task
 
     // read next time frame
     size_t tfNParts = 0, tfSize = 0;
-    LOG(INFO) << "Reading TF#" << mTFIDaccum << " (" << tfID << " at iteration " << loopsDone << ')';
+    LOG(INFO) << "Reading TF#" << mTFCounter << " (" << tfID << " at iteration " << loopsDone << ')';
 
     for (int il = 0; il < nlinks; il++) {
       auto& link = mReader->getLink(il);
 
-      if (!findOutputChannel(link, mTFIDaccum)) { // no output channel
+      if (!findOutputChannel(link, mTFCounter)) { // no output channel
         continue;
       }
 
@@ -142,7 +142,7 @@ class RawReaderSpecs : public o2f::Task
       while (hdrTmpl.splitPayloadIndex < hdrTmpl.splitPayloadParts) {
 
         tfSize += hdrTmpl.payloadSize = link.getNextHBFSize();
-        o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFIDaccum}};
+        o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter}};
 
         auto hdMessage = device->NewMessage(headerStack.size());
         memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
@@ -151,7 +151,7 @@ class RawReaderSpecs : public o2f::Task
         auto bread = link.readNextHBF(reinterpret_cast<char*>(plMessage->GetData()));
         if (bread != hdrTmpl.payloadSize) {
           LOG(ERROR) << "Link " << il << " read " << bread << " bytes instead of " << hdrTmpl.payloadSize
-                     << " expected in TF=" << mTFIDaccum << " part=" << hdrTmpl.splitPayloadIndex;
+                     << " expected in TF=" << mTFCounter << " part=" << hdrTmpl.splitPayloadIndex;
         }
         // check if the RDH to send corresponds to expected orbit
         if (hdrTmpl.splitPayloadIndex == 0) {
@@ -164,8 +164,10 @@ class RawReaderSpecs : public o2f::Task
                    link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
             }
           }
-          hdrTmpl.firstTForbit = hbOrbRead + loopsDone * nhbexp; // for next parts
-          reinterpret_cast<o2::header::DataHeader*>(hdMessage->GetData())->firstTForbit = hdrTmpl.firstTForbit;
+          hdrTmpl.firstTForbit = hbOrbRead;                                                          // will be picked for the
+          hdrTmpl.tfCounter = mTFCounter;                                                            // following parts
+          reinterpret_cast<o2::header::DataHeader*>(hdMessage->GetData())->firstTForbit = hbOrbRead; // but need to fix
+          reinterpret_cast<o2::header::DataHeader*>(hdMessage->GetData())->tfCounter = mTFCounter;   // for the 1st one
         }
         FairMQParts* parts = nullptr;
         parts = messagesPerRoute[link.fairMQChannel].get(); // FairMQParts*
@@ -178,11 +180,11 @@ class RawReaderSpecs : public o2f::Task
         hdrTmpl.splitPayloadIndex++; // prepare for next
         tfNParts++;
       }
-      LOGF(DEBUG, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFIDaccum, tfID,
+      LOGF(DEBUG, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFCounter, tfID,
            loopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
     }
 
-    if (mTFIDaccum) { // delay sending
+    if (mTFCounter) { // delay sending
       usleep(mDelayUSec);
     }
 
@@ -192,12 +194,12 @@ class RawReaderSpecs : public o2f::Task
     }
 
     LOGF(INFO, "Sent payload of %zu bytes in %zu parts in %zu messages for TF %d", tfSize, tfNParts,
-         messagesPerRoute.size(), mTFIDaccum);
+         messagesPerRoute.size(), mTFCounter);
     sentSize += tfSize;
     sentMessages += tfNParts;
 
     mReader->setNextTFToRead(++tfID);
-    ++mTFIDaccum;
+    ++mTFCounter;
   }
 
   uint32_t getMinTFID() const { return mMinTFID; }
@@ -210,7 +212,7 @@ class RawReaderSpecs : public o2f::Task
 
  private:
   int mLoop = 0;                                   // once last TF reached, loop while mLoop>=0
-  size_t mTFIDaccum = 0;                           // TFId accumulator (accounts for looping)
+  uint32_t mTFCounter = 0;                         // TFId accumulator (accounts for looping)
   uint32_t mDelayUSec = 0;                         // Delay in microseconds between TFs
   uint32_t mMinTFID = 0;                           // 1st TF to extract
   uint32_t mMaxTFID = 0xffffffff;                  // last TF to extrct


### PR DESCRIPTION
as agreed, reopening https://github.com/AliceO2Group/AliceO2/pull/3892 with runNumber added.
Unfortunately, the latter changes the size from 88 to 96 bytes (due to the padding). Could be reduced back to 88 by 
reshuffling of old data members (a mix of 64 and 32 bits) but I guess we don't want this...