### PR TITLE
Stream huge ITS clusters in pieces

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -38,7 +38,9 @@ class BuildTopologyDictionary;
 class ClusterPattern
 {
  public:
-  static constexpr int MaxPatternBits = 32 * 16;
+  static constexpr uint8_t MaxRowSpan = 128;
+  static constexpr uint8_t MaxColSpan = 128;
+  static constexpr int MaxPatternBits = MaxRowSpan * MaxColSpan;
   static constexpr int MaxPatternBytes = MaxPatternBits / 8;
   static constexpr int SpanMask = 0x7fff;
   static constexpr int TruncateMask = 0x8000;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -95,7 +95,7 @@ class Clusterer
     uint16_t currCol = 0xffff;                                      ///< Column being processed
     bool noLeftCol = true;                                          ///< flag that there is no column on the left to check
     std::array<Label, MaxLabels> labelsBuff;                        //! temporary buffer for building cluster labels
-    std::array<PixelData, ClusterPattern::MaxPatternBits * 2> pixArrBuff; //! temporary buffer for pattern calc.
+    std::vector<PixelData> pixArrBuff;                              //! temporary buffer for pattern calc.
     //
     /// temporary storage for the thread output
     CompClusCont compClusters;
@@ -130,7 +130,7 @@ class Clusterer
     }
 
     void streamCluster(uint16_t rowMin, uint16_t rowSpanW, uint16_t colMin, uint16_t colSpanW,
-                       int npix, uint16_t chipID,
+                       uint16_t chipID,
                        CompClusCont* compClusPtr, PatternCont* patternsPtr,
                        MCTruth* labelsClusPtr, int nlab);
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -129,7 +129,7 @@ class Clusterer
       curr[row] = lastIndex; // store index of the new precluster in the current column buffer
     }
 
-    void streamCluster(uint16_t rowMin, uint16_t rowSpanW, uint16_t colMin, uint16_t colSpanW,
+    void streamCluster(const std::vector<PixelData>& pixbuf, uint16_t rowMin, uint16_t rowSpanW, uint16_t colMin, uint16_t colSpanW,
                        uint16_t chipID,
                        CompClusCont* compClusPtr, PatternCont* patternsPtr,
                        MCTruth* labelsClusPtr, int nlab);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -129,6 +129,11 @@ class Clusterer
       curr[row] = lastIndex; // store index of the new precluster in the current column buffer
     }
 
