### PR TITLE
TRD new half chamber header

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -123,18 +123,23 @@ struct TrackletHCHeader {
   union {
     //             10987654321098765432109876543210
     // uint32_t:   00000000000000000000000000000000
-    //                 cccccccccccccccc iiiiiiiiiii
-    //             ffff|               y|
-    //             |   |               |------       0-10 half chamber id
-    //             |   |               ------------- 11 always 0x1
-    //             |   ----------------------------- 12-72 MCM Clock counter
+    //                 cccccccccccccccX LLL   SSSSS
+    //             ffff|              |y|  sss|
+    //             |   |              |||  |  |-----  0-4  supermodule
+    //             |   |              |||  |--------  5-7  stack
+    //             |   |              ||------------  8-10 layer
+    //             |   |              |------------- 11    always 0x1
+    //             |   |              |------------- 12 side of chamber
+    //             |   ----------------------------- 13-72 MCM Clock counter
     //             --------------------------------- 28-31 tracklet data format number
     uint32_t word;
-
     struct {
-      uint32_t HCID : 11; // half chamber id 0:1079
+      uint32_t supermodule : 5;
+      uint32_t stack : 3;
+      uint32_t layer : 3;
       uint32_t one : 1;   //always 1
-      uint32_t MCLK : 16; // MCM clock counter 120MHz ... for simulation -- incrementing, and same number in all for each event.
+      uint32_t side : 1;  // side of chamber
+      uint32_t MCLK : 15; // MCM clock counter 120MHz ... for simulation -- incrementing, and same number in all for each event.
       uint32_t format : 4;
       //  0 baseline PID 3 time slices, 7 bit each
       //  1 DO NOT USE ! reserved for tracklet end marker disambiguation
@@ -213,6 +218,8 @@ struct TRDFeeID {
   };
 };
 
+void buildTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format);
+void buildTrackletHCHeaderd(TrackletHCHeader& header, int detector, int rob, int chipclock, int format);
 uint16_t buildTRDFeeID(int supermodule, int side, int endpoint);
 uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid);
 uint32_t setHalfCRUHeaderLinkData(HalfCRUHeader& cruhead, int link, int size, int errors);

