### PR TITLE
Simplify reconstruction of decay candidates.

### DIFF
--- a/Analysis/DataModel/include/Analysis/RecoDecay.h
+++ b/Analysis/DataModel/include/Analysis/RecoDecay.h
@@ -10,75 +10,109 @@
 #ifndef O2_ANALYSIS_RECODECAY_H_
 #define O2_ANALYSIS_RECODECAY_H_
 
-float energy(float px, float py, float pz, float mass)
+double energy(double px, double py, double pz, double mass)
 {
-  float en_ = sqrtf(mass * mass + px * px + py * py + pz * pz);
+  double en_ = sqrt(mass * mass + px * px + py * py + pz * pz);
   return en_;
 };
 
-float invmass2prongs2(float px0, float py0, float pz0, float mass0,
-                      float px1, float py1, float pz1, float mass1)
+double invmass2prongs2(double px0, double py0, double pz0, double mass0,
+                       double px1, double py1, double pz1, double mass1)
 {
 
-  float energy0_ = energy(px0, py0, pz0, mass0);
-  float energy1_ = energy(px1, py1, pz1, mass1);
-  float energytot = energy0_ + energy1_;
+  double energy0_ = energy(px0, py0, pz0, mass0);
+  double energy1_ = energy(px1, py1, pz1, mass1);
+  double energytot = energy0_ + energy1_;
 
-  float psum2 = (px0 + px1) * (px0 + px1) +
-                (py0 + py1) * (py0 + py1) +
-                (pz0 + pz1) * (pz0 + pz1);
+  double psum2 = (px0 + px1) * (px0 + px1) +
+                 (py0 + py1) * (py0 + py1) +
+                 (pz0 + pz1) * (pz0 + pz1);
   return energytot * energytot - psum2;
 };
 
-float invmass3prongs2(float px0, float py0, float pz0, float mass0,
-                      float px1, float py1, float pz1, float mass1,
-                      float px2, float py2, float pz2, float mass2)
+double invmass3prongs2(double px0, double py0, double pz0, double mass0,
+                       double px1, double py1, double pz1, double mass1,
+                       double px2, double py2, double pz2, double mass2)
 {
-  float energy0_ = energy(px0, py0, pz0, mass0);
-  float energy1_ = energy(px1, py1, pz1, mass1);
-  float energy2_ = energy(px2, py2, pz2, mass2);
-  float energytot = energy0_ + energy1_ + energy2_;
+  double energy0_ = energy(px0, py0, pz0, mass0);
+  double energy1_ = energy(px1, py1, pz1, mass1);
+  double energy2_ = energy(px2, py2, pz2, mass2);
+  double energytot = energy0_ + energy1_ + energy2_;
 
-  float psum2 = (px0 + px1 + px2) * (px0 + px1 + px2) +
-                (py0 + py1 + py2) * (py0 + py1 + py2) +
-                (pz0 + pz1 + pz2) * (pz0 + pz1 + pz2);
+  double psum2 = (px0 + px1 + px2) * (px0 + px1 + px2) +
+                 (py0 + py1 + py2) * (py0 + py1 + py2) +
+                 (pz0 + pz1 + pz2) * (pz0 + pz1 + pz2);
   return energytot * energytot - psum2;
 };
 
-float invmass2prongs(float px0, float py0, float pz0, float mass0,
-                     float px1, float py1, float pz1, float mass1)
+double invmass2prongs(double px0, double py0, double pz0, double mass0,
+                      double px1, double py1, double pz1, double mass1)
 {
   return sqrt(invmass2prongs2(px0, py0, pz0, mass0,
                               px1, py1, pz1, mass1));
 };
 
-float invmass3prongs(float px0, float py0, float pz0, float mass0,
-                     float px1, float py1, float pz1, float mass1,
-                     float px2, float py2, float pz2, float mass2)
+double invmass3prongs(double px0, double py0, double pz0, double mass0,
+                      double px1, double py1, double pz1, double mass1,
+                      double px2, double py2, double pz2, double mass2)
 {
   return sqrt(invmass3prongs2(px0, py0, pz0, mass0,
                               px1, py1, pz1, mass1,
                               px2, py2, pz2, mass2));
 };
 
-float ptcand2prong(float px0, float py0, float px1, float py1)
+double ptcand2prong(double px0, double py0, double px1, double py1)
 {
   return sqrt((px0 + px1) * (px0 + px1) + (py0 + py1) * (py0 + py1));
 };
 
