### PR TITLE
DPL Analysis: First version of histogram registry writing

### DIFF
--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -124,3 +124,8 @@ o2_add_dpl_workflow(hist-helpers-test
                     SOURCES src/histHelpersTest.cxx
                     PUBLIC_LINK_LIBRARIES O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME AnalysisTutorial)
+
+o2_add_dpl_workflow(histogram-registry
+                  SOURCES src/histogramRegistry.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisCore O2::AnalysisDataModel
+                  COMPONENT_NAME AnalysisTutorial)

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -23,7 +23,7 @@ using namespace o2::framework;
 //        we need GCC 7.4+ for that
 struct ATask {
   /// Construct a registry object with direct declaration
-  HistogramRegistry registry{"registry", true, {{"eta", "#Eta", {HistogramType::kTH1F, {{102, -2.01, 2.01}}}}, {"phi", "#Phi", {HistogramType::kTH1F, {{100, 0., 2. * M_PI}}}}}};
+  HistogramRegistry registry{"registry", true, {{"eta", "#eta", {HistogramType::kTH1F, {{102, -2.01, 2.01}}}}, {"phi", "#varphi", {HistogramType::kTH1F, {{100, 0., 2. * M_PI}}}}}};
 
   void process(aod::Tracks const& tracks)
   {

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/HistogramRegistry.h"
+#include <TH1F.h>
+
+#include <cmath>
+
+using namespace o2;
+using namespace o2::framework;
+
+// This is a very simple example showing how to create an histogram
+// FIXME: this should really inherit from AnalysisTask but
+//        we need GCC 7.4+ for that
+struct ATask {
+  /// Construct a registry object with direct declaration
+  HistogramRegistry registry{"registry", true, {{"eta", "#Eta", {HistogramType::kTH1F, {{102, -2.01, 2.01}}}}, {"phi", "#Phi", {HistogramType::kTH1F, {{100, 0., 2. * M_PI}}}}}};
+
+  void process(aod::Tracks const& tracks)
+  {
+    for (auto& track : tracks) {
+      registry.get("eta")->Fill(track.eta());
+      registry.get("phi")->Fill(track.phi());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<ATask>("eta-and-phi-histograms")};
+}

--- a/Framework/Core/include/Framework/CommonDataProcessors.h
+++ b/Framework/Core/include/Framework/CommonDataProcessors.h
@@ -26,6 +26,9 @@ using outputObjects = std::vector<std::pair<uint32_t, std::vector<std::string>>>
 
 /// Helpers to create a few general data processors
 struct CommonDataProcessors {
+  /// Match all inputs of kind HIST and write them to a ROOT file,
+  /// one root file per originating task.
+  static DataProcessorSpec getHistogramRegistrySink(outputObjects const& objmap, const outputTasks& tskmap);
   /// Match all inputs of kind ATSK and write them to a ROOT file,
   /// one root file per originating task.
   static DataProcessorSpec getOutputObjSink(outputObjects const& objmap, const outputTasks& tskmap);

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -31,7 +31,6 @@
 
 #include <string>
 #include <variant>
-#include <sstream>
 namespace o2
 {
 
@@ -291,25 +290,9 @@ class HistogramRegistry
   {
     return OutputRef{std::string{this->name}, 0, o2::header::Stack{OutputObjHeader{policy, taskHash}}};
   }
-
   void setHash(uint32_t hash)
   {
     taskHash = hash;
-  }
-
-  std::vector<ROOTSerialized<TH1&, TClass>> getHistogramsToWrite()
-  {
-    std::vector<ROOTSerialized<TH1&, TClass>> histos;
-    for (auto j = 0u; j < MAX_REGISTRY_SIZE; ++j) {
-      if (mRegistryValue[j].get() != nullptr) {
-        auto& hist = *(mRegistryValue[j].get());
-        TClass* hint = TClass::GetClass(typeid(hist));
-        std::string histPrefixedName = getHistName(hist.GetName());
-        hist.SetName(histPrefixedName.c_str());
-        histos.push_back(ROOTSerialized<TH1&, TClass>(hist, hint));
-      }
-    }
-    return histos;
   }
 
   TList* operator*()
@@ -347,13 +330,6 @@ class HistogramRegistry
   {
     return i & mask;
   }
-
-  std::string getHistName(const char* oldName) {
-    std::stringstream ss;
-    ss << name << ":" << oldName;
-    return ss.str();
-  }
-
   std::string name;
   bool enabled;
   OutputObjHandlingPolicy policy;

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -27,6 +27,7 @@
 #include "TH3.h"
 #include "THn.h"
 #include "THnSparse.h"
+#include "TList.h"
 
 #include <string>
 #include <variant>
@@ -309,6 +310,19 @@ class HistogramRegistry
       }
     }
     return histos;
+  }
+
+  TList* operator*()
+  {
+    TList* list = new TList();
+    list->SetName(this->name.c_str());
+    for (auto j = 0u; j < MAX_REGISTRY_SIZE; ++j) {
+      if (mRegistryValue[j].get() != nullptr) {
+        auto hist = mRegistryValue[j].get();
+        list->Add(hist);
+      }
+    }
+    return list;
   }
 
   /// lookup distance counter for benchmarking

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -183,10 +183,12 @@ struct OutputManager<HistogramRegistry> {
 
   static bool postRun(EndOfStreamContext& context, HistogramRegistry& what)
   {
-    for (auto& hist : what.getHistogramsToWrite()) {
-      std::cout << "Writing histogram: " << hist().GetName() << std::endl;
-      context.outputs().snapshot(what.ref(), hist);
-    }
+    //for (auto& hist : what.getHistogramsToWrite()) {
+    //  std::cout << "Writing histogram: " << hist().GetName() << std::endl;
+    //  context.outputs().snapshot(what.ref(), hist);
+    //}
+    TList* list = *what;
+    context.outputs().snapshot(what.ref(), *list);
     return true;
   }
 };

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -22,6 +22,8 @@
 #include "Framework/RootConfigParamHelpers.h"
 #include "../src/ExpressionHelpers.h"
 
+#include <iostream>
+
 namespace o2::framework
 {
 
@@ -163,8 +165,9 @@ struct OutputManager<Produces<TABLE>> {
 /// HistogramRegistry specialization
 template <>
 struct OutputManager<HistogramRegistry> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, HistogramRegistry& what, uint32_t)
+  static bool appendOutput(std::vector<OutputSpec>& outputs, HistogramRegistry& what, uint32_t hash)
   {
+    what.setHash(hash);
     outputs.emplace_back(what.spec());
     return true;
   }
@@ -178,8 +181,12 @@ struct OutputManager<HistogramRegistry> {
     return true;
   }
 
-  static bool postRun(EndOfStreamContext&, HistogramRegistry&)
+  static bool postRun(EndOfStreamContext& context, HistogramRegistry& what)
   {
+    for (auto& hist : what.getHistogramsToWrite()) {
+      std::cout << "Writing histogram: " << hist().GetName() << std::endl;
+      context.outputs().snapshot(what.ref(), hist);
+    }
     return true;
   }
 };

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -22,8 +22,6 @@
 #include "Framework/RootConfigParamHelpers.h"
 #include "../src/ExpressionHelpers.h"
 
-#include <iostream>
-
 namespace o2::framework
 {
 
@@ -183,10 +181,6 @@ struct OutputManager<HistogramRegistry> {
 
   static bool postRun(EndOfStreamContext& context, HistogramRegistry& what)
   {
-    //for (auto& hist : what.getHistogramsToWrite()) {
-    //  std::cout << "Writing histogram: " << hist().GetName() << std::endl;
-    //  context.outputs().snapshot(what.ref(), hist);
-    //}
     TList* list = *what;
     context.outputs().snapshot(what.ref(), *list);
     return true;

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -163,12 +163,12 @@ DataProcessorSpec CommonDataProcessors::getHistogramRegistrySink(outputObjects c
       TNamed* named = static_cast<TNamed*>(obj.obj);
       obj.name = named->GetName();
       LOG(INFO) << "Object name: " << obj.name;
-      auto prefPos = obj.name.find(":", 0);
-      std::string prefix = obj.name.substr(0, prefPos);
-      std::string strippedName = obj.name.substr(prefPos + 1);
-      LOG(INFO) << "Name: " << obj.name << " prefix: " << prefix << " strippedName: " << strippedName;
-      obj.name = strippedName;
-      named->SetName(strippedName.c_str());
+      //auto prefPos = obj.name.find(":", 0);
+      //std::string prefix = obj.name.substr(0, prefPos);
+      //std::string strippedName = obj.name.substr(prefPos + 1);
+      //LOG(INFO) << "Name: " << obj.name << " prefix: " << prefix << " strippedName: " << strippedName;
+      //obj.name = strippedName;
+      //named->SetName(strippedName.c_str());
 
       auto hpos = std::find_if(tskmap.begin(), tskmap.end(), [&](auto&& x) { return x.first == hash; });
       if (hpos == tskmap.end()) {
@@ -188,8 +188,9 @@ DataProcessorSpec CommonDataProcessors::getHistogramRegistrySink(outputObjects c
         LOG(INFO) << o;
       }
       LOG(INFO) << "end of objects";
-      if (std::find(objects.begin(), objects.end(), prefix) == objects.end()) {
-        LOG(ERROR) << "No object " << obj.name << " with prefix " << prefix << " in map for task " << taskname;
+      if (std::find(objects.begin(), objects.end(), obj.name) == objects.end()) {
+        //LOG(ERROR) << "No object " << obj.name << " with prefix " << prefix << " in map for task " << taskname;
+        LOG(ERROR) << "No object " << obj.name << " in map for task " << taskname;
         return;
       }
       auto nameHash = compile_time_hash(obj.name.c_str());

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -360,7 +360,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
   // This is to inject a file sink so that any dangling HIST object is written
   // to a ROOT file.
-  if (providedHist.size() != 0) {
+  if (providedHist.empty() == false) {
     LOG(INFO) << "Provided hist size: " << providedHist.size();
     auto rootSink = CommonDataProcessors::getHistogramRegistrySink(outHistMap, outTskMap);
     extraSpecs.push_back(rootSink);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -216,15 +216,18 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::vector<InputSpec> requestedCCDBs;
   std::vector<OutputSpec> providedCCDBs;
   std::vector<OutputSpec> providedOutputObj;
+  std::vector<OutputSpec> providedHist;
 
   outputTasks outTskMap;
   outputObjects outObjMap;
+  outputObjects outHistMap;
 
   for (size_t wi = 0; wi < workflow.size(); ++wi) {
     auto& processor = workflow[wi];
     auto name = processor.name;
     auto hash = compile_time_hash(name.c_str());
     outTskMap.push_back({hash, name});
+    LOG(INFO) << "Processor name: " << name << " hash: " << hash;
 
     std::string prefix = "internal-dpl-";
     if (processor.inputs.empty() && processor.name.compare(0, prefix.size(), prefix) != 0) {
@@ -278,13 +281,29 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
+        LOG(INFO) << "Found output object: " << output.binding.value;
         providedOutputObj.emplace_back(output);
         auto it = std::find_if(outObjMap.begin(), outObjMap.end(), [&](auto&& x) { return x.first == hash; });
         if (it == outObjMap.end()) {
+          LOG(INFO) << "Pushing new hash: " << hash;
           outObjMap.push_back({hash, {output.binding.value}});
         } else {
+          LOG(INFO) << "Adding to existing list";
           it->second.push_back(output.binding.value);
         }
+        LOG(INFO) << "provided output size: " << providedOutputObj.size() << " output map size: " << outObjMap.size();
+      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"HIST"})) {
+        LOG(INFO) << "Found output histogram: " << output.binding.value;
+        providedHist.emplace_back(output);
+        auto it = std::find_if(outHistMap.begin(), outHistMap.end(), [&](auto&& x) { return x.first == hash; });
+        if (it == outHistMap.end()) {
+          LOG(INFO) << "Pushing new hash: " << hash;
+          outHistMap.push_back({hash, {output.binding.value}});
+        } else {
+          LOG(INFO) << "Adding to existing list";
+          it->second.push_back(output.binding.value);
+        }
+        LOG(INFO) << "provided hist size: " << providedHist.size() << " output hist map size: " << outHistMap.size();
       }
       if (output.lifetime == Lifetime::Condition) {
         providedCCDBs.push_back(output);
@@ -335,7 +354,15 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // This is to inject a file sink so that any dangling ATSK object is written
   // to a ROOT file.
   if (providedOutputObj.empty() == false) {
+    LOG(INFO) << "Provided output objects size: " << providedOutputObj.size();
     auto rootSink = CommonDataProcessors::getOutputObjSink(outObjMap, outTskMap);
+    extraSpecs.push_back(rootSink);
+  }
+  // This is to inject a file sink so that any dangling HIST object is written
+  // to a ROOT file.
+  if (providedHist.size() != 0) {
+    LOG(INFO) << "Provided hist size: " << providedHist.size();
+    auto rootSink = CommonDataProcessors::getHistogramRegistrySink(outHistMap, outTskMap);
     extraSpecs.push_back(rootSink);
   }
 
@@ -367,6 +394,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
 
   if (OutputsInputsAOD.size() > 0) {
+    LOGF(INFO, "AOD outputs size: %lu", OutputsInputsAOD.size());
     auto fileSink = CommonDataProcessors::getGlobalAODSink(OutputsInputsAOD,
                                                            isdangling);
     extraSpecs.push_back(fileSink);
@@ -385,6 +413,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   std::vector<InputSpec> unmatched;
   if (OutputsInputsDangling.size() > 0) {
+    LOGF(INFO, "Dangling outputs detected");
     auto fileSink = CommonDataProcessors::getGlobalFileSink(OutputsInputsDangling, unmatched);
     if (unmatched.size() != OutputsInputsDangling.size()) {
       extraSpecs.push_back(fileSink);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -162,7 +162,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     LOG(INFO) << "To be hidden / removed at some point.";
     // mark this dummy process as ready-to-quit
     ic.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-  
+
     return [](ProcessingContext& pc) {
       // this callback is never called since there is no expiring input
       pc.services().get<RawDeviceService>().waitFor(2000);
@@ -227,7 +227,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     auto name = processor.name;
     auto hash = compile_time_hash(name.c_str());
     outTskMap.push_back({hash, name});
-    LOG(INFO) << "Processor name: " << name << " hash: " << hash;
 
     std::string prefix = "internal-dpl-";
     if (processor.inputs.empty() && processor.name.compare(0, prefix.size(), prefix) != 0) {
@@ -281,29 +280,21 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
-        LOG(INFO) << "Found output object: " << output.binding.value;
         providedOutputObj.emplace_back(output);
         auto it = std::find_if(outObjMap.begin(), outObjMap.end(), [&](auto&& x) { return x.first == hash; });
         if (it == outObjMap.end()) {
-          LOG(INFO) << "Pushing new hash: " << hash;
           outObjMap.push_back({hash, {output.binding.value}});
         } else {
-          LOG(INFO) << "Adding to existing list";
           it->second.push_back(output.binding.value);
         }
-        LOG(INFO) << "provided output size: " << providedOutputObj.size() << " output map size: " << outObjMap.size();
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"HIST"})) {
-        LOG(INFO) << "Found output histogram: " << output.binding.value;
         providedHist.emplace_back(output);
         auto it = std::find_if(outHistMap.begin(), outHistMap.end(), [&](auto&& x) { return x.first == hash; });
         if (it == outHistMap.end()) {
-          LOG(INFO) << "Pushing new hash: " << hash;
           outHistMap.push_back({hash, {output.binding.value}});
         } else {
-          LOG(INFO) << "Adding to existing list";
           it->second.push_back(output.binding.value);
         }
-        LOG(INFO) << "provided hist size: " << providedHist.size() << " output hist map size: " << outHistMap.size();
       }
       if (output.lifetime == Lifetime::Condition) {
         providedCCDBs.push_back(output);
@@ -354,14 +345,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // This is to inject a file sink so that any dangling ATSK object is written
   // to a ROOT file.
   if (providedOutputObj.empty() == false) {
-    LOG(INFO) << "Provided output objects size: " << providedOutputObj.size();
     auto rootSink = CommonDataProcessors::getOutputObjSink(outObjMap, outTskMap);
     extraSpecs.push_back(rootSink);
   }
   // This is to inject a file sink so that any dangling HIST object is written
   // to a ROOT file.
   if (providedHist.empty() == false) {
-    LOG(INFO) << "Provided hist size: " << providedHist.size();
     auto rootSink = CommonDataProcessors::getHistogramRegistrySink(outHistMap, outTskMap);
     extraSpecs.push_back(rootSink);
   }
@@ -394,7 +383,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
 
   if (OutputsInputsAOD.size() > 0) {
-    LOGF(INFO, "AOD outputs size: %lu", OutputsInputsAOD.size());
     auto fileSink = CommonDataProcessors::getGlobalAODSink(OutputsInputsAOD,
                                                            isdangling);
     extraSpecs.push_back(fileSink);
@@ -413,7 +401,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   std::vector<InputSpec> unmatched;
   if (OutputsInputsDangling.size() > 0) {
-    LOGF(INFO, "Dangling outputs detected");
     auto fileSink = CommonDataProcessors::getGlobalFileSink(OutputsInputsDangling, unmatched);
     if (unmatched.size() != OutputsInputsDangling.size()) {
       extraSpecs.push_back(fileSink);

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -42,8 +42,4 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
   auto r = foo();
   auto histo2 = r.get("histo").get();
   BOOST_REQUIRE_EQUAL(histo2->GetNbinsX(), 100);
-
-  /// Get vector of all histograms in registry
-  auto histograms = registry.getHistogramsToWrite();
-  BOOST_REQUIRE_EQUAL(histograms.size(), 4);
 }

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -42,4 +42,8 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
   auto r = foo();
   auto histo2 = r.get("histo").get();
   BOOST_REQUIRE_EQUAL(histo2->GetNbinsX(), 100);
+
+  /// Get vector of all histograms in registry
+  auto histograms = registry.getHistogramsToWrite();
+  BOOST_REQUIRE_EQUAL(histograms.size(), 4);
 }


### PR DESCRIPTION
Ciao @ktf,
I finally managed to save the whole registry by passing it as a TList of histograms. However, I am not sure if it is a valid solution?

When I loop over histograms and snapshot them one by one, then the sink gets only one OutputSpec from the registry and saves the first histogram only. I couldn't find a solution that would allow the sink to process all registry histograms based on a single spec...