### PR TITLE
 DPL: mark a few services as thread safe 

### DIFF
--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_CALLBACKSERVICE_H
 
 #include "CallbackRegistry.h"
+#include "Framework/ServiceHandle.h"
 #include <tuple>
 
 class FairMQRegionInfo;
@@ -27,6 +28,9 @@ class EndOfStreamContext;
 class CallbackService
 {
  public:
+  /// Callbacks are a global service because they will always be
+  /// invoked by the main thread only.
+  constexpr static ServiceKind service_kind = ServiceKind::Global;
   /// the defined processing steps at which a callback can be invoked
   enum class Id {
     Start,     /**< Invoked before the inner loop is started */

--- a/Framework/Core/include/Framework/ControlService.h
+++ b/Framework/Core/include/Framework/ControlService.h
@@ -10,6 +10,8 @@
 #ifndef O2_FRAMEWORK_CONTROLSERVICE_H_
 #define O2_FRAMEWORK_CONTROLSERVICE_H_
 
+#include "Framework/ServiceHandle.h"
+
 namespace o2::framework
 {
 
@@ -25,9 +27,12 @@ enum struct QuitRequest {
 
 /// A service that data processors can use to talk to control and ask for their
 /// own state change or others.
+/// A ControlService is requried to be a ServiceKind::Global kind of service.
 class ControlService
 {
  public:
+  constexpr static ServiceKind service_kind = ServiceKind::Global;
+
   /// Compatibility with old API.
   void readyToQuit(bool all) { this->readyToQuit(all ? QuitRequest::All : QuitRequest::Me); }
   /// Signal control that we are potentially ready to quit some / all

--- a/Framework/Core/include/Framework/TextControlService.h
+++ b/Framework/Core/include/Framework/TextControlService.h
@@ -10,9 +10,12 @@
 #ifndef O2_FRAMEWORK_TEXTCONTROLSERVICE_H_
 #define O2_FRAMEWORK_TEXTCONTROLSERVICE_H_
 
+#include "Framework/ServiceHandle.h"
 #include "Framework/ControlService.h"
+
 #include <string>
 #include <regex>
+#include <mutex>
 
 namespace o2::framework
 {
@@ -49,6 +52,7 @@ class TextControlService : public ControlService
   bool mOnce = false;
   ServiceRegistry& mRegistry;
   DeviceState& mDeviceState;
+  std::mutex mMutex;
 };
 
 bool parseControl(std::string const& s, std::smatch& match);

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -31,12 +31,14 @@ TextControlService::TextControlService(ServiceRegistry& registry, DeviceState& d
 // This will send an end of stream to all the devices downstream.
 void TextControlService::endOfStream()
 {
+  std::scoped_lock lock(mMutex);
   mDeviceState.streaming = StreamingState::EndOfStreaming;
 }
 
 // All we do is to printout
 void TextControlService::readyToQuit(QuitRequest what)
 {
+  std::scoped_lock lock(mMutex);
   if (mOnce == true) {
     return;
   }
@@ -55,6 +57,7 @@ void TextControlService::readyToQuit(QuitRequest what)
 
 void TextControlService::notifyStreamingState(StreamingState state)
 {
+  std::scoped_lock lock(mMutex);
   switch (state) {
     case StreamingState::Idle:
       LOG(INFO) << "CONTROL_ACTION: NOTIFY_STREAMING_STATE IDLE";


### PR DESCRIPTION
A simple mutex should suffice, since in any case it's called very
rarely.