### PR TITLE
[MFT] Storing parameters for MCH matching & minor adjustments

### DIFF
--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -47,6 +47,11 @@ class TrackMFT
 
   ~TrackMFT() = default;
 
+  // Track finding method
+  void setCA(Bool_t method) { mIsCA = method; }
+  const Bool_t isCA() const { return mIsCA; }
+  const Bool_t isLTF() const { return !mIsCA; }
+
   /// return Z coordinate (cm)
   Double_t getZ() const { return mZ; }
   /// set Z coordinate (cm)
@@ -182,6 +187,7 @@ class TrackMFT
   std::uint32_t mROFrame = 0;                ///< RO Frame
   Int_t mNPoints{0};                         // Number of clusters
   std::array<MCCompLabel, 10> mMCCompLabels; // constants::mft::LayersNumber = 10
+  Bool_t mIsCA = false;                      // Track finding method CA vs. LTF
 
   ClusRefs mClusRef; ///< references on clusters
 

--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -106,6 +106,7 @@ class TrackMFT
 
   /// return track parameters
   const SMatrix5& getParameters() const { return mParameters; }
+
   /// set track parameters
   void setParameters(const SMatrix5& parameters) { mParameters = parameters; }
 
@@ -159,6 +160,24 @@ class TrackMFT
   // Extrapolate this track to
   void extrapHelixToZ(double zEnd, double Field);
 
+  // Parameters and Covariances on last track clusters
+  const SMatrix5& getParametersLast() const { return mParametersLast; }
+  void setParametersLast(const SMatrix5& parameters) { mParametersLast = parameters; } // Last cluster
+  const SMatrix55& getCovariancesLast() const;
+  void setCovariancesLast(const SMatrix55& covariances);
+
+  Double_t getZLast() const { return mZLast; }
+  void setZLast(Double_t z) { mZLast = z; }
+  Double_t getXLast() const { return mParametersLast(0); }
+  Double_t getYLast() const { return mParametersLast(1); }
+  Double_t getPhiLast() const { return mParametersLast(2); }
+  Double_t getTanlLast() const { return mParametersLast(3); }
+  Double_t getInvQPtLast() const { return mParametersLast(4); }
+  Double_t getPtLast() const { return TMath::Abs(1.f / mParametersLast(4)); }
+  Double_t getInvPtLast() const { return TMath::Abs(mParametersLast(4)); }
+  Double_t getPLast() const { return getPtLast() * TMath::Sqrt(1. + getTanlLast() * getTanlLast()); }                  // return total momentum last cluster
+  Double_t getEtaLast() const { return -TMath::Log(TMath::Tan((TMath::PiOver2() - TMath::ATan(getTanlLast())) / 2)); } // return total momentum
+
  private:
   std::uint32_t mROFrame = 0;                ///< RO Frame
   Int_t mNPoints{0};                         // Number of clusters
@@ -167,6 +186,7 @@ class TrackMFT
   ClusRefs mClusRef; ///< references on clusters
 
   Double_t mZ = 0.; ///< Z coordinate (cm)
+  Double_t mZLast = 0.; ///< Z coordinate (cm) of Last cluster
 
   /// Track parameters ordered as follow:      <pre>
   /// X       = X coordinate   (cm)
@@ -175,6 +195,7 @@ class TrackMFT
   /// TANL    = tangent of \lambda (dip angle)
   /// INVQPT    = Inverse transverse momentum (GeV/c ** -1) times charge (assumed forward motion)  </pre>
   SMatrix5 mParameters; ///< \brief Track parameters
+  SMatrix5 mParametersLast; ///< \brief Track parameters at last cluster
 
   /// Covariance matrix of track parameters, ordered as follows:    <pre>
   ///  <X,X>         <Y,X>           <PHI,X>       <TANL,X>        <INVQPT,X>
@@ -183,6 +204,8 @@ class TrackMFT
   /// <X,TANL>      <Y,TANL>       <PHI,TANL>     <TANL,TANL>     <INVQPT,TANL>
   /// <X,INVQPT>   <Y,INVQPT>     <PHI,INVQPT>   <TANL,INVQPT>   <INVQPT,INVQPT>  </pre>
   SMatrix55 mCovariances;   ///< \brief Covariance matrix of track parameters
