### PR TITLE
Workflow for TOFcalibCollector

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
@@ -36,7 +36,7 @@ class CalibInfoTOF
   void setDeltaTimePi(float time) { mDeltaTimePi = time; }
   float getDeltaTimePi() const { return mDeltaTimePi; }
 
-  void setTot(int tot) { mTot = tot; }
+  void setTot(float tot) { mTot = tot; }
   float getTot() const { return mTot; }
 
   void setFlags(int flags) { mFlags = flags; }

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOFshort.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOFshort.h
@@ -14,6 +14,8 @@
 #ifndef ALICEO2_CALIBINFOTOFSHORT_H
 #define ALICEO2_CALIBINFOTOFSHORT_H
 
+#include "Rtypes.h"
+
 namespace o2
 {
 namespace dataformats
@@ -43,7 +45,8 @@ class CalibInfoTOFshort
   float mDeltaTimePi;   // raw tof time - expected time for pi hypotesis
   float mTot;           // time-over-threshold
   unsigned char mFlags; // bit mask with quality flags (to be defined)
-  //  ClassDefNV(CalibInfoTOFshort, 1);
+
+  ClassDefNV(CalibInfoTOFshort, 1);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -31,7 +31,9 @@ class TimeSlotCalibration
   TimeSlotCalibration() = default;
   virtual ~TimeSlotCalibration() = default;
   uint32_t getMaxSlotsDelay() const { return mMaxSlotsDelay; }
-  void setMaxSlotsDelay(uint32_t v) { mMaxSlotsDelay = v < 1 ? 1 : v; }
+  void setMaxSlotsDelay(uint32_t v) { mMaxSlotsDelay = v; }
+  //void setMaxSlotsDelay(uint32_t v) { (mSlotLength == 1 && mMaxSlotsDelay == 0) ? mMaxSlotsDelay = 0 : mMaxSlotsDelay = v < 1 ? 1 : v; }
+  //void setMaxSlotsDelay(uint32_t v) { mSlotLength == 1 ? mMaxSlotsDelay = 0 : mMaxSlotsDelay = v < 1 ? 1 : v; }
 
   uint32_t getSlotLength() const { return mSlotLength; }
   void setSlotLength(uint32_t v) { mSlotLength = v < 1 ? 1 : v; }
@@ -88,7 +90,7 @@ bool TimeSlotCalibration<Input, Container>::process(TFType tf, const gsl::span<c
   if (!mUpdateAtTheEndOfRunOnly) {
     int maxDelay = mMaxSlotsDelay * mSlotLength;
     //  if (tf<mLastClosedTF || (!mSlots.empty() && getSlot(0).getTFStart() > tf + maxDelay)) { // ignore TF
-    if (tf < mLastClosedTF || (!mSlots.empty() && getLastSlot().getTFStart() > tf + maxDelay)) { // ignore TF
+    if (maxDelay != 0 && (tf < mLastClosedTF || (!mSlots.empty() && getLastSlot().getTFStart() > tf + maxDelay))) { // ignore TF
       LOG(INFO) << "Ignoring TF " << tf;
       return false;
     }
@@ -111,7 +113,7 @@ void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int 
   // Check which slots can be finalized, provided the newly arrived TF is tf
   // check if some slots are done
   for (auto slot = mSlots.begin(); slot != mSlots.end(); slot++) {
-    if ((slot->getTFEnd() + maxDelay) < tf) {
+    if (maxDelay == 0 || (slot->getTFEnd() + maxDelay) < tf) {
       if (hasEnoughData(*slot)) {
         finalizeSlot(*slot); // will be removed after finalization
       } else if ((slot + 1) != mSlots.end()) {

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/CalibInfoReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/CalibInfoReaderSpec.h
@@ -19,6 +19,8 @@
 #include "Framework/Task.h"
 #include "DataFormatsTOF/CalibInfoTOF.h"
 
+class TTree;
+
 using namespace o2::framework;
 
 namespace o2
@@ -40,6 +42,7 @@ class CalibInfoReader : public Task
   int mNinstances;
   const char* mFileName = nullptr;
   FILE* mFile = nullptr;
+  TTree* mTree = nullptr;
   int mCurrentEntry = 0;
   int mGlobalEntry = 0;
   std::vector<o2::dataformats::CalibInfoTOF> mVect, *mPvect = &mVect;

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/CalibInfoReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/CalibInfoReaderSpec.cxx
@@ -11,6 +11,7 @@
 /// @file   DigitReaderSpec.cxx
 
 #include <vector>
+#include <unistd.h>
 
 #include "TChain.h"
 #include "TTree.h"
@@ -46,30 +47,33 @@ void CalibInfoReader::run(ProcessingContext& pc)
   }
 
   char filename[100];
-  int ientry = 0;
-  while (fscanf(mFile, "%s", filename) == 1) {
-    TFile* fin = TFile::Open(filename);
-    TTree* tin = (TTree*)fin->Get("calibTOF");
-    tin->SetBranchAddress("TOFCalibInfo", &mPvect);
-    for (int i = 0; i < tin->GetEntries(); i += mNinstances) {
-      if ((ientry % mNinstances) == mInstance) {
-        tin->GetEvent(i);
-        LOG(INFO) << "Send " << mVect.size() << " calib infos";
-        pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBINFOS", 0, Lifetime::Timeframe}, mVect);
-      }
-      ientry++;
-    }
-  }
 
-  mState = 2;
-  pc.services().get<ControlService>().endOfStream();
+  if ((mTree && mCurrentEntry < mTree->GetEntries()) || fscanf(mFile, "%s", filename) == 1) {
+    if (!mTree || mCurrentEntry >= mTree->GetEntries()) {
+      TFile* fin = TFile::Open(filename);
+      mTree = (TTree*)fin->Get("calibTOF");
+      mCurrentEntry = 0;
+      mTree->SetBranchAddress("TOFCalibInfo", &mPvect);
+    }
+    if ((mGlobalEntry % mNinstances) == mInstance) {
+      mTree->GetEvent(mCurrentEntry);
+      LOG(INFO) << "Send " << mVect.size() << " calib infos";
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mVect);
+      usleep(10000);
+    }
+    mGlobalEntry++;
+    mCurrentEntry++;
+  } else {
+    mState = 2;
+    pc.services().get<ControlService>().endOfStream();
+  }
   return;
 }
 
 DataProcessorSpec getCalibInfoReaderSpec(int instance, int ninstances, const char* filename)
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBINFOS", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe);
 
   const char* nameSpec;
   if (ninstances == 1)

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -115,7 +115,7 @@ class TOFDPLRecoWorkflowTask
       pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTPCLabelsVector());
       pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedITSLabelsVector());
     }
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBINFOS", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
     mTimer.Stop();
   }
 
@@ -152,7 +152,7 @@ o2::framework::DataProcessorSpec getTOFRecoWorkflowSpec(bool useMC, bool useFIT)
     outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
     outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
   }
