### PR TITLE
DPL: open ipc socket in a tmp directory (O2-1512)

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -19,6 +19,12 @@ if (TARGET AliceO2::DebugGUI)
   set(DEBUGGUI_TARGET AliceO2::DebugGUI)
 endif()
 
+# Given GCC 7.3 does not provide std::filesystem we use Boost instead
+# Drop this once we move to GCC 8.2+
+if (NOT __APPLE__)
+  set(BOOST_FILESYSTEM Boost::filesystem)
+endif()
+
 o2_add_library(Framework
                SOURCES src/AODReaderHelpers.cxx
                        src/ASoA.cxx
@@ -129,6 +135,7 @@ o2_add_library(Framework
                                      ROOT::ROOTDataFrame
                                      O2::FrameworkLogger
                                      Boost::serialization
+                                     ${BOOST_FILESYSTEM}
                                      arrow::gandiva_shared
                                      LibUV::LibUV
                                      )

--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -12,6 +12,25 @@
 #include <ostream>
 #include <cassert>
 #include <stdexcept>
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<boost/filesystem.hpp>)
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#endif
+
+namespace
+{
+std::string getTmpFolder()
+{
+  std::string tmppath = fs::temp_directory_path().native();
+  while (tmppath.back() == '/') {
+    tmppath.pop_back();
+  }
+  return tmppath;
+}
+} // namespace
 
 namespace o2::framework
 {
@@ -48,7 +67,7 @@ std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
+      return fmt::format("ipc://{}/{}_{},transport=shmem", getTmpFolder(), channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
@@ -59,7 +78,7 @@ std::string ChannelSpecHelpers::channelUrl(InputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
+      return fmt::format("ipc://{}/{}_{},transport=shmem", getTmpFolder(), channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);


### PR DESCRIPTION
This has better chances to succeed (e.g. no AFS) and will avoid polluting the
pwd.