### PR TITLE
TRD updated halfcruheader

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -22,119 +22,96 @@ namespace o2
 namespace trd
 {
 
+/// \structure HalfCRUHeader
+/// \brief Header for half a cru, each cru has 2 output, 1 for each pciid.
+//         This comes at the top of the data stream for each event and 1/2cru
+
 struct HalfCRUHeader {
+
   /* Half cru header
 64 bits is too wide, hence reduce to 32 to make it readable.
-
         |31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
         -------------------------------------------------------------------------------------------------
-Word 0  |  link 0  errorflags   |               link 0 datasize                 |  link 1  errorflags   |
+Word 0  |  eventtype   | end point | stopbit|             bunchcrossing         |      headerversion    |
         -------------------------------------------------------------------------------------------------
-Word 0  |   link 0 data size                            |   link 2 error flags  |  link 2 datasize upper|
+Word 0  |                                          reserved 1                                           |
         -------------------------------------------------------------------------------------------------
-Word 1  | link 2 datasize lower |   link 3 errorflags   |              link 3 datasize                  |
+Word 1  |  link 3  errorflags   |    link 2 errorflags  |  link 1 error flags   |  link 0 error flags   |
         -------------------------------------------------------------------------------------------------
-Word 1  |  link 4  errorflags   |               link 4 datasize                 |  link 5  errorflags   |
+Word 1  |  link 7 error flags   |   link 6 error flags  |  link 5 error flags   |  link 4 error flags   |
         -------------------------------------------------------------------------------------------------
-Word 2  |   link 5 data size                            |   link 6 error flags  |  link 6 datasize upper|
+Word 2  |  link 11 error flags  |   link 10 error flags |  link 9 error flags   |  link 8 error flags   |
         -------------------------------------------------------------------------------------------------
-Word 2  | link 6 datasize lower |   link 7 errorflags   |              link 7 datasize                  |
+Word 2  |  link 12 error flags  |  link 13 error flags  |  link 14 error flags  |      reserved 2       |
         -------------------------------------------------------------------------------------------------
-Word 3  |                                          reserved                                             |
+Word 3  |                                          reserved 3                                           |
         -------------------------------------------------------------------------------------------------
-Word 3  | header version        | bunch crossing                    | stop bit  |  event type           |
+Word 3  |                                          reserved 4                                           |
         -------------------------------------------------------------------------------------------------
-Word 4  |                                          reserved                                             |
+Word 4  |            link 1 datasize                    |             link 0 datasize                   |
         -------------------------------------------------------------------------------------------------
-Word 4  |                                          reserved                                             |
+Word 4  |            link 3 datasize                    |             link 2 datasize                   |
         -------------------------------------------------------------------------------------------------
-Word 5  |                      reserved                                         | link 8 error flags    |
+Word 5  |            link 5 datasize                    |             link 4 datasize                   |
         -------------------------------------------------------------------------------------------------
-Word 5  |   link 8 data size                            |   link 9 error flags  |  link 9 datasize upper|
+Word 5  |            link 7 datasize                    |             link 6 datasize                   |
         -------------------------------------------------------------------------------------------------
-Word 6  | link 9 datasize lower |   link 10 errorflags  |              link 10 datasize                 |
+Word 6  |            link 9 datasize                    |             link 8 datasize                   |
         -------------------------------------------------------------------------------------------------
-Word 6  |  link 11 errorflags   |               link 11 datasize                |  link 12 errorflags   |
+Word 6  |            link 11 datasize                   |             link 10 datasize                  |
         -------------------------------------------------------------------------------------------------
-Word 7  |   link 12 data size                            | link 13 error flags  | link 13 datasize upper|
+Word 7  |            link 13 datasize                   |             link 12 datasize                  |
         -------------------------------------------------------------------------------------------------
-Word 7  |link 13 datasize lower |   link 14 errorflags   |              link 14 datasize                |
+Word 7  |              reserved 5                       |             link 14 datasize                  |
         -------------------------------------------------------------------------------------------------
-
-alternate candidate :
-        |31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
-        -------------------------------------------------------------------------------------------------
-Word 0  | header version        | bunch crossing                    | stop bit  |  event type           |
-        -------------------------------------------------------------------------------------------------
-Word 0  |                                          reserved                                             |
-        -------------------------------------------------------------------------------------------------
-Word 1  |  link 0  errorflags   |    link 1 errorflags  | link2 error flags     | link 3 error flags    |
-        -------------------------------------------------------------------------------------------------
-Word 1  |   link 4 error flags  |   link 5 error flags  |  link 6 error flags   | link 7 error flags    |
-        -------------------------------------------------------------------------------------------------
-Word 2  |            link 0 datasize                    |            link 1 datasize                    |
-        -------------------------------------------------------------------------------------------------
-Word 2  |            link 2 datasize                    |            link 3 datasize                    |
-        -------------------------------------------------------------------------------------------------
-Word 3  |            link 4 data size                   |            link 5 datasize                    |
-        -------------------------------------------------------------------------------------------------
-Word 3  |             link 6 datasize                   |            link 7 datasize                    |
-        -------------------------------------------------------------------------------------------------
-Word 4  |                                          reserved                                             |
-        -------------------------------------------------------------------------------------------------
-Word 4  |                                          reserved                                             |
-        -------------------------------------------------------------------------------------------------
-Word 5  |                                         reserved                      |  link 8 error flags   |
-        -------------------------------------------------------------------------------------------------
-Word 5  |   link 9  errorflags  |    link 10 errorflags |   link11 error flags | link 12 error flags    |
-        -------------------------------------------------------------------------------------------------
-Word 6  |   link 13 error flags |   link 14 error flags |            link 8 datasize                    |
-        -------------------------------------------------------------------------------------------------
-Word 6  |            link 9 datasize                    |            link 10 datasize                   |
-        -------------------------------------------------------------------------------------------------
-Word 7  |            link 11 datasize                   |            link 12 datasize                   |
-        -------------------------------------------------------------------------------------------------
-Word 7  |            link 13 datasize                   |            link 14 datasize                   |
-       --------------------------------------------------------------------------------------------------
 */
 
   union {
-    uint64_t word02[3];
-    struct {
-      uint64_t errorflags : 8;
-      uint64_t size : 16;
-    } __attribute__((__packed__)) linksA[8];
-  };
-  union {
-    uint64_t word3 = 0x0;
+    uint64_t word0 = 0x0;
     //first word          *
-    // uint64_t: 0x0000000000000000
-    //             |      - |   ||
-    //             |      | |   |- 0..7 Event type
-    //             |      | |   -- 8..11 Stop bit
-    //             |      | ------ 12..23 bunch crossing id
-    //             |      -------- 24..31 TRD Header version
-    //             --------------- 32..63 reserveda
+    //                6         5         4         3         2         1
+    //             3210987654321098765432109876543210987654321098765432109876543210
+    // uint64_t:   0000000000000000000000000000000000000000000000000000000000000000
+    //             |                               |   |   |   |           |-------- 0..7   TRD Header version
+    //             |                               |   |   |   |-------------------- 8..19  bunch crossing
+    //             |                               |   |   |------------------------ 20..23 stop bit
+    //             |                               |   |---------------------------- 24..27 end point
+    //             |                               |-------------------------------- 28..31 event type
+    //             |---------------------------------------------------------------- 32..63 reserved1
     struct {
-      uint64_t reserveda : 32;     //
       uint64_t HeaderVersion : 8;  // TRD Header Version
       uint64_t BunchCrossing : 12; // bunch crossing
       uint64_t StopBit : 4;        // 8 .. 11 stop bit  0x1 if TRD packet is last data packet of trigger, else 0x0  TODO why 4 bits if only using 1?
-      uint64_t EventType : 8;      // bit 0..7 event type of the data. Trigger bits from TTC-PON message, distinguish physics from calibration events.
+      uint64_t EndPoint : 4;       // bit 0..7 event type of the data. Trigger bits from TTC-PON message, distinguish physics from calibration events.
+      uint64_t EventType : 4;      // bit 0..7 event type of the data. Trigger bits from TTC-PON message, distinguish physics from calibration events.
+      uint64_t reserveda : 32;     //
     } __attribute__((__packed__));
   };
   union {
-    uint64_t word4 = 0x0;
+    uint64_t word12[2];
+    // 15 8 bit error flags and 1 8 bit reserved.
     struct {
-      uint64_t reservedb;
+      struct {
+        uint8_t errorflag : 8;
+      } __attribute__((__packed__)) errorflags[15];
+      uint8_t reserved2 : 8;
     } __attribute__((__packed__));
   };
   union {
-    uint64_t word57[3];
+    uint64_t word3 = 0x0;
     struct {
-      uint64_t errorflags : 8;
-      uint64_t size : 16;
-    } __attribute__((__packed__)) linksB[8]; // although this is 8 dont use index 0 as its part of reserved.
+      uint64_t reserved34;
+    } __attribute__((__packed__));
+  };
+  union {
+    uint64_t word47[4];
+    //15 16 bit data sizes and 1 16 bit reserved word.
+    struct {
+      struct {
+        uint64_t size : 16;
+      } __attribute__((__packed__)) datasizes[15]; // although this is 8 dont use index 0 as its part of reserved.
+      uint16_t reserved5;
+    } __attribute__((__packed__));
   };
 };
 

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -18,44 +18,13 @@ namespace o2
 namespace trd
 {
 
-uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data = true)
-{
-  // cruhead is the incoming header to pass
-  // link is the link you are requesting information on, 0-14
-  //
-  uint32_t info = 0;
-  if (link > 14)
-    return 0xffffffff;
-
-  char* words;
-  if (link < 8)
-    words = (char*)&cruhead.word02[0];
-  if (link < 15)
-    words = (char*)&cruhead.word57[0];
-  uint32_t byteoffset = link * 3; // each link [size+erroflags] is 24 bits, so 3 bytes.
-  if (data)
-    info = ((words[byteoffset + 1]) << 8) + (words[byteoffset + 2]);
-  else
-    info = words[byteoffset];
-
-  return info;
-}
-
 uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link)
 {
   // link is the link you are requesting information on, 0-14
-  uint32_t errorflags = 0;
-  if (link < 8) {
-    //dealing with word0-2
-    errorflags = cruhead.linksA[link].errorflags;
-  } else {
-    if (link < 16) {
-      errorflags = cruhead.linksB[link - 8 + 1].errorflags; // link 0 [actually 9] is in fact the end part of reserved.
-
-    } else
-      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
-  }
-  return errorflags;
+  uint32_t errorflag = 0;
+  //dealing with word0-2
+  errorflag = cruhead.errorflags[link].errorflag;
+  return errorflag;
 }
 
 uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link)
