### PR TITLE
TPC digitization: New const labelcontainer

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/IOMCTruthContainerView.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/IOMCTruthContainerView.h
@@ -49,9 +49,26 @@ class IOMCTruthContainerView
     adopt(input);
   }
 
+  ~IOMCTruthContainerView()
+  {
+    if (!mIsView) {
+      delete[] part1;
+      delete[] part2;
+      delete[] part3;
+      delete[] part4;
+      delete[] part5;
+      delete[] part6;
+      delete[] part7;
+      delete[] part8;
+      delete[] part9;
+      delete[] part10;
+    }
+  }
+
   /// "adopt" (without taking ownership) from an existing buffer
   void adopt(gsl::span<const char> const input)
   {
+    mIsView = true;
     const auto delta = input.size() / N;
     N2 = input.size() - (N - 1) * delta;
     N1 = delta;
@@ -103,6 +120,9 @@ class IOMCTruthContainerView
   const char* part8 = nullptr;  //[N1]
   const char* part9 = nullptr;  //[N1]
   const char* part10 = nullptr; //[N2]
+
+  bool mIsView = false; //! if this was merely adopted from an existing container or actually owns the memory
+                        //  we need to know this for the destructor
 
   template <typename Alloc>
   void copyhelper(const char* input, int size, std::vector<char, Alloc>& output) const

--- a/Detectors/TPC/workflow/src/PublisherSpec.cxx
+++ b/Detectors/TPC/workflow/src/PublisherSpec.cxx
@@ -138,8 +138,8 @@ DataProcessorSpec createPublisherSpec(PublisherConf const& config, bool propagat
                                   publishingMode,
                                   subSpec,
                                   clusterbranchname.c_str(), // name of data branch
-                                  mcbranchname.c_str()       // name of mc label branch
-        );
+                                  mcbranchname.c_str(),      // name of mc label branch
+                                  config.hook);
         if (sectorMode == SectorMode::Full) {
           break;
         }

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -24,7 +24,8 @@
 #include "DataFormatsTPC/Digit.h"
 #include "TPCSimulation/CommonMode.h"
 #include <SimulationDataFormat/MCCompLabel.h>
-#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <SimulationDataFormat/IOMCTruthContainerView.h>
 #include <TFile.h>
 #include <TTree.h>
 #include <TBranch.h>
@@ -55,31 +56,41 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
   // the callback to be set as hook for custom action when the writer is closed
   auto finishWriting = [](TFile* outputfile, TTree* outputtree) {
     // check/verify number of entries (it should be same in all branches)
+    auto leavelist = outputtree->GetListOfLeaves();
+    for (auto entry : *leavelist) {
+      if (TString(entry->GetName()).Contains("_TMP")) {
+        leavelist->Remove(entry);
+      }
+    }
 
     // will return a TObjArray
     const auto brlist = outputtree->GetListOfBranches();
     int entries = -1; // init to -1 (as unitialized)
     for (TObject* entry : *brlist) {
       auto br = static_cast<TBranch*>(entry);
+      if (TString(entry->GetName()).Contains("_TMP")) {
+        br->DeleteBaskets("all");
+        brlist->Remove(br);
+        continue;
+      }
+
       int brentries = br->GetEntries();
-      if (entries == -1) {
-        entries = brentries;
-      } else {
-        if (brentries != entries && !TString(br->GetName()).Contains("CommonMode")) {
-          LOG(WARNING) << "INCONSISTENT NUMBER OF ENTRIES IN BRANCH " << br->GetName() << ": " << entries << " vs " << brentries;
-        }
+      entries = std::max(entries, brentries);
+      if (brentries != entries && !TString(br->GetName()).Contains("CommonMode")) {
+        LOG(WARNING) << "INCONSISTENT NUMBER OF ENTRIES IN BRANCH " << br->GetName() << ": " << entries << " vs " << brentries;
       }
     }
     if (entries > 0) {
+      LOG(INFO) << "Setting entries to " << entries;
       outputtree->SetEntries(entries);
+      // outputtree->Write("", TObject::kOverwrite);
+      outputfile->Close();
     }
-    outputtree->Write();
-    outputfile->Close();
   };
 
   //branch definitions for RootTreeWriter spec
   using DigitsOutputType = std::vector<o2::tpc::Digit>;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using MCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
   using CommonModeOutputType = std::vector<o2::tpc::CommonMode>;
 
   // extracts the sector from header of an input
@@ -156,6 +167,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
     if (sector >= 0) {
       LOG(INFO) << "DIGIT SIZE " << digiData.size();
       const auto& trigS = (*trigP2Sect.get())[sector];
+      int entries = 0;
       if (!trigS.size()) {
         std::runtime_error("Digits for sector " + std::to_string(sector) + " are received w/o info on grouping in triggers");
       } else { // check consistency of Ndigits with that of expected from the trigger
@@ -171,6 +183,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
           auto ptr = &digiData;
           branch.SetAddress(&ptr);
           branch.Fill();
+          entries++;
           branch.ResetAddress();
           branch.DropBaskets("all");
         } else {                                // triggered mode (>1 entries will be written)
@@ -183,20 +196,33 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
               digGroup.emplace_back(digiData[group.getFirstEntry() + i]); // fetch digits of given trigger
             }
             branch.Fill();
+            entries++;
           }
           branch.ResetAddress();
           branch.DropBaskets("all");
         }
       }
