### PR TITLE
Classes to read DCS Data Points 

### DIFF
--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(GlobalTrackingWorkflow)
 add_subdirectory(Vertexing)
 
 add_subdirectory(Calibration)
+add_subdirectory(DCS)
 
 if(BUILD_SIMULATION)
   add_subdirectory(gconfig)

--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+
+o2_add_library(DetectorsDCS
+               SOURCES src/Clock.cxx
+		       src/DataPointCompositeObject.cxx
+		       src/DataPointIdentifier.cxx
+		       src/DataPointValue.cxx
+		       src/DeliveryType.cxx
+		       src/GenericFunctions.cxx
+		       src/StringUtils.cxx)
+
+o2_target_root_dictionary(DetectorsDCS
+                          HEADERS include/DetectorsDCS/DataPointCompositeObject.h
+			          include/DetectorsDCS/DataPointIdentifier.h
+				  include/DetectorsDCS/DataPointValue.h)
+
+

--- a/Detectors/DCS/include/DetectorsDCS/Clock.h
+++ b/Detectors/DCS/include/DetectorsDCS/Clock.h
@@ -1,0 +1,129 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   Clock.hpp
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 29 August 2016, 9:29
+ */
+#ifndef O2_DCS_CLOCK_H
+#define O2_DCS_CLOCK_H
+
+#include <ctime>
+#include <cstdint>
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * Returns a simple timestamp presenting the milliseconds of time passed
+     * since the given time point.
+     *
+     * @param beginning The time point used as a reference for the time interval
+     * calculation.
+     * @return The amount of milliseconds passed since the given time point.
+     */
+inline uint64_t time_since(
+  const std::chrono::steady_clock::time_point beginning) noexcept
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now() - beginning)
+    .count();
+}
+
+/**
+     * Returns the measured number of milliseconds passed since UNIX epoch
+     * (1 January 1970 01:00:00.000). This function uses system clock.
+     *
+     * @return Number of milliseconds since epoch.
+     * @see ADAPRO::Library::now
+     */
+inline uint64_t epoch_time() noexcept
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+
+/**
+     * Returns a timestamp using steady clock. This function is suitable for
+     * measuring time intervals, but it's not meant to be used for calculating
+     * dates.
+     *
+     * @return
+     * @see ADAPRO::Library::epoch_time
+     */
+inline uint64_t now() noexcept
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now().time_since_epoch())
+    .count();
+}
+
+/**
+     * Returns a timestamp of the current point of time in the local timezone.
+     *
+     * @return A simple ISO-8601-esque timestamp (<tt>YYYY-MM-DD HH:MM:SS</tt>).
+     * Every decimal number in the date string has leading zeros and therefore
+     * fixed length.
+     * @see ADAPRO::Control::fs_timestamp
+     */
+inline std::string timestamp() noexcept
+{
+  char buffer[20];
+  std::time_t now = std::time(nullptr);
+  std::strftime(buffer, 32, "%F %T", std::localtime(&now));
+  return std::string(buffer);
+}
+
+/**
+     * Returns a timestamp of the current point of time in the local timezone.
+     * The format of the timestamp is specified with the parameter
+     * <tt>format</tt>. The format of the format string is the same as is used
+     * by <tt>std::strftime</tt>.
+     *
+     * @return A simple timestamp in a format specified with the parameter
+     * <tt>format</tt>.
+     */
+inline std::string timestamp(const std::string& format) noexcept
+{
+  char buffer[20];
+  std::time_t now = std::time(nullptr);
+  std::strftime(buffer, 32, format.c_str(), std::localtime(&now));
+  return std::string(buffer);
+}
+
+/**
+     * Generates a simple timestamp usable file paths. This function is like
+     * <tt>ADAPRO::Control::timestamp</tt>, but with spaces replaced with
+     * underscores and colons with dots in order to ensure compatibility with
+     * (Linux) filesystems. This function uses local timezone.
+     *
+     * @return A simple ISO-8601-esque timestamp (<tt>YYYY-MM-DD_HH.MM.SS</tt>).
+     * Every decimal number in the date string has leading zeros and therefore
+     * fixed length.
+     * @see ADAPRO::Control::timestamp
+     */
+inline std::string fs_timestamp() noexcept
+{
+  char buffer[20];
+  std::time_t now = std::time(nullptr);
+  std::strftime(buffer, 32, "%F_%H.%M.%S", std::localtime(&now));
+  return std::string(buffer);
+}
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_CLOCK_H */

--- a/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
@@ -1,0 +1,262 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   DataPointCompositeObject.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 23 September 2016, 11:28
+ */
+#ifndef O2_DCS_DATAPOINT_COMPOSITE_OBJECT_H
+#define O2_DCS_DATAPOINT_COMPOSITE_OBJECT_H
+
+#include <cstdint>
+#include <stdexcept>
+#include <ostream>
+#include <string>
+#include "Rtypes.h"
+#include "DetectorsDCS/StringUtils.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * DataPointCompositeObject is a composition of a DataPointIdentifier and a
+     * DataPointValue. It is the unit of data points that ADAPOS provides.
+     *
+     * @see ADAPRO::ADAPOS::DataPointIdentifier
+     * @see ADAPRO::ADAPOS::DataPointValue
+     */
+struct alignas(128) DataPointCompositeObject final {
+  /**
+         * The DataPointIdentifier object, which occupies the first 64 bytes of
+         * the DataPointCompositeObject. This object contains the immutable
+         * alias and type information.
+         *
+         * @see ADAPRO::ADAPOS::DataPointIdentifier
+         */
+  const DataPointIdentifier id;
+
+  /**
+         * The DataPointValue object, which occupies the last 64 bytes of the
+         * DataPointCompositeObject. This object contains the mutable parts of
+         * DataPointCompositeObject. These parts are the ADAPOS flags,
+         * timestamp, and the payload data.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue
+         */
+  DataPointValue data;
+
+  /**
+         * The default constructor for DataPointCompositeObject. Uses the
+         * default constructors of its component, which means that their every
+         * field will be filled with zeroes.
+         *
+        * @see ADAPRO::ADAPOS::DataPointIdentifier
+        * @see ADAPRO::ADAPOS::DataPointValue
+         */
+  DataPointCompositeObject() noexcept : id(), data() {}
+
+  /**
+         * This constructor <em>copies</em> the given DataPointIdentifier and
+         * DataPointValue into the fields <tt>id</tt> and <tt>data</tt>.
+         *
+         * @param id    The DPID component.
+         * @param data  The DPVAL component.
+         */
+  DataPointCompositeObject(
+    const DataPointIdentifier& id,
+    const DataPointValue& data) noexcept : id(id), data(data) {}
+
+  /**
+         * Bit-by bit equality comparison of DataPointCompositeObjects.
+         *
+         * @param other The right-hand operand of equality comparison.
+         * @return      <tt>true</tt> or <tt>false</tt>.
+         */
+  inline bool operator==(const DataPointCompositeObject& other) const
+    noexcept
+  {
+    return id == other.id && data == other.data;
+  }
+
+  /**
+         * Negation of the <tt>==</tt> operator.
+         *
+         * @param other The right-hand side operand.
+         * @return      <tt>true</tt> or <tt>false</tt>.
+         */
+  inline bool operator!=(const DataPointCompositeObject& other) const
+    noexcept
+  {
+    return id != other.id || data != other.data;
+  }
+
+  /**
+         * Overwrites a DataPointCompositeObject with the given <tt>id</tt> and
+         * <tt>data</tt> values.
+         *
+         * @param id    The id value.
+         * @param data  The data value.
+         */
+  inline void set(const DataPointIdentifier& id, DataPointValue& data) noexcept
+  {
+    DataPointIdentifier::FILL(this->id, (uint64_t*)&id);
+    this->data = data;
+  }
+
+  /**
+         * Overwrites a DataPointCompositeObject as a copy of the given 128-byte
+         * segment (16 times <tt>sizeof(uint64_t)</tt>) of binary data.
+         *
+         * @param data Beginning of the data segment used for reading. The
+         * length of the segment is assumed to be exactly 128 bytes and contain
+         * a valid binary representation of a DataPointCompositeObject.
+         */
+  inline void set(const uint64_t* const data) noexcept
+  {
+    DataPointIdentifier::FILL(this->id, data);
+    this->data.set(data + 8, id.get_type());
+  }
+
+  /**
+         * Overwrites the state of the <tt>data</tt> field with the state of the
+         * given DPVAL object, <em>except for the control flags, that will be
+         * cleared out</em>.
+         *
+         * @param dpval A DPVAL object representing an update event to the
+         * DPCOM in question.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue
+         * @see ADAPRO::ADAPOS::DataPointValue::CONTROL_MASK
+         */
+  inline void update(const DataPointValue& dpval) noexcept
+  {
+    data.set(
+      dpval.flags & ~DataPointValue::CONTROL_MASK,
+      dpval.msec,
+      dpval.sec,
+      (uint64_t*)&dpval.payload_pt1,
+      id.get_type());
+  }
+
+  /**
+         * Returns a pointer to the beginning of the data part to be given to
+         * DIM, which depends on the <tt>DeliveryType</tt> of this DPCOM. This
+         * method is specific to ADAPOS Load Generator and ADAPOS Engine.
+         *
+         * @return  A <tt>(void*)</tt>.
+         * @throws std::domain_error If the <tt>DeliveryType</tt> of this
+         * DPCOM object was illegal (i.e. <tt>VOID</tt> or something else than
+         * the enumerators of <tt>DeliveryType</tt>).
+         * @see ADAPRO::ADAPOS::DeliveryType
+         */
+  inline void* dim_buffer() const
+  {
+    switch (id.get_type()) {
+      case RAW_INT:
+      case RAW_UINT:
+      case RAW_BOOL:
+      case RAW_CHAR:
+      case RAW_DOUBLE:
+      case RAW_TIME:
+      case RAW_STRING:
+      case RAW_BINARY:
+        return (void*)&data.payload_pt1;
+      case DPVAL_INT:
+      case DPVAL_UINT:
+      case DPVAL_BOOL:
+      case DPVAL_CHAR:
+      case DPVAL_DOUBLE:
+      case DPVAL_TIME:
+      case DPVAL_STRING:
+      case DPVAL_BINARY:
+        return (void*)&data;
+      default:
+      case VOID:
+        throw std::domain_error("Illegal DeliveryType.");
+    }
+  }
+
+  /**
+         * Prints a CSV-representation of the DataPointCompositeObject into the
+         * ostream. The format of the payload data depends on its type and is
+         * handled automatically.
+         *
+         * @param os    The output stream.
+         * @param dpcom The DataPointCompositeObject.
+         * @return      Reference to the stream after the printing operation.
+         */
+  inline friend std::ostream& operator<<(std::ostream& os,
+                                         const DataPointCompositeObject& dpcom) noexcept
+  {
+    std::string payload;
+    os << dpcom.id << ";" << dpcom.data << ";";
+    union Converter {
+      uint64_t raw_data;
+      double double_value;
+      uint32_t uint_value;
+      int32_t int_value;
+      char char_value;
+      bool bool_value;
+    } converter;
+    converter.raw_data = dpcom.data.payload_pt1;
+    switch (dpcom.id.get_type()) {
+      case VOID:
+        return os;
+      case RAW_INT:
+      case DPVAL_INT:
+        return os << converter.int_value;
+      case RAW_UINT:
+      case DPVAL_UINT:
+        return os << converter.uint_value;
+      case RAW_BOOL:
+      case DPVAL_BOOL:
+        return os << (converter.bool_value ? "True" : "False");
+      case RAW_CHAR:
+      case DPVAL_CHAR:
+        return os << converter.char_value;
+      case RAW_DOUBLE:
+      case DPVAL_DOUBLE:
+        return os << converter.double_value;
+      case RAW_STRING:
+      case DPVAL_STRING:
+        return os << std::string((char*)&dpcom.data.payload_pt1);
+      case RAW_TIME:
+      case DPVAL_TIME: {
+        // I have no idea how to properly test the time_t backend.
+        // It's probably even hardware/os/kernel specific...
+#ifdef __linux__
+        char buffer[17];
+        std::time_t ts((dpcom.data.payload_pt1) >> 32);
+        std::strftime(buffer, 32, "%FT%T", std::gmtime(&ts));
+        return os << std::string(buffer) << "." << std::setw(3) << std::setfill('0') << std::to_string((dpcom.data.payload_pt1 & 0x00000000FFFF0000) >> 16)
+                  << "Z";
+#else
+        return os << "[Timestamps not supported on this platform.]";
+#endif
+      }
+      case RAW_BINARY:
+      case DPVAL_BINARY:
+      default:
+        return os << o2::dcs::to_hex_little_endian(
+                 (char*)&dpcom.data.payload_pt1, 56);
+    }
+  }
+  ClassDefNV(DataPointCompositeObject, 1);
+};
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_DATAPOINT_COMPOSITE_OBJECT_H */

