### PR TITLE
[EMCAL-651] Add const for cell indices in cluster

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -178,7 +178,7 @@ class ClusterFactory
   /// \param clustersContainer cluster container
   /// \param inputsContainer cells/digits container
   /// \param cellsIndices for cells/digits indices
-  ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<int> cellsIndices);
+  ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<const int> cellsIndices);
 
   ///
   /// Copy constructor
@@ -225,17 +225,17 @@ class ClusterFactory
 
   ///
   /// Calculates the center of gravity in the local EMCAL-module coordinates
-  void evalLocalPosition(gsl::span<int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalLocalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
 
   ///
   /// Calculates the center of gravity in the global ALICE coordinates
-  void evalGlobalPosition(gsl::span<int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalGlobalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
 
   void evalLocal2TrackingCSTransform() const;
 
   ///
   /// evaluates local position of clusters in SM
-  void evalLocalPositionFit(Double_t deff, Double_t w0, Double_t phiSlope, gsl::span<int> inputsIndices, AnalysisCluster& cluster) const;
+  void evalLocalPositionFit(Double_t deff, Double_t w0, Double_t phiSlope, gsl::span<const int> inputsIndices, AnalysisCluster& cluster) const;
 
   ///
   /// Applied for simulation data with threshold 3 adc
@@ -250,11 +250,11 @@ class ClusterFactory
   /// \return the index of the cells with max enegry
   /// \return the maximum energy
   /// \return the total energy of the cluster
-  std::tuple<int, float, float> getMaximalEnergyIndex(gsl::span<int> inputsIndices) const;
+  std::tuple<int, float, float> getMaximalEnergyIndex(gsl::span<const int> inputsIndices) const;
 
   ///
   /// Calculates the multiplicity of digits/cells with energy larger than level*energy
-  int getMultiplicityAtLevel(float level, gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  int getMultiplicityAtLevel(float level, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   int getSuperModuleNumber() const { return mSuperModuleNumber; }
 
@@ -287,7 +287,7 @@ class ClusterFactory
     mInputsContainer = cellContainer;
   }
 
-  void setCellsIndicesContainer(gsl::span<int> indicesContainer)
+  void setCellsIndicesContainer(gsl::span<const int> indicesContainer)
   {
     mCellsIndices = indicesContainer;
   }
@@ -305,21 +305,21 @@ class ClusterFactory
   /// should be less than 2%
   /// Unfinished - Nov 15,2006
   /// Distance is calculate in (phi,eta) units
-  void evalCoreEnergy(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalCoreEnergy(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Calculates the dispersion of the shower at the origin of the cluster
   /// in cell units
-  void evalDispersion(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalDispersion(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Calculates the axis of the shower ellipsoid in eta and phi
   /// in cell units
-  void evalElipsAxis(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalElipsAxis(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Time is set to the time of the digit with the maximum energy
-  void evalTime(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
+  void evalTime(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const;
 
   ///
   /// Converts Theta (Radians) to Eta (Radians)
@@ -344,9 +344,9 @@ class ClusterFactory
 
   gsl::span<const o2::emcal::Cluster> mClustersContainer; ///< Container for all the clusters in the event
   gsl::span<const InputType> mInputsContainer;            ///< Container for all the cells/digits in the event
-  gsl::span<int> mCellsIndices;                           ///< Container for cells indices in the event
+  gsl::span<const int> mCellsIndices;                     ///< Container for cells indices in the event
 
-  ClassDefNV(ClusterFactory, 1);
+  ClassDefNV(ClusterFactory, 2);
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -25,7 +25,7 @@
 using namespace o2::emcal;
 
 template <class InputType>
-ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<int> cellsIndices)
+ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<const int> cellsIndices)
 {
   setClustersContainer(clustersContainer);
   setCellsContainer(inputsContainer);
@@ -55,7 +55,7 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
   int firstCellIndex = mClustersContainer[clusterIndex].getCellIndexFirst();
   int nCells = mClustersContainer[clusterIndex].getNCells();
 
-  gsl::span<int> inputsIndices = gsl::span<int>(&mCellsIndices[firstCellIndex], nCells);
+  gsl::span<const int> inputsIndices = gsl::span<const int>(&mCellsIndices[firstCellIndex], nCells);
 
   // First calculate the index of input with maximum amplitude and get
   // the supermodule number where it sits.
@@ -107,7 +107,7 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 /// in cell units
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalDispersion(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalDispersion(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   double d = 0., wtot = 0.;
   int nstat = 0;
@@ -180,7 +180,7 @@ void ClusterFactory<InputType>::evalDispersion(gsl::span<int> inputsIndices, Ana
 /// Calculates the center of gravity in the local EMCAL-module coordinates
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalLocalPosition(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalLocalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   int nstat = 0;
@@ -249,7 +249,7 @@ void ClusterFactory<InputType>::evalLocalPosition(gsl::span<int> inputsIndices, 
 /// Calculates the center of gravity in the global ALICE coordinates
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalGlobalPosition(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalGlobalPosition(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   int i = 0, nstat = 0;
@@ -319,7 +319,7 @@ void ClusterFactory<InputType>::evalGlobalPosition(gsl::span<int> inputsIndices,
 //____________________________________________________________________________
 template <class InputType>
 void ClusterFactory<InputType>::evalLocalPositionFit(double deff, double mLogWeight,
-                                                     double phiSlope, gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+                                                     double phiSlope, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   int i = 0, nstat = 0;
   double clXYZ[3] = {0., 0., 0.}, clRmsXYZ[3] = {0., 0., 0.}, xyzi[3], wtot = 0., w = 0.;
@@ -416,7 +416,7 @@ void ClusterFactory<InputType>::getDeffW0(const double esum, double& deff, doubl
 /// Distance is calculate in (phi,eta) units
 //______________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
 
   float coreEnergy = 0.;
@@ -444,7 +444,7 @@ void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<int> inputsIndices, Ana
 /// in cell units
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalElipsAxis(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   TString gn(mGeomPtr->GetName());
 
@@ -521,7 +521,7 @@ void ClusterFactory<InputType>::evalElipsAxis(gsl::span<int> inputsIndices, Anal
 /// Finds the maximum energy in the cluster and computes the Summed amplitude of digits/cells
 //____________________________________________________________________________
 template <class InputType>
-std::tuple<int, float, float> ClusterFactory<InputType>::getMaximalEnergyIndex(gsl::span<int> inputsIndices) const
+std::tuple<int, float, float> ClusterFactory<InputType>::getMaximalEnergyIndex(gsl::span<const int> inputsIndices) const
 {
 
   float energy = 0.;
@@ -544,7 +544,7 @@ std::tuple<int, float, float> ClusterFactory<InputType>::getMaximalEnergyIndex(g
 /// Calculates the multiplicity of inputs with energy larger than H*energy
 //____________________________________________________________________________
 template <class InputType>
-int ClusterFactory<InputType>::getMultiplicityAtLevel(float H, gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+int ClusterFactory<InputType>::getMultiplicityAtLevel(float H, gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   int multipl = 0;
   for (auto iInput : inputsIndices) {
@@ -559,7 +559,7 @@ int ClusterFactory<InputType>::getMultiplicityAtLevel(float H, gsl::span<int> in
 /// Time is set to the time of the input with the maximum energy
 //____________________________________________________________________________
 template <class InputType>
-void ClusterFactory<InputType>::evalTime(gsl::span<int> inputsIndices, AnalysisCluster& clusterAnalysis) const
+void ClusterFactory<InputType>::evalTime(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
   float maxE = 0;
   unsigned short maxAt = 0;


### PR DESCRIPTION
The indices aren't modified, so const is appropriate. Further, this
makes the interface more consistent for converting clusters from the
clusterizer into analysis clusters.

@mfasDa 