### PR TITLE
TPC CalDet wrapper

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -229,7 +229,7 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator*=(const CalArray<T>& other)
 {
   if (!((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber))) {
-    LOG(ERROR) << "pad subste type of the objects it not compatible";
+    LOG(ERROR) << "pad subset type of the objects it not compatible";
     return *this;
   }
   for (size_t i = 0; i < mData.size(); ++i) {
@@ -243,11 +243,16 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator/=(const CalArray<T>& other)
 {
   if (!((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber))) {
-    LOG(ERROR) << "pad subste type of the objects it not compatible";
+    LOG(ERROR) << "pad subset type of the objects it not compatible";
     return *this;
   }
   for (size_t i = 0; i < mData.size(); ++i) {
-    mData[i] /= other.getValue(i);
+    if (other.getValue(i) != 0) {
+      mData[i] /= other.getValue(i);
+    } else {
+      mData[i] = 0;
+      LOG(ERROR) << "Division by 0 detected! Value was set to 0.";
+    }
   }
   return *this;
 }

--- a/Detectors/TPC/qc/CMakeLists.txt
+++ b/Detectors/TPC/qc/CMakeLists.txt
@@ -23,7 +23,8 @@ o2_target_root_dictionary(TPCQC
                                   include/TPCQC/Helpers.h
                                   include/TPCQC/TrackCuts.h
                                   include/TPCQC/Clusters.h
-                                  include/TPCQC/Tracks.h)
+                                  include/TPCQC/Tracks.h
+                                  include/TPCQC/CalPadWrapper.h)
 
 o2_add_test(PID
             COMPONENT_NAME tpc

--- a/Detectors/TPC/qc/include/TPCQC/CalPadWrapper.h
+++ b/Detectors/TPC/qc/include/TPCQC/CalPadWrapper.h
@@ -1,0 +1,61 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CalPadWrapper_H
+#define O2_CalPadWrapper_H
+
+#include <TClass.h>
+#include <TObject.h>
+
+#include "TPCBase/CalDet.h"
+
+namespace o2
+{
+namespace tpc
+{
+namespace qc
+{
+/// Temporary solution until objects not inheriting from TObject can be handled in QualityControl
+/// A wrapper class to easily promote CalDet<float> objects to a TObject
+/// does not take ownership of wrapped object and should not be used
+/// in tight loops since construction expensive
+class CalPadWrapper : public TObject
+{
+ public:
+  CalPadWrapper(o2::tpc::CalDet<float>* obj) : mObj(obj), TObject()
+  {
+  }
+
+  CalPadWrapper() = default;
+
+  void setObj(o2::tpc::CalDet<float>* obj)
+  {
+    mObj = obj;
+  }
+
+  o2::tpc::CalDet<float>* getObj()
+  {
+    return mObj;
+  }
+
+  virtual const char* GetName() const override { return mObj ? mObj->getName().data() : "unset"; }
+
+  virtual ~CalPadWrapper() override = default;
+
+ private:
+  o2::tpc::CalDet<float>* mObj{}; ///< wrapped CalDet<float> (aka CalPad)
+
+  ClassDefOverride(CalPadWrapper, 1);
+};
+} // namespace qc
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/qc/include/TPCQC/Clusters.h
+++ b/Detectors/TPC/qc/include/TPCQC/Clusters.h
@@ -54,6 +54,13 @@ class Clusters
   const CalPad& getSigmaPad() const { return mSigmaPad; }
   const CalPad& getTimeBin() const { return mTimeBin; }
 
+  CalPad& getNClusters() { return mNClusters; }
+  CalPad& getQMax() { return mQMax; }
+  CalPad& getQTot() { return mQTot; }
+  CalPad& getSigmaTime() { return mSigmaTime; }
+  CalPad& getSigmaPad() { return mSigmaPad; }
+  CalPad& getTimeBin() { return mTimeBin; }
+
  private:
   CalPad mNClusters{"N_Clusters"};
   CalPad mQMax{"Q_Max"};

--- a/Detectors/TPC/qc/src/TPCQCLinkDef.h
+++ b/Detectors/TPC/qc/src/TPCQCLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::tpc::qc::TrackCuts+;
 #pragma link C++ class o2::tpc::qc::Clusters+;
 #pragma link C++ class o2::tpc::qc::Tracks+;
+#pragma link C++ class o2::tpc::qc::CalPadWrapper+;
 #pragma link C++ function o2::tpc::qc::helpers::makeLogBinning+;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram1D+;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram2D+;


### PR DESCRIPTION
- Added a wrapper for the TPC CalDet class so that CalDet objects can be published to the CCDB. This is needed only temporarily and will be removed at a later point.

- Added a check in the /= operator of the CalArray class to prevent division by 0