--- a/DataFormats/Detectors/TRD/src/LinkRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/LinkRecord.cxx
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include "DataFormatsTRD/LinkRecord.h"
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2
 {
@@ -17,12 +18,41 @@ namespace o2
 namespace trd
 {
 
-void LinkRecord::printStream(std::ostream& stream) const
+uint32_t LinkRecord::getHalfChamberLinkId(uint32_t detector, uint32_t rob)
 {
-  stream << "Data for link 0x" << std::hex << mLinkId << std::dec << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
+  int sector = (detector % (constants::NLAYER * constants::NSTACK));
+  int stack = (detector % constants::NLAYER);
+  int layer = ((detector % (constants::NLAYER * constants::NSTACK)) / constants::NLAYER);
+  int side = rob % 2;
+  return getHalfChamberLinkId(sector, stack, layer, side);
 }
 
-std::ostream& operator<<(std::ostream& stream, const LinkRecord& trg)
+uint32_t LinkRecord::getHalfChamberLinkId(uint32_t sector, uint32_t stack, uint32_t layer, uint32_t side)
+{
+  LinkId tmplinkid;
+  tmplinkid.supermodule = sector;
+  tmplinkid.stack = stack;
+  tmplinkid.layer = layer;
+  ;
+  tmplinkid.side = side;
+  return tmplinkid.word;
+}
+
+void LinkRecord::setLinkId(const uint32_t sector, const uint32_t stack, const uint32_t layer, const uint32_t side)
+{
+  mLinkId.supermodule = sector;
+  mLinkId.stack = stack;
+  mLinkId.layer = layer;
+  ;
+  mLinkId.side = side;
+}
+
+void LinkRecord::printStream(std::ostream& stream)
+{
+  stream << "Data for link from supermodule:" << this->getSector() << " stack:" << this->getStack() << " layer:" << this->getLayer() << "side :" << this->getSide() << ", starting from entry " << this->getFirstEntry() << " with " << this->getNumberOfObjects() << " objects";
+}
+
+std::ostream& operator<<(std::ostream& stream, LinkRecord& trg)
 {
   trg.printStream(stream);
   return stream;

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -12,12 +12,34 @@
 #include <iostream>
 #include <iomanip>
 #include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/LinkRecord.h"
+#include "DataFormatsTRD/Constants.h"
 
 namespace o2
 {
 
 namespace trd
 {
+
+void buildTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format)
+{
+  header.MCLK = chipclock;
+  header.format = format;
+  header.one = 1;
+  header.supermodule = sector;
+  header.stack = stack;
+  header.layer = layer;
+  header.side = side;
+}
+
+void buildTrackletHCHeaderd(TrackletHCHeader& header, int detector, int rob, int chipclock, int format)
+{
+  int sector = (detector % (constants::NLAYER * constants::NSTACK));
+  int stack = (detector % constants::NLAYER);
+  int layer = ((detector % (constants::NLAYER * constants::NSTACK)) / constants::NLAYER);
+  int side = rob % 2;
+  buildTrackletHCHeader(header, sector, stack, layer, side, chipclock, format);
+}
 
 uint16_t buildTRDFeeID(int supermodule, int side, int endpoint)
 {
@@ -93,7 +115,9 @@ std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchambe
 {
   stream << "TrackletHCHeader : Raw:0x" << std::hex << halfchamberheader.word << " "
          << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: "
-         << halfchamberheader.one << " :: " << halfchamberheader.HCID << std::endl;
+         << halfchamberheader.one << " :: (" << halfchamberheader.supermodule << ","
+         << halfchamberheader.stack << "," << halfchamberheader.layer << ") on side :"
+         << halfchamberheader.side << std::endl;
   return stream;
 }
 
@@ -129,8 +153,8 @@ std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead)
 
 void printHalfChamber(o2::trd::TrackletHCHeader const& halfchamber)
 {
-  LOGF(INFO, "TrackletHCHeader: Raw:0x%08x HCID : 0x%0x MCLK: 0x%0x Format: 0x%0x Always1:0x%0x",
-       halfchamber.HCID, halfchamber.MCLK, halfchamber.format, halfchamber.one);
+  LOGF(INFO, "TrackletHCHeader: Raw:0x%08x SM : %d stack %d layer %d side : %d MCLK: 0x%0x Format: 0x%0x Always1:0x%0x",
+       halfchamber.supermodule, halfchamber.stack, halfchamber.layer, halfchamber.side, halfchamber.MCLK, halfchamber.format, halfchamber.one);
 }
 
 void dumpHalfChamber(o2::trd::TrackletHCHeader const& halfchamber)

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -173,10 +173,10 @@ uint32_t Trap2CRU::buildCRUHeader(HalfCRUHeader& header, uint32_t bc, uint32_t h
   int linkrecord = startlinkrecord;
   int totallinkdatasize = 0; //in units of 256bits
   for (int link = 0; link < NLinksPerHalfCRU; link++) {
-    int hcid = link + halfcru * NLinksPerHalfCRU; // TODO this might have to change to a lut I dont think the mapping is linear.
+    int linkid = link + halfcru * NLinksPerHalfCRU; // TODO this might have to change to a lut I dont think the mapping is linear.
     int errors = 0;
     int linksize = 0; // linkSizePadding will convert it to 1 for the no data case.
-    if (mLinkRecords[linkrecord].getLinkHCID() == hcid) {
+    if (mLinkRecords[linkrecord].getLinkId() == linkid) {
       linksize = mLinkRecords[linkrecord].getNumberOfObjects();
       // this can be done differently by keeping a pointer to halfcruheader and setting it after reading it all in and going back per link to set the size.
       LOG(debug3) << "setting CRU HEADER for halfcru : " << halfcru << "and link : " << link << " contents" << header << ":" << link << ":" << linksize << ":" << errors;
@@ -234,26 +234,26 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& TrigRecord)
     int linkdatasize = 0; // in 32 bit words
     int link = halfcru / 2;
     for (int halfcrulink = 0; halfcrulink < NLinksPerHalfCRU; halfcrulink++) {
-      //links run from 0 to 14, so hcid offset is halfcru*15;
-      int hcid = halfcrulink + halfcru * NLinksPerHalfCRU;
-      LOG(debug) << "Currently checking for data on hcid : " << hcid << " from halfcru=" << halfcru << " and halfcrulink:" << halfcrulink << " ?? " << hcid << "==" << mLinkRecords[currentlinkrecord].getLinkHCID();
+      //links run from 0 to 14, so linkid offset is halfcru*15;
+      int linkid = halfcrulink + halfcru * NLinksPerHalfCRU;
+      LOG(debug) << "Currently checking for data on linkid : " << linkid << " from halfcru=" << halfcru << " and halfcrulink:" << halfcrulink << " ?? " << linkid << "==" << mLinkRecords[currentlinkrecord].getLinkId();
       int errors = 0;           // put no errors in for now.
       int size = 0;             // in 32 bit words
       int datastart = 0;        // in 32 bit words
       int dataend = 0;          // in 32 bit words
       uint32_t paddingsize = 0; // in 32 bit words
       uint32_t crudatasize = 0; // in 256 bit words.
-      if (mLinkRecords[currentlinkrecord].getLinkHCID() == hcid) {
+      if (mLinkRecords[currentlinkrecord].getLinkId() == linkid) {
         //this link has data in the stream.
-        LOG(debug) << "+++ We have data on hcid = " << hcid << " halfcrulink : " << halfcrulink;
+        LOG(debug) << "+++ We have data on linkid = " << linkid << " halfcrulink : " << halfcrulink;
         linkdatasize = mLinkRecords[currentlinkrecord].getNumberOfObjects();
         datastart = mLinkRecords[currentlinkrecord].getFirstEntry();
         dataend = datastart + size;
-        LOG(debug) << "We have data on hcid = " << hcid << " and linksize : " << linkdatasize << " so :" << linkdatasize / 8 << " 256 bit words";
+        LOG(debug) << "We have data on linkid = " << linkid << " and linksize : " << linkdatasize << " so :" << linkdatasize / 8 << " 256 bit words";
         currentlinkrecord++;
       } else {
-        assert(mLinkRecords[currentlinkrecord].getLinkId() < hcid);
-        LOG(debug) << "---We do not have data on hcid = " << hcid << " halfcrulink : " << halfcrulink;
+        assert(mLinkRecords[currentlinkrecord].getLinkId() < linkid);
+        LOG(debug) << "---We do not have data on linkid = " << linkid << " halfcrulink : " << halfcrulink;
         //blank data for this link
         // put in a 1 256 bit word of data for the link and padd with 0xeeee x 8
         linkdatasize = 0;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -86,13 +86,12 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   std::chrono::duration<double> mSortingTime{0};            ///< full timer
 
   uint64_t mTotalRawWordsWritten = 0; // words written for the raw format of 4x32bits, where 4 can be 2 to 4 depending on # of tracklets in the block.
-  int32_t mOldHalfChamberID = 0;
+  int32_t mOldHalfChamberLinkId = 0;
   bool mNewTrackletHCHeaderHasBeenWritten{false};
   TrackletHCHeader mTrackletHCHeader; // the current half chamber header, that will be written if a first tracklet is found for this halfchamber.
   TrapConfig* getTrapConfig();
   void loadTrapConfig();
   void setOnlineGainTables();
-  uint32_t getHalfChamberID(uint32_t detector, uint32_t rob) { return detector * 2 + rob % 2; };
 };
 
 o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec();


### PR DESCRIPTION
- in TrackletHCHeader replace HCID,HalfChamberId [0-1079] with supermodule/stack/layer/side.
- clock is reduced from 16 to 15 bits, details in RawData.h
- LinkRecord now has its HCID replaced with 12bit encoded of supermodule/stack/layer/side of 5/3/3/1 bits.
- Various fixups in TrapSimulator device and Trap2CRU to allow this.
- This solves the sorting problem in raw data as well.
