### PR TITLE
Optional use of FT0 time for ITS/TPC match selection or validation 

### DIFF
--- a/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
@@ -10,8 +10,9 @@
 
 o2_add_library(FT0Reconstruction
   SOURCES src/CollisionTimeRecoTask.cxx 
-  SOURCES src/ReadRaw.cxx
-  src/CTFCoder.cxx
+          src/ReadRaw.cxx
+          src/CTFCoder.cxx
+          src/InteractionTag.cxx
   
   PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::Framework
   O2::FT0Base
@@ -24,6 +25,7 @@ o2_add_library(FT0Reconstruction
 o2_target_root_dictionary(  
   FT0Reconstruction
   HEADERS include/FT0Reconstruction/CollisionTimeRecoTask.h
-  HEADERS include/FT0Reconstruction/ReadRaw.h
-  include/FT0Reconstruction/CTFCoder.h
+          include/FT0Reconstruction/ReadRaw.h
+          include/FT0Reconstruction/CTFCoder.h
+          include/FT0Reconstruction/InteractionTag.h
   )

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_FT0_INTERACTIONTAG_H
+#define ALICEO2_FT0_INTERACTIONTAG_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include "DataFormatsFT0/RecPoints.h"
+#include "CommonConstants/LHCConstants.h"
+
+namespace o2
+{
+namespace ft0
+{
+
+// These are configurable params for FT0 selection as interaction tag
+struct InteractionTag : public o2::conf::ConfigurableParamHelper<InteractionTag> {
+  int minAmplitudeAC = 20; ///< use only FT0 triggers with high enough amplitude
+  float timeBiasMS = 35.0; ///< relative bias in ns to add
+
+  bool isSelected(const RecPoints& rp) const
+  {
+    return rp.isValidTime(RecPoints::TimeMean) && (rp.getTrigger().amplA + rp.getTrigger().amplC) > minAmplitudeAC;
+  }
+
+  float getInteractionTimeNS(const RecPoints& rp, const o2::InteractionRecord& refIR) const
+  {
+    return rp.getInteractionRecord().differenceInBC(refIR) * o2::constants::lhc::LHCBunchSpacingNS + timeBiasMS; // RS FIXME do we want use precise MeanTime?
+  }
+
+  O2ParamDef(InteractionTag, "ft0tag");
+};
+
+} // namespace ft0
+} // end namespace o2
+
+#endif

--- a/Detectors/FIT/FT0/reconstruction/src/InteractionTag.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/InteractionTag.cxx
@@ -8,15 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+/// \file PVertexerParams.cxx
+/// \brief Configurable params for primary vertexer
+/// \author ruben.shahoyan@cern.ch
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "FT0Reconstruction/InteractionTag.h"
 
-#pragma link C++ class o2::ft0::CollisionTimeRecoTask + ;
-#pragma link C++ class o2::ft0::ReadRaw + ;
-#pragma link C++ class o2::ft0::CTFCoder + ;
-#pragma link C++ class o2::ft0::InteractionTag + ;
-
-#endif
+O2ParamImpl(o2::ft0::InteractionTag);

--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(
     O2::DataFormatsFT0
     O2::DataFormatsTOF
     O2::ITSReconstruction
+    O2::FT0Reconstruction
     O2::TPCFastTransformation
     O2::GPUTracking
     O2::TPCBase

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -25,7 +25,12 @@ namespace globaltracking
 
 // There are configurable params for TPC-ITS matching
 struct MatchITSTPCParams : public o2::conf::ConfigurableParamHelper<MatchITSTPCParams> {
-  bool runAfterBurner = false;
+  enum ValidateMatchByFIT { Disable,
+                            Prefer,
+                            Require }; // flags for usage of FT0 in match validation
+
+  bool runAfterBurner = false;                    ///< run afterburner for TPCtrack-ITScluster matching
+  ValidateMatchByFIT validateMatchByFIT = Prefer; ///< when comparing ITS-TPC matches, prefer those which have time of Interaction Candidate
   float crudeAbsDiffCut[o2::track::kNParams] = {2.f, 2.f, 0.2f, 0.2f, 4.f};
   float crudeNSigma2Cut[o2::track::kNParams] = {49.f, 49.f, 49.f, 49.f, 49.f};
 
@@ -40,13 +45,15 @@ struct MatchITSTPCParams : public o2::conf::ConfigurableParamHelper<MatchITSTPCP
 
   int maxMatchCandidates = 5; ///< max allowed matching candidates per TPC track
 
-  int ABRequireToReachLayer = 5; ///< AB tracks should reach at least this layer from above
+  int requireToReachLayerAB = 5; ///< AB tracks should reach at least this layer from above
 
-  float TPCITSTimeBinSafeMargin = 1.f; ///< safety margin (in TPC time bins) for ITS-TPC tracks time (in TPC time bins!) comparison
+  float safeMarginTPCITSTimeBin = 1.f; ///< safety margin (in TPC time bins) for ITS-TPC tracks time (in TPC time bins!) comparison
 
-  float TPCTimeEdgeZSafeMargin = 20.f; ///< safety margin in cm when estimating TPC track tMin and tMax from assigned time0 and its track Z position
+  float safeMarginTPCTimeEdge = 20.f; ///< safety margin in cm when estimating TPC track tMin and tMax from assigned time0 and its track Z position
 
-  float TimeBinTolerance = 10.f; ///<tolerance in time-bin for ITS-TPC time bracket matching (not used ? TODO)
+  float timeBinTolerance = 10.f; ///<tolerance in time-bin for ITS-TPC time bracket matching (not used ? TODO)
+
+  float tpcTimeICMatchingNSigma = 4.; ///< nsigma for matching TPC corrected time and InteractionCandidate from FT0
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT; /// Material correction type
 

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/MatchTPCITSWorkflow.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/MatchTPCITSWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace globaltracking
 {
 
-framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC, bool disableRootInp, bool disableRootOut);
+framework::WorkflowSpec getMatchTPCITSWorkflow(bool useFT0, bool useMC, bool disableRootInp, bool disableRootOut);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
@@ -32,8 +32,7 @@ namespace globaltracking
 class TPCITSMatchingDPL : public Task
 {
  public:
-  TPCITSMatchingDPL(bool useMC)
-    : mUseMC(useMC) {}
+  TPCITSMatchingDPL(bool useFT0, bool useMC) : mUseFT0(useFT0), mUseMC(useMC) {}
   ~TPCITSMatchingDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -42,12 +41,13 @@ class TPCITSMatchingDPL : public Task
  private:
   o2::globaltracking::MatchTPCITS mMatching; // matching engine
   o2::itsmft::TopologyDictionary mITSDict;   // cluster patterns dictionary
+  bool mUseFT0 = false;
   bool mUseMC = true;
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcClusLanes);
+framework::DataProcessorSpec getTPCITSMatchingSpec(bool useFT0, bool useMC, const std::vector<int>& tpcClusLanes);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
@@ -27,7 +27,7 @@ namespace o2
 namespace globaltracking
 {
 
-framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC, bool disableRootInp, bool disableRootOut)
+framework::WorkflowSpec getMatchTPCITSWorkflow(bool useFT0, bool useMC, bool disableRootInp, bool disableRootOut)
 {
   framework::WorkflowSpec specs;
 
@@ -53,11 +53,11 @@ framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC, bool disableRootInp, 
                                                    tpcClusLanes},
                                                  useMC));
 
-    if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
+    if (useFT0) {
       specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
     }
   }
-  specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(useMC, tpcClusLanes));
+  specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(useFT0, useMC, tpcClusLanes));
 
   if (!disableRootOut) {
     specs.emplace_back(o2::globaltracking::getTrackWriterTPCITSSpec(useMC));

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -62,6 +62,7 @@ void TPCITSMatchingDPL::init(InitContext& ic)
     mMatching.setITSROFrameLengthInBC(alpParams.roFrameLengthInBC); // ITS ROFrame duration in \mus
   }
   mMatching.setMCTruthOn(mUseMC);
