### PR TITLE
add option to produce per-link raw data files for MID

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -35,7 +35,7 @@ namespace mid
 class Encoder
 {
  public:
-  void init(const char* filename, int verbosity = 0);
+  void init(const char* filename, bool perLink = false, int verbosity = 0);
   void process(gsl::span<const ColumnData> data, const InteractionRecord& ir, EventType eventType = EventType::Standard);
   /// Sets the maximum size of the superpage
   void setSuperpageSize(int maxSize) { mRawWriter.setSuperPageSize(maxSize); }

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -18,13 +18,14 @@
 #include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "MIDRaw/CrateMasks.h"
+#include <fmt/format.h>
 
 namespace o2
 {
 namespace mid
 {
 
-void Encoder::init(const char* filename, int verbosity)
+void Encoder::init(const char* filename, bool perLink, int verbosity)
 {
   /// Initializes links
 
@@ -32,12 +33,15 @@ void Encoder::init(const char* filename, int verbosity)
   auto gbtIds = mFEEIdConfig.getConfiguredGBTIds();
 
   mRawWriter.setVerbosity(verbosity);
+  int lcnt = 0;
   for (auto& gbtId : gbtIds) {
     auto feeId = mFEEIdConfig.getFeeId(gbtId);
-    mRawWriter.registerLink(feeId, mFEEIdConfig.getCRUId(gbtId), mFEEIdConfig.getLinkId(gbtId), mFEEIdConfig.getEndPointId(gbtId), filename);
+    mRawWriter.registerLink(feeId, mFEEIdConfig.getCRUId(gbtId), mFEEIdConfig.getLinkId(gbtId), mFEEIdConfig.getEndPointId(gbtId),
+                            perLink ? fmt::format("{:s}_L{:d}.raw", filename, lcnt) : fmt::format("{:s}.raw", filename));
     mGBTEncoders[feeId].setFeeId(feeId);
     mGBTEncoders[feeId].setMask(masks.getMask(feeId));
     mGBTIds[feeId] = gbtId;
+    lcnt++;
   }
 }
 

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -85,9 +85,10 @@ std::tuple<std::vector<o2::mid::ColumnData>, std::vector<o2::mid::ROFRecord>> en
 {
   auto severity = fair::Logger::GetConsoleSeverity();
   fair::Logger::SetConsoleSeverity(fair::Severity::WARNING);
-  std::string tmpFilename = "tmp_mid_raw.dat";
+  std::string tmpFilename0 = "tmp_mid_raw";
+  std::string tmpFilename = tmpFilename0 + ".raw";
   o2::mid::Encoder encoder;
-  encoder.init(tmpFilename.c_str());
+  encoder.init(tmpFilename0.c_str());
   for (auto& item : inData) {
     encoder.process(item.second, item.first, inEventType);
   }

--- a/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
@@ -44,6 +44,7 @@ class RawWriterDeviceDPL
   {
     auto filename = ic.options().get<std::string>("mid-raw-outfile");
     auto dirname = ic.options().get<std::string>("mid-raw-outdir");
+    auto perLink = ic.options().get<bool>("mid-raw-perlink");
     if (gSystem->AccessPathName(dirname.c_str())) {
       if (gSystem->mkdir(dirname.c_str(), kTRUE)) {
         LOG(FATAL) << "could not create output directory " << dirname;
@@ -53,7 +54,7 @@ class RawWriterDeviceDPL
     }
 
     std::string fullFName = o2::utils::concat_string(dirname, "/", filename);
-    mEncoder.init(fullFName.c_str());
+    mEncoder.init(fullFName.c_str(), perLink);
 
     std::string inputGRP = o2::base::NameConf::getGRPFileName();
     std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom(inputGRP)};
@@ -97,7 +98,8 @@ framework::DataProcessorSpec getRawWriterSpec()
     of::AlgorithmSpec{of::adaptFromTask<o2::mid::RawWriterDeviceDPL>()},
     of::Options{
       {"mid-raw-outdir", of::VariantType::String, ".", {"Raw file output directory"}},
-      {"mid-raw-outfile", of::VariantType::String, "mid.raw", {"Raw output file name"}},
+      {"mid-raw-outfile", of::VariantType::String, "mid", {"Raw output file name"}},
+      {"mid-raw-perlink", of::VariantType::Bool, false, {"Output file per link"}},
       {"mid-raw-header-offset", of::VariantType::Bool, false, {"Header offset in bytes"}}}};
 }
 } // namespace mid


### PR DESCRIPTION
@dstocco : this is to be able to produce per-link raw data files, as required by DataDistribution for its replay (for the full system test). The default behaviour did not change.