### PR TITLE
DPL Foundation: add own runtime_error.

### DIFF
--- a/Detectors/MUON/MCH/Tracking/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFitterSpec.cxx
@@ -94,7 +94,7 @@ class TrackFitterTask
       try {
         mTrackFitter.fit(track);
       } catch (exception const& e) {
-        throw runtime_error(std::string("Track fit failed: ") + e.what());
+        throw std::runtime_error(std::string("Track fit failed: ") + e.what());
       }
 
       // write the refitted track to the ouput message

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -134,6 +134,5 @@ struct Config {
 /// @param tpcsectors list of sector numbers
 framework::DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int> const& tpcsectors);
 
-o2::framework::CompletionPolicy getCATrackerCompletionPolicy();
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -476,7 +476,8 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
         // for digits and clusters we always have the sector information, activeSectors being zero
         // is thus an error condition. The completion policy makes sure that the data set is complete
         if (activeSectors == 0 || (activeSectors & validInputs.to_ulong()) != activeSectors) {
-          throw std::runtime_error("Incomplete input data, expecting complete data set, buffering has been removed ");
+          throw o2::framework::runtime_error_f("Incomplete input data, expecting complete data set, buffering has been removed (0x%08x & 0x%08x != 0x%08x)",
+                                               activeSectors, validInputs.to_ulong(), activeSectors);
         }
         // MC label blocks must be in the same multimessage with the corresponding data, the completion
         // policy does not check for the MC labels and expects them to be present and thus complete if

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -13,6 +13,7 @@
 
 #include "Framework/ASoA.h"
 #include "Framework/Kernels.h"
+#include "Framework/RuntimeError.h"
 #include <arrow/table.h>
 
 #include <iterator>
@@ -122,7 +123,7 @@ auto groupTable(const T& table, const std::string& categoryColumnName, int minCa
     return doGroupTable<float, arrow::FloatArray>(arrowTable, categoryColumnName, minCatSize, outsider);
   }
   // FIXME: Should we support other types as well?
-  throw std::runtime_error("Combinations: category column must be of integral type");
+  throw o2::framework::runtime_error("Combinations: category column must be of integral type");
 }
 
 // Synchronize categories so as groupedIndices contain elements only of categories common to all tables

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -24,6 +24,7 @@
 #include "Framework/FunctionalHelpers.h"
 #include "Framework/Traits.h"
 #include "Framework/VariantHelpers.h"
+#include "Framework/RuntimeError.h"
 
 #include <arrow/compute/kernel.h>
 #include <arrow/table.h>
@@ -244,10 +245,10 @@ struct AnalysisDataProcessorBuilder {
                                                        &groups[index],
                                                        &offsets[index]);
             if (result.ok() == false) {
-              throw std::runtime_error("Cannot split collection");
+              throw runtime_error("Cannot split collection");
             }
             if (groups[index].size() != gt.tableSize()) {
-              throw std::runtime_error(fmt::format("Splitting collection resulted in different group number ({}) than there is rows in the grouping table ({}).", groups[index].size(), gt.tableSize()));
+              throw runtime_error_f("Splitting collection resulted in different group number (%d) than there is rows in the grouping table (%d).", groups[index].size(), gt.tableSize());
             };
           }
         };

--- a/Framework/Core/include/Framework/CallbackRegistry.h
+++ b/Framework/Core/include/Framework/CallbackRegistry.h
@@ -16,8 +16,8 @@
 /// @brief  A generic registry for callbacks
 
 #include "Framework/TypeTraits.h"
+#include "Framework/RuntimeError.h"
 #include <tuple>
-#include <stdexcept> // runtime_error
 #include <utility>   // declval
 
 namespace o2
@@ -101,7 +101,7 @@ class CallbackRegistry
   template <std::size_t pos, typename U, typename F>
   typename std::enable_if<has_matching_callback<U, F>::value == false>::type setAt(F&& cb)
   {
-    throw std::runtime_error("mismatch in function substitution at position " + std::to_string(pos));
+    throw runtime_error_f("mismatch in function substitution at position %d", pos);
   }
 
   // exec callback of specified id

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -25,6 +25,7 @@
 #include "Framework/SerializationMethods.h"
 #include "Framework/CheckTypes.h"
 #include "Framework/ServiceRegistry.h"
+#include "Framework/RuntimeError.h"
 
 #include "Headers/DataHeader.h"
 #include <TClass.h>
