### PR TITLE
TRD fix feeid, sorting, ori<->hcid.

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -19,6 +19,15 @@ namespace o2
 namespace trd
 {
 
+uint16_t buildTRDFeeID(int supermodule, int side, int endpoint)
+{
+  TRDFeeID feeid;
+  feeid.supermodule = supermodule;
+  feeid.side = side;
+  feeid.endpoint = endpoint;
+  return feeid.word;
+}
+
 uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link)
 {
   // link is the link you are requesting information on, 0-14

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -69,6 +69,13 @@ class FeeParam
   static short chipmaskToMCMlist(unsigned int cmA, unsigned int cmB, unsigned short linkpair, int* mcmList, int listSize);
   static short getRobAB(unsigned short robsel, unsigned short linkpair); // Returns the chamber side (A=0, B=0) of a ROB
 
+  // wiring
+  virtual int getORI(int detector, int readoutboard) const;
+  virtual int getORIinSM(int detector, int readoutboard) const;
+  //  virtual void createORILookUpTable();
+  virtual int getORIfromHCID(int hcid) const;
+  virtual int getHCIDfromORI(int ori, int readoutboard) const; // TODO we need more info than just ori, for now readoutboard is there ... might change
+
   // tracklet simulation
   bool getTracklet() const { return mgTracklet; }
   static void setTracklet(bool trackletSim = true) { mgTracklet = trackletSim; }
@@ -167,6 +174,8 @@ class FeeParam
   static float mgBinDy;                           // bin in dy (140 um)
   static int mgDyMax;                             // max dy for a tracklet (hard limit)
   static int mgDyMin;                             // min dy for a tracklet (hard limit)
+                                                  //std::array<int,30> mgAsideLUT;                          // A side LUT to map ORI to stack/layer/side
+                                                  //std::array<int,30> mgCsideLUT;                          // C side LUT to map ORI to stack/layer/side
 
   // settings
   float mMagField;          // magnetic field

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -37,12 +37,14 @@ class Trap2CRU
   static constexpr int NumberOfHalfCRU = 72;
   static constexpr int NumberOfFLP = 12;
   static constexpr int CRUperFLP = 3;
-  static constexpr int WordSizeInBytes = 256; // word size in bits, everything is done in 256 bit blocks.
-  static constexpr int WordSize = 8;          // 8 standard 32bit words.
-  static constexpr int NLinksPerHalfCRU = 15;
+  static constexpr int WordSizeInBytes = 256;  // word size in bits, everything is done in 256 bit blocks.
+  static constexpr int WordSize = 8;           // 8 standard 32bit words.
+  static constexpr int NLinksPerHalfCRU = 15;  // number of fibers per each half cru
+  static constexpr int TRDLinkID = 15;         // hard coded link id. TODO give reason?
   static constexpr uint32_t PaddWord = 0xeeee; // pad word to fill 256bit blocks or entire block for no data case.
-                                               //TODO come back and change the mapping of 1077 channels to a lut and probably configurable.
-                                               //
+  static constexpr bool DebugDataWriting = false; //dump put very first vector of data to see if the thing going into the rawwriter is correct.
+                                                  //TODO come back and change the mapping of 1077 channels to a lut addnd probably configurable.
+                                                  //
  public:
   Trap2CRU() = default;
   Trap2CRU(const std::string& outputDir, const std::string& inputFilename);
@@ -57,6 +59,7 @@ class Trap2CRU
   int getVerbosity() { return mVerbosity; }
   void setVerbosity(int verbosity) { mVerbosity = verbosity; }
   void buildCRUPayLoad();
+  int sortByORI();
   o2::raw::RawFileWriter& getWriter() { return mWriter; }
   uint32_t buildCRUHeader(HalfCRUHeader& header, uint32_t bc, uint32_t halfcru, int startlinkrecord);
   void linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_t& padding);


### PR DESCRIPTION
- Fix raw data writing.
- Finalise and fix FeeID (supermodule, cru endpoint, detector side[AC])
- Mapping of ORI to HCID 
- Fix sorting, although not sorted per link the ORI data is together which is sufficient.
- Remove hard coded runnumber for trapsimulator, default value is the old hard coded value.