### PR TITLE
Use vector instead of MCTruthContainer for ITS,TPC tracks

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -39,7 +39,8 @@
 #include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
-using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using MCLabelsCl = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using MCLabelsTr = gsl::span<const o2::MCCompLabel>;
 
 namespace o2
 {
@@ -197,24 +198,18 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   //
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblITSPtr = nullptr;
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblITS;
+  MCLabelsTr lblITS;
+  MCLabelsTr lblTPC;
 
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblClusITSPtr = nullptr;
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblClusITS;
-
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblTPCPtr = nullptr;
-  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblTPC;
+  const MCLabelsCl* lblClusITSPtr = nullptr;
+  std::unique_ptr<const MCLabelsCl> lblClusITS;
 
   if (mUseMC) {
-    lblITS = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("trackITSMCTR");
-    lblITSPtr = lblITS.get();
+    lblITS = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSMCTR");
+    lblTPC = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCMCTR");
 
     lblClusITS = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("clusITSMCTR");
     lblClusITSPtr = lblClusITS.get();
-
-    lblTPC = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("trackTPCMCTR");
-    lblTPCPtr = lblTPC.get();
   }
   //
   // create ITS clusters as spacepoints in tracking frame
@@ -234,9 +229,9 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   mMatching.setTPCClustersInp(&clusterIndex);
 
   if (mUseMC) {
-    mMatching.setITSTrkLabelsInp(lblITSPtr);
+    mMatching.setITSTrkLabelsInp(lblITS);
+    mMatching.setTPCTrkLabelsInp(lblTPC);
     mMatching.setITSClsLabelsInp(lblClusITSPtr);
-    mMatching.setTPCTrkLabelsInp(lblTPCPtr);
   }
 
   if (mUseFT0) {

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -103,7 +103,7 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   std::vector<TrackITS>* recArr = nullptr;
   recTree->SetBranchAddress("ITSTrack", &recArr);
   // Track MC labels
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabArr = nullptr;
+  std::vector<o2::MCCompLabel>* trkLabArr = nullptr;
   recTree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
 
   Int_t lastEventIDcl = -1, cf = 0;
@@ -154,7 +154,7 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
       continue;
     int loadedEventTracks = frame;
     for (unsigned int i = 0; i < recArr->size(); i++) { // Find the last MC event within this reconstructed entry
-      auto lab = (trkLabArr->getLabels(i))[0];
+      auto lab = (*trkLabArr)[i];
       if (!lab.isValid()) {
         const TrackITS& recTrack = (*recArr)[i];
         fak->Fill(recTrack.getPt());
@@ -210,7 +210,7 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
       long lastIndex = (frame == f.lastFrame) ? f.lastIndex : nentr - 1;
 
       for (long i = firstIndex; i <= lastIndex; i++) {
-        auto lab = (trkLabArr->getLabels(i))[0];
+        auto lab = (*trkLabArr)[i];
         if (!lab.isValid() || lab.getSourceID() != 0 || lab.getEventID() != n)
           continue;
         int mcid = lab.getTrackID();

--- a/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
+++ b/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
@@ -205,7 +205,7 @@ found:
   tree->SetBranchAddress("ITSTrack", &trkArr);
   tree->SetBranchAddress("ITSTrackClusIdx", &clIdx);
   // Track MC labels
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabArr = nullptr;
+  std::vector<o2::MCCompLabel>* trkLabArr = nullptr;
   tree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
 
   tree->GetEvent(0);
@@ -214,7 +214,7 @@ found:
   n = 0;
   while (nt--) {
     const TrackITS& t = (*trkArr)[nt];
-    auto lab = (trkLabArr->getLabels(nt))[0];
+    auto lab = (*trkLabArr)[nt];
     if (TMath::Abs(lab.getEventID()) != event)
       continue;
     if (TMath::Abs(lab.getTrackID()) != track)

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -99,8 +99,7 @@ class CookedTracker
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::its::GeometryTGeo* geom);
-  void setMCTruthContainers(const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clsLabels,
-                            o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabels)
+  void setMCTruthContainers(const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clsLabels, std::vector<o2::MCCompLabel>* trkLabels)
   {
     mClsLabels = clsLabels;
     mTrkLabels = trkLabels;
@@ -135,7 +134,7 @@ class CookedTracker
   bool mContinuousMode = true;                                                    ///< triggered or cont. mode
   const o2::its::GeometryTGeo* mGeom = nullptr;                                   /// interface to geometry
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; /// Cluster MC labels
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTrkLabels = nullptr;       /// Track MC labels
+  std::vector<o2::MCCompLabel>* mTrkLabels = nullptr;                             /// Track MC labels
   std::uint32_t mFirstInFrame = 0;                                                ///< Index of the 1st cluster of a frame (within the loaded vector of clusters)
 
   Int_t mNumOfThreads; ///< Number of tracking threads

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -571,7 +571,7 @@ std::tuple<int, int> CookedTracker::processLoadedClusters(TrackInserter& inserte
         }
         // the inserter returns the size of the track vector, the index of the last
         // inserted track is thus n - 1
-        mTrkLabels->addElement(nAllTracks - 1, label);
+        mTrkLabels->emplace_back(label);
       }
     }
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -62,7 +62,7 @@ class Tracker
   float getBz() const;
 
   std::vector<TrackITSExt>& getTracks();
-  dataformats::MCTruthContainer<MCCompLabel>& getTrackLabels();
+  auto& getTrackLabels() { return mTrackLabels; }
 
   void clustersToTracks(const ROframe&, std::ostream& = std::cout);
 
@@ -99,7 +99,7 @@ class Tracker
   float mBz = 5.f;
   std::uint32_t mROFrame = 0;
   std::vector<TrackITSExt> mTracks;
-  dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;
+  std::vector<MCCompLabel> mTrackLabels;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
 };
 
@@ -128,11 +128,6 @@ void Tracker::initialisePrimaryVertexContext(T&&... args)
 inline std::vector<TrackITSExt>& Tracker::getTracks()
 {
   return mTracks;
-}
-
-inline dataformats::MCTruthContainer<MCCompLabel>& Tracker::getTrackLabels()
-{
-  return mTrackLabels;
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -567,7 +567,7 @@ void Tracker::computeTracksMClabels(const ROframe& event)
     if (isFakeTrack) {
       maxOccurrencesValue.setFakeFlag();
     }
-    mTrackLabels.addElement(mTrackLabels.getIndexedSize(), maxOccurrencesValue);
+    mTrackLabels.emplace_back(maxOccurrencesValue);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
@@ -48,7 +48,7 @@ class TrackReader : public o2::framework::Task
   std::vector<o2::its::TrackITS> mTracks, *mTracksInp = &mTracks;
   std::vector<Vertex> mVertices, *mVerticesInp = &mVertices;
   std::vector<int> mClusInd, *mClusIndInp = &mClusInd;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+  std::vector<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -112,7 +112,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
 
   LOG(INFO) << "ITSCookedTracker pulled " << compClusters.size() << " clusters, in " << rofs.size() << " RO frames";
 
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> trackLabels;
+  std::vector<o2::MCCompLabel> trackLabels;
   if (mUseMC) {
     mTracker.setMCTruthContainers(labels.get(), &trackLabels);
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -30,7 +30,7 @@ using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
-using LabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using LabelsType = std::vector<o2::MCCompLabel>;
 using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
 using namespace o2::header;
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -112,9 +112,9 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   std::vector<o2::its::TrackITSExt> tracks;
   auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> trackLabels;
+  std::vector<o2::MCCompLabel> trackLabels;
   auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> allTrackLabels;
+  std::vector<o2::MCCompLabel> allTrackLabels;
 
   auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
@@ -193,13 +193,13 @@ void TrackerDPL::run(ProcessingContext& pc)
         tracks.swap(mTracker->getTracks());
         LOG(INFO) << "Found tracks: " << tracks.size();
         int number = tracks.size();
-        trackLabels = mTracker->getTrackLabels(); /// FIXME: assignment ctor is not optimal.
+        trackLabels.swap(mTracker->getTrackLabels()); /// FIXME: assignment ctor is not optimal.
         int shiftIdx = -rof.getFirstEntry();      // cluster entry!!!
         rof.setFirstEntry(first);
         rof.setNEntries(number);
         copyTracks(tracks, allTracks, allClusIdx, shiftIdx);
-        allTrackLabels.mergeAtBack(trackLabels);
-
+        std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
+        trackLabels.clear();
         vtxROF.setNEntries(vtxVecLoc.size());
         for (const auto& vtx : vtxVecLoc) {
           vertices.push_back(vtx);
@@ -214,7 +214,7 @@ void TrackerDPL::run(ProcessingContext& pc)
     mTracker->clustersToTracks(event);
     tracks.swap(mTracker->getTracks());
     copyTracks(tracks, allTracks, allClusIdx);
-    allTrackLabels = mTracker->getTrackLabels(); /// FIXME: assignment ctor is not optimal.
+    allTrackLabels.swap(mTracker->getTrackLabels()); /// FIXME: assignment ctor is not optimal.
   }
 
   LOG(INFO) << "ITSTracker pushed " << allTracks.size() << " tracks";

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -72,7 +72,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
 
   std::vector<TrackTPC>* outputTracks = data->outputTracks;
   std::vector<uint32_t>* outClusRefs = data->outputClusRefs;
-  MCLabelContainer* outputTracksMCTruth = data->outputTracksMCTruth;
+  std::vector<o2::MCCompLabel>* outputTracksMCTruth = data->outputTracksMCTruth;
 
   if (!outputTracks || !outClusRefs) {
     LOG(ERROR) << "Output tracks or clusRefs vectors are not initialized";
@@ -288,7 +288,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
     }
     if (outputTracksMCTruth) {
       if (labels.size() == 0) {
-        outputTracksMCTruth->addElement(iTmp, MCCompLabel()); //default constructor creates NotSet label
+        outputTracksMCTruth->emplace_back(); //default constructor creates NotSet label
       } else {
         int bestLabelNum = 0, bestLabelCount = 0;
         for (int j = 0; j < labels.size(); j++) {
@@ -301,7 +301,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
         if (bestLabelCount < (1.f - sTrackMCMaxFake) * nOutCl) {
           bestLabel.setFakeFlag();
         }
-        outputTracksMCTruth->addElement(iTmp, bestLabel);
+        outputTracksMCTruth->emplace_back(bestLabel);
       }
     }
   }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
@@ -45,7 +45,7 @@ class TrackReader : public Task
 
   std::vector<o2::tpc::TrackTPC>*mTracksInp = nullptr, mTracksOut;
   std::vector<o2::tpc::TPCClRefElem>*mCluRefVecInp = nullptr, mCluRefVecOut;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
+  std::vector<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -539,7 +539,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
 
       std::vector<TrackTPC> tracks;
       std::vector<uint32_t> clusRefs;
-      MCLabelContainer tracksMCTruth;
+      std::vector<o2::MCCompLabel> tracksMCTruth;
       GPUO2InterfaceIOPtrs ptrs;
       ClusterNativeAccess clusterIndex;
       std::unique_ptr<ClusterNative[]> clusterBuffer;
@@ -637,7 +637,7 @@ DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int
         pc.outputs().snapshot(OutputRef{"outTracks"}, tracks);
         pc.outputs().snapshot(OutputRef{"outClusRefs"}, clusRefs);
         if (specconfig.processMC) {
-          LOG(INFO) << "sending " << tracksMCTruth.getIndexedSize() << " track label(s)";
+          LOG(INFO) << "sending " << tracksMCTruth.size() << " track label(s)";
           pc.outputs().snapshot(OutputRef{"mclblout"}, tracksMCTruth);
         }
       }

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -444,7 +444,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
 
     using ClusRefsOutputType = std::vector<o2::tpc::TPCClRefElem>;
 
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+    using MCLabelContainer = std::vector<o2::MCCompLabel>;
     // a spectator callback which will be invoked by the tree writer with the extracted object
     // we are using it for printing a log message
     auto logger = BranchDefinition<TrackOutputType>::Spectator([](TrackOutputType const& tracks) {

--- a/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
@@ -60,7 +60,7 @@ void TrackReader::accumulate(int from, int n)
     mTracksOut.swap(*mTracksInp);
     mCluRefVecOut.swap(*mCluRefVecInp);
     if (mUseMC) {
-      mMCTruthOut.mergeAtBack(*mMCTruthInp);
+      std::copy(mMCTruthInp->begin(), mMCTruthInp->end(), std::back_inserter(mMCTruthOut));
     }
   } else {
     for (int iev = 0; iev < n; iev++) {
@@ -83,7 +83,7 @@ void TrackReader::accumulate(int from, int n)
       std::copy(tr0, tr1, std::back_inserter(mTracksOut));
       // MC
       if (mUseMC) {
-        mMCTruthOut.mergeAtBack(*mMCTruthInp);
+        std::copy(mMCTruthInp->begin(), mMCTruthInp->end(), std::back_inserter(mMCTruthOut));
       }
     }
   }

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -114,7 +114,7 @@ struct GPUO2InterfaceIOPtrs {
   // Input / Output for Merged TPC tracks, two ptrs, for the tracks themselves, and for the MC labels.
   std::vector<o2::tpc::TrackTPC>* outputTracks = nullptr;
   std::vector<uint32_t>* outputClusRefs = nullptr;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr;
+  std::vector<o2::MCCompLabel>* outputTracksMCTruth = nullptr;
 
   // Output for entropy-reduced clusters of TPC compression
   const o2::tpc::CompressedClustersFlat* compressedClusters = nullptr;

--- a/macro/checkTOFMatching.C
+++ b/macro/checkTOFMatching.C
@@ -40,7 +40,7 @@ void checkTOFMatching(bool batchMode = true)
   TTree* tpcTree = (TTree*)ftracksTPC->Get("events");
   std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = new std::vector<o2::tpc::TrackTPC>;
   tpcTree->SetBranchAddress("Tracks", &mTPCTracksArrayInp);
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mcTPC = new o2::dataformats::MCTruthContainer<o2::MCCompLabel>();
+  std::vector<o2::MCCompLabel>* mcTPC = new std::vector<o2::MCCompLabel>();
   tpcTree->SetBranchAddress("TracksMCTruth", &mcTPC);
 
   // getting the ITS tracks
@@ -48,7 +48,7 @@ void checkTOFMatching(bool batchMode = true)
   TTree* itsTree = (TTree*)ftracksITS->Get("o2sim");
   std::vector<o2::its::TrackITS>* mITSTracksArrayInp = new std::vector<o2::its::TrackITS>;
   itsTree->SetBranchAddress("ITSTrack", &mITSTracksArrayInp);
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mcITS = new o2::dataformats::MCTruthContainer<o2::MCCompLabel>();
+  std::vector<o2::MCCompLabel>* mcITS = new std::vector<o2::MCCompLabel>();
   itsTree->SetBranchAddress("ITSTrackMCTruth", &mcITS);
 
   // getting the TOF clusters
@@ -274,23 +274,19 @@ void checkTOFMatching(bool batchMode = true)
       Printf("matched ITStrack index = %d", evIdxITS);
 #endif
       // getting the TPC labels
-      const auto& labelsTPC = mcTPC->getLabels(evIdxTPC);
+      const auto& labelsTPC = (*mcTPC)[evIdxTPC];
 #ifdef DEBUG
-      for (uint ilabel = 0; ilabel < labelsTPC.size(); ilabel++) {
-        Printf("TPC label %d: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsTPC[ilabel].getTrackID(), labelsTPC[ilabel].getEventID(), labelsTPC[ilabel].getSourceID());
-      }
+      Printf("TPC label: trackID = %d, eventID = %d, sourceID = %d", labelsTPC.getTrackID(), labelsTPC.getEventID(), labelsTPC.getSourceID());
 #endif
 
       // getting the ITS labels
-      const auto& labelsITS = mcITS->getLabels(evIdxITS);
+      const auto& labelsITS = (*mcITS)[evIdxITS];
 #ifdef DEBUG
-      for (uint ilabel = 0; ilabel < labelsITS.size(); ilabel++) {
-        Printf("ITS label %d: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsITS[ilabel].getTrackID(), labelsITS[ilabel].getEventID(), labelsITS[ilabel].getSourceID());
-      }
+      Printf("ITS label: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsITS.getTrackID(), labelsITS.getEventID(), labelsITS.getSourceID());
 #endif
       bool bMatched = kFALSE;
       for (uint ilabel = 0; ilabel < labelsTOF.size(); ilabel++) {
-        if ((abs(labelsTPC[0].getTrackID()) == labelsTOF[ilabel].getTrackID() && labelsTPC[0].getEventID() == labelsTOF[ilabel].getEventID() && labelsTPC[0].getSourceID() == labelsTOF[ilabel].getSourceID()) || (labelsITS[0].getTrackID() == labelsTOF[ilabel].getTrackID() && labelsITS[0].getEventID() == labelsTOF[ilabel].getEventID() && labelsITS[0].getSourceID() == labelsTOF[ilabel].getSourceID())) {
+        if ((abs(labelsTPC.getTrackID()) == labelsTOF[ilabel].getTrackID() && labelsTPC.getEventID() == labelsTOF[ilabel].getEventID() && labelsTPC.getSourceID() == labelsTOF[ilabel].getSourceID()) || (labelsITS.getTrackID() == labelsTOF[ilabel].getTrackID() && labelsITS.getEventID() == labelsTOF[ilabel].getEventID() && labelsITS.getSourceID() == labelsTOF[ilabel].getSourceID())) {
           nGoodMatches++;
           bMatched = kTRUE;
           break;
@@ -352,23 +348,19 @@ void checkTOFMatching(bool batchMode = true)
         o2::dataformats::TrackTPCITS trackITSTPC = mTracksArrayInp->at(i);
         const auto evIdxTPCcheck = trackITSTPC.getRefTPC();
         const auto evIdxITScheck = trackITSTPC.getRefITS();
-        const auto& labelsTPCcheck = mcTPC->getLabels(evIdxTPCcheck);
-        for (uint ilabel = 0; ilabel < labelsTPCcheck.size(); ilabel++) {
-          if (abs(labelsTPCcheck[ilabel].getTrackID()) == trackIdTOF && labelsTPCcheck[ilabel].getEventID() == eventIdTOF && labelsTPCcheck[ilabel].getSourceID() == sourceIdTOF) {
+        const auto& labelsTPCcheck = (*mcTPC)[evIdxTPCcheck];
+        if (abs(labelsTPCcheck.getTrackID()) == trackIdTOF && labelsTPCcheck.getEventID() == eventIdTOF && labelsTPCcheck.getSourceID() == sourceIdTOF) {
 #ifdef DEBUG
-            Printf("The TPC track that should have been matched to TOF is number %d", i);
+          Printf("The TPC track that should have been matched to TOF is number %d", i);
 #endif
-            TPCfound = true;
-          }
+          TPCfound = true;
         }
-        const auto& labelsITScheck = mcITS->getLabels(evIdxITScheck);
-        for (uint ilabel = 0; ilabel < labelsITScheck.size(); ilabel++) {
-          if (labelsITScheck[ilabel].getTrackID() == trackIdTOF && labelsITScheck[ilabel].getEventID() == eventIdTOF && labelsITScheck[ilabel].getSourceID() == sourceIdTOF) {
+        const auto& labelsITScheck = (*mcITS)[evIdxITScheck];
+        if (labelsITScheck.getTrackID() == trackIdTOF && labelsITScheck.getEventID() == eventIdTOF && labelsITScheck.getSourceID() == sourceIdTOF) {
 #ifdef DEBUG
-            Printf("The ITS track that should have been matched to TOF is number %d", i);
+          Printf("The ITS track that should have been matched to TOF is number %d", i);
 #endif
-            ITSfound = true;
-          }
+          ITSfound = true;
         }
       }
 #ifdef DEBUG

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -100,7 +100,7 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
 
   vector<TrackTPC> tracks;
   vector<TPCClRefElem> trackClusRefs;
-  MCLabelContainer tracksMC;
+  std::vector<o2::MCCompLabel> tracksMC;
 
   TFile fout(outputFile, "recreate");
   TTree tout("events", "events");

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -165,7 +165,7 @@ void run_trac_ca_its(std::string path = "./",
   std::vector<o2::itsmft::ROFRecord> vertROFvec, *vertROFvecPtr = &vertROFvec;
   std::vector<Vertex> vertices, *verticesPtr = &vertices;
 
-  MCLabCont trackLabels, *trackLabelsPtr = &trackLabels;
+  std::vector<o2::MCCompLabel> trackLabels, *trackLabelsPtr = &trackLabels;
   outTree.Branch("ITSTrack", &tracksITSPtr);
   outTree.Branch("ITSTrackClusIdx", &trackClIdxPtr);
   outTree.Branch("ITSTrackMCTruth", &trackLabelsPtr);

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -38,6 +38,7 @@
 #include "ITStracking/VertexerTraits.h"
 
 using MCLabCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using MCLabContTr = std::vector<o2::MCCompLabel>;
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
 void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.root",
@@ -141,7 +142,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   std::vector<o2::itsmft::ROFRecord> vertROFvec, *vertROFvecPtr = &vertROFvec;
   std::vector<Vertex> vertices, *verticesPtr = &vertices;
 
-  MCLabCont trackLabels, *trackLabelsPtr = &trackLabels;
+  MCLabContTr trackLabels, *trackLabelsPtr = &trackLabels;
   outTree.Branch("ITSTrack", &tracksITSPtr);
   outTree.Branch("ITSTrackClusIdx", &trackClIdxPtr);
   outTree.Branch("ITSTrackMCTruth", &trackLabelsPtr);


### PR DESCRIPTION
Since tracks have just one label, there is no point in using MCTruthContainer (not browsable in the tree, non-messageable and occupy more memory) for them.
