### PR TITLE
ITS DigiParam: suppress initialization from c-tor

### DIFF
--- a/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
@@ -22,7 +22,6 @@ using namespace o2::itsmft;
 DigiParams::DigiParams()
 {
   // make sure the defaults are consistent
-  setROFrameLength(mROFrameLength);
   setNSimSteps(mNSimSteps);
 }
 


### PR DESCRIPTION
do in only once run-time parameters are set