### PR TITLE
Option (Def=on) to merge in the TPC CTF correlated columns (+misc fixes)

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -255,6 +255,7 @@ struct Block {
     setNDict(_ndict);
     setNData(_ndata);
     setNLiterals(_nliterals);
+    getCreatePayload(); // do this even for empty block!!!
     if (getNStored()) {
       payload = reinterpret_cast<W*>(registry->getFreeBlockStart());
       if (getNDict()) {
@@ -291,6 +292,7 @@ class EncodedBlocks
   void setHeader(const H& h) { mHeader = h; }
   const H& getHeader() const { return mHeader; }
   H& getHeader() { return mHeader; }
+  std::shared_ptr<H> cloneHeader() const { return std::shared_ptr<H>(new H(mHeader)); } // for dictionary creation
 
   const auto& getMetadata() const { return mMetadata; }
 
@@ -472,6 +474,7 @@ void EncodedBlocks<H, N, W>::appendToTree(TTree& tree, const std::string& name) 
     int compression = mMetadata[i].opt == Metadata::OptStore::ROOTCompression ? 1 : 0;
     fillTreeBranch(tree, o2::utils::concat_string(name, "_block.", std::to_string(i), "."), const_cast<Block<W>&>(mBlocks[i]), compression);
   }
+  tree.SetEntries(tree.GetEntries() + 1);
 }
 
 ///_____________________________________________________________________________

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
@@ -23,35 +23,49 @@ namespace o2
 namespace tpc
 {
 
+struct CTFHeader : public CompressedClustersCounters {
+  enum : uint32_t { CombinedColumns = 0x1 };
+  uint32_t flags = 0;
+
+  ClassDefNV(CTFHeader, 1);
+};
+
 /// wrapper for the Entropy-encoded clusters of the TF
-struct CTF : public o2::ctf::EncodedBlocks<CompressedClustersCounters, 23, uint32_t> {
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t> {
 
   static constexpr size_t N = getNBlocks();
+  static constexpr int NBitsQTot = 16;
+  static constexpr int NBitsQMax = 10;
+  static constexpr int NBitsSigmaPad = 8;
+  static constexpr int NBitsSigmaTime = 8;
+  static constexpr int NBitsRowDiff = 8;
+  static constexpr int NBitsSliceLegDiff = 7;
+
   enum Slots { BLCqTotA,
-               BLCqMaxA,
+               BLCqMaxA, // can be combined with BLCqTotA
                BLCflagsA,
                BLCrowDiffA,
-               BLCsliceLegDiffA,
+               BLCsliceLegDiffA, // can be combined with BLCrowDiffA
                BLCpadResA,
                BLCtimeResA,
                BLCsigmaPadA,
-               BLCsigmaTimeA,
+               BLCsigmaTimeA, // can be combined with  BLCsigmaPadA
                BLCqPtA,
                BLCrowA,
                BLCsliceA,
                BLCtimeA,
                BLCpadA,
                BLCqTotU,
-               BLCqMaxU,
+               BLCqMaxU, // can be combined with BLCqTotU
                BLCflagsU,
                BLCpadDiffU,
                BLCtimeDiffU,
                BLCsigmaPadU,
-               BLCsigmaTimeU,
+               BLCsigmaTimeU, // can be combined with BLCsigmaPadU
                BLCnTrackClusters,
                BLCnSliceRowClusters };
 
-  ClassDefNV(CTF, 1);
+  ClassDefNV(CTF, 2);
 };
 
 } // namespace tpc

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -46,7 +46,8 @@
 #pragma link C++ class o2::tpc::CompressedClusters + ;
 #pragma link C++ class o2::tpc::CompressedClustersROOT - ;
 #pragma link C++ class o2::tpc::CTF + ;
-#pragma link C++ class o2::ctf::EncodedBlocks < o2::tpc::CompressedClustersCounters, 23, uint32_t> + ;
+#pragma link C++ class o2::tpc::CTFHeader + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::tpc::CTFHeader, 23, uint32_t> + ;
 #pragma link C++ enum o2::tpc::StatisticsType;
 
 #endif

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -18,6 +18,10 @@
 #include <algorithm>
 #include <iterator>
 #include <string>
+#include <cassert>
+#include <type_traits>
+#include <typeinfo>
+#include <vector>
 #include "DataFormatsTPC/CTF.h"
 #include "DataFormatsTPC/CompressedClusters.h"
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -69,8 +73,62 @@ class CTFCoder : public o2::ctf::CTFCoderBase
     ptrR += res ? sz + (ALG - res) : sz;
   }
 
+  bool getCombineColumns() const { return mCombineColumns; }
+  void setCombineColumns(bool v) { mCombineColumns = v; }
+
+ private:
+  void checkDataDictionaryConsistency(const CTFHeader& h);
+
+  template <int NU, int NL>
+  static constexpr auto MVAR()
+  {
+    typename std::conditional<(NU + NL > 16), uint32_t, typename std::conditional<(NU + NL > 8), uint16_t, uint8_t>::type>::type tp = 0;
+    return tp;
+  }
+  template <int NU, int NL>
+  static constexpr auto MPTR()
+  {
+    typename std::conditional<(NU + NL > 16), uint32_t, typename std::conditional<(NU + NL > 8), uint16_t, uint8_t>::type>::type* tp = nullptr;
+    return tp;
+  }
+#define MTYPE(A, B) decltype(CTFCoder::MVAR<A, B>())
+
+  template <int NU, int NL, typename CU, typename CL>
+  static void splitColumns(const std::vector<MTYPE(NU, NL)>& vm, CU*& vu, CL*& vl);
+
+  template <int NU, int NL, typename CU, typename CL>
+  static auto mergeColumns(const CU* vu, const CL* vl, size_t nelem);
+
+  bool mCombineColumns = false; // combine correlated columns
+
   ClassDefNV(CTFCoder, 1);
 };
