### PR TITLE
[EMCAL-610] Circumvent out-of-bounds error

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -89,17 +89,13 @@ class RawWriter
   void setOutputLocation(const char* outputdir) { mOutputLocation = outputdir; }
   void setDigits(gsl::span<o2::emcal::Digit> digits) { mDigits = digits; }
   void setFileFor(FileFor_t filefor) { mFileFor = filefor; }
-  void setTriggerRecords(gsl::span<o2::emcal::TriggerRecord> triggers);
   void setNumberOfADCSamples(int nsamples) { mNADCSamples = nsamples; }
   void setPedestal(int pedestal) { mPedestal = pedestal; }
   void setGeometry(o2::emcal::Geometry* geo) { mGeometry = geo; }
 
-  bool hasNextTrigger() const { return mCurrentTrigger != mTriggers.end(); }
-
   void init();
-  void process();
   void digitsToRaw(gsl::span<o2::emcal::Digit> digits, gsl::span<o2::emcal::TriggerRecord> triggers);
-  bool processNextTrigger();
+  bool processTrigger(const o2::emcal::TriggerRecord& trg);
 
   int carryOverMethod(const header::RDHAny* rdh, const gsl::span<char> data,
                       const char* ptr, int maxSize, int splitID,
@@ -115,17 +111,15 @@ class RawWriter
   std::vector<int> encodeBunchData(const std::vector<int>& data);
 
  private:
-  int mNADCSamples = 15;                                         ///< Number of time samples
-  int mPedestal = 0;                                             ///< Pedestal
-  FileFor_t mFileFor = FileFor_t::kFullDet;                      ///< Granularity of the output files
-  o2::emcal::Geometry* mGeometry = nullptr;                      ///< EMCAL geometry
-  std::string mOutputLocation;                                   ///< Rawfile name
-  std::unique_ptr<o2::emcal::MappingHandler> mMappingHandler;    ///< Mapping handler
-  gsl::span<o2::emcal::Digit> mDigits;                           ///< Digits input vector - must be in digitized format including the time response
-  gsl::span<o2::emcal::TriggerRecord> mTriggers;                 ///< Trigger records, separating the data from different triggers
-  std::vector<SRUDigitContainer> mSRUdata;                       ///< Internal helper of digits assigned to SRUs
-  gsl::span<o2::emcal::TriggerRecord>::iterator mCurrentTrigger; ///< Current trigger in the trigger records
-  std::unique_ptr<o2::raw::RawFileWriter> mRawWriter;            ///< Raw writer
+  int mNADCSamples = 15;                                      ///< Number of time samples
+  int mPedestal = 0;                                          ///< Pedestal
+  FileFor_t mFileFor = FileFor_t::kFullDet;                   ///< Granularity of the output files
+  o2::emcal::Geometry* mGeometry = nullptr;                   ///< EMCAL geometry
+  std::string mOutputLocation;                                ///< Rawfile name
+  std::unique_ptr<o2::emcal::MappingHandler> mMappingHandler; ///< Mapping handler
+  gsl::span<o2::emcal::Digit> mDigits;                        ///< Digits input vector - must be in digitized format including the time response
+  std::vector<SRUDigitContainer> mSRUdata;                    ///< Internal helper of digits assigned to SRUs
+  std::unique_ptr<o2::raw::RawFileWriter> mRawWriter;         ///< Raw writer
 
   ClassDefNV(RawWriter, 1);
 };

--- a/Detectors/EMCAL/simulation/src/RawCreator.cxx
+++ b/Detectors/EMCAL/simulation/src/RawCreator.cxx
@@ -109,5 +109,5 @@ int main(int argc, const char** argv)
   for (auto en : *treereader) {
     rawwriter.digitsToRaw(*digitbranch, *triggerbranch);
   }
-  rawwriter.getWriter().writeConfFile("EMC", "RAWDATA", o2::utils::concat_string(outputdir, "raw.cfg"));
+  rawwriter.getWriter().writeConfFile("EMC", "RAWDATA", o2::utils::concat_string(outputdir, "/EMCraw.cfg"));
 }

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -35,7 +35,7 @@ void RawWriter::init()
     std::string rawfilename = mOutputLocation;
     switch (mFileFor) {
       case FileFor_t::kFullDet:
-        rawfilename += "/emcal.root";
+        rawfilename += "/emcal.raw";
         break;
       case FileFor_t::kSubDet: {
         std::string detstring;
@@ -43,11 +43,11 @@ void RawWriter::init()
           detstring = "emcal";
         else
           detstring = "dcal";
-        rawfilename += fmt::format("/%s", detstring.data());
+        rawfilename += fmt::format("/{:s}.raw", detstring.data());
         break;
       };
       case FileFor_t::kLink:
-        rawfilename += fmt::format("/emcal_%d_%d.root", crorc, link);
+        rawfilename += fmt::format("/emcal_{:d}_{:d}.raw", crorc, link);
     }
     mRawWriter->registerLink(iddl, crorc, link, 0, rawfilename.data());
   }


### PR DESCRIPTION
The iterator mCurrentTrigger seems to be incorrectly
initialized on linux systems, leading to corrupted trigger
recond entries creating an out-of-bounds exception when
iterating over the range in the digits vector. Circumvented
by passing the current trigger directly to the process
method and not storing the trigger records.