### PR TITLE
Fixes in TOF for arbitrary TF processing

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -30,11 +30,11 @@ class Digit
  public:
   Digit() = default;
 
-  Digit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label = -1, Int_t triggerorbit = 0, Int_t triggerbunch = 0);
+  Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label = -1, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0);
   ~Digit() = default;
 
   /// Get global ordering key made of
-  static ULong64_t getOrderingKey(Int_t channel, Int_t bc, Int_t /*tdc*/)
+  static ULong64_t getOrderingKey(Int_t channel, uint64_t bc, Int_t /*tdc*/)
   {
     return ((static_cast<ULong64_t>(bc) << 18) + channel); // channel in the least significant bits; then shift by 18 bits (which cover the total number of channels) to write the BC number
   }
@@ -48,8 +48,8 @@ class Digit
   uint16_t getTOT() const { return mTOT; }
   void setTOT(uint16_t tot) { mTOT = tot; }
 
-  Int_t getBC() const { return mBC; }
-  void setBC(Int_t bc) { mBC = bc; }
+  uint64_t getBC() const { return mBC; }
+  void setBC(uint64_t bc) { mBC = bc; }
 
   Int_t getLabel() const { return mLabel; }
   void setLabel(Int_t label) { mLabel = label; }
@@ -78,10 +78,10 @@ class Digit
   void setIsProblematic(bool flag) { mIsProblematic = flag; }
   bool isProblematic() const { return mIsProblematic; }
 
-  void setTriggerOrbit(int value) { mTriggerOrbit = value; }
-  int getTriggerOrbit() const { return mTriggerOrbit; }
-  void setTriggerBunch(int value) { mTriggerBunch = value; }
-  int getTriggerBunch() const { return mTriggerBunch; }
+  void setTriggerOrbit(uint32_t value) { mTriggerOrbit = value; }
+  uint32_t getTriggerOrbit() const { return mTriggerOrbit; }
+  void setTriggerBunch(uint16_t value) { mTriggerBunch = value; }
+  uint16_t getTriggerBunch() const { return mTriggerBunch; }
 
  private:
   friend class boost::serialization::access;
@@ -90,15 +90,15 @@ class Digit
   Int_t mChannel;          ///< TOF channel index
   uint16_t mTDC;           ///< TDC bin number
   uint16_t mTOT;           ///< TOT bin number
-  Int_t mBC;               ///< Bunch Crossing
+  uint64_t mBC;            ///< Bunch Crossing // RS: since it is used as absolute bunch counter from orbit 0, it has to be 64 bits
   Int_t mLabel;            ///< Index of the corresponding entry in the MC label array
   Int_t mElectronIndex;    //!/< index in electronic format
-  uint16_t mTriggerOrbit = 0;    //!< orbit id of trigger event
+  uint32_t mTriggerOrbit = 0;    //!< orbit id of trigger event // RS: orbit must be 32bits long
   uint16_t mTriggerBunch = 0;    //!< bunch id of trigger event
   Bool_t mIsUsedInCluster;       //!/< flag to declare that the digit was used to build a cluster
   Bool_t mIsProblematic = false; //!< flag to tell whether the channel of the digit was problemati; not persistent; default = ok
 
-  ClassDefNV(Digit, 2);
+  ClassDefNV(Digit, 3);
 };
 
 std::ostream& operator<<(std::ostream& stream, const Digit& dig);

--- a/Detectors/TOF/base/include/TOFBase/Strip.h
+++ b/Detectors/TOF/base/include/TOFBase/Strip.h
@@ -79,7 +79,7 @@ class Strip
   /// reset points container
   o2::tof::Digit* findDigit(ULong64_t key);
 
-  Int_t addDigit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl = 0, int triggerorbit = 0, int triggerbunch = 0); // returns the MC label
+  Int_t addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl = 0, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0); // returns the MC label
 
   void fillOutputContainer(std::vector<o2::tof::Digit>& digits);
 

--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -78,13 +78,13 @@ class WindowFiller
   // arrays with digit and MCLabels out of the current readout windows (stored to fill future readout window)
   std::vector<Digit> mFutureDigits;
 
