### PR TITLE
Rename configurable param Pythia8 -> GeneratorPythia8

### DIFF
--- a/Generators/include/Generators/GeneratorPythia8Param.h
+++ b/Generators/include/Generators/GeneratorPythia8Param.h
@@ -32,7 +32,7 @@ struct GeneratorPythia8Param : public o2::conf::ConfigurableParamHelper<Generato
   std::string config = "";
   std::string hooksFileName = "";
   std::string hooksFuncName = "";
-  O2ParamDef(GeneratorPythia8Param, "Pythia8");
+  O2ParamDef(GeneratorPythia8Param, "GeneratorPythia8");
 };
 
 } // end namespace eventgen

--- a/Generators/share/egconfig/pythia8_userhooks_charm.C
+++ b/Generators/share/egconfig/pythia8_userhooks_charm.C
@@ -1,6 +1,6 @@
 // Pythia8 UserHooks
 //
-//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
+//   usage: o2sim -g pythia8 --configKeyValues "GeneratorPythia8.hooksFileName=pythia8_userhooks_charm.C"
 //
 /// \author R+Preghenella - February 2020
 

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -258,7 +258,7 @@ This functionality might be of use for users who want to be able to steer the ev
 An example of a configuration macro is this one
 
 ```
-//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_charm.C"
+//   usage: o2sim -g pythia8 --configKeyValues "GeneratorPythia8.hooksFileName=pythia8_userhooks_charm.C"
 
 #include "Generators/Trigger.h"
 #include "Pythia8/Pythia.h"

--- a/run/SimExamples/HF_Embedding_Pythia8/o2sim_configuration_sgn.ini
+++ b/run/SimExamples/HF_Embedding_Pythia8/o2sim_configuration_sgn.ini
@@ -1,4 +1,4 @@
-[Pythia8]
+[GeneratorPythia8]
 config = pythia8.cfg
 hooksFileName = pythia8_userhooks_ccbar.macro
 hooksFuncName = pythia8_userhooks_ccbar(1.5)

--- a/run/SimExamples/HF_Embedding_Pythia8/run.sh
+++ b/run/SimExamples/HF_Embedding_Pythia8/run.sh
@@ -13,12 +13,12 @@
 # `GeneratorExternal.fileName=GeneratorHF.macro` by running the code defined in the function `GeneratorExternal.funcName="GeneratorHF()"`.
 # Special configuration parameters are loaded from the INI file `--configFile o2sim_configuration_sgn.ini`.
 #
-# Pythia8.config defines the Pythia8 configuration file name.
+# GeneratorPythia8.config defines the Pythia8 configuration file name.
 #
 # We configured to bias towards c-cbar processes where we can select them baed on pt-hat bins.
 #
-# Pythia8.hooksFileName defines the file name where to load the custom Pythia8 hooks
-# Pythia8.hooskFuncName defines the function call to be run to retrieve the custom Pythia8 hools.
+# GeneratorPythia8.hooksFileName defines the file name where to load the custom Pythia8 hooks
+# GeneratorPythia8.hooskFuncName defines the function call to be run to retrieve the custom Pythia8 hools.
 #
 # Hooks are used in this example to speedup the event generation. Event generation is paused at parton level.
 # We check if there are the partons of our interest, if not we veto the event. This saves time because we

--- a/run/SimExamples/Jet_Embedding_Pythia8/pythia8_userhooks_jets.macro
+++ b/run/SimExamples/Jet_Embedding_Pythia8/pythia8_userhooks_jets.macro
@@ -1,6 +1,6 @@
 // Pythia8 UserHooks
 //
-//   usage: o2sim -g pythia8 --configKeyValues "Pythia8.hooksFileName=pythia8_userhooks_jets.C"
+//   usage: o2sim -g pythia8 --configKeyValues "GeneratorPythia8.hooksFileName=pythia8_userhooks_jets.C"
 //
 /// \author R+Preghenella - April 2020
 

--- a/run/SimExamples/Jet_Embedding_Pythia8/run.sh
+++ b/run/SimExamples/Jet_Embedding_Pythia8/run.sh
@@ -19,7 +19,7 @@ o2-sim -j 20 -n ${NBGR} -g pythia8hi -m PIPE ITS TPC -o bkg --configKeyValues \
 # produce hard jets using a pythia8 configuration given in a file 'pythia8_hard.cfg'; event selection is done by a user hook specified
 # in file 'pythia8_userhooks_jets.macro' and using same vertex setting as background events (via --embedInto)
 NSGN=10
-o2-sim -j 20 -n ${NSGN} -g pythia8 -m PIPE ITS TPC --configKeyValues "Pythia8.config=pythia8_hard.cfg;Pythia8.hooksFileName=pythia8_userhooks_jets.macro" --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1
+o2-sim -j 20 -n ${NSGN} -g pythia8 -m PIPE ITS TPC --configKeyValues "GeneratorPythia8.config=pythia8_hard.cfg;GeneratorPythia8.hooksFileName=pythia8_userhooks_jets.macro" --embedIntoFile bkg_Kine.root -o sgn > logsgn 2>&1
 
 # PART c)
 # digitization with summation of signal on top of background events


### PR DESCRIPTION
This PR is to rename the configurable param `Pythia8` to `GeneratorPythia8`.
This is because it makes it clear that these are parameters of the generator and avoid confusion with `DecayerPythia8`.

Documentation and examples are updated as well.