### PR TITLE
Update in PID tasks and handlers of PID param

### DIFF
--- a/Analysis/DataModel/include/PID/BetheBloch.h
+++ b/Analysis/DataModel/include/PID/BetheBloch.h
@@ -27,7 +27,7 @@ namespace o2::pid::tpc
 class BetheBloch : public Parametrization
 {
  public:
-  BetheBloch() : Parametrization("BetheBloch", 7) { Printf("%s", fName.Data()); };
+  BetheBloch() : Parametrization("BetheBloch", 7){};
   ~BetheBloch() override = default;
   float operator()(const float* x) const override
   {

--- a/Analysis/DataModel/include/PID/TOFReso.h
+++ b/Analysis/DataModel/include/PID/TOFReso.h
@@ -29,7 +29,7 @@ namespace o2::pid::tof
 class TOFReso : public Parametrization
 {
  public:
-  TOFReso() : Parametrization("TOFReso", 5) { Printf("%s", fName.Data()); };
+  TOFReso() : Parametrization("TOFReso", 5){};
   ~TOFReso() override = default;
   float operator()(const float* x) const override
   {

--- a/Analysis/DataModel/include/PID/TPCReso.h
+++ b/Analysis/DataModel/include/PID/TPCReso.h
@@ -26,7 +26,7 @@ namespace o2::pid::tpc
 class TPCReso : public Parametrization
 {
  public:
-  TPCReso() : Parametrization("TPCReso", 2) { Printf("%s", fName.Data()); };
+  TPCReso() : Parametrization("TPCReso", 2){};
   ~TPCReso() override = default;
   float operator()(const float* x) const override
   {

--- a/Analysis/DataModel/include/PIDBase/ParamBase.h
+++ b/Analysis/DataModel/include/PIDBase/ParamBase.h
@@ -108,6 +108,11 @@ class Parametrization : public TNamed
   /// Printer for parameters
   void PrintParametrization() const;
 
+  /// Setter for the parameter at position iparam
+  /// \param iparam index in the array of the parameters
+  /// \param value value of the parameter at position iparam
+  void SetParameter(const unsigned int iparam, const pidvar_t value) { mParameters.SetParameter(iparam, value); }
+
   /// Setter for the parameter, using an array
   /// \param params array with parameters
   void SetParameters(const std::vector<pidvar_t> params) { mParameters.SetParameters(params); }

--- a/Analysis/Tasks/pidTOF.cxx
+++ b/Analysis/Tasks/pidTOF.cxx
@@ -55,7 +55,6 @@ struct pidTOFTask {
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracks)
   {
-    LOGF(info, "Tracks for collision: %d", tracks.size());
     tof::EventTime evt = tof::EventTime();
     evt.SetEvTime(0, collision.collisionTime());
     evt.SetEvTimeReso(0, collision.collisionTimeRes());

--- a/Analysis/Tasks/spectraTPC.cxx
+++ b/Analysis/Tasks/spectraTPC.cxx
@@ -24,12 +24,42 @@
 #define DOTH2F(OBJ, ...) \
   OutputObj<TH2F> OBJ{TH2F(#OBJ, __VA_ARGS__)};
 
+#define TRACKSELECTION                                                                                                \
+  UChar_t clustermap = i.itsClusterMap();                                                                             \
+  bool issel = (i.tpcNClsFindable() > 70) && (i.flags() & 0x4) && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)); \
+  if (!issel)                                                                                                         \
+    continue;
+
+// #define TRACKSELECTION 1;
+
+#define makelogaxis(h)                                            \
+  {                                                               \
+    const Int_t nbins = h->GetNbinsX();                           \
+    double binp[nbins + 1];                                       \
+    double max = h->GetXaxis()->GetBinUpEdge(nbins);              \
+    double min = h->GetXaxis()->GetBinLowEdge(1);                 \
+    double lmin = TMath::Log10(min);                              \
+    double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins); \
+    for (int i = 0; i < nbins; i++) {                             \
+      binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta)); \
+    }                                                             \
+    binp[nbins] = max + 1;                                        \
+    h->GetXaxis()->Set(nbins, binp);                              \
+  }
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"add-tof-histos", VariantType::Bool, false, {"Generate TPC with TOF histograms"}}};
+  std::swap(workflowOptions, options);
+}
+
 struct TPCPIDQAExpSignalTask {
-#define BIN_AXIS 100, 0, 5, 1000, 0, 1000
+#define BIN_AXIS 1000, 0.001, 20, 1000, 0, 1000
 
   DOTH2F(htpcsignal, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
   DOTH2F(hexpEl, ";#it{p} (GeV/#it{c});TPC expected signal e;Tracks", BIN_AXIS);
@@ -44,54 +74,81 @@ struct TPCPIDQAExpSignalTask {
 
 #undef BIN_AXIS
 
+  void init(o2::framework::InitContext&)
+  {
+    // Log binning for p
+    makelogaxis(htpcsignal);
+    makelogaxis(hexpEl);
+    makelogaxis(hexpMu);
+    makelogaxis(hexpPi);
+    makelogaxis(hexpKa);
+    makelogaxis(hexpPr);
+    makelogaxis(hexpDe);
+    makelogaxis(hexpTr);
+    makelogaxis(hexpHe);
+    makelogaxis(hexpAl);
+  }
+
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC> const& tracks)
   {
     for (auto const& i : tracks) {
       // Track selection
-      const UChar_t clustermap = i.itsClusterMap();
-      bool issel = (i.tpcNClsFindable() > 70);
-      issel = issel && (i.flags() & 0x4);
-      issel = issel && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1));
-      if (!issel)
-        continue;
+      TRACKSELECTION;
       //
-      htpcsignal->Fill(i.p(), i.tpcSignal());
-      hexpEl->Fill(i.p(), i.tpcExpSignalEl());
-      hexpMu->Fill(i.p(), i.tpcExpSignalMu());
-      hexpPi->Fill(i.p(), i.tpcExpSignalPi());
-      hexpKa->Fill(i.p(), i.tpcExpSignalKa());
-      hexpPr->Fill(i.p(), i.tpcExpSignalPr());
-      hexpDe->Fill(i.p(), i.tpcExpSignalDe());
-      hexpTr->Fill(i.p(), i.tpcExpSignalTr());
-      hexpHe->Fill(i.p(), i.tpcExpSignalHe());
-      hexpAl->Fill(i.p(), i.tpcExpSignalAl());
+
+      // const float mom = i.p();
+      const float mom = i.tpcInnerParam();
+      htpcsignal->Fill(mom, i.tpcSignal());
+      hexpEl->Fill(mom, i.tpcExpSignalEl());
+      hexpMu->Fill(mom, i.tpcExpSignalMu());
+      hexpPi->Fill(mom, i.tpcExpSignalPi());
+      hexpKa->Fill(mom, i.tpcExpSignalKa());
+      hexpPr->Fill(mom, i.tpcExpSignalPr());
+      hexpDe->Fill(mom, i.tpcExpSignalDe());
+      hexpTr->Fill(mom, i.tpcExpSignalTr());
+      hexpHe->Fill(mom, i.tpcExpSignalHe());
+      hexpAl->Fill(mom, i.tpcExpSignalAl());
     }
   }
 };
 
 struct TPCPIDQANSigmaTask {
+#define BIN_AXIS 1000, 0.001, 20, 1000, -10, 10
+
   // TPC NSigma
-  DOTH2F(hnsigmaEl, ";#it{p} (GeV/#it{c});TPC N_{sigma e};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaMu, ";#it{p} (GeV/#it{c});TPC N_{sigma #mu};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaPi, ";#it{p} (GeV/#it{c});TPC N_{sigma #pi};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaKa, ";#it{p} (GeV/#it{c});TPC N_{sigma K};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaPr, ";#it{p} (GeV/#it{c});TPC N_{sigma p};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaDe, ";#it{p} (GeV/#it{c});TPC N_{sigma d};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaTr, ";#it{p} (GeV/#it{c});TPC N_{sigma t};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaHe, ";#it{p} (GeV/#it{c});TPC N_{sigma ^{3}He};Tracks", 100, 0, 5, 100, -10, 10);
-  DOTH2F(hnsigmaAl, ";#it{p} (GeV/#it{c});TPC N_{sigma #alpha};Tracks", 100, 0, 5, 100, -10, 10);
+  DOTH2F(hnsigmaEl, ";#it{p} (GeV/#it{c});TPC N_{sigma e};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaMu, ";#it{p} (GeV/#it{c});TPC N_{sigma #mu};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaPi, ";#it{p} (GeV/#it{c});TPC N_{sigma #pi};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaKa, ";#it{p} (GeV/#it{c});TPC N_{sigma K};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaPr, ";#it{p} (GeV/#it{c});TPC N_{sigma p};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaDe, ";#it{p} (GeV/#it{c});TPC N_{sigma d};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaTr, ";#it{p} (GeV/#it{c});TPC N_{sigma t};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaHe, ";#it{p} (GeV/#it{c});TPC N_{sigma ^{3}He};Tracks", BIN_AXIS);
+  DOTH2F(hnsigmaAl, ";#it{p} (GeV/#it{c});TPC N_{sigma #alpha};Tracks", BIN_AXIS);
+
+#undef BIN_AXIS
+
+  void init(o2::framework::InitContext&)
+  {
+    // Log binning for p
+    makelogaxis(hnsigmaEl);
+    makelogaxis(hnsigmaMu);
+    makelogaxis(hnsigmaPi);
+    makelogaxis(hnsigmaKa);
+    makelogaxis(hnsigmaPr);
+    makelogaxis(hnsigmaDe);
+    makelogaxis(hnsigmaTr);
+    makelogaxis(hnsigmaHe);
+    makelogaxis(hnsigmaAl);
+  }
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC> const& tracks)
   {
     for (auto const& i : tracks) {
       // Track selection
-      const UChar_t clustermap = i.itsClusterMap();
-      bool issel = (i.tpcNClsFindable() > 70);
-      issel = issel && (i.flags() & 0x4);
-      issel = issel && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1));
-      if (!issel)
-        continue;
+      TRACKSELECTION;
       //
+
       hnsigmaEl->Fill(i.p(), i.tpcNSigmaEl());
       hnsigmaMu->Fill(i.p(), i.tpcNSigmaMu());
       hnsigmaPi->Fill(i.p(), i.tpcNSigmaPi());
@@ -105,9 +162,129 @@ struct TPCPIDQANSigmaTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+struct TPCPIDQASignalwTOFTask {
+#define BIN_AXIS 1000, 0.001, 20, 1000, 0, 1000
+
+  DOTH2F(htpcsignalEl, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalMu, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalPi, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalKa, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalPr, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalDe, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalTr, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalHe, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+  DOTH2F(htpcsignalAl, ";#it{p} (GeV/#it{c});TPC Signal;Tracks", BIN_AXIS);
+
+#undef BIN_AXIS
+
+  void init(o2::framework::InitContext&)
+  {
+    // Log binning for p
+    makelogaxis(htpcsignalEl);
+    makelogaxis(htpcsignalMu);
+    makelogaxis(htpcsignalPi);
+    makelogaxis(htpcsignalKa);
+    makelogaxis(htpcsignalPr);
+    makelogaxis(htpcsignalDe);
+    makelogaxis(htpcsignalTr);
+    makelogaxis(htpcsignalHe);
+    makelogaxis(htpcsignalAl);
+  }
+
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC, aod::pidRespTOF> const& tracks)
+  {
+    for (auto const& i : tracks) {
+      // Track selection
+      TRACKSELECTION;
+      // Require kTIME and kTOFout
+      if (!(i.flags() & 0x2000))
+        continue;
+      if (!(i.flags() & 0x80000000))
+        continue;
+      //
+
+      // const float mom = i.p();
+      const float mom = i.tpcInnerParam();
+      if (abs(i.tofNSigmaEl()) < 2) {
+        htpcsignalEl->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaMu()) < 2) {
+        htpcsignalMu->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaPi()) < 2) {
+        htpcsignalPi->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaKa()) < 2) {
+        htpcsignalKa->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaPr()) < 2) {
+        htpcsignalPr->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaDe()) < 2) {
+        htpcsignalDe->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaTr()) < 2) {
+        htpcsignalTr->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaHe()) < 2) {
+        htpcsignalHe->Fill(mom, i.tpcSignal());
+      }
+      if (abs(i.tofNSigmaAl()) < 2) {
+        htpcsignalAl->Fill(mom, i.tpcSignal());
+      }
+    }
+  }
+};
+
+struct TPCSpectraTask {
+  // Pt
+#define TIT ";#it{p}_{T} (GeV/#it{c});Tracks"
+  DOTH1F(hpt_El, TIT, 100, 0, 20);
+  DOTH1F(hpt_Pi, TIT, 100, 0, 20);
+  DOTH1F(hpt_Ka, TIT, 100, 0, 20);
+  DOTH1F(hpt_Pr, TIT, 100, 0, 20);
+#undef TIT
+  // P
+#define TIT ";#it{p} (GeV/#it{c});Tracks"
+  DOTH1F(hp_El, TIT, 100, 0, 20);
+  DOTH1F(hp_Pi, TIT, 100, 0, 20);
+  DOTH1F(hp_Ka, TIT, 100, 0, 20);
+  DOTH1F(hp_Pr, TIT, 100, 0, 20);
+#undef TIT
+
+  void process(soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC> const& tracks)
+  {
+    for (auto i : tracks) {
+      // Track selection
+      TRACKSELECTION;
+      //
+      if (TMath::Abs(i.tpcNSigmaEl()) < 3) {
+        hp_El->Fill(i.p());
+        hpt_El->Fill(i.pt());
+      }
+      if (TMath::Abs(i.tpcNSigmaPi()) < 3) {
+        hp_Pi->Fill(i.p());
+        hpt_Pi->Fill(i.pt());
+      }
+      if (TMath::Abs(i.tpcNSigmaKa()) < 3) {
+        hp_Ka->Fill(i.p());
+        hpt_Ka->Fill(i.pt());
+      }
+      if (TMath::Abs(i.tpcNSigmaPr()) < 3) {
+        hp_Pr->Fill(i.p());
+        hpt_Pr->Fill(i.pt());
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<TPCPIDQAExpSignalTask>("TPCpidqa-expsignal-task"),
-    adaptAnalysisTask<TPCPIDQANSigmaTask>("TPCpidqa-nsigma-task")};
+  bool TPCwTOF = cfgc.options().get<bool>("add-tof-histos");
+  WorkflowSpec workflow{adaptAnalysisTask<TPCPIDQAExpSignalTask>("TPCpidqa-expsignal-task"),
+                        adaptAnalysisTask<TPCPIDQANSigmaTask>("TPCpidqa-nsigma-task"),
+                        adaptAnalysisTask<TPCSpectraTask>("tpcspectra-task")};
+  if (TPCwTOF)
+    workflow.push_back(adaptAnalysisTask<TPCPIDQASignalwTOFTask>("TPCpidqa-signalwTOF-task"));
+  return workflow;
 }


### PR DESCRIPTION
Updates to TOF and TPC tasks
- TPC task
    - Update TPC qa plots
    - Using log binning for momentum
    - Using TPC momentum instead of momentum at vertex
    - Add TPC with TOF plots
-  TOF task
   - Extend QA plots for TOF PID
   - add event wide info
   - using different tasks for different observables
   - Change TOF task names

Remove verbosity in TOF PID table filler

Add TPC spectra task

Remove useless verbosity

Add param setter from the index

Add possibility to read param from file in TPC param handler