### PR TITLE
TRD correct Q2 calculation for TrapSimulator

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -201,6 +201,9 @@ class TrapSimulator
   static const int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
   static const int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
   static const int mgkMaxTracklets = 4;              // maximum number of tracklet-words submitted per MCM (one per CPU)
+  static constexpr int mQ2Startbin = 3;              // Start range of Q2, for now here. TODO pull from a revised TrapConfig?
+  static constexpr int mQ2Endbin = 5;                // End range of Q2, also pull from a revised trapconfig at some point.
+
   std::vector<Tracklet>& getTrackletArray() { return mTrackletArray; }
   std::vector<Tracklet64>& getTrackletArray64() { return mTrackletArray64; }
   void getTracklet64s(std::vector<Tracklet64>& TrackletStore); // place the trapsim 64 bit tracklets nto the incoming vector

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -17,7 +17,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-//#include "TTreeStream.h"
 
 #include "TRDBase/TRDSimParam.h"
 #include "TRDBase/TRDCommonParam.h"
@@ -1470,12 +1469,9 @@ void TrapSimulator::addHitToFitreg(int adc, unsigned short timebin, unsigned sho
       (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos))) {
     mFitReg[adc].mQ1 += qtot;
   }
-
-  if ((timebin > mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos)) &&
-      (timebin > mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos)) &&
-      (timebin < mNTimeBin)) {
+  // Q2 is simply the addition of times from 3 to 5, for now consts in the header file till they come from a config.
+  if (timebin > mQ2Startbin && timebin < mQ2Endbin) {
     mFitReg[adc].mQ2 += qtot;
-    // TODO I am not sure what happens with Q2, for now just assume its the rest of the time windows after Q0 and Q1 and before the end of the time bins.
   }
 
   if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos)) &&


### PR DESCRIPTION
Correct the calculation of Q2 for the PID.
The sum from times 3 to 5, as consts in the header file.
New TrapConfig to be finalised still.