@@ -63,15 +32,7 @@ uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link)
   // link is the link you are requesting information on, 0-14
   //return number 32 byte blocks for the link 3x64bit ints.
   uint32_t size = 0;
-  if (link < 8) {
-    size = (cruhead.linksA[link].size);
-  } else {
-    if (link < 16) { // link 0 is part of reserved
-      size = cruhead.linksB[link - 8 + 1].size;
-
-    } else
-      std::cout << "error link=" << link << " not in range 0-14" << std::endl;
-  }
+  size = cruhead.datasizes[link].size;
   return size;
 }
 
@@ -175,7 +136,7 @@ std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru) // 
   for (int link = 0; link < 15; link++)
     stream << link << ":" << std::hex << std::setw(2) << getlinkerrorflag(halfcru, link) << ",";
   stream << std::endl;
-  stream << "0x" << halfcru.word02[0] << " 0x" << halfcru.word02[1] << " 0x" << halfcru.word02[2] << " 0x" << halfcru.word3 << " 0x" << halfcru.word4 << " 0x" << halfcru.word57[0] << " 0x" << halfcru.word57[1] << " 0x" << halfcru.word57[2] << std::endl;
+  stream << "0x" << std::hex << halfcru.word0 << " 0x" << halfcru.word12[0] << " 0x" << halfcru.word12[1] << " 0x" << halfcru.word3 << " 0x" << halfcru.word47[0] << " 0x" << halfcru.word47[1] << " 0x" << halfcru.word47[2] << " 0x" << halfcru.word47[3] << std::endl;
   return stream;
 }
 

