### PR TITLE
DPL Analysis: introduce policies for index building

### DIFF
--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -53,12 +53,11 @@ std::shared_ptr<arrow::Table>
   mFinalizer();
   std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
   columns.reserve(mArrays.size());
-  for (size_t i = 0; i < mSchema->num_fields(); ++i) {
+  for (auto i = 0; i < mSchema->num_fields(); ++i) {
     auto column = std::make_shared<arrow::ChunkedArray>(mArrays[i]);
     columns.emplace_back(column);
   }
-  auto table_ = arrow::Table::Make(mSchema, columns);
-  return table_;
+  return arrow::Table::Make(mSchema, columns);
 }
 
 } // namespace o2::framework


### PR DESCRIPTION
Index can now be built with two policies:
* Exclusive: each index row needs to have _all_ entries available
* Sparse: index is isomorphic to the base (i.e. first) table it refers to (e.g. Collisions, see custom_index.cxx)

Example updated to demonstrate how to access indexed information and how the entry validity can be checked when the sparse policy is used. 

Index building callbacks moved from TableBuilder.h to AnalysisTask.h