### PR TITLE
fix for float truncation affecting timing in large timeframe numbers

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -62,10 +62,10 @@ class Geo
 
   static constexpr Int_t RAW_PAGE_MAX_SIZE = 8192;
 
-  static constexpr Float_t BC_TIME = o2::constants::lhc::LHCBunchSpacingNS; // bunch crossing in ns
-  static constexpr Float_t BC_TIME_INV = 1. / BC_TIME;                      // inv bunch crossing in ns
-  static constexpr Float_t BC_TIME_INPS = BC_TIME * 1000;                   // bunch crossing in ps
-  static constexpr Float_t BC_TIME_INPS_INV = 1. / BC_TIME_INPS;            // inv bunch crossing in ps
+  static constexpr Double_t BC_TIME = o2::constants::lhc::LHCBunchSpacingNS; // bunch crossing in ns
+  static constexpr Double_t BC_TIME_INV = 1. / BC_TIME;                      // inv bunch crossing in ns
+  static constexpr Double_t BC_TIME_INPS = BC_TIME * 1000;                   // bunch crossing in ps
+  static constexpr Double_t BC_TIME_INPS_INV = 1. / BC_TIME_INPS;            // inv bunch crossing in ps
   static constexpr int BC_IN_ORBIT = o2::constants::lhc::LHCMaxBunches;     // N. bunch crossing in 1 orbit
 
   static constexpr Int_t NPADX = 48;

--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -15,6 +15,7 @@
 #include "TOFBase/Digit.h"
 #include "TOFBase/Strip.h"
 #include "DetectorsRaw/HBFUtils.h"
+#include "CommonDataFormat/InteractionRecord.h"
 
 namespace o2
 {
@@ -34,7 +35,7 @@ class WindowFiller
 
   Int_t getCurrentReadoutWindow() const { return mReadoutWindowCurrent; }
   void setCurrentReadoutWindow(Double_t value) { mReadoutWindowCurrent = value; }
-  void setEventTime(double value)
+  void setEventTime(InteractionTimeRecord value)
   {
     mEventTime = value;
   }
@@ -54,7 +55,7 @@ class WindowFiller
   Int_t mReadoutWindowCurrent = 0;
   Int_t mFirstOrbit = 0;
   Int_t mFirstBunch = 0;
-  Double_t mEventTime;
+  InteractionTimeRecord mEventTime;
 
   bool mContinuous = true;
   bool mFutureToBeSorted = false;

--- a/Detectors/TOF/reconstruction/src/Decoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Decoder.cxx
@@ -233,7 +233,6 @@ bool Decoder::decode() // return a vector of digits in a TOF readout window
   auto start = std::chrono::high_resolution_clock::now();
 
   // start from the beginning of the timeframe
-  mEventTime = 0;
 
   // loop over CRUs
   for (int icru = 0; icru < NCRU; icru++) {

--- a/Detectors/TOF/simulation/src/Digitizer.cxx
+++ b/Detectors/TOF/simulation/src/Digitizer.cxx
@@ -271,16 +271,19 @@ void Digitizer::addDigit(Int_t channel, UInt_t istrip, Double_t time, Float_t x,
   // Decalibrate
   time -= mCalibApi->getTimeDecalibration(channel, tot); //TODO:  to be checked that "-" is correct, and we did not need "+" instead :-)
 
+  // let's move from time to bc, tdc
+
   Int_t nbc = Int_t(time * Geo::BC_TIME_INPS_INV); // time elapsed in number of bunch crossing
   //Digit newdigit(time, channel, (time - Geo::BC_TIME_INPS * nbc) * Geo::NTDCBIN_PER_PS, tot * Geo::NTOTBIN_PER_NS, nbc);
 
   int tdc = int((time - Geo::BC_TIME_INPS * nbc) * Geo::NTDCBIN_PER_PS);
 
   // additional check to avoid very rare truncation
-  if (tdc < 0) {
+  while (tdc < 0) {
     nbc--;
     tdc += 1024;
-  } else if (tdc >= 1024) {
+  }
+  while (tdc >= 1024) {
     nbc++;
     tdc -= 1024;
   }
@@ -353,12 +356,7 @@ void Digitizer::addDigit(Int_t channel, UInt_t istrip, Double_t time, Float_t x,
     mcTruthContainer = mMCTruthContainerNext[isnext - 1];
   }
 
-  int eventcounter = mReadoutWindowCurrent + isnext;
-  int hittimeTDC = (nbc - eventcounter * Geo::BC_IN_WINDOW) * 1024 + tdc; // time in TDC bin within the TOF WINDOW
-  if (hittimeTDC < 0)
-    LOG(ERROR) << "1) Negative hit " << hittimeTDC << ", something went wrong in filling readout window: isnext=" << isnext << ", isIfOverlap=" << isIfOverlap;
-  else
-    fillDigitsInStrip(strips, mcTruthContainer, channel, tdc, tot, nbc, istrip, trackID, mEventID, mSrcID);
+  fillDigitsInStrip(strips, mcTruthContainer, channel, tdc, tot, nbc, istrip, trackID, mEventID, mSrcID);
 
   if (isIfOverlap > -1 && isIfOverlap < MAXWINDOWS) { // fill also a second readout window because of the overlap
     if (!isIfOverlap) {
@@ -369,12 +367,7 @@ void Digitizer::addDigit(Int_t channel, UInt_t istrip, Double_t time, Float_t x,
       mcTruthContainer = mMCTruthContainerNext[isIfOverlap - 1];
     }
 
-    int eventcounter = mReadoutWindowCurrent + isIfOverlap;
-    int hittimeTDC = (nbc - eventcounter * Geo::BC_IN_WINDOW) * 1024 + tdc; // time in TDC bin within the TOF WINDOW
-    if (hittimeTDC < 0)
-      LOG(ERROR) << "2) Negative hit " << hittimeTDC << ", something went wrong in filling readout window: isnext=" << isnext << ", isIfOverlap=" << isIfOverlap;
-    else
-      fillDigitsInStrip(strips, mcTruthContainer, channel, tdc, tot, nbc, istrip, trackID, mEventID, mSrcID);
+    fillDigitsInStrip(strips, mcTruthContainer, channel, tdc, tot, nbc, istrip, trackID, mEventID, mSrcID);
   }
 }
 //______________________________________________________________________

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -125,7 +125,7 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < timesview.size(); ++collID) {
-      mDigitizer->setEventTime(timesview[collID].getTimeNS());
+      mDigitizer->setEventTime(timesview[collID]);
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)


### PR DESCRIPTION
Required to simulate cosmic rays (low rates --> large number of timeframes)