### PR TITLE
ITS-TPC matching defines times wrt TF's 1st orbit

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -533,7 +533,7 @@ class MatchTPCITS
   bool mFieldON = true;   ///< flag for field ON/OFF
   bool mMCTruthON = false;        ///< flag availability of MC truth
 
-  o2::InteractionRecord mStartIR; ///< IR corresponding to the start of the TF
+  o2::InteractionRecord mStartIR{0, 0}; ///< IR corresponding to the start of the TF
 
   ///========== Parameters to be set externally, e.g. from CCDB ====================
   const Params* mParams = nullptr;

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -33,6 +33,10 @@
 #include "ITStracking/IOUtils.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "Headers/DataHeader.h"
+
+// RSTODO to remove once the framework will start propagating the header.firstTForbit
+#include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
 using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
@@ -239,6 +243,14 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     // worker and the underlying memory is valid throughout the whole computation
     auto fitInfo = pc.inputs().get<gsl::span<o2::ft0::RecPoints>>("fitInfo");
     mMatching.setFITInfoInp(fitInfo);
+  }
+
+  const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("trackITSROF").header);
+  mMatching.setStartIR({0, dh->firstTForbit});
+
+  //RSTODO: below is a hack, to remove once the framework will start propagating the header.firstTForbit
+  if (tracksITSROF.size()) {
+    mMatching.setStartIR(o2::raw::HBFUtils::Instance().getFirstIRofTF(tracksITSROF[0].getBCData()));
   }
 
   mMatching.run();

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -54,10 +54,10 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   IR getIRTF(uint32_t tf) const { return getIRHBF(tf * nHBFPerTF); }
 
   ///< get HBF ID corresponding to this IR
-  int64_t getHBF(const IR& rec) const;
+  uint32_t getHBF(const IR& rec) const;
 
   ///< get TF ID corresponding to this IR
-  int64_t getTF(const IR& rec) const { return getHBF(rec) / nHBFPerTF; }
+  uint32_t getTF(const IR& rec) const { return getHBF(rec) / nHBFPerTF; }
 
   ///< get TF and HB (within TF) for this IR
   std::pair<int, int> getTFandHBinTF(const IR& rec) const
@@ -65,6 +65,9 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
     auto hbf = getHBF(rec);
     return std::pair<int, int>(hbf / nHBFPerTF, hbf % nHBFPerTF);
   }
+
+  ///< get 1st IR of the TF corresponding to provided interaction record
+  IR getFirstIRofTF(const IR& rec) const { return getIRTF(getTF(rec)); }
 
   ///< get TF and HB (abs) for this IR
   std::pair<int, int> getTFandHB(const IR& rec) const

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -20,7 +20,7 @@ using namespace o2::raw;
 O2ParamImpl(o2::raw::HBFUtils);
 
 //_________________________________________________
-int64_t HBFUtils::getHBF(const IR& rec) const
+uint32_t HBFUtils::getHBF(const IR& rec) const
 {
   ///< get HBF ID corresponding to this IR
   auto diff = rec.differenceInBC(getFirstIR());


### PR DESCRIPTION
* Use DataHeader.firstTForbit in ITS/TPC matcher.
Since at the moment the DataHeader.firstTForbit is not propagated, setting of firstTForbit is duplicated by invocation of new HBFUtil method, to be removed once the framework will be fixed.

* HBFUtils getter for 1st IR of TF from arbitrary IR within TF
Also, limit TF and HBF IDs to uint32_t.