### PR TITLE
DPL Analysis: grouping with index tables

### DIFF
--- a/Analysis/Tutorials/src/custom_index.cxx
+++ b/Analysis/Tutorials/src/custom_index.cxx
@@ -39,8 +39,19 @@ struct ATask {
   }
 };
 
+struct BTask {
+  void process(aod::Matched::iterator const& m, aod::Tracks const& tracks)
+  {
+    LOGF(INFO, "Collision %d; Ntrk: %d", m.collisionId(), tracks.size());
+    auto t1 = tracks.begin();
+    auto t2 = t1 + (tracks.size() - 1);
+    LOGF(INFO, "track 1 from %d; track %d from %d", t1.collisionId(), tracks.size(), t2.collisionId());
+  }
+};
+
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-index")};
+    adaptAnalysisTask<ATask>("produce-index"),
+    adaptAnalysisTask<BTask>("consume-index")};
 }


### PR DESCRIPTION
This allows using custom index tables as grouping tables based on their first column. Example custom_index.cxx updated with demonstration.