+      auto tree = branch.GetTree();
+      tree->SetEntries(entries);
+      tree->Write("", TObject::kOverwrite);
     }
   };
 
   // handler for labels
   // TODO: this is almost a copy of the above, reduce to a single methods with amends
-  auto fillLabels = [extractSector, trigP2Sect](TBranch& branch, MCLabelContainer const& labeldata, DataRef const& ref) {
+  auto fillLabels = [extractSector, trigP2Sect](TBranch& branch, std::vector<char> const& labelbuffer, DataRef const& ref) {
+    o2::dataformats::IOMCTruthContainerView outputcontainer;
+    o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> labeldata(labelbuffer);
+    // first of all redefine the output format (special to labels)
+    auto tree = branch.GetTree();
     auto sector = extractSector(ref);
+    std::stringstream str;
+    str << "TPCDigitMCTruth_" << sector;
+    auto br = tree->Branch(str.str().c_str(), &outputcontainer);
+
     auto const* dh = DataRefUtils::getHeader<DataHeader*>(ref);
     LOG(INFO) << "HAVE LABEL DATA FOR SECTOR " << sector << " ON CHANNEL " << dh->subSpecification;
+    int entries = 0;
     if (sector >= 0) {
       LOG(INFO) << "MCTRUTH ELEMENTS " << labeldata.getIndexedSize()
                 << " WITH " << labeldata.getNElements() << " LABELS";
@@ -213,27 +239,30 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
       }
       {
         if (trigS.size() == 1) { // just 1 entry (continous mode?), use labels directly
-          auto ptr = &labeldata;
-          branch.SetAddress(&ptr);
-          branch.Fill();
-          branch.ResetAddress();
-          branch.DropBaskets("all");
+          outputcontainer.adopt(labelbuffer);
+          br->Fill();
+          br->ResetAddress();
+          entries = 1;
         } else {
           o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblGroup; // labels for group of digits related to single trigger
-          auto ptr = &lblGroup;
-          branch.SetAddress(&ptr);
           for (auto const& group : trigS) {
             lblGroup.clear();
             for (int i = 0; i < group.getEntries(); i++) {
               auto lbls = labeldata.getLabels(group.getFirstEntry() + i);
               lblGroup.addElements(i, lbls);
             }
-            branch.Fill();
+            // init the output container
+            std::vector<char> flatbuffer;
+            lblGroup.flatten_to(flatbuffer);
+            outputcontainer.adopt(flatbuffer);
+            br->Fill();
+            entries++;
           }
-          branch.ResetAddress();
-          branch.DropBaskets("all");
+          br->ResetAddress();
         }
       }
+      tree->SetEntries(entries);
+      tree->Write("", TObject::kOverwrite);
     }
   };
 
@@ -252,13 +281,13 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
                                                       getIndex,
                                                       getName};
 
-  auto labelsdef = BranchDefinition<MCLabelContainer>{InputSpec{"labelinput", ConcreteDataTypeMatcher{"TPC", "DIGITSMCTR"}},
-                                                      "TPCDigitMCTruth", "labels-branch-name",
-                                                      // this branch definition is disabled if MC labels are not processed
-                                                      (mctruth ? laneConfiguration.size() : 0),
-                                                      fillLabels,
-                                                      getIndex,
-                                                      getName};
+  auto labelsdef = BranchDefinition<std::vector<char>>{InputSpec{"labelinput", ConcreteDataTypeMatcher{"TPC", "DIGITSMCTR"}},
+                                                       "TPCDigitMCTruth_TMP", "labels-branch-name",
+                                                       // this branch definition is disabled if MC labels are not processed
+                                                       (mctruth ? laneConfiguration.size() : 0),
+                                                       fillLabels,
+                                                       getIndex,
+                                                       getName};
 
   auto commddef = BranchDefinition<CommonModeOutputType>{InputSpec{"commonmode", ConcreteDataTypeMatcher{"TPC", "COMMONMODE"}},
                                                          "TPCCommonMode", "common-mode-branch-name",

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -23,6 +23,7 @@
 #include "TSystem.h"
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
@@ -220,9 +221,8 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       o2::tpc::TPCSectorHeader header{sector};
       header.activeSectors = activeSectors;
       if (mWithMCTruth) {
-        pc.outputs().snapshot(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification),
-                                     Lifetime::Timeframe, header},
-                              const_cast<o2::dataformats::MCTruthContainer<o2::MCCompLabel>&>(labels));
+        auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
+        labels.flatten_to(sharedlabels);
       }
     };
     // lambda that snapshots digits grouping (triggers) to be sent out; prepares and attaches header with sector information


### PR DESCRIPTION
This PR achieves the ability to digitize a full digit time frame including MC labels for TPC.
(Labels for reco are still converted to old format until the reco workflow is refactored).



