### PR TITLE
RawPixelDecoder will fill chip decoding errors/statistics

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(ITSMFTReconstruction
 		       src/RUDecodeData.cxx
 		       src/RawPixelDecoder.cxx
                        src/CTFCoder.cxx
+                       src/DecodingStat.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
                                      O2::CommonDataFormat
 	                             O2::DetectorsRaw
@@ -55,7 +56,8 @@ o2_target_root_dictionary(
           include/ITSMFTReconstruction/AlpideCoder.h
           include/ITSMFTReconstruction/GBTWord.h
           include/ITSMFTReconstruction/PayLoadCont.h
-          include/ITSMFTReconstruction/PayLoadSG.h	  
+          include/ITSMFTReconstruction/PayLoadSG.h
+          include/ITSMFTReconstruction/DecodingStat.h
           include/ITSMFTReconstruction/RUInfo.h)
 
 if (OpenMP_CXX_FOUND)

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -17,13 +17,16 @@
 #include <vector>
 #include <string>
 #include <cstdint>
-#include <FairLogger.h>
-#include <iostream>
+#include "Framework/Logger.h"
 #include "PayLoadCont.h"
 #include <map>
+#include <fmt/format.h>
 
 #include "ITSMFTReconstruction/PixelData.h"
+#include "ITSMFTReconstruction/DecodingStat.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
+
+#define ALPIDE_DECODING_STAT
 
 /// \file AlpideCoder.h
 /// \brief class for the ALPIDE data decoding/encoding
@@ -68,6 +71,7 @@ class AlpideCoder
   static constexpr uint32_t ExpectChipEmpty = 0x1 << 2;
   static constexpr uint32_t ExpectRegion = 0x1 << 3;
   static constexpr uint32_t ExpectData = 0x1 << 4;
+  static constexpr uint32_t ExpectBUSY = 0x1 << 5;
   static constexpr int NRows = 512;
   static constexpr int NCols = 1024;
   static constexpr int NRegions = 32;
@@ -80,7 +84,10 @@ class AlpideCoder
   static constexpr uint32_t MaskDColID = MaskEncoder | MaskPixID; // mask for encoder + dcolumn combination
   static constexpr uint32_t MaskRegion = 0x1f;                    // region ID takes 5 bits max (0:31)
   static constexpr uint32_t MaskChipID = 0x0f;                    // chip id in module takes 4 bit max
-  static constexpr uint32_t MaskROFlags = 0x0f;                   // RO flags in chip header takes 4 bit max
+  static constexpr uint32_t MaskROFlags = 0x0f;                   // RO flags in chip trailer takes 4 bit max
+  static constexpr uint8_t MaskErrBusyViolation = 0x1 << 3;
+  static constexpr uint8_t MaskErrDataOverrun = 0x3 << 2;
+  static constexpr uint8_t MaskErrFatal = 0x7 << 1;
   static constexpr uint32_t MaskTimeStamp = 0xff;                 // Time stamps as BUNCH_COUNTER[10:3] bits
   static constexpr uint32_t MaskReserved = 0xff;                  // mask for reserved byte
   static constexpr uint32_t MaskHitMap = 0x7f;                    // mask for hit map: at most 7 hits in bits (0:6)
@@ -92,6 +99,8 @@ class AlpideCoder
   static constexpr uint32_t CHIPEMPTY = 0xe0;   // flag for empty chip
   static constexpr uint32_t DATALONG = 0x0000;  // flag for DATALONG
   static constexpr uint32_t DATASHORT = 0x4000; // flag for DATASHORT
+  static constexpr uint32_t BUSYOFF = 0xf0;     // flag for BUSY_OFF
+  static constexpr uint32_t BUSYON = 0xf1;      // flag for BUSY_ON
 
   // true if corresponds to DATALONG or DATASHORT: highest bit must be 0
   static bool isData(uint16_t v) { return (v & (0x1 << 15)) == 0; }
@@ -132,8 +141,11 @@ class AlpideCoder
       uint8_t dataCM = dataC & (~MaskChipID);
       //
       if ((expectInp & ExpectChipEmpty) && dataCM == CHIPEMPTY) { // empty chip was expected
-        //chipData.setChipID(dataC & MaskChipID);                   // here we set the chip ID within the module
+        //chipData.setChipID(dataC & MaskChipID);                   // here we set the chip ID within the module // now set upstream
         if (!buffer.next(timestamp)) {
+#ifdef ALPIDE_DECODING_STAT
+          chipData.setError(ChipStat::TruncatedChipEmpty);
+#endif
           return unexpectedEOF("CHIP_EMPTY:Timestamp");
         }
         expectInp = ExpectChipHeader | ExpectChipEmpty;
@@ -141,8 +153,11 @@ class AlpideCoder
       }
 
       if ((expectInp & ExpectChipHeader) && dataCM == CHIPHEADER) { // chip header was expected
-        //chipData.setChipID(dataC & MaskChipID);                     // here we set the chip ID within the module
+        //chipData.setChipID(dataC & MaskChipID);                     // here we set the chip ID within the module // now set upstream
         if (!buffer.next(timestamp)) {
+#ifdef ALPIDE_DECODING_STAT
+          chipData.setError(ChipStat::TruncatedChipHeader);
+#endif
           return unexpectedEOF("CHIP_HEADER");
         }
         expectInp = ExpectRegion; // now expect region info
@@ -159,6 +174,18 @@ class AlpideCoder
       if ((expectInp & ExpectChipTrailer) && dataCM == CHIPTRAILER) { // chip trailer was expected
         expectInp = ExpectChipHeader | ExpectChipEmpty;
         chipData.setROFlags(dataC & MaskROFlags);
+#ifdef ALPIDE_DECODING_STAT
+        uint8_t roErr = dataC & MaskROFlags;
+        if (roErr) {
+          if (roErr == MaskErrBusyViolation) {
+            chipData.setError(ChipStat::BusyViolation);
+          } else if (roErr == MaskErrDataOverrun) {
+            chipData.setError(ChipStat::DataOverrun);
+          } else if (roErr == MaskErrFatal) {
+            chipData.setError(ChipStat::Fatal);
+          }
+        }
+#endif
         // in case there are entries in the "right" columns buffer, add them to the container
         if (nRightCHits) {
           colDPrev++;
@@ -175,6 +202,9 @@ class AlpideCoder
                              // note that here we are checking on the byte rather than the short, need complete to ushort
           dataS = dataC << 8;
           if (!buffer.next(dataC)) {
+#ifdef ALPIDE_DECODING_STAT
+            chipData.setError(ChipStat::TruncatedRegion);
+#endif
             return unexpectedEOF("CHIPDATA");
           }
           dataS |= dataC;
@@ -211,8 +241,16 @@ class AlpideCoder
           if ((dataS & (~MaskDColID)) == DATALONG) { // multiple hits ?
             uint8_t hitsPattern = 0;
             if (!buffer.next(hitsPattern)) {
+#ifdef ALPIDE_DECODING_STAT
+              chipData.setError(ChipStat::TruncatedLondData);
+#endif
               return unexpectedEOF("CHIP_DATA_LONG:Pattern");
             }
+#ifdef ALPIDE_DECODING_STAT
+            if (hitsPattern & (~MaskHitMap)) {
+              chipData.setError(ChipStat::WrongDataLongPattern);
+            }
+#endif
             for (int ip = 0; ip < HitMapSize; ip++) {
               if (hitsPattern & (0x1 << ip)) {
                 uint16_t addr = pixID + ip + 1, rowE = addr >> 1;
@@ -227,6 +265,9 @@ class AlpideCoder
             }
           }
         } else {
+#ifdef ALPIDE_DECODING_STAT
+          chipData.setError(ChipStat::NoDataFound);
+#endif
           LOG(ERROR) << "Expected DataShort or DataLong mask, got : " << dataS;
           return Error;
         }
@@ -234,13 +275,27 @@ class AlpideCoder
         continue; // end of DATA(SHORT or LONG) processing
       }
 
+      if (dataC == BUSYON) {
+#ifdef ALPIDE_DECODING_STAT
+        chipData.setError(ChipStat::BusyOn);
+#endif
+        continue;
+      }
+      if (dataC == BUSYOFF) {
+#ifdef ALPIDE_DECODING_STAT
+        chipData.setError(ChipStat::BusyOff);
+#endif
+        continue;
+      }
+
       if (!dataC) {
         buffer.clear(); // 0 padding reached (end of the cable data), no point in continuing
         break;
       }
-      std::stringstream stream;
-      stream << "Unknown word 0x" << std::hex << int(dataC) << " [mode = 0x" << int(expectInp) << "]";
-      return unexpectedEOF(stream.str().c_str()); // error
+#ifdef ALPIDE_DECODING_STAT
+      chipData.setError(ChipStat::UnknownWord);
+#endif
+      return unexpectedEOF(fmt::format("Unknown word 0x{:x} [expectation = 0x{:x}]", int(dataC), int(expectInp))); // error
     }
 
     return chipData.getData().size();
@@ -362,11 +417,7 @@ class AlpideCoder
   void resetMap();
 
   ///< error message on unexpected EOF
-  static int unexpectedEOF(const char* message)
-  {
-    printf("Error: unexpected EOF on %s\n", message);
-    return Error;
-  }
+  static int unexpectedEOF(const std::string& message);
 
   // =====================================================================
   //

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -1,0 +1,155 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DecodingStat.h
+/// \brief Alpide Chip and GBT link decoding statistics
+
+#ifndef _ALICEO2_DECODINGSTAT_H_
+#define _ALICEO2_DECODINGSTAT_H_
+
+#include <string>
+#include <array>
+#include <Rtypes.h>
+#include "ITSMFTReconstruction/GBTWord.h"
+
+namespace o2
+{
+namespace itsmft
+{
+
+struct ChipStat {
+
+  enum DecErrors : int {
+    BusyViolation,
+    DataOverrun,
+    Fatal,
+    BusyOn,
+    BusyOff,
+    TruncatedChipEmpty,   // Data was truncated after ChipEmpty
+    TruncatedChipHeader,  // Data was truncated after ChipHeader
+    TruncatedRegion,      // Data was truncated after Region record
+    TruncatedLondData,    // Data was truncated in the LongData record
+    WrongDataLongPattern, // LongData pattern has highest bit set
+    NoDataFound,          // Region is not followed by Short or Long data
+    UnknownWord,          // Unknow word was seen
+    NErrorsDefined
+  };
+
+  static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
+    "BusyViolation flag ON",                        // BusyViolation
+    "DataOverrun flag ON",                          // DataOverrun
+    "Fatal flag ON",                                // Fatal
+    "BusyON",                                       // BusyOn
+    "BusyOFF",                                      // BusyOff
+    "Data truncated after ChipEmpty",               // TruncatedChipEmpty
+    "Data truncated after ChipHeader",              // TruncatedChipHeader
+    "Data truncated after Region",                  // TruncatedRegion
+    "Data truncated after LongData",                // TruncatedLondData
+    "LongData pattern has highest bit set",         // WrongDataLongPattern
+    "Region is not followed by Short or Long data", // NoDataFound
+    "Unknow word"                                   // UnknownWord
+  };
+
+  uint16_t chipID = 0;
+  size_t nHits = 0;
+  std::array<uint32_t, NErrorsDefined> errorCounts = {};
+  ChipStat() = default;
+  ChipStat(uint16_t id) : chipID(id) {}
+
+  void clear()
+  {
+    memset(errorCounts.data(), 0, sizeof(uint32_t) * errorCounts.size());
+    nHits = 0;
+  }
+
+  uint32_t getNErrors() const;
+
+  void addErrors(uint32_t mask)
+  {
+    if (mask) {
+      for (int i = NErrorsDefined; i--;) {
+        if (mask & (0x1 << i)) {
+          errorCounts[i]++;
+        }
+      }
+    }
+  }
+
+  void print(bool skipEmpty = true) const;
+
+  ClassDefNV(ChipStat, 1);
+};
+
+/// Statistics for per-link decoding
+struct GBTLinkDecodingStat {
+  /// counters for format checks
+
+  enum DecErrors : int {
+    ErrNoRDHAtStart,             // page does not start with RDH
+    ErrPageNotStopped,           // new HB/trigger page started w/o stopping previous one
+    ErrStopPageNotEmpty,         // Page with RDH.stop is not empty
+    ErrPageCounterDiscontinuity, // RDH page counters for the same RU/trigger are not continuous
+    ErrRDHvsGBTHPageCnt,         // RDH and GBT header page counters are not consistent
+    ErrMissingGBTTrigger,        // GBT trigger word was expected but not found
+    ErrMissingGBTHeader,         // GBT payload header was expected but not found
+    ErrMissingGBTTrailer,        // GBT payload trailer was expected but not found
+    ErrNonZeroPageAfterStop,     // all lanes were stopped but the page counter in not 0
+    ErrUnstoppedLanes,           // end of FEE data reached while not all lanes received stop
+    ErrDataForStoppedLane,       // data was received for stopped lane
+    ErrNoDataForActiveLane,      // no data was seen for lane (which was not in timeout)
+    ErrIBChipLaneMismatch,       // chipID (on module) was different from the lane ID on the IB stave
+    ErrCableDataHeadWrong,       // cable data does not start with chip header or empty chip
+    ErrInvalidActiveLanes,       // active lanes pattern conflicts with expected for given RU type
+    ErrPacketCounterJump,        // jump in RDH.packetCounter
+    ErrPacketDoneMissing,        // packet done is missing in the trailer while CRU page is not over
+    NErrorsDefined
+  };
+  static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
+    "Page data not start with expected RDH",                             // ErrNoRDHAtStart
+    "New HB/trigger page started w/o stopping previous one",             // ErrPageNotStopped
+    "Page with RDH.stop is not empty",                                   // ErrStopPageNotEmpty
+    "RDH page counters for the same RU/trigger are not continuous",      // ErrPageCounterDiscontinuity
+    "RDH and GBT header page counters are not consistent",               // ErrRDHvsGBTHPageCnt
+    "GBT trigger word was expected but not found",                       // ErrMissingGBTTrigger
+    "GBT payload header was expected but not found",                     // ErrMissingGBTHeader
+    "GBT payload trailer was expected but not found",                    // ErrMissingGBTTrailer
+    "All lanes were stopped but the page counter in not 0",              // ErrNonZeroPageAfterStop
+    "End of FEE data reached while not all lanes received stop",         // ErrUnstoppedLanes
+    "Data was received for stopped lane",                                // ErrDataForStoppedLane
+    "No data was seen for lane (which was not in timeout)",              // ErrNoDataForActiveLane
+    "ChipID (on module) was different from the lane ID on the IB stave", // ErrIBChipLaneMismatch
+    "Cable data does not start with chip header or empty chip",          // ErrCableDataHeadWrong
+    "Active lanes pattern conflicts with expected for given RU type",    // ErrInvalidActiveLanes
+    "Jump in RDH_packetCounter",                                         // ErrPacketCounterJump
+    "Packet done is missing in the trailer while CRU page is not over"   // ErrPacketDoneMissing
+  };
+
+  uint32_t ruLinkID = 0; // Link ID within RU
+
+  // Note: packet here is meant as a group of CRU pages belonging to the same trigger
+  uint32_t nPackets = 0;                                                        // total number of packets
+  std::array<uint32_t, NErrorsDefined> errorCounts = {};                        // error counters
+  std::array<uint32_t, GBTDataTrailer::MaxStateCombinations> packetStates = {}; // packet status from the trailer
+
+  void clear()
+  {
+    nPackets = 0;
+    errorCounts.fill(0);
+    packetStates.fill(0);
+  }
+
+  void print(bool skipEmpty = true) const;
+
+  ClassDefNV(GBTLinkDecodingStat, 1);
+};
+
+} // namespace itsmft
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -23,6 +23,7 @@
 #include "ITSMFTReconstruction/PayLoadSG.h"
 #include "ITSMFTReconstruction/GBTWord.h"
 #include "ITSMFTReconstruction/RUDecodeData.h"
+#include "ITSMFTReconstruction/DecodingStat.h"
 #include "ITSMFTReconstruction/RUInfo.h"
 #include "Headers/RAWDataHeader.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -38,69 +39,6 @@ namespace o2
 {
 namespace itsmft
 {
-
-/// Statistics for per-link decoding
-struct GBTLinkDecodingStat {
-  /// counters for format checks
-
-  enum DecErrors : int {
-    ErrNoRDHAtStart,             // page does not start with RDH
-    ErrPageNotStopped,           // new HB/trigger page started w/o stopping previous one
-    ErrStopPageNotEmpty,         // Page with RDH.stop is not empty
-    ErrPageCounterDiscontinuity, // RDH page counters for the same RU/trigger are not continuous
-    ErrRDHvsGBTHPageCnt,         // RDH and GBT header page counters are not consistent
-    ErrMissingGBTTrigger,        // GBT trigger word was expected but not found
-    ErrMissingGBTHeader,         // GBT payload header was expected but not found
-    ErrMissingGBTTrailer,        // GBT payload trailer was expected but not found
-    ErrNonZeroPageAfterStop,     // all lanes were stopped but the page counter in not 0
-    ErrUnstoppedLanes,           // end of FEE data reached while not all lanes received stop
-    ErrDataForStoppedLane,       // data was received for stopped lane
-    ErrNoDataForActiveLane,      // no data was seen for lane (which was not in timeout)
-    ErrIBChipLaneMismatch,       // chipID (on module) was different from the lane ID on the IB stave
-    ErrCableDataHeadWrong,       // cable data does not start with chip header or empty chip
-    ErrInvalidActiveLanes,       // active lanes pattern conflicts with expected for given RU type
-    ErrPacketCounterJump,        // jump in RDH.packetCounter
-    ErrPacketDoneMissing,        // packet done is missing in the trailer while CRU page is not over
-    NErrorsDefined
-  };
-  static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
-    "Page data not start with expected RDH",                             // ErrNoRDHAtStart
-    "New HB/trigger page started w/o stopping previous one",             // ErrPageNotStopped
-    "Page with RDH.stop is not empty",                                   // ErrStopPageNotEmpty
-    "RDH page counters for the same RU/trigger are not continuous",      // ErrPageCounterDiscontinuity
-    "RDH and GBT header page counters are not consistent",               // ErrRDHvsGBTHPageCnt
-    "GBT trigger word was expected but not found",                       // ErrMissingGBTTrigger
-    "GBT payload header was expected but not found",                     // ErrMissingGBTHeader
-    "GBT payload trailer was expected but not found",                    // ErrMissingGBTTrailer
-    "All lanes were stopped but the page counter in not 0",              // ErrNonZeroPageAfterStop
-    "End of FEE data reached while not all lanes received stop",         // ErrUnstoppedLanes
-    "Data was received for stopped lane",                                // ErrDataForStoppedLane
-    "No data was seen for lane (which was not in timeout)",              // ErrNoDataForActiveLane
-    "ChipID (on module) was different from the lane ID on the IB stave", // ErrIBChipLaneMismatch
-    "Cable data does not start with chip header or empty chip",          // ErrCableDataHeadWrong
-    "Active lanes pattern conflicts with expected for given RU type",    // ErrInvalidActiveLanes
-    "Jump in RDH_packetCounter",                                         // ErrPacketCounterJump
-    "Packet done is missing in the trailer while CRU page is not over"   // ErrPacketDoneMissing
-  };
-
-  uint32_t ruLinkID = 0; // Link ID within RU
-
-  // Note: packet here is meant as a group of CRU pages belonging to the same trigger
-  uint32_t nPackets = 0;                                                   // total number of packets
-  std::array<int, NErrorsDefined> errorCounts = {};                        // error counters
-  std::array<int, GBTDataTrailer::MaxStateCombinations> packetStates = {}; // packet status from the trailer
-
-  void clear()
-  {
-    nPackets = 0;
-    errorCounts.fill(0);
-    packetStates.fill(0);
-  }
-
-  void print(bool skipEmpty = true) const;
-
-  ClassDefNV(GBTLinkDecodingStat, 1);
-};
 
 struct RUDecodeData; // forward declaration to allow its linking in the GBTlink
 struct GBTHeader;
@@ -159,7 +97,8 @@ struct GBTLink {
   uint32_t errorBits = 0;     // bits of the error code of last frame decoding (if any)
   const RDH* lastRDH = nullptr;
   o2::InteractionRecord ir;       // interaction record
-  GBTLinkDecodingStat statistics; // decoding statistics
+  GBTLinkDecodingStat statistics; // link decoding statistics
+  ChipStat chipStat;              // chip decoding statistics
   RUDecodeData* ruPtr = nullptr;  // pointer on the parent RU
 
   PayLoadSG rawData;         // scatter-gatter buffer for cached CRU pages, each starting with RDH

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -15,6 +15,8 @@
 
 #include "DataFormatsITSMFT/Digit.h"
 #include "CommonDataFormat/InteractionRecord.h"
+#include "ITSMFTReconstruction/DecodingStat.h"
+
 #include <vector>
 #include <utility>
 #include <cstdint>
@@ -116,11 +118,18 @@ class ChipPixelData
   void setFirstUnmasked(uint32_t n) { mFirstUnmasked = n; }
   void setTrigger(uint32_t t) { mTrigger = t; }
 
+  void setError(ChipStat::DecErrors i) { mErrors |= 0x1 << i; }
+  void setErrorFlags(uint32_t f) { mErrors |= f; }
+  bool isErrorSet(ChipStat::DecErrors i) const { return mErrors & (0x1 << i); }
+  bool isErrorSet() const { return mErrors != 0; }
+  uint32_t getErrorFlags() const { return mErrors; }
+
   void clear()
   {
     mPixels.clear();
     mROFlags = 0;
     mFirstUnmasked = 0;
+    mErrors = 0;
   }
 
   void swap(ChipPixelData& other)
@@ -222,6 +231,7 @@ class ChipPixelData
   uint32_t mFirstUnmasked = 0;                   // first unmasked entry in the mPixels
   uint32_t mStartID = 0;                         // entry of the 1st pixel data in the whole detector data, for MCtruth access
   uint32_t mTrigger = 0;                         // trigger pattern
+  uint32_t mErrors = 0;                          // errors set during decoding
   o2::InteractionRecord mInteractionRecord = {}; // interaction record
   std::vector<PixelData> mPixels;                // vector of pixeld
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -76,7 +76,9 @@ class RawPixelDecoder final : public PixelReader
   void setVerbosity(int v);
   int getVerbosity() const { return mVerbosity; }
 
-  void printReport() const;
+  void printReport(bool decstat = false, bool skipEmpty = true) const;
+
+  void clearStat();
 
   TStopwatch& getTimerTFStart() { return mTimerTFStart; }
   TStopwatch& getTimerDecode() { return mTimerDecode; }
@@ -101,9 +103,8 @@ class RawPixelDecoder final : public PixelReader
 
   std::vector<GBTLink> mGBTLinks;                           // active links pool
   std::unordered_map<uint32_t, LinkEntry> mSubsSpec2LinkID; // link subspec to link entry in the pool mapping
-
-  std::vector<RUDecodeData> mRUDecodeVec;       // set of active RUs
-  std::array<int, Mapping::getNRUs()> mRUEntry; // entry of the RU with given SW ID in the mRUDecodeVec
+  std::vector<RUDecodeData> mRUDecodeVec;                   // set of active RUs
+  std::array<short, Mapping::getNRUs()> mRUEntry;           // entry of the RU with given SW ID in the mRUDecodeVec
   std::string mSelfName;                        // self name
   header::DataOrigin mUserDataOrigin = o2::header::gDataOriginInvalid; // alternative user-provided data origin to pick
   uint16_t mCurRUDecodeID = NORUDECODED;        // index of currently processed RUDecode container

--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -149,3 +149,8 @@ void AlpideCoder::resetMap()
 }
 
 //_____________________________________
+int AlpideCoder::unexpectedEOF(const std::string& message)
+{
+  LOG(ERROR) << message;
+  return Error;
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ChipStat.cxx
+/// \brief Alpide Chip decoding statistics
+
+#include <bitset>
+#include "ITSMFTReconstruction/DecodingStat.h"
+#include "Framework/Logger.h"
+
+using namespace o2::itsmft;
+constexpr std::array<std::string_view, ChipStat::NErrorsDefined> ChipStat::ErrNames;
+
+///_________________________________________________________________
+/// print chip decoding statistics
+void ChipStat::print(bool skipEmpty) const
+{
+  uint32_t nErr = 0;
+  for (int i = NErrorsDefined; i--;) {
+    nErr += errorCounts[i];
+  }
+  LOGF(INFO, "Chip#%5d NHits: %9zu  errors: %u", chipID, nHits, nErr);
+  for (int i = 0; i < NErrorsDefined; i++) {
+    if (!skipEmpty || errorCounts[i]) {
+      LOGF(INFO, "%-70s: %u", ErrNames[i].data(), errorCounts[i]);
+    }
+  }
+}
+
+///_________________________________________________________________
+uint32_t ChipStat::getNErrors() const
+{
+  uint32_t nerr = 0;
+  for (int i = NErrorsDefined; i--;) {
+    nerr += errorCounts[i];
+  }
+  return nerr;
+}
+
+///_________________________________________________________________
+/// print link decoding statistics
+void GBTLinkDecodingStat::print(bool skipEmpty) const
+{
+  int nErr = 0;
+  for (int i = NErrorsDefined; i--;) {
+    nErr += errorCounts[i];
+  }
+  LOGF(INFO, "GBTLink#0x%d Packet States Statistics (total packets: %d)", ruLinkID, nPackets);
+  for (int i = 0; i < GBTDataTrailer::MaxStateCombinations; i++) {
+    if (packetStates[i]) {
+      std::bitset<GBTDataTrailer::NStatesDefined> patt(i);
+      LOGF(INFO, "counts for triggers B[%s] : %d", patt.to_string().c_str(), packetStates[i]);
+    }
+  }
+  LOGF(INFO, "Decoding errors: %u", nErr);
+  for (int i = 0; i < NErrorsDefined; i++) {
+    if (!skipEmpty || errorCounts[i]) {
+      LOGF(INFO, "%-70s: %u", ErrNames[i].data(), errorCounts[i]);
+    }
+  }
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -41,6 +41,7 @@
 #pragma link C++ class o2::itsmft::GBTLink + ;
 #pragma link C++ class o2::itsmft::RUDecodeData + ;
 #pragma link C++ class o2::itsmft::RawDecodingStat + ;
+#pragma link C++ class o2::itsmft::ChipStat + ;
 
 #pragma link C++ class std::map < unsigned long, std::pair < o2::itsmft::ClusterTopology, unsigned long>> + ;
 

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -47,5 +47,13 @@ void RUDecodeData::setROFInfo(ChipPixelData* chipData, const GBTLink* lnk)
   chipData->setInteractionRecord(lnk->ir);
 }
 
+///_________________________________________________________________
+/// fill chip decoding statistics
+void RUDecodeData::fillChipStatistics(int icab, const ChipPixelData* chipData)
+{
+  cableLinkPtr[icab]->chipStat.nHits += chipData->getData().size();
+  cableLinkPtr[icab]->chipStat.addErrors(chipData->getErrorFlags());
+}
+
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -39,7 +39,7 @@ RawPixelDecoder<Mapping>::RawPixelDecoder()
 ///______________________________________________________________
 ///
 template <class Mapping>
-void RawPixelDecoder<Mapping>::printReport() const
+void RawPixelDecoder<Mapping>::printReport(bool decstat, bool skipEmpty) const
 {
   LOGF(INFO, "%s Decoded %zu hits in %zu non-empty chips in %u ROFs with %d threads", mSelfName, mNPixelsFired, mNChipsFired, mROFCounter, mNThreads);
   double cpu = 0, real = 0;
@@ -57,6 +57,15 @@ void RawPixelDecoder<Mapping>::printReport() const
   real += tmrF.RealTime();
   LOGF(INFO, "%s Timing Total:     CPU = %.3e Real = %.3e in %d slots in %s mode", mSelfName, cpu, real, tmrS.Counter() - 1,
        mDecodeNextAuto ? "AutoDecode" : "ExternalCall");
+
+  if (decstat) {
+    LOG(INFO) << "GBT Links decoding statistics";
+    for (auto& lnk : mGBTLinks) {
+      LOG(INFO) << lnk.describe();
+      lnk.statistics.print(skipEmpty);
+      lnk.chipStat.print(skipEmpty);
+    }
+  }
 }
 
 ///______________________________________________________________
@@ -298,6 +307,16 @@ void RawPixelDecoder<Mapping>::setFormat(GBTLink::Format f)
 {
   assert(int(f) >= 0 && int(f) < GBTLink::NFormats);
   mFormat = f;
+}
+
+///______________________________________________________________________
+template <class Mapping>
+void RawPixelDecoder<Mapping>::clearStat()
+{
+  // clear statistics
+  for (auto& lnk : mGBTLinks) {
+    lnk.clear(true, false);
+  }
 }
 
 template class o2::itsmft::RawPixelDecoder<o2::itsmft::ChipMappingITS>;


### PR DESCRIPTION
When AlpideCoder is compiled with ``ALPIDE_DECODING_STAT`` defined, the chip decoding statistics and errors
will be filled in the ``ChipStat chipStat`` stuct of every GBT link.

All counters (also those of ``GBTLink::statistics`` for the link level errors) can be reset via ``RawPixelDecoder::clearStat()``.
Note that in ALPIDE_DECODING_STAT the decoding will add a chip to the list of non-empty chips
(i.e. it will be accessible by ``RawPixelDecoder::getNextChipData``) even if it had no any hit but had
at least 1 error set. These errors on the single trigger level can be accessed via
``uint32_t ChipPixelData::getErrorFlags()`` method, with each bit corresponding to ``ChipStat::DecErrors`` enum.
