### PR TITLE
More host memory optimizations for TPC workflow

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -127,7 +127,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
         gpuDigitsMap.tpcDigits[i] = (*(data->o2Digits))[i].data();
         gpuDigitsMap.nTPCDigits[i] = (*(data->o2Digits))[i].size();
         if (data->o2DigitsMC) {
-          gpuDigitsMapMC.v[i] = (*data->o2DigitsMC)[i].get();
+          gpuDigitsMapMC.v[i] = (*data->o2DigitsMC)[i];
         }
       }
     }

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -106,7 +106,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
         if (maxContTimeBin && d[j].getTimeStamp() >= maxContTimeBin) {
           throw std::runtime_error("Digit time bin exceeds time frame length");
         }
-        if (zsThreshold > 0) {
+        if (zsThreshold > 0 && data->tpcZS == nullptr) {
           if (d[j].getChargeFloat() >= zsThreshold) {
             if (data->o2DigitsMC) {
               for (const auto& element : (*data->o2DigitsMC)[i]->getLabels(j)) {

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -237,6 +237,7 @@ int GPUReconstruction::InitPhaseBeforeDevice()
   }
   if (!IsGPU()) {
     mProcessingSettings.nDeviceHelperThreads = 0;
+    mProcessingSettings.nTPCClustererLanes = 1;
   }
 
   if (param().rec.NonConsecutiveIDs) {

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -108,7 +108,7 @@ struct GPUO2InterfaceIOPtrs {
   // Input: TPC clusters in cluster native format, or digits, or list of ZS pages -  const as it can only be input
   const o2::tpc::ClusterNativeAccess* clusters = nullptr;
   const std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::constants::MAXSECTOR>* o2Digits = nullptr;
-  std::array<std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>>, o2::tpc::constants::MAXSECTOR>* o2DigitsMC = nullptr;
+  std::array<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR>* o2DigitsMC = nullptr;
   const o2::gpu::GPUTrackingInOutZS* tpcZS = nullptr;
 
   // Input / Output for Merged TPC tracks, two ptrs, for the tracks themselves, and for the MC labels.


### PR DESCRIPTION
@shahor02 : With this PR, I can process my dataset with mc labels with 16 GB of memory.
I think I can perhaps still save ~1 GB by optimizing the tracking, but that will be more or less it from the reconstruction side.
On top, I think we might waste quite some memory if the MC label container is serialized and copied during deserialization but I am not yet sure about this.