### PR TITLE
PrimaryVertex - tracks matching + related classes/workflows update

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
@@ -59,10 +59,10 @@ class TrackTPC : public o2::track::TrackParCov
   void setHasCSideClusters() { mFlags |= HasCSideClusters; }
 
   float getTime0() const { return mTime0; }         ///< Reference time of the track, i.e. t-bins of a primary track with eta=0.
-  short getDeltaTBwd() const { return mDeltaTBwd; } ///< max possible decrement to getTimeVertex
-  short getDeltaTFwd() const { return mDeltaTFwd; } ///< max possible increment to getTimeVertex
-  void setDeltaTBwd(short t) { mDeltaTBwd = t; }    ///< set max possible decrement to getTimeVertex
-  void setDeltaTFwd(short t) { mDeltaTFwd = t; }    ///< set max possible increment to getTimeVertex
+  float getDeltaTBwd() const { return mDeltaTBwd; } ///< max possible decrement to getTimeVertex
+  float getDeltaTFwd() const { return mDeltaTFwd; } ///< max possible increment to getTimeVertex
+  void setDeltaTBwd(float t) { mDeltaTBwd = t; }    ///< set max possible decrement to getTimeVertex
+  void setDeltaTFwd(float t) { mDeltaTFwd = t; }    ///< set max possible increment to getTimeVertex
 
   float getChi2() const { return mChi2; }
   const o2::track::TrackParCov& getOuterParam() const { return mOuterParam; }
@@ -112,15 +112,15 @@ class TrackTPC : public o2::track::TrackParCov
   float mTime0 = 0.f;                 ///< Reference Z of the track assumed for the vertex, scaled with pseudo
                                       ///< VDrift and reference timeframe length, unless it was moved to be on the
                                       ///< side of TPC compatible with edge clusters sides.
-  short mDeltaTFwd = 0;               ///< max possible increment to track time
-  short mDeltaTBwd = 0;               ///< max possible decrement to track time
+  float mDeltaTFwd = 0;               ///< max possible increment to track time
+  float mDeltaTBwd = 0;               ///< max possible decrement to track time
   short mFlags = 0;                   ///< various flags, see Flags enum
   float mChi2 = 0.f;                  // Chi2 of the track
   o2::track::TrackParCov mOuterParam; // Track parameters at outer end of TPC.
   dEdxInfo mdEdx;                     // dEdx Information
   ClusRef mClustersReference;         // reference to externale cluster indices
 
-  ClassDefNV(TrackTPC, 3);
+  ClassDefNV(TrackTPC, 4);
 };
 
 } // namespace tpc

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PrimaryVertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PrimaryVertex.h
@@ -29,8 +29,12 @@ class PrimaryVertex : public Vertex<TimeStampWithError<float, float>>
   PrimaryVertex(const PrimaryVertex&) = default;
   ~PrimaryVertex() = default;
 
-  const InteractionRecord& getIR() const { return mIR; }
-  void setIR(const InteractionRecord& ir) { mIR = ir; }
+  const InteractionRecord& getIRMax() const { return mIRMax; }
+  void setIRMax(const InteractionRecord& ir) { mIRMax = ir; }
+  const InteractionRecord& getIRMin() const { return mIRMin; }
+  void setIRMin(const InteractionRecord& ir) { mIRMin = ir; }
+  void setIR(const InteractionRecord& ir) { mIRMin = mIRMax = ir; }
+  bool hasUniqueIR() const { return !mIRMin.isDummy() && (mIRMin == mIRMax); }
 
 #ifndef ALIGPU_GPUCODE
   void print() const;
@@ -38,7 +42,8 @@ class PrimaryVertex : public Vertex<TimeStampWithError<float, float>>
 #endif
 
  protected:
-  InteractionRecord mIR{}; ///< by default not assigned!
+  InteractionRecord mIRMin{}; ///< by default not assigned!
+  InteractionRecord mIRMax{}; ///< by default not assigned!
 
   ClassDefNV(PrimaryVertex, 1);
 };
@@ -48,5 +53,16 @@ std::ostream& operator<<(std::ostream& os, const o2::dataformats::PrimaryVertex&
 #endif
 
 } // namespace dataformats
+
+/// Defining PrimaryVertex explicitly as messageable
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::dataformats::PrimaryVertex> : std::true_type {
+};
+} // namespace framework
+
 } // namespace o2
 #endif

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/VtxTrackIndex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/VtxTrackIndex.h
@@ -12,6 +12,9 @@
 /// \brief Index of track attached to vertx: index in its proper container, container source and flags
 /// \author ruben.shahoyan@cern.ch
 
+#ifndef O2_VERTEX_TRACK_INDEX
+#define O2_VERTEX_TRACK_INDEX
+
 #include "CommonDataFormat/AbstractRef.h"
 #include <iosfwd>
 #include <string>
@@ -32,7 +35,7 @@ class VtxTrackIndex : public AbstractRef<26, 3, 3>
   };
   enum Flags : uint8_t {
     Contributor, // flag that it contributes to vertex fit
-    Attached,    // flag that it is attached w/o contributing
+    Reserved,    //
     Ambiguous,   // flag that attachment is ambiguous
     NFlags
   };
@@ -49,3 +52,5 @@ std::ostream& operator<<(std::ostream& os, const o2::dataformats::VtxTrackIndex&
 
 } // namespace dataformats
 } // namespace o2
+
+#endif

