### PR TITLE
Fix: default init. of some ClusterNativeAccess members

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -155,13 +155,13 @@ struct ClusterNative {
 // This is an index struct to access TPC clusters inside sectors and rows. It shall not own the data, but just point to
 // the data inside a buffer.
 struct ClusterNativeAccess {
-  const ClusterNative* clustersLinear;
+  const ClusterNative* clustersLinear = nullptr;
   const ClusterNative* clusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth;
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth = nullptr;
   unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   unsigned int nClustersSector[constants::MAXSECTOR];
   unsigned int clusterOffset[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
-  unsigned int nClustersTotal;
+  unsigned int nClustersTotal = 0;
 
   void setOffsetPtrs();
 };


### PR DESCRIPTION
@davidrohr While testing Ole's code I often got bad_alloc with stack trace below, due to non-initialized ``ClusterNativeAccess.nClustersTotal``. This PR fixes it.


````
.x run_trd_tracker.C+
....
Event 8: Occured at 213 us after SOR, contains 0 tracklets, index of first tracklet is 780
Event 9: Occured at 222 us after SOR, contains 349 tracklets, index of first tracklet is 780
Event 10: Occured at 222 us after SOR, contains 579 tracklets, index of first tracklet is 1129

Catchpoint 1 (exception thrown), 0x00007ffff71add1d in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb) up
#1  0x00007ffff71ae2dc in operator new(unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb)
#2  0x00007fffdc0b4083 in o2::gpu::GPUReconstruction::AllocateIOMemoryHelper<o2::tpc::ClusterNative> (this=0x555564f3d450, n=<optimized out>,
    ptr=@0x55556567afc0: 0x7ffff6efe470 <main_arena+2096>, u=std::unique_ptr<o2::tpc::ClusterNative []> = {...})
    at /home/shahoian/alice/sw/SOURCES/O2/v1.3.0/0/GPU/GPUTracking/Base/GPUReconstruction.h:430
430        u.reset(new T[n]);
(gdb) up
#3  0x00007fffdc09093c in o2::gpu::GPUChain::AllocateIOMemoryHelper<o2::tpc::ClusterNative> (this=0x555565e7fb10, u=std::unique_ptr<o2::tpc::ClusterNative []> = {...},
    ptr=<optimized out>, n=<optimized out>) at /home/shahoian/alice/sw/SOURCES/O2/v1.3.0/0/GPU/GPUTracking/Global/GPUChain.h:127
127        mRec->AllocateIOMemoryHelper<T>(n, ptr, u);
..#4  o2::gpu::GPUChainTracking::AllocateIOMemory (this=0x555565e7fb10) at /home/shahoian/alice/sw/SOURCES/O2/v1.3.0/0/GPU/GPUTracking/Global/GPUChainTracking.cxx:463
463      AllocateIOMemoryHelper(mIOMem.clusterNativeAccess->nClustersTotal, mIOMem.clusterNativeAccess->clustersLinear, mIOMem.clustersNative);
(gdb) p mIOMem.clusterNativeAccess->nClustersTotal
$2 = 4248285097
````.


