### PR TITLE
DPL: move TracyClient include at the top

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -7,6 +7,10 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#ifdef DPL_ENABLE_TRACING
+#define TRACY_ENABLE
+#include <tracy/TracyClient.cpp>
+#endif
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/ChannelMatching.h"
 #include "Framework/ControlService.h"
@@ -32,10 +36,6 @@
 
 #include "ScopedExit.h"
 
-#ifdef DPL_ENABLE_TRACING
-#define TRACY_ENABLE
-#include <tracy/TracyClient.cpp>
-#endif
 #include <Framework/Tracing.h>
 
 #include <fairmq/FairMQParts.h>


### PR DESCRIPTION
Doing so avoid issues with including Tracy.hpp in the .h (to debug
yet to come mutexes).