### PR TITLE
DPL Analysis: first draft for more generic index binding

### DIFF
--- a/Analysis/Tutorials/src/associatedExample.cxx
+++ b/Analysis/Tutorials/src/associatedExample.cxx
@@ -67,7 +67,7 @@ struct BTask {
     LOGF(INFO, "ID: %d", collision.globalIndex());
     LOGF(INFO, "Tracks: %d", extTracks.size());
     for (auto& track : extTracks) {
-      LOGF(INFO, "(%f, %f) - (%f, %f)", track.eta(), track.phi(), track.etas(), track.phis());
+      LOGF(INFO, "(%f, %f) - (%f, %f)", track.eta(), track.phiraw(), track.etas(), track.phis());
     }
   }
 };

--- a/Analysis/Tutorials/src/associatedExample.cxx
+++ b/Analysis/Tutorials/src/associatedExample.cxx
@@ -15,15 +15,13 @@ namespace o2::aod
 {
 namespace etaphi
 {
-DECLARE_SOA_COLUMN(Eta, etas, float);
-DECLARE_SOA_COLUMN(Phi, phis, float);
-DECLARE_SOA_COLUMN(Pt, pts, float);
+DECLARE_SOA_COLUMN(AEta, etas, float);
+DECLARE_SOA_COLUMN(APhi, phis, float);
+DECLARE_SOA_COLUMN(APt, pts, float);
 } // namespace etaphi
 
 DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
-                  etaphi::Eta, etaphi::Phi);
-DECLARE_SOA_TABLE(EtaPhiPt, "AOD", "ETAPHIPT",
-                  etaphi::Eta, etaphi::Phi, etaphi::Pt);
+                  etaphi::AEta, etaphi::APhi);
 
 namespace collision
 {
@@ -43,16 +41,13 @@ using namespace o2::framework;
 //        we need GCC 7.4+ for that
 struct ATask {
   Produces<aod::EtaPhi> etaphi;
-  Produces<aod::EtaPhiPt> etaphipt;
 
   void process(aod::Tracks const& tracks)
   {
     for (auto& track : tracks) {
       float phi = asin(track.snp()) + track.alpha() + static_cast<float>(M_PI);
       float eta = log(tan(0.25f * static_cast<float>(M_PI) - 0.5f * atan(track.tgl())));
-      float pt = 1.f / track.signed1Pt();
       etaphi(eta, phi);
-      etaphipt(eta, phi, pt);
     }
   }
 };
@@ -77,18 +72,15 @@ struct BTask {
   }
 };
 
-struct CTask {
-  void process(aod::Collision const& collision, soa::Concat<aod::EtaPhi, aod::EtaPhiPt> const& concatenated)
-  {
-    LOGF(INFO, "ID: %d", collision.globalIndex());
-    LOGF(INFO, "Tracks: %d", concatenated.size());
-  }
-};
-
 struct TTask {
+  using myCol = soa::Join<aod::Collisions, aod::CollisionsExtra>;
   void process(soa::Join<aod::Collisions, aod::CollisionsExtra>::iterator const& col, aod::Tracks const& tracks)
   {
-    LOGF(INFO, "ID: %d; %d == %d", col.globalIndex(), col.mult(), tracks.size());
+    LOGF(INFO, "[direct] ID: %d; %d == %d", col.globalIndex(), col.mult(), tracks.size());
+    if (tracks.size() > 0) {
+      auto track0 = tracks.begin();
+      LOGF(INFO, "[index ] ID: %d; %d == %d", track0.collision_as<myCol>().globalIndex(), track0.collision_as<myCol>().mult(), tracks.size());
+    }
   }
 };
 