-  void fillDigitsInStrip(std::vector<Strip>* strips, int channel, int tdc, int tot, int nbc, UInt_t istrip, Int_t triggerorbit = 0, Int_t triggerbunch = 0);
+  void fillDigitsInStrip(std::vector<Strip>* strips, int channel, int tdc, int tot, uint64_t nbc, UInt_t istrip, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0);
   //  void fillDigitsInStrip(std::vector<Strip>* strips, o2::dataformats::MCTruthContainer<o2::tof::MCLabel>* mcTruthContainer, int channel, int tdc, int tot, int nbc, UInt_t istrip, Int_t trackID, Int_t eventID, Int_t sourceID);
 
   void checkIfReuseFutureDigits();
   void checkIfReuseFutureDigitsRO();
 
-  void insertDigitInFuture(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label = 0, Int_t triggerorbit = 0, Int_t triggerbunch = 0)
+  void insertDigitInFuture(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label = 0, uint32_t triggerorbit = 0, uint16_t triggerbunch = 0)
   {
     mFutureDigits.emplace_back(channel, tdc, tot, bc, label, triggerorbit, triggerbunch);
     mFutureToBeSorted = true;

--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -50,11 +50,12 @@ class WindowFiller
 
   void resizeVectorFutureDigit(int size) { mFutureDigits.resize(size); }
 
+  void setFirstIR(const o2::InteractionRecord& ir) { mFirstIR = ir; }
+
  protected:
   // info TOF timewindow
   Int_t mReadoutWindowCurrent = 0;
-  Int_t mFirstOrbit = 0;
-  Int_t mFirstBunch = 0;
+  InteractionRecord mFirstIR{0, 0}; // reference IR (1st IR of the timeframe)
   InteractionTimeRecord mEventTime;
 
   bool mContinuous = true;

--- a/Detectors/TOF/base/src/Digit.cxx
+++ b/Detectors/TOF/base/src/Digit.cxx
@@ -16,7 +16,7 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::Digit);
 
-Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t label, Int_t triggerorbit, Int_t triggerbunch)
+Digit::Digit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t label, uint32_t triggerorbit, uint16_t triggerbunch)
   : mChannel(channel), mTDC(tdc), mTOT(tot), mBC(bc), mLabel(label), mTriggerOrbit(triggerorbit), mTriggerBunch(triggerbunch), mIsUsedInCluster(kFALSE)
 {
 }

--- a/Detectors/TOF/base/src/Strip.cxx
+++ b/Detectors/TOF/base/src/Strip.cxx
@@ -33,7 +33,7 @@ Strip::Strip(Int_t index)
 {
 }
 //_______________________________________________________________________
-Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, Int_t bc, Int_t lbl, Int_t triggerorbit, Int_t triggerbunch)
+Int_t Strip::addDigit(Int_t channel, Int_t tdc, Int_t tot, uint64_t bc, Int_t lbl, uint32_t triggerorbit, uint16_t triggerbunch)
 {
 
   // return the MC label. We pass it also as argument, but it can change in

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -100,7 +100,7 @@ void WindowFiller::reset()
   mFirstBunch = 0;
 }
 //______________________________________________________________________
-void WindowFiller::fillDigitsInStrip(std::vector<Strip>* strips, int channel, int tdc, int tot, int nbc, UInt_t istrip, Int_t triggerorbit, Int_t triggerbunch)
+void WindowFiller::fillDigitsInStrip(std::vector<Strip>* strips, int channel, int tdc, int tot, uint64_t nbc, UInt_t istrip, uint32_t triggerorbit, uint16_t triggerbunch)
 {
   (*strips)[istrip].addDigit(channel, tdc, tot, nbc, 0, triggerorbit, triggerbunch);
 }

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -96,9 +96,10 @@ void WindowFiller::reset()
   mDigitsPerTimeFrame.clear();
   mReadoutWindowData.clear();
 
-  mFirstOrbit = 0;
-  mFirstBunch = 0;
+  mFirstIR.bc = 0;
+  mFirstIR.orbit = 0;
 }
