### PR TITLE
TOF CTF: first prototype

### DIFF
--- a/DataFormats/Detectors/TOF/CMakeLists.txt
+++ b/DataFormats/Detectors/TOF/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(DataFormatsTOF
                        src/CalibInfoTOF.cxx
                        src/CalibLHCphaseTOF.cxx
                        src/CalibTimeSlewingParamTOF.cxx
+                       src/CTF.cxx
                PUBLIC_LINK_LIBRARIES O2::ReconstructionDataFormats
                                      Boost::serialization)
 
@@ -25,4 +26,5 @@ o2_target_root_dictionary(DataFormatsTOF
                                   include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
                                   include/DataFormatsTOF/RawDataFormat.h
                                   include/DataFormatsTOF/CompressedDataFormat.h
+                                  include/DataFormatsTOF/CTF.h
 				  )

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
@@ -58,6 +58,7 @@ struct CompressedInfos {
   std::vector<uint16_t> bcIncROF;    /// increment of ROF BC wrt BC of previous ROF
   std::vector<uint32_t> orbitIncROF; /// increment of ROF orbit wrt orbit of previous ROF
   std::vector<uint32_t> ndigROF;     /// number of digits in ROF
+  std::vector<uint32_t> ndiaROF;     /// number of diagnostic/pattern words in ROF
 
   // Hit data
   std::vector<uint16_t> timeFrameInc; /// time increment with respect of previous digit in TimeFrame units
@@ -65,7 +66,7 @@ struct CompressedInfos {
   std::vector<uint16_t> stripID;      /// increment of stripID wrt that of prev. strip
   std::vector<uint8_t> chanInStrip;   /// channel in strip 0-95 (ordered in time)
   std::vector<uint16_t> tot;          /// Time-Over-Threshold in TOF channel (about 48.8 ps)
-  std::vector<uint16_t> pattMap;      /// explict patterns container
+  std::vector<uint32_t> pattMap;      /// explict patterns container
 
   CompressedInfos() = default;
 
@@ -81,6 +82,7 @@ struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 10, uint32_t> {
   enum Slots { BLCbcIncROF,
                BLCorbitIncROF,
                BLCndigROF,
+               BLCndiaROF,
                BLCtimeFrameInc,
                BLCtimeTDCInc,
                BLCstripID,

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author fnoferin@cern.ch
+/// \brief  Definitions for TOF CTF data
+
+#ifndef O2_TOF_CTF_H
+#define O2_TOF_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+
+namespace o2
+{
+namespace tof
+{
+
+class ROFRecord;
+class CompClusterExt;
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nROFs = 0;         /// number of ROFrame in TF
+  uint32_t nDigits = 0;       /// number of digits in TF
+  uint32_t nPatternBytes = 0; /// number of bytes for explict patterns
+  uint32_t firstOrbit = 0;    /// 1st orbit of TF
+  uint16_t firstBC = 0;       /// 1st BC of TF
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// Compressed but not yet entropy-encoded infos
+struct CompressedInfos {
+
+  CTFHeader header;
+
+  /*
+    ROF = 1/3 orbit = 1188 BC
+    1 TF = 128 * 3 = 364 ROF
+    TIMEFRAME = 2^8 TDC
+    1 BC = 2^10 TDC = 4 TIMEFRAME
+    ROF = 4752 TIMEFRAME < 2^13 TIMEFRAME
+
+    timeFrame = deltaBC/64;
+    timeTDC = (deltaBC%64)*1024+ dig.getTDC();
+    */
+
+  // ROF header data
+  std::vector<uint16_t> bcIncROF;    /// increment of ROF BC wrt BC of previous ROF
+  std::vector<uint32_t> orbitIncROF; /// increment of ROF orbit wrt orbit of previous ROF
+  std::vector<uint32_t> ndigROF;     /// number of digits in ROF
+
+  // Hit data
+  std::vector<uint16_t> timeFrameInc; /// time increment with respect of previous digit in TimeFrame units
+  std::vector<uint16_t> timeTDCInc;   /// time increment with respect of previous digit in TDC channel (about 24.4 ps) within timeframe
+  std::vector<uint16_t> stripID;      /// increment of stripID wrt that of prev. strip
+  std::vector<uint8_t> chanInStrip;   /// channel in strip 0-95 (ordered in time)
+  std::vector<uint16_t> tot;          /// Time-Over-Threshold in TOF channel (about 48.8 ps)
+  std::vector<uint16_t> pattMap;      /// explict patterns container
+
+  CompressedInfos() = default;
+
+  void clear();
+
+  ClassDefNV(CompressedInfos, 1);
+};
+
+/// wrapper for the Entropy-encoded clusters of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 10, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLCbcIncROF,
+               BLCorbitIncROF,
+               BLCndigROF,
+               BLCtimeFrameInc,
+               BLCtimeTDCInc,
+               BLCstripID,
+               BLCchanInStrip,
+               BLCtot,
+               BLCpattMap };
+
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace tof
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TOF/src/CTF.cxx
+++ b/DataFormats/Detectors/TOF/src/CTF.cxx
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "Framework/Logger.h"
+#include "DataFormatsTOF/CTF.h"
+
+using namespace o2::tof;
+
+///________________________________
+void CompressedInfos::clear()
+{
+  bcIncROF.clear();
+  orbitIncROF.clear();
+  ndigROF.clear();
+  timeFrameInc.clear();
+  timeTDCInc.clear();
+  stripID.clear();
+  chanInStrip.clear();
+  tot.clear();
+  pattMap.clear();
+}

--- a/DataFormats/Detectors/TOF/src/CTF.cxx
+++ b/DataFormats/Detectors/TOF/src/CTF.cxx
@@ -21,6 +21,7 @@ void CompressedInfos::clear()
   bcIncROF.clear();
   orbitIncROF.clear();
   ndigROF.clear();
+  ndiaROF.clear();
   timeFrameInc.clear();
   timeTDCInc.clear();
   stripID.clear();

--- a/DataFormats/Detectors/TOF/src/DataFormatsTOFLinkDef.h
+++ b/DataFormats/Detectors/TOF/src/DataFormatsTOFLinkDef.h
@@ -25,4 +25,9 @@
 #pragma link C++ class std::vector < o2::dataformats::CalibInfoTOFshort> + ;
 #pragma link C++ class std::vector < o2::dataformats::CalibInfoTOF> + ;
 
+#pragma link C++ class o2::tof::CTFHeader + ;
+#pragma link C++ class o2::tof::CompressedInfos + ;
+#pragma link C++ class o2::tof::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::tof::CTFHeader, 10, uint32_t> + ;
+
 #endif

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(CTFWorkflow
                                      O2::DetectorsCommonDataFormats
                                      O2::DataFormatsITSMFT
                                      O2::DataFormatsTPC
+                                     O2::DataFormatsTOF
                                      O2::DataFormatsParameters
                                      O2::ITSMFTWorkflow
                                      O2::TPCWorkflow

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -26,6 +26,7 @@
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
 #include "DataFormatsFT0/CTF.h"
+#include "DataFormatsTOF/CTF.h"
 #include "Algorithm/RangeTokenizer.h"
 
 using namespace o2::framework;
@@ -130,6 +131,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::ft0::CTF));
     o2::ft0::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::TOF;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::tof::CTF));
+    o2::tof::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -25,6 +25,7 @@
 #include "TOFWorkflow/TOFRawWriterSpec.h"
 #include "TOFWorkflow/CompressedDecodingTask.h"
 #include "TOFWorkflow/EntropyEncoderSpec.h"
+#include "TOFWorkflow/EntropyDecoderSpec.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "TOFWorkflow/RecoWorkflowSpec.h"
@@ -121,16 +122,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     writectf = 1;
 
   bool dgtinput = 0;
+  bool clusterinput = 0;
+  bool rawinput = 0;
+  bool ctfinput = 0;
   if (inputType == "digits") {
     dgtinput = 1;
-  }
-  bool clusterinput = 0;
-  if (inputType == "clusters") {
+  } else if (inputType == "clusters") {
     clusterinput = 1;
-  }
-  bool rawinput = 0;
-  if (inputType == "raw") {
+  } else if (inputType == "raw") {
     rawinput = 1;
+  } else if (inputType == "ctf") {
+    ctfinput = 1;
   }
 
   auto useMC = !cfgc.options().get<bool>("disable-mc");
@@ -173,6 +175,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       LOG(INFO) << "Insert TOF Digit Writer";
       specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0));
     }
