### PR TITLE
[EMCAL-551] Move cell format to bitfield

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -12,7 +12,6 @@
 #define ALICEO2_EMCAL_CELL_H_
 
 #include <bitset>
-#include "Rtypes.h"
 #include "DataFormatsEMCAL/Constants.h"
 
 namespace o2
@@ -22,62 +21,162 @@ namespace emcal
 
 /// \class Cell
 /// \brief EMCAL compressed cell information
+/// \author Anders Knospe, University of Houston
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since March 6, 2019
 /// \ingroup EMCALDataFormat
 ///
-/// Structure:
-/// Bits 38-39: Cell type: 00=Low Gain, 01=High Gain, 10=LED mon, 11=TRU
-/// Bits 24-37: Energy (input/output in GeV/c^2, resolution 1/16 ADC count)
-/// Bits 15-23: Time (ns)
-/// Bits  0-14: Tower ID
+/// # Base format for EMCAL cell information in the Compressed Timeframe
+///
+/// The cell class contains the relevant information for each tower per event
+/// - Tower ID
+/// - Energy of the raw fit
+/// - Time of the raw fit
+/// - Type of the cell
+/// While cell type and tower ID have a predefined range based on the hardware
+/// design, energy and time have a finite resolution influenced by the resolution
+/// of the digitizer. This is used in order to compress the information stored
+/// in the compressed timeframe by not storing the full double values but instead
+/// assigning a certain amount of bits to each information. Therefore for certain
+/// information (energy, time) precision loss has to be taken into account.
+///
+/// # Internal structure and resolution
+///
+/// The internal structure is a bit field compressing the information to
+/// 48 bits. The definition of the bit field as well as the value range and the resolution
+/// is listed in the table below:
+///
+/// | Bits  | Content       | Resolution    | Range                       |
+/// |-------|---------------|---------------|-----------------------------|
+/// | 0-14  | Tower ID      | -             | 0 to 17644                  |
+/// | 15-26 | Time (ns)     | 0.73 ns       | -600 to 900 ns              |
+/// | 27-40 | Energy (GeV)  | 0.0153 GeV    | 0 to 250 GeV                |
+/// | 41-42 | Cell type     | -             | 0=LG, 1=HG, 2=LEMon, 4=TRU  |
+///
+/// The remaining bits are 0
 class Cell
 {
  public:
-  Cell() = default;
-  Cell(Short_t tower, Double_t energy, Double_t time, ChannelType_t ctype = ChannelType_t::LOW_GAIN);
+  Cell();
+  Cell(short tower, float energy, float time, ChannelType_t ctype = ChannelType_t::LOW_GAIN);
   ~Cell() = default; // override
 
-  void setTower(Short_t tower);
-  Short_t getTower() const;
+  void setTower(short tower) { getDataRepresentation()->mTowerID = tower; }
+  short getTower() const { return getDataRepresentation()->mTowerID; }
 
-  void setTimeStamp(Double_t time);
-  Short_t getTimeStamp() const;
+  /// \brief Set the time stamp
+  /// \param time Time in ns
+  ///
+  /// The time stamp is expressed in ns and has
+  /// a resolution of 1 ns. The time range which can
+  /// be stored is from -1023 to 1023 ns. In case the
+  /// range is exceeded the time is set to the limit
+  /// of the range.
+  void setTimeStamp(float time);
 
-  void setEnergyBits(Short_t ebits);
-  Short_t getEnergyBits() const;
+  /// \brief Get the time stamp
+  /// \return Time in ns
+  ///
+  /// Time has a resolution of 1 ns and can cover
+  /// a range from -1023 to 1023 ns
+  float getTimeStamp() const;
 
-  void setEnergy(Double_t energy);
-  Double_t getEnergy() const;
+  /// \brief Set the energy of the cell
+  /// \brief Energy of the cell in GeV
+  ///
+  /// The energy range covered by the cell
+  /// is 0 - 250 GeV, with a resolution of
+  /// 0.0153 GeV. In case an energy exceeding
+  /// the limits is provided the energy is
+  /// set to the limits (0 in case of negative
+  /// energy, 250. in case of energies > 250 GeV)
+  void setEnergy(float energy);
 
-  void setAmplitude(Double_t energy) { setEnergy(energy); }
-  Double_t getAmplitude() const { return getEnergy(); }
+  /// \brief Get the energy of the cell
+  /// \return Energy of the cell
+  ///
+  /// The energy is truncated to a range
+  /// covering 0 to 250 GeV with a resolution
+  /// of 0.0153 GeV
+  float getEnergy() const;
 
-  void setType(ChannelType_t ctype);
-  ChannelType_t getType() const;
+  /// \brief Set the amplitude of the cell
+  /// \param amplitude Cell amplitude
+  ///
+  /// See setEnergy for more information
+  void setAmplitude(float amplitude) { setEnergy(amplitude); }
 
-  void setLowGain();
-  Bool_t getLowGain() const;
+  /// \brief Get cell amplitude
+  /// \return cell Amplitude
+  ///
+  /// Set getEnergy for more information
+  float getAmplitude() const { return getEnergy(); }
 
-  void setHighGain();
-  Bool_t getHighGain() const;
+  /// \brief Set the type of the cell
+  /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  void setType(ChannelType_t ctype) { getDataRepresentation()->mCellStatus = static_cast<uint16_t>(ctype); }
 
-  void setLEDMon();
-  Bool_t getLEDMon() const;
+  /// \brief Get the type of the cell
+  /// \return Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  ChannelType_t getType() const { return static_cast<ChannelType_t>(getDataRepresentation()->mCellStatus); }
 
-  void setTRU();
-  Bool_t getTRU() const;
+  /// \brief Check whether the cell is of a given type
+  /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  /// \return True if the type of the cell matches the requested type, false otherwise
+  bool isChannelType(ChannelType_t ctype) const { return getType() == ctype; }
 
-  void setLong(ULong_t l);
-  ULong_t getLong() const { return mBits.to_ulong(); }
+  /// \brief Mark cell as low gain cell
+  void setLowGain() { setType(ChannelType_t::LOW_GAIN); }
+
+  /// \brief Check whether the cell is a low gain cell
+  /// \return True if the cell type is low gain, false otherwise
+  Bool_t getLowGain() const { return isChannelType(ChannelType_t::LOW_GAIN); }
+
+  /// \brief Mark cell as high gain cell
+  void setHighGain() { setType(ChannelType_t::HIGH_GAIN); }
+
+  /// \brief Check whether the cell is a high gain cell
+  /// \return True if the cell type is high gain, false otherwise
+  Bool_t getHighGain() const { return isChannelType(ChannelType_t::HIGH_GAIN); };
+
+  /// \brief Mark cell as LED monitor cell
+  void setLEDMon() { setType(ChannelType_t::LEDMON); }
+
+  /// \brief Check whether the cell is a LED monitor cell
+  /// \return True if the cell type is LED monitor, false otherwise
+  Bool_t getLEDMon() const { return isChannelType(ChannelType_t::LEDMON); }
+
+  /// \brief Mark cell as TRU cell
+  void setTRU() { setType(ChannelType_t::TRU); }
+
+  /// \brief Check whether the cell is a TRU cell
+  /// \return True if the cell type is TRU, false otherwise
+  Bool_t getTRU() const { return isChannelType(ChannelType_t::TRU); }
 
   void PrintStream(std::ostream& stream) const;
 
  private:
-  std::bitset<40> mBits;
+  struct __attribute__((packed)) CellData {
+    uint16_t mTowerID : 15;   ///< bits 0-14   Tower ID
+    uint16_t mTime : 11;      ///< bits 15-25: Time (signed, can become negative after calibration)
+    uint16_t mEnergy : 14;    ///< bits 26-39: Energy
+    uint16_t mCellStatus : 2; ///< bits 40-41: Cell status
+    uint16_t mZerod : 6;      ///< bits 42-47: Zerod
+  };
+
+  CellData* getDataRepresentation() { return reinterpret_cast<CellData*>(mCellWords); }
+  const CellData* getDataRepresentation() const { return reinterpret_cast<const CellData*>(mCellWords); }
+
+  uint16_t mCellWords[3]; ///< data word
 
   ClassDefNV(Cell, 1);
 };
 
