### PR TITLE
Account for timeslice in FMQ ChannelRetriever of ExternalFairMQDeviceProxy

### DIFF
--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -21,9 +21,10 @@ namespace o2
 {
 namespace framework
 {
+
 /// A callback function to retrieve the FairMQChannel name to be used for sending
 /// messages of the specified OutputSpec
-using ChannelRetriever = std::function<std::string(OutputSpec const&)>;
+using ChannelRetriever = std::function<std::string(OutputSpec const&, DataProcessingHeader::StartTime)>;
 using InjectorFunction = std::function<void(FairMQDevice& device, FairMQParts& inputs, ChannelRetriever)>;
 
 struct InputChannelSpec;

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -133,11 +133,15 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
       LOG(ERROR) << "data on input " << msgidx << " does not follow the O2 data model, DataHeader missing";
       return;
     }
-
+    auto dph = o2::header::get<DataProcessingHeader*>(inputs.At(msgidx)->GetData());
+    if (!dph) {
+      LOG(ERROR) << "data on input " << msgidx << " does not follow the O2 data model, DataProcessingHeader missing";
+      return;
+    }
     // Note: we want to run both the output and input proxy in the same workflow and thus we need
     // different data identifiers and change the data origin in the forwarding
     OutputSpec query{"PRX", dh->dataDescription, dh->subSpecification};
-    auto channelName = channelRetriever(query);
+    auto channelName = channelRetriever(query, dph->startTime);
     ASSERT_ERROR(!channelName.empty());
     LOG(DEBUG) << "using channel '" << channelName << "' for " << DataSpecUtils::describe(OutputSpec{dh->dataOrigin, dh->dataDescription, dh->subSpecification});
     if (channelName.empty()) {


### PR DESCRIPTION
@davidrohr @ironMann for me with this PR the round-robin over the pipelines works also when data are injected via ``o2-dpl-raw-proxy``. Tested with rawreader, could you check if for you it works with DD?