### PR TITLE
Changes related to HepMC3 upgrade to 3.2.2

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -20,6 +20,10 @@ if(HepMC_FOUND)
   set(hepmcTarget MC::HepMC)
 endif()
 
+if(HepMC3_FOUND)
+  set(hepmcTarget MC::HepMC3)
+endif()
+
 o2_add_library(Generators
                SOURCES src/Generator.cxx
 	       	       src/Trigger.cxx
@@ -40,6 +44,7 @@ o2_add_library(Generators
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8Param.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8Param.cxx>
                        $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
+                       $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMC.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils
                                      O2::SimulationDataFormat ${pythia6Target} ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
@@ -54,6 +59,11 @@ if(pythia_FOUND)
 endif()
 
 if(HepMC_FOUND)
+  target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3)
+  target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3_DEPRECATED)
+endif()
+
+if(HepMC3_FOUND)
   target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3)
 endif()
 
@@ -86,6 +96,10 @@ if(pythia_FOUND)
 endif()
 
 if(HepMC_FOUND)
+  list(APPEND headers include/Generators/GeneratorHepMC.h)
+endif()
+
+if(HepMC3_FOUND)
   list(APPEND headers include/Generators/GeneratorHepMC.h)
 endif()
 

--- a/Generators/include/Generators/GeneratorHepMC.h
+++ b/Generators/include/Generators/GeneratorHepMC.h
@@ -16,12 +16,21 @@
 #include "Generators/Generator.h"
 #include <fstream>
 
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
 namespace HepMC
 {
 class Reader;
 class GenEvent;
 class FourVector;
 } // namespace HepMC
