### PR TITLE
TRD gen raw data

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -41,6 +41,7 @@ class LinkRecord
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
 
   uint32_t getLinkId() { return mLinkId; }
+  uint32_t getLinkHCID() { return mLinkId & 0x7ff; } // the last 11 bits.
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -249,7 +249,8 @@ uint32_t getSlope(const *rawdata, int tracklet)
 }
 due to the interplay of TrackletMCMHeader and TrackletMCMData come back to this. TODO
 */
-
+uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid);
+uint32_t setHalfCRUHeaderLinkData(HalfCRUHeader& cruhead, int link, int size, int errors);
 uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data);
 uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link);

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -10,6 +10,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <iomanip>
 #include "DataFormatsTRD/RawData.h"
 
 namespace o2
@@ -53,6 +54,25 @@ uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 1
   return 0;
 }
 
+uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid)
+{
+  cruhead.BunchCrossing = bunchcrossing;
+  cruhead.StopBit = stopbits;
+  cruhead.EndPoint = endpoint;
+  cruhead.EventType = eventtype;
+  //later versions
+  //   cruhead.rdhversion = crurdhversion;
+  //   cruhead.FeeID = feeid;
+  //   cruhead.CRUID = cruid;
+  return 0;
+}
+
+uint32_t setHalfCRUHeaderLinkData(HalfCRUHeader& cruhead, int link, int size, int errors)
+{
+  cruhead.datasizes[link].size = size;
+  cruhead.errorflags[link].errorflag = errors;
+  return 0;
+}
 //
 //  Printing methods to dump and display the various structures above in pretty format or hexdump
 //  printNameOfStruct(const NameOfStruct& nameofstruct);
@@ -62,37 +82,46 @@ uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 1
 
 std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchamberheader)
 {
-  stream << "TrackletHCHeader : Raw:0x" << std::hex << halfchamberheader.word << " " << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: " << halfchamberheader.one << " :: " << halfchamberheader.HCID << std::endl;
+  stream << "TrackletHCHeader : Raw:0x" << std::hex << halfchamberheader.word << " "
+         << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: "
+         << halfchamberheader.one << " :: " << halfchamberheader.HCID << std::endl;
   return stream;
 }
 
 std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet)
 {
   // make a pretty output of the tracklet.
-  stream << "TrackletMCMData: Raw:0x" << std::hex << tracklet.word << " pos=" << tracklet.pos << "::slope=" << tracklet.slope << "::pid=" << tracklet.pid << "::checkbit=" << tracklet.checkbit << std::endl;
+  stream << "TrackletMCMData: Raw:0x" << std::hex << tracklet.word << " pos=" << tracklet.pos
+         << "::slope=" << tracklet.slope << "::pid=" << tracklet.pid << "::checkbit="
+         << tracklet.checkbit << std::endl;
   return stream;
 }
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet)
 {
-  LOGF(INFO, "TrackletMCMData: Raw:0x%08x pos:%d slope:%d pid:0x%08x checkbit:0x%02x", tracklet.word, tracklet.pos, tracklet.slope, tracklet.pid, tracklet.checkbit);
+  LOGF(INFO, "TrackletMCMData: Raw:0x%08x pos:%d slope:%d pid:0x%08x checkbit:0x%02x",
+       tracklet.word, tracklet.pos, tracklet.slope, tracklet.pid, tracklet.checkbit);
 }
 
 void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead)
 {
-  LOGF(INFO, "MCMRawHeader: Raw:0x%08x 1:%d padrow: 0x%02x col: 0x%01x pid2 0x%02x pid1: 0x%02x pid0: 0x%02x 1:%d", mcmhead.word, mcmhead.onea, mcmhead.padrow, mcmhead.col, mcmhead.pid2, mcmhead.pid1, mcmhead.pid0, mcmhead.oneb);
+  LOGF(INFO, "MCMRawHeader: Raw:0x%08x 1:%d padrow: 0x%02x col: 0x%01x pid2 0x%02x pid1: 0x%02x pid0: 0x%02x 1:%d",
+       mcmhead.word, mcmhead.onea, mcmhead.padrow, mcmhead.col,
+       mcmhead.pid2, mcmhead.pid1, mcmhead.pid0, mcmhead.oneb);
 }
 
 std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead)
 {
   // make a pretty output of the mcm header.
-  // stream << "MCMRawHeader:" << mcmhead.checkbits << "::" << (mcmhead.pid&0xfff000000) << ":"<<  (mcmhead.pid&0xfff000) << ":"<< (mcmhead.pid&0xfff) << std::endl;
-  stream << "MCMRawHeader: Raw:0x" << std::hex << mcmhead.word << " " << mcmhead.onea << "::" << mcmhead.pid2 << ":" << mcmhead.pid1 << ":" << mcmhead.pid0 << "::" << mcmhead.oneb << std::endl;
+  stream << "MCMRawHeader: Raw:0x" << std::hex << mcmhead.word << " " << mcmhead.onea << "::"
+         << mcmhead.pid2 << ":" << mcmhead.pid1 << ":" << mcmhead.pid0 << "::"
+         << mcmhead.oneb << std::endl;
   return stream;
 }
 
 void printHalfChamber(o2::trd::TrackletHCHeader& halfchamber)
 {
-  LOGF(INFO, "TrackletHCHeader: Raw:0x%08x HCID : 0x%0x MCLK: 0x%0x Format: 0x%0x Always1:0x%0x", halfchamber.HCID, halfchamber.MCLK, halfchamber.format, halfchamber.one);
+  LOGF(INFO, "TrackletHCHeader: Raw:0x%08x HCID : 0x%0x MCLK: 0x%0x Format: 0x%0x Always1:0x%0x",
+       halfchamber.HCID, halfchamber.MCLK, halfchamber.format, halfchamber.one);
 }
 
 void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber)
