### PR TITLE
Streamlining definition and reading of tables

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(Framework
                        src/ASoA.cxx
                        ${GUI_SOURCES}
                        src/AnalysisHelpers.cxx
+                       src/AnalysisDataModel.cxx
                        src/BoostOptionsRetriever.cxx
                        src/ChannelConfigurationPolicy.cxx
                        src/ChannelMatching.cxx

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -13,6 +13,7 @@
 #include "Framework/ASoA.h"
 #include "MathUtils/Utils.h"
 #include <cmath>
+#include "Headers/DataHeader.h"
 #include "Framework/DataTypes.h"
 
 namespace o2
@@ -23,6 +24,16 @@ namespace aod
 // the o2::aod namespace.
 DECLARE_SOA_STORE();
 
+// This is required to make getTreeName and getColumnNames
+// available
+// ATTENTION: getTreeName and getColumnNames must be updated
+//            in accordance with changes of the AnalysisDataModel!
+namespace datamodel
+{
+std::string getTreeName(header::DataHeader dh);
+std::vector<std::string> getColumnNames(std::string tableName);
+} // namespace datamodel
+
 namespace bc
 {
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
@@ -30,9 +41,9 @@ DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint64_t);
 } // namespace bc
 
-DECLARE_SOA_TABLE(BCs, "AOD", "BC", o2::soa::Index<>,
-                  bc::RunNumber, bc::GlobalBC,
-                  bc::TriggerMask);
+DECLARE_SOA_TABLE_ANDTREE(BCs, "O2bc", "AOD", "BC", o2::soa::Index<>,
+                          bc::RunNumber, bc::GlobalBC,
+                          bc::TriggerMask);
 using BC = BCs::iterator;
 
 namespace timestamp
@@ -61,7 +72,7 @@ DECLARE_SOA_COLUMN(CollisionTimeRes, collisionTimeRes, float);
 DECLARE_SOA_COLUMN(CollisionTimeMask, collisionTimeMask, uint8_t); // TODO put nature of CollisionTimeRes here, e.g. MSB 0 = exact range / 1 = Gaussian uncertainty
 } // namespace collision
 
-DECLARE_SOA_TABLE(Collisions, "AOD", "COLLISION", o2::soa::Index<>, collision::BCId, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2, collision::NumContrib, collision::CollisionTime, collision::CollisionTimeRes, collision::CollisionTimeMask);
+DECLARE_SOA_TABLE_ANDTREE(Collisions, "O2collision", "AOD", "COLLISION", o2::soa::Index<>, collision::BCId, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2, collision::NumContrib, collision::CollisionTime, collision::CollisionTimeRes, collision::CollisionTimeMask);
 
 using Collision = Collisions::iterator;
 
@@ -196,16 +207,16 @@ DECLARE_SOA_DYNAMIC_COLUMN(TPCFractionSharedCls, tpcFractionSharedCls, [](uint8_
 });
 } // namespace track
 
-DECLARE_SOA_TABLE_FULL(StoredTracks, "Tracks", "AOD", "TRACKPAR",
-                       o2::soa::Index<>, track::CollisionId, track::TrackType,
-                       track::X, track::Alpha,
-                       track::Y, track::Z, track::Snp, track::Tgl,
-                       track::Signed1Pt,
-                       track::NormalizedPhi<track::RawPhi>,
-                       track::Px<track::Signed1Pt, track::Snp, track::Alpha>,
-                       track::Py<track::Signed1Pt, track::Snp, track::Alpha>,
-                       track::Pz<track::Signed1Pt, track::Tgl>,
-                       track::Charge<track::Signed1Pt>);
+DECLARE_SOA_TABLE_FULL_ANDTREE(StoredTracks, "Tracks", "O2track", "AOD", "TRACKPAR",
+                               o2::soa::Index<>, track::CollisionId, track::TrackType,
+                               track::X, track::Alpha,
+                               track::Y, track::Z, track::Snp, track::Tgl,
+                               track::Signed1Pt,
+                               track::NormalizedPhi<track::RawPhi>,
+                               track::Px<track::Signed1Pt, track::Snp, track::Alpha>,
+                               track::Py<track::Signed1Pt, track::Snp, track::Alpha>,
+                               track::Pz<track::Signed1Pt, track::Tgl>,
+                               track::Charge<track::Signed1Pt>);
 
 DECLARE_SOA_EXTENDED_TABLE(Tracks, StoredTracks, "TRACKPAR",
                            aod::track::Pt,
@@ -213,10 +224,10 @@ DECLARE_SOA_EXTENDED_TABLE(Tracks, StoredTracks, "TRACKPAR",
                            aod::track::Eta,
                            aod::track::RawPhi);
 
-DECLARE_SOA_TABLE_FULL(StoredTracksCov, "TracksCov", "AOD", "TRACKPARCOV",
-                       track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
-                       track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,
-                       track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl);
+DECLARE_SOA_TABLE_FULL_ANDTREE(StoredTracksCov, "TracksCov", "O2track", "AOD", "TRACKPARCOV",
+                               track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,
+                               track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,
+                               track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksCov, StoredTracksCov, "TRACKPARCOV",
                            aod::track::CYY,
@@ -235,17 +246,17 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCov, StoredTracksCov, "TRACKPARCOV",
                            aod::track::C1PtTgl,
                            aod::track::C1Pt21Pt2);
 
-DECLARE_SOA_TABLE(TracksExtra, "AOD", "TRACKEXTRA",
-                  track::TPCInnerParam, track::Flags, track::ITSClusterMap,
-                  track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
-                  track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
-                  track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
-                  track::TPCSignal, track::TRDSignal, track::TOFSignal, track::Length, track::TOFExpMom,
-                  track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
-                  track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
-                  track::ITSNCls<track::ITSClusterMap>,
-                  track::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
-                  track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>);
+DECLARE_SOA_TABLE_ANDTREE(TracksExtra, "O2track", "AOD", "TRACKEXTRA",
+                          track::TPCInnerParam, track::Flags, track::ITSClusterMap,
+                          track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
+                          track::TPCNClsShared, track::TRDPattern, track::ITSChi2NCl,
+                          track::TPCChi2NCl, track::TRDChi2, track::TOFChi2,
+                          track::TPCSignal, track::TRDSignal, track::TOFSignal, track::Length, track::TOFExpMom,
+                          track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
+                          track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
+                          track::ITSNCls<track::ITSClusterMap>,
+                          track::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>,
+                          track::TPCFractionSharedCls<track::TPCNClsShared, track::TPCNClsFindable, track::TPCNClsFindableMinusFound>);
 
 using Track = Tracks::iterator;
 using TrackCov = TracksCov::iterator;
@@ -257,8 +268,8 @@ DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN(Track, track);
 } // namespace unassignedtracks
 
