### PR TITLE
An example of use of AMPT from AliRoot

### DIFF
--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -451,6 +451,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | Example               | Short Description                                                                      |
 | --------------------- | -------------------------------------------------------------------------------------- |
 | [AliRoot_Hijing](../run/SimExamples/AliRoot_Hijing) | Example showing how to use Hijing from AliRoot for event generation |
+| [AliRoot_AMPT](../run/SimExamples/AliRoot_AMPT) | Example showing how to use AMPT from AliRoot for event generation |
 | [Adaptive_Pythia8](../run/SimExamples/Adaptive_Pythia8) | Complex example showing **generator configuration for embedding** that cat adapt the response based on the background event |
 | [Signal_ImpactB](../run/SimExamples/Signal_ImpactB) | Example showing **generator configuration for embedding** that cat adapt to the impact parameter of the background event |
 | [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |

--- a/run/SimExamples/AliRoot_AMPT/README.md
+++ b/run/SimExamples/AliRoot_AMPT/README.md
@@ -1,0 +1,21 @@
+<!-- doxy
+\page refrunSimExamplesAliRoot_AMPT Example AliRoot_AMPT
+/doxy -->
+
+This is a complex simulation example showing how to run event simulation using the AMPT event generator interface from AliRoot.
+A wrapper class AliRoot_AMPT is defined to keep the AliGenAmpt instance and configure it.
+It also provides methods to set a random event plane before event generation and to update the event header.
+The overall setup is steered by the function `ampt(double energy = 5020., double bMin = 0., double bMax = 20.)` defined in the macro `aliroot_ampt.macro`.
+
+The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieven the configuration is specified via the argument of `--extGenFunc`.
+ 
+# IMPORTANT
+To run this example you need to load an AliRoot package compatible with the O2.
+for more details, https://alice.its.cern.ch/jira/browse/AOGM-246
+
+AliRoot needs to be loaded **after** O2 in the following sense:
+`alienv enter O2/latest,AliRoot/latest`
+The other order may show unresolved symbol problems.
+
+# WARNING
+The physics output of this simulation is not fully tested and validated.

--- a/run/SimExamples/AliRoot_AMPT/aliroot_ampt.macro
+++ b/run/SimExamples/AliRoot_AMPT/aliroot_ampt.macro
@@ -1,0 +1,103 @@
+// configures a AliGenAmpt class from AliRoot
+//   usage: o2sim -g extgen --extGenFile aliroot_ampt.macro
+// options:                 --extGenFunc aliroot_ampt(5020., 0., 20.)
+
+/// \author R+Preghenella - October 2018
+
+R__LOAD_LIBRARY(libAMPT)
+R__LOAD_LIBRARY(libTAmpt)
+
+class AliRoot_AMPT : public o2::eventgen::GeneratorTGenerator
+{
+
+public:
+
+  AliRoot_AMPT() {
+
+    // instance and configure AMPT
+    AliGenAmpt *genHi = new AliGenAmpt(-1);
+    genHi->SetEnergyCMS(5020.);
+    genHi->SetReferenceFrame("CMS");
+    genHi->SetProjectile("A", 208, 82);
+    genHi->SetTarget("A", 208, 82);
+    genHi->SetIsoft(1);  //1: defaul - 4: string melting
+    genHi->SetStringFrag(0.5, 0.9); //Lund string frgmentation parameters
+    genHi->SetPtHardMin(3);
+    genHi->SetImpactParameterRange(0., 20.);
+    
+    // Xmu = 3.2 fm^-1 and as = 0.33 ==> sigma_{partonic} = 1.5mb
+    // Ntmax = 150
+    // v_2{2} = 0.102105 +/- 0.000266894
+    // v_2{4} = 0.0829477 +/- 0.00106158
+    
+    genHi->SetNtMax(150);         // NTMAX: number of timesteps (D=150)
+    genHi->SetXmu(3.2264);        // parton screening mass in fm^(-1) (D=3.2264d0)
+    
+    genHi->SetJetQuenching(0);  // enable jet quenching
+    genHi->SetShadowing(1);     // enable shadowing
+    //  genHi->SetDecaysOff(1);     // neutral pion and heavy particle decays switched off
+    genHi->SetSpectators(0);    // track spectators
+    //Boost into LHC lab frame
+    genHi->SetBoostLHC(1);
+    //  genHi->Init();
+    genHi->SetRandomReactionPlane(kTRUE);
+
+
+    // save pointers to objects
+    mGenAMPT = genHi;
+  };
+
+  ~AliRoot_AMPT() {
+    delete mGenAMPT;
+  }
+
+  bool Init() {
+
+    // initialize AMPT
+    mGenAMPT->Init();
+    
+    // configure TGenerator interface
+    setMomentumUnit(1.);        // [GeV/c]
+    setEnergyUnit(1.);          // [GeV/c]
+    setPositionUnit(0.1);       // [cm]
+    setTimeUnit(3.3356410e-12); // [s]
+    setTGenerator(mGenAMPT->GetMC());
+
+    // initialise TGenerator interface
+    return o2::eventgen::GeneratorTGenerator::Init();
+  }
+
+  bool generateEvent() {
+    // set a random event plane
+    auto theAMPT = (TAmpt *)mGenAMPT->GetMC();
+    TRandom *r = AliAmptRndm::GetAmptRandom();
+    theAMPT->SetReactionPlaneAngle(TMath::TwoPi()*r->Rndm());
+
+    // generate the event
+    return o2::eventgen::GeneratorTGenerator::generateEvent();
+  }
+
+  void updateHeader(FairMCEventHeader* eventHeader) {
+    auto theAMPT = (TAmpt *)mGenAMPT->GetMC();
+    auto impactB = theAMPT->GetHINT1(19);
+    auto evPlane = theAMPT->GetReactionPlaneAngle();    
+    eventHeader->SetB(impactB);
+    eventHeader->SetRotX(0.);
+    eventHeader->SetRotY(0.);
+    eventHeader->SetRotZ(evPlane);
+    std::cout << " Updated the event header: impactB = " << impactB << ", evPlane = " << evPlane << std::endl;
+  };
+  
+  AliGenAmpt *mGenAMPT = nullptr;
+};
+
+
+FairGenerator*
+ampt(double energy = 5020., double bMin = 0., double bMax = 20., int isoft = 1)
+{
+  auto gen = new AliRoot_AMPT();
+  gen->mGenAMPT->SetEnergyCMS(energy);
+  gen->mGenAMPT->SetImpactParameterRange(bMin, bMax);
+  gen->mGenAMPT->SetIsoft(isoft);
+  return gen;
+}

--- a/run/SimExamples/AliRoot_AMPT/run.sh
+++ b/run/SimExamples/AliRoot_AMPT/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Please, refer to the README.md for more information
+#
+
+set -x
+
+NEV=5
+ENERGY=5020.
+BMIN=15.
+BMAX=20.
+o2-sim -j 20 -n ${NEV} -g extgen -m PIPE ITS TPC -o sim \
+       --extGenFile "aliroot_ampt.macro" --extGenFunc "ampt(${ENERGY}, ${BMIN}, ${BMAX})"

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -9,6 +9,7 @@
 * \subpage refrunSimExamplesTrigger_ImpactB_Pythia8
 * \subpage refrunSimExamplesAdaptive_Pythia8
 * \subpage refrunSimExamplesAliRoot_Hijing
+* \subpage refrunSimExamplesAliRoot_AMPT
 * \subpage refrunSimExamplesHepMC_STARlight
 * \subpage refrunSimExamplesJet_Embedding_Pythia8
 * \subpage refrunSimExamplesStepMonitoringSimple1


### PR DESCRIPTION
This is a complex simulation example showing how to run event simulation using the AMPT event generator interface from AliRoot.
A wrapper class AliRoot_AMPT is defined to keep the AliGenAmpt instance and configure it.
It also provides methods to set a random event plane before event generation and to update the event header.
The overall setup is steered by the function `ampt(double energy = 5020., double bMin = 0., double bMax = 20.)` defined in the macro `aliroot_ampt.macro`.

The macro file is specified via the argument of `--extGenFile` whereas the specific function call to retrieven the configuration is specified via the argument of `--extGenFunc`.

# IMPORTANT
To run this example you need to load an AliRoot package compatible with the O2.
for more details, https://alice.its.cern.ch/jira/browse/AOGM-246

AliRoot needs to be loaded **after** O2 in the following sense:
`alienv enter O2/latest,AliRoot/latest`
The other order may show unresolved symbol problems.

# WARNING
The physics output of this simulation is not fully tested and validated.