### PR TITLE
Add abs.charge data member to TrackPar (change in base track model)

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -22,6 +22,7 @@ namespace constants
 namespace physics
 {
 // particles masses
+constexpr float MassPhoton = 0.0;
 constexpr float MassElectron = 0.000511;
 constexpr float MassMuon = 0.105658;
 constexpr float MassPionCharged = 0.139570;
@@ -29,10 +30,12 @@ constexpr float MassPionNeutral = 0.134976;
 constexpr float MassKaonCharged = 0.493677;
 constexpr float MassKaonNeutral = 0.497648;
 constexpr float MassProton = 0.938272;
+constexpr float MassLambda = 1.115683;
 constexpr float MassDeuteron = 1.875613;
 constexpr float MassTriton = 2.809250;
 constexpr float MassHelium3 = 2.809230;
 constexpr float MassAlpha = 3.727379;
+constexpr float MassHyperTriton = 2.992;
 
 constexpr float LightSpeedCm2S = 299792458.e2;           // C in cm/s
 constexpr float LightSpeedCm2NS = LightSpeedCm2S * 1e-9; // C in cm/ns

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -87,9 +87,6 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov& getParamOut() { return mParamOut; }
   const o2::track::TrackParCov& getParamOut() const { return mParamOut; }
 
-  void setPID(uint8_t p) { mPID = p; }
-  int getPID() const { return mPID; }
-
   void setPattern(uint8_t p) { mPattern = p; }
   int getPattern() const { return mPattern; }
   bool hasHitOnLayer(int i) { return mPattern & (0x1 << i); }
@@ -98,7 +95,6 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov mParamOut; ///< parameter at largest radius
   ClusRefs mClusRef;                ///< references on clusters
   float mChi2 = 0.;                 ///< Chi2 for this track
-  uint8_t mPID = 0;                 ///< pid info (at the moment not used)
   uint8_t mPattern = 0;             ///< layers pattern
 
   ClassDefNV(TrackITS, 4);
@@ -137,7 +133,7 @@ class TrackITSExt : public TrackITS
 
  private:
   std::array<int, MaxClusters> mIndex = {-1}; ///< Indices of associated clusters
-  ClassDefNV(TrackITSExt, 1);
+  ClassDefNV(TrackITSExt, 2);
 };
 } // namespace its
 } // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_track_PID_H_
 #define ALICEO2_track_PID_H_
 
-#include <Rtypes.h>
+#include "GPUCommonRtypes.h"
 #include "CommonConstants/PhysicsConstants.h"
 
 namespace o2
@@ -26,7 +26,7 @@ class PID
 {
  public:
   // particle identifiers, continuos starting from 0
-  typedef std::int32_t ID;
+  typedef uint8_t ID;
 
   static constexpr ID Electron = 0;
   static constexpr ID Muon = 1;
@@ -40,7 +40,17 @@ class PID
 
   static constexpr ID First = Electron;
   static constexpr ID Last = Alpha;     ///< if extra IDs added, update this !!!
-  static constexpr int NIDs = Last + 1; ///< number of defined IDs
+  static constexpr ID NIDs = Last + 1;  ///< number of defined IDs
+
+  // PID for derived particles
+  static constexpr ID PI0 = 9;
+  static constexpr ID Photon = 10;
+  static constexpr ID K0 = 11;
+  static constexpr ID Lambda = 12;
+  static constexpr ID HyperTriton = 13;
+  static constexpr ID FirstExt = PI0;
+  static constexpr ID LastExt = HyperTriton;
+  static constexpr ID NIDsTot = LastExt + 1; ///< total number of defined IDs
 
   PID() = default;
   PID(ID id) : mID(id) {}
@@ -49,6 +59,7 @@ class PID
   PID& operator=(const PID& src) = default;
 
   ID getID() const { return mID; }
+  operator ID() const { return getID(); }
 
   float getMass() const { return getMass(mID); }
   float getMass2Z() const { return getMass2Z(mID); }
@@ -69,32 +80,39 @@ class PID
     return !*x && !*y ? true : /* default */ (*x == *y && sameStr(x + 1, y + 1));
   }
 
