### PR TITLE
TRD and TPC constants in subsidiary namespace

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -156,11 +156,11 @@ struct ClusterNative {
 // the data inside a buffer.
 struct ClusterNativeAccess {
   const ClusterNative* clustersLinear;
-  const ClusterNative* clusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  const ClusterNative* clusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth;
-  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
-  unsigned int nClustersSector[Constants::MAXSECTOR];
-  unsigned int clusterOffset[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
+  unsigned int nClustersSector[constants::MAXSECTOR];
+  unsigned int clusterOffset[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   unsigned int nClustersTotal;
 
   void setOffsetPtrs();
@@ -169,9 +169,9 @@ struct ClusterNativeAccess {
 inline void ClusterNativeAccess::setOffsetPtrs()
 {
   int offset = 0;
-  for (unsigned int i = 0; i < Constants::MAXSECTOR; i++) {
+  for (unsigned int i = 0; i < constants::MAXSECTOR; i++) {
     nClustersSector[i] = 0;
-    for (unsigned int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+    for (unsigned int j = 0; j < constants::MAXGLOBALPADROW; j++) {
       clusterOffset[i][j] = offset;
       clusters[i][j] = &clustersLinear[offset];
       nClustersSector[i] += nClusters[i][j];

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -82,7 +82,7 @@ struct ClusterNativeBuffer : public ClusterGroupHeader {
 // This is the header for the transport format of TPC ClusterNative data,
 // followed by a linear buffer of clusters.
 struct alignas(64) ClusterCountIndex {
-  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
 };
 
 // @struct ClusterCountIndex
@@ -91,13 +91,13 @@ struct alignas(64) ClusterCountIndex {
 struct alignas(64) ClusterIndexBuffer {
   using value_type = ClusterNative;
 
-  unsigned int nClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
 
   size_t getNClusters() const
   {
     size_t count = 0;
-    for (auto sector = 0; sector < Constants::MAXSECTOR; sector++) {
-      for (auto row = 0; row < Constants::MAXGLOBALPADROW; row++) {
+    for (auto sector = 0; sector < constants::MAXSECTOR; sector++) {
+      for (auto row = 0; row < constants::MAXGLOBALPADROW; row++) {
         count += nClusters[sector][row];
       }
     }
@@ -135,8 +135,8 @@ class ClusterNativeHelper
   ClusterNativeHelper() = default;
   ~ClusterNativeHelper() = default;
 
-  constexpr static unsigned int NSectors = Constants::MAXSECTOR;
-  constexpr static unsigned int NPadRows = Constants::MAXGLOBALPADROW;
+  constexpr static unsigned int NSectors = constants::MAXSECTOR;
+  constexpr static unsigned int NPadRows = constants::MAXGLOBALPADROW;
 
   /// convert clusters stored in binary cluster native format to a tree and write to root file
   /// the cluster parameters are stored in the tree together with sector and padrow numbers.

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Constants.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Constants.h
@@ -20,23 +20,30 @@ namespace o2
 {
 namespace tpc
 {
-
-class Constants
+namespace constants
 {
- public:
-  // the number of sectors
-  static constexpr int MAXSECTOR = 36;
 
-  // the number of global pad rows
+// the number of sectors
+constexpr int MAXSECTOR = 36;
+
+// the number of global pad rows
 #if defined(GPUCA_STANDALONE) && !defined(GPUCA_O2_LIB) && !defined(GPUCA_TPC_GEOMETRY_O2)
-  static constexpr int MAXGLOBALPADROW = 159; // Number of pad rows in Run 2, used for GPU TPC tests with Run 2 data
+constexpr int MAXGLOBALPADROW = 159; // Number of pad rows in Run 2, used for GPU TPC tests with Run 2 data
 #else
-  static constexpr int MAXGLOBALPADROW = 152; // Correct number of pad rows in Run 3
+constexpr int MAXGLOBALPADROW = 152; // Correct number of pad rows in Run 3
 #endif
 
-  // number of LHC bunch crossings per TPC time bin (40 MHz / 5 MHz)
-  static constexpr int LHCBCPERTIMEBIN = 8;
-};
+// number of LHC bunch crossings per TPC time bin (40 MHz / 5 MHz)
+constexpr int LHCBCPERTIMEBIN = 8;
+} // namespace constants
+
+// FIXME: Temporary workaround to not break the QC build which depends on the removed class o2::tpc::Constants
+//        Once https://github.com/AliceO2Group/QualityControl/pull/459 is merged this can be removed
+namespace Constants
+{
+using namespace constants;
+}
+
 } // namespace tpc
 } // namespace o2
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
@@ -25,7 +25,7 @@ struct TPCSectorHeader : public o2::header::BaseHeader {
   // Required to do the lookup
   constexpr static const o2::header::HeaderType sHeaderType = "TPCSectH";
   static const uint32_t sVersion = 2;
-  static constexpr int NSectors = o2::tpc::Constants::MAXSECTOR;
+  static constexpr int NSectors = o2::tpc::constants::MAXSECTOR;
 
   TPCSectorHeader(int s)
     : BaseHeader(sizeof(TPCSectorHeader), sHeaderType, o2::header::gSerializationMethodNone, sVersion), sectorBits(((uint64_t)0x1) << s)

--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -20,6 +20,7 @@
 #include <iostream>
 
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 
 void ClusterNativeHelper::convert(const char* fromFile, const char* toFile, const char* toTreeName)
 {
@@ -177,7 +178,7 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex, st
 }
 
 int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, gsl::span<MCLabelContainer const> const& mcinput, ClusterNativeAccess& clusterIndex,
-                                             const MCLabelContainer* (&clustersMCTruth)[Constants::MAXSECTOR])
+                                             const MCLabelContainer* (&clustersMCTruth)[MAXSECTOR])
 {
   if (!buffer || size < sizeof(ClusterCountIndex)) {
     return 0;
@@ -187,9 +188,9 @@ int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, gs
   ClusterCountIndex const& counts = *reinterpret_cast<const ClusterCountIndex*>(buffer);
   ClusterNative const* clusters = reinterpret_cast<ClusterNative const*>(buffer + sizeof(ClusterCountIndex));
   size_t numberOfClusters = 0;
-  for (int i = 0; i < Constants::MAXSECTOR; i++) {
+  for (int i = 0; i < MAXSECTOR; i++) {
     int nSectorClusters = 0;
-    for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+    for (int j = 0; j < MAXGLOBALPADROW; j++) {
       if (counts.nClusters[i][j] == 0) {
         continue;
       }
@@ -246,8 +247,8 @@ int ClusterNativeHelper::TreeWriter::fillFrom(ClusterNativeAccess const& cluster
     return -1;
   }
   int result = 0;
-  for (size_t sector = 0; sector < Constants::MAXSECTOR; ++sector) {
-    for (size_t padrow = 0; padrow < Constants::MAXGLOBALPADROW; ++padrow) {
+  for (size_t sector = 0; sector < MAXSECTOR; ++sector) {
+    for (size_t padrow = 0; padrow < MAXGLOBALPADROW; ++padrow) {
       int locres = fillFrom(sector, padrow, clusterIndex.clusters[sector][padrow], clusterIndex.nClusters[sector][padrow]);
       if (result >= 0 && locres >= 0) {
         result += locres;

--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -19,5 +19,5 @@ o2_add_library(DataFormatsTRD
                HEADERS include/DataFormatsTRD/TriggerRecord.h
                        include/DataFormatsTRD/LinkRecord.h
                        include/DataFormatsTRD/Tracklet64.h
-                       include/DataFormatsTRD/RawData.h)
-
+                       include/DataFormatsTRD/RawData.h
+                       include/DataFormatsTRD/Constants.h)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Constants.h
+/// \brief Global TRD definitions and constants
+/// \author ole.schmidt@cern.ch
+
+#ifndef AliceO2_TRD_Constants_H
+#define AliceO2_TRD_Constants_H
+
+namespace o2
+{
+namespace trd
+{
+namespace constants
+{
+constexpr int NSECTOR = 18;        // the number of sectors
+constexpr int NSTACK = 5;          // the number of stacks per sector
+constexpr int NLAYER = 6;          // the number of layers
+constexpr int NCHAMBERPERSEC = 30; // the number of chambers per sector
+constexpr int MAXCHAMBER = 540;    // the maximum number of installed chambers
+constexpr int NCHAMBER = 521;      // the number of chambers actually installed
+
+constexpr int NCOLUMN = 144; // the number of pad columns for each chamber
+constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (installed stack 0,1,3 and 4)
+constexpr int NROWC1 = 16;   // the number of pad rows for chambers of type C1 (installed in stack 2)
+
+constexpr int NMCMROB = 16;     // the number of MCMs per ROB
+constexpr int NMCMROBINROW = 4; // the number of MCMs per ROB in row direction
+constexpr int NMCMROBINCOL = 4; // the number of MCMs per ROB in column direction
+constexpr int NROBC0 = 6;       // the number of ROBs per C0 chamber
+constexpr int NROBC1 = 8;       // the number of ROBs per C1 chamber
+constexpr int NADCMCM = 21;     // the number of ADC channels per MCM
+constexpr int NCOLMCM = 18;     // the number of pads per MCM
+
+// OS: Should this not be flexible for example in case of Kr calib?
+constexpr int TIMEBINS = 30; // the number of time bins
+
+} //namespace constants
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -82,16 +82,6 @@ class Tracklet64
     mtrackletWord = trackletword;
     return 0;
   }
-  static const int mgkNmcmRob = 16;     // Number of MCMs per ROB
-  static const int mgkNmcmRobInRow = 4; // Number of MCMs per ROB in row dir.
-  static const int mgkNmcmRobInCol = 4; // Number of MCMs per ROB in col dir.
-  static const int mgkNrobC0 = 6;       // Number of ROBs per C0 chamber
-  static const int mgkNrobC1 = 8;       // Number of ROBs per C1 chamber
-  static const int mgkNadcMcm = 21;     // Number of ADC channels per MCM
-  static const int mgkNcol = 144;       // Number of pads per padplane row
-  static const int mgkNcolMcm = 18;     // Number of pads per MCM
-  static const int mgkNrowC0 = 12;      // Number of Rows per C0 chamber
-  static const int mgkNrowC1 = 16;      // Number of Rows per C1 chamber
 
   // ----- Getters for tracklet information -----
   int getMCM() const

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -101,7 +101,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   //---------------------------->> TPC Clusters loading >>------------------------------------------
   int operation = 0;
   uint64_t activeSectors = 0;
-  std::bitset<o2::tpc::Constants::MAXSECTOR> validSectors = 0;
+  std::bitset<o2::tpc::constants::MAXSECTOR> validSectors = 0;
   std::map<int, DataRef> datarefs;
   std::vector<InputSpec> filter = {
     {"check", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe},
@@ -114,7 +114,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
       throw std::runtime_error("sector header missing on header stack");
     }
     int sector = sectorHeader->sector();
-    std::bitset<o2::tpc::Constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    std::bitset<o2::tpc::constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
     LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
     if ((validSectors & sectorMask).any()) {
       // have already data for this sector, this should not happen in the current
@@ -133,7 +133,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
               << std::endl                                                                   //
               << "  input status:   " << validSectors                                        //
               << std::endl                                                                   //
-              << "  active sectors: " << std::bitset<o2::tpc::Constants::MAXSECTOR>(activeSectors);
+              << "  active sectors: " << std::bitset<o2::tpc::constants::MAXSECTOR>(activeSectors);
   };
 
   if (activeSectors == 0 || (activeSectors & validSectors.to_ulong()) != activeSectors) {

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -54,7 +54,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   //---------------------------->> TPC Clusters loading >>------------------------------------------
   int operation = 0;
   uint64_t activeSectors = 0;
-  std::bitset<o2::tpc::Constants::MAXSECTOR> validSectors = 0;
+  std::bitset<o2::tpc::constants::MAXSECTOR> validSectors = 0;
   std::map<int, DataRef> datarefs;
   std::vector<InputSpec> filter = {
     {"check", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe},
@@ -67,7 +67,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
       throw std::runtime_error("sector header missing on header stack");
     }
     const int& sector = sectorHeader->sector();
-    std::bitset<o2::tpc::Constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    std::bitset<o2::tpc::constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
     LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
     if ((validSectors & sectorMask).any()) {
       // have already data for this sector, this should not happen in the current
@@ -86,7 +86,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
               << std::endl                                                                   //
               << "  input status:   " << validSectors                                        //
               << std::endl                                                                   //
-              << "  active sectors: " << std::bitset<o2::tpc::Constants::MAXSECTOR>(activeSectors);
+              << "  active sectors: " << std::bitset<o2::tpc::constants::MAXSECTOR>(activeSectors);
   };
 
   if (activeSectors == 0 || (activeSectors & validSectors.to_ulong()) != activeSectors) {

--- a/Detectors/TPC/base/include/TPCBase/Sector.h
+++ b/Detectors/TPC/base/include/TPCBase/Sector.h
@@ -40,7 +40,7 @@ class Sector
 {
  public:
   // the number of sectors
-  static constexpr int MAXSECTOR = Constants::MAXSECTOR;
+  static constexpr int MAXSECTOR = constants::MAXSECTOR;
 
   /// constructor
   Sector() = default;

--- a/Detectors/TPC/base/src/ZeroSuppress.cxx
+++ b/Detectors/TPC/base/src/ZeroSuppress.cxx
@@ -27,6 +27,7 @@
 #include "DataFormatsTPC/Helpers.h"
 
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 
 void ZeroSuppress::process()
 {
@@ -62,7 +63,7 @@ void ZeroSuppress::DecodeZSPages(gsl::span<const ZeroSuppressedContainer8kb>* z0
 
     const o2::header::RAWDataHeader* rdh = (const o2::header::RAWDataHeader*)&inputPage;
     auto orbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdh);
-    int timeBin = (_timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
+    int timeBin = (_timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
 
     unsigned int ct = 0;
     startPtr += (sizeof(z0Container->rdh) + sizeof(z0Container->hdr)); // move to first time bin

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
@@ -51,7 +51,7 @@ static constexpr float RowX[NPadRows] = {                            ///< x-posi
 
 #else  // not defined TPC_RUN2
 /// TPC geometric constants for Run 3+
-static constexpr int NPadRows = o2::tpc::Constants::MAXGLOBALPADROW;
+static constexpr int NPadRows = o2::tpc::constants::MAXGLOBALPADROW;
 static constexpr int NROCTypes = 4;
 static constexpr int NRowsPerROC[NROCTypes] = {63, 34, 30, 25};
 static constexpr int NRowsAccumulated[NROCTypes] = {63, 97, 127, 152};

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -197,7 +197,7 @@ class TrackInterpolation
   std::vector<TPCClusterResiduals> mClRes{};            ///< residuals for each available TPC cluster of all tracks
 
   // cache
-  std::array<CacheStruct, Constants::MAXGLOBALPADROW> mCache{{}}; ///< caching positions, covariances and angles for track extrapolations and interpolation
+  std::array<CacheStruct, constants::MAXGLOBALPADROW> mCache{{}}; ///< caching positions, covariances and angles for track extrapolations and interpolation
 
   // helpers
   std::unique_ptr<TPCFastTransform> mFastTransform{}; ///< TPC cluster transformation

--- a/Detectors/TPC/qc/macro/runClusters.C
+++ b/Detectors/TPC/qc/macro/runClusters.C
@@ -38,8 +38,8 @@ void runClusters(std::string_view outputFile = "ClusterQC.root", std::string_vie
     tpcClusterReader.read(i);
     tpcClusterReader.fillIndex(clusterIndex, clusterBuffer, clusterMCBuffer);
     size_t iClusters = 0;
-    for (int isector = 0; isector < Constants::MAXSECTOR; ++isector) {
-      for (int irow = 0; irow < Constants::MAXGLOBALPADROW; ++irow) {
+    for (int isector = 0; isector < constants::MAXSECTOR; ++isector) {
+      for (int irow = 0; irow < constants::MAXGLOBALPADROW; ++irow) {
         const int nClusters = clusterIndex.nClusters[isector][irow];
         if (!nClusters) {
           continue;

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/DigitalCurrentClusterIntegrator.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/DigitalCurrentClusterIntegrator.h
@@ -55,7 +55,7 @@ class DigitalCurrentClusterIntegrator
   void reset(); //Free all allocated current buffers
 
  private:
-  std::unique_ptr<unsigned long long int[]> mIntegratedCurrents[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW];
+  std::unique_ptr<unsigned long long int[]> mIntegratedCurrents[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
 };
 
 } // namespace tpc

--- a/Detectors/TPC/reconstruction/src/DigitalCurrentClusterIntegrator.cxx
+++ b/Detectors/TPC/reconstruction/src/DigitalCurrentClusterIntegrator.cxx
@@ -14,11 +14,12 @@
 #include "TPCReconstruction/DigitalCurrentClusterIntegrator.h"
 
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 
 void DigitalCurrentClusterIntegrator::clear()
 {
-  for (int i = 0; i < Constants::MAXSECTOR; i++) {
-    for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+  for (int i = 0; i < MAXSECTOR; i++) {
+    for (int j = 0; j < MAXGLOBALPADROW; j++) {
       if (mIntegratedCurrents[i][j]) {
         int nPads = Mapper::instance().getNumberOfPadsInRowSector(j);
         memset(&mIntegratedCurrents[i][j][0], 0, nPads * sizeof(mIntegratedCurrents[i][j][0]));
@@ -29,8 +30,8 @@ void DigitalCurrentClusterIntegrator::clear()
 
 void DigitalCurrentClusterIntegrator::reset()
 {
-  for (int i = 0; i < Constants::MAXSECTOR; i++) {
-    for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+  for (int i = 0; i < MAXSECTOR; i++) {
+    for (int j = 0; j < MAXGLOBALPADROW; j++) {
       mIntegratedCurrents[i][j].reset(nullptr);
     }
   }

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -47,10 +47,10 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
   }
   ClusterNative* outputClusterBuffer = nullptr;
   // the number of clusters in a {sector,row}
-  int nRowClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
+  int nRowClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW] = {0};
   // offset of first cluster of {sector,row} in the output buffer
-  size_t clusterOffsets[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
-  int containerRowCluster[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
+  size_t clusterOffsets[constants::MAXSECTOR][constants::MAXGLOBALPADROW] = {0};
+  int containerRowCluster[constants::MAXSECTOR][constants::MAXGLOBALPADROW] = {0};
   Mapper& mapper = Mapper::instance();
   int numberOfOutputContainers = 0;
   for (int loop = 0; loop < 2; loop++) {
@@ -105,8 +105,8 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
     }
     if (loop == 1) {
       //We are done with filling the buffers, sort all output buffers
-      for (int i = 0; i < Constants::MAXSECTOR; i++) {
-        for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+      for (int i = 0; i < constants::MAXSECTOR; i++) {
+        for (int j = 0; j < constants::MAXGLOBALPADROW; j++) {
           if (nRowClusters[i][j] == 0) {
             continue;
           }
@@ -129,8 +129,8 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
       outputClusterBuffer = reinterpret_cast<ClusterNative*>(rawOutputBuffer + sizeof(ClusterCountIndex));
       nTotalClusters = 0;
       numberOfOutputContainers = 0;
-      for (int i = 0; i < Constants::MAXSECTOR; i++) {
-        for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+      for (int i = 0; i < constants::MAXSECTOR; i++) {
+        for (int j = 0; j < constants::MAXGLOBALPADROW; j++) {
           clusterCounts.nClusters[i][j] = nRowClusters[i][j];
           if (nRowClusters[i][j] == 0) {
             continue;
@@ -149,8 +149,8 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
   if (outMCLabels) {
     auto& labels = *outMCLabels;
     int nCls = 0;
-    for (int i = 0; i < Constants::MAXSECTOR; i++) {
-      for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+    for (int i = 0; i < constants::MAXSECTOR; i++) {
+      for (int j = 0; j < constants::MAXGLOBALPADROW; j++) {
         if (nRowClusters[i][j] == 0) {
           continue;
         }

--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -78,9 +78,9 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
   config.configCalib.dEdxSplines = dEdxSplines.get();
 
   tracker.initialize(config);
-  std::vector<ClusterNativeContainer> cont(Constants::MAXGLOBALPADROW);
+  std::vector<ClusterNativeContainer> cont(constants::MAXGLOBALPADROW);
 
-  for (int i = 0; i < Constants::MAXGLOBALPADROW; i++) {
+  for (int i = 0; i < constants::MAXGLOBALPADROW; i++) {
     cont[i].sector = 0;
     cont[i].globalPadRow = i;
     cont[i].clusters.resize(1);

--- a/Detectors/TPC/simulation/src/SpaceCharge.cxx
+++ b/Detectors/TPC/simulation/src/SpaceCharge.cxx
@@ -28,6 +28,7 @@
 #include "TPCSimulation/SpaceCharge.h"
 
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 using namespace o2::math_utils;
 
 const float o2::tpc::SpaceCharge::sEzField = (AliTPCPoissonSolver::fgkCathodeV - AliTPCPoissonSolver::fgkGG) / AliTPCPoissonSolver::fgkTPCZ0;
@@ -35,23 +36,23 @@ const float o2::tpc::SpaceCharge::sEzField = (AliTPCPoissonSolver::fgkCathodeV -
 SpaceCharge::SpaceCharge()
   : mNZ(MaxNZ),
     mNPhi(MaxNPhi),
-    mNR(Constants::MAXGLOBALPADROW),
+    mNR(MAXGLOBALPADROW),
     mVoxelSizeZ(AliTPCPoissonSolver::fgkTPCZ0 / (MaxNZ - 1)),
     mDriftTimeVoxel(IonDriftTime / (MaxNZ - 1)),
     mVoxelSizePhi(TWOPI / MaxNPhi),
-    mVoxelSizeR((AliTPCPoissonSolver::fgkOFCRadius - AliTPCPoissonSolver::fgkIFCRadius) / (Constants::MAXGLOBALPADROW - 1)),
+    mVoxelSizeR((AliTPCPoissonSolver::fgkOFCRadius - AliTPCPoissonSolver::fgkIFCRadius) / (MAXGLOBALPADROW - 1)),
     mCoordZ(MaxNZ),
     mCoordPhi(MaxNPhi),
-    mCoordR(Constants::MAXGLOBALPADROW),
+    mCoordR(MAXGLOBALPADROW),
     mInterpolationOrder(2),
     mUseInitialSCDensity(false),
     mInitLookUpTables(false),
     mMemoryAllocated(false),
     mTimeInit(-1),
     mSCDistortionType(SpaceCharge::SCDistortionType::SCDistortionsRealistic),
-    mLookUpTableCalculator(Constants::MAXGLOBALPADROW, MaxNZ, MaxNPhi, 2, 3, 0),
-    mSpaceChargeDensityA(MaxNPhi * Constants::MAXGLOBALPADROW * MaxNZ),
-    mSpaceChargeDensityC(MaxNPhi * Constants::MAXGLOBALPADROW * MaxNZ),
+    mLookUpTableCalculator(MAXGLOBALPADROW, MaxNZ, MaxNPhi, 2, 3, 0),
+    mSpaceChargeDensityA(MaxNPhi * MAXGLOBALPADROW * MaxNZ),
+    mSpaceChargeDensityC(MaxNPhi * MAXGLOBALPADROW * MaxNZ),
     mRandomFlat(RandomRing<>::RandomType::Flat)
 {
   mLookUpTableCalculator.SetCorrectionType(0);

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -120,7 +120,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
       config.configInterface.dumpEvents = confParam.dump;
 
       if (config.configEvent.continuousMaxTimeBin == -1) {
-        config.configEvent.continuousMaxTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * Constants::LHCBCPERTIMEBIN - 2) / Constants::LHCBCPERTIMEBIN;
+        config.configEvent.continuousMaxTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * constants::LHCBCPERTIMEBIN - 2) / constants::LHCBCPERTIMEBIN;
       }
       if (config.configProcessing.deviceNum == -2) {
         int myId = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;

--- a/Detectors/TRD/base/include/TRDBase/CalDet.h
+++ b/Detectors/TRD/base/include/TRDBase/CalDet.h
@@ -18,6 +18,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "DataFormatsTRD/Constants.h"
+
 class TRDGeometry;
 class TRDPadPlane;
 
@@ -31,10 +33,6 @@ namespace trd
 class CalDet
 {
  public:
-  enum { kNplan = 6,
-         kNcham = 5,
-         kNsect = 18,
-         kNdet = 540 };
   CalDet(std::string name = "CalDet", std::string title = "CalDet") : mName(name), mTitle(title){};
   ~CalDet() = default;
   //
@@ -71,7 +69,7 @@ class CalDet
   void divide(const CalDet* calDet);
 
  protected:
-  std::array<float, kNdet> mData{}; // Data
+  std::array<float, constants::NSECTOR> mData{}; // Data
   std::string mName;                // name for spectra, carried over originally from inheritence from TNamed
   std::string mTitle;               // title prepend for spectra, carried over originally from inheritence from TNamed
 };

--- a/Detectors/TRD/base/include/TRDBase/CalPad.h
+++ b/Detectors/TRD/base/include/TRDBase/CalPad.h
@@ -17,6 +17,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "DataFormatsTRD/Constants.h"
+
 class CalROC;
 class CalDet;
 class TH2F;
@@ -26,10 +28,6 @@ class CalPad
 {
 
  public:
-  enum { kNplan = 6,
-         kNcham = 5,
-         kNsect = 18,
-         kNdet = 540 };
 
   CalPad();
   CalPad(const std::string& name, const std::String& title);
@@ -37,7 +35,7 @@ class CalPad
   ~CalPad();
   CalPad& operator=(const CalPad& c);
 
-  static int getDet(int p, int c, int s) { return p + c * kNplan + s * kNplan * kNcham; };
+  static int getDet(int p, int c, int s) { return p + c * Constants::NLAYER + s * Constants::NLAYER * Constants::NSTACK; };
 
   CalROC* getCalROC(int d) const { return mROC[d]; };
   CalROC* getCalROC(int p, int c, int s) const
@@ -69,7 +67,7 @@ class CalPad
   bool divide(const CalPad* pad, const CalDet* calDet1 = 0, const CalDet* calDet2 = 0, int type = 0);
 
  protected:
-  std::vector<CalROC> mROC(kNdet); //  Array of ROC objects which contain the values per pad
+  std::vector<CalROC> mROC(Constants::MAXCHAMBER); //  Array of ROC objects which contain the values per pad
 
   ClassDef(CalPad, 1) //  TRD calibration class for parameters which are saved per pad
 };

--- a/Detectors/TRD/base/include/TRDBase/ChamberCalibrations.h
+++ b/Detectors/TRD/base/include/TRDBase/ChamberCalibrations.h
@@ -19,6 +19,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "TRDBase/TRDSimParam.h"
+#include "DataFormatsTRD/Constants.h"
 //
 class TRDGeometry;
 
@@ -52,10 +53,10 @@ class ChamberCalibrations
   bool init(int run2run = 0);
 
  protected:
-  std::array<float, TRDSimParam::kNdet> mVDrift{};     // mean drift velocity per chamber.
-  std::array<float, TRDSimParam::kNdet> mGainFactor{}; // mean gas gain per chamber
-  std::array<float, TRDSimParam::kNdet> mT0{};         // Min timeoffset in the chamber
-  std::array<float, TRDSimParam::kNdet> mExB{};        //
+  std::array<float, constants::MAXCHAMBER> mVDrift{};     // mean drift velocity per chamber.
+  std::array<float, constants::MAXCHAMBER> mGainFactor{}; // mean gas gain per chamber
+  std::array<float, constants::MAXCHAMBER> mT0{};         // Min timeoffset in the chamber
+  std::array<float, constants::MAXCHAMBER> mExB{};        //
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/include/TRDBase/ChamberNoise.h
+++ b/Detectors/TRD/base/include/TRDBase/ChamberNoise.h
@@ -19,6 +19,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "TRDBase/TRDSimParam.h"
+#include "DataFormatsTRD/Constants.h"
 //
 class TRDGeometry;
 
@@ -38,7 +39,7 @@ class ChamberNoise
   void setNoise(int det, float noise) { mNoise[det] = noise; };
   //bulk gets ?
  protected:
-  std::array<float, TRDSimParam::kNdet> mNoise{};
+  std::array<float, constants::MAXCHAMBER> mNoise{};
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/include/TRDBase/ChamberStatus.h
+++ b/Detectors/TRD/base/include/TRDBase/ChamberStatus.h
@@ -23,6 +23,7 @@
 #include <array>
 #include "TRDBase/TRDGeometry.h"
 #include "TRDBase/TRDSimParam.h"
+#include "DataFormatsTRD/Constants.h"
 class TH2D;
 
 namespace o2
@@ -67,7 +68,7 @@ class ChamberStatus
   TH2D* plotBadCalibrated(int sm, int rphi); // Plot calibration status for sm and halfchamberside
   TH2D* plot(int sm);                        // Plot mStatus for sm
  protected:
-  std::array<char, TRDSimParam::kNdet> mStatus{};
+  std::array<char, constants::MAXCHAMBER> mStatus{};
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -19,6 +19,7 @@
 
 #include "CommonDataFormat/TimeStamp.h"
 #include "TRDBase/TRDCommonParam.h"
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2
 {
@@ -26,7 +27,7 @@ namespace trd
 {
 
 using ADC_t = std::uint16_t;
-using ArrayADC = std::array<ADC_t, kTimeBins>;
+using ArrayADC = std::array<ADC_t, constants::TIMEBINS>;
 
 using TimeStamp = o2::dataformats::TimeStamp<double>;
 

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -26,6 +26,8 @@
 //                                                                        //
 ////////////////////////////////////////////////////////////////////////////
 
+#include "DataFormatsTRD/Constants.h"
+
 #include <array>
 #include <vector>
 
@@ -66,31 +68,6 @@ class FeeParam
   static int extAliToAli(unsigned int dest, unsigned short linkpair, unsigned short rocType, int* list, int listSize); // translates an extended MCM ALICE ID to a list of MCMs
   static short chipmaskToMCMlist(unsigned int cmA, unsigned int cmB, unsigned short linkpair, int* mcmList, int listSize);
   static short getRobAB(unsigned short robsel, unsigned short linkpair); // Returns the chamber side (A=0, B=0) of a ROB
-
-  // geometry
-  static float getSamplingFrequency() { return (float)mgkLHCfrequency / 4000000.0; } //TODO put the 40MHz into a static variable somewhere.
-  static int getNmcmRob() { return mgkNmcmRob; }
-  static int getNmcmRobInRow() { return mgkNmcmRobInRow; }
-  static int getNmcmRobInCol() { return mgkNmcmRobInCol; }
-  static int getNrobC0() { return mgkNrobC0; }
-  static int getNrobC1() { return mgkNrobC1; }
-  static int getNadcMcm() { return mgkNadcMcm; }
-  static int getNcol() { return mgkNcol; }
-  static int getNcolMcm() { return mgkNcolMcm; }
-  static int getNrowC0() { return mgkNrowC0; }
-  static int getNrowC1() { return mgkNrowC1; }
-  // Basic Geometrical numbers
-  static const int mgkLHCfrequency = 40079000; // [Hz] LHC clock
-  static const int mgkNmcmRob = 16;            // Number of MCMs per ROB
-  static const int mgkNmcmRobInRow = 4;        // Number of MCMs per ROB in row dir.
-  static const int mgkNmcmRobInCol = 4;        // Number of MCMs per ROB in col dir.
-  static const int mgkNrobC0 = 6;              // Number of ROBs per C0 chamber
-  static const int mgkNrobC1 = 8;              // Number of ROBs per C1 chamber
-  static const int mgkNadcMcm = 21;            // Number of ADC channels per MCM
-  static const int mgkNcol = 144;              // Number of pads per padplane row
-  static const int mgkNcolMcm = 18;            // Number of pads per MCM
-  static const int mgkNrowC0 = 12;             // Number of Rows per C0 chamber
-  static const int mgkNrowC1 = 16;             // Number of Rows per C1 chamber
 
   // tracklet simulation
   bool getTracklet() const { return mgTracklet; }
@@ -174,17 +151,17 @@ class FeeParam
   static const int mgkMaxRAWversion = 3; // Maximum raw version number supported
 
   // geometry constants
-  static std::array<float, 30> mgZrow;            // z-position of pad row edge 6x5
-  static std::array<float, 6> mgX;                // x-position for all layers
-  static std::array<float, 6> mgInvX;             // inverse x-position for all layers (to remove divisions)
-  static std::array<float, 6> mgTiltingAngle;     // tilting angle for every layer
-  static std::array<float, 6> mgTiltingAngleTan;  // tan of tilting angle for every layer (look up table to avoid tan calculations)
-  static std::array<float, 6> mgWidthPad;         // pad width for all layers
-  static std::array<float, 6> mgInvWidthPad;      // inverse pad width for all layers (to remove divisions)
+  static std::array<float, constants::NCHAMBERPERSEC> mgZrow;    // z-position of pad row edge 6x5
+  static std::array<float, constants::NLAYER> mgX;               // x-position for all layers
+  static std::array<float, constants::NLAYER> mgInvX;            // inverse x-position for all layers (to remove divisions)
+  static std::array<float, constants::NLAYER> mgTiltingAngle;    // tilting angle for every layer
+  static std::array<float, constants::NLAYER> mgTiltingAngleTan; // tan of tilting angle for every layer (look up table to avoid tan calculations)
+  static std::array<float, constants::NLAYER> mgWidthPad;        // pad width for all layers
+  static std::array<float, constants::NLAYER> mgInvWidthPad;     // inverse pad width for all layers (to remove divisions)
   static float mgLengthInnerPadC0;                // inner pad length C0 chamber
   static float mgLengthOuterPadC0;                // outer pad length C0 chamber
-  static std::array<float, 6> mgLengthInnerPadC1; // inner pad length C1 chambers
-  static std::array<float, 6> mgLengthOuterPadC1; // outer pad length C1 chambers
+  static std::array<float, constants::NLAYER> mgLengthInnerPadC1; // inner pad length C1 chambers
+  static std::array<float, constants::NLAYER> mgLengthOuterPadC1; // outer pad length C1 chambers
   static float mgScalePad;                        // scaling factor for pad width
   static float mgDriftLength;                     // length of the  parse gaintbl Krypton_2009-01 drift region
   static float mgBinDy;                           // bin in dy (140 um)

--- a/Detectors/TRD/base/include/TRDBase/PadCalibrations.h
+++ b/Detectors/TRD/base/include/TRDBase/PadCalibrations.h
@@ -22,6 +22,7 @@
 
 #include "TRDBase/PadParameters.h"
 #include "TRDBase/TRDSimParam.h"
+#include "DataFormatsTRD/Constants.h"
 
 class TRDGeometry;
 
@@ -46,7 +47,7 @@ class PadCalibrations
   void reset(int roc, int col, int row, std::vector<T>& data);
   void init();
  protected:
-  std::array<PadParameters<T>, TRDSimParam::kNdet> mreadOutChamber;
+  std::array<PadParameters<T>, constants::MAXCHAMBER> mreadOutChamber;
 };
 
 template <class T>

--- a/Detectors/TRD/base/include/TRDBase/PadParameters.h
+++ b/Detectors/TRD/base/include/TRDBase/PadParameters.h
@@ -25,6 +25,7 @@
 #include "TRDBase/TRDGeometry.h"
 #include "TRDBase/TRDSimParam.h"
 #include "TRDBase/FeeParam.h"
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2
 {
@@ -52,12 +53,12 @@ class PadParameters
   int reset(int chamberindex, int col, int row, std::vector<T>& data);
 
  protected:
-  int mPlane{0};                 //  Plane number
-  int mChamber{0};               //  Chamber number
-  int mNrows{0};                 //  Number of rows
-  int mNcols{FeeParam::mgkNcol}; //  Number of columns
-  int mNchannels;                //  Number of channels = rows*columns
-  std::vector<T> mData;          // Size is mNchannels
+  int mPlane{0};                  //  Plane number
+  int mChamber{0};                //  Chamber number
+  int mNrows{0};                  //  Number of rows
+  int mNcols{constants::NCOLUMN}; //  Number of columns
+  int mNchannels;                 //  Number of channels = rows*columns
+  std::vector<T> mData;           // Size is mNchannels
 };
 
 template <class T>
@@ -72,9 +73,9 @@ int PadParameters<T>::init(int chamberindex)
   mPlane = TRDGeometry::getLayer(chamberindex);
   mChamber = TRDGeometry::getStack(chamberindex);
   if (mChamber == 2)
-    mNrows = FeeParam::mgkNrowC0;
+    mNrows = constants::NROWC0;
   else
-    mNrows = FeeParam::mgkNrowC1;
+    mNrows = constants::NROWC1;
   // the FeeParam variables need to be unprotected, and dont want to change FeeParam in this PR.
   mNchannels = mNrows * mNcols;
   mData.resize(mNchannels);

--- a/Detectors/TRD/base/include/TRDBase/PadResponse.h
+++ b/Detectors/TRD/base/include/TRDBase/PadResponse.h
@@ -12,7 +12,7 @@
 #define ALICEO2_TRD_PADRESPONSE_H_
 
 #include <array>
-#include "TRDBase/TRDCommonParam.h" // For kNLayer
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2
 {
@@ -32,7 +32,7 @@ class PadResponse
   static constexpr float mPRFhi{1.5};             // Higher boundary of the PRF
   float mPRFwid;                                  // Bin width of the sampled PRF
   int mPRFpad;                                    // Distance to next pad in PRF
-  std::array<float, kNlayer * mPRFbin> mPRFsmp{}; // Sampled pad response
+  std::array<float, constants::NLAYER * mPRFbin> mPRFsmp{}; // Sampled pad response
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/include/TRDBase/TRDCalPadStatus.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCalPadStatus.h
@@ -11,6 +11,8 @@
 #ifndef O2_TRDCALPADSTATUS_H
 #define O2_TRDCALPADSTATUS_H
 
+#include "DataFormatsTRD/Constants.h"
+
 #include "TH1F.h"
 #include "TH2F.h"
 #include <string>
@@ -32,10 +34,6 @@ class TRDCalPadStatus
 {
 
  public:
-  enum { kNplan = 6,
-         kNcham = 5,
-         kNsect = 18,
-         kNdet = 540 };
   enum { kMasked = 2,
          kPadBridgedLeft = 4,
          kPadBridgedRight = 8,
@@ -86,7 +84,7 @@ class TRDCalPadStatus
   void setName(const std::string newName) { mName = newName; };
 
  protected:
-  TRDCalSingleChamberStatus* mROC[kNdet]; //  Array of ROC objects which contain the values per pad
+  TRDCalSingleChamberStatus* mROC[constants::MAXCHAMBER]; //  Array of ROC objects which contain the values per pad
 
  private:
   std::string mName;

--- a/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
@@ -19,8 +19,6 @@ namespace trd
 {
 
 class TRDPadPlane;
-constexpr int kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540;
-constexpr int kTimeBins = 30;
 
 class TRDCommonParam
 {

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -13,6 +13,7 @@
 
 #include "GPUCommonDef.h"
 #include "TRDBase/TRDCommonParam.h"
+#include "DataFormatsTRD/Constants.h"
 #include "TRDBase/TRDPadPlane.h"
 
 namespace o2
@@ -39,11 +40,11 @@ class TRDGeometryBase
     }
   }
   GPUd() bool getSMstatus(int sm) const { return (mSMStatus & (0x1 << sm)) != 0; }
-  GPUd() static int getDetectorSec(int det) { return (det % (kNlayer * kNstack)); }
-  GPUd() static int getDetectorSec(int layer, int stack) { return (layer + stack * kNlayer); }
-  GPUd() static int getDetector(int layer, int stack, int sector) { return (layer + stack * kNlayer + sector * kNlayer * kNstack); }
-  GPUd() static int getLayer(int det) { return (det % kNlayer); }
-  GPUd() static int getStack(int det) { return ((det % (kNlayer * kNstack)) / kNlayer); }
+  GPUd() static int getDetectorSec(int det) { return (det % (constants::NLAYER * constants::NSTACK)); }
+  GPUd() static int getDetectorSec(int layer, int stack) { return (layer + stack * constants::NLAYER); }
+  GPUd() static int getDetector(int layer, int stack, int sector) { return (layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK); }
+  GPUd() static int getLayer(int det) { return (det % constants::NLAYER); }
+  GPUd() static int getStack(int det) { return ((det % (constants::NLAYER * constants::NSTACK)) / constants::NLAYER); }
   GPUd() int getStack(float z, int layer) const;
 
   GPUd() const TRDPadPlane* getPadPlane(int layer, int stack) const { return &mPadPlanes[getDetectorSec(layer, stack)]; }
@@ -59,13 +60,13 @@ class TRDGeometryBase
   GPUd() float getRow0(int layer, int stack) { return mPadPlanes[getDetectorSec(layer, stack)].getRow0(); }
   GPUd() float getRowEnd(int layer, int stack) { return mPadPlanes[getDetectorSec(layer, stack)].getRowEnd(); }
 
-  static constexpr int getSector(int det) { return (det / (kNlayer * kNstack)); }
+  static constexpr int getSector(int det) { return (det / (constants::NLAYER * constants::NSTACK)); }
   static constexpr float getTime0(int layer) { return TIME0[layer]; }
   static constexpr float getXtrdBeg() { return XTRDBEG; }
   static constexpr float getXtrdEnd() { return XTRDEND; }
   static constexpr float getChamberWidth(int layer) { return CWIDTH[layer]; }
   static constexpr float getChamberLength(int layer, int stack) { return CLENGTH[layer][stack]; }
-  static constexpr float getAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
+  static constexpr float getAlpha() { return 2.0 * 3.14159265358979324 / constants::NSECTOR; }
   static constexpr float cheight() { return CH; }
   static constexpr float cheightSV() { return CHSV; }
   static constexpr float cspace() { return VSPACE; }
@@ -199,11 +200,11 @@ class TRDGeometryBase
   static constexpr float XTRDEND = 366.33; ///< X-coordinate in tracking system of end of TRD mother volume
 
   // The outer width of the chambers
-  static constexpr float CWIDTH[kNlayer] = {90.4, 94.8, 99.3, 103.7, 108.1, 112.6};
+  static constexpr float CWIDTH[constants::NLAYER] = {90.4, 94.8, 99.3, 103.7, 108.1, 112.6};
 
   // The outer lengths of the chambers
   // Includes the spacings between the chambers!
-  static constexpr float CLENGTH[kNlayer][kNstack] = {
+  static constexpr float CLENGTH[constants::NLAYER][constants::NSTACK] = {
     {124.0, 124.0, 110.0, 124.0, 124.0},
     {124.0, 124.0, 110.0, 124.0, 124.0},
     {131.0, 131.0, 110.0, 131.0, 131.0},
@@ -211,7 +212,7 @@ class TRDGeometryBase
     {145.0, 145.0, 110.0, 145.0, 145.0},
     {147.0, 147.0, 110.0, 147.0, 147.0}};
 
-  TRDPadPlane mPadPlanes[kNlayer * kNstack];
+  TRDPadPlane mPadPlanes[constants::NLAYER * constants::NSTACK];
 
   int mSMStatus = 0x3ffff;
 

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryFlat.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryFlat.h
@@ -19,6 +19,7 @@
 #include "GPUCommonTransform3D.h"
 #include "TRDBase/TRDGeometryBase.h"
 #include "TRDBase/TRDPadPlane.h"
+#include "DataFormatsTRD/Constants.h"
 
 using namespace o2::trd;
 
@@ -58,7 +59,7 @@ class TRDGeometryFlat : public o2::gpu::FlatObject, public TRDGeometryBase
 
  private:
   o2::gpu::Transform3D mMatrixCache[MAXMATRICES];
-  short mMatrixIndirection[kNdet];
+  short mMatrixIndirection[constants::MAXCHAMBER];
 };
 
 } // namespace trd

--- a/Detectors/TRD/base/include/TRDBase/TRDSimParam.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDSimParam.h
@@ -26,11 +26,8 @@ namespace trd
 class TRDSimParam
 {
  public:
-  enum { kNplan = 6,
-         kNcham = 5,
-         kNsect = 18,
-         kNdet = 540,
-         kNPadsInPadResponse = 3 // Number of pads included in the pad response
+  enum {
+    kNPadsInPadResponse = 3 // Number of pads included in the pad response
   };
 
   static TRDSimParam* Instance();

--- a/Detectors/TRD/base/src/CalDet.cxx
+++ b/Detectors/TRD/base/src/CalDet.cxx
@@ -26,6 +26,7 @@
 // #include "AliMathBase.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 //___________________________________________________________________________________
 double CalDet::getMean(CalDet* const outlierDet) const
@@ -35,11 +36,11 @@ double CalDet::getMean(CalDet* const outlierDet) const
   //
 
   if (!outlierDet) {
-    return TMath::Mean(kNdet, mData.data());
+    return TMath::Mean(MAXCHAMBER, mData.data());
   }
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     if (!(outlierDet->getValue(i))) {
       ddata[nPoints] = mData[nPoints];
       nPoints++;
@@ -56,11 +57,11 @@ double CalDet::getMedian(CalDet* const outlierDet) const
   //
 
   if (!outlierDet) {
-    return (double)TMath::Median(kNdet, mData.data());
+    return (double)TMath::Median(MAXCHAMBER, mData.data());
   }
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     if (!(outlierDet->getValue(i))) {
       ddata[nPoints] = mData[nPoints];
       nPoints++;
@@ -77,11 +78,11 @@ double CalDet::getRMS(CalDet* const outlierDet) const
   //
 
   if (!outlierDet) {
-    return TMath::RMS(kNdet, mData.data());
+    return TMath::RMS(MAXCHAMBER, mData.data());
   }
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     if (!(outlierDet->getValue(i))) {
       ddata[nPoints] = mData[nPoints];
       nPoints++;
@@ -98,26 +99,26 @@ double CalDet::getRMSRobust(double robust) const
   //
 
   // sorted
-  std::array<int, kNdet> index;
-  TMath::Sort((int)kNdet, mData.data(), index.data());
+  std::array<int, MAXCHAMBER> index;
+  TMath::Sort((int)MAXCHAMBER, mData.data(), index.data());
 
   // reject
-  double reject = (int)(kNdet * (1 - robust) / 2.0);
+  double reject = (int)(MAXCHAMBER * (1 - robust) / 2.0);
   if (reject <= 0) {
     reject = 0;
   }
-  if (reject >= kNdet) {
+  if (reject >= MAXCHAMBER) {
     reject = 0;
   }
 
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     bool rej = kFALSE;
     for (int k = 0; k < reject; k++) {
       if (i == index[k])
         rej = kTRUE;
-      if (i == index[kNdet - (k + 1)])
+      if (i == index[MAXCHAMBER - (k + 1)])
         rej = kTRUE;
     }
     if (!rej) {
@@ -136,24 +137,24 @@ double CalDet::getMeanRobust(double robust) const
   //
 
   // sorted
-  std::array<int, kNdet> index;
-  TMath::Sort((int)kNdet, mData.data(), index.data());
+  std::array<int, MAXCHAMBER> index;
+  TMath::Sort((int)MAXCHAMBER, mData.data(), index.data());
 
   // reject
-  double reject = (int)(kNdet * (1 - robust) / 2.0);
+  double reject = (int)(MAXCHAMBER * (1 - robust) / 2.0);
   if (reject <= 0)
     reject = 0;
-  if (reject >= kNdet)
+  if (reject >= MAXCHAMBER)
     reject = 0;
 
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     bool rej = kFALSE;
     for (int k = 0; k < reject; k++) {
       if (i == index[k])
         rej = kTRUE;
-      if (i == index[kNdet - (k + 1)])
+      if (i == index[MAXCHAMBER - (k + 1)])
         rej = kTRUE;
     }
     if (!rej) {
@@ -171,10 +172,10 @@ double CalDet::getLTM(double* sigma, double fraction, CalDet* const outlierDet)
   //  Calculate LTM mean and sigma
   //
 
-  std::array<double, kNdet> ddata;
+  std::array<double, MAXCHAMBER> ddata;
   double mean = 0, lsigma = 0;
   unsigned int nPoints = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     if (!outlierDet || !(outlierDet->getValue(i))) {
       ddata[nPoints] = mData[nPoints];
       nPoints++;
@@ -232,7 +233,7 @@ TH1F* CalDet::makeHisto1Distribution(float min, float max, int type)
   title << mTitle.c_str() << " CalDet 1Distribution";
   std::string titlestr = title.str();
   TH1F* his = new TH1F(mName.c_str(), titlestr.c_str(), 100, min, max);
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     his->Fill(getValue(idet));
   }
   return his;
@@ -276,8 +277,8 @@ TH1F* CalDet::makeHisto1DAsFunctionOfDet(float min, float max, int type)
   std::stringstream title;
   title << mTitle.c_str() << " CalDet as function of det";
   std::string titlestr = title.str();
-  TH1F* his = new TH1F(mName.c_str(), titlestr.c_str(), kNdet, 0, kNdet);
-  for (int det = 0; det < kNdet; det++) {
+  TH1F* his = new TH1F(mName.c_str(), titlestr.c_str(), MAXCHAMBER, 0, MAXCHAMBER);
+  for (int det = 0; det < MAXCHAMBER; det++) {
     his->Fill(det + 0.5, getValue(det));
   }
   his->SetMaximum(max);
@@ -334,8 +335,8 @@ TH2F* CalDet::makeHisto2DCh(int ch, float min, float max, int type)
   // Where we begin
   int offsetch = 6 * ch;
 
-  for (int isec = 0; isec < kNsect; isec++) {
-    for (int ipl = 0; ipl < kNplan; ipl++) {
+  for (int isec = 0; isec < NSECTOR; isec++) {
+    for (int ipl = 0; ipl < NLAYER; ipl++) {
       int det = offsetch + isec * 30 + ipl;
       const TRDPadPlane* padPlane = trdGeo->getPadPlane(ipl, ch);
       for (int icol = 0; icol < padPlane->getNcols(); icol++) {
@@ -406,9 +407,9 @@ TH2F* CalDet::makeHisto2DSmPl(int sm, int pl, float min, float max, int type)
   // Where we begin
   int offsetsmpl = 30 * sm + pl;
 
-  for (int k = 0; k < kNcham; k++) {
+  for (int k = 0; k < NSTACK; k++) {
     int det = offsetsmpl + k * 6;
-    int kb = kNcham - 1 - k;
+    int kb = NSTACK - 1 - k;
     his->SetBinContent(kb + 1, 2, mData[det]);
     his->SetBinContent(kb + 1, 3, mData[det]);
   }
@@ -427,7 +428,7 @@ void CalDet::add(float c1)
   // Add constant for all detectors
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     mData[idet] += c1;
   }
 }
@@ -439,7 +440,7 @@ void CalDet::multiply(float c1)
   // multiply constant for all detectors
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     mData[idet] *= c1;
   }
 }
@@ -451,7 +452,7 @@ void CalDet::add(const CalDet* calDet, double c1)
   // add caldet channel by channel multiplied by c1
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     mData[idet] += calDet->getValue(idet) * c1;
   }
 }
@@ -463,7 +464,7 @@ void CalDet::multiply(const CalDet* calDet)
   // multiply caldet channel by channel
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     mData[idet] *= calDet->getValue(idet);
   }
 }
@@ -476,7 +477,7 @@ void CalDet::divide(const CalDet* calDet)
   //
 
   float eps = 0.00000000000000001;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (TMath::Abs(calDet->getValue(idet)) > eps) {
       mData[idet] /= calDet->getValue(idet);
     }

--- a/Detectors/TRD/base/src/CalOnlineGainTables.cxx
+++ b/Detectors/TRD/base/src/CalOnlineGainTables.cxx
@@ -18,8 +18,10 @@
 #include "TRDBase/CalOnlineGainTables.h"
 #include "TRDBase/TRDGeometry.h"
 #include "TRDBase/FeeParam.h"
+#include "DataFormatsTRD/Constants.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 using namespace std;
 
 float o2::trd::CalOnlineGainTables::UnDef = -999.0;
@@ -30,7 +32,7 @@ int CalOnlineGainTables::getArrayOffset(int det, int row, int col) const
   int rob = mFeeParam->getROBfromPad(row, col);
   int mcm = mFeeParam->getMCMfromPad(row, col);
   int detoffset = det * 128; //TODO find this constant from somewhere else max rob=8, max mcm=16, so 7x16+15=127
-  int mcmoffset = rob * (mFeeParam->mgkNmcmRob) + mcm;
+  int mcmoffset = rob * NMCMROB + mcm;
   return detoffset + mcmoffset;
 }
 
@@ -41,7 +43,7 @@ int CalOnlineGainTables::getChannel(int col) const
 
 int CalOnlineGainTables::getArrayOffsetrm(int det, int rob, int mcm) const
 {
-  return det * 128 + rob * FeeParam::instance()->mgkNmcmRob + mcm;
+  return det * 128 + rob * NMCMROB + mcm;
 }
 
 float CalOnlineGainTables::getGainCorrectionFactor(int det, int row, int col) const

--- a/Detectors/TRD/base/src/CalPad.cxx
+++ b/Detectors/TRD/base/src/CalPad.cxx
@@ -21,6 +21,7 @@
 #include "CalDet.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
@@ -35,7 +36,7 @@ CalPad::CalPad()
   // CalPad default constructor
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     fROC[idet] = nullptr;
   }
 }
@@ -47,9 +48,9 @@ CalPad::CalPad(const Text_t* name, const Text_t* title)
   // CalPad constructor
   //
 
-  for (int isec = 0; isec < kNsect; isec++) {
-    for (int ipla = 0; ipla < kNplan; ipla++) {
-      for (int icha = 0; icha < kNcham; icha++) {
+  for (int isec = 0; isec < NSECTOR; isec++) {
+    for (int ipla = 0; ipla < NLAYER; ipla++) {
+      for (int icha = 0; icha < NSTACK; icha++) {
         int idet = getDet(ipla, icha, isec);
         fROC[idet] = new CalROC(ipla, icha);
       }
@@ -66,7 +67,7 @@ CalPad::CalPad(const CalPad& c)
   // CalPad copy constructor
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     fROC[idet] = new CalROC(*((CalPad&)c).fROC[idet]);
   }
   mName = c.mName;
@@ -80,7 +81,7 @@ CalPad::~CalPad()
   // CalPad destructor
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (fROC[idet]) {
       delete fROC[idet];
       fROC[idet] = 0;
@@ -107,7 +108,7 @@ void CalPad::Copy(TObject& c) const
   // Copy function
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (((CalPad&)c).fROC[idet]) {
       delete ((CalPad&)c).fROC[idet];
     }
@@ -133,7 +134,7 @@ bool CalPad::scaleROCs(const CalDet* values)
   if (!values)
     return kFALSE;
   bool result = kTRUE;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (fROC[idet]) {
       if (!fROC[idet]->multiply(values->getValue(idet)))
         result = kFALSE;
@@ -172,7 +173,7 @@ double CalPad::getMeanRMS(double& rms, const CalDet* calDet, int type)
   if (type == 0)
     factor = 1.0;
   double sum = 0, sum2 = 0, n = 0, val;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     CalROC* calRoc = fROC[idet];
@@ -208,9 +209,9 @@ double CalPad::getMean(const CalDet* calDet, int type, CalPad* const outlierPad)
   double factor = 0.0;
   if (type == 0)
     factor = 1.0;
-  double arr[kNdet];
+  double arr[MAXCHAMBER];
   int n = 0;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     CalROC* calRoc = fROC[idet];
@@ -240,9 +241,9 @@ double CalPad::getRMS(const CalDet* calDet, int type, CalPad* const outlierPad)
   double factor = 0.0;
   if (type == 0)
     factor = 1.0;
-  double arr[kNdet];
+  double arr[MAXCHAMBER];
   int n = 0;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     CalROC* calRoc = fROC[idet];
@@ -272,9 +273,9 @@ double CalPad::getMedian(const CalDet* calDet, int type, CalPad* const outlierPa
   double factor = 0.0;
   if (type == 0)
     factor = 1.0;
-  double arr[kNdet];
+  double arr[MAXCHAMBER];
   int n = 0;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     CalROC* calRoc = fROC[idet];
@@ -304,12 +305,12 @@ double CalPad::getLTM(double* sigma, double fraction, const CalDet* calDet, int 
   double factor = 0.0;
   if (type == 0)
     factor = 1.0;
-  double arrm[kNdet];
-  double arrs[kNdet];
+  double arrm[MAXCHAMBER];
+  double arrs[MAXCHAMBER];
   double* sTemp = 0x0;
   int n = 0;
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     CalROC* calRoc = fROC[idet];
@@ -390,7 +391,7 @@ TH1F* CalPad::makeHisto1D(const CalDet* calDet, int typedet, float min, float ma
   char name[1000];
   snprintf(name, 1000, "%s Pad 1D", getTitle());
   TH1F* his = new TH1F(name, name, 100, min, max);
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet)
       factor = calDet->getValue(idet);
     if (fROC[idet]) {
@@ -478,7 +479,7 @@ TH2F* CalPad::makeHisto2DSmPl(int sm, int pl, const CalDet* calDet, int typedet,
   // Where we begin
   int offsetsmpl = 30 * sm + pl;
 
-  for (int k = 0; k < kNcham; k++) {
+  for (int k = 0; k < NSTACK; k++) {
     int det = offsetsmpl + k * 6;
     if (calDet)
       factor = calDet->getValue(det);
@@ -488,7 +489,7 @@ TH2F* CalPad::makeHisto2DSmPl(int sm, int pl, const CalDet* calDet, int typedet,
         for (int icol = 0; icol < calRoc->getNcols(); icol++) {
           if (TMath::Abs(calRoc->getValue(icol, irow)) > kEpsilon) {
             int binz = 0;
-            int kb = kNcham - 1 - k;
+            int kb = NSTACK - 1 - k;
             int krow = calRoc->getNrows() - 1 - irow;
             int kcol = calRoc->getNcols() - 1 - icol;
             if (kb > 2)
@@ -584,8 +585,8 @@ TH2F* CalPad::makeHisto2DCh(int ch, const CalDet* calDet, int typedet, float min
   // Where we begin
   int offsetch = 6 * ch;
 
-  for (int isec = 0; isec < kNsect; isec++) {
-    for (int ipl = 0; ipl < kNplan; ipl++) {
+  for (int isec = 0; isec < NSECTOR; isec++) {
+    for (int ipl = 0; ipl < NLAYER; ipl++) {
       int det = offsetch + isec * 30 + ipl;
       if (calDet)
         factor = calDet->getValue(det);
@@ -635,7 +636,7 @@ bool CalPad::add(float c1)
   //
 
   bool result = kTRUE;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (fROC[idet]) {
       if (!fROC[idet]->add(c1))
         result = kFALSE;
@@ -651,7 +652,7 @@ bool CalPad::multiply(float c1)
   // multiply constant for all channels of all ROCs
   //
   bool result = kTRUE;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (fROC[idet]) {
       if (!fROC[idet]->multiply(c1))
         result = kFALSE;
@@ -680,7 +681,7 @@ bool CalPad::add(const CalPad* pad, double c1, const CalDet* calDet1, const CalD
     factor2 = 1.0;
   }
   bool result = kTRUE;
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet1)
       factor1 = calDet1->getValue(idet);
     if (calDet2)
@@ -723,7 +724,7 @@ bool CalPad::multiply(const CalPad* pad, const CalDet* calDet1, const CalDet* ca
     factor1 = 1.0;
     factor2 = 1.0;
   }
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet1)
       factor1 = calDet1->getValue(idet);
     if (calDet2)
@@ -773,7 +774,7 @@ bool CalPad::divide(const CalPad* pad, const CalDet* calDet1, const CalDet* calD
     factor1 = 1.0;
     factor2 = 1.0;
   }
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (calDet1)
       factor1 = calDet1->getValue(idet);
     if (calDet2)

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -42,6 +42,7 @@
 
 using namespace std;
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 //_____________________________________________________________________________
 
@@ -55,24 +56,24 @@ bool FeeParam::mgLUTPadNumberingFilled = false;
 std::vector<short> FeeParam::mgLUTPadNumbering;
 
 // definition of geometry constants
-std::array<float, 30> FeeParam::mgZrow = {
+std::array<float, NCHAMBERPERSEC> FeeParam::mgZrow = {
   301, 177, 53, -57, -181,
   301, 177, 53, -57, -181,
   315, 184, 53, -57, -188,
   329, 191, 53, -57, -195,
   343, 198, 53, -57, -202,
   347, 200, 53, -57, -204};
-std::array<float, 6> FeeParam::mgX = {300.65, 313.25, 325.85, 338.45, 351.05, 363.65};
-std::array<float, 6> FeeParam::mgTiltingAngle = {-2., 2., -2., 2., -2., 2.};
+std::array<float, NLAYER> FeeParam::mgX = {300.65, 313.25, 325.85, 338.45, 351.05, 363.65};
+std::array<float, NLAYER> FeeParam::mgTiltingAngle = {-2., 2., -2., 2., -2., 2.};
 int FeeParam::mgDyMax = 63;
 int FeeParam::mgDyMin = -64;
 float FeeParam::mgBinDy = 140e-4;
-std::array<float, 6> FeeParam::mgWidthPad = {0.635, 0.665, 0.695, 0.725, 0.755, 0.785};
-std::array<float, 6> FeeParam::mgLengthInnerPadC1 = {7.5, 7.5, 8.0, 8.5, 9.0, 9.0};
-std::array<float, 6> FeeParam::mgLengthOuterPadC1 = {7.5, 7.5, 7.5, 7.5, 7.5, 8.5};
-std::array<float, 6> FeeParam::mgInvX;
-std::array<float, 6> FeeParam::mgTiltingAngleTan;
-std::array<float, 6> FeeParam::mgInvWidthPad;
+std::array<float, NLAYER> FeeParam::mgWidthPad = {0.635, 0.665, 0.695, 0.725, 0.755, 0.785};
+std::array<float, NLAYER> FeeParam::mgLengthInnerPadC1 = {7.5, 7.5, 8.0, 8.5, 9.0, 9.0};
+std::array<float, NLAYER> FeeParam::mgLengthOuterPadC1 = {7.5, 7.5, 7.5, 7.5, 7.5, 8.5};
+std::array<float, NLAYER> FeeParam::mgInvX;
+std::array<float, NLAYER> FeeParam::mgTiltingAngleTan;
+std::array<float, NLAYER> FeeParam::mgInvWidthPad;
 
 float FeeParam::mgLengthInnerPadC0 = 9.0;
 float FeeParam::mgLengthOuterPadC0 = 8.0;
@@ -196,7 +197,7 @@ int FeeParam::getPadRowFromMCM(int irob, int imcm) const
   // Return on which pad row this mcm sits
   //
 
-  return mgkNmcmRobInRow * (irob / 2) + imcm / mgkNmcmRobInCol;
+  return NMCMROBINROW * (irob / 2) + imcm / NMCMROBINCOL;
 }
 
 //_____________________________________________________________________________
@@ -215,11 +216,11 @@ int FeeParam::getPadColFromADC(int irob, int imcm, int iadc) const
   // http://wiki.kip.uni-heidelberg.de/ti/TRD/index.php/Image:ROB_MCM_numbering.pdf
   //
 
-  if (iadc < 0 || iadc > mgkNadcMcm)
+  if (iadc < 0 || iadc > NADCMCM)
     return -100;
-  int mcmcol = imcm % mgkNmcmRobInCol + getRobSide(irob) * mgkNmcmRobInCol; // MCM column number on ROC [0..7]
-  int padcol = mcmcol * mgkNcolMcm + mgkNcolMcm + 1 - iadc;
-  if (padcol < 0 || padcol >= mgkNcol) {
+  int mcmcol = imcm % NMCMROBINCOL + getRobSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
+  int padcol = mcmcol * NCOLMCM + NCOLMCM + 1 - iadc;
+  if (padcol < 0 || padcol >= NCOLUMN) {
     return -1; // this is commented because of reason above OK
   }
   return padcol;
@@ -234,10 +235,10 @@ int FeeParam::getExtendedPadColFromADC(int irob, int imcm, int iadc) const
   // so we have to introduce new virtual pad numbering scheme for this purpose.
   //
 
-  if (iadc < 0 || iadc > mgkNadcMcm)
+  if (iadc < 0 || iadc > NADCMCM)
     return -100;
-  int mcmcol = imcm % mgkNmcmRobInCol + getRobSide(irob) * mgkNmcmRobInCol; // MCM column number on ROC [0..7]
-  int padcol = mcmcol * mgkNadcMcm + mgkNcolMcm + 2 - iadc;
+  int mcmcol = imcm % NMCMROBINCOL + getRobSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
+  int padcol = mcmcol * NADCMCM + NCOLMCM + 2 - iadc;
 
   return padcol;
 }
@@ -250,9 +251,9 @@ int FeeParam::getMCMfromPad(int irow, int icol) const
   // Return -1 for error.
   //
 
-  if (irow < 0 || icol < 0 || irow > mgkNrowC1 || icol > mgkNcol)
+  if (irow < 0 || icol < 0 || irow > NROWC1 || icol > NCOLUMN)
     return -1;
-  return (icol % (mgkNcol / 2)) / mgkNcolMcm + mgkNmcmRobInCol * (irow % mgkNmcmRobInRow);
+  return (icol % (NCOLUMN / 2)) / NCOLMCM + NMCMROBINCOL * (irow % NMCMROBINROW);
 }
 
 //_____________________________________________________________________________
@@ -263,7 +264,7 @@ int FeeParam::getMCMfromSharedPad(int irow, int icol) const
   // Return -1 for error.
   //
 
-  if (irow < 0 || icol < 0 || irow > mgkNrowC1 || icol > mgkNcol + 8 * 3)
+  if (irow < 0 || icol < 0 || irow > NROWC1 || icol > NCOLUMN + 8 * 3)
     return -1;
 
   int adc = 20 - (icol % 18) - 1;
@@ -282,7 +283,7 @@ int FeeParam::getMCMfromSharedPad(int irow, int icol) const
       break;
   }
 
-  return (icol % (mgkNcol / 2)) / mgkNcolMcm + mgkNmcmRobInCol * (irow % mgkNmcmRobInRow);
+  return (icol % (NCOLUMN / 2)) / NCOLMCM + NMCMROBINCOL * (irow % NMCMROBINROW);
 }
 
 //_____________________________________________________________________________
@@ -291,7 +292,7 @@ int FeeParam::getROBfromPad(int irow, int icol) const
   //
   // Return on which rob this pad is
   //
-  return (int)((int)irow / (int)mgkNmcmRobInRow) * 2 + getColSide(icol);
+  return (irow / NMCMROBINROW) * 2 + getColSide(icol);
 }
 
 //_____________________________________________________________________________
@@ -302,9 +303,9 @@ int FeeParam::getROBfromSharedPad(int irow, int icol) const
   //
 
   if (icol < 72) {
-    return (irow / mgkNmcmRobInRow) * 2 + getColSide(icol + 5);
+    return (irow / NMCMROBINROW) * 2 + getColSide(icol + 5);
   } else {
-    return (irow / mgkNmcmRobInRow) * 2 + getColSide(icol - 5);
+    return (irow / NMCMROBINROW) * 2 + getColSide(icol - 5);
   }
 }
 
@@ -315,7 +316,7 @@ int FeeParam::getRobSide(int irob) const
   // Return on which side this rob sits (A side = 0, B side = 1)
   //
 
-  if (irob < 0 || irob >= mgkNrobC1)
+  if (irob < 0 || irob >= NROBC1)
     return -1;
 
   return irob % 2;
@@ -328,10 +329,10 @@ int FeeParam::getColSide(int icol) const
   // Return on which side this column sits (A side = 0, B side = 1)
   //
 
-  if (icol < 0 || icol >= mgkNcol)
+  if (icol < 0 || icol >= NCOLUMN)
     return -1;
 
-  return icol / (mgkNcol / 2);
+  return icol / (NCOLUMN / 2);
 }
 
 unsigned int FeeParam::aliToExtAli(int rob, int aliid)
@@ -491,7 +492,7 @@ void FeeParam::setRAWversion(int rawver)
   }
 }
 
-/* 
+/*
  * This was originally moved here from arrayADC, signalADC etc. We now longer use those classes
  * so removing this for now as its crashing.
 */
@@ -504,9 +505,9 @@ void FeeParam::createPad2MCMLookUpTable()
   //
   if (!mgLUTPadNumberingFilled) {
 
-    LOG(debug) << " resizing lookup array to : " << getNcol() << " elements previously : " << mgLUTPadNumbering.size();
-    mgLUTPadNumbering.resize(FeeParam::getNcol());
-    memset(&mgLUTPadNumbering[0], 0, sizeof(mgLUTPadNumbering[0]) * getNcol());
+    LOG(debug) << " resizing lookup array to : " << NCOLUMN << " elements previously : " << mgLUTPadNumbering.size();
+    mgLUTPadNumbering.resize(NCOLUMN);
+    memset(&mgLUTPadNumbering[0], 0, sizeof(mgLUTPadNumbering[0]) * NCOLUMN);
     for (int mcm = 0; mcm < 8; mcm++) {
       int lowerlimit = 0 + mcm * 18;
       int upperlimit = 18 + mcm * 18;
@@ -524,7 +525,7 @@ int FeeParam::getDyCorrection(int det, int rob, int mcm) const
   // calculate the correction of the deflection
   // i.e. Lorentz angle and tilt correction (if active)
 
-  int layer = det % 6;
+  int layer = det % NLAYER;
 
   float dyTilt = (mgDriftLength * std::tan(mgTiltingAngle[layer] * M_PI / 180.) *
                   getLocalZ(det, rob, mcm) * mgInvX[layer]);
@@ -598,7 +599,7 @@ float FeeParam::getElongation(int det, int rob, int mcm, int ch) const
   // calculate the ratio of the distance to the primary vertex and the
   // distance in x-direction for the given ADC channel
 
-  int layer = det % 6;
+  int layer = det % NLAYER;
 
   float elongation = std::abs(getDist(det, rob, mcm, ch) * mgInvX[layer]);
 
@@ -638,7 +639,7 @@ float FeeParam::getX(int det, int /* rob */, int /* mcm */) const
 {
   // return the distance to the beam axis in x-direction
 
-  int layer = det % 6;
+  int layer = det % NLAYER;
   return mgX[layer];
 }
 
@@ -646,7 +647,7 @@ float FeeParam::getLocalY(int det, int rob, int mcm, int ch) const
 {
   // get local y-position (r-phi) w.r.t. the chamber centre
 
-  int layer = det % 6;
+  int layer = det % NLAYER;
   // calculate the pad position as in the TRAP
   float ypos = (-4 + 1 + (rob & 0x1) * 4 + (mcm & 0x3)) * 18 - ch - 0.5; // y position in bins of pad widths
   return ypos * mgWidthPad[layer];
@@ -656,24 +657,24 @@ float FeeParam::getLocalZ(int det, int rob, int mcm) const
 {
   // get local z-position w.r.t. to the chamber boundary
 
-  int stack = (det % 30) / 6;
-  int layer = det % 6;
+  int stack = (det % NCHAMBERPERSEC) / NLAYER;
+  int layer = det % NLAYER;
   int row = (rob / 2) * 4 + mcm / 4;
 
   if (stack == 2) {
     if (row == 0)
-      return (mgZrow[layer * 6 + stack] - 0.5 * mgLengthOuterPadC0);
+      return (mgZrow[layer * NLAYER + stack] - 0.5 * mgLengthOuterPadC0);
     else if (row == 11)
-      return (mgZrow[layer * 6 + stack] - 1.5 * mgLengthOuterPadC0 - (row - 1) * mgLengthInnerPadC0);
+      return (mgZrow[layer * NLAYER + stack] - 1.5 * mgLengthOuterPadC0 - (row - 1) * mgLengthInnerPadC0);
     else
-      return (mgZrow[layer * 6 + stack] - mgLengthOuterPadC0 - (row - 0.5) * mgLengthInnerPadC0);
+      return (mgZrow[layer * NLAYER + stack] - mgLengthOuterPadC0 - (row - 0.5) * mgLengthInnerPadC0);
   } else {
     if (row == 0)
-      return (mgZrow[layer * 6 + stack] - 0.5 * mgLengthOuterPadC1[layer]);
+      return (mgZrow[layer * NLAYER + stack] - 0.5 * mgLengthOuterPadC1[layer]);
     else if (row == 15)
-      return (mgZrow[layer * 6 + stack] - 1.5 * mgLengthOuterPadC1[layer] - (row - 1) * mgLengthInnerPadC1[layer]);
+      return (mgZrow[layer * NLAYER + stack] - 1.5 * mgLengthOuterPadC1[layer] - (row - 1) * mgLengthInnerPadC1[layer]);
     else
-      return (mgZrow[layer * 6 + stack] - mgLengthOuterPadC1[layer] - (row - 0.5) * mgLengthInnerPadC1[layer]);
+      return (mgZrow[layer * NLAYER + stack] - mgLengthOuterPadC1[layer] - (row - 0.5) * mgLengthInnerPadC1[layer]);
   }
 }
 

--- a/Detectors/TRD/base/src/PadResponse.cxx
+++ b/Detectors/TRD/base/src/PadResponse.cxx
@@ -11,6 +11,7 @@
 #include "TRDBase/PadResponse.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 void PadResponse::samplePRF()
 {
@@ -19,7 +20,7 @@ void PadResponse::samplePRF()
   //
 
   constexpr int kPRFbin = 61; // arbitraty value - need documentation/ref.
-  constexpr float prf[kNlayer][kPRFbin] = {
+  constexpr float prf[NLAYER][kPRFbin] = {
     {2.9037e-02, 3.3608e-02, 3.9020e-02, 4.5292e-02,
      5.2694e-02, 6.1362e-02, 7.1461e-02, 8.3362e-02,
      9.7063e-02, 1.1307e-01, 1.3140e-01, 1.5235e-01,
@@ -132,7 +133,7 @@ void PadResponse::samplePRF()
   int ipos2;
   float diff;
 
-  for (int iLayer = 0; iLayer < kNlayer; ++iLayer) {
+  for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
     for (int iBin = 0; iBin < mPRFbin; ++iBin) {
       float bin = (((float)iBin) + 0.5) * mPRFwid + mPRFlo;
       ipos1 = ipos2 = 0;
@@ -171,12 +172,12 @@ int PadResponse::getPRF(double signal, double dist, int layer, double* pad) cons
   pad[1] = 0;
   pad[2] = 0;
 
-  if ((iBin1 >= 0) && (iBin1 < (mPRFbin * kNlayer))) {
+  if ((iBin1 >= 0) && (iBin1 < (mPRFbin * NLAYER))) {
     if (iBin0 >= 0) {
       pad[0] = signal * mPRFsmp[iBin0];
     }
     pad[1] = signal * mPRFsmp[iBin1];
-    if (iBin2 < (mPRFbin * kNlayer)) {
+    if (iBin2 < (mPRFbin * NLAYER)) {
       pad[2] = signal * mPRFsmp[iBin2];
     }
     return 1;

--- a/Detectors/TRD/base/src/TRDCalPadStatus.cxx
+++ b/Detectors/TRD/base/src/TRDCalPadStatus.cxx
@@ -29,6 +29,7 @@
 #include "TRDBase/TRDCalPadStatus.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 //_____________________________________________________________________________
 TRDCalPadStatus::TRDCalPadStatus()
@@ -37,7 +38,7 @@ TRDCalPadStatus::TRDCalPadStatus()
   // TRDCalPadStatus default constructor
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     mROC[idet] = nullptr;
   }
 }
@@ -49,9 +50,9 @@ TRDCalPadStatus::TRDCalPadStatus(const Text_t* name, const Text_t* title)
   // TRDCalPadStatus constructor
   //
   //TRDGeometry fgeom;
-  for (int isec = 0; isec < kNsect; isec++) {
-    for (int ipla = 0; ipla < kNplan; ipla++) {
-      for (int icha = 0; icha < kNcham; icha++) {
+  for (int isec = 0; isec < NSECTOR; isec++) {
+    for (int ipla = 0; ipla < NLAYER; ipla++) {
+      for (int icha = 0; icha < NSTACK; icha++) {
         int idet = o2::trd::TRDGeometry::getDetector(ipla, icha, isec);
         //    int idet = fgeom.getDetector(ipla,icha,isec);//TRDGeometryBase::getDetector(ipla,icha,isec);
         mROC[idet] = new TRDCalSingleChamberStatus(ipla, icha, 144);
@@ -79,7 +80,7 @@ TRDCalPadStatus::~TRDCalPadStatus()
   // TRDCalPadStatus destructor
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (mROC[idet]) {
       delete mROC[idet];
       mROC[idet] = nullptr;
@@ -106,7 +107,7 @@ void TRDCalPadStatus::Copy(TRDCalPadStatus& c) const
   // Copy function
   //
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (mROC[idet]) {
       mROC[idet]->Copy(*((TRDCalPadStatus&)c).mROC[idet]);
     }
@@ -156,7 +157,7 @@ TH1F* TRDCalPadStatus::makeHisto1D()
   his->GetXaxis()->SetBinLabel(5, "ReadSecond");
   his->GetXaxis()->SetBinLabel(6, "NotConnected");
 
-  for (int idet = 0; idet < kNdet; idet++) {
+  for (int idet = 0; idet < MAXCHAMBER; idet++) {
     if (mROC[idet]) {
       for (int ichannel = 0; ichannel < mROC[idet]->getNchannels(); ichannel++) {
         int status = (int)mROC[idet]->getStatus(ichannel);
@@ -198,14 +199,14 @@ TH2F* TRDCalPadStatus::makeHisto2DSmPl(int sm, int pl)
   // Where we begin
   int offsetsmpl = 30 * sm + pl;
 
-  for (int k = 0; k < kNcham; k++) {
+  for (int k = 0; k < NSTACK; k++) {
     int det = offsetsmpl + k * 6;
     if (mROC[det]) {
       TRDCalSingleChamberStatus* calRoc = mROC[det];
       for (int icol = 0; icol < calRoc->getNcols(); icol++) {
         for (int irow = 0; irow < calRoc->getNrows(); irow++) {
           int binz = 0;
-          int kb = kNcham - 1 - k;
+          int kb = NSTACK - 1 - k;
           int krow = calRoc->getNrows() - 1 - irow;
           int kcol = calRoc->getNcols() - 1 - icol;
           if (kb > 2)
@@ -220,7 +221,7 @@ TH2F* TRDCalPadStatus::makeHisto2DSmPl(int sm, int pl)
       for (int icol = 1; icol < 147; icol++) {
         for (int l = 0; l < 2; l++) {
           int binz = 0;
-          int kb = kNcham - 1 - k;
+          int kb = NSTACK - 1 - k;
           if (kb > 2)
             binz = 16 * (kb - 1) + 12 + 1 + 2 * (kb + 1) - (l + 1);
           else

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -20,6 +20,7 @@
 #include "TRDBase/TRDPadPlane.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 //_____________________________________________________________________________
 
@@ -40,7 +41,7 @@ bool TRDGeometry::rotateBack(int det, const float* const loc, float* glb) const
   //
 
   int sector = getSector(det);
-  float phi = 2.0 * TMath::Pi() / (float)kNsector * ((float)sector + 0.5);
+  float phi = 2.0 * TMath::Pi() / (float)NSECTOR * ((float)sector + 0.5);
 
   glb[0] = loc[0] * TMath::Cos(phi) - loc[1] * TMath::Sin(phi);
   glb[1] = loc[0] * TMath::Sin(phi) + loc[1] * TMath::Cos(phi);
@@ -56,8 +57,8 @@ void TRDGeometry::createPadPlaneArray()
   // Creates the array of TRDPadPlane objects
   //
 
-  for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-    for (int istack = 0; istack < kNstack; istack++) {
+  for (int ilayer = 0; ilayer < NLAYER; ilayer++) {
+    for (int istack = 0; istack < NSTACK; istack++) {
       createPadPlane(ilayer, istack);
     }
   }
@@ -371,8 +372,8 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   createVolume("UTF1", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTF2", "TRD1", idtmed[2], parTrd, kNparTrd);
 
-  for (int istack = 0; istack < kNstack; istack++) {
-    for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (int istack = 0; istack < NSTACK; istack++) {
+    for (int ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
 
       // The lower part of the readout chambers (drift volume + radiator)
@@ -705,8 +706,8 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   // Create the volumes of the services
   createServices(idtmed);
 
-  for (int istack = 0; istack < kNstack; istack++) {
-    for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (int istack = 0; istack < NSTACK; istack++) {
+    for (int ilayer = 0; ilayer < NLAYER; ilayer++) {
       assembleChamber(ilayer, istack);
     }
   }
@@ -732,7 +733,7 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   xpos = 0.0;
   ypos = 0.0;
   zpos = 0.0;
-  for (int isector = 0; isector < kNsector; isector++) {
+  for (int isector = 0; isector < NSECTOR; isector++) {
     if (getSMstatus(isector)) {
       snprintf(cTagV, kTag, "BTRD%d", isector);
       switch (isector) {
@@ -763,7 +764,7 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   xpos = 0.0;
   ypos = 0.5 * SLENGTH + 0.5 * FLENGTH;
   zpos = 0.0;
-  for (int isector = 0; isector < kNsector; isector++) {
+  for (int isector = 0; isector < NSECTOR; isector++) {
     if (getSMstatus(isector)) {
       snprintf(cTagV, kTag, "BTRD%d", isector);
       TVirtualMC::GetMC()->Gspos("UTF1", 1, cTagV, xpos, ypos, zpos, 0, "ONLY");
@@ -937,19 +938,19 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   xpos = 0.0;
   ypos = 0.0;
   zpos = 0.0;
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     xpos = CWIDTH[ilayer] / 2.0 + kSRLwidA / 2.0 + kSRLdst;
     ypos = 0.0;
     zpos = VROCSM + SMPLTT - CALZPOS - SHEIGHT / 2.0 + CRAH + CDRH - CALH - kSRLhgt / 2.0 +
            ilayer * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 2 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 3 * kNlayer, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 4 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[2], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 5 * kNlayer, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 6 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[2], "ONLY");
-    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 7 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + NLAYER, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 2 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 3 * NLAYER, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 4 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[2], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 5 * NLAYER, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 6 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[2], "ONLY");
+    TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 7 * NLAYER, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY");
   }
 
   //
@@ -972,7 +973,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   xpos = 0.0;
   ypos = 0.0;
   zpos = 0.0;
-  for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 0; ilayer < NLAYER; ilayer++) {
     // The aluminum of the cross bars
     parSCB[0] = CWIDTH[ilayer] / 2.0 + kSRLdst / 2.0;
     snprintf(cTagV, kTag, "USF%01d", ilayer);
@@ -1025,7 +1026,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   const int kNparSCH = 3;
   float parSCH[kNparSCH];
 
-  for (ilayer = 1; ilayer < kNlayer - 1; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER - 1; ilayer++) {
     parSCH[0] = CWIDTH[ilayer] / 2.0;
     parSCH[1] = (CLENGTH[ilayer + 1][2] / 2.0 + CLENGTH[ilayer + 1][1] - CLENGTH[ilayer][2] / 2.0 -
                  CLENGTH[ilayer][1]) /
@@ -1593,7 +1594,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UTC2", 1, "UTC1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTC4", 1, "UTC3", xpos, ypos, zpos, 0, "ONLY");
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // Along the chambers
     xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx;
     ypos = 0.0;
@@ -1603,19 +1604,19 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parCOL[1] = SLENGTH / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTC1", ilayer, "UTI1", xpos, ypos, zpos, matrix[0], "ONLY", parCOL, kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + NLAYER, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 6 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 6 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 7 * kNlayer, "UTI2", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 7 * NLAYER, "UTI2", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 8 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 8 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 9 * kNlayer, "UTI3", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 9 * NLAYER, "UTI3", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 10 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + 11 * NLAYER, "UTI4", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
 
     // Front of supermodules
@@ -1626,17 +1627,17 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parCOL[0] = kCOLwid / 2.0;
     parCOL[1] = FLENGTH / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 2 * NLAYER, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 3 * NLAYER, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 4 * NLAYER, "UTF2", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 5 * NLAYER, "UTF2", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
   }
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // In baby frame
     xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 2.5;
     ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
@@ -1645,13 +1646,13 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parCOL[0] = kCOLwid / 2.0;
     parCOL[1] = kBBSdz / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 6 * NLAYER, "BBTRD", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 7 * NLAYER, "BBTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
   }
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // In back frame
     xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 0.3;
     ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
@@ -1660,9 +1661,9 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parCOL[0] = kCOLwid / 2.0;
     parCOL[1] = kBFSdz / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 6 * kNlayer, "BFTRD", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 6 * NLAYER, "BFTRD", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
-    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 7 * kNlayer, "BFTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
+    TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 7 * NLAYER, "BFTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
                                 kNparCOL);
   }
 
@@ -1675,13 +1676,13 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parCOL[1] = SLENGTH / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTC1", 6, "UTI1", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 6 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 7 * kNlayer, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 8 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 9 * kNlayer, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + NLAYER, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 6 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 7 * NLAYER, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 8 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 9 * NLAYER, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 10 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 11 * NLAYER, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // Front of supermodules
   xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
   ypos = 0.0;
@@ -1689,10 +1690,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parCOL[0] = kCOLwid / 2.0;
   parCOL[1] = FLENGTH / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 2 * NLAYER, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 3 * NLAYER, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 4 * NLAYER, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 5 * NLAYER, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // In baby frame
   xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 3.1;
   ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
@@ -1700,8 +1701,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parCOL[0] = kCOLwid / 2.0;
   parCOL[1] = kBBSdz / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 6 * NLAYER, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 7 * NLAYER, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // In back frame
   xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
   ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
@@ -1709,8 +1710,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parCOL[0] = kCOLwid / 2.0;
   parCOL[1] = kBFSdz / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 6 * kNlayer, "BFTRD", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
-  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 7 * kNlayer, "BFTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 6 * NLAYER, "BFTRD", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
+  TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 7 * NLAYER, "BFTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
 
   //
   // The power bus bars
@@ -1731,7 +1732,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   createVolume("UTP1", "BOX ", idtmed[25], parPWR, 0);
   createVolume("UTP3", "BOX ", idtmed[25], parPWR, 0);
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // Along the chambers
     xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx;
     ypos = 0.0;
@@ -1741,19 +1742,19 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parPWR[1] = SLENGTH / 2.0;
     parPWR[2] = kPWRhgtA / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTP1", ilayer, "UTI1", xpos, ypos, zpos, matrix[0], "ONLY", parPWR, kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + NLAYER, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 6 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 6 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 7 * kNlayer, "UTI2", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 7 * NLAYER, "UTI2", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 8 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 8 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 9 * kNlayer, "UTI3", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 9 * NLAYER, "UTI3", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 10 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + 11 * NLAYER, "UTI4", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
 
     // Front of supermodule
@@ -1764,17 +1765,17 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parPWR[0] = kPWRwid / 2.0;
     parPWR[1] = FLENGTH / 2.0;
     parPWR[2] = kPWRhgtA / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 2 * NLAYER, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 3 * NLAYER, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 4 * NLAYER, "UTF2", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 5 * NLAYER, "UTF2", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
   }
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // In baby frame
     xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 2.5;
     ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
@@ -1783,13 +1784,13 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parPWR[0] = kPWRwid / 2.0;
     parPWR[1] = kBBSdz / 2.0;
     parPWR[2] = kPWRhgtB / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 6 * NLAYER, "BBTRD", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 7 * NLAYER, "BBTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
   }
 
-  for (ilayer = 1; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 1; ilayer < NLAYER; ilayer++) {
     // In back frame
     xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 0.3;
     ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
@@ -1798,9 +1799,9 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parPWR[0] = kPWRwid / 2.0;
     parPWR[1] = kBFSdz / 2.0;
     parPWR[2] = kPWRhgtB / 2.0;
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 8 * kNlayer, "BFTRD", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 8 * NLAYER, "BFTRD", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
-    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 9 * kNlayer, "BFTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
+    TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 9 * NLAYER, "BFTRD", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
                                 kNparPWR);
   }
 
@@ -1813,13 +1814,13 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parPWR[1] = SLENGTH / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTP1", 6, "UTI1", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 6 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 7 * kNlayer, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 8 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 9 * kNlayer, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + NLAYER, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 6 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 7 * NLAYER, "UTI2", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 8 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 9 * NLAYER, "UTI3", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 10 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 11 * NLAYER, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // Front of supermodules
   xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
   ypos = 0.0;
@@ -1827,10 +1828,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parPWR[0] = kPWRwid / 2.0;
   parPWR[1] = FLENGTH / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 2 * NLAYER, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 3 * NLAYER, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 4 * NLAYER, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 5 * NLAYER, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // In baby frame
   xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 3.0;
   ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
@@ -1838,8 +1839,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parPWR[0] = kPWRwid / 2.0;
   parPWR[1] = kBBSdz / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 6 * NLAYER, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 7 * NLAYER, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // In back frame
   xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
   ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
@@ -1847,8 +1848,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parPWR[0] = kPWRwid / 2.0;
   parPWR[1] = kBFSdz / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 8 * kNlayer, "BFTRD", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
-  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 9 * kNlayer, "BFTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 8 * NLAYER, "BFTRD", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
+  TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 9 * NLAYER, "BFTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
 
   //
   // The gas tubes connecting the chambers in the super modules with holes
@@ -1868,7 +1869,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   ypos = 0.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTG2", 1, "UTG1", xpos, ypos, zpos, 0, "ONLY");
-  for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (ilayer = 0; ilayer < NLAYER; ilayer++) {
     xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 - 1.5;
     ypos = 0.0;
     zpos = VROCSM + SMPLTT + kCOLhgt / 2.0 - SHEIGHT / 2.0 + 5.0 + ilayer * (CH + VSPACE);
@@ -1901,8 +1902,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   const int kNparServ = 3;
   float parServ[kNparServ];
 
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
 
       snprintf(cTagV, kTag, "UU%02d", iDet);
@@ -1934,8 +1935,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UTCH", 1, "UTCP", xpos, ypos, zpos, 0, "ONLY");
 
   // Position the cooling pipes in the mother volume
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 100;
       int nMCMrow = getRowMax(ilayer, istack, 0);
@@ -1966,8 +1967,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   createVolume("UTPL", "TUBE", idtmed[5], parTube, 0);
 
   // Position the power lines in the mother volume
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 100;
       int nMCMrow = getRowMax(ilayer, istack, 0);
@@ -2041,8 +2042,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UMC4", 1, "UMCM", xpos, ypos, zpos, 0, "ONLY");
 
   // Position the MCMs in the mother volume
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 1000;
       int nMCMrow = getRowMax(ilayer, istack, 0);
@@ -2121,8 +2122,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UDC3", 1, "UDCS", xpos, ypos, zpos, 0, "ONLY");
 
   // Put the DCS board in the chamber services mother volume
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
       xpos = CWIDTH[ilayer] / 2.0 -
@@ -2181,8 +2182,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UOR3", 1, "UORI", xpos, ypos, zpos, 0, "ONLY");
 
   // Put the ORI board in the chamber services mother volume
-  for (istack = 0; istack < kNstack; istack++) {
-    for (ilayer = 0; ilayer < kNlayer; ilayer++) {
+  for (istack = 0; istack < NSTACK; istack++) {
+    for (ilayer = 0; ilayer < NLAYER; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
       xpos = CWIDTH[ilayer] / 2.0 -
@@ -2196,7 +2197,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
       ypos = -16.0;
       zpos = kORIz / 2.0 - CSVH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
-      TVirtualMC::GetMC()->Gspos("UORI", iCopy + kNdet, cTagV, xpos, ypos, zpos, 0, "ONLY");
+      TVirtualMC::GetMC()->Gspos("UORI", iCopy + MAXCHAMBER, cTagV, xpos, ypos, zpos, 0, "ONLY");
     }
   }
 
@@ -2218,7 +2219,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   ypos = 0.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTG4", 1, "UTG3", xpos, ypos, zpos, 0, "ONLY");
-  for (ilayer = 0; ilayer < kNlayer - 1; ilayer++) {
+  for (ilayer = 0; ilayer < NLAYER - 1; ilayer++) {
     xpos = 0.0;
     ypos = CLENGTH[ilayer][2] / 2.0 + CLENGTH[ilayer][1] + CLENGTH[ilayer][0];
     zpos = 9.0 - SHEIGHT / 2.0 + ilayer * (CH + VSPACE);
@@ -2226,19 +2227,19 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     parTube[1] = 1.5 / 2.0;
     parTube[2] = CWIDTH[ilayer] / 2.0 - 2.5;
     TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY", parTube, kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 1 * kNlayer, "UTI1", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 1 * NLAYER, "UTI1", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 2 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 2 * NLAYER, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 3 * kNlayer, "UTI2", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 3 * NLAYER, "UTI2", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 4 * kNlayer, "UTI3", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 4 * NLAYER, "UTI3", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 5 * kNlayer, "UTI3", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 5 * NLAYER, "UTI3", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 6 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 6 * NLAYER, "UTI4", xpos, ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
-    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 7 * kNlayer, "UTI4", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
+    TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 7 * NLAYER, "UTI4", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
   }
 
@@ -2346,18 +2347,18 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parBox[1] = 15.0 / 2.0;
   parBox[2] = 7.0 / 2.0;
   createVolume("UTPC", "BOX ", idtmed[25], parBox, kNparBox);
-  for (ilayer = 0; ilayer < kNlayer - 1; ilayer++) {
+  for (ilayer = 0; ilayer < NLAYER - 1; ilayer++) {
     xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0;
     ypos = 0.0;
     zpos = VROCSM + SMPLTT + kPWRhgtA / 2.0 - SHEIGHT / 2.0 + kPWRposz + (ilayer + 1) * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos("UTPC", ilayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY");
-    TVirtualMC::GetMC()->Gspos("UTPC", ilayer + kNlayer, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY");
+    TVirtualMC::GetMC()->Gspos("UTPC", ilayer + NLAYER, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY");
   }
   xpos = CWIDTH[5] / 2.0 + kPWRhgtA / 2.0 - 2.0;
   ypos = 0.0;
   zpos = SHEIGHT / 2.0 - SMPLTT - 2.0;
   TVirtualMC::GetMC()->Gspos("UTPC", 5, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY");
-  TVirtualMC::GetMC()->Gspos("UTPC", 5 + kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY");
+  TVirtualMC::GetMC()->Gspos("UTPC", 5 + NLAYER, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY");
 
   // Power connection panel (Al)
   parBox[0] = 60.0 / 2.0;
@@ -2571,9 +2572,9 @@ void TRDGeometry::fillMatrixCache(int mask)
   const std::string vpApp3c{"/UTR3_1/UTS3_1/UTI3_1"};
   const std::string vpApp3d{"/UTR4_1/UTS4_1/UTI4_1"};
 
-  for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-    for (int isector = 0; isector < kNsector; isector++) {
-      for (int istack = 0; istack < kNstack; istack++) {
+  for (int ilayer = 0; ilayer < NLAYER; ilayer++) {
+    for (int isector = 0; isector < NSECTOR; isector++) {
+      for (int istack = 0; istack < NSTACK; istack++) {
         Int_t lid = getDetector(ilayer, istack, isector);
         // Check for disabled supermodules
         volPath = vpStr;
@@ -2661,7 +2662,7 @@ void TRDGeometry::addAlignableVolumes() const
 
   // The super modules
   // The symbolic names are: TRD/sm00 ... TRD/sm17
-  for (int isector = 0; isector < kNsector; isector++) {
+  for (int isector = 0; isector < NSECTOR; isector++) {
     volPath = vpStr;
     volPath += std::to_string(isector);
     volPath += vpApp1;
@@ -2674,11 +2675,11 @@ void TRDGeometry::addAlignableVolumes() const
   // The readout chambers
   // The symbolic names are: TRD/sm00/st0/pl0 ... TRD/sm17/st4/pl5
 
-  for (int isector = 0; isector < kNsector; isector++) {
+  for (int isector = 0; isector < NSECTOR; isector++) {
     if (!getSMstatus(isector))
       continue;
-    for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-      for (int istack = 0; istack < kNstack; istack++) {
+    for (int ilayer = 0; ilayer < NLAYER; ilayer++) {
+      for (int istack = 0; istack < NSTACK; istack++) {
         Int_t lid = getDetector(ilayer, istack, isector);
         int idet = getDetectorSec(ilayer, istack);
 
@@ -2750,7 +2751,7 @@ bool TRDGeometry::createClusterMatrixArray()
     return true; // already initialized
   }
 
-  setSize(MAXMATRICES, kNdet); //Only MAXMATRICES=521 of kNdet matrices are filled
+  setSize(MAXMATRICES, MAXCHAMBER); //Only MAXMATRICES=521 of MAXCHAMBER matrices are filled
   fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L) | o2::utils::bit2Mask(o2::TransformType::L2G) |
                   o2::utils::bit2Mask(o2::TransformType::T2G) | o2::utils::bit2Mask(o2::TransformType::T2GRot));
   return true;

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -11,6 +11,7 @@
 #include "TRDBase/TRDGeometryBase.h"
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 //_____________________________________________________________________________
 GPUd() int TRDGeometryBase::getStack(float z, int layer) const
@@ -21,10 +22,10 @@ GPUd() int TRDGeometryBase::getStack(float z, int layer) const
   // The return function has to be protected for positiveness !!
   //
 
-  if ((layer < 0) || (layer >= kNlayer))
+  if ((layer < 0) || (layer >= NLAYER))
     return -1;
 
-  int istck = kNstack;
+  int istck = NSTACK;
   float zmin = 0.0;
   float zmax = 0.0;
 
@@ -49,11 +50,11 @@ GPUd() bool TRDGeometryBase::isOnBoundary(int det, float y, float z, float eps) 
   //
 
   int ly = getLayer(det);
-  if ((ly < 0) || (ly >= kNlayer))
+  if ((ly < 0) || (ly >= NLAYER))
     return true;
 
   int stk = getStack(det);
-  if ((stk < 0) || (stk >= kNstack))
+  if ((stk < 0) || (stk >= NSTACK))
     return true;
 
   const TRDPadPlane* pp = &mPadPlanes[getDetectorSec(ly, stk)];

--- a/Detectors/TRD/base/src/TRDGeometryFlat.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryFlat.cxx
@@ -10,6 +10,9 @@
 
 #include "TRDBase/TRDGeometryFlat.h"
 #include "TRDBase/TRDGeometry.h"
+#include "DataFormatsTRD/Constants.h"
+
+using namespace o2::trd::constants;
 
 TRDGeometryFlat::TRDGeometryFlat(const TRDGeometry& geo)
 {
@@ -17,7 +20,7 @@ TRDGeometryFlat::TRDGeometryFlat(const TRDGeometry& geo)
   const TRDGeometryBase& b2 = geo;
   memcpy((void*)&b1, (void*)&b2, sizeof(b1));
   int matrixCount = 0;
-  for (int i = 0; i < kNdet; i++) {
+  for (int i = 0; i < MAXCHAMBER; i++) {
     if (geo.chamberInGeometry(i)) {
       double v[12];
       geo.getMatrixT2L(i).GetComponents(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11]);

--- a/Detectors/TRD/macros/CMakeLists.txt
+++ b/Detectors/TRD/macros/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_test_root_macro(CheckCCDBvalues.C
 
 o2_add_test_root_macro(CheckDigits.C
                        PUBLIC_LINK_LIBRARIES O2::TRDBase
+                                             O2::DataFormatsTRD
                        LABELS trd)
 
 o2_add_test_root_macro(CheckHits.C

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -24,6 +24,7 @@
 #include "TRDBase/Digit.h"
 #include "TRDBase/TRDSimParam.h"
 #include "TRDBase/TRDCommonParam.h"
+#include "DataFormatsTRD/Constants.h"
 #endif
 
 using namespace o2::trd;
@@ -74,7 +75,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
       hDet->Fill(det);
       hRow->Fill(row);
       hPad->Fill(pad);
-      for (int tb = 0; tb < kTimeBins; ++tb) {
+      for (int tb = 0; tb < o2::trd::constants::TIMEBINS; ++tb) {
         ADC_t adc = adcs[tb];
         if (adc == (ADC_t)TRDSimParam::Instance()->GetADCoutRange()) {
           // LOG(INFO) << "Out of range ADC " << adc;

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -18,6 +18,7 @@
 #include "TRDBase/MCLabel.h"
 #include "TRDBase/TRDCommonParam.h"
 #include "TRDBase/TRDDiffAndTimeStructEstimator.h"
+#include "DataFormatsTRD/Constants.h"
 
 #include "MathUtils/RandomRing.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -40,7 +41,7 @@ class PadResponse;
 
 struct SignalArray {
   double firstTBtime;                     // first TB time
-  std::array<float, kTimeBins> signals{}; // signals
+  std::array<float, constants::TIMEBINS> signals{}; // signals
   std::unordered_map<int, int> trackIds;  // tracks Ids associated to the signal
   std::vector<MCLabel> labels;            // labels associated to the signal
 };
@@ -115,10 +116,10 @@ class Digitizer
   // Digitization containers
   std::vector<HitType> mHitContainer;                            // the container of hits in a given detector
   std::vector<MCLabel> mMergedLabels;                            // temporary label container
-  std::array<SignalContainer, kNdet> mSignalsMapCollection;      // container for caching signals over a timeframe
-  std::deque<std::array<SignalContainer, kNdet>> mPileupSignals; // container for piled up signals
+  std::array<SignalContainer, constants::MAXCHAMBER> mSignalsMapCollection;      // container for caching signals over a timeframe
+  std::deque<std::array<SignalContainer, constants::MAXCHAMBER>> mPileupSignals; // container for piled up signals
 
-  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
+  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, constants::MAXCHAMBER>&);
   void setSimulationParameters();
 
   // Digitization chain methods

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapConfigHandler.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapConfigHandler.h
@@ -77,10 +77,6 @@ class TrapConfigHandler
   static const unsigned int mgkScsnCmdOri = 26;     // SCSN command for ORI configuration
   static const unsigned int mgkScsnLTUparam = 27;   // extended SCSN command for the LTU configuration
 
-  static const int mgkMCMperROBCol = 4; // MCMs per ROB column
-  static const int mgkPadsPerMCM = 18;  // readout pads per MCM
-  static const int mgkMCMperROBRow = 4; // MCMs per ROB row
-
   static const int mgkMaxLinkPairs = 4;  // number of linkpairs used during configuration
   static const int mgkMcmlistSize = 256; // list of MCMs to which a value has to be written
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -34,6 +34,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 //#include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Constants.h"
 
 class TH2F;
 
@@ -287,7 +288,7 @@ class TrapSimulator
       mSumXY = 0;
     }
   };
-  std::array<FitReg, FeeParam::mgkNadcMcm> mFitReg{};
+  std::array<FitReg, constants::NADCMCM> mFitReg{};
 
  protected:
   void setNTimebins(int ntimebins); // allocate data arrays corr. to the no. of timebins
@@ -302,7 +303,7 @@ class TrapSimulator
   //TODO adcr adcf labels zerosupressionmap can all go into their own class. Refactor when stable.
   std::vector<int> mADCR; // Array with MCM ADC values (Raw, 12 bit) 2d with dimension mNTimeBin
   std::vector<int> mADCF; // Array with MCM ADC values (Filtered, 12 bit) 2d with dimension mNTimeBin
-  std::array<std::vector<o2::MCCompLabel>, FeeParam::mgkNadcMcm> mADCLabels{}; // MC Labels sent in from the digits coming in.
+  std::array<std::vector<o2::MCCompLabel>, constants::NADCMCM> mADCLabels{}; // MC Labels sent in from the digits coming in.
   std::vector<unsigned int> mMCMT;      // tracklet word for one mcm/trap-chip
   std::vector<Tracklet> mTrackletArray; // Array of TRDtrackletMCM which contains MC information in addition to the tracklet word
   std::vector<Tracklet64> mTrackletArray64; // Array of TRDtrackletMCM which contains MC information in addition to the tracklet word
@@ -319,9 +320,9 @@ class TrapSimulator
   TrapConfigHandler mTrapConfigHandler;
   //  CalOnlineGainTables mGainTable;
 
-  static const int NOfAdcPerMcm = FeeParam::mgkNadcMcm;
+  static const int NOfAdcPerMcm = constants::NADCMCM;
 
-  std::array<FilterReg, FeeParam::mgkNadcMcm> mInternalFilterRegisters;
+  std::array<FilterReg, constants::NADCMCM> mInternalFilterRegisters;
   int mADCFilled = 0; // stores bitpattern of fillted adc, for know when to fill with pure baseline, for use with setData(int iadc, const ArrayADC& adc);
   int mNHits; // Number of detected hits
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -13,6 +13,7 @@
 #include "TRDBase/TRDCommonParam.h"
 #include "TRDBase/TRDGeometry.h"
 #include "TRDSimulation/TRsim.h"
+#include "DataFormatsTRD/Constants.h"
 
 #include "CommonUtils/ShmAllocator.h"
 #include "SimulationDataFormat/Stack.h"
@@ -27,6 +28,7 @@
 #include <string>
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("TRD", active)
@@ -118,12 +120,12 @@ bool Detector::ProcessHits(FairVolume* v)
   if (r2 != 1) {
     LOG(FATAL) << "Something went wrong with the geometry volume name " << fMC->CurrentVolOffName(7);
   }
-  if (sector < 0 || sector >= kNsector) {
+  if (sector < 0 || sector >= NSECTOR) {
     LOG(FATAL) << "Sector out of bounds";
   }
   // The detector number (0 - 539)
   int det = mGeom->getDetector(mGeom->getLayer(idChamber), mGeom->getStack(idChamber), sector);
-  if (det < 0 || det >= kNdet) {
+  if (det < 0 || det >= MAXCHAMBER) {
     LOG(FATAL) << "Detector number out of bounds";
   }
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -28,6 +28,7 @@
 #endif
 
 using namespace o2::trd;
+using namespace o2::trd::constants;
 using namespace o2::math_utils;
 
 // init method for late initialization
@@ -78,8 +79,8 @@ void Digitizer::setSimulationParameters()
   if (mSimParam->TRFOn()) {
     mTimeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->GetSamplingFrequency())) - 1;
   }
-  mMaxTimeBins = kTimeBins;     // for signals, usually set at 30 tb = 3 microseconds
-  mMaxTimeBinsTRAP = kTimeBins; // for adcs; should be read from the CCDB or the TRAP config
+  mMaxTimeBins = TIMEBINS;     // for signals, usually set at 30 tb = 3 microseconds
+  mMaxTimeBinsTRAP = TIMEBINS; // for adcs; should be read from the CCDB or the TRAP config
   mSamplingRate = mCommonParam->GetSamplingFrequency();
   mElAttachProp = mSimParam->GetElAttachProp() / 100;
 }
@@ -119,7 +120,7 @@ SignalContainer Digitizer::addSignalsFromPileup()
   int count = 0;
   SignalContainer addedSignalsMap;
   for (const auto& collection : mPileupSignals) {
-    for (int det = 0; det < kNdet; ++det) {
+    for (int det = 0; det < MAXCHAMBER; ++det) {
       const auto& signalMap = collection[det]; //--> a map with active pads only for this chamber
       for (const auto& signal : signalMap) {   // loop over active pads only, if there is any
         const int& key = signal.first;
@@ -222,7 +223,7 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits
   int status = triggerEventProcessing(digits, labels);
 
   // Get the a hit container for all the hits in a given detector then call convertHits for a given detector (0 - 539)
-  std::array<std::vector<HitType>, kNdet> hitsPerDetector;
+  std::array<std::vector<HitType>, MAXCHAMBER> hitsPerDetector;
   getHitContainerPerDetector(hits, hitsPerDetector);
 
 #ifdef WITH_OPENMP
@@ -230,7 +231,7 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits
 // Loop over all TRD detectors (in a parallel fashion)
 #pragma omp parallel for schedule(dynamic)
 #endif
-  for (int det = 0; det < kNdet; ++det) {
+  for (int det = 0; det < MAXCHAMBER; ++det) {
 #ifdef WITH_OPENMP
     const int threadid = omp_get_thread_num();
 #else
@@ -258,10 +259,10 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits
   }
 }
 
-void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, kNdet>& hitsPerDetector)
+void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, MAXCHAMBER>& hitsPerDetector)
 {
   //
-  // Fill an array of size kNdet (540)
+  // Fill an array of size MAXCHAMBER (540)
   // The i-element of the array contains the hit collection for the i-detector
   // To be called once, before doing the loop over all detectors and process the hits
   //

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -23,6 +23,7 @@
 #include "DataFormatsTRD/LinkRecord.h"
 #include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Constants.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RawFileWriter.h"
 #include "TRDSimulation/Trap2CRU.h"
@@ -185,7 +186,7 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& TrigRecord)
   for (int halfcru = 0; halfcru < NumberOfHalfCRU; halfcru++) {     //TODO come back and replace 72 with something.
                                                                     //   TrackletHC
     memset(&mRawData[0], 0, sizeof(mRawData[0]) * mRawData.size()); //   zero the rawdata storage
-    int numberofdetectors = o2::trd::kNdet;
+    int numberofdetectors = o2::trd::constants::MAXCHAMBER;
     HalfCRUHeader halfcruheader;
     //now write the cruheader at the head of all the data for this halfcru.
     LOG(debug) << "cru before building cruheader for halfcru index : " << halfcru << " with contents \n"

--- a/Detectors/TRD/simulation/src/TrapConfig.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfig.cxx
@@ -19,6 +19,7 @@
 #include "TRDBase/TRDGeometry.h"
 #include "TRDBase/FeeParam.h"
 #include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/Constants.h"
 #include <fairlogger/Logger.h>
 
 #include <fstream>
@@ -28,6 +29,7 @@
 
 using namespace std;
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 bool TrapConfig::mgRegAddressMapInitialized = false;
 
@@ -663,9 +665,9 @@ bool TrapConfig::printTrapReg(TrapReg_t reg, int det, int rob, int mcm)
   // print the value stored in the given register
   // if it is individual a valid MCM has to be specified
 
-  if ((det >= 0 && det < kNdet) &&
-      (rob >= 0 && rob < FeeParam::getNrobC1()) &&
-      (mcm >= 0 && mcm < FeeParam::getNmcmRob() + 2)) {
+  if ((det >= 0 && det < MAXCHAMBER) &&
+      (rob >= 0 && rob < NROBC1) &&
+      (mcm >= 0 && mcm < NMCMROB + 2)) {
     LOG(info) << getRegName((TrapReg_t)reg) << "(" << std::setw(2) << getRegNBits((TrapReg_t)reg)
               << " bits) at 0x" << hex << std::setw(4) << getRegAddress((TrapReg_t)reg)
               << " is 0x" << hex << std::setw(8) << mRegisterValue[reg].getValue(det, rob, mcm)
@@ -999,7 +1001,7 @@ void TrapConfig::configureOnlineGains()
 {
   // we dont want to do this anymore .... but here for future reference.
   /* if (hasOnlineFilterGain()) {
-    const int nDets = kNdet;
+    const int nDets = MAXCHAMBER;
     const int nMcms = TRDGeometry::MCMmax();
     const int nChs = TRDGeometry::ADCmax();
 
@@ -1011,8 +1013,8 @@ void TrapConfig::configureOnlineGains()
     }
 
     for (int iDet = 0; iDet < nDets; ++iDet) {
-      //const int MaxRows = TRDGeometry::getStack(iDet) == 2 ? FeeParam::mgkNrowC0 : FeeParam::mgkNrowC1;
-      int MaxCols = FeeParam::mgkNcol;
+      //const int MaxRows = TRDGeometry::getStack(iDet) == 2 ? NROWC0 : NROWC1;
+      int MaxCols = NCOLUMN;
       //	CalOnlineGainTableROC gainTbl = mGainTable.getGainTableROC(iDet);
       const int nRobs = TRDGeometry::getStack(iDet) == 2 ? TRDGeometry::ROBmaxC0() : TRDGeometry::ROBmaxC1();
 

--- a/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
@@ -28,12 +28,14 @@
 #include "TRDSimulation/TrapConfigHandler.h"
 #include "TRDSimulation/TrapConfig.h"
 #include "TRDSimulation/TrapSimulator.h"
+#include "DataFormatsTRD/Constants.h"
 #include "TMath.h"
 #include "TGeoMatrix.h"
 #include "TGraph.h"
 
 using namespace std;
 using namespace o2::trd;
+using namespace o2::trd::constants;
 
 TrapConfigHandler::TrapConfigHandler(TrapConfig* cfg) : mFeeParam(), mRestrictiveMask((0x3ffff << 11) | (0x1f << 6) | 0x3f), mTrapConfig(cfg), mGtbl()
 {
@@ -276,7 +278,7 @@ int TrapConfigHandler::loadConfig(std::string filename)
     if (cmd != 999 && addr != -1 && extali != -1) {
 
       if (cmd == mgkScsnCmdWrite) {
-        for (int det = 0; det < kNdet; det++) {
+        for (int det = 0; det < MAXCHAMBER; det++) {
           unsigned int rocpos = (1 << (TRDGeometry::getSector(det) + 11)) | (1 << (TRDGeometry::getStack(det) + 6)) | (1 << TRDGeometry::getLayer(det));
           LOG(debug) << "checking restriction: mask=0x" << hex << std::setw(8) << mRestrictiveMask << " rocpos=0x" << hex << std::setw(8) << rocpos;
           if ((mRestrictiveMask & rocpos) == rocpos) {
@@ -304,7 +306,7 @@ int TrapConfigHandler::loadConfig(std::string filename)
       else if (cmd == mgkScsnCmdSetHC) {
         int fullVersion = ((data & 0x7F00) >> 1) | (data & 0x7f);
 
-        for (int iDet = 0; iDet < kNdet; iDet++) {
+        for (int iDet = 0; iDet < MAXCHAMBER; iDet++) {
           int smls = (TRDGeometry::getSector(iDet) << 6) | (TRDGeometry::getLayer(iDet) << 3) | TRDGeometry::getStack(iDet);
 
           for (int iRob = 0; iRob < 8; iRob++) {
@@ -383,7 +385,7 @@ void TrapConfigHandler::processLTUparam(int dest, int addr, unsigned int data)
   switch (dest) {
 
     case 0: // set the parameters in TrapConfig
-      for (int det = 0; det < kNdet; det++) {
+      for (int det = 0; det < MAXCHAMBER; det++) {
         configureDyCorr(det);
         configureDRange(det);    // deflection range
         configureNTimebins(det); // timebins in the drift region
@@ -551,10 +553,10 @@ void TrapConfigHandler::configurePIDcorr(int det)
   int MaxRows;
   FeeParam* feeparam = FeeParam::instance();
   if (TRDGeometry::getStack(det) == 2)
-    MaxRows = FeeParam::mgkNrowC0;
+    MaxRows = NROWC0;
   else
-    MaxRows = FeeParam::mgkNrowC1;
-  int MaxCols = FeeParam::mgkNcol;
+    MaxRows = NROWC1;
+  int MaxCols = NCOLUMN;
   for (int row = 0; row < MaxRows; row++) { //TODO put this back to rob/mcm and not row/col as done in TrapSimulator
     for (int col = 0; col < MaxCols; col++) {
       readoutboard = feeparam->getROBfromPad(row, col);

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -54,6 +54,7 @@
 
 using namespace o2::trd;
 using namespace std;
+using namespace o2::trd::constants;
 
 #define DEBUGTRAP 1
 
@@ -99,16 +100,16 @@ void TrapSimulator::init(TrapConfig* trapconfig, int det, int robPos, int mcmPos
 
   if (!mInitialized) {
     mNTimeBin = mTrapConfig->getTrapReg(TrapConfig::kC13CPUA, mDetector, mRobPos, mMcmPos);
-    mZSMap.resize(FeeParam::getNadcMcm());
+    mZSMap.resize(NADCMCM);
 
     // tracklet calculation
-    //now a 25 slot array mFitReg.resize(FeeParam::getNadcMcm()); //TODO for now this is constant size in an array not a vector
+    //now a 25 slot array mFitReg.resize(NADCMCM); //TODO for now this is constant size in an array not a vector
     //  mTrackletArray-.resize(mgkMaxTracklets);
     //now a 100 slot array as per run2  mHits.resize(50);
     mMCMT.resize(mgkMaxTracklets);
 
-    mADCR.resize(mNTimeBin * FeeParam::getNadcMcm());
-    mADCF.resize(mNTimeBin * FeeParam::getNadcMcm());
+    mADCR.resize(mNTimeBin * NADCMCM);
+    mADCF.resize(mNTimeBin * NADCMCM);
   }
 
   mInitialized = true;
@@ -140,7 +141,7 @@ void TrapSimulator::reset()
   for (auto filterreg : mInternalFilterRegisters)
     filterreg.ClearReg();
   // Default unread, low active bit mask
-  memset(&mZSMap[0], 0, sizeof(mZSMap[0]) * FeeParam::getNadcMcm());
+  memset(&mZSMap[0], 0, sizeof(mZSMap[0]) * NADCMCM);
   memset(&mMCMT[0], 0, sizeof(mMCMT[0]) * mgkMaxTracklets);
   //mDict1.clear();
   //mDict2.clear();
@@ -194,25 +195,25 @@ std::ostream& o2::trd::operator<<(std::ostream& os, const TrapSimulator& mcm)
 
     os << "----- Unfiltered ADC data (10 bit) -----" << std::endl;
     os << "ch    ";
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+    for (int iChannel = 0; iChannel < NADCMCM; iChannel++)
       os << std::setw(5) << iChannel;
     os << std::endl;
     for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
       os << "tb " << std::setw(2) << iTimeBin << ":";
-      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
         os << std::setw(5) << (mcm.getDataRaw(iChannel, iTimeBin) >> mcm.mgkAddDigits);
       }
       os << std::endl;
     }
     os << "----- Filtered ADC data (10+2 bit) -----" << std::endl;
     os << "ch    ";
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+    for (int iChannel = 0; iChannel < NADCMCM; iChannel++)
       os << std::setw(4) << iChannel
          << ((~mcm.getZeroSupressionMap(iChannel) != 0) ? "!" : " ");
     os << std::endl;
     for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
       os << "tb " << std::setw(2) << iTimeBin << ":";
-      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
         os << std::setw(4) << (mcm.getDataFiltered(iChannel, iTimeBin))
            << (((mcm.getZeroSupressionMap(iChannel) & (1 << iTimeBin)) == 0) ? "!" : " ");
       }
@@ -227,7 +228,7 @@ std::ostream& o2::trd::operator<<(std::ostream& os, const TrapSimulator& mcm)
     int addrStep = 0x80;
 
     for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
-      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
         os << std::setw(5) << 10
            << std::setw(5) << addrOffset + iChannel * addrStep + iTimeBin
            << std::setw(5) << (mcm.getDataFiltered(iChannel, iTimeBin))
@@ -353,7 +354,7 @@ void TrapSimulator::printAdcDatTxt(ostream& os) const
   os << "# MCM " << mMcmPos << " on ROB " << mRobPos << " in detector " << mDetector << std::endl;
 
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); ++iChannel) {
+    for (int iChannel = 0; iChannel < NADCMCM; ++iChannel) {
       os << std::setw(5) << (getDataRaw(iChannel, iTimeBin) >> mgkAddDigits);
     }
     os << std::endl;
@@ -368,12 +369,12 @@ void TrapSimulator::printAdcDatHuman(ostream& os) const
 
   os << "----- Unfiltered ADC data (10 bit) -----" << std::endl;
   os << "ch    ";
-  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+  for (int iChannel = 0; iChannel < NADCMCM; iChannel++)
     os << std::setw(5) << iChannel;
   os << std::endl;
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
     os << "tb " << std::setw(2) << iTimeBin << ":";
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+    for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
       os << std::setw(5) << (getDataRaw(iChannel, iTimeBin) >> mgkAddDigits);
     }
     os << std::endl;
@@ -381,13 +382,13 @@ void TrapSimulator::printAdcDatHuman(ostream& os) const
 
   os << "----- Filtered ADC data (10+2 bit) -----" << std::endl;
   os << "ch    ";
-  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+  for (int iChannel = 0; iChannel < NADCMCM; iChannel++)
     os << std::setw(4) << iChannel
        << ((~mZSMap[iChannel] != 0) ? "!" : " ");
   os << std::endl;
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
     os << "tb " << std::setw(2) << iTimeBin << ":";
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+    for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
       os << std::setw(4) << (getDataFiltered(iChannel, iTimeBin))
          << (((mZSMap[iChannel] & (1 << iTimeBin)) == 0) ? "!" : " ");
     }
@@ -407,7 +408,7 @@ void TrapSimulator::printAdcDatXml(ostream& os) const
   os << " <ro-board rob=\"" << mRobPos << "\">" << std::endl;
   os << "  <m mcm=\"" << mMcmPos << "\">" << std::endl;
 
-  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+  for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
     os << "   <ch chnr=\"" << iChannel << "\">" << std::endl;
     for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
       os << "<tb>" << mADCF[iChannel * mNTimeBin + iTimeBin] / 4 << "</tb>";
@@ -435,7 +436,7 @@ void TrapSimulator::printAdcDatDatx(ostream& os, bool broadcast, int timeBinOffs
   int addrOffsetEBSIA = 0x20;
 
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+    for (int iChannel = 0; iChannel < NADCMCM; iChannel++) {
       if ((iTimeBin < timeBinOffset) || (iTimeBin >= mNTimeBin + timeBinOffset)) {
         if (broadcast == false)
           mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, 10, getRobPos(), getMcmPos());
@@ -485,7 +486,7 @@ void TrapSimulator::setNTimebins(int ntimebins)
     return;
 
   mNTimeBin = ntimebins;
-  // for( int iAdc = 0 ; iAdc < FeeParam::getNadcMcm(); iAdc++ ) {
+  // for( int iAdc = 0 ; iAdc < NADCMCM; iAdc++ ) {
   //  delete [] mADCR[iAdc];
   //  delete [] mADCF[iAdc];
   //  mADCR[iAdc] = new int[mNTimeBin];
@@ -674,9 +675,9 @@ void TrapSimulator::draw(int choice, int index)
   TCanvas* c1 = new TCanvas(Form("canvas_%i_%i:%i:%i_%i", index, mDetector, mRobPos, mMcmPos, (int)mTrackletArray.size()));
   TH2F* hist = new TH2F(Form("mcmdata_%i", index),
                         Form("Data of MCM %i on ROB %i in detector %i ", mMcmPos, mRobPos, mDetector),
-                        FeeParam::getNadcMcm(),
+                        NADCMCM,
                         -0.5,
-                        FeeParam::getNadcMcm() - 0.5,
+                        NADCMCM - 0.5,
                         getNumberOfTimeBins(),
                         -0.5,
                         getNumberOfTimeBins() - 0.5);
@@ -685,9 +686,9 @@ void TrapSimulator::draw(int choice, int index)
   hist->SetStats(false);
   TH2F* histfiltered = new TH2F(Form("mcmdataf_%i", index),
                                 Form("Data of MCM %i on ROB %i in detector %i filtered", mMcmPos, mRobPos, mDetector),
-                                FeeParam::getNadcMcm(),
+                                NADCMCM,
                                 -0.5,
-                                FeeParam::getNadcMcm() - 0.5,
+                                NADCMCM - 0.5,
                                 getNumberOfTimeBins(),
                                 -0.5,
                                 getNumberOfTimeBins() - 0.5);
@@ -696,14 +697,14 @@ void TrapSimulator::draw(int choice, int index)
 
   if ((choice & PLOTRAW) != 0) {
     for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-      for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+      for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
         hist->SetBinContent(iAdc + 1, iTimeBin + 1, mADCR[iAdc * mNTimeBin + iTimeBin] >> mgkAddDigits);
       }
     }
     hist->Draw("COLZ");
   } else {
     for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-      for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+      for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
         histfiltered->SetBinContent(iAdc + 1, iTimeBin + 1, mADCF[iAdc * mNTimeBin + iTimeBin] >> mgkAddDigits);
       }
     }
@@ -766,8 +767,8 @@ void TrapSimulator::setData(int adc, const ArrayADC& data, std::vector<o2::MCCom
   if (!checkInitialized())
     return;
 
-  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
-    //    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << FeeParam::getNadcMcm() - 1 << ")";
+  if (adc < 0 || adc >= NADCMCM) {
+    //    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << NADCMCM - 1 << ")";
     return;
   }
 
@@ -797,8 +798,8 @@ void TrapSimulator::setData(int adc, int it, int data)
   if (!checkInitialized())
     return;
 
-  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
-    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << FeeParam::getNadcMcm() - 1 << ")";
+  if (adc < 0 || adc >= NADCMCM) {
+    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << NADCMCM - 1 << ")";
     return;
   }
 
@@ -816,7 +817,7 @@ void TrapSimulator::setBaselines()
 
   LOG(info) << "ENTER: " << __FILE__ << ":" << __func__ << ":" << __LINE__ << " for " << mDetector << ":" << mRobPos << ":" << mMcmPos;
   //loop over all adcs.
-  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+  for (int adc = 0; adc < NADCMCM; adc++) {
     LOG(info) << "Setting baselines for adc: " << adc << " of " << mDetector << ":" << mRobPos << ":" << mMcmPos << hex << mADCFilled << " if of : " << (mADCFilled & (1 << adc));
     if ((mADCFilled & (1 << adc)) == 0) { // adc is empty by construction of mADCFilled.
       LOG(info) << "past if Setting baselines for adc: " << adc << " of " << mDetector << ":" << mRobPos << ":" << mMcmPos;
@@ -837,7 +838,7 @@ void TrapSimulator::setDataPedestal(int adc)
   if (!checkInitialized())
     return;
 
-  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
+  if (adc < 0 || adc >= NADCMCM) {
     return;
   }
 
@@ -880,7 +881,7 @@ int TrapSimulator::getCol(int adc)
     return -1;
 
   int col = mFeeParam->getPadColFromADC(mRobPos, mMcmPos, adc);
-  if (col < 0 || col >= mFeeParam->getNcol())
+  if (col < 0 || col >= NCOLUMN)
     return -1;
   else
     return col;
@@ -907,8 +908,8 @@ int TrapSimulator::packData(std::vector<uint32_t>& rawdata, uint32_t offset)
   mcmhead.oneb = 1;
   mcmhead.onea = 1;
   mcmhead.padrow = ((mRobPos >> 1) << 2) | (mMcmPos >> 2);
-  int mcmcol = mMcmPos % FeeParam::mgkNmcmRobInCol + (mRobPos % 2) * FeeParam::mgkNmcmRobInCol;
-  int padcol = mcmcol * FeeParam::mgkNcolMcm + FeeParam::mgkNcolMcm + 1;
+  int mcmcol = mMcmPos % NMCMROBINCOL + (mRobPos % 2) * NMCMROBINCOL;
+  int padcol = mcmcol * NCOLMCM + NCOLMCM + 1;
   mcmhead.col = 1; //TODO check this, cant call FeeParam due to virtual function
   LOG(debug) << "packing data with trackletarry64 size of : " << mTrackletArray64.size();
   for (int i = 0; i < 3; i++) {
@@ -1005,7 +1006,7 @@ int TrapSimulator::getRawStream(std::vector<uint32_t>& buf, uint32_t offset, uns
   if (rawVer >= 3 &&
       (mTrapConfig->getTrapReg(TrapConfig::kC15CPUA, mDetector, mRobPos, mMcmPos) & (1 << 13))) { // check for zs flag in TRAP configuration
     int nActiveADC = 0;                                                                           // number numberOverFlowWordsWritten activated ADC bits in a word
-    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+    for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
       if (~mZSMap[iAdc] != 0) {       //  0 means not suppressed
         adcMask |= (1 << (iAdc + 4)); // last 4 digit reserved for 1100=0xc
         nActiveADC++;                 // number numberOverFlowWordsWritten 1 in mmm....m
@@ -1123,7 +1124,7 @@ void TrapSimulator::filterPedestalInit(int baseline)
 
   unsigned short fptc = mTrapConfig->getTrapReg(TrapConfig::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
 
-  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++)
+  for (int adc = 0; adc < NADCMCM; adc++)
     mInternalFilterRegisters[adc].mPedAcc = (baseline << 2) * (1 << mgkFPshifts[fptc]);
   //  LOG(info) << "LEAVE: " << __FILE__ << ":" << __func__ << ":" << __LINE__ ;
 }
@@ -1179,7 +1180,7 @@ void TrapSimulator::filterPedestal()
   // LOG(info) << "BEGIN: " << __FILE__ << ":" << __func__ << ":" << __LINE__ ;
 
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+    for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
       int oldadc = mADCF[iAdc * mNTimeBin + iTimeBin];
       mADCF[iAdc * mNTimeBin + iTimeBin] = filterPedestalNextSample(iAdc, iTimeBin, mADCR[iAdc * mNTimeBin + iTimeBin]);
       //    LOG(info) << "mADCF : time : " << iTimeBin << " adc : " << iAdc << " change : " << oldadc << " -> " << mADCF[iAdc * mNTimeBin + iTimeBin];
@@ -1193,7 +1194,7 @@ void TrapSimulator::filterGainInit()
   // Initializes the gain filter. In this case, only threshold
   // counters are reset.
 
-  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+  for (int adc = 0; adc < NADCMCM; adc++) {
     // these are counters which in hardware continue
     // until maximum or reset
     mInternalFilterRegisters[adc].mGainCounterA = 0;
@@ -1256,7 +1257,7 @@ void TrapSimulator::filterGain()
 {
   // Read data from mADCF and apply gain filter.
 
-  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+  for (int adc = 0; adc < NADCMCM; adc++) {
     for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
       mADCF[adc * mNTimeBin + iTimeBin] = filterGainNextSample(adc, mADCF[adc * mNTimeBin + iTimeBin]);
     }
@@ -1290,7 +1291,7 @@ void TrapSimulator::filterTailInit(int baseline)
   ql = lambdaL * (1 - lambdaS) * alphaL;
   qs = lambdaS * (1 - lambdaL) * (1 - alphaL);
 
-  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+  for (int adc = 0; adc < NADCMCM; adc++) {
     int value = baseline & 0xFFF;
     int corr = (value * mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), mDetector, mRobPos, mMcmPos)) >> 11;
     corr = corr > 0xfff ? 0xfff : corr;
@@ -1357,7 +1358,7 @@ void TrapSimulator::filterTail()
   // Apply tail cancellation filter to all data.
 
   for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
-    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+    for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
       mADCF[iAdc * mNTimeBin + iTimeBin] = filterTailNextSample(iAdc, mADCF[iAdc * mNTimeBin + iTimeBin]);
     }
   }
@@ -1381,7 +1382,7 @@ void TrapSimulator::zeroSupressionMapping()
   int eBIL = mTrapConfig->getTrapReg(TrapConfig::kEBIL, mDetector, mRobPos, mMcmPos);
   int eBIN = mTrapConfig->getTrapReg(TrapConfig::kEBIN, mDetector, mRobPos, mMcmPos);
 
-  for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++)
+  for (int iAdc = 0; iAdc < NADCMCM; iAdc++)
     mZSMap[iAdc] = -1;
 
   for (int it = 0; it < mNTimeBin; it++) {
@@ -1411,7 +1412,7 @@ void TrapSimulator::zeroSupressionMapping()
     }
 
     // ----- last channel -----
-    iAdc = FeeParam::getNadcMcm() - 1;
+    iAdc = NADCMCM - 1;
 
     ap = mADCF[(iAdc - 1) * mNTimeBin + it] >> mgkAddDigits; // previous
     ac = mADCF[iAdc * mNTimeBin + it] >> mgkAddDigits;       // current
@@ -1429,7 +1430,7 @@ void TrapSimulator::zeroSupressionMapping()
     }
 
     // ----- middle channels -----
-    for (iAdc = 1; iAdc < FeeParam::getNadcMcm() - 1; iAdc++) {
+    for (iAdc = 1; iAdc < NADCMCM - 1; iAdc++) {
       ap = mADCF[(iAdc - 1) * mNTimeBin + it] >> mgkAddDigits; // previous
       ac = mADCF[iAdc * mNTimeBin + it] >> mgkAddDigits;       // current
       an = mADCF[(iAdc + 1) * mNTimeBin + it] >> mgkAddDigits; // next
@@ -1563,7 +1564,7 @@ void TrapSimulator::calcFitreg()
   for (timebin = timebin1; timebin < timebin2; timebin++) {
     // first find the hit candidates and store the total cluster charge in qTotal array
     // in case of not hit store 0 there.
-    for (adcch = 0; adcch < FeeParam::getNadcMcm() - 2; adcch++) {
+    for (adcch = 0; adcch < NADCMCM - 2; adcch++) {
       if (((adcMask >> adcch) & 7) == 7) //??? all 3 channels are present in case of ZS
       {
         adcLeft = mADCF[adcch * mNTimeBin + timebin];
@@ -1729,8 +1730,8 @@ void TrapSimulator::calcFitreg()
       }
     }
   }
-  /* 
-       for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+  /*
+       for (int iAdc = 0; iAdc < NADCMCM; iAdc++) {
        if (mFitReg[iAdc].mNhits != 0) {
        LOG(debug) << "fitreg[" << iAdc << "]: nHits = " << mFitReg[iAdc].mNhits << "]: sumX = " << mFitReg[iAdc].mSumX << ", sumY = " << mFitReg[iAdc].mSumY << ", sumX2 = " << mFitReg[iAdc].mSumX2 << ", sumY2 = " << mFitReg[iAdc].mSumY2 << ", sumXY = " << mFitReg[iAdc].mSumXY;
        }
@@ -2529,4 +2530,3 @@ bool TrapSimulator::readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data
   LOG(debug) << "no end marker! " << idx << " words read";
   return -err; // only if the max length of the block reached!
 }
-

--- a/EventVisualisation/Detectors/src/DataInterpreterTPC.cxx
+++ b/EventVisualisation/Detectors/src/DataInterpreterTPC.cxx
@@ -67,8 +67,8 @@ std::unique_ptr<VisualisationEvent> DataInterpreterTPC::interpretDataForType(TOb
     const auto& mapper = tpc::Mapper::instance();
     const auto& clusterRefs = access->clusters;
 
-    for (int sector = 0; sector < o2::tpc::Constants::MAXSECTOR; sector++) {
-      for (int row = 0; row < o2::tpc::Constants::MAXGLOBALPADROW; row++) {
+    for (int sector = 0; sector < o2::tpc::constants::MAXSECTOR; sector++) {
+      for (int row = 0; row < o2::tpc::constants::MAXGLOBALPADROW; row++) {
         const auto& c = clusterRefs[sector][row];
 
         const auto pad = mapper.globalPadNumber(tpc::PadPos(row, c->getPad()));

--- a/GPU/Common/GPUDefConstantsAndSettings.h
+++ b/GPU/Common/GPUDefConstantsAndSettings.h
@@ -61,8 +61,8 @@
 #if defined(HAVE_O2HEADERS) && (!defined(__OPENCL__) || defined(__OPENCLCPP__)) && !(defined(ROOT_VERSION_CODE) && ROOT_VERSION_CODE < 393216)
   //Use definitions from the O2 headers if available for nicer code and type safety
   #include "DataFormatsTPC/Constants.h"
-  #define GPUCA_NSLICES o2::tpc::Constants::MAXSECTOR
-  #define GPUCA_ROW_COUNT o2::tpc::Constants::MAXGLOBALPADROW
+  #define GPUCA_NSLICES o2::tpc::constants::MAXSECTOR
+  #define GPUCA_ROW_COUNT o2::tpc::constants::MAXGLOBALPADROW
 #else
   //Define it manually, if O2 headers not available, ROOT5, and OpenCL 1.2, which do not know C++11.
   #define GPUCA_NSLICES 36

--- a/GPU/GPUTracking/Base/GPUHostDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUHostDataTypes.h
@@ -38,7 +38,7 @@ namespace gpu
 {
 
 struct GPUTPCDigitsMCInput {
-  std::array<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*, o2::tpc::Constants::MAXSECTOR> v;
+  std::array<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR> v;
 };
 
 struct GPUTPCClusterMCInterim {

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -40,6 +40,7 @@
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 
 void GPUReconstructionConvert::ConvertNativeToClusterData(o2::tpc::ClusterNativeAccess* native, std::unique_ptr<GPUTPCClusterData[]>* clusters, unsigned int* nClusters, const TPCFastTransform* transform, int continuousMaxTimeBin)
 {
@@ -160,7 +161,7 @@ int GPUReconstructionConvert::GetMaxTimeBin(const GPUTrackingInOutZS& zspages)
         for (unsigned int l = 0; l < zspages.slice[i].nZSPtr[j][k]; l++) {
           RAWDataHeaderGPU* rdh = (RAWDataHeaderGPU*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE);
           TPCZSHDR* hdr = (TPCZSHDR*)(page + l * TPCZSHDR::TPC_ZS_PAGE_SIZE + sizeof(RAWDataHeaderGPU));
-          unsigned int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN + hdr->nTimeBins;
+          unsigned int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN + hdr->nTimeBins;
           if (timeBin > retVal) {
             retVal = timeBin;
           }
@@ -308,7 +309,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           lastEndpoint = -1;
         }
         if (ZSEncoderGetTime(tmpBuffer[k]) != lastTime) {
-          nexthbf = ((long)ZSEncoderGetTime(tmpBuffer[k]) * Constants::LHCBCPERTIMEBIN + bcShiftInFirstHBF) / o2::constants::lhc::LHCMaxBunches;
+          nexthbf = ((long)ZSEncoderGetTime(tmpBuffer[k]) * LHCBCPERTIMEBIN + bcShiftInFirstHBF) / o2::constants::lhc::LHCMaxBunches;
           if (hbf != nexthbf) {
             lastEndpoint = -2;
           }
@@ -389,7 +390,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         hdr->cruID = i * 10 + region;
         rawcru = i * 10 + region;
         rawendpoint = endpoint & 1;
-        hdr->timeOffset = ZSEncoderGetTime(tmpBuffer[k]) * Constants::LHCBCPERTIMEBIN - (hbf - 0) * o2::constants::lhc::LHCMaxBunches;
+        hdr->timeOffset = ZSEncoderGetTime(tmpBuffer[k]) * LHCBCPERTIMEBIN - (hbf - 0) * o2::constants::lhc::LHCMaxBunches;
         lastTime = -1;
         tbHdr = nullptr;
         lastEndpoint = endpoint;
@@ -474,7 +475,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           }
           int nRowsRegion = param.tpcGeometry.GetRegionRows(region);
 
-          int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstOrbit) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
+          int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstOrbit) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
           for (int l = 0; l < hdr->nTimeBins; l++) {
             if ((pagePtr - reinterpret_cast<unsigned char*>(page)) & 1) {
               pagePtr++;

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -70,6 +70,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 
 using namespace o2::tpc;
 using namespace o2::trd;
+using namespace o2::tpc::constants;
 
 namespace GPUCA_NAMESPACE
 {
@@ -483,7 +484,7 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
           continue;
         }
         const TPCZSHDR* const hdr = (const TPCZSHDR*)(page + sizeof(RAWDataHeaderGPU));
-        unsigned int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
+        unsigned int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
         for (unsigned int m = 0; m < 2; m++) {
           CfFragment& fm = m ? fNext : f;
           if (timeBin + hdr->nTimeBins >= (unsigned int)fm.first() && timeBin < (unsigned int)fm.last() && !fm.isEnd()) {
@@ -1265,7 +1266,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
     bool anyLaneHasData = false;
     for (int lane = 0; lane < GetProcessingSettings().nTPCClustererLanes && iSliceBase + lane < NSLICES; lane++) {
       unsigned int iSlice = iSliceBase + lane;
-      std::fill(&tmpNative->nClusters[iSlice][0], &tmpNative->nClusters[iSlice][0] + tpc::Constants::MAXGLOBALPADROW, 0);
+      std::fill(&tmpNative->nClusters[iSlice][0], &tmpNative->nClusters[iSlice][0] + MAXGLOBALPADROW, 0);
       SynchronizeStream(lane);
       GPUTPCClusterFinder& clusterer = processors()->tpcClusterer[iSlice];
       GPUTPCClusterFinder& clustererShadow = doGPU ? processorsShadow()->tpcClusterer[iSlice] : clusterer;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -107,8 +107,8 @@ struct GPUO2InterfaceConfiguration {
 struct GPUO2InterfaceIOPtrs {
   // Input: TPC clusters in cluster native format, or digits, or list of ZS pages -  const as it can only be input
   const o2::tpc::ClusterNativeAccess* clusters = nullptr;
-  const std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::Constants::MAXSECTOR>* o2Digits = nullptr;
-  std::array<std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>>, o2::tpc::Constants::MAXSECTOR>* o2DigitsMC = nullptr;
+  const std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::constants::MAXSECTOR>* o2Digits = nullptr;
+  std::array<std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>>, o2::tpc::constants::MAXSECTOR>* o2DigitsMC = nullptr;
   const o2::gpu::GPUTrackingInOutZS* tpcZS = nullptr;
 
   // Input / Output for Merged TPC tracks, two ptrs, for the tracks themselves, and for the MC labels.

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDecodeZS.cxx
@@ -24,6 +24,7 @@
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace GPUCA_NAMESPACE::gpu::tpccf;
 using namespace o2::tpc;
+using namespace o2::tpc::constants;
 
 template <>
 GPUdii() void GPUTPCCFDecodeZS::Thread<GPUTPCCFDecodeZS::decodeZS>(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, int firstHBF)
@@ -87,7 +88,7 @@ GPUdii() void GPUTPCCFDecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUShared
       const unsigned int decodeBits = decode12bit ? TPCZSHDR::TPC_ZS_NBITS_V2 : TPCZSHDR::TPC_ZS_NBITS_V1;
       const float decodeBitsFactor = 1.f / (1 << (decodeBits - 10));
       unsigned int mask = (1 << decodeBits) - 1;
-      int timeBin = (hdr->timeOffset + (GPURawDataUtils::getOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / Constants::LHCBCPERTIMEBIN;
+      int timeBin = (hdr->timeOffset + (GPURawDataUtils::getOrbit(rdh) - firstHBF) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
       const int rowOffset = s.regionStartRow + ((endpoint & 1) ? (s.nRowsRegion / 2) : 0);
       const int nRows = (endpoint & 1) ? (s.nRowsRegion - s.nRowsRegion / 2) : (s.nRowsRegion / 2);
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
@@ -49,6 +49,7 @@ class TObjArray;
 #include "GPUDef.h"
 #include "TRDBase/TRDGeometryFlat.h"
 #include "TRDBase/TRDPadPlane.h"
+#include "DataFormatsTRD/Constants.h"
 #include "GPUCommonTransform3D.h"
 
 namespace GPUCA_NAMESPACE
@@ -98,7 +99,7 @@ class GPUTRDGeometry : private o2::trd::TRDGeometryFlat
   GPUd() int GetRowMax(int layer, int stack, int sector) const { return getRowMax(layer, stack, sector); }
   GPUd() bool ChamberInGeometry(int det) const { return chamberInGeometry(det); }
 
-  static constexpr int kNstack = o2::trd::kNstack;
+  static constexpr int kNstack = o2::trd::constants::NSTACK;
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -74,8 +74,8 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
   bool doMC = true;
 
   TFile fin(inputFile);
-  for (int i = 0; i < Constants::MAXSECTOR; i++) {
-    for (int j = 0; j < Constants::MAXGLOBALPADROW; j++) {
+  for (int i = 0; i < o2::tpc::constants::MAXSECTOR; i++) {
+    for (int j = 0; j < o2::tpc::constants::MAXGLOBALPADROW; j++) {
       TString contName = Form("clusters_sector_%d_row_%d", i, j);
       TObject* tmp = fin.FindObjectAny(contName);
       if (tmp == nullptr) {


### PR DESCRIPTION
Hi @jolopezl @bazinski and @tdietel 

I was going through the TRD code in O2 and noticed that some fixed constants of the TRD (Nlayers, Nstacks, ...) are defined quite often in different header files. Shall we collect these constants and add them to a separate header file? The TPC is doing the same and it would make our code more readable I think.
I could replace all obsolete definitions, but I don't want to mess around with the same files that you are working on. Please let me know what you think.

Cheers,
Ole