### PR TITLE
DPL: move Service callback responsibility to ServiceRegistry

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -71,19 +71,7 @@ struct DataProcessorContext {
   AlgorithmSpec::ProcessCallback* statefulProcess = nullptr;
   AlgorithmSpec::ProcessCallback* statelessProcess = nullptr;
   AlgorithmSpec::ErrorCallback* error = nullptr;
-  /// Callbacks for services to be executed before every process method invokation
-  std::vector<ServiceProcessingHandle>* preProcessingHandles = nullptr;
-  /// Callbacks for services to be executed after every process method invokation
-  std::vector<ServiceProcessingHandle>* postProcessingHandles = nullptr;
-  /// Callbacks for services to be executed before every dangling check
-  std::vector<ServiceDanglingHandle>* preDanglingHandles = nullptr;
-  /// Callbacks for services to be executed after every dangling check
-  std::vector<ServiceDanglingHandle>* postDanglingHandles = nullptr;
-  /// Callbacks for services to be executed before every EOS user callback invokation
-  std::vector<ServiceEOSHandle>* preEOSHandles = nullptr;
-  /// Callbacks for services to be executed after every EOS user callback invokation
-  std::vector<ServiceEOSHandle>* postEOSHandles = nullptr;
-  /// Callback for the error handling
+
   std::function<void(std::exception& e, InputRecord& record)>* errorHandling = nullptr;
   int* errorCount = nullptr;
 };
@@ -102,7 +90,6 @@ class DataProcessingDevice : public FairMQDevice
   void ResetTask() final;
   bool ConditionalRun() final;
   void SetErrorPolicy(enum TerminationPolicy policy) { mErrorPolicy = policy; }
-  void bindService(ServiceSpec const& spec, void* service);
 
   // Processing functions are now renetrant
   static void doRun(DataProcessorContext& context);
@@ -135,18 +122,6 @@ class DataProcessingDevice : public FairMQDevice
   std::vector<ExpirationHandler> mExpirationHandlers;
   /// Completed actions
   std::vector<DataRelayer::RecordAction> mCompleted;
-  /// Callbacks for services to be executed before every process method invokation
-  std::vector<ServiceProcessingHandle> mPreProcessingHandles;
-  /// Callbacks for services to be executed after every process method invokation
-  std::vector<ServiceProcessingHandle> mPostProcessingHandles;
-  /// Callbacks for services to be executed before every dangling check
-  std::vector<ServiceDanglingHandle> mPreDanglingHandles;
-  /// Callbacks for services to be executed after every dangling check
-  std::vector<ServiceDanglingHandle> mPostDanglingHandles;
-  /// Callbacks for services to be executed before every EOS user callback invokation
-  std::vector<ServiceEOSHandle> mPreEOSHandles;
-  /// Callbacks for services to be executed after every EOS user callback invokation
-  std::vector<ServiceEOSHandle> mPostEOSHandles;
 
   int mErrorCount;
   uint64_t mLastSlowMetricSentTimestamp = 0;         /// The timestamp of the last time we sent slow metrics

