### PR TITLE
Add access to jet constituents

### DIFF
--- a/Analysis/Tutorials/src/jetAnalysis.cxx
+++ b/Analysis/Tutorials/src/jetAnalysis.cxx
@@ -27,21 +27,24 @@ using namespace o2;
 using namespace o2::framework;
 
 struct JetAnalysis {
-  OutputObj<TH1F> hJetPt{"pt"};
+  OutputObj<TH1F> hJetPt{"jetPt"};
+  OutputObj<TH1F> hConstPt{"constPt"};
 
   void init(InitContext const&)
   {
-    hJetPt.setObject(new TH1F("pt", "jet p_{T};p_{T} (GeV/#it{c})",
+    hJetPt.setObject(new TH1F("jetPt", "jet p_{T};p_{T} (GeV/#it{c})",
                               100, 0., 100.));
+    hConstPt.setObject(new TH1F("constPt", "constituent p_{T};p_{T} (GeV/#it{c})",
+                                100, 0., 100.));
   }
 
-  // TODO: add aod::Tracks (when available)
   void process(aod::Jet const& jet,
-               aod::JetConstituents const& constituents)
+               aod::JetConstituents const& constituents, aod::Tracks const& tracks)
   {
     hJetPt->Fill(jet.pt());
     for (const auto c : constituents) {
-      LOGF(INFO, "jet %d: track id %d", jet.index(), c.trackId());
+      LOGF(DEBUG, "jet %d: track id %d, track pt %g", jet.index(), c.trackId(), c.track().pt());
+      hConstPt->Fill(c.track().pt());
     }
   }
 };


### PR DESCRIPTION
Access the tracks constituting a jet with the indirection through the index table. Short of the integration of the indices in the jet table, this is probably what we should advertise as access to jet constituents.

@nzardosh @aalkin Could you have a look if that makes sense to you?