### PR TITLE
Fix crash in TPC reco workflow

### DIFF
--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -122,7 +122,7 @@ generPbPb="pythia8hi"
 engine="TGeant3"
 
 # options to pass to every workflow
-gloOpt=" -b --run "
+gloOpt=" -b --run --shm-segment-size 10000000000"
 
 # option to set the number of sim workers
 simWorker=""
@@ -196,7 +196,7 @@ fi
 if [ "$dodigi" == "1" ]; then
   echo "Running digitization for $intRate kHz interaction rate"
   intRate=$((1000*(intRate)));
-  taskwrapper digi.log o2-sim-digitizer-workflow $gloOpt --shm-segment-size 10000000000 --interactionRate $intRate $tpcLanes
+  taskwrapper digi.log o2-sim-digitizer-workflow $gloOpt --interactionRate $intRate $tpcLanes
   echo "Return status of digitization: $?"
   # existing checks
   #root -b -q O2/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C+


### PR DESCRIPTION
apply shared mem segement size to all workflows. Fixes https://alice.its.cern.ch/jira/browse/O2-1657.