### PR TITLE
Improve treatment of triggered events

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
@@ -54,16 +54,15 @@ class GBTOutputHandler
   std::vector<ROFRecord> mROFRecords{}; /// List of ROF records
   uint16_t mFeeId{0};                   /// FEE ID
   InteractionRecord mIRFirstPage{};     /// Interaction record of the first page
+  uint16_t mReceivedCalibration{0};     /// Flag to test if a calibration trigger was received
 
-  std::array<InteractionRecord, crateparams::sNELinksPerGBT> mIRs{}; /// Interaction records per link
-  std::array<uint16_t, crateparams::sNELinksPerGBT> mCalibClocks{};  /// Calibration clock
-  std::array<uint16_t, crateparams::sNELinksPerGBT> mLastClock{};    /// Last clock per link
+  std::array<InteractionRecord, crateparams::sNELinksPerGBT> mIRs{};     /// Interaction records per link
+  std::array<uint16_t, crateparams::sNELinksPerGBT> mExpectedFETClock{}; /// Expected FET clock
+  std::array<uint16_t, crateparams::sNELinksPerGBT> mLastClock{};        /// Last clock per link
 
-  void addBoard(size_t ilink, const ELinkDecoder& decoder);
-  void addLoc(size_t ilink, const ELinkDecoder& decoder);
+  void addLoc(size_t ilink, const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock);
   bool checkLoc(size_t ilink, const ELinkDecoder& decoder);
-  bool updateIR(size_t ilink, const ELinkDecoder& decoder);
-  bool invertPattern(LocalBoardRO& loc);
+  bool processTrigger(size_t ilink, const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock);
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
@@ -54,7 +54,7 @@ class GBTOutputHandler
   std::vector<ROFRecord> mROFRecords{}; /// List of ROF records
   uint16_t mFeeId{0};                   /// FEE ID
   InteractionRecord mIRFirstPage{};     /// Interaction record of the first page
-  uint16_t mReceivedCalibration{0};     /// Flag to test if a calibration trigger was received
+  uint16_t mReceivedCalibration{0};     /// Word with one bit per e-link indicating if the calibration trigger was received by the e-link
 
   std::array<InteractionRecord, crateparams::sNELinksPerGBT> mIRs{};     /// Interaction records per link
   std::array<uint16_t, crateparams::sNELinksPerGBT> mExpectedFETClock{}; /// Expected FET clock

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
@@ -62,6 +62,9 @@ class GBTOutputHandler
 
   void addLoc(size_t ilink, const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock);
   bool checkLoc(size_t ilink, const ELinkDecoder& decoder);
+  EventType processCalibrationTrigger(size_t ilink, uint16_t localClock);
+  void processOrbitTrigger(size_t ilink, uint16_t localClock, uint8_t triggerWord);
+  EventType processSelfTriggered(size_t ilink, uint16_t localClock, uint16_t& correctedClock);
   bool processTrigger(size_t ilink, const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock);
 };
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
@@ -37,12 +37,7 @@ void GBTOutputHandler::setIR(uint16_t bc, uint32_t orbit, int pageCnt)
       ir.bc = bc;
       ir.orbit = orbit;
     }
-    for (auto& clock : mLastClock) {
-      clock = constants::lhc::LHCMaxBunches;
-    }
-    for (auto& clock : mCalibClocks) {
-      clock = constants::lhc::LHCMaxBunches;
-    }
+    mLastClock.fill(constants::lhc::LHCMaxBunches);
   }
 
   if (pageCnt == 0) {
@@ -62,112 +57,121 @@ bool GBTOutputHandler::checkLoc(size_t ilink, const ELinkDecoder& decoder)
   return (ilink == decoder.getId() % 8);
 }
 