-DECLARE_SOA_TABLE(UnassignedTracks, "AOD", "UNASSIGNEDTRACK",
-                  unassignedtracks::CollisionId, unassignedtracks::TrackId);
+DECLARE_SOA_TABLE_ANDTREE(UnassignedTracks, "O2unassignedtrack", "AOD", "UNASSIGNEDTRACK",
+                          unassignedtracks::CollisionId, unassignedtracks::TrackId);
 
 using UnassignedTrack = UnassignedTracks::iterator;
 
@@ -272,9 +283,9 @@ DECLARE_SOA_COLUMN(CellType, cellType, int8_t);
 DECLARE_SOA_COLUMN(CaloType, caloType, int8_t);
 } // namespace calo
 
-DECLARE_SOA_TABLE(Calos, "AOD", "CALO", calo::BCId,
-                  calo::CellNumber, calo::Amplitude, calo::Time,
-                  calo::CellType, calo::CaloType);
+DECLARE_SOA_TABLE_ANDTREE(Calos, "O2calo", "AOD", "CALO", calo::BCId,
+                          calo::CellNumber, calo::Amplitude, calo::Time,
+                          calo::CellType, calo::CaloType);
 using Calo = Calos::iterator;
 
 namespace calotrigger
@@ -289,11 +300,11 @@ DECLARE_SOA_COLUMN(TriggerBits, triggerBits, int32_t);
 DECLARE_SOA_COLUMN(CaloType, caloType, int8_t);
 } // namespace calotrigger
 
-DECLARE_SOA_TABLE(CaloTriggers, "AOD", "CALOTRIGGER",
-                  calotrigger::BCId, calotrigger::FastOrAbsId,
-                  calotrigger::L0Amplitude, calotrigger::L0Time,
-                  calotrigger::L1TimeSum, calotrigger::NL0Times,
-                  calotrigger::TriggerBits, calotrigger::CaloType);
+DECLARE_SOA_TABLE_ANDTREE(CaloTriggers, "O2calotrigger", "AOD", "CALOTRIGGER",
+                          calotrigger::BCId, calotrigger::FastOrAbsId,
+                          calotrigger::L0Amplitude, calotrigger::L0Time,
+                          calotrigger::L1TimeSum, calotrigger::NL0Times,
+                          calotrigger::TriggerBits, calotrigger::CaloType);
 using CaloTrigger = CaloTriggers::iterator;
 
 namespace muon
