### PR TITLE
TRD trapsimulator correctly produce raw data.

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -10,15 +10,14 @@
 
 o2_add_library(DataFormatsTRD
                SOURCES src/TriggerRecord.cxx
-                       src/RawData.cxx
+                       src/LinkRecord.cxx
                        src/Tracklet64.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
-                                     O2::SimulationDataFormat
-                                     O2::TRDBase
-                                     )
+                       src/RawData.cxx
+                       PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
-o2_target_root_dictionary(DataFormatsTRD
-                          HEADERS include/DataFormatsTRD/TriggerRecord.h 
-                          include/DataFormatsTRD/RawData.h 
-                                  include/DataFormatsTRD/Tracklet64.h)
+           o2_target_root_dictionary(DataFormatsTRD
+               HEADERS include/DataFormatsTRD/TriggerRecord.h
+                       include/DataFormatsTRD/LinkRecord.h
+                       include/DataFormatsTRD/Tracklet64.h
+                       include/DataFormatsTRD/RawData.h)
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_LINKRECORD_H
+#define ALICEO2_TRD_LINKRECORD_H
+
+#include <iosfwd>
+#include "Rtypes.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+#include "DataFormatsTRD/RawData.h"
+
+namespace o2
+{
+
+namespace trd
+{
+
+/// \class LinkRecord
+/// \brief Header for data corresponding to the indexing of the links in the raw data output
+/// adapted from DataFormatsTRD/TriggerRecord
+class LinkRecord
+{
+  using DataRange = o2::dataformats::RangeReference<int>;
+
+ public:
+  LinkRecord() = default;
+  LinkRecord(const uint32_t hcid, int firstentry, int nentries) : mLinkId(hcid), mDataRange(firstentry, nentries) {}
+  ~LinkRecord() = default;
+
+  void setLinkId(const uint32_t linkid) { mLinkId = linkid; }
+  void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
+  void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
+  void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
+
+  uint32_t getLinkId() { return mLinkId; }
+  int getNumberOfObjects() const { return mDataRange.getEntries(); }
+  int getFirstEntry() const { return mDataRange.getFirstEntry(); }
+
+  void printStream(std::ostream& stream) const;
+
+ private:
+  uint32_t mLinkId;     /// The link ID for this set of data, hcid as well
+  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
+
+  ClassDefNV(LinkRecord, 1);
+};
+
+std::ostream& operator<<(std::ostream& stream, const LinkRecord& trg);
+
+} // namespace trd
+
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -11,11 +11,8 @@
 #ifndef ALICEO2_TRD_RAWDATA_H
 #define ALICEO2_TRD_RAWDATA_H
 
-#include <iosfwd>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
 #include "fairlogger/Logger.h"
+
 /// \class TRDRDH
 /// \brief Header for TRD raw data header
 //  this is the header added by the CRU
@@ -141,11 +138,11 @@ Word 7  |            link 13 datasize                   |            link 14 dat
   };
 };
 
-/// \structure HalfChamberHeader
+/// \structure TrackletHCHeader
 /// \brief Header for each half chamber
 //         Coming before all other tracklet data, a single tracklet word as a header for its half chamber
 
