### PR TITLE
DPL Analysis: Added partitions

### DIFF
--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -62,6 +62,11 @@ o2_add_dpl_workflow(filters
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
+o2_add_dpl_workflow(partitions
+                  SOURCES src/partitions.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME AnalysisTutorial)
+
 o2_add_dpl_workflow(aodwriter
                   SOURCES src/aodwriter.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -64,29 +64,39 @@ struct ETask {
   float etalim = 0.0f;
   float philow = 1.0f;
   float phiup = 2.0f;
-  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaLeftPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 < philow && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
-  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaMidPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= philow && aod::etaphi::phi2 < phiup && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
-  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaRightPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= phiup && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaLeftPhiP =
+    aod::etaphi::eta2 < etalim && aod::etaphi::phi2 < philow &&
+    aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaMidPhiP =
+    aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= philow && aod::etaphi::phi2 < phiup &&
+    aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaRightPhiP =
+    aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= phiup &&
+    aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::EtaPhi> const& tracks)
   {
     auto& leftPhi = *(negEtaLeftPhiP.mFiltered);
     auto& midPhi = *(negEtaMidPhiP.mFiltered);
     auto& rightPhi = *(negEtaRightPhiP.mFiltered);
-    LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]", collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
-    
+    LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]",
+         collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
+
     for (auto& track : tracks) {
       LOGF(INFO, "id = %d; pt: %.3f < %.3f < %.3f", track.collisionId(), ptlow, track.pt(), ptup);
     }
 
     for (auto& track : leftPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, track.phi2(), philow, ptlow, track.pt(), ptup);
-    } 
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.eta2(), etalim, track.phi2(), philow, ptlow, track.pt(), ptup);
+    }
     for (auto& track : midPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, philow, track.phi2(), phiup, ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.eta2(), etalim, philow, track.phi2(), phiup, ptlow, track.pt(), ptup);
     }
     for (auto& track : rightPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, phiup, track.phi2(), ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.eta2(), etalim, phiup, track.phi2(), ptlow, track.pt(), ptup);
     }
   }
 };

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -1,0 +1,69 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+// This is a very simple example showing how to iterate over tracks
+// and create a new collection for them.
+// FIXME: this should really inherit from AnalysisTask but
+//        we need GCC 7.4+ for that
+struct TTask {
+  // FIXME: For some reason filtering with Charge does not work??
+  //Partition<aod::Tracks> negativeTracksP = aod::track::Charge < 0;
+  //Partition<aod::Tracks> positiveTracksP = aod::track::Charge > 0;
+  Partition<aod::Tracks> negativeTracksP = aod::track::pt2 < 1.0f;
+  Partition<aod::Tracks> positiveTracksP = aod::track::pt2 > 1.0f;
+
+  void process(aod::Tracks const& tracks)
+  {
+    auto& negativeTracks = *(negativeTracksP.mFiltered);
+    auto& positiveTracks = *(positiveTracksP.mFiltered);
+    LOGF(INFO, "[negative tracks: %d] [positive tracks: %d]", negativeTracks.size(), positiveTracks.size());
+    for (auto& track : negativeTracks) {
+      LOGF(INFO, "negative track id: %d pt: %.3f < 1.0", track.collisionId(), track.pt2());
+    }
+    for (auto& track : positiveTracks) {
+      LOGF(INFO, "positive track id: %d pt: %.3f > 1.0", track.collisionId(), track.pt2());
+    }
+  }
+};
+
+struct CTask {
+  // FIXME: For some reason filtering with Charge does not work??
+  //Partition<aod::Tracks> negativeTracksP = aod::track::Charge < 0;
+  //Partition<aod::Tracks> positiveTracksP = aod::track::Charge > 0;
+  Partition<aod::Tracks> negativeTracksP = aod::track::pt2 < 1.0f;
+  Partition<aod::Tracks> positiveTracksP = aod::track::pt2 > 1.0f;
+
+  void process(aod::Collision const& collision, aod::Tracks const& tracks)
+  {
+    auto& negativeTracks = *(negativeTracksP.mFiltered);
+    auto& positiveTracks = *(positiveTracksP.mFiltered);
+    LOGF(INFO, "[negative tracks: %d] [positive tracks: %d]", negativeTracks.size(), positiveTracks.size());
+    for (auto& track : negativeTracks) {
+      LOGF(INFO, "negative track id: %d pt: %.3f < 1.0", track.collisionId(), track.pt2());
+    }
+    for (auto& track : positiveTracks) {
+      LOGF(INFO, "positive track id: %d pt: %.3f > 1.0", track.collisionId(), track.pt2());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<TTask>("consume-tracks")};
+    //adaptAnalysisTask<CTask>("consume-tracks-with-col")};
+}

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -23,42 +23,38 @@ struct ETask {
   float fPI = static_cast<float>(M_PI);
   float ptlow = 0.5f;
   float ptup = 2.0f;
-  float etalim = 0.0f;
+  Filter ptFilter_a = aod::track::pt > ptlow;
+  Filter ptFilter_b = aod::track::pt < ptup;
+
+  float etalow = -1.0f;
+  float etaup = 1.0f;
+  Filter etafilter = (aod::track::eta < etaup) && (aod::track::eta > etalow);
+
   float philow = 1.0f;
   float phiup = 2.0f;
-  Partition<aod::Tracks> negEtaLeftPhiP =
-    aod::track::eta < etalim && aod::track::phiraw < philow &&
-    aod::track::pt > ptlow && aod::track::pt < ptup;
-  Partition<aod::Tracks> negEtaMidPhiP =
-    aod::track::eta < etalim && aod::track::phiraw >= philow && aod::track::phiraw < phiup &&
-    aod::track::pt > ptlow && aod::track::pt < ptup;
-  Partition<aod::Tracks> negEtaRightPhiP =
-    aod::track::eta < etalim && aod::track::phiraw >= phiup &&
-    aod::track::pt > ptlow && aod::track::pt < ptup;
+  Partition<soa::Filtered<aod::Tracks>> leftPhiP = aod::track::phiraw < philow;
+  Partition<soa::Filtered<aod::Tracks>> midPhiP = aod::track::phiraw >= philow && aod::track::phiraw < phiup;
+  Partition<soa::Filtered<aod::Tracks>> rightPhiP = aod::track::phiraw >= phiup;
 
-  void process(aod::Collision const& collision, aod::Tracks const& tracks)
+  void process(aod::Collision const& collision, soa::Filtered<aod::Tracks> const& tracks)
   {
-    auto& leftPhi = negEtaLeftPhiP.getPartition();
-    auto& midPhi = negEtaMidPhiP.getPartition();
-    auto& rightPhi = negEtaRightPhiP.getPartition();
+    auto& leftPhi = leftPhiP.getPartition();
+    auto& midPhi = midPhiP.getPartition();
+    auto& rightPhi = rightPhiP.getPartition();
     LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]",
          collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
 
-    for (auto& track : tracks) {
-      LOGF(INFO, "id = %d; pt: %.3f < %.3f < %.3f", track.collisionId(), ptlow, track.pt(), ptup);
-    }
-
     for (auto& track : leftPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), track.eta(), etalim, track.phiraw(), philow, ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d; eta:  %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), etalow, track.eta(), etaup, track.phiraw(), philow, ptlow, track.pt(), ptup);
     }
     for (auto& track : midPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), track.eta(), etalim, philow, track.phiraw(), phiup, ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), etalow, track.eta(), etaup, philow, track.phiraw(), phiup, ptlow, track.pt(), ptup);
     }
     for (auto& track : rightPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), track.eta(), etalim, phiup, track.phiraw(), ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), etalow, track.eta(), etaup, phiup, track.phiraw(), ptlow, track.pt(), ptup);
     }
   }
 };

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -11,6 +11,17 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 
+namespace o2::aod
+{
+namespace etaphi
+{
+DECLARE_SOA_COLUMN(Eta, eta2, float);
+DECLARE_SOA_COLUMN(Phi, phi2, float);
+} // namespace etaphi
+DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
+                  etaphi::Eta, etaphi::Phi);
+} // namespace o2::aod
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
@@ -20,6 +31,8 @@ using namespace o2::framework::expressions;
 // FIXME: this should really inherit from AnalysisTask but
 //        we need GCC 7.4+ for that
 struct TTask {
+  Produces<aod::EtaPhi> etaphi;
+
   // FIXME: For some reason filtering with Charge does not work??
   //Partition<aod::Tracks> negativeTracksP = aod::track::Charge < 0;
   //Partition<aod::Tracks> positiveTracksP = aod::track::Charge > 0;
@@ -28,6 +41,10 @@ struct TTask {
 
   void process(aod::Tracks const& tracks)
   {
+    for (auto& track : tracks) {
+      etaphi(track.eta(), track.phi());
+    }
+
     auto& negativeTracks = *(negativeTracksP.mFiltered);
     auto& positiveTracks = *(positiveTracksP.mFiltered);
     LOGF(INFO, "[negative tracks: %d] [positive tracks: %d]", negativeTracks.size(), positiveTracks.size());
@@ -40,23 +57,36 @@ struct TTask {
   }
 };
 
-struct CTask {
-  // FIXME: For some reason filtering with Charge does not work??
-  //Partition<aod::Tracks> negativeTracksP = aod::track::Charge < 0;
-  //Partition<aod::Tracks> positiveTracksP = aod::track::Charge > 0;
-  Partition<aod::Tracks> negativeTracksP = aod::track::pt2 < 1.0f;
-  Partition<aod::Tracks> positiveTracksP = aod::track::pt2 > 1.0f;
+struct ETask {
+  float fPI = static_cast<float>(M_PI);
+  float ptlow = 0.5f;
+  float ptup = 2.0f;
+  float etalim = 0.0f;
+  float philow = 1.0f;
+  float phiup = 2.0f;
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaLeftPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 < philow && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaMidPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= philow && aod::etaphi::phi2 < phiup && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
+  Partition<soa::Join<aod::Tracks, aod::EtaPhi>> negEtaRightPhiP = aod::etaphi::eta2 < etalim && aod::etaphi::phi2 >= phiup && aod::track::pt2 > (ptlow * ptlow) && aod::track::pt2 < (ptup * ptup);
 
-  void process(aod::Collision const& collision, aod::Tracks const& tracks)
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::EtaPhi> const& tracks)
   {
-    auto& negativeTracks = *(negativeTracksP.mFiltered);
-    auto& positiveTracks = *(positiveTracksP.mFiltered);
-    LOGF(INFO, "[negative tracks: %d] [positive tracks: %d]", negativeTracks.size(), positiveTracks.size());
-    for (auto& track : negativeTracks) {
-      LOGF(INFO, "negative track id: %d pt: %.3f < 1.0", track.collisionId(), track.pt2());
+    auto& leftPhi = *(negEtaLeftPhiP.mFiltered);
+    auto& midPhi = *(negEtaMidPhiP.mFiltered);
+    auto& rightPhi = *(negEtaRightPhiP.mFiltered);
+    LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]", collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
+    
+    for (auto& track : tracks) {
+      LOGF(INFO, "id = %d; pt: %.3f < %.3f < %.3f", track.collisionId(), ptlow, track.pt(), ptup);
     }
-    for (auto& track : positiveTracks) {
-      LOGF(INFO, "positive track id: %d pt: %.3f > 1.0", track.collisionId(), track.pt2());
+
+    for (auto& track : leftPhi) {
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, track.phi2(), philow, ptlow, track.pt(), ptup);
+    } 
+    for (auto& track : midPhi) {
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, philow, track.phi2(), phiup, ptlow, track.pt(), ptup);
+    }
+    for (auto& track : rightPhi) {
+      LOGF(INFO, "id = %d; eta: %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f", track.collisionId(), track.eta2(), etalim, phiup, track.phi2(), ptlow, track.pt(), ptup);
     }
   }
 };
@@ -64,6 +94,6 @@ struct CTask {
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<TTask>("consume-tracks")};
-    //adaptAnalysisTask<CTask>("consume-tracks-with-col")};
+    adaptAnalysisTask<TTask>("produce-etaphi"),
+    adaptAnalysisTask<ETask>("consume-etaphi")};
 }

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -19,7 +19,7 @@ using namespace o2::framework::expressions;
 // and create a new collection for them.
 // FIXME: this should really inherit from AnalysisTask but
 //        we need GCC 7.4+ for that