--- a/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointIdentifier.h
@@ -1,0 +1,219 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   DataPointIdentifier.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 23 September 2016, 12:00
+ */
+#ifndef O2_DCS_DATAPOINT_IDENTIFIER_H
+#define O2_DCS_DATAPOINT_IDENTIFIER_H
+
+#include <cstring>
+#include <string>
+#include <cstdint>
+#include <iostream>
+#include <iomanip>
+#include <functional>
+#include "Rtypes.h"
+#include "DetectorsDCS/StringUtils.h"
+#include "DetectorsDCS/GenericFunctions.h"
+#include "DetectorsDCS/DeliveryType.h"
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * DataPointIdentifier object is responsible for storing the alias and type
+     * information of a data point.
+     */
+class alignas(64) DataPointIdentifier final
+{
+  const uint64_t pt1;
+  const uint64_t pt2;
+  const uint64_t pt3;
+  const uint64_t pt4;
+  const uint64_t pt5;
+  const uint64_t pt6;
+  const uint64_t pt7;
+  const uint64_t pt8; // Contains the last 6 chars of alias and the type.
+
+  DataPointIdentifier(
+    const uint64_t pt1, const uint64_t pt2, const uint64_t pt3,
+    const uint64_t pt4, const uint64_t pt5, const uint64_t pt6,
+    const uint64_t pt7, const uint64_t pt8) noexcept : pt1(pt1), pt2(pt2), pt3(pt3), pt4(pt4), pt5(pt5), pt6(pt6), pt7(pt7), pt8(pt8) {}
+
+ public:
+  /**
+         * The default constructor for DataPointIdentifier. Creates a DPID that
+         * contains only zeroes. To fill it with alias and type, please use the
+         * factory procedure <tt>fill</tt>.
+         *
+         * @see ADAPRO::ADAPOS::DataPointIdentifier::fill
+         */
+  DataPointIdentifier() noexcept : pt1(0), pt2(0), pt3(0), pt4(0), pt5(0), pt6(0), pt7(0), pt8(0)
+  {
+  }
+
+  /**
+         * A constructor for DataPointIdentifier. Copies the given arguments to
+         * the memory segment owned by the object under construction.
+         *
+         * @param alias The alias of the DataPointIdentifier. Maximum length is
+         * 62 characaters.
+         * @param type  Type of the payload value associated with the service
+         * identified by this DataPointIdentifier.
+         */
+  DataPointIdentifier(const std::string& alias, const DeliveryType type) noexcept : DataPointIdentifier()
+  {
+    strncpy((char*)this, alias.c_str(), 62);
+    ((char*)&pt8)[7] = type;
+  }
+
+  /**
+         * This stati procedure fills the given DataPointIdentifier object with
+         * the given parameters.
+         *
+         * @param dpid  The DataPointIdentifier to be filled (i.e. overwritten).
+         * @param alias Alias of the data point. This is used for identifying
+         * the DIM service that publishes updates to a data point.
+         * @param type  Type of the data point payload value.
+         */
+  static inline void FILL(
+    const DataPointIdentifier& dpid,
+    const std::string& alias,
+    const DeliveryType type) noexcept
+  {
+    strncpy((char*)&dpid, alias.c_str(), 62);
+    ((char*)&dpid.pt8)[7] = type;
+  }
+
+  /**
+         * This static procedure copies the given 64-byte binary segment into
+         * the DataPointIdentifier object.
+         *
+         * @param dpid  The DataPointIdentifier to be filled (i.e. overwritten).
+         * @param data  Beginning of the 64-byte binary segment.
+         */
+  static inline void FILL(
+    const DataPointIdentifier& dpid,
+    const uint64_t* const data) noexcept
+  {
+    std::strncpy((char*)&dpid, (char*)data, 62);
+    ((char*)&dpid)[63] = ((data[7] & 0xFF00000000000000) >> 56);
+  }
+
+  /**
+         * The equality comparison object of DPIDs.
+         *
+         * @param other The other DPID object for comparison.
+         * @return      <tt>true</tt> if and only if the other DPID object
+         * has exactly (bit-by-bit) the same state.
+         */
+  inline bool operator==(const DataPointIdentifier& other) const
+  {
+    return memcmp((char*)this, (char*)&other, 64) == 0;
+  }
+
+  /**
+         * Negation of the equality comparison.
+         *
+         * @param other The second operand.
+         * @return      <tt>true</tt> or <tt>false</tt>.
+         */
+  inline bool operator!=(const DataPointIdentifier& other) const
+  {
+    return !(*this == other);
+  }
+
+  /**
+         * Appends DataPointIdentifier object to the given stream using CSV
+         * format (i.e. <tt>&lt;alias&gt; ";" &lt;type&gt;</tt>).
+         */
+  friend inline std::ostream& operator<<(std::ostream& os,
+                                         const DataPointIdentifier& dpid) noexcept
+  {
+    return os << std::string((char*)&dpid) << ";" << o2::dcs::show((DeliveryType)((dpid.pt8 & 0xFF00000000000000) >> 56));
+  }
+
+  /**
+         * Returns the alias of the DPID object as a C-style string (i.e.
+         * null-terminated char array).
+         *
+         * @return The alias.
+         */
+  inline const char* const get_alias() const noexcept
+  {
+    return (char*)&pt1;
+  }
+
+  /**
+         * Getter for the payload type information.
+         *
+         * @return a DeliveryType object.
+         */
+  inline DeliveryType get_type() const noexcept
+  {
+    return (DeliveryType)((pt8 & 0xFF00000000000000) >> 56);
+  }
+
+  /**
+         * Returns a hash code calculated from the alias. <em>Note that the
+         * hash code is recalculated every time when this function is called.
+         * </em>
+         *
+         * @return An unsigned integer.
+         */
+  inline size_t hash_code() const noexcept
+  {
+    return o2::dcs::hash_code(std::string((char*)&pt1));
+  }
+
+  /**
+         * The destructor for DataPointIdentifier.
+         */
+  ~DataPointIdentifier() noexcept = default;
+  ClassDefNV(DataPointIdentifier, 1);
+};
+
+/**
+     * This simple function object is used for calculating the hash code for a
+     * DataPointIdentifier object in a STL container.
+     *
+     * @param dpid  The DataPointIdentifier object, whose hash code is to be
+     * calculated.
+     * @return      The calculated hash code.
+     */
+struct DPIDHash {
+  uint64_t operator()(const o2::dcs::DataPointIdentifier& dpid)
+    const
+  {
+    return dpid.hash_code();
+  }
+};
+} // namespace dcs
+
+} // namespace o2
+
+// specailized std::hash
+namespace std
+{
+template <>
+struct hash<o2::dcs::DataPointIdentifier> {
+  std::size_t operator()(const o2::dcs::DataPointIdentifier& dpid) const
+  {
+    return std::hash<uint64_t>{}(dpid.hash_code());
+  }
+};
+} // namespace std
+
+#endif /* O2_DCS_DATAPOINT_IDENTIFIER_H */

