### PR TITLE
fix in tof decoding to recover first readout window

### DIFF
--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -157,6 +157,8 @@ void WindowFiller::flushOutputContainer(std::vector<Digit>& digits)
 
   printf("Future digits = %lu\n", mFutureDigits.size());
 
+  checkIfReuseFutureDigitsRO();
+
   if (!mContinuous)
     fillOutputContainer(digits);
   else {


### PR DESCRIPTION
This is needed to fix a bug which excluded the first digits during decoding.
With the fix the error messages "Digit lost because we jump too ahead in future" (traced also in PR 3972) are no longer present.
