### PR TITLE
TRD tracker can handle time frames instead of single collisions only

### DIFF
--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ struct o2::trd::TrackletMCMHeader + ;
 #pragma link C++ struct o2::trd::TrackletMCMData + ;
 #pragma link C++ class o2::trd::Tracklet64 + ;
+#pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::TriggerRecord > +;
 #pragma link C++ class std::vector < o2::trd::LinkRecord > +;
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -200,7 +200,7 @@ class propagatorInterface<o2::base::Propagator>
   propagatorInterface<o2::base::Propagator>(const propagatorInterface<o2::base::Propagator>&) = delete;
   propagatorInterface<o2::base::Propagator>& operator=(const propagatorInterface<o2::base::Propagator>&) = delete;
 
-  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep); }
+  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep, o2::base::Propagator::MatCorrType::USEMatCorrNONE); }
   int getPropagatedYZ(My_Float x, My_Float& projY, My_Float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
 
   void setTrack(trackInterface<o2::dataformats::TrackTPCITS>* trk) { mParam = trk; }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -80,6 +80,7 @@ class trackInterface<AliExternalTrackParam> : public AliExternalTrackParam
 
   const My_Float* getPar() const { return GetParameter(); }
   const My_Float* getCov() const { return GetCovariance(); }
+  float getTime() const { return -1.f; }
   bool CheckNumericalQuality() const { return true; }
 
   // parameter manipulation
@@ -179,11 +180,16 @@ class trackInterface<o2::dataformats::TrackTPCITS> : public o2::dataformats::Tra
     }
   }
 
-  const float* getPar() { return getParams(); }
+  const float* getPar() const { return getParams(); }
+  float getTime() const { return mTime; }
+  void setTime(float t) { mTime = t; }
 
   bool CheckNumericalQuality() const { return true; }
 
   typedef o2::dataformats::TrackTPCITS baseClass;
+
+ private:
+  float mTime;
 };
 
 template <>
@@ -294,6 +300,7 @@ class trackInterface<GPUTPCGMTrackParam> : public GPUTPCGMTrackParam
 
   GPUd() const float* getPar() const { return GetPar(); }
   GPUd() const float* getCov() const { return GetCov(); }
+  GPUd() float getTime() const { return -1.f; }
 
   GPUd() void setAlpha(float alpha) { mAlpha = alpha; }
   GPUd() void set(float x, float alpha, const float param[5], const float cov[15])
@@ -338,7 +345,6 @@ class propagatorInterface<GPUTPCGMPropagator> : public GPUTPCGMPropagator
   {
     //bool ok = PropagateToXAlpha(x, GetAlpha(), true) == 0 ? true : false;
     int retVal = PropagateToXAlpha(x, GetAlpha(), true);
-    printf("Return value of PropagateToXAlpha: %i\n", retVal);
     bool ok = (retVal == 0) ? true : false;
     ok = mTrack->CheckNumericalQuality();
     return ok;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -191,31 +191,13 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
 }
 
 template <class TRDTRK, class PROP>
-void GPUTRDTracker_t<TRDTRK, PROP>::Reset(bool fast)
+void GPUTRDTracker_t<TRDTRK, PROP>::Reset()
 {
   //--------------------------------------------------------------------
   // Reset tracker
   //--------------------------------------------------------------------
   mNTracklets = 0;
   mNTracks = 0;
-  if (fast) {
-    return;
-  }
-  for (int i = 0; i < mNMaxSpacePoints; ++i) {
-    mTracklets[i] = 0x0;
-    mSpacePoints[i].mR = 0.f;
-    mSpacePoints[i].mX[0] = 0.f;
-    mSpacePoints[i].mX[1] = 0.f;
-    mSpacePoints[i].mCov[0] = 0.f;
-    mSpacePoints[i].mCov[1] = 0.f;
-    mSpacePoints[i].mCov[2] = 0.f;
-    mSpacePoints[i].mDy = 0.f;
-    mSpacePoints[i].mId = 0;
-    mSpacePoints[i].mLabel[0] = -1;
-    mSpacePoints[i].mLabel[1] = -1;
-    mSpacePoints[i].mLabel[2] = -1;
-    mSpacePoints[i].mVolumeId = 0;
-  }
 }
 
 template <class TRDTRK, class PROP>

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -107,7 +107,7 @@ class GPUTRDTracker_t : public GPUProcessor
   short MemoryTracks() const { return mMemoryTracks; }
 
   GPUhd() void OverrideGPUGeometry(TRD_GEOMETRY_CONST GPUTRDGeometry* geo) { mGeo = geo; }
