### PR TITLE
Fix ITS3 simulation

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
@@ -89,7 +89,7 @@ class SimTraits
       /*ACO*/ VS{ "ACOHit" }
 #ifdef ENABLE_UPGRADES
       ,
-      /*IT3*/ VS{ "ITS3Hit" }
+      /*IT3*/ VS{ "IT3Hit" }
 #endif
     };
   // clang-format on

--- a/Detectors/Upgrades/IT3/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/IT3/base/src/GeometryTGeo.cxx
@@ -285,7 +285,7 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(int index) const
 
   int wrID = mLayerToWrapper[lay];
 
-  TString path = Form("/cave_1/%s_2/", GeometryTGeo::getITSVolPattern());
+  TString path = Form("/cave_1/barrel_1/%s_2/", GeometryTGeo::getITSVolPattern());
 
   if (wrID >= 0) {
     path += Form("%s%d_1/", getITSWrapVolPattern(), wrID);

--- a/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
@@ -919,14 +919,14 @@ void Detector::constructDetectorGeometry()
   // Create the geometry and insert it in the mother volume ITSV
   TGeoManager* geoManager = gGeoManager;
 
-  TGeoVolume* vALIC = geoManager->GetVolume("cave");
+  TGeoVolume* vALIC = geoManager->GetVolume("barrel");
 
   if (!vALIC) {
     LOG(FATAL) << "Could not find the top volume";
   }
   new TGeoVolumeAssembly(GeometryTGeo::getITSVolPattern());
   TGeoVolume* vITSV = geoManager->GetVolume(GeometryTGeo::getITSVolPattern());
-  vALIC->AddNode(vITSV, 2, nullptr); // Copy number is 2 to cheat AliGeoManager::CheckSymNamesLUT
+  vALIC->AddNode(vITSV, 2, new TGeoTranslation(0, 30., 0)); // Copy number is 2 to cheat AliGeoManager::CheckSymNamesLUT
 
   const Int_t kLength = 100;
   Char_t vstrng[kLength] = "xxxRS"; //?
@@ -1200,7 +1200,7 @@ void Detector::addAlignableVolumes() const
     return;
   }
 
-  TString path = Form("/cave_1/%s_2", GeometryTGeo::getITSVolPattern());
+  TString path = Form("/cave_1/barrel_1/%s_2", GeometryTGeo::getITSVolPattern());
   TString sname = GeometryTGeo::composeSymNameITS3();
 
   LOG(DEBUG) << sname << " <-> " << path;


### PR DESCRIPTION
Geometry path now is consistent with what is used with ITS.
o2sim_HitsIT3.root is now filled correctly.

@mario6829 for knowledge.

Compile O2 with 
```bash
ENABLE_UPGRADES=ON aliBuild build O2 --defaults o2
```
to test it:

```bash
o2-sim -n1 -m PIPE IT3 -g boxgen --configKeyValues 'BoxGun.pdg=211 ; BoxGun.eta[0]=0 ; BoxGun.eta[1]=0; BoxGun.number=1'
```
