### PR TITLE
DPL Analysis: redefine extended tables as Join

### DIFF
--- a/Analysis/DataModel/src/dumpDataModel.cxx
+++ b/Analysis/DataModel/src/dumpDataModel.cxx
@@ -143,19 +143,19 @@ edge[dir=back, arrowtail=empty]
   (dumpIndex<Ts>(typename Ts::iterator::external_index_columns_t{}), ...);
 }
 
-int main(int argc, char** argv)
+int main(int, char**)
 {
   fmt::printf("%s", R"(digraph hierarchy {
 size="5,5"
 node[shape=plain,style=filled,fillcolor=gray95]
 edge[dir=back, arrowtail=empty]
 )");
-  dumpCluster<Tracks, TracksCov, TracksExtra, TracksExtended, TrackSelection>();
+  /// FIXME: topology should account for predefined Joins
+  dumpCluster<StoredTracks, TracksExtension, StoredTracksCov, TracksCovExtension, TracksExtra, TracksExtended, TrackSelection>();
   dumpTable<Collisions>();
   dumpTable<Calos>();
   dumpTable<CaloTriggers>();
-  dumpTable<Muons>();
-  dumpTable<StoredMuons>();
+  dumpCluster<StoredMuons, MuonsExtension>();
   dumpTable<MuonClusters>();
   dumpTable<Zdcs>();
   dumpTable<Run2V0s>();

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1032,6 +1032,12 @@ struct PackToTable<framework::pack<C...>> {
   using table = o2::soa::Table<C...>;
 };
 
+template <typename... T>
+struct TableWrap {
+  using all_columns = framework::concatenated_pack_unique_t<typename T::columns...>;
+  using table_t = typename PackToTable<all_columns>::table;
+};
+
 template <typename T>
 struct FilterPersistentColumns {
   static_assert(framework::always_static_assert_v<T>, "Not a soa::Table");
@@ -1056,9 +1062,45 @@ class TableMetadata
 };
 
 template <typename... C1, typename... C2>
-constexpr auto join(o2::soa::Table<C1...> const& t1, o2::soa::Table<C2...> const& t2)
+constexpr auto joinTables(o2::soa::Table<C1...> const& t1, o2::soa::Table<C2...> const& t2)
 {
   return o2::soa::Table<C1..., C2...>(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename T, typename... C, typename... O>
+constexpr auto joinLeft(T const& t1, o2::soa::Table<C...> const& t2, framework::pack<O...>)
+{
+  return typename o2::soa::TableWrap<O..., o2::soa::Table<C...>>::table_t(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename T, typename... C, typename... O>
+constexpr auto joinRight(o2::soa::Table<C...> const& t1, T const& t2, framework::pack<O...>)
+{
+  return typename o2::soa::TableWrap<o2::soa::Table<C...>, O...>::table_t(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename T1, typename T2, typename... O1, typename... O2>
+constexpr auto joinBoth(T1 const& t1, T2 const& t2, framework::pack<O1...>, framework::pack<O2...>)
+{
+  return typename o2::soa::TableWrap<O1..., O2...>::table_t(ArrowHelpers::joinTables({t1.asArrowTable(), t2.asArrowTable()}));
+}
+
+template <typename T1, typename T2>
+constexpr auto join(T1 const& t1, T2 const& t2)
+{
+  if constexpr (soa::is_type_with_originals_v<T1>) {
+    if constexpr (soa::is_type_with_originals_v<T2>) {
+      return joinBoth(t1, t2, typename T1::originals{}, typename T2::originals{});
+    } else {
+      return joinLeft(t1, t2, typename T1::originals{});
+    }
+  } else {
+    if constexpr (soa::is_type_with_originals_v<T2>) {
+      return joinRight(t1, t2, typename T2::originals{});
+    } else {
+      return joinTables(t1, t2);
+    }
+  }
 }
 
 template <typename T1, typename T2, typename... Ts>
@@ -1306,27 +1348,23 @@ using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
 #define DECLARE_SOA_TABLE(_Name_, _Origin_, _Description_, ...) \
   DECLARE_SOA_TABLE_FULL(_Name_, #_Name_, _Origin_, _Description_, __VA_ARGS__);
 
-#define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)      \
-  using _Name_ = o2::soa::JoinBase<typename _Table_::table_t, o2::soa::Table<__VA_ARGS__>>; \
-                                                                                            \
-  struct _Name_##Metadata : o2::soa::TableMetadata<_Name_##Metadata> {                      \
-    using table_t = _Name_;                                                                 \
-    using base_table_t = _Table_;                                                           \
-    using expression_pack_t = framework::pack<__VA_ARGS__>;                                 \
-    using originals = soa::originals_pack_t<_Table_>;                                       \
-    static constexpr char const* mLabel = #_Name_;                                          \
-    static constexpr char const mOrigin[4] = _Origin_;                                      \
-    static constexpr char const mDescription[16] = _Description_;                           \
-  };                                                                                        \
-                                                                                            \
-  template <>                                                                               \
-  struct MetadataTrait<_Name_> {                                                            \
-    using metadata = _Name_##Metadata;                                                      \
-  };                                                                                        \
-                                                                                            \
-  template <>                                                                               \
-  struct MetadataTrait<_Name_::unfiltered_iterator> {                                       \
-    using metadata = _Name_##Metadata;                                                      \
+#define DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, _Origin_, _Description_, ...)   \
+  using _Name_##Extension = o2::soa::Table<__VA_ARGS__>;                                 \
+  using _Name_ = o2::soa::Join<_Name_##Extension, _Table_>;                              \
+                                                                                         \
+  struct _Name_##ExtensionMetadata : o2::soa::TableMetadata<_Name_##ExtensionMetadata> { \
+    using table_t = _Name_##Extension;                                                   \
+    using base_table_t = typename _Table_::table_t;                                      \
+    using expression_pack_t = framework::pack<__VA_ARGS__>;                              \
+    using originals = soa::originals_pack_t<_Table_>;                                    \
+    static constexpr char const* mLabel = #_Name_ "Extension";                           \
+    static constexpr char const mOrigin[4] = _Origin_;                                   \
+    static constexpr char const mDescription[16] = _Description_;                        \
+  };                                                                                     \
+                                                                                         \
+  template <>                                                                            \
+  struct MetadataTrait<_Name_##Extension> {                                              \
+    using metadata = _Name_##ExtensionMetadata;                                          \
   };
 
 #define DECLARE_SOA_EXTENDED_TABLE(_Name_, _Table_, _Description_, ...) \
@@ -1745,16 +1783,12 @@ auto spawner(framework::pack<C...> columns, arrow::Table* atable)
     arrays[i] = std::make_shared<arrow::ChunkedArray>(chunks[i]);
   }
 
-  auto extra_schema = o2::soa::createSchemaFromColumns(columns);
-  auto original_fields = atable->schema()->fields();
-  auto original_columns = atable->columns();
-  std::vector<std::shared_ptr<arrow::Field>> new_fields(original_fields);
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> new_columns(original_columns);
+  auto new_schema = o2::soa::createSchemaFromColumns(columns);
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> new_columns;
   for (auto i = 0u; i < sizeof...(C); ++i) {
-    new_fields.emplace_back(extra_schema->field(i));
     new_columns.push_back(arrays[i]);
   }
-  return arrow::Table::Make(std::make_shared<arrow::Schema>(new_fields), new_columns);
+  return arrow::Table::Make(new_schema, new_columns);
 }
 
 /// On-the-fly adding of expression columns

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1038,18 +1038,6 @@ struct TableWrap {
   using table_t = typename PackToTable<all_columns>::table;
 };
 
-template <typename T>
-struct FilterPersistentColumns {
-  static_assert(framework::always_static_assert_v<T>, "Not a soa::Table");
-};
-
-template <typename... C>
-struct FilterPersistentColumns<soa::Table<C...>> {
-  using columns = typename soa::Table<C...>::columns;
-  using persistent_columns_pack = framework::selected_pack<is_persistent_t, C...>;
-  using persistent_table_t = typename PackToTable<persistent_columns_pack>::table;
-};
-
 /// Template trait which allows to map a given
 /// Table type to its O2 DataModel origin and description
 template <typename INHERIT>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -97,7 +97,7 @@ struct Produces {
 /// means of the WritingCursor helper class, from which produces actually
 /// derives.
 template <typename... C>
-struct Produces<soa::Table<C...>> : WritingCursor<typename soa::FilterPersistentColumns<soa::Table<C...>>::persistent_table_t> {
+struct Produces<soa::Table<C...>> : WritingCursor<typename soa::Table<C...>::persistent_columns_t> {
   using table_t = soa::Table<C...>;
   using metadata = typename aod::MetadataTrait<table_t>::metadata;
 

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -113,12 +113,19 @@ struct Produces<soa::Table<C...>> : WritingCursor<typename soa::FilterPersistent
   }
 };
 
-/// Base template for table transformation declarations
+/// This helper struct allows you to declare extended tables which should be
+/// created by the task (as opposed to those pre-defined by data model)
 template <typename T>
-struct TransformTable {
-  using metadata = typename aod::MetadataTrait<T>::metadata;
-  using originals = typename metadata::originals;
+struct Spawns {
+  using extension_t = framework::pack_head_t<typename T::originals>;
+  using metadata = typename aod::MetadataTrait<extension_t>::metadata;
+  using sources = typename metadata::originals;
+  using expression_pack_t = typename metadata::expression_pack_t;
 
+  constexpr auto pack()
+  {
+    return expression_pack_t{};
+  }
   template <typename O>
   InputSpec const base_spec()
   {
@@ -137,7 +144,7 @@ struct TransformTable {
 
   std::vector<InputSpec> const base_specs()
   {
-    return base_specs_impl(originals{});
+    return base_specs_impl(sources{});
   }
 
   OutputSpec const spec() const
@@ -161,23 +168,10 @@ struct TransformTable {
 
   auto asArrowTable()
   {
-    return table->asArrowTable();
+    return extension->asArrowTable();
   }
-  std::shared_ptr<T> table = nullptr;
-};
-
-/// This helper struct allows you to declare extended tables which should be
-/// created by the task (as opposed to those pre-defined by data model)
-template <typename T>
-struct Spawns : TransformTable<T> {
-  using metadata = typename TransformTable<T>::metadata;
-  using originals = typename metadata::originals;
-  using expression_pack_t = typename metadata::expression_pack_t;
-
-  constexpr auto pack()
-  {
-    return expression_pack_t{};
-  }
+  std::shared_ptr<typename T::table_t> table = nullptr;
+  std::shared_ptr<extension_t> extension = nullptr;
 };
 
 /// Policy to control index building
@@ -305,13 +299,59 @@ struct IndexSparse {
 
 /// This helper struct allows you to declare index tables to be created in a task
 template <typename T, typename IP = IndexSparse>
-struct Builds : TransformTable<T> {
-  using metadata = typename TransformTable<T>::metadata;
+struct Builds {
+  using metadata = typename aod::MetadataTrait<T>::metadata;
   using originals = typename metadata::originals;
   using Key = typename T::indexing_t;
   using H = typename T::first_t;
   using Ts = typename T::rest_t;
   using index_pack_t = typename metadata::index_pack_t;
+
+  template <typename O>
+  InputSpec const base_spec()
+  {
+    using o_metadata = typename aod::MetadataTrait<O>::metadata;
+    return InputSpec{
+      o_metadata::tableLabel(),
+      header::DataOrigin{o_metadata::origin()},
+      header::DataDescription{o_metadata::description()}};
+  }
+
+  template <typename... Os>
+  std::vector<InputSpec> const base_specs_impl(framework::pack<Os...>)
+  {
+    return {base_spec<Os>()...};
+  }
+
+  std::vector<InputSpec> const base_specs()
+  {
+    return base_specs_impl(originals{});
+  }
+
+  OutputSpec const spec() const
+  {
+    return OutputSpec{OutputLabel{metadata::tableLabel()}, metadata::origin(), metadata::description()};
+  }
+
+  OutputRef ref() const
+  {
+    return OutputRef{metadata::tableLabel(), 0};
+  }
+
+  T* operator->()
+  {
+    return table.get();
+  }
+  T& operator*()
+  {
+    return *table.get();
+  }
+
+  auto asArrowTable()
+  {
+    return table->asArrowTable();
+  }
+  std::shared_ptr<T> table = nullptr;
 
   constexpr auto pack()
   {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -97,7 +97,7 @@ struct Produces {
 /// means of the WritingCursor helper class, from which produces actually
 /// derives.
 template <typename... C>
-struct Produces<soa::Table<C...>> : WritingCursor<typename soa::Table<C...>::persistent_columns_t> {
+struct Produces<soa::Table<C...>> : WritingCursor<typename soa::PackToTable<typename soa::Table<C...>::persistent_columns_t>::table> {
   using table_t = soa::Table<C...>;
   using metadata = typename aod::MetadataTrait<table_t>::metadata;
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -45,7 +45,6 @@ namespace o2::framework
 // FIXME: for the moment this needs to stay outside AnalysisTask
 //        because we cannot inherit from it due to a C++17 bug
 //        in GCC 7.3. We need to move to 7.4+
-
 struct AnalysisTask {
 };
 

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -511,19 +511,17 @@ class TableBuilder
   template <typename T>
   auto cursor()
   {
-    using persistent_filter = soa::FilterPersistentColumns<T>;
-    using persistent_columns_pack = typename persistent_filter::persistent_columns_pack;
+    using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename persistent_filter::persistent_table_t>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename T::table_t>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename T, typename E>
   auto cursor()
   {
-    using persistent_filter = soa::FilterPersistentColumns<T>;
-    using persistent_columns_pack = typename persistent_filter::persistent_columns_pack;
+    using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename persistent_filter::persistent_table_t, E>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename T::table_t, E>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename... ARGS>

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -513,7 +513,7 @@ class TableBuilder
   {
     using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>::table>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename T, typename E>
@@ -521,7 +521,7 @@ class TableBuilder
   {
     using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>, E>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>::table, E>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename... ARGS>

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -513,7 +513,7 @@ class TableBuilder
   {
     using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename T::table_t>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename T, typename E>
@@ -521,7 +521,7 @@ class TableBuilder
   {
     using persistent_columns_pack = typename T::table_t::persistent_columns_t;
     constexpr auto persistent_size = pack_size(persistent_columns_pack{});
-    return cursorHelper<typename T::table_t, E>(std::make_index_sequence<persistent_size>());
+    return cursorHelper<typename soa::PackToTable<persistent_columns_pack>, E>(std::make_index_sequence<persistent_size>());
   }
 
   template <typename... ARGS>

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -116,7 +116,7 @@ uint64_t getMask(header::DataDescription description)
   }
 }
 
-uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataOrigin const& origin)
+uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataOrigin const&)
 {
   uint64_t readMask = None;
   for (auto& route : routes) {
@@ -176,11 +176,11 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> reques
         };
 
         if (description == header::DataDescription{"TRACKPAR"}) {
-          outputs.adopt(Output{origin, description}, maker(o2::aod::TracksMetadata{}));
+          outputs.adopt(Output{origin, description}, maker(o2::aod::TracksExtensionMetadata{}));
         } else if (description == header::DataDescription{"TRACKPARCOV"}) {
-          outputs.adopt(Output{origin, description}, maker(o2::aod::TracksCovMetadata{}));
+          outputs.adopt(Output{origin, description}, maker(o2::aod::TracksCovExtensionMetadata{}));
         } else if (description == header::DataDescription{"MUON"}) {
-          outputs.adopt(Output{origin, description}, maker(o2::aod::MuonsMetadata{}));
+          outputs.adopt(Output{origin, description}, maker(o2::aod::MuonsExtensionMetadata{}));
         } else {
           throw std::runtime_error("Not an extended table");
         }

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -233,9 +233,9 @@ struct OutputManager<Spawns<T>> {
 
   static bool prepare(ProcessingContext& pc, Spawns<T>& what)
   {
-    using metadata = typename std::decay_t<decltype(what)>::metadata;
-    auto original_table = soa::ArrowHelpers::joinTables(extractOriginals(typename metadata::originals{}, pc));
-    what.table = std::make_shared<T>(o2::soa::spawner(what.pack(), original_table.get()));
+    auto original_table = soa::ArrowHelpers::joinTables(extractOriginals(typename Spawns<T>::sources{}, pc));
+    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::soa::spawner(what.pack(), original_table.get()));
+    what.table = std::make_shared<typename T::table_t>(soa::ArrowHelpers::joinTables({what.extension->asArrowTable(), original_table}));
     return true;
   }
 

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -335,7 +335,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   // This is to inject a file sink so that any dangling ATSK object is written
   // to a ROOT file.
-  if (providedOutputObj.size() != 0) {
+  if (providedOutputObj.empty() == false) {
     auto rootSink = CommonDataProcessors::getOutputObjSink(outObjMap, outTskMap);
     extraSpecs.push_back(rootSink);
   }
@@ -356,7 +356,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // select outputs of type AOD
   std::vector<InputSpec> OutputsInputsAOD;
   std::vector<bool> isdangling;
-  for (int ii = 0; ii < OutputsInputs.size(); ii++) {
+  for (auto ii = 0u; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 2) == 2) {
 
       // temporarily also request to be dangling
@@ -379,7 +379,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   // select dangling outputs which are not of type AOD
   std::vector<InputSpec> OutputsInputsDangling;
-  for (int ii = 0; ii < OutputsInputs.size(); ii++) {
+  for (auto ii = 0u; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 1) == 1 && (outputtypes[ii] & 2) == 0)
       OutputsInputsDangling.emplace_back(OutputsInputs[ii]);
   }
@@ -783,7 +783,7 @@ std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec cons
   auto [OutputsInputs, outputtypes] = analyzeOutputs(workflow);
 
   std::vector<InputSpec> results;
-  for (int ii = 0; ii < OutputsInputs.size(); ii++) {
+  for (auto ii = 0u; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 1) == 1) {
       results.emplace_back(OutputsInputs[ii]);
     }

--- a/Framework/Core/src/verifyAODFile.cxx
+++ b/Framework/Core/src/verifyAODFile.cxx
@@ -43,11 +43,11 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  verifyTable<o2::aod::Collisions>(infile.get(), "O2collisions");
-  verifyTable<o2::aod::Tracks>(infile.get(), "O2tracks");
-  verifyTable<o2::aod::TracksCov>(infile.get(), "O2tracks");
-  verifyTable<o2::aod::TracksExtra>(infile.get(), "O2tracks");
+  verifyTable<o2::aod::Collisions>(infile.get(), "O2collision");
+  verifyTable<o2::aod::StoredTracks>(infile.get(), "O2track");
+  verifyTable<o2::aod::StoredTracksCov>(infile.get(), "O2track");
+  verifyTable<o2::aod::TracksExtra>(infile.get(), "O2track");
   verifyTable<o2::aod::Calos>(infile.get(), "O2calo");
-  verifyTable<o2::aod::Muons>(infile.get(), "O2muon");
+  verifyTable<o2::aod::StoredMuons>(infile.get(), "O2muon");
   return 0;
 }

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -19,6 +19,8 @@ using namespace o2::framework;
 using namespace arrow;
 using namespace o2::soa;
 
+/// FIXME: do not use data model tables
+
 namespace test
 {
 DECLARE_SOA_COLUMN_FULL(X, x, float, "x");
@@ -162,21 +164,20 @@ static void BM_ASoAHelpersNaiveTracksPairs(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
+  auto rowWriter = builder.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto table = builder.finalize();
 
-  o2::aod::Tracks tracks{table};
+  o2::aod::Calos Calos{table};
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto t0 = tracks.begin(); t0 + 1 != tracks.end(); ++t0) {
-      for (auto t1 = t0 + 1; t1 != tracks.end(); ++t1) {
+    for (auto t0 = Calos.begin(); t0 + 1 != Calos.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 != Calos.end(); ++t1) {
         auto comb = std::make_tuple(t0, t1);
         count++;
         benchmark::DoNotOptimize(comb);
@@ -197,24 +198,23 @@ static void BM_ASoAHelpersNaiveTracksFives(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
+  auto rowWriter = builder.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto table = builder.finalize();
 
-  o2::aod::Tracks tracks{table};
+  o2::aod::Calos calos{table};
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto t0 = tracks.begin(); t0 + 4 != tracks.end(); ++t0) {
-      for (auto t1 = t0 + 1; t1 + 3 != tracks.end(); ++t1) {
-        for (auto t2 = t1 + 1; t2 + 2 != tracks.end(); ++t2) {
-          for (auto t3 = t2 + 1; t3 + 1 != tracks.end(); ++t3) {
-            for (auto t4 = t3 + 1; t4 != tracks.end(); ++t4) {
+    for (auto t0 = calos.begin(); t0 + 4 != calos.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 + 3 != calos.end(); ++t1) {
+        for (auto t2 = t1 + 1; t2 + 2 != calos.end(); ++t2) {
+          for (auto t3 = t2 + 1; t3 + 1 != calos.end(); ++t3) {
+            for (auto t4 = t3 + 1; t4 != calos.end(); ++t4) {
               auto comb = std::make_tuple(t0, t1, t2, t3, t4);
               count++;
               benchmark::DoNotOptimize(comb);
@@ -300,21 +300,20 @@ static void BM_ASoAHelpersCombGenTracksPairs(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
+  auto rowWriter = builder.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto table = builder.finalize();
 
-  o2::aod::Tracks tracks{table};
+  o2::aod::Calos calos{table};
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(tracks, tracks)) {
+    for (auto& comb : combinations(calos, calos)) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -332,21 +331,20 @@ static void BM_ASoAHelpersCombGenTracksFives(benchmark::State& state)
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builder;
-  auto rowWriter = builder.cursor<o2::aod::StoredTracks>();
+  auto rowWriter = builder.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto table = builder.finalize();
 
-  o2::aod::Tracks tracks{table};
+  o2::aod::Calos calos{table};
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(tracks, tracks, tracks, tracks, tracks)) {
+    for (auto& comb : combinations(calos, calos, calos, calos, calos)) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -405,32 +403,30 @@ static void BM_ASoAHelpersCombGenTracksFivesMultipleChunks(benchmark::State& sta
   std::uniform_real_distribution<float> uniform_dist(0, 1);
 
   TableBuilder builderA;
-  auto rowWriterA = builderA.cursor<o2::aod::StoredTracks>();
+  auto rowWriterA = builderA.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriterA(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
                uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto tableA = builderA.finalize();
 
   TableBuilder builderB;
-  auto rowWriterB = builderB.cursor<o2::aod::StoredTracks>();
+  auto rowWriterB = builderB.cursor<o2::aod::Calos>();
   for (auto i = 0; i < state.range(0); ++i) {
     rowWriterB(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
-               uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
                uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
   }
   auto tableB = builderB.finalize();
 
-  using ConcatTest = Concat<o2::aod::Tracks, o2::aod::Tracks>;
+  using ConcatTest = Concat<o2::aod::Calos, o2::aod::Calos>;
 
-  ConcatTest tracks{tableA, tableB};
+  ConcatTest calos{tableA, tableB};
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(tracks, tracks, tracks, tracks, tracks)) {
+    for (auto& comb : combinations(calos, calos, calos, calos, calos)) {
       count++;
     }
     benchmark::DoNotOptimize(count);

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -22,30 +22,41 @@
 
 using namespace o2::framework;
 using namespace arrow;
-using namespace o2::soa;
-using namespace o2::aod;
+
+DECLARE_SOA_STORE();
+
+namespace col
+{
+DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Z, z, float);
+DECLARE_SOA_COLUMN(D, d, float);
+} // namespace col
+
+DECLARE_SOA_TABLE(XY, "AOD", "XY", col::X, col::Y);
+DECLARE_SOA_TABLE(ZD, "AOD", "ZD", col::Z, col::D);
 
 BOOST_AUTO_TEST_CASE(TestJoinedTables)
 {
-  TableBuilder trackBuilder;
+  TableBuilder XYBuilder;
   //FIXME: using full tracks, instead of stored because of unbound dynamic
   //       column (normalized phi)
-  auto trackWriter = trackBuilder.cursor<Tracks>();
-  trackWriter(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-  auto tracks = trackBuilder.finalize();
+  auto xyWriter = XYBuilder.cursor<XY>();
+  xyWriter(0, 0, 0);
+  auto tXY = XYBuilder.finalize();
 
-  TableBuilder trackParCovBuilder;
-  auto trackParCovWriter = trackParCovBuilder.cursor<StoredTracksCov>();
-  trackParCovWriter(0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4);
-  auto covs = trackParCovBuilder.finalize();
+  TableBuilder ZDBuilder;
+  auto zdWriter = ZDBuilder.cursor<ZD>();
+  zdWriter(0, 7, 1);
+  auto tZD = ZDBuilder.finalize();
 
-  using Test = Join<Tracks, StoredTracksCov>;
+  using Test = o2::soa::Join<XY, ZD>;
 
-  Test tests{0, tracks, covs};
+  Test tests{0, tXY, tZD};
   BOOST_REQUIRE(tests.asArrowTable()->num_columns() != 0);
   BOOST_REQUIRE_EQUAL(tests.asArrowTable()->num_columns(),
-                      tracks->num_columns() + covs->num_columns());
-  auto tests2 = join(Tracks{tracks}, StoredTracksCov{covs});
+                      tXY->num_columns() + tZD->num_columns());
+  auto tests2 = join(XY{tXY}, ZD{tZD});
   static_assert(std::is_same_v<Test::table_t, decltype(tests2)>,
                 "Joined tables should have the same type, regardless how we construct them");
 }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -146,29 +146,34 @@ struct JTask {
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
   auto task1 = adaptAnalysisTask<ATask>("test1");
-  BOOST_CHECK_EQUAL(task1.inputs.size(), 1);
+  BOOST_CHECK_EQUAL(task1.inputs.size(), 2);
   BOOST_CHECK_EQUAL(task1.outputs.size(), 1);
-  BOOST_CHECK_EQUAL(task1.inputs[0].binding, std::string("Tracks"));
+  BOOST_CHECK_EQUAL(task1.inputs[0].binding, std::string("TracksExtension"));
+  BOOST_CHECK_EQUAL(task1.inputs[1].binding, std::string("Tracks"));
   BOOST_CHECK_EQUAL(task1.outputs[0].binding.value, std::string("FooBars"));
 
   auto task2 = adaptAnalysisTask<BTask>("test2");
-  BOOST_CHECK_EQUAL(task2.inputs.size(), 7);
+  BOOST_CHECK_EQUAL(task2.inputs.size(), 9);
   BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions");
-  BOOST_CHECK_EQUAL(task2.inputs[1].binding, "Tracks");
-  BOOST_CHECK_EQUAL(task2.inputs[2].binding, "TracksExtra");
-  BOOST_CHECK_EQUAL(task2.inputs[3].binding, "TracksCov");
-  BOOST_CHECK_EQUAL(task2.inputs[4].binding, "UnassignedTracks");
-  BOOST_CHECK_EQUAL(task2.inputs[5].binding, "Calos");
-  BOOST_CHECK_EQUAL(task2.inputs[6].binding, "CaloTriggers");
+  BOOST_CHECK_EQUAL(task2.inputs[1].binding, "TracksExtension");
+  BOOST_CHECK_EQUAL(task2.inputs[2].binding, "Tracks");
+  BOOST_CHECK_EQUAL(task2.inputs[3].binding, "TracksExtra");
+  BOOST_CHECK_EQUAL(task2.inputs[4].binding, "TracksCovExtension");
+  BOOST_CHECK_EQUAL(task2.inputs[5].binding, "TracksCov");
+  BOOST_CHECK_EQUAL(task2.inputs[6].binding, "UnassignedTracks");
+  BOOST_CHECK_EQUAL(task2.inputs[7].binding, "Calos");
+  BOOST_CHECK_EQUAL(task2.inputs[8].binding, "CaloTriggers");
 
   auto task3 = adaptAnalysisTask<CTask>("test3");
-  BOOST_CHECK_EQUAL(task3.inputs.size(), 2);
+  BOOST_CHECK_EQUAL(task3.inputs.size(), 3);
   BOOST_CHECK_EQUAL(task3.inputs[0].binding, "Collisions");
-  BOOST_CHECK_EQUAL(task3.inputs[1].binding, "Tracks");
+  BOOST_CHECK_EQUAL(task3.inputs[1].binding, "TracksExtension");
+  BOOST_CHECK_EQUAL(task3.inputs[2].binding, "Tracks");
 
   auto task4 = adaptAnalysisTask<DTask>("test4");
-  BOOST_CHECK_EQUAL(task4.inputs.size(), 1);
-  BOOST_CHECK_EQUAL(task4.inputs[0].binding, "Tracks");
+  BOOST_CHECK_EQUAL(task4.inputs.size(), 2);
+  BOOST_CHECK_EQUAL(task4.inputs[0].binding, "TracksExtension");
+  BOOST_CHECK_EQUAL(task4.inputs[1].binding, "Tracks");
 
   auto task5 = adaptAnalysisTask<ETask>("test5");
   BOOST_CHECK_EQUAL(task5.inputs.size(), 1);

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -29,6 +29,7 @@ static BindingNode eta{"eta", atype::FLOAT};
 
 static BindingNode tgl{"tgl", atype::FLOAT};
 static BindingNode signed1Pt{"signed1Pt", atype::FLOAT};
+static BindingNode testInt{"testInt", atype::INT32};
 } // namespace nodes
 
 namespace o2::aod::track

--- a/Framework/Core/test/test_SimpleTracksED.cxx
+++ b/Framework/Core/test/test_SimpleTracksED.cxx
@@ -33,7 +33,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   return WorkflowSpec{
     {"trackDisplay",
      Inputs{
-       {"tracks", "AOD", "TRACKPAR"}},
+       {"Collisions", "AOD", "COLLISION"}},
      Outputs{},
      AlgorithmSpec{adaptStateful(
        [](CallbackService& callbacks) {
@@ -51,12 +51,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
                        [count, window, guiCallback]() {
                     (*count)++; window ? pollGUI(window, guiCallback) : false; });
          return adaptStateless([count](InputRecord& inputs, ControlService& control) {
-           auto input = inputs.get<TableConsumer>("tracks");
+           auto input = inputs.get<TableConsumer>("Collisions");
 
-           o2::aod::Tracks myTracks{input->asArrowTable()};
+           o2::aod::Collisions myCollisions{{input->asArrowTable()}};
 
-           for (auto& track : myTracks) {
-             LOGF(info, "CollisionId %d", track.collisionId());
+           for (auto& collision : myCollisions) {
+             LOGF(info, "CollisionId %d", collision.globalIndex());
            }
 
            if (*count > 1000) {

--- a/Framework/Foundation/test/test_FunctionalHelpers.cxx
+++ b/Framework/Foundation/test/test_FunctionalHelpers.cxx
@@ -44,6 +44,12 @@ BOOST_AUTO_TEST_CASE(TestOverride)
   static_assert(std::is_same_v<concatenated_pack_t<pack<int, float, char>, pack<float, double>>, pack<int, float, char, float, double>>, "pack should be concatenated");
   static_assert(std::is_same_v<concatenated_pack_t<pack<int, float, char>, pack<float, double>, pack<char, short>>, pack<int, float, char, float, double, char, short>>, "pack should be concatenated");
 
+  using p1 = pack<int, float, bool>;
+  using p2 = pack<int, double, char>;
+  using p3 = concatenated_pack_unique_t<p1, p2>;
+  print_pack<p3>();
+  static_assert(std::is_same_v<p3, pack<float, bool, int, double, char>>, "pack should not have duplicated types");
+
   struct ForwardDeclared;
   static_assert(is_type_complete_v<ForwardDeclared> == false, "This should not be complete because the struct is simply forward declared.");
 


### PR DESCRIPTION
* Extended tables are now defined as a Join<>
* This allows to use extension as a separate FairMQ message thus preventing extra copy of original being allocated in shared memory
* Join now supports nesting (i.e. Join<Join<>, Join<>>, etc.)
* Extra utility templates for pack<>