### PR TITLE
Flag to allow use of compressed decoder in CONET mode

### DIFF
--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/DecoderBase.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/DecoderBase.h
@@ -41,6 +41,10 @@ class DecoderBaseT
   inline bool run()
   {
     rewind();
+    if (mDecoderCONET) {
+      mDecoderPointerMax = reinterpret_cast<const uint32_t*>(mDecoderBuffer + mDecoderBufferSize);
+      return processDRM();
+    }
     while (!processHBF())
       ;
     return false;
@@ -54,6 +58,7 @@ class DecoderBaseT
   void setDecoderVerbose(bool val) { mDecoderVerbose = val; };
   void setDecoderBuffer(const char* val) { mDecoderBuffer = val; };
   void setDecoderBufferSize(long val) { mDecoderBufferSize = val; };
+  void setDecoderCONET(bool val) { mDecoderCONET = val; };
 
  private:
   /** handlers **/
@@ -88,6 +93,7 @@ class DecoderBaseT
   bool mDecoderVerbose = false;
   bool mDecoderError = false;
   bool mDecoderFatal = false;
+  bool mDecoderCONET = false;
   char mDecoderSaveBuffer[1048576];
   uint32_t mDecoderSaveBufferDataSize = 0;
   uint32_t mDecoderSaveBufferDataLeft = 0;


### PR DESCRIPTION
This PR allows the use of the TOF compressed decoder in `CONET` mode.
This is a special mode that will be used for running QC and analyses on the TOF DCS computer nodes.