@@ -326,13 +327,13 @@ class DataAllocator
           cl = TClass::GetClass(reinterpret_cast<const char*>(object.getHint()));
         }
         if (has_root_dictionary<WrappedType>::value == false && cl == nullptr) {
-          std::string msg("ROOT serialization not supported, dictionary not found for type ");
           if (std::is_same<typename T::hint_type, const char>::value) {
-            msg += reinterpret_cast<const char*>(object.getHint());
+            throw runtime_error_f("ROOT serialization not supported, dictionary not found for type %s",
+                                  reinterpret_cast<const char*>(object.getHint()));
           } else {
-            msg += typeid(WrappedType).name();
+            throw runtime_error_f("ROOT serialization not supported, dictionary not found for type %s",
+                                  typeid(WrappedType).name());
           }
-          throw std::runtime_error(msg);
         }
         TMessageSerializer().Serialize(*payloadMessage, &object(), cl);
       } else {

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -12,6 +12,7 @@
 
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataProcessingHeader.h"
+#include "Framework/RuntimeError.h"
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
 

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.inc
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.inc
@@ -81,7 +81,7 @@ inline OriginValueMatcher::OriginValueMatcher(std::string const& s)
   : ValueHolder{s}
 {
   if (s.size() > header::gSizeDataOriginString) {
-    throw std::runtime_error("Header DataDescription too long");
+    throw runtime_error("Header DataDescription too long");
   }
 }
 
@@ -100,7 +100,7 @@ inline DescriptionValueMatcher::DescriptionValueMatcher(std::string const& s)
   : ValueHolder{s}
 {
   if (s.size() > header::gSizeDataDescriptionString) {
-    throw std::runtime_error("Header DataDescription too long");
+    throw runtime_error("Header DataDescription too long");
   }
 }
 

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -73,7 +73,7 @@ struct DataProcessorContext {
   AlgorithmSpec::ProcessCallback* statelessProcess = nullptr;
   AlgorithmSpec::ErrorCallback* error = nullptr;
 
-  std::function<void(std::exception& e, InputRecord& record)>* errorHandling = nullptr;
+  std::function<void(o2::framework::RuntimeErrorRef e, InputRecord& record)>* errorHandling = nullptr;
   int* errorCount = nullptr;
 };
 
@@ -113,7 +113,7 @@ class DataProcessingDevice : public FairMQDevice
   AlgorithmSpec::ProcessCallback mStatefulProcess;
   AlgorithmSpec::ProcessCallback mStatelessProcess;
   AlgorithmSpec::ErrorCallback mError;
-  std::function<void(std::exception& e, InputRecord& record)> mErrorHandling;
+  std::function<void(RuntimeErrorRef e, InputRecord& record)> mErrorHandling;
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
   TimingInfo mTimingInfo;

--- a/Framework/Core/include/Framework/ErrorContext.h
+++ b/Framework/Core/include/Framework/ErrorContext.h
@@ -7,17 +7,14 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_ERROR_CONTEXT_H
-#define FRAMEWORK_ERROR_CONTEXT_H
+#ifndef O2_FRAMEWORK_ERROR_CONTEXT_H_
+#define O2_FRAMEWORK_ERROR_CONTEXT_H_
 
 #include "Framework/InputRecord.h"
 #include "Framework/ServiceRegistry.h"
+#include "Framework/RuntimeError.h"
 
-#include <exception>
-
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 // This is a utility class to reduce the amount of boilerplate when defining
@@ -25,23 +22,23 @@ namespace framework
 class ErrorContext
 {
  public:
-  ErrorContext(InputRecord& inputs, ServiceRegistry& services, std::exception& e)
+  ErrorContext(InputRecord& inputs, ServiceRegistry& services, RuntimeErrorRef e)
     : mInputs{inputs},
       mServices{services},
-      mException{e}
+      mExceptionRef{e}
   {
   }
 
   InputRecord const& inputs() { return mInputs; }
   ServiceRegistry const& services() { return mServices; }
-  std::exception const& exception() { return mException; }
+  RuntimeErrorRef exception() { return mExceptionRef; }
 
+ private:
   InputRecord& mInputs;
   ServiceRegistry& mServices;
-  std::exception& mException;
+  RuntimeErrorRef mExceptionRef;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif
+#endif // o2::framework

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -19,6 +19,7 @@
 #include "Framework/InitContext.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/RootConfigParamHelpers.h"
+#include "Framework/RuntimeError.h"
 #include <arrow/type_fwd.h>
 #include <gandiva/gandiva_aliases.h>
 #include <arrow/type.h>
@@ -29,7 +30,6 @@
 #include <gandiva/node.h>
 #include <gandiva/filter.h>
 #include <gandiva/projector.h>
-#include <fmt/format.h>
 #else
 namespace gandiva
 {
@@ -573,7 +573,7 @@ std::shared_ptr<gandiva::Projector> createProjectors(framework::pack<C...>, gand
   if (s.ok()) {
     return projector;
   } else {
-    throw std::runtime_error(fmt::format("Failed to create projector: {}", s.ToString()));
+    throw o2::framework::runtime_error_f("Failed to create projector: %s", s.ToString().c_str());
   }
 }
 } // namespace o2::framework::expressions

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -20,6 +20,7 @@
 #include "Framework/SerializationMethods.h"
 #include "Framework/StringHelpers.h"
 #include "Framework/TableBuilder.h"
+#include "Framework/RuntimeError.h"
 
 #include "TClass.h"
 #include "TH1.h"
@@ -129,7 +130,7 @@ template <typename T>
 std::unique_ptr<TH1> createTH1FromSpec(HistogramSpec const& spec)
 {
   if (spec.config.axes.size() == 0) {
-    throw std::runtime_error("No arguments available in spec to create a histogram");
+    throw runtime_error("No arguments available in spec to create a histogram");
   }
   if (spec.config.binsEqual) {
     return std::make_unique<T>(spec.name.data(), spec.readableName.data(), spec.config.axes[0].nBins, spec.config.axes[0].bins[0], spec.config.axes[0].bins[1]);
@@ -141,7 +142,7 @@ template <typename T>
 std::unique_ptr<TH2> createTH2FromSpec(HistogramSpec const& spec)
 {
   if (spec.config.axes.size() == 0) {
-    throw std::runtime_error("No arguments available in spec to create a histogram");
+    throw runtime_error("No arguments available in spec to create a histogram");
   }
   if (spec.config.binsEqual) {
     return std::make_unique<T>(spec.name.data(), spec.readableName.data(), spec.config.axes[0].nBins, spec.config.axes[0].bins[0], spec.config.axes[0].bins[1], spec.config.axes[1].nBins, spec.config.axes[1].bins[0], spec.config.axes[1].bins[1]);
@@ -153,7 +154,7 @@ template <typename T>
 std::unique_ptr<TH3> createTH3FromSpec(HistogramSpec const& spec)
 {
   if (spec.config.axes.size() == 0) {
-    throw std::runtime_error("No arguments available in spec to create a histogram");
+    throw runtime_error("No arguments available in spec to create a histogram");
   }
   if (spec.config.binsEqual) {
     return std::make_unique<T>(spec.name.data(), spec.readableName.data(), spec.config.axes[0].nBins, spec.config.axes[0].bins[0], spec.config.axes[0].bins[1], spec.config.axes[1].nBins, spec.config.axes[1].bins[0], spec.config.axes[1].bins[1], spec.config.axes[2].nBins, spec.config.axes[2].bins[0], spec.config.axes[2].bins[1]);
@@ -269,7 +270,7 @@ class HistogramRegistry
         return mRegistryValue[imask(j + i)];
       }
     }
-    throw std::runtime_error("No match found!");
+    throw runtime_error("No match found!");
   }
 
   /// @return the histogram registered with name @a name
@@ -323,7 +324,7 @@ class HistogramRegistry
         return;
       }
     }
-    throw std::runtime_error("Internal array is full.");
+    throw runtime_error("Internal array is full.");
   }
 
   inline constexpr uint32_t imask(uint32_t i) const

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -14,6 +14,7 @@
 #include "Framework/FairMQDeviceProxy.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/TypeTraits.h"
+#include "Framework/RuntimeError.h"
 #include "Headers/DataHeader.h"
 #include "MemoryResources/MemoryResources.h"
 
@@ -22,7 +23,6 @@
 
 #include <cassert>
 #include <functional>
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -233,10 +233,10 @@ class MessageContext
       // FIXME: drop this repeated check and make sure at initial setup of devices that everything is fine
       // introduce error policy
       if (mFactory == nullptr) {
-        throw std::runtime_error(std::string("failed to get transport factory for channel ") + bindingChannel);
+        throw runtime_error_f("failed to get transport factory for channel %s", bindingChannel.c_str());
       }
       if (mResource.isValid() == false) {
-        throw std::runtime_error(std::string("no memory resource for channel ") + bindingChannel);
+        throw runtime_error_f("no memory resource for channel %s", bindingChannel.c_str());
       }
     }
     ~ContainerRefObject() override = default;
@@ -406,7 +406,7 @@ class MessageContext
         // TODO: decide whether this is an error or not
         // can also check if the standard constructor can be dropped to make sure that
         // the ScopeHook is always set up with a context
-        throw std::runtime_error("No context available to schedule the context object");
+        throw runtime_error("No context available to schedule the context object");
         return base::operator()(ptr);
       }
       // keep the object alive and add to message list of the context

--- a/Framework/Core/include/Framework/RootConfigParamHelpers.h
+++ b/Framework/Core/include/Framework/RootConfigParamHelpers.h
@@ -11,6 +11,7 @@
 #define O2_FRAMEWORK_ROOTCONFIGPARAMHELPERS_H_
 
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/RuntimeError.h"
 #include <TClass.h>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <type_traits>
@@ -34,7 +35,7 @@ struct RootConfigParamHelpers {
   {
     auto cl = TClass::GetClass<T>();
     if (!cl) {
-      throw std::runtime_error(std::string("Unable to convert object ") + typeid(T).name());
+      throw runtime_error_f("Unable to convert object %s", typeid(T).name());
     }
 
     return asConfigParamSpecsImpl(mainKey, cl, reinterpret_cast<void*>(const_cast<T*>(&proto)));

--- a/Framework/Core/include/Framework/ServiceRegistry.h
+++ b/Framework/Core/include/Framework/ServiceRegistry.h
@@ -15,15 +15,14 @@
 #include "Framework/ServiceRegistryHelpers.h"
 #include "Framework/CompilerBuiltins.h"
 #include "Framework/TypeIdHelpers.h"
+#include "Framework/RuntimeError.h"
 
 #include <algorithm>
 #include <array>
-#include <exception>
 #include <functional>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
-#include <stdexcept>
 #include <thread>
 #include <atomic>
 #include <mutex>
@@ -281,9 +280,8 @@ struct ServiceRegistry {
         return *reinterpret_cast<T*>(ptr);
       }
     }
-    throw std::runtime_error(std::string("Unable to find service of kind ") +
-                             typeid(T).name() +
-                             ". Make sure you use const / non-const correctly.");
+    throw runtime_error_f("Unable to find service of kind %s. Make sure you use const / non-const correctly.",
+                          typeid(T).name());
   }
 };
 

--- a/Framework/Core/include/Framework/ServiceRegistryHelpers.h
+++ b/Framework/Core/include/Framework/ServiceRegistryHelpers.h
@@ -15,12 +15,10 @@
 
 #include <algorithm>
 #include <array>
-#include <exception>
 #include <functional>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
-#include <stdexcept>
 #include <thread>
 
 namespace o2::framework

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -15,6 +15,7 @@
 #include "Framework/StructToTuple.h"
 #include "Framework/FunctionalHelpers.h"
 #include "Framework/VariantHelpers.h"
