### PR TITLE
MFT: fill vector tree with cluster external indices

### DIFF
--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -53,44 +53,25 @@ class TrackMFT : public o2::track::TrackParCovFwd
   void setChi2QPtSeed(Double_t chi2) { mSeedinvQPtFitChi2 = chi2; }
   const Double_t getChi2QPtSeed() const { return mSeedinvQPtFitChi2; }
 
-  // Other functions
-  int getNumberOfClusters() const { return mClusRef.getEntries(); }
-  int getFirstClusterEntry() const { return mClusRef.getFirstEntry(); }
-  int getClusterEntry(int i) const { return getFirstClusterEntry() + i; }
-  void shiftFirstClusterEntry(int bias)
-  {
-    mClusRef.setFirstEntry(mClusRef.getFirstEntry() + bias);
-  }
-  void setFirstClusterEntry(int offs)
-  {
-    mClusRef.setFirstEntry(offs);
-  }
-  void setNumberOfClusters(int n)
-  {
-    mClusRef.setEntries(n);
-  }
-  void setClusterRefs(int firstEntry, int n)
-  {
-    mClusRef.set(firstEntry, n);
-  }
-
-  const ClusRefs& getClusterRefs() const { return mClusRef; }
-  ClusRefs& getClusterRefs() { return mClusRef; }
-
   std::uint32_t getROFrame() const { return mROFrame; }
   void setROFrame(std::uint32_t f) { mROFrame = f; }
 
-  const Int_t getNPoints() const { return mNPoints; }
+  const int getNumberOfPoints() const { return mClusRef.getEntries(); }
+
+  const int getExternalClusterIndexOffset() const { return mClusRef.getFirstEntry(); }
+
+  void setExternalClusterIndexOffset(int offset = 0) { mClusRef.setFirstEntry(offset); }
+
+  void setNumberOfPoints(int n) { mClusRef.setEntries(n); }
 
   void print() const;
 
-  const o2::track::TrackParCovFwd& GetOutParam() const { return mOutParameters; }
-  void SetOutParam(const o2::track::TrackParCovFwd parcov) { mOutParameters = parcov; }
+  const o2::track::TrackParCovFwd& getOutParam() const { return mOutParameters; }
+  void setOutParam(const o2::track::TrackParCovFwd parcov) { mOutParameters = parcov; }
 
  private:
-  std::uint32_t mROFrame = 0;                ///< RO Frame
-  Int_t mNPoints{0};                         // Number of clusters
-  Bool_t mIsCA = false;                      // Track finding method CA vs. LTF
+  std::uint32_t mROFrame = 0; ///< RO Frame
+  Bool_t mIsCA = false;       // Track finding method CA vs. LTF
 
   ClusRefs mClusRef; ///< references on clusters
 
@@ -114,24 +95,16 @@ class TrackMFTExt : public TrackMFT
   static constexpr int MaxClusters = 10;
   using TrackMFT::TrackMFT; // inherit base constructors
 
-  void setClusterIndex(int l, int i, int ncl)
+  int getExternalClusterIndex(int i) const { return mExtClsIndex[i]; }
+
+  void setExternalClusterIndex(int np, int idx)
   {
-    mIndex[ncl] = (l << 27) + i;
-    getClusterRefs().setEntries(ncl);
+    mExtClsIndex[np] = idx;
   }
 
-  int getClusterIndex(int lr) const { return mIndex[lr]; }
+ protected:
+  std::array<int, MaxClusters> mExtClsIndex = {-1}; ///< External indices of associated clusters
 
