### PR TITLE
DPL: fix ServiceRegistry::active method when service is just declared (O2-1638)

### DIFF
--- a/Framework/Core/include/Framework/ServiceRegistry.h
+++ b/Framework/Core/include/Framework/ServiceRegistry.h
@@ -218,6 +218,9 @@ struct ServiceRegistry {
     constexpr auto typeHash = TypeIdHelpers::uniqueId<T>();
     auto tid = std::this_thread::get_id();
     std::hash<std::thread::id> hasher;
+    if (this->getPos(typeHash, 0) != -1) {
+      return true;
+    }
     auto result = this->getPos(typeHash, hasher(tid)) != -1;
     return result;
   }

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -190,7 +190,7 @@ o2::framework::ServiceSpec CommonServices::configurationSpec()
     nullptr,
     nullptr,
     nullptr,
-    ServiceKind::Serial};
+    ServiceKind::Global};
 }
 
 o2::framework::ServiceSpec CommonServices::controlSpec()

--- a/Framework/Core/test/test_Services.cxx
+++ b/Framework/Core/test/test_Services.cxx
@@ -14,7 +14,10 @@
 #include "Framework/ServiceHandle.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/CallbackService.h"
+#include "Framework/CommonServices.h"
+#include <Framework/DeviceState.h>
 #include <boost/test/unit_test.hpp>
+#include <options/FairMQProgOptions.h>
 #include <iostream>
 #include <memory>
 
@@ -55,6 +58,9 @@ BOOST_AUTO_TEST_CASE(TestServiceRegistry)
   BOOST_CHECK(registry.get<InterfaceA>().method() == true);
   BOOST_CHECK(registry.get<InterfaceB>().method() == false);
   BOOST_CHECK(registry.get<InterfaceC const>().method() == false);
+  BOOST_CHECK(registry.active<InterfaceA>() == true);
+  BOOST_CHECK(registry.active<InterfaceB>() == true);
+  BOOST_CHECK(registry.active<InterfaceC>() == false);
   BOOST_CHECK_THROW(registry.get<InterfaceA const>(), std::runtime_error);
   BOOST_CHECK_THROW(registry.get<InterfaceC>(), std::runtime_error);
 }
@@ -160,4 +166,20 @@ BOOST_AUTO_TEST_CASE(TestServiceRegistryCtor)
   using namespace o2::framework;
   ServiceRegistry registry;
   registry = ServiceRegistry();
+}
+
+BOOST_AUTO_TEST_CASE(TestServiceDeclaration)
+{
+  using namespace o2::framework;
+  ServiceRegistry registry;
+  DeviceState state;
+  FairMQProgOptions options;
+  options.SetProperty("monitoring-backend", "no-op://");
+  options.SetProperty("infologger-mode", "no-op://");
+  options.SetProperty("infologger-severity", "info");
+  options.SetProperty("configuration", "command-line");
+
+  registry.declareService(CommonServices::callbacksSpec(), state, options);
+  BOOST_CHECK(registry.active<CallbackService>() == true);
+  BOOST_CHECK(registry.active<DummyService>() == false);
 }


### PR DESCRIPTION
Fixes issue where --configuration option was ignored.