--- a/Framework/Core/src/ServiceRegistry.cxx
+++ b/Framework/Core/src/ServiceRegistry.cxx
@@ -15,7 +15,7 @@
 namespace o2::framework
 {
 
-ServiceRegistryBase::ServiceRegistryBase()
+ServiceRegistry::ServiceRegistry()
 {
   mServicesKey.fill(0L);
   mServicesValue.fill(nullptr);
@@ -28,7 +28,7 @@ ServiceRegistryBase::ServiceRegistryBase()
 /// hash used to identify the service, @a service is
 /// a type erased pointer to the service itself.
 /// This method is supposed to be thread safe
-void ServiceRegistryBase::registerService(hash_type typeHash, void* service, ServiceKind kind, uint64_t threadId, const char* name) const
+void ServiceRegistry::registerService(hash_type typeHash, void* service, ServiceKind kind, uint64_t threadId, const char* name) const
 {
   hash_type id = typeHash & MAX_SERVICES_MASK;
   hash_type threadHashId = (typeHash ^ threadId) & MAX_SERVICES_MASK;
@@ -58,6 +58,85 @@ void ServiceRegistryBase::registerService(hash_type typeHash, void* service, Ser
   throw std::runtime_error(std::string("Unable to find a spot in the registry for service ") +
                            std::to_string(typeHash) +
                            ". Make sure you use const / non-const correctly.");
+}
+
+void ServiceRegistry::declareService(ServiceSpec const& spec, DeviceState& state, fair::mq::ProgOptions& options)
+{
+  mSpecs.push_back(spec);
+  // Services which are not stream must have a single instance created upfront.
+  if (spec.kind != ServiceKind::Stream) {
+    ServiceHandle handle = spec.init(*this, state, options);
+    this->registerService(handle.hash, handle.instance, handle.kind, 0, handle.name.c_str());
+    this->bindService(spec, handle.instance);
+  }
+}
+
+void ServiceRegistry::bindService(ServiceSpec const& spec, void* service)
+{
+  if (spec.preProcessing) {
+    mPreProcessingHandles.push_back(ServiceProcessingHandle{spec.preProcessing, service});
+  }
+  if (spec.postProcessing) {
+    mPostProcessingHandles.push_back(ServiceProcessingHandle{spec.postProcessing, service});
+  }
+  if (spec.preDangling) {
+    mPreDanglingHandles.push_back(ServiceDanglingHandle{spec.preDangling, service});
+  }
+  if (spec.postDangling) {
+    mPostDanglingHandles.push_back(ServiceDanglingHandle{spec.postDangling, service});
+  }
+  if (spec.preEOS) {
+    mPreEOSHandles.push_back(ServiceEOSHandle{spec.preEOS, service});
+  }
+  if (spec.postEOS) {
+    mPostEOSHandles.push_back(ServiceEOSHandle{spec.postEOS, service});
+  }
+}
+
+/// Invoke callbacks to be executed before every process method invokation
+void ServiceRegistry::preProcessingCallbacks(ProcessingContext& processContext)
+{
+  for (auto& handle : mPreProcessingHandles) {
+    handle.callback(processContext, handle.service);
+  }
+}
+/// Invoke callbacks to be executed after every process method invokation
+void ServiceRegistry::postProcessingCallbacks(ProcessingContext& processContext)
+{
+  for (auto& handle : mPostProcessingHandles) {
+    handle.callback(processContext, handle.service);
+  }
+}
+/// Invoke callbacks to be executed before every dangling check
+void ServiceRegistry::preDanglingCallbacks(DanglingContext& danglingContext)
+{
+  for (auto preDanglingHandle : mPreDanglingHandles) {
+    preDanglingHandle.callback(danglingContext, preDanglingHandle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every dangling check
+void ServiceRegistry::postDanglingCallbacks(DanglingContext& danglingContext)
+{
+  for (auto postDanglingHandle : mPostDanglingHandles) {
+    postDanglingHandle.callback(danglingContext, postDanglingHandle.service);
+  }
+}
+
+/// Invoke callbacks to be executed before every EOS user callback invokation
+void ServiceRegistry::preEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& eosHandle : mPreEOSHandles) {
+    eosHandle.callback(eosContext, eosHandle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every EOS user callback invokation
+void ServiceRegistry::postEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& eosHandle : mPostEOSHandles) {
+    eosHandle.callback(eosContext, eosHandle.service);
+  }
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -753,10 +753,8 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry, const o2::f
 
       /// Create all the requested services and initialise them
       for (auto& service : spec.services) {
-        LOG(info) << "Initialising service " << service.name;
-        auto handle = service.init(serviceRegistry, *deviceState.get(), r.fConfig);
-        serviceRegistry.registerService(handle);
-        dynamic_cast<DataProcessingDevice*>(r.fDevice.get())->bindService(service, handle.instance);
+        LOG(info) << "Declaring service " << service.name;
+        serviceRegistry.declareService(service, *deviceState.get(), r.fConfig);
       }
       if (ResourcesMonitoringHelper::isResourcesMonitoringEnabled(spec.resourceMonitoringInterval)) {
         serviceRegistry.get<Monitoring>().enableProcessMonitoring(spec.resourceMonitoringInterval);

--- a/Framework/Core/test/test_Services.cxx
+++ b/Framework/Core/test/test_Services.cxx
@@ -86,7 +86,7 @@ struct DummyService {
 BOOST_AUTO_TEST_CASE(TestSerialServices)
 {
   using namespace o2::framework;
-  ServiceRegistryBase registry;
+  ServiceRegistry registry;
 
   DummyService t0{0};
   /// We register it pretending to be on thread 0
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(TestSerialServices)
 BOOST_AUTO_TEST_CASE(TestGlobalServices)
 {
   using namespace o2::framework;
-  ServiceRegistryBase registry;
+  ServiceRegistry registry;
 
   DummyService t0{0};
   /// We register it pretending to be on thread 0
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(TestGlobalServices)
 BOOST_AUTO_TEST_CASE(TestGlobalServices02)
 {
   using namespace o2::framework;
-  ServiceRegistryBase registry;
+  ServiceRegistry registry;
 
   DummyService t0{1};
   /// We register it pretending to be on thread 0
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(TestGlobalServices02)
 BOOST_AUTO_TEST_CASE(TestStreamServices)
 {
   using namespace o2::framework;
-  ServiceRegistryBase registry;
+  ServiceRegistry registry;
 
   DummyService t0{0};
   DummyService t1{1};


### PR DESCRIPTION
Since the ServiceRegistry is needed to manage the lifetime of services, in
particular in a multithreaded environment, this moves the responsibility of
managing / invoking the ServiceSpec associated callback (including the one
which actually creates the service, possibly on a per thread basis) to the
service registry.