### PR TITLE
pass second mother ID to MCTrack + corresponding setters and getters

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -40,7 +40,7 @@ class MCTrackT
   MCTrackT();
 
   ///  Standard constructor
-  MCTrackT(Int_t pdgCode, Int_t motherID, Int_t firstDaighterID, Int_t lastDaughterID,
+  MCTrackT(Int_t pdgCode, Int_t motherID, Int_t secondMotherID, Int_t firstDaughterID, Int_t lastDaughterID,
            Double_t px, Double_t py, Double_t pz, Double_t x, Double_t y, Double_t z, Double_t t,
            Int_t nPoints);
 
@@ -59,6 +59,7 @@ class MCTrackT
   ///  Accessors
   Int_t GetPdgCode() const { return mPdgCode; }
   Int_t getMotherTrackId() const { return mMotherTrackId; }
+  Int_t getSecondMotherTrackId() const { return mSecondMotherTrackId; }
   bool isSecondary() const { return mMotherTrackId != -1; }
   Int_t getFirstDaughterTrackId() const { return mFirstDaughterTrackId; }
   Int_t getLastDaughterTrackId() const { return mLastDaughterTrackId; }
@@ -133,6 +134,7 @@ class MCTrackT
   void setHitMask(Int_t m) { ((PropEncoding)mProp).hitmask = m; }
   ///  Modifiers
   void SetMotherTrackId(Int_t id) { mMotherTrackId = id; }
+  void SetSecondMotherTrackId(Int_t id) { mSecondMotherTrackId = id; }
   void SetFirstDaughterTrackId(Int_t id) { mFirstDaughterTrackId = id; }
   void SetLastDaughterTrackId(Int_t id) { mLastDaughterTrackId = id; }
   // set bit indicating that this track
@@ -193,8 +195,9 @@ class MCTrackT
   ///  PDG particle code
   Int_t mPdgCode;
 
-  ///  Index of mother track.
+  ///  Index of mother tracks
   Int_t mMotherTrackId;
+  Int_t mSecondMotherTrackId;
 
   Int_t mFirstDaughterTrackId;
   Int_t mLastDaughterTrackId;
@@ -215,7 +218,7 @@ class MCTrackT
     };
   };
 
-  ClassDefNV(MCTrackT, 2);
+  ClassDefNV(MCTrackT, 3);
 };
 
 template <typename T>
@@ -248,6 +251,7 @@ template <typename T>
 inline MCTrackT<T>::MCTrackT()
   : mPdgCode(0),
     mMotherTrackId(-1),
+    mSecondMotherTrackId(-1),
     mFirstDaughterTrackId(-1),
     mLastDaughterTrackId(-1),
     mStartVertexMomentumX(0.),
@@ -262,11 +266,12 @@ inline MCTrackT<T>::MCTrackT()
 }
 
 template <typename T>
-inline MCTrackT<T>::MCTrackT(Int_t pdgCode, Int_t motherId, Int_t firstDaughterId, Int_t lastDaughterId,
+inline MCTrackT<T>::MCTrackT(Int_t pdgCode, Int_t motherId, Int_t secondMotherId, Int_t firstDaughterId, Int_t lastDaughterId,
                              Double_t px, Double_t py, Double_t pz, Double_t x,
                              Double_t y, Double_t z, Double_t t, Int_t mask)
   : mPdgCode(pdgCode),
     mMotherTrackId(motherId),
+    mSecondMotherTrackId(secondMotherId),
     mFirstDaughterTrackId(firstDaughterId),
     mLastDaughterTrackId(lastDaughterId),
     mStartVertexMomentumX(px),
@@ -284,6 +289,7 @@ template <typename T>
 inline MCTrackT<T>::MCTrackT(const TParticle& part)
   : mPdgCode(part.GetPdgCode()),
     mMotherTrackId(part.GetMother(0)),
+    mSecondMotherTrackId(part.GetMother(1)),
     mFirstDaughterTrackId(part.GetFirstDaughter()),
     mLastDaughterTrackId(part.GetLastDaughter()),
     mStartVertexMomentumX(part.Px()),

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -177,7 +177,6 @@ class Stack : public FairGenericStack
   /// Clone for worker (used in MT mode only)
   FairGenericStack* CloneStack() const override;
 
-
   // methods concerning track references
   void addTrackReference(const o2::TrackReference& p);
 
@@ -232,9 +231,9 @@ class Stack : public FairGenericStack
 
   /// Array of TParticles (contains all TParticles put into or created
   /// by the transport)
-  std::vector<o2::MCTrack> mParticles; //!
-  std::vector<int> mTransportedIDs;    //! prim + sec trackIDs transported for "current" primary
-  std::vector<int> mIndexOfPrimaries;  //! index of primaries in mParticles
+  std::vector<o2::MCTrack> mParticles;       //!
+  std::vector<int> mTransportedIDs;          //! prim + sec trackIDs transported for "current" primary
+  std::vector<int> mIndexOfPrimaries;        //! index of primaries in mParticles
   std::vector<int> mTrackIDtoParticlesEntry; //! an O(1) mapping of trackID to the entry of mParticles
   // the current TParticle object
   TParticle mCurrentParticle;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -148,7 +148,7 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
 
 void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px, Double_t py, Double_t pz, Double_t e,
                       Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
-                      TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondparentID)
+                      TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondparentId)
 {
   //  printf("Pushing %s toBeDone %5d parentId %5d pdgCode %5d is %5d entries %5d \n",
   //	 proc == kPPrimary ? "Primary:   " : "Secondary: ",
@@ -167,11 +167,10 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
   Int_t trackId = mNumberOfEntriesInParticles;
   // Set track variable
   ntr = trackId;
-  Int_t nPoints = 0;
   Int_t daughter1Id = -1;
   Int_t daughter2Id = -1;
   Int_t iStatus = (proc == kPPrimary) ? is : trackId;
-  TParticle p(pdgCode, iStatus, parentId, nPoints, daughter1Id, daughter2Id, px, py, pz, e, vx, vy, vz, time);
+  TParticle p(pdgCode, iStatus, parentId, secondparentId, daughter1Id, daughter2Id, px, py, pz, e, vx, vy, vz, time);
   p.SetPolarisation(polx, poly, polz);
   p.SetWeight(weight);
   p.SetUniqueID(proc); // using the unique ID to transfer process ID
@@ -535,6 +534,7 @@ void Stack::UpdateTrackIndex(TRefArray* detList)
 
 void Stack::Reset()
 {
+
   mIndexOfCurrentTrack = -1;
   mNumberOfPrimaryParticles = mNumberOfEntriesInParticles = mNumberOfEntriesInTracks = 0;
   while (!mStack.empty()) {


### PR DESCRIPTION
Option to store second mother Id in MCTrack (needed for example by Pythia8)