### PR TITLE
[EMCAL-610] Fix segfault in Raw creator

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -161,8 +161,8 @@ class RCUTrailer
  private:
   int mRCUId = -1;                    ///< current RCU identifier
   unsigned char mFirmwareVersion = 0; ///< RCU firmware version
-  unsigned int mTrailerSize = 0;      ///< Size of the trailer
-  unsigned int mPayloadSize = 0;      ///< Size of the payload
+  unsigned int mTrailerSize = 0;      ///< Size of the trailer (in number of 32 bit words)
+  unsigned int mPayloadSize = 0;      ///< Size of the payload (in nunber of 32 bit words)
   unsigned int mFECERRA = 0;          ///< contains errors related to ALTROBUS transactions
   unsigned int mFECERRB = 0;          ///< contains errors related to ALTROBUS transactions
   unsigned short mERRREG2 = 0;        ///< contains errors related to ALTROBUS transactions or trailer of ALTRO channel block

--- a/Detectors/EMCAL/base/src/Mapper.cxx
+++ b/Detectors/EMCAL/base/src/Mapper.cxx
@@ -115,6 +115,6 @@ Mapper& MappingHandler::getMappingForDDL(int ddl)
 
 std::ostream& o2::emcal::operator<<(std::ostream& stream, const Mapper::ChannelID& channel)
 {
-  stream << "Row " << channel.mRow << ", Column " << channel.mColumn << ", type " << o2::emcal::channelTypeToString(channel.mChannelType);
+  stream << "Row " << static_cast<int>(channel.mRow) << ", Column " << static_cast<int>(channel.mColumn) << ", type " << o2::emcal::channelTypeToString(channel.mChannelType);
   return stream;
 }


### PR DESCRIPTION
- Fix buffer overrun in findBunches leading to segfault
- In getting online ID (SRU ID in supermodule had to be
   scaled with the number of supermodules in order to get
   the DDL ID)
- Convert trailer size as size in 32bit words to size in byte in
   carryOverMethod in order to calculate properly the
   payload size