### PR TITLE
[EMCAL-610] Use mapping handler to access channel address mapping

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -120,7 +120,7 @@ class RawWriter
   FileFor_t mFileFor = FileFor_t::kFullDet;                      ///< Granularity of the output files
   o2::emcal::Geometry* mGeometry = nullptr;                      ///< EMCAL geometry
   std::string mOutputLocation;                                   ///< Rawfile name
-  std::array<o2::emcal::Mapper, 4> mMappers;                     ///< EMCAL mappers
+  std::unique_ptr<o2::emcal::MappingHandler> mMappingHandler;    ///< Mapping handler
   gsl::span<o2::emcal::Digit> mDigits;                           ///< Digits input vector - must be in digitized format including the time response
   gsl::span<o2::emcal::TriggerRecord> mTriggers;                 ///< Trigger records, separating the data from different triggers
   std::vector<SRUDigitContainer> mSRUdata;                       ///< Internal helper of digits assigned to SRUs

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -56,12 +56,8 @@ void RawWriter::init()
     mRawWriter->registerLink(iddl, crorc, link, 0, rawfilename.data());
   }
   // initialize mappers
-  std::array<char, 4> sides = {{'A', 'C'}};
-  for (auto iside = 0; iside < sides.size(); iside++) {
-    for (auto isru = 0; isru < 20; isru++) {
-      mMappers[iside * 2 + isru].setMapping(Form("%s/share/Detectors/EMC/file/RCU%d%c.data", gSystem->Getenv("O2_ROOT"), isru, sides[iside]));
-    }
-  }
+  if (!mMappingHandler)
+    mMappingHandler = std::make_unique<o2::emcal::MappingHandler>();
 
   // initialize containers for SRU
   for (auto isru = 0; isru < 40; isru++) {
@@ -116,7 +112,7 @@ bool RawWriter::processNextTrigger()
 
     for (const auto& [tower, channel] : srucont.mChannels) {
       // Find out hardware address of the channel
-      auto hwaddress = mMappers[srucont.mSRUid].getHardwareAddress(channel.mRow, channel.mCol, ChannelType_t::HIGH_GAIN); // @TODO distinguish between high- and low-gain cells
+      auto hwaddress = mMappingHandler->getMappingForDDL(srucont.mSRUid).getHardwareAddress(channel.mRow, channel.mCol, ChannelType_t::HIGH_GAIN); // @TODO distinguish between high- and low-gain cells
 
       std::vector<int> rawbunches;
       for (auto& bunch : findBunches(channel.mDigits)) {


### PR DESCRIPTION
The mapping handler takes care of caching the mapping
and providing the correct channel mapping for a given
DDL ID. Replacing internal caching which was buggy.