### PR TITLE
More efficient structures for MCTruth sharing and ROOT IO

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -37,6 +37,7 @@ o2_target_root_dictionary(
           include/SimulationDataFormat/LabelContainer.h
           include/SimulationDataFormat/MCEventHeader.h
           include/SimulationDataFormat/MCEventStats.h
+          include/SimulationDataFormat/IOMCTruthContainerView.h
   LINKDEF src/SimulationDataLinkDef.h)
 # note the explicit LINKDEF as the linkdef in src is
 #

--- a/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
@@ -1,0 +1,118 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ConstMCTruthContainer.h
+/// \brief A const (ready only) version of MCTruthContainer
+/// \author Sandro Wenzel - August 2020
+
+#ifndef O2_CONSTMCTRUTHCONTAINER_H
+#define O2_CONSTMCTRUTHCONTAINER_H
+
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <Framework/Traits.h>
+
+namespace o2
+{
+namespace dataformats
+{
+
+/// @class ConstMCTruthContainer
+/// @brief A read-only version of MCTruthContainer allowing for storage optimisation
+///
+/// This provides access functionality to MCTruthContainer with optimized linear storage
+/// so that the data can easily be shared in memory or sent over network.
+/// This container needs to be initialized by calling "flatten_to" from an existing
+/// MCTruthContainer
+template <typename TruthElement>
+class ConstMCTruthContainer : public std::vector<char>
+{
+ public:
+  // (unfortunately we need these constructors for DPL)
+  using std::vector<char>::vector;
+  ConstMCTruthContainer() = default;
+
+  // const data access
+  // get individual const "view" container for a given data index
+  // the caller can't do modifications on this view
+  MCTruthHeaderElement const& getMCTruthHeader(uint32_t dataindex) const
+  {
+    return getHeaderStart()[dataindex];
+  }
+
+  gsl::span<const TruthElement> getLabels(uint32_t dataindex) const
+  {
+    if (dataindex >= getIndexedSize()) {
+      return gsl::span<const TruthElement>();
+    }
+    const auto start = getMCTruthHeader(dataindex).index;
+    const auto labelsptr = getLabelStart();
+    return gsl::span<const TruthElement>(&labelsptr[start], getSize(dataindex));
+  }
+
+  // return the number of original data indexed here
+  size_t getIndexedSize() const { return size() >= sizeof(FlatHeader) ? getHeader().nofHeaderElements : 0; }
+
+  // return the number of labels  managed in this container
+  size_t getNElements() const { return size() >= sizeof(FlatHeader) ? getHeader().nofTruthElements : 0; }
+
+ private:
+  using FlatHeader = typename MCTruthContainer<TruthElement>::FlatHeader;
+
+  size_t getSize(uint32_t dataindex) const
+  {
+    // calculate size / number of labels from a difference in pointed indices
+    const auto size = (dataindex < getIndexedSize() - 1)
+                        ? getMCTruthHeader(dataindex + 1).index - getMCTruthHeader(dataindex).index
+                        : getNElements() - getMCTruthHeader(dataindex).index;
+    return size;
+  }
+
+  /// Restore internal vectors from a raw buffer
+  /// The two vectors are resized according to the information in the \a FlatHeader
+  /// struct at the beginning of the buffer. Data is copied to the vectors.
+  TruthElement const* const getLabelStart() const
+  {
+    auto* source = &(*this)[0];
+    auto flatheader = getHeader();
+    source += sizeof(FlatHeader);
+    const size_t headerSize = flatheader.sizeofHeaderElement * flatheader.nofHeaderElements;
+    source += headerSize;
+    return (TruthElement const* const)source;
+  }
+
+  FlatHeader const& getHeader() const
+  {
+    const auto* source = &(*this)[0];
+    const auto& flatheader = *reinterpret_cast<FlatHeader const*>(source);
+    return flatheader;
+  }
+
+  MCTruthHeaderElement const* const getHeaderStart() const
+  {
+    auto* source = &(*this)[0];
+    source += sizeof(FlatHeader);
+    return (MCTruthHeaderElement const* const)source;
+  }
+};
+} // namespace dataformats
+} // namespace o2
+
+// This is done so that DPL treats this container as a vector.
+// In particular in enables
+// a) --> snapshot without ROOT dictionary (as a flat buffer)
+// b) --> requesting the resource in shared mem using make<T>
+namespace o2::framework
+{
+template <typename T>
+struct is_specialization<o2::dataformats::ConstMCTruthContainer<T>, std::vector> : std::true_type {
+};
+} // namespace o2::framework
+
+#endif //O2_CONSTMCTRUTHCONTAINER_H