@@ -106,23 +135,25 @@ void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
   std::array<uint32_t, 15> errorflags;
   getlinkdatasizes(halfcru, sizes);
   getlinkerrorflags(halfcru, errorflags);
-  LOGF(INFO, "V:%d BC:%d SB:%d EType:%d", halfcru.HeaderVersion, halfcru.BunchCrossing, halfcru.StopBit, halfcru.EventType);
+  LOGF(INFO, "V:%d BC:%d SB:%d EType:%d", halfcru.HeaderVersion, halfcru.BunchCrossing,
+       halfcru.StopBit, halfcru.EventType);
   for (int i = 0; i < 15; i++)
     LOGF(INFO, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
 }
 
 void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
 {
-  std::array<uint32_t, 16> raw{};
+  std::array<uint64_t, 8> raw{};
   memcpy(&raw[0], &halfcru, sizeof(halfcru));
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 2; i++) {
     int index = 4 * i;
-    LOGF(INFO, "[1/2CRUHeader %d] 0x%08x 0x%08x 0x%08x 0x%08x", i, raw[index + 3], raw[index + 2], raw[index + 1], raw[index + 0]);
+    LOGF(INFO, "[1/2CRUHeader %d] 0x%08x 0x%08x 0x%08x 0x%08x", i, raw[index + 3], raw[index + 2],
+         raw[index + 1], raw[index + 0]);
   }
 }
 