-struct HalfChamberHeader {
+struct TrackletHCHeader {
   union {
     //             10987654321098765432109876543210
     // uint32_t:   00000000000000000000000000000000
@@ -170,10 +167,10 @@ struct HalfChamberHeader {
   };
 };
 
-/// \structure MCMRawDataHeader
+/// \structure TrackletMCMHeader
 /// \brief Header for MCM tracklet data outuput
-//         This constitutes the "4x32" bits of information from a single MCM, MCMRawDataHeader and 1-3 TrapRawTracklet.
-struct MCMRawDataHeader {
+//         This constitutes the "4x32" bits of information from a single MCM, TrackletMCMHeader and 1-3 TrackletMCMData.
+struct TrackletMCMHeader {
   //first word          *
   //             10987654321098765432109876543210
   // uint32_t:   00000000000000000000000000000000
@@ -190,9 +187,9 @@ struct MCMRawDataHeader {
     uint32_t word;
     struct {
       uint32_t oneb : 1;   //
-      uint32_t pid0 : 8;   // 3 parts of pid for each tracklet
-      uint32_t pid1 : 8;   // 3 parts of pid for each tracklet
-      uint32_t pid2 : 8;   // 3 parts of pid for each tracklet
+      uint32_t pid0 : 8;   // part of pid for tracklet 0
+      uint32_t pid1 : 8;   // part of pid for tracklet 1
+      uint32_t pid2 : 8;   // part of pid for tracklet 2
       uint32_t col : 2;    //  2 bits for position in pad direction.
       uint32_t padrow : 4; //  padrow,z coordinate for chip.
       uint32_t onea : 1;   //
@@ -200,16 +197,16 @@ struct MCMRawDataHeader {
   };
 };
 
-//  \structure TrapRawTracklet.
+//  \structure TrackletMCMData.
 //  \brief Raw Data of a tracklet, part is how ever in the MCM Header hence both are grouped together in the same file
 
-struct TrapRawTracklet { // This is a bad name as part of the tracklet data is in the MCMHeader.
+struct TrackletMCMData { // This is a bad name as part of the tracklet data is in the MCMHeader.
   union {
     uint32_t word;
     struct {
-      uint8_t checkbit : 1; // The size of the data for this link
-      uint16_t pid : 15;    // Particle Identity
+      uint8_t checkbit : 1; //
       uint16_t slope : 6;   // Deflection angle of tracklet
+      uint16_t pid : 15;    // Particle Identity
       uint16_t pos : 10;    // Position of tracklet, signed 10 bits, granularity 0.02 pad widths, -10.22 to +10.22, relative to centre of pad 10
     } __attribute__((__packed__));
   };
@@ -220,15 +217,15 @@ std::vector<uint32_t> getPID(char *rawdata, int tracklet)
 {
     // extract the 2 parts of the pid and return the combined PID
     // rawdata starts with the mcmheader
-    uint32_t pid = 1;//(rawdata.pid[tracklet]<<15) + rawdata.pid[]; TODO figure out a better way that is not *undefined* c++ to progress to following 32bit words after MCMRawDataHeader.
+    uint32_t pid = 1;//(rawdata.pid[tracklet]<<15) + rawdata.pid[]; TODO figure out a better way that is not *undefined* c++ to progress to following 32bit words after TrackletMCMHeader.
     //TODO come back here, marker to come back.
     std::vector<uint32_t> pids;
-    MCMRawDataHeader mcmheader;
-    TrapRawTracklet trackletdata;
+    TrackletMCMHeader mcmheader;
+    TrackletMCMData trackletdata;
     //memcpy(&mcmheader,&rawdata[0],sizeof(mcmheader));
     std::copy(rawdata.begin(), rawdata.begin()+sizeof(mcmheader),(char*)&mcmheader);
     for(int tracklet=0;tracklet<3;tracklet++){
-        memcpy(&trackletdata,&rawdata[0]+sizeof(mcmheader)+tracklet*sizeof(trackletdata),sizeof(TrapRawTracklet));
+        memcpy(&trackletdata,&rawdata[0]+sizeof(mcmheader)+tracklet*sizeof(trackletdata),sizeof(TrackletMCMData));
         uint32_t headpid=0;
         switch(tracklet){
             case 0 : headpid=mcmheader.pid0;break;
@@ -243,193 +240,54 @@ std::vector<uint32_t> getPID(char *rawdata, int tracklet)
 
 uint32_t getPadRow(const char *rawdata)
 {
-    MCMRawDataHeader mcmheader;
-    memcpy(&mcmheader, rawdata,sizeof(MCMRawDataHeader));
+    TrackletMCMHeader mcmheader;
+    memcpy(&mcmheader, rawdata,sizeof(TrackletMCMHeader));
     return mcmheader.padrow;
 
 }
 uint32_t getCol(const char* rawdata)
 {
-    MCMRawDataHeader mcmheader;
-    memcpy(&mcmheader, rawdata,sizeof(MCMRawDataHeader));
+    TrackletMCMHeader mcmheader;
+    memcpy(&mcmheader, rawdata,sizeof(TrackletMCMHeader));
     return mcmheader.col;
 
 }
 int16_t getPos(const char* rawdata, int tracklet) 
 {
     // extract y from the tracklet word, raw data points to the mcmheader of this data.
-    //rawdata points to the MCMRawDataHeader
-     TrapRawTracklet trackletdata;
-    MCMRawDataHeader mcmrawdataheader;
-    memcpy(&mcmrawdataheader,rawdata,sizeof(MCMRawDataHeader));
-    memcpy(&trackletdata,rawdata+sizeof(MCMRawDataHeader));
+    //rawdata points to the TrackletMCMHeader
+     TrackletMCMData trackletdata;
+    TrackletMCMHeader mcmrawdataheader;
+    memcpy(&mcmrawdataheader,rawdata,sizeof(TrackletMCMHeader));
+    memcpy(&trackletdata,rawdata+sizeof(TrackletMCMHeader));
     return trackletdata.pos;
     return 1;
 }
 uint32_t getSlope(const *rawdata, int tracklet)
 {
     // extract dy or slope from the tracklet word, raw data points to the mcmheader of this data.
-    TrapRawTracklet trackletdata;
-    memcpy(&trackletdata,&rawdata[0]+sizeof(MCMRawDataHeader)+tracklet*sizeof(trackletdata),sizeof(TrapRawTracklet));
+    TrackletMCMData trackletdata;
+    memcpy(&trackletdata,&rawdata[0]+sizeof(TrackletMCMHeader)+tracklet*sizeof(trackletdata),sizeof(TrackletMCMData));
     return trackletdata.slope;
 }
-due to the interplay of MCMRawDataHeader and TrapRawTracklet come back to this. TODO
+due to the interplay of TrackletMCMHeader and TrackletMCMData come back to this. TODO
 */
 
-uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data = true)
-{
-  //TODO this needs some more ellaborate testing. I got the packing to work so for now,
-  //     its a question of unpacking info in line 88 and 89.
-  uint32_t info = 0;
-  if (link > 14)
-    return 0xffffffff;
-
-  char* words;
-  if (link < 8)
-    words = (char*)&cruhead.word02[0];
-  if (link < 15)
-    words = (char*)&cruhead.word57[0];
-  uint32_t byteoffset = link * 3; // each link [size+erroflags] is 24 bits, so 3 bytes.
-  if (data)
-    info = ((words[byteoffset + 1]) << 8) + (words[byteoffset + 2]);
-  else
-    info = words[byteoffset];
-
-  return info;
+uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data);
+uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link);
+uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link);
+uint32_t getlinkerrorflags(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linkerrorflags);
+uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linksizes);
+std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchamberheader);
+std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet);
+void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet);
+void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead);
+std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead);
+void printHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
+void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
+void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
+void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
+std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
 }
