### PR TITLE
HepMC via configurable params, cleanup of deprecated old HepMC version

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -27,7 +27,6 @@ struct SimConfigData {
   std::string mTrigger;                      // chosen VMC generator trigger
   unsigned int mNEvents;                     // number of events to be simulated
   std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
-  std::string mHepMCFileName;                // file name of HepMC file
   std::string mExtGenFileName;               // file name containing the external generator configuration
   std::string mExtGenFuncName;               // function call to retrieve the external generator configuration
   std::string mExtTrgFileName;               // file name containing the external trigger configuration
@@ -101,7 +100,6 @@ class SimConfig
   unsigned int getNEvents() const { return mConfigData.mNEvents; }
 
   std::string getExtKinematicsFileName() const { return mConfigData.mExtKinFileName; }
-  std::string getHepMCFileName() const { return mConfigData.mHepMCFileName; }
   std::string getExtGeneratorFileName() const { return mConfigData.mExtGenFileName; }
   std::string getExtGeneratorFuncName() const { return mConfigData.mExtGenFuncName; }
   std::string getExtTriggerFileName() const { return mConfigData.mExtTrgFileName; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -31,8 +31,6 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
     "name of kinematics file for event generator from file (when applicable)")(
-    "HepMCFile", bpo::value<std::string>()->default_value("kinematics.hepmc"),
-    "name of HepMC file for event generator from file (when applicable)")(
     "extGenFile", bpo::value<std::string>()->default_value("extgen.C"),
     "name of .C file with definition of external event generator")(
     "extGenFunc", bpo::value<std::string>()->default_value(""),
@@ -94,7 +92,6 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mTrigger = vm["trigger"].as<std::string>();
   mConfigData.mNEvents = vm["nEvents"].as<unsigned int>();
   mConfigData.mExtKinFileName = vm["extKinFile"].as<std::string>();
-  mConfigData.mHepMCFileName = vm["HepMCFile"].as<std::string>();
   mConfigData.mExtGenFileName = vm["extGenFile"].as<std::string>();
   mConfigData.mExtGenFuncName = vm["extGenFunc"].as<std::string>();
   mConfigData.mExtTrgFileName = vm["extTrgFile"].as<std::string>();

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -16,10 +16,6 @@ if(pythia_FOUND)
   set(pythiaTarget MC::Pythia)
 endif()
 
-if(HepMC_FOUND)
-  set(hepmcTarget MC::HepMC)
-endif()
-
 if(HepMC3_FOUND)
   set(hepmcTarget MC::HepMC3)
 endif()
@@ -43,8 +39,8 @@ o2_add_library(Generators
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8Param.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8Param.cxx>
-                       $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMC.cxx>
+                       $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMCParam.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils
                                      O2::SimulationDataFormat ${pythia6Target} ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
@@ -56,11 +52,6 @@ endif()
 
 if(pythia_FOUND)
   target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_PYTHIA8)
-endif()
-
-if(HepMC_FOUND)
-  target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3)
-  target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3_DEPRECATED)
 endif()
 
 if(HepMC3_FOUND)
@@ -95,12 +86,9 @@ if(pythia_FOUND)
               include/Generators/GeneratorFactory.h)
 endif()
 
-if(HepMC_FOUND)
-  list(APPEND headers include/Generators/GeneratorHepMC.h)
-endif()
-
 if(HepMC3_FOUND)
   list(APPEND headers include/Generators/GeneratorHepMC.h)
+  list(APPEND headers include/Generators/GeneratorHepMCParam.h)
 endif()
 
 o2_target_root_dictionary(Generators HEADERS ${headers})