+
 //______________________________________________________________________
 void WindowFiller::fillDigitsInStrip(std::vector<Strip>* strips, int channel, int tdc, int tot, uint64_t nbc, UInt_t istrip, uint32_t triggerorbit, uint16_t triggerbunch)
 {
@@ -258,7 +259,7 @@ void WindowFiller::checkIfReuseFutureDigitsRO() // the same but using readout in
 
   for (std::vector<Digit>::reverse_iterator digit = mFutureDigits.rbegin(); digit != mFutureDigits.rend(); ++digit) {
 
-    int row = (digit->getTriggerOrbit() - mFirstOrbit) * Geo::BC_IN_ORBIT + (digit->getTriggerBunch() - mFirstBunch) + 100; // N bunch id of the trigger from timeframe start + 100 bunches
+    int row = (digit->getTriggerOrbit() - mFirstIR.orbit) * Geo::BC_IN_ORBIT + (digit->getTriggerBunch() - mFirstIR.bc) + 100; // N bunch id of the trigger from timeframe start + 100 bunches
 
     row *= Geo::BC_IN_WINDOW_INV;
 

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
@@ -52,6 +52,9 @@ class Clusterer
     Printf("mCalibApi = %p", mCalibApi);
   }
 
+  void setFirstOrbit(uint32_t orb);
+  uint32_t getFirstOrbit() const { return mFirstOrbit; }
+
  private:
   void calibrateStrip();
   void processStrip(std::vector<Cluster>& clusters, MCLabelContainer const* digitMCTruth);
@@ -66,6 +69,8 @@ class Clusterer
   void addContributingDigit(Digit* dig);
   void buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth);
   CalibApi* mCalibApi = nullptr; //! calib api to handle the TOF calibration
+  uint32_t mFirstOrbit = 0;      //! 1st orbit of the TF
+  uint64_t mBCOffset = 0;        //! 1st orbit of the TF converted to BCs
 };
 
 } // namespace tof

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Decoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Decoder.h
@@ -44,8 +44,8 @@ class Decoder : public WindowFiller
   bool open(std::string name);
 
   bool decode();
-  void readTRM(int icru, int icrate, int orbit, int bunchid);
-  void InsertDigit(int icrate, int itrm, int itdc, int ichain, int channel, int orbit, int bunchid, int time_ext, int tdc, int tot);
+  void readTRM(int icru, int icrate, uint32_t orbit, uint16_t bunchid);
+  void InsertDigit(int icrate, int itrm, int itdc, int ichain, int channel, uint32_t orbit, uint16_t bunchid, int time_ext, int tdc, int tot);
   void FillWindows();
   void clear();
 
@@ -58,7 +58,16 @@ class Decoder : public WindowFiller
   void printCrateTrailerInfo(int icru) const;
   void printHitInfo(int icru) const;
 
-  static void fromRawHit2Digit(int icrate, int itrm, int itdc, int ichain, int channel, int orbit, int bunchid, int tdc, int tot, std::array<int, 6>& digitInfo); // convert raw info in digit info (channel, tdc, tot, bc), tdc = packetHit.time + (frameHeader.frameID << 13)
+  struct DigitInfo {
+    uint64_t bcAbs;
+    int channel;
+    int tdc;
+    int tot;
+    uint32_t orbit;
+    uint16_t bc;
+  };
+
+  static void fromRawHit2Digit(int icrate, int itrm, int itdc, int ichain, int channel, uint32_t orbit, uint16_t bunchid, int tdc, int tot, DigitInfo& dinfo); // convert raw info in digit info (channel, tdc, tot, bc), tdc = packetHit.time + (frameHeader.frameID << 13)
 
   char* nextPage(void* current, int shift = 8192);
 

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -40,9 +40,6 @@ void Clusterer::process(DataReader& reader, std::vector<Cluster>& clusters, MCLa
 
   LOG(DEBUG) << "We had " << totNumDigits << " digits in this event";
   timerProcess.Stop();
-  printf("Timing:\n");
-  printf("Clusterer::process:        ");
-  timerProcess.Print();
 }
 
 //__________________________________________________
@@ -53,6 +50,7 @@ void Clusterer::calibrateStrip()
   for (int idig = 0; idig < mStripData.digits.size(); idig++) {
     //    LOG(DEBUG) << "Checking digit " << idig;
     Digit* dig = &mStripData.digits[idig];
+    dig->setBC(dig->getBC() - mBCOffset); // RS Don't use raw BC, always start from the beginning of the TF
     double calib = mCalibApi->getTimeCalibration(dig->getChannel(), dig->getTOT() * Geo::TOTBIN_NS);
     //printf("channel %d) isProblematic = %d, fractionUnderPeak = %f\n",dig->getChannel(),mCalibApi->isProblematic(dig->getChannel()),mCalibApi->getFractionUnderPeak(dig->getChannel())); // toberem
     dig->setIsProblematic(mCalibApi->isProblematic(dig->getChannel()));
@@ -257,4 +255,11 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
   c.setErrors(errY2, errZ2, errYZ);
 
   return;
+}
+
+//_____________________________________________________________________
+void Clusterer::setFirstOrbit(uint32_t orb)
+{
+  mFirstOrbit = orb;
+  mBCOffset = orb * o2::constants::lhc::LHCMaxBunches;
 }

