### PR TITLE
New digit label handling for ITSMFT 

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
@@ -11,6 +11,7 @@
 /// @file   DigitReaderSpec.cxx
 
 #include <vector>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
 
 #include "TTree.h"
 
@@ -20,8 +21,10 @@
 #include "ITSWorkflow/DigitReaderSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
+#include "SimulationDataFormat/IOMCTruthContainerView.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include <cmath>
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -59,7 +62,8 @@ void DigitReader::run(ProcessingContext& pc)
     std::vector<ROFRecord> rofs, *profs = &rofs;
     treeDig->SetBranchAddress("ITSDigitROF", &profs);
 
-    o2::dataformats::MCTruthContainer<o2::MCCompLabel> labels, *plabels = &labels;
+    o2::dataformats::IOMCTruthContainerView* plabels = nullptr;
+
     std::vector<MC2ROFRecord> mc2rofs, *pmc2rofs = &mc2rofs;
     if (mUseMC) {
       treeDig->SetBranchAddress("ITSDigitMCTruth", &plabels);
@@ -73,7 +77,9 @@ void DigitReader::run(ProcessingContext& pc)
     pc.outputs().snapshot(Output{"ITS", "DIGITS", 0, Lifetime::Timeframe}, digits);
     pc.outputs().snapshot(Output{"ITS", "DIGITSROF", 0, Lifetime::Timeframe}, *profs);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{"ITS", "DIGITSMCTR", 0, Lifetime::Timeframe}, labels);
+      auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"ITS", "DIGITSMCTR", 0, Lifetime::Timeframe});
+      plabels->copyandflatten(sharedlabels);
+      delete plabels;
       pc.outputs().snapshot(Output{"ITS", "DIGITSMC2ROF", 0, Lifetime::Timeframe}, *pmc2rofs);
     }
   } else {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -42,6 +42,8 @@ class MCCompLabel;
 namespace dataformats
 {
 template <typename T>
+class ConstMCTruthContainerView;
+template <typename T>
 class MCTruthContainer;
 }
 
@@ -63,6 +65,7 @@ class Clusterer
   using CompClusterExt = o2::itsmft::CompClusterExt;
   using Label = o2::MCCompLabel;
   using MCTruth = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using ConstMCTruth = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
 
  public:
   static constexpr int MaxLabels = 10;
@@ -134,15 +137,15 @@ class Clusterer
                        CompClusCont* compClusPtr, PatternCont* patternsPtr,
                        MCTruth* labelsClusPtr, int nlab, bool isHuge = false);
 
-    void fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled);
+    void fetchMCLabels(int digID, const ConstMCTruth* labelsDig, int& nfilled);
     void initChip(const ChipPixelData* curChipData, uint32_t first);
     void updateChip(const ChipPixelData* curChipData, uint32_t ip);
     void finishChip(ChipPixelData* curChipData, CompClusCont* compClus, PatternCont* patterns,
-                    const MCTruth* labelsDig, MCTruth* labelsClus);
+                    const ConstMCTruth* labelsDig, MCTruth* labelsClus);
     void finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, CompClusCont* compClusPtr,
-                                 PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPTr);
+                                 PatternCont* patternsPtr, const ConstMCTruth* labelsDigPtr, MCTruth* labelsClusPTr);
     void process(uint16_t chip, uint16_t nChips, CompClusCont* compClusPtr, PatternCont* patternsPtr,
-                 const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr);
+                 const ConstMCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr);
 
     ClustererThread(Clusterer* par = nullptr) : parent(par), curr(column2 + 1), prev(column1 + 1)
     {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
@@ -19,7 +19,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include <TTree.h>
 #include <vector>
@@ -59,12 +59,12 @@ class DigitPixelReader : public PixelReader
     mIdDig = 0;
   }
 
-  void setDigitsMCTruth(const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* m)
+  void setDigitsMCTruth(const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* m)
   {
     mDigitsMCTruth = m;
   }
 
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* getDigitsMCTruth() const override
+  const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* getDigitsMCTruth() const override
   {
     return mDigitsMCTruth;
   }
@@ -99,13 +99,13 @@ class DigitPixelReader : public PixelReader
   std::vector<o2::itsmft::Digit>* mDigitsSelf = nullptr;
   std::vector<o2::itsmft::ROFRecord>* mROFRecVecSelf = nullptr;
   std::vector<o2::itsmft::MC2ROFRecord>* mMC2ROFRecVecSelf = nullptr;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mDigitsMCTruthSelf = nullptr;
