### PR TITLE
Add ability to code-format a PR.

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,0 +1,81 @@
+name: Check PR with clang-format
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Run clang format
+      id: clang_format
+      run: |
+        set -x
+        # We need to fetch the other commit.
+        git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}
+        
+        # We create a new branch which we will use for the eventual PR.
+        git config --global user.email "alibuild@cern.ch"
+        git config --global user.name "ALICE Action Bot"
+        git checkout -b alibot-cleanup-${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.sha }}
+
+        BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+        echo "Running clang-format-8 against branch ${{ github.event.pull_request.base.ref }} , with hash ${{ github.event.pull_request.base.sha }}"
+        COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -ivE 'LinkDef|Utilities/PCG/')
+        RESULT_OUTPUT="$(git-clang-format-8 --commit $BASE_COMMIT --diff --binary `which clang-format-8` $COMMIT_FILES)"
+        git-clang-format-8 --commit $BASE_COMMIT --diff --binary `which clang-format-8` $COMMIT_FILES | patch -p1
+
+        for x in $COMMIT_FILES; do
+          case $x in
+            *.h|*.cxx)
+              # We remove the header from the diff as it contains +++ then
+              # we only select the added lines to check for the long ones.
+              # We do not need to check for the lines which have been removed
+              # and we do not want to check for the lines which were not changed
+              # to avoid extra work.
+              # 120 characters are allowed, meaning the error should start with 122,
+              # to allow for the starting + at the end of the line.
+              git diff $x | tail -n +5 | grep -e '^+' | grep '.\{122,\}' && { echo "Line longer than 120 chars in $x." && exit 1; } || true ;;
+            *.hxx|*.cc|*.hpp) echo "$x uses non-allowed extension." && exit 1 ;;
+            *) ;;
+          esac
+        done
+
+        if [ "$RESULT_OUTPUT" == "no modified files to format" ] \
+          || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ] ; then
+          echo "clang-format passed."
+          git push --set-upstream origin :alibot-cleanup-${{ github.event.pull_request.number }} -f || true
+          echo ::set-output name=clean::true
+        else
+          echo "clang-format failed."
+          echo "To reproduce it locally please run"
+          echo -e "\tgit checkout $TRAVIS_BRANCH"
+          echo -e "\tgit-clang-format --commit $BASE_COMMIT --diff --binary $(which clang-format)"
+          echo "Opening a PR to your branch with the fixes"
+          git commit -m "Please consider the following formatting changes" -a
+          git show | cat
+          git push --set-upstream origin HEAD:refs/heads/alibot-cleanup-${{ github.event.pull_request.number }} -f
+          echo ::set-output name=clean::false
+        fi
+
+    - name: pull-request
+      uses: alisw/pull-request@master
+      with:
+        source_branch: 'AliceO2Group:alibot-cleanup-${{ github.event.pull_request.number }}'
+        destination_branch: '${{ github.event.pull_request.user.login }}:${{ github.event.pull_request.head.ref }}'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_title: "Please consider the following formatting changes to #${{ github.event.pull_request.number }}"
+        pr_body: "Please consider the following formatting changes"
+      continue-on-error: true # We do not create PRs if the branch is not there.
+
+    - name: Exit with error if the PR is not clean
+      run: |
+        case ${{ steps.clang_format.outputs.clean }} in
+          true) echo "PR clean" ; exit 0 ;;
+          false) echo "PR not clean" ; exit 1 ;;
+        esac
+
+


### PR DESCRIPTION
This will complain as usual when clang-format fails, but it should also propose changes in form of a PR with the fixes.