### PR TITLE
Further speed up of rANS cummulative frequency rescaling

### DIFF
--- a/Utilities/rANS/include/rANS/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/SymbolStatistics.h
@@ -84,7 +84,7 @@ class SymbolStatistics
 
  private:
   void buildCumulativeFrequencyTable();
-
+  auto getCumulativeFrequency(size_t i) const { return mCumulativeFrequencyTable[i + 1] - mCumulativeFrequencyTable[i]; }
   template <typename IT>
   void buildFrequencyTable(const IT begin, const IT end, size_t range);
 
@@ -92,7 +92,6 @@ class SymbolStatistics
   int64_t mMax;
   size_t mNUsedAlphabetSymbols;
   size_t mMessageLength;
-
   std::vector<uint32_t> mFrequencyTable;
   std::vector<uint32_t> mCumulativeFrequencyTable;
 };

--- a/Utilities/rANS/include/rANS/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/SymbolStatistics.h
@@ -84,7 +84,7 @@ class SymbolStatistics
 
  private:
   void buildCumulativeFrequencyTable();
-  auto getCumulativeFrequency(size_t i) const { return mCumulativeFrequencyTable[i + 1] - mCumulativeFrequencyTable[i]; }
+  auto getFrequency(size_t i) const { return mCumulativeFrequencyTable[i + 1] - mCumulativeFrequencyTable[i]; }
   template <typename IT>
   void buildFrequencyTable(const IT begin, const IT end, size_t range);
 


### PR DESCRIPTION
Supersedes #4074 
@shahor02 @MichaelLettrich : Could you check this attemp. It does everything in 2-3 iterations over the data, and should actually be more exact than before, since the ideal scaling is computed under the restriction that it must not produce 0 frequency without stealing.
It is significantly faster for me in first tests, will try with full system test now. Encoding runs through, but I didn't check decoding or compression factors yet.