-  inline static constexpr int nameToID(char const* name, int id)
+  inline static constexpr ID nameToID(char const* name, ID id)
   {
-    return id > Last ? id : sameStr(name, sNames[id]) ? id : nameToID(name, id + 1);
+    return id > LastExt ? id : sameStr(name, sNames[id]) ? id : nameToID(name, id + 1);
   }
 
-  static constexpr const char* sNames[NIDs + 1] = ///< defined particle names
-    {"Electron", "Muon", "Pion", "Kaon", "Proton", "Deuteron", "Triton", "He3", "Alpha", nullptr};
+  static constexpr const char* sNames[NIDsTot + 1] = ///< defined particle names
+    {"Electron", "Muon", "Pion", "Kaon", "Proton", "Deuteron", "Triton", "He3", "Alpha",
+     "Pion0", "Photon", "K0", "Lambda", "HyperTriton",
+     nullptr};
 
-  static constexpr const float sMasses[NIDs] = ///< defined particle masses
+  static constexpr const float sMasses[NIDsTot] = ///< defined particle masses
     {o2::constants::physics::MassElectron, o2::constants::physics::MassMuon,
      o2::constants::physics::MassPionCharged, o2::constants::physics::MassKaonCharged,
      o2::constants::physics::MassProton, o2::constants::physics::MassDeuteron,
      o2::constants::physics::MassTriton, o2::constants::physics::MassHelium3,
-     o2::constants::physics::MassAlpha};
+     o2::constants::physics::MassAlpha,
+     o2::constants::physics::MassPionNeutral, o2::constants::physics::MassPhoton,
+     o2::constants::physics::MassKaonNeutral, o2::constants::physics::MassLambda,
+     o2::constants::physics::MassHyperTriton};
 
-  static constexpr const float sMasses2Z[NIDs] = ///< defined particle masses / Z
+  static constexpr const float sMasses2Z[NIDsTot] = ///< defined particle masses / Z
     {o2::constants::physics::MassElectron, o2::constants::physics::MassMuon,
      o2::constants::physics::MassPionCharged, o2::constants::physics::MassKaonCharged,
      o2::constants::physics::MassProton, o2::constants::physics::MassDeuteron,
      o2::constants::physics::MassTriton, o2::constants::physics::MassHelium3 / 2.,
-     o2::constants::physics::MassAlpha / 2.};
+     o2::constants::physics::MassAlpha / 2.,
+     0, 0, 0, 0, o2::constants::physics::MassHyperTriton};
 
-  static constexpr const int sCharges[NIDs] = ///< defined particle charges
-    {1, 1, 1, 1, 1, 1, 1, 2, 2};
+  static constexpr const int sCharges[NIDsTot] = ///< defined particle charges
+    {1, 1, 1, 1, 1, 1, 1, 2, 2,
+     0, 0, 0, 0, 1};
 
-  ClassDefNV(PID, 1);
+  ClassDefNV(PID, 2);
 };
 } // namespace track
 } // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
@@ -43,6 +43,7 @@
 #include "CommonConstants/MathConstants.h"
 #include "MathUtils/Utils.h"
 #include "MathUtils/Primitive2D.h"
+#include "ReconstructionDataFormats/PID.h"
 
 //Forward declarations, since we cannot include the headers if we eventually want to use track.h on GPU
 namespace ROOT
@@ -153,6 +154,13 @@ class TrackPar
   float getTgl() const { return mP[kTgl]; }
   float getQ2Pt() const { return mP[kQ2Pt]; }
   float getCharge2Pt() const { return mAbsCharge ? mP[kQ2Pt] : 0.; }
+  int getAbsCharge() const { return mAbsCharge; }
+  PID getPID() const { return mPID; }
+  void setPID(const PID pid)
+  {
+    mPID = pid;
+    setAbsCharge(pid.getCharge());
+  }
 
   /// calculate cos^2 and cos of track direction in rphi-tracking
   float getCsp2() const
