### PR TITLE
DPL: fix 100% CPU utilization when timepipeline idle (O2-1541)

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -276,7 +276,7 @@ void DataProcessingDevice::InitTask()
         continue;
       }
       // We only watch receiving sockets.
-      if (x.first.rfind("from_" + mSpec.name + "_to", 0) == 0) {
+      if (x.first.rfind("from_" + mSpec.name + "_", 0) == 0) {
         LOG(debug) << x.first << " is to send data. Not polling." << std::endl;
         continue;
       }
@@ -306,7 +306,7 @@ void DataProcessingDevice::InitTask()
           LOG(debug) << x.first << " is an internal channel. Not polling." << std::endl;
           continue;
         }
-        assert(x.first.rfind("from_" + mSpec.name + "_to", 0) == 0);
+        assert(x.first.rfind("from_" + mSpec.name + "_", 0) == 0);
         // We assume there is always a ZeroMQ socket behind.
         int zmq_fd = 0;
         size_t zmq_fd_len = sizeof(zmq_fd);


### PR DESCRIPTION
The issue seems to be that UV_READABLE events are triggereded on a socket which
should be used for writing. Such a socket should not really be subscribing to
such events, but it happens because the rfind is not taking into account the
_tX. This prevents from subscribing in the first place.