### PR TITLE
Rename --mft to --runmft to avoid ambiguity

### DIFF
--- a/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
@@ -22,7 +22,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{
     ConfigParamSpec{"disable-mc", VariantType::Bool, false, {"disable mc truth"}},
-    ConfigParamSpec{"mft", VariantType::Bool, false, {"expect MFT data"}},
+    ConfigParamSpec{"runmft", VariantType::Bool, false, {"expect MFT data"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -40,7 +40,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  if (cfgc.options().get<bool>("mft")) {
+  if (cfgc.options().get<bool>("runmft")) {
     wf.emplace_back(o2::itsmft::getMFTDigitWriterSpec(useMC));
   } else {
     wf.emplace_back(o2::itsmft::getITSDigitWriterSpec(useMC));

--- a/Detectors/ITSMFT/common/workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/entropy-encoder-workflow.cxx
@@ -21,7 +21,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{
-    ConfigParamSpec{"mft", VariantType::Bool, false, {"source detector is MFT (default ITS)"}},
+    ConfigParamSpec{"runmft", VariantType::Bool, false, {"source detector is MFT (default ITS)"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -37,7 +37,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  if (cfgc.options().get<bool>("mft")) {
+  if (cfgc.options().get<bool>("runmft")) {
     wf.emplace_back(o2::itsmft::getEntropyEncoderSpec("MFT"));
   } else {
     wf.emplace_back(o2::itsmft::getEntropyEncoderSpec("ITS"));

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -21,7 +21,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{
-    ConfigParamSpec{"mft", VariantType::Bool, false, {"source detector is MFT (default ITS)"}},
+    ConfigParamSpec{"runmft", VariantType::Bool, false, {"source detector is MFT (default ITS)"}},
     ConfigParamSpec{"no-clusters", VariantType::Bool, false, {"do not produce clusters (def: produce)"}},
     ConfigParamSpec{"no-cluster-patterns", VariantType::Bool, false, {"do not produce clusters patterns (def: produce)"}},
     ConfigParamSpec{"digits", VariantType::Bool, false, {"produce digits (def: skip)"}},
@@ -48,7 +48,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  if (cfgc.options().get<bool>("mft")) {
+  if (cfgc.options().get<bool>("runmft")) {
     wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, dict, noise));
   } else {
     wf.emplace_back(o2::itsmft::getSTFDecoderITSSpec(doClusters, doPatterns, doDigits, dict, noise));


### PR DESCRIPTION
@shahor02 : I had some trouble that workflows were complaining that `--mft` is ambiguous.
I believe what happens is that there are processors called `mft-entropy-encoder` and `mft-ctf-dictionary` both not knowing about the `--mft` option, and the parser is trying to find out where to apply the `--mft` and then it tries to expand the option to `--mft...` and then hits this ambiguity. Perhaps it is not a good idea to have options with a name that matches the beginning of the name of a processor. Not sure if `runmft` is ideal, but it seemed the simplest way for me to work around this without adding plenty of manual options only to the processors that shall receive the `--mft` option.