### PR TITLE
DPL: Option to globally disable IPC (shared memory) in a workflow

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -49,6 +49,7 @@ struct DeviceSpecHelpers {
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
+    bool optimizeTopology = false,
     unsigned short resourcesMonitoringInterval = 0);
 
   static void dataProcessorSpecs2DeviceSpecs(
@@ -58,11 +59,12 @@ struct DeviceSpecHelpers {
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
+    bool optimizeTopology = false,
     unsigned short resourcesMonitoringInterval = 0)
   {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies,
-                                   dispatchPolicies, devices, resourceManager, uniqueWorkflowId, resourcesMonitoringInterval);
+                                   dispatchPolicies, devices, resourceManager, uniqueWorkflowId, optimizeTopology, resourcesMonitoringInterval);
   }
 
   /// Helper to provide the channel configuration string for an input channel

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -930,6 +930,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                                             deviceSpecs,
                                                             *resourceManager,
                                                             driverInfo.uniqueWorkflowId,
+                                                            !varmap["no-IPC"].as<bool>(),
                                                             driverInfo.resourcesMonitoringInterval);
 
           // This should expand nodes so that we can build a consistent DAG.
@@ -1448,6 +1449,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
     ("dump-workflow,dump", bpo::value<bool>()->zero_tokens()->default_value(false), "dump workflow as JSON")                                   //                                                                                                                                    //
     ("dump-workflow-file", bpo::value<std::string>()->default_value("-"), "file to which do the dump")                                         //                                                                                                                                      //
     ("run", bpo::value<bool>()->zero_tokens()->default_value(false), "run workflow merged so far")                                             //                                                                                                                                        //
+    ("no-IPC", bpo::value<bool>()->zero_tokens()->default_value(false), "disable IPC topology optimization")                                   //                                                                                                                                        //
     ("o2-control,o2", bpo::value<bool>()->zero_tokens()->default_value(false), "create O2 Control configuration")                              //
     ("resources-monitoring", bpo::value<unsigned short>()->default_value(0), "enable cpu/memory monitoring for provided interval in seconds"); //
   // some of the options must be forwarded by default to the device


### PR DESCRIPTION
This let's the user decide to disable IPC/shm backend optimization, which might
be sometimes needed:
a) for testing purposes and benchmarks
b) when there is not enough shared memory on a system
c) on AFS where IPC does not work well

Related to https://alice.its.cern.ch/jira/browse/O2-1549