+  } else if (ctfinput) {
+    LOG(INFO) << "Insert TOF CTF decoder";
+    specs.emplace_back(o2::tof::getEntropyDecoderSpec());
   }
 
   if (!clusterinput && writecluster) {

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -178,6 +178,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   } else if (ctfinput) {
     LOG(INFO) << "Insert TOF CTF decoder";
     specs.emplace_back(o2::tof::getEntropyDecoderSpec());
+
+    if (writedigit && !disableRootOutput) {
+      // add TOF digit writer without mc labels
+      LOG(INFO) << "Insert TOF Digit Writer";
+      specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0));
+    }
   }
 
   if (!clusterinput && writecluster) {

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -24,6 +24,7 @@
 #include "TOFWorkflow/TOFCalibWriterSpec.h"
 #include "TOFWorkflow/TOFRawWriterSpec.h"
 #include "TOFWorkflow/CompressedDecodingTask.h"
+#include "TOFWorkflow/EntropyEncoderSpec.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "TOFWorkflow/RecoWorkflowSpec.h"
@@ -46,8 +47,8 @@
 // including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"input-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "clusters,matching-info,calib-info", {"digits,clusters, matching-info, calib-info, TBI"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters, ctf"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "clusters,matching-info,calib-info", {"digits, clusters, matching-info, calib-info, raw, ctf"}});
   workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}});
   workflowOptions.push_back(ConfigParamSpec{"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}});
   workflowOptions.push_back(ConfigParamSpec{"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}});
@@ -104,6 +105,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool writecalib = 0;
   bool writedigit = 0;
   bool writeraw = 0;
+  bool writectf = 0;
 
   if (outputType.rfind("clusters") < outputType.size())
     writecluster = 1;
@@ -115,6 +117,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     writedigit = 1;
   if (outputType.rfind("raw") < outputType.size())
     writeraw = 1;
+  if (outputType.rfind("ctf") < outputType.size())
+    writectf = 1;
 
   bool dgtinput = 0;
   if (inputType == "digits") {
@@ -201,6 +205,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       specs.emplace_back(o2::tof::getTOFCalibWriterSpec());
     }
   }
+  if (writectf) {
+    LOG(INFO) << "Insert TOF CTF encoder";
+    specs.emplace_back(o2::tof::getEntropyEncoderSpec());
+  }
+
   LOG(INFO) << "Number of active devices = " << specs.size();
 
   return std::move(specs);

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -39,6 +39,10 @@ class Digit
   {
     return ((static_cast<ULong64_t>(bc) << 18) + channel); // channel in the least significant bits; then shift by 18 bits (which cover the total number of channels) to write the BC number
   }
+  ULong64_t getOrderingKey()
+  {
+    return getOrderingKey(mChannel, mBC, mTDC);
+  }
 
   Int_t getChannel() const { return mChannel; }
   void setChannel(Int_t channel) { mChannel = channel; }

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -15,6 +15,7 @@
 #include "Rtypes.h"
 #include "TOFBase/Geo.h"
 #include "CommonDataFormat/RangeReference.h"
+#include "CommonDataFormat/InteractionRecord.h"
 #include <gsl/span>
 
 #include <boost/serialization/base_object.hpp> // for base_object
@@ -107,6 +108,23 @@ struct ReadoutWindowData {
   // 1st entry and number of entries in the full vector of digits
   // for given trigger (or BC or RO frame)
   o2::dataformats::RangeReference<int, int> ref;
+  InteractionRecord mFirstIR{0, 0};
+
+  const InteractionRecord& getBCData() const { return mFirstIR; }
+
+  void setBCData(int orbit, int bc)
+  {
+    mFirstIR.orbit = orbit;
+    mFirstIR.bc = bc;
+  }
+  void setBCData(InteractionRecord& src)
+  {
+    mFirstIR.orbit = src.orbit;
+    mFirstIR.bc = src.bc;
+  }
+  void SetBC(int bc) { mFirstIR.bc = bc; }
+  void SetOrbit(int orbit) { mFirstIR.orbit = orbit; }
+
   gsl::span<const Digit> getBunchChannelData(const gsl::span<const Digit> tfdata) const
   {
     // extract the span of channel data for this readout window from the whole TF data
@@ -123,7 +141,10 @@ struct ReadoutWindowData {
   int first() const { return ref.getFirstEntry(); }
   int size() const { return ref.getEntries(); }
 
-  ClassDefNV(ReadoutWindowData, 1);
+  void setFirstEntry(int first) { ref.setFirstEntry(first); }
+  void setNEntries(int ne) { ref.setEntries(ne); }
+
+  ClassDefNV(ReadoutWindowData, 2);
 };
 
 } // namespace tof

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -108,6 +108,7 @@ struct ReadoutWindowData {
   // 1st entry and number of entries in the full vector of digits
   // for given trigger (or BC or RO frame)
   o2::dataformats::RangeReference<int, int> ref;
+  o2::dataformats::RangeReference<int, int> refDiagnostic;
   InteractionRecord mFirstIR{0, 0};
 
   const InteractionRecord& getBCData() const { return mFirstIR; }
@@ -136,15 +137,21 @@ struct ReadoutWindowData {
   {
     ref.setFirstEntry(first);
     ref.setEntries(ne);
+    refDiagnostic.setFirstEntry(0);
+    refDiagnostic.setEntries(0);
   }
 
   int first() const { return ref.getFirstEntry(); }
   int size() const { return ref.getEntries(); }
+  int firstDia() const { return refDiagnostic.getFirstEntry(); }
+  int sizeDia() const { return refDiagnostic.getEntries(); }
 
   void setFirstEntry(int first) { ref.setFirstEntry(first); }
   void setNEntries(int ne) { ref.setEntries(ne); }
+  void setFirstEntryDia(int first) { refDiagnostic.setFirstEntry(first); }
+  void setNEntriesDia(int ne) { refDiagnostic.setEntries(ne); }
 
-  ClassDefNV(ReadoutWindowData, 2);
+  ClassDefNV(ReadoutWindowData, 3);
 };
 
 } // namespace tof

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -121,6 +121,9 @@ void WindowFiller::fillOutputContainer(std::vector<Digit>& digits)
     int first = mDigitsPerTimeFrame.size();
     int ne = digits.size();
     ReadoutWindowData info(first, ne);
+    int orbit_shift = mReadoutWindowData.size() / 3;
+    int bc_shift = (mReadoutWindowData.size() % 3) * Geo::BC_IN_WINDOW;
+    info.setBCData(mFirstIR.orbit + orbit_shift, mFirstIR.bc + bc_shift);
     if (digits.size())
       mDigitsPerTimeFrame.insert(mDigitsPerTimeFrame.end(), digits.begin(), digits.end());
     mReadoutWindowData.push_back(info);

--- a/Detectors/TOF/reconstruction/CMakeLists.txt
+++ b/Detectors/TOF/reconstruction/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_library(TOFReconstruction
                                      O2::SimulationDataFormat
                                      O2::CommonDataFormat
                                      O2::DataFormatsTOF
-                                     O2::rANS
+                                     O2::rANS O2::DPLUtils
 				     O2::TOFCalibration O2::DetectorsRaw)
 
 o2_target_root_dictionary(TOFReconstruction

--- a/Detectors/TOF/reconstruction/CMakeLists.txt
+++ b/Detectors/TOF/reconstruction/CMakeLists.txt
@@ -13,8 +13,12 @@ o2_add_library(TOFReconstruction
                        src/ClustererTask.cxx src/Encoder.cxx
                	       src/DecoderBase.cxx
                        src/Decoder.cxx
+                       src/CTFCoder.cxx
                PUBLIC_LINK_LIBRARIES O2::TOFBase O2::DataFormatsTOF
                                      O2::SimulationDataFormat
+                                     O2::CommonDataFormat
+                                     O2::DataFormatsTOF
+                                     O2::rANS
 				     O2::TOFCalibration O2::DetectorsRaw)
 
 o2_target_root_dictionary(TOFReconstruction
@@ -23,4 +27,5 @@ o2_target_root_dictionary(TOFReconstruction
                                   include/TOFReconstruction/ClustererTask.h
                                   include/TOFReconstruction/Encoder.h
                			  include/TOFReconstruction/DecoderBase.h
-                                  include/TOFReconstruction/Decoder.h)
+                                  include/TOFReconstruction/Decoder.h
+                                  include/TOFReconstruction/CTFCoder.h)

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -35,7 +35,7 @@ class CTFCoder
  public:
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
-  static void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec);
+  static void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec);
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VDIG, typename VPAT>
@@ -43,18 +43,154 @@ class CTFCoder
 
  private:
   /// compres compact clusters to CompressedInfos
-  static void compress(CompressedInfos& cc, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec);
+  static void compress(CompressedInfos& cc, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec);
 
   /// decompress CompressedInfos to compact clusters
   template <typename VROF, typename VDIG, typename VPAT>
   static void decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
 
   static void appendToTree(TTree& tree, o2::detectors::DetID id, CTF& ec);
-  static void readFromTree(TTree& tree, int entry, o2::detectors::DetID id, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<unsigned char>& pattVec);
+  static void readFromTree(TTree& tree, int entry, o2::detectors::DetID id, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint32_t>& pattVec);
 
  protected:
   ClassDefNV(CTFCoder, 1);
 };
+
+///___________________________________________________________________________________
+/// entropy-encode digits to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, //BLCbcIncROF
+    MD::EENCODE, //BLCorbitIncROF
+    MD::EENCODE, //BLCndigROF
+    MD::EENCODE, //BLCndiaROF
+    MD::EENCODE, //BLCtimeFrameInc
+    MD::EENCODE, //BLCtimeTDCInc
+    MD::EENCODE, //BLCstripID
+    MD::EENCODE, //BLCchanInStrip
+    MD::EENCODE, //BLCtot
+    MD::EENCODE, //BLCpattMap
+  };
+  CompressedInfos cc;
+  compress(cc, rofRecVec, cdigVec, pattVec);
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(cc.header);
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODE CTF::get(buff.data())->encode
+  // clang-format off
+  ENCODE(cc.bcIncROF, CTF::BLCbcIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCbcIncROF], &buff);
+  ENCODE(cc.orbitIncROF, CTF::BLCorbitIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCorbitIncROF], &buff);
+  ENCODE(cc.ndigROF, CTF::BLCndigROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCndigROF], &buff);
+  ENCODE(cc.ndiaROF, CTF::BLCndiaROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCndiaROF], &buff);
+  ENCODE(cc.timeFrameInc, CTF::BLCtimeFrameInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeFrameInc], &buff);
+  ENCODE(cc.timeTDCInc, CTF::BLCtimeTDCInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeTDCInc], &buff);
+  ENCODE(cc.stripID, CTF::BLCstripID, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCstripID], &buff);
+  ENCODE(cc.chanInStrip, CTF::BLCchanInStrip, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCchanInStrip], &buff);
+  ENCODE(cc.tot, CTF::BLCtot, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtot], &buff);
+  ENCODE(cc.pattMap,      CTF::BLCpattMap,      o2::rans::ProbabilityBits16Bit, optField[CTF::BLCpattMap], &buff);
+  // clang-format on
+}
+///___________________________________________________________________________________
+/// decode entropy-encoded digits to standard compact digits
+template <typename VROF, typename VDIG, typename VPAT>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
+{
+  CompressedInfos cc;
+  cc.header = ec.getHeader();
+  // clang-format off
+    ec.decode(cc.bcIncROF, CTF::BLCbcIncROF);
+    ec.decode(cc.orbitIncROF, CTF::BLCorbitIncROF);
+    ec.decode(cc.ndigROF, CTF::BLCndigROF);
+    ec.decode(cc.ndiaROF, CTF::BLCndiaROF);
+
+    ec.decode(cc.timeFrameInc, CTF::BLCtimeFrameInc);
+    ec.decode(cc.timeTDCInc, CTF::BLCtimeTDCInc);
+    ec.decode(cc.stripID, CTF::BLCstripID);
+    ec.decode(cc.chanInStrip, CTF::BLCchanInStrip);
+    ec.decode(cc.tot, CTF::BLCtot);
+    ec.decode(cc.pattMap,      CTF::BLCpattMap);
+  // clang-format on
+  //
+  decompress(cc, rofRecVec, cdigVec, pattVec);
+}
+///___________________________________________________________________________________
+/// decompress compressed infos to standard compact digits
+template <typename VROF, typename VDIG, typename VPAT>
+void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
+{
+  rofRecVec.resize(cc.header.nROFs);
+  cdigVec.resize(cc.header.nDigits);
+  pattVec.resize(cc.header.nPatternBytes);
+
+  o2::InteractionRecord prevIR(cc.header.firstBC, cc.header.firstOrbit);
+  uint32_t firstEntry = 0, digCount = 0, stripCount = 0, ndiagnostic = 0;
+  for (uint32_t irof = 0; irof < cc.header.nROFs; irof++) {
+    // restore ROFRecord
+    auto& rofRec = rofRecVec[irof];
+    if (cc.orbitIncROF[irof]) {      // new orbit
+      prevIR.bc = cc.bcIncROF[irof]; // bcInc has absolute meaning
+      prevIR.orbit += cc.orbitIncROF[irof];
+    } else {
+      prevIR.bc += cc.bcIncROF[irof];
+    }
+    rofRec.setBCData(prevIR);
+    rofRec.setFirstEntry(firstEntry);
+    rofRec.setNEntries(cc.ndigROF[irof]);
+    rofRec.setFirstEntryDia(ndiagnostic);
+    rofRec.setNEntriesDia(cc.ndiaROF[irof]);
+    firstEntry += cc.ndigROF[irof];
+    ndiagnostic += cc.ndiaROF[irof];
+
+    // restore hit data
+    uint ctimeframe = 0;
+    uint ctdc = 0;
+
+    int firstDig = digCount;
+
+    for (uint32_t idig = 0; idig < cc.ndigROF[irof]; idig++) {
+      auto& digit = cdigVec[digCount];
+      if (cc.timeFrameInc[digCount]) { // new time frame
+        ctdc = cc.timeTDCInc[digCount];
+        ctimeframe += cc.timeFrameInc[digCount];
+      } else {
+        ctdc += cc.timeTDCInc[digCount];
+      }
+
+      digit.setBC(uint32_t(ctimeframe) * 64 + ctdc / 1024);
+      digit.setTDC(ctdc % 1024);
+      digit.setTOT(cc.tot[digCount]);
+      digit.setChannel(uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
+
+      digCount++;
+    }
+
+    // sort digits according to strip number within the ROF
+    if (digCount > firstDig) {
+      std::partial_sort(cdigVec.begin() + firstDig, cdigVec.begin() + digCount - 1, cdigVec.end(),
+                        [](o2::tof::Digit a, o2::tof::Digit b) {
+                          int str1 = a.getChannel() / 1600;
+                          int str2 = b.getChannel() / 1600;
+                          return (str1 <= str2);
+                        });
+    }
+  }
+  // explicit patterns
+  memcpy(pattVec.data(), cc.pattMap.data(), cc.header.nPatternBytes); // RSTODO use swap?
+  assert(digCount == cc.header.nDigits);
+
+  if (digCount != cc.header.nDigits) {
+    LOG(ERROR) << "expected " << cc.header.nDigits << " but counted " << digCount << " in ROFRecords";
+    throw std::runtime_error("mismatch between expected and counter number of digits");
+  }
+}
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author fnoferin@cern.ch
+/// \brief class for entropy encoding/decoding of TOF compressed infos data
+
+#ifndef O2_TOF_CTFCODER_H
+#define O2_TOF_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include "DataFormatsTOF/CTF.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "rANS/rans.h"
+#include "TOFBase/Digit.h"
+
+class TTree;
+
+namespace o2
+{
+namespace tof
+{
+
+class CTFCoder
+{
+ public:
+  /// entropy-encode clusters to buffer with CTF
+  template <typename VEC>
+  static void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec);
+
+  /// entropy decode clusters from buffer with CTF
+  template <typename VROF, typename VDIG, typename VPAT>
+  static void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
+
+ private:
+  /// compres compact clusters to CompressedInfos
+  static void compress(CompressedInfos& cc, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec);
+
+  /// decompress CompressedInfos to compact clusters
+  template <typename VROF, typename VDIG, typename VPAT>
+  static void decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
+
+  static void appendToTree(TTree& tree, o2::detectors::DetID id, CTF& ec);
+  static void readFromTree(TTree& tree, int entry, o2::detectors::DetID id, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<unsigned char>& pattVec);
+
+ protected:
+  ClassDefNV(CTFCoder, 1);
+};
+
+} // namespace tof
+} // namespace o2
+
+#endif // O2_TOF_CTFCODER_H

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -1,0 +1,269 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author fnoferin@cern.ch
+/// \brief class for entropy encoding/decoding of TOF compressed digits data
+
+#include "TOFReconstruction/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::tof;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, o2::detectors::DetID id, CTF& ec)
+{
+  ec.appendToTree(tree, id.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, o2::detectors::DetID id,
+                            std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<unsigned char>& pattVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, id.getName(), entry);
+  decode(ec, rofRecVec, cdigVec, pattVec);
+}
+
+///________________________________
+void CTFCoder::compress(CompressedInfos& cc,
+                        const gsl::span<const ReadoutWindowData>& rofRecVec,
+                        const gsl::span<const Digit>& cdigVec,
+                        const gsl::span<const unsigned char>& pattVec)
+{
+  // store in the header the orbit of 1st ROF
+  cc.clear();
+  if (!rofRecVec.size()) {
+    return;
+  }
+  const auto& rofRec0 = rofRecVec[0];
+  int nrof = rofRecVec.size();
+
+  cc.header.nROFs = nrof;
+  cc.header.firstOrbit = rofRec0.getBCData().orbit;
+  cc.header.firstBC = rofRec0.getBCData().bc;
+  cc.header.nPatternBytes = pattVec.size();
+  cc.header.nDigits = cdigVec.size();
+
+  cc.bcIncROF.resize(cc.header.nROFs);
+  cc.orbitIncROF.resize(cc.header.nROFs);
+  cc.ndigROF.resize(cc.header.nROFs);
+  //
+  cc.timeFrameInc.resize(cc.header.nDigits);
+  cc.timeTDCInc.resize(cc.header.nDigits);
+  cc.stripID.resize(cc.header.nDigits);
+  cc.chanInStrip.resize(cc.header.nDigits);
+  cc.tot.resize(cc.header.nDigits);
+  cc.pattMap.resize(cc.header.nPatternBytes);
+
+  uint16_t prevBC = cc.header.firstBC;
+  uint32_t prevOrbit = cc.header.firstOrbit;
+
+  std::vector<Digit> digCopy;
+
+  for (uint32_t irof = 0; irof < rofRecVec.size(); irof++) {
+    const auto& rofRec = rofRecVec[irof];
+
+    const auto& intRec = rofRec.getBCData();
+    int rofInBC = intRec.toLong();
+    // define interaction record
+    if (intRec.orbit == prevOrbit) {
+      cc.orbitIncROF[irof] = 0;
+      cc.bcIncROF[irof] = intRec.bc - prevBC; // store increment of BC if in the same orbit
+    } else {
+      cc.orbitIncROF[irof] = intRec.orbit - prevOrbit;
+      cc.bcIncROF[irof] = intRec.bc; // otherwise, store absolute bc
+      prevOrbit = intRec.orbit;
+    }
+    prevBC = intRec.bc;
+    auto ndig = rofRec.size();
+    cc.ndigROF[irof] = ndig;
+
+    if (!ndig) { // no hits data for this ROF --> not fill
+      continue;
+    }
+
+    int idig = rofRec.first(), idigMax = idig + ndig;
+
+    // make a copy of digits
+    digCopy.clear();
+    for (; idig < idigMax; idig++) {
+      digCopy.emplace_back(cdigVec[idig]);
+    }
+
+    // sort digits according to time (ascending order)
+    std::sort(digCopy.begin(), digCopy.end(),
+              [](o2::tof::Digit a, o2::tof::Digit b) {
+                if (a.getBC() == b.getBC())
+                  return a.getTDC() < b.getTDC();
+                else
+                  return a.getBC() < b.getBC();
+              });
+
+    int timeframe = 0;
+    int tdc = 0;
+    idig = 0;
+    for (; idig < ndig; idig++) {
+      const auto& dig = digCopy[idig];
+      int deltaBC = dig.getBC() - rofInBC;
+      int ctimeframe = deltaBC / 64;
+      int cTDC = (deltaBC % 64) * 1024 + dig.getTDC();
+      if (ctimeframe == timeframe) {
+        cc.timeFrameInc[idig] = 0;
+        cc.timeTDCInc[idig] = cTDC - tdc;
+      } else {
+        cc.timeFrameInc[idig] = ctimeframe - timeframe;
+        cc.timeTDCInc[idig] = cTDC;
+        timeframe = ctimeframe;
+      }
+      tdc = cTDC;
+
+      int chan = dig.getChannel();
+      cc.stripID[idig] = chan / Geo::NPADS;
+      cc.chanInStrip[idig] = chan % Geo::NPADS;
+      cc.tot[idig] = dig.getTOT();
+    }
+  }
+  // store explicit patters as they are
+  memcpy(cc.pattMap.data(), pattVec.data(), cc.header.nPatternBytes); // RSTODO: do we need this?
+}
+///___________________________________________________________________________________
+/// entropy-encode digits to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, //BLCbcIncROF
+    MD::EENCODE, //BLCorbitIncROF
+    MD::EENCODE, //BLCndigROF
+    MD::EENCODE, //BLCtimeFrameInc
+    MD::EENCODE, //BLCtimeTDCInc
+    MD::EENCODE, //BLCstripID
+    MD::EENCODE, //BLCchanInStrip
+    MD::EENCODE, //BLCtot
+    MD::EENCODE, //BLCpattMap
+  };
+  CompressedInfos cc;
+  compress(cc, rofRecVec, cdigVec, pattVec);
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(cc.header);
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODE CTF::get(buff.data())->encode
+  // clang-format off
+  ENCODE(cc.bcIncROF, CTF::BLCbcIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCbcIncROF], &buff);
+  ENCODE(cc.orbitIncROF, CTF::BLCorbitIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCorbitIncROF], &buff);
+  ENCODE(cc.ndigROF, CTF::BLCndigROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCndigROF], &buff);
+  ENCODE(cc.timeFrameInc, CTF::BLCtimeFrameInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeFrameInc], &buff);
+  ENCODE(cc.timeTDCInc, CTF::BLCtimeTDCInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeTDCInc], &buff);
+  ENCODE(cc.stripID, CTF::BLCstripID, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCstripID], &buff);
+  ENCODE(cc.chanInStrip, CTF::BLCchanInStrip, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCchanInStrip], &buff);
+  ENCODE(cc.tot, CTF::BLCtot, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtot], &buff);
+  ENCODE(cc.pattMap,      CTF::BLCpattMap,      o2::rans::ProbabilityBits16Bit, optField[CTF::BLCpattMap], &buff);
+  // clang-format on
+}
+///___________________________________________________________________________________
+/// decode entropy-encoded digits to standard compact digits
+template <typename VROF, typename VDIG, typename VPAT>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
+{
+  CompressedInfos cc;
+  cc.header = ec.getHeader();
+  // clang-format off
+    ec.decode(cc.bcIncROF, CTF::BLCbcIncROF);
+    ec.decode(cc.orbitIncROF, CTF::BLCorbitIncROF);
+    ec.decode(cc.ndigROF, CTF::BLCndigROF);
+
+    ec.decode(cc.timeFrameInc, CTF::BLCtimeFrameInc);
+    ec.decode(cc.timeTDCInc, CTF::BLCtimeTDCInc);
+    ec.decode(cc.stripID, CTF::BLCstripID);
+    ec.decode(cc.chanInStrip, CTF::BLCchanInStrip);
+    ec.decode(cc.tot, CTF::BLCtot);
+    ec.decode(cc.pattMap,      CTF::BLCpattMap);
+  // clang-format on
+  //
+  decompress(cc, rofRecVec, cdigVec, pattVec);
+}
+///___________________________________________________________________________________
+/// decompress compressed infos to standard compact digits
+template <typename VROF, typename VDIG, typename VPAT>
+void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
+{
+  rofRecVec.resize(cc.header.nROFs);
+  cdigVec.resize(cc.header.nDigits);
+  pattVec.resize(cc.header.nPatternBytes);
+
+  o2::InteractionRecord prevIR(cc.header.firstBC, cc.header.firstOrbit);
+  uint32_t firstEntry = 0, digCount = 0, stripCount = 0;
+  for (uint32_t irof = 0; irof < cc.header.nROFs; irof++) {
+    // restore ROFRecord
+    auto& rofRec = rofRecVec[irof];
+    if (cc.orbitIncROF[irof]) {      // new orbit
+      prevIR.bc = cc.bcIncROF[irof]; // bcInc has absolute meaning
+      prevIR.orbit += cc.orbitIncROF[irof];
+    } else {
+      prevIR.bc += cc.bcIncROF[irof];
+    }
+    rofRec.setBCData(prevIR);
+    rofRec.setFirstEntry(firstEntry);
+    rofRec.setNEntries(cc.ndigROF[irof]);
+    firstEntry += cc.ndigROF[irof];
+
+    // restore hit data
+    uint ctimeframe = 0;
+    uint ctdc = 0;
+
+    int firstDig = digCount;
+
+    for (uint32_t idig = 0; idig < cc.ndigROF[irof]; idig++) {
+      auto& digit = cdigVec[digCount];
+      if (cc.timeFrameInc[digCount]) { // new time frame
+        ctdc = cc.timeTDCInc[digCount];
+        ctimeframe += cc.timeFrameInc[digCount];
+      } else {
+        ctdc += cc.timeTDCInc[digCount];
+      }
+
+      digit.setBC(uint32_t(ctimeframe) * 64 + ctdc / 1024);
+      digit.setTDC(ctdc % 1024);
+      digit.setTOT(cc.tot[digCount]);
+      digit.setChannel(uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
+
+      digCount++;
+    }
+
+    // sort digits according to strip number within the ROF
+    if (digCount > firstDig) {
+      std::partial_sort(cdigVec.begin() + firstDig, cdigVec.begin() + digCount - 1, cdigVec.end(),
+                        [](o2::tof::Digit a, o2::tof::Digit b) {
+                          int str1 = a.getChannel() / 1600;
+                          int str2 = b.getChannel() / 1600;
+                          return (str1 <= str2);
+                        });
+    }
+  }
+  // explicit patterns
+  memcpy(pattVec.data(), cc.pattMap.data(), cc.header.nPatternBytes); // RSTODO use swap?
+  assert(digCount == cc.header.nDigits);
+
+  if (digCount != cc.header.nDigits) {
+    LOG(ERROR) << "expected " << cc.header.nDigits << " but counted " << digCount << " in ROFRecords";
+    throw std::runtime_error("mismatch between expected and counter number of digits");
+  }
+}

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -50,6 +50,8 @@ void CTFCoder::compress(CompressedInfos& cc,
   const auto& rofRec0 = rofRecVec[0];
   int nrof = rofRecVec.size();
 
+  printf("TOF compress %d ReadoutWindow with %ld digits\n", nrof, cdigVec.size());
+
   cc.header.nROFs = nrof;
   cc.header.firstOrbit = rofRec0.getBCData().orbit;
   cc.header.firstBC = rofRec0.getBCData().bc;

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -98,7 +98,8 @@ void CTFCoder::compress(CompressedInfos& cc,
       continue;
     }
 
-    int idig = rofRec.first(), idigMax = idig + ndig;
+    int idigMin = rofRec.first(), idigMax = idigMin + ndig;
+    int idig = idigMin;
 
     // make a copy of digits
     digCopy.clear();
@@ -117,9 +118,9 @@ void CTFCoder::compress(CompressedInfos& cc,
 
     int timeframe = 0;
     int tdc = 0;
-    idig = 0;
-    for (; idig < ndig; idig++) {
-      const auto& dig = digCopy[idig];
+    idig = idigMin;
+    for (; idig < idigMax; idig++) {
+      const auto& dig = digCopy[idig - idigMin];
       int deltaBC = dig.getBC() - rofInBC;
       int ctimeframe = deltaBC / 64;
       int cTDC = (deltaBC % 64) * 1024 + dig.getTDC();
@@ -137,6 +138,8 @@ void CTFCoder::compress(CompressedInfos& cc,
       cc.stripID[idig] = chan / Geo::NPADS;
       cc.chanInStrip[idig] = chan % Geo::NPADS;
       cc.tot[idig] = dig.getTOT();
+      printf("%d) TOFBC = %d, deltaBC = %d, TDC = %d, CH=%d\n", irof, rofInBC, deltaBC, cTDC, chan);
+      printf("%d) TF=%d, TDC=%d, STRIP=%d, CH=%d, TOT=%d\n", idig, cc.timeFrameInc[idig], cc.timeTDCInc[idig], cc.stripID[idig], cc.chanInStrip[idig], cc.tot[idig]);
     }
   }
   // store explicit patters as they are

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -28,7 +28,7 @@ void CTFCoder::appendToTree(TTree& tree, o2::detectors::DetID id, CTF& ec)
 ///___________________________________________________________________________________
 // extract and decode data from the tree
 void CTFCoder::readFromTree(TTree& tree, int entry, o2::detectors::DetID id,
-                            std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<unsigned char>& pattVec)
+                            std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint32_t>& pattVec)
 {
   assert(entry >= 0 && entry < tree.GetEntries());
   CTF ec;
@@ -40,7 +40,7 @@ void CTFCoder::readFromTree(TTree& tree, int entry, o2::detectors::DetID id,
 void CTFCoder::compress(CompressedInfos& cc,
                         const gsl::span<const ReadoutWindowData>& rofRecVec,
                         const gsl::span<const Digit>& cdigVec,
-                        const gsl::span<const unsigned char>& pattVec)
+                        const gsl::span<const uint32_t>& pattVec)
 {
   // store in the header the orbit of 1st ROF
   cc.clear();
@@ -59,6 +59,7 @@ void CTFCoder::compress(CompressedInfos& cc,
   cc.bcIncROF.resize(cc.header.nROFs);
   cc.orbitIncROF.resize(cc.header.nROFs);
   cc.ndigROF.resize(cc.header.nROFs);
+  cc.ndiaROF.resize(cc.header.nROFs);
   //
   cc.timeFrameInc.resize(cc.header.nDigits);
   cc.timeTDCInc.resize(cc.header.nDigits);
@@ -89,6 +90,7 @@ void CTFCoder::compress(CompressedInfos& cc,
     prevBC = intRec.bc;
     auto ndig = rofRec.size();
     cc.ndigROF[irof] = ndig;
+    cc.ndiaROF[irof] = rofRec.sizeDia();
 
     if (!ndig) { // no hits data for this ROF --> not fill
       continue;
@@ -137,133 +139,4 @@ void CTFCoder::compress(CompressedInfos& cc,
   }
   // store explicit patters as they are
   memcpy(cc.pattMap.data(), pattVec.data(), cc.header.nPatternBytes); // RSTODO: do we need this?
-}
-///___________________________________________________________________________________
-/// entropy-encode digits to buffer with CTF
-template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const unsigned char>& pattVec)
-{
-  using MD = o2::ctf::Metadata::OptStore;
-  // what to do which each field: see o2::ctd::Metadata explanation
-  constexpr MD optField[CTF::getNBlocks()] = {
-    MD::EENCODE, //BLCbcIncROF
-    MD::EENCODE, //BLCorbitIncROF
-    MD::EENCODE, //BLCndigROF
-    MD::EENCODE, //BLCtimeFrameInc
-    MD::EENCODE, //BLCtimeTDCInc
-    MD::EENCODE, //BLCstripID
-    MD::EENCODE, //BLCchanInStrip
-    MD::EENCODE, //BLCtot
-    MD::EENCODE, //BLCpattMap
-  };
-  CompressedInfos cc;
-  compress(cc, rofRecVec, cdigVec, pattVec);
-  auto ec = CTF::create(buff);
-  using ECB = CTF::base;
-
-  ec->setHeader(cc.header);
-  ec->getANSHeader().majorVersion = 0;
-  ec->getANSHeader().minorVersion = 1;
-  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
-#define ENCODE CTF::get(buff.data())->encode
-  // clang-format off
-  ENCODE(cc.bcIncROF, CTF::BLCbcIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCbcIncROF], &buff);
-  ENCODE(cc.orbitIncROF, CTF::BLCorbitIncROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCorbitIncROF], &buff);
-  ENCODE(cc.ndigROF, CTF::BLCndigROF, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCndigROF], &buff);
-  ENCODE(cc.timeFrameInc, CTF::BLCtimeFrameInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeFrameInc], &buff);
-  ENCODE(cc.timeTDCInc, CTF::BLCtimeTDCInc, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtimeTDCInc], &buff);
-  ENCODE(cc.stripID, CTF::BLCstripID, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCstripID], &buff);
-  ENCODE(cc.chanInStrip, CTF::BLCchanInStrip, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCchanInStrip], &buff);
-  ENCODE(cc.tot, CTF::BLCtot, o2::rans::ProbabilityBits16Bit, optField[CTF::BLCtot], &buff);
-  ENCODE(cc.pattMap,      CTF::BLCpattMap,      o2::rans::ProbabilityBits16Bit, optField[CTF::BLCpattMap], &buff);
-  // clang-format on
-}
-///___________________________________________________________________________________
-/// decode entropy-encoded digits to standard compact digits
-template <typename VROF, typename VDIG, typename VPAT>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
-{
-  CompressedInfos cc;
-  cc.header = ec.getHeader();
-  // clang-format off
-    ec.decode(cc.bcIncROF, CTF::BLCbcIncROF);
-    ec.decode(cc.orbitIncROF, CTF::BLCorbitIncROF);
-    ec.decode(cc.ndigROF, CTF::BLCndigROF);
-
-    ec.decode(cc.timeFrameInc, CTF::BLCtimeFrameInc);
-    ec.decode(cc.timeTDCInc, CTF::BLCtimeTDCInc);
-    ec.decode(cc.stripID, CTF::BLCstripID);
-    ec.decode(cc.chanInStrip, CTF::BLCchanInStrip);
-    ec.decode(cc.tot, CTF::BLCtot);
-    ec.decode(cc.pattMap,      CTF::BLCpattMap);
-  // clang-format on
-  //
-  decompress(cc, rofRecVec, cdigVec, pattVec);
-}
-///___________________________________________________________________________________
-/// decompress compressed infos to standard compact digits
-template <typename VROF, typename VDIG, typename VPAT>
-void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
-{
-  rofRecVec.resize(cc.header.nROFs);
-  cdigVec.resize(cc.header.nDigits);
-  pattVec.resize(cc.header.nPatternBytes);
-
-  o2::InteractionRecord prevIR(cc.header.firstBC, cc.header.firstOrbit);
-  uint32_t firstEntry = 0, digCount = 0, stripCount = 0;
-  for (uint32_t irof = 0; irof < cc.header.nROFs; irof++) {
-    // restore ROFRecord
-    auto& rofRec = rofRecVec[irof];
-    if (cc.orbitIncROF[irof]) {      // new orbit
-      prevIR.bc = cc.bcIncROF[irof]; // bcInc has absolute meaning
-      prevIR.orbit += cc.orbitIncROF[irof];
-    } else {
-      prevIR.bc += cc.bcIncROF[irof];
-    }
-    rofRec.setBCData(prevIR);
-    rofRec.setFirstEntry(firstEntry);
-    rofRec.setNEntries(cc.ndigROF[irof]);
-    firstEntry += cc.ndigROF[irof];
-
-    // restore hit data
-    uint ctimeframe = 0;
-    uint ctdc = 0;
-
-    int firstDig = digCount;
-
-    for (uint32_t idig = 0; idig < cc.ndigROF[irof]; idig++) {
-      auto& digit = cdigVec[digCount];
-      if (cc.timeFrameInc[digCount]) { // new time frame
-        ctdc = cc.timeTDCInc[digCount];
-        ctimeframe += cc.timeFrameInc[digCount];
-      } else {
-        ctdc += cc.timeTDCInc[digCount];
-      }
-
-      digit.setBC(uint32_t(ctimeframe) * 64 + ctdc / 1024);
-      digit.setTDC(ctdc % 1024);
-      digit.setTOT(cc.tot[digCount]);
-      digit.setChannel(uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
-
-      digCount++;
-    }
-
-    // sort digits according to strip number within the ROF
-    if (digCount > firstDig) {
-      std::partial_sort(cdigVec.begin() + firstDig, cdigVec.begin() + digCount - 1, cdigVec.end(),
-                        [](o2::tof::Digit a, o2::tof::Digit b) {
-                          int str1 = a.getChannel() / 1600;
-                          int str2 = b.getChannel() / 1600;
-                          return (str1 <= str2);
-                        });
-    }
-  }
-  // explicit patterns
-  memcpy(pattVec.data(), cc.pattMap.data(), cc.header.nPatternBytes); // RSTODO use swap?
-  assert(digCount == cc.header.nDigits);
-
-  if (digCount != cc.header.nDigits) {
-    LOG(ERROR) << "expected " << cc.header.nDigits << " but counted " << digCount << " in ROFRecords";
-    throw std::runtime_error("mismatch between expected and counter number of digits");
-  }
 }

--- a/Detectors/TOF/reconstruction/src/TOFReconstructionLinkDef.h
+++ b/Detectors/TOF/reconstruction/src/TOFReconstructionLinkDef.h
@@ -20,5 +20,6 @@
 #pragma link C++ class o2::tof::ClustererTask + ;
 #pragma link C++ class o2::tof::raw::Encoder + ;
 #pragma link C++ class o2::tof::compressed::Decoder + ;
+#pragma link C++ class o2::tof::CTFCoder + ;
 
 #endif

--- a/Detectors/TOF/simulation/src/Digitizer.cxx
+++ b/Detectors/TOF/simulation/src/Digitizer.cxx
@@ -784,6 +784,9 @@ void Digitizer::fillOutputContainer(std::vector<Digit>& digits)
     int first = mDigitsPerTimeFrame.size();
     int ne = digits.size();
     ReadoutWindowData info(first, ne);
+    int orbit_shift = mReadoutWindowData.size() / 3;
+    int bc_shift = (mReadoutWindowData.size() % 3) * Geo::BC_IN_WINDOW;
+    info.setBCData(mFirstIR.orbit + orbit_shift, mFirstIR.bc + bc_shift);
     mDigitsPerTimeFrame.insert(mDigitsPerTimeFrame.end(), digits.begin(), digits.end());
     mReadoutWindowData.push_back(info);
   }

