### PR TITLE
DPL Analysis: Allow for nested filtering and partitioning on filtered

### DIFF
--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -32,15 +32,12 @@ struct ATask {
 
   float philow = 1.0f;
   float phiup = 2.0f;
-  Partition<soa::Filtered<aod::Tracks>> leftPhiP = aod::track::phiraw < philow;
-  Partition<soa::Filtered<aod::Tracks>> midPhiP = aod::track::phiraw >= philow && aod::track::phiraw < phiup;
-  Partition<soa::Filtered<aod::Tracks>> rightPhiP = aod::track::phiraw >= phiup;
+  Partition<soa::Filtered<aod::Tracks>> leftPhi = aod::track::phiraw < philow;
+  Partition<soa::Filtered<aod::Tracks>> midPhi = aod::track::phiraw >= philow && aod::track::phiraw < phiup;
+  Partition<soa::Filtered<aod::Tracks>> rightPhi = aod::track::phiraw >= phiup;
 
   void process(aod::Collision const& collision, soa::Filtered<aod::Tracks> const& tracks)
   {
-    auto& leftPhi = leftPhiP.getPartition();
-    auto& midPhi = midPhiP.getPartition();
-    auto& rightPhi = rightPhiP.getPartition();
     LOGF(INFO, "Collision: %d [N = %d] [left phis = %d] [mid phis = %d] [right phis = %d]",
          collision.globalIndex(), tracks.size(), leftPhi.size(), midPhi.size(), rightPhi.size());
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -327,7 +327,7 @@ struct Partition {
   Partition(expressions::Node&& node)
   {
     auto filter = expressions::Filter(std::move(node));
-    auto schema = o2::soa::createSchemaFromColumns(typename T::table_t::persistent_columns_t{});
+    auto schema = o2::soa::createSchemaFromColumns(typename T::persistent_columns_t{});
     expressions::Operations ops = createOperations(filter);
     if (isSchemaCompatible(schema, ops)) {
       mTree = createExpressionTree(ops, schema);
@@ -338,7 +338,7 @@ struct Partition {
 
   void setTable(const T& table)
   {
-    mFiltered.reset(new o2::soa::Filtered<typename T::table_t>{{table.asArrowTable()}, mTree});
+    mFiltered.reset(new o2::soa::Filtered<T>{{table}, mTree});
   }
 
   template <typename... Ts>
@@ -357,13 +357,13 @@ struct Partition {
     }
   }
 
-  o2::soa::Filtered<typename T::table_t>& getPartition()
+  o2::soa::Filtered<T>& getPartition()
   {
     return *mFiltered;
   }
 
   gandiva::NodePtr mTree;
-  std::unique_ptr<o2::soa::Filtered<typename T::table_t>> mFiltered;
+  std::unique_ptr<o2::soa::Filtered<T>> mFiltered;
 };
 
 template <typename ANY>


### PR DESCRIPTION
Hi @ktf @aalkin ,
as per Anton's suggestions I've added union and intersection of Filtered selections.
Now the partitions work properly on filtered data and it is also possible to define next filters on already Filtered tables.