### PR TITLE
[WIP] DPL: initial support for multithreading

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -48,6 +48,7 @@ struct DataProcessorContext {
   // These are specific of a given context and therefore
   // not shared by threads.
   bool* wasActive = nullptr;
+  bool allDone = false;
 
   // These are pointers to the one owned by the DataProcessingDevice
   // but they are fully reentrant / thread safe and therefore can
@@ -105,6 +106,7 @@ class DataProcessingDevice : public FairMQDevice
 
   // Processing functions are now renetrant
   static void doRun(DataProcessorContext& context);
+  static void doPrepare(DataProcessorContext& context);
   static void handleData(DataProcessorContext& context, FairMQParts&, InputChannelInfo&);
   static bool tryDispatchComputation(DataProcessorContext& context, std::vector<DataRelayer::RecordAction>& completed);
   std::vector<DataProcessorContext> mDataProcessorContexes;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -116,6 +116,7 @@ class DataProcessingDevice : public FairMQDevice
   void fillContext(DataProcessorContext& context);
 
  private:
+  std::vector<void*> mTaskHandles;
   /// The specification used to create the initial state of this device
   DeviceSpec const& mSpec;
   /// The current internal state of this device.
@@ -156,6 +157,11 @@ class DataProcessingDevice : public FairMQDevice
   std::vector<FairMQRegionInfo> mPendingRegionInfos; /// A list of the region infos not yet notified.
   enum TerminationPolicy mErrorPolicy = TerminationPolicy::WAIT; /// What to do when an error arises
   bool mWasActive = false;                                       /// Whether or not the device was active at last iteration.
+  bool mProcessingRequired = false;
+  TracyLockableN(std::mutex, mGlobalMutex, "global mutex");
+
+ public:
+  decltype(mGlobalMutex)& globalMutex() { return mGlobalMutex; }
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -17,6 +17,7 @@
 #include "Framework/RawDeviceService.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/EndOfStreamContext.h"
+#include "Framework/Tracing.h"
 
 #include <options/FairMQProgOptions.h>
 
@@ -41,6 +42,7 @@ struct CommonMessageBackendsHelpers {
   static ServiceProcessingCallback sendCallback()
   {
     return [](ProcessingContext& ctx, void* service) {
+      ZoneScopedN("send message callback");
       T* context = reinterpret_cast<T*>(service);
       auto& device = ctx.services().get<RawDeviceService>();
       DataProcessor::doSend(*device.device(), *context);

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -515,12 +515,6 @@ bool DataProcessingDevice::ConditionalRun()
 void DataProcessingDevice::doPrepare(DataProcessorContext& context)
 {
   ZoneScopedN("DataProcessingDevice::doPrepare");
-  auto switchState = [& registry = context.registry,
-                      &state = context.state->streaming](StreamingState newState) {
-    LOG(debug) << "New state " << (int)newState << " old state " << (int)state;
-    state = newState;
-    registry->get<ControlService>().notifyStreamingState(state);
-  };
   context.registry->get<DataProcessingStats>().beginIterationTimestamp = uv_hrtime() / 1000000;
 
   *context.wasActive = false;
@@ -563,10 +557,10 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
 void DataProcessingDevice::doRun(DataProcessorContext& context)
 {
   auto switchState = [& registry = context.registry,
-                      &state = context.state->streaming](StreamingState newState) {
-    LOG(debug) << "New state " << (int)newState << " old state " << (int)state;
-    state = newState;
-    registry->get<ControlService>().notifyStreamingState(state);
+                      &state = context.state](StreamingState newState) {
+    LOG(debug) << "New state " << (int)newState << " old state " << (int)state->streaming;
+    state->streaming = newState;
+    registry->get<ControlService>().notifyStreamingState(state->streaming);
   };
 
   context.completed->clear();
@@ -964,9 +958,9 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
   };
 
   auto switchState = [& control = context.registry->get<ControlService>(),
-                      &state = context.state->streaming](StreamingState newState) {
-    state = newState;
-    control.notifyStreamingState(state);
+                      &state = context.state](StreamingState newState) {
+    state->streaming = newState;
+    control.notifyStreamingState(state->streaming);
   };
 
   if (canDispatchSomeComputation() == false) {


### PR DESCRIPTION
This includes initial support for multithreading in a given device. To be done:

* Add option to specify number of threads, falling back to old
  way of running by default.
* Allocate some services per thread.
* Provide per thread initialisation.
* Remove the global lock.

At the moment this simply means you do not know on which thread the processing
will happen.