### PR TITLE
[EMCAL-658] Fix calculation of pos. in sm from global pos

### DIFF
--- a/Detectors/EMCAL/base/CMakeLists.txt
+++ b/Detectors/EMCAL/base/CMakeLists.txt
@@ -36,3 +36,7 @@ o2_add_test(Mapper
             COMPONENT_NAME emcal
             LABELS emcal
             ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+            
+o2_add_test_root_macro(test/testGeometryRowColIndexing.C
+            PUBLIC_LINK_LIBRARIES O2::EMCALBase
+            LABELS emcal)

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -186,9 +186,19 @@ class Geometry
   Float_t GetDCALStandardPhiMax() const { return mDCALStandardPhiMax; }
   Int_t GetNECLayers() const { return mNECLayers; }
   Float_t GetDCALInnerExtandedEta() const { return mDCALInnerExtandedEta; }
+
+  /// \brief Get the number of modules in supermodule in z- (beam) direction
+  /// \return Number of modules
   Int_t GetNZ() const { return mNZ; }
+
+  /// \brief Get the number of modules in supermodule in #eta direction
+  /// \return Number of modules
   Int_t GetNEta() const { return mNZ; }
+
+  /// \brief Get the number of modules in supermodule in #phi direction
+  /// \return Number of modules
   Int_t GetNPhi() const { return mNPhi; }
+
   Float_t GetECPbRadThick() const { return mECPbRadThickness; }
   Float_t GetECScintThick() const { return mECScintThick; }
   Float_t GetSampling() const { return mSampling; }
@@ -336,34 +346,40 @@ class Geometry
   /// \brief get (Column,Row) pair of cell in global numbering scheme
   /// \param cellID Absolute cell ID
   /// \return tuple with position in global numbering scheme (0 - row, 1 - column)
+  /// \throw InvalidCellIDException
   std::tuple<int, int> GlobalRowColFromIndex(int cellID) const;
 
   /// \brief Get column number of cell in global numbering scheme
   /// \param cellID Absolute cell ID
   /// \return Column number in global numbering scheme
+  /// \throw InvalidCellIDException
   int GlobalCol(int cellID) const;
 
   /// \brief Get row number of cell in global numbering scheme
   /// \param cellID Absolute cell ID
   /// \return Row number in global numbering scheme
+  /// \throw InvalidCellIDException
   int GlobalRow(int cellID) const;
 
   /// \brief Get the absolute cell ID from global position in the EMCAL
   /// \param row Global row ID
   /// \param col Global col ID
   /// \return absolute cell ID
+  /// \throw RowColException
   int GetCellAbsIDFromGlobalRowCol(int row, int col) const;
 
   /// \brief Get the posision (row, col) of a global row-col position
   /// \param row Global row ID
   /// \param col Global col ID
   /// \return Position in supermodule: [0 - supermodule ID, 1 - row in supermodule - col in supermodule]
+  /// \throw RowColException
   std::tuple<int, int, int> GetPositionInSupermoduleFromGlobalRowCol(int col, int row) const;
 
   /// \brief Get the cell indices from global position in the EMCAL
   /// \param row Global row ID
   /// \param col Global col ID
   /// \return Cell indices [0 - supermodule, 1 - module, 2 - phi in module, 3 - eta in module]
+  /// \throw RowColException
   std::tuple<int, int, int, int> GetCellIndexFromGlobalRowCol(int row, int col) const;
 
   /// \brief Given a global eta/phi point check if it belongs to a supermodule covered region.

--- a/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
@@ -189,6 +189,40 @@ class SupermoduleIndexException : public std::exception
   std::string mMessage;  ///< Error message
 };
 
+/// \class RowColException
+/// \brief Handling error for invalid positions in row-column space
+/// \ingroup EMCALBase
+class RowColException : public std::exception
+{
+ public:
+  /// \brief Constructor, initializing the exception with invalid row-column position
+  /// \param row Row ID of the position
+  /// \param col Column ID of the position
+  RowColException(int row, int col) : mRow(row), mCol(col), mMessage("")
+  {
+    mMessage = "Invalid position: row " + std::to_string(mRow) + ", col " + std::to_string(mCol);
+  }
+
+  /// \brief Destructor
+  ~RowColException() noexcept final = default;
+
+  /// \brief Get row of the position raising the exception
+  /// \return Row ID
+  int getRow() const noexcept { return mRow; }
+
+  /// \brief Get column of the position raising the exception
+  /// \brief Column ID
+  int getCol() const noexcept { return mCol; }
+
+  /// \brief Access tp error message of the exception
+  /// \return Error message
+  const char* what() const noexcept final { return mMessage.data(); }
+
+ private:
+  int mRow, mCol;
+  std::string mMessage;
+};
+
 } // namespace emcal
 } // namespace o2
 

--- a/Detectors/EMCAL/base/test/testGeometryRowColIndexing.C
+++ b/Detectors/EMCAL/base/test/testGeometryRowColIndexing.C
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction
+
+void testGeometryRowColIndexing()
+{
+  auto geo = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+  TH1* habsid = new TH1D("hAbsID", "Cell abs ID", 20001, -0.5, 20000.5);
+  TH1* hsmod = new TH1D("hsmod", "Supermodule ID", 21, -0.5, 20.5);
+  for (int icol = 0; icol < 96; icol++) {
+    for (int irow = 0; irow < 208; irow++) {
+      // exclude PHOS hole
+      if (icol >= 32 && icol < 64 && irow >= 128 && irow < 200)
+        continue;
+      int absID = geo->GetCellAbsIDFromGlobalRowCol(irow, icol);
+      habsid->Fill(absID);
+      auto [smod, mod, iphi, ieta] = geo->GetCellIndexFromGlobalRowCol(irow, icol);
+      hsmod->Fill(smod);
+      std::cout << "Col " << icol << ", row " << irow << ": ID " << absID << ", sm " << smod << ", module " << mod << ", iphi " << iphi << ", ieta " << ieta << std::endl;
+    }
+  }
+  auto plot = new TCanvas("geotest", "Geometry test", 1200, 700);
+  plot->Divide(2, 1);
+  plot->cd(1);
+  habsid->Draw();
+  plot->cd(2);
+  hsmod->Draw();
+  plot->cd();
+  plot->Update();
+}


### PR DESCRIPTION

- Fix calculation of SM ID (GetEta and GetPhi returning
  number of modules, not towers)
- Fix column shift of the DCAL odd supermodules
- Add exception for invalid row-col position, either with
  row/col outside the valid area or within the PHOS hole
- Throw InvalidCellIDException for cell index outside range