+
+/// split words of input vector to columns assigned to provided pointers (memory must be allocated in advance)
+template <int NU, int NL, typename CU, typename CL>
+void CTFCoder::splitColumns(const std::vector<MTYPE(NU, NL)>& vm, CU*& vu, CL*& vl)
+{
+  static_assert(NU <= sizeof(CU) * 8 && NL <= sizeof(CL) * 8, "output columns bit count is wrong");
+  size_t n = vm.size();
+  for (size_t i = 0; i < n; i++) {
+    vu[i] = static_cast<CU>(vm[i] >> NL);
+    vl[i] = static_cast<CL>(vm[i] & ((0x1 << NL) - 1));
+  }
+}
+
+/// merge elements of 2 columns pointed by vu and vl to a single vector with wider field
+template <int NU, int NL, typename CU, typename CL>
+auto CTFCoder::mergeColumns(const CU* vu, const CL* vl, size_t nelem)
+{
+  // merge 2 columns to 1
+  static_assert(NU <= sizeof(NU) * 8 && NL <= sizeof(NL) * 8, "input columns bit count is wrong");
+  std::vector<MTYPE(NU, NL)> outv;
+  outv.reserve(nelem);
+  for (size_t i = 0; i < nelem; i++) {
+    outv.push_back((static_cast<MTYPE(NU, NL)>(vu[i]) << NL) | static_cast<MTYPE(NU, NL)>(vl[i]));
+  }
+  return std::move(outv);
+}
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
@@ -109,33 +167,77 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   buff.resize(szIni);
 
   auto ec = CTF::create(buff);