@@ -331,14 +342,14 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, float, -1.0f * nsqrt(1.0f + ntan(aod::muon
 DECLARE_SOA_DYNAMIC_COLUMN(Charge, charge, [](float inverseBendingMomentum) -> short { return (inverseBendingMomentum > 0.0f) ? 1 : -1; });
 } // namespace muon
 
-DECLARE_SOA_TABLE_FULL(StoredMuons, "Muons", "AOD", "MUON",
-                       muon::BCId, muon::InverseBendingMomentum,
-                       muon::ThetaX, muon::ThetaY, muon::ZMu,
-                       muon::BendingCoor, muon::NonBendingCoor,
-                       muon::Chi2, muon::Chi2MatchTrigger,
-                       muon::Eta<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY>,
-                       muon::Phi<muon::ThetaX, muon::ThetaY>,
-                       muon::Charge<muon::InverseBendingMomentum>);
+DECLARE_SOA_TABLE_FULL_ANDTREE(StoredMuons, "Muons", "O2muon", "AOD", "MUON",
+                               muon::BCId, muon::InverseBendingMomentum,
+                               muon::ThetaX, muon::ThetaY, muon::ZMu,
+                               muon::BendingCoor, muon::NonBendingCoor,
+                               muon::Chi2, muon::Chi2MatchTrigger,
+                               muon::Eta<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY>,
+                               muon::Phi<muon::ThetaX, muon::ThetaY>,
+                               muon::Charge<muon::InverseBendingMomentum>);
 
 DECLARE_SOA_EXTENDED_TABLE(Muons, StoredMuons, "MUON",
                            aod::muon::Pt,
@@ -362,11 +373,11 @@ DECLARE_SOA_COLUMN(Charge, charge, float);
 DECLARE_SOA_COLUMN(Chi2, chi2, float);
 } // namespace muoncluster
 
-DECLARE_SOA_TABLE(MuonClusters, "AOD", "MUONCLUSTER",
-                  muoncluster::TrackId,
-                  muoncluster::X, muoncluster::Y, muoncluster::Z,
-                  muoncluster::ErrX, muoncluster::ErrY,
-                  muoncluster::Charge, muoncluster::Chi2);
+DECLARE_SOA_TABLE_ANDTREE(MuonClusters, "O2muoncluster", "AOD", "MUONCLUSTER",
+                          muoncluster::TrackId,
+                          muoncluster::X, muoncluster::Y, muoncluster::Z,
+                          muoncluster::ErrX, muoncluster::ErrY,
+                          muoncluster::Charge, muoncluster::Chi2);
 
 using MuonCluster = MuonClusters::iterator;
 
@@ -391,10 +402,10 @@ DECLARE_SOA_COLUMN(TimeZPA, timeZPA, float);
 DECLARE_SOA_COLUMN(TimeZPC, timeZPC, float);
 } // namespace zdc
 
-DECLARE_SOA_TABLE(Zdcs, "AOD", "ZDC", o2::soa::Index<>, zdc::BCId, zdc::EnergyZEM1, zdc::EnergyZEM2,
-                  zdc::EnergyCommonZNA, zdc::EnergyCommonZNC, zdc::EnergyCommonZPA, zdc::EnergyCommonZPC,
-                  zdc::EnergySectorZNA, zdc::EnergySectorZNC, zdc::EnergySectorZPA, zdc::EnergySectorZPC,
-                  zdc::TimeZEM1, zdc::TimeZEM2, zdc::TimeZNA, zdc::TimeZNC, zdc::TimeZPA, zdc::TimeZPC);
+DECLARE_SOA_TABLE_ANDTREE(Zdcs, "O2zdc", "AOD", "ZDC", o2::soa::Index<>, zdc::BCId, zdc::EnergyZEM1, zdc::EnergyZEM2,
+                          zdc::EnergyCommonZNA, zdc::EnergyCommonZNC, zdc::EnergyCommonZPA, zdc::EnergyCommonZPC,
+                          zdc::EnergySectorZNA, zdc::EnergySectorZNC, zdc::EnergySectorZPA, zdc::EnergySectorZPC,
+                          zdc::TimeZEM1, zdc::TimeZEM2, zdc::TimeZNA, zdc::TimeZNC, zdc::TimeZPA, zdc::TimeZPC);
 using Zdc = Zdcs::iterator;
 
 namespace ft0
@@ -406,9 +417,9 @@ DECLARE_SOA_COLUMN(TimeC, timeC, float);
 DECLARE_SOA_COLUMN(BCSignal, triggerSignal, uint8_t);
 } // namespace ft0
 
-DECLARE_SOA_TABLE(FT0s, "AOD", "FT0", ft0::BCId,
-                  ft0::Amplitude, ft0::TimeA, ft0::TimeC,
-                  ft0::BCSignal);
+DECLARE_SOA_TABLE_ANDTREE(FT0s, "O2ft0", "AOD", "FT0", ft0::BCId,
+                          ft0::Amplitude, ft0::TimeA, ft0::TimeC,
+                          ft0::BCSignal);
 using FT0 = FT0s::iterator;
 
 namespace fv0
@@ -419,8 +430,8 @@ DECLARE_SOA_COLUMN(TimeA, timeA, float);
 DECLARE_SOA_COLUMN(BCSignal, triggerSignal, uint8_t);
 } // namespace fv0
 
-DECLARE_SOA_TABLE(FV0s, "AOD", "FV0", fv0::BCId,
-                  fv0::Amplitude, fv0::TimeA, fv0::BCSignal);
+DECLARE_SOA_TABLE_ANDTREE(FV0s, "O2fv0", "AOD", "FV0", fv0::BCId,
+                          fv0::Amplitude, fv0::TimeA, fv0::BCSignal);
 using FV0 = FV0s::iterator;
 
 namespace fdd
@@ -432,9 +443,9 @@ DECLARE_SOA_COLUMN(TimeC, timeC, float);
 DECLARE_SOA_COLUMN(BCSignal, triggerSignal, uint8_t);
 } // namespace fdd
 
-DECLARE_SOA_TABLE(FDDs, "AOD", "FDD", fdd::BCId,
-                  fdd::Amplitude, fdd::TimeA, fdd::TimeC,
-                  fdd::BCSignal);
+DECLARE_SOA_TABLE_ANDTREE(FDDs, "O2fdd", "AOD", "FDD", fdd::BCId,
+                          fdd::Amplitude, fdd::TimeA, fdd::TimeC,
+                          fdd::BCSignal);
 using FDD = FDDs::iterator;
 
 namespace v0
@@ -479,11 +490,11 @@ DECLARE_SOA_COLUMN(BBFlag, bbFlag, uint64_t);
 DECLARE_SOA_COLUMN(BGFlag, bgFlag, uint64_t);
 } // namespace run2v0
 
