### PR TITLE
DPL driver: allow {timeslice0} and {timeslice1} in --environment

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -415,7 +415,11 @@ void spawnDevice(std::string const& forwardedStdin,
       }
     }
     for (auto& env : execution.environ) {
-      putenv(env);
+      char* formatted = strdup(fmt::format(env,
+                                           fmt::arg("timeslice0", spec.inputTimesliceId),
+                                           fmt::arg("timeslice1", spec.inputTimesliceId + 1))
+                                 .c_str());
+      putenv(formatted);
     }
     execvp(execution.args[0], execution.args.data());
   }


### PR DESCRIPTION
When passing environment to a pipelined process, one can use `{timeslice0}` (0
based index) or `{timeslice1}` (1 based) which will be substituted with the
actual timeslice of the given dataprocessor.