### PR TITLE
Introduction of fired channels in ZDC digitization

### DIFF
--- a/DataFormats/Detectors/ZDC/src/BCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/BCData.cxx
@@ -24,7 +24,7 @@ void BCData::print() const
       printf("%s ", channelName(ic));
     }
   }
-  printf("] Triggered: [");
+  printf("] Hits: [");
   for (int ic = 0; ic < NChannels; ic++) {
     if (triggers & (0x1 << ic)) {
       printf("%s ", channelName(ic));

--- a/Detectors/ZDC/base/include/ZDCBase/Constants.h
+++ b/Detectors/ZDC/base/include/ZDCBase/Constants.h
@@ -54,7 +54,9 @@ constexpr int NChannels = 2 * (NChannelsZN + NChannelsZP) + NChannelsZEM;
 constexpr uint32_t AllChannelsMask = (0x1 << NChannels) - 1;
 
 constexpr int NModules = 8;
-constexpr int MaxTriggerChannels = 10;
+constexpr int NChPerModule = 4;
+constexpr int NWPerBc = 3;
+constexpr int MaxTriggerChannels = NChannels;
 
 constexpr int MaxTDCValues = 5;  // max number of TDC values to store in reconstructed event
 constexpr int NTDCChannels = 10; // max number of TDC values to store in reconstructed event

--- a/Detectors/ZDC/base/src/ModuleConfig.cxx
+++ b/Detectors/ZDC/base/src/ModuleConfig.cxx
@@ -26,7 +26,7 @@ void Module::print() const
     const auto& cnf = trigChannelConf[ic];
     if (trigChannel[ic]) {
       printf("[TRIG %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
-    }else if (cnf.shift > 0 && cnf.threshold > 0){
+    } else if (cnf.shift > 0 && cnf.threshold > 0) {
       printf("[DISC %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
     }
   }
@@ -76,7 +76,7 @@ void Module::setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig
   // Therefore we put the trig flag just for the triggering channels
   // Discriminator parameters are stored for all modules
   trigChannel[slot] = trig;
-  if (tS>0 && tT>0) { 
+  if (tS > 0 && tT > 0) {
     if (tL + tS + 1 >= NTimeBinsPerBC) {
       LOG(FATAL) << "Sum of Last and Shift trigger parameters exceed allowed range";
     }

--- a/Detectors/ZDC/base/src/ModuleConfig.cxx
+++ b/Detectors/ZDC/base/src/ModuleConfig.cxx
@@ -23,9 +23,11 @@ void Module::print() const
   printf("\n");
   printf("Trigger conf: ");
   for (int ic = 0; ic < MaxChannels; ic++) {
+    const auto& cnf = trigChannelConf[ic];
     if (trigChannel[ic]) {
-      const auto& cnf = trigChannelConf[ic];
-      printf("[%s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
+      printf("[TRIG %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
+    }else if (cnf.shift > 0 && cnf.threshold > 0){
+      printf("[DISC %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
     }
   }
   printf("\n");
@@ -70,8 +72,11 @@ void Module::setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig
   linkID[slot] = lID;
   channelID[slot] = chID;
   readChannel[slot] = read;
+  // In the 2020 firmware implementation, autotrigger bits are computed for each channel
+  // Therefore we put the trig flag just for the triggering channels
+  // Discriminator parameters are stored for all modules
   trigChannel[slot] = trig;
-  if (trig) {
+  if (tS>0 && tT>0) { 
     if (tL + tS + 1 >= NTimeBinsPerBC) {
       LOG(FATAL) << "Sum of Last and Shift trigger parameters exceed allowed range";
     }

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -32,14 +32,16 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
   int modID;
 
   //-------------------------------------------
+  // Up to 8 modules with four channels
+  // setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig = false, int tF = 0, int tL = 0, int tS = 0, int tT = 0)
   {
     modID = 0;
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNAC, 0, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 1, false, false);
-    module.setChannel(2, IdZNA1, 2, true, false);
-    module.setChannel(3, IdZNA2, 3, true, false);
+    module.setChannel(1, IdZNASum, 1, false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA1, 2, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA2, 3, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -48,9 +50,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNAC, 4, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 5, true, false);
-    module.setChannel(2, IdZNA3, 6, true, false);
-    module.setChannel(3, IdZNA4, 7, true, false);
+    module.setChannel(1, IdZNASum, 5, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA3, 6, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA4, 7, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -59,9 +61,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNCC, 8, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 9, false, false);
-    module.setChannel(2, IdZNC1, 10, true, false);
-    module.setChannel(3, IdZNC2, 11, true, false);
+    module.setChannel(1, IdZNCSum, 9, false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC1, 10, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC2, 11, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -70,9 +72,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNCC, 12, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 13, true, false);
-    module.setChannel(2, IdZNC3, 14, true, false);
-    module.setChannel(3, IdZNC4, 15, true, false);
+    module.setChannel(1, IdZNCSum, 13, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC3, 14, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC4, 15, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -82,8 +84,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPAC, 16, true, true, -5, 6, 4, 12);
     module.setChannel(1, IdZEM1, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPA1, 17, true, false);
-    module.setChannel(3, IdZPA2, 17, true, false);
+    module.setChannel(2, IdZPA1, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA2, 17, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -92,9 +94,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZPAC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPASum, 18, true, false);
-    module.setChannel(2, IdZPA3, 19, true, false);
-    module.setChannel(3, IdZPA4, 19, true, false);
+    module.setChannel(1, IdZPASum, 18, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPA3, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA4, 19, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -104,8 +106,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPCC, 16, true, true, -5, 6, 4, 12);
     module.setChannel(1, IdZEM2, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC1, 17, true, false);
-    module.setChannel(3, IdZPC2, 17, true, false);
+    module.setChannel(2, IdZPC1, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC2, 17, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -114,9 +116,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZPCC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPCSum, 18, true, false);
-    module.setChannel(2, IdZPC3, 19, true, false);
-    module.setChannel(3, IdZPC4, 19, true, false);
+    module.setChannel(1, IdZPCSum, 18, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPC3, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC4, 19, true, false, -5, 6, 4, 12);
     //
   }
   conf.check();

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -49,8 +49,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZNAC, 4, false, true, -5, 6, 4, 12);
     module.setChannel(1, IdZNASum, 5, true, false);
-    module.setChannel(2, IdZNA1, 6, true, false);
-    module.setChannel(3, IdZNA2, 7, true, false);
+    module.setChannel(2, IdZNA3, 6, true, false);
+    module.setChannel(3, IdZNA4, 7, true, false);
     //
   }
   //-------------------------------------------
@@ -93,8 +93,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPAC, 18, false, true, -5, 6, 4, 12);
     module.setChannel(1, IdZPASum, 18, true, false);
-    module.setChannel(2, IdZPA1, 19, true, false);
-    module.setChannel(3, IdZPA2, 19, true, false);
+    module.setChannel(2, IdZPA3, 19, true, false);
+    module.setChannel(3, IdZPA4, 19, true, false);
     //
   }
   //-------------------------------------------

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -40,11 +40,11 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
   std::string ShapeName[o2::zdc::NChannels] = {
     "znatc", "znatc", "znatc", "znatc", "znatc", "znatc", // ZNAC, ZNA1, ZNA2, ZNA3, ZNA4, ZNAS (shape not used)
     "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", // ZPAC, ZPA1, ZPA2, ZPA3, ZPA4, ZPAS (shape not used)
-    "zem2","zem2",					  // ZEM1, ZEM2
+    "zem2", "zem2",                                       // ZEM1, ZEM2
     "znctc", "znctc", "znctc", "znctc", "znctc", "znctc", // ZNCC, ZNC1, ZNC2, ZNC3, ZNC4, ZNCS (shape not used)
     "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc"  // ZPCC, ZPC1, ZPC2, ZPC3, ZPC4, ZPCS (shape not used)
   };
-  
+
   for (int ic = 0; ic < o2::zdc::NChannels; ic++) {
 
     auto& channel = conf.channels[ic];

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -35,6 +35,16 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
   const float Gains[5] = {15.e-3, 30.e-3, 100.e-3, 15.e-3, 30.e-3}; // gain (response per photoelectron)
   const float fudgeFactor = 2.7;                                    // ad hoc factor to tune the gain in the MC
 
+  // Source of line shapes, pedestal and noise for each channel
+  // Missing histos for: towers 1-4 of all calorimeters, zem1, all towers of zpc
+  std::string ShapeName[o2::zdc::NChannels] = {
+    "znatc", "znatc", "znatc", "znatc", "znatc", "znatc", // ZNAC, ZNA1, ZNA2, ZNA3, ZNA4, ZNAS (shape not used)
+    "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", // ZPAC, ZPA1, ZPA2, ZPA3, ZPA4, ZPAS (shape not used)
+    "zem2","zem2",					  // ZEM1, ZEM2
+    "znctc", "znctc", "znctc", "znctc", "znctc", "znctc", // ZNCC, ZNC1, ZNC2, ZNC3, ZNC4, ZNCS (shape not used)
+    "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc"  // ZPCC, ZPC1, ZPC2, ZPC3, ZPC4, ZPCS (shape not used)
+  };
+  
   for (int ic = 0; ic < o2::zdc::NChannels; ic++) {
 
     auto& channel = conf.channels[ic];
@@ -43,9 +53,7 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
     //
     channel.gain = (tower != o2::zdc::Sum) ? fudgeFactor * Gains[det - 1] : 1.0;
     //
-    // at the moment we use wf_znatc histo for all channels, to be fixed when
-    // more histos are created. So, we read in the loop the same histo
-    std::string histoShapeName = "hw_znatc";
+    std::string histoShapeName = "hw_" + ShapeName[ic];
     TH1* histoShape = (TH1*)sourceData.GetObjectUnchecked(histoShapeName.c_str());
     if (!histoShape) {
       LOG(FATAL) << "Failed to extract the shape histogram  " << histoShapeName;
@@ -72,14 +80,14 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
     //
     channel.pedestal = gRandom->Gaus(1800., 30.);
     //
-    std::string histoPedNoiseName = "hb_znatc"; // same comment here (at the moment the same histo used)
+    std::string histoPedNoiseName = "hb_" + ShapeName[ic];
     TH1* histoPedNoise = (TH1*)sourceData.GetObjectUnchecked(histoPedNoiseName.c_str());
     if (!histoPedNoise) {
       LOG(FATAL) << "Failed to extract the pedestal noise histogram  " << histoPedNoise;
     }
     channel.pedestalNoise = histoPedNoise->GetRMS();
     //
-    std::string histoPedFluctName = "hp_znatc"; // same comment here (at the moment the same histo used)
+    std::string histoPedFluctName = "hp_" + ShapeName[ic];
     TH1* histoPedFluct = (TH1*)sourceData.GetObjectUnchecked(histoPedFluctName.c_str());
     if (!histoPedFluct) {
       LOG(FATAL) << "Failed to extract the pedestal fluctuation histogram  " << histoPedFluct;

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that can actually trigger a module
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -133,7 +133,7 @@ class Digitizer
   o2::InteractionTimeRecord mIR;
   std::deque<o2::InteractionRecord> mIRExternalTrigger; // IRs of externally provided triggered (at the moment MC sampled interactions)
 
-  std::deque<BCCache> mCache; // cached BCs data
+  std::deque<BCCache> mCache;                                    // cached BCs data
   std::array<std::vector<int16_t>, NChannels> mTrigChannelsData; // buffer for fast access to triggered channels data
   int mTrigBinMin = 0xffff;                                      // prefetched min and max
   int mTrigBinMax = -0xffff;                                     // bins to be checked for trigger
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that can actually trigger a module
+  uint32_t mTriggerableChanMask = 0;                ///< mask of digital discriminators that can actually trigger a module
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -41,7 +41,7 @@ class Digitizer
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
-    static constexpr uint32_t AllChannelsMask = 0x1 << NChannels;
+    static constexpr uint32_t AllChannelsMask = 0x80000000;
 
     BCCache();
 

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t triggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -35,12 +35,12 @@ class Digitizer
   using ChannelBCDataF = std::array<float, NTimeBinsPerBC>;
 
  public:
+  uint32_t triggerableChanMask = 0; // mask of triggerable channels IDs
   struct BCCache : public o2::InteractionRecord {
     std::array<ChannelBCDataF, NChannels> data = {};
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
-    uint32_t trigChanMask = 0; // mask of triggered channels IDs
     static constexpr uint32_t AllChannelsMask = 0x1 << NChannels;
 
     BCCache();
@@ -143,6 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
+  uint32_t trigChanMask = 0;			    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -35,12 +35,12 @@ class Digitizer
   using ChannelBCDataF = std::array<float, NTimeBinsPerBC>;
 
  public:
-  uint32_t triggerableChanMask = 0; // mask of triggerable channels IDs
   struct BCCache : public o2::InteractionRecord {
     std::array<ChannelBCDataF, NChannels> data = {};
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
+    uint32_t trigChanMask = 0; // mask of triggered channels IDs
     static constexpr uint32_t AllChannelsMask = 0x80000000;
 
     BCCache();
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t trigChanMask = 0;			    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t triggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -226,7 +226,7 @@ bool Digitizer::triggerBC(int ibc)
     for (int ic = mTriggerConfig.size(); ic--;) {
       const auto& trigCh = mTriggerConfig[ic];
       bool okPrev = false;
-      int last1 = trigCh.last + 2;
+      int last1 = trigCh.last + 2; // To be modified. The new requirement is 3 consecutive samples
       // look for 2 consecutive bins (the 1st one spanning trigCh.first : trigCh.last range) so that
       // signal[bin]-signal[bin+trigCh.shift] > trigCh.threshold
       for (int ib = trigCh.first; ib < last1; ib++) { // ib may be negative, so we shift by offs and look in the ADC cache
@@ -237,7 +237,7 @@ bool Digitizer::triggerBC(int ibc)
         bool ok = bcF.data[trigCh.id][binF] - bcL.data[trigCh.id][binL] > trigCh.threshold;
         if (ok && okPrev) {                          // trigger ok!
           bcCached.trigChanMask |= 0x1 << trigCh.id; // register trigger mask
-          LOG(DEBUG) << " triggering channel " << int(trigCh.id) << " => " << bcCached.trigChanMask;
+          LOG(DEBUG) << " triggering channel " << int(trigCh.id) << "(" << ChannelNames[trigCh.id] << ") => " << bcCached.trigChanMask;
           break;
         }
         okPrev = ok;
@@ -251,7 +251,7 @@ bool Digitizer::triggerBC(int ibc)
     }
   }
 
-  if (bcCached.trigChanMask) { // there are triggered channels, flag modules/channels to read
+  if (bcCached.trigChanMask & triggerableChanMask) { // there are triggered channels, flag modules/channels to read
     for (int ibcr = ibc - mNBCAHead; ibcr <= ibc; ibcr++) {
       auto& bcr = mStoreChanMask[ibcr + mNBCAHead];
       for (const auto& mdh : mModConfAux) {
@@ -398,11 +398,10 @@ void Digitizer::refreshCCDB()
     for (const auto& md : mModuleConfig->modules) {
       if (md.id >= 0) {
         mModConfAux.emplace_back(md);
-        //
         for (int ic = Module::MaxChannels; ic--;) {
-          if (md.trigChannel[ic]) { // check if this triggering channel was already registered
+          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift>0 && md.trigChannelConf[ic].threshold>0)) {
             bool skip = false;
-            for (int is = mTriggerConfig.size(); is--;) {
+            for (int is = mTriggerConfig.size(); is--;) {  // check if this triggering channel was already registered
               if (mTriggerConfig[is].id == md.channelID[ic]) {
                 skip = true;
                 break;
@@ -414,7 +413,12 @@ void Digitizer::refreshCCDB()
                 LOG(FATAL) << "Wrong trigger settings";
               }
               mTriggerConfig.emplace_back(trgChanConf);
-              LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+	      if(md.trigChannel[ic]){
+        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+		triggerableChanMask |= 0x1 << trgChanConf.id;
+	      }else{
+        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
+	      }
               if (trgChanConf.first < mTrigBinMin) {
                 mTrigBinMin = trgChanConf.first;
               }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -399,9 +399,9 @@ void Digitizer::refreshCCDB()
       if (md.id >= 0) {
         mModConfAux.emplace_back(md);
         for (int ic = Module::MaxChannels; ic--;) {
-          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift>0 && md.trigChannelConf[ic].threshold>0)) {
+          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift > 0 && md.trigChannelConf[ic].threshold > 0)) {
             bool skip = false;
-            for (int is = mTriggerConfig.size(); is--;) {  // check if this triggering channel was already registered
+            for (int is = mTriggerConfig.size(); is--;) { // check if this triggering channel was already registered
               if (mTriggerConfig[is].id == md.channelID[ic]) {
                 skip = true;
                 break;
@@ -413,12 +413,12 @@ void Digitizer::refreshCCDB()
                 LOG(FATAL) << "Wrong trigger settings";
               }
               mTriggerConfig.emplace_back(trgChanConf);
-	      if(md.trigChannel[ic]){
-        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
-		mTriggerableChanMask |= 0x1 << trgChanConf.id;
-	      }else{
-        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
-	      }
+              if (md.trigChannel[ic]) {
+                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+                mTriggerableChanMask |= 0x1 << trgChanConf.id;
+              } else {
+                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
+              }
               if (trgChanConf.first < mTrigBinMin) {
                 mTrigBinMin = trgChanConf.first;
               }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -181,7 +181,7 @@ void Digitizer::digitizeBC(BCCache& bc)
   auto& bcdata = bc.data;
   // apply gain
   for (int idet : {ZNA, ZPA, ZNC, ZPC}) {
-    for (int ic : {Ch1, Ch2, Ch3, Ch4}) {
+    for (int ic : {Common, Ch1, Ch2, Ch3, Ch4}) {
       int chan = toChannel(idet, ic);
       auto gain = mSimCondition->channels[chan].gain;
       for (int ib = NTimeBinsPerBC; ib--;) {
@@ -314,7 +314,7 @@ void Digitizer::phe2Sample(int nphe, int parID, double timeHit, std::array<o2::I
         break;
       }
       if (sample >= 0) {
-        auto signal = chanConfig.shape[sample] * nphe; // signal accounting for the gain
+        auto signal = chanConfig.shape[sample] * nphe; // signal not accounting for the gain
         (*bcCache).data[channel][ib] += signal;
         added = true;
       }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -251,7 +251,7 @@ bool Digitizer::triggerBC(int ibc)
     }
   }
 
-  if (bcCached.trigChanMask & triggerableChanMask) { // there are triggered channels, flag modules/channels to read
+  if (bcCached.trigChanMask & mTriggerableChanMask) { // there are triggered channels, flag modules/channels to read
     for (int ibcr = ibc - mNBCAHead; ibcr <= ibc; ibcr++) {
       auto& bcr = mStoreChanMask[ibcr + mNBCAHead];
       for (const auto& mdh : mModConfAux) {
@@ -415,7 +415,7 @@ void Digitizer::refreshCCDB()
               mTriggerConfig.emplace_back(trgChanConf);
 	      if(md.trigChannel[ic]){
         	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
-		triggerableChanMask |= 0x1 << trgChanConf.id;
+		mTriggerableChanMask |= 0x1 << trgChanConf.id;
 	      }else{
         	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
 	      }


### PR DESCRIPTION
Latest firmware development introduced the idea of fired channels (hits) besides (auto)triggering channels. The digital discrimination is therefore enabled on all channels and a trigger mask is used to filter out the channels that are not triggering.
This update is not necessary for standard simulation but it is needed to fill properly the RAW data format.