--- a/DataFormats/simulation/include/SimulationDataFormat/IOMCTruthContainerView.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/IOMCTruthContainerView.h
@@ -1,0 +1,105 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IOMCTruthContainerView.h
+/// \brief A special IO container - splitting a given vector to enable ROOT IO
+/// \author Sandro Wenzel - August 2020
+
+#ifndef ALICEO2_DATAFORMATS_IOMCTRUTHVIEW_H_
+#define ALICEO2_DATAFORMATS_IOMCTRUTHVIEW_H_
+
+#include "GPUCommonRtypes.h" // to have the ClassDef macros
+#include <vector>
+#include <gsl/span>
+
+namespace o2
+{
+namespace dataformats
+{
+
+///
+/// A specially constructed class allowing to stream a very large
+/// vector buffer to a ROOT file. This is needed since ROOT currently has a size
+/// limitation of ~1GB for data that it can stream per entry in a branch.
+/// The solution is based on the ability of ROOT to split entries per data member, so
+/// some input buffer gets divided into multiple parts.
+///
+/// TODO: We could template this class to encode original type information (for the input buffer).
+class IOMCTruthContainerView
+{
+ public:
+  IOMCTruthContainerView() = default;
+
+  /// Constructor taking an existing flat vector as input; No copy is done - the
+  /// container is just a split view on the original buffer.
+  IOMCTruthContainerView(std::vector<char> const& input)
+  {
+    const auto delta = input.size() / N;
+    N2 = input.size() - (N - 1) * delta;
+    N1 = delta;
+    // TODO: this could benefit from a loop expansion
+    part1 = &input[0];
+    part2 = &input[delta];
+    part3 = &input[2 * delta];
+    part4 = &input[3 * delta];
+    part5 = &input[4 * delta];
+    part6 = &input[5 * delta];
+    part7 = &input[6 * delta];
+    part8 = &input[7 * delta];
+    part9 = &input[8 * delta];
+    part10 = &input[9 * delta];
+  }
+
+  /// A function to recreate a flat output vector from this buffer. This
+  /// function is copying the data.
+  template <typename Alloc>
+  void copyandflatten(std::vector<char, Alloc>& output) const
+  {
+    // TODO: this could benefit from a loop expansion
+    copyhelper(part1, N1, output);
+    copyhelper(part2, N1, output);
+    copyhelper(part3, N1, output);
+    copyhelper(part4, N1, output);
+    copyhelper(part5, N1, output);
+    copyhelper(part6, N1, output);
+    copyhelper(part7, N1, output);
+    copyhelper(part8, N1, output);
+    copyhelper(part9, N1, output);
+    copyhelper(part10, N2, output);
+  }
+
+ private:
+  static constexpr int N = 10;
+  int N1 = 0;
+  int N2 = 0;
+  const char* part1 = nullptr;  //[N1]
+  const char* part2 = nullptr;  //[N1]
+  const char* part3 = nullptr;  //[N1]
+  const char* part4 = nullptr;  //[N1]
+  const char* part5 = nullptr;  //[N1]
+  const char* part6 = nullptr;  //[N1]
+  const char* part7 = nullptr;  //[N1]
+  const char* part8 = nullptr;  //[N1]
+  const char* part9 = nullptr;  //[N1]
+  const char* part10 = nullptr; //[N2]
+
+  template <typename Alloc>
+  void copyhelper(const char* input, int size, std::vector<char, Alloc>& output) const
+  {
+    gsl::span<const char> tmp(input, size);
+    std::copy(tmp.begin(), tmp.end(), std::back_inserter(output));
+  }
+
+  ClassDefNV(IOMCTruthContainerView, 1);
+};
+} // namespace dataformats
+} // namespace o2
+
+#endif

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -310,7 +310,7 @@ class MCTruthContainer
   /// The flattened data starts with a specific header @ref FlatHeader describing
   /// size and content of the two vectors within the raw buffer.
   template <typename ContainerType>
