### PR TITLE
MID CTF, related workflows, test + fixes

### DIFF
--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -9,8 +9,12 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(DataFormatsMID
-               SOURCES src/ColumnData.cxx src/Track.cxx
-               PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils
+               SOURCES src/ColumnData.cxx
+                       src/Track.cxx
+                       src/CTF.cxx
+	       PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils
+	                             O2::CommonDataFormat
+	                             O2::DetectorsCommonDataFormats
                                      O2::ReconstructionDataFormats)
 
 o2_target_root_dictionary(DataFormatsMID
@@ -18,4 +22,5 @@ o2_target_root_dictionary(DataFormatsMID
                                   include/DataFormatsMID/Cluster3D.h
                                   include/DataFormatsMID/ColumnData.h
                                   include/DataFormatsMID/ROFRecord.h
-                                  include/DataFormatsMID/Track.h)
+                                  include/DataFormatsMID/Track.h
+                                  include/DataFormatsMID/CTF.h)

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/CTF.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/CTF.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for MID CTF data
+
+#ifndef O2_MID_CTF_H
+#define O2_MID_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+
+namespace o2
+{
+namespace mid
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nROFs = 0;      /// number of ROFrames in TF
+  uint32_t nColumns = 0;   /// number of referred columns in TF
+  uint32_t firstOrbit = 0; /// 1st orbit of TF
+  uint16_t firstBC = 0;    /// 1st BC of TF
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded clusters of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 7, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncROF,
+               BLC_orbitIncROF,
+               BLC_entriesROF,
+               BLC_evtypeROF,
+               BLC_pattern,
+               BLC_deId,
+               BLC_colId };
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/MUON/MID/src/CTF.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/CTF.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsMID/CTF.h"
+
+using namespace o2::mid;

--- a/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
+++ b/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
@@ -22,4 +22,7 @@
 #pragma link C++ class std::vector < o2::mid::ROFRecord > +;
 #pragma link C++ struct o2::mid::Track + ;
 