-DECLARE_SOA_TABLE(Run2V0s, "AOD", "RUN2V0", run2v0::BCId,
-                  run2v0::Adc, run2v0::Time, run2v0::Width,
-                  run2v0::MultA, run2v0::MultC,
-                  run2v0::TimeA, run2v0::TimeC,
-                  run2v0::BBFlag, run2v0::BGFlag);
+DECLARE_SOA_TABLE_ANDTREE(Run2V0s, "Run2v0", "AOD", "RUN2V0", run2v0::BCId,
+                          run2v0::Adc, run2v0::Time, run2v0::Width,
+                          run2v0::MultA, run2v0::MultC,
+                          run2v0::TimeA, run2v0::TimeC,
+                          run2v0::BBFlag, run2v0::BGFlag);
 using Run2V0 = Run2V0s::iterator;
 
 // ---- MC tables ----
@@ -500,10 +511,10 @@ DECLARE_SOA_COLUMN(Weight, weight, float);
 DECLARE_SOA_COLUMN(ImpactParameter, impactParameter, float);
 } // namespace mccollision
 
-DECLARE_SOA_TABLE(McCollisions, "AOD", "MCCOLLISION", o2::soa::Index<>, mccollision::BCId,
-                  mccollision::GeneratorsID,
-                  mccollision::PosX, mccollision::PosY, mccollision::PosZ, mccollision::T, mccollision::Weight,
-                  mccollision::ImpactParameter);
+DECLARE_SOA_TABLE_ANDTREE(McCollisions, "O2mccollision", "AOD", "MCCOLLISION", o2::soa::Index<>, mccollision::BCId,
+                          mccollision::GeneratorsID,
+                          mccollision::PosX, mccollision::PosY, mccollision::PosZ, mccollision::T, mccollision::Weight,
+                          mccollision::ImpactParameter);
 using McCollision = McCollisions::iterator;
 
 namespace mcparticle
@@ -531,16 +542,16 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float px, float py) -> float { return std:
 DECLARE_SOA_DYNAMIC_COLUMN(ProducedByGenerator, producedByGenerator, [](uint8_t flags) -> bool { return (flags & 0x1) == 0x0; });
 } // namespace mcparticle
 
-DECLARE_SOA_TABLE(McParticles, "AOD", "MCPARTICLE",
-                  o2::soa::Index<>, mcparticle::McCollisionId,
-                  mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
-                  mcparticle::Mother0, mcparticle::Mother1, mcparticle::Daughter0, mcparticle::Daughter1, mcparticle::Weight,
-                  mcparticle::Px, mcparticle::Py, mcparticle::Pz, mcparticle::E,
-                  mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
-                  mcparticle::Phi<mcparticle::Px, mcparticle::Py>,
-                  mcparticle::Eta<mcparticle::Px, mcparticle::Py, mcparticle::Pz>,
-                  mcparticle::Pt<mcparticle::Px, mcparticle::Py>,
-                  mcparticle::ProducedByGenerator<mcparticle::Flags>);
+DECLARE_SOA_TABLE_ANDTREE(McParticles, "O2mcparticle", "AOD", "MCPARTICLE",
+                          o2::soa::Index<>, mcparticle::McCollisionId,
+                          mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
+                          mcparticle::Mother0, mcparticle::Mother1, mcparticle::Daughter0, mcparticle::Daughter1, mcparticle::Weight,
+                          mcparticle::Px, mcparticle::Py, mcparticle::Pz, mcparticle::E,
+                          mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
+                          mcparticle::Phi<mcparticle::Px, mcparticle::Py>,
+                          mcparticle::Eta<mcparticle::Px, mcparticle::Py, mcparticle::Pz>,
+                          mcparticle::Pt<mcparticle::Px, mcparticle::Py>,
+                          mcparticle::ProducedByGenerator<mcparticle::Flags>);
 using McParticle = McParticles::iterator;
 
 namespace mctracklabel
@@ -553,8 +564,8 @@ DECLARE_SOA_COLUMN(LabelMask, labelMask, uint16_t);
 /// Bit 10: TRD, bit 11: TOF, bit 15: indicates negative label
 } // namespace mctracklabel
 
-DECLARE_SOA_TABLE(McTrackLabels, "AOD", "MCTRACKLABEL",
-                  mctracklabel::LabelId, mctracklabel::LabelMask);
+DECLARE_SOA_TABLE_ANDTREE(McTrackLabels, "O2mctracklabel", "AOD", "MCTRACKLABEL",
+                          mctracklabel::LabelId, mctracklabel::LabelMask);
 using McTrackLabel = McTrackLabels::iterator;
 
 namespace mccalolabel
@@ -565,8 +576,8 @@ DECLARE_SOA_COLUMN(LabelMask, labelMask, uint16_t);
 /// Bit 15: indicates negative label
 } // namespace mccalolabel
 
-DECLARE_SOA_TABLE(McCaloLabels, "AOD", "MCCALOLABEL",
-                  mccalolabel::LabelId, mccalolabel::LabelMask);
+DECLARE_SOA_TABLE_ANDTREE(McCaloLabels, "O2mccalolabel", "AOD", "MCCALOLABEL",
+                          mccalolabel::LabelId, mccalolabel::LabelMask);
 using McCaloLabel = McCaloLabels::iterator;
 
 namespace mccollisionlabel