-  size_t flatten_to(ContainerType& container)
+  size_t flatten_to(ContainerType& container) const
   {
     size_t bufferSize = sizeof(FlatHeader) + sizeof(MCTruthHeaderElement) * mHeaderArray.size() + sizeof(TruthElement) * mTruthArray.size();
     container.resize((bufferSize / sizeof(typename ContainerType::value_type)) + ((bufferSize % sizeof(typename ContainerType::value_type)) > 0 ? 1 : 0));

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -68,4 +68,6 @@
 #pragma link C++ class o2::dataformats::MCEventStats + ;
 #pragma link C++ class o2::dataformats::MCEventHeader + ;
 
+#pragma link C++ class o2::dataformats::IOMCTruthContainerView + ;
+
 #endif

--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -13,9 +13,14 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/LabelContainer.h"
+#include "SimulationDataFormat/IOMCTruthContainerView.h"
 #include <algorithm>
 #include <iostream>
+#include <TFile.h>
+#include <TTree.h>
 
 namespace o2
 {
@@ -180,6 +185,19 @@ BOOST_AUTO_TEST_CASE(MCTruthContainer_flatten)
   BOOST_CHECK(restoredContainer.getElement(1) == 2);
   BOOST_CHECK(restoredContainer.getElement(2) == 1);
   BOOST_CHECK(restoredContainer.getElement(3) == 10);
+
+  // check the special version ConstMCTruthContainer
+  using ConstMCTruthContainer = dataformats::ConstMCTruthContainer<TruthElement>;
+  ConstMCTruthContainer cc;
+  container.flatten_to(cc);
+
+  BOOST_CHECK(cc.getIndexedSize() == container.getIndexedSize());
+  BOOST_CHECK(cc.getNElements() == container.getNElements());
+  BOOST_CHECK(cc.getLabels(0).size() == container.getLabels(0).size());
+  BOOST_CHECK(cc.getLabels(1).size() == container.getLabels(1).size());
+  BOOST_CHECK(cc.getLabels(2).size() == container.getLabels(2).size());
+  BOOST_CHECK(cc.getLabels(2)[0] == container.getLabels(2)[0]);
+  BOOST_CHECK(cc.getLabels(2)[0] == 10);
 }
 
 BOOST_AUTO_TEST_CASE(LabelContainer_noncont)
@@ -303,6 +321,54 @@ BOOST_AUTO_TEST_CASE(MCTruthContainer_move)
   BOOST_CHECK(container2.getNElements() == 0);
   BOOST_CHECK(container.getIndexedSize() == 3);
   BOOST_CHECK(container.getNElements() == 4);
+}
+
+BOOST_AUTO_TEST_CASE(MCTruthContainer_ROOTIO)
+{
+  using TruthElement = o2::MCCompLabel;
+  using Container = dataformats::MCTruthContainer<TruthElement>;
+  Container container;
+  const size_t BIGSIZE{1000000};
+  for (int i = 0; i < BIGSIZE; ++i) {
+    container.addElement(i, TruthElement(i, i, i));
+    container.addElement(i, TruthElement(i + 1, i, i));
+  }
+  std::vector<char> buffer;
+  container.flatten_to(buffer);
+
+  // We use the special IO split container to stream to a file and back
+  dataformats::IOMCTruthContainerView io(buffer);
+  {
+    TFile f("tmp2.root", "RECREATE");
+    TTree tree("o2sim", "o2sim");
+    auto br = tree.Branch("Labels", &io, 32000, 2);
+    tree.Fill();
+    tree.Write();
+    f.Close();
+  }
+
+  // read back
+  TFile f2("tmp2.root", "OPEN");
+  auto tree2 = (TTree*)f2.Get("o2sim");
+  dataformats::IOMCTruthContainerView* io2 = nullptr;
+  auto br2 = tree2->GetBranch("Labels");
+  BOOST_CHECK(br2 != nullptr);
+  br2->SetAddress(&io2);
+  br2->GetEntry(0);
+
+  // make a const MC label container out of it
+  using ConstMCTruthContainer = dataformats::ConstMCTruthContainer<TruthElement>;
+  ConstMCTruthContainer cc;
+  io2->copyandflatten(cc);
+
+  BOOST_CHECK(cc.getNElements() == BIGSIZE * 2);
+  BOOST_CHECK(cc.getIndexedSize() == BIGSIZE);
+  BOOST_CHECK(cc.getLabels(0).size() == 2);
+  BOOST_CHECK(cc.getLabels(0)[0] == TruthElement(0, 0, 0));
+  BOOST_CHECK(cc.getLabels(0)[1] == TruthElement(1, 0, 0));
+  BOOST_CHECK(cc.getLabels(BIGSIZE - 1).size() == 2);
+  BOOST_CHECK(cc.getLabels(BIGSIZE - 1)[0] == TruthElement(BIGSIZE - 1, BIGSIZE - 1, BIGSIZE - 1));
+  BOOST_CHECK(cc.getLabels(BIGSIZE - 1)[1] == TruthElement(BIGSIZE, BIGSIZE - 1, BIGSIZE - 1));
 }
 
 } // namespace o2

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -54,3 +54,12 @@ o2_add_executable(digitizer-workflow
                                         O2::TRDWorkflow
                                         O2::DataFormatsTRD
                                         O2::ZDCSimulation)