+  mMatching.setUseFT0(mUseFT0);
   //
   std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
   std::string dictFile = o2::base::NameConf::getDictionaryFileName(o2::detectors::DetID::ITS, dictPath, ".bin");
@@ -238,7 +239,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     mMatching.setTPCTrkLabelsInp(lblTPCPtr);
   }
 
-  if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
+  if (mUseFT0) {
     // Note: the particular variable will go out of scope, but the span is passed by copy to the
     // worker and the underlying memory is valid throughout the whole computation
     auto fitInfo = pc.inputs().get<gsl::span<o2::ft0::RecPoints>>("fitInfo");
@@ -269,7 +270,7 @@ void TPCITSMatchingDPL::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcClusLanes)
+DataProcessorSpec getTPCITSMatchingSpec(bool useFT0, bool useMC, const std::vector<int>& tpcClusLanes)
 {
 
   std::vector<InputSpec> inputs;
@@ -285,7 +286,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcC
 
   inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
 
-  if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
+  if (useFT0) {
     inputs.emplace_back("fitInfo", "FT0", "RECPOINTS", 0, Lifetime::Timeframe);
   }
 
@@ -304,7 +305,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcC
     "itstpc-track-matcher",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCITSMatchingDPL>(useMC)},
+    AlgorithmSpec{adaptFromTask<TPCITSMatchingDPL>(useFT0, useMC)},
     Options{
       {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -22,6 +22,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
+    {"use-ft0", o2::framework::VariantType::Bool, false, {"use FT0 in matching"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
@@ -52,8 +53,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // write the configuration used for the workflow
   o2::conf::ConfigurableParam::writeINI("o2matchtpcits-workflow_configuration.ini");
 
+  auto useFT0 = configcontext.options().get<bool>("use-ft0");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
-  return std::move(o2::globaltracking::getMatchTPCITSWorkflow(useMC, disableRootInp, disableRootOut));
+  return std::move(o2::globaltracking::getMatchTPCITSWorkflow(useFT0, useMC, disableRootInp, disableRootOut));
 }

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(DetectorsVertexing
 	                             O2::CommonUtils
                                      O2::ReconstructionDataFormats
                                      O2::SimulationDataFormat
+                                     O2::FT0Reconstruction
                                      O2::DataFormatsFT0
                                      ms_gsl::ms_gsl)
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
@@ -21,7 +21,7 @@ namespace o2
 namespace vertexing
 {
 
-// There are configurable params for Primary Vertexer
+// These are configurable params for Primary Vertexer
 struct PVertexerParams : public o2::conf::ConfigurableParamHelper<PVertexerParams> {
   static constexpr float kDefTukey = 5.0f; ///< def.value for tukey constant
 
@@ -39,8 +39,6 @@ struct PVertexerParams : public o2::conf::ConfigurableParamHelper<PVertexerParam
   // validation with FT0
   bool requireFT0ValidTimeMean = false; //true;///< require both FT0A/C
   int minNContributorsForFT0cut = 4;    ///< do not apply FT0 cut to vertice below FT0 efficiency threshold
-  int minFT0AmplitudeAC = 20;           ///< use only FT0 triggers with high enough aplitude
-  float timeBiasMS = 0.0;               ///< relative bias in ms between TPC/ITS time and IR
   float maxTError = 0.2;                ///< use min of vertex time error or this for nsigma evaluation
   float minTError = 0.003;              ///< don't use error smaller than that (~BC/2/minNContributorsForFT0cut)
   float nSigmaFT0cut = 4.;              ///< eliminate vertex if there is no FT0 signal within this cut


### PR DESCRIPTION
* Extract FT0 interaction selection params to separate configurable class 
``o2::ft0::InteractionTag`` configurable param to values of FT0 trigger selection as interaction tag (A+C amplitude threshold, time bias correction (ns) to match to other detectors.

* Providing option ``--use-ft0`` option to ``o2-tpcits-match-workflow`` will add FIT (currently FT0 only) recpoints input, which can be used either for validation or for selection of matching candidates. Option provided via MatchITSTPCParams configurable param:
``--configKeyValues "tpcitsMatch.validateMatchByFIT=Disable"`` will force to ignore FT0 data
``--configKeyValues "tpcitsMatch.validateMatchByFIT=Prefer"`` will affect comparison of matching candidates: the one with
FIT match will be preferred irrespectively to chi2 of its competitor w/o such FIT tag.
``--configKeyValues "tpcitsMatch.validateMatchByFIT=Require"`` will require obligatory match to FIT for every TPC/ITS match.