### PR TITLE
Memory improvements in TPC digitizer workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -172,6 +172,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
           branch.SetAddress(&ptr);
           branch.Fill();
           branch.ResetAddress();
+          branch.DropBaskets("all");
         } else {                                // triggered mode (>1 entries will be written)
           std::vector<o2::tpc::Digit> digGroup; // group of digits related to single trigger
           auto ptr = &digGroup;
@@ -184,6 +185,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
             branch.Fill();
           }
           branch.ResetAddress();
+          branch.DropBaskets("all");
         }
       }
     }
@@ -215,6 +217,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
           branch.SetAddress(&ptr);
           branch.Fill();
           branch.ResetAddress();
+          branch.DropBaskets("all");
         } else {
           o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblGroup; // labels for group of digits related to single trigger
           auto ptr = &lblGroup;
@@ -228,6 +231,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
             branch.Fill();
           }
           branch.ResetAddress();
+          branch.DropBaskets("all");
         }
       }
     }


### PR DESCRIPTION
* create digit accumulator as DPL owned resource, avoiding
  one data copy
* in the ROOT writer callback: free memory taken by branches early
  by calling DropBaskets("all")

For a 100PbPb digitization (8 lanes) I see memory spikes going from
~21GB to ~16GB (with --disable-mc).