### PR TITLE
[rANS] automatic calculation of rescaling factor

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -784,8 +784,6 @@ void EncodedBlocks<H, N, W>::encode(const S* const srcBegin, // begin of source 
       encoder = encoderLoc.get();
       dictSize = frequencies->size();
     }
-    assert(probabilityBits == encoder->getProbabilityBits());
-    //    const o2::rans::LiteralEncoder64<S> encoder{*frequencies, probabilityBits};
 
     // estimate size of encode buffer
     int dataSize = rans::calculateMaxBufferSize(messageLength, encoder->getAlphabetRangeBits(), sizeof(S));
@@ -811,7 +809,7 @@ void EncodedBlocks<H, N, W>::encode(const S* const srcBegin, // begin of source 
       expandStorage(literalSize);
       bl->storeLiterals(literalSize, reinterpret_cast<const stream_t*>(literals.data()));
     }
-    *meta = Metadata{messageLength, literals.size(), sizeof(uint64_t), sizeof(stream_t), probabilityBits, opt,
+    *meta = Metadata{messageLength, literals.size(), sizeof(uint64_t), sizeof(stream_t), static_cast<uint8_t>(encoder->getProbabilityBits()), opt,
                      encoder->getMinSymbol(), encoder->getMaxSymbol(), dictSize, dataSize, literalSize};
 
   } else { // store original data w/o EEncoding

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
@@ -91,15 +91,15 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Digit>& digitVec, const g
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODEFT0(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODEFT0(cd.trigger,   CTF::BLC_trigger,  o2::rans::ProbabilityBits16Bit);
-  ENCODEFT0(cd.bcInc,     CTF::BLC_bcInc,    o2::rans::ProbabilityBits16Bit);
-  ENCODEFT0(cd.orbitInc,  CTF::BLC_orbitInc, o2::rans::ProbabilityBits16Bit);
-  ENCODEFT0(cd.nChan,     CTF::BLC_nChan,    o2::rans::ProbabilityBits8Bit);
-  //  ENCODEFT0(cd.eventFlags, CTF::BLC_flags,    o2::rans::ProbabilityBits8Bit);
-  ENCODEFT0(cd.idChan ,   CTF::BLC_idChan,   o2::rans::ProbabilityBits8Bit);
-  ENCODEFT0(cd.qtcChain,  CTF::BLC_qtcChain,      o2::rans::ProbabilityBits8Bit);
-  ENCODEFT0(cd.cfdTime,   CTF::BLC_cfdTime,  o2::rans::ProbabilityBits16Bit);
-  ENCODEFT0(cd.qtcAmpl,   CTF::BLC_qtcAmpl,  o2::rans::ProbabilityBits25Bit);
+  ENCODEFT0(cd.trigger,   CTF::BLC_trigger,  0);
+  ENCODEFT0(cd.bcInc,     CTF::BLC_bcInc,    0);
+  ENCODEFT0(cd.orbitInc,  CTF::BLC_orbitInc, 0);
+  ENCODEFT0(cd.nChan,     CTF::BLC_nChan,    0);
+  //  ENCODEFT0(cd.eventFlags, CTF::BLC_flags,    0);
+  ENCODEFT0(cd.idChan ,   CTF::BLC_idChan,   0);
+  ENCODEFT0(cd.qtcChain,  CTF::BLC_qtcChain, 0);
+  ENCODEFT0(cd.cfdTime,   CTF::BLC_cfdTime,  0);
+  ENCODEFT0(cd.qtcAmpl,   CTF::BLC_qtcAmpl,  0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }

--- a/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
@@ -89,13 +89,13 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& digitVec, const 
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODEFV0(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODEFV0(cd.bcInc,     CTF::BLC_bcInc,    o2::rans::ProbabilityBits16Bit);
-  ENCODEFV0(cd.orbitInc,  CTF::BLC_orbitInc, o2::rans::ProbabilityBits16Bit);
-  ENCODEFV0(cd.nChan,     CTF::BLC_nChan,    o2::rans::ProbabilityBits8Bit);
+  ENCODEFV0(cd.bcInc,     CTF::BLC_bcInc,    0);
+  ENCODEFV0(cd.orbitInc,  CTF::BLC_orbitInc, 0);
+  ENCODEFV0(cd.nChan,     CTF::BLC_nChan,    0);
 
-  ENCODEFV0(cd.idChan ,   CTF::BLC_idChan,   o2::rans::ProbabilityBits8Bit);
-  ENCODEFV0(cd.time,      CTF::BLC_time,     o2::rans::ProbabilityBits16Bit);
-  ENCODEFV0(cd.charge,    CTF::BLC_charge,   o2::rans::ProbabilityBits25Bit);
+  ENCODEFV0(cd.idChan ,   CTF::BLC_idChan,   0);
+  ENCODEFV0(cd.time,      CTF::BLC_time,     0);
+  ENCODEFV0(cd.charge,    CTF::BLC_charge,   0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -92,17 +92,17 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, co
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODEITSMFT(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.bcIncROF, CTF::BLCbcIncROF, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.orbitIncROF, CTF::BLCorbitIncROF, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.nclusROF, CTF::BLCnclusROF, o2::rans::ProbabilityBits16Bit);
+  ENCODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF, 0);
+  ENCODEITSMFT(cc.bcIncROF, CTF::BLCbcIncROF, 0);
+  ENCODEITSMFT(cc.orbitIncROF, CTF::BLCorbitIncROF, 0);
+  ENCODEITSMFT(cc.nclusROF, CTF::BLCnclusROF, 0);
   //
-  ENCODEITSMFT(cc.chipInc, CTF::BLCchipInc, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.chipMul, CTF::BLCchipMul, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.row, CTF::BLCrow, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.colInc, CTF::BLCcolInc, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.pattID, CTF::BLCpattID, o2::rans::ProbabilityBits16Bit);
-  ENCODEITSMFT(cc.pattMap, CTF::BLCpattMap, o2::rans::ProbabilityBits16Bit);
+  ENCODEITSMFT(cc.chipInc, CTF::BLCchipInc, 0);
+  ENCODEITSMFT(cc.chipMul, CTF::BLCchipMul, 0);
+  ENCODEITSMFT(cc.row, CTF::BLCrow, 0);
+  ENCODEITSMFT(cc.colInc, CTF::BLCcolInc, 0);
+  ENCODEITSMFT(cc.pattID, CTF::BLCpattID, 0);
+  ENCODEITSMFT(cc.pattMap, CTF::BLCpattMap, 0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -92,16 +92,16 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRe
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODETOF(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODETOF(cc.bcIncROF,     CTF::BLCbcIncROF,     o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF,  o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.ndigROF,      CTF::BLCndigROF,      o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.ndiaROF,      CTF::BLCndiaROF,      o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc, o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc,   o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.stripID,      CTF::BLCstripID,      o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.chanInStrip,  CTF::BLCchanInStrip,  o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.tot,          CTF::BLCtot,          o2::rans::ProbabilityBits16Bit);
-  ENCODETOF(cc.pattMap,      CTF::BLCpattMap,      o2::rans::ProbabilityBits16Bit);
+  ENCODETOF(cc.bcIncROF,     CTF::BLCbcIncROF,     0);
+  ENCODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF,  0);
+  ENCODETOF(cc.ndigROF,      CTF::BLCndigROF,      0);
+  ENCODETOF(cc.ndiaROF,      CTF::BLCndiaROF,      0);
+  ENCODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc, 0);
+  ENCODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc,   0);
+  ENCODETOF(cc.stripID,      CTF::BLCstripID,      0);
+  ENCODETOF(cc.chanInStrip,  CTF::BLCchanInStrip,  0);
+  ENCODETOF(cc.tot,          CTF::BLCtot,          0);
+  ENCODETOF(cc.pattMap,      CTF::BLCpattMap,      0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -110,29 +110,29 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODETPC(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODETPC(ccl.qTotA,             ccl.qTotA + ccl.nAttachedClusters,                CTF::BLCqTotA,             o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.qMaxA,             ccl.qMaxA + ccl.nAttachedClusters,                CTF::BLCqMaxA,             o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.flagsA,            ccl.flagsA + ccl.nAttachedClusters,               CTF::BLCflagsA,            o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.rowDiffA,          ccl.rowDiffA + ccl.nAttachedClustersReduced,      CTF::BLCrowDiffA,          o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.sliceLegDiffA,     ccl.sliceLegDiffA + ccl.nAttachedClustersReduced, CTF::BLCsliceLegDiffA,     o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.padResA,           ccl.padResA + ccl.nAttachedClustersReduced,       CTF::BLCpadResA,           o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.timeResA,          ccl.timeResA + ccl.nAttachedClustersReduced,      CTF::BLCtimeResA,          o2::rans::ProbabilityBits25Bit);
-  ENCODETPC(ccl.sigmaPadA,         ccl.sigmaPadA + ccl.nAttachedClusters,            CTF::BLCsigmaPadA,         o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.sigmaTimeA,        ccl.sigmaTimeA + ccl.nAttachedClusters,           CTF::BLCsigmaTimeA,        o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.qPtA,              ccl.qPtA + ccl.nTracks,                           CTF::BLCqPtA,              o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.rowA,              ccl.rowA + ccl.nTracks,                           CTF::BLCrowA,              o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.sliceA,            ccl.sliceA + ccl.nTracks,                         CTF::BLCsliceA,            o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.timeA,             ccl.timeA + ccl.nTracks,                          CTF::BLCtimeA,             o2::rans::ProbabilityBits25Bit);
-  ENCODETPC(ccl.padA,              ccl.padA + ccl.nTracks,                           CTF::BLCpadA,              o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.qTotU,             ccl.qTotU + ccl.nUnattachedClusters,              CTF::BLCqTotU,             o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.qMaxU,             ccl.qMaxU + ccl.nUnattachedClusters,              CTF::BLCqMaxU,             o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.flagsU,            ccl.flagsU + ccl.nUnattachedClusters,             CTF::BLCflagsU,            o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.padDiffU,          ccl.padDiffU + ccl.nUnattachedClusters,           CTF::BLCpadDiffU,          o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.timeDiffU,         ccl.timeDiffU + ccl.nUnattachedClusters,          CTF::BLCtimeDiffU,         o2::rans::ProbabilityBits25Bit);
-  ENCODETPC(ccl.sigmaPadU,         ccl.sigmaPadU + ccl.nUnattachedClusters,          CTF::BLCsigmaPadU,         o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.sigmaTimeU,        ccl.sigmaTimeU + ccl.nUnattachedClusters,         CTF::BLCsigmaTimeU,        o2::rans::ProbabilityBits8Bit);
-  ENCODETPC(ccl.nTrackClusters,    ccl.nTrackClusters + ccl.nTracks,                 CTF::BLCnTrackClusters,    o2::rans::ProbabilityBits16Bit);
-  ENCODETPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows,           CTF::BLCnSliceRowClusters, o2::rans::ProbabilityBits25Bit);
+  ENCODETPC(ccl.qTotA,             ccl.qTotA + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
+  ENCODETPC(ccl.qMaxA,             ccl.qMaxA + ccl.nAttachedClusters,                CTF::BLCqMaxA,             0);
+  ENCODETPC(ccl.flagsA,            ccl.flagsA + ccl.nAttachedClusters,               CTF::BLCflagsA,            0);
+  ENCODETPC(ccl.rowDiffA,          ccl.rowDiffA + ccl.nAttachedClustersReduced,      CTF::BLCrowDiffA,          0);
+  ENCODETPC(ccl.sliceLegDiffA,     ccl.sliceLegDiffA + ccl.nAttachedClustersReduced, CTF::BLCsliceLegDiffA,     0);
+  ENCODETPC(ccl.padResA,           ccl.padResA + ccl.nAttachedClustersReduced,       CTF::BLCpadResA,           0);
+  ENCODETPC(ccl.timeResA,          ccl.timeResA + ccl.nAttachedClustersReduced,      CTF::BLCtimeResA,          0);
+  ENCODETPC(ccl.sigmaPadA,         ccl.sigmaPadA + ccl.nAttachedClusters,            CTF::BLCsigmaPadA,         0);
+  ENCODETPC(ccl.sigmaTimeA,        ccl.sigmaTimeA + ccl.nAttachedClusters,           CTF::BLCsigmaTimeA,        0);
+  ENCODETPC(ccl.qPtA,              ccl.qPtA + ccl.nTracks,                           CTF::BLCqPtA,              0);
+  ENCODETPC(ccl.rowA,              ccl.rowA + ccl.nTracks,                           CTF::BLCrowA,              0);
+  ENCODETPC(ccl.sliceA,            ccl.sliceA + ccl.nTracks,                         CTF::BLCsliceA,            0);
+  ENCODETPC(ccl.timeA,             ccl.timeA + ccl.nTracks,                          CTF::BLCtimeA,             0);
+  ENCODETPC(ccl.padA,              ccl.padA + ccl.nTracks,                           CTF::BLCpadA,              0);
+  ENCODETPC(ccl.qTotU,             ccl.qTotU + ccl.nUnattachedClusters,              CTF::BLCqTotU,             0);
+  ENCODETPC(ccl.qMaxU,             ccl.qMaxU + ccl.nUnattachedClusters,              CTF::BLCqMaxU,             0);
+  ENCODETPC(ccl.flagsU,            ccl.flagsU + ccl.nUnattachedClusters,             CTF::BLCflagsU,            0);
+  ENCODETPC(ccl.padDiffU,          ccl.padDiffU + ccl.nUnattachedClusters,           CTF::BLCpadDiffU,          0);
+  ENCODETPC(ccl.timeDiffU,         ccl.timeDiffU + ccl.nUnattachedClusters,          CTF::BLCtimeDiffU,         0);
+  ENCODETPC(ccl.sigmaPadU,         ccl.sigmaPadU + ccl.nUnattachedClusters,          CTF::BLCsigmaPadU,         0);
+  ENCODETPC(ccl.sigmaTimeU,        ccl.sigmaTimeU + ccl.nUnattachedClusters,         CTF::BLCsigmaTimeU,        0);
+  ENCODETPC(ccl.nTrackClusters,    ccl.nTrackClusters + ccl.nTracks,                 CTF::BLCnTrackClusters,    0);
+  ENCODETPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows,           CTF::BLCnSliceRowClusters, 0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -93,10 +93,11 @@ Decoder<coder_T, stream_T, source_T>::Decoder(const FrequencyTable& frequencies,
   using namespace internal;
 
   SymbolStatistics stats(frequencies, mProbabilityBits);
+  mProbabilityBits = stats.getSymbolTablePrecision();
 
   RANSTimer t;
   t.start();
-  mSymbolTable = std::make_unique<decoderSymbolTable_t>(stats, mProbabilityBits);
+  mSymbolTable = std::make_unique<decoderSymbolTable_t>(stats);
   t.stop();
   LOG(debug1) << "Decoder SymbolTable inclusive time (ms): " << t.getDurationMS();
   t.start();

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -103,10 +103,11 @@ Encoder<coder_T, stream_T, source_T>::Encoder(const FrequencyTable& frequencies,
   using namespace internal;
 
   SymbolStatistics stats(frequencies, mProbabilityBits);
+  mProbabilityBits = stats.getSymbolTablePrecision();
 
   RANSTimer t;
   t.start();
-  mSymbolTable = std::make_unique<encoderSymbolTable_t>(stats, probabilityBits);
+  mSymbolTable = std::make_unique<encoderSymbolTable_t>(stats);
   t.stop();
   LOG(debug1) << "Encoder SymbolTable inclusive time (ms): " << t.getDurationMS();
 }

--- a/Utilities/rANS/include/rANS/internal/SymbolTable.h
+++ b/Utilities/rANS/include/rANS/internal/SymbolTable.h
@@ -35,7 +35,7 @@ class SymbolTable
 {
 
  public:
-  SymbolTable(const SymbolStatistics& symbolStats, size_t probabiltyBits);
+  SymbolTable(const SymbolStatistics& symbolStats);
 
   const T& operator[](int64_t index) const;
 
@@ -56,7 +56,7 @@ class SymbolTable
 };
 
 template <typename T>
-SymbolTable<T>::SymbolTable(const SymbolStatistics& symbolStats, size_t probabiltyBits) : mMin(symbolStats.getMinSymbol()), mMax(symbolStats.getMaxSymbol()), mIndex(), mSymbols(), mEscapeSymbol(nullptr)
+SymbolTable<T>::SymbolTable(const SymbolStatistics& symbolStats) : mMin(symbolStats.getMinSymbol()), mMax(symbolStats.getMaxSymbol()), mIndex(), mSymbols(), mEscapeSymbol(nullptr)
 {
   LOG(trace) << "start building symbol table";
 
@@ -67,7 +67,7 @@ SymbolTable<T>::SymbolTable(const SymbolStatistics& symbolStats, size_t probabil
     const auto it = symbolStats.getEscapeSymbol();
     if (it != symbolStats.end()) {
       const auto [symFrequency, symCumulated] = *(it);
-      return std::make_unique<T>(symCumulated, symFrequency, probabiltyBits);
+      return std::make_unique<T>(symCumulated, symFrequency, symbolStats.getSymbolTablePrecision());
     } else {
       return nullptr;
     }
@@ -76,7 +76,7 @@ SymbolTable<T>::SymbolTable(const SymbolStatistics& symbolStats, size_t probabil
   for (auto it = symbolStats.begin(); it != symbolStats.getEscapeSymbol(); ++it) {
     const auto [symFrequency, symCumulated] = *it;
     if (symFrequency) {
-      mSymbols.emplace_back(symCumulated, symFrequency, probabiltyBits);
+      mSymbols.emplace_back(symCumulated, symFrequency, symbolStats.getSymbolTablePrecision());
       mIndex.emplace_back(&mSymbols.back());
     } else {
       mIndex.emplace_back(mEscapeSymbol.get());

--- a/Utilities/rANS/include/rANS/rans.h
+++ b/Utilities/rANS/include/rANS/rans.h
@@ -59,11 +59,6 @@ using DedupDecoder32 = DedupDecoder<uint32_t, uint8_t, source_T>;
 template <typename source_T>
 using DedupDecoder64 = DedupDecoder<uint64_t, uint32_t, source_T>;
 
-//rans default values
-constexpr size_t ProbabilityBits8Bit = 10;
-constexpr size_t ProbabilityBits16Bit = 22;
-constexpr size_t ProbabilityBits25Bit = 25;
-
 inline size_t calculateMaxBufferSize(size_t num, size_t rangeBits, size_t sizeofStreamT)
 {
   //  // RS: w/o safety margin the o2-test-ctf-io produces an overflow in the Encoder::process

--- a/Utilities/rANS/run/bin-encode-decode.cxx
+++ b/Utilities/rANS/run/bin-encode-decode.cxx
@@ -29,7 +29,6 @@ using source_t = SOURCE_T;
 using coder_t = uint64_t;
 using stream_t = uint32_t;
 static const uint REPETITIONS = 5;
-static const uint PROB_BITS = 18;
 
 template <typename T>
 void readFile(const std::string& filename, std::vector<T>* tokens)
@@ -68,7 +67,7 @@ int main(int argc, char* argv[])
     ("help,h", "print usage message")
     ("file,f",bpo::value<std::string>(), "file to compress")
     ("samples,s",bpo::value<uint32_t>(), "how often to run benchmark")
-    ("bits,b",bpo::value<uint32_t>()->default_value(20), "resample dictionary to N Bits")
+    ("bits,b",bpo::value<uint32_t>(), "resample dictionary to N Bits")
     ("range,r",bpo::value<uint32_t>()->default_value(0), "range of the source data")
   	("log_severity,l",bpo::value<std::string>(), "severity of FairLogger");
   // clang-format on
@@ -95,7 +94,7 @@ int main(int argc, char* argv[])
     if (vm.count("bits")) {
       return vm["bits"].as<uint32_t>();
     } else {
-      return PROB_BITS;
+      return 0u;
     }
   }();
 


### PR DESCRIPTION
the rescaling factor determines the precision of the rANS compression
algorithm SymbolTable and this it's compression efficiency and
performance.
Until now it had to be set manually. The parameter now has become
optional and the optimal precision is automatically estimated based on
the FrequencyTable that is used to compress the data.