-void GBTOutputHandler::addBoard(size_t ilink, const ELinkDecoder& decoder)
+bool GBTOutputHandler::processTrigger(size_t ilink, const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock)
 {
-  /// Adds the local or regional board to the output data vector
-  uint16_t localClock = decoder.getCounter();
-  EventType eventType = EventType::Standard;
-  if (decoder.getTriggerWord() & raw::sCALIBRATE) {
-    mCalibClocks[ilink] = localClock;
-    eventType = EventType::Noise;
-  } else if (localClock == mCalibClocks[ilink] + sDelayCalibToFET) {
-    eventType = EventType::Dead;
+  /// Processes the trigger information
+  /// Returns true if the event should be further processed,
+  /// returns false otherwise.
+  uint16_t linkMask = 1 << ilink;
+  eventType = EventType::Standard;
+
+  if (decoder.getTriggerWord() == 0) {
+    // This is a self-triggered event
+    auto localClock = decoder.getCounter();
+    if ((mReceivedCalibration & linkMask) && (localClock == mExpectedFETClock[ilink])) {
+      mReceivedCalibration &= ~linkMask;
+      eventType = EventType::Dead;
+    }
+    correctedClock = localClock - sDelayBCToLocal;
+    return true;
   }
-  auto firstEntry = mData.size();
-  mData.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), decoder.getId()), decoder.getInputs()});
-  InteractionRecord intRec(mIRs[ilink].bc + localClock - sDelayBCToLocal, mIRs[ilink].orbit);
-  mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
+
+  // From here we treat triggered events
+  bool goOn = false;
+  correctedClock = decoder.getCounter();
+  if (decoder.getTriggerWord() & raw::sCALIBRATE) {
+    mExpectedFETClock[ilink] = correctedClock + sDelayCalibToFET;
+    mReceivedCalibration |= linkMask;
+    eventType = EventType::Noise;
+    goOn = true;
+  }
+
+  if (decoder.getTriggerWord() & raw::sORB) {
+    // This is the answer to an orbit trigger
+    // The local clock is reset: we are now in synch with the new HB
+    // ++mIRs[ilink].orbit;
+    mIRs[ilink] = mIRFirstPage; // TODO: CHECK
+    if ((decoder.getTriggerWord() & raw::sSOX) == 0) {
+      mLastClock[ilink] = correctedClock;
+    }
+    // The orbit trigger resets the clock.
+    // If we received a calibration trigger, we need to change the value of the expected clock accordingly
+    if (mReceivedCalibration & linkMask) {
+      mExpectedFETClock[ilink] -= (correctedClock + 1);
+    }
+  }
+
+  return goOn;
 }
 
-void GBTOutputHandler::addLoc(size_t ilink, const ELinkDecoder& decoder)
+void GBTOutputHandler::addLoc(size_t ilink, const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock)
 {
   /// Adds the local board to the output data vector
-  addBoard(ilink, decoder);
+  auto firstEntry = mData.size();
+  mData.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), decoder.getId()), decoder.getInputs()});
+  InteractionRecord intRec(mIRs[ilink].bc + correctedClock, mIRs[ilink].orbit);
+  mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
   for (int ich = 0; ich < 4; ++ich) {
     if ((mData.back().firedChambers & (1 << ich))) {
       mData.back().patternsBP[ich] = decoder.getPattern(0, ich);
       mData.back().patternsNBP[ich] = decoder.getPattern(1, ich);
     }
   }