-  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBINFOS", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "TOFRecoWorkflow",

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFCalibWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFCalibWriterSpec.cxx
@@ -43,7 +43,7 @@ DataProcessorSpec getTOFCalibWriterSpec()
   return MakeRootTreeWriterSpec("TOFCalibWriter",
                                 "o2calib_tof.root",
                                 "calibTOF",
-                                BranchDefinition<CalibInfosType>{InputSpec{"input", o2::header::gDataOriginTOF, "CALIBINFOS", 0},
+                                BranchDefinition<CalibInfosType>{InputSpec{"input", o2::header::gDataOriginTOF, "CALIBDATA", 0},
                                                                  "TOFCalibInfo",
                                                                  "calibinfo-branch-name",
                                                                  1,

--- a/Detectors/TOF/calibration/CMakeLists.txt
+++ b/Detectors/TOF/calibration/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(TOFCalibration
 		       src/CollectCalibInfoTOF.cxx
                        src/LHCClockCalibrator.cxx
 		       src/TOFChannelCalibrator.cxx
+		       src/TOFCalibCollector.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTOF O2::TOFBase
                                      O2::CCDB
 	                             O2::DetectorsCalibration
@@ -26,6 +27,7 @@ o2_target_root_dictionary(TOFCalibration
                                   include/TOFCalibration/CalibTOF.h
                                   include/TOFCalibration/LHCClockCalibrator.h
                                   include/TOFCalibration/TOFChannelCalibrator.h
+                                  include/TOFCalibration/TOFCalibCollector.h
                                   include/TOFCalibration/CollectCalibInfoTOF.h)
 
 
@@ -61,6 +63,13 @@ o2_add_executable(tof-calib-workflow
 o2_add_executable(tof-dummy-ccdb-for-calib
                   COMPONENT_NAME calibration
                   SOURCES testWorkflow/tof-dummy-ccdb-for-calib.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+ 		                        O2::TOFCalibration
+	                                O2::DetectorsCalibration)
+
+o2_add_executable(tof-collect-calib-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES testWorkflow/tof-collect-calib-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
  		                        O2::TOFCalibration
 	                                O2::DetectorsCalibration)

--- a/Detectors/TOF/calibration/include/TOFCalibration/CalibTOFapi.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/CalibTOFapi.h
@@ -58,6 +58,7 @@ class CalibTOFapi
 
   SlewParam* getSlewParam() { return mSlewParam; }
   SlewParam& getSlewParamObj() { return *mSlewParam; }
+  LhcPhase* getLhcPhase() { return mLHCphase; }
 
  private:
   long mTimeStamp;                 ///< timeStamp for queries

--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -51,7 +51,7 @@ struct LHCClockDataHisto {
   ClassDefNV(LHCClockDataHisto, 1);
 };
 
-class LHCClockCalibrator : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto>
+class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto>
 {
   using TFType = uint64_t;
   using Slot = o2::calibration::TimeSlot<o2::tof::LHCClockDataHisto>;

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TOF_CALIB_COLLECTOR_H_
+#define TOF_CALIB_COLLECTOR_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
+#include "TOFBase/Geo.h"
+#include "DataFormatsTOF/CalibInfoTOFshort.h"
+
+#include <array>
+
+namespace o2
+{
+namespace tof
+{
+
+class TOFCalibInfoSlot
+{
+
+  using Slot = o2::calibration::TimeSlot<o2::tof::TOFCalibInfoSlot>;
+  using Geo = o2::tof::Geo;
+
+ public:
+  static constexpr int NCHANNELSXSECTOR = o2::tof::Geo::NCHANNELS / o2::tof::Geo::NSECTORS;
+
+  TOFCalibInfoSlot()
+  {
+    for (int ch = 0; ch < Geo::NCHANNELS; ch++) {
+      mEntriesSlot[ch] = 0;
+    }
+  }
+
+  ~TOFCalibInfoSlot() = default;
+
+  void print() const;
+  void printEntries() const;
+  void fill(const gsl::span<const o2::dataformats::CalibInfoTOF> data);
+  void merge(const TOFCalibInfoSlot* prev);
+
+  auto& getEntriesPerChannel() const { return mEntriesSlot; }
+  auto& getEntriesPerChannel() { return mEntriesSlot; }
+  auto& getCollectedCalibInfoSlot() { return mTOFCollectedCalibInfoSlot; }
+  auto& getCollectedCalibInfoSlot() const { return mTOFCollectedCalibInfoSlot; }
+
+ private:
+  std::array<int, Geo::NCHANNELS> mEntriesSlot;                               // vector containing number of entries per channel
+  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCollectedCalibInfoSlot; ///< output TOF calibration info
+
+  ClassDefNV(TOFCalibInfoSlot, 1);
+};
+
+class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot>
+{
+  using TFType = uint64_t;
+  using Slot = o2::calibration::TimeSlot<o2::tof::TOFCalibInfoSlot>;
+
+ public:
+  TOFCalibCollector(bool TFsendingPolicy, int maxNumOfHits, bool test = false) : mTFsendingPolicy(TFsendingPolicy), mMaxNumOfHits(maxNumOfHits), mTest(test){};
+
+  ~TOFCalibCollector() final = default;
+
+  bool hasEnoughData(const Slot& slot) const final;
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+  void isTest(bool istest) { mTest = istest; }
+  auto& getCollectedCalibInfo() const { return mTOFCollectedCalibInfo; }
+  auto& getEntriesPerChannel() const { return mEntries; }
+  void isMaxNumberOfHitsAbsolute(bool absNumber) { mAbsMaxNumOfHits = absNumber; }
+
+ private:
+  bool mTFsendingPolicy = false;                                          // whether we will send information at every TF or only when we have a certain statistics
+  int mMaxNumOfHits = 500;                                                // maximum number of hits for one single channel to trigger the sending of the information (if mTFsendingPolicy = false)
+  bool mTest = false;                                                     // flag to say whether we are in test mode or not
+  bool mAbsMaxNumOfHits = true;                                           // to decide if the mMaxNumOfHits should be multiplied by the number of TOF channels
+  std::array<int, Geo::NCHANNELS> mEntries;                               // vector containing number of entries per channel
+  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCollectedCalibInfo; ///< output TOF calibration info
+
+  ClassDefOverride(TOFCalibCollector, 1);
+};
+
+} // end namespace tof
+} // end namespace o2
+
+#endif /* TOF_CHANNEL_CALIBRATOR_H_ */

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
@@ -73,10 +73,10 @@ class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::
   void initOutput() final;
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
-  void isTest(bool istest) { mTest = istest; }
+  void setIsTest(bool istest) { mTest = istest; }
   auto& getCollectedCalibInfo() const { return mTOFCollectedCalibInfo; }
   auto& getEntriesPerChannel() const { return mEntries; }
-  void isMaxNumberOfHitsAbsolute(bool absNumber) { mAbsMaxNumOfHits = absNumber; }
+  void setIsMaxNumberOfHitsAbsolute(bool absNumber) { mAbsMaxNumOfHits = absNumber; }
 
  private:
   bool mTFsendingPolicy = false;                                          // whether we will send information at every TF or only when we have a certain statistics

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -120,7 +120,7 @@ class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o
   const CcdbObjectInfoVector& getTimeSlewingInfoVector() const { return mInfoVector; }
   CcdbObjectInfoVector& getTimeSlewingInfoVector() { return mInfoVector; }
 
-  void isTest(bool isTest) { mTest = isTest; }
+  void setIsTest(bool isTest) { mTest = isTest; }
   bool isTest() const { return mTest; }
 
   void setCalibTOFapi(CalibTOFapi* api) { mCalibTOFapi = api; }

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -95,7 +95,7 @@ class TOFChannelData
   ClassDefNV(TOFChannelData, 1);
 };
 
-class TOFChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::TOFChannelData>
+class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::TOFChannelData>
 {
   using TFType = uint64_t;
   using Slot = o2::calibration::TimeSlot<o2::tof::TOFChannelData>;

--- a/Detectors/TOF/calibration/src/TOFCalibCollector.cxx
+++ b/Detectors/TOF/calibration/src/TOFCalibCollector.cxx
@@ -1,0 +1,147 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFCalibration/TOFCalibCollector.h"
+#include "Framework/Logger.h"
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace tof
+{
+
+using Slot = o2::calibration::TimeSlot<o2::tof::TOFCalibInfoSlot>;
+
+//_____________________________________________
+void TOFCalibInfoSlot::fill(const gsl::span<const o2::dataformats::CalibInfoTOF> data)
+{
+  // fill container
+  // we do not apply any calibration at this stage, it will be applied when we
+  // process the data before filling the CCDB in the separate process
+
+  for (int i = data.size(); i--;) {
+    auto ch = data[i].getTOFChIndex();
+    auto offset = std::accumulate(mEntriesSlot.begin(), mEntriesSlot.begin() + ch, 0);
+    mTOFCollectedCalibInfoSlot.emplace(mTOFCollectedCalibInfoSlot.begin() + offset, data[i].getTimestamp(), data[i].getDeltaTimePi(), data[i].getTot(), data[i].getFlags());
+    mEntriesSlot[ch]++;
+  }
+}
+
+//_____________________________________________
+void TOFCalibInfoSlot::merge(const TOFCalibInfoSlot* prev)
+{
+  // merge data of 2 slots
+
+  int addedPerChannel = 0;
+  int offset = 0;
+
+  LOG(DEBUG) << "Merging two slots with entries: current slot -> " << mTOFCollectedCalibInfoSlot.size() << " , previous slot -> " << prev->mTOFCollectedCalibInfoSlot.size();
+  for (int ch = 0; ch < Geo::NCHANNELS; ch++) {
+    offset += mEntriesSlot[ch];
+    if (prev->mEntriesSlot[ch] == 0)
+      continue;
+    auto offsetprevStart = addedPerChannel;
+    auto offsetprevEnd = addedPerChannel + prev->mEntriesSlot[ch];
+    addedPerChannel += prev->mEntriesSlot[ch];
+    mTOFCollectedCalibInfoSlot.insert(mTOFCollectedCalibInfoSlot.begin() + offset, prev->mTOFCollectedCalibInfoSlot.begin() + offsetprevStart, prev->mTOFCollectedCalibInfoSlot.begin() + offsetprevEnd);
+    mEntriesSlot[ch] += prev->mEntriesSlot[ch];
+  }
+  LOG(DEBUG) << "After merging the size is " << mTOFCollectedCalibInfoSlot.size();
+  return;
+}
+//_____________________________________________
+void TOFCalibInfoSlot::print() const
+{
+  // to print number of entries in the tree and the channel with the max number of entries
+
+  LOG(INFO) << "Total number of entries " << mTOFCollectedCalibInfoSlot.size();
+  auto maxElementIndex = std::max_element(mEntriesSlot.begin(), mEntriesSlot.end());
+  auto channelIndex = std::distance(mEntriesSlot.begin(), maxElementIndex);
+  LOG(INFO) << "The maximum number of entries per channel in the current mTOFCollectedCalibInfo is " << *maxElementIndex << " for channel " << channelIndex;
+  return;
+}
+
+//_____________________________________________
+void TOFCalibInfoSlot::printEntries() const
+{
+  // to print number of entries in the tree and per channel
+
+  LOG(INFO) << "Total number of entries " << mTOFCollectedCalibInfoSlot.size();
+  for (int i = 0; i < mEntriesSlot.size(); ++i) {
+    if (mEntriesSlot[i] != 0) {
+      LOG(INFO) << "channel " << i << " has " << mEntriesSlot[i] << " entries";
+    }
+  }
+  return;
+}
+
+//===================================================================
+
+//_____________________________________________
+void TOFCalibCollector::initOutput()
+{
+  // emptying the vectors
+
+  mTOFCollectedCalibInfo.clear();
+  for (int ch = 0; ch < Geo::NCHANNELS; ch++) {
+    mEntries[ch] = 0;
+  }
+
+  return;
+}
+
+//_____________________________________________
+bool TOFCalibCollector::hasEnoughData(const Slot& slot) const
+{
+
+  // We define that we have enough data if the tree is big enough.
+  // each CalibInfoTOFShort is composed of one int, two floats, one unsigned char --> 13 bytes
+  // E.g. supposing that we have 256 entries per channel (which is an upper limit ) --> ~523 MB
+  // we can check if we have at least 1 GB of data --> 500*o2::tof::Geo::NCHANNELS entries in the vector
+  // (see header file for the fact that mMaxNumOfHits = 500)
+  // The case in which mScaleMaxNumOfHits = false allows for a fast check
+
+  if (mTest)
+    return true;
+  const o2::tof::TOFCalibInfoSlot* c = slot.getContainer();
+  LOG(DEBUG) << "we have " << c->getCollectedCalibInfoSlot().size() << " entries";
+  int maxNumberOfHits = mAbsMaxNumOfHits ? mMaxNumOfHits : mMaxNumOfHits * o2::tof::Geo::NCHANNELS;
+  if (mTFsendingPolicy || c->getCollectedCalibInfoSlot().size() > maxNumberOfHits)
+    return true;
+  return false;
+}
+
+//_____________________________________________
+void TOFCalibCollector::finalizeSlot(Slot& slot)
+{
+  // here we fill the tree with the remaining stuff that was not filled before
+
+  o2::tof::TOFCalibInfoSlot* c = slot.getContainer();
+  mTOFCollectedCalibInfo = c->getCollectedCalibInfoSlot();
+  LOG(DEBUG) << "vector of CalibTOFInfoShort received with size = " << mTOFCollectedCalibInfo.size();
+  mEntries = c->getEntriesPerChannel();
+  return;
+}
+
+//_____________________________________________
+Slot& TOFCalibCollector::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<TOFCalibInfoSlot>());
+  return slot;
+}
+
+} // end namespace tof
+} // end namespace o2

--- a/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
+++ b/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
@@ -28,4 +28,9 @@
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFChannelData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFChannelData> + ;
 
+#pragma link C++ class o2::tof::TOFCalibInfoSlot + ;
+#pragma link C++ class o2::tof::TOFCalibCollector + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFCalibInfoSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot> + ;
+
 #endif

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -123,7 +123,7 @@ void TOFChannelData::print(int isect) const
   LOG(INFO) << "Number of entries in histogram: " << boost::histogram::algorithm::sum(mHisto[isect]);
   for (auto&& x : indexed(mHisto[isect])) { // does not work also when I use indexed(*(mHisto[sector]))
     cnt++;
-    //LOG(INFO) << " c " << cnt << " i " << x.index(0) << " j " << x.index(1) << " b0 " <<  x.bin(0) <<  " b1 " <<  x.bin(1) << " val= " << *x << "|" << x.get();
+    LOG(DEBUG) << " c " << cnt << " i " << x.index(0) << " j " << x.index(1) << " b0 " << x.bin(0) << " b1 " << x.bin(1) << " val= " << *x << "|" << x.get();
     if (x.get() > 0) {
       LOG(INFO) << "x = " << x.get() << " c " << cnt;
     }
@@ -148,12 +148,11 @@ int TOFChannelData::findBin(float v) const
   if (v == mRange)
     v -= 1.e-1;
 
-  /*
-  LOG(INFO) << "In FindBin, v = : " << v;
-  LOG(INFO) << "bin0 limits: lower = " << mHisto[0].axis(0).bin(0).lower() << ", upper = " << mHisto[0].axis(0).bin(0).upper();
-  LOG(INFO) << "bin1000 limits: lower = " << mHisto[0].axis(0).bin(mNBins-1).lower() << ", upper = " << mHisto[0].axis(0).bin(mNBins-1).upper();
-  LOG(INFO) << "v = " << v << " is in bin " << mHisto[0].axis(0).index(v);
-  */
+  LOG(DEBUG) << "In FindBin, v = : " << v;
+  LOG(DEBUG) << "bin0 limits: lower = " << mHisto[0].axis(0).bin(0).lower() << ", upper = " << mHisto[0].axis(0).bin(0).upper();
+  LOG(DEBUG) << "bin1000 limits: lower = " << mHisto[0].axis(0).bin(mNBins - 1).lower() << ", upper = " << mHisto[0].axis(0).bin(mNBins - 1).upper();
+  LOG(DEBUG) << "v = " << v << " is in bin " << mHisto[0].axis(0).index(v);
+
   return mHisto[0].axis(0).index(v);
 }
 
@@ -175,28 +174,23 @@ float TOFChannelData::integral(int chmin, int chmax, float binmin, float binmax)
 
   int chinsectormin = chmin % o2::tof::Geo::NPADSXSECTOR;
   int chinsectormax = chmax % o2::tof::Geo::NPADSXSECTOR;
-  //LOG(INFO) << "Calculating integral for channel " << ich << " which is in sector " << sector
-  //	    << " (channel in sector is " << chinsector << ")";;
-  //  LOG(INFO) << "Bin min = " << binmin << ", binmax = " << binmax <<
-  //             ", chmin = " << chmin << ", chmax = " << chmax <<
-  //             ", chinsectormin = " << chinsectormin << ", chinsector max = " << chinsectormax;
 
   float res2 = 0;
-  //TStopwatch t3;
+  TStopwatch t3;
   int ind = -1;
   int binxmin = findBin(binmin);
   int binxmax = findBin(binmax);
   LOG(DEBUG) << "binxmin = " << binxmin << ", binxmax = " << binxmax;
-  //t3.Start();
+  t3.Start();
   for (unsigned j = chinsectormin; j <= chinsectormax; ++j) {
     for (unsigned i = binxmin; i <= binxmax; ++i) {
       const auto& v = mHisto[sector].at(i, j);
       res2 += v;
     }
   }
-  //t3.Stop();
-  //LOG(DEBUG) << "Time for integral looping over axis (result = " << res2 << "):";
-  //t3.Print();
+  t3.Stop();
+  LOG(DEBUG) << "Time for integral looping over axis (result = " << res2 << "):";
+  t3.Print();
 
   return res2;
 
@@ -303,23 +297,19 @@ float TOFChannelData::integral(int chmin, int chmax, int binxmin, int binxmax) c
 
   int chinsectormin = chmin % o2::tof::Geo::NPADSXSECTOR;
   int chinsectormax = chmax % o2::tof::Geo::NPADSXSECTOR;
-  //LOG(INFO) << "Calculating integral for channel " << ich << " which is in sector " << sector
-  //	    << " (channel in sector is " << chinsector << ")";;
-  //LOG(INFO) << "Bin min = " << binmin << ", binmax = " << binmax <<
-  //             ", chmin = " << chmin << ", chmax" << chmax <<
-  //             ", chinsectormin = " << chinsector min << ", chinsector max = " << chinsectormax;
+
   float res2 = 0;
-  //TStopwatch t3;
-  //t3.Start();
+  TStopwatch t3;
+  t3.Start();
   for (unsigned j = chinsectormin; j <= chinsectormax; ++j) {
     for (unsigned i = binxmin; i <= binxmax; ++i) {
       const auto& v = mHisto[sector].at(i, j);
       res2 += v;
     }
   }
-  //t3.Stop();
-  //LOG(DEBUG) << "Time for integral looping over axis (result = " << res2 << "):";
-  //t3.Print();
+  t3.Stop();
+  LOG(DEBUG) << "Time for integral looping over axis (result = " << res2 << "):";
+  t3.Print();
   return res2;
 
   /* // all that is below is alternative methods, all proved to be slower

--- a/Detectors/TOF/calibration/testWorkflow/DataGeneratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/DataGeneratorSpec.h
@@ -122,7 +122,7 @@ DataProcessorSpec getTFDispatcherSpec()
   return DataProcessorSpec{
     "calib-tf-dispatcher",
     Inputs{},
-    Outputs{{{"output"}, "DUM", "DATASIZE"}},
+    Outputs{{{"output"}, "TOF", "DATASIZE"}},
     AlgorithmSpec{adaptFromTask<o2::calibration::TFDispatcher>()},
     Options{{"max-timeframes", VariantType::Int64, 99999999999ll, {"max TimeFrames to generate"}}}};
 }
@@ -131,8 +131,8 @@ DataProcessorSpec getTFProcessorSpec()
 {
   return DataProcessorSpec{
     "calib-tf-data-processor",
-    Inputs{{"input", "DUM", "DATASIZE"}},
-    Outputs{{{"output"}, "DUM", "CALIBDATA"}},
+    Inputs{{"input", "TOF", "DATASIZE"}},
+    Outputs{{{"output"}, "TOF", "CALIBDATA"}},
     AlgorithmSpec{adaptFromTask<o2::calibration::TFProcessor>()},
     Options{
       {"mean-latency", VariantType::Int, 1000, {"mean latency of the generator in microseconds"}},

--- a/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
@@ -107,7 +107,7 @@ DataProcessorSpec getLHCClockCalibDeviceSpec()
   outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
   return DataProcessorSpec{
     "calib-lhcclock-calibration",
-    Inputs{{"input", "DUM", "CALIBDATA"}},
+    Inputs{{"input", "TOF", "CALIBDATA"}},
     outputs,
     AlgorithmSpec{adaptFromTask<device>()},
     Options{

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
@@ -1,0 +1,124 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_TOFCALIB_COLLECTOR_H
+#define O2_CALIBRATION_TOFCALIB_COLLECTOR_H
+
+/// @file   TOFCalibCollectorSpec.h
+/// @brief  Device to collect information for TOF time slewing calibration.
+
+#include "TOFCalibration/TOFCalibCollector.h"
+#include "DetectorsCalibration/Utils.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+
+class TOFCalibCollectorDevice : public o2::framework::Task
+{
+
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+
+    bool isTFsendingPolicy = ic.options().get<bool>("tf-sending-policy");
+    int maxEnt = ic.options().get<int>("max-number-hits-to-fill-tree");
+    bool isTest = ic.options().get<bool>("running-in-test-mode");
+    bool absMaxEnt = ic.options().get<bool>("is-max-number-hits-to-fill-tree-absolute");
+    mCollector = std::make_unique<o2::tof::TOFCalibCollector>(isTFsendingPolicy, maxEnt);
+    mCollector->isTest(isTest);
+    mCollector->isMaxNumberOfHitsAbsolute(absMaxEnt);
+    mCollector->setSlotLength(1);
+    mCollector->setMaxSlotsDelay(0);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime; // is this the timestamp of the current TF?
+    auto data = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOF>>("input");
+    LOG(INFO) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+    mCollector->process(tfcounter, data);
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    constexpr uint64_t INFINITE_TF = 0xffffffffffffffff;
+    mCollector->checkSlotsToFinalize(INFINITE_TF);
+    // we force finalizing slot zero (unless everything was already finalized), no matter how many entries we had
+    if (mCollector->getNSlots() != 0)
+      mCollector->finalizeSlot(mCollector->getSlot(0));
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  std::unique_ptr<o2::tof::TOFCalibCollector> mCollector;
+  int mMaxNumOfHits = 0;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // in output we send the calibration tree
+    auto& collectedInfo = mCollector->getCollectedCalibInfo();
+    LOG(DEBUG) << "In CollectorSpec sendOutput: size = " << collectedInfo.size();
+    if (collectedInfo.size()) {
+      auto entries = collectedInfo.size();
+      // this means that we are ready to send the output
+      auto entriesPerChannel = mCollector->getEntriesPerChannel();
+      output.snapshot(Output{o2::header::gDataOriginTOF, "COLLECTEDINFO", 0, Lifetime::Timeframe}, collectedInfo);
+      output.snapshot(Output{o2::header::gDataOriginTOF, "ENTRIESCH", 0, Lifetime::Timeframe}, entriesPerChannel);
+      mCollector->initOutput(); // reset the output for the next round
+    }
+  }
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getTOFCalibCollectorDeviceSpec()
+{
+  using device = o2::calibration::TOFCalibCollectorDevice;
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTOF, "COLLECTEDINFO", 0, Lifetime::Timeframe);
+  // or should I use the ConcreteDataTypeMatcher? e.g.: outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  outputs.emplace_back(o2::header::gDataOriginTOF, "ENTRIESCH", 0, Lifetime::Timeframe);
+
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("input", "TOF", "CALIBDATA");
+
+  return DataProcessorSpec{
+    "calib-tofcalib-collector",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{
+      {"max-number-hits-to-fill-tree", VariantType::Int, 500, {"maximum number of entries in one channel to trigger teh filling of the tree"}},
+      {"is-max-number-hits-to-fill-tree-absolute", VariantType::Bool, false, {"to decide if we want to multiply the max-number-hits-to-fill-tree by the number of channels (when set to true), or not (when set to false) for fast checks"}},
+      {"tf-sending-policy", VariantType::Bool, false, {"if we are sending output at every TF; otherwise, we use the max-number-hits-to-fill-tree"}},
+      {"running-in-test-mode", VariantType::Bool, false, {"to run in test mode for simplification"}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorSpec.h
@@ -41,8 +41,8 @@ class TOFCalibCollectorDevice : public o2::framework::Task
     bool isTest = ic.options().get<bool>("running-in-test-mode");
     bool absMaxEnt = ic.options().get<bool>("is-max-number-hits-to-fill-tree-absolute");
     mCollector = std::make_unique<o2::tof::TOFCalibCollector>(isTFsendingPolicy, maxEnt);
-    mCollector->isTest(isTest);
-    mCollector->isMaxNumberOfHitsAbsolute(absMaxEnt);
+    mCollector->setIsTest(isTest);
+    mCollector->setIsMaxNumberOfHitsAbsolute(absMaxEnt);
     mCollector->setSlotLength(1);
     mCollector->setMaxSlotsDelay(0);
   }

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
@@ -1,0 +1,126 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_TOFCALIB_COLLECTOR_WRITER_H
+#define O2_CALIBRATION_TOFCALIB_COLLECTOR_WRITER_H
+
+/// @file   TOFCalibCollectorWriterSpec.h
+/// @brief  Device to write to tree the information for TOF time slewing calibration.
+
+#include "TOFCalibration/TOFCalibCollector.h"
+#include "DataFormatsTOF/CalibInfoTOFshort.h"
+#include <TTree.h>
+#include <gsl/span>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+
+class TOFCalibCollectorWriter : public o2::framework::Task
+{
+
+  using Geo = o2::tof::Geo;
+
+ public:
+  void createAndOpenFileAndTree()
+  {
+    TString filename = TString::Format("collTOF_%d.root", mCount);
+    LOG(DEBUG) << "opening file " << filename.Data();
+    mfileOut = new TFile(TString::Format("%s", filename.Data()), "RECREATE");
+    mOutputTree = new TTree("treeCollectedCalibInfo", "Tree with TOF calib info for Time Slewing");
+    mOutputTree->Branch(mOutputBranchName.data(), &mPTOFCalibInfoOut);
+  }
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    mCount = 0;
+    createAndOpenFileAndTree();
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto collectedInfo = pc.inputs().get<std::vector<o2::dataformats::CalibInfoTOFshort>>("collectedInfo");
+    //auto collectedInfo = pc.inputs().get<gsl::span<const o2::dataformats::CalibInfoTOFshort>>("collectedInfo");
+    auto entriesPerChannel = pc.inputs().get<std::array<int, Geo::NCHANNELS>>("entriesCh");
+    int offsetStart = 0;
+    for (int ich = 0; ich < o2::tof::Geo::NCHANNELS; ich++) {
+      mTOFCalibInfoOut.clear();
+      auto offsetEnd = offsetStart + entriesPerChannel[ich] - 1;
+      if (offsetEnd >= offsetStart) {
+        mTOFCalibInfoOut.resize(entriesPerChannel[ich]);
+        std::copy(collectedInfo.begin() + offsetStart, collectedInfo.begin() + offsetEnd + 1, mTOFCalibInfoOut.begin()); //mTOFCalibInfoOut->begin()); // this is very inefficient; maybe instead of vectors, using span and then one could avoid copying? https://solarianprogrammer.com/2019/11/03/cpp-20-span-tutorial/ --> did not work
+      }
+      mOutputTree->Fill();
+      offsetStart += entriesPerChannel[ich];
+    }
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    mIsEndOfStream = true;
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  int mCount = 0; // how many times we filled the tree
+  bool mIsEndOfStream = false;
+  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCalibInfoOut, *mPTOFCalibInfoOut = &mTOFCalibInfoOut; ///< these are the object and pointer to the CalibInfo of a specific channel that we need to fill the output tree
+  TTree* mOutputTree;                                                                                       ///< tree for the collected calib tof info
+  std::string mTOFCalibInfoBranchName = "TOFCalibInfo";                                                     ///< name of branch containing input TOF calib infos
+  std::string mOutputBranchName = "TOFCollectedCalibInfo";                                                  ///< name of branch containing output
+  TFile* mfileOut = nullptr;                                                                                // file in which to write the output
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // This is to fill the tree.
+    // One file with an empty tree will be created at the end, because we have to have a
+    // tree opened before processing, since we do not know a priori if something else
+    // will still come. The size of this extra file is ~6.5 kB
+
+    mfileOut->cd();
+    mOutputTree->Write();
+    mfileOut->Close();
+    delete mfileOut;
+    mCount++;
+    if (!mIsEndOfStream)
+      createAndOpenFileAndTree();
+  }
+};
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getTOFCalibCollectorWriterSpec()
+{
+  using device = o2::calibration::TOFCalibCollectorWriter;
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("collectedInfo", o2::header::gDataOriginTOF, "COLLECTEDINFO");
+  inputs.emplace_back("entriesCh", o2::header::gDataOriginTOF, "ENTRIESCH");
+
+  std::vector<OutputSpec> outputs; // empty
+
+  return DataProcessorSpec{
+    "calib-tofcalib-collector-writer",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
@@ -50,14 +50,14 @@ class TOFCalibCollectorWriter : public o2::framework::Task
 
   void run(o2::framework::ProcessingContext& pc) final
   {
-    auto collectedInfo = pc.inputs().get<std::vector<o2::dataformats::CalibInfoTOFshort>>("collectedInfo");
-    auto entriesPerChannel = pc.inputs().get<std::array<int, Geo::NCHANNELS>>("entriesCh");
+    auto collectedInfo = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOFshort>>("collectedInfo");
+    auto entriesPerChannel = pc.inputs().get<gsl::span<int>>("entriesCh");
     int offsetStart = 0;
     for (int ich = 0; ich < o2::tof::Geo::NCHANNELS; ich++) {
       mTOFCalibInfoOut.clear();
       if (entriesPerChannel[ich] > 0) {
         mTOFCalibInfoOut.resize(entriesPerChannel[ich]);
-        auto subSpanVect = gsl::span<const o2::dataformats::CalibInfoTOFshort>(&collectedInfo[offsetStart], entriesPerChannel[ich]);
+        auto subSpanVect = collectedInfo.subspan(offsetStart, entriesPerChannel[ich]);
         memcpy(&mTOFCalibInfoOut[0], subSpanVect.data(), sizeof(o2::dataformats::CalibInfoTOFshort) * subSpanVect.size());
         const o2::dataformats::CalibInfoTOFshort* tmp = subSpanVect.data();
       }

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -43,7 +43,7 @@ class TOFChannelCalibDevice : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
 
-    int minEnt = std::max(50, ic.options().get<int>("min-entries"));
+    int minEnt = ic.options().get<int>("min-entries"); //std::max(50, ic.options().get<int>("min-entries"));
     int nb = std::max(500, ic.options().get<int>("nbins"));
     float range = ic.options().get<float>("range");
     int isTest = ic.options().get<bool>("do-TOF-channel-calib-in-test-mode");
@@ -186,7 +186,7 @@ DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool attachChannelO
   outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("input", "DUM", "CALIBDATA");
+  inputs.emplace_back("input", "TOF", "CALIBDATA");
   if (useCCDB) {
     inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase");
     inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib");

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -49,7 +49,7 @@ class TOFChannelCalibDevice : public o2::framework::Task
     int isTest = ic.options().get<bool>("do-TOF-channel-calib-in-test-mode");
     mCalibrator = std::make_unique<o2::tof::TOFChannelCalibrator>(minEnt, nb, range);
     mCalibrator->setUpdateAtTheEndOfRunOnly();
-    mCalibrator->isTest(isTest);
+    mCalibrator->setIsTest(isTest);
 
     // calibration objects set to zero
     mPhase.addLHCphase(0, 0);

--- a/Detectors/TOF/calibration/testWorkflow/tof-collect-calib-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/tof-collect-calib-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFCalibCollectorSpec.h"
+#include "TOFCalibCollectorWriterSpec.h"
+#include "Framework/DataProcessorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getTOFCalibCollectorDeviceSpec());
+  specs.emplace_back(getTOFCalibCollectorWriterSpec());
+
+  return specs;
+}

--- a/Detectors/TOF/calibration/testWorkflow/tof-dummy-ccdb-for-calib.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/tof-dummy-ccdb-for-calib.cxx
@@ -22,7 +22,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
   return {
     DataProcessorSpec{
       "simple",
-      Inputs{{"input", "DUM", "CALIBDATA"}},
+      Inputs{{"input", "TOF", "CALIBDATA"}},
       Outputs{OutputSpec{{"phase"}, "TOF", "LHCphase"},
               OutputSpec{{"timeSlewing"}, "TOF", "ChannelCalib"},
               OutputSpec{{"startLHCphase"}, "TOF", "StartLHCphase"},


### PR DESCRIPTION
It will reformat the calibration information coming from the matching
saving them to file, to be subsequently processed to extract the
time slewing (which does not seem appropriate for a data processor).

Some changes implemented also in the TimeSlotCalibration, when
the maxDelay is set to zero (--> we accept all data).

The PR includes work from @noferini .

To run the calibration:

> test mode: o2-calibration-data-generator-workflow --lanes 10 --mean-latency 100000 --max-timeframes 10 -b | o2-calibration-tof-collect-calib-workflow --tf-sending-policy --running-in-test-mode -b

> non-test but simplified (using option "is-max-number-hits-to-fill-tree-absolute"): o2-calibration-data-generator-workflow --lanes 10 --mean-latency 100000 --max-timeframes 10 -b | o2-calibration-tof-collect-calib-workflow --max-number-hits-to-fill-tree 300  --is-max-number-hits-to-fill-tree-absolute -b

==================

Detail of the various commits:

Just not to lose work :-)

compiling version

Changing philosophy.

Since we cannot send trees, the tree will have to be filled by the data processor
that will then also write the output file.
First version of the Spec also committed - but still using the tree. Now it is too
late, I will go to bed and take care another time.

Addng writer + other changes

Things compile, but were not yet tested.
Probably to change from std::vector to gsl::span.

Fixing issues + new features.

E.g.: using gsl::span for the output that goes in the tree.
Workflow not yet working, but everything compiles.

Fixes

Going back to std::vectors (tree cannot contain gsl::span)

Fixes to have the whole thing working. One change also to TimeSlotCalibration.h

The change in TimeSlotCalibration.h is needed because we want to update at every TF,
which means that the mMaxSlotsDelay should be 0.

fix for size of vector

I think this is correct, but I did not test it

move resize

fix for TOF channel offset calibration from reco flow

Several changes.

Main ones:

- bug fixes (seg fault due to missing initialization; merging function fixed)
- changes in the TimeSlotCalibration to not discard anything if maxDelay = 0
- force sending output at the end of the processing even if there is not
necessarily the requested statistics

Clang-format