@@ -97,7 +89,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   return WorkflowSpec{
     adaptAnalysisTask<ATask>("produce-etaphi"),
     adaptAnalysisTask<BTask>("consume-etaphi"),
-    adaptAnalysisTask<CTask>("consume-etaphi-twice"),
     adaptAnalysisTask<MTask>("produce-mult"),
     adaptAnalysisTask<TTask>("consume-mult")};
 }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1242,7 +1242,7 @@ constexpr auto is_binding_compatible_v()
     template <typename T>                                                          \
     bool setCurrent(T* current)                                                    \
     {                                                                              \
-      if constexpr (soa::is_binding_compatible_v<T, binding_t>()) {                \
+      if constexpr (o2::soa::is_binding_compatible_v<T, binding_t>()) {            \
         assert(current != nullptr);                                                \
         this->mBinding = current;                                                  \
         return true;                                                               \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1114,7 +1114,7 @@ template <typename T1, typename T2>
 constexpr auto is_binding_compatible_v()
 {
   return framework::pack_size(
-           framework::intersected_pack_t<typename T1::table_t::persistent_columns_t, typename T2::table_t::persistent_columns_t>{}) > 0;
+           framework::intersected_pack_t<originals_pack_t<T1>, originals_pack_t<T2>>{}) > 0;
 }
 
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1110,6 +1110,13 @@ using JoinBase = decltype(join(std::declval<Ts>()...));
 template <typename T1, typename T2>
 using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
 
+template <typename T1, typename T2>
+constexpr auto is_binding_compatible_v()
+{
+  return framework::pack_size(
+           framework::intersected_pack_t<typename T1::table_t::persistent_columns_t, typename T2::table_t::persistent_columns_t>{}) > 0;
+}
+
 } // namespace o2::soa
 
 #define DECLARE_SOA_STORE()          \
@@ -1220,24 +1227,30 @@ using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
       return *mColumnIterator >= 0;                                                \
     }                                                                              \
                                                                                    \
-    binding_t::iterator _Getter_() const                                           \
+    template <typename T>                                                          \
+    auto _Getter_##_as() const                                                     \
     {                                                                              \
       assert(mBinding != nullptr);                                                 \
-      return mBinding->begin() + *mColumnIterator;                                 \
+      return static_cast<T*>(mBinding)->begin() + *mColumnIterator;                \
+    }                                                                              \
+                                                                                   \
+    auto _Getter_() const                                                          \
+    {                                                                              \
+      return _Getter_##_as<binding_t>();                                           \
     }                                                                              \
                                                                                    \
     template <typename T>                                                          \
     bool setCurrent(T* current)                                                    \
     {                                                                              \
-      if constexpr (std::is_same_v<T, binding_t>) {                                \
+      if constexpr (soa::is_binding_compatible_v<T, binding_t>()) {                \
         assert(current != nullptr);                                                \
         this->mBinding = current;                                                  \
         return true;                                                               \
       }                                                                            \
       return false;                                                                \
     }                                                                              \
-    binding_t* getCurrent() { return mBinding; }                                   \
-    binding_t* mBinding = nullptr;                                                 \
+    binding_t* getCurrent() { return static_cast<binding_t*>(mBinding); }          \
+    void* mBinding = nullptr;                                                      \
   };                                                                               \
   static const o2::framework::expressions::BindingNode _Getter_##Id { _Label_,     \
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -186,13 +186,13 @@ constexpr std::size_t has_type_at_t = decltype(select<W>(
 } // namespace
 
 template <typename W>
-constexpr std::size_t has_type_at_v(o2::framework::pack<> p)
+constexpr std::size_t has_type_at_v(o2::framework::pack<>)
 {
   return -1;
 }
 
 template <typename W, typename... Ts>
-constexpr std::size_t has_type_at_v(o2::framework::pack<Ts...> p)
+constexpr std::size_t has_type_at_v(o2::framework::pack<Ts...>)
 {
   return has_type_at_t<W, Ts...>;
 }


### PR DESCRIPTION
* Index columns will now be bound not only to the origin type they were declared with, but also to any compatible (i.e. containing same columns) table type. In data model all indices should refer to the "smallest" origin table type with least columns, to make them more generic.
* Default index getter still uses the declared binding, to get correct binding one needs to use templated version:

```
using myCol = soa::Join<aod::Collisions, aod::CollisionsExtra>;
auto id = track0.collision_as<myCol>().globalIndex();
```
