### PR TITLE
o2-raw-file-reader-workflow --cache-data will cache data at 1st reading

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -305,6 +305,8 @@ o2-raw-file-reader-workflow
   --super-page-size arg (=1048576)      super-page size for FMQ parts definition
   --part-per-hbf                        FMQ parts per superpage (default) of HBF
   --raw-channel-config arg              optional raw FMQ channel for non-DPL output
+  --cache-data                          cache data at 1st reading, may require excessive memory!!!
+
   --configKeyValues arg                 semicolon separated key=value strings
 
   # to suppress various error checks / reporting
@@ -323,7 +325,8 @@ The workflow takes an input from the configuration file (as described in `RawFil
 with the `OutputSpec`s indicated in the configuration file (or defaults). Each link data gets `SubSpecification` according to DataDistribution
 scheme.
 
-If `--loop` argument is provided, data will be re-played in loop. The delay (in seconds) can be added between sensding of consecutive TFs to avoid pile-up of TFs.
+If `--loop` argument is provided, data will be re-played in loop. The delay (in seconds) can be added between sensding of consecutive TFs to avoid pile-up of TFs. By default at each iteration the data will be again read from the disk.
+Using `--cache-data` option one can force caching the data to memory during the 1st reading, this avoiding disk I/O for following iterations, but this option should be used with care as it will eventually create a memory copy of all TFs to read.
 
 At every invocation of the device `processing` callback a full TimeFrame for every link will be added as a multi-part `FairMQ` message and relayed by the relevant channel.
 By default each part will be a single CRU super-page of the link. This behaviour can be changed by providing `part-per-hbf` option, in which case each HBF will be added as a separate HBF.

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -97,6 +97,13 @@ class RawFileReader
   using InputsMap = std::map<OrigDescCard, std::vector<std::string>>;
 
   //=====================================================================================
+
+  // reference on blocks making single message part
+  struct PartStat {
+    int size;    // total size
+    int nBlocks; // number of consecutive LinkBlock objects
+  };
+
   // info on the smallest block of data to be read when fetching the HBF
   struct LinkBlock {
     enum { StartTF = 0x1,
@@ -109,6 +116,7 @@ class RawFileReader
     IR ir = 0;           //! ir starting the block
     uint16_t fileID = 0; //! file id where the block is located
     uint8_t flags = 0;   //! different flags
+    std::unique_ptr<char[]> dataCache; //! optional cache for fast access
     LinkBlock() = default;
     LinkBlock(int fid, size_t offs) : offset(offs), fileID(fid) {}
     void setFlag(uint8_t fl, bool v = true)
@@ -155,12 +163,12 @@ class RawFileReader
     size_t getLargestTF() const;
     size_t getNextHBFSize() const;
     size_t getNextTFSize() const;
-    size_t getNextTFSuperPagesStat(std::vector<size_t>& parts) const;
+    size_t getNextTFSuperPagesStat(std::vector<PartStat>& parts) const;
     int getNHBFinTF() const;
 
     size_t readNextHBF(char* buff);
     size_t readNextTF(char* buff);
-    size_t readNextSuperPage(char* buff);
+    size_t readNextSuperPage(char* buff, const PartStat* pstat = nullptr);
     size_t skipNextHBF();
     size_t skipNextTF();
 
@@ -220,6 +228,9 @@ class RawFileReader
   uint32_t getOrbitMin() const { return mOrbitMin; }
   uint32_t getOrbitMax() const { return mOrbitMax; }
 
+  bool getCacheData() const { return mCacheData; }
+  void setCacheData(bool v) { mCacheData = v; }
+
   o2::header::DataOrigin getDefaultDataOrigin() const { return mDefDataOrigin; }
   o2::header::DataDescription getDefaultDataSpecification() const { return mDefDataDescription; }
   ReadoutCardType getDefaultReadoutCardType() const { return mDefCardType; }
@@ -261,6 +272,7 @@ class RawFileReader
   int mCurrentFileID = 0;                           //! current file being processed
   long int mPosInFile = 0;                          //! current position in the file
   bool mMultiLinkFile = false;                      //! was > than 1 link seen in the file?
+  bool mCacheData = false;                          //! cache data to block after 1st scan (may require excessive memory, use with care)
   uint32_t mCheckErrors = 0;                        //! mask for errors to check
   int mVerbosity = 0;
 

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -22,7 +22,7 @@ namespace raw
 {
 
 framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff,
-                                                 uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, bool partPerSP = true,
+                                                 uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, bool partPerSP = true, bool cache = false,
                                                  size_t spSize = 1024L * 1024L, size_t bufferSize = 1024L * 1024L,
                                                  const std::string& rawChannelConfig = "");
 

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -32,6 +32,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"super-page-size", VariantType::Int64, 1024L * 1024L, {"super-page size for FMQ parts definition"}});
   options.push_back(ConfigParamSpec{"part-per-hbf", VariantType::Bool, false, {"FMQ parts per superpage (default) of HBF"}});
   options.push_back(ConfigParamSpec{"raw-channel-config", VariantType::String, "", {"optional raw FMQ channel for non-DPL output"}});
+  options.push_back(ConfigParamSpec{"cache-data", VariantType::Bool, false, {"cache data at 1st reading, may require excessive memory!!!"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -55,6 +56,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   uint64_t buffSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
   uint64_t spSize = uint64_t(configcontext.options().get<int64_t>("super-page-size"));
   bool partPerSP = !configcontext.options().get<bool>("part-per-hbf");
+  bool cache = configcontext.options().get<bool>("cache-data");
   std::string rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
   uint32_t errmap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
@@ -67,5 +69,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, partPerSP, spSize, buffSize, rawChannelConfig));
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, partPerSP, cache, spSize, buffSize, rawChannelConfig));
 }


### PR DESCRIPTION
Then, with --loop option, all following iterations will avoid disk IO