-  void setExternalClusterIndex(int layer, int idx, bool newCluster = false)
-  {
-    if (newCluster) {
-      getClusterRefs().setEntries(getNumberOfClusters() + 1);
-    }
-    mIndex[layer] = idx;
-  }
-
- private:
-  std::array<int, MaxClusters> mIndex = {-1}; ///< Indices of associated clusters
   ClassDefNV(TrackMFTExt, 1);
 };
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
@@ -26,11 +26,11 @@ namespace mft
 {
 
 struct Cluster : public o2::BaseCluster<float> {
-  Cluster(const Float_t x, const Float_t y, const Float_t z, const Float_t phi, const Float_t r, const Int_t idx, const Int_t bin, const Float_t sigX2, const Float_t sigY2, const Int_t sensorID)
+  Cluster(const Float_t x, const Float_t y, const Float_t z, const Float_t phi, const Float_t r, const Int_t id, const Int_t bin, const Float_t sigX2, const Float_t sigY2, const Int_t sensorID)
     : BaseCluster(sensorID, x, y, z),
       phiCoordinate{phi},
       rCoordinate{r},
-      clusterId{idx},
+      clusterId{id},
       indexTableBin{bin},
       sigmaX2{sigX2},
       sigmaY2{sigY2} {};

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
@@ -52,10 +52,10 @@ class ROframe final
   const std::vector<Cluster>& getClustersInLayer(Int_t layerId) const { return mClusters[layerId]; }
 
   const MCCompLabel& getClusterLabels(Int_t layerId, const Cluster& cl) const { return mClusterLabels[layerId][cl.clusterId]; }
-  const MCCompLabel& getClusterLabels(Int_t layerId, const Int_t clId) const { return mClusterLabels[layerId][clId]; }
+  const MCCompLabel& getClusterLabels(Int_t layerId, const Int_t clusterId) const { return mClusterLabels[layerId][clusterId]; }
 
   const std::map<Int_t, std::pair<Int_t, Int_t>>& getClusterBinIndexRange(Int_t layerId) const { return mClusterBinIndexRange[layerId]; }
-  Int_t getClusterExternalIndex(Int_t layerId, const Int_t clId) const { return mClusterExternalIndices[layerId][clId]; }
+  const Int_t getClusterExternalIndex(Int_t layerId, const Int_t clusterId) const { return mClusterExternalIndices[layerId][clusterId]; }
 
   const std::array<std::vector<Cell>, constants::mft::LayersNumber>& getCells() const;
   const std::vector<Cell>& getCellsInLayer(Int_t layerId) const { return mCells[layerId]; }
@@ -134,7 +134,6 @@ inline Bool_t ROframe::isClusterUsed(Int_t layer, Int_t clusterId) const
 }
 
 inline void ROframe::markUsedCluster(Int_t layer, Int_t clusterId) { mUsedClusters[layer][clusterId] = kTRUE; }
-
 
 inline TrackLTF& ROframe::getCurrentTrackLTF()
 {

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -255,7 +255,7 @@ inline void Tracker::computeTracksMClabels(const T& tracks)
     MCCompLabel maxOccurrencesValue{-1, -1, -1, false};
     int count{0};
     bool isFakeTrack{false};
-    auto nClusters = track.getNumberOfClusters();
+    auto nClusters = track.getNumberOfPoints();
     for (int iCluster = 0; iCluster < nClusters; ++iCluster) {
       const MCCompLabel& currentLabel = track.getMCCompLabels()[iCluster];
       if (currentLabel == maxOccurrencesValue) {

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -49,8 +49,11 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
     Point3D<float> locXYZ;
     float sigmaX2 = ioutils::DefClusError2Row, sigmaY2 = ioutils::DefClusError2Col; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaX2 = dict.getErr2X(pattID); // ALPIDE local X coordinate => MFT global X coordinate (ALPIDE rows)
-      sigmaY2 = dict.getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      //sigmaX2 = dict.getErr2X(pattID); // ALPIDE local X coordinate => MFT global X coordinate (ALPIDE rows)
+      //sigmaY2 = dict.getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      // temporary, until ITS bug fix
+      sigmaX2 = dict.getErrX(pattID) * dict.getErrX(pattID);
+      sigmaY2 = dict.getErrZ(pattID) * dict.getErrZ(pattID);
       if (!dict.isGroup(pattID)) {
         locXYZ = dict.getClusterCoordinates(c);
       } else {
@@ -73,7 +76,6 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
     int phiBinIndex = constants::index_table::getPhiBinIndex(phiCoord);
     int binIndex = constants::index_table::getBinIndex(rBinIndex, phiBinIndex);
     // TODO: Check consistency of sigmaX2 and sigmaY2
-    // std::cout << "ClusterID = " << clusterId << " ; pattID = " << pattID << " ; sigmaX2 = " << sigmaX2 << " ; sigmaY2 = " << sigmaY2 << std::endl;
     event.addClusterToLayer(layer, gloXYZ.x(), gloXYZ.y(), gloXYZ.z(), phiCoord, rCoord, event.getClustersInLayer(layer).size(), binIndex, sigmaX2, sigmaY2, sensorID);
     if (mcLabels) {
       event.addClusterLabelToLayer(layer, *(mcLabels->getLabels(first + clusterId).begin()));

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -113,14 +113,12 @@ void TrackerDPL::run(ProcessingContext& pc)
   LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
 
   // snippet to convert found tracks to final output tracks with separate cluster indices
-  auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx, int offset = 0) {
+  auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx) {
     for (auto& trc : tracks) {
-      trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
-      int ncl = trc.getNumberOfClusters();
+      trc.setExternalClusterIndexOffset(allClusIdx.size());
+      int ncl = trc.getNumberOfPoints();
       for (int ic = 0; ic < ncl; ic++) {
-        auto layer_clID = trc.getClustersId()[ic];
-        auto layer = trc.getLayers()[ic];
-        auto externalClusterID = event.getClusterExternalIndex(layer, trc.getClustersId()[ic]);
+        auto externalClusterID = trc.getExternalClusterIndex(ic);
         allClusIdx.push_back(externalClusterID);
       }
       allTracks.emplace_back(trc);


### PR DESCRIPTION
Main changes:
- modify the extraction and the writing of the external indices of the clusters of a track
- bug fix in the Fast Circle Fit function
- a temporary extraction of cluster errors from the patterns dictionary (ITS fix expected)
- some cosmetics in the notations