### PR TITLE
Add async. reco mode to ITS workflow with ca-tracker + misc.fixes

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -42,8 +42,8 @@ class TrackITS : public o2::track::TrackParCov
   TrackITS() = default;
   TrackITS(const TrackITS& t) = default;
   TrackITS(const o2::track::TrackParCov& parcov) : TrackParCov{parcov} {}
-  TrackITS(const o2::track::TrackParCov& parCov, float chi2, std::uint32_t rof, const o2::track::TrackParCov& outer)
-    : o2::track::TrackParCov{parCov}, mChi2{chi2}, mROFrame{rof}, mParamOut{outer} {}
+  TrackITS(const o2::track::TrackParCov& parCov, float chi2, const o2::track::TrackParCov& outer)
+    : o2::track::TrackParCov{parCov}, mChi2{chi2}, mParamOut{outer} {}
   TrackITS& operator=(const TrackITS& tr) = default;
   ~TrackITS() = default;
 
@@ -82,21 +82,26 @@ class TrackITS : public o2::track::TrackParCov
 
   void setChi2(float chi2) { mChi2 = chi2; }
 
-  std::uint32_t getROFrame() const { return mROFrame; }
-  void setROFrame(std::uint32_t f) { mROFrame = f; }
   bool isBetter(const TrackITS& best, float maxChi2) const;
 
   o2::track::TrackParCov& getParamOut() { return mParamOut; }
   const o2::track::TrackParCov& getParamOut() const { return mParamOut; }
 
+  void setPID(uint8_t p) { mPID = p; }
+  int getPID() const { return mPID; }
+
+  void setPattern(uint8_t p) { mPattern = p; }
+  int getPattern() const { return mPattern; }
+  bool hasHitOnLayer(int i) { return mPattern & (0x1 << i); }
+
  private:
-  float mMass = 0.139;              ///< Assumed mass for this track
-  float mChi2 = 0.;                 ///< Chi2 for this track
-  std::uint32_t mROFrame = 0;       ///< RO Frame
   o2::track::TrackParCov mParamOut; ///< parameter at largest radius
   ClusRefs mClusRef;                ///< references on clusters
+  float mChi2 = 0.;                 ///< Chi2 for this track
+  uint8_t mPID = 0;                 ///< pid info (at the moment not used)
+  uint8_t mPattern = 0;             ///< layers pattern
 
-  ClassDefNV(TrackITS, 3);
+  ClassDefNV(TrackITS, 4);
 };
 
 class TrackITSExt : public TrackITS
@@ -106,9 +111,9 @@ class TrackITSExt : public TrackITS
   static constexpr int MaxClusters = 7;
   using TrackITS::TrackITS; // inherit base constructors
 
-  TrackITSExt(o2::track::TrackParCov&& parCov, short ncl, float chi2, std::uint32_t rof,
+  TrackITSExt(o2::track::TrackParCov&& parCov, short ncl, float chi2,
               o2::track::TrackParCov&& outer, std::array<int, MaxClusters> cls)
-    : TrackITS(parCov, chi2, rof, outer), mIndex{cls}
+    : TrackITS(parCov, chi2, outer), mIndex{cls}
   {
     setNumberOfClusters(ncl);
   }

--- a/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
+++ b/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
@@ -26,9 +26,5 @@
 
 #pragma link C++ class std::pair < o2::dataformats::EvIndex < int, int>, o2::dataformats::MatchInfoTOF> + ;
 #pragma link C++ class std::vector < std::pair < o2::dataformats::EvIndex < int, int>, o2::dataformats::MatchInfoTOF>> + ;
-#pragma link C++ class std::vector < o2::dataformats::TrackTPCITS> + ;
-#pragma link C++ class std::vector < o2::tpc::TrackTPC> + ;
-#pragma link C++ class std::vector < o2::its::TrackITS> + ;
-#pragma link C++ class std::vector < o2::tof::Cluster> + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -91,6 +91,7 @@ class CookedTracker
         clusIdx.emplace_back(idx);
       }
       trackNew.setClusterRefs(clEntry, noc);
+      trackNew.setPattern(0x7f); // this tracker finds only complete tracks
       return tracks.size();
     };
     process(clusters, it, dict, inserter, rof);

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -285,7 +285,6 @@ void Tracker::findTracks(const ROframe& event)
     if (!fitSuccess)
       continue;
     CA_DEBUGGER(refitCounters[nClusters - 4]++);