-
-uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link)
-{
-  uint32_t errorflags = 0;
-  if (link < 8) {
-    //dealing with word0-2
-    errorflags = cruhead.linksA[link].errorflags;
-  } else {
-    if (link < 16) {
-      errorflags = cruhead.linksB[link - 8 + 1].errorflags; // link 0 [actually 9] is in fact the end part of reserved.
-
-    } else
-      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
-  }
-  return errorflags;
 }
-
-uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link)
-{
-  //return number 32 byte blocks for the link 3x64bit ints.
-  uint32_t size = 0;
-  if (link < 8) {
-    size = (cruhead.linksA[link].size);
-  } else {
-    if (link < 16) { // link 0 is part of reserved
-      size = cruhead.linksB[link - 8 + 1].size;
-
-    } else
-      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
-  }
-  return size;
-}
-
-uint32_t getlinkerrorflags(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linkerrorflags)
-{
-  for (uint32_t link = 0; link < 15; link++) {
-    linkerrorflags[link] = getlinkerrorflag(cruheader, link);
-  }
-  return 0;
-}
-uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linksizes)
-{
-  for (uint32_t link = 0; link < 15; link++) {
-    linksizes[link] = getlinkdatasize(cruheader, link);
-  }
-  return 0;
-}
-
-/*
- *  Printing methods to dump and display the various structures above in pretty format or hexdump
- */
-
-std::ostream& operator<<(std::ostream& stream, const HalfChamberHeader halfchamberheader)
-{
-  stream << "HalfChamberHeader : " << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: " << halfchamberheader.one << " :: " << halfchamberheader.HCID << std::endl;
-  return stream;
-}
-
-std::ostream& operator<<(std::ostream& stream, const TrapRawTracklet& tracklet)
-{
-  // make a pretty output of the tracklet.
-  stream << "TrapRawTracklet: pos=" << tracklet.pos << "::slope=" << tracklet.slope << "::pid=" << tracklet.pid << "::checkbit=" << tracklet.checkbit << std::endl;
-  return stream;
-}
-void printTrapRawTracklet(o2::trd::TrapRawTracklet& tracklet)
-{
-  LOGF(INFO, "TrapRawTracklet: ");
-}
-
-void printMCMHeader(o2::trd::MCMRawDataHeader& mcmhead)
-{
-  LOGF(INFO, "MCMRawHeader: 1:%d padrow: 0x%02x col: 0x%01x pid2 0x%02x pid1: 0x%02x pid0: 0x%02x 1:%d", mcmhead.onea, mcmhead.padrow, mcmhead.col, mcmhead.pid2, mcmhead.pid1, mcmhead.pid0, mcmhead.oneb);
-}
-
-std::ostream& operator<<(std::ostream& stream, const MCMRawDataHeader& mcmhead)
-{
-  // make a pretty output of the mcm header.
-  // stream << "MCMRawHeader:" << mcmhead.checkbits << "::" << (mcmhead.pid&0xfff000000) << ":"<<  (mcmhead.pid&0xfff000) << ":"<< (mcmhead.pid&0xfff) << std::endl;
-  stream << "MCMRawHeader:" << mcmhead.onea << "::" << mcmhead.pid2 << ":" << mcmhead.pid1 << ":" << mcmhead.pid0 << "::" << mcmhead.oneb << std::endl;
-  return stream;
-}
-
-void printHalfChamber(o2::trd::HalfChamberHeader& halfchamber)
-{
-  LOGF(INFO, "HCID : %d MCLK: %d Format: %d Always1:%d", halfchamber.HCID, halfchamber.MCLK, halfchamber.format, halfchamber.one);
-}
-
-void dumpHalfChamber(o2::trd::HalfChamberHeader& halfchamber)
-{
-  LOGF(INFO, "HalfChamber : 0x%08x", halfchamber.word);
-}
-
-void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
-{
-  std::array<uint32_t, 15> sizes;
-  std::array<uint32_t, 15> errorflags;
-  getlinkdatasizes(halfcru, sizes);
-  getlinkerrorflags(halfcru, errorflags);
-  LOGF(INFO, "V:%d BC:%d SB:%d EType:%d", halfcru.HeaderVersion, halfcru.BunchCrossing, halfcru.StopBit, halfcru.EventType);
-  for (int i = 0; i < 15; i++)
-    LOGF(INFO, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
-}
-
-void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
-{
-  std::array<uint32_t, 16> raw{};
-  memcpy(&raw[0], &halfcru, sizeof(halfcru));
-  for (int i = 0; i < 4; i++) {
-    int index = 4 * i;
-    LOGF(INFO, "[1/2CRUHeader %d] 0x%08x 0x%08x 0x%08x 0x%08x", i, raw[index + 3], raw[index + 2], raw[index + 1], raw[index + 0]);
-  }
-}
-
-std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru) // make a pretty output of the header.
-{
-  stream << std::hex;
-  stream << "EventType : " << halfcru.EventType << std::endl;
-  stream << "StopBit : " << halfcru.StopBit << std::endl;
-  stream << "BunchCrossing : " << halfcru.BunchCrossing << std::endl;
-  stream << "HeaderVersion : " << halfcru.HeaderVersion << std::endl;
-  stream << "link  sizes : ";
-  for (int link = 0; link < 15; link++)
-    stream << link << ":" << std::hex << std::setw(4) << getlinkdatasize(halfcru, link) << ",";
-  stream << std::endl;
-  stream << "link  errorflags : ";
-  for (int link = 0; link < 15; link++)
-    stream << link << ":" << std::hex << std::setw(2) << getlinkerrorflag(halfcru, link) << ",";
-  stream << std::endl;
-  stream << "0x" << halfcru.word02[0] << " 0x" << halfcru.word02[1] << " 0x" << halfcru.word02[2] << " 0x" << halfcru.word3 << " 0x" << halfcru.word4 << " 0x" << halfcru.word57[0] << " 0x" << halfcru.word57[1] << " 0x" << halfcru.word57[2] << std::endl;
-  return stream;
-}
-
-} // namespace trd
-} // namespace o2
-
 #endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -15,11 +15,13 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::trd::TriggerRecord + ;