-std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru) // make a pretty output of the header.
-{
+std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru)
+{ // make a pretty output of the header.
   stream << std::hex;
   stream << "EventType : " << halfcru.EventType << std::endl;
   stream << "StopBit : " << halfcru.StopBit << std::endl;

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TRDSimulation
                        src/TrapConfig.cxx 
                        src/TrapConfigHandler.cxx 
                        src/TrapSimulator.cxx
+                       src/Trap2CRU.cxx
                        PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::DataFormatsTRD O2::DetectorsRaw)
 
 o2_target_root_dictionary(TRDSimulation
@@ -29,6 +30,7 @@ o2_target_root_dictionary(TRDSimulation
 				                  include/TRDSimulation/TRDSimParams.h
                                   include/TRDSimulation/TrapConfig.h
                                   include/TRDSimulation/TrapConfigHandler.h
+                                  include/TRDSimulation/Trap2CRU.h
                                   include/TRDSimulation/TrapSimulator.h)
 
 if (OpenMP_CXX_FOUND)
@@ -38,3 +40,12 @@ endif()
 
 o2_data_file(COPY data DESTINATION Detectors/TRD/simulation)
 
+o2_add_executable(trap2raw
+                  COMPONENT_NAME trd
+                  SOURCES src/trap2raw.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TRDSimulation
+                                        O2::DetectorsRaw
+                                        O2::DetectorsCommonDataFormats
+                                        O2::CommonUtils
+										O2::DataFormatsTRD
+                                        Boost::program_options)

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -1,0 +1,94 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD Trap2CRU class                                                       //
+//  Class to take the trap output that arrives at the cru and produce        //
+//  the cru output. I suppose a cru simulator                                //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ALICE_O2_TRD_TRAP2CRU_H
+#define ALICE_O2_TRD_TRAP2CRU_H
+
+#include <string>
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/LinkRecord.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/Tracklet64.h"
+//#include "DetectorsRaw/HBFUtils.h"
+#include "DetectorsRaw/RawFileWriter.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class Trap2CRU
+{
+  static constexpr int NumberOfCRU = 36;
+  static constexpr int NumberOfHalfCRU = 72;
+  static constexpr int NumberOfFLP = 12;
+  static constexpr int CRUperFLP = 3;
+  static constexpr int WordSizeInBytes = 256; // word size in bits, everything is done in 256 bit blocks.
+  static constexpr int WordSize = 8;          // 8 standard 32bit words.
+  static constexpr int NLinksPerHalfCRU = 15;
+  static constexpr uint32_t PaddWord = 0xeeee; // pad word to fill 256bit blocks or entire block for no data case.
+                                               //TODO come back and change the mapping of 1077 channels to a lut and probably configurable.
+                                               //
+ public:
+  Trap2CRU() = default;
+  Trap2CRU(const std::string& outputDir, const std::string& inputFilename);
+  void readTrapData(const std::string& otuputDir, const std::string& inputFilename, int superPageSizeInB);
+  void convertTrapData(o2::trd::TriggerRecord const& TrigRecord);
+  // default for now will be file per half cru as per the files Guido did for us.
+  // TODO come back and give users a choice.
+  //       void setFilePerLink(){mfileGranularity = mgkFilesPerLink;};
+  //       bool getFilePerLink(){return (mfileGranularity==mgkFilesPerLink);};
+  //       void setFilePerHalfCRU(){mfileGranularity = mgkFilesPerHalfCRU;};
+  //       bool getFilePerHalfCRU(){return (mfileGranularity==mgkFilesPerHalfCRU);};  //
+  int getVerbosity() { return mVerbosity; }
+  void setVerbosity(int verbosity) { mVerbosity = verbosity; }
+  void buildCRUPayLoad();
+  o2::raw::RawFileWriter& getWriter() { return mWriter; }
+  uint32_t buildCRUHeader(HalfCRUHeader& header, uint32_t bc, uint32_t halfcru, int startlinkrecord);
+  void linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_t& padding);
+
+ private:
+  int mfileGranularity; /// per link or per half cru for each file
+  uint32_t mLinkID;
+  uint16_t mCruID;
+  uint64_t mFeeID;
+  uint32_t mEndPointID;
+  std::string mInputFilename;
+  std::string mOutputFilename;
+  int mVerbosity = 0;
+  HalfCRUHeader mHalfCRUHeader;
+  TrackletMCMHeader mTrackletMCMHeader;
+  TrackletMCMData mTrackletMCMData;
+
+  std::vector<char> mRawData; // store for building data event for a single half cru
+  uint32_t mRawDataPos = 0;
+  TFile* mTrapRawFile;
+  TTree* mTrapRawTree; // incoming data tree
+  // locations to store the incoming data branches
+  std::vector<o2::trd::LinkRecord> mLinkRecords, *mLinkRecordsPtr = &mLinkRecords;
+  std::vector<o2::trd::TriggerRecord> mTriggerRecords, *mTriggerRecordsPtr = &mTriggerRecords;
+  std::vector<uint32_t> mTrapRawData, *mTrapRawDataPtr = &mTrapRawData;
+
+  const o2::raw::HBFUtils& mSampler = o2::raw::HBFUtils::Instance();
+  o2::raw::RawFileWriter mWriter{"TRD"};
+
+  ClassDefNV(Trap2CRU, 1);
+};
+
+} // end namespace trd
+} // end namespace o2
+#endif

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -25,6 +25,7 @@
 #pragma link C++ class o2::trd::TrapConfig::TrapDmemWord + ;
 #pragma link C++ class o2::trd::TrapConfig::TrapRegister + ;
 #pragma link C++ class o2::trd::TrapSimulator + ;
