### PR TITLE
Add a reset interval option for the TPC track interpolation workflow

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -49,6 +49,7 @@ void TrackInterpolation::process()
     LOG(error) << "Initialization not yet done. Aborting...";
     return;
   }
+  reset();
 
 #ifdef TPC_RUN2
   // processing will not work if the run 2 geometry is defined in the parameter class SpacePointsCalibParam.h


### PR DESCRIPTION
@martenole @shahor02 : I guess this needs to be done properly later based on statistics, but for now I need a quick option to fix the amount of data that is collected to keep the memory size constant in order to check for leaks., and also the output becomes outrageously large after running >1 hour with 8 GPUs.