### PR TITLE
DPL: add missing include arrow/config.h

### DIFF
--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -20,6 +20,7 @@
 #if __has_include(<arrow/util/config.h>)
 #include <arrow/util/config.h>
 #endif
+
 #include <arrow/compute/kernel.h>
 #include <arrow/status.h>
 #include <arrow/util/visibility.h>

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -14,6 +14,12 @@
 #include "Framework/BasicOps.h"
 #include "Framework/TableBuilder.h"
 
+#if __has_include(<arrow/config.h>)
+#include <arrow/config.h>
+#endif
+#if __has_include(<arrow/util/config.h>)
+#include <arrow/util/config.h>
+#endif
 #include <arrow/compute/kernel.h>
 #include <arrow/status.h>
 #include <arrow/util/visibility.h>

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -10,6 +10,13 @@
 #include "Framework/TableTreeHelpers.h"
 #include "Framework/Logger.h"
 
+#if __has_include(<arrow/config.h>)
+#include <arrow/config.h>
+#endif
+#if __has_include(<arrow/util/config.h>)
+#include <arrow/util/config.h>
+#endif
+
 #include "arrow/type_traits.h"
 
 namespace o2


### PR DESCRIPTION
Fixes compilation with arrow 1.0 due to arrow/config.h not included through other arrow header and thus ARROW_VERSION nor being defined