--- a/Detectors/TOF/workflow/CMakeLists.txt
+++ b/Detectors/TOF/workflow/CMakeLists.txt
@@ -17,5 +17,5 @@ o2_add_library(TOFWorkflowUtils
                        src/TOFRawWriterSpec.cxx
                        src/CompressedDecodingTask.cxx
                        src/CompressedInspectorTask.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::TOFBase O2::DataFormatsTOF
-                                     O2::TOFReconstruction)
+                       src/EntropyEncoderSpec.cxx
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::TOFBase O2::DataFormatsTOF O2::TOFReconstruction)

--- a/Detectors/TOF/workflow/CMakeLists.txt
+++ b/Detectors/TOF/workflow/CMakeLists.txt
@@ -18,4 +18,11 @@ o2_add_library(TOFWorkflowUtils
                        src/CompressedDecodingTask.cxx
                        src/CompressedInspectorTask.cxx
                        src/EntropyEncoderSpec.cxx
+                       src/EntropyDecoderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::TOFBase O2::DataFormatsTOF O2::TOFReconstruction)
+
+o2_add_executable(entropy-encoder-workflow
+                  SOURCES src/entropy-encoder-workflow.cxx
+                  COMPONENT_NAME tof
+                  PUBLIC_LINK_LIBRARIES O2::TOFWorkflow)
+

