### PR TITLE
DPL Analysis: Spawns<> template for user-defined extended tables

### DIFF
--- a/Framework/Core/src/ExpressionHelpers.h
+++ b/Framework/Core/src/ExpressionHelpers.h
@@ -96,25 +96,6 @@ struct ColumnOperationSpec {
     result.type = type;
   }
 };
-
-template <typename... C>
-std::shared_ptr<gandiva::Projector> createProjectors(framework::pack<C...>, gandiva::SchemaPtr schema)
-{
-  std::shared_ptr<gandiva::Projector> projector;
-  auto s = gandiva::Projector::Make(
-    schema,
-    {makeExpression(
-      framework::expressions::createExpressionTree(
-        framework::expressions::createOperations(C::Projector()),
-        schema),
-      C::asArrowField())...},
-    &projector);
-  if (s.ok()) {
-    return projector;
-  } else {
-    throw std::runtime_error(fmt::format("Failed to create projector: {}", s.ToString()));
-  }
-}
 } // namespace o2::framework::expressions
 
 #endif // O2_FRAMEWORK_EXPRESSIONS_HELPERS_H_


### PR DESCRIPTION
* Slight rework of the spawner code to make it available not only in AODReaderHelpers
* Spawns<> template to mark the task as an origin of a particular extended table. The table is available in the originating task as well, through this template, and can be subscribed by subsequent tasks.
* Primitive example/test in filters.cxx
