### PR TITLE
Accept missing Data[Input,Output]Director in json file

### DIFF
--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -207,8 +207,8 @@ bool DataInputDirector::readJsonDocument(Document* jsonDoc)
   itemName = "InputDirector";
   const Value& didirItem = (*jsonDoc)[itemName];
   if (!didirItem.IsObject()) {
-    LOGP(ERROR, "Check the JSON document! Couldn't find an \"{}\" object!", itemName);
-    return false;
+    LOGP(INFO, "No \"{}\" object found in the JSON document!", itemName);
+    return true;
   }
 
   // now read various items

--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -265,7 +265,7 @@ std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(D
   itemName = "OutputDirector";
   const Value& dodirItem = (*jsonDocument)[itemName];
   if (!dodirItem.IsObject()) {
-    LOGP(ERROR, "Check the JSON document! Couldn't find an \"{}\" object!", itemName);
+    LOGP(INFO, "No \"{}\" object found in the JSON document!", itemName);
     return memptyanswer;
   }
 


### PR DESCRIPTION
so far a missing Data[Input,Output]Director in the file passed via the --json-file command line option resulted in the termination of the program.  With this modification this does no longer happen.