@@ -577,8 +588,8 @@ DECLARE_SOA_COLUMN(LabelMask, labelMask, uint16_t);
 /// Bit 15: indicates negative label
 } // namespace mccollisionlabel
 
-DECLARE_SOA_TABLE(McCollisionLabels, "AOD", "MCCOLLISLABEL",
-                  mccollisionlabel::LabelId, mccollisionlabel::LabelMask);
+DECLARE_SOA_TABLE_ANDTREE(McCollisionLabels, "O2mccollisionlabel", "AOD", "MCCOLLISLABEL",
+                          mccollisionlabel::LabelId, mccollisionlabel::LabelMask);
 using McCollisionLabel = McCollisionLabels::iterator;
 
 } // namespace aod

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -10,6 +10,7 @@
 #ifndef FRAMEWORK_DATAALLOCATOR_H
 #define FRAMEWORK_DATAALLOCATOR_H
 
+#include "Framework/AnalysisDataModel.h"
 #include "Framework/MessageContext.h"
 #include "Framework/StringContext.h"
 #include "Framework/RawBufferContext.h"
@@ -133,7 +134,16 @@ class DataAllocator
       void* t2tr = nullptr;
       call_if_defined<struct TreeToTable>([&](auto* p) {
         auto t2t = new std::decay_t<decltype(*p)>(args...);
-        t2t->addAllColumns();
+
+        auto colnames = aod::datamodel::getColumnNames(std::string(spec.description.str));
+        if (colnames.size() == 0) {
+          t2t->addAllColumns();
+        } else {
+          for (auto colname : colnames) {
+            t2t->addColumn(colname.c_str());
+          }
+        }
+
         adopt(spec, t2t);
         t2tr = t2t;
       });

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -14,6 +14,7 @@
 #include "TTreeReader.h"
 
 #include "Framework/DataDescriptorMatcher.h"
+#include "Framework/AnalysisDataModel.h"
 
 #include <regex>
 #include "rapidjson/fwd.h"

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -42,105 +42,6 @@
 
 namespace o2::framework::readers
 {
-enum AODTypeMask : uint64_t {
-  None = 0,
-  Track = 1 << 0,
-  TrackCov = 1 << 1,
-  TrackExtra = 1 << 2,
-  Calo = 1 << 3,
-  CaloTrigger = 1 << 4,
-  Muon = 1 << 5,
-  MuonCluster = 1 << 6,
-  Zdc = 1 << 7,
-  BC = 1 << 8,
-  Collision = 1 << 9,
-  FT0 = 1 << 10,
-  FV0 = 1 << 11,
-  FDD = 1 << 12,
-  UnassignedTrack = 1 << 13,
-  Run2V0 = 1 << 14,
-  McCollision = 1 << 15,
-  McTrackLabel = 1 << 16,
-  McCaloLabel = 1 << 17,
-  McCollisionLabel = 1 << 18,
-  McParticle = 1 << 19,
-  Unknown = 1 << 20
-};
-
-uint64_t getMask(header::DataDescription description)
-{
-
-  if (description == header::DataDescription{"TRACKPAR"}) {
-    return AODTypeMask::Track;
-  } else if (description == header::DataDescription{"TRACKPARCOV"}) {
-    return AODTypeMask::TrackCov;
-  } else if (description == header::DataDescription{"TRACKEXTRA"}) {
-    return AODTypeMask::TrackExtra;
-  } else if (description == header::DataDescription{"CALO"}) {
-    return AODTypeMask::Calo;
-  } else if (description == header::DataDescription{"CALOTRIGGER"}) {
-    return AODTypeMask::CaloTrigger;
-  } else if (description == header::DataDescription{"MUON"}) {
-    return AODTypeMask::Muon;
-  } else if (description == header::DataDescription{"MUONCLUSTER"}) {
-    return AODTypeMask::MuonCluster;
-  } else if (description == header::DataDescription{"ZDC"}) {
-    return AODTypeMask::Zdc;
-  } else if (description == header::DataDescription{"BC"}) {
-    return AODTypeMask::BC;
-  } else if (description == header::DataDescription{"COLLISION"}) {
-    return AODTypeMask::Collision;
-  } else if (description == header::DataDescription{"FT0"}) {
-    return AODTypeMask::FT0;
-  } else if (description == header::DataDescription{"FV0"}) {
-    return AODTypeMask::FV0;
-  } else if (description == header::DataDescription{"FDD"}) {
-    return AODTypeMask::FDD;
-  } else if (description == header::DataDescription{"UNASSIGNEDTRACK"}) {
-    return AODTypeMask::UnassignedTrack;
-  } else if (description == header::DataDescription{"RUN2V0"}) {
-    return AODTypeMask::Run2V0;
-  } else if (description == header::DataDescription{"MCCOLLISION"}) {
-    return AODTypeMask::McCollision;
-  } else if (description == header::DataDescription{"MCTRACKLABEL"}) {
-    return AODTypeMask::McTrackLabel;
-  } else if (description == header::DataDescription{"MCCALOLABEL"}) {
-    return AODTypeMask::McCaloLabel;
-  } else if (description == header::DataDescription{"MCCOLLISLABEL"}) {
-    return AODTypeMask::McCollisionLabel;
-  } else if (description == header::DataDescription{"MCPARTICLE"}) {
-    return AODTypeMask::McParticle;
-  } else {
-    LOG(DEBUG) << "This is a tree of unknown type! " << description.str;
-    return AODTypeMask::Unknown;
-  }
-}
-
-uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataOrigin const& origin)
-{
-  uint64_t readMask = None;
-  for (auto& route : routes) {
-    auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
-    auto description = concrete.description;
-
-    readMask |= getMask(description);
-  }
-  return readMask;
-}
-
-std::vector<OutputRoute> getListOfUnknown(std::vector<OutputRoute> const& routes)
-{
-
-  std::vector<OutputRoute> unknows;
-  for (auto& route : routes) {
-    auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
-
-    if (getMask(concrete.description) == AODTypeMask::Unknown)
-      unknows.push_back(route);
-  }
-  return unknows;
-}
-
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
@@ -207,16 +108,11 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
     // get the run time watchdog
     auto* watchdog = new RuntimeWatchdog(options.get<int64_t>("time-limit"));
 