+#pragma link C++ class o2::trd::LinkRecord + ;
 #pragma link C++ struct o2::trd::HalfCRUHeader + ;
-#pragma link C++ struct o2::trd::HalfChamberHeader + ;
-#pragma link C++ struct o2::trd::MCMRawDataHeader + ;
-#pragma link C++ struct o2::trd::TrapRawTracklet + ;
+#pragma link C++ struct o2::trd::TrackletHCHeader + ;
+#pragma link C++ struct o2::trd::TrackletMCMHeader + ;
+#pragma link C++ struct o2::trd::TrackletMCMData + ;
 #pragma link C++ class o2::trd::Tracklet64 + ;
 #pragma link C++ class std::vector < o2::trd::TriggerRecord > +;
+#pragma link C++ class std::vector < o2::trd::LinkRecord > +;
 
 #endif

--- a/DataFormats/Detectors/TRD/src/LinkRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/LinkRecord.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include <iostream>
-#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/LinkRecord.h"
 
 namespace o2
 {
@@ -17,16 +17,12 @@ namespace o2
 namespace trd
 {
 
-void Tracklet64::printStream(std::ostream& stream) const
+void LinkRecord::printStream(std::ostream& stream) const
 {
-  stream << "Tracklet64 : 0x" << std::hex << getTrackletWord();
-  stream << "\t hcid : " << getHCID() << " row:" << getPadRow() << " col:" << getColumn()
-         << " Position:" << getPosition() << " slope:" << getSlope()
-         << " PID:0x" << getPID()
-         << " Q0:" << getQ0() << " Q1:" << getQ1() << " Q2:" << getQ2();
+  stream << "Data for link 0x" << std::hex << mLinkId << std::dec << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
 }
 
-std::ostream& operator<<(std::ostream& stream, const Tracklet64& trg)
+std::ostream& operator<<(std::ostream& stream, const LinkRecord& trg)
 {
   trg.printStream(stream);
   return stream;

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -8,14 +8,176 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <iomanip>
 #include <iostream>
-//#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/RawData.h"
 
 namespace o2
 {
 
 namespace trd
 {
+
+uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data = true)
+{
+  // cruhead is the incoming header to pass
+  // link is the link you are requesting information on, 0-14
+  //
+  uint32_t info = 0;
+  if (link > 14)
+    return 0xffffffff;
+
+  char* words;
+  if (link < 8)
+    words = (char*)&cruhead.word02[0];
+  if (link < 15)
+    words = (char*)&cruhead.word57[0];
+  uint32_t byteoffset = link * 3; // each link [size+erroflags] is 24 bits, so 3 bytes.
+  if (data)
+    info = ((words[byteoffset + 1]) << 8) + (words[byteoffset + 2]);
+  else
+    info = words[byteoffset];
+
+  return info;
+}
+
+uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link)
+{
+  // link is the link you are requesting information on, 0-14
+  uint32_t errorflags = 0;
+  if (link < 8) {
+    //dealing with word0-2
+    errorflags = cruhead.linksA[link].errorflags;
+  } else {
+    if (link < 16) {
+      errorflags = cruhead.linksB[link - 8 + 1].errorflags; // link 0 [actually 9] is in fact the end part of reserved.
+
+    } else
+      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
+  }
+  return errorflags;
+}
+
+uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link)
+{
+  // link is the link you are requesting information on, 0-14
+  //return number 32 byte blocks for the link 3x64bit ints.
+  uint32_t size = 0;
+  if (link < 8) {
+    size = (cruhead.linksA[link].size);
+  } else {
+    if (link < 16) { // link 0 is part of reserved
+      size = cruhead.linksB[link - 8 + 1].size;
+
+    } else
+      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
+  }
+  return size;
+}
+
+uint32_t getlinkerrorflags(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linkerrorflags)
+{
+  // retrieve all the link error flags for this half cru
+  for (uint32_t link = 0; link < 15; link++) {
+    linkerrorflags[link] = getlinkerrorflag(cruheader, link);
+  }
+  return 0;
+}
+uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linksizes)
+{
+  // retrieve all the link sizes for this half cru
+  for (uint32_t link = 0; link < 15; link++) {
+    linksizes[link] = getlinkdatasize(cruheader, link);
+  }
+  return 0;
+}
+
+//
+//  Printing methods to dump and display the various structures above in pretty format or hexdump
+//  printNameOfStruct(const NameOfStruct& nameofstruct);
+//  dumpNameOfStruct(const NameOfStruct& nameofstruct);
+//  std::ostrea& operator<<(std::ostream& stream, const NameOfStruct& nameofstruct);
+//
+
+std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchamberheader)
+{
+  stream << "TrackletHCHeader : Raw:0x" << std::hex << halfchamberheader.word << " " << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: " << halfchamberheader.one << " :: " << halfchamberheader.HCID << std::endl;
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet)
+{
+  // make a pretty output of the tracklet.
+  stream << "TrackletMCMData: Raw:0x" << std::hex << tracklet.word << " pos=" << tracklet.pos << "::slope=" << tracklet.slope << "::pid=" << tracklet.pid << "::checkbit=" << tracklet.checkbit << std::endl;
+  return stream;
+}
+void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet)
+{
+  LOGF(INFO, "TrackletMCMData: Raw:0x%08x pos:%d slope:%d pid:0x%08x checkbit:0x%02x", tracklet.word, tracklet.pos, tracklet.slope, tracklet.pid, tracklet.checkbit);
+}
+
+void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead)
+{
+  LOGF(INFO, "MCMRawHeader: Raw:0x%08x 1:%d padrow: 0x%02x col: 0x%01x pid2 0x%02x pid1: 0x%02x pid0: 0x%02x 1:%d", mcmhead.word, mcmhead.onea, mcmhead.padrow, mcmhead.col, mcmhead.pid2, mcmhead.pid1, mcmhead.pid0, mcmhead.oneb);
+}
+
+std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead)
+{
+  // make a pretty output of the mcm header.
+  // stream << "MCMRawHeader:" << mcmhead.checkbits << "::" << (mcmhead.pid&0xfff000000) << ":"<<  (mcmhead.pid&0xfff000) << ":"<< (mcmhead.pid&0xfff) << std::endl;
+  stream << "MCMRawHeader: Raw:0x" << std::hex << mcmhead.word << " " << mcmhead.onea << "::" << mcmhead.pid2 << ":" << mcmhead.pid1 << ":" << mcmhead.pid0 << "::" << mcmhead.oneb << std::endl;
+  return stream;
+}
+
+void printHalfChamber(o2::trd::TrackletHCHeader& halfchamber)
+{
+  LOGF(INFO, "TrackletHCHeader: Raw:0x%08x HCID : 0x%0x MCLK: 0x%0x Format: 0x%0x Always1:0x%0x", halfchamber.HCID, halfchamber.MCLK, halfchamber.format, halfchamber.one);
+}
+
+void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber)
+{
+  LOGF(INFO, "HalfChamber : 0x%08x", halfchamber.word);
+}
+
+void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
+{
+  std::array<uint32_t, 15> sizes;
+  std::array<uint32_t, 15> errorflags;
+  getlinkdatasizes(halfcru, sizes);
+  getlinkerrorflags(halfcru, errorflags);
+  LOGF(INFO, "V:%d BC:%d SB:%d EType:%d", halfcru.HeaderVersion, halfcru.BunchCrossing, halfcru.StopBit, halfcru.EventType);
+  for (int i = 0; i < 15; i++)
+    LOGF(INFO, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
+}
+
+void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
+{
+  std::array<uint32_t, 16> raw{};
+  memcpy(&raw[0], &halfcru, sizeof(halfcru));
+  for (int i = 0; i < 4; i++) {
+    int index = 4 * i;
+    LOGF(INFO, "[1/2CRUHeader %d] 0x%08x 0x%08x 0x%08x 0x%08x", i, raw[index + 3], raw[index + 2], raw[index + 1], raw[index + 0]);
+  }
+}
+
+std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru) // make a pretty output of the header.
+{
+  stream << std::hex;
+  stream << "EventType : " << halfcru.EventType << std::endl;
+  stream << "StopBit : " << halfcru.StopBit << std::endl;
+  stream << "BunchCrossing : " << halfcru.BunchCrossing << std::endl;
+  stream << "HeaderVersion : " << halfcru.HeaderVersion << std::endl;
+  stream << "link  sizes : ";
+  for (int link = 0; link < 15; link++)
+    stream << link << ":" << std::hex << std::setw(4) << getlinkdatasize(halfcru, link) << ",";
+  stream << std::endl;
+  stream << "link  errorflags : ";
+  for (int link = 0; link < 15; link++)
+    stream << link << ":" << std::hex << std::setw(2) << getlinkerrorflag(halfcru, link) << ",";
+  stream << std::endl;
+  stream << "0x" << halfcru.word02[0] << " 0x" << halfcru.word02[1] << " 0x" << halfcru.word02[2] << " 0x" << halfcru.word3 << " 0x" << halfcru.word4 << " 0x" << halfcru.word57[0] << " 0x" << halfcru.word57[1] << " 0x" << halfcru.word57[2] << std::endl;
+  return stream;
+}
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -36,6 +36,7 @@ o2_add_library(TRDBase
                                      O2::DetectorsBase
                                      ROOT::Physics
                                      O2::SimulationDataFormat
+                                     O2::DataFormatsTRD
                                      O2::CCDB)
 
 o2_target_root_dictionary(TRDBase

--- a/Detectors/TRD/base/test/testRawData.cxx
+++ b/Detectors/TRD/base/test/testRawData.cxx
@@ -35,16 +35,16 @@ namespace trd
 BOOST_AUTO_TEST_CASE(TRDRawDataHeaderSizes)
 {
   //check the sizes of header structs due to packing
-  BOOST_CHECK_EQUAL(sizeof(o2::trd::TrapRawTracklet), 4);
-  BOOST_CHECK_EQUAL(sizeof(o2::trd::HalfChamberHeader), 4);
-  BOOST_CHECK_EQUAL(sizeof(o2::trd::MCMRawDataHeader), 4);
+  BOOST_CHECK_EQUAL(sizeof(o2::trd::TrackletMCMData), 4);
+  BOOST_CHECK_EQUAL(sizeof(o2::trd::TrackletHCHeader), 4);
+  BOOST_CHECK_EQUAL(sizeof(o2::trd::TrackletMCMHeader), 4);
   BOOST_CHECK_EQUAL(sizeof(o2::trd::HalfCRUHeader), 64);
 }
 
 BOOST_AUTO_TEST_CASE(TRDRawDataHeaderInternals)
 {
-  o2::trd::TrapRawTracklet tracklet;
-  o2::trd::HalfChamberHeader halfchamberheader;
+  o2::trd::TrackletMCMData tracklet;
+  o2::trd::TrackletHCHeader halfchamberheader;
   o2::trd::HalfCRUHeader halfcruheader;
   halfcruheader.word02[0] = 0x102;
   BOOST_CHECK_EQUAL(halfcruheader.linksA[0].errorflags, 2);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(TRDRawDataHeaderInternals)
   halfcruheader.word02[0] = (uint64_t)0x1000000000000000;
   halfcruheader.word02[1] = (uint64_t)0xa00b000c000d0ebf;
   BOOST_CHECK_EQUAL(halfcruheader.linksA[2].size, 0xbf10); // check a size that spans a 64bit word.
-  o2::trd::MCMRawDataHeader mcmrawdataheader;
+  o2::trd::TrackletMCMHeader mcmrawdataheader;
   mcmrawdataheader.word = 0x78000000;
   BOOST_CHECK_EQUAL(mcmrawdataheader.padrow, 15);
   mcmrawdataheader.word = 0x06000000;

--- a/Detectors/TRD/macros/ParseTrapRawOutput.C
+++ b/Detectors/TRD/macros/ParseTrapRawOutput.C
@@ -1,0 +1,64 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TChain.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/LinkData.h"
+#include <memory>
+#endif
+
+//Parse the trackletraw output of a trap simulation
+//Display on the screen and indent for half chamber, mcmheader and mcmtracklet.
+//Create a raw dump as well of the incoming data.
+
+using namespace o2::trd;
+
+void ParseTrapRawOutput(std::string path = "./", std::string inputTracklets = "trdtrapraw.root")
+{
+  TChain trdtrapraw("o2sim");
+  trdtrapraw.AddFile((path + inputTracklets).c_str());
+
+  std::vector<o2::trd::LinkRecord> links;
+  std::vector<o2::trd::LinkRecord>* linksptr = &links;
+
+  std::vector<uint32_t> trapraw;
+  std::vector<uint32_t>* traprawptr = &trapraw;
+  trdtrapraw.SetBranchAddress("TrapRaw", &traprawptr);
+  trdtrapraw.SetBranchAddress("TrapLinkRecord", &linksptr);
+  trdtrapraw.GetEntry(0);
+
+  ofstream outfile("rawdata", std::ios::out | std::ofstream::binary);
+  outfile.write((char*)(&trapraw[0]), sizeof(trapraw[0]) * trapraw.size());
+  outfile.close();
+  uint64_t mcmheadcount = 0;
+  uint64_t halfchamberheadcount = 0;
+  uint64_t traprawtrackletount = 0;
+  //at each linkrecord data we should have a halfchamberheader;
+  // with in the range specified by the linkrecord we have a structure of :
+  // mcmheader, traprawtracklet[1-3], mcmheader, traprawtracklet[1-3], etc. etc.
+  for (auto& link : links) {
+    o2::trd::TrackletHCHeader halfchamber;
+    halfchamber.word = link.getLinkId();
+    std::cout << "in link with HCID of " << halfchamber;
+    for (int i = link.getFirstEntry(); i < link.getFirstEntry() + link.getNumberOfObjects(); i++) {
+      //read TrackletMCMHeader
+      //read 1 to 3 TrackletMCMDatas
+      if (((trapraw[i]) & 0x1) == 1 && (trapraw[i] & 0x80000000) != 0) {
+        TrackletMCMHeader mcm;
+        mcm.word = trapraw[i];
+        std::cout << "\t\t" << mcm;
+        mcmheadcount++;
+      } else if (((trapraw[i]) & 0x1) == 0) {
+        //tracklet word
+        //
+        TrackletMCMData tracklet;
+        tracklet.word = trapraw[i];
+        std::cout << "\t\t\t\tTracklet : 0x" << std::hex << tracklet.word << std::dec << std::endl;
+        traprawtrackletount++;
+      } else
+        std::cout << "most sig bit is not binary ?? 0x" << std::hex << trapraw[i] << std::dec << std::endl;
+    }
+  }
+  std::cout << "counts " << halfchamberheadcount << "::" << mcmheadcount << "::" << traprawtrackletount << std::endl;
+}

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -20,7 +20,7 @@ o2_add_library(TRDSimulation
                        src/TrapConfig.cxx 
                        src/TrapConfigHandler.cxx 
                        src/TrapSimulator.cxx
-               PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
+                       PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::DataFormatsTRD O2::DetectorsRaw)
 
 o2_target_root_dictionary(TRDSimulation
                           HEADERS include/TRDSimulation/Detector.h
@@ -37,3 +37,4 @@ if (OpenMP_CXX_FOUND)
 endif()
 
 o2_data_file(COPY data DESTINATION Detectors/TRD/simulation)
+

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -21,15 +21,19 @@
 #include <iostream>
 #include <ostream>
 #include <fstream>
+#include <gsl/span>
 
 #include "TRDBase/Tracklet.h"
 #include "TRDBase/FeeParam.h"
 #include "TRDBase/Digit.h"
+#include "TRDBase/Tracklet.h"
 #include "TRDSimulation/Digitizer.h"
 #include "TRDSimulation/TrapConfigHandler.h" //TODO I think i can dump this.
 #include "TRDSimulation/TrapConfig.h"
 #include "TRDBase/MCLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+//#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/Tracklet64.h"
 
 class TH2F;
 
@@ -82,6 +86,8 @@ class TrapSimulator
     for (auto& tmplabel : mADCLabels)
       tmplabel.clear();      // clear MC Labels sent in from the digits coming in.
     mTrackletLabels.clear(); // clear the stored labels.
+    mTrackletArray.clear();
+    mTrackletArray64.clear();
   };
   //  void setData(int iadc, const std::vector<int>& adc);                                                                              // set ADC data with array
   void setData(int iadc, const ArrayADC& adc, std::vector<o2::MCCompLabel>& labels); // set ADC data with array
@@ -117,9 +123,9 @@ class TrapSimulator
   std::string getTrklBranchName() const { return mTrklBranchName; }
   void setTrklBranchName(std::string name) { mTrklBranchName = name; }
 
-  int packData(std::vector<uint32_t>& buf);
-  int produceRawStream(std::vector<uint32_t>& buf, unsigned int iEv = 0) const; // Produce raw data stream - Real data format
-  int produceTrackletStream(std::vector<uint32_t>& buf);                        // produce the tracklet stream for this MCM
+  int packData(std::vector<uint32_t>& rawdata, uint32_t offset);
+  int getRawStream(std::vector<uint32_t>& buf, uint32_t offset, unsigned int iEv = 0) const; // Produce raw data stream - Real data format
+  int getTrackletStream(std::vector<uint32_t>& buf, uint32_t offset);                        // produce the tracklet stream for this MCM
 
   // different stages of processing in the TRAP
   void filter();                // Apply digital filters for existing data (according to configuration)
@@ -195,9 +201,9 @@ class TrapSimulator
   static const int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
   static const int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
   static const int mgkMaxTracklets = 4;              // maximum number of tracklet-words submitted per MCM (one per CPU)
-  //std::array<TrackletMCM> getTrackletArray() const { return mTrackletArray; }
   std::vector<Tracklet>& getTrackletArray() { return mTrackletArray; }
-  void getTracklets(std::vector<Tracklet>& TrackletStore); // place the trapsim tracklets nto the incoming vector
+  std::vector<Tracklet64>& getTrackletArray64() { return mTrackletArray64; }
+  void getTracklet64s(std::vector<Tracklet64>& TrackletStore); // place the trapsim 64 bit tracklets nto the incoming vector
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>& getTrackletLabels() { return mTrackletLabels; }
 
   bool checkInitialized() const;     // Check whether the class is initialized
@@ -259,6 +265,7 @@ class TrapSimulator
     int mNhits;          // number of hits
     unsigned int mQ0;    // charge accumulated in first window
     unsigned int mQ1;    // charge accumulated in second window
+    unsigned int mQ2;    // charge accumulated in some other windows TODO find or write the documentation for window3
     unsigned int mSumX;  // sum x
     int mSumY;           // sum y
     unsigned int mSumX2; // sum x**2
@@ -269,6 +276,7 @@ class TrapSimulator
       mNhits = 0;
       mQ0 = 0;
       mQ1 = 0;
+      mQ2 = 0; //TODO should this go here as its calculated differeintly in softwaren not hardware like the other 2?
       mSumX = 0;
       mSumY = 0;
       mSumX2 = 0;
@@ -294,6 +302,7 @@ class TrapSimulator
   std::array<std::vector<o2::MCCompLabel>, FeeParam::mgkNadcMcm> mADCLabels{}; // MC Labels sent in from the digits coming in.
   std::vector<unsigned int> mMCMT;      // tracklet word for one mcm/trap-chip
   std::vector<Tracklet> mTrackletArray; // Array of TRDtrackletMCM which contains MC information in addition to the tracklet word
+  std::vector<Tracklet64> mTrackletArray64; // Array of TRDtrackletMCM which contains MC information in addition to the tracklet word
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mTrackletLabels;
   std::vector<int> mZSMap;              // Zero suppression map (1 dimensional projection)
 
@@ -341,6 +350,7 @@ class TrapSimulator
   static bool mgStoreClusters; // whether to store all clusters in the tracklets
   bool mDataIsSet = false;
   Calibrations* mCalib;
+  static constexpr bool debugheaders = false;
 };
 
 std::ostream& operator<<(std::ostream& os, const TrapSimulator& mcm);

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(TRDWorkflow
                        src/TRDDigitWriterSpec.cxx
                        src/TRDDigitReaderSpec.cxx
                        src/TRDTrackletWriterSpec.cxx
+                       src/TRDTrapRawWriterSpec.cxx
                        src/TRDTrapSimulatorSpec.cxx
                        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
 

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapRawWriterSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapRawWriterSpec.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPSIMULATORRAWWRITER_H
+#define O2_TRDTRAPSIMULATORRAWWRITER_H
+
+#include <fstream>
+#include <iostream>
+
+// This is the raw data that is output by the trap trap chip.
+// mcmheader word followed by 1 or more traprawtracklet words.
+// and a halfchamber header at the beginning of a half chamber.
+// halfchamber header + mcmheader uniquely identifies the chip producing the data.
+
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+}
+} // namespace o2
+
+namespace o2
+{
+namespace trd
+{
+
+o2::framework::DataProcessorSpec getTRDTrapRawWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDTRAPSIMULATORRAWWRITER_H

--- a/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
@@ -18,8 +18,8 @@
 #include "TRDBase/Digit.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TRDBase/MCLabel.h"
-#include "TRDBase/Tracklet.h"
 #include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/Tracklet64.h"
 
 #include <fstream>
 #include <iostream>
@@ -52,7 +52,7 @@ o2::framework::DataProcessorSpec getTRDTrackletWriterSpec()
                                 "trdtracklets.root",
                                 "o2sim",
                                 1,
-                                BranchDefinition<std::vector<o2::trd::Tracklet>>{InputSpec{"tracklets", "TRD", "TRACKLETS"}, "Tracklet"},
+                                BranchDefinition<std::vector<o2::trd::Tracklet64>>{InputSpec{"tracklets", "TRD", "TRACKLETS"}, "Tracklet"},
                                 //BranchDefinition<o2::dataformats::MCTruthContainer<o2::trd::MCLabel>>{InputSpec{"trklabels", "TRD", "TRKLABELS"}, "TRKLabels"},
                                 BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"tracklettrigs", "TRD", "TRKTRGRD"}, "TrackTrg"})();
 };