+#else
+namespace HepMC3
+{
+class Reader;
+class GenEvent;
+class FourVector;
+} // namespace HepMC3
+#endif
 
 namespace o2
 {
@@ -60,14 +69,23 @@ class GeneratorHepMC : public Generator
   Bool_t importParticles() override;
 
   /** methods **/
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
   const HepMC::FourVector getBoostedVector(const HepMC::FourVector& vector, Double_t boost);
+#else
+  const HepMC3::FourVector getBoostedVector(const HepMC3::FourVector& vector, Double_t boost);
+#endif
 
   /** HepMC interface **/
   std::ifstream mStream; //!
   std::string mFileName;
   Int_t mVersion;
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
   HepMC::Reader* mReader;  //!
   HepMC::GenEvent* mEvent; //!
+#else
+  HepMC3::Reader* mReader;  //!
+  HepMC3::GenEvent* mEvent; //!
+#endif
 
   ClassDefOverride(GeneratorHepMC, 1);
 

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -10,6 +10,8 @@
 
 /// \author R+Preghenella - August 2017
 
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
+
 #include "Generators/GeneratorHepMC.h"
 #include "HepMC/ReaderAscii.h"
 #include "HepMC/ReaderAsciiHepMC2.h"
@@ -25,6 +27,19 @@
 **/
 #ifdef DEBUG
 #undef DEBUG
+#endif
+
+#else
+
+#include "Generators/GeneratorHepMC.h"
+#include "HepMC3/ReaderAscii.h"
+#include "HepMC3/ReaderAsciiHepMC2.h"
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+#include "HepMC3/FourVector.h"
+#include "TParticle.h"
+
 #endif
 
 #include "FairLogger.h"
@@ -44,7 +59,11 @@ GeneratorHepMC::GeneratorHepMC()
 {
   /** default constructor **/
 
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
   mEvent = new HepMC::GenEvent();
+#else
+  mEvent = new HepMC3::GenEvent();
+#endif
   mInterface = reinterpret_cast<void*>(mEvent);
   mInterfaceName = "hepmc";
 }
@@ -56,7 +75,11 @@ GeneratorHepMC::GeneratorHepMC(const Char_t* name, const Char_t* title)
 {
   /** constructor **/
 
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
   mEvent = new HepMC::GenEvent();
+#else
+  mEvent = new HepMC3::GenEvent();
+#endif
   mInterface = reinterpret_cast<void*>(mEvent);
   mInterfaceName = "hepmc";
 }
@@ -89,7 +112,11 @@ Bool_t GeneratorHepMC::generateEvent()
   if (mReader->failed())
     return kFALSE;
   /** set units to desired output **/
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
   mEvent->set_units(HepMC::Units::GEV, HepMC::Units::MM);
+#else
+  mEvent->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
+#endif
 
   /** success **/
   return kTRUE;
@@ -163,10 +190,18 @@ Bool_t GeneratorHepMC::Init()
   switch (mVersion) {
     case 2:
       mStream.close();
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
       mReader = new HepMC::ReaderAsciiHepMC2(mFileName);
+#else
+      mReader = new HepMC3::ReaderAsciiHepMC2(mFileName);
+#endif
       break;
     case 3:
+#ifdef GENERATORS_WITH_HEPMC3_DEPRECATED
       mReader = new HepMC::ReaderAscii(mStream);
+#else
+      mReader = new HepMC3::ReaderAscii(mStream);
+#endif
       break;
     default:
       LOG(FATAL) << "Unsupported HepMC version: " << mVersion << std::endl;

--- a/dependencies/FindHepMC3.cmake
+++ b/dependencies/FindHepMC3.cmake
@@ -1,0 +1,28 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+# use the HepMCConfig.cmake provided by the HepMC3 installation to create a
+# single target HepMC with the include directories and libraries we need
+
+find_package(HepMC3 NO_MODULE)
+if(NOT HepMC3_FOUND)
+        return()
+endif()
+
+add_library(HepMC3 IMPORTED INTERFACE)
+
+set_target_properties(HepMC3
+        PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${HEPMC3_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HEPMC3_INCLUDE_DIR}")
+
+# Promote the imported target to global visibility (so we can alias it)
+set_target_properties(HepMC3 PROPERTIES IMPORTED_GLOBAL TRUE)
+add_library(MC::HepMC3 ALIAS HepMC3)

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -69,8 +69,19 @@ set_package_properties(VGM PROPERTIES TYPE ${mcPackageRequirement})
 find_package(HepMC MODULE)
 set_package_properties(HepMC
 		       PROPERTIES
-		       TYPE ${mcPackageRequirement} DESCRIPTION
-		       	    "the HepMC3 event record package")
+		       TYPE OPTIONAL DESCRIPTION
+		       "the HepMC3 event record package (deprecated old find_package call)")
+		     
+find_package(HepMC3 MODULE)
+set_package_properties(HepMC3
+		       PROPERTIES
+		       TYPE OPTIONAL DESCRIPTION
+		       "the HepMC3 event record package")
+
+if(HepMC_FOUND AND HepMC3_FOUND)
+  message(ERROR "Both HepMC3 packages have been found, something is wrong")
+endif()
+		     
 set(doBuildSimulation OFF)
 
 if(pythia_FOUND
@@ -79,7 +90,7 @@ if(pythia_FOUND
    AND Geant4_FOUND
    AND Geant4VMC_FOUND
    AND VGM_FOUND
-   AND HepMC_FOUND)
+   AND (HepMC_FOUND OR HepMC3_FOUND))
   set(doBuildSimulation ON)
 endif()
 


### PR DESCRIPTION
This is a complex PR because it depends on an `alidist` update.
That PR on `alidist` will be opened soon.

This PR aligns the `o2` code to the upgraded `HepMC3`.
The latest `HepMC3` tag (3.2.2) is supposed to solve a few issues.
Most importantly, the name of the library is now `libHepMC3.so`.
This solves library-name clashes with HepMC2 (lib name was the same before) and possibly allows users to load packages with dependencies on both HepMC versions at the same time (see AliRoot).

Also, a `DEBUG` macro that was clashing with `FairRoot` was renamed.

Unfortunately the `HepMC3` authors have also modified the name of the directory with the files to be included and the namespace name. Hence this update.

Changes are also in the cmake machinery, that requires adjustments in the `o2` as well.

This PR will fail the checks, because currently `alidist` points to an older version which is not compatible anymore.
This is also true the other way around: updating `alidist` to point to the new `HepMC3` version will make the `o2` fail.

I hope there is a way to deal with it somehow.