--- a/Detectors/TOF/workflow/include/TOFWorkflow/DigitReaderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/DigitReaderSpec.h
@@ -38,11 +38,13 @@ class DigitReader : public Task
 
  private:
   int mState = 0;
+  int mCurrentEntry = 0;
   bool mUseMC = true;
   std::unique_ptr<TFile> mFile = nullptr;
   std::vector<o2::tof::Digit> mDigits, *mPdigits = &mDigits;
   std::vector<o2::tof::ReadoutWindowData> mRow, *mProw = &mRow;
   std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>> mLabels, *mPlabels = &mLabels;
+  std::vector<uint32_t> mPatterns, *mPpatterns = &mPatterns;
 };
 
 /// create a processor spec

--- a/Detectors/TOF/workflow/include/TOFWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to FT0 digit/channels strean
+
+#ifndef O2_TOF_ENTROPYDECODER_SPEC
+#define O2_TOF_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace tof
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace tof
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/workflow/include/TOFWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert clusters streams to CTF (EncodedBlocks)
+
+#ifndef O2_TOF_ENTROPYENCODER_SPEC
+#define O2_TOF_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace tof
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace tof
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TOFReconstruction/CTFCoder.h"
+#include "TOFWorkflow/EntropyDecoderSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tof
+{
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& digits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
+  auto& row = pc.outputs().make<std::vector<ReadoutWindowData>>(OutputRef{"row"});
+  auto& patterns = pc.outputs().make<std::vector<uint32_t>>(OutputRef{"patterns"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::tof::CTF::getImage(buff.data());
+  CTFCoder::decode(ctfImage, row, digits, patterns);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << digits.size() << " digits in " << row.size() << " ROF in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "TOF Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"digits"}, o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe},
+    OutputSpec{{"row"}, o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe},
+    OutputSpec{{"patterns"}, o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "tof-entropy-decoder",
+    Inputs{InputSpec{"ctf", o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{}};
+}
+
+} // namespace tof
+} // namespace o2

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TOFBase/Digit.h"
+#include "TOFReconstruction/CTFCoder.h"
+#include "TOFWorkflow/EntropyEncoderSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tof
+{
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto compDigits = pc.inputs().get<gsl::span<Digit>>("compClusters");
+  auto pspan = pc.inputs().get<gsl::span<uint32_t>>("patterns");
+  auto rofs = pc.inputs().get<gsl::span<ReadoutWindowData>>("ROframes");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe});
+  CTFCoder::encode(buffer, rofs, compDigits, pspan);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for TOF in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "%s Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots TOF",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("compDigits", o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("patterns", o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "tof-entropy-encoder",
+    inputs,
+    Outputs{{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{}};
+}
+
+} // namespace tof
+} // namespace o2

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
-  auto compDigits = pc.inputs().get<gsl::span<Digit>>("compClusters");
+  auto compDigits = pc.inputs().get<gsl::span<Digit>>("compDigits");
   auto pspan = pc.inputs().get<gsl::span<uint32_t>>("patterns");
   auto rofs = pc.inputs().get<gsl::span<ReadoutWindowData>>("ROframes");
 