-std::ostream& operator<<(std::ostream& stream, const Cell& c);
+/// \brief Stream operator for EMCAL cell
+/// \param stream Stream where to print the EMCAL cell
+/// \param cell Cell to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const Cell& cell);
 } // namespace emcal
 } // namespace o2
 

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -15,192 +15,62 @@
 
 using namespace o2::emcal;
 
-Cell::Cell(Short_t tower, Double_t energy, Double_t time, ChannelType_t ctype)
+const float TIME_SHIFT = 600.,
+            TIME_RANGE = 1500.,
+            TIME_RESOLUTION = TIME_RANGE / 2047.,
+            ENERGY_TRUNCATION = 250.,
+            ENERGY_RESOLUTION = ENERGY_TRUNCATION / 16383.;
+
+Cell::Cell()
 {
+  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+}
+
+Cell::Cell(short tower, float energy, float time, ChannelType_t ctype)
+{
+  memset(mCellWords, 0, sizeof(uint16_t) * 3);
   setTower(tower);
   setTimeStamp(time);
   setEnergy(energy);
   setType(ctype);
 }
 
-void Cell::setTower(Short_t tower)
+void Cell::setTimeStamp(float timestamp)
 {
-  if (tower > 0x7fff || tower < 0) {
-    tower = 0x7fff;
+  // truncate:
+  const float TIME_MIN = -1. * TIME_SHIFT,
+              TIME_MAX = TIME_RANGE - TIME_SHIFT;
+  if (timestamp < TIME_MIN)
+    timestamp = TIME_MIN;
+  else if (timestamp > TIME_MAX)
+    timestamp = TIME_MAX;
+  getDataRepresentation()->mTime = static_cast<uint16_t>((timestamp + TIME_SHIFT) / TIME_RESOLUTION);
+}
+
+float Cell::getTimeStamp() const
+{
+  return (static_cast<float>(getDataRepresentation()->mTime) * TIME_RESOLUTION) - TIME_SHIFT;
+}
+
+void Cell::setEnergy(float energy)
+{
+  double truncatedEnergy = energy;
+  if (truncatedEnergy < 0.) {
+    truncatedEnergy = 0.;
+  } else if (truncatedEnergy > ENERGY_TRUNCATION) {
+    truncatedEnergy = ENERGY_TRUNCATION;
   }
-  ULong_t t = (ULong_t)tower;
-
-  ULong_t b = getLong() & 0xffffff8000; // 1111111111111111111111111000000000000000
-  mBits = b + t;
+  getDataRepresentation()->mEnergy = static_cast<int16_t>(truncatedEnergy / ENERGY_RESOLUTION);
 }
 
-Short_t Cell::getTower() const
+float Cell::getEnergy() const
 {
-  ULong_t t = getLong();
-  t &= 0x7fff;
-  return ((Short_t)t);
-}
-
-void Cell::setTimeStamp(Double_t time)
-{
-  ULong_t t = 0;
-  if (time > 0x1ff) {
-    t = 0x1ff;
-  } else if (time < 0) {
-    t = 0;
-  } else {
-    t = (ULong_t)time;
-  }
-
-  t <<= 15;
-  ULong_t b = getLong() & 0xffff007fff; // 1111111111111111000000000111111111111111
-  mBits = b + t;
-}
-
-Short_t Cell::getTimeStamp() const
-{
-  ULong_t t = getLong();
-  t >>= 15;
-  t &= 0x1ff;
-  return ((Short_t)t);
-}
-
-void Cell::setEnergyBits(Short_t ebits)
-{
-  if (ebits > 0x3fff) {
-    ebits = 0x3fff;
-  } else if (ebits < 0) {
-    ebits = 0;
-  }
-  ULong_t a = (ULong_t)ebits;
-
-  a <<= 24;
-  ULong_t b = getLong() & 0xc00ffffff; // 1100000000000000111111111111111111111111
-  mBits = b + a;
-}
-
-Short_t Cell::getEnergyBits() const
-{
-  ULong_t a = getLong();
-  a >>= 24;
-  a &= 0x3fff;
-  return ((Short_t)a);
-}
-
-void Cell::setEnergy(Double_t energy)
-{
-  ULong_t a = static_cast<ULong_t>(energy / 0.0153);
-  a = a & 0x3FFF;
-
-  a <<= 24;
-  ULong_t b = getLong() & 0xc000ffffff; // 1100000000000000111111111111111111111111
-  mBits = b + a;
-}
-
-Double_t Cell::getEnergy() const
-{
-  return double(getEnergyBits() * 0.0153);
-}
-
-void Cell::setType(ChannelType_t ctype)
-{
-  switch (ctype) {
-    case ChannelType_t::HIGH_GAIN:
-      setHighGain();
-      break;
-    case ChannelType_t::LOW_GAIN:
-      setLowGain();
-      break;
-    case ChannelType_t::TRU:
-      setTRU();
-      break;
-    case ChannelType_t::LEDMON:
-      setHighGain();
-      break;
-  };
-}
-
-ChannelType_t Cell::getType() const
-{
-  if (getHighGain()) {
-    return ChannelType_t::HIGH_GAIN;
-  } else if (getLEDMon()) {
-    return ChannelType_t::LEDMON;
-  } else if (getTRU()) {
-    return ChannelType_t::TRU;
-  }
-  return ChannelType_t::LOW_GAIN;
-}
-
-void Cell::setLowGain()
-{
-  std::bitset<40> b(0x3fffffffff); // 0011111111111111111111111111111111111111
-  mBits = (mBits & b);
-}
-
-Bool_t Cell::getLowGain() const
-{
-  ULong_t t = (getLong() >> 38);
-  if (t) {
-    return false;
-  }
-  return true;
-}
-
-void Cell::setHighGain()
-{
-  ULong_t b = getLong() & 0x3fffffffff; // 0011111111111111111111111111111111111111
-  mBits = b + 0x4000000000;             // 0100000000000000000000000000000000000000
-}
-
-Bool_t Cell::getHighGain() const
-{
-  ULong_t t = (getLong() >> 38);
-  if (t == 1) {
-    return true;
-  }
-  return false;
-}
-
-void Cell::setLEDMon()
-{
-  ULong_t b = getLong() & 0x3fffffffff; // 0011111111111111111111111111111111111111
-  mBits = b + 0x8000000000;             // 1000000000000000000000000000000000000000
-}
-
-Bool_t Cell::getLEDMon() const
-{
-  ULong_t t = (getLong() >> 38);
-  if (t == 2) {
-    return true;
-  }
-  return false;
-}
-
-void Cell::setTRU()
-{
-  ULong_t b = getLong() & 0x3fffffffff; // 0011111111111111111111111111111111111111
-  mBits = b + 0xc000000000;             // 1100000000000000000000000000000000000000
-}
-
-Bool_t Cell::getTRU() const
-{
-  ULong_t t = (getLong() >> 38);
-  if (t == 3) {
-    return true;
-  }
-  return false;
-}
-
-void Cell::setLong(ULong_t l)
-{
-  std::bitset<40> b(l);
-  mBits = b;
+  return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION;
 }
 
 void Cell::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL Cell: Type " << getType() << ", Energy " << getEnergy() << ", Time " << getTimeStamp() << ", Tower " << getTower() << ", Bits " << mBits;
+  stream << "EMCAL Cell: Type " << getType() << ", Energy " << getEnergy() << ", Time " << getTimeStamp() << ", Tower " << getTower();
 }
 
 std::ostream& operator<<(std::ostream& stream, const Cell& c)