--- a/Generators/include/Generators/GeneratorHepMCParam.h
+++ b/Generators/include/Generators/GeneratorHepMCParam.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#ifndef ALICEO2_EVENTGEN_GENERATORHEPMCPARAM_H_
+#define ALICEO2_EVENTGEN_GENERATORHEPMCPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include <string>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the HepMC event generator and
+ ** allow the user to modify them 
+ **/
+
+struct GeneratorHepMCParam : public o2::conf::ConfigurableParamHelper<GeneratorHepMCParam> {
+  std::string fileName = "";
+  int version = 2;
+  O2ParamDef(GeneratorHepMCParam, "HepMC");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_GENERATORHEPMCPARAM_H_

--- a/Generators/share/egconfig/pythia8_userhooks_charm.C
+++ b/Generators/share/egconfig/pythia8_userhooks_charm.C
@@ -1,6 +1,6 @@
 // Pythia8 UserHooks
 //
-//   usage: o2sim -g pythia8 --configKeyValue "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
+//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
 //
 /// \author R+Preghenella - February 2020
 

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -28,6 +28,7 @@
 #include <Generators/GeneratorTGenerator.h>
 #ifdef GENERATORS_WITH_HEPMC3
 #include <Generators/GeneratorHepMC.h>
+#include <Generators/GeneratorHepMCParam.h>
 #endif
 #include <Generators/BoxGunParam.h>
 #include <Generators/TriggerParticle.h>
@@ -136,9 +137,12 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
 #ifdef GENERATORS_WITH_HEPMC3
   } else if (genconfig.compare("hepmc") == 0) {
     // external HepMC file
+    auto& param = GeneratorHepMCParam::Instance();
+    LOG(INFO) << "Init \'GeneratorHepMC\' with following parameters";
+    LOG(INFO) << param;
     auto hepmcGen = new o2::eventgen::GeneratorHepMC();
-    hepmcGen->setFileName(conf.getHepMCFileName());
-    hepmcGen->setVersion(2);
+    hepmcGen->setFileName(param.fileName);
+    hepmcGen->setVersion(param.version);
     primGen->AddGenerator(hepmcGen);
 #endif
 #ifdef GENERATORS_WITH_PYTHIA6

--- a/Generators/src/GeneratorHepMCParam.cxx
+++ b/Generators/src/GeneratorHepMCParam.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#include "Generators/GeneratorHepMCParam.h"
+O2ParamImpl(o2::eventgen::GeneratorHepMCParam);

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
 #ifdef GENERATORS_WITH_HEPMC3
 #pragma link C++ class o2::eventgen::GeneratorHepMC + ;
+#pragma link C++ class o2::eventgen::GeneratorHepMCParam + ;
 #endif
 #ifdef GENERATORS_WITH_PYTHIA6
 #pragma link C++ class o2::eventgen::GeneratorPythia6 + ;

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -66,22 +66,12 @@ set_package_properties(Geant4VMC PROPERTIES TYPE ${mcPackageRequirement})
 find_package(VGM MODULE)
 set_package_properties(VGM PROPERTIES TYPE ${mcPackageRequirement})
 
-find_package(HepMC MODULE)
-set_package_properties(HepMC
-		       PROPERTIES
-		       TYPE OPTIONAL DESCRIPTION
-		       "the HepMC3 event record package (deprecated old find_package call)")
-		     
 find_package(HepMC3 MODULE)
 set_package_properties(HepMC3
 		       PROPERTIES
 		       TYPE OPTIONAL DESCRIPTION
 		       "the HepMC3 event record package")
 
-if(HepMC_FOUND AND HepMC3_FOUND)
-  message(ERROR "Both HepMC3 packages have been found, something is wrong")
-endif()
-		     
 set(doBuildSimulation OFF)
 
 if(pythia_FOUND
@@ -90,7 +80,7 @@ if(pythia_FOUND
    AND Geant4_FOUND
    AND Geant4VMC_FOUND
    AND VGM_FOUND
-   AND (HepMC_FOUND OR HepMC3_FOUND))
+   AND HepMC3_FOUND)
   set(doBuildSimulation ON)
 endif()
 

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -92,6 +92,7 @@ Important parameters influencing the transport simulation are:
 | Diamond | Parameter allowing to set the interaction vertex location and the spread/width. Is used in all event generators. |
 | Pythia6 | Parameters that influence the pythia6 generator. |
 | Pythia8 | Parameters that influence the pythia8 generator. |
+| HepMC | Parameters that influence the HepMC generator. |
 | TriggerParticle | Parameters influencing the trigger mechanism in particle generators. |
 
 Detectors may also have parameters influencing various pieces such geometry layout, material composition etc.
@@ -258,7 +259,7 @@ This functionality might be of use for users who want to be able to steer the ev
 An example of a configuration macro is this one
 
 ```
-//   usage: o2sim -g pythia8 --configKeyValue "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
+//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
 
 #include "Generators/Trigger.h"
 #include "Pythia8/Pythia.h"

--- a/prodtests/embedding_benchmark.sh
+++ b/prodtests/embedding_benchmark.sh
@@ -169,13 +169,13 @@ done
 produce_background() 
 {
   echo "Running background simulation for $nevBG $collSyst events with $generBG generator and engine $engine"
-  taskwrapper sim_bg.log o2-sim -j ${NCPUS} -n"$nevBG" --configKeyValue "Diamond.width[2]=6." -g "$generBG" -e "$engine" -o o2simbg --skipModules ZDC --seed ${SEED:-1}
+  taskwrapper sim_bg.log o2-sim -j ${NCPUS} -n"$nevBG" --configKeyValues "Diamond.width[2]=6." -g "$generBG" -e "$engine" -o o2simbg --skipModules ZDC --seed ${SEED:-1}
 }
 
 produce_signal() 
 {
   echo "Running signal simulation for $nevS $collSyst events with $generS generator and engine $engine"
-  taskwrapper sim_s.log o2-sim -j ${NCPUS} -n"$nevS" --configKeyValue "Diamond.width[2]=6." -g "$generS" -e "$engine" -o o2sims --embedIntoFile o2simbg_Kine.root --skipModules ZDC --seed ${SEED:-1}
+  taskwrapper sim_s.log o2-sim -j ${NCPUS} -n"$nevS" --configKeyValues "Diamond.width[2]=6." -g "$generS" -e "$engine" -o o2sims --embedIntoFile o2simbg_Kine.root --skipModules ZDC --seed ${SEED:-1}
 }
 
 do_transport_local() 

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -221,8 +221,8 @@ o2_add_test_wrapper(NAME o2sim_hepmc
                                       2
 				      -g
 				      hepmc
-				      --HepMCFile
-				      ${CMAKE_SOURCE_DIR}/Generators/share/data/pythia.hepmc
+				      --configKeyValues
+				      "HepMC.fileName=${CMAKE_SOURCE_DIR}/Generators/share/data/pythia.hepmc;HepMC.version=2"
                                       -o
                                       o2simhepmc
                     LABELS long sim hepmc3

--- a/run/SimExamples/Adaptive_Pythia8/run.sh
+++ b/run/SimExamples/Adaptive_Pythia8/run.sh
@@ -11,7 +11,7 @@ set -x
 
 # PART a)
 NBGR=5
-o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValue \
+o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValues \
        "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
 
 # PART b)

--- a/run/SimExamples/AliRoot_Hijing/run.sh
+++ b/run/SimExamples/AliRoot_Hijing/run.sh
@@ -27,4 +27,4 @@ BMIN=0
 BMAX=20.
 o2-sim -j 20 -n ${NEV} -g extgen -m PIPE ITS TPC -o sim \
        --extGenFile "aliroot_hijing.macro" --extGenFunc "hijing(${ENERGY}, ${BMIN}, ${BMAX})" \
-       --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
+       --configKeyValues "Diamond.position[2]=0.1;Diamond.width[2]=0.05"

--- a/run/SimExamples/HepMC_STARlight/run.sh
+++ b/run/SimExamples/HepMC_STARlight/run.sh
@@ -15,5 +15,4 @@ env -i HOME="$HOME" USER="$USER" PATH="/bin:/usr/bin:/usr/local/bin" \
 # PART b)
 NEV=1000
 o2-sim -j 20 -n ${NEV} -g hepmc -m PIPE ITS -o sim \
-       --HepMCFile starlight.hepmc \
-       --configKeyValue "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
+       --configKeyValues "HepMC.fileName=starlight.hepmc;HepMC.version=2;Diamond.position[2]=0.1;Diamond.width[2]=0.05"

--- a/run/SimExamples/Jet_Embedding_Pythia8/pythia8_userhooks_jets.macro
+++ b/run/SimExamples/Jet_Embedding_Pythia8/pythia8_userhooks_jets.macro
@@ -1,6 +1,6 @@
 // Pythia8 UserHooks
 //
-//   usage: o2sim -g pythia8 --configKeyValue "Pythia8.hooksFileName=pythia8_userhooks_jets.C"
+//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_jets.C"
 //
 /// \author R+Preghenella - April 2020
 

--- a/run/SimExamples/Jet_Embedding_Pythia8/run.sh
+++ b/run/SimExamples/Jet_Embedding_Pythia8/run.sh
@@ -12,14 +12,14 @@ set -x
 
 # PART a)
 NBGR=5
-o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS TPC -o bkg --configKeyValue \
+o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS TPC -o bkg --configKeyValues \
        "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
 
 # PART b)
 # produce hard jets using a pythia8 configuration given in a file 'pythia8_hard.cfg'; event selection is done by a user hook specified
 # in file 'pythia8_userhooks_jets.macro' and using same vertex setting as background events (via --embedInto)
 NSGN=10
-o2-sim -j 20 -n ${NSGN} -g pythia8 -m PIPE ITS TPC --configKeyValue "Pythia8.config=pythia8_hard.cfg;Pythia8.hooksFileName=pythia8_userhooks_jets.macro" --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1
+o2-sim -j 20 -n ${NSGN} -g pythia8 -m PIPE ITS TPC --configKeyValues "Pythia8.config=pythia8_hard.cfg;Pythia8.hooksFileName=pythia8_userhooks_jets.macro" --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1
 
 # PART c)
 # digitization with summation of signal on top of background events

--- a/run/SimExamples/Signal_ImpactB/run.sh
+++ b/run/SimExamples/Signal_ImpactB/run.sh
@@ -11,7 +11,7 @@ set -x
 
 # PART a)
 NBGR=5
-o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValue \
+o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS -o bkg --configKeyValues \
        "Diamond.position[2]=0.1;Diamond.width[2]=0.05"
 
 # PART b)


### PR DESCRIPTION
This PR brings the following features
* clean up the temporary solution to transition to the new HepMC3 version
* HepMC is now configured via `ConfigrableParam` 
* removed the HepMC filename setup via `o2-sim` command line
* updated simulation example
* and documentation