### PR TITLE
DPL: do proper endOfStream for test_RegionInfoCallbackService

### DIFF
--- a/Framework/Core/test/test_RegionInfoCallbackService.cxx
+++ b/Framework/Core/test/test_RegionInfoCallbackService.cxx
@@ -34,6 +34,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
          auto& out = ctx.outputs().make<int>(OutputRef{"test", 0});
+         ctx.services().get<ControlService>().endOfStream();
+         ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
        }}},
     {"dest",
      Inputs{


### PR DESCRIPTION
Somehow breaks only during the threading setup.