--- a/DataFormats/Detectors/EMCAL/test/testCell.cxx
+++ b/DataFormats/Detectors/EMCAL/test/testCell.cxx
@@ -27,25 +27,26 @@ namespace emcal
 /// - verify that set and get functions return consistent values
 BOOST_AUTO_TEST_CASE(Cell_test)
 {
-  Cell c;
+  Cell c(0, 0, 0, o2::emcal::ChannelType_t::HIGH_GAIN);
 
   for (short j = 0; j < 17664; j++) {
     c.setTower(j);
     BOOST_CHECK_EQUAL(c.getTower(), j);
-    BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+    BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
     BOOST_CHECK_EQUAL(c.getEnergy(), 0);
-    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+    BOOST_CHECK_EQUAL(c.getHighGain(), true);
   }
 
   c.setTower(0);
-  std::vector<int> times = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100, 200};
+  // Test time over the full range
+  std::vector<int> times = {-500, -200, -100, -50, -20, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100, 200, 500, 900};
 
   for (auto t : times) {
     c.setTimeStamp(t);
     BOOST_CHECK_EQUAL(c.getTower(), 0);
-    BOOST_CHECK_EQUAL(c.getTimeStamp(), t);
+    BOOST_CHECK_SMALL(double(c.getTimeStamp() - t), 0.73);
     BOOST_CHECK_EQUAL(c.getEnergy(), 0);
-    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+    BOOST_CHECK_EQUAL(c.getHighGain(), true);
   }
 
   c.setTimeStamp(0);
