### PR TITLE
Fix missing constructors and assignment operator

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
@@ -26,6 +26,7 @@ namespace mft
 {
 
 struct Cluster : public o2::BaseCluster<float> {
+  Cluster() = default;
   Cluster(const Float_t x, const Float_t y, const Float_t z, const Float_t phi, const Float_t r, const Int_t id, const Int_t bin, const Float_t sigX2, const Float_t sigY2, const Int_t sensorID)
     : BaseCluster(sensorID, x, y, z),
       phiCoordinate{phi},

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackParam.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackParam.h
@@ -36,8 +36,8 @@ class TrackParam
 
   TrackParam(const TrackParam& tp);
   TrackParam& operator=(const TrackParam& tp);
-  TrackParam(TrackParam&&) = delete;
-  TrackParam& operator=(TrackParam&&) = delete;
+  TrackParam(TrackParam&&) = default;
+  TrackParam& operator=(TrackParam&&) = default;
 
   /// return Z coordinate (cm)
   Double_t getZ() const { return mZ; }


### PR DESCRIPTION
These changes were necessary on some systems trying to run the prototype class for Global Muon Tracking, which is being coded outside O2. We are not branching O2 yet, please accept this trivial commit. 