--- a/DataFormats/Reconstruction/src/PrimaryVertex.cxx
+++ b/DataFormats/Reconstruction/src/PrimaryVertex.cxx
@@ -22,9 +22,13 @@ namespace dataformats
 
 std::string PrimaryVertex::asString() const
 {
-  return o2::utils::concat_string(VertexBase::asString(),
-                                  fmt::format("Chi2={:.2f} NCont={:d}: T={:.3f}+-{:.3f} IR=", mChi2, mNContributors, mTimeStamp.getTimeStamp(), mTimeStamp.getTimeStampError()),
-                                  mIR.asString());
+  auto str = o2::utils::concat_string(VertexBase::asString(),
+                                      fmt::format("Chi2={:.2f} NCont={:d}: T={:.3f}+-{:.3f} IR=", mChi2, mNContributors, mTimeStamp.getTimeStamp(), mTimeStamp.getTimeStampError()),
+                                      mIRMin.asString());
+  if (!hasUniqueIR()) {
+    str = o2::utils::concat_string(str, " : ", mIRMax.asString());
+  }
+  return str;
 }
 
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::PrimaryVertex& v)

--- a/DataFormats/common/include/CommonDataFormat/BunchFilling.h
+++ b/DataFormats/common/include/CommonDataFormat/BunchFilling.h
@@ -29,6 +29,8 @@ class BunchFilling
   void setBCTrains(int nTrains, int trainSpacingInBC, int nBC, int bcSpacing, int firstBC);
   void print(int bcPerLine = 100) const;
   const auto& getPattern() const { return mPattern; }
+  int getFirstFilledBC() const;
+  int getLastFilledBC() const;
   // set BC filling a la TPC TDR, 12 50ns trains of 48 BCs
   // but instead of uniform train spacing we add 96empty BCs after each train
   void setDefault()

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -98,6 +98,16 @@ struct InteractionRecord {
     return diffBC;
   }
 