+#pragma link C++ class o2::trd::Trap2CRU + ;
 
 #pragma link C++ class o2::trd::TRDSimParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDSimParams> + ;

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -1,0 +1,302 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD Trap2CRU class                                                       //
+//  Class to take the trap output that arrives at the cru and produce        //
+//  the cru output. A data mapping more than a cru simulator                 //
+///////////////////////////////////////////////////////////////////////////////
+
+#include <string>
+
+#include "Headers/RAWDataHeader.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/LinkRecord.h"
+#include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DetectorsRaw/HBFUtils.h"
+#include "DetectorsRaw/RawFileWriter.h"
+#include "TRDSimulation/Trap2CRU.h"
+#include "CommonUtils/StringUtils.h"
+#include "TRDBase/TRDCommonParam.h"
+#include "TFile.h"
+#include "TTree.h"
+#include <TStopwatch.h>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <array>
+#include <string>
+#include <bitset>
+#include <vector>
+#include <gsl/span>
+
+using namespace o2::raw;
+
+namespace o2
+{
+namespace trd
+{
+
+Trap2CRU::Trap2CRU(const std::string& outputDir, const std::string& inputFilename)
+{
+  readTrapData(outputDir, inputFilename, 1024 * 1024);
+}
+
+void Trap2CRU::readTrapData(const std::string& otuputDir, const std::string& inputFilename, int superPageSizeInB)
+{
+  //set things up, read the file and then deligate to convertTrapdata to do the conversion.
+  //
+  mRawData.reserve(1024 * 1024); //TODO take out the hardcoded 1MB its supposed to come in from the options
+  LOG(info) << "Trap2CRU::readTrapData";
+  // data comes in index by event (triggerrecord) and link (linke record) both sequentially.
+  // first 15 links go to cru0a, second 15 links go to cru0b, 3rd 15 links go to cru1a ... first 90 links to flp0 and then repate for 12 flp
+  // then do next event
+
+  // lets register our links
+  for (int link = 0; link < NumberOfCRU; link++) {
+    mFeeID = link;
+    mCruID = link;
+    mEndPointID = link * 2;
+    mLinkID = link;
+    std::string outputFilelink = o2::utils::concat_string("trd_cru_", std::to_string(link), "_a.raw");
+    mWriter.registerLink(mFeeID, mCruID, mLinkID, mEndPointID, outputFilelink);
+    outputFilelink = o2::utils::concat_string("trd_cru_", std::to_string(link), "_b.raw");
+    mEndPointID++;
+    mWriter.registerLink(mFeeID, mCruID, mLinkID, mEndPointID, outputFilelink);
+  }
+  mTrapRawFile = TFile::Open(inputFilename.data());
+  assert(mTrapRawFile != nullptr);
+  LOG(info) << "Trap Raw file open " << inputFilename;
+  mTrapRawTree = (TTree*)mTrapRawFile->Get("o2sim");
+
+  mTrapRawTree->SetBranchAddress("TrapLinkRecord", &mLinkRecordsPtr);      // branch with the link records
+  mTrapRawTree->SetBranchAddress("RawTriggerRecord", &mTriggerRecordsPtr); // branch with the trigger records
+  mTrapRawTree->SetBranchAddress("TrapRaw", &mTrapRawDataPtr);             // branch with the actual incoming data.
+
+  for (int entry = 0; entry < mTrapRawTree->GetEntries(); entry++) {
+    mTrapRawTree->GetEntry(entry);
+    LOG(debug) << "Before Trigger Reord loop Event starts at:" << mTriggerRecords[0].getFirstEntry() << " and has " << mTriggerRecords[0].getNumberOfObjects() << " entries";
+    uint32_t linkcount = 0;
+    for (auto trigger : mTriggerRecords) {
+      //get the event limits from TriggerRecord;
+      uint32_t eventstart = trigger.getFirstEntry();
+      uint32_t eventend = trigger.getFirstEntry() + trigger.getNumberOfObjects();
+      LOG(info) << "Event starts at:" << eventstart << " and ends at :" << eventend;
+      convertTrapData(trigger);
+    }
+  }
+}
+
+void Trap2CRU::buildCRUPayLoad()
+{
+  // go through the data for the event in question, produce the raw stream for each cru.
+  // i.e. 30 link per cru, 3cru per flp.
+  // 30x [HalfCRUHeader, TrackletHCHeader0, [MCMHeader TrackletMCMData. .....] TrackletHCHeader1 ..... TrackletHCHeader30 ...]
+  //
+  // data must be padded into blocks of 256bit so on average 4 padding 32 bit words.
+}
+
+void Trap2CRU::linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_t& padding)
+{
+  // all data must be 256 bit aligned (8x64bit).
+  // if zero the whole 256 bit must be padded (empty link)
+  // crudatasize is the size to be stored in the cruheader, i.e. units of 256bits.
+  // linksize is the incoming link size from the linkrecord,
+  // padding is of course the amount of padding in 32bit words.
+  uint32_t rem = 0;
+  if (linksize != 0) {
+    //data, so figure out padding cru word, the other case is simple, full padding if size=0
+    rem = linksize % 8;
+    if (rem != 0) {
+      crudatasize = linksize / 8 + 1;
+      padding = 8 - rem;
+    } else {
+
+      crudatasize = linksize / 8; // 32 bit word to 256 bit word.
+      padding = 0;
+    }
+    LOG(debug) << "We have data with linkdatasize=" << linksize << " with size number in header of:" << crudatasize << " padded with " << padding << " 32bit words";
+  } else {
+    //linksize is zero so no data, pad fully.
+    crudatasize = 1;
+    padding = 8;
+    LOG(debug) << "We have data with linkdatasize=" << linksize << " with size number in header of:" << crudatasize << " padded with " << padding << " 32bit words";
+  }
+  LOG(debug) << "linkSizePadding : CRUDATASIZE : " << crudatasize;
+}
+
+uint32_t Trap2CRU::buildCRUHeader(HalfCRUHeader& header, uint32_t bc, uint32_t halfcru, int startlinkrecord)
+{
+  int bunchcrossing = bc;
+  int stopbits = 0x01; // do we care about this and eventtype in simulations?
+  int eventtype = 0x01;
+  int crurdhversion = 6;
+  int feeid = 0;                      //TODO must be in cruheader down the road, inside the reserved somewhere ...
+  int cruid = 0;                      //TODO """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+  uint32_t crudatasize = 0;           //link size in units of 256 bits.
+  int endpoint = halfcru % 2 ? 1 : 0; //TODO figure out a value ... endpoint needs a rebase to PR4106
+  uint32_t padding = 0;
+  //setHalfCRUHeader(halfcruheader, rdhversion, bunchcrossing, stopbits, endpoint, eventtype); //TODO come back and pull this from somewhere.
+  setHalfCRUHeader(header, crurdhversion, bunchcrossing, stopbits, endpoint, eventtype, feeid, cruid); //TODO come back and pull this from somewhere.
+                                                                                                       //  memset(&tmpLinkInfo[0],0,sizeof(tmpLinkInfo[0])*tmpLinkInfo.size());
+
+  // halfcruheader from the relevant mLinkRecords.
+  int linkrecord = startlinkrecord;
+  int totallinkdatasize = 0; //in units of 256bits
+  for (int link = 0; link < NLinksPerHalfCRU; link++) {
+    int hcid = link + halfcru * NLinksPerHalfCRU; // TODO this might have to change to a lut I dont think the mapping is linear.
+    int errors = 0;
+    int linksize = 0; // linkSizePadding will convert it to 1 for the no data case.
+    if (mLinkRecords[linkrecord].getLinkHCID() == hcid) {
+      linksize = mLinkRecords[linkrecord].getNumberOfObjects();
+      // this can be done differently by keeping a pointer to halfcruheader and setting it after reading it all in and going back per link to set the size.
+      // LOG(info) << "setting CRU HEADER for halfcru : " << halfcru << "and link : " << link << " contents" << halfcruheader << ":" << link << ":" << linksize << ":" << errors;
+      linkrecord++; // increment locally for walking through linkrecords.
+    }
+    linkSizePadding(linksize, crudatasize, padding);
+    setHalfCRUHeaderLinkData(header, link, crudatasize, errors); // write one padding block for empty links.
+    totallinkdatasize += crudatasize;
+  }
+  return totallinkdatasize;
+}
+
+void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& TrigRecord)
+{
+
+  //build a HalfCRUHeader for this event/cru/endpoint
+  //loop over cru's
+  //  loop over all half chambers, thankfully they data is sorted.
+  //    check if current chamber has a link
+  //      if not blank, else fill in data from link records
+  //  dump data to rawwriter
+  //finished for event. this method is only called per event.
+  int currentlinkrecord = 0;
+  char* traprawdataptr = (char*)&mTrapRawData[0];
+  for (int halfcru = 0; halfcru < NumberOfHalfCRU; halfcru++) {     //TODO come back and replace 72 with something.
+                                                                    //   TrackletHC
+    memset(&mRawData[0], 0, sizeof(mRawData[0]) * mRawData.size()); //   zero the rawdata storage
+    int numberofdetectors = o2::trd::kNdet;
+    HalfCRUHeader halfcruheader;
+    //now write the cruheader at the head of all the data for this halfcru.
+    LOG(debug) << "cru before building cruheader for halfcru index : " << halfcru << " with contents \n"
+               << halfcruheader;
+    uint32_t totalhalfcrudatasize = buildCRUHeader(halfcruheader, TrigRecord.getBCData().bc, halfcru, currentlinkrecord);
+
+    std::vector<char> rawdatavector(totalhalfcrudatasize * 32 + sizeof(halfcruheader)); // sum of link sizes + padding in units of bytes and some space for the header (512 bytes).
+    char* rawdataptr = rawdatavector.data();
+    LOG(info) << "before writing halfcruheader pionter is sitting at " << std::hex << static_cast<void*>(rawdataptr);
+    dumpHalfCRUHeader(halfcruheader);
+    memcpy(rawdataptr, (char*)&halfcruheader, sizeof(halfcruheader));
+    std::array<uint64_t, 8> raw{};
+    memcpy((char*)&raw[0], rawdataptr, sizeof(halfcruheader));
+    for (int i = 0; i < 2; i++) {
+      int index = 4 * i;
+      LOGF(debug, "[1/2rawdaptr %d] 0x%08x 0x%08x 0x%08x 0x%08x", i, raw[index + 3], raw[index + 2], raw[index + 1], raw[index + 0]);
+    }
+    rawdataptr += sizeof(halfcruheader);
+    LOG(info) << "For writing halfcruheader pionter advanced by " << std::dec << sizeof(halfcruheader) << " ptr is now at:" << std::hex << static_cast<void*>(rawdataptr);
+    LOG(debug) << "Just wrote cruheader for halfcru index : " << halfcru << " with contents \n"
+               << halfcruheader;
+    LOG(debug) << "end of halfcruheader";
+
+    int linkdatasize = 0; // in 32 bit words
+    int link = halfcru / 2;
+    int endpoint = halfcru;
+    for (int halfcrulink = 0; halfcrulink < NLinksPerHalfCRU; halfcrulink++) {
+      //links run from 0 to 14, so hcid offset is halfcru*15;
+      int hcid = halfcrulink + halfcru * NLinksPerHalfCRU; // TODO this might have to change to a lut I dont think the mapping is linear.
+      LOG(info) << "Currently checking for data on hcid : " << hcid << " from halfcru=" << halfcru << " and halfcrulink:" << halfcrulink << " ?? " << hcid << "==" << mLinkRecords[currentlinkrecord].getLinkHCID();
+      int errors = 0;           // put no errors in for now.
+      int size = 0;             // in 32 bit words
+      int datastart = 0;        // in 32 bit words
+      int dataend = 0;          // in 32 bit words
+      uint32_t paddingsize = 0; // in 32 bit words
+      uint32_t crudatasize = 0; // in 256 bit words.
+      if (mLinkRecords[currentlinkrecord].getLinkHCID() == hcid) {
+        //this link has data in the stream.
+        LOG(info) << "+++ We have data on hcid = " << hcid << " halfcrulink : " << halfcrulink;
+        linkdatasize = mLinkRecords[currentlinkrecord].getNumberOfObjects();
+        datastart = mLinkRecords[currentlinkrecord].getFirstEntry();
+        dataend = datastart + size;
+        LOG(info) << "We have data on hcid = " << hcid << " and linksize : " << linkdatasize << " so :" << linkdatasize / 8 << " 256 bit words";
+        currentlinkrecord++;
+      } else {
+        assert(mLinkRecords[currentlinkrecord].getLinkId() < hcid);
+        LOG(info) << "---We do not have data on hcid = " << hcid << " halfcrulink : " << halfcrulink;
+        //blank data for this link??? what do i do?
+        // put in a 1 256 bit word of data for the link and padd with 0xeeee x 8
+        //     tmpLinkInfo[halfcrulink] = -1;
+        linkdatasize = 0;
+        paddingsize = 8;
+      }
+      // now copy data to rawdata, padding as and where needed.
+      //
+      linkSizePadding(linkdatasize, crudatasize, paddingsize); //TODO this can come out as we have already called it, but previously we have lost the #padding words, solve to remove.
+
+      LOG(info) << "WRITING " << crudatasize << " 256 bit data words to output stream";
+      LOG(info) << "setting CRY HEADER for " << halfcruheader << ":" << halfcrulink << ":" << crudatasize << ":" << errors;
+      // now pad ....
+      LOG(info) << " now to pump data into the stream with : " << linkdatasize << " crudatasize:" << crudatasize << " paddingsize: " << paddingsize << " and rem:" << linkdatasize % 8;
+      char* olddataptr = rawdataptr; // store the old pointer so we can do some sanity checks for how far we advance.
+      //linkdatasize is the #of 32 bit words coming from the incoming tree.
+      //paddingsize is the number of padding words to add 0xeeee
+      uint32_t bytestocopy = linkdatasize * (sizeof(uint32_t));
+      LOG(info) << "copying " << bytestocopy << " bytes of link tracklet data at pos:" << std::hex << static_cast<void*>(rawdataptr);
+      memcpy(rawdataptr, traprawdataptr, bytestocopy);
+      //increment pointer
+      rawdataptr += bytestocopy;
+      traprawdataptr += bytestocopy;
+      //now for padding
+      uint16_t padbytes = paddingsize * sizeof(uint32_t);
+      LOG(info) << "writing " << padbytes << " bytes of padding data  at pos:" << std::hex << static_cast<void*>(rawdataptr);
+      memset(rawdataptr, 0xee, padbytes);
+      //increment pointer.
+      rawdataptr += padbytes;
+      if (padbytes + bytestocopy != crudatasize * 32) {
+        LOG(info) << "something wrong with data size writing padbytes:" << padbytes << " bytestocopy : " << bytestocopy << " crudatasize:" << crudatasize;
+      }
+      LOG(debug3) << std::hex << " rawdataptr:" << static_cast<void*>(rawdataptr) << " traprawdataptr " << static_cast<void*>(traprawdataptr);
+      // printf(std::cout << std::hex << " rawdataptr:0x"<<&rawdataptr << " traprawdataptr 0x"<<&traprawdataptr << std::endl;
+      //sanity check for now:
+      if (((char*)rawdataptr - (char*)olddataptr) != crudatasize * 32) { // cru words are 8 uint32 and comparison is in bytes.
+        LOG(debug) << "according to pointer arithmatic we have added " << rawdataptr - olddataptr << "bytes from " << static_cast<void*>(rawdataptr) << "-" << static_cast<void*>(olddataptr) << " when we should have added  " << crudatasize * 8 * 4 << " because crudatasize=" << crudatasize;
+      }
+      if (crudatasize != o2::trd::getlinkdatasize(halfcruheader, halfcrulink)) {
+        // we have written the wrong amount of data ....
+        LOG(debug) << "crudata is ! = get link data size " << crudatasize << "!=" << o2::trd::getlinkdatasize(halfcruheader, halfcrulink);
+      }
+      //    if(crudatasize ==0)LOG(info) << "CRUDATASIZ EIS ZERO" ;
+      //      if(crudatasize>0){
+      //      std::ofstream out1("crutestdumphalfcrurawdata");
+      //      std::ofstream out2("crutestdumprawdatavector");
+      //      LOG(info) << "writing out " << halfcrurawdata.size() << " and"  << crudatasize*32;
+      //      out1.write(halfcrurawdata.data(),halfcrurawdata.size());
+      //      out2.write(rawdatavector.data(),crudatasize*32);
+      //      out1.flush();
+      //      out2.flush();
+      //      exit(1);
+      //      }
+      LOG(info) << "copied " << crudatasize * 32 << "bytes to halfcrurawdata which now has  size of " << rawdatavector.size() << " for " << link << ":" << endpoint;
+    }
+    // std::vector<char> halfcrurawdata(crudatasize * 32); // vector of 256bit words * 32 to get to 8 bit words
+
+    mWriter.addData(link, link, link, endpoint, TrigRecord.getBCData(), rawdatavector);
+    std::ofstream out2("crutestdumprawdatavector");
+    out2.write(rawdatavector.data(), rawdatavector.size());
+    out2.flush();
+    //    halfcru = NumberOfHalfCRU; // exit loop after 1 half cru for now.
+  }
+}
+
+} // end namespace trd
+} // end namespace o2

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -1,0 +1,140 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD Raw data format generation                                           //
+//  Take the output of the trapsimulator the [2-4]x32 bit words and          //
+//  associated headers and links etc. and produce the output of the cru.     //
+//  Hence the incredibly original name.                                      //
+//                                                                           //
+//  Some parts bare a striking resemblence to (at least when written)        //
+//  FIT/FTO/simulation/src/digit2raw.cxx                                     //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "fairlogger/Logger.h"
+
+#include <DataFormatsTRD/RawData.h>
+#include <DataFormatsTRD/Tracklet64.h>
+#include <DataFormatsTRD/LinkRecord.h>
+#include <DataFormatsTRD/TriggerRecord.h>
+
+#include "CommonUtils/StringUtils.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsRaw/HBFUtils.h"
+#include "TRDSimulation/Trap2CRU.h"
+#include "DataFormatsParameters/GRPObject.h"
+
+#include <boost/program_options.hpp>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TStopwatch.h>
+#include <string>
+#include <iomanip>
+#include <iostream>
+#include <iomanip>
+#include "TCanvas.h"
+#include <TTree.h>
+#include <TFile.h>
+#include <ostream>
+#include <fstream>
+
+namespace bpo = boost::program_options;
+
+void trap2raw(const std::string& inpName, const std::string& outDir, int verbosity,
+              bool filePerLink, uint32_t rdhV = 4, bool noEmptyHBF = false,
+              int superPageSizeInB = 1024 * 1024);
+
+int main(int argc, char** argv)
+{
+  bpo::variables_map vm;
+  bpo::options_description opt_general("Usage:\n  " + std::string(argv[0]) +
+                                       "Convert TRD sim otuput to CRU raw data\n");
+  bpo::options_description opt_hidden("");
+  bpo::options_description opt_all;
+  bpo::positional_options_description opt_pos;
+
+  try {
+    auto add_option = opt_general.add_options();
+    add_option("help,h", "Print this help message");
+    add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
+    add_option("input-file,i", bpo::value<std::string>()->default_value("trdtrapraw.root"), "input Trapsim raw file");
+    add_option("file-per-halfcru,l", bpo::value<bool>()->default_value(false)->implicit_value(true), "create output file per half cru, 2 files per cru 15 links each.");
+    add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
+    uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
+    add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
+    add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //    add_option("data-format,d", bpo::value<uint32_t>()->default_value(1)->implicit_value(true), "format of data, default 1, see documentation.");
+    add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
+
+    opt_all.add(opt_general).add(opt_hidden);
+    bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
+
+    if (vm.count("help")) {
+      std::cout << opt_general << std::endl;
+      exit(0);
+    }
+
+    bpo::notify(vm);
+  } catch (bpo::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl
+              << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(1);
+  } catch (std::exception& e) {
+    std::cerr << e.what() << ", application will now exit" << std::endl;
+    exit(2);
+  }
+  //  o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
+
+  std::cout << "yay it ran" << std::endl;
+  trap2raw(vm["input-file"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["verbosity"].as<int>(),
+           vm["file-per-halfcru"].as<bool>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>());
+
+  return 0;
+}
+
+void trap2raw(const std::string& inpName, const std::string& outDir, int verbosity, bool filePerLink, uint32_t rdhV, bool noEmptyHBF, int superPageSizeInB)
+{
+
+  TStopwatch swTot;
+  swTot.Start();
+  o2::trd::Trap2CRU mc2raw;
+  //mc2raw.setFilePerLink(filePerLink); TODO come back to this, lets get it working first.
+  mc2raw.setVerbosity(verbosity);
+  auto& wr = mc2raw.getWriter();
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+  // wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TRD)); // must be set explicitly
+  wr.setContinuousReadout(false); // above should work, but I know this is correct, come back TODO
+  wr.setSuperPageSize(superPageSizeInB);
+  wr.useRDHVersion(rdhV);
+  wr.setDontFillEmptyHBF(noEmptyHBF);
+
+  std::string outDirName(outDir);
+  if (outDirName.back() != '/') {
+    outDirName += '/';
+  }
+  // if needed, create output directory
+  if (gSystem->AccessPathName(outDirName.c_str())) {
+    if (gSystem->mkdir(outDirName.c_str(), kTRUE)) {
+      LOG(FATAL) << "could not create output directory " << outDirName;
+    } else {
+      LOG(INFO) << "created output directory " << outDirName;
+    }
+  }
+
+  mc2raw.readTrapData(outDirName, inpName, superPageSizeInB);
+  wr.writeConfFile(wr.getOrigin().str, "RAWDATA", o2::utils::concat_string(outDirName, wr.getOrigin().str, "raw.cfg"));
+  //
+  swTot.Stop();
+  swTot.Print();
+}

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -70,23 +70,43 @@ bool msgDigitSortComparator(o2::trd::Digit const& a, o2::trd::Digit const& b)
   int rowb = b.getRow();
   int pada = a.getPad();
   int padb = b.getPad();
+  int deta = a.getDetector();
+  int detb = b.getDetector();
   double timea = a.getTimeStamp();
   double timeb = b.getTimeStamp();
   int roba = fee->getROBfromPad(rowa, pada);
   int robb = fee->getROBfromPad(rowb, padb);
   int mcma = fee->getMCMfromPad(rowa, pada);
   int mcmb = fee->getMCMfromPad(rowb, padb);
+  int hcida = deta * 2 + roba % 2;
+  int hcidb = detb * 2 + robb % 2;
   //LOG(info) << "comparing " << rowa << ":" << pada <<":" << roba <<" "<< mcma  << " with " << rowb << ":" << padb <<":" << robb <<" "<< mcmb;
   if (timea < timeb) {
     //  LOG(info) << "yip timea < timeb " << timea <<"<" << timeb;
     return 1;
   } else if (timea == timeb) {
-
-    if (a.getDetector() < b.getDetector())
+    if (hcida < hcidb)
       return 1;
     else {
-      if (a.getDetector() == b.getDetector()) {
-        if (roba < robb)
+      if (hcida == hcidb) {
+        if (mcma < mcmb)
+          return 1;
+        else
+          return 0;
+      } else
+        return 0;
+    }
+    return 0;
+
+    /* 
+    if (deta < detb)
+      return 1;
+    else {
+      if (deta == detb) {
+        if(hcida < hcidb) 
+          return 1;
+        else { 
+            if (roba < robb)
           return 1;
         else {
           if (roba == robb) {
@@ -100,8 +120,10 @@ bool msgDigitSortComparator(o2::trd::Digit const& a, o2::trd::Digit const& b)
         return 0;
       }
       return 0;
+      }
+      return 0;
     }
-    return 0;
+    return 0;*/
   }
   return 0;
 }
@@ -516,6 +538,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
             //mTotalRawWordsWritten++; //no longer writing to raw stream
             mNewTrackletHCHeaderHasBeenWritten = true;
             LOG(debug) << mTrackletHCHeader;
+            LOG(info) << " add HCID : " << mTrackletHCHeader.HCID;
           }
           LOG(debug) << "getting trackletsteram for trapcounter = " << trapcounter;
           auto wordswritten = mTrapSimulator[trapcounter].getTrackletStream(rawdata, mTotalRawWordsWritten); // view of data from current marker and only 5 words long (can only have 4 words at most in the trackletstream for 1 MCM)


### PR DESCRIPTION
Take output of trap simulation (data that is received by cru) and generate raw data.

- trap2raw standalone executable converts trapoutput to cru output(raw data)
- Speed up sort in trap simulator, only sort on time, hcid, mcm
- Raw files generated 1 per half cru, option to change later.
- Files pass o2-raw-file-check.
- Mapping of half chambers to cru inputs will be done seperately, for now linear 0-1079.
