### PR TITLE
TPCClusterFinder: Reduce memory usage on MC propagation.

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
@@ -23,9 +23,6 @@ using namespace GPUCA_NAMESPACE::gpu::tpccf;
 MCLabelAccumulator::MCLabelAccumulator(GPUTPCClusterFinder& clusterer)
   : mIndexMap(clusterer.mPindexMap), mLabels(clusterer.mPinputLabels), mOutput(clusterer.mPlabelsByRow)
 {
-  if (engaged()) {
-    mClusterLabels.reserve(32);
-  }
 }
 
 void MCLabelAccumulator::collect(const ChargePos& pos, Charge q)


### PR DESCRIPTION
@davidrohr This is a quick fix that should save some more memory when propagating mc labels.