-  void Reset(bool fast = false);
+  void Reset();
   GPUd() int LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels = nullptr);
   //template <class T>
   GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1)

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -95,11 +95,10 @@ class GPUTRDTracker_t : public GPUProcessor
     int mCandidateId; // to which track candidate the hypothesis belongs
     int mTrackletId;  // tracklet index to be used for update
     float mChi2;      // predicted chi2 for given space point
-    float mChi2YZPhi; // not yet ready (see GetPredictedChi2 method in cxx file)
 
     GPUd() float GetReducedChi2() { return mLayers > 0 ? mChi2 / mLayers : mChi2; }
     GPUd() Hypothesis() : mLayers(0), mCandidateId(-1), mTrackletId(-1), mChi2(9999.f) {}
-    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2, float chi2YZPhi = -1.f) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2), mChi2YZPhi(chi2YZPhi) {}
+    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2, float chi2YZPhi = -1.f) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2) {}
   };
 
   short MemoryPermanent() const { return mMemoryPermanent; }
@@ -149,7 +148,6 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);
   GPUd() bool CalculateSpacePoints(int iCollision = 0);
   GPUd() bool FollowProlongation(PROP* prop, TRDTRK* t, int threadId, int collisionId);
-  GPUd() float GetPredictedChi2(const My_Float* pTRD, const My_Float* covTRD, const My_Float* pTrk, const My_Float* covTrk) const;
   GPUd() int GetDetectorNumber(const float zPos, const float alpha, const int layer) const;
   GPUd() bool AdjustSector(PROP* prop, TRDTRK* t, const int layer) const;
   GPUd() int GetSector(float alpha) const;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
@@ -95,9 +95,7 @@ class GPUTRDTrackerDebug
     fTrackYReal.ResizeTo(6);
     fTrackZReal.ResizeTo(6);
     fTrackSecReal.ResizeTo(6);
-    fChi2YZPhiUpdate.ResizeTo(6);
     fChi2Update.ResizeTo(6);
-    fChi2YZPhiReal.ResizeTo(6);
     fChi2Real.ResizeTo(6);
     fNmatchesAvail.ResizeTo(6);
     fFindable.ResizeTo(6);
@@ -151,9 +149,7 @@ class GPUTRDTrackerDebug
     fTrackYReal.Zero();
     fTrackZReal.Zero();
     fTrackSecReal.Zero();
-    fChi2YZPhiUpdate.Zero();
     fChi2Update.Zero();
-    fChi2YZPhiReal.Zero();
     fChi2Real.Zero();
     fNmatchesAvail.Zero();
     fFindable.Zero();
@@ -290,8 +286,6 @@ class GPUTRDTrackerDebug
   // update information
   void SetChi2Update(float chi2, int ly) { fChi2Update(ly) = chi2; }
   void SetChi2Real(float chi2, int ly) { fChi2Real(ly) = chi2; }
-  void SetChi2YZPhiUpdate(float chi2, int ly) { fChi2YZPhiUpdate(ly) = chi2; }
-  void SetChi2YZPhiReal(float chi2, int ly) { fChi2YZPhiReal(ly) = chi2; }
 
   // other infos
   void SetRoad(float roadY, float roadZ, int ly)