+
+
+o2_add_executable(mctruth-testworkflow
+                  COMPONENT_NAME sim
+                  SOURCES src/MCTruthTestWorkflow.cxx
+		          src/MCTruthSourceSpec.cxx
+	                  src/MCTruthWriterSpec.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::SimulationDataFormat)

--- a/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
@@ -1,0 +1,104 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_MCTRUTHREADERSPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_MCTRUTHREADERSPEC_H_
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <SimulationDataFormat/MCCompLabel.h>
+#include "SimulationDataFormat/IOMCTruthContainerView.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TString.h"
+#include <sstream>
+
+using namespace o2::framework;
+
+namespace o2
+{
+
+class MCTruthReaderTask : public o2::framework::Task
+{
+ public:
+  MCTruthReaderTask(bool newmctruth) : mNew{newmctruth} {}
+
+  void init(framework::InitContext& ic) override
+  {
+    LOG(INFO) << "Initializing MCTruth reader ";
+  }
+
+  void run(framework::ProcessingContext& pc) override
+  {
+    if (mFinished) {
+      return;
+    }
+    LOG(INFO) << "Running MCTruth reader ";
+    auto labelfilename = pc.inputs().get<TString*>("trigger");
+    LOG(INFO) << "Opening file " << labelfilename->Data();
+    TFile f(labelfilename->Data(), "OPEN");
+    auto tree = (TTree*)f.Get("o2sim");
+    auto br = tree->GetBranch("Labels");
+
+    if (mNew) {
+      //
+      dataformats::IOMCTruthContainerView* iocontainer = nullptr;
+      br->SetAddress(&iocontainer);
+      br->GetEntry(0);
+
+      // publish the labels in a const shared memory container
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS2", 0, Lifetime::Timeframe});
+      iocontainer->copyandflatten(sharedlabels);
+
+    } else {
+      // the original way with the MCTruthContainer
+      dataformats::MCTruthContainer<MCCompLabel>* mccontainer = nullptr;
+      br->SetAddress(&mccontainer);
+      br->GetEntry(0);
+
+      LOG(INFO) << "MCCONTAINER CHECK" << mccontainer;
+      LOG(INFO) << "MCCONTAINER CHECK" << mccontainer->getNElements();
+
+      // publish the original labels
+      pc.outputs().snapshot(Output{"TST", "LABELS2", 0, Lifetime::Timeframe}, *mccontainer);
+    }
+    // we should be only called once; tell DPL that this process is ready to exit
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+    mFinished = true;
+  }
+
+ private:
+  bool mFinished = false;
+  bool mNew = false;
+};
+
+o2::framework::DataProcessorSpec getMCTruthReaderSpec(bool newmctruth)
+{
+  std::vector<InputSpec> inputs;
+  // input to notify that labels can be read
+  inputs.emplace_back("trigger", "TST", "TRIGGERREAD", 0, Lifetime::Timeframe);
+  return DataProcessorSpec{
+    "MCTruthReader",
+    inputs,
+    Outputs{{"TST", "LABELS2", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<MCTruthReaderTask>(newmctruth)},
+    Options{}};
+}
+
+} // end namespace o2
+
+#endif

--- a/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <SimulationDataFormat/MCCompLabel.h>
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+
+class MCTruthSourceTask : public o2::framework::Task
+{
+ public:
+  MCTruthSourceTask(bool newmctruth) : mNew{newmctruth} {}
+
+  void init(framework::InitContext& ic) override
+  {
+    LOG(INFO) << "Initializing MCTruth source";
+    mSize = ic.options().get<int>("size");
+  }
+
+  void run(framework::ProcessingContext& pc) override
+  {
+    if (mFinished) {
+      return;
+    }
+    LOG(INFO) << "Creating MCTruth container";
+
+    using TruthElement = o2::MCCompLabel;
+    using Container = dataformats::MCTruthContainer<TruthElement>;
+    Container container;
+    // create a very large container and stream it to TTree
+    for (int i = 0; i < mSize; ++i) {
+      container.addElement(i, TruthElement(i, i, i));
+      container.addElement(i, TruthElement(i + 1, i, i));
+    }
+
+    if (mNew) {
+      LOG(INFO) << "New serialization";
+      // we need to flatten it and write to managed shared memory container
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TST", "LABELS", 0, Lifetime::Timeframe});
+      container.flatten_to(sharedlabels);
+      sleep(1);
+    } else {
+      LOG(INFO) << "Old serialization";
+      pc.outputs().snapshot({"TST", "LABELS", 0, Lifetime::Timeframe}, container);
+      sleep(1);
+    }
+
+    // we should be only called once; tell DPL that this process is ready to exit
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+    mFinished = true;
+  }
+
+ private:
+  bool mFinished = false;
+  int mSize = 0;
+  bool mNew = false;
+  o2::dataformats::MCTruthContainer<long> mLabels; // labels which get filled
+};
+
+o2::framework::DataProcessorSpec getMCTruthSourceSpec(bool newmctruth)
+{
+  // create the full data processor spec using
+  //  a name identifier
+  //  input description
+  //  algorithmic description (here a lambda getting called once to setup the actual processing function)
+  //  options that can be used for this processor (here: input file names where to take the hits)
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("TST", "LABELS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "MCTruthSource",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<MCTruthSourceTask>(newmctruth)},
+    Options{
+      {"size", VariantType::Int, 100000, {"Sample size"}}}};
+}
+
+} // end namespace o2

