### PR TITLE
Use random seeding in digitization (interaction records)

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -85,6 +85,10 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
     // initialize fundamental objects
     auto& mgr = steer::HitProcessingManager::instance();
 
+    // init gRandom to random start
+    // TODO: offer option to set seed
+    gRandom->SetSeed(0);
+
     if (simprefixes.size() == 0) {
       LOG(ERROR) << "No simulation prefix available";
     } else {


### PR DESCRIPTION
So far, the same interaction records were produced for each digitization
invocation. This commit forces random start seeding as a quick fix.