### PR TITLE
DPL: Make sure forceful exit message is printed only once

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1128,7 +1128,11 @@ int runStateMachine(DataProcessorSpecs const& workflow,
         // I allow queueing of more sigchld only when
         // I process the previous call
         if (forceful_exit == true) {
-          LOG(INFO) << "Forceful exit requested.";
+          static bool forcefulExitMessage = true;
+          if (forcefulExitMessage) {
+            LOG(INFO) << "Forceful exit requested.";
+            forcefulExitMessage = false;
+          }
           killChildren(infos, SIGCONT);
           killChildren(infos, SIGKILL);
         }


### PR DESCRIPTION
@ktf : Can we use this as a workaround for now to stop flooding my logs?