@@ -370,8 +364,6 @@ class GPUTRDTrackerDebug
       "trackletDetReal.=" << &fTrackletDetReal <<          // detector number for matching or related tracklet if available, otherwise -1
       "chi2Update.=" << &fChi2Update <<                    // chi2 for update
       "chi2Real.=" << &fChi2Real <<                        // chi2 for first tracklet w/ matching MC label
-      "chi2YZPhiUpdate.=" << &fChi2YZPhiUpdate <<          // chi2 for update taking into account full tracklet information (y, z, dY aka sin(phi))
-      "chi2YZPhiReal.=" << &fChi2YZPhiReal <<              // chi2 for first tracklet w/ matching MC label taking into account full tracklet information (y, z, dY aka sin(phi))
       "chi2Total=" << fChi2 <<                             // total chi2 for track
       "nLayers=" << fNlayers <<                            // number of layers in which track was findable
       "nTracklets=" << fNtrklts <<                         // number of attached tracklets
@@ -456,8 +448,6 @@ class GPUTRDTrackerDebug
   TVectorF fTrackletDetReal;
   TVectorF fChi2Update;
   TVectorF fChi2Real;
-  TVectorF fChi2YZPhiUpdate;
-  TVectorF fChi2YZPhiReal;
   TVectorF fRoadY;
   TVectorF fRoadZ;
   TVectorF fFindable;
@@ -512,7 +502,6 @@ class GPUTRDTrackerDebug
   GPUd() void SetChi2Update(float chi2, int ly) {}
   GPUd() void SetChi2Real(float chi2, int ly) {}
   GPUd() void SetChi2YZPhiUpdate(float chi2, int ly) {}
-  GPUd() void SetChi2YZPhiReal(float chi2, int ly) {}
 
   // other infos
   GPUd() void SetRoad(float roadY, float roadZ, int ly) {}

--- a/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
+++ b/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
@@ -15,24 +15,29 @@
 #include "GPUTRDGeometry.h"
 
 // O2 header
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "CommonConstants/LHCConstants.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
 #include "TRDBase/Tracklet.h"