-    temporaryTrack.setROFrame(mROFrame);
     tracks.emplace_back(temporaryTrack);
     CA_DEBUGGER(assert(nClusters == temporaryTrack.getNumberOfClusters()));
   }

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -27,7 +27,7 @@ namespace its
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
+framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, bool async, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
                                     bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool eencode = false);
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -38,7 +38,7 @@ namespace its
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(bool isMC, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
+  TrackerDPL(bool isMC, bool async, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -46,6 +46,7 @@ class TrackerDPL : public framework::Task
 
  private:
   bool mIsMC = false;
+  bool mAsyncMode = false;
   o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
   std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
@@ -56,7 +57,7 @@ class TrackerDPL : public framework::Task
 
 /// create a processor spec
 /// run ITS CA tracker
-framework::DataProcessorSpec getTrackerSpec(bool useMC, o2::gpu::GPUDataTypes::DeviceType dType);
+framework::DataProcessorSpec getTrackerSpec(bool useMC, bool async, o2::gpu::GPUDataTypes::DeviceType dType);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -28,7 +28,7 @@ namespace its
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, o2::gpu::GPUDataTypes::DeviceType dtype,
+framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, bool async, o2::gpu::GPUDataTypes::DeviceType dtype,
                                     bool upstreamDigits, bool upstreamClusters, bool disableRootOutput,
                                     bool eencode)
 {
@@ -45,7 +45,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, o2::gpu::GPUD
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
   }
   if (useCAtracker) {
-    specs.emplace_back(o2::its::getTrackerSpec(useMC, dtype));
+    specs.emplace_back(o2::its::getTrackerSpec(useMC, async, dtype));
   } else {
     specs.emplace_back(o2::its::getCookedTrackerSpec(useMC));
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -35,6 +35,7 @@
 
 #include "ITSReconstruction/FastMultEstConfig.h"
 #include "ITSReconstruction/FastMultEst.h"
+#include <fmt/format.h>
 
 namespace o2
 {
@@ -132,10 +133,15 @@ void TrackerDPL::run(ProcessingContext& pc)
   auto copyTracks = [](auto& tracks, auto& allTracks, auto& allClusIdx, int offset = 0) {
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
-      int ncl = trc.getNumberOfClusters();
-      for (int ic = ncl; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
-        allClusIdx.push_back(trc.getClusterIndex(ic) + offset);
+      int ncl = trc.getNumberOfClusters(), nclf = 0;
+      for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
+        auto clid = trc.getClusterIndex(ic);
+        if (clid >= 0) {
+          allClusIdx.push_back(clid + offset);
+          nclf++;
+        }
       }
+      assert(ncl == nclf);
       allTracks.emplace_back(trc);
     }
   };

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -143,14 +143,17 @@ void TrackerDPL::run(ProcessingContext& pc)
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
       int ncl = trc.getNumberOfClusters(), nclf = 0;
+      uint8_t patt = 0;
       for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
         auto clid = trc.getClusterIndex(ic);
         if (clid >= 0) {
           allClusIdx.push_back(clid + offset);
           nclf++;
+          patt |= 0x1 << ic;
         }
       }
       assert(ncl == nclf);
+      trc.setPattern(patt);
       allTracks.emplace_back(trc);
     }
   };

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -31,6 +31,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (default: trackerCM)"}},
+    {"async-phase", o2::framework::VariantType::Bool, false, {"perform multiple passes for async. phase reconstruction"}},
     {"entropy-encoding", o2::framework::VariantType::Bool, false, {"produce entropy encoded data"}},
     {"gpuDevice", o2::framework::VariantType::Int, 1, {"use gpu device: CPU=1,CUDA=2,HIP=3 (default: CPU)"}}};
 
@@ -43,6 +44,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 // ------------------------------------------------------------------
 
 #include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
@@ -53,10 +55,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto useCAtracker = configcontext.options().get<bool>("trackerCA");
+  auto async = configcontext.options().get<bool>("async-phase");
   auto gpuDevice = static_cast<o2::gpu::GPUDataTypes::DeviceType>(configcontext.options().get<int>("gpuDevice"));
   auto extDigits = configcontext.options().get<bool>("digits-from-upstream");
   auto extClusters = configcontext.options().get<bool>("clusters-from-upstream");
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto eencode = configcontext.options().get<bool>("entropy-encoding");
-  return std::move(o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, gpuDevice, extDigits, extClusters, disableRootOutput, eencode));
+
+  if (async && !useCAtracker) {
+    LOG(ERROR) << "Async.mode is not supported by CookedTracker, use --trackerCA";
+    throw std::runtime_error("incompatible options provided");
+  }
+  return std::move(o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, async, gpuDevice, extDigits, extClusters, disableRootOutput, eencode));
 }

--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -113,7 +113,6 @@ int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Clust
                                      {trkin.Cov()[0], trkin.Cov()[1], trkin.Cov()[2], trkin.Cov()[3], trkin.Cov()[4], trkin.Cov()[5], trkin.Cov()[6], trkin.Cov()[7], trkin.Cov()[8], trkin.Cov()[9], trkin.Cov()[10], trkin.Cov()[11], trkin.Cov()[12], trkin.Cov()[13], trkin.Cov()[14]}},
                                     (short int)((trkin.NDF() + 5) / 2),
                                     trkin.Chi2(),
-                                    0,
                                     {trkin.mOuterParam.X,
                                      trkin.mOuterParam.alpha,
                                      {trkin.mOuterParam.P[0], trkin.mOuterParam.P[1], trkin.mOuterParam.P[2], trkin.mOuterParam.P[3], trkin.mOuterParam.P[4]},


### PR DESCRIPTION
@mpuccio, @iouribelikov : I've added the extra passes code as it is in https://github.com/AliceO2Group/AliceO2/blob/9f587108fe0e6eaabf8c642cc3ea81443ec7ad28/macro/run_trac_ca_its.C#L187-L195 to CA TrackerSpec, activated by ``--async-phase`` option. Works fine and fast but eventually this need to be converted to something configurable.
Also fixed the cluster id's extraction from the tracker.

I've suppressed the ROFrame and mass data members of the TrackITS as they are not used and added PID and contributing layers pattern.