@@ -53,35 +54,40 @@ BOOST_AUTO_TEST_CASE(Cell_test)
 
   for (auto e : energies) {
     c.setEnergy(e);
+    if (e > 16)
+      c.setLowGain();
     BOOST_CHECK_EQUAL(c.getTower(), 0);
-    BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+    BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
     BOOST_CHECK_SMALL(e - c.getEnergy(), 0.02); // Require 20 MeV resolution
-    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+    if (e > 16)
+      BOOST_CHECK_EQUAL(c.getLowGain(), true);
+    else
+      BOOST_CHECK_EQUAL(c.getHighGain(), true);
   }
 
   c.setEnergy(0);
 
   c.setLowGain();
   BOOST_CHECK_EQUAL(c.getTower(), 0);
-  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
   BOOST_CHECK_EQUAL(c.getEnergy(), 0);
-  BOOST_CHECK_EQUAL(c.getLowGain(), true);
   BOOST_CHECK_EQUAL(c.getHighGain(), false);
+  BOOST_CHECK_EQUAL(c.getLowGain(), true);
   BOOST_CHECK_EQUAL(c.getLEDMon(), false);
   BOOST_CHECK_EQUAL(c.getTRU(), false);
 
   c.setHighGain();
   BOOST_CHECK_EQUAL(c.getTower(), 0);
