### PR TITLE
Set boost parsing style explictily to exclude allow_guessing

### DIFF
--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -69,8 +69,11 @@ void BoostOptionsRetriever::update(std::vector<ConfigParamSpec> const& specs,
     };
   }
 
-  auto parsed = mIgnoreUnknown ? bpo::command_line_parser(mArgc, mArgv).options(mDescription).allow_unregistered().run()
-                               : bpo::parse_command_line(mArgc, mArgv, mDescription);
+  using namespace bpo::command_line_style;
+  auto style = (allow_short | short_allow_adjacent | short_allow_next | allow_long | long_allow_adjacent | long_allow_next | allow_sticky | allow_dash_for_short);
+
+  auto parsed = mIgnoreUnknown ? bpo::command_line_parser(mArgc, mArgv).options(mDescription).style(style).allow_unregistered().run()
+                               : bpo::parse_command_line(mArgc, mArgv, mDescription, style);
   bpo::variables_map vmap;
   bpo::store(parsed, vmap);
   PropertyTreeHelpers::populate(specs, store, vmap, provenance);

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -909,8 +909,12 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
     // if found in the argument list. If not found they will be added with the default value
     FilterFunctionT filterArgsFct = [&](int largc, char** largv, const bpo::options_description& odesc) {
       // spec contains options
+      using namespace bpo::command_line_style;
+      auto style = (allow_short | short_allow_adjacent | short_allow_next | allow_long | long_allow_adjacent | long_allow_next | allow_sticky | allow_dash_for_short);
+
       bpo::command_line_parser parser{largc, largv};
       parser.options(odesc).allow_unregistered();
+      parser.style(style);
       bpo::parsed_options parsed_options = parser.run();
 
       bpo::variables_map varmap;


### PR DESCRIPTION
@ktf for me this solves the problem of greedy parsing: before in the chain
```
`o2-raw-file-reader-workflow --input-conf ITSraw.cfg  | o2-itsmft-stf-decoder-workflow  --old-format --shm-segment-size 16000000000 --decoder-verbosity 2 --run | tee xx.log
````
the  ``--run`` was interpreted as ``--runmft`` option set (though I thought the ambiguity should lead to an exception), because both are defined for the workflow:
````
shahoian@alicers02:/data2/itsdata/ML$  o2-itsmft-stf-decoder-workflow  -h
...
Executor options:
...
 --run                                 run workflow merged so far
...
Global workflow options:
  --runmft                              source detector is MFT (default ITS)
...
````
With this PR the confusion is gone.