### PR TITLE
Various fixes for EMCAL workflows

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
@@ -67,6 +67,11 @@ class Clusterizer
   Clusterizer();
   ~Clusterizer() = default;
 
+  void clear()
+  {
+    mFoundClusters.clear();
+    mInputIndices.clear();
+  }
   void initialize(double timeCut, double timeMin, double timeMax, double gradientCut, bool doEnergyGradientCut, double thresholdSeedE, double thresholdCellE);
   void findClusters(const gsl::span<InputType const>& inputArray);
   const std::vector<Cluster>* getFoundClusters() const { return &mFoundClusters; }

--- a/Detectors/EMCAL/reconstruction/src/Clusterizer.cxx
+++ b/Detectors/EMCAL/reconstruction/src/Clusterizer.cxx
@@ -124,8 +124,7 @@ void Clusterizer<InputType>::getTopologicalRowColumn(const InputType& input, int
 template <class InputType>
 void Clusterizer<InputType>::findClusters(const gsl::span<InputType const>& inputArray)
 {
-  mFoundClusters.clear();
-  mInputIndices.clear();
+  clear();
 
   // Algorithm
   // - Fill cells/digits in 2D topological map

--- a/Detectors/EMCAL/reconstruction/src/ClusterizerTask.cxx
+++ b/Detectors/EMCAL/reconstruction/src/ClusterizerTask.cxx
@@ -83,9 +83,9 @@ void ClusterizerTask<InputType>::process(const std::string inputFileName, const 
 
   // Create output tree
   std::unique_ptr<TTree> outTree = std::make_unique<TTree>("o2sim", "EMCAL clusters");
-  outTree->Branch("EMCCluster", &mClustersArray);
-  outTree->Branch("EMCClusterInputIndex", &mClustersInputIndices);
-  outTree->Branch("EMCClusterTRGR", &mClusterTriggerRecordsClusters);
+  outTree->Branch("EMCALCluster", &mClustersArray);
+  outTree->Branch("EMCALClusterInputIndex", &mClustersInputIndices);
+  outTree->Branch("EMCALClusterTRGR", &mClusterTriggerRecordsClusters);
   outTree->Branch("EMCIndicesTRGR", &mClusterTriggerRecordsIndices);
 
   mClustersArray->clear();

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -27,11 +27,10 @@ namespace reco_workflow
 /// \enum InputType
 /// \brief Input types of the workflow
 /// \ingroup EMCALworkflow
-enum struct InputType { Digitizer, ///< directly read digits from channel {TPC:DIGITS)
-                        Digits,    ///< read digits from file
-                        Cells,     ///< read compressed cells from file
-                        Raw,       ///< read data in raw page format from file
-                        Clusters   ///< read native clusters from file
+enum struct InputType { Digits,  ///< read digits from file
+                        Cells,   ///< read compressed cells from file
+                        Raw,     ///< read data in raw page format from file
+                        Clusters ///< read native clusters from file
 };
 
 /// \enum OutputType
@@ -53,9 +52,10 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \ingroup EMCALwokflow
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool enableDigitsPrinter = false,
-                                    std::string const& cfgInput = "digits",   //
-                                    std::string const& cfgOutput = "clusters" //
-);
+                                    std::string const& cfgInput = "digits",    //
+                                    std::string const& cfgOutput = "clusters", //
+                                    bool disableRootInput = false,
+                                    bool disableRootOutput = false);
 } // namespace reco_workflow
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -14,7 +14,7 @@
 #include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
 #include "Framework/ControlService.h"
-#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 using namespace o2::emcal::reco_workflow;
@@ -62,7 +62,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   if (mPropagateMC) {
     // copy mc truth container without modification
     // as indexing doesn't change
-    auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("digitsmctr");
+    auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>*>("digitsmctr");
     ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, *truthcont);
   }
 }

--- a/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
@@ -78,9 +78,11 @@ void ClusterizerSpec<InputType>::run(framework::ProcessingContext& ctx)
   int currentStartClusters = mOutputClusters->size();
   int currentStartIndices = mOutputCellDigitIndices->size();
   for (auto iTrgRcrd : InputTriggerRecord) {
-
-    mClusterizer.findClusters(gsl::span<const InputType>(&Inputs[iTrgRcrd.getFirstEntry()], iTrgRcrd.getNumberOfObjects())); // Find clusters on cells/digits (pass by ref)
-
+    if (Inputs.size() && iTrgRcrd.getNumberOfObjects()) {
+      mClusterizer.findClusters(gsl::span<const InputType>(&Inputs[iTrgRcrd.getFirstEntry()], iTrgRcrd.getNumberOfObjects())); // Find clusters on cells/digits (pass by ref)
+    } else {
+      mClusterizer.clear();
+    }
     // Get found clusters + cell/digit indices for output
     // * A cluster contains a range that correspond to the vector of cell/digit indices
     // * The cell/digit index vector contains the indices of the clusterized cells/digits wrt to the original cell/digit array

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -28,7 +28,7 @@
 #include "EMCALWorkflow/PublisherSpec.h"
 #include "EMCALWorkflow/RawToCellConverterSpec.h"
 #include "Framework/DataSpecUtils.h"
-#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
@@ -243,11 +243,12 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                            std::move(CellsBranch),
                                                            std::move(TriggerRecordBranch)));
   };