-float pttrack(float px, float py)
+double pttrack(double px, double py)
 {
   return sqrt(px * px + py * py);
 };
 
-float declength(float xdecay, float ydecay, float zdecay, float xvtx, float yvtx, float zvtx)
+double declength(double xdecay, double ydecay, double zdecay, double xvtx, double yvtx, double zvtx)
 {
-  return sqrtf((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx) + (zdecay - zvtx) * (zdecay - zvtx));
+  return sqrt((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx) + (zdecay - zvtx) * (zdecay - zvtx));
 };
 
-float declengthxy(float xdecay, float ydecay, float xvtx, float yvtx)
+double declengthxy(double xdecay, double ydecay, double xvtx, double yvtx)
 {
-  return sqrtf((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx));
+  return sqrt((xdecay - xvtx) * (xdecay - xvtx) + (ydecay - yvtx) * (ydecay - yvtx));
 };
+
+/// Add a track object to a list.
+/// \param list      vector of track objects
+/// \param momentum  3-momentum components (x, y, z)
+/// \param temporal  mass or energy (depends on the vector type)
+template <typename T, typename U, typename V>
+void addTrack(std::vector<T>& list, U momentum_x, U momentum_y, U momentum_z, V temporal)
+{
+  T track(momentum_x, momentum_y, momentum_z, temporal);
+  list.push_back(track);
+}
+
+/// Add a track object to a list.
+/// \param list      vector of track objects
+/// \param momentum  array of 3-momentum components (x, y, z)
+/// \param temporal  mass or energy (depends on the vector type)
+template <typename T, typename U, typename V>
+void addTrack(std::vector<T>& list, const std::array<U, 3>& momentum, V temporal)
+{
+  addTrack(list, momentum[0], momentum[1], momentum[2], temporal);
+}
+
+/// Sum up track objects in a list.
+/// \param list  vector of track objects
+/// \return      Return the sum of the vector elements.
+template <typename T>
+T sumOfTracks(const std::vector<T>& list)
+{
+  T sum;
+  for (const auto& track : list) {
+    sum += track;
+  }
+  return sum;
+}
 
 #endif // O2_ANALYSIS_RECODECAY_H_

--- a/Analysis/DataModel/include/Analysis/trackUtilities.h
+++ b/Analysis/DataModel/include/Analysis/trackUtilities.h
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Utilities for manipulating track parameters
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, CERN
+
+#ifndef O2_ANALYSIS_TRACKUTILITIES_H_
+#define O2_ANALYSIS_TRACKUTILITIES_H_
+
+template <typename T>
+auto getTrackParCov(T track)
+{
+  std::array<float, 5> arraypar = {track.y(), track.z(), track.snp(),
+                                   track.tgl(), track.signed1Pt()};
+  std::array<float, 15> covpar = {track.cYY(), track.cZY(), track.cZZ(),
+                                  track.cSnpY(), track.cSnpZ(),
+                                  track.cSnpSnp(), track.cTglY(), track.cTglZ(),
+                                  track.cTglSnp(), track.cTglTgl(),
+                                  track.c1PtY(), track.c1PtZ(), track.c1PtSnp(),
+                                  track.c1PtTgl(), track.c1Pt21Pt2()};
+  return o2::track::TrackParCov(track.x(), track.alpha(), std::move(arraypar), std::move(covpar));
+}
+
+#endif // O2_ANALYSIS_TRACKUTILITIES_H_

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -19,6 +19,7 @@
 
 #include <TFile.h>
 #include <TH1F.h>
+#include <Math/Vector4D.h>
 #include <cmath>
 #include <array>
 #include <cstdlib>