--- a/Detectors/TRD/workflow/src/TRDTrapRawWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapRawWriterSpec.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPSIMULATORTRAPRAWWRITER_H
+#define O2_TRDTRAPSIMULATORTRAPRAWWRITER_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "TRDWorkflow/TRDTrapRawWriterSpec.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/LinkRecord.h"
+
+#include <fstream>
+#include <iostream>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDTrapRawWriterSpec()
+{
+  //  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  return MakeRootTreeWriterSpec("TRDTrkltRawWrt",
+                                "trdtrapraw.root",
+                                "o2sim",
+                                1,
+                                BranchDefinition<std::vector<uint32_t>>{InputSpec{"trapraw", "TRD", "RAWDATA"}, "TrapRaw"},
+                                BranchDefinition<std::vector<o2::trd::LinkRecord>>{InputSpec{"traplinks", "TRD", "RAWLNKRD"}, "TrapLinkRecord"},
+                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"traprawtrigrec", "TRD", "RAWTRGRD"}, "RawTriggerRecord"})();
+};
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDTRAPSIMULATORTRACKLETWRITER_H

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -20,6 +20,7 @@
 // for TRD
 #include "TRDWorkflow/TRDTrapSimulatorSpec.h"
 #include "TRDWorkflow/TRDTrackletWriterSpec.h"
