### PR TITLE
DPL: added table builder warning for empty tables

### DIFF
--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -435,12 +435,11 @@ class TableBuilder
   template <typename... ARGS>
   auto makeFinalizer()
   {
-    mFinalizer = [schema = mSchema, &arrays = mArrays, builders = mBuilders]() -> std::shared_ptr<arrow::Table> {
+    mFinalizer = [schema = mSchema, &arrays = mArrays, builders = mBuilders]() -> void {
       auto status = TableBuilderHelpers::finalize(arrays, *(BuildersTuple<ARGS...>*)builders, std::make_index_sequence<sizeof...(ARGS)>{});
       if (status == false) {
         throw std::runtime_error("Unable to finalize");
       }
-      return arrow::Table::Make(schema, arrays);
     };
   }
 

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -151,7 +151,7 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
   auto finalizer = [payload = p](std::shared_ptr<FairMQResizableBuffer> b) -> void {
     auto table = payload->finalize();
     if (O2_BUILTIN_UNLIKELY(table->num_rows() == 0)) {
-      LOG(WARN) << "Adopting empty table: " << table->ToString();
+      LOG(WARN) << "Empty table was produced: " << table->ToString();
     }
 
     auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
@@ -184,9 +184,6 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
   std::shared_ptr<TreeToTable> p(t2t);
   auto finalizer = [payload = p](std::shared_ptr<FairMQResizableBuffer> b) -> void {
     auto table = payload->finalize();
-    if (O2_BUILTIN_UNLIKELY(table->num_rows() == 0)) {
-      LOG(WARN) << "Adopting empty table: " << table->ToString();
-    }
 
     auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
     std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -150,6 +150,9 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
   std::shared_ptr<TableBuilder> p(tb);
   auto finalizer = [payload = p](std::shared_ptr<FairMQResizableBuffer> b) -> void {
     auto table = payload->finalize();
+    if (O2_BUILTIN_UNLIKELY(table->num_rows() == 0)) {
+      LOG(WARN) << "Adopting empty table: " << table->ToString();
+    }
 
     auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
     auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
@@ -181,6 +184,9 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
   std::shared_ptr<TreeToTable> p(t2t);
   auto finalizer = [payload = p](std::shared_ptr<FairMQResizableBuffer> b) -> void {
     auto table = payload->finalize();
+    if (O2_BUILTIN_UNLIKELY(table->num_rows() == 0)) {
+      LOG(WARN) << "Adopting empty table: " << table->ToString();
+    }
 
     auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
     std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -51,13 +51,8 @@ std::shared_ptr<arrow::Table>
   TableBuilder::finalize()
 {
   mFinalizer();
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
-  columns.reserve(mArrays.size());
-  for (auto i = 0; i < mSchema->num_fields(); ++i) {
-    auto column = std::make_shared<arrow::ChunkedArray>(mArrays[i]);
-    columns.emplace_back(column);
-  }
-  return arrow::Table::Make(mSchema, columns);
+  assert(mSchema->num_fields() > 0 && "Schema needs to be non-empty");
+  return arrow::Table::Make(mSchema, mArrays);
 }
 
 } // namespace o2::framework


### PR DESCRIPTION
* Removed extra `arrow::Table::Make`
* Arrow can now construct a table directly from array vector