--- a/Detectors/TRD/base/test/testRawData.cxx
+++ b/Detectors/TRD/base/test/testRawData.cxx
@@ -46,47 +46,41 @@ BOOST_AUTO_TEST_CASE(TRDRawDataHeaderInternals)
   o2::trd::TrackletMCMData tracklet;
   o2::trd::TrackletHCHeader halfchamberheader;
   o2::trd::HalfCRUHeader halfcruheader;
-  halfcruheader.word02[0] = 0x102;
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[0].errorflags, 2);
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[0].size, 1);
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[0].errorflags, o2::trd::getlinkerrorflag(halfcruheader, 0));
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[0].size, o2::trd::getlinkdatasize(halfcruheader, 0));
-  //ab is size
-  halfcruheader.word02[2] = 0xffffaa0000000000;
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[7].size, 0xffff);
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[7].errorflags, 0xaa);
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[7].errorflags, o2::trd::getlinkerrorflag(halfcruheader, 7));
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[7].size, o2::trd::getlinkdatasize(halfcruheader, 7));
-  halfcruheader.word3 = (0x222LL) << 40; //bc is at 0x000ffff000000000
+  // changed as now nothing spans a 32 or 16 bit boundary
+  halfcruheader.word0 = 0x22200; //bc is at 0x0000000fff00
   BOOST_CHECK_EQUAL(halfcruheader.BunchCrossing, 0x222);