+#include "Framework/RuntimeError.h"
 #include "arrow/type_traits.h"
 
 // Apparently needs to be on top of the arrow includes.
@@ -176,7 +177,7 @@ struct BuilderUtils {
     auto valueBuilder = reinterpret_cast<ValueBuilderType*>(builder->value_builder());
     status &= valueBuilder->AppendValues(&*ip.first, std::distance(ip.first, ip.second));
     if (!status.ok()) {
-      throw std::runtime_error("Unable to append values to valueBuilder!");
+      throw runtime_error("Unable to append values to valueBuilder!");
     }
     return;
   }
@@ -412,10 +413,10 @@ class TableBuilder
   {
     constexpr int nColumns = sizeof...(ARGS);
     if (nColumns != columnNames.size()) {
-      throw std::runtime_error("Mismatching number of column types and names");
+      throw runtime_error("Mismatching number of column types and names");
     }
     if (mBuilders != nullptr) {
-      throw std::runtime_error("TableBuilder::persist can only be invoked once per instance");
+      throw runtime_error("TableBuilder::persist can only be invoked once per instance");
     }
   }
 
@@ -438,7 +439,7 @@ class TableBuilder
     mFinalizer = [schema = mSchema, &arrays = mArrays, builders = (BuildersTuple<ARGS...>*)mBuilders]() -> std::shared_ptr<arrow::Table> {
       auto status = TableBuilderHelpers::finalize(arrays, *builders, std::make_index_sequence<sizeof...(ARGS)>{});
       if (status == false) {
-        throw std::runtime_error("Unable to finalize");
+        throw runtime_error("Unable to finalize");
       }
       return arrow::Table::Make(schema, arrays);
     };
@@ -501,7 +502,7 @@ class TableBuilder
     return [builders = (BuildersTuple<ARGS...>*)mBuilders](unsigned int slot, FillTuple const& t) -> void {
       auto status = TableBuilderHelpers::append(*builders, std::index_sequence_for<ARGS...>{}, t);
       if (status == false) {
-        throw std::runtime_error("Unable to append");
+        throw runtime_error("Unable to append");
       }
     };
   }

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -9,11 +9,12 @@
 // or submit itself to any jurisdiction.
 #ifndef FRAMEWORK_VARIANT_H
 #define FRAMEWORK_VARIANT_H
+
+#include "Framework/RuntimeError.h"
 #include <type_traits>
 #include <cstring>
 #include <cstdint>
 #include <cstdlib>
-#include <stdexcept>
 #include <iosfwd>
 #include <initializer_list>
 #include <string_view>
@@ -220,7 +221,7 @@ class Variant
   {
     auto v = variant_trait_v<T>;
     if (mType != variant_trait_v<T>) {
-      throw std::runtime_error("Mismatch between types");
+      throw runtime_error("Mismatch between types");
     }
     return variant_helper<storage_t, T>::get(&mStore);
   }

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -82,7 +82,7 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> reques
         } else if (description == header::DataDescription{"MUON"}) {
           outputs.adopt(Output{origin, description}, maker(o2::aod::MuonsExtensionMetadata{}));
         } else {
-          throw std::runtime_error("Not an extended table");
+          throw runtime_error("Not an extended table");
         }
       }
     };

--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -8,10 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "ChannelSpecHelpers.h"
+#include "Framework/RuntimeError.h"
 #include <fmt/format.h>
 #include <ostream>
 #include <cassert>
-#include <stdexcept>
 #if 0
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -49,7 +49,7 @@ char const* ChannelSpecHelpers::typeAsString(enum ChannelType type)
     case ChannelType::Pair:
       return "pair";
   }
-  throw std::runtime_error("Unknown ChannelType");
+  throw runtime_error("Unknown ChannelType");
 }
 
 char const* ChannelSpecHelpers::methodAsString(enum ChannelMethod method)
@@ -60,7 +60,7 @@ char const* ChannelSpecHelpers::methodAsString(enum ChannelMethod method)
     case ChannelMethod::Connect:
       return "connect";
   }
-  throw std::runtime_error("Unknown ChannelMethod");
+  throw runtime_error("Unknown ChannelMethod");
 }
 
 std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -31,6 +31,7 @@
 #include "Framework/StringHelpers.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/ExternalFairMQDeviceProxy.h"
+#include "Framework/RuntimeError.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -40,7 +41,6 @@
 #include <ROOT/RArrowDS.hxx>
 #include <ROOT/RVec.hxx>
 #include <chrono>
-#include <exception>
 #include <fstream>
 #include <functional>
 #include <memory>
@@ -518,7 +518,7 @@ DataProcessorSpec
     auto keepString = ic.options().get<std::string>("keep");
 
     if (filename.empty()) {
-      throw std::runtime_error("output file missing");
+      throw runtime_error("output file missing");
     }
 
     bool hasOutputsToWrite = false;

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -50,12 +50,12 @@ std::string const& DataAllocator::matchDataHeader(const Output& spec, size_t tim
       return output.channel;
     }
   }
-  std::ostringstream str;
-  str << "Worker is not authorised to create message with "
-      << "origin(" << spec.origin.as<std::string>() << ")"
-      << "description(" << spec.description.as<std::string>() << ")"
-      << "subSpec(" << spec.subSpec << ")";
-  throw std::runtime_error(str.str());
+  throw runtime_error_f(
+    "Worker is not authorised to create message with "
+    "origin(%s) description(%s) subSpec(%d)",
+    spec.origin.as<std::string>().c_str(),
+    spec.description.as<std::string>().c_str(),
+    spec.subSpec);
 }
 
 DataChunk& DataAllocator::newChunk(const Output& spec, size_t size)
@@ -155,7 +155,7 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
     auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
     auto outStatus = outBatch.ValueOrDie()->WriteTable(*table);
     if (outStatus.ok() == false) {
-      throw std::runtime_error("Unable to Write table");
+      throw runtime_error("Unable to Write table");
     }
   };
 
@@ -187,7 +187,7 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
     auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
     auto outStatus = outBatch.ValueOrDie()->WriteTable(*table);
     if (outStatus.ok() == false) {
-      throw std::runtime_error("Unable to Write table");
+      throw runtime_error("Unable to Write table");
     }
   };
 
@@ -210,7 +210,7 @@ void DataAllocator::adopt(const Output& spec, std::shared_ptr<arrow::Table> ptr)
     auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
     auto outStatus = outBatch.ValueOrDie()->WriteTable(*table);
     if (outStatus.ok() == false) {
-      throw std::runtime_error("Unable to Write table");
+      throw runtime_error("Unable to Write table");
     }
   };
 
@@ -230,7 +230,7 @@ void DataAllocator::snapshot(const Output& spec, const char* payload, size_t pay
 Output DataAllocator::getOutputByBind(OutputRef&& ref)
 {
   if (ref.label.empty()) {
-    throw std::runtime_error("Invalid (empty) OutputRef provided.");
+    throw runtime_error("Invalid (empty) OutputRef provided.");
   }
   for (auto ri = 0ul, re = mAllowedOutputRoutes.size(); ri != re; ++ri) {
     if (mAllowedOutputRoutes[ri].matcher.binding.value == ref.label) {
@@ -239,7 +239,7 @@ Output DataAllocator::getOutputByBind(OutputRef&& ref)
       return Output{dataType.origin, dataType.description, ref.subSpec, spec.lifetime, std::move(ref.headerStack)};
     }
   }
-  throw std::runtime_error("Unable to find OutputSpec with label " + ref.label);
+  throw runtime_error_f("Unable to find OutputSpec with label %s", ref.label.c_str());
   O2_BUILTIN_UNREACHABLE();
 }
 

--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DataMatcherWalker.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/VariantHelpers.h"
+#include "Framework/RuntimeError.h"
 #include <iostream>
 
 namespace o2
@@ -63,7 +64,7 @@ bool OriginValueMatcher::match(header::DataHeader const& header, VariableContext
   } else if (auto s = std::get_if<std::string>(&mValue)) {
     return strncmp(header.dataOrigin.str, s->c_str(), 4) == 0;
   }
-  throw std::runtime_error("Mismatching type for variable");
+  throw runtime_error("Mismatching type for variable");
 }
 
 bool DescriptionValueMatcher::match(header::DataHeader const& header, VariableContext& context) const