--- a/Detectors/DCS/include/DetectorsDCS/DataPointValue.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointValue.h
@@ -1,0 +1,701 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   DataPointValue.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 23 September 2016, 12:20
+ */
+#ifndef O2_DCS_DATAPOINT_VALUE
+#define O2_DCS_DATAPOINT_VALUE
+
+#include <cstring>
+#include <cstdint>
+#include <ctime>
+#include <atomic>
+#include <string>
+#include <ostream>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#include <memory>
+#include <stdexcept>
+#include "Rtypes.h"
+#include "DetectorsDCS/StringUtils.h"
+#include "DetectorsDCS/Clock.h"
+#include "DetectorsDCS/DeliveryType.h"
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * DataPointValue is the struct responsible for containing the flags,
+     * timestamp, and payload value of a data point. It represents a discrete
+     * update event to a data point. <em>It should be noted that the
+     * constructors and setters of this struct, that take an array containing
+     * binary data as parameter, don't check the length of the given array.</em>
+     */
+struct alignas(64) DataPointValue final {
+  /**
+         * <p>This flag is used for signaling that a DPVAL stream connection is
+         * working, but there is no data to be sent.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>A</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t KEEP_ALIVE_FLAG = 0x0001;
+
+  /**
+         * <p>This flag is used for signaling the end of transmission.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>Z</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t END_FLAG = 0x0002;
+
+  /**
+         * <p>This flag is set in the ADAPOS FBI Master DPCOM object.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>M</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t FBI_FLAG = 0x0004;
+
+  /**
+         * <p>This flag is set by Producer to signal Consumer that this
+         * DataPointValue object belongs to a new service, that doesn't yet have
+         * its DataPointCompositeObject in the image.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>N</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t NEW_FLAG = 0x0008;
+
+  /**
+         * <p>This flag is reserved for the ADAPRO/ADAPOS Producer-Consumer
+         * model. A DataPointValue is dirty if and only if it's stored in the
+         * ring buffer but not been fully processed yet. This flag should always
+         * be set when a DPCOM containing the DataPointValue object arrives from
+         * ADAPOS Engine via TCP.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>D</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t DIRTY_FLAG = 0x0010;
+
+  /**
+         * <p>This flag is used as a part of the DPVAL mutual exclusion
+         * mechanism. This flag should be set iff reader has the turn.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>U</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint64_t TURN_FLAG = 0x0020;
+
+  /**
+         * <p>This flag is used by the DPVAL mutual exclusion mechanism.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>W</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t WRITE_FLAG = 0x0040;
+
+  /**
+         * <p>This flag is used by the DPVAL mutual exclusion mechanism.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>R</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t READ_FLAG = 0x0080;
+
+  /**
+         * <p>This flag should be set if and only if there is a ring buffer
+         * overflow happening. Ring buffer overflow is manifested as an
+         * overwrite of a dirty DPVAL.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>O</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t OVERWRITE_FLAG = 0x0100;
+
+  /**
+         * <p>In case of buffer overflow, this flag can be used for indicating a
+         * service that lost an update. <em>Not receiving this flag shouldn't be
+         * taken as an indication that every update was successfully
+         * transmitted.</em></p>
+         * <p>If this flag is set, it will be denoted with letter <tt>V</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t VICTIM_FLAG = 0x0200;
+
+  /**
+         * <p>This flag should be set if and only if there is a DIM error
+         * (namely, connection failure with the DIM service) in ADAPOS Engine
+         * affecting this DataPointValue object.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>E</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t DIM_ERROR_FLAG = 0x0400;
+
+  /**
+         * <p>This flag should be set if and only if the DPID of the DPCOM
+         * containing this DPVAL has incorrect or unexpected value.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>I</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t BAD_DPID_FLAG = 0x0800;
+
+  /**
+         * <p>This flag should be set if and only if the flags themselves have
+         * bad or unexpedcted value.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>F</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t BAD_FLAGS_FLAG = 0x1000;
+
+  /**
+         * <p>This flag should be set if and only if the timestamp is
+         * incorrect.</p>
+         * <p>If this flag is set, it will be denoted with letter <tt>T</tt> in
+         * the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t BAD_TIMESTAMP_FLAG = 0x2000;
+
+  /**
+         * <p>This flag should be set if and only if the payload value is bad.
+         * </p><p>If this flag is set, it will be denoted with letter <tt>P</tt>
+         * in the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t BAD_PAYLOAD_FLAG = 0x4000;
+
+  /**
+         * <p>This flag should be set if it a FBI contains duplicated DPCOMs
+         * (i.e. DPCOMs with identical DPIDs). Also, partial FBI (with missing
+         * DPCOMs) can be indicated with this flag.</p>
+         * </p><p>If this flag is set, it will be denoted with letter <tt>B</tt>
+         * in the CSV output generated from this DPVAL object.</p>
+         */
+  static constexpr uint16_t BAD_FBI_FLAG = 0x8000;
+
+  /**
+         * This mask covers the session flags: <tt>KEEP_ALIVE_FLAG</tt>,
+         * <tt>END_FLAG</tt>, and <tt>FBI_MASTER_FLAG</tt>.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::KEEPALIVE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::END_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::FBI_FLAG
+         */
+  static constexpr uint16_t SESSION_MASK = 0x0007;
+
+  /**
+         * This mask covers the control flags: <tt>NEW_FLAG</tt>,
+         * <tt>DIRTY_FLAG</tt>, <tt>TURN_FLAG</tt>, <tt>WRITE_FLAG</tt>, and
+         * <tt>READ_FLAG</tt>.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::NEW_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::DIRTY_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::TURN_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::WRITE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::READ_FLAG
+         */
+  static constexpr uint16_t CONTROL_MASK = 0x00F8;
+
+  /**
+         * This mask covers the error flags: <tt>DIM_ERROR_FLAG</tt>,
+         * <tt>OVERWRITE_FLAG</tt>, <tt>VICTIM_FLAG</tt>,
+         * <tt>BAD_DPID_FLAG</tt>, <tt>BAD_FLAGS_FLAG</tt>,
+         * <tt>BAD_TIMESTAMP_FLAG</tt>, <tt>BAD_PAYLOAD_FLAG</tt>, and
+         * <tt>BAD_FBI_FLAG</tt>.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::DIM_ERROR_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::OVERWRITE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::VICTIM_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_DPID_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_FLAGS_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_TIMESTAMP_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_PAYLOAD_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_FBI_FLAG
+         */
+  static constexpr uint16_t ERROR_MASK = 0xFF00;
+
+  /**
+         * The ADAPOS flags, i.e. a bitmask of the 16 different DPVAL flags.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::KEEPALIVE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::END_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::FBI_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::NEW_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::DIRTY_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::TURN_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::WRITE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::READ_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::DIM_ERROR_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::OVERWRITE_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_DPID_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_FLAGS_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_TIMESTAMP_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_PAYLOAD_FLAG
+         * @see ADAPRO::ADAPOS::DataPointValue::BAD_FBI_FLAG
+         */
+  uint16_t flags = 0;
+
+  /**
+         * Milliseconds of the timestamp. This is the measured number of
+         * milliseconds passed since the UNIX epoch
+         * (1 January 1970, 01:00:00.000) modulo 1000. The purpose of this field
+         * together with <tt>sec</tt> is to store a timestamp indicating the
+         * moment of creation/modification of the DataPointValue object.
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::sec
+         */
+  uint16_t msec = 0;
+
+  /**
+         * Seconds of the timestamp. This is the measured number of seconds
+         * passed since the UNIX epoch (1 January 1970, 01:00:00.000). The
+         * purpose of this field together with <tt>msec</tt> is to store a
+         * timestamp indicating the moment of creation/modification of the
+         * DataPointValue object.
+         */
+  uint32_t sec = 0;
+
+  /**
+         * First part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt1 = 0;
+
+  /**
+         * Second part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt2 = 0;
+
+  /**
+         * Third part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt3 = 0;
+
+  /**
+         * Fourth part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt4 = 0;
+
+  /**
+         * Fifth part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt5 = 0;
+
+  /**
+         * Sixth part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt6 = 0;
+
+  /**
+         * Seventh part of the 56-byte binary payload value.
+         */
+  uint64_t payload_pt7 = 0;
+
+  /**
+         * The default constuctor of DataPointValue. Fills the object with
+         * zeroes.
+         */
+  DataPointValue() = default;
+
+  /**
+         * The trivial copy constructor of DataPointValue.
+         *
+         * @param other The DataPointValue instance, whose state is to be copied
+         * to the new object.
+         */
+  DataPointValue(const DataPointValue& other) = default;
+
+  /**
+         * Constructor for DataPointValue. <em>This constructor assumes that the
+         * <tt>payload</tt> parameter points to a <tt>unit64_t</tt> array with
+         * (at least) seven elements.</em> The data will be treated as binary
+         * and will be written to the new DataPointValue object using
+         * <tt>std::memcpy</tt>. Use of this constructor is discouraged, since
+         * it might copy garbage data. Please consider using the constructor
+         * with a <tt>DeliveryType</tt> parameter instead.
+         *
+         * @param flags         The ADAPOS flags.
+         * @param milliseconds  Milliseconds of the timestamp.
+         * @param seconds       Seconds of the timestamp.
+         * @param payload       Pointer to a memory segment containing the
+         * binary payload data. The next seven <tt>uint64_t</tt> values (i.e. 56
+         * <tt>char</tt>s) will be copied to the DataPointValue object.
+         * <em>payload</em> must not be <tt>nullptr</tt>. For an empty DPVAL,
+         * use the default constructor.
+         *
+         * @deprecated Since ADAPRO 4.1.0, this constructor has become
+         * deprecated. Please consider using the constructor with a
+         * <tt>DeliveryType</tt> parameter instead.
+         */
+  [[deprecated]] DataPointValue(
+    const uint16_t flags,
+    const uint16_t milliseconds,
+    const uint32_t seconds,
+    const uint64_t* const payload) noexcept : flags(flags), msec(milliseconds), sec(seconds)
+  {
+    memcpy((void*)&payload_pt1, (void*)payload, 56);
+  }
+
+  /**
+         * <p>Constructor for DataPointValue. Copies a data segment from the
+         * array <tt>payload</tt>. Length of the copied data is determined by
+         * the argument <tt>type</tt>. <em>No sanity checks on the given
+         * array are performed.</em></p>
+         * <p>If the given <tt>DeliveryType</t> is invalid, then the payload
+         * of the new DataPointValue object will be filled with zeros.</p>
+         *
+         * @param flags         The ADAPOS flags.
+         * @param milliseconds  Milliseconds of the timestamp.
+         * @param seconds       Seconds of the timestamp.
+         * @param payload       Pointer to a contiguous block of memory
+         * containing the binary payload data.
+         * @param type          Used for setting the payload correctly, using
+         * <tt>set_payload</tt>. If this argument is <tt>VOID</tt>, then the
+         * contents of the payload remain undefined.
+         *
+         * @throws std::domain_error If applied with an invalid DeliveryType.
+         * @see ADAPRO::Data::DataPointValue::set_payload
+         */
+  DataPointValue(
+    const uint16_t flags,
+    const uint16_t milliseconds,
+    const uint32_t seconds,
+    const uint64_t* const payload,
+    const DeliveryType type)
+    : flags(flags), msec(milliseconds), sec(seconds)
+  {
+    set_payload(payload, type);
+  }
+
+  /**
+         * Sets the given payload data to the DataPointValue. This setter avoids
+         * copying garbage, because it uses the type information. However, it
+         * assumes the given array to have at least the length determined by the
+         * payload type.
+         *
+         * @param data  A binary segment containing the new payload data.
+         * @param type  Type of the payload data.
+         *
+         * @throws std::domain_error If applied with an invalid DeliveryType.
+         */
+  inline void set_payload(
+    const uint64_t* const data,
+    const DeliveryType type)
+  {
+    switch (type) {
+      case RAW_INT:
+      case DPVAL_INT:
+      case RAW_UINT:
+      case DPVAL_UINT:
+        this->payload_pt1 = data[0] & 0x00000000FFFFFFFF;
+        break;
+      case RAW_BOOL:
+      case DPVAL_BOOL:
+        this->payload_pt1 = (data[0] ? 1 : 0);
+        break;
+      case RAW_CHAR:
+      case DPVAL_CHAR:
+        this->payload_pt1 = data[0] & 0x00000000000000FF;
+        break;
+      case RAW_DOUBLE:
+      case DPVAL_DOUBLE:
+      case RAW_TIME:
+      case DPVAL_TIME:
+        this->payload_pt1 = data[0];
+        break;
+      case RAW_STRING:
+      case DPVAL_STRING:
+        std::strncpy((char*)&payload_pt1, (char*)data, 56);
+        break;
+      case RAW_BINARY:
+      case DPVAL_BINARY:
+        memcpy((void*)&payload_pt1, (void*)data, 56);
+      case VOID:
+        break;
+      default:
+        throw std::domain_error("Invalid DeliveryType.");
+    }
+  }
+
+  /**
+         * Returns the ADAPOS flags of the DataPointValue.
+         *
+         * @return ADAPOS flags.
+         */
+  inline uint16_t get_flags() const noexcept
+  {
+    return flags;
+  }
+
+  /**
+         * Updates the timestamp of this DataPointValue object using system
+         * clock.
+         */
+  inline void update_timestamp() noexcept
+  {
+    const uint64_t current_time(o2::dcs::epoch_time());
+    msec = current_time % 1000;
+    sec = current_time / 1000;
+  }
+
+  /**
+         * <p>On Linux platforms, Returns a unique pointer to a string
+         * containing an ISO 8601 timestamp. The value of the timestamp will be
+         * calculated from the values of the fields <tt>msec</tt> and
+         * <tt>sec</tt> and assuming the UTC timezone. The timestamp has the
+         * following format:</p>
+         * <p><tt>&lt;YYYY-MM-DD&gt; "T" &lt;HH:MM:SS.SSS&gt; "Z"</tt></p>
+         *
+         * @return An ISO 8601 compliant timestamp.
+         */
+  inline std::unique_ptr<std::string> get_timestamp() const noexcept
+  {
+#ifdef __linux__
+    // time_t should be uint64_t (compatible) on 64-bit Linux platforms:
+    char buffer[17];
+    std::time_t ts((uint64_t)sec);
+    std::strftime(buffer, 32, "%FT%T", std::gmtime(&ts));
+    std::ostringstream oss;
+    oss << std::string(buffer) << "." << std::setw(3) << std::setfill('0') << std::to_string(msec) << "Z";
+    return std::make_unique<std::string>(
+      std::move(oss.str()));
+#else
+    return std::make_unique<std::string>("Unsupported platform");
+#endif
+  }
+
+  /**
+         * Returns a 64-bit unsigned integer containing the timestamp value of
+         * the DPVAL object.
+         *
+         * @return Milliseconds since the UNIX epoch (1.1.1970 01:00:00.000).
+         */
+  inline uint64_t get_epoch_time() const noexcept
+  {
+    return (((uint64_t)sec) * 1000) + msec;
+  }
+
+  /**
+         * <p>The standard copy assignment operator. Performs a normal deep copy
+         * operation overwriting this DataPointValue object with the other.</p>
+         * <p><em>Note that this operator always copies a fixed size data
+         * segment from the given DPVAL to this DPVAL regardless of the payload
+         * value type. </em>Therefore, non-zero garbage data might be copied as
+         * well. Using the setters with the <tt>type</tt> parameter is
+         * recommended.</p>
+         *
+         * @param other The DataPointValue object, whose state will be copied to
+         * this object.
+         * @return <tt>*this</tt> after performing the copying.
+         */
+  DataPointValue& operator=(const DataPointValue& other) = default;
+
+  /**
+         * Bit-by bit equality comparison of DPVAL objects.
+         *
+         * @param other The second operand of equality comparison.
+         * @return      <tt>true</tt> or <tt>false</tt>.
+         */
+  inline bool operator==(const DataPointValue& other) const noexcept
+  {
+    return memcmp((void*)this, (void*)&other, sizeof(DataPointValue)) == 0;
+  }
+
+  /**
+         * Negation of the equality comparison.
+         *
+         * @param other The second operand.
+         * @return      <tt>true</tt> or <tt>false</tt>.
+         */
+  inline bool operator!=(const DataPointValue& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  /**
+         * Sets the state of the DataPointValue. Copies a data segment from the
+         * array <tt>payload</tt>. Length of the copied data is determined by
+         * the argument <tt>type</tt>. <em>No sanity checks on the given array
+         * are performed.</em>
+         *
+         * @param flags         New value for ADAPOS flags.
+         * @param milliseconds  New value for milliseconds.
+         * @param seconds       New value for seconds.
+         * @param payload       New payload data.
+         * @param type          Used for setting the payload correctly, using
+         * <tt>set_payload</tt>.
+         *
+         * @throws std::domain_error If applied with an invalid DeliveryType.
+         * @see ADAPRO::Data::DataPointValue::set_payload
+         */
+  inline void set(
+    const uint16_t flags,
+    const uint16_t milliseconds,
+    const uint32_t seconds,
+    const uint64_t* const payload,
+    const DeliveryType type)
+  {
+    this->flags = flags;
+    this->msec = milliseconds;
+    this->sec = seconds;
+    set_payload(payload, type);
+  }
+
+  /**
+         * Sets the state of the DataPointValue, except for the flags. This
+         * setter can be used for safely setting the state of the object without
+         * interfering with the locking mechanism or invalidating the mutual
+         * exclusion. This setter was added in <em>ADAPRO 2.4.0</em>.
+         *
+         * @param milliseconds  Milliseconds of the new timestamp.
+         * @param seconds       Seconds of the new timestamp.
+         * @param payload       New payload.
+         * @param type          Used for setting the payload correctly, using
+         * <tt>set_payload</tt>.
+         *
+         * @throws std::domain_error If applied with an invalid DeliveryType.
+         * @see ADAPRO::Data::DataPointValue::set_payload
+         */
+  inline void set(
+    const uint16_t milliseconds,
+    const uint32_t seconds,
+    const uint64_t* const payload,
+    const DeliveryType type)
+  {
+    msec = milliseconds;
+    sec = seconds;
+    set_payload(payload, type);
+  }
+
+  /**
+         * Sets the state of the DataPointValue. <em>No sanity checks on the
+         * given array are performed.</em> The first array element is assumed to
+         * contain data for the flags and the timestamp with their respective
+         * sizes and order, while the rest of the array is assumed to contain
+         * the payload data.
+         *
+         * @param data  New DPVAL contents.
+         * @param type          Used for setting the payload correctly, using
+         * <tt>set_payload</tt>.
+         *
+         * @throws std::domain_error If applied with an invalid DeliveryType.
+         * @see ADAPRO::Data::DataPointValue::set_payload
+         */
+  inline void set(
+    const uint64_t* const data,
+    const DeliveryType type)
+  {
+    this->flags = data[0];
+    this->msec = data[0] >> 16;
+    this->sec = data[0] >> 32;
+    set_payload(data + 1, type);
+  }
+
+  /**
+         * Prints the flags and timestamp of the DataPointValue object into the
+         * <tt>ostream</tt>, but not the payload data. The reason for omitting
+         * the payload value is that DataPointValue lacks payload data typing
+         * information, so conversion from binary to string is not meaningful.
+         */
+  friend inline std::ostream& operator<<(std::ostream& os,
+                                         const DataPointValue& dpval) noexcept
+  {
+    return os << ((dpval.flags & KEEP_ALIVE_FLAG) ? "A" : "-")
+              << ((dpval.flags & END_FLAG) ? "Z" : "-")
+              << ((dpval.flags & FBI_FLAG) ? "M" : "-")
+              << ((dpval.flags & NEW_FLAG) ? "N" : "-")
+              << ((dpval.flags & DIRTY_FLAG) ? "D" : "-")
+              << ((dpval.flags & TURN_FLAG) ? "U" : "-")
+              << ((dpval.flags & WRITE_FLAG) ? "W" : "-")
+              << ((dpval.flags & READ_FLAG) ? "R " : "- ")
+              << ((dpval.flags & OVERWRITE_FLAG) ? "O" : "-")
+              << ((dpval.flags & VICTIM_FLAG) ? "V" : "-")
+              << ((dpval.flags & DIM_ERROR_FLAG) ? "E" : "-")
+              << ((dpval.flags & BAD_DPID_FLAG) ? "I" : "-")
+              << ((dpval.flags & BAD_FLAGS_FLAG) ? "F" : "-")
+              << ((dpval.flags & BAD_TIMESTAMP_FLAG) ? "T" : "-")
+              << ((dpval.flags & BAD_PAYLOAD_FLAG) ? "P" : "-")
+              << ((dpval.flags & BAD_FBI_FLAG) ? "B;" : "-;")
+              << *(dpval.get_timestamp());
+  }
+
+  /**
+         * <p>Acquires the lock for writing into this DPVAL. This method is
+         * based on Peterson's algorithm (with a spinlock). It can be used for
+         * ensuring mutual exclusion between two threads accessing this DPVAL
+         * object. <em>It is important to release the write lock by calling
+         * <tt>release_write_lock()</tt> after use.</em></p>
+         * <p><em>This method may or may not work due to CPU instruction
+         * reordering, caching, and other optimizations.</em> Using
+         * <tt>std::mutex</tt> instead is recommended.</p>
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::release_write_lock
+         */
+  inline void acquire_write_lock()
+  {
+    flags |= WRITE_FLAG;
+    flags |= TURN_FLAG;
+    while (flags & READ_FLAG && flags & TURN_FLAG) {
+    }
+  }
+
+  /**
+         * <p>Releases the lock for writing into this DPVAL. This function is
+         * based on Peterson's algorithm (with a spinlock). It can be used for
+         * ensuring mutual exclusion between two threads accessing this DPVAL
+         * object.</p>
+         * <p><em>This method may or may not work due to CPU instruction
+         * reordering, caching, and other optimizations.</em> Using
+         * <tt>std::mutex</tt> instead is recommended.</p>
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::acquire_write_lock
+         */
+  inline void release_write_lock()
+  {
+    flags &= ~WRITE_FLAG;
+  }
+
+  /**
+         * <p>Acquires the lock for reading from this DPVAL. This function is
+         * based on Peterson's algorithm (with a spinlock). It can be used for
+         * ensuring mutual exclusion between two threads accessing this DPVAL
+         * object. <em>It is important to release the read lock by calling
+         * <tt>release_read_lock()</tt> after use.</em></p>
+         * <p><em>This method may or may not work due to CPU instruction
+         * reordering, caching, and other optimizations.</em> Using
+         * <tt>std::mutex</tt> instead is recommended.</p>
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::release_read_lock
+         */
+  inline void acquire_read_lock()
+  {
+    flags |= READ_FLAG;
+    flags &= ~TURN_FLAG;
+    while (flags & WRITE_FLAG && !(flags & TURN_FLAG)) {
+    }
+  }
+
+  /**
+         * <p>Releases the lock for reading from this DPVAL. This function is
+         * based on Peterson's algorithm (with a spinlock). It can be used for
+         * ensuring mutual exclusion between two threads accessing this DPVAL
+         * object.</p>
+         * <p><em>This method may or may not work due to CPU instruction
+         * reordering, caching, and other optimizations.</em> Using
+         * <tt>std::mutex</tt> instead is recommended.</p>
+         *
+         * @see ADAPRO::ADAPOS::DataPointValue::acquire_read_lock
+         */
+  inline void release_read_lock()
+  {
+    flags &= ~READ_FLAG;
+  }
+  ClassDefNV(DataPointValue, 1);
+};
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_DATAPOINT_VALUE_H */

--- a/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
+++ b/Detectors/DCS/include/DetectorsDCS/DeliveryType.h
@@ -1,0 +1,380 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   DeliveryType.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 17 July 2015, 9:54
+ */
+
+#ifndef O2_DCS_DELIVERY_TYPE
+#define O2_DCS_DELIVERY_TYPE
+
+#include <string>
+#include <regex>
+#include <stdexcept>
+#include "DetectorsDCS/GenericFunctions.h"
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * This regular expression matches with strings representing payload types.
+     */
+static const std::regex REGEX_PT(
+  "^(Raw|DPVAL)/(Int|Uint|Double|Bool|Char|String|Time|Binary)$");
+
+/**
+     * <p>DeliveryType is a piece of meta-information used for deducing types of
+     * DPVAL payloads and DIM service description strings used with services
+     * providing data to ADAPOS. DPCOMs use the DeliveryType of DPIDs to infer
+     * the correct interpretation of payload data when being put into a
+     * <tt>std::ofstream</tt>. Also, ADAPOS Engine uses DeliveryTypes for DIM
+     * service subscription (and Load Generator for generating services).</p>
+     * <p>Every DeliveryType, except <tt>VOID</tt>, has a raw and DPVAL
+     * variant. A DIM service publishing payloads in DPVALs has a different
+     * format and binary layout than a DIM service publishing only raw data, so
+     * this distinction is critical to ADAPOS Engine.</p>
+     *
+     * @see ADAPRO::ADAPOS::DataPointCompositeObject
+     * @see ADAPRO::ADAPOS::DataPointIdentifier
+     * @see ADAPRO::ADAPOS::DataPointValue
+     */
+enum DeliveryType {
+  /**
+         * This DeliveryType is included only for testing and debugging
+         * when the payload of a DPVAL is not going to be accessed. Accessing
+         * the payload of a DPVAL with this DeliveryType results in a domain
+         * error.
+         */
+  VOID = 0,
+
+  /**
+         * <tt>Binary</tt> is the general payload data type. This is the raw
+         * variant.
+         */
+  RAW_BINARY = 64,
+
+  /**
+         * <tt>Binary</tt> is the general payload data type. This is the DPVAL
+         * variant.
+         */
+  DPVAL_BINARY = 192,
+
+  /**
+         * <tt>Int</tt> stands for a 32-bit signed integer. This is the raw
+         * variant. The numerical value of <tt>RAW_INT</tt> corresponds with the
+         * WinCC constant <tt>DPEL_INT</tt>.
+         */
+  RAW_INT = 21,
+
+  /**
+         * <tt>Int</tt> stands for a 32-bit signed integer. This is the DPVAL
+         * variant.
+         */
+  DPVAL_INT = 149,
+
+  /**
+         * <tt>Uint</tt> stands for a 32-bit unsigned integer. This is the raw
+         * variant. The numerical value of <tt>RAW_UINT</tt> corresponds with
+         * the WinCC constant <tt>DPEL_UINT</tt>.
+         */
+  RAW_UINT = 20,
+
+  /**
+         * <tt>Uint</tt> stands for a 32-bit insigned integer. This is the DPVAL
+         * variant.
+         */
+  DPVAL_UINT = 148,
+
+  /**
+         * <tt>Double</tt> stands for IEEE 754 double precision floating point
+         * number (64 bit). This is the raw variant. The numerical value of
+         * <tt>RAW_INT</tt> corresponds with the WinCC constant
+         * <tt>DPEL_FLOAT</tt>.
+         */
+  RAW_DOUBLE = 22,
+
+  /**
+         * <tt>Double</tt> stands for IEEE 754 double precision floating point
+         * number (64 bit). This is the DPVAL variant.
+         */
+  DPVAL_DOUBLE = 150,
+
+  /**
+         * <tt>Bool</tt> stands for a boolean. This is the raw variant. The
+         * numerical value of <tt>RAW_BOOL</tt> corresponds with the WinCC
+         * constant <tt>DPEL_BOOL</tt>.
+         */
+  RAW_BOOL = 23,
+
+  /**
+         * <tt>Bool</tt> stands for a boolean. This is the DPVAL variant.
+         */
+  DPVAL_BOOL = 151,
+
+  /**
+         * <tt>Char</tt> stands for an ASCII character. This is the raw variant.
+         * The numerical value of <tt>RAW_CHAR</tt> corresponds with the WinCC
+         * constant <tt>DPEL_CHAR</tt>.
+         */
+  RAW_CHAR = 19,
+
+  /**
+         * <tt>Char</tt> stands for an ASCII character. This is the raw variant.
+         */
+  DPVAL_CHAR = 147,
+
+  /**
+         * <tt>String</tt> stands for a null-terminated array of ASCII
+         * characters. This is the raw variant. The numerical value of
+         * <tt>RAW_STRING</tt> corresponds with the WinCC constant
+         * <tt>DPEL_STRING</tt>.
+         */
+  RAW_STRING = 25,
+
+  /**
+         * <tt>String</tt> stands for a null-terminated array of ASCII
+         * characters. This is the DPVAL variant.
+         */
+  DPVAL_STRING = 153,
+
+  /**
+         * <tt>Time</tt> stands for two 32-bit (unsigned) integers containing
+         * the milliseconds and secodns of a UNIX timestamp. This is the raw
+         * variant. The numerical value of <tt>RAW_TIME</tt> corresponds with
+         * the WinCC constant <tt>DPEL_DYN_UINT</tt>.
+         */
+  RAW_TIME = 4,
+
+  /**
+         * <tt>Time</tt> stands for two 32-bit (unsigned) integers containing
+         * the milliseconds and secodns of a UNIX timestamp. This is the DPVAL
+         * variant.
+         */
+  DPVAL_TIME = 132
+};
+
+template <>
+inline DeliveryType read(const std::string& str)
+{
+  if (str == "Raw/Int") {
+    return RAW_INT;
+  } else if (str == "Raw/Uint") {
+    return RAW_UINT;
+  } else if (str == "Raw/Double") {
+    return RAW_DOUBLE;
+  } else if (str == "Raw/Bool") {
+    return RAW_BOOL;
+  } else if (str == "Raw/Char") {
+    return RAW_CHAR;
+  } else if (str == "Raw/String") {
+    return RAW_STRING;
+  } else if (str == "Raw/Binary") {
+    return RAW_BINARY;
+  } else if (str == "Raw/Time") {
+    return RAW_TIME;
+  } else if (str == "DPVAL/Int") {
+    return DPVAL_INT;
+  } else if (str == "DPVAL/Uint") {
+    return DPVAL_UINT;
+  } else if (str == "DPVAL/Double") {
+    return DPVAL_DOUBLE;
+  } else if (str == "DPVAL/Bool") {
+    return DPVAL_BOOL;
+  } else if (str == "DPVAL/Char") {
+    return DPVAL_CHAR;
+  } else if (str == "DPVAL/String") {
+    return DPVAL_STRING;
+  } else if (str == "DPVAL/Binary") {
+    return DPVAL_BINARY;
+  } else if (str == "DPVAL/Time") {
+    return DPVAL_TIME;
+  } else if (str == "Void") {
+    return VOID;
+  } else {
+    throw std::domain_error("\"" + str +
+                            "\" doesn't represent a DeliveryType.");
+  }
+}
+
+template <>
+inline std::string show(const DeliveryType type)
+{
+  switch (type) {
+    case RAW_INT:
+      return "Raw/Int";
+    case RAW_UINT:
+      return "Raw/Uint";
+    case RAW_BOOL:
+      return "Raw/Bool";
+    case RAW_CHAR:
+      return "Raw/Char";
+    case RAW_DOUBLE:
+      return "Raw/Double";
+    case RAW_TIME:
+      return "Raw/Time";
+    case RAW_STRING:
+      return "Raw/String";
+    case RAW_BINARY:
+      return "Raw/Binary";
+    case DPVAL_INT:
+      return "DPVAL/Int";
+    case DPVAL_UINT:
+      return "DPVAL/Uint";
+    case DPVAL_BOOL:
+      return "DPVAL/Bool";
+    case DPVAL_CHAR:
+      return "DPVAL/Char";
+    case DPVAL_DOUBLE:
+      return "DPVAL/Double";
+    case DPVAL_TIME:
+      return "DPVAL/Time";
+    case DPVAL_STRING:
+      return "DPVAL/String";
+    case DPVAL_BINARY:
+      return "DPVAL/Binary";
+    case VOID:
+      return "Void";
+    default:
+      throw std::domain_error("Illegal DeliveryType.");
+  }
+}
+
+/**
+     * Returns <tt>true</tt> if and only if the given DeliveryType is a DPVAL
+     * variant.
+     *
+     * @param type  The DeliveryType to be checked.
+     * @return      The result.
+     * @throws std::domain_error If applied to an invalid value.
+     */
+inline bool DPVAL_variant(const DeliveryType type)
+{
+  switch (type) {
+    case DPVAL_INT:
+    case DPVAL_UINT:
+    case DPVAL_BOOL:
+    case DPVAL_CHAR:
+    case DPVAL_DOUBLE:
+    case DPVAL_TIME:
+    case DPVAL_STRING:
+    case DPVAL_BINARY:
+      return true;
+    case RAW_INT:
+    case RAW_UINT:
+    case RAW_BOOL:
+    case RAW_CHAR:
+    case RAW_DOUBLE:
+    case RAW_TIME:
+    case RAW_STRING:
+    case RAW_BINARY:
+    case VOID:
+      return false;
+    default:
+      throw std::domain_error("Illegal DeliveryType.");
+  }
+}
+
+/**
+     * Returns the DIM description string for a DIM service with the given
+     * DeliveryType.
+     *
+     * @param type  The DeliveryType.
+     * @return      The corresponding DIM service description string.
+     * @throws std::domain_error If applied to an invalid value.
+     */
+inline std::string dim_description(const DeliveryType type)
+{
+
+  switch (type) {
+    case RAW_INT:
+      return "I:1";
+    case RAW_UINT:
+      return "I:1";
+    case RAW_BOOL:
+      return "I:1";
+    case RAW_CHAR:
+      return "C:4";
+    case RAW_DOUBLE:
+      return "D:1";
+    case RAW_TIME:
+      return "I:2";
+    case RAW_STRING:
+      return "C:55";
+    case RAW_BINARY:
+      return "C:56";
+    case DPVAL_INT:
+      return "S:2;I:1;I:1";
+    case DPVAL_UINT:
+      return "S:2;I:1;I:1";
+    case DPVAL_BOOL:
+      return "S:2;I:1;I:1";
+    case DPVAL_CHAR:
+      return "S:2;I:1;C:4";
+    case DPVAL_DOUBLE:
+      return "S:2;I:1;D:1";
+    case DPVAL_TIME:
+      return "S:2;I:1;I:2";
+    case DPVAL_STRING:
+      return "S:2;I:1;C:55";
+    case DPVAL_BINARY:
+      return "S:2;I:1;C:56";
+    case VOID:
+    default:
+      throw std::domain_error("Illegal DeliveryType.");
+  }
+}
+
+/**
+     * Returns the size of a buffer required to store the binary contents of a
+     * DIM service of the given data type.
+     *
+     * @param type  The DeliveryType.
+     * @return      Size of the payload.
+     * @throws std::domain_error If applied to an invalid value.
+     */
+inline size_t dim_buffer_size(const DeliveryType type)
+{
+  switch (type) {
+    case RAW_INT:
+    case RAW_UINT:
+    case RAW_BOOL:
+    case RAW_CHAR:
+      return 4;
+    case RAW_DOUBLE:
+    case RAW_TIME:
+      return 8;
+    case RAW_STRING:
+      return 55;
+    case RAW_BINARY:
+      return 56;
+    case DPVAL_INT:
+    case DPVAL_UINT:
+    case DPVAL_BOOL:
+    case DPVAL_CHAR:
+    case DPVAL_DOUBLE:
+    case DPVAL_TIME:
+    case DPVAL_STRING:
+    case DPVAL_BINARY:
+      return 64;
+    case VOID:
+      return 0;
+    default:
+      throw std::domain_error("Illegal DeliveryType.");
+  }
+}
+} // namespace dcs
+
+} // namespace o2
+
+#endif /* O2_DCS_DELIVERY_TYPE */