+#pragma link C++ struct o2::mid::CTFHeader + ;
+#pragma link C++ struct o2::mid::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::mid::CTFHeader, 7, uint32_t> + ;
 #endif

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -7,7 +7,6 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
-
 add_subdirectory(workflow)
 
 o2_add_test(itsmft
@@ -51,3 +50,10 @@ o2_add_test(tof
             COMPONENT_NAME ctf
             LABELS ctf)
 
+o2_add_test(mid
+            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                                  O2::DataFormatsMID
+                                  O2::MIDCTF
+            SOURCES test/test_ctf_io_mid.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf)

--- a/Detectors/CTF/test/test_ctf_io_mid.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mid.cxx
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MIDCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "MIDCTF/CTFCoder.h"
+#include "DataFormatsMID/CTF.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::mid;
+
+BOOST_AUTO_TEST_CASE(CTFTest)
+{
+  std::vector<ROFRecord> rofs;
+  std::vector<ColumnData> cols;
+  // RS: don't understand why, but this library is not loaded automatically, although the dependencies are clearly
+  // indicated. What it more weird is that for similar tests of other detectors the library is loaded!
+  // Absence of the library leads to complains about the StreamerInfo and eventually segm.faul when appending the
+  // CTH to the tree. For this reason I am loading it here manually
+  gSystem->Load("libO2DetectorsCommonDataFormats.so");
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir(0, 0);
+  std::array<uint16_t, 5> pattern;
+  for (int irof = 0; irof < 1000; irof++) {
+    ir += 1 + gRandom->Integer(200);
+    uint8_t nch = 0, evtyp = gRandom->Integer(3);
+    while (nch == 0) {
+      nch = gRandom->Poisson(10);
+    }
+    auto start = cols.size();
+    for (int ich = 0; ich < nch; ich++) {
+      uint8_t deId = gRandom->Integer(128);
+      uint8_t columnId = gRandom->Integer(128);
+      for (int i = 0; i < 5; i++) {
+        pattern[i] = gRandom->Integer(0x7fff);
+      }
+      cols.emplace_back(ColumnData{deId, columnId, pattern});
+    }
+    rofs.emplace_back(ROFRecord{ir, EventType(evtyp), start, cols.size() - start});
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, rofs, cols); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::mid::CTF::get(vec.data());
+    TFile flOut("test_ctf_mid.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "MID");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  {
+    sw.Start();
+    TFile flIn("test_ctf_mid.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::mid::CTF::readFromTree(vec, *(tree.get()), "MID");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<ROFRecord> rofsD;
+  std::vector<ColumnData> colsD;
+
+  sw.Start();
+  const auto ctfImage = o2::mid::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, rofsD, colsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  BOOST_CHECK(rofsD.size() == rofs.size());
+  BOOST_CHECK(colsD.size() == cols.size());
+  LOG(INFO) << " BOOST_CHECK rofsD.size() " << rofsD.size() << " rofs.size() " << rofs.size()
+            << " BOOST_CHECK(colsD.size() " << colsD.size() << " cols.size()) " << cols.size();
+
+  for (size_t i = 0; i < rofs.size(); i++) {
+    const auto& dor = rofs[i];
+    const auto& ddc = rofsD[i];
+    LOG(DEBUG) << " Orig.ROFRecord " << i << " " << dor.interactionRecord << " " << dor.firstEntry << " " << dor.nEntries;
+    LOG(DEBUG) << " Deco.ROFRecord " << i << " " << ddc.interactionRecord << " " << ddc.firstEntry << " " << ddc.nEntries;
+
+    BOOST_CHECK(dor.interactionRecord == ddc.interactionRecord);
+    BOOST_CHECK(dor.firstEntry == ddc.firstEntry);
+    BOOST_CHECK(dor.nEntries == dor.nEntries);
+  }
+
+  for (size_t i = 0; i < cols.size(); i++) {
+    const auto& cor = cols[i];
+    const auto& cdc = colsD[i];
+    BOOST_CHECK(cor.deId == cdc.deId);
+    BOOST_CHECK(cor.columnId == cdc.columnId);
+    for (int j = 0; j < 5; j++) {
+      BOOST_CHECK(cor.patterns[j] == cdc.patterns[j]);
+      LOG(DEBUG) << "col " << i << " pat " << j << " : " << cor.patterns[j] << " : " << cdc.patterns[j];
+    }
+  }
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -18,12 +18,14 @@ o2_add_library(CTFWorkflow
                                      O2::DataFormatsTOF
                                      O2::DataFormatsFT0
                                      O2::DataFormatsFV0
+				     O2::DataFormatsMID
                                      O2::DataFormatsParameters
                                      O2::ITSMFTWorkflow
                                      O2::TPCWorkflow
                                      O2::FT0Workflow
                                      O2::FV0Workflow
                                      O2::TOFWorkflow
+                                     O2::MIDWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -28,6 +28,7 @@
 #include "DataFormatsFT0/CTF.h"
 #include "DataFormatsFV0/CTF.h"
 #include "DataFormatsTOF/CTF.h"
+#include "DataFormatsMID/CTF.h"
 #include "Algorithm/RangeTokenizer.h"
 
 using namespace o2::framework;
@@ -146,6 +147,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::tof::CTF));
     o2::tof::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::MID;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mid::CTF));
+    o2::mid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -25,6 +25,7 @@
 #include "DataFormatsFT0/CTF.h"
 #include "DataFormatsFV0/CTF.h"
 #include "DataFormatsTOF/CTF.h"
+#include "DataFormatsMID/CTF.h"
 
 using namespace o2::framework;
 
@@ -96,6 +97,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::tof::CTF>(pc, DetID::TOF, header, treeOut.get());
   processDet<o2::ft0::CTF>(pc, DetID::FT0, header, treeOut.get());
   processDet<o2::fv0::CTF>(pc, DetID::FV0, header, treeOut.get());
+  processDet<o2::mid::CTF>(pc, DetID::MID, header, treeOut.get());
 
   mTimer.Stop();
 
@@ -163,6 +165,7 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::tof::CTF>(DetID::TOF, header);
   storeDictionary<o2::ft0::CTF>(DetID::FT0, header);
   storeDictionary<o2::fv0::CTF>(DetID::FV0, header);
+  storeDictionary<o2::mid::CTF>(DetID::MID, header);
   // close remnants
   if (mDictTreeOut) {
     closeDictionaryTreeAndFile(header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -23,7 +23,9 @@
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "TPCWorkflow/EntropyDecoderSpec.h"
 #include "FT0Workflow/EntropyDecoderSpec.h"
+#include "FV0Workflow/EntropyDecoderSpec.h"
 #include "TOFWorkflow/EntropyDecoderSpec.h"
+#include "MIDWorkflow/EntropyDecoderSpec.h"
 
 using namespace o2::framework;
 using DetID = o2::detectors::DetID;
@@ -80,5 +82,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (dets[DetID::FT0]) {
     specs.push_back(o2::ft0::getEntropyDecoderSpec());
   }
+  if (dets[DetID::FV0]) {
+    specs.push_back(o2::fv0::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::MID]) {
+    specs.push_back(o2::mid::getEntropyDecoderSpec());
+  }
+
   return std::move(specs);
 }

--- a/Detectors/MUON/MID/CTF/CMakeLists.txt
+++ b/Detectors/MUON/MID/CTF/CMakeLists.txt
@@ -8,12 +8,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Clustering)
-add_subdirectory(QC)
-add_subdirectory(Raw)
-add_subdirectory(CTF)
-add_subdirectory(Simulation)
-add_subdirectory(TestingSimTools)
-add_subdirectory(Tracking)
-add_subdirectory(Workflow)
+o2_add_library(MIDCTF
+               SOURCES src/CTFCoder.cxx src/CTFHelper.cxx
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsMID
+                                     O2::DetectorsBase
+                                     O2::CommonDataFormat
+				     O2::DetectorsCommonDataFormats
+                                     O2::rANS
+                                     ms_gsl::ms_gsl)
+

--- a/Detectors/MUON/MID/CTF/README.md
+++ b/Detectors/MUON/MID/CTF/README.md
@@ -1,0 +1,7 @@
+<!-- doxy
+\page refMUONMIDCTF MID CTF encoding library
+/doxy -->
+
+# MID CTF
+This directory contains the classes to handle entropy encoding of MID
+ROFRecord and ColumnData data.

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -1,0 +1,153 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MID column data
+
+#ifndef O2_MID_CTFCODER_H
+#define O2_MID_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsMID/CTF.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "rANS/rans.h"
+#include "MIDCTF/CTFHelper.h"
+
+class TTree;
+
+namespace o2
+{
+namespace mid
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MID) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const ColumnData>& colData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VROF, typename VCOL>
+  void decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<ColumnData>& colVec);
+};
+
+/// entropy-encode clusters to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const ColumnData>& colData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncROF
+    MD::EENCODE, // BLC_orbitIncROF
+    MD::EENCODE, // BLC_entriesROF
+    MD::EENCODE, // BLC_evtypeROF
+    MD::EENCODE, // BLC_pattern
+    MD::EENCODE, // BLC_deId
+    MD::EENCODE  // BLC_colId
+  };
+  CTFHelper helper(rofData, colData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() / 4; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODEMID(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODEMID(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,    0);
+  ENCODEMID(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF, 0);
+  ENCODEMID(helper.begin_entriesROF(),  helper.end_entriesROF(),   CTF::BLC_entriesROF,  0);
+  ENCODEMID(helper.begin_evtypeROF(),   helper.end_evtypeROF(),    CTF::BLC_evtypeROF,   0);
+
+  ENCODEMID(helper.begin_pattern(),     helper.end_pattern(),      CTF::BLC_pattern,     0);
+  ENCODEMID(helper.begin_deId(),        helper.end_deId(),         CTF::BLC_deId,        0);
+  ENCODEMID(helper.begin_colId(),       helper.end_colId(),        CTF::BLC_colId,       0);
+  // clang-format on
+  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded clusters to standard compact clusters
+template <typename VROF, typename VCOL>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+  std::vector<uint16_t> bcInc, entries, pattern;
+  std::vector<uint32_t> orbitInc;
+  std::vector<uint8_t> evType, deId, colId;
+
+#define DECODEFT0(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODEFT0(bcInc,       CTF::BLC_bcIncROF); 
+  DECODEFT0(orbitInc,    CTF::BLC_orbitIncROF);
+  DECODEFT0(entries,     CTF::BLC_entriesROF);
+  DECODEFT0(evType,      CTF::BLC_evtypeROF);
+
+  DECODEFT0(pattern,     CTF::BLC_pattern);
+  DECODEFT0(deId,        CTF::BLC_deId);
+  DECODEFT0(colId,       CTF::BLC_colId);
+  // clang-format on
+  //
+  rofVec.clear();
+  colVec.clear();
+  rofVec.reserve(header.nROFs);
+  colVec.reserve(header.nColumns);
+
+  uint32_t firstEntry = 0, rofCount = 0, colCount = 0, pCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  for (uint32_t irof = 0; irof < header.nROFs; irof++) {
+    // restore ROFRecord
+    if (orbitInc[irof]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[irof]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[irof];
+    } else {
+      ir.bc += bcInc[irof];
+    }
+
+    firstEntry = colVec.size();
+    for (uint8_t ic = 0; ic < entries[irof]; ic++) {
+      colVec.emplace_back(ColumnData{deId[colCount], colId[colCount], std::array{pattern[pCount], pattern[pCount + 1], pattern[pCount + 2], pattern[pCount + 3], pattern[pCount + 4]}});
+      pCount += 5;
+      colCount++;
+    }
+    rofVec.emplace_back(ROFRecord{ir, EventType(evType[irof]), firstEntry, entries[irof]});
+  }
+  assert(colCount == header.nColumns);
+}
+
+} // namespace mid
+} // namespace o2
+
+#endif // O2_MID_CTFCODER_H

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
@@ -1,0 +1,196 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MID CTF creation
+
+#ifndef O2_MID_CTF_HELPER_H
+#define O2_MID_CTF_HELPER_H
+
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/CTF.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace mid
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const o2::mid::ROFRecord>& rofData, const gsl::span<const o2::mid::ColumnData>& colData)
+    : mROFData(rofData), mColData(colData) {}
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mColData.size()), 0, 0};
+    if (mROFData.size()) {
+      h.firstOrbit = mROFData[0].interactionRecord.orbit;
+      h.firstBC = mROFData[0].interactionRecord.bc;
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mROFData.size() * sizeof(o2::mid::ROFRecord) + mColData.size() * sizeof(o2::mid::ColumnData); }
+
+  //>>> =========================== ITERATORS ========================================
+
+  template <typename I, typename D, typename T, int M = 1>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncROF : public _Iter<Iter_bcIncROF, ROFRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncROF, ROFRecord, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].interactionRecord.orbit == mData[mIndex - 1].interactionRecord.orbit) {
+          return mData[mIndex].interactionRecord.bc - mData[mIndex - 1].interactionRecord.bc;
+        } else {
+          return mData[mIndex].interactionRecord.bc;
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncROF : public _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].interactionRecord.orbit - mData[mIndex - 1].interactionRecord.orbit : 0; }
+  };
+
+  //_______________________________________________
+  // Number of entries in the ROF
+  class Iter_entriesROF : public _Iter<Iter_entriesROF, ROFRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_entriesROF, ROFRecord, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].nEntries; }
+  };
+
+  //_______________________________________________
+  // Event type for the ROF
+  class Iter_evtypeROF : public _Iter<Iter_evtypeROF, ROFRecord, uint8_t>
+  {
+   public:
+    using _Iter<Iter_evtypeROF, ROFRecord, uint8_t>::_Iter;
+    value_type operator*() const { return value_type(mData[mIndex].eventType); }
+  };
+
+  //_______________________________________________
+  class Iter_pattern : public _Iter<Iter_pattern, ColumnData, uint16_t, 5>
+  {
+   public:
+    using _Iter<Iter_pattern, ColumnData, uint16_t, 5>::_Iter;
+    value_type operator*() const { return mData[mIndex / 5].patterns[mIndex % 5]; }
+  };
+
+  //_______________________________________________
+  class Iter_deId : public _Iter<Iter_deId, ColumnData, uint8_t>
+  {
+   public:
+    using _Iter<Iter_deId, ColumnData, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].deId; }
+  };
+
+  //_______________________________________________
+  class Iter_colId : public _Iter<Iter_colId, ColumnData, uint8_t>
+  {
+   public:
+    using _Iter<Iter_colId, ColumnData, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].columnId; }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncROF begin_bcIncROF() const { return Iter_bcIncROF(mROFData, false); }
+  Iter_bcIncROF end_bcIncROF() const { return Iter_bcIncROF(mROFData, true); }
+
+  Iter_orbitIncROF begin_orbitIncROF() const { return Iter_orbitIncROF(mROFData, false); }
+  Iter_orbitIncROF end_orbitIncROF() const { return Iter_orbitIncROF(mROFData, true); }
+
+  Iter_entriesROF begin_entriesROF() const { return Iter_entriesROF(mROFData, false); }
+  Iter_entriesROF end_entriesROF() const { return Iter_entriesROF(mROFData, true); }
+
+  Iter_evtypeROF begin_evtypeROF() const { return Iter_evtypeROF(mROFData, false); }
+  Iter_evtypeROF end_evtypeROF() const { return Iter_evtypeROF(mROFData, true); }
+
+  Iter_pattern begin_pattern() const { return Iter_pattern(mColData, false); }
+  Iter_pattern end_pattern() const { return Iter_pattern(mColData, true); }
+
+  Iter_deId begin_deId() const { return Iter_deId(mColData, false); }
+  Iter_deId end_deId() const { return Iter_deId(mColData, true); }
+
+  Iter_colId begin_colId() const { return Iter_colId(mColData, false); }
+  Iter_colId end_colId() const { return Iter_colId(mColData, true); }
+
+ private:
+  const gsl::span<const o2::mid::ROFRecord> mROFData;
+  const gsl::span<const o2::mid::ColumnData> mColData;
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MID  data
+
+#include "MIDCTF/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::mid;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<ColumnData>& colVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, rofVec, colVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc = 0, entries = 0, pattern = 0;
+  uint32_t orbitInc = 0;
+  uint8_t evType = 0, deId = 0, colId = 0;
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+  // clang-format off
+  MAKECODER(bcInc,    CTF::BLC_bcIncROF); 
+  MAKECODER(orbitInc, CTF::BLC_orbitIncROF);
+  MAKECODER(entries,  CTF::BLC_entriesROF);
+  MAKECODER(evType,   CTF::BLC_evtypeROF);
+  MAKECODER(pattern,  CTF::BLC_pattern);
+  MAKECODER(deId,     CTF::BLC_deId);
+  MAKECODER(colId,    CTF::BLC_colId);
+  // clang-format on
+}