+#include "DataFormatsTRD/TriggerRecord.h"
 
 #endif
 
 using namespace GPUCA_NAMESPACE::gpu;
 
 void run_trd_tracker(std::string path = "./",
-                     std::string inputGRP = "o2sim_grp.root",
                      std::string inputTracks = "o2match_itstpc.root",
                      std::string inputTracklets = "trdtracklets.root")
 {
+  //-------- debug time information from tracks and tracklets
+  std::vector<float> trdTriggerTimes;
+  std::vector<int> trdTriggerIndices;
 
   //-------- init geometry and field --------//
-  o2::base::GeometryManager::loadGeometry(path);
-  o2::base::Propagator::initFieldFromGRP(path + inputGRP);
+  o2::base::GeometryManager::loadGeometry();
+  o2::base::Propagator::initFieldFromGRP(o2::base::NameConf::getGRPFileName());
 
   auto geo = o2::trd::TRDGeometry::instance();
   geo->createPadPlaneArray();
@@ -43,9 +48,11 @@ void run_trd_tracker(std::string path = "./",
   GPUSettingsEvent cfgEvent;                       // defaults should be ok
   GPUSettingsRec cfgRec;                           // don't care for now, NWaysOuter is set in here for instance
   GPUSettingsProcessing cfgDeviceProcessing;       // also keep defaults here, or adjust debug level
-  cfgDeviceProcessing.debugLevel = 10;
+  cfgDeviceProcessing.debugLevel = 5;
   GPURecoStepConfiguration cfgRecoStep;
   cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
+  cfgRecoStep.inputs.clear();
+  cfgRecoStep.outputs.clear();
   auto rec = GPUReconstruction::CreateInstance("CPU", true);
   rec->SetSettings(&cfgEvent, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
 
@@ -53,12 +60,14 @@ void run_trd_tracker(std::string path = "./",
 
   auto tracker = new GPUTRDTracker();
   tracker->SetNCandidates(1); // must be set before initialization
+  tracker->SetProcessPerTimeFrame();
+  tracker->SetNMaxCollisions(100);
 
   rec->RegisterGPUProcessor(tracker, false);
   chainTracking->SetTRDGeometry(&geoFlat);
-  tracker->SetTrackingChain(chainTracking);
-  rec->Init();
-  rec->AllocateRegisteredMemory(nullptr);
+  if (rec->Init()) {
+    printf("ERROR: GPUReconstruction not initialized\n");
+  }
 
   // configure the tracker
   //tracker->EnableDebugOutput();
@@ -85,23 +94,34 @@ void run_trd_tracker(std::string path = "./",
   TChain trdTracklets("o2sim");
   trdTracklets.AddFile((path + inputTracklets).c_str());
 
+  std::vector<o2::trd::TriggerRecord>* triggerRecordsInArrayPtr = nullptr;
+  trdTracklets.SetBranchAddress("TrackTrg", &triggerRecordsInArrayPtr);
   std::vector<o2::trd::Tracklet>* trackletsInArrayPtr = nullptr;
   trdTracklets.SetBranchAddress("Tracklet", &trackletsInArrayPtr);
   trdTracklets.GetEntry(0);
+  int nCollisions = triggerRecordsInArrayPtr->size();
   int nTracklets = trackletsInArrayPtr->size();
-  printf("There are %i tracklets in total\n", nTracklets);
+  printf("There are %i tracklets in total from %i trigger records\n", nTracklets, nCollisions);
 
-  auto pp = geo->getPadPlane(0, 0);
-  printf("Tilt=%f\n", pp->getTiltingAngle());
+  for (int iEv = 0; iEv < nCollisions; ++iEv) {
+    o2::trd::TriggerRecord& trg = triggerRecordsInArrayPtr->at(iEv);
+    int nTrackletsCurrent = trg.getNumberOfObjects();
+    int iFirstTracklet = trg.getFirstEntry();
+    int64_t evTime = trg.getBCData().toLong() * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
+    trdTriggerTimes.push_back(evTime / 1000.);
+    trdTriggerIndices.push_back(iFirstTracklet);
+    printf("Event %i: Occured at %li us after SOR, contains %i tracklets, index of first tracklet is %i\n", iEv, evTime / 1000, nTrackletsCurrent, iFirstTracklet);
+  }
 
-  tracker->Reset(true);
+  tracker->Reset();
 
   chainTracking->mIOPtrs.nMergedTracks = nTracks;
   chainTracking->mIOPtrs.nTRDTracklets = nTracklets;
   chainTracking->AllocateIOMemory();
   rec->PrepareEvent();
-  rec->AllocateRegisteredMemory(tracker->MemoryTracks());
+  rec->SetupGPUProcessor(tracker, true);
 
+  printf("Start loading input into TRD tracker\n");
   // load everything into the tracker
   for (int iTrk = 0; iTrk < nTracks; ++iTrk) {
     auto trk = tracksInArrayPtr->at(iTrk);
@@ -114,8 +134,11 @@ void run_trd_tracker(std::string path = "./",
     for (int i = 0; i < 15; ++i) {
       trkLoad.setCov(trk.getCov()[i], i);
     }
+    trkLoad.setTime(trk.getTimeMUS().getTimeStamp());
     tracker->LoadTrack(trkLoad);
+    printf("Loaded track %i with time %f\n", iTrk, trkLoad.getTime());
   }
+
   for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
     auto trklt = trackletsInArrayPtr->at(iTrklt);
     unsigned int trkltWord = trklt.getTrackletWord();
@@ -127,9 +150,11 @@ void run_trd_tracker(std::string path = "./",
       printf("Could not load tracklet %i\n", iTrklt);
     }
   }
+  tracker->SetTriggerRecordTimes(&(trdTriggerTimes[0]));
+  tracker->SetTriggerRecordIndices(&(trdTriggerIndices[0]));
+  tracker->SetNCollisions(nCollisions);
   tracker->DumpTracks();
-  tracker->DoTracking();
+  tracker->DoTracking(chainTracking);
   tracker->DumpTracks();
-
   printf("Done\n");
 }

--- a/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
+++ b/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
@@ -19,13 +19,24 @@
 #include "CommonConstants/LHCConstants.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
+#include "TRDBase/TRDGeometry.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
-#include "TRDBase/Tracklet.h"
+#include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 
 #endif
 
 using namespace GPUCA_NAMESPACE::gpu;
+
+unsigned int convertTrkltWordToRun2Format(uint64_t trkltWordRun3)
+{
+  // FIXME: this is currently a dummy function
+  // need proper functionality to convert the new tracklet data format to
+  // something compatible with the TRD tracker, but this macro is probably
+  // not the right place for this
+  unsigned int trkltWord = 0;
+  return trkltWord;
+}
 
 void run_trd_tracker(std::string path = "./",
                      std::string inputTracks = "o2match_itstpc.root",
@@ -96,7 +107,7 @@ void run_trd_tracker(std::string path = "./",
 
   std::vector<o2::trd::TriggerRecord>* triggerRecordsInArrayPtr = nullptr;
   trdTracklets.SetBranchAddress("TrackTrg", &triggerRecordsInArrayPtr);
-  std::vector<o2::trd::Tracklet>* trackletsInArrayPtr = nullptr;
+  std::vector<o2::trd::Tracklet64>* trackletsInArrayPtr = nullptr;
   trdTracklets.SetBranchAddress("Tracklet", &trackletsInArrayPtr);
   trdTracklets.GetEntry(0);
   int nCollisions = triggerRecordsInArrayPtr->size();
@@ -141,10 +152,10 @@ void run_trd_tracker(std::string path = "./",
 
   for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
     auto trklt = trackletsInArrayPtr->at(iTrklt);
-    unsigned int trkltWord = trklt.getTrackletWord();
+    unsigned int trkltWord = convertTrkltWordToRun2Format(trklt.getTrackletWord());
     GPUTRDTrackletWord trkltLoad;
     trkltLoad.SetId(iTrklt);
-    trkltLoad.SetHCId(trklt.getHCId());
+    trkltLoad.SetHCId(trklt.getHCID());
     trkltLoad.SetTrackletWord(trkltWord);
     if (tracker->LoadTracklet(trkltLoad) > 0) {
       printf("Could not load tracklet %i\n", iTrklt);


### PR DESCRIPTION
Hi @davidrohr 
thanks a lot for providing the fix for the standalone build! The floating point exception was caused by a function I had implemented to check the chi 2 calculation. This function is not needed, so I simply removed it.
Unfortunately, currently I can only run the tracking with the standalone framework. When I try to execute the macro `GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C` in O2 I get a segfault and an error from `o2::gpu::GPUChain::AllocateIOMemoryHelper`. Did the memory allocation mechanism for the reconstruction chain change? I paste the full error log below. In AliRoot I see the same error.
Cheers,
Ole

#6  0x00007ff99d0bf666 in o2::gpu::GPUChain::AllocateIOMemoryHelper<o2::tpc::ClusterNative> (this=0x55dadb078220, u=std::unique_ptr<struct o2::tpc::ClusterNative []> = {...}, ptr=<error reading variable>, n=<error reading variable: Cannot access memory at address 0x156a0>) at /home/oschmidt/alice/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Global/GPUChain.h:125
#7  o2::gpu::GPUChainTracking::AllocateIOMemory (this=0x55dadb078220) at /home/oschmidt/alice/sw/SOURCES/O2/v1.2.0/0/GPU/GPUTracking/Global/GPUChainTracking.cxx:462
#8  0x00007ff9926f045c in run_trd_tracker(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) () from /home/oschmidt/alice/O2/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker_C.so