@@ -79,7 +80,7 @@ bool DescriptionValueMatcher::match(header::DataHeader const& header, VariableCo
   } else if (auto s = std::get_if<std::string>(&this->mValue)) {
     return strncmp(header.dataDescription.str, s->c_str(), 16) == 0;
   }
-  throw std::runtime_error("Mismatching type for variable");
+  throw runtime_error("Mismatching type for variable");
 }
 
 bool SubSpecificationTypeValueMatcher::match(header::DataHeader const& header, VariableContext& context) const
@@ -94,7 +95,7 @@ bool SubSpecificationTypeValueMatcher::match(header::DataHeader const& header, V
   } else if (auto v = std::get_if<header::DataHeader::SubSpecificationType>(&mValue)) {
     return header.subSpecification == *v;
   }
-  throw std::runtime_error("Mismatching type for variable");
+  throw runtime_error("Mismatching type for variable");
 }
 
 /// This will match the timing information which is currently in
@@ -112,7 +113,7 @@ bool StartTimeValueMatcher::match(DataProcessingHeader const& dph, VariableConte
   } else if (auto v = std::get_if<uint64_t>(&mValue)) {
     return (dph.startTime / mScale) == *v;
   }
-  throw std::runtime_error("Mismatching type for variable");
+  throw runtime_error("Mismatching type for variable");
 }
 
 DataDescriptorMatcher::DataDescriptorMatcher(DataDescriptorMatcher const& other)
@@ -241,19 +242,19 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
   if (auto pval0 = std::get_if<OriginValueMatcher>(&mLeft)) {
     auto dh = o2::header::get<header::DataHeader*>(d);
     if (dh == nullptr) {
-      throw std::runtime_error("Cannot find DataHeader");
+      throw runtime_error("Cannot find DataHeader");
     }
     leftValue = pval0->match(*dh, context);
   } else if (auto pval1 = std::get_if<DescriptionValueMatcher>(&mLeft)) {
     auto dh = o2::header::get<header::DataHeader*>(d);
     if (dh == nullptr) {
-      throw std::runtime_error("Cannot find DataHeader");
+      throw runtime_error("Cannot find DataHeader");
     }
     leftValue = pval1->match(*dh, context);
   } else if (auto pval2 = std::get_if<SubSpecificationTypeValueMatcher>(&mLeft)) {
     auto dh = o2::header::get<header::DataHeader*>(d);
     if (dh == nullptr) {
-      throw std::runtime_error("Cannot find DataHeader");
+      throw runtime_error("Cannot find DataHeader");
     }
     leftValue = pval2->match(*dh, context);
   } else if (auto pval3 = std::get_if<std::unique_ptr<DataDescriptorMatcher>>(&mLeft)) {
@@ -263,11 +264,11 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
   } else if (auto pval5 = std::get_if<StartTimeValueMatcher>(&mLeft)) {
     auto dph = o2::header::get<DataProcessingHeader*>(d);
     if (dph == nullptr) {
-      throw std::runtime_error("Cannot find DataProcessingHeader");
+      throw runtime_error("Cannot find DataProcessingHeader");
     }
     leftValue = pval5->match(*dph, context);
   } else {
-    throw std::runtime_error("Bad parsing tree");
+    throw runtime_error("Bad parsing tree");
   }
   // Common speedup.
   if (mOp == Op::And && leftValue == false) {
@@ -309,7 +310,7 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
     case Op::Just:
       return leftValue;
   }
-  throw std::runtime_error("Bad parsing tree");
+  throw runtime_error("Bad parsing tree");
 };
 
 bool DataDescriptorMatcher::operator==(DataDescriptorMatcher const& other) const

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -53,6 +53,7 @@
 #include <memory>
 #include <unordered_map>
 #include <uv.h>
+#include <execinfo.h>
 
 using namespace o2::framework;
 using Key = o2::monitoring::tags::Key;
@@ -95,18 +96,22 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
   /// FIXME: move erro handling to a service?
   if (mError != nullptr) {
     mErrorHandling = [& errorCallback = mError,
-                      &serviceRegistry = mServiceRegistry](std::exception& e, InputRecord& record) {
+                      &serviceRegistry = mServiceRegistry](RuntimeErrorRef e, InputRecord& record) {
       ZoneScopedN("Error handling");
-      LOG(ERROR) << "Exception caught: " << e.what() << std::endl;
+      auto& err = error_from_ref(e);
+      LOGP(ERROR, "Exception caught: {} ", err.what);
+      backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       serviceRegistry.get<Monitoring>().send({1, "error"});
       ErrorContext errorContext{record, serviceRegistry, e};
       errorCallback(errorContext);
     };
   } else {
     mErrorHandling = [& errorPolicy = mErrorPolicy,
-                      &serviceRegistry = mServiceRegistry](std::exception& e, InputRecord& record) {
+                      &serviceRegistry = mServiceRegistry](RuntimeErrorRef e, InputRecord& record) {
       ZoneScopedN("Error handling");
-      LOG(ERROR) << "Exception caught: " << e.what() << std::endl;
+      auto& err = error_from_ref(e);
+      LOGP(ERROR, "Exception caught: {} ", err.what);
+      backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
       serviceRegistry.get<Monitoring>().send({1, "error"});
       switch (errorPolicy) {
         case TerminationPolicy::QUIT:
@@ -975,7 +980,14 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
           context.registry->postProcessingCallbacks(processContext);
         }
       }
-    } catch (std::exception& e) {
+    } catch (std::exception& ex) {
+      ZoneScopedN("error handling");
+      /// Convert a standatd exception to a RuntimeErrorRef
+      /// Notice how this will lose the backtrace information
+      /// and report the exception coming from here.
+      auto e = runtime_error(ex.what());
+      (*context.errorHandling)(e, record);
+    } catch (o2::framework::RuntimeErrorRef e) {
       ZoneScopedN("error handling");
       (*context.errorHandling)(e, record);
     }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -112,6 +112,17 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
       auto& err = error_from_ref(e);
       LOGP(ERROR, "Exception caught: {} ", err.what);
       backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+      auto lastCheckpoint = get_last_checkpoint();
+      LOG(ERROR) << "Previous checkpoints: ";
+      for (auto ci = 0; ci < Checkpoint::MAX_CHECKPOINTS; ++ci) {
+        if ((lastCheckpoint - ci) < 0) {
+          break;
+        }
+        auto pos = (lastCheckpoint - ci) & Checkpoint::MAX_CHECKPOINTS;
+        auto& c = get_checkpoint(pos);
+        LOG(ERROR) << c.what;
+        //backtrace_symbols_fd(c.backtrace, c.maxBacktrace, STDERR_FILENO);
+      }
       serviceRegistry.get<Monitoring>().send({1, "error"});
       switch (errorPolicy) {
         case TerminationPolicy::QUIT:

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -12,6 +12,8 @@
 #include "Framework/DataMatcherWalker.h"
 #include "Framework/VariantHelpers.h"
 #include "Framework/Logger.h"
+#include "Framework/RuntimeError.h"
+
 #include <cstring>
 #include <cinttypes>
 
@@ -70,7 +72,7 @@ std::string DataSpecUtils::describe(InputSpec const& spec)
     ss << "<matcher query: " << *matcher << ">";
     return ss.str();
   }
-  throw std::runtime_error("Unhandled InputSpec kind.");
+  throw runtime_error("Unhandled InputSpec kind.");
 }
 
 std::string DataSpecUtils::describe(OutputSpec const& spec)
@@ -95,7 +97,7 @@ void DataSpecUtils::describe(char* buffer, size_t size, InputSpec const& spec)
     ss << "<matcher query: " << *matcher << ">";
     strncpy(buffer, ss.str().c_str(), size - 1);
   } else {
-    throw std::runtime_error("Unsupported InputSpec");
+    throw runtime_error("Unsupported InputSpec");
   }
 }
 