-struct ETask {
+struct ATask {
   float fPI = static_cast<float>(M_PI);
   float ptlow = 0.5f;
   float ptup = 2.0f;
@@ -45,16 +45,16 @@ struct ETask {
          collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
 
     for (auto& track : leftPhi) {
-      LOGF(INFO, "id = %d; eta:  %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), etalow, track.eta(), etaup, track.phiraw(), philow, ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d, from collision: %d, collision: %d; eta:  %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.collision().globalIndex(), collision.globalIndex(), etalow, track.eta(), etaup, track.phiraw(), philow, ptlow, track.pt(), ptup);
     }
     for (auto& track : midPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), etalow, track.eta(), etaup, philow, track.phiraw(), phiup, ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d, from collision: %d, collision: %d; eta: %.3f < %.3f < %.3f; phi: %.3f <= %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.collision().globalIndex(), collision.globalIndex(), etalow, track.eta(), etaup, philow, track.phiraw(), phiup, ptlow, track.pt(), ptup);
     }
     for (auto& track : rightPhi) {
-      LOGF(INFO, "id = %d; eta: %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), etalow, track.eta(), etaup, phiup, track.phiraw(), ptlow, track.pt(), ptup);
+      LOGF(INFO, "id = %d, from collision: %d, collision: %d; eta: %.3f < %.3f < %.3f; phi: %.3f < %.3f; pt: %.3f < %.3f < %.3f",
+           track.collisionId(), track.collision().globalIndex(), collision.globalIndex(), etalow, track.eta(), etaup, phiup, track.phiraw(), ptlow, track.pt(), ptup);
     }
   }
 };
@@ -62,5 +62,5 @@ struct ETask {
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ETask>("consume-etaphi")};
+    adaptAnalysisTask<ATask>("consume-tracks")};
 }

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -45,8 +45,8 @@ struct TTask {
       etaphi(track.eta(), track.phi());
     }
 