+  float differenceInBCns(const InteractionRecord& other) const
+  {
+    // return differenc in bunch-crossings
+    int64_t diffBC = int(bc) - other.bc;
+    if (orbit != other.orbit) {
+      diffBC += (int64_t(orbit) - other.orbit) * o2::constants::lhc::LHCMaxBunches;
+    }
+    return diffBC;
+  }
+
   int64_t toLong() const
   {
     // return as single long number

--- a/DataFormats/common/src/BunchFilling.cxx
+++ b/DataFormats/common/src/BunchFilling.cxx
@@ -16,6 +16,28 @@
 using namespace o2;
 
 //_________________________________________________
+int BunchFilling::getFirstFilledBC() const
+{
+  for (int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++) {
+    if (testBC(bc)) {
+      return bc;
+    }
+  }
+  return -1;
+}
+
+//_________________________________________________
+int BunchFilling::getLastFilledBC() const
+{
+  for (int bc = o2::constants::lhc::LHCMaxBunches; bc--;) {
+    if (testBC(bc)) {
+      return bc;
+    }
+  }
+  return -1;
+}
+
+//_________________________________________________
 void BunchFilling::setBC(int bcID, bool active)
 {
   // add interacting BC slot

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
@@ -26,7 +26,6 @@ namespace ft0
 // These are configurable params for FT0 selection as interaction tag
 struct InteractionTag : public o2::conf::ConfigurableParamHelper<InteractionTag> {
   int minAmplitudeAC = 20; ///< use only FT0 triggers with high enough amplitude
-  float timeBiasMS = 35.0; ///< relative bias in ns to add
 
   bool isSelected(const RecPoints& rp) const
   {
@@ -35,7 +34,7 @@ struct InteractionTag : public o2::conf::ConfigurableParamHelper<InteractionTag>
 
   float getInteractionTimeNS(const RecPoints& rp, const o2::InteractionRecord& refIR) const
   {
-    return rp.getInteractionRecord().differenceInBC(refIR) * o2::constants::lhc::LHCBunchSpacingNS + timeBiasMS; // RS FIXME do we want use precise MeanTime?
+    return rp.getInteractionRecord().differenceInBCns(refIR); // RS FIXME do we want use precise MeanTime?
   }
 
   O2ParamDef(InteractionTag, "ft0tag");

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(GlobalTrackingWorkflow
                        src/PrimaryVertexingSpec.cxx
                        src/PrimaryVertexWriterSpec.cxx
                        src/PrimaryVertexReaderSpec.cxx
+                       src/VertexTrackMatcherSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::ITStracking
                                      O2::ITSWorkflow
@@ -40,6 +41,7 @@ o2_add_executable(vertex-reader-workflow
                   COMPONENT_NAME primary
                   SOURCES src/primary-vertex-reader-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow )
+
 
 add_subdirectory(tofworkflow)
 add_subdirectory(tpcinterpolationworkflow)

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(GlobalTrackingWorkflow
                                      O2::TPCWorkflow
                                      O2::FT0Workflow
                                      O2::ITSMFTWorkflow
+                                     O2::SimulationDataFormat
                                      O2::DetectorsVertexing)
 
 o2_add_executable(match-workflow

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexReaderSpec.h
@@ -21,6 +21,7 @@
 
 #include "CommonDataFormat/TimeStamp.h"
 #include "CommonDataFormat/RangeReference.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 #include "SimulationDataFormat/MCEventLabel.h"
 
@@ -35,6 +36,7 @@ class PrimaryVertexReader : public o2::framework::Task
   using Label = o2::MCEventLabel;
   using V2TRef = o2::dataformats::RangeReference<int, int>;
   using PVertex = o2::dataformats::PrimaryVertex;
+  using GIndex = o2::dataformats::VtxTrackIndex;
 
  public:
   PrimaryVertexReader(bool useMC) : mUseMC(useMC) {}
@@ -43,18 +45,20 @@ class PrimaryVertexReader : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
 
  protected:
-  void connectTree(const std::string& filename);
+  void connectTree();
 
+  bool mVerbose = false;
   bool mUseMC = false;
 
   std::vector<PVertex> mVertices, *mVerticesPtr = &mVertices;
-  std::vector<int> mPVTrIdx, *mPVTrIdxPtr = &mPVTrIdx;
-  std::vector<V2TRef> mPV2TrIdx, *mPV2TrIdxPtr = &mPV2TrIdx;
   std::vector<Label> mLabels, *mLabelsPtr = &mLabels;
+  std::vector<V2TRef> mPV2MatchIdxRef, *mPV2MatchIdxRefPtr = &mPV2MatchIdxRef;
+  std::vector<GIndex> mPV2MatchIdx, *mPV2MatchIdxPtr = &mPV2MatchIdx;
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
   std::string mFileName = "";
+  std::string mFileNameMatches = "";
   std::string mVertexTreeName = "o2sim";
   std::string mVertexBranchName = "PrimaryVertex";
   std::string mVertexTrackIDsBranchName = "PVTrackIndices";

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexWriterSpec.h
@@ -21,7 +21,7 @@ namespace vertexing
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getPrimaryVertexWriterSpec(bool useMC);
+framework::DataProcessorSpec getPrimaryVertexWriterSpec(bool disableMatching, bool useMC);
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/VertexTrackMatcherSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/VertexTrackMatcherSpec.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_VERTEX_TRACK_MATCHER_SPEC_H
+#define O2_VERTEX_TRACK_MATCHER_SPEC_H
+
+/// @file VertexTrackMatcherSpec.h
+/// @brief Specs for vertex track association device
+/// @author ruben.shahoyan@cern.ch
+
+#include "DetectorsVertexing/VertexTrackMatcher.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "TStopwatch.h"
+
+namespace o2
+{
+namespace vertexing
+{
+
+using namespace o2::framework;
+
+class VertexTrackMatcherSpec : public Task
+{
+ public:
+  VertexTrackMatcherSpec() = default;
+  ~VertexTrackMatcherSpec() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
+
+ private:
+  o2::vertexing::VertexTrackMatcher mMatcher;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+DataProcessorSpec getVertexTrackMatcherSpec();
+
+} // namespace vertexing
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexWriterSpec.cxx
@@ -33,19 +33,20 @@ using Label = o2::MCEventLabel;
 
 using namespace o2::header;
 
-DataProcessorSpec getPrimaryVertexWriterSpec(bool useMC)
+DataProcessorSpec getPrimaryVertexWriterSpec(bool disableMatching, bool useMC)
 {
   auto logger = [](std::vector<PVertex> const& v) {
     LOG(INFO) << "PrimaryVertexWriter pulled " << v.size() << " vertices";
   };
-
+  auto inpID = disableMatching ? InputSpec{"vttrackID", "GLO", "PVTX_CONTID", 0} : InputSpec{"vttrackID", "GLO", "PVTX_TRMTC", 0};
+  auto inpIDRef = disableMatching ? InputSpec{"v2tref", "GLO", "PVTX_CONTIDREFS", 0} : InputSpec{"v2tref", "GLO", "PVTX_TRMTCREFS", 0};
   return MakeRootTreeWriterSpec("primary-vertex-writer",
                                 "o2_primary_vertex.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with Primary Vertices"},
-                                BranchDefinition<std::vector<PVertex>>{InputSpec{"vertices", "GLO", "PVERTEX", 0}, "PrimaryVertex", logger},
-                                BranchDefinition<std::vector<V2TRef>>{InputSpec{"v2tref", "GLO", "PVERTEX_TRIDREFS", 0}, "PV2TrackRefs"},
-                                BranchDefinition<std::vector<int>>{InputSpec{"vttrackID", "GLO", "PVERTEX_TRID", 0}, "PVTrackIndices"},
-                                BranchDefinition<std::vector<Label>>{InputSpec{"labels", "GLO", "PVERTEX_MCTR", 0}, "PVMCTruth", (useMC ? 1 : 0), ""})();
+                                BranchDefinition<std::vector<PVertex>>{InputSpec{"vertices", "GLO", "PVTX", 0}, "PrimaryVertex", logger},
+                                BranchDefinition<std::vector<V2TRef>>{inpIDRef, "PV2TrackRefs"},
+                                BranchDefinition<std::vector<GIndex>>{inpID, "PVTrackIndices"},
+                                BranchDefinition<std::vector<Label>>{InputSpec{"labels", "GLO", "PVTX_MCTR", 0}, "PVMCTruth", (useMC ? 1 : 0), ""})();
 }
 
 } // namespace vertexing

--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -1,0 +1,109 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  VertexTrackMatcherSpec.cxx
+/// @brief Specs for vertex track association device
+/// @author ruben.shahoyan@cern.ch
+
+#include "GlobalTrackingWorkflow/VertexTrackMatcherSpec.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace vertexing
+{
+
+void VertexTrackMatcherSpec::init(InitContext& ic)
+{
+  //-------- init geometry and field --------//
+  mTimer.Stop();
+  mTimer.Reset();
+
+  mMatcher.init();
+}
+
+void VertexTrackMatcherSpec::run(ProcessingContext& pc)
+{
+  double timeCPU0 = mTimer.CpuTime(), timeReal0 = mTimer.RealTime();
+  mTimer.Start(false);
+
+  // eventually, this should be set per TF from CCDB?
+  if (mMatcher.getITSROFrameLengthInBC() == 0) {
+    std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom(o2::base::NameConf::getGRPFileName())};
+    const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
+    if (grp->isDetContinuousReadOut(o2::detectors::DetID::ITS)) {
+      mMatcher.setITSROFrameLengthInBC(alpParams.roFrameLengthInBC);
+    } else {
+      mMatcher.setITSROFrameLengthInBC(alpParams.roFrameLengthTrig / o2::constants::lhc::LHCOrbitNS);
+    }
+  }
+
+  // RS FIXME this will not have effect until the 1st orbit is propagated, until that will work only for TF starting at orbit 0
+  const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("vertices").header);
+  mMatcher.setStartIR({0, dh->firstTForbit});
+
+  const auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("tpcits");
+  const auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("tpc");
+  const auto tracksITS = pc.inputs().get<gsl::span<o2::its::TrackITS>>("its");
+  const auto tracksITSROF = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("itsROF");
+  const auto vertices = pc.inputs().get<gsl::span<o2::dataformats::PrimaryVertex>>("vertices");
+  const auto vtxTracks = pc.inputs().get<gsl::span<o2::dataformats::VtxTrackIndex>>("vtxTracks");
+  const auto vtxTrackRefs = pc.inputs().get<gsl::span<o2::dataformats::RangeReference<int, int>>>("vtxTrackRefs");
+
+  std::vector<o2::dataformats::VtxTrackIndex> trackIndex;
+  std::vector<o2::dataformats::RangeReference<int, int>> vtxRefs;
+
+  mMatcher.process(vertices, vtxTracks, vtxTrackRefs, tracksITSTPC, tracksITS, tracksITSROF, tracksTPC, trackIndex, vtxRefs);
+
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTC", 0, Lifetime::Timeframe}, trackIndex);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_TRMTCREFS", 0, Lifetime::Timeframe}, vtxRefs);
+
+  mTimer.Stop();
+  LOG(INFO) << "Made " << trackIndex.size() << " track associationgs for " << vertices.size() << " vertices, timing: CPU: "
+            << mTimer.CpuTime() - timeCPU0 << " Real: " << mTimer.RealTime() - timeReal0 << " s";
+}
+
+void VertexTrackMatcherSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "Primary vertex - track matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getVertexTrackMatcherSpec()
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+
+  inputs.emplace_back("tpcits", "GLO", "TPCITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("its", "ITS", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("itsROF", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("tpc", "TPC", "TRACKS", 0, Lifetime::Timeframe);
+
+  inputs.emplace_back("vertices", "GLO", "PVTX", 0, Lifetime::Timeframe);
+  inputs.emplace_back("vtxTracks", "GLO", "PVTX_CONTID", 0, Lifetime::Timeframe);
+  inputs.emplace_back("vtxTrackRefs", "GLO", "PVTX_CONTIDREFS", 0, Lifetime::Timeframe);
+
+  outputs.emplace_back("GLO", "PVTX_TRMTC", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "PVTX_TRMTCREFS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "pvertex-track-matching",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<VertexTrackMatcherSpec>()},
+    Options{}};
+}
+
+} // namespace vertexing
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -11,6 +11,9 @@
 #include "GlobalTrackingWorkflow/PrimaryVertexingSpec.h"
 #include "GlobalTrackingWorkflow/PrimaryVertexWriterSpec.h"
 #include "GlobalTrackingWorkflow/TrackTPCITSReaderSpec.h"
+#include "GlobalTrackingWorkflow/VertexTrackMatcherSpec.h"
+#include "ITSWorkflow/TrackReaderSpec.h"
+#include "TPCWorkflow/TrackReaderSpec.h"
 #include "FT0Workflow/RecPointReaderSpec.h"
 
 #include "CommonUtils/ConfigurableParam.h"
@@ -30,6 +33,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"validate-with-ft0", o2::framework::VariantType::Bool, false, {"use FT0 time for vertex validation"}},
+    {"disable-vertex-track-matching", o2::framework::VariantType::Bool, false, {"disable matching of vertex to non-contributor tracks"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);
@@ -50,6 +54,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto validateWithFT0 = configcontext.options().get<bool>("validate-with-ft0");
+  auto disableMatching = configcontext.options().get<bool>("disable-vertex-track-matching");
 
   WorkflowSpec specs;
   if (!disableRootInp) {
@@ -59,8 +64,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
   specs.emplace_back(o2::vertexing::getPrimaryVertexingSpec(validateWithFT0, useMC));
+
+  if (!disableMatching) {
+    specs.emplace_back(o2::its::getITSTrackReaderSpec(false));
+    specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(false));
+    specs.emplace_back(o2::vertexing::getVertexTrackMatcherSpec());
+  }
+
   if (!disableRootOut) {
-    specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(useMC));
+    specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(disableMatching, useMC));
   }
   return std::move(specs);
 }

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -13,9 +13,13 @@ o2_add_library(DetectorsVertexing
                        src/PVertexer.cxx
                        src/PVertexerHelpers.cxx
                        src/PVertexerParams.cxx
+                       src/VertexTrackMatcher.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Core
 	                             O2::CommonUtils
                                      O2::ReconstructionDataFormats
+                                     O2::DataFormatsTPC
+                                     O2::DataFormatsITS
+                                     O2::TPCBase
                                      O2::SimulationDataFormat
                                      O2::FT0Reconstruction
                                      O2::DataFormatsFT0
@@ -25,6 +29,7 @@ o2_target_root_dictionary(DetectorsVertexing
                           HEADERS include/DetectorsVertexing/HelixHelper.h
                                   include/DetectorsVertexing/PVertexer.h
                                   include/DetectorsVertexing/PVertexerHelpers.h
+                                  include/DetectorsVertexing/VertexTrackMatcher.h
                                   include/DetectorsVertexing/DCAFitterN.h)
 
 o2_add_test(

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -16,9 +16,11 @@
 #define O2_PVERTEXER_H
 
 #include <array>
+#include <utility>
 #include "CommonConstants/LHCConstants.h"
 #include "CommonDataFormat/TimeStamp.h"
 #include "CommonDataFormat/RangeReference.h"
+#include "CommonDataFormat/BunchFilling.h"
 #include "SimulationDataFormat/MCEventLabel.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "MathUtils/Utils.h"
@@ -50,12 +52,14 @@ class PVertexer
 
   void init();
   int process(gsl::span<const o2d::TrackTPCITS> tracksITSTPC, gsl::span<const o2::ft0::RecPoints> ft0Data,
-              std::vector<PVertex>& vertices, std::vector<int>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs,
+              std::vector<PVertex>& vertices, std::vector<o2d::VtxTrackIndex>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs,
               gsl::span<const o2::MCCompLabel> lblITS, gsl::span<const o2::MCCompLabel> lblTPC, std::vector<o2::MCEventLabel>& lblVtx);
+
   int process(gsl::span<const o2d::TrackTPCITS> tracksITSTPC, gsl::span<const o2::ft0::RecPoints> ft0Data,
-              std::vector<PVertex>& vertices, std::vector<int>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
+              std::vector<PVertex>& vertices, std::vector<o2d::VtxTrackIndex>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
+
   static void createMCLabels(gsl::span<const o2::MCCompLabel> lblITS, gsl::span<const o2::MCCompLabel> lblTPC,
-                             const std::vector<PVertex> vertices, const std::vector<int> vertexTrackIDs, const std::vector<V2TRef> v2tRefs,
+                             const std::vector<PVertex> vertices, const std::vector<o2d::VtxTrackIndex> vertexTrackIDs, const std::vector<V2TRef> v2tRefs,
                              std::vector<o2::MCEventLabel>& lblVtx);
   bool findVertex(const VertexingInput& input, PVertex& vtx);
 
@@ -68,6 +72,9 @@ class PVertexer
   float getTukey() const;
 
   void finalizeVertex(const VertexingInput& input, const PVertex& vtx, std::vector<PVertex>& vertices, std::vector<V2TRef>& v2tRefs, std::vector<int>& vertexTrackIDs, SeedHisto& histo);
+  bool setCompatibleIR(PVertex& vtx);
+
+  void setBunchFilling(const o2::BunchFilling& bf);
 
   void setBz(float bz) { mBz = bz; }
   void setValidateWithFT0(bool v) { mValidateWithFT0 = v; }
@@ -105,8 +112,11 @@ class PVertexer
   void clusterizeTimeBruteForce(float margin = 0.1, float cut = 25);
   void clusterizeTime(float binSize = 0.1, float maxTDist = 0.6);
   int findVertices(const VertexingInput& input, std::vector<PVertex>& vertices, std::vector<int>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
-  int getBestFT0Trigger(const PVertex& vtx, gsl::span<const o2::ft0::RecPoints> ft0Data, int& currEntry) const;
+  std::pair<int, int> getBestFT0Trigger(const PVertex& vtx, gsl::span<const o2::ft0::RecPoints> ft0Data, int& currEntry) const;
 
+  o2::BunchFilling mBunchFilling;
+  std::array<int16_t, o2::constants::lhc::LHCMaxBunches> mClosestBunchAbove; // closest filled bunch from above
+  std::array<int16_t, o2::constants::lhc::LHCMaxBunches> mClosestBunchBelow; // closest filled bunch from below
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   std::array<float, 3> mXYConstraintInvErr = {1.0f, 0.f, 1.0f}; ///< nominal vertex constraint inverted errors^2
   //

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
@@ -18,6 +18,7 @@
 #include "gsl/span"
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 #include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "CommonDataFormat/TimeStamp.h"
 #include "CommonDataFormat/RangeReference.h"
 
@@ -29,6 +30,7 @@ namespace vertexing
 using PVertex = o2::dataformats::PrimaryVertex;
 using TimeEst = o2::dataformats::TimeStampWithError<float, float>;
 using V2TRef = o2::dataformats::RangeReference<int, int>;
+using GIndex = o2::dataformats::VtxTrackIndex;
 
 ///< weights and scaling params for current vertex
 struct VertexSeed : public PVertex {

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
@@ -41,7 +41,9 @@ struct PVertexerParams : public o2::conf::ConfigurableParamHelper<PVertexerParam
   int minNContributorsForFT0cut = 4;    ///< do not apply FT0 cut to vertice below FT0 efficiency threshold
   float maxTError = 0.2;                ///< use min of vertex time error or this for nsigma evaluation
   float minTError = 0.003;              ///< don't use error smaller than that (~BC/2/minNContributorsForFT0cut)
-  float nSigmaFT0cut = 4.;              ///< eliminate vertex if there is no FT0 signal within this cut
+  float nSigmaTimeCut = 4.;             ///< eliminate vertex if there is no FT0 signal within this cut
+  float timeBiasMS = -0.035;            ///< relative bias in ms to add to TPCITS-based time stamp
+
   //
   // stopping condition params
   float maxChi2Mean = 10.;          ///< max mean chi2 of vertex to accept

--- a/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file VertexTrackMatcher.h
+/// \brief Class for vertex track association
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_VERTEX_TRACK_MATCHER_
+#define ALICEO2_VERTEX_TRACK_MATCHER_
+
+#include "gsl/span"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DetectorsVertexing/PVertexerParams.h"
+#include "MathUtils/Bracket.h"
+
+namespace o2
+{
+namespace vertexing
+{
+
+class VertexTrackMatcher
+{
+ public:
+  using GIndex = o2::dataformats::VtxTrackIndex;
+  using RRef = o2::dataformats::RangeReference<int, int>;
+  using PVertex = const o2::dataformats::PrimaryVertex;
+  using TrackTPCITS = o2::dataformats::TrackTPCITS;
+  using TrackITS = o2::its::TrackITS;
+  using ITSROFR = o2::itsmft::ROFRecord;
+  using TrackTPC = o2::tpc::TrackTPC;
+  using TmpMap = std::unordered_map<int, std::vector<GIndex>>;
+  using TimeEst = o2::dataformats::TimeStampWithError<float, float>;
+  using TBracket = o2::utils::Bracket<float>;
+
+  void init();
+  void process(const gsl::span<const PVertex>& vertices,   // vertices
+               const gsl::span<const GIndex>& v2tfitIDs,   // IDs of contributor tracks used in fit
+               const gsl::span<const RRef>& v2tfitRefs,    // references on these tracks
+               const gsl::span<const TrackTPCITS>& tpcits, // global tracks
+               const gsl::span<const TrackITS>& its,       // ITS tracks
+               const gsl::span<const ITSROFR>& itsROFR,    // ITS tracks ROFRecords
+               const gsl::span<const TrackTPC>& tpc,       // TPC tracks
+               std::vector<GIndex>& trackIndex,            // Global ID's for associated tracks
+               std::vector<RRef>& vtxRefs);                // references on these tracks
+
+  ///< set InteractionRecods for the beginning of the TF
+  void setStartIR(const o2::InteractionRecord& ir) { mStartIR = ir; }
+  void setITSROFrameLengthInBC(int nbc);
+  int getITSROFrameLengthInBC() const { return mITSROFrameLengthInBC; }
+
+ private:
+  void attachTPCITS(TmpMap& tmpMap, const gsl::span<const TrackTPCITS>& tpcits, const std::vector<int>& idTPCITS, const gsl::span<const PVertex>& vertices);
+  void attachITS(TmpMap& tmpMap, const gsl::span<const TrackITS>& its, const gsl::span<const ITSROFR>& itsROFR, const std::vector<int>& flITS,
+                 const gsl::span<const PVertex>& vertices, std::vector<int>& idxVtx);
+  void attachTPC(TmpMap& tmpMap, const std::vector<TBracket>& tpcTimes, const std::vector<int>& idTPC, const gsl::span<const PVertex>& vertices, std::vector<int>& idVtx);
+  bool compatibleTimes(const TimeEst& vtxT, const TimeEst& trcT) const;
+  void updateTPCTimeDependentParams();
+  float tpcTimeBin2MUS(float t)
+  { // convert TPC time bin to microseconds
+    return t * mTPCBin2MUS;
+  }
+
+  o2::InteractionRecord mStartIR{0, 0}; ///< IR corresponding to the start of the TF
+  int mITSROFrameLengthInBC = 0;        ///< ITS RO frame in BC (for ITS cont. mode only)
+  float mMaxTPCDriftTimeMUS = 0;
+  float mTPCBin2MUS = 0;
+  const o2::vertexing::PVertexerParams* mPVParams = nullptr;
+
+  ClassDefNV(VertexTrackMatcher, 1);
+};
+
+} // namespace vertexing
+} // namespace o2
+
+#endif

--- a/Detectors/Vertexing/src/DetectorsVertexingLinkDef.h
+++ b/Detectors/Vertexing/src/DetectorsVertexingLinkDef.h
@@ -21,6 +21,7 @@
 
 #pragma link C++ class o2::vertexing::PVertexer + ;
 #pragma link C++ class o2::vertexing::PVertexerParams + ;
+#pragma link C++ class o2::vertexing::VertexTrackMatcher + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::vertexing::PVertexerParams> + ;
 
 #pragma link C++ class o2::track::TrackAuxPar + ;

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -1,0 +1,246 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file VertexTrackMatcher.cxx
+/// \brief Class for vertex track association
+/// \author ruben.shahoyan@cern.ch
+
+#include "DetectorsVertexing/VertexTrackMatcher.h"
+#include <unordered_map>
+#include <numeric>
+#include "TPCBase/ParameterElectronics.h"
+#include "TPCBase/ParameterDetector.h"
+#include "TPCBase/ParameterGas.h"
+
+using namespace o2::vertexing;
+
+//___________________________________________________________________
+void VertexTrackMatcher::init()
+{
+  mPVParams = &o2::vertexing::PVertexerParams::Instance();
+  updateTPCTimeDependentParams(); // RS FIXME eventually should be set from CCDB for every TF
+}
+
+void VertexTrackMatcher::updateTPCTimeDependentParams()
+{
+  // tpc time bin in microseconds
+  auto& gasParam = o2::tpc::ParameterGas::Instance();
+  auto& elParam = o2::tpc::ParameterElectronics::Instance();
+  auto& detParam = o2::tpc::ParameterDetector::Instance();
+  mTPCBin2MUS = elParam.ZbinWidth;
+  mMaxTPCDriftTimeMUS = detParam.TPClength / gasParam.DriftV;
+}
+
+void VertexTrackMatcher::process(const gsl::span<const PVertex>& vertices,
+                                 const gsl::span<const GIndex>& v2tfitIDs,
+                                 const gsl::span<const RRef>& v2tfitRefs,
+                                 const gsl::span<const TrackTPCITS>& tpcitsTracks,
+                                 const gsl::span<const TrackITS>& itsTracks,
+                                 const gsl::span<const ITSROFR>& itsROFR,
+                                 const gsl::span<const TrackTPC>& tpcTracks,
+                                 std::vector<GIndex>& trackIndex,
+                                 std::vector<RRef>& vtxRefs)
+{
+
+  TmpMap tmpMap;
+  tmpMap.reserve(vertices.size());
+
+  // TPC/ITS and TPC tracks are not sorted in time, do this and exclude indiced of tracks used in the vertex fit
+  std::vector<int> idTPCITS(tpcitsTracks.size()); // indices of TPCITS tracks sorted in time
+  std::vector<int> idVtxIRMin(vertices.size());   // indices of vertices sorted in IRmin
+  std::vector<int> flgITS(itsTracks.size(), 0);
+  std::vector<int> idTPC(tpcTracks.size()); // indices of TPC tracks sorted in min time
+  std::iota(idTPC.begin(), idTPC.end(), 0);
+  std::iota(idTPCITS.begin(), idTPCITS.end(), 0);
+  std::iota(idVtxIRMin.begin(), idVtxIRMin.end(), 0);
+  for (auto id : v2tfitIDs) { // flag matched ITS-TPC tracks used in the vertex fit, we exclude them from this association
+    idTPCITS[id.getIndex()] = -1;
+  }
+  for (const auto& tpcits : tpcitsTracks) { // flag standalone ITS and TPC tracks used in global matched, we exclude them from association to vertex
+    flgITS[tpcits.getRefITS()] = -1;
+    idTPC[tpcits.getRefTPC()] = -1;
+  }
+  std::sort(idVtxIRMin.begin(), idVtxIRMin.end(), [&vertices](int i, int j) { // sort according to IRMin
+    return vertices[i].getIRMin() < vertices[j].getIRMin();
+  });
+  std::sort(idTPCITS.begin(), idTPCITS.end(), [&tpcitsTracks](int i, int j) { // sort according to central time
+    float tI = (i < 0) ? 1e9 : tpcitsTracks[i].getTimeMUS().getTimeStamp();
+    float tJ = (j < 0) ? 1e9 : tpcitsTracks[j].getTimeMUS().getTimeStamp();
+    return tI < tJ;
+  });
+
+  std::vector<TBracket> tpcTimes;
+  tpcTimes.reserve(tpcTracks.size());
+  for (const auto& trc : tpcTracks) {
+    tpcTimes.emplace_back(tpcTimeBin2MUS(trc.getTime0() - trc.getDeltaTBwd()), tpcTimeBin2MUS(trc.getTime0() + trc.getDeltaTFwd()));
+  }
+  std::sort(idTPC.begin(), idTPC.end(), [&tpcTimes](int i, int j) { // sort according to max time
+    float tI = (i < 0) ? 1e9 : tpcTimes[i].max();
+    float tJ = (j < 0) ? 1e9 : tpcTimes[j].max();
+    return tI < tJ;
+  });
+
+  attachTPCITS(tmpMap, tpcitsTracks, idTPCITS, vertices);
+  attachITS(tmpMap, itsTracks, itsROFR, flgITS, vertices, idVtxIRMin);
+  attachTPC(tmpMap, tpcTimes, idTPC, vertices, idVtxIRMin);
+
+  // build vector of global indices
+  trackIndex.clear();
+  vtxRefs.clear();
+  memset(idTPCITS.data(), 0, sizeof(int) * idTPCITS.size());
+  memset(idTPC.data(), 0, sizeof(int) * idTPC.size());
+  memset(flgITS.data(), 0, sizeof(int) * flgITS.size());
+  std::array<std::vector<int>*, GIndex::NSources> vptr;
+  vptr[GIndex::TPCITS] = &idTPCITS;
+  vptr[GIndex::ITS] = &flgITS;
+  vptr[GIndex::TPC] = &idTPC;
+  int nv = vertices.size();
+  // flag tracks attached to >1 vertex
+  for (int iv = 0; iv < nv; iv++) {
+    const auto& trvec = tmpMap[iv];
+    for (auto gid : trvec) {
+      (*vptr[gid.getSource()])[gid.getIndex()]++;
+    }
+  }
+  for (int iv = 0; iv < nv; iv++) {
+    int entry = trackIndex.size();
+    // 1st: attach indices of global tracks used in vertex fit
+    int idMin = v2tfitRefs[iv].getFirstEntry(), idMax = idMin + v2tfitRefs[iv].getEntries();
+    for (int id = idMin; id < idMax; id++) {
+      trackIndex.push_back(v2tfitIDs[id]);
+    }
+    // 2nd: attach non-contributing tracks
+    const auto& trvec = tmpMap[iv];
+    for (const auto gid0 : trvec) {
+      auto& gid = trackIndex.emplace_back(gid0);
+      if ((*vptr[gid.getSource()])[gid.getIndex()] > 1) {
+        gid.setBit(GIndex::Ambiguous);
+      }
+    }
+    vtxRefs.emplace_back(entry, trackIndex.size() - entry);
+  }
+}
+
+///______________________________________________________________________________________
+void VertexTrackMatcher::attachTPCITS(TmpMap& tmpMap, const gsl::span<const TrackTPCITS>& tpcits, const std::vector<int>& idTPCITS, const gsl::span<const PVertex>& vertices)
+{
+  int itrCurr = 0, nvt = vertices.size(), ntr = tpcits.size();
+  // indices of tracks used for vertex fit will be in the end, find their start and max error
+  float maxErr = 0;
+  for (int i = 0; i < ntr; i++) {
+    if (idTPCITS[i] < 0) {
+      ntr = i;
+      break;
+    }
+    float err = tpcits[idTPCITS[i]].getTimeMUS().getTimeStampError();
+    if (maxErr < err) {
+      maxErr = err;
+    }
+  }
+  auto maxErr2 = maxErr * maxErr;
+  for (int ivtCurr = 0; ivtCurr < nvt; ivtCurr++) {
+    const auto& vtxT = vertices[ivtCurr].getTimeStamp();
+    auto rangeT = mPVParams->nSigmaTimeCut * std::sqrt(maxErr2 + vtxT.getTimeStampError() * vtxT.getTimeStampError());
+    float minTime = vtxT.getTimeStamp() - rangeT, maxTime = vtxT.getTimeStamp() + rangeT;
+    // proceed to the 1st track having compatible time
+    int itr = itrCurr;
+    while (itr < ntr) {
+      const auto& trcT = tpcits[idTPCITS[itr]].getTimeMUS();
+      if (trcT.getTimeStamp() < minTime) {
+        itrCurr = itr;
+      } else if (trcT.getTimeStamp() > maxTime) {
+        break;
+      } else if (compatibleTimes(vtxT, trcT)) {
+        tmpMap[ivtCurr].emplace_back(idTPCITS[itr], GIndex::TPCITS);
+      }
+      itr++;
+    }
+  }
+}
+
+///______________________________________________________________________________________
+void VertexTrackMatcher::attachITS(TmpMap& tmpMap, const gsl::span<const TrackITS>& itsTracks, const gsl::span<const ITSROFR>& itsROFR, const std::vector<int>& flITS,
+                                   const gsl::span<const PVertex>& vertices, std::vector<int>& idxVtx)
+{
+  int irofCurr = 0, nvt = vertices.size(), ntr = itsTracks.size();
+  int nROFs = itsROFR.size();
+
+  for (int ivtCurr = 0; ivtCurr < nvt; ivtCurr++) {
+    const auto& vtx = vertices[idxVtx[ivtCurr]]; // we iterate over vertices in order of their getIRMin()
+    int irof = irofCurr;
+    while (irof < nROFs) {
+      const auto& rofr = itsROFR[irof];
+      auto irMin = rofr.getBCData(), irMax = irMin + mITSROFrameLengthInBC;
+      if (irMax < vtx.getIRMin()) {
+        irofCurr = irof;
+      } else if (irMin > vtx.getIRMax()) {
+        break;
+      } else {
+        if (irMax == vtx.getIRMin()) {
+          irofCurr = irof;
+        }
+        int maxItr = rofr.getNEntries() + rofr.getFirstEntry();
+        for (int itr = rofr.getFirstEntry(); itr < maxItr; itr++) {
+          if (flITS[itr] != -1) {
+            tmpMap[ivtCurr].emplace_back(itr, GIndex::ITS);
+          }
+        }
+      }
+      irof++;
+    }
+  }
+}
+
+///______________________________________________________________________________________
+void VertexTrackMatcher::attachTPC(TmpMap& tmpMap, const std::vector<TBracket>& tpcTimes, const std::vector<int>& idTPC,
+                                   const gsl::span<const PVertex>& vertices, std::vector<int>& idVtx)
+{
+  int itrCurr = 0, nvt = vertices.size(), ntr = idTPC.size();
+  // indices of tracks used for vertex fit will be in the end, find their start and max error
+  for (int i = 0; i < ntr; i++) {
+    if (idTPC[i] < 0) {
+      ntr = i;
+      break;
+    }
+  }
+  for (int ivtCurr = 0; ivtCurr < nvt; ivtCurr++) {
+    const auto& vtx = vertices[idVtx[ivtCurr]];
+    TBracket tV(vtx.getIRMin().differenceInBC(mStartIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3,
+                vtx.getIRMax().differenceInBC(mStartIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3);
+    // proceed to the 1st track having compatible time, idTPC provides track IDs ordered in max time
+    int itr = itrCurr;
+    while (itr < ntr) {
+      const auto& tT = tpcTimes[idTPC[itr]];
+      auto rel = tV.isOutside(tT);
+      if (rel == TBracket::Below) { // tmax of track < tmin of vtx
+        itrCurr = itr;
+      } else if (rel == TBracket::Inside) {
+        tmpMap[ivtCurr].emplace_back(idTPC[itr], GIndex::TPC);
+      } else if (tT.max() - mMaxTPCDriftTimeMUS > tV.max()) {
+        break;
+      }
+      itr++;
+    }
+  }
+}
+
+//______________________________________________
+void VertexTrackMatcher::setITSROFrameLengthInBC(int nbc)
+{
+  mITSROFrameLengthInBC = nbc;
+}
+
+//______________________________________________
+bool VertexTrackMatcher::compatibleTimes(const TimeEst& vtxT, const TimeEst& trcT) const
+{
+  float err2 = vtxT.getTimeStampError() * vtxT.getTimeStampError() + trcT.getTimeStampError() * trcT.getTimeStampError();
+  float dfred = (vtxT.getTimeStamp() - trcT.getTimeStamp()) * mPVParams->nSigmaTimeCut;
+  return dfred * dfred < err2;
+}


### PR DESCRIPTION
At the moment the pr.vertex - track matching is done in time only (except vertex fit contributor TPC/ITS tracks), for every vertex list of global indices (VtxTrackIndex) is added, providing the source (global, or ITS or TPC track), ID in the source and bit flags for contributors and ambiguous assignment.