+    void streamCluster(uint16_t rowMin, uint16_t rowSpanW, uint16_t colMin, uint16_t colSpanW,
+                       int npix, uint16_t chipID,
+                       CompClusCont* compClusPtr, PatternCont* patternsPtr,
+                       MCTruth* labelsClusPtr, int nlab);
+
     void fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled);
     void initChip(const ChipPixelData* curChipData, uint32_t first);
     void updateChip(const ChipPixelData* curChipData, uint32_t ip);

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -199,7 +199,7 @@ void Clusterer::ClustererThread::process(uint16_t chip, uint16_t nChips, CompClu
 
 //__________________________________________________
 void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClusCont* compClusPtr,
-                                            PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr)
+                                            PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
 {
   auto clustersCount = compClusPtr->size();
   const auto& pixData = curChipData->getData();
@@ -218,7 +218,7 @@ void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClus
       if (npix < pixArrBuff.size()) {
         pixArrBuff[npix++] = pix; // needed for cluster topology
         adjustBoundingBox(pix.getRowDirect(), pix.getCol(), rowMin, rowMax, colMin, colMax);
-        if (labelsClusPTr) { // the MCtruth for this pixel is at curChipData->startID+pixEntry.second
+        if (labelsClusPtr) { // the MCtruth for this pixel is at curChipData->startID+pixEntry.second
           fetchMCLabels(pixEntry.second + curChipData->getStartID(), labelsDigPtr, nlab);
         }
         next = pixEntry.first;
@@ -236,7 +236,7 @@ void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClus
         if (npix < pixArrBuff.size()) {
           pixArrBuff[npix++] = pix; // needed for cluster topology
           adjustBoundingBox(pix.getRowDirect(), pix.getCol(), rowMin, rowMax, colMin, colMax);
-          if (labelsClusPTr) { // the MCtruth for this pixel is at curChipData->startID+pixEntry.second
+          if (labelsClusPtr) { // the MCtruth for this pixel is at curChipData->startID+pixEntry.second
             fetchMCLabels(pixEntry.second + curChipData->getStartID(), labelsDigPtr, nlab);
           }
           next = pixEntry.first;
@@ -244,73 +244,93 @@ void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClus
       }
       preClusterIndices[i2] = -1;
     }
-    uint16_t rowSpan = rowMax - rowMin + 1, colSpan = colMax - colMin + 1;
-    uint16_t colSpanW = colSpan, rowSpanW = rowSpan;
-    if (colSpan * rowSpan > ClusterPattern::MaxPatternBits) { // need to store partial info
-      // will curtail largest dimension
-      if (colSpan > rowSpan) {
-        if ((colSpanW = ClusterPattern::MaxPatternBits / rowSpan) == 0) {
-          colSpanW = 1;
-          rowSpanW = ClusterPattern::MaxPatternBits;
-        }
-      } else {
-        if ((rowSpanW = ClusterPattern::MaxPatternBits / colSpan) == 0) {
-          rowSpanW = 1;
-          colSpanW = ClusterPattern::MaxPatternBits;
-        }
-      }
-    }
 
-    if (labelsClusPTr) { // MC labels were requested
-      auto cnt = compClusPtr->size();
-      for (int i = nlab; i--;) {
-        labelsClusPTr->addElement(cnt, labelsBuff[i]);
-      }
-    }
+    auto chipID = curChipData->getChipID();
+    uint16_t colSpan = (colMax - colMin + 1);
+    uint16_t rowSpan = (rowMax - rowMin + 1);
+    if (colSpan <= o2::itsmft::ClusterPattern::MaxColSpan &&
+        rowSpan <= o2::itsmft::ClusterPattern::MaxRowSpan) {
+      streamCluster(rowMin, rowSpan, colMin, colSpan, npix, chipID,
+                    compClusPtr, patternsPtr, labelsClusPtr, nlab);
+    } else {
+      LOG(WARNING) << "Splitting a huge cluster !  ChipID: " << chipID;
 
-    // add to compact clusters, which must be always filled
-    unsigned char patt[ClusterPattern::MaxPatternBytes] = {0}; // RSTODO FIX pattern filling
-    for (int i = 0; i < npix; i++) {
-      const auto pix = pixArrBuff[i];
-      unsigned short ir = pix.getRowDirect() - rowMin, ic = pix.getCol() - colMin;
-      if (ir < rowSpanW && ic < colSpanW) {
-        int nbits = ir * colSpanW + ic;
-        patt[nbits >> 3] |= (0x1 << (7 - (nbits % 8)));
-      }
+      colSpan %= o2::itsmft::ClusterPattern::MaxColSpan;
+      if (colSpan == 0)
+        colSpan = o2::itsmft::ClusterPattern::MaxColSpan;
+
+      rowSpan %= o2::itsmft::ClusterPattern::MaxRowSpan;
+      if (rowSpan == 0)
+        rowSpan = o2::itsmft::ClusterPattern::MaxRowSpan;
+
+      do {
+        uint16_t r = rowMin, rsp = rowSpan;
+
+        do {
+          streamCluster(r, rsp, colMin, colSpan, npix, chipID,
+                        compClusPtr, patternsPtr, labelsClusPtr, nlab);
+          r += rsp;
+          rsp = o2::itsmft::ClusterPattern::MaxRowSpan;
+        } while (r < rowMax);
+
+        colMin += colSpan;
+        colSpan = o2::itsmft::ClusterPattern::MaxColSpan;
+      } while (colMin < colMax);
     }
-    uint16_t pattID = (parent->mPattIdConverter.size() == 0) ? CompCluster::InvalidPatternID : parent->mPattIdConverter.findGroupID(rowSpanW, colSpanW, patt);
-    if (pattID == CompCluster::InvalidPatternID || parent->mPattIdConverter.isGroup(pattID)) {
-      float xCOG = 0., zCOG = 0.;
-      ClusterPattern::getCOG(rowSpanW, colSpanW, patt, xCOG, zCOG);
-      rowMin += round(xCOG);
-      colMin += round(zCOG);
-      if (patternsPtr) {
-        patternsPtr->emplace_back((unsigned char)rowSpanW);
-        patternsPtr->emplace_back((unsigned char)colSpanW);
-        int nBytes = rowSpanW * colSpanW / 8;
-        if (((rowSpanW * colSpanW) % 8) != 0)
-          nBytes++;
-        patternsPtr->insert(patternsPtr->end(), std::begin(patt), std::begin(patt) + nBytes);
-      }
-    }
-    compClusPtr->emplace_back(rowMin, colMin, pattID, curChipData->getChipID());
   }
+}
+
+void Clusterer::ClustererThread::streamCluster(uint16_t rowMin, uint16_t rowSpanW, uint16_t colMin, uint16_t colSpanW, int npix, uint16_t chipID, CompClusCont* compClusPtr, PatternCont* patternsPtr, MCTruth* labelsClusPtr, int nlab)
+{
+  if (labelsClusPtr) { // MC labels were requested
+    auto cnt = compClusPtr->size();
+    for (int i = nlab; i--;) {
+      labelsClusPtr->addElement(cnt, labelsBuff[i]);
+    }
+  }
+
+  // add to compact clusters, which must be always filled
+  unsigned char patt[ClusterPattern::MaxPatternBytes] = {0}; // RSTODO FIX pattern filling
+  for (int i = 0; i < npix; i++) {
+    const auto pix = pixArrBuff[i];
+    unsigned short ir = pix.getRowDirect() - rowMin, ic = pix.getCol() - colMin;
+    if (ir < rowSpanW && ic < colSpanW) {
+      int nbits = ir * colSpanW + ic;
+      patt[nbits >> 3] |= (0x1 << (7 - (nbits % 8)));
+    }
+  }
+  uint16_t pattID = (parent->mPattIdConverter.size() == 0) ? CompCluster::InvalidPatternID : parent->mPattIdConverter.findGroupID(rowSpanW, colSpanW, patt);
+  if (pattID == CompCluster::InvalidPatternID || parent->mPattIdConverter.isGroup(pattID)) {
+    float xCOG = 0., zCOG = 0.;
+    ClusterPattern::getCOG(rowSpanW, colSpanW, patt, xCOG, zCOG);
+    rowMin += round(xCOG);
+    colMin += round(zCOG);
+    if (patternsPtr) {
+      patternsPtr->emplace_back((unsigned char)rowSpanW);
+      patternsPtr->emplace_back((unsigned char)colSpanW);
+      int nBytes = rowSpanW * colSpanW / 8;
+      if (((rowSpanW * colSpanW) % 8) != 0)
+        nBytes++;
+      patternsPtr->insert(patternsPtr->end(), std::begin(patt), std::begin(patt) + nBytes);
+    }
+  }
+  compClusPtr->emplace_back(rowMin, colMin, pattID, chipID);
 }
 
 //__________________________________________________
 void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, CompClusCont* compClusPtr,
-                                                         PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr)
+                                                         PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
 {
   auto clustersCount = compClusPtr->size();
   auto pix = curChipData->getData()[hit];
   uint16_t row = pix.getRowDirect(), col = pix.getCol();
 
-  if (labelsClusPTr) { // MC labels were requested
+  if (labelsClusPtr) { // MC labels were requested
     int nlab = 0;
     fetchMCLabels(curChipData->getStartID() + hit, labelsDigPtr, nlab);
     auto cnt = compClusPtr->size();
     for (int i = nlab; i--;) {
-      labelsClusPTr->addElement(cnt, labelsBuff[i]);
+      labelsClusPtr->addElement(cnt, labelsBuff[i]);
     }
   }
 

--- a/scripts/py-analysis-benchmark.py
+++ b/scripts/py-analysis-benchmark.py
@@ -1,3 +1,16 @@
+"""
+Script for the local benchmarking of the o2 analysis tasks,
+running them with multiple processing jobs (NCORES)
+and multiple readers (NREADERS) over input files (INPUT_FILE).
+Tasks to be benchmarked are in the BENCHMARK_TASKS dict.
+
+Usage: python3 py-analysis-benchmark.py
+
+Ouput: CSV file (OUTPUT_CSV) with benchmarking results:
+'tname', 'ncores', 'nreaders', 'time_mean' (s), 'time_std' (s), 
+'input_size' (MB), 'input_length', 'timestamp', 'cpu_load', 'ncpu', 'machine'
+"""
+
 import csv
 from datetime import datetime
 import itertools
@@ -7,55 +20,85 @@ from string import Template
 import subprocess
 import timeit
 
+
+def get_cl_output(cmd) -> str:
+    try:
+        output_ = str(subprocess.check_output(cmd, shell=True), 'utf-8')
+    except subprocess.CalledProcessError:
+        output_ = ''
+    return output_.strip('\n')
+
+
+def get_cpu_load():
+    uptime_ = get_cl_output('uptime')
+    load_last_15 = uptime_.split(' ')[-1]
+    return load_last_15
+
+
+def get_timestamp():
+    return datetime.now().strftime("%m/%d/%Y %H:%M")
+    
+    
+def get_time_std(t_res):
+    try:
+        std_ = stat.stdev(t_res)
+    except stat.StatisticsError:
+        std_ = -1
+    return std_
+
+
+#benchmarking setup    
+INPUT_FILE = '@filelist.txt'
+OUTPUT_CSV = 'benchmark_data.csv' 
+NCORES = [1, 2, 4]
+NREADERS = [1, 2, 4]
+NTRIALS = 2
+LARGE_SHM_SEGMENT_SIZE = False
+CPU_SELECTION = False
+
+#tasks to be benchmarked
+BENCHMARK_TASKS = {
+      'o2-analysistutorial-void': '-b --pipeline void:${n}',
+      'o2-analysistutorial-histograms': '-b --pipeline eta-and-phi-histograms:${n},pt-histogram:${n},etaphi-histogram:${n}',
+      'o2-analysis-trackselection': '-b --pipeline track-selection:${n},track_extension:${n}',
+      'o2-analysis-correlations': '-b --pipeline correlation-task:${n}',
+      #'o2-analysis-vertexing-hf': '-b --pipeline vertexerhf-candidatebuildingDzero:${n},vertexerhf-decayvertexbuilder2prong:${n}'
+    }
+
+
 O2_ROOT = os.environ.get('O2_ROOT')
 if not O2_ROOT:
     print('O2_ROOT not found')
-    raise ValueError
+    raise ValueError 
     
-INPUT_FILE = '@filelist.txt'
-OUTPUT_CSV = 'benchmark_data.csv' 
-
+MACHINE = get_cl_output('hostname')
+NCPU = get_cl_output('grep processor /proc/cpuinfo | wc -l')
 with open(INPUT_FILE[1:],'r') as f:
     fnames = f.readlines()
-    input_size = round(sum([os.stat(l.strip('\n')).st_size for l in fnames])/1024/1024)
-    input_length = len(fnames)
-
-NCORES = [1, 2, 4]
-NREADERS = [1, 2, 4]
-NTRIALS = 3
-
-CPU_SELECTION = False 
+    INPUT_SIZE = round(sum([os.stat(l.strip('\n')).st_size for l in fnames])/1024/1024)
+    INPUT_LENGTH = len(fnames)
+    
 
 SHA256SUM_TASK = Template('cat ${file_list} | xargs -P ${n} -n1 -I{} sha256sum {}')
-
 #COMPOSITE_TASK = Template('o2-analysis-trackselection -b --pipeline track-selection:${n},track-extension:${n} --aod-file ${file_list} --readers ${n} | o2-analysistutorial-histogram-track-selection -b --pipeline histogram-track-selection:${n} --select=0')
 
-BENCHMARK_TASKS = {
-      'o2-analysistutorial-histograms': '-b --pipeline eta-and-phi-histograms:${n},pt-histogram:${n},etaphi-histogram:${n}',
-      'o2-analysis-trackselection': '-b --pipeline track-selection:${n},track_extension:${n}',
-      #'o2-analysis-vertexing-hf': '-b --pipeline vertexerhf-candidatebuildingDzero:${n},vertexerhf-decayvertexbuilder2prong:${n}',
-    }
-        
 for k in BENCHMARK_TASKS:
     BENCHMARK_TASKS[k] = Template(BENCHMARK_TASKS[k])
     
 with open(OUTPUT_CSV, 'w') as f:
     writer = csv.writer(f)
-    writer.writerow(['tname', 'ncores', 'nreaders', 'time_mean', 'time_std', 'input_size', 'input_length'])
+    writer.writerow(('tname', 'ncores', 'nreaders', 'time_mean', 'time_std', 
+                     'input_size', 'input_length', 'timestamp', 'cpu_load', 'ncpu', 'machine'))
     
     for ncores in NCORES:
         cmd_sha256sum = SHA256SUM_TASK.substitute(file_list=INPUT_FILE[1:], n=str(ncores))
         t = timeit.Timer('os.system(cmd_sha256sum)', globals=globals())
         t_res = t.repeat(NTRIALS, 1)
-        writer.writerow( ('sha256sum', ncores, -1, stat.mean(t_res), stat.stdev(t_res), input_size, input_length) )
+        writer.writerow( ('sha256sum', ncores, -1, stat.mean(t_res), get_time_std(t_res), 
+                          INPUT_SIZE, INPUT_LENGTH, get_timestamp(), get_cpu_load(), NCPU, MACHINE) )
     
     for ncores, nreaders in itertools.product(NCORES, NREADERS):
-        
-        #cmd_composite = COMPOSITE_TASK.substitute(file_list=INPUT_FILE,n=str(ncores))
-        #t = timeit.Timer('os.system(cmd_composite)', globals=globals())
-        #t_res = t.repeat(NTRIALS, 1)
-        #writer.writerow( ('analysistutorial-histogram-track-selection', ncores, nreaders, stat.mean(t_res), stat.stdev(t_res), input_size, input_length) )
-    
+
         for tname, targ in BENCHMARK_TASKS.items():
             targ = targ.substitute(n=str(ncores))
             cmd_list = [tname] + targ.split(' ')
@@ -65,13 +108,17 @@ with open(OUTPUT_CSV, 'w') as f:
                     cmd_list = ['taskset','-c','5,15'] + cmd_list
                 elif ncores == 4:
                     cmd_list = ['taskset','-c','1,3,11,13'] + cmd_list
+            
+            if LARGE_SHM_SEGMENT_SIZE:
+                cmd_list += ['--shm-segment-size', str(16000000000)]
 
             cmd_list += ['--aod-file', INPUT_FILE]
             cmd_list += ['--readers', str(nreaders)]
             
             t = timeit.Timer('subprocess.run(cmd_list)', globals=globals())
             t_res = t.repeat(NTRIALS, 1)
-            writer.writerow( (tname[3:], ncores, nreaders, stat.mean(t_res), stat.stdev(t_res), input_size, input_length) )
+            writer.writerow( (tname[3:], ncores, nreaders, stat.mean(t_res), get_time_std(t_res), 
+                              INPUT_SIZE, INPUT_LENGTH, get_timestamp(), get_cpu_load(), NCPU, MACHINE) )
 
 #alinsure
 #numa0 0-11,24-35


### PR DESCRIPTION
When at least one of bounding box dimensions of a cluster does not fit one byte, such a cluster is split into pieces that have smaller bounding boxes. The initial huge cluster is then streamed piece by piece. 