@@ -112,7 +114,7 @@ std::string DataSpecUtils::label(InputSpec const& spec)
 
     return result;
   }
-  throw std::runtime_error("Unsupported InputSpec");
+  throw runtime_error("Unsupported InputSpec");
 }
 
 std::string DataSpecUtils::label(OutputSpec const& spec)
@@ -129,7 +131,7 @@ std::string DataSpecUtils::restEndpoint(InputSpec const& spec)
   if (auto concrete = std::get_if<ConcreteDataMatcher>(&spec.matcher)) {
     return std::string("/") + join(*concrete, "/");
   } else {
-    throw std::runtime_error("Unsupported InputSpec kind");
+    throw runtime_error("Unsupported InputSpec kind");
   }
 }
 
@@ -215,7 +217,7 @@ bool DataSpecUtils::match(InputSpec const& spec, ConcreteDataMatcher const& targ
     data_matcher::VariableContext context;
     return matcher->match(target, context);
   } else {
-    throw std::runtime_error("Unsupported InputSpec");
+    throw runtime_error("Unsupported InputSpec");
   }
 }
 
@@ -406,7 +408,7 @@ ConcreteDataTypeMatcher DataSpecUtils::asConcreteDataTypeMatcher(InputSpec const
                         if (state.hasUniqueOrigin && state.hasUniqueDescription) {
                           return ConcreteDataTypeMatcher{state.origin, state.description};
                         }
-                        throw std::runtime_error("Could not extract data type from query");
+                        throw runtime_error("Could not extract data type from query");
                       }},
                     spec.matcher);
 }
@@ -422,7 +424,7 @@ header::DataOrigin DataSpecUtils::asConcreteOrigin(InputSpec const& spec)
                         if (state.hasUniqueOrigin) {
                           return state.origin;
                         }
-                        throw std::runtime_error("Could not extract data type from query");
+                        throw runtime_error("Could not extract data type from query");
                       }},
                     spec.matcher);
 }
@@ -438,7 +440,7 @@ header::DataDescription DataSpecUtils::asConcreteDataDescription(InputSpec const
                         if (state.hasUniqueDescription) {
                           return state.description;
                         }
-                        throw std::runtime_error("Could not extract data type from query");
+                        throw runtime_error("Could not extract data type from query");
                       }},
                     spec.matcher);
 }
@@ -457,7 +459,7 @@ OutputSpec DataSpecUtils::asOutputSpec(InputSpec const& spec)
                           return OutputSpec{{spec.binding}, ConcreteDataTypeMatcher{state.origin, state.description}, spec.lifetime};
                         }
 
-                        throw std::runtime_error("Could not extract neither ConcreteDataMatcher nor ConcreteDataTypeMatcher from query" + describe(spec));
+                        throw runtime_error_f("Could not extract neither ConcreteDataMatcher nor ConcreteDataTypeMatcher from query %s", describe(spec).c_str());
                       }},
                     spec.matcher);
 }
@@ -554,7 +556,7 @@ std::optional<header::DataHeader::SubSpecificationType> DataSpecUtils::getOption
                         if (state.hasUniqueSubSpec) {
                           return std::make_optional(state.subSpec);
                         } else if (state.hasError) {
-                          throw std::runtime_error("Could not extract subSpec from query");
+                          throw runtime_error("Could not extract subSpec from query");
                         }
                         return {};
                       }},

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -30,6 +30,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ComputingResource.h"
 #include "Framework/Logger.h"
+#include "Framework/RuntimeError.h"
 
 #include "WorkflowHelpers.h"
 
@@ -110,7 +111,7 @@ struct ExpirationHandlerHelpers {
     /// FIXME: seems convoluted... Maybe there is a way to avoid all this checking???
     auto m = std::get_if<ConcreteDataMatcher>(&spec.matcher);
     if (m == nullptr) {
-      throw std::runtime_error("InputSpec for Conditions must be fully qualified");
+      throw runtime_error("InputSpec for Conditions must be fully qualified");
     }
 
     return [s = spec, matcher = *m, sourceChannel](DeviceState&, ConfigParamRegistry const& options) {
@@ -151,7 +152,7 @@ struct ExpirationHandlerHelpers {
   {
     auto m = std::get_if<ConcreteDataMatcher>(&spec.matcher);
     if (m == nullptr) {
-      throw std::runtime_error("InputSpec for Timers must be fully qualified");
+      throw runtime_error("InputSpec for Timers must be fully qualified");
     }
     // We copy the matcher to avoid lifetime issues.
     return [matcher = *m, sourceChannel](DeviceState&, ConfigParamRegistry const&) { return LifetimeHelpers::enumerate(matcher, sourceChannel); };
@@ -161,7 +162,7 @@ struct ExpirationHandlerHelpers {
   {
     auto m = std::get_if<ConcreteDataMatcher>(&spec.matcher);
     if (m == nullptr) {
-      throw std::runtime_error("InputSpec for Enumeration must be fully qualified");
+      throw runtime_error("InputSpec for Enumeration must be fully qualified");
     }
     // We copy the matcher to avoid lifetime issues.
     return [matcher = *m, sourceChannel](DeviceState&, ConfigParamRegistry const&) {
@@ -752,7 +753,7 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
       }
       return deviceEdge.deviceIndex;
     }
-    throw std::runtime_error("Unable to find device.");
+    throw runtime_error("Unable to find device.");
   };
 
   // Optimize the topology when two devices are
@@ -789,7 +790,7 @@ void DeviceSpecHelpers::reworkShmSegmentSize(std::vector<DataProcessorInfo>& inf
     }
     auto value = it + 1;
     if (value == info.cmdLineArgs.end()) {
-      throw std::runtime_error("--shm-segment-size requires an argument");
+      throw runtime_error("--shm-segment-size requires an argument");
     }
     char* err = nullptr;
     int64_t size = strtoll(value->c_str(), &err, 10);

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -11,6 +11,7 @@
 #include "../src/ExpressionHelpers.h"
 #include "Framework/VariantHelpers.h"
 #include "Framework/Logger.h"
+#include "Framework/RuntimeError.h"
 #include "gandiva/tree_expr_builder.h"
 #include "arrow/table.h"
 #include "fmt/format.h"
@@ -89,7 +90,7 @@ std::string upcastTo(atype::type f)
     case atype::DOUBLE:
       return "castFLOAT8";
     default:
-      throw std::runtime_error(fmt::format("Do not know how to cast to {}", f));
+      throw runtime_error_f("Do not know how to cast to %d", f);
   }
 }
 
@@ -237,7 +238,7 @@ Operations createOperations(Filter const& expression)
   auto inferResultType = [&resultTypes](DatumSpec& left, DatumSpec& right) {
     // if the left datum is monostate (error)
     if (left.datum.index() == 0) {
-      throw std::runtime_error("Malformed operation spec: empty left datum");
+      throw runtime_error("Malformed operation spec: empty left datum");
     }
 
     // check if the datums are references
@@ -277,7 +278,7 @@ Operations createOperations(Filter const& expression)
     if (t1 == atype::DOUBLE) {
       return atype::DOUBLE;
     }
-    throw std::runtime_error(fmt::format("Invalid combination of argument types {} and {}", t1, t2));
+    throw runtime_error_f("Invalid combination of argument types %d and %d", t1, t2);
   };
 
   for (auto it = OperationSpecs.rbegin(); it != OperationSpecs.rend(); ++it) {
@@ -309,11 +310,10 @@ std::shared_ptr<gandiva::Filter>
   auto s = gandiva::Filter::Make(Schema,
                                  makeCondition(createExpressionTree(opSpecs, Schema)),
                                  &filter);
-  if (s.ok()) {
-    return filter;
-  } else {
-    throw std::runtime_error(fmt::format("Failed to create filter: {}", s.ToString()));
+  if (!s.ok()) {
+    throw runtime_error_f("Failed to create filter: %s", s.ToString().c_str());
   }
+  return filter;
 }
 
 std::shared_ptr<gandiva::Filter>
@@ -323,11 +323,10 @@ std::shared_ptr<gandiva::Filter>
   auto s = gandiva::Filter::Make(Schema,
                                  condition,
                                  &filter);
-  if (s.ok()) {
-    return filter;
-  } else {
-    throw std::runtime_error(fmt::format("Failed to create filter: {}", s.ToString()));
+  if (!s.ok()) {
+    throw runtime_error_f("Failed to create filter: %s", s.ToString().c_str());
   }
+  return filter;
 }
 
 std::shared_ptr<gandiva::Projector>
@@ -337,11 +336,10 @@ std::shared_ptr<gandiva::Projector>
   auto s = gandiva::Projector::Make(Schema,
                                     {makeExpression(createExpressionTree(opSpecs, Schema), result)},
                                     &projector);
-  if (s.ok()) {
-    return projector;
-  } else {
-    throw std::runtime_error(fmt::format("Failed to create projector: {}", s.ToString()));
+  if (!s.ok()) {
+    throw runtime_error_f("Failed to create projector: %s", s.ToString().c_str());
   }
+  return projector;
 }
 
 std::shared_ptr<gandiva::Projector>
@@ -357,21 +355,21 @@ Selection createSelection(std::shared_ptr<arrow::Table> table, std::shared_ptr<g
                                                arrow::default_memory_pool(),
                                                &selection);
   if (!s.ok()) {
-    throw std::runtime_error(fmt::format("Cannot allocate selection vector {}", s.ToString()));
+    throw runtime_error_f("Cannot allocate selection vector %s", s.ToString().c_str());
   }
   arrow::TableBatchReader reader(*table);
   std::shared_ptr<arrow::RecordBatch> batch;
   while (true) {
     s = reader.ReadNext(&batch);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s.ToString()));
+      throw runtime_error_f("Cannot read batches from table %s", s.ToString().c_str());
     }
     if (batch == nullptr) {
       break;
     }
     s = gfilter->Evaluate(*batch, selection);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot apply filter {}", s.ToString()));
+      throw runtime_error_f("Cannot apply filter %s", s.ToString().c_str());
     }
   }
 