--- a/Detectors/DCS/include/DetectorsDCS/GenericFunctions.h
+++ b/Detectors/DCS/include/DetectorsDCS/GenericFunctions.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* 
+ * File:   GenericFunctions.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 9 June 2017, 17:29
+ */
+
+#ifndef O2_DCS_GENERIC_FUNCTIONS_H
+#define O2_DCS_GENERIC_FUNCTIONS_H
+
+#include <string>
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * This function template is used for converting ADAPRO enumerated values
+     * into strings in a fashion similar to the function show in the Show type 
+     * class in Haskell. The exact implementation depends on the specialization.
+     * 
+     * @param input A T value to be converted.
+     * @return      A string representation of the given value.
+     * @throws std::domain_error The specialized function may throw a domain
+     * error if applied with an invalid input value.
+     */
+template <typename T>
+std::string show(const T input);
+
+/**
+     * This function template is used for parsing strings as ADAPRO enumerated
+     * values. The exact implementation depends on the specialization.
+     * 
+     * @param input A string to be interpreted as a T value.
+     * @return      The T value corresponding with the input.
+     * @throws std::domain_error The specialized function may throw a domain
+     * error if the given string couldn't be converted into a T value.
+     */
+template <typename T>
+T read(const std::string& input);
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_GENERIC_FUNCTIONS_H */

