### PR TITLE
HistHelpers: add some more features

### DIFF
--- a/Analysis/Core/include/Analysis/HistHelpers.h
+++ b/Analysis/Core/include/Analysis/HistHelpers.h
@@ -48,11 +48,11 @@ struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {
 //**************************************************************************************************
 /**
  * Container class for storing and saving root histograms of any type.
- * RootContainer (TObjArray or TList) inheritance is required to interface with O2 file writing functionality.
+ * RootContainer (TObjArray, TList or TFolder) inheritance is used to interface with O2 file writing functionality.
  */
 //**************************************************************************************************
 template <class RootContainer>
-class HistContainer : public RootContainer
+class HistContainer : private RootContainer
 {
  public:
   HistContainer(const std::string& name) : RootContainer()
@@ -122,11 +122,13 @@ class HistContainer : public RootContainer
     Fill<true>(histID, std::forward<Ts>(positionAndWeight)...);
   }
 
- private:
-  std::map<uint8_t, HistType> mHistos;
+  // make accessible only the RootContainer functions needed for writing to file
+  using RootContainer::Class;
+  using RootContainer::GetName;
 
-  // disallow user to call RootContainer::Add() to avoid memory leaks
-  using RootContainer::Add;
+ private:
+  // FIXME: map is most likely not the fastest -> array?
+  std::map<uint8_t, HistType> mHistos;
 
   template <bool fillWeight = false, typename T, typename... Ts>
   void GenericFill(std::shared_ptr<T> hist, const Ts&... position)

--- a/Analysis/Core/include/Analysis/HistHelpers.h
+++ b/Analysis/Core/include/Analysis/HistHelpers.h
@@ -25,9 +25,9 @@
 #include <TProfile2D.h>
 #include <TProfile3D.h>
 
+#include <TFolder.h>
 #include <TObjArray.h>
 #include <TList.h>
-//#include <TDirectory.h>
 
 #include "Framework/Logger.h"
 
@@ -154,7 +154,7 @@ class HistContainer : public RootContainer
       else
         hist->Fill(tempArray);
     }
-  };
+  }
 
   template <typename T>
   std::optional<HistType> GetHistVariant(std::shared_ptr<TObject> obj)
@@ -183,9 +183,9 @@ class HistContainer : public RootContainer
 };
 
 //**************************************************************************************************
+using HistFolder = HistContainer<TFolder>;
 using HistArray = HistContainer<TObjArray>;
 using HistList = HistContainer<TList>;
-//using HistDirectory = HistContainer<TDirectory>;
 //**************************************************************************************************
 
 //**************************************************************************************************

--- a/Analysis/Tutorials/src/histHelpersTest.cxx
+++ b/Analysis/Tutorials/src/histHelpersTest.cxx
@@ -58,6 +58,8 @@ struct HistHelpersTest {
   OutputObj<HistFolder> tpc{HistFolder("TPC"), OutputObjHandlingPolicy::QAObject};
   OutputObj<HistList> its{HistList("ITS"), OutputObjHandlingPolicy::QAObject};
 
+  OutputObj<THnF> standaloneHist{"standaloneHist", OutputObjHandlingPolicy::QAObject};
+
   void init(o2::framework::InitContext&)
   {
     // add some plain and simple histograms
@@ -157,6 +159,13 @@ struct HistHelpersTest {
     thirdHist.AddAxes(baseDimensions);
     thirdHist.AddAxis("myLastDimension", "a (m/(s*s))", 10, -1, 1);
     its->Add(Hist_test_8d_THnC_third, thirdHist.Create("thirdHist"));
+
+    // we can also use the Hist heleper tool independent of the HistCollections:
+    Hist<THnF> myHist;
+    myHist.AddAxis(ptAxis);
+    myHist.AddAxis(etaAxis);
+    myHist.AddAxis(phiAxis);
+    standaloneHist.setObject(myHist.Create("standaloneHist"));
   }
 
   void process(soa::Join<aod::Tracks, aod::TracksExtra>::iterator const& track)
@@ -189,12 +198,17 @@ struct HistHelpersTest {
     tpc->Fill(Hist_Chi2PerClTPC, track.itsChi2NCl());
 
     its->Fill(Hist_Chi2PerClITS, track.tpcChi2NCl());
+
+    double dummyArray[] = {track.pt(), track.eta(), track.phi()};
+    standaloneHist->Fill(dummyArray);
   }
 };
 
-//--------------------------------------------------------------------
-// Workflow definition
-//--------------------------------------------------------------------
+//****************************************************************************************
+/**
+ * Workflow definition.
+ */
+//****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{

--- a/Analysis/Tutorials/src/histHelpersTest.cxx
+++ b/Analysis/Tutorials/src/histHelpersTest.cxx
@@ -55,7 +55,7 @@ struct HistHelpersTest {
 
   OutputObj<HistArray> test{HistArray("Test"), OutputObjHandlingPolicy::QAObject};
   OutputObj<HistArray> kine{HistArray("Kine"), OutputObjHandlingPolicy::QAObject};
-  OutputObj<HistArray> tpc{HistArray("TPC"), OutputObjHandlingPolicy::QAObject};
+  OutputObj<HistFolder> tpc{HistFolder("TPC"), OutputObjHandlingPolicy::QAObject};
   OutputObj<HistList> its{HistList("ITS"), OutputObjHandlingPolicy::QAObject};
 
   void init(o2::framework::InitContext&)

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -400,6 +400,12 @@ struct OutputObj {
     object->SetName(label.c_str());
   }
 
+  void setObject(std::shared_ptr<T> t)
+  {
+    object = t;
+    object->SetName(label.c_str());
+  }
+
   void setHash(uint32_t hash)
   {
     mTaskHash = hash;


### PR DESCRIPTION
- support TFolder based collections
- disallow user to access functions of underlying ROOT container
- modify OutputObj to use existing shared pointers
- add example how to make use of Hist<> also independent of HistCollection<>