### PR TITLE
TPC: Fix reading of TPC raw pages with interim empty pages

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -518,6 +518,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
                 continue;
               }
               ptr = current;
+            } else if (ptr == nullptr) {
+              ptr = current;
             }
             count++;
           }

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -116,8 +116,6 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
         c.timeResA[cidx] = (orgCl.getTimePacked() - orgCl.packTime(time)) & 0xFFFFFF;
         lastLeg = hit.leg;
       }
-      lastRow = hit.row;
-      lastSlice = hit.slice;
       unsigned short qtot = orgCl.qTot, qmax = orgCl.qMax;
       unsigned char sigmapad = orgCl.sigmaPadPacked, sigmatime = orgCl.sigmaTimePacked;
       if (param.rec.tpcCompressionModes & GPUSettings::CompressionTruncate) {
@@ -134,6 +132,8 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step0at
       if (k && track.Filter(y, z, hit.row)) {
         break;
       }
+      lastRow = hit.row;
+      lastSlice = hit.slice;
     }
     if (nClustersStored) {
       CAMath::AtomicAdd(&compressor.mMemory->nStoredAttachedClusters, nClustersStored);


### PR DESCRIPTION
@shahor02 : should fix the issue. The problem appeared when there was an empty page in the middle of a buffer. This happens when you have the empty HBFs in the same superpage.