-  if (mROFRecords.back().eventType == EventType::Dead) {
-    if (invertPattern(mData.back())) {
-      mData.pop_back();
-      mROFRecords.pop_back();
-    }
-  }
-}
-
-bool GBTOutputHandler::updateIR(size_t ilink, const ELinkDecoder& decoder)
-{
-  /// Updates the interaction record for the link
-  if (decoder.getTriggerWord() & raw::sORB) {
-    // This is the answer to an orbit trigger
-    // The local clock is reset: we are now in synch with the new HB
-    mIRs[ilink] = mIRFirstPage;
-    if (!(decoder.getTriggerWord() & (raw::sSOX | raw::sEOX))) {
-      mLastClock[ilink] = decoder.getCounter();
-    }
-    return true;
-  }
-  return false;
 }
 
 void GBTOutputHandler::onDoneLoc(size_t ilink, const ELinkDecoder& decoder)
 {
   /// Performs action on decoded local board
-  if (updateIR(ilink, decoder)) {
-    return;
-  }
-  if (checkLoc(ilink, decoder)) {
-    addLoc(ilink, decoder);
+  EventType eventType;
+  uint16_t correctedClock;
+  if (processTrigger(ilink, decoder, eventType, correctedClock) && checkLoc(ilink, decoder)) {
+    addLoc(ilink, decoder, eventType, correctedClock);
   }
 }
 
 void GBTOutputHandler::onDoneLocDebug(size_t ilink, const ELinkDecoder& decoder)
 {
-
   /// This always adds the local board to the output, without performing tests
-  updateIR(ilink, decoder);
-  addLoc(ilink, decoder);
+  EventType eventType;
+  uint16_t correctedClock;
+  processTrigger(ilink, decoder, eventType, correctedClock);
+  addLoc(ilink, decoder, eventType, correctedClock);
+  if (decoder.getTriggerWord() & raw::sORB) {
+    // The local clock is increased when receiving an orbit trigger,
+    // but the local counter returned in answering the trigger
+    // belongs to the previous orbit
+    --mROFRecords.back().interactionRecord.orbit;
+  }
 }
 
 void GBTOutputHandler::onDoneRegDebug(size_t ilink, const ELinkDecoder& decoder)
 {
   /// Performs action on decoded regional board in debug mode.
-  updateIR(ilink, decoder);
-  addBoard(ilink, decoder);
-  // The board creation is optimized for the local boards, not the regional
-  // (which are transmitted only in debug mode).
-  // So, at this point, for the regional board, the local Id is actually the crate ID.
+  EventType eventType;
+  uint16_t correctedClock;
+  processTrigger(ilink, decoder, eventType, correctedClock);
   // If we want to distinguish the two regional e-links, we can use the link ID instead
-  mData.back().boardId = crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1));
-  if (mData.back().triggerWord == 0) {
-    if (mROFRecords.back().interactionRecord.bc < sDelayRegToLocal) {
+  auto firstEntry = mData.size();
+  mData.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1)), decoder.getInputs()});
+
+  auto orbit = (decoder.getTriggerWord() & raw::sORB) ? mIRs[ilink].orbit - 1 : mIRs[ilink].orbit;
+
+  InteractionRecord intRec(mIRs[ilink].bc + correctedClock, orbit);
+  if (decoder.getTriggerWord() == 0) {
+    if (intRec.bc < sDelayRegToLocal) {
       // In the tests, the HB does not really correspond to a change of orbit
       // So we need to keep track of the last clock at which the HB was received
       // and come back to that value
       // FIXME: Remove this part as well as mLastClock when tests are no more needed
-      mROFRecords.back().interactionRecord -= (constants::lhc::LHCMaxBunches - mLastClock[ilink] - 1);
+      intRec -= (constants::lhc::LHCMaxBunches - mLastClock[ilink] - 1);
     }
     // This is a self-triggered event.
     // In this case the regional card needs to wait to receive the tracklet decision of each local
     // which result in a delay that needs to be subtracted if we want to be able to synchronize
     // local and regional cards for the checks
-    mROFRecords.back().interactionRecord -= sDelayRegToLocal;
+    intRec -= sDelayRegToLocal;
   }
-}
-
-bool GBTOutputHandler::invertPattern(LocalBoardRO& loc)
-{
-  /// Gets the proper pattern
-  for (int ich = 0; ich < 4; ++ich) {
-    loc.patternsBP[ich] = ~loc.patternsBP[ich];
-    loc.patternsNBP[ich] = ~loc.patternsNBP[ich];
-    if (loc.patternsBP[ich] == 0 && loc.patternsNBP[ich] == 0) {
-      loc.firedChambers &= ~(1 << ich);
-    }
-  }
-  return (loc.firedChambers == 0);
+  mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
@@ -35,7 +35,11 @@ void GBTOutputHandler::setIR(uint16_t bc, uint32_t orbit, int pageCnt)
   if (mIRs[0].isDummy()) {
     for (auto& ir : mIRs) {
       ir.bc = bc;
-      ir.orbit = orbit;
+      // The reset changes depending on the way we synch with the orbit
+      // (see processOrbitTrigger for details)
+      // FIXME: pick one of the two
+      ir.orbit = orbit - 1; // with orbit increase
+      // ir.orbit = orbit; // with reset to RDH
     }
     mLastClock.fill(constants::lhc::LHCMaxBunches);
   }
@@ -57,48 +61,77 @@ bool GBTOutputHandler::checkLoc(size_t ilink, const ELinkDecoder& decoder)
   return (ilink == decoder.getId() % 8);
 }
 