--- a/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
@@ -8,23 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDWorkflow/RecoWorkflow.h
-/// \brief  Definition of the reconstruction workflow for MID
-/// \author Diego Stocco <Diego.Stocco at cern.ch>
-/// \date   11 April 2019
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MID CTF creation
 
-#ifndef O2_MID_RECOWORKFLOWSPEC_H
-#define O2_MID_RECOWORKFLOWSPEC_H
-
-#include "Framework/RootSerializationSupport.h"
-#include "Framework/WorkflowSpec.h"
-
-namespace o2
-{
-namespace mid
-{
-framework::WorkflowSpec getRecoWorkflow(bool ctfInput);
-}
-} // namespace o2
-
-#endif //O2_MID_RECOWORKFLOWSPEC_H
+#include "MIDCTF/CTFHelper.h"

--- a/Detectors/MUON/MID/README.md
+++ b/Detectors/MUON/MID/README.md
@@ -13,4 +13,5 @@ This is a top page for the MID detector documentation.
 * \subpage refMUONMIDRawExe
 * \subpage refMUONMIDTracking
 * \subpage refMUONMIDWorkflow
+* \subpage refMUONMIDCTF
 /doxy -->

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -23,6 +23,8 @@ o2_add_library(MIDWorkflow
 		       src/DigitReaderSpec.cxx
 		       src/DigitsToRawWorkflow.cxx
 		       src/RawWriterSpec.cxx
+                       src/EntropyDecoderSpec.cxx
+                       src/EntropyEncoderSpec.cxx
 		       PUBLIC_LINK_LIBRARIES
 		       O2::Framework
 		       O2::SimConfig
@@ -35,6 +37,7 @@ o2_add_library(MIDWorkflow
 		       O2::MIDClustering
 		       O2::MIDTracking
 		       O2::MIDRaw
+                       O2::MIDCTF
 		       )
 		     
 o2_add_executable(
@@ -69,3 +72,14 @@ o2_add_executable(
 
 target_include_directories(
   ${exenameraw} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
+
+o2_add_executable(
+  entropy-encoder-workflow
+  COMPONENT_NAME mid
+  SOURCES src/entropy-encoder-workflow.cxx
+  TARGETVARNAME exenameentropy
+  PUBLIC_LINK_LIBRARIES
+    O2::MIDWorkflow)
+
+target_include_directories(
+  ${exenameentropy} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -45,3 +45,16 @@ Processing time / 90 ROFs: full: 3.55542 us  tracking: 2.02182 us
 ```
 Two timing values are provided: one is for the full execution of the device (including retrieval and sending of the DPL messages) and one which concerns only the execution of the algorithm (the tracking algorithm in the above example)
 The timing refers to the time needed to process one read-out-frame, i.e. one event.
+
+## Operations with CTF 
+
+The MID contribution can be added to CTF by attaching the ``o2-mid-entropy-encoder-workflow`` device to reconstruction workflow ending by CTF writer, e.g.:
+```bash
+o2-raw-file-reader-workflow --input-conf raw/MID/MIDraw.cfg | o2-mid-reco-workflow | o2-mid-entropy-encoder-workflow | o2-ctf-writer-workflow
+```
+
+The reconstruction staring from CTF can be done as (option ``--input-ctf`` will prevent the ``o2-mid-reco-workflow`` from
+adding raw data decoding/aggregation to the workflow):
+```bash
+o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root  --onlyDet MID | o2-mid-reco-workflow --input-ctf
+```

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to MID ROFRecords/ColumnData stream
+
+#ifndef O2_MID_ENTROPYDECODER_SPEC
+#define O2_MID_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "MIDCTF/CTFCoder.h"
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace mid
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mid::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert MID data to CTF (EncodedBlocks)
+/// @author ruben.shahoyan@cern.ch
+
+#ifndef O2_MID_ENTROPYENCODER_SPEC
+#define O2_MID_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include <TStopwatch.h>
+#include "MIDCTF/CTFCoder.h"
+
+namespace o2
+{
+namespace mid
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mid::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "MIDWorkflow/EntropyDecoderSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("mid-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& rofs = pc.outputs().make<std::vector<o2::mid::ROFRecord>>(OutputRef{"rofs"});
+  auto& cols = pc.outputs().make<std::vector<o2::mid::ColumnData>>(OutputRef{"cols"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::mid::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, rofs, cols);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << cols.size() << " MID columns in " << rofs.size() << " ROFRecords in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MID Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"rofs"}, "MID", "DATAROF", 0, Lifetime::Timeframe},
+    OutputSpec{{"cols"}, "MID", "DATA", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "mid-entropy-decoder",
+    Inputs{InputSpec{"ctf", "MID", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"mid-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,81 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+/// @brief  Convert MID DATA to CTF (EncodedBlocks)
+/// @author ruben.shahoyan@cern.ch
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "MIDWorkflow/EntropyEncoderSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("mid-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto rofs = pc.inputs().get<gsl::span<o2::mid::ROFRecord>>("rofs");
+  auto cols = pc.inputs().get<gsl::span<o2::mid::ColumnData>>("cols");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MID", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, rofs, cols);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for MID in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MID Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("rofs", "MID", "DATAROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("cols", "MID", "DATA", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "mid-entropy-encoder",
+    inputs,
+    Outputs{{"MID", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"mid-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/RecoWorkflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RecoWorkflow.cxx
@@ -29,7 +29,7 @@ namespace o2
 namespace mid
 {
 
-of::WorkflowSpec getRecoWorkflow()
+of::WorkflowSpec getRecoWorkflow(bool ctf)
 {
 
   auto checkReady = [](o2::framework::DataRef const& ref) {
@@ -44,8 +44,10 @@ of::WorkflowSpec getRecoWorkflow()
 
   of::WorkflowSpec specs;
 
-  specs.emplace_back(getRawDecoderSpec(false));
-  specs.emplace_back(getRawAggregatorSpec());
+  if (!ctf) {
+    specs.emplace_back(getRawDecoderSpec(false));
+    specs.emplace_back(getRawAggregatorSpec());
+  }
   specs.emplace_back(getClusterizerSpec());
   specs.emplace_back(getTrackerSpec());
   specs.emplace_back(of::MakeRootTreeWriterSpec("MIDTracksWriter",

--- a/Detectors/MUON/MID/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MIDWorkflow/EntropyEncoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::mid::getEntropyEncoderSpec());
+  return wf;
+}

--- a/Detectors/MUON/MID/Workflow/src/mid-entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/mid-entropy-encoder-workflow.cxx
@@ -8,16 +8,15 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   mid-reco-workflow.cxx
+/// \file   mid-entropy-encoder-workflow.cxx
 /// \brief  MID reconstruction workflow
-/// \author Diego Stocco <Diego.Stocco at cern.ch>
-/// \date   12 June 2019
+/// \author ruben.shahoyan@cern.ch
 
 #include <string>
 #include <vector>
 #include "Framework/Variant.h"
 #include "CommonUtils/ConfigurableParam.h"
-#include "MIDWorkflow/RecoWorkflow.h"
+#include "MIDWorkflow/EntropyEncoderSpec.h"
 
 using namespace o2::framework;
 
@@ -26,10 +25,6 @@ using namespace o2::framework;
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{
-    {"input-ctf", VariantType::Bool, false, {"Input data comes from CTF"}}};
-  std::swap(workflowOptions, options);
-
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
 }
@@ -43,8 +38,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  // write the configuration used for the digitizer workflow
-  o2::conf::ConfigurableParam::writeINI("o2mid-recoflow_configuration.ini");
-  auto ctf = configcontext.options().get<bool>("input-ctf");
-  return std::move(o2::mid::getRecoWorkflow(ctf));
+
+  WorkflowSpec wf;
+  wf.emplace_back(o2::mid::getEntropyEncoderSpec());
+  return std::move(wf);
 }

--- a/Utilities/rANS/include/rANS/FrequencyTable.h
+++ b/Utilities/rANS/include/rANS/FrequencyTable.h
@@ -120,7 +120,7 @@ void FrequencyTable::addSamples(Source_IT begin, Source_IT end, value_t min, val
     resizeFrequencyTable(min, max);
   }
 
-  for (auto it = begin; it != end; it++) {
+  for (auto it = begin; it != end; ++it) {
     assert((*it - mMin) < mFrequencyTable.size());
     mFrequencyTable[*it - mMin]++;
   }


### PR DESCRIPTION
@dstocco @aphecetche this pr adds the MID to CTF writing/reading workflows.

The nominal command to write the CTF is
````
o2-raw-file-reader-workflow --input-conf raw/MID/MIDraw.cfg | o2-mid-reco-workflow | o2-mid-entropy-encoder-workflow | o2-ctf-writer-workflow
```
To run reco from CTF:
````
o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root  --onlyDet MID | o2-mid-reco-workflow --input-ctf
````
@dstocco I think it is worth to add to ``o2-mid-reco-workflow`` an option to not run reconstruction but only RawDecoderSpec + RawAggregatorSpec, i.e. the inverse to ``--input-ctf`` option I've added.
