### PR TITLE
Using noise maps inside the ITSMFT raw data decoder

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -11,6 +11,7 @@
 o2_add_library(DataFormatsITSMFT
                SOURCES src/ROFRecord.cxx
                        src/Digit.cxx
+                       src/NoiseMap.cxx
                        src/Cluster.cxx
                        src/CompCluster.cxx
                        src/ClusterPattern.cxx
@@ -24,6 +25,7 @@ o2_add_library(DataFormatsITSMFT
 o2_target_root_dictionary(DataFormatsITSMFT
                           HEADERS include/DataFormatsITSMFT/ROFRecord.h
 			          include/DataFormatsITSMFT/Digit.h
+			          include/DataFormatsITSMFT/NoiseMap.h
                                   include/DataFormatsITSMFT/Cluster.h
                                   include/DataFormatsITSMFT/CompCluster.h
                                   include/DataFormatsITSMFT/ClusterPattern.h

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file NoiseMap.h
+/// \brief Definition of the ITSMFT NoiseMap
+#ifndef ALICEO2_ITSMFT_NOISEMAP_H
+#define ALICEO2_ITSMFT_NOISEMAP_H
+
+#include "Rtypes.h" // for Double_t, ULong_t, etc
+#include <climits>
+#include <vector>
+#include <map>
+
+namespace o2
+{
+
+namespace itsmft
+{
+/// \class NoiseMap
+/// \brief NoiseMap class for the ITS and MFT
+///
+
+class NoiseMap
+{
+
+ public:
+  /// Constructor, initializing values for position, charge and readout frame
+  NoiseMap(std::vector<std::map<int, int>>& noise) { mNoisyPixels.swap(noise); }
+
+  /// Destructor
+  ~NoiseMap() = default;
+
+  /// Get the noise level for this pixels
+  int getNoiseLevel(int chip, int row, int col) const
+  {
+    if (chip > mNoisyPixels.size())
+      return 0;
+    auto key = row * 1024 + col;
+    const auto keyIt = mNoisyPixels[chip].find(key);
+    if (keyIt != mNoisyPixels[chip].end())
+      return keyIt->second;
+    return 0;
+  }
+
+ private:
+  std::vector<std::map<int, int>> mNoisyPixels; ///< Internal noise map representation
+
+  ClassDefNV(NoiseMap, 1);
+};
+} // namespace itsmft
+} // namespace o2
+
+#endif /* ALICEO2_ITSMFT_NOISEMAP_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -36,9 +36,11 @@ class NoiseMap
   NoiseMap(std::vector<std::map<int, int>>& noise) { mNoisyPixels.swap(noise); }
 
   /// Constructor
-  NoiseMap()
+  NoiseMap() = default;
+  /// Constructor
+  NoiseMap(int nchips)
   {
-    mNoisyPixels.assign(24120, std::map<int, int>());
+    mNoisyPixels.assign(nchips, std::map<int, int>());
   }
   /// Destructor
   ~NoiseMap() = default;

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -15,6 +15,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::itsmft::Digit + ;
+#pragma link C++ class o2::itsmft::NoiseMap + ;
 #pragma link C++ class std::vector < o2::itsmft::Digit> + ;
 
 #pragma link C++ class o2::itsmft::ROFRecord + ;

--- a/DataFormats/Detectors/ITSMFT/common/src/NoiseMap.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/NoiseMap.cxx
@@ -1,0 +1,16 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file NoiseMap.cxx
+/// \brief Implementation of the ITSMFT NoiseMap
+
+#include "DataFormatsITSMFT/NoiseMap.h"
+
+ClassImp(o2::itsmft::NoiseMap);

--- a/Detectors/ITSMFT/ITS/macros/Calib/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/Calib/CMakeLists.txt
@@ -13,3 +13,8 @@ o2_add_test_root_macro(MakeNoiseMapFromDigits.C
                                              O2::ITSMFTBase
                                              O2::ITSBase)
 
+o2_add_test_root_macro(MakeNoiseMapFromClusters.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsITSMFT
+                                             O2::ITSMFTBase
+                                             O2::ITSBase)
+

--- a/Detectors/ITSMFT/ITS/macros/Calib/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/Calib/CMakeLists.txt
@@ -8,6 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(EVE)
-add_subdirectory(test)
-add_subdirectory(Calib)
+o2_add_test_root_macro(MakeNoiseMapFromDigits.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsITSMFT
+                                             O2::ITSMFTBase
+                                             O2::ITSBase)
+

--- a/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
@@ -1,0 +1,71 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <iostream>
+#include <vector>
+#include <map>
+#include <string>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include "ITSBase/GeometryTGeo.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+
+#pragma link C++ class std::vector < std::map < int, int>> + ;
+
+#endif
+
+void MakeNoiseMapFromClusters(std::string dictfile = "ITSdictionary.bin", std::string input = "o2clus_its.root", std::string output = "noise.root")
+{
+  o2::itsmft::TopologyDictionary dict;
+  std::ifstream file(dictfile.c_str());
+  if (!file.good()) {
+    std::cerr << "Cannot open the dictionary file: " << dictfile << '\n';
+    return;
+  }
+  dict.readBinaryFile(dictfile);
+
+  TFile in(input.data());
+  if (!in.IsOpen()) {
+    std::cerr << "Can not open the input file " << input << '\n';
+    return;
+  }
+  auto clusTree = (TTree*)in.Get("o2sim");
+  if (!clusTree) {
+    std::cerr << "Can not get cluster tree\n";
+    return;
+  }
+  std::vector<o2::itsmft::CompClusterExt>* clusters = nullptr;
+  clusTree->SetBranchAddress("ITSClusterComp", &clusters);
+
+  std::vector<std::map<int, int>> noiseMap;
+  noiseMap.assign(24120, std::map<int, int>());
+
+  auto nevents = clusTree->GetEntries();
+  for (int n = 0; n < nevents; n++) {
+    clusTree->GetEntry(n);
+
+    for (const auto& c : *clusters) {
+      auto pattID = c.getPatternID();
+      auto npix = dict.getNpixels(pattID);
+
+      if (npix > 1)
+        continue;
+
+      auto id = c.getSensorID();
+      int row = c.getRow();
+      int col = c.getCol();
+      int key = row * 1024 + col;
+
+      noiseMap[id][key]++;
+    }
+  }
+
+  TFile out(output.data(), "new");
+  if (!out.IsOpen()) {
+    std::cerr << "Can not open the output file " << output << '\n';
+    return;
+  }
+  out.WriteObject(&noiseMap, "Noise");
+  out.Close();
+}

--- a/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
@@ -41,7 +41,7 @@ void MakeNoiseMapFromClusters(std::string input = "o2clus_its.root", std::string
   std::vector<o2::itsmft::ROFRecord>* rofVec = nullptr;
   clusTree->SetBranchAddress("ITSClustersROF", &rofVec);
 
-  o2::itsmft::NoiseMap noiseMap;
+  o2::itsmft::NoiseMap noiseMap(24120);
 
   int n1pix = 0;
   auto nevents = clusTree->GetEntries();

--- a/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromClusters.C
@@ -10,8 +10,7 @@
 #include "ITSBase/GeometryTGeo.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
-
-#pragma link C++ class std::vector < std::map < int, int>> + ;
+#include "DataFormatsITSMFT/NoiseMap.h"
 
 #endif
 
@@ -38,8 +37,7 @@ void MakeNoiseMapFromClusters(std::string dictfile = "ITSdictionary.bin", std::s
   std::vector<o2::itsmft::CompClusterExt>* clusters = nullptr;
   clusTree->SetBranchAddress("ITSClusterComp", &clusters);
 
-  std::vector<std::map<int, int>> noiseMap;
-  noiseMap.assign(24120, std::map<int, int>());
+  o2::itsmft::NoiseMap noiseMap;
 
   auto nevents = clusTree->GetEntries();
   for (int n = 0; n < nevents; n++) {
@@ -55,9 +53,7 @@ void MakeNoiseMapFromClusters(std::string dictfile = "ITSdictionary.bin", std::s
       auto id = c.getSensorID();
       int row = c.getRow();
       int col = c.getCol();
-      int key = row * 1024 + col;
-
-      noiseMap[id][key]++;
+      noiseMap.increaseNoiseCount(id, row, col);
     }
   }
 

--- a/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromDigits.C
@@ -13,7 +13,7 @@ void MakeNoiseMapFromDigits(std::string digifile = "itsdigits.root", int hitCut 
   std::vector<o2::itsmft::Digit>* digArr = nullptr;
   digTree->SetBranchAddress("ITSDigit", &digArr);
 
-  o2::itsmft::NoiseMap noiseMap;
+  o2::itsmft::NoiseMap noiseMap(24120);
 
   int nevD = digTree->GetEntries(), nd = 0;
   for (int iev = 0; iev < nevD; iev++) {

--- a/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/Calib/MakeNoiseMapFromDigits.C
@@ -1,0 +1,54 @@
+#include <TFile.h>
+#include <TTree.h>
+#include <iostream>
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsITSMFT/Digit.h"
+
+#pragma link C++ class std::vector < std::map < int, int>> + ;
+
+void MakeNoiseMapFromDigits(std::string digifile = "itsdigits.root", int hitCut = 3)
+{
+  // Digits
+  TFile* file1 = TFile::Open(digifile.data());
+  TTree* digTree = (TTree*)file1->Get("o2sim");
+  std::vector<o2::itsmft::Digit>* digArr = nullptr;
+  digTree->SetBranchAddress("ITSDigit", &digArr);
+
+  std::vector<std::map<int, int>> noisyPixels;
+  noisyPixels.assign(24120, std::map<int, int>());
+
+  int nevD = digTree->GetEntries(), nd = 0;
+  for (int iev = 0; iev < nevD; iev++) {
+    digTree->GetEvent(iev);
+    for (const auto& d : *digArr) {
+      nd++;
+      auto id = d.getChipIndex();
+      auto row = d.getRow();
+      auto col = d.getColumn();
+      auto key = row * 1024 + col;
+      noisyPixels[id][key]++;
+    }
+  }
+
+  int nPixelCalib = 0;
+  for (int i = 0; i < noisyPixels.size(); i++) {
+    const auto& map = noisyPixels[i];
+    for (const auto& pair : map) {
+      if (pair.second > hitCut) {
+        auto key = pair.first;
+        auto row = key / 1024;
+        auto col = key % 1024;
+        std::cout << "Chip, row, col: " << i << ' ' << row << ' ' << col << "  Hits: " << pair.second << '\n';
+        nPixelCalib++;
+      }
+    }
+  }
+
+  TFile* fout = new TFile("ITSnoise.root", "new");
+  fout->cd();
+  fout->WriteObject(&noisyPixels, "Noise");
+  fout->Close();
+
+  std::cout << "Total Digits Processed = " << nd << '\n';
+  std::cout << "Noise threshold = " << hitCut << "  Noisy pixels = " << nPixelCalib << '\n';
+}

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -131,7 +131,7 @@ class AlpideCoder
       uint8_t dataCM = dataC & (~MaskChipID);
       //
       if ((expectInp & ExpectChipEmpty) && dataCM == CHIPEMPTY) { // empty chip was expected
-        chipData.setChipID(dataC & MaskChipID);                   // here we set the chip ID within the module
+        //chipData.setChipID(dataC & MaskChipID);                   // here we set the chip ID within the module
         if (!buffer.next(timestamp)) {
           return unexpectedEOF("CHIP_EMPTY:Timestamp");
         }
@@ -140,7 +140,7 @@ class AlpideCoder
       }
 
       if ((expectInp & ExpectChipHeader) && dataCM == CHIPHEADER) { // chip header was expected
-        chipData.setChipID(dataC & MaskChipID);                     // here we set the chip ID within the module
+        //chipData.setChipID(dataC & MaskChipID);                     // here we set the chip ID within the module
         if (!buffer.next(timestamp)) {
           return unexpectedEOF("CHIP_HEADER");
         }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -23,6 +23,7 @@
 #include <map>
 
 #include "ITSMFTReconstruction/PixelData.h"
+#include "DataFormatsITSMFT/NoiseMap.h"
 
 /// \file AlpideCoder.h
 /// \brief class for the ALPIDE data decoding/encoding
@@ -100,7 +101,7 @@ class AlpideCoder
   static constexpr int EOFFlag = -100; // flag for EOF in reading
 
   AlpideCoder() = default;
-  ~AlpideCoder() = default;
+  ~AlpideCoder() { delete mNoisyPixels; }
 
   static bool isEmptyChip(uint8_t b) { return (b & CHIPEMPTY) == CHIPEMPTY; }
 
@@ -279,10 +280,9 @@ class AlpideCoder
   /// Output a non-noisy fired pixel
   static void addHit(ChipPixelData& chipData, short row, short col)
   {
-    if (!mNoisyPixels.empty()) {
+    if (mNoisyPixels) {
       auto chipID = chipData.getChipID();
-      int key = row * 1024 + col;
-      if (mNoisyPixels[chipID][key] > mNoiseThreshold) {
+      if (mNoisyPixels->getNoiseLevel(chipID, row, col) > mNoiseThreshold) {
         return;
       }
     }
@@ -371,7 +371,7 @@ class AlpideCoder
   // =====================================================================
   //
 
-  static std::vector<std::map<int, int>> mNoisyPixels;
+  static NoiseMap* mNoisyPixels;
   static int mNoiseThreshold;
 
   // cluster map used for the ENCODING only

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -101,11 +101,11 @@ class AlpideCoder
   static constexpr int EOFFlag = -100; // flag for EOF in reading
 
   AlpideCoder() = default;
-  ~AlpideCoder() { delete mNoisyPixels; }
+  ~AlpideCoder() = default;
 
   static bool isEmptyChip(uint8_t b) { return (b & CHIPEMPTY) == CHIPEMPTY; }
 
-  static void loadNoisyPixels(const std::string& noise);
+  static void setNoisyPixels(const NoiseMap* noise) { mNoisyPixels = noise; }
   static void setNoiseThreshold(int t) { mNoiseThreshold = t; }
 
   /// decode alpide data for the next non-empty chip from the buffer
@@ -371,7 +371,7 @@ class AlpideCoder
   // =====================================================================
   //
 
-  static NoiseMap* mNoisyPixels;
+  static const NoiseMap* mNoisyPixels;
   static int mNoiseThreshold;
 
   // cluster map used for the ENCODING only

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -268,6 +268,12 @@ class AlpideCoder
   void print() const;
   void reset();
   //
+  template <class T>
+  static int getChipID(T& buffer)
+  {
+    uint8_t id = 0;
+    return (buffer.current(id) && isChipHeaderOrEmpty(id)) ? (id & AlpideCoder::MaskChipID) : -1;
+  }
 
  private:
   /// Output a non-noisy fired pixel

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -73,9 +73,11 @@ int RUDecodeData::decodeROF(const Mapping& mp)
       continue;
     }
     int nhits = 0;
-    uint8_t id = 0;
-    cableData[icab].current(id);
-    chipData->setChipID(mp.getGlobalChipID(id & AlpideCoder::MaskChipID, cableHWID[icab], *ruInfo));
+    int cid = AlpideCoder::getChipID(cableData[icab]);
+    if (cid < 0) {
+      continue;
+    }
+    chipData->setChipID(mp.getGlobalChipID(cid, cableHWID[icab], *ruInfo));
     while ((nhits = AlpideCoder::decodeChip(*chipData, cableData[icab]))) { // we register only chips with hits or errors flags set
       if (nhits > 0) {
         // convert HW chip id within the module to absolute chip id
@@ -84,8 +86,11 @@ int RUDecodeData::decodeROF(const Mapping& mp)
         ntot += nhits;
         if (++nChipsFired < chipsData.size()) { // fetch next free chip
           chipData = &chipsData[nChipsFired];
-          cableData[icab].current(id);
-          chipData->setChipID(mp.getGlobalChipID(id & AlpideCoder::MaskChipID, cableHWID[icab], *ruInfo));
+          cid = AlpideCoder::getChipID(cableData[icab]);
+          if (cid < 0) {
+            continue;
+          }
+          chipData->setChipID(mp.getGlobalChipID(cid, cableHWID[icab], *ruInfo));
         } else {
           break; // last chip decoded
         }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -73,14 +73,19 @@ int RUDecodeData::decodeROF(const Mapping& mp)
       continue;
     }
     int nhits = 0;
+    uint8_t id = 0;
+    cableData[icab].current(id);
+    chipData->setChipID(mp.getGlobalChipID(id & AlpideCoder::MaskChipID, cableHWID[icab], *ruInfo));
     while ((nhits = AlpideCoder::decodeChip(*chipData, cableData[icab]))) { // we register only chips with hits or errors flags set
       if (nhits > 0) {
         // convert HW chip id within the module to absolute chip id
-        chipData->setChipID(mp.getGlobalChipID(chipData->getChipID(), cableHWID[icab], *ruInfo));
+        //chipData->setChipID(mp.getGlobalChipID(chipData->getChipID(), cableHWID[icab], *ruInfo));
         setROFInfo(chipData, cableLinkPtr[icab]);
         ntot += nhits;
         if (++nChipsFired < chipsData.size()) { // fetch next free chip
           chipData = &chipsData[nChipsFired];
+          cableData[icab].current(id);
+          chipData->setChipID(mp.getGlobalChipID(id & AlpideCoder::MaskChipID, cableHWID[icab], *ruInfo));
         } else {
           break; // last chip decoded
         }

--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -17,7 +17,7 @@
 
 using namespace o2::itsmft;
 
-std::vector<std::map<int, int>> AlpideCoder::mNoisyPixels;
+NoiseMap* AlpideCoder::mNoisyPixels = nullptr;
 int AlpideCoder::mNoiseThreshold = 3;
 
 //______________________________________________________________
@@ -32,7 +32,7 @@ void AlpideCoder::loadNoisyPixels(const std::string& noise)
   LOG(INFO) << "Loading noisy pixels from " << noise << '\n';
 
   auto pnoise = (std::vector<std::map<int, int>>*)f.Get("Noise");
-  mNoisyPixels.assign(pnoise->begin(), pnoise->end());
+  mNoisyPixels = new NoiseMap(*pnoise);
   delete pnoise;
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -13,8 +13,28 @@
 
 #include "ITSMFTReconstruction/AlpideCoder.h"
 #include <TClass.h>
+#include <TFile.h>
 
 using namespace o2::itsmft;
+
+std::vector<std::map<int, int>> AlpideCoder::mNoisyPixels;
+int AlpideCoder::mNoiseThreshold = 3;
+
+//______________________________________________________________
+void AlpideCoder::loadNoisyPixels(const std::string& noise)
+{
+  TFile f(noise.data(), "old");
+  if (!f.IsOpen()) {
+    LOG(ERROR) << "Cannot load noisy pixels from " << noise << '\n';
+    return;
+  }
+
+  LOG(INFO) << "Loading noisy pixels from " << noise << '\n';
+
+  auto pnoise = (std::vector<std::map<int, int>>*)f.Get("Noise");
+  mNoisyPixels.assign(pnoise->begin(), pnoise->end());
+  delete pnoise;
+}
 
 //_____________________________________
 void AlpideCoder::print() const

--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -17,24 +17,8 @@
 
 using namespace o2::itsmft;
 
-NoiseMap* AlpideCoder::mNoisyPixels = nullptr;
+const NoiseMap* AlpideCoder::mNoisyPixels = nullptr;
 int AlpideCoder::mNoiseThreshold = 3;
-
-//______________________________________________________________
-void AlpideCoder::loadNoisyPixels(const std::string& noise)
-{
-  TFile f(noise.data(), "old");
-  if (!f.IsOpen()) {
-    LOG(ERROR) << "Cannot load noisy pixels from " << noise << '\n';
-    return;
-  }
-
-  LOG(INFO) << "Loading noisy pixels from " << noise << '\n';
-
-  auto pnoise = (std::vector<std::map<int, int>>*)f.Get("Noise");
-  mNoisyPixels = new NoiseMap(*pnoise);
-  delete pnoise;
-}
 
 //_____________________________________
 void AlpideCoder::print() const

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -37,7 +37,7 @@ template <class Mapping>
 class STFDecoder : public Task
 {
  public:
-  STFDecoder(bool clusters = true, bool pattern = true, bool digits = false, std::string_view dict = "");
+  STFDecoder(bool clusters = true, bool pattern = true, bool digits = false, std::string_view dict = "", std::string_view noise = "");
   ~STFDecoder() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -53,6 +53,7 @@ class STFDecoder : public Task
   size_t mTFCounter = 0;
   std::string mSelfName;
   std::string mDictName;
+  std::string mNoiseName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;
   std::unique_ptr<Clusterer> mClusterer;
 };
@@ -61,8 +62,8 @@ using STFDecoderITS = STFDecoder<ChipMappingITS>;
 using STFDecoderMFT = STFDecoder<ChipMappingMFT>;
 
 /// create a processor spec
-o2::framework::DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict);
-o2::framework::DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict);
+o2::framework::DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise);
+o2::framework::DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise);
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -40,8 +40,8 @@ using namespace o2::framework;
 
 ///_______________________________________
 template <class Mapping>
-STFDecoder<Mapping>::STFDecoder(bool doClusters, bool doPatterns, bool doDigits, std::string_view dict)
-  : mDoClusters(doClusters), mDoPatterns(doPatterns), mDoDigits(doDigits), mDictName(dict)
+STFDecoder<Mapping>::STFDecoder(bool doClusters, bool doPatterns, bool doDigits, std::string_view dict, std::string_view noise)
+  : mDoClusters(doClusters), mDoPatterns(doPatterns), mDoDigits(doDigits), mDictName(dict), mNoiseName(noise)
 {
   mSelfName = o2::utils::concat_string(Mapping::getName(), "STFDecoder");
   mTimer.Stop();
@@ -60,6 +60,15 @@ void STFDecoder<Mapping>::init(InitContext& ic)
   mDecoder->setNThreads(mNThreads);
   mDecoder->setFormat(ic.options().get<bool>("old-format") ? GBTLink::OldFormat : GBTLink::NewFormat);
   mDecoder->setVerbosity(ic.options().get<int>("decoder-verbosity"));
+
+  std::string noiseFile = o2::base::NameConf::getDictionaryFileName(detID, mNoiseName, ".root");
+  if (o2::base::NameConf::pathExists(noiseFile)) {
+    AlpideCoder::loadNoisyPixels(noiseFile);
+    LOG(INFO) << mSelfName << " loading noise map file: " << noiseFile;
+  } else {
+    LOG(INFO) << mSelfName << " Noise file " << noiseFile << " is absent, " << Mapping::getName() << " running without noise suppression";
+  }
+
   if (mDoClusters) {
     mClusterer = std::make_unique<Clusterer>();
     mClusterer->setNChips(Mapping::getNChips());
@@ -149,7 +158,7 @@ void STFDecoder<Mapping>::endOfStream(EndOfStreamContext& ec)
   }
 }
 
-DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict)
+DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise)
 {
   std::vector<OutputSpec> outputs;
   auto orig = o2::header::gDataOriginITS;
@@ -168,14 +177,14 @@ DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool do
     "its-stf-decoder",
     Inputs{{"stf", ConcreteDataTypeMatcher{orig, "RAWDATA"}, Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(doClusters, doPatterns, doDigits, dict)},
+    AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingITS>>(doClusters, doPatterns, doDigits, dict, noise)},
     Options{
       {"nthreads", VariantType::Int, 1, {"Number of decoding/clustering threads"}},
       {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},
       {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data)"}}}};
 }
 
-DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict)
+DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise)
 {
   std::vector<OutputSpec> outputs;
   auto orig = o2::header::gDataOriginMFT;
@@ -196,7 +205,7 @@ DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool do
     "mft-stf-decoder",
     Inputs{{"stf", ConcreteDataTypeMatcher{orig, "RAWDATA"}, Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingMFT>>(doClusters, doPatterns, doDigits, dict)},
+    AlgorithmSpec{adaptFromTask<STFDecoder<ChipMappingMFT>>(doClusters, doPatterns, doDigits, dict, noise)},
     Options{
       {"nthreads", VariantType::Int, 1, {"Number of decoding/clustering threads"}},
       {"old-format", VariantType::Bool, false, {"Use old format (1 trigger per CRU page)"}},

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -63,7 +63,9 @@ void STFDecoder<Mapping>::init(InitContext& ic)
 
   std::string noiseFile = o2::base::NameConf::getDictionaryFileName(detID, mNoiseName, ".root");
   if (o2::base::NameConf::pathExists(noiseFile)) {
-    AlpideCoder::loadNoisyPixels(noiseFile);
+    TFile* f = TFile::Open(noiseFile.data(), "old");
+    auto pnoise = (NoiseMap*)f->Get("Noise");
+    AlpideCoder::setNoisyPixels(pnoise);
     LOG(INFO) << mSelfName << " loading noise map file: " << noiseFile;
   } else {
     LOG(INFO) << mSelfName << " Noise file " << noiseFile << " is absent, " << Mapping::getName() << " running without noise suppression";

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -26,6 +26,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"no-cluster-patterns", VariantType::Bool, false, {"do not produce clusters patterns (def: produce)"}},
     ConfigParamSpec{"digits", VariantType::Bool, false, {"produce digits (def: skip)"}},
     ConfigParamSpec{"dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}},
+    ConfigParamSpec{"noise-file", VariantType::String, "", {"name of the noise map file"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -42,14 +43,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto doPatterns = doClusters && !cfgc.options().get<bool>("no-cluster-patterns");
   auto doDigits = cfgc.options().get<bool>("digits");
   auto dict = cfgc.options().get<std::string>("dict-file");
+  auto noise = cfgc.options().get<std::string>("noise-file");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   if (cfgc.options().get<bool>("mft")) {
-    wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, dict));
+    wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, dict, noise));
   } else {
-    wf.emplace_back(o2::itsmft::getSTFDecoderITSSpec(doClusters, doPatterns, doDigits, dict));
+    wf.emplace_back(o2::itsmft::getSTFDecoderITSSpec(doClusters, doPatterns, doDigits, dict, noise));
   }
   return wf;
 }


### PR DESCRIPTION
These changes allow for taking into account the positions of noisy pixels at the level of raw-data decoding.  The implementation of noise maps themselves is functional, but not yet the best possible. This will be improved with a separate PR.  