### PR TITLE
DPL: Always use boost::filesystem

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -21,9 +21,9 @@ endif()
 
 # Given GCC 7.3 does not provide std::filesystem we use Boost instead
 # Drop this once we move to GCC 8.2+
-if (NOT __APPLE__)
+# if (NOT __APPLE__)
   set(BOOST_FILESYSTEM Boost::filesystem)
-endif()
+# endif()
 
 o2_add_library(Framework
                SOURCES src/AODReaderHelpers.cxx

--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -12,7 +12,7 @@
 #include <ostream>
 #include <cassert>
 #include <stdexcept>
-#if __has_include(<filesystem>)
+#if 0
 #include <filesystem>
 namespace fs = std::filesystem;
 #elif __has_include(<boost/filesystem.hpp>)


### PR DESCRIPTION
GCC 8.x not happy with `std::filesystem`.