--- a/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.h
+++ b/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.h
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_MCTRUTHSOURCESPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_MCTRUTHSOURCESPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+o2::framework::DataProcessorSpec getMCTruthSourceSpec(bool mctruth = true);
+} // end namespace o2
+
+#endif

--- a/Steer/DigitizerWorkflow/src/MCTruthTestWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthTestWorkflow.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/program_options.hpp>
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "MCTruthSourceSpec.h"
+#include "MCTruthWriterSpec.h"
+#include "MCTruthReaderSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option to disable MC truth
+  workflowOptions.push_back(ConfigParamSpec{"newmctruth", o2::framework::VariantType::Bool, false, {"enable new container"}});
+  workflowOptions.push_back(ConfigParamSpec{"consumers", o2::framework::VariantType::Int, 1, {"number of mc consumers"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+/// This function is required to be implemented to define the workflow
+/// specifications
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  bool newmctruth = configcontext.options().get<bool>("newmctruth");
+
+  // connect the source
+  specs.emplace_back(o2::getMCTruthSourceSpec(newmctruth));
+  // connect some consumers
+  for (int i = 0; i < configcontext.options().get<int>("consumers"); ++i) {
+    specs.emplace_back(o2::getMCTruthWriterSpec(i, i == 0, newmctruth));
+  }
+  // connect a device reading back the labels
+  specs.emplace_back(o2::getMCTruthReaderSpec(newmctruth));
+  // connect a device reading back the labels
+  specs.emplace_back(o2::getMCTruthWriterSpec(-1, false, newmctruth));
+
+  return specs;
+}

--- a/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
@@ -1,0 +1,127 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <SimulationDataFormat/MCCompLabel.h>
+#include "SimulationDataFormat/IOMCTruthContainerView.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TString.h"
+#include <sstream>
+
+using namespace o2::framework;
+
+namespace o2
+{
+
+class MCTruthWriterTask : public o2::framework::Task
+{
+ public:
+  MCTruthWriterTask(int id, bool doio, bool newmctruth) : mID{id}, mIO{doio}, mNew{newmctruth} {}
+
+  void init(framework::InitContext& ic) override
+  {
+    LOG(INFO) << "Initializing MCTruth consumer " << mID;
+  }
+
+  void run(framework::ProcessingContext& pc) override
+  {
+    if (mFinished) {
+      return;
+    }
+    LOG(INFO) << "Running MCTruth consumer " << mID;
+    TString labelfilename;
+    if (mNew) {
+      auto labels = pc.inputs().get<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(mID >= 0 ? "labels" : "labels2");
+      LOG(INFO) << "GOT " << labels.getNElements() << " labels";
+
+      sleep(1);
+
+      if (mIO) {
+        dataformats::IOMCTruthContainerView io(labels);
+        labelfilename = "labels_new.root";
+        TFile f(labelfilename.Data(), "RECREATE");
+        TTree tree("o2sim", "o2sim");
+        auto br = tree.Branch("Labels", &io);
+        tree.Fill();
+        f.Write();
+        f.Close();
+      }
+
+      sleep(1);
+    } else {
+      auto labels = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>(mID >= 0 ? "labels" : "labels2");
+      LOG(INFO) << "GOT " << labels->getNElements() << " labels";
+
+      sleep(1);
+
+      if (mIO) {
+        labelfilename = "labels_old.root";
+        TFile f(labelfilename.Data(), "RECREATE");
+        TTree tree("o2sim", "o2sim");
+        auto rawptr = labels.get();
+        auto br = tree.Branch("Labels", &rawptr);
+        tree.Fill();
+        f.Write();
+        f.Close();
+      }
+      sleep(1);
+    }
+    if (mIO) {
+      // this triggers the reader process
+      pc.outputs().snapshot({"TST", "TRIGGERREAD", 0, Lifetime::Timeframe}, labelfilename);
+    }
+
+    // we should be only called once; tell DPL that this process is ready to exit
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+    mFinished = true;
+  }
+
+ private:
+  bool mFinished = false;
+  bool mNew = false;
+  bool mIO = false;
+  int mID = 0;
+  o2::dataformats::MCTruthContainer<long> mLabels; // labels which get filled
+};
+
+o2::framework::DataProcessorSpec getMCTruthWriterSpec(int id, bool doio, bool newmctruth)
+{
+  std::vector<InputSpec> inputs;
+  if (id == -1) {
+    // we use this id as a secondary consumer of the LABELS2 channel
+    inputs.emplace_back("labels2", "TST", "LABELS2", 0, Lifetime::Timeframe);
+  } else {
+    inputs.emplace_back("labels", "TST", "LABELS", 0, Lifetime::Timeframe);
+  }
+  std::stringstream str;
+  str << "MCTruthWriter" << id;
+
+  std::vector<OutputSpec> outputs;
+  if (doio) {
+    outputs.emplace_back("TST", "TRIGGERREAD", 0, Lifetime::Timeframe);
+  }
+  return DataProcessorSpec{
+    str.str(),
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<MCTruthWriterTask>(id, doio, newmctruth)},
+    Options{}};
+}
+
+} // end namespace o2

--- a/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.h
@@ -1,0 +1,26 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_ZDCDIGITWRITERSPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_ZDCDIGITWRITERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/InputSpec.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+namespace o2
+{
+
+o2::framework::DataProcessorSpec getMCTruthWriterSpec(int id, bool doio, bool newmctruth = true);
+
+} // end namespace o2
+
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_ZDCDIGITWRITERSPEC_H_ */


### PR DESCRIPTION
This commit removes the bottleneck/blocker coming from MC labels
to simulate full-sized timeframes. 

In detail, this commit achieves/provides the following:

* A new class ConstMCTruthContainer, allowing to
  share **read-only** MC labels in a flat buffer and
  in shared memory (using the DPL->make mechanism).
  This avoids going through ROOT IO when communicating between
  DPL devices and reduces the overall memory usage and CPU time.

* A new class IOMCTruthContainerView, allowing to overcome
  the size limitation of labels when writing to a TTree entry.
  This is achieved by splitting the buffer into several members, which
  ROOT serializes separately.

* A test workflow is provided, exchanging MClabels between a couple
  of DPL processes. The workflow can run with the existing as well
  the new way of sharing labels.