### PR TITLE
Protect TGeo material query by mutex and enable its usage in TRD tracking

### DIFF
--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -25,7 +25,7 @@
 #include "FairLogger.h" // for LOG
 #include "MathUtils/Cartesian3D.h"
 #include "DetectorsBase/MatCell.h"
-
+#include <mutex>
 class TGeoHMatrix; // lines 11-11
 class TGeoManager; // lines 9-9
 
@@ -126,7 +126,6 @@ class GeometryManager : public TObject
   /// detector geometry. The output global matrix is stored in 'm'.
   /// Returns kFALSE in case TGeo has not been initialized or the volume path is not valid.
   static Bool_t getOriginalMatrixFromPath(const char* path, TGeoHMatrix& m);
-
  private:
 /// sensitive volume identifier composed from (det_mask<<sDetOffset)|(sensid&sSensorMask)
 #ifdef ENABLE_UPGRADES
@@ -136,6 +135,7 @@ class GeometryManager : public TObject
 #endif
   static constexpr UInt_t sSensorMask =
     (0x1 << sDetOffset) - 1; /// mask=max sensitive volumes allowed per detector (0xffff)
+  static std::mutex sTGMutex;
 
   ClassDefOverride(GeometryManager, 0); // Manager of geometry information for alignment
 };

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -200,7 +200,7 @@ class propagatorInterface<o2::base::Propagator>
   propagatorInterface<o2::base::Propagator>(const propagatorInterface<o2::base::Propagator>&) = delete;
   propagatorInterface<o2::base::Propagator>& operator=(const propagatorInterface<o2::base::Propagator>&) = delete;
 
-  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep, o2::base::Propagator::MatCorrType::USEMatCorrNONE); }
+  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep); }
   int getPropagatedYZ(My_Float x, My_Float& projY, My_Float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
 
   void setTrack(trackInterface<o2::dataformats::TrackTPCITS>* trk) { mParam = trk; }


### PR DESCRIPTION
@martenole @davidrohr the crash in mat. query in https://github.com/AliceO2Group/AliceO2/pull/4297 was because of multithreading: most of TGeometry operations are not thread-safe. I've protected TGeo calls by mutex and enabled material corrections in TRD, but for production benchmarks, we should only LUT (which is thread-safe) since the TGeo, apart from being extremely slow, with mutex may make the multithreading meaningless.