### PR TITLE
Small arrangements for more flexibility + selectFromAncestor util function

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -42,6 +42,14 @@ class GeneratorPythia8 : public Generator
   void setConfig(std::string val) { mConfig = val; };
   void setHooksFileName(std::string val) { mHooksFileName = val; };
   void setHooksFuncName(std::string val) { mHooksFuncName = val; };
+  void setUserHooks(Pythia8::UserHooks* hooks)
+  {
+#if PYTHIA_VERSION_INTEGER < 8300
+    mPythia.setUserHooksPtr(hooks);
+#else
+    mPythia.setUserHooksPtr(std::shared_ptr<Pythia8::UserHooks>(hooks));
+#endif
+  }
 
   /** methods **/
   bool readString(std::string val) { return mPythia.readString(val, true); };
@@ -55,10 +63,16 @@ class GeneratorPythia8 : public Generator
 
   /** methods to override **/
   Bool_t generateEvent() override;
-  Bool_t importParticles() override;
+  Bool_t importParticles() override { return importParticles(mPythia.event); };
 
   /** methods that can be overridded **/
   void updateHeader(FairMCEventHeader* eventHeader) override;
+
+  /** internal methods **/
+  Bool_t importParticles(Pythia8::Event& event);
+
+  /** utilities **/
+  void selectFromAncestor(int ancestor, Pythia8::Event& inputEvent, Pythia8::Event& outputEvent);
 
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!


### PR DESCRIPTION
This PR bring some small re-arrangements to `GeneratorPythia8` class in order to be able to
* set a user hook class directly and not only from a file
* be able to import particles from a generic Pythia8 event and not only from the one of the Pythia8 instance

The PR also provides a utility function that allows the user to fill an output Pythia8 event with particles selected from the input Pythia8 event. The selection is based on the index of the ancestor and all the daughters are appended in the output event.
The function takes care of adjusting the particle indices (mothers and daughters).

An example of usage of this function will be provided soon for an HF event generator where the `c-cbar` sub-event is stripped out from the full input event and appended to the output event.
Given the function is generic and can be used for other purposes, it is offered here in the core `o2::eventgen::GeneratorPythia8`. 
