### PR TITLE
Avoid non-trivial c-tor for ClusterNativeAccess, reset it by filling 0s

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -155,13 +155,13 @@ struct ClusterNative {
 // This is an index struct to access TPC clusters inside sectors and rows. It shall not own the data, but just point to
 // the data inside a buffer.
 struct ClusterNativeAccess {
-  const ClusterNative* clustersLinear = nullptr;
+  const ClusterNative* clustersLinear;
   const ClusterNative* clusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth = nullptr;
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth;
   unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   unsigned int nClustersSector[constants::MAXSECTOR];
   unsigned int clusterOffset[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
-  unsigned int nClustersTotal = 0;
+  unsigned int nClustersTotal;
 
   void setOffsetPtrs();
 };

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -470,6 +470,7 @@ void GPUChainTracking::AllocateIOMemory()
     AllocateIOMemoryHelper(mIOPtrs.nSliceClusters[i], mIOPtrs.sliceClusters[i], mIOMem.sliceClusters[i]);
   }
   mIOMem.clusterNativeAccess.reset(new ClusterNativeAccess);
+  std::memset(mIOMem.clusterNativeAccess.get(), 0, sizeof(ClusterNativeAccess)); // ClusterNativeAccess has no its own constructor
   AllocateIOMemoryHelper(mIOMem.clusterNativeAccess->nClustersTotal, mIOMem.clusterNativeAccess->clustersLinear, mIOMem.clustersNative);
   mIOPtrs.clustersNative = mIOMem.clusterNativeAccess->nClustersTotal ? mIOMem.clusterNativeAccess.get() : nullptr;
   AllocateIOMemoryHelper(mIOPtrs.nMCLabelsTPC, mIOPtrs.mcLabelsTPC, mIOMem.mcLabelsTPC);


### PR DESCRIPTION
@davidrohr my [PR](https://github.com/AliceO2Group/AliceO2/pull/4445) led to gpu CI [failure](https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/AliceO2/4455/96439b93aa9685f7c44893f29d928ca1440dd1f1/build_O2_gpu/fullLog.txt) in https://github.com/AliceO2Group/AliceO2/pull/4455 due to the 
````
/mnt/mesos/sandbox/sandbox/sw/SOURCES/QualityControl/v1.1.4/v1.1.4/Modules/TPC/src/Clusters.cxx: In member function 'virtual void o2::quality_control_modules::tpc::Clusters::monitorData(o2::framework::ProcessingContext&)':
/mnt/mesos/sandbox/sandbox/sw/SOURCES/QualityControl/v1.1.4/v1.1.4/Modules/TPC/src/Clusters.cxx:185:48: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct o2::tpc::ClusterNativeAccess'; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&clusterIndex, 0, sizeof(clusterIndex));
                                                ^
In file included from /mnt/mesos/sandbox/sandbox/sw/SOURCES/QualityControl/v1.1.4/v1.1.4/Modules/TPC/src/Clusters.cxx:41:
/mnt/mesos/sandbox/sandbox/sw/slc8_x86-64/O2/4455-1/include/DataFormatsTPC/ClusterNative.h:157:8: note: 'struct o2::tpc::ClusterNativeAccess' declared here
 struct ClusterNativeAccess {
        ^~~~~~~~~~~~~~~~~~~
````
Not clear why this warning about memseting an object with non-trivial c-tor pops-up only in the QC while there are plenty of them also in O2 code. 
Anyway, this PR reverts default initialization of ClusterNativeAccess and instead uses the same memset in GPUChainTracking
(whould be more rigorous to add a full fledged ClusterNativeAccess c-tor and get rid of these memsets, but then it would need to be done in many places and also in QC, not sure it is worth it).