--- a/Detectors/DCS/include/DetectorsDCS/StringUtils.h
+++ b/Detectors/DCS/include/DetectorsDCS/StringUtils.h
@@ -1,0 +1,156 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * File:   StringUtils.h
+ * Author: John Lång (john.larry.lang@cern.ch)
+ *
+ * Created on 14 July 2015, 10:37
+ *
+ * This library contains miscellaneous functions used in this program for
+ * handling (C-style) strings.
+ */
+
+#ifndef O2_DCS_STRING_UTILS_H
+#define O2_DCS_STRING_UTILS_H
+
+#include <string>
+#include <vector>
+#include <list>
+#include <memory>
+
+namespace o2
+{
+namespace dcs
+{
+/**
+     * Returns an uniformly distributed string of exactly the given length. The
+     * alphabet of the string is ASCII characters between <tt>32</tt>
+     * (<tt>' '</tt>) and <tt>126</tt> (<tt>'~'</tt>), inclusive.
+     *
+     * @param length    Length for the random string.
+     * @return          The random string.
+     */
+std::string random_string(const size_t length) noexcept;
+
+/**
+     * Returns a random string of exactly the given length. The alphabet for the
+     * string contains upper case letters, digits and the symbols <tt>'_'</tt>,
+     * <tt>'/'</tt>, and <tt>'?'</tt>. Their distribution is geometric and tries
+     * to roughly approximate the symbol frequencies in ALICE DCS DIM service
+     * aliases.
+     *
+     * @param length    Length for the random string.
+     * @return          The random string.
+     */
+std::string random_string2(const size_t length) noexcept;
+
+/**
+     * Calculates a hash code for the given string. Up to 52 first characters of
+     * the string contribute to the hash code. The hash code is case
+     * insensitive, so for example <tt>"abc"</tt> and <tt>"ABC"</tt> will have
+     * colliding hash codes.
+     *
+     * @param input A string.
+     * @return      An unsigned integer.
+     */
+uint64_t hash_code(const std::string& input) noexcept;
+
+/**
+    * Converts the C-style strings of the command line parameters to a more
+    * civilized data type.
+    */
+std::unique_ptr<std::vector<std::string>> convert_strings(const int argc,
+                                                          char** argv) noexcept;
+
+/**
+     * Converts the given string into upper case. <em>This function will change
+     * the state of the given string</em>, instead of returning a copy.
+     *
+     * @param str The string to be converted into upper case.
+     */
+inline void to_upper_case(std::string& str) noexcept
+{
+  for (char& c : str) {
+    c = toupper(c);
+  }
+}
+
+/**
+     * Converts the given string into lower case. <em>This function will change
+     * the state of the given string</em>, instead of returning a copy.
+     *
+     * @param str The string to be converted into lower case.
+     */
+inline void to_lower_case(std::string& str) noexcept
+{
+  for (char& c : str) {
+    c = tolower(c);
+  }
+}
+
+/**
+     * Splits a string using the given separator.
+     *
+     * @param source    The string to be splitted.
+     * @param separator The delimiting character.
+     * @return          A vector containing the substrings.
+     */
+std::unique_ptr<std::vector<std::string>> split(const std::string& source,
+                                                const char separator) noexcept;
+
+/**
+     * Splits a string using whitespace as separator. Only the non-whitespace
+     * substrings will be returned.
+     *
+     * @param source    The string to be splitted.
+     * @return          A vector containing the substrings.
+     */
+std::unique_ptr<std::vector<std::string>> split_by_whitespace(
+  const std::string& source) noexcept;
+
+/**
+     * Returns a simple big endian hexadecimal presentation of the given
+     * segment of memory.
+     *
+     * @param start     Address of a memory segment.
+     * @param length    Length of the memory segment.
+     * @return          A hexadecimal string representation of the segment in
+     * bytes.
+     */
+std::string to_hex_big_endian(const char* const start, size_t length) noexcept;
+
+/**
+     * Returns a simple little endian hexadecimal presentation of the given
+     * segment of memory.
+     *
+     * @param start     Address of a memory segment.
+     * @param length    Length of the memory segment (in chars).
+     * @return          A hexadecimal string representation of the segment in
+     * bytes.
+     */
+std::string to_hex_little_endian(const char* const start, size_t length) noexcept;
+
+/**
+     * Prints the given list of key-value pairs.
+     *
+     * @param logger        The Logger instance used for output.
+     * @param list_name     Name of the list to be printed as a heading.
+     * @param parameters    The list to be printed
+     */
+
+void print_k_v_list(
+  const std::string& list_name,
+  const std::list<std::pair<std::string, std::string>>& parameters) noexcept;
+
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_STRING_UTILS_H */

--- a/Detectors/DCS/src/Clock.cxx
+++ b/Detectors/DCS/src/Clock.cxx
@@ -1,0 +1,11 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/Clock.h"

--- a/Detectors/DCS/src/DataPointCompositeObject.cxx
+++ b/Detectors/DCS/src/DataPointCompositeObject.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DataPointCompositeObject.h"
+
+using namespace o2::dcs;
+
+ClassImp(DataPointCompositeObject);

--- a/Detectors/DCS/src/DataPointIdentifier.cxx
+++ b/Detectors/DCS/src/DataPointIdentifier.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DataPointIdentifier.h"
+
+using namespace o2::dcs;
+
+ClassImp(DataPointIdentifier);

--- a/Detectors/DCS/src/DataPointValue.cxx
+++ b/Detectors/DCS/src/DataPointValue.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DataPointValue.h"
+
+using namespace o2::dcs;
+
+ClassImp(DataPointValue);

--- a/Detectors/DCS/src/DeliveryType.cxx
+++ b/Detectors/DCS/src/DeliveryType.cxx
@@ -1,0 +1,11 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DeliveryType.h"

--- a/Detectors/DCS/src/DetectorsDCSLinkDef.h
+++ b/Detectors/DCS/src/DetectorsDCSLinkDef.h
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if defined(__CINT__) || defined(__CLING__)
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ struct o2::dcs::DataPointCompositeObject + ;
+#pragma link C++ class o2::dcs::DataPointIdentifier + ;
+#pragma link C++ struct o2::dcs::DataPointValue + ;
+
+#endif

--- a/Detectors/DCS/src/GenericFunctions.cxx
+++ b/Detectors/DCS/src/GenericFunctions.cxx
@@ -1,0 +1,11 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/GenericFunctions.h"

--- a/Detectors/DCS/src/StringUtils.cxx
+++ b/Detectors/DCS/src/StringUtils.cxx
@@ -1,0 +1,383 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <cctype>
+#include <cstdint>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <random>
+#include <vector>
+#include <list>
+#include <memory>
+#include <fstream>
+#include <regex>
+#include <map>
+#include <functional>
+#include <utility>
+#include <sstream>
+#include <istream>
+#include <iomanip>
+#include <sstream>
+#include <iterator>
+#include "DetectorsDCS/StringUtils.h"
+
+using namespace std;
+
+random_device dev;
+default_random_engine gen(dev());
+uniform_int_distribution<char> uniform_dist(32, 126);
+geometric_distribution<char> geom_dist(0.1);
+
+constexpr char ALPHABET[39]{
+  'E', 'T', 'A', 'O', 'I', '_', 'N', 'S', 'H', 'R',
+  '/', 'D', 'L', '1', '2', 'C', 'U', 'M', 'W', '3',
+  '4', '5', '6', '7', '8', '9', '0', 'F', 'G', 'Y',
+  'P', 'B', 'V', 'K', 'J', 'X', 'Q', 'Z', '?'};
+
+/**
+ * The first 52 prime numbers used for calculating the hash code. Each symbol of
+ * the alias will be multiplied (mod 256) with a prime of the same index and
+ * adding the obtained number to the sum that is the hash code.
+ */
+constexpr uint64_t PRIMES[52]{
+  2, 3, 5, 7, 11, 13, 17, 19, 23, 29,
+  31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+  73, 79, 83, 89, 97, 101, 103, 107, 109, 113,
+  127, 131, 137, 139, 149, 151, 157, 163, 167, 173,
+  179, 181, 191, 193, 197, 199, 211, 223, 227, 229,
+  233, 239};
+
+/**
+ * The modulo used in the hash function after calculating the sum. It is the
+ * prime number closest to 1.5 * 2^63.
+ */
+constexpr uint64_t MODULO(13835058055282163729ULL);
+
+/**
+ * Transforms the given character into a 8-bit unsigned code symbol.
+ *
+ * @param input
+ * @return
+ */
+uint8_t lookup(const char input) noexcept
+{
+  switch (input) {
+    case 'e':
+    case 'E':
+      return 0;
+    case 't':
+    case 'T':
+      return 1;
+    case 'a':
+    case 'A':
+      return 2;
+    case 'o':
+    case 'O':
+      return 3;
+    case 'i':
+    case 'I':
+      return 4;
+    case '_':
+      return 5;
+    case 'n':
+    case 'N':
+      return 6;
+    case 's':
+    case 'S':
+      return 7;
+    case 'h':
+    case 'H':
+      return 8;
+    case 'r':
+    case 'R':
+      return 9;
+    case '/':
+      return 10;
+    case 'd':
+    case 'D':
+      return 11;
+    case 'l':
+    case 'L':
+      return 12;
+    case '1':
+      return 13;
+    case '2':
+      return 14;
+    case 'c':
+    case 'C':
+      return 15;
+    case 'u':
+    case 'U':
+      return 16;
+    case 'm':
+    case 'M':
+      return 17;
+    case 'w':
+    case 'W':
+      return 18;
+    case '3':
+      return 19;
+    case '4':
+      return 20;
+    case '5':
+      return 21;
+    case '6':
+      return 22;
+    case '7':
+      return 23;
+    case '8':
+      return 24;
+    case '9':
+      return 25;
+    case '0':
+      return 26;
+    case 'f':
+    case 'F':
+      return 27;
+    case 'g':
+    case 'G':
+      return 28;
+    case 'y':
+    case 'Y':
+      return 29;
+    case 'p':
+    case 'P':
+      return 30;
+    case 'b':
+    case 'B':
+      return 31;
+    case 'v':
+    case 'V':
+      return 32;
+    case 'k':
+    case 'K':
+      return 33;
+    case 'j':
+    case 'J':
+      return 34;
+    case 'x':
+    case 'X':
+      return 35;
+    case 'q':
+    case 'Q':
+      return 36;
+    case 'z':
+    case 'Z':
+      return 37;
+    default:
+      return 38;
+  }
+}
+
+/**
+ * An all-integer exponent function. The orgiginal algorithm was submitted as an
+ * answer at StackOverflow, by Elias Yarrkow. The code was obtained from
+ * http://stackoverflow.com/a/101613 in 14 February 2017, 11:24, and modified to
+ * work with the unsigned C integer types. It is well-known that these kind of
+ * functions usually overflow, and overflows are ignored in this case.
+ *
+ * @param base  The base of the exponent function.
+ * @param exp   The exponent.
+ * @return      The result.
+ */
+uint64_t exp(uint64_t base, uint8_t exp) noexcept
+{
+  uint64_t result(1);
+  while (exp) {
+    if (exp & 1) {
+      result *= base;
+    }
+    exp >>= 1;
+    base *= base;
+  }
+  return result;
+}
+
+string o2::dcs::random_string(const size_t length) noexcept
+{
+  string s;
+  s.reserve(length);
+  for (size_t i = 0; i < length; ++i) {
+    s.push_back(uniform_dist(gen));
+  }
+  return s;
+}
+
+string o2::dcs::random_string2(const size_t length) noexcept
+{
+  string s;
+  s.reserve(length);
+  for (size_t i = 0; i < length; ++i) {
+    s.push_back(ALPHABET[geom_dist(gen) % 39]);
+  }
+  return s;
+}
+
+uint64_t o2::dcs::hash_code(const std::string& input) noexcept
+{
+  size_t result(0);
+  const size_t length(min(input.length(), (string::size_type)52));
+  for (size_t i = 0; i < length; ++i) {
+    //        result += exp(PRIMES[i], (uint8_t) input[i]);
+    result += exp(PRIMES[i], lookup(input[i]));
+    //        result += exp(PRIMES[i], ((uint8_t) input[i]) & 0x1F);
+  }
+  return result;
+}
+
+unique_ptr<vector<string>> o2::dcs::convert_strings(const int argc,
+                                                    char** argv) noexcept
+{
+  vector<string>* arguments = new vector<string>();
+
+  for (int i = 0; i < argc; ++i) {
+    arguments->push_back(std::move(string(argv[i])));
+  }
+
+  return unique_ptr<vector<string>>(arguments);
+}
+
+unique_ptr<vector<string>> o2::dcs::split(const string& source,
+                                          const char separator) noexcept
+{
+  stringstream ss(source);
+  string item;
+  vector<string>* substrings = new vector<string>();
+  while (getline(ss, item, separator)) {
+    substrings->push_back(item);
+  }
+  return unique_ptr<vector<string>>(substrings);
+}
+
+unique_ptr<vector<string>> o2::dcs::split_by_whitespace(const string& source) noexcept
+{
+  istringstream buffer(source);
+  vector<string>* ret = new vector<string>();
+
+  std::copy(istream_iterator<string>(buffer),
+            istream_iterator<string>(),
+            back_inserter(*ret));
+  return unique_ptr<vector<string>>(ret);
+}
+
+inline char to_alpha_numeric(const uint8_t c) noexcept
+{
+  switch (c) {
+    case 0x00:
+      return '0';
+    case 0x01:
+    case 0x10:
+      return '1';
+    case 0x02:
+    case 0x20:
+      return '2';
+    case 0x03:
+    case 0x30:
+      return '3';
+    case 0x04:
+    case 0x40:
+      return '4';
+    case 0x05:
+    case 0x50:
+      return '5';
+    case 0x06:
+    case 0x60:
+      return '6';
+    case 0x07:
+    case 0x70:
+      return '7';
+    case 0x08:
+    case 0x80:
+      return '8';
+    case 0x09:
+    case 0x90:
+      return '9';
+    case 0x0A:
+    case 0xA0:
+      return 'A';
+    case 0x0B:
+    case 0xB0:
+      return 'B';
+    case 0x0C:
+    case 0xC0:
+      return 'C';
+    case 0x0D:
+    case 0xD0:
+      return 'D';
+    case 0x0E:
+    case 0xE0:
+      return 'E';
+    case 0x0F:
+    case 0xF0:
+      return 'F';
+    default:
+      return '?';
+  }
+}
+
+string o2::dcs::to_hex_big_endian(const char* const start, const size_t length) noexcept
+{
+  string s;
+  s.reserve(length * 3);
+  // My machine is little endian:
+  size_t i = length - 1;
+  do {
+    const char next = start[i];
+    s.push_back(to_alpha_numeric(next & 0xF0));
+    s.push_back(to_alpha_numeric(next & 0x0F));
+    s.push_back(' ');
+    --i;
+  } while (i < length);
+  s.pop_back();
+  return s;
+}
+
+string o2::dcs::to_hex_little_endian(const char* const start, const size_t length) noexcept
+{
+  string s;
+  s.reserve(length * 3);
+  // My machine is little endian:
+  size_t i = 0;
+  do {
+    const char next = start[i];
+    s.push_back(to_alpha_numeric(next & 0xF0));
+    s.push_back(to_alpha_numeric(next & 0x0F));
+    s.push_back(' ');
+    ++i;
+  } while (i < length);
+  s.pop_back();
+  return s;
+}
+
+void o2::dcs::print_k_v_list(
+  const string& list_name,
+  const list<pair<string, string>>& parameters) noexcept
+{
+  stringstream ss;
+  ss << list_name << endl
+     << string(list_name.length() + 26, '-') << endl
+     << endl;
+  uint32_t key_length(0);
+  for (auto k_v : parameters) {
+    if (k_v.first.length() > key_length) {
+      key_length = k_v.first.length();
+    }
+  }
+  key_length += 4 - (key_length % 4);
+  for (auto k_v : parameters) {
+    ss << "    " << k_v.first << string(key_length - k_v.first.length(), ' ') << k_v.second << endl;
+  }
+  ss << endl
+     << "=========================================================="
+        "======================"
+     << endl
+     << endl;
+}


### PR DESCRIPTION
The classes are taken from ADAPRO, with small modifications, in order to not have to include the full ADAPRO in O2. 
The DCS data points are to be used in calibration.
