### PR TITLE
GPU: Fix incorrect number of blocks for TPC track merging on CPU with OMP without ompKernels

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1972,7 +1972,7 @@ int GPUChainTracking::RunTPCTrackingMerger(bool synchronizeOutput)
     mOutputQueue.clear();
   }
 
-  runKernel<GPUTPCGMMergerTrackFit>(GetGrid(Merger.NOutputTracks(), 0), krnlRunRangeNone, krnlEventNone, GetProcessingSettings().mergerSortTracks ? 1 : 0);
+  runKernel<GPUTPCGMMergerTrackFit>(doGPU ? GetGrid(Merger.NOutputTracks(), 0) : GetGridAuto(0), krnlRunRangeNone, krnlEventNone, GetProcessingSettings().mergerSortTracks ? 1 : 0);
   if (param().rec.retryRefit == 1) {
     runKernel<GPUTPCGMMergerTrackFit>(GetGridAuto(0), krnlRunRangeNone, krnlEventNone, -1);
   }


### PR DESCRIPTION
@shahor02 : This fixes the performance problem for me when the number of omp threads is not forced to 1.
Could you check whether it works for you as well?

Another question is: What do we want as default for the number of threads?
- Before my config change this was defaulted to 1 for the TPC workflow and must be set on the command line.
- Now, it takes the default from OpenMP, which is $OMP_NUM_THREADS or just the number of cores available if unset.
- Alternatively, we also have the option GPU_proc.ompKernels. This applies multi-threading in more places and speeds up the processing on the CPU significantly. However, it looses reproducibiltiy of the output. Without this option, OMP is applied only where the concurrency cannot change the output. By default this new option is disabled. Should we leave it disabled, or should we use this omp version by default?