+  const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* mDigitsMCTruthSelf = nullptr;
 
   gsl::span<const o2::itsmft::Digit> mDigits;
   gsl::span<const o2::itsmft::ROFRecord> mROFRecVec;
   gsl::span<const o2::itsmft::MC2ROFRecord> mMC2ROFRecVec;
 
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mDigitsMCTruth = nullptr;
+  const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* mDigitsMCTruth = nullptr;
   Int_t mIdDig = 0; // Digits slot read within ROF
   Int_t mIdROF = 0; // ROFRecord being red
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
@@ -17,7 +17,7 @@
 #include <Rtypes.h>
 #include "ITSMFTReconstruction/PixelData.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include <vector>
 
@@ -45,7 +45,7 @@ class PixelReader
 
   // prepare data of next trigger, return number of non-empty links or chips
   virtual int decodeNextTrigger() = 0;
-  virtual const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* getDigitsMCTruth() const
+  virtual const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* getDigitsMCTruth() const
   {
     return nullptr;
   }

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -156,7 +156,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
 
 //__________________________________________________
 void Clusterer::ClustererThread::process(uint16_t chip, uint16_t nChips, CompClusCont* compClusPtr, PatternCont* patternsPtr,
-                                         const MCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr)
+                                         const ConstMCTruth* labelsDigPtr, MCTruth* labelsClPtr, const ROFRecord& rofPtr)
 {
   if (stats.empty() || stats.back().firstChip + stats.back().nChips < chip) { // there is a jump, register new block
     stats.emplace_back(ThreadStat{chip, 0, uint32_t(compClusPtr->size()), patternsPtr ? uint32_t(patternsPtr->size()) : 0, 0, 0});
@@ -199,7 +199,7 @@ void Clusterer::ClustererThread::process(uint16_t chip, uint16_t nChips, CompClu
 
 //__________________________________________________
 void Clusterer::ClustererThread::finishChip(ChipPixelData* curChipData, CompClusCont* compClusPtr,
-                                            PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
+                                            PatternCont* patternsPtr, const ConstMCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
 {
   auto clustersCount = compClusPtr->size();
   const auto& pixData = curChipData->getData();
@@ -325,7 +325,7 @@ void Clusterer::ClustererThread::streamCluster(const std::vector<PixelData>& pix
 
 //__________________________________________________
 void Clusterer::ClustererThread::finishChipSingleHitFast(uint32_t hit, ChipPixelData* curChipData, CompClusCont* compClusPtr,
-                                                         PatternCont* patternsPtr, const MCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
+                                                         PatternCont* patternsPtr, const ConstMCTruth* labelsDigPtr, MCTruth* labelsClusPtr)
 {
   auto clustersCount = compClusPtr->size();
   auto pix = curChipData->getData()[hit];
@@ -435,7 +435,7 @@ void Clusterer::ClustererThread::updateChip(const ChipPixelData* curChipData, ui
 }
 
 //__________________________________________________
-void Clusterer::ClustererThread::fetchMCLabels(int digID, const MCTruth* labelsDig, int& nfilled)
+void Clusterer::ClustererThread::fetchMCLabels(int digID, const ConstMCTruth* labelsDig, int& nfilled)
 {
   // transfer MC labels to cluster
   if (nfilled >= MaxLabels) {

--- a/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
@@ -16,11 +16,16 @@
 #include "Headers/DataHeader.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
+#include "SimulationDataFormat/IOMCTruthContainerView.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include <vector>
 #include <string>
 #include <algorithm>
+#ifdef NDEBUG
+#undef NDEBUG
+#include <cassert>
+#endif
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -32,7 +37,33 @@ namespace itsmft
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
-using MCCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using MCCont = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
+
+// #define CUSTOM 1
+// make a std::vec use a gsl::span as internal buffer without copy
+template <typename T>
+void adopt(gsl::span<const T> const& data, std::vector<T>& v)
+{
+  static_assert(sizeof(v) == 24);
+  if (data.size() == 0) {
+    return;
+  }
+  // we assume a standard layout of begin, end, end_capacity and overwrite the internal members of the vector
+  struct Impl {
+    const T* start;
+    const T* end;
+    const T* cap;
+  };
+
+  Impl impl;
+  impl.start = &(data[0]);
+  impl.end = &(data[data.size() - 1]) + 1; // end pointer (beyond last element)
+  impl.cap = impl.end;
+  std::memcpy(&v, &impl, sizeof(Impl));
+  assert(data.size() == v.size());
+  assert(v.capacity() == v.size());
+  assert((void*)&data[0] == (void*)&v[0]);
+}
 
 /// create the processor spec
 /// describing a processor receiving digits for ITS/MFT and writing them to file
@@ -41,15 +72,98 @@ DataProcessorSpec getDigitWriterSpec(bool mctruth, o2::header::DataOrigin detOri
   std::string detStr = o2::detectors::DetID::getName(detId);
   std::string detStrL = detStr;
   std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
+#ifdef CUSTOM
+  std::vector<o2::framework::InputSpec> inputs;
+  if (mctruth) {
+    inputs.emplace_back(InputSpec{"digitsMCTR", detOrig, "DIGITSMCTR", 0});
+    inputs.emplace_back(InputSpec{"digitsMC2ROF", detOrig, "DIGITSMC2ROF", 0});
+  }
+  inputs.emplace_back(InputSpec{"digits", detOrig, "DIGITS", 0});
+  inputs.emplace_back(InputSpec{"digitsROF", detOrig, "DIGITSROF", 0});
+
+  return {(detStr + "DigitWriter").c_str(),
+          inputs,
+          {},
+          AlgorithmSpec{
+            [detStrL, detStr, mctruth](ProcessingContext& ctx) {
+              static bool mFinished = false;
+              if (mFinished) {
+                return;
+              }
+
+              TFile f((detStrL + "digits.root").c_str(), "RECREATE");
+              TTree t("o2sim", "o2sim");
+              // define data
+              auto digits = new std::vector<itsmft::Digit>; // needs to be a pointer since the message memory is managed by DPL and we have to avoid double deletes
+              auto rof = new std::vector<itsmft::ROFRecord>;
+              auto mc2rofrecords = new std::vector<itsmft::MC2ROFRecord>;
+              o2::dataformats::IOMCTruthContainerView labelview;
+
+              auto fillBranch = [](TBranch* br) {
+                br->Fill();
+                br->ResetAddress();
+                br->DropBaskets("all");
+              };
+              // get the data as gsl::span so that ideally no copy is made
+              // but immediately adopt the views in standard std::vectors *** THIS IS AN INTERNAL HACK ***
+              if (mctruth) {
+                labelview.adopt(ctx.inputs().get<gsl::span<char>>("digitsMCTR"));
+                fillBranch(t.Branch((detStr + "DigitMCTruth").c_str(), &labelview));
+                adopt(ctx.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("digitsMC2ROF"), *mc2rofrecords);
+                fillBranch(t.Branch((detStr + "DigitMC2ROF").c_str(), &mc2rofrecords));
+              }
+              adopt(ctx.inputs().get<gsl::span<itsmft::Digit>>("digits"), *digits);
+              fillBranch(t.Branch((detStr + "Digits").c_str(), &digits));
+              adopt(ctx.inputs().get<gsl::span<itsmft::ROFRecord>>("digitsROF"), *rof);
+              fillBranch(t.Branch((detStr + "DigitROF").c_str(), &rof));
+              t.SetEntries(1);
+              f.Write();
+              f.Close();
+              ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+              mFinished = true;
+            }}};
+#else
   auto logger = [](std::vector<o2::itsmft::Digit> const& inDigits) {
     LOG(INFO) << "RECEIVED DIGITS SIZE " << inDigits.size();
   };
+
+  // the callback to be set as hook for custom action when the writer is closed
+  auto finishWriting = [](TFile* outputfile, TTree* outputtree) {
+    outputtree->SetEntries(1);
+    outputtree->Write("", TObject::kOverwrite);
+    outputfile->Close();
+  };
+
+  // handler for labels
+  // This is necessary since we can't store the original label buffer in a ROOT entry -- as is -- if it exceeds a certain size.
+  // We therefore convert it to a special split class.
+  auto fillLabels = [detStr](TBranch& branch, std::vector<char> const& labelbuffer, DataRef const& /*ref*/) {
+    o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> labels(labelbuffer);
+    LOG(INFO) << "WRITING " << labels.getNElements() << " LABELS ";
+
+    o2::dataformats::IOMCTruthContainerView outputcontainer;
+    // first of all redefine the output format (special to labels)
+    auto tree = branch.GetTree();
+
+    std::stringstream str;
+    str << detStr + "DigitMCTruth";
+    auto br = tree->Branch(str.str().c_str(), &outputcontainer);
+    outputcontainer.adopt(labelbuffer);
+    br->Fill();
+    br->ResetAddress();
+    const int entries = 1;
+    tree->SetEntries(entries);
+    tree->Write("", TObject::kOverwrite);
+  };
+
   return MakeRootTreeWriterSpec((detStr + "DigitWriter").c_str(),
                                 (detStrL + "digits.root").c_str(),
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Digits tree"},
-                                BranchDefinition<MCCont>{InputSpec{"digitsMCTR", detOrig, "DIGITSMCTR", 0},
-                                                         (detStr + "DigitMCTruth").c_str(),
-                                                         (mctruth ? 1 : 0)},
+                                MakeRootTreeWriterSpec::CustomClose(finishWriting),
+                                // in case of labels we first read them as std::vector<char> and process them correctly in the fillLabels hook
+                                BranchDefinition<std::vector<char>>{InputSpec{"digitsMCTR", detOrig, "DIGITSMCTR", 0},
+                                                                    (detStr + "DigitMCTruth_TMP").c_str(),
+                                                                    (mctruth ? 1 : 0), fillLabels},
                                 BranchDefinition<std::vector<itsmft::MC2ROFRecord>>{InputSpec{"digitsMC2ROF", detOrig, "DIGITSMC2ROF", 0},
                                                                                     (detStr + "DigitMC2ROF").c_str(),
                                                                                     (mctruth ? 1 : 0)},
@@ -58,6 +172,7 @@ DataProcessorSpec getDigitWriterSpec(bool mctruth, o2::header::DataOrigin detOri
                                                                              logger},
                                 BranchDefinition<std::vector<itsmft::ROFRecord>>{InputSpec{"digitsROF", detOrig, "DIGITSROF", 0},
                                                                                  (detStr + "DigitROF").c_str()})();
+#endif
 }
 
 DataProcessorSpec getITSDigitWriterSpec(bool mctruth)

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -101,6 +101,51 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     mDigitizer.setROFRecords(&mROFRecords);
     mDigitizer.setMCLabels(&mLabels);
 
+    // digits are directly put into DPL owned resource
+    auto digitsAccum = pc.outputs().make<std::vector<itsmft::Digit>>(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe});
+
+    auto accumulate = [this, &digitsAccum]() {
+      // accumulate result of single event processing, called after processing every event supplied
+      // AND after the final flushing via digitizer::fillOutputContainer
+      if (!mDigits.size()) {
+        return; // no digits were flushed, nothing to accumulate
+      }
+      static int fixMC2ROF = 0; // 1st entry in mc2rofRecordsAccum to be fixed for ROFRecordID
+      auto ndigAcc = digitsAccum.size();
+      std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(digitsAccum));
+
+      // fix ROFrecords references on ROF entries
+      auto nROFRecsOld = mROFRecordsAccum.size();
+
+      for (int i = 0; i < mROFRecords.size(); i++) {
+        auto& rof = mROFRecords[i];
+        rof.setFirstEntry(ndigAcc + rof.getFirstEntry());
+        rof.print();
+
+        if (mFixMC2ROF < mMC2ROFRecordsAccum.size()) { // fix ROFRecord entry in MC2ROF records
+          for (int m2rid = mFixMC2ROF; m2rid < mMC2ROFRecordsAccum.size(); m2rid++) {
+            // need to register the ROFRecors entry for MC event starting from this entry
+            auto& mc2rof = mMC2ROFRecordsAccum[m2rid];
+            if (rof.getROFrame() == mc2rof.minROF) {
+              mFixMC2ROF++;
+              mc2rof.rofRecordID = nROFRecsOld + i;
+              mc2rof.print();
+            }
+          }
+        }
+      }
+
+      std::copy(mROFRecords.begin(), mROFRecords.end(), std::back_inserter(mROFRecordsAccum));
+      if (mWithMCTruth) {
+        mLabelsAccum.mergeAtBack(mLabels);
+      }
+      LOG(INFO) << "Added " << mDigits.size() << " digits ";
+      // clean containers from already accumulated stuff
+      mLabels.clear();
+      mDigits.clear();
+      mROFRecords.clear();
+    }; // and accumulate lambda
+
     auto& eventParts = context->getEventParts(withQED);
     // loop over all composite collisions given from context (aka loop over all the interaction records)
     for (int collID = 0; collID < timesview.size(); ++collID) {
@@ -129,8 +174,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     accumulate();
 
     // here we have all digits and labels and we can send them to consumer (aka snapshot it onto output)
-    pc.outputs().snapshot(Output{mOrigin, "DIGITS", 0, Lifetime::Timeframe}, mDigitsAccum);
-    mDigitsAccum = std::vector<itsmft::Digit>(); // free mem immediately
+
     pc.outputs().snapshot(Output{mOrigin, "DIGITSROF", 0, Lifetime::Timeframe}, mROFRecordsAccum);
     if (mWithMCTruth) {
       pc.outputs().snapshot(Output{mOrigin, "DIGITSMC2ROF", 0, Lifetime::Timeframe}, mMC2ROFRecordsAccum);
@@ -155,48 +199,6 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
  protected:
   ITSMFTDPLDigitizerTask(bool mctruth = true) : BaseDPLDigitizer(InitServices::FIELD | InitServices::GEOM), mWithMCTruth(mctruth) {}
 
-  void accumulate()
-  {
-    // accumulate result of single event processing, called after processing every event supplied
-    // AND after the final flushing via digitizer::fillOutputContainer
-    if (!mDigits.size()) {
-      return; // no digits were flushed, nothing to accumulate
-    }
-    static int fixMC2ROF = 0; // 1st entry in mc2rofRecordsAccum to be fixed for ROFRecordID
-    auto ndigAcc = mDigitsAccum.size();
-    std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(mDigitsAccum));
-
-    // fix ROFrecords references on ROF entries
-    auto nROFRecsOld = mROFRecordsAccum.size();
-
-    for (int i = 0; i < mROFRecords.size(); i++) {
-      auto& rof = mROFRecords[i];
-      rof.setFirstEntry(ndigAcc + rof.getFirstEntry());
-      rof.print();
-
-      if (mFixMC2ROF < mMC2ROFRecordsAccum.size()) { // fix ROFRecord entry in MC2ROF records
-        for (int m2rid = mFixMC2ROF; m2rid < mMC2ROFRecordsAccum.size(); m2rid++) {
-          // need to register the ROFRecors entry for MC event starting from this entry
-          auto& mc2rof = mMC2ROFRecordsAccum[m2rid];
-          if (rof.getROFrame() == mc2rof.minROF) {
-            mFixMC2ROF++;
-            mc2rof.rofRecordID = nROFRecsOld + i;
-            mc2rof.print();
-          }
-        }
-      }
-    }
-    std::copy(mROFRecords.begin(), mROFRecords.end(), std::back_inserter(mROFRecordsAccum));
-    if (mWithMCTruth) {
-      mLabelsAccum.mergeAtBack(mLabels);
-    }
-    LOG(INFO) << "Added " << mDigits.size() << " digits ";
-    // clean containers from already accumulated stuff
-    mLabels.clear();
-    mDigits.clear();
-    mROFRecords.clear();
-  }
-
   bool mWithMCTruth = true;
   bool mFinished = false;
   bool mDisableQED = false;
@@ -204,7 +206,6 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   o2::itsmft::Digitizer mDigitizer;
   std::vector<o2::itsmft::Digit> mDigits;
-  std::vector<o2::itsmft::Digit> mDigitsAccum;
   std::vector<o2::itsmft::ROFRecord> mROFRecords;
   std::vector<o2::itsmft::ROFRecord> mROFRecordsAccum;
   std::vector<o2::itsmft::Hit> mHits;


### PR DESCRIPTION
This PR achieves the following breakthroughs:

a) Ability to digitize a full digit time frame including MC labels for ITS.
b) Spike memory reduction by a factor of ~2 for the ITS digitizer workflow.

This is achieved through:

a) Application of the new const + view-only label containers in digitization and reconstruction. This application achieves
almost zero-copy treatment of labels.
b) A demonstrator showing how to do zero-copy writing to a ROOT tree (directly streaming from the buffers in shared memory) in the ITSMFT digit writer. This demonstrator may be interesting for application inside the RootTreeWriter in general.

This PR needs merging of #4411 first. Since data formats are changed, a few other places (such as macros) need to be adapted to the new label container. @shahor02 @iouribelikov : Please take a look and let me know your opinion.

In future, other things such as cluster labels can be converted in the same spirit.