-    auto& negativeTracks = *(negativeTracksP.mFiltered);
-    auto& positiveTracks = *(positiveTracksP.mFiltered);
+    auto& negativeTracks = negativeTracksP.getPartition();
+    auto& positiveTracks = positiveTracksP.getPartition();
     LOGF(INFO, "[negative tracks: %d] [positive tracks: %d]", negativeTracks.size(), positiveTracks.size());
     for (auto& track : negativeTracks) {
       LOGF(INFO, "negative track id: %d pt: %.3f < 1.0", track.collisionId(), track.pt2());
@@ -76,9 +76,9 @@ struct ETask {
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::EtaPhi> const& tracks)
   {
-    auto& leftPhi = *(negEtaLeftPhiP.mFiltered);
-    auto& midPhi = *(negEtaMidPhiP.mFiltered);
-    auto& rightPhi = *(negEtaRightPhiP.mFiltered);
+    auto& leftPhi = negEtaLeftPhiP.getPartition();
+    auto& midPhi = negEtaMidPhiP.getPartition();
+    auto& rightPhi = negEtaRightPhiP.getPartition();
     LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]",
          collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -279,16 +279,16 @@ struct Partition {
 
   void setTable(const T& table)
   {
-    mFiltered.reset(new o2::soa::Filtered<T>{{table.asArrowTable()}, mTree});
+    mFiltered.reset(new o2::soa::Filtered<typename T::table_t>{{table.asArrowTable()}, mTree});
   }
 
-  o2::soa::Filtered<T>& getPartition()
+  o2::soa::Filtered<typename T::table_t>& getPartition()
   {
     return *mFiltered;
   }
 
   gandiva::NodePtr mTree;
-  std::unique_ptr<o2::soa::Filtered<T>> mFiltered;
+  std::unique_ptr<o2::soa::Filtered<typename T::table_t>> mFiltered;
 };
 
 template <typename ANY>

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -265,9 +265,9 @@ struct Configurable {
 
 template <typename T>
 struct Partition {
-  Partition(expressions::Node&& node_)
+  Partition(expressions::Node&& node)
   {
-    auto filter = expressions::Filter(std::move(node_));
+    auto filter = expressions::Filter(std::move(node));
     auto schema = o2::soa::createSchemaFromColumns(typename T::table_t::persistent_columns_t{});
     expressions::Operations ops = createOperations(filter);
     if (isSchemaCompatible(schema, ops)) {
@@ -282,8 +282,13 @@ struct Partition {
     mFiltered.reset(new o2::soa::Filtered<T>{{table.asArrowTable()}, mTree});
   }
 
+  o2::soa::Filtered<T>& getPartition()
+  {
+    return *mFiltered;
+  }
+
   gandiva::NodePtr mTree;
-  std::shared_ptr<o2::soa::Filtered<T>> mFiltered;
+  std::unique_ptr<o2::soa::Filtered<T>> mFiltered;
 };
 
 template <typename ANY>

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -20,6 +20,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Expressions.h"
+#include "../src/ExpressionHelpers.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/Logger.h"
 #include "Framework/HistogramRegistry.h"
@@ -285,20 +286,44 @@ struct Partition {
   std::shared_ptr<o2::soa::Filtered<T>> mFiltered;
 };
 
-template <typename ANY, typename T>
+template <typename ANY>
 struct PartitionManager {
-  static bool setPartition(ANY&, T const& table)
+  template<typename... T2s>
+  static bool setPartition(ANY&, T2s&... tables)
   {
     return false;
+  }
+
+  template<typename... Ts>
+  static void setPartitions(ANY&, std::tuple<Ts...> tables)
+  {
   }
 };
 
 template <typename T>
-struct PartitionManager<Partition<T>, T> {
-  static bool setPartition(Partition<T> & partition, T const& table)
+struct PartitionManager<Partition<T>> {
+  template <typename T2>
+  static bool doSetPartition(Partition<T>& partition, T2& table)
   {
-    partition.setTable(table);
-    return true;
+    if constexpr (std::is_same_v<T, T2>) {
+      partition.setTable(table);
+      return true;
+    }
+    return false;
+  }
+
+  template<typename... T2s>
+  static bool setPartition(Partition<T>& partition, T2s&... tables)
+  {
+    return (doSetPartition(partition, tables) || ...);
+  }
+
+  template<typename... Ts>
+  static void setPartitions(Partition<T>& partition, std::tuple<Ts...> tables)
+  {
+    std::apply([&partition](auto&... table) {
+      return setPartition(partition, table...);
+    }, tables);
   }
 };
 
@@ -630,13 +655,14 @@ struct AnalysisDataProcessorBuilder {
   static void invokeProcess(Task& task, InputRecord& inputs, R (C::*)(Grouping, Associated...), std::vector<ExpressionInfo> const& infos)
   {
     auto tupledTask = o2::framework::to_tuple_refs(task);
-    // set filtered tables for partitions with grouping
     using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, &C::process, infos);
+
+    // set filtered tables for partitions with grouping
     std::apply([&groupingTable](auto&... x) {
-      return (PartitionManager<std::decay_t<decltype(x)>, G>::setPartition(x, groupingTable), ...);
-    },
-               tupledTask);
+      return (PartitionManager<std::decay_t<decltype(x)>>::setPartition(x, groupingTable), ...);
+    }, tupledTask);
+
     if constexpr (sizeof...(Associated) == 0) {
       // single argument to process
       if constexpr (soa::is_soa_iterator_t<G>::value) {
@@ -653,15 +679,6 @@ struct AnalysisDataProcessorBuilder {
       static_assert(((soa::is_soa_iterator_t<std::decay_t<Associated>>::value == false) && ...),
                     "Associated arguments of process() should not be iterators");
       auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, &C::process, infos);
-      // set filtered tables for partitions with associated tables
-      // TODO: Make partitions for grouped with associated working.
-      std::apply([&associatedTables](auto&... x) {
-        std::apply([&x...](auto& associatedTable) {
-          return (PartitionManager<std::decay_t<decltype(x)>, std::decay_t<decltype(associatedTable)>>::setPartition(x, associatedTable), ...);
-        },
-        associatedTables);
-      },
-                 tupledTask);
       auto binder = [&](auto&& x) {
         x.bindExternalIndices(&groupingTable, &std::get<std::decay_t<Associated>>(associatedTables)...);
       };
@@ -672,6 +689,13 @@ struct AnalysisDataProcessorBuilder {
         auto slicer = GroupSlicer(groupingTable, associatedTables);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
+
+          // set filtered tables for partitions with associated tables
+          std::apply([&associatedSlices](auto&... x) {
+            (PartitionManager<std::decay_t<decltype(x)>>::setPartitions(x, associatedSlices), ...);
+          },
+                     tupledTask);
+
           std::apply(
             [&](auto&&... x) {
               (binder(x), ...);
@@ -682,6 +706,13 @@ struct AnalysisDataProcessorBuilder {
         }
       } else {
         // non-grouping case
+
+        // set filtered tables for partitions with associated tables
+        std::apply([&associatedTables](auto&... x) {
+          (PartitionManager<std::decay_t<decltype(x)>>::setPartitions(x, associatedTables), ...);
+        },
+                   tupledTask);
+
         std::apply(
           [&](auto&&... x) {
             (binder(x), ...);

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -263,7 +263,7 @@ struct Configurable {
   }
 };
 
-template<typename T>
+template <typename T>
 struct Partition {
   Partition(expressions::Node&& node_)
   {
@@ -288,13 +288,13 @@ struct Partition {
 
 template <typename ANY>
 struct PartitionManager {
-  template<typename... T2s>
+  template <typename... T2s>
   static bool setPartition(ANY&, T2s&... tables)
   {
     return false;
   }
 
-  template<typename... Ts>
+  template <typename... Ts>
   static void setPartitions(ANY&, std::tuple<Ts...> tables)
   {
   }
@@ -312,18 +312,19 @@ struct PartitionManager<Partition<T>> {
     return false;
   }
 
-  template<typename... T2s>
+  template <typename... T2s>
   static bool setPartition(Partition<T>& partition, T2s&... tables)
   {
     return (doSetPartition(partition, tables) || ...);
   }
 
-  template<typename... Ts>
+  template <typename... Ts>
   static void setPartitions(Partition<T>& partition, std::tuple<Ts...> tables)
   {
     std::apply([&partition](auto&... table) {
       return setPartition(partition, table...);
-    }, tables);
+    },
+               tables);
   }
 };
 
@@ -661,7 +662,8 @@ struct AnalysisDataProcessorBuilder {
     // set filtered tables for partitions with grouping
     std::apply([&groupingTable](auto&... x) {
       return (PartitionManager<std::decay_t<decltype(x)>>::setPartition(x, groupingTable), ...);
-    }, tupledTask);
+    },
+               tupledTask);
 
     if constexpr (sizeof...(Associated) == 0) {
       // single argument to process
@@ -733,13 +735,11 @@ struct AnalysisDataProcessorBuilder {
 
 template <typename ANY>
 struct FilterManager {
-  //template <typename ANY>
   static bool createExpressionTrees(ANY&, std::vector<ExpressionInfo>&)
   {
     return false;
   }
 };
-
 
 template <>
 struct FilterManager<expressions::Filter> {


### PR DESCRIPTION
Input tables can be partitioned for use inside `process()`, added partitions.cxx example.
Pinging also @aalkin for review.