-  ec->setHeader(reinterpret_cast<const CompressedClustersCounters&>(ccl));
+  uint32_t flags = 0;
+  if (mCombineColumns) {
+    flags |= CTFHeader::CombinedColumns;
+  }
+  ec->setHeader(CTFHeader{reinterpret_cast<const CompressedClustersCounters&>(ccl), flags});
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODETPC(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODETPC(ccl.qTotA,             ccl.qTotA + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
-  ENCODETPC(ccl.qMaxA,             ccl.qMaxA + ccl.nAttachedClusters,                CTF::BLCqMaxA,             0);
+
+  if (mCombineColumns) {
+    auto mrg = mergeColumns<CTF::NBitsQTot, CTF::NBitsQMax>(ccl.qTotA, ccl.qMaxA, ccl.nAttachedClusters);
+    ENCODETPC(&mrg[0],             (&mrg[0]) + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
+  }
+  else {
+    ENCODETPC(ccl.qTotA,           ccl.qTotA + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
+  }
+  ENCODETPC(ccl.qMaxA,             ccl.qMaxA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCqMaxA,    0);
+  
   ENCODETPC(ccl.flagsA,            ccl.flagsA + ccl.nAttachedClusters,               CTF::BLCflagsA,            0);
-  ENCODETPC(ccl.rowDiffA,          ccl.rowDiffA + ccl.nAttachedClustersReduced,      CTF::BLCrowDiffA,          0);
-  ENCODETPC(ccl.sliceLegDiffA,     ccl.sliceLegDiffA + ccl.nAttachedClustersReduced, CTF::BLCsliceLegDiffA,     0);
+  
+  if (mCombineColumns) {
+    auto mrg = mergeColumns<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>(ccl.rowDiffA, ccl.sliceLegDiffA, ccl.nAttachedClustersReduced);    
+    ENCODETPC(&mrg[0],             (&mrg[0]) + ccl.nAttachedClustersReduced,         CTF::BLCrowDiffA,          0);
+  }
+  else {
+    ENCODETPC(ccl.rowDiffA,        ccl.rowDiffA + ccl.nAttachedClustersReduced,      CTF::BLCrowDiffA,          0);
+  }
+  ENCODETPC(ccl.sliceLegDiffA,     ccl.sliceLegDiffA + (mCombineColumns ? 0 : ccl.nAttachedClustersReduced), CTF::BLCsliceLegDiffA, 0);
+
   ENCODETPC(ccl.padResA,           ccl.padResA + ccl.nAttachedClustersReduced,       CTF::BLCpadResA,           0);
   ENCODETPC(ccl.timeResA,          ccl.timeResA + ccl.nAttachedClustersReduced,      CTF::BLCtimeResA,          0);
-  ENCODETPC(ccl.sigmaPadA,         ccl.sigmaPadA + ccl.nAttachedClusters,            CTF::BLCsigmaPadA,         0);
-  ENCODETPC(ccl.sigmaTimeA,        ccl.sigmaTimeA + ccl.nAttachedClusters,           CTF::BLCsigmaTimeA,        0);
+
+  if (mCombineColumns) {
+    auto mrg = mergeColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(ccl.sigmaPadA, ccl.sigmaTimeA, ccl.nAttachedClusters);
+    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nAttachedClusters,                  CTF::BLCsigmaPadA,         0);
+  }
+  else {
+    ENCODETPC(ccl.sigmaPadA,       ccl.sigmaPadA + ccl.nAttachedClusters,            CTF::BLCsigmaPadA,         0);
+  }
+  ENCODETPC(ccl.sigmaTimeA,        ccl.sigmaTimeA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCsigmaTimeA, 0);  
+
   ENCODETPC(ccl.qPtA,              ccl.qPtA + ccl.nTracks,                           CTF::BLCqPtA,              0);
   ENCODETPC(ccl.rowA,              ccl.rowA + ccl.nTracks,                           CTF::BLCrowA,              0);
   ENCODETPC(ccl.sliceA,            ccl.sliceA + ccl.nTracks,                         CTF::BLCsliceA,            0);
   ENCODETPC(ccl.timeA,             ccl.timeA + ccl.nTracks,                          CTF::BLCtimeA,             0);
   ENCODETPC(ccl.padA,              ccl.padA + ccl.nTracks,                           CTF::BLCpadA,              0);
-  ENCODETPC(ccl.qTotU,             ccl.qTotU + ccl.nUnattachedClusters,              CTF::BLCqTotU,             0);
-  ENCODETPC(ccl.qMaxU,             ccl.qMaxU + ccl.nUnattachedClusters,              CTF::BLCqMaxU,             0);
+
+  if (mCombineColumns) {
+    auto mrg = mergeColumns<CTF::NBitsQTot, CTF::NBitsQMax>(ccl.qTotU,ccl.qMaxU,ccl.nUnattachedClusters);
+    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nUnattachedClusters,                CTF::BLCqTotU,             0);
+  }
+  else {    
+    ENCODETPC(ccl.qTotU,           ccl.qTotU + ccl.nUnattachedClusters,              CTF::BLCqTotU,             0);
+  }
+  ENCODETPC(ccl.qMaxU,             ccl.qMaxU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCqMaxU,  0);
+
   ENCODETPC(ccl.flagsU,            ccl.flagsU + ccl.nUnattachedClusters,             CTF::BLCflagsU,            0);
   ENCODETPC(ccl.padDiffU,          ccl.padDiffU + ccl.nUnattachedClusters,           CTF::BLCpadDiffU,          0);
   ENCODETPC(ccl.timeDiffU,         ccl.timeDiffU + ccl.nUnattachedClusters,          CTF::BLCtimeDiffU,         0);
-  ENCODETPC(ccl.sigmaPadU,         ccl.sigmaPadU + ccl.nUnattachedClusters,          CTF::BLCsigmaPadU,         0);
-  ENCODETPC(ccl.sigmaTimeU,        ccl.sigmaTimeU + ccl.nUnattachedClusters,         CTF::BLCsigmaTimeU,        0);
+
+  if (mCombineColumns) {
+    auto mrg = mergeColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(ccl.sigmaPadU, ccl.sigmaTimeU, ccl.nUnattachedClusters);
+    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nUnattachedClusters,                CTF::BLCsigmaPadU,         0);
+  }
+  else {
+    ENCODETPC(ccl.sigmaPadU,       ccl.sigmaPadU + ccl.nUnattachedClusters,          CTF::BLCsigmaPadU,         0);
+  }
+  ENCODETPC(ccl.sigmaTimeU,        ccl.sigmaTimeU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCsigmaTimeU, 0);
+
   ENCODETPC(ccl.nTrackClusters,    ccl.nTrackClusters + ccl.nTracks,                 CTF::BLCnTrackClusters,    0);
   ENCODETPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows,           CTF::BLCnSliceRowClusters, 0);
   // clang-format on