-
+  /*
+    // RS getting input digits and outputing them under the same outputspec will create dependency loop when piping the workflows
   if (isEnabled(OutputType::Digits) && !disableRootOutput) {
     using DigitOutputType = std::vector<o2::emcal::Digit>;
     using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>;
     specs.push_back(makeWriterSpec("emcal-digits-writer",
                                    inputType == InputType::Digits ? "emc-filtered-digits.root" : "emcdigits.root",
                                    "o2sim",
@@ -261,12 +262,12 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                                       "EMCDigitMCTruth",
                                                                       "digitmc-branch-name"})());
   }
-
+  */
   if (isEnabled(OutputType::Cells) && !disableRootOutput) {
     if (inputType == InputType::Digits) {
       using DigitOutputType = std::vector<o2::emcal::Cell>;
       using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
-      using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+      using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>;
       specs.push_back(makeWriterSpec("emcal-cells-writer", "emccells.root", "o2sim",
                                      BranchDefinition<DigitOutputType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
                                                                        "EMCALCell",

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -235,22 +235,34 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                                       "digitmc-branch-name"})());
   }
 
-  if (isEnabled(OutputType::Cells) && inputType == InputType::Digits) {
-    using DigitOutputType = std::vector<o2::emcal::Cell>;
-    using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-    specs.push_back(makeWriterSpec("emcal-cells-writer",
-                                   inputType == InputType::Cells ? "emc-filtered-cells.root" : "emccells.root",
-                                   "o2sim",
-                                   BranchDefinition<DigitOutputType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
-                                                                     "EMCCell",
-                                                                     "cell-branch-name"},
-                                   BranchDefinition<TriggerOutputType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
-                                                                       "EMCACellTRGR",
-                                                                       "celltrigger-branch-name"},
-                                   BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "EMC", "CELLSMCTR", 0},
-                                                                      "EMCCellMCTruth",
-                                                                      "cellmc-branch-name"})());
+  if (isEnabled(OutputType::Cells) && !disableRootOutput) {
+    if (inputType == InputType::Digits) {
+      using DigitOutputType = std::vector<o2::emcal::Cell>;
+      using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
+      using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+      specs.push_back(makeWriterSpec("emcal-cells-writer", "emccells.root", "o2sim",
+                                     BranchDefinition<DigitOutputType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
+                                                                       "EMCALCell",
+                                                                       "cell-branch-name"},
+                                     BranchDefinition<TriggerOutputType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
+                                                                         "EMCALCellTRGR",
+                                                                         "celltrigger-branch-name"},
+                                     BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "EMC", "CELLSMCTR", 0},
+                                                                        "EMCALCellMCTruth",
+                                                                        "cellmc-branch-name"})());
+    } else {
+      using CellsDataType = std::vector<o2::emcal::Cell>;
+      using TriggerRecordDataType = std::vector<o2::emcal::TriggerRecord>;
+      specs.push_back(makeWriterSpec_CellsTR("emcal-cells-writer",
+                                             "emccells.root",
+                                             "o2sim",
+                                             BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
+                                                                             "EMCALCell",
+                                                                             "cell-branch-name"},
+                                             BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
+                                                                                     "EMCALCellTRGR",
+                                                                                     "celltrigger-branch-name"})());
+    }
   }
 
   if (isEnabled(OutputType::Clusters)) {

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -30,6 +30,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"input-type", o2::framework::VariantType::String, "digits", {"digitizer, digits, raw, clusters"}},
     {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters"}},
     {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"do not initialize root files readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not initialize root file writers"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
   };
   std::swap(workflowOptions, options);
@@ -55,6 +57,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   return o2::emcal::reco_workflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),        //
                                                cfgc.options().get<bool>("enable-digits-printer"), //
                                                cfgc.options().get<std::string>("input-type"),     //
-                                               cfgc.options().get<std::string>("output-type")     //
-  );
+                                               cfgc.options().get<std::string>("output-type"),    //
+                                               cfgc.options().get<bool>("disable-root-input"),
+                                               cfgc.options().get<bool>("disable-root-output"));
 }


### PR DESCRIPTION
@mfasDa I've tried to make run different combinations of workflow options but got lot of conflicts: sometimes ``o2::MCCompLabel`` is used instead of ``o2::emcal::MCLabel`` and the same tree branch can be created with name EMCXXX but queried as EMCALXXX... I've fixed the latter by renaming all to EMCALXXX convention to not invalidate large amount of digitized MC, but I don't like it: internally detector is referred as EMC, also the the Hit branches use EMC. Eventually, we should consider to rename all to EMC.

Also I've simplified your RecoWorkflow + added a check for consistent input / output types + added a fix against a crash in the clusterizer if empty cells input is provided.

Now the workflows 
````o2-emcal-reco-workflow --input-type=digits  --output-type=cells,clusters  --infile=emcaldigits.root ```` 
or 
````o2-emcal-reco-workflow --input-type=cells  --output-type=clusters  --infile=emccells.root````
work fine and seem to produce meaningful output.
But the 
````
o2-emcal-rawcreator -o raw/EMC
o2-raw-file-reader-workflow --input-conf raw/EMC/EMCraw.cfg  | o2-emcal-reco-workflow  --input-type raw --output-type cells | o2-emcal-reco-workflow  --input-type cells --output-type clusters --disable-root-input
````
while running w/o errors, produces an empty cells output vector, and as a consequence, the clusters output is also empty. 
Could you check if the problem is in raw data decoding or in the RawToCellConverter?
