### PR TITLE
raw-file-reader can send TF data to non-DPL FMQ channel

### DIFF
--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -18,7 +18,7 @@
 
 ## Example of DPL chain:
 
-`o2-raw-file-reader-workflow --conf file-reader.cfg --loop 0 --message-per-tf -b | o2-mch-raw-to-digits-workflow -b | o2-mch-digits-to-preclusters-workflow -b | o2-mch-preclusters-sink-workflow -b`
+`o2-raw-file-reader-workflow --conf file-reader.cfg --loop 0  -b | o2-mch-raw-to-digits-workflow -b | o2-mch-digits-to-preclusters-workflow -b | o2-mch-preclusters-sink-workflow -b`
 
 where the `file-reader.cfg` looks like this:
 

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -33,7 +33,7 @@ Notice that the executable also generate a configuration file that is needed to 
 ### Reconstruction from raw data
 To reconstruct the raw data (either from converted MC digits or real data), run:
 ```bash
-o2-raw-file-reader-workflow --conf mid_raw.cfg --message-per-tf | o2-mid-reco-workflow
+o2-raw-file-reader-workflow --conf mid_raw.cfg | o2-mid-reco-workflow
 ```
 
 ## Timing

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -230,6 +230,8 @@ dataOrigin = ITS
 #optional, if missing then default is used
 dataDescription = RAWDATA     
 filePath = path_and_name_of_the_data_file0
+# for CRU detectors the "readoutCard" record below is optional
+# readoutCard = CRU
 
 [input-1]
 dataOrigin = TPC              
@@ -237,6 +239,14 @@ filePath = path_and_name_of_the_data_file1
 
 [input-2]
 filePath = path_and_name_of_the_data_file2
+
+[input-1-RORC]
+dataOrigin = EMC
+filePath = path_and_name_of_the_data_fileX
+# for RORC detectors the record below is obligatory
+readoutCard = RORC 
+
+
 
 #...
 # [input-XXX] blocks w/o filePath will be ignoder, XXX is irrelevant
@@ -290,8 +300,6 @@ o2-raw-file-reader-workflow
   --loop arg (=1)                       loop N times (infinite for N<0)
   --min-tf arg (=0)                     min TF ID to process
   --max-tf arg (=4294967295)            max TF ID to process
-  --message-per-tf                      send TF of each link as a single FMQ message rather than multipart with message per HB
-  --output-per-link                     send message per Link rather than per FMQ output route
   --delay arg (=0)                      delay in seconds between consecutive TFs sending
   --configKeyValues arg                 semicolon separated key=value strings
 
@@ -315,10 +323,6 @@ If `--loop` argument is provided, data will be re-played in loop. The delay (in 
 
 At every invocation of the device `processing` callback a full TimeFrame for every link will be added as N-HBFs parts (one for each HBF in the TF) to the multipart
 relayed by the `FairMQ` channel.
-In case the `--message-per-tf` option is asked, the whole TF is sent as the only part of the `FairMQPart`.
-
-Instead of sending a single output (for multiple links) per output route (which means their data will be received together) one can request sending an output per link
-by using option `--output-per-link`.
 
 The standard use case of this workflow is to provide the input for other worfklows using the piping, e.g.
 ```cpp

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -92,7 +92,7 @@ class RawFileReader
   //================================================================================
 
   using RDHAny = header::RDHAny;
-  using RDH = o2::header::RAWDataHeaderV4;
+  using RDH = o2::header::RAWDataHeader;
   using OrigDescCard = std::tuple<o2::header::DataOrigin, o2::header::DataDescription, ReadoutCardType>;
   using InputsMap = std::map<OrigDescCard, std::vector<std::string>>;
 

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -14,15 +14,16 @@
 /// @file   RawFileReaderWorkflow.h
 
 #include "Framework/WorkflowSpec.h"
+class string;
 
 namespace o2
 {
 namespace raw
 {
 
-framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile,
-                                                 int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff,
-                                                 uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, size_t bufferSize = 1024L * 1024L);
+framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff,
+                                                 uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, size_t bufferSize = 1024L * 1024L,
+                                                 const std::string& rawChannelConfig = "");
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace raw
 {
 
-framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, bool outPerRoute = true,
+framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile,
                                                  int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff,
                                                  uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, size_t bufferSize = 1024L * 1024L);
 

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -27,8 +27,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"min-tf", VariantType::Int64, 0L, {"min TF ID to process"}});
   options.push_back(ConfigParamSpec{"max-tf", VariantType::Int64, 0xffffffffL, {"max TF ID to process"}});
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
-  options.push_back(ConfigParamSpec{"message-per-tf", VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
-  options.push_back(ConfigParamSpec{"output-per-link", VariantType::Bool, false, {"send message per Link rather than per FMQ output route"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
   options.push_back(ConfigParamSpec{"buffer-size", VariantType::Int64, 1024L * 1024L, {"buffer size for files preprocessing"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
@@ -52,8 +50,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   uint32_t maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
   uint32_t minTF = uint32_t(configcontext.options().get<int64_t>("min-tf"));
   uint64_t buffSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
-  auto tfAsMessage = configcontext.options().get<bool>("message-per-tf");
-  auto outPerRoute = !configcontext.options().get<bool>("output-per-link");
 
   uint32_t errmap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
@@ -66,5 +62,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, outPerRoute, loop, delay_us, errmap, minTF, maxTF, buffSize));
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, buffSize));
 }

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 1, {"loop N times (infinite for N<0)"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
   options.push_back(ConfigParamSpec{"buffer-size", VariantType::Int64, 1024L * 1024L, {"buffer size for files preprocessing"}});
+  options.push_back(ConfigParamSpec{"raw-channel-config", VariantType::String, "", {"optional raw FMQ channel for non-DPL output"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -50,7 +51,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   uint32_t maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
   uint32_t minTF = uint32_t(configcontext.options().get<int64_t>("min-tf"));
   uint64_t buffSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
-
+  std::string rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
   uint32_t errmap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     auto ei = RawFileReader::ErrTypes(i);
@@ -62,5 +63,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, buffSize));
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, buffSize, rawChannelConfig));
 }


### PR DESCRIPTION
* raw-file-reader can send TF data to non-DPL FMQ channel
Provide e.g. --session default --raw-channel-config "name=raw-reader,type=push,method=bind,address=ipc://@rr-to-dpl,transport=shmem,rateLogging=1"

* Eliminate obsolete options of raw-file-reader
No need for options message-per-tf (must be always sent as a multipart of HBFs) and output-per-link (must be always sent per output_channel)