-    // analyze type of requested tables
-    uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{"AOD"});
-    std::vector<OutputRoute> unknowns;
-    if (readMask & AODTypeMask::Unknown) {
-      unknowns = getListOfUnknown(spec.outputs);
-    }
+    // create list of requested tables
+    std::vector<OutputRoute> requestedTables(spec.outputs);
 
     auto counter = std::make_shared<int>(0);
-    return adaptStateless([readMask,
-                           unknowns,
+    return adaptStateless([requestedTables,
                            watchdog,
                            didir](DataAllocator& outputs, ControlService& control, DeviceSpec const& device) {
       // check if RuntimeLimit is reached
@@ -243,66 +139,26 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         return;
       }
 
-      auto tableMaker = [&readMask, &outputs, fi, didir](auto metadata, AODTypeMask mask, char const* treeName) {
-        if (readMask & mask) {
+      // loop over requested tables
+      for (auto route : requestedTables) {
 
-          auto dh = header::DataHeader(decltype(metadata)::description(), decltype(metadata)::origin(), 0);
-          auto reader = didir->getTreeReader(dh, fi, treeName);
+        // create a TreeToTable object
+        auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
+        auto dh = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
 
-          using table_t = typename decltype(metadata)::table_t;
-          if (!reader || (reader->IsInvalid())) {
-            LOGP(ERROR, "Requested \"{}\" tree not found in input file \"{}\"", treeName, didir->getInputFilename(dh, fi));
-          } else {
-            auto& builder = outputs.make<TableBuilder>(Output{decltype(metadata)::origin(), decltype(metadata)::description()});
-            RootTableBuilderHelpers::convertASoA<table_t>(builder, *reader);
-          }
+        auto tr = didir->getDataTree(dh, fi);
+        if (!tr) {
+          char* table;
+          sprintf(table, "%s/%s/%" PRIu32, concrete.origin.str, concrete.description.str, concrete.subSpec);
+          LOGP(ERROR, "Error while retrieving the tree for \"{}\"!", table);
+          return;
         }
-      };
-      tableMaker(o2::aod::CollisionsMetadata{}, AODTypeMask::Collision, "O2collision");
-      tableMaker(o2::aod::StoredTracksMetadata{}, AODTypeMask::Track, "O2track");
-      tableMaker(o2::aod::StoredTracksCovMetadata{}, AODTypeMask::TrackCov, "O2track");
-      tableMaker(o2::aod::TracksExtraMetadata{}, AODTypeMask::TrackExtra, "O2track");
-      tableMaker(o2::aod::CalosMetadata{}, AODTypeMask::Calo, "O2calo");
-      tableMaker(o2::aod::CaloTriggersMetadata{}, AODTypeMask::Calo, "O2calotrigger");
-      tableMaker(o2::aod::StoredMuonsMetadata{}, AODTypeMask::Muon, "O2muon");
-      tableMaker(o2::aod::MuonClustersMetadata{}, AODTypeMask::Muon, "O2muoncluster");
-      tableMaker(o2::aod::ZdcsMetadata{}, AODTypeMask::Zdc, "O2zdc");
-      tableMaker(o2::aod::BCsMetadata{}, AODTypeMask::BC, "O2bc");
-      tableMaker(o2::aod::FT0sMetadata{}, AODTypeMask::FT0, "O2ft0");
-      tableMaker(o2::aod::FV0sMetadata{}, AODTypeMask::FV0, "O2fv0");
-      tableMaker(o2::aod::FDDsMetadata{}, AODTypeMask::FDD, "O2fdd");
-      tableMaker(o2::aod::UnassignedTracksMetadata{}, AODTypeMask::UnassignedTrack, "O2unassignedtrack");
-      tableMaker(o2::aod::Run2V0sMetadata{}, AODTypeMask::Run2V0, "Run2v0");
-      tableMaker(o2::aod::McCollisionsMetadata{}, AODTypeMask::McCollision, "O2mccollision");
-      tableMaker(o2::aod::McTrackLabelsMetadata{}, AODTypeMask::McTrackLabel, "O2mctracklabel");
-      tableMaker(o2::aod::McCaloLabelsMetadata{}, AODTypeMask::McCaloLabel, "O2mccalolabel");
-      tableMaker(o2::aod::McCollisionLabelsMetadata{}, AODTypeMask::McCollisionLabel, "O2mccollisionlabel");
-      tableMaker(o2::aod::McParticlesMetadata{}, AODTypeMask::McParticle, "O2mcparticle");
 
-      // tables not included in the DataModel
-      if (readMask & AODTypeMask::Unknown) {
+        auto o = Output(dh);
+        auto& t2t = outputs.make<TreeToTable>(o, tr);
 
-        // loop over unknowns
-        for (auto route : unknowns) {
-
-          // create a TreeToTable object
-          auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
-          auto dh = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
-
-          auto tr = didir->getDataTree(dh, fi);
-          if (!tr) {
-            char* table;
-            sprintf(table, "%s/%s/%" PRIu32, concrete.origin.str, concrete.description.str, concrete.subSpec);
-            LOGP(ERROR, "Error while retrieving the tree for \"{}\"!", table);
-            return;
-          }
-
-          auto o = Output(dh);
-          auto& t2t = outputs.make<TreeToTable>(o, tr);
-
-          // fill the table
-          t2t.fill();
-        }
+        // fill the table
+        t2t.fill();
       }
     });
   })};