+EventType GBTOutputHandler::processSelfTriggered(size_t ilink, uint16_t localClock, uint16_t& correctedClock)
+{
+  /// Processes the self-triggered event
+  correctedClock = localClock - sDelayBCToLocal;
+  uint16_t linkMask = 1 << ilink;
+  if ((mReceivedCalibration & linkMask) && (localClock == mExpectedFETClock[ilink])) {
+    // Reset the calibration flag for this e-link
+    mReceivedCalibration &= ~linkMask;
+    return EventType::Dead;
+  }
+  return EventType::Standard;
+}
+
+EventType GBTOutputHandler::processCalibrationTrigger(size_t ilink, uint16_t localClock)
+{
+  /// Processes the calibration event
+  mExpectedFETClock[ilink] = localClock + sDelayCalibToFET;
+  mReceivedCalibration |= (1 << ilink);
+  return EventType::Noise;
+}
+
+void GBTOutputHandler::processOrbitTrigger(size_t ilink, uint16_t localClock, uint8_t triggerWord)
+{
+  /// Processes the orbit trigger event
+
+  // The local clock is reset: we are now in synch with the new HB
+  // We have to way to account for the orbit change:
+  // - increase the orbit counter by 1 for this e-link
+  //   (CAVEAT: synch is lost if we lose some orbit)
+  // - set the orbit to the one found in RDH
+  //   (CAVEAT: synch is lost if we have lot of data, spanning over two orbits)
+  // FIXME: pick one of the two
+  ++mIRs[ilink].orbit; // orbit increase
+  // mIRs[ilink] = mIRFirstPage; // reset to RDH
+  if ((triggerWord & raw::sSOX) == 0) {
+    mLastClock[ilink] = localClock;
+  }
+  // The orbit trigger resets the clock.
+  // If we received a calibration trigger, we need to change the value of the expected clock accordingly
+  if (mReceivedCalibration & (1 << ilink)) {
+    mExpectedFETClock[ilink] -= (localClock + 1);
+  }
+}
+
 bool GBTOutputHandler::processTrigger(size_t ilink, const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock)
 {
   /// Processes the trigger information
   /// Returns true if the event should be further processed,
   /// returns false otherwise.
   uint16_t linkMask = 1 << ilink;
-  eventType = EventType::Standard;
+  auto localClock = decoder.getCounter();
 
   if (decoder.getTriggerWord() == 0) {
     // This is a self-triggered event
-    auto localClock = decoder.getCounter();
-    if ((mReceivedCalibration & linkMask) && (localClock == mExpectedFETClock[ilink])) {
-      mReceivedCalibration &= ~linkMask;
-      eventType = EventType::Dead;
-    }
-    correctedClock = localClock - sDelayBCToLocal;
+    eventType = processSelfTriggered(ilink, localClock, correctedClock);
     return true;
   }
 
   // From here we treat triggered events
   bool goOn = false;
-  correctedClock = decoder.getCounter();
+  correctedClock = localClock;
   if (decoder.getTriggerWord() & raw::sCALIBRATE) {
-    mExpectedFETClock[ilink] = correctedClock + sDelayCalibToFET;
-    mReceivedCalibration |= linkMask;
-    eventType = EventType::Noise;
+    // This is an answer to a calibration trigger
+    eventType = processCalibrationTrigger(ilink, localClock);
     goOn = true;
   }
 
   if (decoder.getTriggerWord() & raw::sORB) {
     // This is the answer to an orbit trigger
-    // The local clock is reset: we are now in synch with the new HB
-    // ++mIRs[ilink].orbit;
-    mIRs[ilink] = mIRFirstPage; // TODO: CHECK
-    if ((decoder.getTriggerWord() & raw::sSOX) == 0) {
-      mLastClock[ilink] = correctedClock;
-    }
-    // The orbit trigger resets the clock.
-    // If we received a calibration trigger, we need to change the value of the expected clock accordingly
-    if (mReceivedCalibration & linkMask) {
-      mExpectedFETClock[ilink] -= (correctedClock + 1);
-    }
+    processOrbitTrigger(ilink, localClock, decoder.getTriggerWord());
+    eventType = EventType::Standard;
   }
 
   return goOn;


### PR DESCRIPTION
The MID electronics replies with special notification events each time it receives a trigger from the CTP.
The treatment of such events depends on the trigger received.
For example, the answer to an orbit trigger does not provide any fired strips and only implies that the following data will belong to a different orbit.
On the other hand, the response to a calibration trigger also provides the strips that were fired when the trigger was received (this information is used to determine the noisy channel).
The treatment of these signals was performed in the function that added the fired patterns.
This PR is meant to better separate the treatment of the response to a trigger from the treatment of the fired strips.