@@ -178,7 +186,6 @@ class TrackPar
   void getCircleParams(float bz, o2::utils::CircleXY& circle, float& sna, float& csa) const;
   void getLineParams(o2::utils::IntervalXY& line, float& sna, float& csa) const;
   float getCurvature(float b) const { return mAbsCharge ? mP[kQ2Pt] * b * o2::constants::math::B2C : 0.; }
-  int getAbsCharge() const { return mAbsCharge; }
   int getCharge() const { return getSign() > 0 ? mAbsCharge : -mAbsCharge; }
   int getSign() const { return mAbsCharge ? (mP[kQ2Pt] > 0.f ? 1 : -1) : 0; }
   float getPhi() const;
@@ -239,6 +246,7 @@ class TrackPar
   float mAlpha = 0.f;         /// track frame angle
   float mP[kNParams] = {0.f}; /// 5 parameters: Y,Z,sin(phi),tg(lambda),q/pT
   char mAbsCharge = 1;        /// Extra info about the abs charge, to be taken into account only if not 1
+  PID mPID{};                 /// 8 bit PID
 
   ClassDefNV(TrackPar, 2);
 };

--- a/DataFormats/Reconstruction/src/PID.cxx
+++ b/DataFormats/Reconstruction/src/PID.cxx
@@ -18,14 +18,14 @@
 
 using namespace o2::track;
 
-constexpr const char* PID::sNames[NIDs + 1];
-constexpr const float PID::sMasses[NIDs];
-constexpr const float PID::sMasses2Z[NIDs];
-constexpr const int PID::sCharges[NIDs];
+constexpr const char* PID::sNames[NIDsTot + 1];
+constexpr const float PID::sMasses[NIDsTot];
+constexpr const float PID::sMasses2Z[NIDsTot];
+constexpr const int PID::sCharges[NIDsTot];
 
 //_______________________________
 PID::PID(const char* name) : mID(nameToID(name, First))
 {
   // construct from the name
-  assert(mID < NIDs);
+  assert(mID < NIDsTot);
 }

--- a/DataFormats/Reconstruction/src/Track.cxx
+++ b/DataFormats/Reconstruction/src/Track.cxx
@@ -458,7 +458,8 @@ float TrackPar::getYAt(float xk, float b) const
 std::string TrackPar::asString() const
 {
   // print parameters as string
-  return fmt::format("X:{:+.4e} Alp:{:+.3e} Par: {:+.4e} {:+.4e} {:+.4e} {:+.4e} {:+.4e} |Q|:{:d}", getX(), getAlpha(), getY(), getZ(), getSnp(), getTgl(), getQ2Pt(), getAbsCharge());
+  return fmt::format("X:{:+.4e} Alp:{:+.3e} Par: {:+.4e} {:+.4e} {:+.4e} {:+.4e} {:+.4e} |Q|:{:d} {:s}",
+                     getX(), getAlpha(), getY(), getZ(), getSnp(), getTgl(), getQ2Pt(), getAbsCharge(), getPID().getName());
 }
 
 //______________________________________________________________


### PR DESCRIPTION
This is needed for uniform treatment of tracks with non-standard charge: 0 (for V0s) and e.g. 2 for hypernuclei.
In the aliroot AliExternalTrackParam this was treated by derived classes using virtual methods, which we don't use in O2.
The meaning of mP[kQ2Pt] remains exactly the same, except for q=0 case: in this case the mP[kQ2Pt] is just an alias to
1/pT, regardless of its sign, and the getCurvature() will 0 (because mAbsCharge is 0).
The methods returning lab momentum or its combination account for eventual q>1.

Also, track::PID list extended by derived particles (V0 and cascade candidates) and changed to uint8_t base, 
the mPID data member added TrackPar class (will use one of the padding bytes appearing after adding the charge)