### PR TITLE
Add method to enforce oldest slot finalization/removal

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -52,6 +52,7 @@ class TimeSlotCalibration
 
   virtual bool process(TFType tf, const gsl::span<const Input> data);
   virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
+  virtual void finalizeOldestSlot();
 
   // Methods to be implemented by the derived user class
 
@@ -134,6 +135,20 @@ void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int 
       break;
     }
   }
+}
+
+//_________________________________________________
+template <typename Input, typename Container>
+void TimeSlotCalibration<Input, Container>::finalizeOldestSlot()
+{
+  // Enforce finalization and removal of the oldest slot
+  if (mSlots.empty()) {
+    LOG(WARNING) << "There are no slots defined";
+    return;
+  }
+  finalizeSlot(mSlots.front());
+  mLastClosedTF = mSlots.front().getTFEnd() + 1; // do not accept any TF below this
+  mSlots.erase(mSlots.begin());
 }
 
 //________________________________________


### PR DESCRIPTION
@mfasDa the workflow  https://github.com/AliceO2Group/AliceO2/blob/dev/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h of @chiarazampolli has almost everything you need to run the calibration in a way we discussed. You will need to

1. call ``setUpdateAtTheEndOfRunOnly()`` in your workflow with ``TimeSlotCalibration``-based calibration class, see e.g. https://github.com/AliceO2Group/AliceO2/blob/985099d9f87094f1de830b402d31bc9f0df17d1d/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h#L51
This will ensure that the accumulation will be done on a unique slot, whatever the TF id you are processing and there will be no attempt to automatically finalize it during the processing.

2. if you need to close this unique slot (due to the PAR or other reason) you can call the method I've just added: ``finalizeOldestSlot()`` which unconditionally will trigger your ``finalizeSlot`` method and remove the slot. Then the following call to ``getSlotForTF(tf)`` will create a new slot. You could also call ``checkSlotsToFinalize(0xffffffffffffffff)``, it will do effectively the same but after the check for ``hasEnoughData`` (the slot will be discarded if there are no enough data).

3. in the ``endOfStream`` you need to close the slot in a same way, by calling either ``finalizeOldestSlot()`` or ``checkSlotsToFinalize(0xffffffffffffffff)``.