--- a/Detectors/TOF/reconstruction/src/Decoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Decoder.cxx
@@ -112,32 +112,31 @@ void Decoder::clear()
   reset();
 }
 
-void Decoder::InsertDigit(int icrate, int itrm, int itdc, int ichain, int channel, int orbit, int bunchid, int time_ext, int tdc, int tot)
+void Decoder::InsertDigit(int icrate, int itrm, int itdc, int ichain, int channel, uint32_t orbit, uint16_t bunchid, int time_ext, int tdc, int tot)
 {
-  std::array<int, 6> digitInfo;
+  DigitInfo digitInfo;
 
   fromRawHit2Digit(icrate, itrm, itdc, ichain, channel, orbit, bunchid, time_ext + tdc, tot, digitInfo);
 
   mHitDecoded++;
 
-  int isnext = digitInfo[3] * Geo::BC_IN_WINDOW_INV;
+  uint64_t isnext = digitInfo.bcAbs * Geo::BC_IN_WINDOW_INV;
 
-  if (isnext >= MAXWINDOWS) { // accumulate all digits which are not in the first windows
-
-    insertDigitInFuture(digitInfo[0], digitInfo[1], digitInfo[2], digitInfo[3], 0, digitInfo[4], digitInfo[5]);
+  if (isnext >= uint64_t(MAXWINDOWS)) { // accumulate all digits which are not in the first windows
+    insertDigitInFuture(digitInfo.channel, digitInfo.tdc, digitInfo.tot, digitInfo.bcAbs, 0, digitInfo.orbit, digitInfo.bc);
   } else {
     std::vector<Strip>* cstrip = mStripsCurrent; // first window
-    if (isnext)
+    if (isnext) {
       cstrip = mStripsNext[isnext - 1]; // next window
-
-    UInt_t istrip = digitInfo[0] / Geo::NPADS;
+    }
+    UInt_t istrip = digitInfo.channel / Geo::NPADS;
 
     // add digit
-    fillDigitsInStrip(cstrip, digitInfo[0], digitInfo[1], digitInfo[2], digitInfo[3], istrip);
+    fillDigitsInStrip(cstrip, digitInfo.channel, digitInfo.tdc, digitInfo.tot, digitInfo.bcAbs, istrip);
   }
 }
 
-void Decoder::readTRM(int icru, int icrate, int orbit, int bunchid)
+void Decoder::readTRM(int icru, int icrate, uint32_t orbit, uint16_t bunchid)
 {
 
   if (orbit < mFirstOrbit || (orbit == mFirstOrbit && bunchid < mFirstBunch)) {
@@ -145,8 +144,9 @@ void Decoder::readTRM(int icru, int icrate, int orbit, int bunchid)
     mFirstBunch = bunchid;
   }
 
-  if (mVerbose)
+  if (mVerbose) {
     printTRMInfo(icru);
+  }
   int nhits = mUnion[icru]->frameHeader.numberOfHits;
   int time_ext = mUnion[icru]->frameHeader.frameID << 13;
   int itrm = mUnion[icru]->frameHeader.trmID;
@@ -157,37 +157,31 @@ void Decoder::readTRM(int icru, int icrate, int orbit, int bunchid)
   mUnion[icru]++;
   mIntegratedBytes[icru] += 4;
 
-  // read hits
-  Int_t channel, echannel;
-  Int_t tdc;
-  Int_t tot;
-  Int_t bc;
-  Int_t time;
-
-  std::array<int, 6> digitInfo;
+  DigitInfo digitInfo;
 
   for (int i = 0; i < nhits; i++) {
-    fromRawHit2Digit(icrate, itrm, mUnion[icru]->packedHit.tdcID, mUnion[icru]->packedHit.chain, mUnion[icru]->packedHit.channel, orbit, bunchid, time_ext + mUnion[icru]->packedHit.time, mUnion[icru]->packedHit.tot, digitInfo);
+    fromRawHit2Digit(icrate, itrm, mUnion[icru]->packedHit.tdcID, mUnion[icru]->packedHit.chain, mUnion[icru]->packedHit.channel, orbit, bunchid,
+                     time_ext + mUnion[icru]->packedHit.time, mUnion[icru]->packedHit.tot, digitInfo);
 
     mHitDecoded++;
 
     if (mVerbose)
       printHitInfo(icru);
 
-    int isnext = digitInfo[3] * Geo::BC_IN_WINDOW_INV;
+    uint64_t isnext = digitInfo.bcAbs * Geo::BC_IN_WINDOW_INV;
 
     if (isnext >= MAXWINDOWS) { // accumulate all digits which are not in the first windows
 
-      insertDigitInFuture(digitInfo[0], digitInfo[1], digitInfo[2], digitInfo[3], 0, digitInfo[4], digitInfo[5]);
+      insertDigitInFuture(digitInfo.channel, digitInfo.tdc, digitInfo.tot, digitInfo.bcAbs, 0, digitInfo.orbit, digitInfo.bc);
     } else {
       std::vector<Strip>* cstrip = mStripsCurrent; // first window
       if (isnext)
         cstrip = mStripsNext[isnext - 1]; // next window
 
-      UInt_t istrip = digitInfo[0] / Geo::NPADS;
+      UInt_t istrip = digitInfo.channel / Geo::NPADS;
 
       // add digit
-      fillDigitsInStrip(cstrip, digitInfo[0], digitInfo[1], digitInfo[2], digitInfo[3], istrip);
+      fillDigitsInStrip(cstrip, digitInfo.channel, digitInfo.tdc, digitInfo.tot, digitInfo.bcAbs, istrip);
     }
 
     mUnion[icru]++;
@@ -195,21 +189,17 @@ void Decoder::readTRM(int icru, int icrate, int orbit, int bunchid)
   }
 }
 
-void Decoder::fromRawHit2Digit(int icrate, int itrm, int itdc, int ichain, int channel, int orbit, int bunchid, int tdc, int tot, std::array<int, 6>& digitInfo)
+void Decoder::fromRawHit2Digit(int icrate, int itrm, int itdc, int ichain, int channel, uint32_t orbit, uint16_t bunchid, int tdc, int tot, Decoder::DigitInfo& dinfo)
 {
   // convert raw info in digit info (channel, tdc, tot, bc)
   // tdc = packetHit.time + (frameHeader.frameID << 13)
   int echannel = Geo::getECHFromIndexes(icrate, itrm, ichain, itdc, channel);
-  digitInfo[0] = Geo::getCHFromECH(echannel);
-  digitInfo[2] = tot;
-
-  digitInfo[3] = int(orbit * o2::tof::Geo::BC_IN_ORBIT);
-  digitInfo[3] += bunchid;
-  digitInfo[3] += tdc / 1024;
-  digitInfo[1] = tdc % 1024;
-
-  digitInfo[4] = orbit;
-  digitInfo[5] = bunchid;
+  dinfo.channel = Geo::getCHFromECH(echannel);
+  dinfo.tot = tot;
+  dinfo.bcAbs = uint64_t(orbit) * o2::tof::Geo::BC_IN_ORBIT + bunchid + tdc / 1024;
+  dinfo.tdc = tdc % 1024;
+  dinfo.orbit = orbit;
+  dinfo.bc = bunchid;
 }
 
 char* Decoder::nextPage(void* current, int shift)

--- a/Detectors/TOF/reconstruction/src/Decoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Decoder.cxx
@@ -139,9 +139,9 @@ void Decoder::InsertDigit(int icrate, int itrm, int itdc, int ichain, int channe
 void Decoder::readTRM(int icru, int icrate, uint32_t orbit, uint16_t bunchid)
 {
 
-  if (orbit < mFirstOrbit || (orbit == mFirstOrbit && bunchid < mFirstBunch)) {
-    mFirstOrbit = orbit;
-    mFirstBunch = bunchid;
+  if (orbit < mFirstIR.orbit || (orbit == mFirstIR.orbit && bunchid < mFirstIR.bc)) {
+    mFirstIR.orbit = orbit;
+    mFirstIR.bc = bunchid;
   }
 
   if (mVerbose) {
@@ -213,8 +213,8 @@ char* Decoder::nextPage(void* current, int shift)
 bool Decoder::decode() // return a vector of digits in a TOF readout window
 {
   mReadoutWindowCurrent = 0;
-  mFirstOrbit = 0;
-  mFirstBunch = 0;
+  mFirstIR.orbit = 0;
+  mFirstIR.bc = 0;
 
 #ifdef VERBOSE
   if (mVerbose)

--- a/Detectors/TOF/reconstruction/src/Encoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Encoder.cxx
@@ -179,7 +179,7 @@ void Encoder::encodeTRM(const std::vector<Digit>& summary, Int_t icrate, Int_t i
 
       if (hittimeTDC < 0) {
         LOG(ERROR) << "Negative hit encoded " << hittimeTDC << ", something went wrong in filling readout window";
-        printf("%d %d %d\n", summary[istart].getBC(), mEventCounter * Geo::BC_IN_WINDOW, summary[istart].getTDC());
+        printf("%llu %d %d\n", (unsigned long long)summary[istart].getBC(), mEventCounter * Geo::BC_IN_WINDOW, summary[istart].getTDC());
       }
       // leading time
       mUnion[icrate]->trmDataHit.time = hittimeTDC;

--- a/Detectors/TOF/workflow/include/TOFWorkflow/CompressedDecodingTask.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/CompressedDecodingTask.h
@@ -55,7 +55,7 @@ class CompressedDecodingTask : public DecoderBase, public Task
   int mNCrateOpenTF = 0;
   int mNCrateCloseTF = 0;
   bool mHasToBePosted = false;
-  int mInitOrbit = 0;
+  uint32_t mInitOrbit = 0;
   TStopwatch mTimer;
 };
 

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -67,8 +67,8 @@ void CompressedDecodingTask::postData(ProcessingContext& pc)
 
   static o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::CONTINUOUS;
 
-  LOG(INFO) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe}, roMode);
+  setFirstTFOrbit(Output{o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe}, mInitOrbit);
+  setFirstTFOrbit(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, mInitOrbit);
 
   mDecoder.clear();
 
@@ -150,7 +150,6 @@ DataProcessorSpec getCompressedDecodingSpec(const std::string& inputDesc)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back(o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe);
-  outputs.emplace_back(o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "tof-compressed-decoder",

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -28,6 +28,9 @@
 #include <memory> // for make_shared, make_unique, unique_ptr
 #include <vector>
 
+// RSTODO to remove once the framework will start propagating the header.firstTForbit
+#include "DetectorsRaw/HBFUtils.h"
+
 using namespace o2::framework;
 
 namespace o2
@@ -58,6 +61,17 @@ class TOFDPLClustererTask
     // get digit data
     auto digits = pc.inputs().get<gsl::span<o2::tof::Digit>>("tofdigits");
     auto row = pc.inputs().get<std::vector<o2::tof::ReadoutWindowData>*>("readoutwin");
+
+    auto header = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("tofdigits").header);
+    mClusterer.setFirstOrbit(header->firstTForbit);
+
+    //RSTODO: below is a hack, to remove once the framework will start propagating the header.firstTForbit
+    //Here I extract the orbit/BC from the abs.BC, since the triggerer orbit/bunch are not set. Then why they are needed?
+    if (digits.size()) {
+      auto bcabs = digits[0].getBC();
+      auto ir0 = o2::raw::HBFUtils::Instance().getFirstIRofTF({uint16_t(bcabs % Geo::BC_IN_ORBIT), uint32_t(bcabs / Geo::BC_IN_ORBIT)});
+      mClusterer.setFirstOrbit(ir0.orbit);
+    }
 
     auto labelvector = std::make_shared<std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>>();
     if (mUseMC) {
@@ -101,7 +115,7 @@ class TOFDPLClustererTask
     mClustersArray.clear();
 
     for (int i = 0; i < row->size(); i++) {
-      printf("# TOF readout window for clusterization = %d/%lu (N digits = %d)\n", i, row->size(), row->at(i).size());
+      //printf("# TOF readout window for clusterization = %d/%lu (N digits = %d)\n", i, row->size(), row->at(i).size());
       auto digitsRO = row->at(i).getBunchChannelData(digits);
 
       mReader.setDigitArray(&digitsRO);


### PR DESCRIPTION
* Ensure TOF matching uses TF 1st orbit for time reference

* Do not send ROMode for GRPUpdated from CompressedDecodingTask

* Fix TOF digit fields to allow multiple TF processing
Since the TOF digit stores as BC the absolute bunch count from orbit 0, with int32 it will overflow after ~100 s. Change it uint64_t.
Also fix the orbit/bc to uint32_t / uint16_t resp.