+  SMatrix55 mCovariancesLast; ///< \brief Covariance matrix of track parameters at last cluster
+
   Double_t mTrackChi2 = 0.; ///< Chi2 of the track when the associated cluster was attached
 
   // Results from quadratic regression of clusters X,Y positions

--- a/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
+++ b/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
@@ -54,6 +54,19 @@ void TrackMFT::setCovariances(const SMatrix55& covariances)
   mCovariances = covariances;
 }
 
+//__________________________________________________________________________
+const SMatrix55& TrackMFT::getCovariancesLast() const
+{
+  /// Return the covariance matrix for last cluster
+  return mCovariancesLast;
+}
+
+//__________________________________________________________________________
+void TrackMFT::setCovariancesLast(const SMatrix55& covariances)
+{
+  mCovariancesLast = covariances;
+}
+
 //_________________________________________________________________________________________________
 void TrackMFT::extrapHelixToZ(double zEnd, double Field)
 {

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
@@ -104,6 +104,11 @@ class FitterTrackMFT
 
   const Int_t getNPoints() const { return mNPoints; }
 
+  // Track finding method
+  void setCA(Bool_t method) { mIsCA = method; }
+  const Bool_t isCA() const { return mIsCA; }
+  const Bool_t isLTF() const { return !mIsCA; }
+
   // Charge and momentum from quadratic regression of clusters X,Y positions
   void setInvQPtQuadtratic(Double_t invqpt) { mInvQPtQuadtratic = invqpt; }
   const Double_t getInvQPtQuadtratic() const { return mInvQPtQuadtratic; } // Inverse charged pt
@@ -121,6 +126,7 @@ class FitterTrackMFT
   bool mRemovable = false;                        ///< flag telling if this track should be deleted
   Int_t mNPoints{0};                              // Number of clusters
   std::array<MCCompLabel, 10> mMCCompLabels;      // constants::mft::LayersNumber = 10
+  Bool_t mIsCA = false;                           // Track finding method CA vs. LTF
 
   // Results from quadratic regression of clusters X,Y positions
   // Chi2 of the quadratic regression used to estimate track pT and charge

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -39,7 +39,7 @@ enum MFTTrackModel {
 struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingParam> {
   Int_t seed = MFTTrackingSeed::DH;
   Int_t trackmodel = MFTTrackModel::Helix;
-  double sigmaboost = 1e0;
+  double sigmaboost = 1e3;
   double seedH_k = 1.0;
   double MFTRadLenghts = 0.041; // MFT average material budget within acceptance
   bool verbose = false;

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackExtrap.cxx
@@ -43,16 +43,16 @@ void TrackExtrap::linearExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   }
 
   // Compute track parameters
-  double dZ = (zEnd - trackParam->getZ());
-  double x0 = trackParam->getX();
-  double y0 = trackParam->getY();
-  double phi0 = trackParam->getPhi();
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
-  double invtanl0 = 1.0 / trackParam->getTanl();
-  double n = dZ * invtanl0;
-  double x = x0 + n * cosphi0;
-  double y = y0 + n * sinphi0;
+  auto invtanl0 = 1.0 / trackParam->getTanl();
+  auto n = dZ * invtanl0;
+  auto x = x0 + n * cosphi0;
+  auto y = y0 + n * sinphi0;
   trackParam->setX(x);
   trackParam->setY(y);
   trackParam->setZ(zEnd);
@@ -65,20 +65,23 @@ void TrackExtrap::linearExtrapToZCov(TrackParamMFT* trackParam, double zEnd, boo
   /// On return, results from the extrapolation are updated in trackParam.
 
   // Calculate the jacobian related to the track parameters extrapolated to "zEnd"
-  double dZ = (zEnd - trackParam->getZ());
-  double phi0 = trackParam->getPhi();
-  double tanl0 = trackParam->getTanl();
-  double invtanl0 = 1.0 / tanl0;
-  //  double invqpt0 = trackParam->getInvQPt();
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
+  auto tanl0 = trackParam->getTanl();
+  auto invtanl0 = 1.0 / tanl0;
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
-  // double k = TMath::Abs(o2::constants::math::B2C * getBz());
-  double n = dZ * invtanl0;
-  double m = n * invtanl0;
-  //  double theta = -invqpt0 * dZ * k * invtanl0;
-  //  auto Hz = getSignBz();
+  auto n = dZ * invtanl0;
+  auto m = n * invtanl0;
 
-  linearExtrapToZ(trackParam, zEnd);
+  // Extrapolate track parameters to "zEnd"
+  auto x = x0 + n * cosphi0;
+  auto y = y0 + n * sinphi0;
+  trackParam->setX(x);
+  trackParam->setY(y);
+  trackParam->setZ(zEnd);
 
   // Calculate Jacobian
   TMatrixD jacob(5, 5);
@@ -110,62 +113,21 @@ void TrackExtrap::quadraticExtrapToZ(TrackParamMFT* trackParam, double zEnd)
   }
 
   // Compute track parameters
-  double dZ = (zEnd - trackParam->getZ());
-  double x0 = trackParam->getX();
-  double y0 = trackParam->getY();
-  double phi0 = trackParam->getPhi();
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
-  double invtanl0 = 1.0 / trackParam->getTanl();
-  double invqpt0 = trackParam->getInvQPt();
+  auto invtanl0 = 1.0 / trackParam->getTanl();
+  auto invqpt0 = trackParam->getInvQPt();
   auto Hz = getSignBz();
-  double k = TMath::Abs(o2::constants::math::B2C * getBz());
-  double n = dZ * invtanl0;
-  double theta = -invqpt0 * dZ * k * invtanl0;
-  double deltax = n * cosphi0 - 0.5 * n * theta * Hz * sinphi0;
-  double deltay = n * sinphi0 + 0.5 * n * theta * Hz * cosphi0;
-
-  double x = x0 + deltax;
-  double y = y0 + deltay;
-  double phi = phi0 + Hz * theta;
-
-  trackParam->setX(x);
-  trackParam->setY(y);
-  trackParam->setZ(zEnd);
-  trackParam->setPhi(phi);
-}
-
-//__________________________________________________________________________
-void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
-{
-  /// Track parameters extrapolated to the plane at "zEnd" considering a helix
-  /// On return, results from the extrapolation are updated in trackParam.
-
-  if (trackParam->getZ() == zEnd) {
-    return; // nothing to be done if same z
-  }
-
-  // Compute track parameters
-  double dZ = (zEnd - trackParam->getZ());
-  double x0 = trackParam->getX();
-  double y0 = trackParam->getY();
-  double px0 = trackParam->getPx();
-  double py0 = trackParam->getPy();
-  double invtanl0 = 1.0 / trackParam->getTanl();
-  double invqpt0 = trackParam->getInvQPt();
-  auto q = trackParam->getCharge();
-  auto Hz = getSignBz();
-  double k = TMath::Abs(o2::constants::math::B2C * getBz());
-  auto invk = 1.0 / k;
-  double theta = -invqpt0 * dZ * k * invtanl0;
-  double costheta, sintheta;
-  o2::utils::sincos(theta, sintheta, costheta);
-  double deltax = Hz * py0 * invk * (1.0 - costheta) - px0 * q * invk * sintheta;
-  double deltay = -Hz * px0 * invk * (1.0 - costheta) - py0 * q * invk * sintheta;
-
-  double x = x0 + deltax;
-  double y = y0 + deltay;
-  double phi = trackParam->getPhi() + Hz * theta;
+  auto k = TMath::Abs(o2::constants::math::B2C * getBz());
+  auto n = dZ * invtanl0;
+  auto theta = -invqpt0 * dZ * k * invtanl0;
+  auto x = x0 + n * cosphi0 - 0.5 * n * theta * Hz * sinphi0;
+  auto y = y0 + n * sinphi0 + 0.5 * n * theta * Hz * cosphi0;
+  auto phi = phi0 + Hz * theta;
 
   trackParam->setX(x);
   trackParam->setY(y);
@@ -177,21 +139,34 @@ void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
 void TrackExtrap::quadraticExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool updatePropagator)
 {
 
-  // Calculate the jacobian related to the track parameters extrapolated to "zEnd"
-  double dZ = (zEnd - trackParam->getZ());
-  double phi0 = trackParam->getPhi();
-  double tanl0 = trackParam->getTanl();
-  double invtanl0 = 1.0 / tanl0;
-  double invqpt0 = trackParam->getInvQPt();
+  // Extrapolate track parameters and covariances matrix to "zEnd"
+  if (trackParam->getZ() == zEnd) {
+    return; // nothing to be done if same z
+  }
+
+  // Compute track parameters
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
-  double k = TMath::Abs(o2::constants::math::B2C * getBz());
-  double n = dZ * invtanl0;
-  double m = n * invtanl0;
-  double theta = -invqpt0 * dZ * k * invtanl0;
+  auto invtanl0 = 1.0 / trackParam->getTanl();
+  auto invqpt0 = trackParam->getInvQPt();
   auto Hz = getSignBz();
+  auto k = TMath::Abs(o2::constants::math::B2C * getBz());
+  auto n = dZ * invtanl0;
+  auto m = n * invtanl0;
+  auto theta = -invqpt0 * dZ * k * invtanl0;
 
-  quadraticExtrapToZ(trackParam, zEnd);
+  // Extrapolate track parameters to "zEnd"
+  auto x = x0 + n * cosphi0 - 0.5 * n * theta * Hz * sinphi0;
+  auto y = y0 + n * sinphi0 + 0.5 * n * theta * Hz * cosphi0;
+  auto phi = phi0 + Hz * theta;
+  trackParam->setX(x);
+  trackParam->setY(y);
+  trackParam->setZ(zEnd);
+  trackParam->setPhi(phi);
 
   // Calculate Jacobian
   TMatrixD jacob(5, 5);
@@ -217,21 +192,67 @@ void TrackExtrap::quadraticExtrapToZCov(TrackParamMFT* trackParam, double zEnd, 
 }
 
 //__________________________________________________________________________
-void TrackExtrap::helixExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool updatePropagator)
+void TrackExtrap::helixExtrapToZ(TrackParamMFT* trackParam, double zEnd)
 {
+  /// Track parameters extrapolated to the plane at "zEnd" considering a helix
+  /// On return, results from the extrapolation are updated in trackParam.
 
-  // Calculate the jacobian related to the track parameters extrapolated to "zEnd"
-  double dZ = (zEnd - trackParam->getZ());
-  double phi0 = trackParam->getPhi();
-  double tanl0 = trackParam->getTanl();
-  double invtanl0 = 1.0 / tanl0;
-  double invqpt0 = trackParam->getInvQPt();
+  if (trackParam->getZ() == zEnd) {
+    return; // nothing to be done if same z
+  }
+
+  // Compute track parameters
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
+  auto tanl0 = trackParam->getTanl();
+  auto invtanl0 = 1.0 / tanl0;
+  auto invqpt0 = trackParam->getInvQPt();
   auto qpt0 = 1.0 / invqpt0;
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
-  double k = TMath::Abs(o2::constants::math::B2C * getBz());
-  double invk = 1.0 / k;
-  double theta = -invqpt0 * dZ * k * invtanl0;
+  auto k = TMath::Abs(o2::constants::math::B2C * getBz());
+  auto invk = 1.0 / k;
+  auto theta = -invqpt0 * dZ * k * invtanl0;
+  double costheta, sintheta;
+  o2::utils::sincos(theta, sintheta, costheta);
+  auto Hz = getSignBz();
+  auto Y = sinphi0 * qpt0 * invk;
+  auto X = cosphi0 * qpt0 * invk;
+  auto YC = Y * costheta;
+  auto YS = Y * sintheta;
+  auto XC = X * costheta;
+  auto XS = X * sintheta;
+
+  // Extrapolate track parameters to "zEnd"
+  auto x = x0 + Hz * (Y - YC) - XS;
+  auto y = y0 + Hz * (-X + XC) - YS;
+  auto phi = phi0 + Hz * theta;
+  trackParam->setX(x);
+  trackParam->setY(y);
+  trackParam->setZ(zEnd);
+  trackParam->setPhi(phi);
+}
+
+//__________________________________________________________________________
+void TrackExtrap::helixExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool updatePropagator)
+{
+
+  // Extrapolate track parameters and covariances matrix to "zEnd"
+  auto dZ = (zEnd - trackParam->getZ());
+  auto x0 = trackParam->getX();
+  auto y0 = trackParam->getY();
+  auto phi0 = trackParam->getPhi();
+  auto tanl0 = trackParam->getTanl();
+  auto invtanl0 = 1.0 / tanl0;
+  auto invqpt0 = trackParam->getInvQPt();
+  auto qpt0 = 1.0 / invqpt0;
+  double cosphi0, sinphi0;
+  o2::utils::sincos(phi0, sinphi0, cosphi0);
+  auto k = TMath::Abs(o2::constants::math::B2C * getBz());
+  auto invk = 1.0 / k;
+  auto theta = -invqpt0 * dZ * k * invtanl0;
   double costheta, sintheta;
   o2::utils::sincos(theta, sintheta, costheta);
   auto Hz = getSignBz();
@@ -250,11 +271,17 @@ void TrackExtrap::helixExtrapToZCov(TrackParamMFT* trackParam, double zEnd, bool
   auto T = qpt0 * costheta;
   auto U = qpt0 * sintheta;
   auto V = qpt0;
-  double n = dZ * invtanl0;
-  double m = n * invtanl0;
+  auto n = dZ * invtanl0;
+  auto m = n * invtanl0;
 
   // Extrapolate track parameters to "zEnd"
-  helixExtrapToZ(trackParam, zEnd);
+  auto x = x0 + Hz * (Y - YC) - XS;
+  auto y = y0 + Hz * (-X + XC) - YS;
+  auto phi = phi0 + Hz * theta;
+  trackParam->setX(x);
+  trackParam->setY(y);
+  trackParam->setZ(zEnd);
+  trackParam->setPhi(phi);
 
   // Calculate Jacobian
   TMatrixD jacob(5, 5);
@@ -334,20 +361,20 @@ void TrackExtrap::addMCSEffect(TrackParamMFT* trackParam, double dZ, double x0)
   /// All scattering evaluated happens at the position of the first cluster
 
   bool debug = false;
-  double phi0 = trackParam->getPhi();
-  double tanl0 = trackParam->getTanl();
-  double invtanl0 = 1.0 / tanl0;
-  double invqpt0 = trackParam->getInvQPt();
-  double p = trackParam->getP();
+  auto phi0 = trackParam->getPhi();
+  auto tanl0 = trackParam->getTanl();
+  auto invtanl0 = 1.0 / tanl0;
+  auto invqpt0 = trackParam->getInvQPt();
+  auto p = trackParam->getP();
 
   double cosphi0, sinphi0;
   o2::utils::sincos(phi0, sinphi0, cosphi0);
 
-  double csclambda = TMath::Abs(TMath::Sqrt(1 + tanl0 * tanl0) * invtanl0);
-  double pathLengthOverX0 = x0 * csclambda;
+  auto csclambda = TMath::Abs(TMath::Sqrt(1 + tanl0 * tanl0) * invtanl0);
+  auto pathLengthOverX0 = x0 * csclambda;
 
   // Angular dispersion square of the track (variance) in a plane perpendicular to the trajectory
-  double sigmathetasq = 0.0136 * invqpt0 * (1 + 0.038 * TMath::Log(pathLengthOverX0));
+  auto sigmathetasq = 0.0136 * invqpt0 * (1 + 0.038 * TMath::Log(pathLengthOverX0));
   sigmathetasq *= sigmathetasq * pathLengthOverX0;
 
   // Get covariance matrix
@@ -358,14 +385,14 @@ void TrackExtrap::addMCSEffect(TrackParamMFT* trackParam, double dZ, double x0)
   }
 
   if (dZ > 0) {
-    double A = tanl0 * tanl0 + 1;
-    double B = dZ * cosphi0 * invtanl0;
-    double C = dZ * sinphi0 * invtanl0;
-    double D = A * B * invtanl0;
-    double E = -A * C * invtanl0;
-    double F = -C - D;
-    double G = B + E;
-    double H = -invqpt0 * tanl0;
+    auto A = tanl0 * tanl0 + 1;
+    auto B = dZ * cosphi0 * invtanl0;
+    auto C = dZ * sinphi0 * invtanl0;
+    auto D = A * B * invtanl0;
+    auto E = -A * C * invtanl0;
+    auto F = -C - D;
+    auto G = B + E;
+    auto H = -invqpt0 * tanl0;
 
     newParamCov(0, 0) += sigmathetasq * F * F;
 
@@ -408,8 +435,8 @@ void TrackExtrap::addMCSEffect(TrackParamMFT* trackParam, double dZ, double x0)
     newParamCov(4, 4) += sigmathetasq * tanl0 * tanl0 * invqpt0 * invqpt0;
   } else {
 
-    double A = tanl0 * tanl0 + 1;
-    double H = -invqpt0 * tanl0;
+    auto A = tanl0 * tanl0 + 1;
+    auto H = -invqpt0 * tanl0;
 
     newParamCov(2, 2) += sigmathetasq;
 

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -186,7 +186,7 @@ void TrackFitter::initTrack(const Cluster& cl, TrackParamMFT& param)
   if (mftTrackingParam.verbose) {
     auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
     std::cout << "Track Model: " << model << std::endl;
-    std::cout << "  initTrack: X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
+    std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
   }
 
   // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -183,24 +183,22 @@ void TrackFitter::initTrack(const Cluster& cl, TrackParamMFT& param)
         std::cout << " Init track with Seed D.\n";
       break;
   }
-
   if (mftTrackingParam.verbose) {
     auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
     std::cout << "Track Model: " << model << std::endl;
-    std::cout << "initTrack Cluster    X =  " << x0 << "   Y = " << y0 << "   Z = " << z0 << std::endl;
-    std::cout << "  seed Phi, Tanl, InvQpt = " << param.getPhi() << " " << param.getTanl() << " " << param.getInvQPt() << std::endl;
+    std::cout << "  initTrack: X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << " Tgl = " << param.getTanl() << "  Phi = " << param.getPhi() << " pz = " << param.getPz() << " qpt = " << 1.0 / param.getInvQPt() << std::endl;
   }
 
   // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)
   TMatrixD lastParamCov(5, 5);
   lastParamCov.Zero();
-  lastParamCov(0, 0) = sigmaboost * sigmax0sq;      // <X,X>
+  lastParamCov(0, 0) = sigmax0sq;                   // <X,X>
   lastParamCov(0, 1) = 0;                           // <Y,X>
   lastParamCov(0, 2) = sigmaboost * -sigmax0sq * y0 * invr0sq;      // <PHI,X>
   lastParamCov(0, 3) = sigmaboost * -z0 * sigmax0sq * x0 * invr0cu; // <TANL,X>
   lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq * invr0cu;      // <INVQPT,X>
 
-  lastParamCov(1, 1) = sigmaboost * sigmay0sq;                      // <Y,Y>
+  lastParamCov(1, 1) = sigmay0sq;                                   // <Y,Y>
   lastParamCov(1, 2) = sigmaboost * sigmay0sq * x0 * invr0sq;       // <PHI,Y>
   lastParamCov(1, 3) = sigmaboost * -z0 * sigmay0sq * y0 * invr0cu; // <TANL,Y>
   lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq * invr0cu;       //1e-2; // <INVQPT,Y>

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -95,6 +95,7 @@ void TrackFitterTask::run(ProcessingContext& pc)
   for (const auto& track : tracksCA) {
     auto& temptrack = fittertracks.at(nTracksLTF + nFailedTracksLTF + nTracksCA + nFailedTracksCA);
     convertTrack(track, temptrack, clusters);
+    temptrack.setCA(true);
     mTrackFitter->fit(temptrack, true, true) ? nTracksCA++ : nFailedTracksCA++;
   } // end fit CA tracks
 
@@ -116,7 +117,7 @@ void TrackFitterTask::run(ProcessingContext& pc)
       temptrack.setMCCompLabels(track.getMCCompLabels(), track.getNPoints());
       temptrack.setInvQPtQuadtratic(track.getInvQPtQuadtratic());
       temptrack.setChi2QPtQuadtratic(track.getChi2QPtQuadtratic());
-      //finalMFTtracks.back().printMCCompLabels();
+      temptrack.setCA(track.isCA());
       nTotalTracks++;
     }
   }


### PR DESCRIPTION
* Enables MFT track fitting smoother and stores parameters closest to the absorber: MFT-MCH track matching
* Optimized track propagation
* Minor change on track seed configuration
* Storing track finding method for each track