### PR TITLE
Proper protection in case BUILD_SIMULATION=OFF

### DIFF
--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -187,7 +187,7 @@ o2_add_test_root_macro(
                                              O2::CPVSimulation
                                              O2::ZDCSimulation)
 
-if(Geant4_FOUND)
+if(Geant4_FOUND AND BUILD_SIMULATION)
 o2_add_test_root_macro(o2sim.C
                        PUBLIC_LINK_LIBRARIES O2::Generators
                                              O2::DetectorsPassive


### PR DESCRIPTION
The o2sim.C macro needs O2::SimSetup which is not built when BUILD_SIMULATION=OFF

In the case where BUILD_SIMULATION=OFF but Geant4 is actually found, the CMake generation step failed (see https://alice-talk.web.cern.ch/t/o2-build-fails-in-centos-7-due-to-glfw/678/20)