@@ -27,6 +28,7 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
+using namespace ROOT::Math;
 
 struct HFCandidateCreator2Prong {
   Produces<aod::HfCandProng2> hfcandprong2;
@@ -57,6 +59,10 @@ struct HFCandidateCreator2Prong {
     df.setMinParamChange(d_minparamchange);
     df.setMinRelChi2Change(d_minrelchi2change);
 
+    std::vector<PxPyPzMVector> listTracks;
+    double masspion = 0.140;
+    double masskaon = 0.494;
+
     for (auto& hfpr2 : hftrackindexprong2s) {
       auto trackparvar_p1 = getTrackParCov(hfpr2.index0());
       auto trackparvar_n1 = getTrackParCov(hfpr2.index1());
@@ -69,16 +75,15 @@ struct HFCandidateCreator2Prong {
       std::array<float, 3> pvec1;
       df.getTrack(0).getPxPyPzGlo(pvec0);
       df.getTrack(1).getPxPyPzGlo(pvec1);
-      float masspion = 0.140;
-      float masskaon = 0.494;
-      float mass_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
-                                         pvec0[2], masspion,
-                                         pvec1[0], pvec1[1],
-                                         pvec1[2], masskaon));
-      float masssw_ = sqrt(invmass2prongs2(pvec0[0], pvec0[1],
-                                           pvec0[2], masskaon,
-                                           pvec1[0], pvec1[1],
-                                           pvec1[2], masspion));
+
+      addTrack(listTracks, pvec0, masspion);
+      addTrack(listTracks, pvec1, masskaon);
+      double mass_ = (sumOfTracks(listTracks)).M();
+      listTracks[0].SetM(masskaon);
+      listTracks[1].SetM(masspion);
+      double masssw_ = (sumOfTracks(listTracks)).M();
+      listTracks.clear();
+
       hfcandprong2(collision.posX(), collision.posY(), collision.posZ(),
                    pvec0[0], pvec0[1], pvec0[2], pvec1[0], pvec1[1], pvec1[2],
                    vtx[0], vtx[1], vtx[2], mass_, masssw_);

--- a/Analysis/Tasks/hfcandidatecreator2prong.cxx
+++ b/Analysis/Tasks/hfcandidatecreator2prong.cxx
@@ -15,6 +15,7 @@
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "Analysis/RecoDecay.h"
+#include "Analysis/trackUtilities.h"
 
 #include <TFile.h>
 #include <TH1F.h>
@@ -57,29 +58,8 @@ struct HFCandidateCreator2Prong {
     df.setMinRelChi2Change(d_minrelchi2change);
 
     for (auto& hfpr2 : hftrackindexprong2s) {
-      float x_p1 = hfpr2.index0().x();
-      float alpha_p1 = hfpr2.index0().alpha();
-      std::array<float, 5> arraypar_p1 = {hfpr2.index0().y(), hfpr2.index0().z(), hfpr2.index0().snp(),
-                                          hfpr2.index0().tgl(), hfpr2.index0().signed1Pt()};
-      std::array<float, 15> covpar_p1 = {hfpr2.index0().cYY(), hfpr2.index0().cZY(), hfpr2.index0().cZZ(),
-                                         hfpr2.index0().cSnpY(), hfpr2.index0().cSnpZ(),
-                                         hfpr2.index0().cSnpSnp(), hfpr2.index0().cTglY(), hfpr2.index0().cTglZ(),
-                                         hfpr2.index0().cTglSnp(), hfpr2.index0().cTglTgl(),
-                                         hfpr2.index0().c1PtY(), hfpr2.index0().c1PtZ(), hfpr2.index0().c1PtSnp(),
-                                         hfpr2.index0().c1PtTgl(), hfpr2.index0().c1Pt21Pt2()};
-      o2::track::TrackParCov trackparvar_p1(x_p1, alpha_p1, arraypar_p1, covpar_p1);
-
-      float x_n1 = hfpr2.index1().x();
-      float alpha_n1 = hfpr2.index1().alpha();
-      std::array<float, 5> arraypar_n1 = {hfpr2.index1().y(), hfpr2.index1().z(), hfpr2.index1().snp(),
-                                          hfpr2.index1().tgl(), hfpr2.index1().signed1Pt()};
-      std::array<float, 15> covpar_n1 = {hfpr2.index1().cYY(), hfpr2.index1().cZY(), hfpr2.index1().cZZ(),
-                                         hfpr2.index1().cSnpY(), hfpr2.index1().cSnpZ(),
-                                         hfpr2.index1().cSnpSnp(), hfpr2.index1().cTglY(), hfpr2.index1().cTglZ(),
-                                         hfpr2.index1().cTglSnp(), hfpr2.index1().cTglTgl(),
-                                         hfpr2.index1().c1PtY(), hfpr2.index1().c1PtZ(), hfpr2.index1().c1PtSnp(),
-                                         hfpr2.index1().c1PtTgl(), hfpr2.index1().c1Pt21Pt2()};
-      o2::track::TrackParCov trackparvar_n1(x_n1, alpha_n1, arraypar_n1, covpar_n1);
+      auto trackparvar_p1 = getTrackParCov(hfpr2.index0());
+      auto trackparvar_n1 = getTrackParCov(hfpr2.index1());
       df.setUseAbsDCA(true);
       int nCand = df.process(trackparvar_p1, trackparvar_n1);
       if (nCand == 0)

--- a/Analysis/Tasks/hftrackindexskimscreator.cxx
+++ b/Analysis/Tasks/hftrackindexskimscreator.cxx
@@ -15,6 +15,7 @@
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "Analysis/RecoDecay.h"
+#include "Analysis/trackUtilities.h"
 
 #include <TFile.h>
 #include <TH1F.h>
@@ -67,17 +68,7 @@ struct SelectTracks {
       if (!isselected_0)
         status = 0;
       array<float, 2> dca;
-      float x0_ = track_0.x();
-      float alpha0_ = track_0.alpha();
-      std::array<float, 5> arraypar0 = {track_0.y(), track_0.z(), track_0.snp(),
-                                        track_0.tgl(), track_0.signed1Pt()};
-      std::array<float, 15> covpar0 = {track_0.cYY(), track_0.cZY(), track_0.cZZ(),
-                                       track_0.cSnpY(), track_0.cSnpZ(),
-                                       track_0.cSnpSnp(), track_0.cTglY(), track_0.cTglZ(),
-                                       track_0.cTglSnp(), track_0.cTglTgl(),
-                                       track_0.c1PtY(), track_0.c1PtZ(), track_0.c1PtSnp(),
-                                       track_0.c1PtTgl(), track_0.c1Pt21Pt2()};
-      o2::track::TrackParCov trackparvar0(x0_, alpha0_, arraypar0, covpar0);
+      auto trackparvar0 = getTrackParCov(track_0);
       trackparvar0.propagateParamToDCA(vtxXYZ, d_bz, &dca);
       if (abs(dca[0]) < dcatoprimxymin)
         status = 0;
@@ -150,32 +141,12 @@ struct HFTrackIndexSkimsCreator {
       auto& track_p1 = *i_p1;
       if (track_p1.signed1Pt() < 0)
         continue;
-      float x_p1 = track_p1.x();
-      float alpha_p1 = track_p1.alpha();
-      std::array<float, 5> arraypar_p1 = {track_p1.y(), track_p1.z(), track_p1.snp(),
-                                          track_p1.tgl(), track_p1.signed1Pt()};
-      std::array<float, 15> covpar_p1 = {track_p1.cYY(), track_p1.cZY(), track_p1.cZZ(),
-                                         track_p1.cSnpY(), track_p1.cSnpZ(),
-                                         track_p1.cSnpSnp(), track_p1.cTglY(), track_p1.cTglZ(),
-                                         track_p1.cTglSnp(), track_p1.cTglTgl(),
-                                         track_p1.c1PtY(), track_p1.c1PtZ(), track_p1.c1PtSnp(),
-                                         track_p1.c1PtTgl(), track_p1.c1Pt21Pt2()};
-      o2::track::TrackParCov trackparvar_p1(x_p1, alpha_p1, arraypar_p1, covpar_p1);
+      auto trackparvar_p1 = getTrackParCov(track_p1);
       for (auto i_n1 = tracks.begin(); i_n1 != tracks.end(); ++i_n1) {
         auto& track_n1 = *i_n1;
         if (track_n1.signed1Pt() > 0)
           continue;
-        float x_n1 = track_n1.x();
-        float alpha_n1 = track_n1.alpha();
-        std::array<float, 5> arraypar_n1 = {track_n1.y(), track_n1.z(), track_n1.snp(),
-                                            track_n1.tgl(), track_n1.signed1Pt()};
-        std::array<float, 15> covpar_n1 = {track_n1.cYY(), track_n1.cZY(), track_n1.cZZ(),
-                                           track_n1.cSnpY(), track_n1.cSnpZ(),
-                                           track_n1.cSnpSnp(), track_n1.cTglY(), track_n1.cTglZ(),
-                                           track_n1.cTglSnp(), track_n1.cTglTgl(),
-                                           track_n1.c1PtY(), track_n1.c1PtZ(), track_n1.c1PtSnp(),
-                                           track_n1.c1PtTgl(), track_n1.c1Pt21Pt2()};
-        o2::track::TrackParCov trackparvar_n1(x_n1, alpha_n1, arraypar_n1, covpar_n1);
+        auto trackparvar_n1 = getTrackParCov(track_n1);
         df.setUseAbsDCA(true);
         int nCand = df.process(trackparvar_p1, trackparvar_n1);
         if (nCand == 0)
@@ -206,8 +177,6 @@ struct HFTrackIndexSkimsCreator {
             auto& track_p2 = *i_p2;
             if (track_p2.signed1Pt() < 0)
               continue;
-            float x_p2 = track_p2.x();
-            float alpha_p2 = track_p2.alpha();
             double mass3prong2 = invmass3prongs2(track_p1.px(), track_p1.py(), track_p1.pz(), masspion,
                                                  track_n1.px(), track_n1.py(), track_n1.pz(), masskaon,
                                                  track_p2.px(), track_p2.py(), track_p2.pz(), masspion);
@@ -215,15 +184,7 @@ struct HFTrackIndexSkimsCreator {
               continue;
             if (b_dovalplots == true)
               hmass3->Fill(sqrt(mass3prong2));
-            std::array<float, 5> arraypar_p2 = {track_p2.y(), track_p2.z(), track_p2.snp(),
-                                                track_p2.tgl(), track_p2.signed1Pt()};
-            std::array<float, 15> covpar_p2 = {track_p2.cYY(), track_p2.cZY(), track_p2.cZZ(),
-                                               track_p2.cSnpY(), track_p2.cSnpZ(),
-                                               track_p2.cSnpSnp(), track_p2.cTglY(), track_p2.cTglZ(),
-                                               track_p2.cTglSnp(), track_p2.cTglTgl(),
-                                               track_p2.c1PtY(), track_p2.c1PtZ(), track_p2.c1PtSnp(),
-                                               track_p2.c1PtTgl(), track_p2.c1Pt21Pt2()};
-            o2::track::TrackParCov trackparvar_p2(x_p2, alpha_p2, arraypar_p2, covpar_p2);
+            auto trackparvar_p2 = getTrackParCov(track_p2);
             df3.setUseAbsDCA(true);
             int nCand3 = df3.process(trackparvar_p1, trackparvar_n1, trackparvar_p2);
             if (nCand3 == 0)
@@ -254,23 +215,13 @@ struct HFTrackIndexSkimsCreator {
             auto& track_n2 = *i_n2;
             if (track_n2.signed1Pt() > 0)
               continue;
-            float x_n2 = track_n2.x();
-            float alpha_n2 = track_n2.alpha();
             double mass3prong2 = invmass3prongs2(track_n1.px(), track_n1.py(), track_n1.pz(), masspion,
                                                  track_p1.px(), track_p1.py(), track_p1.pz(), masskaon,
                                                  track_n2.px(), track_n2.py(), track_n2.pz(), masspion);
             if (mass3prong2 < d_minmassDp * d_minmassDp || mass3prong2 > d_maxmassDp * d_maxmassDp)
               continue;
             hmass3->Fill(sqrt(mass3prong2));
-            std::array<float, 5> arraypar_n2 = {track_n2.y(), track_n2.z(), track_n2.snp(),
-                                                track_n2.tgl(), track_n2.signed1Pt()};
-            std::array<float, 15> covpar_n2 = {track_n2.cYY(), track_n2.cZY(), track_n2.cZZ(),
-                                               track_n2.cSnpY(), track_n2.cSnpZ(),
-                                               track_n2.cSnpSnp(), track_n2.cTglY(), track_n2.cTglZ(),
-                                               track_n2.cTglSnp(), track_n2.cTglTgl(),
-                                               track_n2.c1PtY(), track_n2.c1PtZ(), track_n2.c1PtSnp(),
-                                               track_n2.c1PtTgl(), track_n2.c1Pt21Pt2()};
-            o2::track::TrackParCov trackparvar_n2(x_n2, alpha_n2, arraypar_n2, covpar_n2);
+            auto trackparvar_n2 = getTrackParCov(track_n2);
             df3.setUseAbsDCA(true);
             int nCand3 = df3.process(trackparvar_n1, trackparvar_p1, trackparvar_n2);
             if (nCand3 == 0)


### PR DESCRIPTION
* Add function getTrackParCov to construct a TrackParCov object from track parameters.
* Simplify manipulation with 4-momenta of daughter prongs of a decay candidate using the ROOT classes.