### PR TITLE
DPL: introduce forking hooks

### DIFF
--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -16,6 +16,10 @@
 namespace o2::framework
 {
 
+struct ThreadPool {
+  int poolSize;
+};
+
 /// A few ServiceSpecs for services we know about and that / are needed by
 /// everyone.
 struct CommonServices {
@@ -55,8 +59,9 @@ struct CommonServices {
   static ServiceSpec timesliceIndex();
   static ServiceSpec dataRelayer();
   static ServiceSpec tracingSpec();
+  static ServiceSpec threadPool(int numWorkers);
 
-  static std::vector<ServiceSpec> defaultServices();
+  static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
   static std::vector<ServiceSpec> requiredServices();
 };
 

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/program_options/variables_map.hpp>
+
 namespace fair::mq
 {
 struct ProgOptions;
@@ -51,6 +53,19 @@ using ServiceProcessingCallback = std::function<void(ProcessingContext&, void*)>
 /// A callback which is executed before the end of stream loop.
 using ServiceEOSCallback = std::function<void(EndOfStreamContext&, void*)>;
 
+/// Callback executed before the forking of a given device in the driver
+/// Notice the forking can happen multiple times. It's responsibility of
+/// the service to track how many times it happens and act accordingly.
+using ServicePreFork = std::function<void(ServiceRegistry&, boost::program_options::variables_map const&)>;
+
+/// Callback executed after forking a given device in the driver,
+/// but before doing exec / starting the device.
+using ServicePostForkChild = std::function<void(ServiceRegistry&)>;
+
+/// Callback executed after forking a given device in the driver,
+/// but before doing exec / starting the device.
+using ServicePostForkParent = std::function<void(ServiceRegistry&)>;
+
 /// The kind of service we are asking for
 enum struct ServiceKind {
   /// A Service which is not thread safe, therefore all accesses to it must be mutexed.
@@ -82,6 +97,17 @@ struct ServiceSpec {
   ServiceEOSCallback preEOS = nullptr;
   /// Callback executed after the end of stream callback of the user happended
   ServiceEOSCallback postEOS = nullptr;
+  /// Callback executed before the forking of a given device in the driver
+  /// Notice the forking can happen multiple times. It's responsibility of
+  /// the service to track how many times it happens and act accordingly.
+  ServicePreFork preFork = nullptr;
+  /// Callback executed after forking a given device in the driver,
+  /// but before doing exec / starting the device.
+  ServicePostForkChild postForkChild = nullptr;
+  /// Callback executed after forking a given device in the driver,
+  /// but before doing exec / starting the device.
+  ServicePostForkParent postForkParent = nullptr;
+
   /// Kind of service being specified.
   ServiceKind kind;
 };

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -83,6 +83,9 @@ o2::framework::ServiceSpec CommonMessageBackends::arrowBackendSpec()
                      CommonMessageBackendsHelpers<ArrowContext>::sendCallback(),
                      CommonMessageBackendsHelpers<ArrowContext>::clearContextEOS(),
                      CommonMessageBackendsHelpers<ArrowContext>::sendCallbackEOS(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -115,6 +118,9 @@ o2::framework::ServiceSpec CommonMessageBackends::fairMQBackendSpec()
                      CommonMessageBackendsHelpers<MessageContext>::sendCallback(),
                      CommonMessageBackendsHelpers<MessageContext>::clearContextEOS(),
                      CommonMessageBackendsHelpers<MessageContext>::sendCallbackEOS(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -127,6 +133,9 @@ o2::framework::ServiceSpec CommonMessageBackends::stringBackendSpec()
                      CommonMessageBackendsHelpers<StringContext>::sendCallback(),
                      CommonMessageBackendsHelpers<StringContext>::clearContextEOS(),
                      CommonMessageBackendsHelpers<StringContext>::sendCallbackEOS(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -139,6 +148,9 @@ o2::framework::ServiceSpec CommonMessageBackends::rawBufferBackendSpec()
                      CommonMessageBackendsHelpers<RawBufferContext>::sendCallback(),
                      CommonMessageBackendsHelpers<RawBufferContext>::clearContextEOS(),
                      CommonMessageBackendsHelpers<RawBufferContext>::sendCallbackEOS(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -27,7 +27,7 @@
 
 #include <options/FairMQProgOptions.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 using AliceO2::InfoLogger::InfoLogger;
 using AliceO2::InfoLogger::InfoLoggerContext;

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -27,6 +27,8 @@
 
 #include <options/FairMQProgOptions.h>
 
+#include <stdlib.h>
+
 using AliceO2::InfoLogger::InfoLogger;
 using AliceO2::InfoLogger::InfoLoggerContext;
 using o2::configuration::ConfigurationFactory;
@@ -48,6 +50,9 @@ o2::framework::ServiceSpec CommonServices::monitoringSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -56,6 +61,9 @@ o2::framework::ServiceSpec CommonServices::infologgerContextSpec()
   return ServiceSpec{"infologger-contex",
                      simpleServiceInit<InfoLoggerContext, InfoLoggerContext>(),
                      noConfiguration(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      nullptr,
                      nullptr,
                      nullptr,
@@ -140,6 +148,9 @@ o2::framework::ServiceSpec CommonServices::infologgerSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
+                     nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -160,6 +171,9 @@ o2::framework::ServiceSpec CommonServices::configurationSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -176,6 +190,9 @@ o2::framework::ServiceSpec CommonServices::controlSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -185,6 +202,9 @@ o2::framework::ServiceSpec CommonServices::rootFileSpec()
     "localrootfile",
     simpleServiceInit<LocalRootFileService, LocalRootFileService>(),
     noConfiguration(),
+    nullptr,
+    nullptr,
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -206,6 +226,9 @@ o2::framework::ServiceSpec CommonServices::parallelSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -219,6 +242,9 @@ o2::framework::ServiceSpec CommonServices::timesliceIndex()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -228,6 +254,9 @@ o2::framework::ServiceSpec CommonServices::callbacksSpec()
     "callbacks",
     simpleServiceInit<CallbackService, CallbackService>(),
     noConfiguration(),
+    nullptr,
+    nullptr,
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -248,6 +277,9 @@ o2::framework::ServiceSpec CommonServices::dataRelayer()
                                            services.get<TimesliceIndex>())};
     },
     noConfiguration(),
+    nullptr,
+    nullptr,
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -279,12 +311,44 @@ o2::framework::ServiceSpec CommonServices::tracingSpec()
     },
     nullptr,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
-std::vector<ServiceSpec> CommonServices::defaultServices()
+// FIXME: allow configuring the default number of threads per device
+//        This should probably be done by overriding the preFork
+//        callback and using the boost program options there to
+//        get the default number of threads.
+o2::framework::ServiceSpec CommonServices::threadPool(int numWorkers)
 {
-  return {
+  return ServiceSpec{
+    "threadpool",
+    [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      return ServiceHandle{TypeIdHelpers::uniqueId<ThreadPool>(), new ThreadPool()};
+    },
+    [numWorkers](InitContext&, void* service) -> void* {
+      ThreadPool* t = reinterpret_cast<ThreadPool*>(service);
+      t->poolSize = numWorkers;
+      return service;
+    },
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    [numWorkers](ServiceRegistry& service) -> void {
+      auto numWorkersS = std::to_string(numWorkers);
+      setenv("UV_THREADPOOL_SIZE", numWorkersS.c_str(), 0);
+    },
+    nullptr,
+    ServiceKind::Serial};
+}
+
+std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
+{
+  std::vector<ServiceSpec> specs{
     timesliceIndex(),
     monitoringSpec(),
     infologgerContextSpec(),
@@ -299,6 +363,10 @@ std::vector<ServiceSpec> CommonServices::defaultServices()
     CommonMessageBackends::arrowBackendSpec(),
     CommonMessageBackends::stringBackendSpec(),
     CommonMessageBackends::rawBufferBackendSpec()};
+  if (numThreads) {
+    specs.push_back(threadPool(numThreads));
+  }
+  return specs;
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -359,6 +359,8 @@ void spawnDevice(std::string const& forwardedStdin,
                  DeviceControl& control,
                  DeviceExecution& execution,
                  std::vector<DeviceInfo>& deviceInfos,
+                 ServiceRegistry& serviceRegistry,
+                 boost::program_options::variables_map& varmap,
                  uv_loop_t* loop,
                  std::vector<uv_poll_t*> handles)
 {
@@ -375,6 +377,11 @@ void spawnDevice(std::string const& forwardedStdin,
   // Not how the first port is actually used to broadcast clients.
   driverInfo.tracyPort++;
 
+  for (auto& service : spec.services) {
+    if (service.preFork != nullptr) {
+      service.preFork(serviceRegistry, varmap);
+    }
+  }
   // If we have a framework id, it means we have already been respawned
   // and that we are in a child. If not, we need to fork and re-exec, adding
   // the framework-id as one of the options.
@@ -401,12 +408,22 @@ void spawnDevice(std::string const& forwardedStdin,
     dup2(childstderr[1], STDERR_FILENO);
     auto portS = std::to_string(driverInfo.tracyPort);
     setenv("TRACY_PORT", portS.c_str(), 1);
+    for (auto& service : spec.services) {
+      if (service.postForkChild != nullptr) {
+        service.postForkChild(serviceRegistry);
+      }
+    }
     execvp(execution.args[0], execution.args.data());
   }
-
   // This is the parent. We close the write end of
   // the child pipe and and keep track of the fd so
   // that we can later select on it.
+  for (auto& service : spec.services) {
+    if (service.postForkParent != nullptr) {
+      service.postForkParent(serviceRegistry);
+    }
+  }
+
   struct sigaction sa_handle_int;
   sa_handle_int.sa_handler = handle_sigint;
   sigemptyset(&sa_handle_int.sa_mask);
@@ -632,8 +649,7 @@ bool processSigChild(DeviceInfos& infos)
   return hasError;
 }
 
-
-int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec, TerminationPolicy errorPolicy,
+int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry, const o2::framework::DeviceSpec& spec, TerminationPolicy errorPolicy,
             uv_loop_t* loop)
 {
   fair::Logger::SetConsoleColor(false);
@@ -653,10 +669,6 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec, Termin
         ("infologger-mode", bpo::value<std::string>()->default_value(""), "INFOLOGGER_MODE override");
       r.fConfig.AddToCmdLineOptions(optsDesc, true);
     });
-
-    // We initialise this in the driver, because different drivers might have
-    // different versions of the service
-    ServiceRegistry serviceRegistry;
 
     // This is to control lifetime. All these services get destroyed
     // when the runner is done.
@@ -753,6 +765,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                     DriverControl& driverControl,
                     DriverInfo& driverInfo,
                     std::vector<DeviceMetricsInfo>& metricsInfos,
+                    boost::program_options::variables_map& varmap,
                     std::string frameworkId)
 {
   DeviceSpecs deviceSpecs;
@@ -808,6 +821,10 @@ int runStateMachine(DataProcessorSpecs const& workflow,
 
   uv_timer_t force_step_timer;
   uv_timer_init(loop, &force_step_timer);
+
+  // We initialise this in the driver, because different drivers might have
+  // different versions of the service
+  ServiceRegistry serviceRegistry;
 
   while (true) {
     // If control forced some transition on us, we push it to the queue.
@@ -925,7 +942,9 @@ int runStateMachine(DataProcessorSpecs const& workflow,
         }
         for (auto& spec : deviceSpecs) {
           if (spec.id == frameworkId) {
-            return doChild(driverInfo.argc, driverInfo.argv, spec, driverInfo.errorPolicy, loop);
+            return doChild(driverInfo.argc, driverInfo.argv,
+                           serviceRegistry, spec,
+                           driverInfo.errorPolicy, loop);
           }
         }
         {
@@ -985,7 +1004,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
             spawnDevice(forwardedStdin.str(),
                         deviceSpecs[di], driverInfo,
                         controls[di], deviceExecutions[di], infos,
-                        loop, pollHandles);
+                        serviceRegistry, varmap, loop, pollHandles);
           }
         }
         assert(infos.empty() == false);
@@ -1645,6 +1664,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
                          driverControl,
                          driverInfo,
                          gDeviceMetricsInfos,
+                         varmap,
                          frameworkId);
 }
 


### PR DESCRIPTION
There is now three new hooks:

* Before forking.
* After forking on the parent path.
* After forking on the child path.

This will allow having services which exploit Copy-On-Write when
we get rid of the execvp.

We also use these hooks to set the number of available threads for
libuv.