### PR TITLE
DPL Analysis: fix for integer comparison in expressions

### DIFF
--- a/Analysis/Tutorials/src/filters.cxx
+++ b/Analysis/Tutorials/src/filters.cxx
@@ -84,7 +84,8 @@ struct CTask {
 };
 
 struct DTask {
-  void process(aod::Collision const&, aod::MTracks const& tracks)
+  Filter notTracklet = aod::track::trackType != 3; // only works with literal now
+  void process(aod::Collision const&, soa::Filtered<aod::MTracks> const& tracks)
   {
     for (auto& track : tracks) {
       LOGF(INFO, "%.3f == %.3f", track.spt(), std::abs(track.sigma1Pt() / track.signed1Pt()));

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -10,6 +10,8 @@
 #ifndef O2_FRAMEWORK_DATATYPES_H_
 #define O2_FRAMEWORK_DATATYPES_H_
 
+#include <cstdint>
+
 namespace o2::aod::track
 {
 enum TrackTypeEnum : uint8_t {


### PR DESCRIPTION
Adds type upcast so that smaller integer types can be compared with larger ones directly. Fixes filtering on track type (see filters.cxx example).