--- a/Framework/Core/src/AnalysisDataModel.cxx
+++ b/Framework/Core/src/AnalysisDataModel.cxx
@@ -1,0 +1,127 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2
+{
+namespace aod
+{
+namespace datamodel
+{
+std::string getTreeName(header::DataHeader dh)
+{
+  std::string tableName = std::string(dh.dataDescription.str);
+
+  // convert table name to tree name
+  // default: tree name = table name
+  if (tableName == "TRACKPAR") {
+    return decltype(StoredTracksMetadata{})::mTreeName;
+  } else if (tableName == "TRACKPARCOV") {
+    return decltype(StoredTracksCovMetadata{})::mTreeName;
+  } else if (tableName == "TRACKEXTRA") {
+    return decltype(TracksExtraMetadata{})::mTreeName;
+  } else if (tableName == "CALO") {
+    return decltype(CalosMetadata{})::mTreeName;
+  } else if (tableName == "CALOTRIGGER") {
+    return decltype(CaloTriggersMetadata{})::mTreeName;
+  } else if (tableName == "MUON") {
+    return decltype(MuonsMetadata{})::mTreeName;
+  } else if (tableName == "MUONCLUSTER") {
+    return decltype(MuonClustersMetadata{})::mTreeName;
+  } else if (tableName == "ZDC") {
+    return decltype(ZdcsMetadata{})::mTreeName;
+  } else if (tableName == "BC") {
+    return decltype(BCsMetadata{})::mTreeName;
+  } else if (tableName == "COLLISION") {
+    return decltype(CollisionsMetadata{})::mTreeName;
+  } else if (tableName == "FT0") {
+    return decltype(FT0sMetadata{})::mTreeName;
+  } else if (tableName == "FV0") {
+    return decltype(FV0sMetadata{})::mTreeName;
+  } else if (tableName == "FDD") {
+    return decltype(FDDsMetadata{})::mTreeName;
+  } else if (tableName == "UNASSIGNEDTRACK") {
+    return decltype(UnassignedTracksMetadata{})::mTreeName;
+  } else if (tableName == "RUN2V0") {
+    return decltype(Run2V0sMetadata{})::mTreeName;
+  } else if (tableName == "MCCOLLISION") {
+    return decltype(McCollisionsMetadata{})::mTreeName;
+  } else if (tableName == "MCTRACKLABEL") {
+    return decltype(McTrackLabelsMetadata{})::mTreeName;
+  } else if (tableName == "MCCALOLABEL") {
+    return decltype(McCaloLabelsMetadata{})::mTreeName;
+  } else if (tableName == "MCCOLLISLABEL") {
+    return decltype(McCollisionLabelsMetadata{})::mTreeName;
+  } else if (tableName == "MCPARTICLE") {
+    return decltype(McParticlesMetadata{})::mTreeName;
+  } else {
+    return tableName;
+  }
+}
+
+template <typename... C>
+static auto columnNamesTrait(framework::pack<C...>)
+{
+  return std::vector<std::string>{C::columnLabel()...};
+}
+
+std::vector<std::string> getColumnNames(std::string tableName)
+{
+  // get coulmn names
+  // default: column names = {}
+  if (tableName == "TRACKPAR") {
+    return columnNamesTrait(decltype(StoredTracksMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "TRACKPARCOV") {
+    return columnNamesTrait(decltype(StoredTracksCovMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "TRACKEXTRA") {
+    return columnNamesTrait(decltype(TracksExtraMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "CALO") {
+    return columnNamesTrait(decltype(CalosMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "CALOTRIGGER") {
+    return columnNamesTrait(decltype(CaloTriggersMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MUON") {
+    return columnNamesTrait(decltype(MuonsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MUONCLUSTER") {
+    return columnNamesTrait(decltype(MuonClustersMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "ZDC") {
+    return columnNamesTrait(decltype(ZdcsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "BC") {
+    return columnNamesTrait(decltype(BCsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "COLLISION") {
+    return columnNamesTrait(decltype(CollisionsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "FT0") {
+    return columnNamesTrait(decltype(FT0sMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "FV0") {
+    return columnNamesTrait(decltype(FV0sMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "FDD") {
+    return columnNamesTrait(decltype(FDDsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "UNASSIGNEDTRACK") {
+    return columnNamesTrait(decltype(UnassignedTracksMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "RUN2V0") {
+    return columnNamesTrait(decltype(Run2V0sMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MCCOLLISION") {
+    return columnNamesTrait(decltype(McCollisionsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MCTRACKLABEL") {
+    return columnNamesTrait(decltype(McTrackLabelsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MCCALOLABEL") {
+    return columnNamesTrait(decltype(McCaloLabelsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MCCOLLISLABEL") {
+    return columnNamesTrait(decltype(McCollisionLabelsMetadata{})::table_t::persistent_columns_t{});
+  } else if (tableName == "MCPARTICLE") {
+    return columnNamesTrait(decltype(McParticlesMetadata{})::table_t::persistent_columns_t{});
+  } else {
+    return std::vector<std::string>({});
+  }
+}
+
+} // namespace datamodel
+} // namespace aod
+} // namespace o2

--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -448,24 +448,24 @@ std::string DataInputDirector::getInputFilename(header::DataHeader dh, int count
 
 TTree* DataInputDirector::getDataTree(header::DataHeader dh, int counter)
 {
-  const char* treename;
+  std::string treename;
   TTree* tree = nullptr;
 
   auto didesc = getDataInputDescriptor(dh);
   if (didesc) {
     // if match then use filename and treename from DataInputDescriptor
-    treename = didesc->treename.c_str();
+    treename = didesc->treename;
   } else {
     // if NOT match then use
     //  . filename from defaultDataInputDescriptor
     //  . treename from DataHeader
     didesc = mdefaultDataInputDescriptor;
-    treename = dh.dataDescription.str;
+    treename = aod::datamodel::getTreeName(dh);
   }
 
   auto file = didesc->getInputFile(counter);
   if (file) {
-    tree = (TTree*)file->Get(treename);
+    tree = (TTree*)file->Get(treename.c_str());
     if (!tree) {
       throw std::runtime_error(fmt::format(R"(Couldn't get TTree "{}" from "{}")", treename, file->GetName()));
     }

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -387,10 +387,10 @@ ColumnIterator::ColumnIterator(TTreeReader* reader, const char* colname)
     LOGP(FATAL, "Can not locate tree!");
     return;
   }
-  //tree->Print();
+
   auto br = tree->GetBranch(colname);
   if (!br) {
-    LOGP(FATAL, "Can not locate branch {}", colname);
+    LOGP(INFO, "Can not locate branch {}", colname);
     return;
   }
   mColumnName = colname;


### PR DESCRIPTION
This is to simplify the AODReaderHelpers::rootFileReaderCallback() and the handling of DataModel and other tables.

So far the reading of tables of the DataModel and all other tables has been treated with distinct code with slightly different functionality.

DataModel tables:
. the name of the tree to read from is hard coded and part of the DataModel however contained in AODReaderHelpers.cxx
e.g.    Table description       Tree name

        TRACKPAR                 O2track
        TRACKPARCOV         O2track
        TRACKEXTRA            O2track
        CALOTRIGGER          O2calotrigger
        RUN2V0                      Run2v0
        
. there is a fixed relation between the table column names and the tree branches: colname -> fcolname.
. the reading of the DataModel tables is based on the table definition which includes a list of columns. Only branches which contain data of a defined column are read.


other tables:
. the name of the tree to read is by default assumed to have the name of the table description. This can however be configured by command line options.
. the branch names are assumed to be equal to the column names.
. the reading of the other tables is based on the tree definition. All branches of the tree are read and filled into a table.


What we strive for is:

. fix the table name - tree name relation of DataModel tables and allow for command line configuration in all other cases
. fix the column name - branch name relation of DataModel tables and allow for command line configuration in all other cases.
. in all cases only branches containing requested information should be read.


The current PR provides a first step towards the final solution and includes the following modifications:

. the set of pre-processor commands DECLARE_SOA_TABLE_* (see ASoA.h) has been extended with
  
  DECLARE_SOA_TABLE_FULL_ANDTREE(_Name_, _Label_, _Tree_, _Origin_, _Description_, ...)
  DECLARE_SOA_TABLE_ANDTREE(_Name_, _Tree_, _Origin_, _Description_, ...)
  
  The extra _Tree_ argument allows to specify the name of the tree to read from. These commands are supposed to be used in AnalysisDataModel.h only and not in user tasks. In DECLARE_SOA_EXTENDED_TABLE_FULL and DECLARE_SOA_EXTENDED_TABLE the tree name is inherited from the base table (parameter _Tabel_).
  
  In order to read this information back the tree name is included in the _Name_##Metadata structure which then can be accessed through the function
  
  o2::aod::datamodel::getTreeName(std::string tableName)
  
  in AnalysisDataModel.cxx.
  
. to retrieve the defined columns of a table the function

  o2::aod::datamodel::getColumnNames(DataHeader dh)
  
  is added to AnalysisDataModel.cxx.
  When new tables are added to the DataModel the functions in AnalysisDataModel.cxx have to be updated accordingly. With these modifications all DataModel definitions are now included in AnalysisDataModel.[cxx,h].
  
  For other tables the function getTreeName currently returns the table description and getColumnNames the empty vector std::vector<std::string>({}).