+#include "TRDWorkflow/TRDTrapRawWriterSpec.h"
 #include "TRDWorkflow/TRDDigitReaderSpec.h"
 
 #include "DataFormatsParameters/GRPObject.h"
@@ -85,5 +86,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     // connect the TRD digitization
     o2::trd::getTRDTrapSimulatorSpec(),
     // connect the TRD digit writer
-    o2::trd::getTRDTrackletWriterSpec()};
+    o2::trd::getTRDTrackletWriterSpec(),
+    // connect the TRD digit writer
+    o2::trd::getTRDTrapRawWriterSpec()};
 }

--- a/Detectors/TRD/workflow/src/TRDWorkflowLinkDef.h
+++ b/Detectors/TRD/workflow/src/TRDWorkflowLinkDef.h
@@ -15,6 +15,6 @@
 #pragma link off all functions;
 
 //#pragma link C++ class o2::trd::TRDDPLDigitizerTask + ;
-
+#pragma link C++ class gsl::span < uint32_t > +;
 #endif
 

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -28,6 +28,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             Detectors/TRD/base/macros/Readocdb.C
             Detectors/TRD/base/macros/PrintTrapConfig.C
             Detectors/TRD/base/macros/ConvertRun2DigitsAndTracklets.C
+            Detectors/TRD/macros/ParseTrapRawOutput.C
             Detectors/EMCAL/calib/macros/ReadTestBadChannelMap_CCDBApi.C
             GPU/GPUTracking/Merger/macros/checkPropagation.C # Needs AliRoot AliExternalTrackParam
             GPU/GPUTracking/Merger/macros/fitPolynomialFieldIts.C # Needs AliRoot AliMagF


### PR DESCRIPTION
- Change to 64 tracklet output of trapsimulator.
- Correctly implement raw data out of trapsimulator.
- halfchamber header in a separate link record akin to the way the hardware actually works. 
- Add additional output of TrapSimulator to TRDTrackRawWriterSpec.
- Some other sundry fixups to sort all the above out.
- Header data structures for raw data names changed