-  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
   BOOST_CHECK_EQUAL(c.getEnergy(), 0);
-  BOOST_CHECK_EQUAL(c.getLowGain(), false);
   BOOST_CHECK_EQUAL(c.getHighGain(), true);
+  BOOST_CHECK_EQUAL(c.getLowGain(), false);
   BOOST_CHECK_EQUAL(c.getLEDMon(), false);
   BOOST_CHECK_EQUAL(c.getTRU(), false);
 
   c.setLEDMon();
   BOOST_CHECK_EQUAL(c.getTower(), 0);
-  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
   BOOST_CHECK_EQUAL(c.getEnergy(), 0);
   BOOST_CHECK_EQUAL(c.getLowGain(), false);
   BOOST_CHECK_EQUAL(c.getHighGain(), false);
@@ -90,7 +96,7 @@ BOOST_AUTO_TEST_CASE(Cell_test)
 
   c.setTRU();
   BOOST_CHECK_EQUAL(c.getTower(), 0);
-  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_SMALL(double(c.getTimeStamp()), 0.73);
   BOOST_CHECK_EQUAL(c.getEnergy(), 0);
   BOOST_CHECK_EQUAL(c.getLowGain(), false);
   BOOST_CHECK_EQUAL(c.getHighGain(), false);


### PR DESCRIPTION
- Move underlying structure to bitfield and expand to
  48 bit (min. size)
- Increase number of time bits from 9 to 11 and make
  range signed in order to store negative times
- Add truncations for time and energy
- Add doxygen documentation for cell class