@@ -392,14 +390,14 @@ auto createProjection(std::shared_ptr<arrow::Table> table, std::shared_ptr<gandi
   while (true) {
     auto s = reader.ReadNext(&batch);
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot read batches from table {}", s.ToString()));
+      throw runtime_error_f("Cannot read batches from table %s", s.ToString().c_str());
     }
     if (batch == nullptr) {
       break;
     }
     s = gprojector->Evaluate(*batch, arrow::default_memory_pool(), v.get());
     if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot apply projector {}", s.ToString()));
+      throw runtime_error_f("Cannot apply projector %s", s.ToString().c_str());
     }
   }
   return v;
@@ -433,7 +431,7 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
         return gandiva::TreeExprBuilder::MakeLiteral(std::get<double>(content));
       if (content.index() == 4)
         return gandiva::TreeExprBuilder::MakeLiteral(std::get<uint8_t>(content));
-      throw std::runtime_error("Malformed LiteralNode");
+      throw runtime_error("Malformed LiteralNode");
     }
 
     if (spec.datum.index() == 3) {
@@ -444,13 +442,13 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
       }
       auto field = Schema->GetFieldByName(name);
       if (field == nullptr) {
-        throw std::runtime_error(fmt::format("Cannot find field \"{}\"", name));
+        throw runtime_error_f("Cannot find field \"%s\"", name.c_str());
       }
       auto node = gandiva::TreeExprBuilder::MakeField(field);
       fieldNodes.insert({name, node});
       return node;
     }
-    throw std::runtime_error("Malformed DatumSpec");
+    throw runtime_error("Malformed DatumSpec");
   };
 
   gandiva::NodePtr tree = nullptr;