@@ -148,7 +250,9 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
 {
   CompressedClusters cc;
   CompressedClustersCounters& ccCount = cc;
-  ccCount = ec.getHeader(); // ec.getHeader is a saved copy of the CompressedClustersCounters
+  auto& header = ec.getHeader();
+  checkDataDictionaryConsistency(header);
+  ccCount = reinterpret_cast<const CompressedClustersCounters&>(header);
   CompressedClustersFlat* ccFlat = nullptr;
   size_t sizeCFlatBody = alignSize(ccFlat);
   size_t sz = sizeCFlatBody + estimateSize(cc);                                             // total size of the buffVec accounting for the alignment
@@ -160,34 +264,80 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   setCompClusAddresses(cc, buff);
   ccFlat->set(sz, cc); // set offsets
   ec.print(getPrefix());
+
   // decode encoded data directly to destination buff
 #define DECODETPC(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODETPC(cc.qTotA,             CTF::BLCqTotA);
-  DECODETPC(cc.qMaxA,             CTF::BLCqMaxA);
-  DECODETPC(cc.flagsA,            CTF::BLCflagsA);
-  DECODETPC(cc.rowDiffA,          CTF::BLCrowDiffA);
-  DECODETPC(cc.sliceLegDiffA,     CTF::BLCsliceLegDiffA);
-  DECODETPC(cc.padResA,           CTF::BLCpadResA);
-  DECODETPC(cc.timeResA,          CTF::BLCtimeResA);
-  DECODETPC(cc.sigmaPadA,         CTF::BLCsigmaPadA);
-  DECODETPC(cc.sigmaTimeA,        CTF::BLCsigmaTimeA);
-  DECODETPC(cc.qPtA,              CTF::BLCqPtA);
-  DECODETPC(cc.rowA,              CTF::BLCrowA);
-  DECODETPC(cc.sliceA,            CTF::BLCsliceA);
-  DECODETPC(cc.timeA,             CTF::BLCtimeA);
-  DECODETPC(cc.padA,              CTF::BLCpadA);
-  DECODETPC(cc.qTotU,             CTF::BLCqTotU);
-  DECODETPC(cc.qMaxU,             CTF::BLCqMaxU);
-  DECODETPC(cc.flagsU,            CTF::BLCflagsU);
-  DECODETPC(cc.padDiffU,          CTF::BLCpadDiffU);
-  DECODETPC(cc.timeDiffU,         CTF::BLCtimeDiffU);
-  DECODETPC(cc.sigmaPadU,         CTF::BLCsigmaPadU);
-  DECODETPC(cc.sigmaTimeU,        CTF::BLCsigmaTimeU);
-  DECODETPC(cc.nTrackClusters,    CTF::BLCnTrackClusters);
-  DECODETPC(cc.nSliceRowClusters, CTF::BLCnSliceRowClusters);
+  if (mCombineColumns) {
+    std::vector<MTYPE(CTF::NBitsQTot, CTF::NBitsQMax)> mrg;
+    DECODETPC(mrg,                  CTF::BLCqTotA);
+    splitColumns<CTF::NBitsQTot, CTF::NBitsQMax>(mrg, cc.qTotA, cc.qMaxA);
+  }
+  else {
+    DECODETPC(cc.qTotA,             CTF::BLCqTotA);
+    DECODETPC(cc.qMaxA,             CTF::BLCqMaxA);
+  }
+  
+  DECODETPC(cc.flagsA,              CTF::BLCflagsA);
+  
+  if (mCombineColumns) {
+    std::vector<MTYPE(CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff)> mrg;
+    DECODETPC(mrg,                  CTF::BLCrowDiffA);
+    splitColumns<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>(mrg, cc.rowDiffA, cc.sliceLegDiffA);
+  }
+  else {
+    DECODETPC(cc.rowDiffA,          CTF::BLCrowDiffA);
+    DECODETPC(cc.sliceLegDiffA,     CTF::BLCsliceLegDiffA);
+  }
+  
+  DECODETPC(cc.padResA,             CTF::BLCpadResA);
+  DECODETPC(cc.timeResA,            CTF::BLCtimeResA);
+
+  if (mCombineColumns) {
+    std::vector<MTYPE(CTF::NBitsSigmaPad, CTF::NBitsSigmaTime)> mrg;
+    DECODETPC(mrg,                  CTF::BLCsigmaPadA);
+    splitColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(mrg, cc.sigmaPadA, cc.sigmaTimeA);
+  }
+  else { 
+    DECODETPC(cc.sigmaPadA,         CTF::BLCsigmaPadA);
+    DECODETPC(cc.sigmaTimeA,        CTF::BLCsigmaTimeA);
+  }
+  
+  DECODETPC(cc.qPtA,                CTF::BLCqPtA);
+  DECODETPC(cc.rowA,                CTF::BLCrowA);
+  DECODETPC(cc.sliceA,              CTF::BLCsliceA);
+  DECODETPC(cc.timeA,               CTF::BLCtimeA);
+  DECODETPC(cc.padA,                CTF::BLCpadA);
+
+  if (mCombineColumns) {
+    std::vector<MTYPE(CTF::NBitsQTot, CTF::NBitsQMax)> mrg;
+    DECODETPC(mrg,                  CTF::BLCqTotU);
+    splitColumns<CTF::NBitsQTot, CTF::NBitsQMax>(mrg, cc.qTotU, cc.qMaxU);
+  }
+  else {
+    DECODETPC(cc.qTotU,             CTF::BLCqTotU);
+    DECODETPC(cc.qMaxU,             CTF::BLCqMaxU);
+  }
+
+  DECODETPC(cc.flagsU,              CTF::BLCflagsU);
+  DECODETPC(cc.padDiffU,            CTF::BLCpadDiffU);
+  DECODETPC(cc.timeDiffU,           CTF::BLCtimeDiffU);
+
+  if (mCombineColumns) {
+    std::vector<MTYPE(CTF::NBitsSigmaPad, CTF::NBitsSigmaTime)> mrg;
+    DECODETPC(mrg,                  CTF::BLCsigmaPadU);
+    splitColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(mrg, cc.sigmaPadU, cc.sigmaTimeU);
+  }
+  else {
+    DECODETPC(cc.sigmaPadU,         CTF::BLCsigmaPadU);
+    DECODETPC(cc.sigmaTimeU,        CTF::BLCsigmaTimeU);
+  }
+  
+  DECODETPC(cc.nTrackClusters,      CTF::BLCnTrackClusters);
+  DECODETPC(cc.nSliceRowClusters,   CTF::BLCnSliceRowClusters);
   // clang-format on
 }