-  halfcruheader.word3 = 0x7700000000; //headerversion is at 0x00ff0000000
+  halfcruheader.word0 = 0x00000077; //headerversion is at 0x000000000
   BOOST_CHECK_EQUAL(halfcruheader.HeaderVersion, 119);
-  halfcruheader.word57[0] = 0x345869faba;
-  halfcruheader.word57[2] = 0xaaade1277;
-  //linkb[0] zero is undefined.
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[1].errorflags, 0x58);
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[1].size, 0x34);
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[1].errorflags, o2::trd::getlinkerrorflag(halfcruheader, 8));
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[1].size, o2::trd::getlinkdatasize(halfcruheader, 8));
-  //ab is size
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[5].size, 0x1277);
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[6].size, 0xaaa);
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[6].errorflags, 0xde);
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[6].errorflags, o2::trd::getlinkerrorflag(halfcruheader, 13));
-  BOOST_CHECK_EQUAL(halfcruheader.linksB[6].size, o2::trd::getlinkdatasize(halfcruheader, 13));
-  //now test the boundary crossing of the int64_t
-  halfcruheader.word02[0] = (uint64_t)0x1000000000000000;
-  halfcruheader.word02[1] = (uint64_t)0xa00b000c000d0ebf;
-  BOOST_CHECK_EQUAL(halfcruheader.linksA[2].size, 0xbf10); // check a size that spans a 64bit word.
+  //error flags
+  halfcruheader.word12[0] = 0xa02;
+  halfcruheader.word12[1] = 0xab0000;
+  BOOST_CHECK_EQUAL(halfcruheader.errorflags[0].errorflag, 2);
+  BOOST_CHECK_EQUAL(halfcruheader.errorflags[1].errorflag, 0xa);
+  halfcruheader.word12[1] = 0x00ed000000000000; // should link 14 error flags.
+  BOOST_CHECK_EQUAL(halfcruheader.errorflags[14].errorflag, 0xed);
+  BOOST_CHECK_EQUAL(halfcruheader.errorflags[14].errorflag, o2::trd::getlinkerrorflag(halfcruheader, 14));
+  //datasizes
+  halfcruheader.word47[0] = 0xbdbd;
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[0].size, 0xbdbd);
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[0].size, o2::trd::getlinkdatasize(halfcruheader, 0));
+  halfcruheader.word47[1] = 0xabcd;
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[4].size, 0xabcd);
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[4].size, o2::trd::getlinkdatasize(halfcruheader, 4));
+  halfcruheader.word47[2] = 0xaaade127;
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[8].size, 0xe127);
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[8].size, o2::trd::getlinkdatasize(halfcruheader, 8));
+  halfcruheader.word47[3] = 0xefaadebc0000;
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[14].size, 0xefaa);
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[14].size, o2::trd::getlinkdatasize(halfcruheader, 14));
   o2::trd::TrackletMCMHeader mcmrawdataheader;
   mcmrawdataheader.word = 0x78000000;
   BOOST_CHECK_EQUAL(mcmrawdataheader.padrow, 15);
   mcmrawdataheader.word = 0x06000000;
   BOOST_CHECK_EQUAL(mcmrawdataheader.col, 3);
   mcmrawdataheader.word = 0x01fe0000;
-  BOOST_CHECK_EQUAL(mcmrawdataheader.pid2, 0xff); // 8 bits  // gave up seperating pid, so its a flat 24 bit needs to be masked 0xfff 0xfff000 and 0xfff000000
+  BOOST_CHECK_EQUAL(mcmrawdataheader.pid2, 0xff); // 8 bits
   mcmrawdataheader.word = 0x01fe;
-  BOOST_CHECK_EQUAL(mcmrawdataheader.pid0, 0xff); // 8 bits  // gave up seperating pid, so its a flat 24 bit needs to be masked 0xfff 0xfff000 and 0xfff000000
+  BOOST_CHECK_EQUAL(mcmrawdataheader.pid0, 0xff); // 8 bits
   //check tracklet
   tracklet.word = 0xffc00000;
   BOOST_CHECK_EQUAL((uint32_t)tracklet.pos, 0x3ff);


### PR DESCRIPTION
- Reorganise halfcruheader (512bit)
- add a 4bit endpoint
- All info aligned 8bit/16bit.
- Types no longer split across 64 and 32 bit boundaries.
- tests fixed for new format.
- check TDP for details, or the comments