@@ -526,7 +524,7 @@ bool isSchemaCompatible(gandiva::SchemaPtr const& Schema, Operations const& opSp
 void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos)
 {
   if (eInfos.empty()) {
-    throw std::runtime_error("Empty expression info vector.");
+    throw runtime_error("Empty expression info vector.");
   }
   Operations ops = createOperations(filter);
   for (auto& info : eInfos) {

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -180,7 +180,7 @@ ExpirationHandler::Handler
   char* err;
   uint64_t overrideTimestampMilliseconds = strtoll(overrideTimestamp.c_str(), &err, 10);
   if (*err != 0) {
-    throw std::runtime_error("fetchFromCCDBCache: Unable to parse forced timestamp for conditions");
+    throw runtime_error("fetchFromCCDBCache: Unable to parse forced timestamp for conditions");
   }
   if (overrideTimestampMilliseconds) {
     LOGP(info, "fetchFromCCDBCache: forcing timestamp for conditions to {} milliseconds from epoch UTC", overrideTimestampMilliseconds);
@@ -199,7 +199,7 @@ ExpirationHandler::Handler
 
     CURL* curl = curl_easy_init();
     if (curl == nullptr) {
-      throw std::runtime_error("fetchFromCCDBCache: Unable to initialise CURL");
+      throw runtime_error("fetchFromCCDBCache: Unable to initialise CURL");
     }
     CURLcode res;
     if (overrideTimestampMilliseconds) {
@@ -216,13 +216,13 @@ ExpirationHandler::Handler
 
     res = curl_easy_perform(curl);
     if (res != CURLE_OK) {
-      throw std::runtime_error(std::string("fetchFromCCDBCache: Unable to fetch ") + url + " from CCDB");
+      throw runtime_error_f("fetchFromCCDBCache: Unable to fetch %s from CCDB", url.c_str());
     }
     long responseCode;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 
     if (responseCode != 200) {
-      throw std::runtime_error(std::string("fetchFromCCDBCache: HTTP error ") + std::to_string(responseCode) + " while fetching " + url + " from CCDB");
+      throw runtime_error_f("fetchFromCCDBCache: HTTP error %d while fetching %s from CCDB", responseCode, url.c_str());
     }
 
     curl_easy_cleanup(curl);
@@ -254,7 +254,7 @@ ExpirationHandler::Handler
 ExpirationHandler::Handler LifetimeHelpers::fetchFromQARegistry()
 {
   return [](ServiceRegistry&, PartRef& ref, uint64_t) -> void {
-    throw std::runtime_error("fetchFromQARegistry: Not yet implemented");
+    throw runtime_error("fetchFromQARegistry: Not yet implemented");
     return;
   };
 }
@@ -265,7 +265,7 @@ ExpirationHandler::Handler LifetimeHelpers::fetchFromQARegistry()
 ExpirationHandler::Handler LifetimeHelpers::fetchFromObjectRegistry()
 {
   return [](ServiceRegistry&, PartRef& ref, uint64_t) -> void {
-    throw std::runtime_error("fetchFromObjectRegistry: Not yet implemented");
+    throw runtime_error("fetchFromObjectRegistry: Not yet implemented");
     return;
   };
 }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -107,6 +107,7 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <execinfo.h>
 #if __has_include(<linux/getcpu.h>)
 #include <linux/getcpu.h>
 #elif __has_include(<cpuid.h>)
@@ -761,11 +762,16 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry, const o2::f
     runner.AddHook<fair::mq::hooks::InstantiateDevice>(afterConfigParsingCallback);
     return runner.Run();
   } catch (boost::exception& e) {
-    LOG(ERROR) << "Unhandled exception reached the top of main, device shutting down. Details follow: \n"
+    LOG(ERROR) << "Unhandled boost::exception reached the top of main, device shutting down. Details follow: \n"
                << boost::current_exception_diagnostic_information(true);
     return 1;
+  } catch (o2::framework::RuntimeErrorRef e) {
+    LOG(ERROR) << "Unhandled o2::framework::runtime_error reached the top of main, device shutting down. Details follow: \n";
+    auto& err = o2::framework::error_from_ref(e);
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+    return 1;
   } catch (std::exception& e) {
-    LOG(ERROR) << "Unhandled exception reached the top of main: " << e.what() << ", device shutting down.";
+    LOG(ERROR) << "Unhandled std::exception reached the top of main: " << e.what() << ", device shutting down.";
     return 1;
   } catch (...) {
     LOG(ERROR) << "Unknown exception reached the top of main.\n";

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -22,7 +22,7 @@ using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
 using Stack = o2::header::Stack;
 
-bool any_exception(std::exception const& ex) { return true; }
+bool any_exception(RuntimeErrorRef const& ex) { return true; }
 
 BOOST_AUTO_TEST_CASE(TestInputRecord)
 {
@@ -48,12 +48,12 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   // bunch of exceptions.
   InputRecord emptyRecord(schema, {[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0});
 
-  BOOST_CHECK_EXCEPTION(emptyRecord.get("x"), std::exception, any_exception);
-  BOOST_CHECK_EXCEPTION(emptyRecord.get("y"), std::exception, any_exception);
-  BOOST_CHECK_EXCEPTION(emptyRecord.get("z"), std::exception, any_exception);
-  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(0), std::exception, any_exception);
-  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(1), std::exception, any_exception);
-  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(2), std::exception, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.get("x"), RuntimeErrorRef, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.get("y"), RuntimeErrorRef, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.get("z"), RuntimeErrorRef, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(0), RuntimeErrorRef, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(1), RuntimeErrorRef, any_exception);
+  BOOST_CHECK_EXCEPTION(emptyRecord.getByPos(2), RuntimeErrorRef, any_exception);
   // Then we actually check with a real set of inputs.
 
   std::vector<void*> inputs;
@@ -97,13 +97,13 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   auto ref00 = record.get("x");
   auto ref10 = record.get("y");
   auto ref20 = record.get("z");
-  BOOST_CHECK_EXCEPTION(record.get("err"), std::exception, any_exception);
+  BOOST_CHECK_EXCEPTION(record.get("err"), RuntimeErrorRef, any_exception);
 
   // Or we can get it positionally
   BOOST_CHECK_NO_THROW(record.get("x"));
   auto ref01 = record.getByPos(0);
   auto ref11 = record.getByPos(1);
-  BOOST_CHECK_EXCEPTION(record.getByPos(10), std::exception, any_exception);
+  BOOST_CHECK_EXCEPTION(record.getByPos(10), RuntimeErrorRef, any_exception);
 
   // This should be exactly the same pointers
   BOOST_CHECK_EQUAL(ref00.header, ref01.header);

--- a/Framework/Core/test/test_Services.cxx
+++ b/Framework/Core/test/test_Services.cxx
@@ -61,8 +61,8 @@ BOOST_AUTO_TEST_CASE(TestServiceRegistry)
   BOOST_CHECK(registry.active<InterfaceA>() == true);
   BOOST_CHECK(registry.active<InterfaceB>() == true);
   BOOST_CHECK(registry.active<InterfaceC>() == false);
-  BOOST_CHECK_THROW(registry.get<InterfaceA const>(), std::runtime_error);
-  BOOST_CHECK_THROW(registry.get<InterfaceC>(), std::runtime_error);
+  BOOST_CHECK_THROW(registry.get<InterfaceA const>(), RuntimeErrorRef);
+  BOOST_CHECK_THROW(registry.get<InterfaceC>(), RuntimeErrorRef);
 }
 
 BOOST_AUTO_TEST_CASE(TestCallbackService)
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(TestCallbackService)
   registry.get<CallbackService>().set(CallbackService::Id::Stop, cb);
 
   // check to set with the wrong type
-  BOOST_CHECK_THROW(registry.get<CallbackService>().set(CallbackService::Id::Stop, [](int) {}), std::runtime_error);
+  BOOST_CHECK_THROW(registry.get<CallbackService>().set(CallbackService::Id::Stop, [](int) {}), RuntimeErrorRef);
 
   // execute and check
   registry.get<CallbackService>()(CallbackService::Id::Stop);

--- a/Framework/Core/test/test_Variants.cxx
+++ b/Framework/Core/test/test_Variants.cxx
@@ -13,15 +13,15 @@
 
 #include <boost/test/unit_test.hpp>
 #include "Framework/Variant.h"
-#include <stdexcept>
 #include <sstream>
 #include <cstring>
 
 using namespace o2::framework;
 
-bool unknown_type(std::runtime_error const& ex)
+bool unknown_type(RuntimeErrorRef const& ref)
 {
-  return strcmp(ex.what(), "Mismatch between types") == 0;
+  auto& err = error_from_ref(ref);
+  return strcmp(err.what, "Mismatch between types") == 0;
 }
 
 BOOST_AUTO_TEST_CASE(VariantTest)
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(VariantTest)
   Variant c(10.2);
   BOOST_CHECK(c.get<double>() == 10.2);
   ss << c;
-  BOOST_CHECK_EXCEPTION(a.get<char*>(), std::runtime_error, unknown_type);
+  BOOST_CHECK_EXCEPTION(a.get<char*>(), RuntimeErrorRef, unknown_type);
   Variant d("foo");
   ss << d;
   BOOST_CHECK(std::string(d.get<const char*>()) == "foo");

--- a/Framework/Core/test/unittest_DataSpecUtils.cxx
+++ b/Framework/Core/test/unittest_DataSpecUtils.cxx
@@ -302,5 +302,5 @@ BOOST_AUTO_TEST_CASE(GettingConcreteMembers)
 
   BOOST_REQUIRE_EQUAL(justOriginInputSpec.size(), 1);
   BOOST_CHECK_EQUAL(DataSpecUtils::asConcreteOrigin(justOriginInputSpec.at(0)).as<std::string>(), "TST");
-  BOOST_CHECK_THROW(DataSpecUtils::asConcreteDataDescription(justOriginInputSpec.at(0)).as<std::string>(), std::runtime_error);
+  BOOST_CHECK_THROW(DataSpecUtils::asConcreteDataDescription(justOriginInputSpec.at(0)).as<std::string>(), RuntimeErrorRef);
 }

--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -8,7 +8,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_header_only_library(FrameworkFoundation)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/Framework
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+o2_add_library(FrameworkFoundation
+               SOURCES src/RuntimeError.cxx)
 
 o2_add_test(test_FunctionalHelpers NAME test_FrameworkFoundation_test_FunctionalHelpers
             COMPONENT_NAME FrameworkFoundation
@@ -33,4 +37,9 @@ o2_add_test(test_CompilerBuiltins NAME test_FrameworkFoundation_CompilerBuiltins
 o2_add_test(test_Signpost NAME test_FrameworkFoundation_Signpost
             COMPONENT_NAME FrameworkFoundation
             SOURCES test/test_Signpost.cxx
+            PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation)
+
+o2_add_test(test_RuntimeError NAME test_FrameworkFoundation_RuntimeError
+            COMPONENT_NAME FrameworkFoundation
+            SOURCES test/test_RuntimeError.cxx
             PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation)

--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -12,7 +12,13 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/Framework
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 o2_add_library(FrameworkFoundation
-               SOURCES src/RuntimeError.cxx)
+               SOURCES src/RuntimeError.cxx
+               TARGETVARNAME targetName
+              )
+if (DPL_ENABLE_BACKTRACE)
+target_compile_definitions(${targetName} PUBLIC -DDPL_ENABLE_BACKTRACE)
+endif()
+
 
 o2_add_test(test_FunctionalHelpers NAME test_FrameworkFoundation_test_FunctionalHelpers
             COMPONENT_NAME FrameworkFoundation

--- a/Framework/Foundation/include/Framework/RuntimeError.h
+++ b/Framework/Foundation/include/Framework/RuntimeError.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_RUNTIMEERROR_H_
+#define O2_FRAMEWORK_RUNTIMEERROR_H_
+
+namespace o2::framework
+{
+
+struct RuntimeError {
+  static constexpr unsigned int MAX_RUNTIME_ERRORS = 64;
+  static constexpr unsigned int MAX_RUNTIME_ERROR_SIZE = 1024;
+  static constexpr unsigned int MAX_BACKTRACE_SIZE = 100;
+  char what[MAX_RUNTIME_ERROR_SIZE];
+  void* backtrace[MAX_BACKTRACE_SIZE];
+  int maxBacktrace = 0;
+};
+
+struct RuntimeErrorRef {
+  int index = 0;
+};
+
+RuntimeErrorRef runtime_error(const char*);
+RuntimeErrorRef runtime_error_f(const char*, ...);
+RuntimeError& error_from_ref(RuntimeErrorRef);
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_RUNTIMEERROR_H_

--- a/Framework/Foundation/include/Framework/RuntimeError.h
+++ b/Framework/Foundation/include/Framework/RuntimeError.h
@@ -10,6 +10,8 @@
 #ifndef O2_FRAMEWORK_RUNTIMEERROR_H_
 #define O2_FRAMEWORK_RUNTIMEERROR_H_
 
+#include <cstdint>
+
 namespace o2::framework
 {
 
@@ -22,6 +24,17 @@ struct RuntimeError {
   int maxBacktrace = 0;
 };
 
+struct Checkpoint {
+  static constexpr unsigned int MAX_CHECKPOINTS = 64;
+  static constexpr unsigned int MAX_CHECKPOINT_SIZE = 1024;
+  static constexpr unsigned int MAX_BACKTRACE_SIZE = 10;
+  char what[MAX_CHECKPOINT_SIZE];
+  void* backtrace[MAX_BACKTRACE_SIZE];
+  int maxBacktrace = 0;
+  int64_t index = -1;
+  int64_t threadId = 0;
+};
+
 struct RuntimeErrorRef {
   int index = 0;
 };
@@ -30,6 +43,25 @@ RuntimeErrorRef runtime_error(const char*);
 RuntimeErrorRef runtime_error_f(const char*, ...);
 RuntimeError& error_from_ref(RuntimeErrorRef);
 
+int get_last_checkpoint();
+Checkpoint& get_checkpoint(int pos);
+void checkpoint(const char*);
+void checkpoint_f(const char*, ...);
+
 } // namespace o2::framework
+
+/// Use this macro to define a conditional checkpoint.
+#define CHECKPOINT(condition, error)             \
+  if (condition) {                               \
+    ::o2::framework::checkpoint(#condition);     \
+  } else {                                       \
+    throw ::o2::framework::runtime_error(error); \
+  }
+#define CHECKPOINT_F(condition, error, ...)                     \
+  if (condition) {                                              \
+    ::o2::framework::checkpoint(#condition);                    \
+  } else {                                                      \
+    throw ::o2::framework::runtime_error_f(error, __VA_ARGS__); \
+  }
 
 #endif // O2_FRAMEWORK_RUNTIMEERROR_H_

--- a/Framework/Foundation/src/RuntimeError.cxx
+++ b/Framework/Foundation/src/RuntimeError.cxx
@@ -1,0 +1,80 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/RuntimeError.h"
+
+#include <cstdio>
+#include <atomic>
+#include <cstdarg>
+#include <execinfo.h>
+#include <cstring>
+
+namespace o2::framework
+{
+
+namespace
+{
+static RuntimeError gError[RuntimeError::MAX_RUNTIME_ERRORS];
+static std::atomic<bool> gErrorBooking[RuntimeError::MAX_RUNTIME_ERRORS];
+
+bool canDumpBacktrace()
+{
+#ifdef DPL_ENABLE_BACKTRACE
+  return true;
+#else
+  return false;
+#endif
+}
+} // namespace
+
+void clean_all_runtime_errors()
+{
+  for (size_t i = 0; i < RuntimeError::MAX_RUNTIME_ERRORS; ++i) {
+    gErrorBooking[i].store(false);
+  }
+}
+
+void clean_runtime_error(int i)
+{
+  gErrorBooking[i].store(false);
+}
+
+RuntimeError& error_from_ref(RuntimeErrorRef ref)
+{
+  return gError[ref.index];
+}
+
+RuntimeErrorRef runtime_error_f(const char* format, ...)
+{
+  int i = 0;
+  bool expected = false;
+  while (gErrorBooking[i].compare_exchange_strong(expected, true) == false) {
+    ++i;
+  }
+  va_list args;
+  va_start(args, format);
+  vsnprintf(gError[i].what, RuntimeError::MAX_RUNTIME_ERROR_SIZE, format, args);
+  gError[i].maxBacktrace = canDumpBacktrace() ? backtrace(gError[i].backtrace, RuntimeError::MAX_BACKTRACE_SIZE) : 0;
+  return RuntimeErrorRef{i};
+}
+
+RuntimeErrorRef runtime_error(const char* s)
+{
+  int i = 0;
+  bool expected = false;
+  while (gErrorBooking[i].compare_exchange_strong(expected, true) == false) {
+    ++i;
+  }
+  strncpy(gError[i].what, s, RuntimeError::MAX_RUNTIME_ERROR_SIZE);
+  gError[i].maxBacktrace = canDumpBacktrace() ? backtrace(gError[i].backtrace, RuntimeError::MAX_BACKTRACE_SIZE) : 0;
+  return RuntimeErrorRef{i};
+}
+
+} // namespace o2::framework

--- a/Framework/Foundation/test/test_RuntimeError.cxx
+++ b/Framework/Foundation/test/test_RuntimeError.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework RuntimeError
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/RuntimeError.h"
+#include <execinfo.h>
+
+BOOST_AUTO_TEST_CASE(TestRuntimeError)
+{
+  try {
+    throw o2::framework::runtime_error("foo");
+  } catch (o2::framework::RuntimeErrorRef ref) {
+    auto& err = o2::framework::error_from_ref(ref);
+    BOOST_CHECK_EQUAL(strncmp(err.what, "foo", 3), 0);
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+#endif
+  }
+
+  try {
+    throw o2::framework::runtime_error_f("foo %d", 1);
+  } catch (o2::framework::RuntimeErrorRef ref) {
+    auto& err = o2::framework::error_from_ref(ref);
+    BOOST_CHECK_EQUAL(strncmp(err.what, "foo", 3), 0);
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+#endif
+  }
+}

--- a/Framework/Foundation/test/test_RuntimeError.cxx
+++ b/Framework/Foundation/test/test_RuntimeError.cxx
@@ -37,4 +37,22 @@ BOOST_AUTO_TEST_CASE(TestRuntimeError)
     backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
 #endif
   }
+
+  try {
+    int i = 0;
+    CHECKPOINT(i++ == 0, "nice");
+    CHECKPOINT_F(i++ == 0, "not correct %d", i);
+  } catch (o2::framework::RuntimeErrorRef ref) {
+    auto& err = o2::framework::error_from_ref(ref);
+    BOOST_CHECK_EQUAL(strncmp(err.what, "not correct 2", 13), 0);
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+#endif
+    std::cerr << "Previous checkpoints" << std::endl;
+    auto& c = o2::framework::get_checkpoint(0);
+    BOOST_CHECK_EQUAL(c.what, std::string("i++ == 0"));
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(c.backtrace, c.maxBacktrace, STDERR_FILENO);
+#endif
+  }
 }

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -42,6 +42,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
   return AlgorithmSpec{adaptStateful([what, minDelay]() {
     srand(getpid());
     return adaptStateless([what, minDelay](DataAllocator& outputs) {
+      throw runtime_error_f("This is an error %d", 1);
       std::this_thread::sleep_for(std::chrono::seconds((rand() % 5) + minDelay));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });

--- a/Framework/Utils/include/DPLUtils/RootTreeWriter.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeWriter.h
@@ -616,7 +616,7 @@ class RootTreeWriter
           mStore[branchIdx] = &clone;
           branch->Fill();
         }
-      } catch (const std::runtime_error& e) {
+      } catch (RuntimeErrorRef e) {
         if constexpr (has_root_dictionary<value_type>::value == true) {
           // try extracting from message with serialization method ROOT
           auto data = context.get<typename std::add_pointer<value_type>::type>(ref);


### PR DESCRIPTION
A few features:

* No need to include <stdexcept> hopefully reducing bload.
* No allocation on throw.
* Includes backtrace.

We should use this to remove all the runtime_error from at least the framework.