### PR TITLE
TPC: Forward digits and digit MC labels to tracking in case of tpc-zs-on-the-fly, so we can create cluster MC labels

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -64,8 +64,8 @@ void GPUCATracking::deinitialize()
 
 int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* outputs)
 {
-  if ((int)(data->tpcZS != nullptr) + (int)(data->o2Digits != nullptr) + (int)(data->clusters != nullptr) + (int)(data->compressedClusters != nullptr) != 1) {
-    return 0;
+  if ((int)(data->tpcZS != nullptr) + (int)(data->o2Digits != nullptr && (data->tpcZS == nullptr || data->o2DigitsMC == nullptr)) + (int)(data->clusters != nullptr) + (int)(data->compressedClusters != nullptr) != 1) {
+    throw std::runtime_error("Invalid input for gpu tracking");
   }
 
   std::vector<TrackTPC>* outputTracks = data->outputTracks;


### PR DESCRIPTION
@fweig : With this PR the tpc workflow can forward both the zs pages and digits + digit mc labels to the tpc clusterizer, as we discussed to create cluster mc labels also in case of zs input (Needs #4140 to work properly).

However, right now there are no TPC cluster MC labels created. I believe we just never tried to do it in this setup, but if I understand the design correctly, we could just run the MC label flattener on the digits and digits MC labels input and then create the MC labels as we do for digits.

Command to run in this mode:
```
o2-tpc-reco-workflow -b --infile tpcdigits.root --output-type clusters,tracks --ca-clusterer --tpc-zs-on-the-fly
```
Could you have a look, and if possible fix that up in a separate PR.