### PR TITLE
Temp.fix for TOF raw->digit orbit reset to 0 (O2-1633)

### DIFF
--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -59,13 +59,18 @@ void CompressedDecodingTask::postData(ProcessingContext& pc)
   std::vector<o2::tof::ReadoutWindowData>* row = mDecoder.getReadoutWindowData();
 
   ReadoutWindowData* last = nullptr;
-  if (row->size())
-    last = &(row->at(row->size() - 1));
-  int lastval = last->first() + last->size();
+  o2::InteractionRecord lastIR;
+  int lastval = 0;
+  if (!row->empty()) {
+    last = &row->back();
+    lastval = last->first() + last->size();
+    lastIR = last->mFirstIR;
+  }
 
   while (row->size() < nwindowperTF) {
     // complete timeframe with empty readout windows
-    row->emplace_back(lastval, 0);
+    auto& dummy = row->emplace_back(lastval, 0);
+    dummy.mFirstIR = lastIR;
   }
   while (row->size() > nwindowperTF) {
     // remove extra readout windows after a check they are empty


### PR DESCRIPTION
@noferini @preghenella 

This fixes the problem raw->divits conversion leading to orbit in ``ReadoutWindowData`` vector jumping to 0 (leading to negative value in https://github.com/AliceO2Group/AliceO2/blob/c168b1a41c803004095d87d75249661eb5e4eaa3/Detectors/TOF/reconstruction/src/CTFCoder.cxx#L88, which crashes differential compression).

I consider this as a temporary fix only: I don't understand why do you need to complete the ``WindowFiller::mReadoutWindowData`` vector to have expected number of windows (if raw data decoding skips some window). But even if you need to do this, empty slots with meaningful BC/Orbit identifiers must be filled during data decoding rather than before postData. As it is now, you are not guaranteed to have a complete vector for all orbits of the TF with 3 entries per orbit.

I don't know why some window is not filled (happens to be the last, 3d window of the 3d TF, which is strange, I see lot of other windows w/o data which are properly filled), I think it is worth investigation, there might be a data loss in ``digit->row->compressed->decompression`` chain.

BTW, I see that in tofdigits created by digitization, the ``TOFReadoutWindow`` has only ``mFirstIR`` filled and not the reference, at the same time the ``Digit.mTriggerOrbit`` and ``Digit.mTriggerBunch`` is never filled (also when digits are extracted from raw data), instead, always "long" mBC (abs. BC ID) is filled. What is the point of such redundant references which are anyway not used?