+#undef MTYPE
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -28,6 +28,7 @@ namespace tpc
 
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
+  mCTFCoder.setCombineColumns(!ic.options().get<bool>("no-ctf-columns-combining"));
   std::string dictPath = ic.options().get<std::string>("tpc-ctf-dictionary");
   if (!dictPath.empty() && dictPath != "none") {
     mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
@@ -81,7 +82,8 @@ DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile)
     Inputs{{"input", "TPC", inputType, 0, Lifetime::Timeframe}},
     Outputs{{"TPC", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>(inputFromFile)},
-    Options{{"tpc-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+    Options{{"tpc-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}},
+            {"no-ctf-columns-combining", VariantType::Bool, false, {"Do not combine correlated columns in CTF"}}}};
 }
 
 } // namespace tpc

--- a/Utilities/rANS/include/rANS/FrequencyTable.h
+++ b/Utilities/rANS/include/rANS/FrequencyTable.h
@@ -108,7 +108,7 @@ void FrequencyTable::addSamples(Source_IT begin, Source_IT end, value_t min, val
   t.start();
 
   if (begin == end) {
-    LOG(warning) << "Passed empty message to " << __func__;
+    LOG(debug) << "Passed empty message to " << __func__;  // RS this is ok for empty columns
     return;
   }
 
@@ -145,7 +145,7 @@ void FrequencyTable::addFrequencies(Freq_IT begin, Freq_IT end, value_t min, val
   t.start();
 
   if (begin == end) {
-    LOG(warning) << "Passed empty FrequencyTable to " << __func__;
+    LOG(debug) << "Passed empty FrequencyTable to " << __func__;  // RS this is ok for empty columns
     return;
   }
 

--- a/Utilities/rANS/include/rANS/internal/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/internal/SymbolStatistics.h
@@ -123,7 +123,7 @@ SymbolStatistics::SymbolStatistics(const Source_IT begin, const Source_IT end, i
   t.start();
 
   if (begin == end) {
-    LOG(warning) << "Passed empty message to " << __func__;
+    LOG(debug) << "Passed empty message to " << __func__; // RS this is ok for empty columns
     return;
   }
 


### PR DESCRIPTION
@davidrohr Indeed, I see 5% improvement in TPC CTF size with merged columns. Decoding time does not change (10.6s for my 120 pbpb events at 2.4GHz cpu clock), encoding time improves by 22%! (from 5.1 to 3.9 s). So, apparently encoding less data wins over doing this with larger dictionary.

I am enabling the columns merging by default. Merging can be disabled by passing option
``--no-ctf-columns-combining`` to tpc workflow (this is an option of ``tpc-entropy-encoder`` processor).
The used option is stored in the CTF and the dictionary. When encoding with external dictionary the flag extracted from it will define if the columns are merged or not (irrespectively of the provided option).
An attempt of decoding with inconsistent flags of stored in data and dictionary will throw an exception.
You will need to regenerate the dictionary, since the TPC CTFHeader is changed.