@@ -47,11 +47,12 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   //  eeb->print();
   mTimer.Stop();
   LOG(INFO) << "Created encoded data of size " << eeb->size() << " for TOF in " << mTimer.CpuTime() - cput << " s";
+  //  pc.services().get<ControlService>().endOfStream();
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "%s Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots TOF",
+  LOGF(INFO, "TOF Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/TOF/workflow/src/TOFDigitWriterSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFDigitWriterSpec.cxx
@@ -26,6 +26,7 @@ template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 using OutputType = std::vector<o2::tof::Digit>;
 using ReadoutWinType = std::vector<o2::tof::ReadoutWindowData>;
+using PatternType = std::vector<uint32_t>;
 using LabelsType = std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>;
 using namespace o2::header;
 
@@ -52,6 +53,9 @@ DataProcessorSpec getTOFDigitWriterSpec(bool useMC)
   auto loggerROW = [nCalls](ReadoutWinType const& row) {
     LOG(INFO) << "RECEIVED READOUT WINDOWS " << row.size();
   };
+  auto loggerPatterns = [nCalls](PatternType const& patterns) {
+    LOG(INFO) << "RECEIVED PATTERNS " << patterns.size();
+  };
   return MakeRootTreeWriterSpec("TOFDigitWriter",
                                 "tofdigits.root",
                                 "o2sim",
@@ -68,6 +72,11 @@ DataProcessorSpec getTOFDigitWriterSpec(bool useMC)
                                                                  "rowindow-branch-name",
                                                                  1,
                                                                  loggerROW},
+                                BranchDefinition<PatternType>{InputSpec{"patterns", gDataOriginTOF, "PATTERNS", 0},
+                                                              "TOFPatterns",
+                                                              "patterns-branch-name",
+                                                              1,
+                                                              loggerPatterns},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", gDataOriginTOF, "DIGITSMCTR", 0},
                                                              "TOFDigitMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled

--- a/Detectors/TOF/workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/TOF/workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFWorkflow/EntropyEncoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::tof::getEntropyEncoderSpec());
+  return wf;
+}

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -163,6 +163,11 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
       pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "DIGITSMCTR", 0, Lifetime::Timeframe}, *mcLabVecOfVec);
     }
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, *readoutwindow);
+
+    // send empty pattern from digitizer (it may change in future)
+    static std::vector<uint32_t> patterns;
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}, patterns);
+
     LOG(INFO) << "TOF: Sending ROMode= " << roMode << " to GRPUpdater";
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "ROMode", 0, Lifetime::Timeframe}, roMode);
 
@@ -199,6 +204,7 @@ DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back(o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe);
   if (mctruth) {
     outputs.emplace_back(o2::header::gDataOriginTOF, "DIGITSMCTR", 0, Lifetime::Timeframe);
   }


### PR DESCRIPTION
A first prototype of TOF CTF is provided.
digit->CTF and viceversa implemented and tested:
o2-tof-reco-workflow -b --output-type ctf|o2-ctf-writer-workflow -b --onlyDet TOF
o2-ctf-reader-workflow -b --ctf-input o2_ctf_0000000000.root |o2-tof-reco-workflow -b --input-type ctf --output-type digits

Currently TOF CTF size too large and needs optimization BUT this PR is needed to continue the work (since changes in digit structure are required to run on the grid pbpb)