### PR TITLE
DCSProcessor

### DIFF
--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -20,6 +20,8 @@ o2_add_library(DetectorsDCS
 		       src/DCSProcessor.cxx
                PUBLIC_LINK_LIBRARIES O2::Headers
 	                             O2::CommonUtils
+				     O2::CCDB
+				     O2::DetectorsCalibration
 	                             ms_gsl::ms_gsl)
 
 o2_target_root_dictionary(DetectorsDCS

--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -8,8 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-
 o2_add_library(DetectorsDCS
+               TARGETVARNAME targetName
                SOURCES src/Clock.cxx
 		       src/DataPointCompositeObject.cxx
 		       src/DataPointIdentifier.cxx
@@ -33,3 +33,8 @@ o2_add_executable(dcs-data-workflow
 		  SOURCES testWorkflow/dcs-data-workflow.cxx
 		  PUBLIC_LINK_LIBRARIES O2::Framework
 					O2::DetectorsDCS)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -28,4 +28,8 @@ o2_target_root_dictionary(DetectorsDCS
 				  include/DetectorsDCS/DataPointValue.h
 				  include/DetectorsDCS/DCSProcessor.h)
 
-
+o2_add_executable(dcs-data-workflow
+		  COMPONENT_NAME dcs
+		  SOURCES testWorkflow/dcs-data-workflow.cxx
+		  PUBLIC_LINK_LIBRARIES O2::Framework
+					O2::DetectorsDCS)

--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -16,11 +16,16 @@ o2_add_library(DetectorsDCS
 		       src/DataPointValue.cxx
 		       src/DeliveryType.cxx
 		       src/GenericFunctions.cxx
-		       src/StringUtils.cxx)
+		       src/StringUtils.cxx
+		       src/DCSProcessor.cxx
+               PUBLIC_LINK_LIBRARIES O2::Headers
+	                             O2::CommonUtils
+	                             ms_gsl::ms_gsl)
 
 o2_target_root_dictionary(DetectorsDCS
                           HEADERS include/DetectorsDCS/DataPointCompositeObject.h
 			          include/DetectorsDCS/DataPointIdentifier.h
-				  include/DetectorsDCS/DataPointValue.h)
+				  include/DetectorsDCS/DataPointValue.h
+				  include/DetectorsDCS/DCSProcessor.h)
 
 

--- a/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
@@ -90,7 +90,7 @@ class DCSProcessor
   DQBinaries& getVectorForAliasBinary(const DPID& id) { return mDpsbinariesmap[id]; }
 
  private:
-  float mAvgTestInt0 = 0; // moving average for DP named TestInt0
+  std::vector<float> mAvgTestInt; // moving average for DP named TestInt0
   std::unordered_map<DPID, DQChars> mDpscharsmap;
   std::unordered_map<DPID, DQInts> mDpsintsmap;
   std::unordered_map<DPID, DQDoubles> mDpsdoublesmap;
@@ -152,9 +152,9 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType 
       if (processFlag(flags, array[i].get_alias()) == 0) {
         auto etime = val.get_epoch_time();
         // fill only if new value has a timestamp different from the timestamp of the previous one
-        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        LOG(DEBUG) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
         if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
-          LOG(INFO) << "adding new value";
+          LOG(DEBUG) << "adding new value";
           destmap[array[i]].push_back(val.payload_pt1);
           latestTimeStamp[i] = etime;
         }

--- a/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
@@ -1,0 +1,176 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_DCS_DCSPROCESSOR_H_
+#define DETECTOR_DCS_DCSPROCESSOR_H_
+
+#include <memory>
+#include <Rtypes.h>
+#include <unordered_map>
+#include <deque>
+#include "Framework/Logger.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+
+/// @brief Class to process DCS data points
+
+namespace o2
+{
+namespace dcs
+{
+
+class DCSProcessor
+{
+
+ public:
+  using Ints = std::vector<int>;
+  using Chars = std::vector<char>;
+  using Doubles = std::vector<double>;
+  using Binaries = std::array<uint64_t, 7>;
+  using Strings = std::array<char, 56>;
+
+  using DQChars = std::deque<char>;
+  using DQInts = std::deque<int>;
+  using DQDoubles = std::deque<double>;
+  using DQUInts = std::deque<uint32_t>;
+  using DQBools = std::deque<bool>;
+  using DQStrings = std::deque<Strings>;
+  using DQTimes = std::deque<uint32_t>;
+  using DQBinaries = std::deque<Binaries>;
+
+  using DPID = o2::dcs::DataPointIdentifier;
+  using DPVAL = o2::dcs::DataPointValue;
+  using DPCOM = o2::dcs::DataPointCompositeObject;
+
+  DCSProcessor() = default;
+  ~DCSProcessor() = default;
+
+  void init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
+            const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
+            const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
+            const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries);
+
+  void init(const std::vector<DPID>& aliases);
+
+  int process(const std::unordered_map<DPID, DPVAL>& map);
+
+  std::unordered_map<DPID, DPVAL>::const_iterator processAlias(const DPID& alias, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map);
+
+  template <typename T>
+  int processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DPID, T>& destmap);
+
+  virtual void processChars();
+  virtual void processInts();
+  virtual void processDoubles();
+  virtual void processUInts();
+  virtual void processBools();
+  virtual void processStrings();
+  virtual void processTimes();
+  virtual void processBinaries();
+  virtual uint64_t processFlag(uint64_t flag, const char* alias);
+
+  void doSimpleMovingAverage(int nelements, std::deque<int>& vect, float& avg, bool& isSMA);
+
+  DQChars& getVectorForAliasChar(const DPID& id) { return mDpscharsmap[id]; }
+  DQInts& getVectorForAliasInt(const DPID& id) { return mDpsintsmap[id]; }
+  DQDoubles& getVectorForAliasDouble(const DPID& id) { return mDpsdoublesmap[id]; }
+  DQUInts& getVectorForAliasUInt(const DPID& id) { return mDpsUintsmap[id]; }
+  DQBools& getVectorForAliasBool(const DPID& id) { return mDpsboolsmap[id]; }
+  DQStrings& getVectorForAliasString(const DPID& id) { return mDpsstringsmap[id]; }
+  DQTimes& getVectorForAliasTime(const DPID& id) { return mDpstimesmap[id]; }
+  DQBinaries& getVectorForAliasBinary(const DPID& id) { return mDpsbinariesmap[id]; }
+
+ private:
+  float mAvgTestInt0 = 0; // moving average for DP named TestInt0
+  std::unordered_map<DPID, DQChars> mDpscharsmap;
+  std::unordered_map<DPID, DQInts> mDpsintsmap;
+  std::unordered_map<DPID, DQDoubles> mDpsdoublesmap;
+  std::unordered_map<DPID, DQUInts> mDpsUintsmap;
+  std::unordered_map<DPID, DQBools> mDpsboolsmap;
+  std::unordered_map<DPID, DQStrings> mDpsstringsmap;
+  std::unordered_map<DPID, DQTimes> mDpstimesmap;
+  std::unordered_map<DPID, DQBinaries> mDpsbinariesmap;
+  std::vector<DPID> mAliaseschars;
+  std::vector<DPID> mAliasesints;
+  std::vector<DPID> mAliasesdoubles;
+  std::vector<DPID> mAliasesUints;
+  std::vector<DPID> mAliasesbools;
+  std::vector<DPID> mAliasesstrings;
+  std::vector<DPID> mAliasestimes;
+  std::vector<DPID> mAliasesbinaries;
+  std::vector<uint64_t> mLatestTimestampchars;
+  std::vector<uint64_t> mLatestTimestampints;
+  std::vector<uint64_t> mLatestTimestampdoubles;
+  std::vector<uint64_t> mLatestTimestampUints;
+  std::vector<uint64_t> mLatestTimestampbools;
+  std::vector<uint64_t> mLatestTimestampstrings;
+  std::vector<uint64_t> mLatestTimestamptimes;
+  std::vector<uint64_t> mLatestTimestampbinaries;
+
+  ClassDefNV(DCSProcessor, 0);
+};
+
+using Ints = std::vector<int>;
+using Chars = std::vector<char>;
+using Doubles = std::vector<double>;
+using Binaries = std::array<uint64_t, 7>;
+using Strings = std::array<char, 56>;
+
+using DQStrings = std::deque<Strings>;
+using DQBinaries = std::deque<Binaries>;
+
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+
+template <typename T>
+int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DPID, T>& destmap)
+{
+
+  // processing the array of type T
+
+  int found = 0;
+  auto s = array.size();
+  if (s > 0) {
+    for (size_t i = 0; i != s; ++i) {
+      auto it = processAlias(array[i], type, map);
+      if (it == map.end()) {
+        LOG(ERROR) << "Element " << array[i] << " not found " << std::endl;
+        continue;
+      }
+      found++;
+      auto& val = it->second;
+      auto flags = val.get_flags();
+      if (processFlag(flags, array[i].get_alias()) == 0) {
+        auto etime = val.get_epoch_time();
+        // fill only if new value has a timestamp different from the timestamp of the previous one
+        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
+          LOG(INFO) << "adding new value";
+          destmap[array[i]].push_back(val.payload_pt1);
+          latestTimeStamp[i] = etime;
+        }
+      }
+    }
+  }
+  return found;
+}
+
+template <>
+int DCSProcessor::processArrayType(const std::vector<DCSProcessor::DPID>& array, DeliveryType type, const std::unordered_map<DCSProcessor::DPID, DCSProcessor::DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DCSProcessor::DPID, DCSProcessor::DQStrings>& destmap);
+
+template <>
+int DCSProcessor::processArrayType(const std::vector<DCSProcessor::DPID>& array, DeliveryType type, const std::unordered_map<DCSProcessor::DPID, DCSProcessor::DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DCSProcessor::DPID, DCSProcessor::DQBinaries>& destmap);
+
+} // namespace dcs
+} // namespace o2
+
+#endif

--- a/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
@@ -76,13 +76,16 @@ class DCSProcessor
 
   int processDP(const std::pair<DPID, DPVAL>& dpcom);
 
-  std::unordered_map<DPID, DPVAL>::const_iterator findAndCheckAlias(const DPID& alias, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map);
+  std::unordered_map<DPID, DPVAL>::const_iterator findAndCheckAlias(const DPID& alias, DeliveryType type,
+                                                                    const std::unordered_map<DPID, DPVAL>& map);
 
   template <typename T>
-  int processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
+  int processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
+                       std::vector<int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
 
   template <typename T>
-  void checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, T>& destmap);
+  void checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                         std::unordered_map<DPID, T>& destmap);
 
   virtual void processCharDP(const DPID& alias);
   virtual void processIntDP(const DPID& alias);
@@ -125,16 +128,21 @@ class DCSProcessor
   uint64_t getNCyclesNoFullMap() const { return mNCyclesNoFullMap; }
 
   template <typename T>
-  void prepareCCDBobject(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf, const std::map<std::string, std::string>& md);
+  void prepareCCDBobject(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf,
+                         const std::map<std::string, std::string>& md);
 
   void setName(std::string name) { mName = name; }
   const std::string getName() const { return mName; }
 
  private:
-  bool mFullMapSent = false;                            // set to true as soon as a full map was sent. No delta can be received if there was never a full map sent
+  bool mFullMapSent = false;                            // set to true as soon as a full map was sent. No delta can
+                                                        // be received if there was never a full map sent
   int64_t mNCyclesNoFullMap = 0;                        // number of times the delta was sent withoug a full map
-  int64_t mMaxCyclesNoFullMap = 6000;                   // max number of times when the delta can be sent between two full maps (assuming DCS sends data every 50 ms, this means a 5 minutes threshold)
-  bool mIsDelta = false;                                // set to true in case you are processing  delta map (containing only DPs that changed)
+  int64_t mMaxCyclesNoFullMap = 6000;                   // max number of times when the delta can be sent between
+                                                        // two full maps (assuming DCS sends data every 50 ms, this
+                                                        // means a 5 minutes threshold)
+  bool mIsDelta = false;                                // set to true in case you are processing  delta map
+                                                        // (containing only DPs that changed)
   std::unordered_map<DPID, float> mSimpleMovingAverage; // moving average for several DPs
   std::unordered_map<DPID, DQChars> mDpscharsmap;
   std::unordered_map<DPID, DQInts> mDpsintsmap;
@@ -161,9 +169,14 @@ class DCSProcessor
   std::vector<int64_t> mLatestTimestamptimes;
   std::vector<int64_t> mLatestTimestampbinaries;
   int mNThreads = 1;                                               // number of  threads
-  std::unordered_map<std::string, float> mccdbSimpleMovingAverage; // unordered map in which to store the CCDB entry for the DPs for which we calculated the simple moving average
-  CcdbObjectInfo mccdbSimpleMovingAverageInfo;                     // info to store the output of the calibration for the DPs for which we calculated the simple moving average
-  TFType mTF = 0;                                                  // TF index for processing, used to store CCDB object
+  std::unordered_map<std::string, float> mccdbSimpleMovingAverage; // unordered map in which to store the CCDB entry
+                                                                   // for the DPs for which we calculated the simple
+                                                                   // moving average
+  CcdbObjectInfo mccdbSimpleMovingAverageInfo;                     // info to store the output of the calibration for
+                                                                   // the DPs for which we calculated
+                                                                   // the simple moving average
+  TFType mTF = 0;                                                  // TF index for processing,
+                                                                   // used to store CCDB object
   std::string mName = "";                                          // to be used to determine CCDB path
 
   ClassDefNV(DCSProcessor, 0);
@@ -182,7 +195,10 @@ using DPID = o2::dcs::DataPointIdentifier;
 using DPVAL = o2::dcs::DataPointValue;
 
 template <typename T>
-int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap)
+int DCSProcessor::processArrayType(const std::vector<DPID>& array,
+                                   DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
+                                   std::vector<int64_t>& latestTimeStamp,
+                                   std::unordered_map<DPID, std::deque<T>>& destmap)
 {
 
   // processing the array of type T
@@ -228,7 +244,8 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType 
 //______________________________________________________________________
 
 template <typename T>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, T>& destmap)
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                                     std::unordered_map<DPID, T>& destmap)
 {
 
   // check the flags for the upcoming data, and if ok, fill the accumulator
@@ -251,12 +268,14 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, DCSProcessor::DQStrings>& destmap);
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                                     std::unordered_map<DPID, DCSProcessor::DQStrings>& destmap);
 
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, DCSProcessor::DQBinaries>& destmap);
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                                     std::unordered_map<DPID, DCSProcessor::DQBinaries>& destmap);
 
 //______________________________________________________________________
 
@@ -268,7 +287,7 @@ void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<T>& vect, flo
 
   if (vect.size() <= nelements) {
     //avg = std::accumulate(vect.begin(), vect.end(), 0.0) / vect.size();
-    avg = (avg * (vect.size() - 1) + vect[vect.size() - 1]) / vect.size();
+    avg = (avg * (vect.size() - 1) + vect.back()) / vect.size();
     return;
   }
 
@@ -280,7 +299,8 @@ void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<T>& vect, flo
 //______________________________________________________________________
 
 template <typename T>
-void DCSProcessor::prepareCCDBobject(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf, const std::map<std::string, std::string>& md)
+void DCSProcessor::prepareCCDBobject(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf,
+                                     const std::map<std::string, std::string>& md)
 {
 
   // prepare all info to be sent to CCDB for object obj

--- a/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
@@ -65,12 +65,12 @@ class DCSProcessor
   DCSProcessor() = default;
   ~DCSProcessor() = default;
 
-  void init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
-            const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
-            const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
-            const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries);
+  void init(const std::unordered_map<DPID, int>& dpidmapchars, const std::unordered_map<DPID, int>& dpidmapints,
+            const std::unordered_map<DPID, int>& dpidmapdoubles, const std::unordered_map<DPID, int>& dpidmapUints,
+            const std::unordered_map<DPID, int>& dpidmapbools, const std::unordered_map<DPID, int>& dpidmapstrings,
+            const std::unordered_map<DPID, int>& dpidmaptimes, const std::unordered_map<DPID, int>& dpidmapbinaries);
 
-  void init(const std::vector<DPID>& aliases);
+  void init(const std::unordered_map<DPID, int>& dpidmap);
 
   int processMap(const std::unordered_map<DPID, DPVAL>& map, bool isDelta = false);
 
@@ -80,8 +80,9 @@ class DCSProcessor
                                                                     const std::unordered_map<DPID, DPVAL>& map);
 
   template <typename T>
-  int processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
-                       std::vector<int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
+  int processArrayType(const std::unordered_map<DPID, int>& array, DeliveryType type,
+                       const std::unordered_map<DPID, DPVAL>& map,
+                       std::unordered_map<DPID, int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
 
   template <typename T>
   void checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
@@ -152,22 +153,22 @@ class DCSProcessor
   std::unordered_map<DPID, DQStrings> mDpsstringsmap;
   std::unordered_map<DPID, DQTimes> mDpstimesmap;
   std::unordered_map<DPID, DQBinaries> mDpsbinariesmap;
-  std::vector<DPID> mAliaseschars;
-  std::vector<DPID> mAliasesints;
-  std::vector<DPID> mAliasesdoubles;
-  std::vector<DPID> mAliasesUints;
-  std::vector<DPID> mAliasesbools;
-  std::vector<DPID> mAliasesstrings;
-  std::vector<DPID> mAliasestimes;
-  std::vector<DPID> mAliasesbinaries;
-  std::vector<int64_t> mLatestTimestampchars;
-  std::vector<int64_t> mLatestTimestampints;
-  std::vector<int64_t> mLatestTimestampdoubles;
-  std::vector<int64_t> mLatestTimestampUints;
-  std::vector<int64_t> mLatestTimestampbools;
-  std::vector<int64_t> mLatestTimestampstrings;
-  std::vector<int64_t> mLatestTimestamptimes;
-  std::vector<int64_t> mLatestTimestampbinaries;
+  std::unordered_map<DPID, int> mMapchars;
+  std::unordered_map<DPID, int> mMapints;
+  std::unordered_map<DPID, int> mMapdoubles;
+  std::unordered_map<DPID, int> mMapUints;
+  std::unordered_map<DPID, int> mMapbools;
+  std::unordered_map<DPID, int> mMapstrings;
+  std::unordered_map<DPID, int> mMaptimes;
+  std::unordered_map<DPID, int> mMapbinaries;
+  std::unordered_map<DPID, int64_t> mLatestTimestampchars;
+  std::unordered_map<DPID, int64_t> mLatestTimestampints;
+  std::unordered_map<DPID, int64_t> mLatestTimestampdoubles;
+  std::unordered_map<DPID, int64_t> mLatestTimestampUints;
+  std::unordered_map<DPID, int64_t> mLatestTimestampbools;
+  std::unordered_map<DPID, int64_t> mLatestTimestampstrings;
+  std::unordered_map<DPID, int64_t> mLatestTimestamptimes;
+  std::unordered_map<DPID, int64_t> mLatestTimestampbinaries;
   int mNThreads = 1;                                               // number of  threads
   std::unordered_map<std::string, float> mccdbSimpleMovingAverage; // unordered map in which to store the CCDB entry
                                                                    // for the DPs for which we calculated the simple
@@ -195,9 +196,9 @@ using DPID = o2::dcs::DataPointIdentifier;
 using DPVAL = o2::dcs::DataPointValue;
 
 template <typename T>
-int DCSProcessor::processArrayType(const std::vector<DPID>& array,
+int DCSProcessor::processArrayType(const std::unordered_map<DPID, int>& mapDPid,
                                    DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
-                                   std::vector<int64_t>& latestTimeStamp,
+                                   std::unordered_map<DPID, int64_t>& latestTimeStamp,
                                    std::unordered_map<DPID, std::deque<T>>& destmap)
 {
 
@@ -208,33 +209,33 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array,
   //omp_set_num_threads(mNThreads);
   //#pragma omp parallel for schedule(dynamic)
   //#endif
-  for (size_t i = 0; i != array.size(); ++i) {
-    auto it = findAndCheckAlias(array[i], type, map);
+  for (const auto& el : mapDPid) {
+    auto it = findAndCheckAlias(el.first, type, map);
     if (it == map.end()) {
       if (!mIsDelta) {
-        LOG(ERROR) << "Element " << array[i] << " not found " << std::endl;
+        LOG(ERROR) << "Element " << el.first << " not found " << std::endl;
       }
       continue;
     }
     found++;
     std::pair<DPID, DPVAL> pairIt = *it;
-    checkFlagsAndFill(pairIt, latestTimeStamp[i], destmap);
+    checkFlagsAndFill(pairIt, latestTimeStamp[pairIt.first], destmap);
     if (type == RAW_CHAR) {
-      processCharDP(array[i]);
+      processCharDP(el.first);
     } else if (type == RAW_INT) {
-      processIntDP(array[i]);
+      processIntDP(el.first);
     } else if (type == RAW_DOUBLE) {
-      processDoubleDP(array[i]);
+      processDoubleDP(el.first);
     } else if (type == RAW_UINT) {
-      processUIntDP(array[i]);
+      processUIntDP(el.first);
     } else if (type == RAW_BOOL) {
-      processBoolDP(array[i]);
+      processBoolDP(el.first);
     } else if (type == RAW_STRING) {
-      processStringDP(array[i]);
+      processStringDP(el.first);
     } else if (type == RAW_TIME) {
-      processTimeDP(array[i]);
+      processTimeDP(el.first);
     } else if (type == RAW_BINARY) {
-      processBinaryDP(array[i]);
+      processBinaryDP(el.first);
     }
     // todo: better to move the "found++" after the process, in case it fails?
   }

--- a/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSProcessor.h
@@ -65,50 +65,50 @@ class DCSProcessor
   DCSProcessor() = default;
   ~DCSProcessor() = default;
 
-  void init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
-            const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
-            const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
-            const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries);
+  void init(const std::vector<DPID>& pidschars, const std::vector<DPID>& pidsints,
+            const std::vector<DPID>& pidsdoubles, const std::vector<DPID>& pidsUints,
+            const std::vector<DPID>& pidsbools, const std::vector<DPID>& pidsstrings,
+            const std::vector<DPID>& pidstimes, const std::vector<DPID>& pidsbinaries);
 
-  void init(const std::vector<DPID>& aliases);
+  void init(const std::vector<DPID>& pids);
 
   int processMap(const std::unordered_map<DPID, DPVAL>& map, bool isDelta = false);
 
   int processDP(const std::pair<DPID, DPVAL>& dpcom);
 
-  std::unordered_map<DPID, DPVAL>::const_iterator findAndCheckAlias(const DPID& alias, DeliveryType type,
-                                                                    const std::unordered_map<DPID, DPVAL>& map);
+  std::unordered_map<DPID, DPVAL>::const_iterator findAndCheckPid(const DPID& pid, DeliveryType type,
+                                                                  const std::unordered_map<DPID, DPVAL>& map);
 
   template <typename T>
   int processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
-                       std::vector<int64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
+                       std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DPID, std::deque<T>>& destmap);
 
   template <typename T>
-  void checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+  void checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                          std::unordered_map<DPID, T>& destmap);
 
-  virtual void processCharDP(const DPID& alias);
-  virtual void processIntDP(const DPID& alias);
-  virtual void processDoubleDP(const DPID& alias);
-  virtual void processUIntDP(const DPID& alias);
-  virtual void processBoolDP(const DPID& alias);
-  virtual void processStringDP(const DPID& alias);
-  virtual void processTimeDP(const DPID& alias);
-  virtual void processBinaryDP(const DPID& alias);
+  virtual void processCharDP(const DPID& pid);
+  virtual void processIntDP(const DPID& pid);
+  virtual void processDoubleDP(const DPID& pid);
+  virtual void processUIntDP(const DPID& pid);
+  virtual void processBoolDP(const DPID& pid);
+  virtual void processStringDP(const DPID& pid);
+  virtual void processTimeDP(const DPID& pid);
+  virtual void processBinaryDP(const DPID& pid);
 
-  virtual uint64_t processFlag(uint64_t flag, const char* alias);
+  virtual uint64_t processFlag(uint64_t flag, const char* pid);
 
   template <typename T>
   void doSimpleMovingAverage(int nelements, std::deque<T>& vect, float& avg, bool& isSMA);
 
-  DQChars& getVectorForAliasChar(const DPID& id) { return mDpscharsmap[id]; }
-  DQInts& getVectorForAliasInt(const DPID& id) { return mDpsintsmap[id]; }
-  DQDoubles& getVectorForAliasDouble(const DPID& id) { return mDpsdoublesmap[id]; }
-  DQUInts& getVectorForAliasUInt(const DPID& id) { return mDpsUintsmap[id]; }
-  DQBools& getVectorForAliasBool(const DPID& id) { return mDpsboolsmap[id]; }
-  DQStrings& getVectorForAliasString(const DPID& id) { return mDpsstringsmap[id]; }
-  DQTimes& getVectorForAliasTime(const DPID& id) { return mDpstimesmap[id]; }
-  DQBinaries& getVectorForAliasBinary(const DPID& id) { return mDpsbinariesmap[id]; }
+  DQChars& getVectorForPidChar(const DPID& id) { return mDpscharsmap[id]; }
+  DQInts& getVectorForPidInt(const DPID& id) { return mDpsintsmap[id]; }
+  DQDoubles& getVectorForPidDouble(const DPID& id) { return mDpsdoublesmap[id]; }
+  DQUInts& getVectorForPidUInt(const DPID& id) { return mDpsUintsmap[id]; }
+  DQBools& getVectorForPidBool(const DPID& id) { return mDpsboolsmap[id]; }
+  DQStrings& getVectorForPidString(const DPID& id) { return mDpsstringsmap[id]; }
+  DQTimes& getVectorForPidTime(const DPID& id) { return mDpstimesmap[id]; }
+  DQBinaries& getVectorForPidBinary(const DPID& id) { return mDpsbinariesmap[id]; }
 
   void setNThreads(int n);
   int getNThreads() const { return mNThreads; }
@@ -152,22 +152,24 @@ class DCSProcessor
   std::unordered_map<DPID, DQStrings> mDpsstringsmap;
   std::unordered_map<DPID, DQTimes> mDpstimesmap;
   std::unordered_map<DPID, DQBinaries> mDpsbinariesmap;
-  std::vector<DPID> mAliaseschars;
-  std::vector<DPID> mAliasesints;
-  std::vector<DPID> mAliasesdoubles;
-  std::vector<DPID> mAliasesUints;
-  std::vector<DPID> mAliasesbools;
-  std::vector<DPID> mAliasesstrings;
-  std::vector<DPID> mAliasestimes;
-  std::vector<DPID> mAliasesbinaries;
-  std::vector<int64_t> mLatestTimestampchars;
-  std::vector<int64_t> mLatestTimestampints;
-  std::vector<int64_t> mLatestTimestampdoubles;
-  std::vector<int64_t> mLatestTimestampUints;
-  std::vector<int64_t> mLatestTimestampbools;
-  std::vector<int64_t> mLatestTimestampstrings;
-  std::vector<int64_t> mLatestTimestamptimes;
-  std::vector<int64_t> mLatestTimestampbinaries;
+  std::vector<DPID> mPidschars;
+  std::vector<DPID> mPidsints;
+  std::vector<DPID> mPidsdoubles;
+  std::vector<DPID> mPidsUints;
+  std::vector<DPID> mPidsbools;
+  std::vector<DPID> mPidsstrings;
+  std::vector<DPID> mPidstimes;
+  std::vector<DPID> mPidsbinaries;
+  std::unordered_map<DPID, int> mPids; // contains all PIDs for the current processor; the value correspond to the index
+                                       // in the mPidschars/ints/doubles.. vectors
+  std::vector<uint64_t> mLatestTimestampchars;
+  std::vector<uint64_t> mLatestTimestampints;
+  std::vector<uint64_t> mLatestTimestampdoubles;
+  std::vector<uint64_t> mLatestTimestampUints;
+  std::vector<uint64_t> mLatestTimestampbools;
+  std::vector<uint64_t> mLatestTimestampstrings;
+  std::vector<uint64_t> mLatestTimestamptimes;
+  std::vector<uint64_t> mLatestTimestampbinaries;
   int mNThreads = 1;                                               // number of  threads
   std::unordered_map<std::string, float> mccdbSimpleMovingAverage; // unordered map in which to store the CCDB entry
                                                                    // for the DPs for which we calculated the simple
@@ -197,7 +199,7 @@ using DPVAL = o2::dcs::DataPointValue;
 template <typename T>
 int DCSProcessor::processArrayType(const std::vector<DPID>& array,
                                    DeliveryType type, const std::unordered_map<DPID, DPVAL>& map,
-                                   std::vector<int64_t>& latestTimeStamp,
+                                   std::vector<uint64_t>& latestTimeStamp,
                                    std::unordered_map<DPID, std::deque<T>>& destmap)
 {
 
@@ -209,7 +211,7 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array,
   //#pragma omp parallel for schedule(dynamic)
   //#endif
   for (size_t i = 0; i != array.size(); ++i) {
-    auto it = findAndCheckAlias(array[i], type, map);
+    auto it = findAndCheckPid(array[i], type, map);
     if (it == map.end()) {
       if (!mIsDelta) {
         LOG(ERROR) << "Element " << array[i] << " not found " << std::endl;
@@ -244,7 +246,7 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array,
 //______________________________________________________________________
 
 template <typename T>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                                      std::unordered_map<DPID, T>& destmap)
 {
 
@@ -257,7 +259,7 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
     auto etime = val.get_epoch_time();
     // fill only if new value has a timestamp different from the timestamp of the previous one
     LOG(DEBUG) << "destmap[pid].size() = " << destmap[dpid].size();
-    if (destmap[dpid].size() == 0 || etime != std::abs(latestTimeStamp)) {
+    if (destmap[dpid].size() == 0 || etime != latestTimeStamp) {
       LOG(DEBUG) << "adding new value";
       destmap[dpid].push_back(val.payload_pt1);
       latestTimeStamp = etime;
@@ -268,13 +270,13 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                                      std::unordered_map<DPID, DCSProcessor::DQStrings>& destmap);
 
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                                      std::unordered_map<DPID, DCSProcessor::DQBinaries>& destmap);
 
 //______________________________________________________________________

--- a/Detectors/DCS/include/DetectorsDCS/DataPointValue.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointValue.h
@@ -408,7 +408,13 @@ struct alignas(64) DataPointValue final {
         break;
       case RAW_STRING:
       case DPVAL_STRING:
-        std::strncpy((char*)&payload_pt1, (char*)data, 56);
+        std::strncpy((char*)&payload_pt1, (char*)data, 8);
+        std::strncpy((char*)&payload_pt2, (char*)data + 8, 8);
+        std::strncpy((char*)&payload_pt3, (char*)data + 16, 8);
+        std::strncpy((char*)&payload_pt4, (char*)data + 24, 8);
+        std::strncpy((char*)&payload_pt5, (char*)data + 32, 8);
+        std::strncpy((char*)&payload_pt6, (char*)data + 40, 8);
+        std::strncpy((char*)&payload_pt7, (char*)data + 48, 8);
         break;
       case RAW_BINARY:
       case DPVAL_BINARY:

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -23,8 +23,9 @@ using DPVAL = o2::dcs::DataPointValue;
 
 //ClassImp(o2::dcs::DCSProcessor);
 
-void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints, const std::vector<DPID>& aliasesdoubles,
-                        const std::vector<DPID>& aliasesUints, const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
+void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
+                        const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
+                        const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
                         const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries)
 {
 
@@ -192,7 +193,8 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
   foundInts = processArrayType(mAliasesints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
 
   // double type
-  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles, mDpsdoublesmap);
+  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
+                                  mDpsdoublesmap);
 
   // UInt type
   foundUInts = processArrayType(mAliasesUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
@@ -201,13 +203,15 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
   foundBools = processArrayType(mAliasesbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
 
   // String type
-  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings, mDpsstringsmap);
+  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
+                                  mDpsstringsmap);
 
   // Time type
   foundTimes = processArrayType(mAliasestimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
 
   // Binary type
-  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries, mDpsbinariesmap);
+  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
+                                   mDpsbinariesmap);
 
   if (!isDelta) {
     if (foundChars != mAliaseschars.size())
@@ -230,7 +234,8 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
 
   // filling CCDB info to be sent in output
   std::map<std::string, std::string> md;
-  prepareCCDBobject(mccdbSimpleMovingAverage, mccdbSimpleMovingAverageInfo, mName + "/TestDCS/SimpleMovingAverageDPs", mTF, md);
+  prepareCCDBobject(mccdbSimpleMovingAverage, mccdbSimpleMovingAverageInfo,
+                    mName + "/TestDCS/SimpleMovingAverageDPs", mTF, md);
 
   LOG(DEBUG) << "Size of unordered_map for CCDB = " << mccdbSimpleMovingAverage.size();
   LOG(DEBUG) << "CCDB entry for TF " << mTF << " will be:";
@@ -346,7 +351,8 @@ int DCSProcessor::processDP(const std::pair<DPID, DPVAL>& dpcom)
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, DQStrings>& destmap)
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                                     std::unordered_map<DPID, DQStrings>& destmap)
 {
 
   // check the flags for the upcoming data, and if ok, fill the accumulator
@@ -369,7 +375,8 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp, std::unordered_map<DPID, DQBinaries>& destmap)
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+                                     std::unordered_map<DPID, DQBinaries>& destmap)
 {
 
   // check the flags for the upcoming data, and if ok, fill the accumulator
@@ -462,7 +469,10 @@ void DCSProcessor::processBinaryDP(const DPID& alias)
 
 //______________________________________________________________________
 
-std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckAlias(const DPID& alias, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map)
+std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckAlias(const DPID& alias,
+                                                                                DeliveryType type,
+                                                                                const std::unordered_map<DPID, DPVAL>&
+                                                                                  map)
 {
 
   // processing basic checks for map: all needed aliases must be present
@@ -472,7 +482,8 @@ std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckAlias(
   auto it = map.find(alias);
   DeliveryType tt = alias.get_type();
   if (tt != type) {
-    LOG(FATAL) << "Delivery Type of alias " << alias.get_alias() << " does not match definition in DCSProcessor (" << type << ")! Please fix";
+    LOG(FATAL) << "Delivery Type of alias " << alias.get_alias() << " does not match definition in DCSProcessor ("
+               << type << ")! Please fix";
   }
   return it;
 }

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -100,6 +100,7 @@ void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector
   mLatestTimestampstrings.resize(aliasesstrings.size(), 0);
   mLatestTimestamptimes.resize(aliasestimes.size(), 0);
   mLatestTimestampbinaries.resize(aliasesbinaries.size(), 0);
+  mAvgTestInt.resize(aliasesints.size(), 0);
 }
 
 //______________________________________________________________________
@@ -152,6 +153,7 @@ void DCSProcessor::init(const std::vector<DPID>& aliases)
   mLatestTimestampstrings.resize(nstrings, 0);
   mLatestTimestamptimes.resize(ntimes, 0);
   mLatestTimestampbinaries.resize(nbinaries, 0);
+  mAvgTestInt.resize(nints, 0);
 }
 
 //__________________________________________________________________
@@ -249,7 +251,7 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType 
       if (processFlag(flags, array[i].get_alias()) == 0) {
         auto etime = val.get_epoch_time();
         // fill only if new value has a timestamp different from the timestamp of the previous one
-        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        LOG(DEBUG) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
         if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
           auto& tmp = destmap[array[i]].emplace_back();
           std::strncpy(tmp.data(), (char*)&(val.payload_pt1), 56);
@@ -284,7 +286,7 @@ int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType 
       if (processFlag(flags, array[i].get_alias()) == 0) {
         auto etime = val.get_epoch_time();
         // fill only if new value has a timestamp different from the timestamp of the previous one
-        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        LOG(DEBUG) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
         if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
           auto& tmp = destmap[array[i]].emplace_back();
           memcpy(tmp.data(), &(val.payload_pt1), 7);
@@ -303,7 +305,7 @@ std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::processAlias(const
 
   // processing basic checks for map: all needed aliases must be present
 
-  LOG(INFO) << "Processing " << alias;
+  LOG(DEBUG) << "Processing " << alias;
   auto it = map.find(alias);
   DeliveryType tt = alias.get_type();
   if (tt != type) {
@@ -320,12 +322,12 @@ void DCSProcessor::processChars()
   // function to process aliases of Char type; it will just print them
 
   for (size_t i = 0; i != mAliaseschars.size(); ++i) {
-    LOG(INFO) << "processChars: mAliaseschars[" << i << "] = " << mAliaseschars[i];
+    LOG(DEBUG) << "processChars: mAliaseschars[" << i << "] = " << mAliaseschars[i];
     auto& id = mAliaseschars[i];
     auto& vchar = getVectorForAliasChar(id);
-    LOG(INFO) << "vchar size = " << vchar.size();
+    LOG(DEBUG) << "vchar size = " << vchar.size();
     for (size_t j = 0; j < vchar.size(); j++) {
-      LOG(INFO) << "DP = " << mAliaseschars[i] << " , value[" << j << "] = " << vchar[j];
+      LOG(DEBUG) << "DP = " << mAliaseschars[i] << " , value[" << j << "] = " << vchar[j];
     }
   }
 }
@@ -338,21 +340,19 @@ void DCSProcessor::processInts()
   // function to process aliases of Int type
 
   for (size_t i = 0; i != mAliasesints.size(); ++i) {
-    LOG(INFO) << "processInts: mAliasesints[" << i << "] = " << mAliasesints[i];
+    LOG(DEBUG) << "processInts: mAliasesints[" << i << "] = " << mAliasesints[i];
     auto& id = mAliasesints[i];
     auto& vint = getVectorForAliasInt(id);
-    LOG(INFO) << "vint size = " << vint.size();
+    LOG(DEBUG) << "vint size = " << vint.size();
     for (size_t j = 0; j < vint.size(); j++) {
-      LOG(INFO) << "DP = " << mAliasesints[i] << " , value[" << j << "] = " << vint[j];
+      LOG(DEBUG) << "DP = " << mAliasesints[i] << " , value[" << j << "] = " << vint[j];
     }
     bool isSMA = false;
-    LOG(INFO) << "get alias = " << id.get_alias();
-    if (strcmp(id.get_alias(), "TestInt_0") == 0) {
-      doSimpleMovingAverage(2, vint, mAvgTestInt0, isSMA);
-      LOG(INFO) << "Moving average = " << mAvgTestInt0;
-      if (isSMA) {
-        // populate CCDB
-      }
+    LOG(DEBUG) << "get alias = " << id.get_alias();
+    doSimpleMovingAverage(2, vint, mAvgTestInt[i], isSMA);
+    LOG(DEBUG) << "Moving average = " << mAvgTestInt[i];
+    if (isSMA) {
+      // populate CCDB
     }
   }
 }

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -23,138 +23,140 @@ using DPVAL = o2::dcs::DataPointValue;
 
 //ClassImp(o2::dcs::DCSProcessor);
 
-void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
-                        const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
-                        const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
-                        const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries)
+void DCSProcessor::init(const std::unordered_map<DPID, int>& dpidmapchars,
+                        const std::unordered_map<DPID, int>& dpidmapints,
+                        const std::unordered_map<DPID, int>& dpidmapdoubles,
+                        const std::unordered_map<DPID, int>& dpidmapUints,
+                        const std::unordered_map<DPID, int>& dpidmapbools,
+                        const std::unordered_map<DPID, int>& dpidmapstrings,
+                        const std::unordered_map<DPID, int>& dpidmaptimes,
+                        const std::unordered_map<DPID, int>& dpidmapbinaries)
 {
 
   // init from separate vectors of aliases (one per data point type)
 
   // chars
-  for (auto it = std::begin(aliaseschars); it != std::end(aliaseschars); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_CHAR) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a char";
+  for (const auto& el : dpidmapchars) {
+    if ((el.first).get_type() != DeliveryType::RAW_CHAR) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a char";
     }
-    mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+    mMapchars[el.first] = el.second;
+    mLatestTimestampchars[el.first] = 0;
   }
 
   // ints
-  for (auto it = std::begin(aliasesints); it != std::end(aliasesints); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_INT) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a int";
+  for (const auto& el : dpidmapints) {
+    if ((el.first).get_type() != DeliveryType::RAW_INT) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a int";
     }
-    mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+    mMapints[el.first] = el.second;
+    mLatestTimestampints[el.first] = 0;
   }
 
   // doubles
-  for (auto it = std::begin(aliasesdoubles); it != std::end(aliasesdoubles); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_DOUBLE) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a double";
+  for (const auto& el : dpidmapdoubles) {
+    if ((el.first).get_type() != DeliveryType::RAW_DOUBLE) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a double";
     }
-    mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+    mMapdoubles[el.first] = el.second;
+    mLatestTimestampdoubles[el.first] = 0;
   }
 
   // uints
-  for (auto it = std::begin(aliasesUints); it != std::end(aliasesUints); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_UINT) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a uint";
+  for (const auto& el : dpidmapUints) {
+    if ((el.first).get_type() != DeliveryType::RAW_UINT) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a uint";
     }
-    mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+    mMapUints[el.first] = el.second;
+    mLatestTimestampUints[el.first] = 0;
   }
 
   // bools
-  for (auto it = std::begin(aliasesbools); it != std::end(aliasesbools); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_BOOL) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a bool";
+  for (const auto& el : dpidmapbools) {
+    if ((el.first).get_type() != DeliveryType::RAW_BOOL) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a bool";
     }
-    mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+    mMapbools[el.first] = el.second;
+    mLatestTimestampbools[el.first] = 0;
   }
 
   // strings
-  for (auto it = std::begin(aliasesstrings); it != std::end(aliasesstrings); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_STRING) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a string";
+  for (const auto& el : dpidmapstrings) {
+    if ((el.first).get_type() != DeliveryType::RAW_STRING) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a string";
     }
-    mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+    mMapstrings[el.first] = el.second;
+    mLatestTimestampstrings[el.first] = 0;
   }
 
   // times
-  for (auto it = std::begin(aliasestimes); it != std::end(aliasestimes); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_TIME) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a time";
+  for (const auto& el : dpidmaptimes) {
+    if ((el.first).get_type() != DeliveryType::RAW_TIME) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a time";
     }
-    mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+    mMaptimes[el.first] = el.second;
+    mLatestTimestamptimes[el.first] = 0;
   }
 
   // binaries
-  for (auto it = std::begin(aliasesbinaries); it != std::end(aliasesbinaries); ++it) {
-    if ((*it).get_type() != DeliveryType::RAW_BINARY) {
-      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a binary";
+  for (const auto& el : dpidmapbinaries) {
+    if ((el.first).get_type() != DeliveryType::RAW_BINARY) {
+      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a binary";
     }
-    mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+    mMapbinaries[el.first] = el.second;
+    mLatestTimestampbinaries[el.first] = 0;
   }
-
-  mLatestTimestampchars.resize(aliaseschars.size(), 0);
-  mLatestTimestampints.resize(aliasesints.size(), 0);
-  mLatestTimestampdoubles.resize(aliasesdoubles.size(), 0);
-  mLatestTimestampUints.resize(aliasesUints.size(), 0);
-  mLatestTimestampbools.resize(aliasesbools.size(), 0);
-  mLatestTimestampstrings.resize(aliasesstrings.size(), 0);
-  mLatestTimestamptimes.resize(aliasestimes.size(), 0);
-  mLatestTimestampbinaries.resize(aliasesbinaries.size(), 0);
 }
 
 //______________________________________________________________________
 
-void DCSProcessor::init(const std::vector<DPID>& aliases)
+void DCSProcessor::init(const std::unordered_map<DPID, int>& dpidmap)
 {
 
   int nchars = 0, nints = 0, ndoubles = 0, nUints = 0,
       nbools = 0, nstrings = 0, ntimes = 0, nbinaries = 0;
-  for (auto it = std::begin(aliases); it != std::end(aliases); ++it) {
-    if ((*it).get_type() == DeliveryType::RAW_CHAR) {
-      mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+  for (const auto& el : dpidmap) {
+    if ((el.first).get_type() == DeliveryType::RAW_CHAR) {
+      mMapchars[el.first] = el.second;
+      mLatestTimestampchars[el.first] = 0;
       nchars++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_INT) {
-      mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+    if ((el.first).get_type() == DeliveryType::RAW_INT) {
+      mMapints[el.first] = el.second;
+      mLatestTimestampints[el.first] = 0;
       nints++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_DOUBLE) {
-      mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+    if ((el.first).get_type() == DeliveryType::RAW_DOUBLE) {
+      mMapdoubles[el.first] = el.second;
+      mLatestTimestampdoubles[el.first] = 0;
       ndoubles++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_UINT) {
-      mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+    if ((el.first).get_type() == DeliveryType::RAW_UINT) {
+      mMapUints[el.first] = el.second;
+      mLatestTimestampUints[el.first] = 0;
       nUints++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_BOOL) {
-      mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+    if ((el.first).get_type() == DeliveryType::RAW_BOOL) {
+      mMapbools[el.first] = el.second;
+      mLatestTimestampbools[el.first] = 0;
       nbools++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_STRING) {
-      mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+    if ((el.first).get_type() == DeliveryType::RAW_STRING) {
+      mMapstrings[el.first] = el.second;
+      mLatestTimestampstrings[el.first] = 0;
       nstrings++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_TIME) {
-      mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+    if ((el.first).get_type() == DeliveryType::RAW_TIME) {
+      mMaptimes[el.first] = el.second;
+      mLatestTimestamptimes[el.first] = 0;
       ntimes++;
     }
-    if ((*it).get_type() == DeliveryType::RAW_BINARY) {
-      mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+    if ((el.first).get_type() == DeliveryType::RAW_BINARY) {
+      mMapbinaries[el.first] = el.second;
+      mLatestTimestampbinaries[el.first] = 0;
       nbinaries++;
     }
   }
-
-  mLatestTimestampchars.resize(nchars, 0);
-  mLatestTimestampints.resize(nints, 0);
-  mLatestTimestampdoubles.resize(ndoubles, 0);
-  mLatestTimestampUints.resize(nUints, 0);
-  mLatestTimestampbools.resize(nbools, 0);
-  mLatestTimestampstrings.resize(nstrings, 0);
-  mLatestTimestamptimes.resize(ntimes, 0);
-  mLatestTimestampbinaries.resize(nbinaries, 0);
 }
 
 //__________________________________________________________________
@@ -187,48 +189,48 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
       foundBools = 0, foundStrings = 0, foundTimes = 0, foundBinaries = 0;
 
   // char type
-  foundChars = processArrayType(mAliaseschars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
+  foundChars = processArrayType(mMapchars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
 
   // int type
-  foundInts = processArrayType(mAliasesints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
+  foundInts = processArrayType(mMapints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
 
   // double type
-  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
+  foundDoubles = processArrayType(mMapdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
                                   mDpsdoublesmap);
 
   // UInt type
-  foundUInts = processArrayType(mAliasesUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
+  foundUInts = processArrayType(mMapUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
 
   // Bool type
-  foundBools = processArrayType(mAliasesbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
+  foundBools = processArrayType(mMapbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
 
   // String type
-  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
+  foundStrings = processArrayType(mMapstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
                                   mDpsstringsmap);
 
   // Time type
-  foundTimes = processArrayType(mAliasestimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
+  foundTimes = processArrayType(mMaptimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
 
   // Binary type
-  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
+  foundBinaries = processArrayType(mMapbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
                                    mDpsbinariesmap);
 
   if (!isDelta) {
-    if (foundChars != mAliaseschars.size())
+    if (foundChars != mMapchars.size())
       LOG(INFO) << "Not all expected char-typed DPs found!";
-    if (foundInts != mAliasesints.size())
+    if (foundInts != mMapints.size())
       LOG(INFO) << "Not all expected int-typed DPs found!";
-    if (foundDoubles != mAliasesdoubles.size())
+    if (foundDoubles != mMapdoubles.size())
       LOG(INFO) << "Not all expected double-typed DPs found!";
-    if (foundUInts != mAliasesUints.size())
+    if (foundUInts != mMapUints.size())
       LOG(INFO) << "Not all expected uint-typed DPs found!";
-    if (foundBools != mAliasesbools.size())
+    if (foundBools != mMapbools.size())
       LOG(INFO) << "Not all expected bool-typed DPs found!";
-    if (foundStrings != mAliasesstrings.size())
+    if (foundStrings != mMapstrings.size())
       LOG(INFO) << "Not all expected string-typed DPs found!";
-    if (foundTimes != mAliasestimes.size())
+    if (foundTimes != mMaptimes.size())
       LOG(INFO) << "Not all expected time-typed DPs found!";
-    if (foundBinaries != mAliasesbinaries.size())
+    if (foundBinaries != mMapbinaries.size())
       LOG(INFO) << "Not all expected binary-typed DPs found!";
   }
 
@@ -258,90 +260,128 @@ int DCSProcessor::processDP(const std::pair<DPID, DPVAL>& dpcom)
 
   // first we check if the DP is in the list for the detector
   if (type == DeliveryType::RAW_CHAR) {
-    auto it = std::find(mAliaseschars.begin(), mAliaseschars.end(), dpid);
-    if (it == mAliaseschars.end()) {
+    auto el = mMapchars.find(dpid);
+    if (el == mMapchars.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliaseschars.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampchars[index], mDpscharsmap);
+    auto elTime = mLatestTimestampchars.find(dpid);
+    if (elTime == mLatestTimestampchars.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampchars[dpid], mDpscharsmap);
     processCharDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_INT) {
-    auto it = std::find(mAliasesints.begin(), mAliasesints.end(), dpid);
-    if (it == mAliasesints.end()) {
+    std::vector<int64_t> tmp;
+    tmp.resize(100, 0);
+    auto el = mMapints.find(dpid);
+    if (el == mMapints.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesints.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampints[index], mDpsintsmap);
+
+    auto elTime = mLatestTimestampints.find(dpid);
+    if (elTime == mLatestTimestampints.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+
+    checkFlagsAndFill(dpcom, (*elTime).second, mDpsintsmap);
+    //checkFlagsAndFill(dpcom, tmp[0], mDpsintsmap);
+    //checkFlagsAndFill(dpcom, mLatestTimestampints[dpid], mDpsintsmap);
     processIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_DOUBLE) {
-    auto it = std::find(mAliasesdoubles.begin(), mAliasesdoubles.end(), dpid);
-    if (it == mAliasesdoubles.end()) {
+    auto el = mMapdoubles.find(dpid);
+    if (el == mMapdoubles.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesdoubles.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[index], mDpsdoublesmap);
+    auto elTime = mLatestTimestampdoubles.find(dpid);
+    if (elTime == mLatestTimestampdoubles.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[dpid], mDpsdoublesmap);
     processDoubleDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_UINT) {
-    auto it = std::find(mAliasesUints.begin(), mAliasesUints.end(), dpid);
-    if (it == mAliasesUints.end()) {
+    auto el = mMapUints.find(dpid);
+    if (el == mMapUints.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesUints.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampUints[index], mDpsUintsmap);
+    auto elTime = mLatestTimestampUints.find(dpid);
+    if (elTime == mLatestTimestampUints.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampUints[dpid], mDpsUintsmap);
     processUIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BOOL) {
-    auto it = std::find(mAliasesbools.begin(), mAliasesbools.end(), dpid);
-    if (it == mAliasesbools.end()) {
+    auto el = mMapbools.find(dpid);
+    if (el == mMapbools.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesbools.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampbools[index], mDpsboolsmap);
+    auto elTime = mLatestTimestampbools.find(dpid);
+    if (elTime == mLatestTimestampbools.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampbools[dpid], mDpsboolsmap);
     processBoolDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_STRING) {
-    auto it = std::find(mAliasesstrings.begin(), mAliasesstrings.end(), dpid);
-    if (it == mAliasesstrings.end()) {
+    auto el = mMapstrings.find(dpid);
+    if (el == mMapstrings.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesstrings.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampstrings[index], mDpsstringsmap);
+    auto elTime = mLatestTimestampstrings.find(dpid);
+    if (elTime == mLatestTimestampstrings.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampstrings[dpid], mDpsstringsmap);
     processStringDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_TIME) {
-    auto it = std::find(mAliasestimes.begin(), mAliasestimes.end(), dpid);
-    if (it == mAliasestimes.end()) {
+    auto el = mMaptimes.find(dpid);
+    if (el == mMaptimes.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasestimes.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestamptimes[index], mDpstimesmap);
+    auto elTime = mLatestTimestamptimes.find(dpid);
+    if (elTime == mLatestTimestamptimes.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestamptimes[dpid], mDpstimesmap);
     processTimeDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BINARY) {
-    auto it = std::find(mAliasesbinaries.begin(), mAliasesbinaries.end(), dpid);
-    if (it == mAliasesbinaries.end()) {
+    auto el = mMapbinaries.find(dpid);
+    if (el == mMapbinaries.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    int index = std::distance(mAliasesbinaries.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[index], mDpsbinariesmap);
+    auto elTime = mLatestTimestampbinaries.find(dpid);
+    if (elTime == mLatestTimestampbinaries.end()) {
+      LOG(ERROR) << "Timestamp not found for this DP, please check";
+      return 1;
+    }
+    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[dpid], mDpsbinariesmap);
     processBinaryDP(dpid);
   }
 

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -347,7 +347,7 @@ void DCSProcessor::processInts()
     }
     bool isSMA = false;
     LOG(INFO) << "get alias = " << id.get_alias();
-    if (strcmp(id.get_alias(), "TestInt0") == 0) {
+    if (strcmp(id.get_alias(), "TestInt_0") == 0) {
       doSimpleMovingAverage(2, vint, mAvgTestInt0, isSMA);
       LOG(INFO) << "Moving average = " << mAvgTestInt0;
       if (isSMA) {

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -163,7 +163,10 @@ int DCSProcessor::process(const std::unordered_map<DPID, DPVAL>& map)
 
   // process function to do "something" with the DCS map that is passed
 
-  // first, we need to check if there are the Data Points that we need
+  // resetting the content of the CCDB object to be sent
+  mccdbInt.clear();
+
+  // we need to check if there are the Data Points that we need
 
   int foundChars = 0, foundInts = 0, foundDoubles = 0, foundUInts = 0,
       foundBools = 0, foundStrings = 0, foundTimes = 0, foundBinaries = 0;
@@ -353,32 +356,14 @@ void DCSProcessor::processInts()
     doSimpleMovingAverage(2, vint, mAvgTestInt[i], isSMA);
     LOG(DEBUG) << "Moving average = " << mAvgTestInt[i];
     if (isSMA) {
-      // populate CCDB
+      // create CCDB object
+      mccdbInt[id.get_alias()] = mAvgTestInt[i];
     }
   }
+  std::map<std::string, std::string> md;
+  prepareCCDBobject(mccdbInt, mccdbIntInfo, "TestDCS/IntDPs", mTF, md);
 }
 
-//______________________________________________________________________
-/*
-void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<int>& vect, float& avg, bool& isSMA)
-{
-
-  // Do simple moving average on vector of ints
-  if (vect.size() < nelements) {
-    avg += vect[vect.size() - 1];
-    return;
-  }
-  if (vect.size() == nelements) {
-    avg += vect[vect.size() - 1];
-    avg /= nelements;
-    isSMA = true;
-    return;
-  }
-  avg += (vect[vect.size() - 1] - vect[0]) / nelements;
-  vect.pop_front();
-  isSMA = true;
-}
-*/
 //______________________________________________________________________
 
 void DCSProcessor::processDoubles()
@@ -489,10 +474,11 @@ uint64_t DCSProcessor::processFlag(const uint64_t flags, const char* alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::setNThreads(int n) {
+void DCSProcessor::setNThreads(int n)
+{
 
   // to set number of threads used to process the DPs
-  
+
 #ifdef WITH_OPENMP
   mNThreads = n > 0 ? n : 1;
 #else

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -1,0 +1,487 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <DetectorsDCS/DCSProcessor.h>
+#include "Rtypes.h"
+#include <deque>
+#include <string.h>
+
+using namespace o2::dcs;
+
+using DeliveryType = o2::dcs::DeliveryType;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+
+//ClassImp(o2::dcs::DCSProcessor);
+
+void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints, const std::vector<DPID>& aliasesdoubles,
+                        const std::vector<DPID>& aliasesUints, const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
+                        const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries)
+{
+
+  // init from separate vectors of aliases (one per data point type)
+
+  // chars
+  for (auto it = std::begin(aliaseschars); it != std::end(aliaseschars); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_CHAR) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a char";
+    }
+    mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+  }
+
+  // ints
+  for (auto it = std::begin(aliasesints); it != std::end(aliasesints); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_INT) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a int";
+    }
+    mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+  }
+
+  // doubles
+  for (auto it = std::begin(aliasesdoubles); it != std::end(aliasesdoubles); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_DOUBLE) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a double";
+    }
+    mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+  }
+
+  // uints
+  for (auto it = std::begin(aliasesUints); it != std::end(aliasesUints); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_UINT) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a uint";
+    }
+    mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+  }
+
+  // bools
+  for (auto it = std::begin(aliasesbools); it != std::end(aliasesbools); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_BOOL) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a bool";
+    }
+    mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+  }
+
+  // strings
+  for (auto it = std::begin(aliasesstrings); it != std::end(aliasesstrings); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_STRING) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a string";
+    }
+    mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+  }
+
+  // times
+  for (auto it = std::begin(aliasestimes); it != std::end(aliasestimes); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_TIME) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a time";
+    }
+    mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+  }
+
+  // binaries
+  for (auto it = std::begin(aliasesbinaries); it != std::end(aliasesbinaries); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_BINARY) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a binary";
+    }
+    mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+  }
+
+  mLatestTimestampchars.resize(aliaseschars.size(), 0);
+  mLatestTimestampints.resize(aliasesints.size(), 0);
+  mLatestTimestampdoubles.resize(aliasesdoubles.size(), 0);
+  mLatestTimestampUints.resize(aliasesUints.size(), 0);
+  mLatestTimestampbools.resize(aliasesbools.size(), 0);
+  mLatestTimestampstrings.resize(aliasesstrings.size(), 0);
+  mLatestTimestamptimes.resize(aliasestimes.size(), 0);
+  mLatestTimestampbinaries.resize(aliasesbinaries.size(), 0);
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::init(const std::vector<DPID>& aliases)
+{
+
+  int nchars = 0, nints = 0, ndoubles = 0, nUints = 0,
+      nbools = 0, nstrings = 0, ntimes = 0, nbinaries = 0;
+  for (auto it = std::begin(aliases); it != std::end(aliases); ++it) {
+    if ((*it).get_type() == DeliveryType::RAW_CHAR) {
+      mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+      nchars++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_INT) {
+      mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+      nints++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_DOUBLE) {
+      mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+      ndoubles++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_UINT) {
+      mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+      nUints++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_BOOL) {
+      mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+      nbools++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_STRING) {
+      mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+      nstrings++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_TIME) {
+      mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+      ntimes++;
+    }
+    if ((*it).get_type() == DeliveryType::RAW_BINARY) {
+      mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+      nbinaries++;
+    }
+  }
+
+  mLatestTimestampchars.resize(nchars, 0);
+  mLatestTimestampints.resize(nints, 0);
+  mLatestTimestampdoubles.resize(ndoubles, 0);
+  mLatestTimestampUints.resize(nUints, 0);
+  mLatestTimestampbools.resize(nbools, 0);
+  mLatestTimestampstrings.resize(nstrings, 0);
+  mLatestTimestamptimes.resize(ntimes, 0);
+  mLatestTimestampbinaries.resize(nbinaries, 0);
+}
+
+//__________________________________________________________________
+
+int DCSProcessor::process(const std::unordered_map<DPID, DPVAL>& map)
+{
+
+  // process function to do "something" with the DCS map that is passed
+
+  // first, we need to check if there are the Data Points that we need
+
+  int foundChars = 0, foundInts = 0, foundDoubles = 0, foundUInts = 0,
+      foundBools = 0, foundStrings = 0, foundTimes = 0, foundBinaries = 0;
+
+  // char type
+  foundChars = processArrayType(mAliaseschars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
+  if (foundChars > 0)
+    processChars();
+
+  // int type
+  foundInts = processArrayType(mAliasesints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
+  if (foundInts > 0)
+    processInts();
+
+  // double type
+  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles, mDpsdoublesmap);
+  if (foundDoubles > 0)
+    processDoubles();
+
+  // UInt type
+  foundUInts = processArrayType(mAliasesUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
+  if (foundUInts > 0)
+    processUInts();
+
+  // Bool type
+  foundBools = processArrayType(mAliasesbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
+  if (foundBools > 0)
+    processBools();
+
+  // String type
+  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings, mDpsstringsmap);
+  if (foundStrings > 0)
+    processStrings();
+
+  // Time type
+  foundTimes = processArrayType(mAliasestimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
+  if (foundTimes > 0)
+    processTimes();
+
+  // Binary type
+  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries, mDpsbinariesmap);
+  if (foundBinaries > 0)
+    processBinaries();
+
+  if (foundChars != mAliaseschars.size())
+    LOG(INFO) << "Not all expected char-typed DPs found!";
+  if (foundInts != mAliasesints.size())
+    LOG(INFO) << "Not all expected int-typed DPs found!";
+  if (foundDoubles != mAliasesdoubles.size())
+    LOG(INFO) << "Not all expected double-typed DPs found!";
+  if (foundUInts != mAliasesUints.size())
+    LOG(INFO) << "Not all expected uint-typed DPs found!";
+  if (foundBools != mAliasesbools.size())
+    LOG(INFO) << "Not all expected bool-typed DPs found!";
+  if (foundStrings != mAliasesstrings.size())
+    LOG(INFO) << "Not all expected string-typed DPs found!";
+  if (foundTimes != mAliasestimes.size())
+    LOG(INFO) << "Not all expected time-typed DPs found!";
+  if (foundBinaries != mAliasesbinaries.size())
+    LOG(INFO) << "Not all expected binary-typed DPs found!";
+
+  return 0;
+}
+
+//______________________________________________________________________
+
+template <>
+int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DPID, DQStrings>& destmap)
+{
+
+  // processing the array of type T
+
+  int found = 0;
+  auto s = array.size();
+  if (s > 0) {
+    for (size_t i = 0; i != s; ++i) {
+      auto it = processAlias(array[i], type, map);
+      if (it == map.end()) {
+        LOG(ERROR) << "Element " << array[i] << " not found " << std::endl;
+        continue;
+      }
+      found++;
+      auto& val = it->second;
+      auto flags = val.get_flags();
+      if (processFlag(flags, array[i].get_alias()) == 0) {
+        auto etime = val.get_epoch_time();
+        // fill only if new value has a timestamp different from the timestamp of the previous one
+        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
+          auto& tmp = destmap[array[i]].emplace_back();
+          std::strncpy(tmp.data(), (char*)&(val.payload_pt1), 56);
+          latestTimeStamp[i] = etime;
+        }
+      }
+    }
+  }
+  return found;
+}
+
+//______________________________________________________________________
+
+template <>
+int DCSProcessor::processArrayType(const std::vector<DPID>& array, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map, std::vector<uint64_t>& latestTimeStamp, std::unordered_map<DPID, DQBinaries>& destmap)
+{
+
+  // processing the array of type T
+
+  int found = 0;
+  auto s = array.size();
+  if (s > 0) {
+    for (size_t i = 0; i != s; ++i) {
+      auto it = processAlias(array[i], type, map);
+      if (it == map.end()) {
+        LOG(ERROR) << "Element " << array[i] << " not found " << std::endl;
+        continue;
+      }
+      found++;
+      auto& val = it->second;
+      auto flags = val.get_flags();
+      if (processFlag(flags, array[i].get_alias()) == 0) {
+        auto etime = val.get_epoch_time();
+        // fill only if new value has a timestamp different from the timestamp of the previous one
+        LOG(INFO) << "destmap[array[" << i << "]].size() = " << destmap[array[i]].size();
+        if (destmap[array[i]].size() == 0 || etime != latestTimeStamp[i]) {
+          auto& tmp = destmap[array[i]].emplace_back();
+          memcpy(tmp.data(), &(val.payload_pt1), 7);
+          latestTimeStamp[i] = etime;
+        }
+      }
+    }
+  }
+  return found;
+}
+
+//______________________________________________________________________
+
+std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::processAlias(const DPID& alias, DeliveryType type, const std::unordered_map<DPID, DPVAL>& map)
+{
+
+  // processing basic checks for map: all needed aliases must be present
+
+  LOG(INFO) << "Processing " << alias;
+  auto it = map.find(alias);
+  DeliveryType tt = alias.get_type();
+  if (tt != type) {
+    LOG(FATAL) << "Delivery Type of alias " << alias.get_alias() << " does not match definition in DCSProcessor (" << type << ")! Please fix";
+  }
+  return it;
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processChars()
+{
+
+  // function to process aliases of Char type; it will just print them
+
+  for (size_t i = 0; i != mAliaseschars.size(); ++i) {
+    LOG(INFO) << "processChars: mAliaseschars[" << i << "] = " << mAliaseschars[i];
+    auto& id = mAliaseschars[i];
+    auto& vchar = getVectorForAliasChar(id);
+    LOG(INFO) << "vchar size = " << vchar.size();
+    for (size_t j = 0; j < vchar.size(); j++) {
+      LOG(INFO) << "DP = " << mAliaseschars[i] << " , value[" << j << "] = " << vchar[j];
+    }
+  }
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processInts()
+{
+
+  // function to process aliases of Int type
+
+  for (size_t i = 0; i != mAliasesints.size(); ++i) {
+    LOG(INFO) << "processInts: mAliasesints[" << i << "] = " << mAliasesints[i];
+    auto& id = mAliasesints[i];
+    auto& vint = getVectorForAliasInt(id);
+    LOG(INFO) << "vint size = " << vint.size();
+    for (size_t j = 0; j < vint.size(); j++) {
+      LOG(INFO) << "DP = " << mAliasesints[i] << " , value[" << j << "] = " << vint[j];
+    }
+    bool isSMA = false;
+    LOG(INFO) << "get alias = " << id.get_alias();
+    if (strcmp(id.get_alias(), "TestInt0") == 0) {
+      doSimpleMovingAverage(2, vint, mAvgTestInt0, isSMA);
+      LOG(INFO) << "Moving average = " << mAvgTestInt0;
+      if (isSMA) {
+        // populate CCDB
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<int>& vect, float& avg, bool& isSMA)
+{
+
+  // Do simple moving average on vector of ints
+  if (vect.size() < nelements) {
+    avg += vect[vect.size() - 1];
+    return;
+  }
+  if (vect.size() == nelements) {
+    avg += vect[vect.size() - 1];
+    avg /= nelements;
+    isSMA = true;
+    return;
+  }
+  avg += (vect[vect.size() - 1] - vect[0]) / nelements;
+  vect.pop_front();
+  isSMA = true;
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processDoubles()
+{
+
+  // function to process aliases of Double type
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processUInts()
+{
+
+  // function to process aliases of UInt type
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processBools()
+{
+
+  // function to process aliases of Bool type
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processStrings()
+{
+
+  // function to process aliases of String type
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processTimes()
+{
+
+  // function to process aliases of Time type
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::processBinaries()
+{
+
+  // function to process aliases of Time binary
+}
+
+//______________________________________________________________________
+
+uint64_t DCSProcessor::processFlag(const uint64_t flags, const char* alias)
+{
+
+  // function to process the flag. the return code zero means that all is fine.
+  // anything else means that there was an issue
+
+  if (flags & DataPointValue::KEEP_ALIVE_FLAG) {
+    LOG(INFO) << "KEEP_ALIVE_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::END_FLAG) {
+    LOG(INFO) << "END_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::FBI_FLAG) {
+    LOG(INFO) << "FBI_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::NEW_FLAG) {
+    LOG(INFO) << "NEW_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::DIRTY_FLAG) {
+    LOG(INFO) << "DIRTY_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::TURN_FLAG) {
+    LOG(INFO) << "TURN_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::WRITE_FLAG) {
+    LOG(INFO) << "WRITE_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::READ_FLAG) {
+    LOG(INFO) << "READ_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::OVERWRITE_FLAG) {
+    LOG(INFO) << "OVERWRITE_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::VICTIM_FLAG) {
+    LOG(INFO) << "VICTIM_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::DIM_ERROR_FLAG) {
+    LOG(INFO) << "DIM_ERROR_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::BAD_DPID_FLAG) {
+    LOG(INFO) << "BAD_DPID_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::BAD_FLAGS_FLAG) {
+    LOG(INFO) << "BAD_FLAGS_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::BAD_TIMESTAMP_FLAG) {
+    LOG(INFO) << "BAD_TIMESTAMP_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::BAD_PAYLOAD_FLAG) {
+    LOG(INFO) << "BAD_PAYLOAD_FLAG active for DP " << alias;
+  }
+  if (flags & DataPointValue::BAD_FBI_FLAG) {
+    LOG(INFO) << "BAD_FBI_FLAG active for DP " << alias;
+  }
+
+  return 0;
+}

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -23,126 +23,142 @@ using DPVAL = o2::dcs::DataPointValue;
 
 //ClassImp(o2::dcs::DCSProcessor);
 
-void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
-                        const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
-                        const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
-                        const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries)
+void DCSProcessor::init(const std::vector<DPID>& pidschars, const std::vector<DPID>& pidsints,
+                        const std::vector<DPID>& pidsdoubles, const std::vector<DPID>& pidsUints,
+                        const std::vector<DPID>& pidsbools, const std::vector<DPID>& pidsstrings,
+                        const std::vector<DPID>& pidstimes, const std::vector<DPID>& pidsbinaries)
 {
 
-  // init from separate vectors of aliases (one per data point type)
+  // init from separate vectors of pids (one per data point type)
 
   // chars
-  for (auto it = std::begin(aliaseschars); it != std::end(aliaseschars); ++it) {
+  for (auto it = std::begin(pidschars); it != std::end(pidschars); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_CHAR) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a char";
     }
-    mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+    mPidschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+    mPids[*it] = mPidschars.size() - 1;
   }
 
   // ints
-  for (auto it = std::begin(aliasesints); it != std::end(aliasesints); ++it) {
+  for (auto it = std::begin(pidsints); it != std::end(pidsints); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_INT) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a int";
     }
-    mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+    mPidsints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+    mPids[*it] = mPidsints.size() - 1;
   }
 
   // doubles
-  for (auto it = std::begin(aliasesdoubles); it != std::end(aliasesdoubles); ++it) {
+  for (auto it = std::begin(pidsdoubles); it != std::end(pidsdoubles); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_DOUBLE) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a double";
     }
-    mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+    mPidsdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+    mPids[*it] = mPidsdoubles.size() - 1;
   }
 
   // uints
-  for (auto it = std::begin(aliasesUints); it != std::end(aliasesUints); ++it) {
+  for (auto it = std::begin(pidsUints); it != std::end(pidsUints); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_UINT) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a uint";
     }
-    mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+    mPidsUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+    mPids[*it] = mPidsUints.size() - 1;
   }
 
   // bools
-  for (auto it = std::begin(aliasesbools); it != std::end(aliasesbools); ++it) {
+  for (auto it = std::begin(pidsbools); it != std::end(pidsbools); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_BOOL) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a bool";
     }
-    mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+    mPidsbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+    mPids[*it] = mPidsbools.size() - 1;
   }
 
   // strings
-  for (auto it = std::begin(aliasesstrings); it != std::end(aliasesstrings); ++it) {
+  for (auto it = std::begin(pidsstrings); it != std::end(pidsstrings); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_STRING) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a string";
     }
-    mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+    mPidsstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+    mPids[*it] = mPidsstrings.size() - 1;
   }
 
   // times
-  for (auto it = std::begin(aliasestimes); it != std::end(aliasestimes); ++it) {
+  for (auto it = std::begin(pidstimes); it != std::end(pidstimes); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_TIME) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a time";
     }
-    mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+    mPidstimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+    mPids[*it] = mPidstimes.size() - 1;
   }
 
   // binaries
-  for (auto it = std::begin(aliasesbinaries); it != std::end(aliasesbinaries); ++it) {
+  for (auto it = std::begin(pidsbinaries); it != std::end(pidsbinaries); ++it) {
     if ((*it).get_type() != DeliveryType::RAW_BINARY) {
       LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a binary";
     }
-    mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+    mPidsbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+    mPids[*it] = mPidsbinaries.size() - 1;
   }
 
-  mLatestTimestampchars.resize(aliaseschars.size(), 0);
-  mLatestTimestampints.resize(aliasesints.size(), 0);
-  mLatestTimestampdoubles.resize(aliasesdoubles.size(), 0);
-  mLatestTimestampUints.resize(aliasesUints.size(), 0);
-  mLatestTimestampbools.resize(aliasesbools.size(), 0);
-  mLatestTimestampstrings.resize(aliasesstrings.size(), 0);
-  mLatestTimestamptimes.resize(aliasestimes.size(), 0);
-  mLatestTimestampbinaries.resize(aliasesbinaries.size(), 0);
+  mLatestTimestampchars.resize(pidschars.size(), 0);
+  mLatestTimestampints.resize(pidsints.size(), 0);
+  mLatestTimestampdoubles.resize(pidsdoubles.size(), 0);
+  mLatestTimestampUints.resize(pidsUints.size(), 0);
+  mLatestTimestampbools.resize(pidsbools.size(), 0);
+  mLatestTimestampstrings.resize(pidsstrings.size(), 0);
+  mLatestTimestamptimes.resize(pidstimes.size(), 0);
+  mLatestTimestampbinaries.resize(pidsbinaries.size(), 0);
 }
 
 //______________________________________________________________________
 
-void DCSProcessor::init(const std::vector<DPID>& aliases)
+void DCSProcessor::init(const std::vector<DPID>& pids)
 {
 
   int nchars = 0, nints = 0, ndoubles = 0, nUints = 0,
       nbools = 0, nstrings = 0, ntimes = 0, nbinaries = 0;
-  for (auto it = std::begin(aliases); it != std::end(aliases); ++it) {
+  for (auto it = std::begin(pids); it != std::end(pids); ++it) {
     if ((*it).get_type() == DeliveryType::RAW_CHAR) {
-      mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+      mPidschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
+      mPids[*it] = nchars;
       nchars++;
     }
     if ((*it).get_type() == DeliveryType::RAW_INT) {
-      mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+      mPidsints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
+      mPids[*it] = nints;
       nints++;
     }
     if ((*it).get_type() == DeliveryType::RAW_DOUBLE) {
-      mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+      mPidsdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
+      mPids[*it] = ndoubles;
       ndoubles++;
     }
     if ((*it).get_type() == DeliveryType::RAW_UINT) {
-      mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+      mPidsUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
+      mPids[*it] = nUints;
       nUints++;
     }
     if ((*it).get_type() == DeliveryType::RAW_BOOL) {
-      mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+      mPidsbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
+      mPids[*it] = nbools;
       nbools++;
     }
     if ((*it).get_type() == DeliveryType::RAW_STRING) {
-      mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+      mPidsstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
+      mPids[*it] = nstrings;
       nstrings++;
     }
     if ((*it).get_type() == DeliveryType::RAW_TIME) {
-      mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+      mPidstimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
+      mPids[*it] = ntimes;
       ntimes++;
     }
     if ((*it).get_type() == DeliveryType::RAW_BINARY) {
-      mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+      mPidsbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
+      mPids[*it] = nbinaries;
       nbinaries++;
     }
   }
@@ -187,48 +203,48 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
       foundBools = 0, foundStrings = 0, foundTimes = 0, foundBinaries = 0;
 
   // char type
-  foundChars = processArrayType(mAliaseschars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
+  foundChars = processArrayType(mPidschars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
 
   // int type
-  foundInts = processArrayType(mAliasesints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
+  foundInts = processArrayType(mPidsints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
 
   // double type
-  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
+  foundDoubles = processArrayType(mPidsdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
                                   mDpsdoublesmap);
 
   // UInt type
-  foundUInts = processArrayType(mAliasesUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
+  foundUInts = processArrayType(mPidsUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
 
   // Bool type
-  foundBools = processArrayType(mAliasesbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
+  foundBools = processArrayType(mPidsbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
 
   // String type
-  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
+  foundStrings = processArrayType(mPidsstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
                                   mDpsstringsmap);
 
   // Time type
-  foundTimes = processArrayType(mAliasestimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
+  foundTimes = processArrayType(mPidstimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
 
   // Binary type
-  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
+  foundBinaries = processArrayType(mPidsbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
                                    mDpsbinariesmap);
 
   if (!isDelta) {
-    if (foundChars != mAliaseschars.size())
+    if (foundChars != mPidschars.size())
       LOG(INFO) << "Not all expected char-typed DPs found!";
-    if (foundInts != mAliasesints.size())
+    if (foundInts != mPidsints.size())
       LOG(INFO) << "Not all expected int-typed DPs found!";
-    if (foundDoubles != mAliasesdoubles.size())
+    if (foundDoubles != mPidsdoubles.size())
       LOG(INFO) << "Not all expected double-typed DPs found!";
-    if (foundUInts != mAliasesUints.size())
+    if (foundUInts != mPidsUints.size())
       LOG(INFO) << "Not all expected uint-typed DPs found!";
-    if (foundBools != mAliasesbools.size())
+    if (foundBools != mPidsbools.size())
       LOG(INFO) << "Not all expected bool-typed DPs found!";
-    if (foundStrings != mAliasesstrings.size())
+    if (foundStrings != mPidsstrings.size())
       LOG(INFO) << "Not all expected string-typed DPs found!";
-    if (foundTimes != mAliasestimes.size())
+    if (foundTimes != mPidstimes.size())
       LOG(INFO) << "Not all expected time-typed DPs found!";
-    if (foundBinaries != mAliasesbinaries.size())
+    if (foundBinaries != mPidsbinaries.size())
       LOG(INFO) << "Not all expected binary-typed DPs found!";
   }
 
@@ -257,91 +273,50 @@ int DCSProcessor::processDP(const std::pair<DPID, DPVAL>& dpcom)
   DeliveryType type = dpid.get_type();
 
   // first we check if the DP is in the list for the detector
+  auto el = mPids.find(dpid);
+  if (el == mPids.end()) {
+    LOG(ERROR) << "DP not found for this detector, please check";
+    return 1;
+  }
+  int posInVector = (*el).second;
+
   if (type == DeliveryType::RAW_CHAR) {
-    auto it = std::find(mAliaseschars.begin(), mAliaseschars.end(), dpid);
-    if (it == mAliaseschars.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliaseschars.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampchars[index], mDpscharsmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampchars[posInVector], mDpscharsmap);
     processCharDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_INT) {
-    auto it = std::find(mAliasesints.begin(), mAliasesints.end(), dpid);
-    if (it == mAliasesints.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesints.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampints[index], mDpsintsmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampints[posInVector], mDpsintsmap);
     processIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_DOUBLE) {
-    auto it = std::find(mAliasesdoubles.begin(), mAliasesdoubles.end(), dpid);
-    if (it == mAliasesdoubles.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesdoubles.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[index], mDpsdoublesmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[posInVector], mDpsdoublesmap);
     processDoubleDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_UINT) {
-    auto it = std::find(mAliasesUints.begin(), mAliasesUints.end(), dpid);
-    if (it == mAliasesUints.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesUints.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampUints[index], mDpsUintsmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampUints[posInVector], mDpsUintsmap);
     processUIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BOOL) {
-    auto it = std::find(mAliasesbools.begin(), mAliasesbools.end(), dpid);
-    if (it == mAliasesbools.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesbools.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampbools[index], mDpsboolsmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampbools[posInVector], mDpsboolsmap);
     processBoolDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_STRING) {
-    auto it = std::find(mAliasesstrings.begin(), mAliasesstrings.end(), dpid);
-    if (it == mAliasesstrings.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesstrings.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampstrings[index], mDpsstringsmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampstrings[posInVector], mDpsstringsmap);
     processStringDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_TIME) {
-    auto it = std::find(mAliasestimes.begin(), mAliasestimes.end(), dpid);
-    if (it == mAliasestimes.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasestimes.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestamptimes[index], mDpstimesmap);
+    checkFlagsAndFill(dpcom, mLatestTimestamptimes[posInVector], mDpstimesmap);
     processTimeDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BINARY) {
-    auto it = std::find(mAliasesbinaries.begin(), mAliasesbinaries.end(), dpid);
-    if (it == mAliasesbinaries.end()) {
-      LOG(ERROR) << "DP not found for this detector, please check";
-      return 1;
-    }
-    int index = std::distance(mAliasesbinaries.begin(), it);
-    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[index], mDpsbinariesmap);
+    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[posInVector], mDpsbinariesmap);
     processBinaryDP(dpid);
   }
 
@@ -351,7 +326,7 @@ int DCSProcessor::processDP(const std::pair<DPID, DPVAL>& dpcom)
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                                      std::unordered_map<DPID, DQStrings>& destmap)
 {
 
@@ -364,7 +339,7 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
     auto etime = val.get_epoch_time();
     // fill only if new value has a timestamp different from the timestamp of the previous one
     LOG(DEBUG) << "destmap[pid].size() = " << destmap[dpid].size();
-    if (destmap[dpid].size() == 0 || etime != std::abs(latestTimeStamp)) {
+    if (destmap[dpid].size() == 0 || etime != latestTimeStamp) {
       auto& tmp = destmap[dpid].emplace_back();
       std::strncpy(tmp.data(), (char*)&(val.payload_pt1), 56);
       latestTimeStamp = etime;
@@ -375,7 +350,7 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
 //______________________________________________________________________
 
 template <>
-void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_t& latestTimeStamp,
+void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, uint64_t& latestTimeStamp,
                                      std::unordered_map<DPID, DQBinaries>& destmap)
 {
 
@@ -388,7 +363,7 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
     auto etime = val.get_epoch_time();
     // fill only if new value has a timestamp different from the timestamp of the previous one
     LOG(DEBUG) << "destmap[pid].size() = " << destmap[dpid].size();
-    if (destmap[dpid].size() == 0 || etime != std::abs(latestTimeStamp)) {
+    if (destmap[dpid].size() == 0 || etime != latestTimeStamp) {
       auto& tmp = destmap[dpid].emplace_back();
       memcpy(tmp.data(), &(val.payload_pt1), 7);
       latestTimeStamp = etime;
@@ -398,7 +373,7 @@ void DCSProcessor::checkFlagsAndFill(const std::pair<DPID, DPVAL>& dpcom, int64_
 
 //______________________________________________________________________
 
-void DCSProcessor::processCharDP(const DPID& alias)
+void DCSProcessor::processCharDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -406,22 +381,22 @@ void DCSProcessor::processCharDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processIntDP(const DPID& alias)
+void DCSProcessor::processIntDP(const DPID& pid)
 {
-  // processing the single alias of type int
+  // processing the single pid of type int
   bool isSMA = false;
-  doSimpleMovingAverage(2, mDpsintsmap[alias], mSimpleMovingAverage[alias], isSMA);
-  LOG(DEBUG) << "dpid = " << alias << " --> Moving average = " << mSimpleMovingAverage[alias];
+  doSimpleMovingAverage(2, mDpsintsmap[pid], mSimpleMovingAverage[pid], isSMA);
+  LOG(DEBUG) << "dpid = " << pid << " --> Moving average = " << mSimpleMovingAverage[pid];
   // create CCDB object
   //if (isSMA) {
-  mccdbSimpleMovingAverage[alias.get_alias()] = mSimpleMovingAverage[alias];
+  mccdbSimpleMovingAverage[pid.get_alias()] = mSimpleMovingAverage[pid];
   //}
   return;
 }
 
 //______________________________________________________________________
 
-void DCSProcessor::processDoubleDP(const DPID& alias)
+void DCSProcessor::processDoubleDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -429,7 +404,7 @@ void DCSProcessor::processDoubleDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processUIntDP(const DPID& alias)
+void DCSProcessor::processUIntDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -437,7 +412,7 @@ void DCSProcessor::processUIntDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processBoolDP(const DPID& alias)
+void DCSProcessor::processBoolDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -445,7 +420,7 @@ void DCSProcessor::processBoolDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processStringDP(const DPID& alias)
+void DCSProcessor::processStringDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -453,7 +428,7 @@ void DCSProcessor::processStringDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processTimeDP(const DPID& alias)
+void DCSProcessor::processTimeDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -461,7 +436,7 @@ void DCSProcessor::processTimeDP(const DPID& alias)
 
 //______________________________________________________________________
 
-void DCSProcessor::processBinaryDP(const DPID& alias)
+void DCSProcessor::processBinaryDP(const DPID& pid)
 {
   // empty for the example
   return;
@@ -469,20 +444,20 @@ void DCSProcessor::processBinaryDP(const DPID& alias)
 
 //______________________________________________________________________
 
-std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckAlias(const DPID& alias,
-                                                                                DeliveryType type,
-                                                                                const std::unordered_map<DPID, DPVAL>&
-                                                                                  map)
+std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckPid(const DPID& pid,
+                                                                              DeliveryType type,
+                                                                              const std::unordered_map<DPID, DPVAL>&
+                                                                                map)
 {
 
-  // processing basic checks for map: all needed aliases must be present
-  // finds dp defined by "alias" in received map "map"
+  // processing basic checks for map: all needed pids must be present
+  // finds dp defined by "pid" in received map "map"
 
-  LOG(DEBUG) << "Processing " << alias;
-  auto it = map.find(alias);
-  DeliveryType tt = alias.get_type();
+  LOG(DEBUG) << "Processing " << pid;
+  auto it = map.find(pid);
+  DeliveryType tt = pid.get_type();
   if (tt != type) {
-    LOG(FATAL) << "Delivery Type of alias " << alias.get_alias() << " does not match definition in DCSProcessor ("
+    LOG(FATAL) << "Delivery Type of pid " << pid.get_alias() << " does not match definition in DCSProcessor ("
                << type << ")! Please fix";
   }
   return it;
@@ -490,59 +465,59 @@ std::unordered_map<DPID, DPVAL>::const_iterator DCSProcessor::findAndCheckAlias(
 
 //______________________________________________________________________
 
-uint64_t DCSProcessor::processFlag(const uint64_t flags, const char* alias)
+uint64_t DCSProcessor::processFlag(const uint64_t flags, const char* pid)
 {
 
   // function to process the flag. the return code zero means that all is fine.
   // anything else means that there was an issue
 
   if (flags & DataPointValue::KEEP_ALIVE_FLAG) {
-    LOG(INFO) << "KEEP_ALIVE_FLAG active for DP " << alias;
+    LOG(INFO) << "KEEP_ALIVE_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::END_FLAG) {
-    LOG(INFO) << "END_FLAG active for DP " << alias;
+    LOG(INFO) << "END_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::FBI_FLAG) {
-    LOG(INFO) << "FBI_FLAG active for DP " << alias;
+    LOG(INFO) << "FBI_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::NEW_FLAG) {
-    LOG(INFO) << "NEW_FLAG active for DP " << alias;
+    LOG(INFO) << "NEW_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::DIRTY_FLAG) {
-    LOG(INFO) << "DIRTY_FLAG active for DP " << alias;
+    LOG(INFO) << "DIRTY_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::TURN_FLAG) {
-    LOG(INFO) << "TURN_FLAG active for DP " << alias;
+    LOG(INFO) << "TURN_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::WRITE_FLAG) {
-    LOG(INFO) << "WRITE_FLAG active for DP " << alias;
+    LOG(INFO) << "WRITE_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::READ_FLAG) {
-    LOG(INFO) << "READ_FLAG active for DP " << alias;
+    LOG(INFO) << "READ_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::OVERWRITE_FLAG) {
-    LOG(INFO) << "OVERWRITE_FLAG active for DP " << alias;
+    LOG(INFO) << "OVERWRITE_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::VICTIM_FLAG) {
-    LOG(INFO) << "VICTIM_FLAG active for DP " << alias;
+    LOG(INFO) << "VICTIM_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::DIM_ERROR_FLAG) {
-    LOG(INFO) << "DIM_ERROR_FLAG active for DP " << alias;
+    LOG(INFO) << "DIM_ERROR_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::BAD_DPID_FLAG) {
-    LOG(INFO) << "BAD_DPID_FLAG active for DP " << alias;
+    LOG(INFO) << "BAD_DPID_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::BAD_FLAGS_FLAG) {
-    LOG(INFO) << "BAD_FLAGS_FLAG active for DP " << alias;
+    LOG(INFO) << "BAD_FLAGS_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::BAD_TIMESTAMP_FLAG) {
-    LOG(INFO) << "BAD_TIMESTAMP_FLAG active for DP " << alias;
+    LOG(INFO) << "BAD_TIMESTAMP_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::BAD_PAYLOAD_FLAG) {
-    LOG(INFO) << "BAD_PAYLOAD_FLAG active for DP " << alias;
+    LOG(INFO) << "BAD_PAYLOAD_FLAG active for DP " << pid;
   }
   if (flags & DataPointValue::BAD_FBI_FLAG) {
-    LOG(INFO) << "BAD_FBI_FLAG active for DP " << alias;
+    LOG(INFO) << "BAD_FBI_FLAG active for DP " << pid;
   }
 
   return 0;

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -23,140 +23,138 @@ using DPVAL = o2::dcs::DataPointValue;
 
 //ClassImp(o2::dcs::DCSProcessor);
 
-void DCSProcessor::init(const std::unordered_map<DPID, int>& dpidmapchars,
-                        const std::unordered_map<DPID, int>& dpidmapints,
-                        const std::unordered_map<DPID, int>& dpidmapdoubles,
-                        const std::unordered_map<DPID, int>& dpidmapUints,
-                        const std::unordered_map<DPID, int>& dpidmapbools,
-                        const std::unordered_map<DPID, int>& dpidmapstrings,
-                        const std::unordered_map<DPID, int>& dpidmaptimes,
-                        const std::unordered_map<DPID, int>& dpidmapbinaries)
+void DCSProcessor::init(const std::vector<DPID>& aliaseschars, const std::vector<DPID>& aliasesints,
+                        const std::vector<DPID>& aliasesdoubles, const std::vector<DPID>& aliasesUints,
+                        const std::vector<DPID>& aliasesbools, const std::vector<DPID>& aliasesstrings,
+                        const std::vector<DPID>& aliasestimes, const std::vector<DPID>& aliasesbinaries)
 {
 
   // init from separate vectors of aliases (one per data point type)
 
   // chars
-  for (const auto& el : dpidmapchars) {
-    if ((el.first).get_type() != DeliveryType::RAW_CHAR) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a char";
+  for (auto it = std::begin(aliaseschars); it != std::end(aliaseschars); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_CHAR) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a char";
     }
-    mMapchars[el.first] = el.second;
-    mLatestTimestampchars[el.first] = 0;
+    mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
   }
 
   // ints
-  for (const auto& el : dpidmapints) {
-    if ((el.first).get_type() != DeliveryType::RAW_INT) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a int";
+  for (auto it = std::begin(aliasesints); it != std::end(aliasesints); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_INT) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a int";
     }
-    mMapints[el.first] = el.second;
-    mLatestTimestampints[el.first] = 0;
+    mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
   }
 
   // doubles
-  for (const auto& el : dpidmapdoubles) {
-    if ((el.first).get_type() != DeliveryType::RAW_DOUBLE) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a double";
+  for (auto it = std::begin(aliasesdoubles); it != std::end(aliasesdoubles); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_DOUBLE) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a double";
     }
-    mMapdoubles[el.first] = el.second;
-    mLatestTimestampdoubles[el.first] = 0;
+    mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
   }
 
   // uints
-  for (const auto& el : dpidmapUints) {
-    if ((el.first).get_type() != DeliveryType::RAW_UINT) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a uint";
+  for (auto it = std::begin(aliasesUints); it != std::end(aliasesUints); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_UINT) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a uint";
     }
-    mMapUints[el.first] = el.second;
-    mLatestTimestampUints[el.first] = 0;
+    mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
   }
 
   // bools
-  for (const auto& el : dpidmapbools) {
-    if ((el.first).get_type() != DeliveryType::RAW_BOOL) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a bool";
+  for (auto it = std::begin(aliasesbools); it != std::end(aliasesbools); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_BOOL) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a bool";
     }
-    mMapbools[el.first] = el.second;
-    mLatestTimestampbools[el.first] = 0;
+    mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
   }
 
   // strings
-  for (const auto& el : dpidmapstrings) {
-    if ((el.first).get_type() != DeliveryType::RAW_STRING) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a string";
+  for (auto it = std::begin(aliasesstrings); it != std::end(aliasesstrings); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_STRING) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a string";
     }
-    mMapstrings[el.first] = el.second;
-    mLatestTimestampstrings[el.first] = 0;
+    mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
   }
 
   // times
-  for (const auto& el : dpidmaptimes) {
-    if ((el.first).get_type() != DeliveryType::RAW_TIME) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a time";
+  for (auto it = std::begin(aliasestimes); it != std::end(aliasestimes); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_TIME) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a time";
     }
-    mMaptimes[el.first] = el.second;
-    mLatestTimestamptimes[el.first] = 0;
+    mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
   }
 
   // binaries
-  for (const auto& el : dpidmapbinaries) {
-    if ((el.first).get_type() != DeliveryType::RAW_BINARY) {
-      LOG(FATAL) << "Type for data point " << el.first << " does not match with expectations! It should be a binary";
+  for (auto it = std::begin(aliasesbinaries); it != std::end(aliasesbinaries); ++it) {
+    if ((*it).get_type() != DeliveryType::RAW_BINARY) {
+      LOG(FATAL) << "Type for data point " << *it << " does not match with expectations! It should be a binary";
     }
-    mMapbinaries[el.first] = el.second;
-    mLatestTimestampbinaries[el.first] = 0;
+    mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
   }
+
+  mLatestTimestampchars.resize(aliaseschars.size(), 0);
+  mLatestTimestampints.resize(aliasesints.size(), 0);
+  mLatestTimestampdoubles.resize(aliasesdoubles.size(), 0);
+  mLatestTimestampUints.resize(aliasesUints.size(), 0);
+  mLatestTimestampbools.resize(aliasesbools.size(), 0);
+  mLatestTimestampstrings.resize(aliasesstrings.size(), 0);
+  mLatestTimestamptimes.resize(aliasestimes.size(), 0);
+  mLatestTimestampbinaries.resize(aliasesbinaries.size(), 0);
 }
 
 //______________________________________________________________________
 
-void DCSProcessor::init(const std::unordered_map<DPID, int>& dpidmap)
+void DCSProcessor::init(const std::vector<DPID>& aliases)
 {
 
   int nchars = 0, nints = 0, ndoubles = 0, nUints = 0,
       nbools = 0, nstrings = 0, ntimes = 0, nbinaries = 0;
-  for (const auto& el : dpidmap) {
-    if ((el.first).get_type() == DeliveryType::RAW_CHAR) {
-      mMapchars[el.first] = el.second;
-      mLatestTimestampchars[el.first] = 0;
+  for (auto it = std::begin(aliases); it != std::end(aliases); ++it) {
+    if ((*it).get_type() == DeliveryType::RAW_CHAR) {
+      mAliaseschars.emplace_back((*it).get_alias(), DeliveryType::RAW_CHAR);
       nchars++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_INT) {
-      mMapints[el.first] = el.second;
-      mLatestTimestampints[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_INT) {
+      mAliasesints.emplace_back((*it).get_alias(), DeliveryType::RAW_INT);
       nints++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_DOUBLE) {
-      mMapdoubles[el.first] = el.second;
-      mLatestTimestampdoubles[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_DOUBLE) {
+      mAliasesdoubles.emplace_back((*it).get_alias(), DeliveryType::RAW_DOUBLE);
       ndoubles++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_UINT) {
-      mMapUints[el.first] = el.second;
-      mLatestTimestampUints[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_UINT) {
+      mAliasesUints.emplace_back((*it).get_alias(), DeliveryType::RAW_UINT);
       nUints++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_BOOL) {
-      mMapbools[el.first] = el.second;
-      mLatestTimestampbools[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_BOOL) {
+      mAliasesbools.emplace_back((*it).get_alias(), DeliveryType::RAW_BOOL);
       nbools++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_STRING) {
-      mMapstrings[el.first] = el.second;
-      mLatestTimestampstrings[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_STRING) {
+      mAliasesstrings.emplace_back((*it).get_alias(), DeliveryType::RAW_STRING);
       nstrings++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_TIME) {
-      mMaptimes[el.first] = el.second;
-      mLatestTimestamptimes[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_TIME) {
+      mAliasestimes.emplace_back((*it).get_alias(), DeliveryType::RAW_TIME);
       ntimes++;
     }
-    if ((el.first).get_type() == DeliveryType::RAW_BINARY) {
-      mMapbinaries[el.first] = el.second;
-      mLatestTimestampbinaries[el.first] = 0;
+    if ((*it).get_type() == DeliveryType::RAW_BINARY) {
+      mAliasesbinaries.emplace_back((*it).get_alias(), DeliveryType::RAW_BINARY);
       nbinaries++;
     }
   }
+
+  mLatestTimestampchars.resize(nchars, 0);
+  mLatestTimestampints.resize(nints, 0);
+  mLatestTimestampdoubles.resize(ndoubles, 0);
+  mLatestTimestampUints.resize(nUints, 0);
+  mLatestTimestampbools.resize(nbools, 0);
+  mLatestTimestampstrings.resize(nstrings, 0);
+  mLatestTimestamptimes.resize(ntimes, 0);
+  mLatestTimestampbinaries.resize(nbinaries, 0);
 }
 
 //__________________________________________________________________
@@ -189,48 +187,48 @@ int DCSProcessor::processMap(const std::unordered_map<DPID, DPVAL>& map, bool is
       foundBools = 0, foundStrings = 0, foundTimes = 0, foundBinaries = 0;
 
   // char type
-  foundChars = processArrayType(mMapchars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
+  foundChars = processArrayType(mAliaseschars, DeliveryType::RAW_CHAR, map, mLatestTimestampchars, mDpscharsmap);
 
   // int type
-  foundInts = processArrayType(mMapints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
+  foundInts = processArrayType(mAliasesints, DeliveryType::RAW_INT, map, mLatestTimestampints, mDpsintsmap);
 
   // double type
-  foundDoubles = processArrayType(mMapdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
+  foundDoubles = processArrayType(mAliasesdoubles, DeliveryType::RAW_DOUBLE, map, mLatestTimestampdoubles,
                                   mDpsdoublesmap);
 
   // UInt type
-  foundUInts = processArrayType(mMapUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
+  foundUInts = processArrayType(mAliasesUints, DeliveryType::RAW_UINT, map, mLatestTimestampUints, mDpsUintsmap);
 
   // Bool type
-  foundBools = processArrayType(mMapbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
+  foundBools = processArrayType(mAliasesbools, DeliveryType::RAW_BOOL, map, mLatestTimestampbools, mDpsboolsmap);
 
   // String type
-  foundStrings = processArrayType(mMapstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
+  foundStrings = processArrayType(mAliasesstrings, DeliveryType::RAW_STRING, map, mLatestTimestampstrings,
                                   mDpsstringsmap);
 
   // Time type
-  foundTimes = processArrayType(mMaptimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
+  foundTimes = processArrayType(mAliasestimes, DeliveryType::RAW_TIME, map, mLatestTimestamptimes, mDpstimesmap);
 
   // Binary type
-  foundBinaries = processArrayType(mMapbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
+  foundBinaries = processArrayType(mAliasesbinaries, DeliveryType::RAW_BINARY, map, mLatestTimestampbinaries,
                                    mDpsbinariesmap);
 
   if (!isDelta) {
-    if (foundChars != mMapchars.size())
+    if (foundChars != mAliaseschars.size())
       LOG(INFO) << "Not all expected char-typed DPs found!";
-    if (foundInts != mMapints.size())
+    if (foundInts != mAliasesints.size())
       LOG(INFO) << "Not all expected int-typed DPs found!";
-    if (foundDoubles != mMapdoubles.size())
+    if (foundDoubles != mAliasesdoubles.size())
       LOG(INFO) << "Not all expected double-typed DPs found!";
-    if (foundUInts != mMapUints.size())
+    if (foundUInts != mAliasesUints.size())
       LOG(INFO) << "Not all expected uint-typed DPs found!";
-    if (foundBools != mMapbools.size())
+    if (foundBools != mAliasesbools.size())
       LOG(INFO) << "Not all expected bool-typed DPs found!";
-    if (foundStrings != mMapstrings.size())
+    if (foundStrings != mAliasesstrings.size())
       LOG(INFO) << "Not all expected string-typed DPs found!";
-    if (foundTimes != mMaptimes.size())
+    if (foundTimes != mAliasestimes.size())
       LOG(INFO) << "Not all expected time-typed DPs found!";
-    if (foundBinaries != mMapbinaries.size())
+    if (foundBinaries != mAliasesbinaries.size())
       LOG(INFO) << "Not all expected binary-typed DPs found!";
   }
 
@@ -260,128 +258,90 @@ int DCSProcessor::processDP(const std::pair<DPID, DPVAL>& dpcom)
 
   // first we check if the DP is in the list for the detector
   if (type == DeliveryType::RAW_CHAR) {
-    auto el = mMapchars.find(dpid);
-    if (el == mMapchars.end()) {
+    auto it = std::find(mAliaseschars.begin(), mAliaseschars.end(), dpid);
+    if (it == mAliaseschars.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampchars.find(dpid);
-    if (elTime == mLatestTimestampchars.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampchars[dpid], mDpscharsmap);
+    int index = std::distance(mAliaseschars.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampchars[index], mDpscharsmap);
     processCharDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_INT) {
-    std::vector<int64_t> tmp;
-    tmp.resize(100, 0);
-    auto el = mMapints.find(dpid);
-    if (el == mMapints.end()) {
+    auto it = std::find(mAliasesints.begin(), mAliasesints.end(), dpid);
+    if (it == mAliasesints.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-
-    auto elTime = mLatestTimestampints.find(dpid);
-    if (elTime == mLatestTimestampints.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-
-    checkFlagsAndFill(dpcom, (*elTime).second, mDpsintsmap);
-    //checkFlagsAndFill(dpcom, tmp[0], mDpsintsmap);
-    //checkFlagsAndFill(dpcom, mLatestTimestampints[dpid], mDpsintsmap);
+    int index = std::distance(mAliasesints.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampints[index], mDpsintsmap);
     processIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_DOUBLE) {
-    auto el = mMapdoubles.find(dpid);
-    if (el == mMapdoubles.end()) {
+    auto it = std::find(mAliasesdoubles.begin(), mAliasesdoubles.end(), dpid);
+    if (it == mAliasesdoubles.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampdoubles.find(dpid);
-    if (elTime == mLatestTimestampdoubles.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[dpid], mDpsdoublesmap);
+    int index = std::distance(mAliasesdoubles.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampdoubles[index], mDpsdoublesmap);
     processDoubleDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_UINT) {
-    auto el = mMapUints.find(dpid);
-    if (el == mMapUints.end()) {
+    auto it = std::find(mAliasesUints.begin(), mAliasesUints.end(), dpid);
+    if (it == mAliasesUints.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampUints.find(dpid);
-    if (elTime == mLatestTimestampUints.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampUints[dpid], mDpsUintsmap);
+    int index = std::distance(mAliasesUints.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampUints[index], mDpsUintsmap);
     processUIntDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BOOL) {
-    auto el = mMapbools.find(dpid);
-    if (el == mMapbools.end()) {
+    auto it = std::find(mAliasesbools.begin(), mAliasesbools.end(), dpid);
+    if (it == mAliasesbools.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampbools.find(dpid);
-    if (elTime == mLatestTimestampbools.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampbools[dpid], mDpsboolsmap);
+    int index = std::distance(mAliasesbools.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampbools[index], mDpsboolsmap);
     processBoolDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_STRING) {
-    auto el = mMapstrings.find(dpid);
-    if (el == mMapstrings.end()) {
+    auto it = std::find(mAliasesstrings.begin(), mAliasesstrings.end(), dpid);
+    if (it == mAliasesstrings.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampstrings.find(dpid);
-    if (elTime == mLatestTimestampstrings.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampstrings[dpid], mDpsstringsmap);
+    int index = std::distance(mAliasesstrings.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampstrings[index], mDpsstringsmap);
     processStringDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_TIME) {
-    auto el = mMaptimes.find(dpid);
-    if (el == mMaptimes.end()) {
+    auto it = std::find(mAliasestimes.begin(), mAliasestimes.end(), dpid);
+    if (it == mAliasestimes.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestamptimes.find(dpid);
-    if (elTime == mLatestTimestamptimes.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestamptimes[dpid], mDpstimesmap);
+    int index = std::distance(mAliasestimes.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestamptimes[index], mDpstimesmap);
     processTimeDP(dpid);
   }
 
   else if (type == DeliveryType::RAW_BINARY) {
-    auto el = mMapbinaries.find(dpid);
-    if (el == mMapbinaries.end()) {
+    auto it = std::find(mAliasesbinaries.begin(), mAliasesbinaries.end(), dpid);
+    if (it == mAliasesbinaries.end()) {
       LOG(ERROR) << "DP not found for this detector, please check";
       return 1;
     }
-    auto elTime = mLatestTimestampbinaries.find(dpid);
-    if (elTime == mLatestTimestampbinaries.end()) {
-      LOG(ERROR) << "Timestamp not found for this DP, please check";
-      return 1;
-    }
-    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[dpid], mDpsbinariesmap);
+    int index = std::distance(mAliasesbinaries.begin(), it);
+    checkFlagsAndFill(dpcom, mLatestTimestampbinaries[index], mDpsbinariesmap);
     processBinaryDP(dpid);
   }
 

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -349,6 +349,7 @@ void DCSProcessor::processInts()
     }
     bool isSMA = false;
     LOG(DEBUG) << "get alias = " << id.get_alias();
+    // I do the moving average always of the last 2 points, no matter if it was updated or not
     doSimpleMovingAverage(2, vint, mAvgTestInt[i], isSMA);
     LOG(DEBUG) << "Moving average = " << mAvgTestInt[i];
     if (isSMA) {
@@ -358,7 +359,7 @@ void DCSProcessor::processInts()
 }
 
 //______________________________________________________________________
-
+/*
 void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<int>& vect, float& avg, bool& isSMA)
 {
 
@@ -377,7 +378,7 @@ void DCSProcessor::doSimpleMovingAverage(int nelements, std::deque<int>& vect, f
   vect.pop_front();
   isSMA = true;
 }
-
+*/
 //______________________________________________________________________
 
 void DCSProcessor::processDoubles()
@@ -484,4 +485,18 @@ uint64_t DCSProcessor::processFlag(const uint64_t flags, const char* alias)
   }
 
   return 0;
+}
+
+//______________________________________________________________________
+
+void DCSProcessor::setNThreads(int n) {
+
+  // to set number of threads used to process the DPs
+  
+#ifdef WITH_OPENMP
+  mNThreads = n > 0 ? n : 1;
+#else
+  LOG(WARNING) << " Multithreading is not supported, imposing single thread";
+  mNThreads = 1;
+#endif
 }

--- a/Detectors/DCS/src/DCSProcessor.cxx
+++ b/Detectors/DCS/src/DCSProcessor.cxx
@@ -11,7 +11,7 @@
 #include <DetectorsDCS/DCSProcessor.h>
 #include "Rtypes.h"
 #include <deque>
-#include <string.h>
+#include <string>
 
 using namespace o2::dcs;
 

--- a/Detectors/DCS/src/DetectorsDCSLinkDef.h
+++ b/Detectors/DCS/src/DetectorsDCSLinkDef.h
@@ -18,5 +18,6 @@
 #pragma link C++ class o2::dcs::DataPointIdentifier + ;
 #pragma link C++ struct o2::dcs::DataPointValue + ;
 #pragma link C++ class o2::dcs::DCSProcessor + ;
+#pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue> + ;
 
 #endif

--- a/Detectors/DCS/src/DetectorsDCSLinkDef.h
+++ b/Detectors/DCS/src/DetectorsDCSLinkDef.h
@@ -17,5 +17,6 @@
 #pragma link C++ struct o2::dcs::DataPointCompositeObject + ;
 #pragma link C++ class o2::dcs::DataPointIdentifier + ;
 #pragma link C++ struct o2::dcs::DataPointValue + ;
+#pragma link C++ class o2::dcs::DCSProcessor + ;
 
 #endif

--- a/Detectors/DCS/test/processor_dpcom_o2.C
+++ b/Detectors/DCS/test/processor_dpcom_o2.C
@@ -1,0 +1,115 @@
+using namespace o2::dcs;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPCOM = o2::dcs::DataPointCompositeObject;
+
+int processor_dpcom_o2()
+{
+
+  std::unordered_map<DPID, DPVAL> dpmap;
+
+  o2::dcs::DCSProcessor dcsproc;
+  std::vector<DPID> aliasChars;
+  std::vector<DPID> aliasInts;
+  std::vector<DPID> aliasDoubles;
+  std::vector<DPID> aliasUInts;
+  std::vector<DPID> aliasBools;
+  std::vector<DPID> aliasStrings;
+  std::vector<DPID> aliasTimes;
+  std::vector<DPID> aliasBinaries;
+
+  DeliveryType typechar = RAW_CHAR;
+  std::string dpAliaschar = "TestChar0";
+  DPID charVar(dpAliaschar, typechar);
+  aliasChars.push_back(charVar);
+
+  DeliveryType typeint = RAW_INT;
+  std::string dpAliasint0 = "TestInt0";
+  DPID intVar0(dpAliasint0, typeint);
+  aliasInts.push_back(intVar0);
+
+  std::string dpAliasint1 = "TestInt1";
+  DPID intVar1(dpAliasint1, typeint);
+  aliasInts.push_back(intVar1);
+
+  std::string dpAliasint2 = "TestInt2";
+  DPID intVar2(dpAliasint2, typeint);
+  aliasInts.push_back(intVar2);
+
+  DeliveryType typedouble = RAW_DOUBLE;
+  std::string dpAliasdouble0 = "TestDouble0";
+  DPID doubleVar0(dpAliasdouble0, typedouble);
+  aliasDoubles.push_back(doubleVar0);
+
+  std::string dpAliasdouble1 = "TestDouble1";
+  DPID doubleVar1(dpAliasdouble1, typedouble);
+  aliasDoubles.push_back(doubleVar1);
+
+  std::string dpAliasdouble2 = "TestDouble2";
+  DPID doubleVar2(dpAliasdouble2, typedouble);
+  aliasDoubles.push_back(doubleVar2);
+
+  std::string dpAliasdouble3 = "TestDouble3";
+  DPID doubleVar3(dpAliasdouble3, typedouble);
+  aliasDoubles.push_back(doubleVar3);
+
+  DeliveryType typestring = RAW_STRING;
+  std::string dpAliasstring0 = "TestString0";
+  DPID stringVar0(dpAliasstring0, typestring);
+  aliasStrings.push_back(stringVar0);
+
+  dcsproc.init(aliasChars, aliasInts, aliasDoubles, aliasUInts, aliasBools, aliasStrings, aliasTimes, aliasBinaries);
+
+  uint16_t flags = 0;
+  uint16_t milliseconds = 0;
+  TDatime currentTime;
+  uint32_t seconds = currentTime.Get();
+  uint64_t* payload = new uint64_t[7];
+
+  // loop that emulates the number of times the DCS DataPoints are sent
+  for (auto k = 0; k < 4; k++) {
+    payload[0] = (uint64_t)k + 33; // adding 33 to have visible chars and strings
+
+    DPVAL valchar(flags, milliseconds + k * 10, seconds + k, payload, typechar);
+    DPVAL valint(flags, milliseconds + k * 10, seconds + k, payload, typeint);
+    DPVAL valdouble(flags, milliseconds + k * 10, seconds + k, payload, typedouble);
+    DPVAL valstring(flags, milliseconds + k * 10, seconds + k, payload, typestring);
+
+    dpmap[charVar] = valchar;
+    dpmap[intVar0] = valint;
+    dpmap[intVar1] = valint;
+    dpmap[intVar2] = valint;
+    dpmap[doubleVar0] = valdouble;
+    dpmap[doubleVar1] = valdouble;
+    dpmap[doubleVar2] = valdouble;
+    dpmap[stringVar0] = valstring;
+    if (k != 3)
+      dpmap[doubleVar3] = valdouble; // to test the case when a DP is not updated
+    std::cout << "index = " << k << std::endl;
+    std::cout << charVar << std::endl
+              << valchar << " --> " << (char)valchar.payload_pt1 << std::endl;
+    std::cout << intVar0 << std::endl
+              << valint << " --> " << (int)valchar.payload_pt1 << std::endl;
+    std::cout << intVar1 << std::endl
+              << valint << " --> " << (int)valchar.payload_pt1 << std::endl;
+    std::cout << intVar2 << std::endl
+              << valint << " --> " << (int)valchar.payload_pt1 << std::endl;
+    std::cout << doubleVar0 << std::endl
+              << valdouble << " --> " << (double)valchar.payload_pt1 << std::endl;
+    std::cout << doubleVar1 << std::endl
+              << valdouble << " --> " << (double)valchar.payload_pt1 << std::endl;
+    std::cout << doubleVar2 << std::endl
+              << valdouble << " --> " << (double)valchar.payload_pt1 << std::endl;
+    std::cout << doubleVar3 << std::endl
+              << valdouble << " --> " << (double)valchar.payload_pt1 << std::endl;
+    char tt[56];
+    memcpy(&tt[0], &valstring.payload_pt1, 56);
+    printf("tt = %s\n", tt);
+    std::cout << stringVar0 << std::endl
+              << valstring << " --> " << tt << std::endl;
+
+    dcsproc.process(dpmap);
+  }
+  std::cout << "The map has " << dpmap.size() << " entries" << std::endl;
+  return 0;
+}

--- a/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
@@ -57,7 +57,7 @@ class DCSDataGenerator : public o2::framework::Task
     mNumDPschar++;
 
     // ints
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, mtypeint);
       mDPIDvect.push_back(dpidtmp);
@@ -141,7 +141,7 @@ class DCSDataGenerator : public o2::framework::Task
     auto svect = dpcomVect.size();
     LOG(INFO) << "dpcomVect has size " << svect;
     for (int i = 0; i < svect; i++) {
-      LOG(INFO) << "i = " << i << ", DPCOM = " << dpcomVect[i];
+      LOG(DEBUG) << "i = " << i << ", DPCOM = " << dpcomVect[i];
     }
     std::vector<char> buff(mNumDPs * sizeof(DPCOM));
     char* dptr = buff.data();
@@ -149,15 +149,17 @@ class DCSDataGenerator : public o2::framework::Task
       memcpy(dptr + i * sizeof(DPCOM), &dpcomVect[i], sizeof(DPCOM));
     }
     auto sbuff = buff.size();
-    LOG(INFO) << "size of output buffer = " << sbuff;
+    LOG(DEBUG) << "size of output buffer = " << sbuff;
     pc.outputs().snapshot(Output{"DCS", "DATAPOINTS", 0, Lifetime::Timeframe}, buff.data(), sbuff);
 
+    /*
     LOG(INFO) << "Reading back";
     DPCOM dptmp;
     for (int i = 0; i < svect; i++) {
       memcpy(&dptmp, dptr + i * sizeof(DPCOM), sizeof(DPCOM));
-      LOG(INFO) << "Check: Reading from generator: i = " << i << ", DPCOM = " << dptmp;
+      LOG(DEBUG) << "Check: Reading from generator: i = " << i << ", DPCOM = " << dptmp;
     }
+    */
     /*
     auto& tmpDPmap = pc.outputs().make<std::unordered_map<DPID, DPVAL>>(o2::framework::OutputRef{"output", 0});
     tmpDPmap[mcharVar] = valchar;

--- a/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
@@ -53,42 +53,47 @@ class DCSDataGenerator : public o2::framework::Task
     // chars
     std::string dpAliaschar = "TestChar_0";
     DPID::FILL(dpidtmp, dpAliaschar, mtypechar);
-    mDPIDvect.push_back(dpidtmp);
-    mNumDPs++;
-    mNumDPschar++;
+    mDPIDvectFull.push_back(dpidtmp);
+    mNumDPsFull++;
+    mNumDPscharFull++;
 
     // ints
     for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, mtypeint);
-      mDPIDvect.push_back(dpidtmp);
-      mNumDPs++;
-      mNumDPsint++;
+      mDPIDvectFull.push_back(dpidtmp);
+      mNumDPsFull++;
+      mNumDPsintFull++;
+      if (i < 100) {
+        mDPIDvectDelta.push_back(dpidtmp);
+        mNumDPsDelta++;
+        mNumDPsintDelta++;
+      }
     }
 
     // doubles
     for (int i = 0; i < 4; i++) {
       std::string dpAliasdouble = "TestDouble_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasdouble, mtypedouble);
-      mDPIDvect.push_back(dpidtmp);
-      mNumDPs++;
-      mNumDPsdouble++;
+      mDPIDvectFull.push_back(dpidtmp);
+      mNumDPsFull++;
+      mNumDPsdoubleFull++;
     }
 
     // strings
     std::string dpAliasstring0 = "TestString_0";
     DPID::FILL(dpidtmp, dpAliasstring0, mtypestring);
-    mDPIDvect.push_back(dpidtmp);
-    mNumDPs++;
-    mNumDPsstring++;
+    mDPIDvectFull.push_back(dpidtmp);
+    mNumDPsFull++;
+    mNumDPsstringFull++;
 
-    LOG(INFO) << "Number of DCS data points = " << mNumDPs;
+    LOG(INFO) << "Number of DCS data points: " << mNumDPsFull << " (full map); " << mNumDPsDelta << " (delta map)";
   }
 
   void run(o2::framework::ProcessingContext& pc) final
   {
 
-    TStopwatch s; 
+    TStopwatch s;
     uint64_t tfid;
     for (auto& input : pc.inputs()) {
       tfid = header::get<o2::framework::DataProcessingHeader*>(input.header)->startTime;
@@ -107,7 +112,7 @@ class DCSDataGenerator : public o2::framework::Task
     uint16_t milliseconds = 0;
     TDatime currentTime;
     uint32_t seconds = currentTime.Get();
-    uint64_t* payload = new uint64_t[7];
+    uint64_t payload[7];
     memset(payload, 0, sizeof(uint64_t) * 7);
 
     payload[0] = (uint64_t)tfid + 33; // adding 33 to have visible chars and strings
@@ -128,29 +133,46 @@ class DCSDataGenerator : public o2::framework::Task
     LOG(DEBUG) << "Value used for string DPs:";
     LOG(DEBUG) << valstring << " --> " << tt;
 
-    std::vector<DPCOM> dpcomVect;
-    for (int i = 0; i < mNumDPschar; i++) {
-      dpcomVect.emplace_back(mDPIDvect[i], valchar);
+    // full map (all DPs)
+    std::vector<DPCOM> dpcomVectFull;
+    for (int i = 0; i < mNumDPscharFull; i++) {
+      dpcomVectFull.emplace_back(mDPIDvectFull[i], valchar);
     }
-    for (int i = 0; i < mNumDPsint; i++) {
-      dpcomVect.emplace_back(mDPIDvect[mNumDPschar + i], valint);
+    for (int i = 0; i < mNumDPsintFull; i++) {
+      dpcomVectFull.emplace_back(mDPIDvectFull[mNumDPscharFull + i], valint);
     }
-    for (int i = 0; i < mNumDPsdouble; i++) {
-      dpcomVect.emplace_back(mDPIDvect[mNumDPschar + mNumDPsint + i], valdouble);
+    for (int i = 0; i < mNumDPsdoubleFull; i++) {
+      dpcomVectFull.emplace_back(mDPIDvectFull[mNumDPscharFull + mNumDPsintFull + i], valdouble);
     }
-    for (int i = 0; i < mNumDPsstring; i++) {
-      dpcomVect.emplace_back(mDPIDvect[mNumDPschar + mNumDPsint + mNumDPsdouble + i], valstring);
+    for (int i = 0; i < mNumDPsstringFull; i++) {
+      dpcomVectFull.emplace_back(mDPIDvectFull[mNumDPscharFull + mNumDPsintFull + mNumDPsdoubleFull + i], valstring);
     }
 
-    auto svect = dpcomVect.size();
-    LOG(DEBUG) << "dpcomVect has size " << svect;
-    for (int i = 0; i < svect; i++) {
-      LOG(DEBUG) << "i = " << i << ", DPCOM = " << dpcomVect[i];
+    // delta map (only DPs that changed)
+    std::vector<DPCOM> dpcomVectDelta;
+    for (int i = 0; i < mNumDPscharDelta; i++) {
+      dpcomVectDelta.emplace_back(mDPIDvectDelta[i], valchar);
     }
-    std::vector<char> buff(mNumDPs * sizeof(DPCOM));
+    for (int i = 0; i < mNumDPsintDelta; i++) {
+      dpcomVectDelta.emplace_back(mDPIDvectDelta[mNumDPscharDelta + i], valint);
+    }
+    for (int i = 0; i < mNumDPsdoubleDelta; i++) {
+      dpcomVectDelta.emplace_back(mDPIDvectDelta[mNumDPscharDelta + mNumDPsintDelta + i], valdouble);
+    }
+    for (int i = 0; i < mNumDPsstringDelta; i++) {
+      dpcomVectDelta.emplace_back(mDPIDvectDelta[mNumDPscharDelta + mNumDPsintDelta + mNumDPsdoubleDelta + i], valstring);
+    }
+
+    // Full map
+    auto svect = dpcomVectFull.size();
+    LOG(DEBUG) << "dpcomVectFull has size " << svect;
+    for (int i = 0; i < svect; i++) {
+      LOG(DEBUG) << "i = " << i << ", DPCOM = " << dpcomVectFull[i];
+    }
+    std::vector<char> buff(mNumDPsFull * sizeof(DPCOM));
     char* dptr = buff.data();
     for (int i = 0; i < svect; i++) {
-      memcpy(dptr + i * sizeof(DPCOM), &dpcomVect[i], sizeof(DPCOM));
+      memcpy(dptr + i * sizeof(DPCOM), &dpcomVectFull[i], sizeof(DPCOM));
     }
     auto sbuff = buff.size();
     LOG(DEBUG) << "size of output buffer = " << sbuff;
@@ -161,6 +183,27 @@ class DCSDataGenerator : public o2::framework::Task
     pc.outputs().snapshot(Output{"DCS", "DATAPOINTS", 0, Lifetime::Timeframe}, buff.data(), sbuff);
     s.Stop();
     LOG(INFO) << "TF: " << tfid << " --> ...snapshot sent: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
+    // Delta map
+    auto svectDelta = dpcomVectDelta.size();
+    LOG(DEBUG) << "dpcomVectDelta has size " << svect;
+    for (int i = 0; i < svectDelta; i++) {
+      LOG(DEBUG) << "i = " << i << ", DPCOM = " << dpcomVectDelta[i];
+    }
+    std::vector<char> buffDelta(mNumDPsDelta * sizeof(DPCOM));
+    char* dptrDelta = buffDelta.data();
+    for (int i = 0; i < svectDelta; i++) {
+      memcpy(dptrDelta + i * sizeof(DPCOM), &dpcomVectDelta[i], sizeof(DPCOM));
+    }
+    auto sbuffDelta = buffDelta.size();
+    LOG(DEBUG) << "size of output (delta) buffer = " << sbuffDelta;
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " --> ...binary (delta) blob prepared: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+    LOG(INFO) << "TF: " << tfid << " --> sending (delta) snapshot...";
+    s.Start();
+    pc.outputs().snapshot(Output{"DCS", "DATAPOINTSdelta", 0, Lifetime::Timeframe}, buffDelta.data(), sbuffDelta);
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " --> ...snapshot (delta) sent: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
 
     /*
     LOG(INFO) << "Reading back";
@@ -183,16 +226,22 @@ class DCSDataGenerator : public o2::framework::Task
       tmpDPmap[mdoubleVar3] = valdouble; // to test the case when a DP is not updated, we skip some updates
     tmpDPmap[mstringVar0] = valstring;
     */
-    delete payload;
   }
 
  private:
   uint64_t mMaxTF = 1;
-  uint64_t mNumDPs = 0;
-  uint64_t mNumDPschar = 0;
-  uint64_t mNumDPsint = 0;
-  uint64_t mNumDPsdouble = 0;
-  uint64_t mNumDPsstring = 0;
+
+  uint64_t mNumDPsFull = 0;
+  uint64_t mNumDPscharFull = 0;
+  uint64_t mNumDPsintFull = 0;
+  uint64_t mNumDPsdoubleFull = 0;
+  uint64_t mNumDPsstringFull = 0;
+
+  uint64_t mNumDPsDelta = 0;
+  uint64_t mNumDPscharDelta = 0;
+  uint64_t mNumDPsintDelta = 0;
+  uint64_t mNumDPsdoubleDelta = 0;
+  uint64_t mNumDPsstringDelta = 0;
   /*
   DPID mcharVar;
   DPID mintVar0;
@@ -204,7 +253,8 @@ class DCSDataGenerator : public o2::framework::Task
   DPID mdoubleVar3;
   DPID mstringVar0;
   */
-  std::vector<DPID> mDPIDvect;
+  std::vector<DPID> mDPIDvectFull;  // for full map
+  std::vector<DPID> mDPIDvectDelta; // for delta map (containing only DPs that changed)
   DeliveryType mtypechar = RAW_CHAR;
   DeliveryType mtypeint = RAW_INT;
   DeliveryType mtypedouble = RAW_DOUBLE;
@@ -221,7 +271,7 @@ DataProcessorSpec getDCSDataGeneratorSpec()
   return DataProcessorSpec{
     "dcs-data-generator",
     Inputs{},
-    Outputs{{{"outputDCS"}, "DCS", "DATAPOINTS"}},
+    Outputs{{{"outputDCS"}, "DCS", "DATAPOINTS"}, {{"outputDCSdelta"}, "DCS", "DATAPOINTSdelta"}},
     AlgorithmSpec{adaptFromTask<o2::dcs::DCSDataGenerator>()},
     Options{{"max-timeframes", VariantType::Int64, 99999999999ll, {"max TimeFrames to generate"}}}};
 }

--- a/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataGeneratorSpec.h
@@ -1,0 +1,166 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DCS_DATAGENERATOR_H
+#define O2_DCS_DATAGENERATOR_H
+
+/// @file   DataGeneratorSpec.h
+/// @brief  Dummy data generator
+#include <unistd.h>
+#include <TRandom.h>
+#include <TDatime.h>
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+namespace o2
+{
+namespace dcs
+{
+class DCSDataGenerator : public o2::framework::Task
+{
+
+  using DPID = o2::dcs::DataPointIdentifier;
+  using DPVAL = o2::dcs::DataPointValue;
+
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    mMaxTF = ic.options().get<int64_t>("max-timeframes");
+
+    LOG(INFO) << "mMaxTF = " << mMaxTF;
+    std::string dpAliaschar = "TestChar0";
+    DPID::FILL(mcharVar, dpAliaschar, mtypechar);
+
+    std::string dpAliasint0 = "TestInt0";
+    DPID::FILL(mintVar0, dpAliasint0, mtypeint);
+    std::string dpAliasint1 = "TestInt1";
+    DPID::FILL(mintVar1, dpAliasint1, mtypeint);
+    std::string dpAliasint2 = "TestInt2";
+    DPID::FILL(mintVar2, dpAliasint2, mtypeint);
+
+    std::string dpAliasdouble0 = "TestDouble0";
+    DPID::FILL(mdoubleVar0, dpAliasdouble0, mtypedouble);
+    std::string dpAliasdouble1 = "TestDouble1";
+    DPID::FILL(mdoubleVar1, dpAliasdouble1, mtypedouble);
+    std::string dpAliasdouble2 = "TestDouble2";
+    DPID::FILL(mdoubleVar2, dpAliasdouble2, mtypedouble);
+    std::string dpAliasdouble3 = "TestDouble3";
+    DPID::FILL(mdoubleVar3, dpAliasdouble3, mtypedouble);
+
+    std::string dpAliasstring0 = "TestString0";
+    DPID::FILL(mstringVar0, dpAliasstring0, mtypestring);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+
+    uint64_t tfid;
+    for (auto& input : pc.inputs()) {
+      tfid = header::get<o2::framework::DataProcessingHeader*>(input.header)->startTime;
+      LOG(INFO) << "tfid = " << tfid;
+      if (tfid >= mMaxTF) {
+        LOG(INFO) << "Data generator reached TF " << tfid << ", stopping";
+        pc.services().get<o2::framework::ControlService>().endOfStream();
+        pc.services().get<o2::framework::ControlService>().readyToQuit(o2::framework::QuitRequest::Me);
+        break;
+      }
+    }
+
+    uint16_t flags = 0;
+    uint16_t milliseconds = 0;
+    TDatime currentTime;
+    uint32_t seconds = currentTime.Get();
+    uint64_t* payload = new uint64_t[7];
+    memset(payload, 0, sizeof(uint64_t) * 7);
+
+    payload[0] = (uint64_t)tfid + 33; // adding 33 to have visible chars and strings
+
+    DPVAL valchar(flags, milliseconds + tfid * 10, seconds + tfid, payload, mtypechar);
+    DPVAL valint(flags, milliseconds + tfid * 10, seconds + tfid, payload, mtypeint);
+    DPVAL valdouble(flags, milliseconds + tfid * 10, seconds + tfid, payload, mtypedouble);
+    DPVAL valstring(flags, milliseconds + tfid * 10, seconds + tfid, payload, mtypestring);
+
+    LOG(DEBUG) << mcharVar;
+    LOG(DEBUG) << valchar << " --> " << (char)valchar.payload_pt1;
+    LOG(DEBUG) << mintVar0;
+    LOG(DEBUG) << valint << " --> " << (int)valint.payload_pt1;
+    LOG(DEBUG) << mintVar1;
+    LOG(DEBUG) << valint << " --> " << (int)valint.payload_pt1;
+    LOG(DEBUG) << mintVar2;
+    LOG(DEBUG) << valint << " --> " << (int)valint.payload_pt1;
+    LOG(DEBUG) << mdoubleVar0;
+    LOG(DEBUG) << valdouble << " --> " << (double)valdouble.payload_pt1;
+    LOG(DEBUG) << mdoubleVar1;
+    LOG(DEBUG) << valdouble << " --> " << (double)valdouble.payload_pt1;
+    LOG(DEBUG) << mdoubleVar2;
+    LOG(DEBUG) << valdouble << " --> " << (double)valdouble.payload_pt1;
+    LOG(DEBUG) << mdoubleVar3;
+    LOG(DEBUG) << valdouble << " --> " << (double)valdouble.payload_pt1;
+    char tt[56];
+    memcpy(&tt[0], &valstring.payload_pt1, 56);
+    LOG(DEBUG) << mstringVar0;
+    LOG(DEBUG) << valstring << " --> " << tt;
+    auto& tmpDPmap = pc.outputs().make<std::unordered_map<DPID, DPVAL>>(o2::framework::OutputRef{"output", 0});
+    tmpDPmap[mcharVar] = valchar;
+    tmpDPmap[mintVar0] = valint;
+    tmpDPmap[mintVar1] = valint;
+    tmpDPmap[mintVar2] = valint;
+    tmpDPmap[mdoubleVar0] = valdouble;
+    tmpDPmap[mdoubleVar1] = valdouble;
+    tmpDPmap[mdoubleVar2] = valdouble;
+    if (tfid % 3 == 0)
+      tmpDPmap[mdoubleVar3] = valdouble; // to test the case when a DP is not updated, we skip some updates
+    tmpDPmap[mstringVar0] = valstring;
+    delete payload;
+  }
+
+ private:
+  uint64_t mMaxTF = 1;
+  o2::dcs::DataPointIdentifier mcharVar;
+  DPID mintVar0;
+  DPID mintVar1;
+  DPID mintVar2;
+  DPID mdoubleVar0;
+  DPID mdoubleVar1;
+  DPID mdoubleVar2;
+  DPID mdoubleVar3;
+  DPID mstringVar0;
+  DeliveryType mtypechar = RAW_CHAR;
+  DeliveryType mtypeint = RAW_INT;
+  DeliveryType mtypedouble = RAW_DOUBLE;
+  DeliveryType mtypestring = RAW_STRING;
+};
+
+} // namespace dcs
+
+namespace framework
+{
+
+DataProcessorSpec getDCSDataGeneratorSpec()
+{
+  return DataProcessorSpec{
+    "dcs-data-generator",
+    Inputs{},
+    Outputs{{{"output"}, "DCS", "DATAPOINTS"}},
+    AlgorithmSpec{adaptFromTask<o2::dcs::DCSDataGenerator>()},
+    Options{{"max-timeframes", VariantType::Int64, 99999999999ll, {"max TimeFrames to generate"}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -52,13 +52,13 @@ class DCSDataProcessor : public o2::framework::Task
 
   void init(o2::framework::InitContext& ic) final
   {
-    std::unordered_map<DPID, int> dpMap;
+    std::vector<DPID> aliasVect;
 
     DPID dpidtmp;
     DeliveryType typechar = RAW_CHAR;
     std::string dpAliaschar = "TestChar_0";
     DPID::FILL(dpidtmp, dpAliaschar, typechar);
-    dpMap[dpidtmp] = 1;
+    aliasVect.push_back(dpidtmp);
 
     //std::vector<int> vectDet{kTest, kTPC}; // only one detector for now
     std::vector<int> vectDet{kTest};
@@ -68,7 +68,7 @@ class DCSDataProcessor : public o2::framework::Task
     for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, typeint);
-      dpMap[dpidtmp] = 1;
+      aliasVect.push_back(dpidtmp);
       mDetectorAlias[dpidtmp] = vectDet;
     }
 
@@ -76,21 +76,21 @@ class DCSDataProcessor : public o2::framework::Task
     for (int i = 0; i < 4; i++) {
       std::string dpAliasdouble = "TestDouble_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasdouble, typedouble);
-      dpMap[dpidtmp] = 1;
+      aliasVect.push_back(dpidtmp);
       mDetectorAlias[dpidtmp] = vectDet;
     }
 
     DeliveryType typestring = RAW_STRING;
     std::string dpAliasstring0 = "TestString_0";
     DPID::FILL(dpidtmp, dpAliasstring0, typestring);
-    dpMap[dpidtmp] = 1;
+    aliasVect.push_back(dpidtmp);
     mDetectorAlias[dpidtmp] = vectDet;
 
-    mDCSproc.init(dpMap);
+    mDCSproc.init(aliasVect);
     mDCSproc.setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
     mDCSproc.setName("Test0Det");
     for (int idet = 0; idet < kNdetectors; idet++) {
-      mDCSprocVect[idet].init(dpMap);
+      mDCSprocVect[idet].init(aliasVect);
       mDCSprocVect[idet].setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
       mDCSprocVect[idet].setName("Test1Det");
     }
@@ -295,8 +295,8 @@ class DCSDataProcessor : public o2::framework::Task
     const auto& payload = mDCSproc.getCCDBSimpleMovingAverage();
     auto& info = mDCSproc.getCCDBSimpleMovingAverageInfo();
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
-    LOG(DEBUG) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
-               << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+    LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+              << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
     output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
     output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -87,8 +87,10 @@ class DCSDataProcessor : public o2::framework::Task
 
     mDCSproc.init(aliasVect);
     mDCSproc.setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
+    mDCSproc.setName("Test0Det");
     mDCSprocVect[kTest].init(aliasVect);
     mDCSprocVect[kTest].setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
+    mDCSprocVect[kTest].setName("Test1Det");
     mProcessFullDeltaMap = ic.options().get<bool>("process-full-delta-map");
   }
 
@@ -180,6 +182,12 @@ class DCSDataProcessor : public o2::framework::Task
           }
         }
         LOG(INFO) << "TF: " << tfid << " -->  ...processing (delta) in detector loop done: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+        // now preparing CCDB object
+        //for (int idet = 0; idet < detVect.size(); idet++) {
+        for (int idet = 0; idet < 1; idet++) { // for now I test only 1 DCS processor
+          std::map<std::string, std::string> md;
+          mDCSprocVect[idet].prepareCCDBobject(mDCSprocVect[idet].getCCDBSimpleMovingAverage(), mDCSprocVect[idet].getCCDBSimpleMovingAverageInfo(), mDCSprocVect[idet].getName() + "/TestDCS/SimpleMovingAverageDPs", tfid, md);
+        }
       }
     }
     sendOutput(pc.outputs());

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -1,0 +1,113 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DCS_DATAPROCESSOR_H
+#define O2_DCS_DATAPROCESSOR_H
+
+/// @file   DataGeneratorSpec.h
+/// @brief  Dummy data generator
+
+#include <unistd.h>
+#include <TRandom.h>
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "DetectorsDCS/DCSProcessor.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+namespace o2
+{
+namespace dcs
+{
+
+using namespace o2::dcs;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+
+class DCSDataProcessor : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    std::vector<DPID> aliasVect;
+
+    DeliveryType typechar = RAW_CHAR;
+    std::string dpAliaschar = "TestChar0";
+    DPID charVar(dpAliaschar, typechar);
+    aliasVect.push_back(charVar);
+
+    DeliveryType typeint = RAW_INT;
+    std::string dpAliasint0 = "TestInt0";
+    DPID intVar0(dpAliasint0, typeint);
+    aliasVect.push_back(intVar0);
+    std::string dpAliasint1 = "TestInt1";
+    DPID intVar1(dpAliasint1, typeint);
+    aliasVect.push_back(intVar1);
+    std::string dpAliasint2 = "TestInt2";
+    DPID intVar2(dpAliasint2, typeint);
+    aliasVect.push_back(intVar2);
+
+    DeliveryType typedouble = RAW_DOUBLE;
+    std::string dpAliasdouble0 = "TestDouble0";
+    DPID doubleVar0(dpAliasdouble0, typedouble);
+    aliasVect.push_back(doubleVar0);
+    std::string dpAliasdouble1 = "TestDouble1";
+    DPID doubleVar1(dpAliasdouble1, typedouble);
+    aliasVect.push_back(doubleVar1);
+    std::string dpAliasdouble2 = "TestDouble2";
+    DPID doubleVar2(dpAliasdouble2, typedouble);
+    aliasVect.push_back(doubleVar2);
+    std::string dpAliasdouble3 = "TestDouble3";
+    DPID doubleVar3(dpAliasdouble3, typedouble);
+    aliasVect.push_back(doubleVar3);
+
+    DeliveryType typestring = RAW_STRING;
+    std::string dpAliasstring0 = "TestString0";
+    DPID stringVar0(dpAliasstring0, typestring);
+    aliasVect.push_back(stringVar0);
+
+    mDCSproc.init(aliasVect);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto dcsmap = pc.inputs().get<std::unordered_map<DPID, DPVAL>*>("input");
+    mDCSproc.process(*dcsmap);
+  }
+
+ private:
+  o2::dcs::DCSProcessor mDCSproc;
+};
+
+} // namespace dcs
+
+namespace framework
+{
+
+DataProcessorSpec getDCSDataProcessorSpec()
+{
+  return DataProcessorSpec{
+    "dcs-data-processor",
+    Inputs{{"input", "DCS", "DATAPOINTS"}},
+    Outputs{{}},
+    AlgorithmSpec{adaptFromTask<o2::dcs::DCSDataProcessor>()},
+    Options{}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -52,45 +52,52 @@ class DCSDataProcessor : public o2::framework::Task
 
   void init(o2::framework::InitContext& ic) final
   {
-    std::vector<DPID> aliasVect;
+
+    // stopping all stopwatches, since they start counting from the moment they are created
+    for (int idet = 0; idet < kNdetectors; idet++) {
+      mDeltaProcessingDetLoop[idet].Stop();
+      mDeltaProcessingDetLoop[idet].Reset();
+    }
+
+    std::vector<DPID> pidVect;
 
     DPID dpidtmp;
     DeliveryType typechar = RAW_CHAR;
     std::string dpAliaschar = "TestChar_0";
     DPID::FILL(dpidtmp, dpAliaschar, typechar);
-    aliasVect.push_back(dpidtmp);
+    pidVect.push_back(dpidtmp);
 
     //std::vector<int> vectDet{kTest, kTPC}; // only one detector for now
     std::vector<int> vectDet{kTest};
-    mDetectorAlias[dpidtmp] = vectDet;
+    mDetectorPid[dpidtmp] = vectDet;
 
     DeliveryType typeint = RAW_INT;
     for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, typeint);
-      aliasVect.push_back(dpidtmp);
-      mDetectorAlias[dpidtmp] = vectDet;
+      pidVect.push_back(dpidtmp);
+      mDetectorPid[dpidtmp] = vectDet;
     }
 
     DeliveryType typedouble = RAW_DOUBLE;
     for (int i = 0; i < 4; i++) {
       std::string dpAliasdouble = "TestDouble_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasdouble, typedouble);
-      aliasVect.push_back(dpidtmp);
-      mDetectorAlias[dpidtmp] = vectDet;
+      pidVect.push_back(dpidtmp);
+      mDetectorPid[dpidtmp] = vectDet;
     }
 
     DeliveryType typestring = RAW_STRING;
     std::string dpAliasstring0 = "TestString_0";
     DPID::FILL(dpidtmp, dpAliasstring0, typestring);
-    aliasVect.push_back(dpidtmp);
-    mDetectorAlias[dpidtmp] = vectDet;
+    pidVect.push_back(dpidtmp);
+    mDetectorPid[dpidtmp] = vectDet;
 
-    mDCSproc.init(aliasVect);
+    mDCSproc.init(pidVect);
     mDCSproc.setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
     mDCSproc.setName("Test0Det");
     for (int idet = 0; idet < kNdetectors; idet++) {
-      mDCSprocVect[idet].init(aliasVect);
+      mDCSprocVect[idet].init(pidVect);
       mDCSprocVect[idet].setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
       mDCSprocVect[idet].setName("Test1Det");
     }
@@ -190,7 +197,7 @@ class DCSDataProcessor : public o2::framework::Task
 
         LOG(DEBUG) << "TF: " << tfid << " -->  starting (delta) processing in detector loop...";
         for (const auto& dpcom : dcsmapDelta) {
-          std::vector<int> detVect = mDetectorAlias[dpcom.first];
+          std::vector<int> detVect = mDetectorPid[dpcom.first];
           for (int idet = 0; idet < detVect.size(); idet++) {
             mDeltaProcessingDetLoop[idet].Start(mResetStopwatchDeltaProcessingDetLoop);
             mDCSprocVect[idet].processDP(dpcom);
@@ -266,7 +273,7 @@ class DCSDataProcessor : public o2::framework::Task
   }
 
  private:
-  std::unordered_map<DPID, std::vector<int>> mDetectorAlias;
+  std::unordered_map<DPID, std::vector<int>> mDetectorPid;
   std::array<DCSProcessor, kNdetectors> mDCSprocVect;
   o2::dcs::DCSProcessor mDCSproc;
   TStopwatch mReceiveBinaryData;

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -52,13 +52,13 @@ class DCSDataProcessor : public o2::framework::Task
 
   void init(o2::framework::InitContext& ic) final
   {
-    std::vector<DPID> aliasVect;
+    std::unordered_map<DPID, int> dpMap;
 
     DPID dpidtmp;
     DeliveryType typechar = RAW_CHAR;
     std::string dpAliaschar = "TestChar_0";
     DPID::FILL(dpidtmp, dpAliaschar, typechar);
-    aliasVect.push_back(dpidtmp);
+    dpMap[dpidtmp] = 1;
 
     //std::vector<int> vectDet{kTest, kTPC}; // only one detector for now
     std::vector<int> vectDet{kTest};
@@ -68,7 +68,7 @@ class DCSDataProcessor : public o2::framework::Task
     for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, typeint);
-      aliasVect.push_back(dpidtmp);
+      dpMap[dpidtmp] = 1;
       mDetectorAlias[dpidtmp] = vectDet;
     }
 
@@ -76,21 +76,21 @@ class DCSDataProcessor : public o2::framework::Task
     for (int i = 0; i < 4; i++) {
       std::string dpAliasdouble = "TestDouble_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasdouble, typedouble);
-      aliasVect.push_back(dpidtmp);
+      dpMap[dpidtmp] = 1;
       mDetectorAlias[dpidtmp] = vectDet;
     }
 
     DeliveryType typestring = RAW_STRING;
     std::string dpAliasstring0 = "TestString_0";
     DPID::FILL(dpidtmp, dpAliasstring0, typestring);
-    aliasVect.push_back(dpidtmp);
+    dpMap[dpidtmp] = 1;
     mDetectorAlias[dpidtmp] = vectDet;
 
-    mDCSproc.init(aliasVect);
+    mDCSproc.init(dpMap);
     mDCSproc.setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
     mDCSproc.setName("Test0Det");
     for (int idet = 0; idet < kNdetectors; idet++) {
-      mDCSprocVect[idet].init(aliasVect);
+      mDCSprocVect[idet].init(dpMap);
       mDCSprocVect[idet].setMaxCyclesNoFullMap(ic.options().get<int64_t>("max-cycles-no-full-map"));
       mDCSprocVect[idet].setName("Test1Det");
     }
@@ -295,8 +295,8 @@ class DCSDataProcessor : public o2::framework::Task
     const auto& payload = mDCSproc.getCCDBSimpleMovingAverage();
     auto& info = mDCSproc.getCCDBSimpleMovingAverageInfo();
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
-    LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
-              << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+    LOG(DEBUG) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+               << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
 
     output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get());
     output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -16,6 +16,7 @@
 
 #include <unistd.h>
 #include <TRandom.h>
+#include <TStopwatch.h>
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
@@ -75,21 +76,34 @@ class DCSDataProcessor : public o2::framework::Task
 
   void run(o2::framework::ProcessingContext& pc) final
   {
-    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    TStopwatch s; 
+    LOG(INFO) << "TF: " << tfid << " -->  receiving binary data...";
+    s.Start();
     auto rawchar = pc.inputs().get<const char*>("input");
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...binary data received: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("input").header);
     auto sz = dh->payloadSize;
     int nDPs = sz / sizeof(DPCOM);
     LOG(INFO) << "Number of DPs received = " << nDPs;
     std::unordered_map<DPID, DPVAL> dcsmap;
     DPCOM dptmp;
+    LOG(INFO) << "TF: " << tfid << " -->  building unordered_map...";
+    s.Start();
     for (int i = 0; i < nDPs; i++) {
       memcpy(&dptmp, rawchar + i * sizeof(DPCOM), sizeof(DPCOM));
       dcsmap[dptmp.id] = dptmp.data;
       LOG(DEBUG) << "Reading from generator: i = " << i << ", DPCOM = " << dptmp;
       LOG(DEBUG) << "Reading from generator: i = " << i << ", DPID = " << dptmp.id;
     }
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...unordered_map built = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+    LOG(INFO) << "TF: " << tfid << " -->  starting processing...";
+    s.Start();
     mDCSproc.process(dcsmap);
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...processing done: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
   }
 
  private:

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -52,7 +52,7 @@ class DCSDataProcessor : public o2::framework::Task
     aliasVect.push_back(dpidtmp);
 
     DeliveryType typeint = RAW_INT;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 50000; i++) {
       std::string dpAliasint = "TestInt_" + std::to_string(i);
       DPID::FILL(dpidtmp, dpAliasint, typeint);
       aliasVect.push_back(dpidtmp);
@@ -86,8 +86,8 @@ class DCSDataProcessor : public o2::framework::Task
     for (int i = 0; i < nDPs; i++) {
       memcpy(&dptmp, rawchar + i * sizeof(DPCOM), sizeof(DPCOM));
       dcsmap[dptmp.id] = dptmp.data;
-      LOG(INFO) << "Reading from generator: i = " << i << ", DPCOM = " << dptmp;
-      LOG(INFO) << "Reading from generator: i = " << i << ", DPID = " << dptmp.id;
+      LOG(DEBUG) << "Reading from generator: i = " << i << ", DPCOM = " << dptmp;
+      LOG(DEBUG) << "Reading from generator: i = " << i << ", DPID = " << dptmp.id;
     }
     mDCSproc.process(dcsmap);
   }

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -130,9 +130,15 @@ class DCSDataProcessor : public o2::framework::Task
 
     LOG(INFO) << "TF: " << tfid << " -->  starting processing...";
     s.Start();
-    mDCSproc.process(dcsmap);
+    mDCSproc.process(dcsmap, false);
     s.Stop();
     LOG(INFO) << "TF: " << tfid << " -->  ...processing done: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
+    LOG(INFO) << "TF: " << tfid << " -->  starting (delta) processing...";
+    s.Start();
+    mDCSproc.process(dcsmapDelta, true);
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...processing (delta) done: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
 
     sendOutput(pc.outputs());
   }

--- a/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSDataProcessorSpec.h
@@ -22,6 +22,8 @@
 #include "DetectorsDCS/DataPointCompositeObject.h"
 #include "DetectorsDCS/DeliveryType.h"
 #include "DetectorsDCS/DCSProcessor.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CCDB/CcdbApi.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
@@ -77,12 +79,21 @@ class DCSDataProcessor : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final
   {
     auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
-    TStopwatch s; 
+    mDCSproc.setTF(tfid);
+
+    TStopwatch s;
     LOG(INFO) << "TF: " << tfid << " -->  receiving binary data...";
     s.Start();
     auto rawchar = pc.inputs().get<const char*>("input");
     s.Stop();
     LOG(INFO) << "TF: " << tfid << " -->  ...binary data received: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+    LOG(INFO) << "TF: " << tfid << " -->  receiving (delta) binary data...";
+    s.Start();
+    auto rawcharDelta = pc.inputs().get<const char*>("inputDelta");
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...binary (delta) data received: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
+    // full map
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("input").header);
     auto sz = dh->payloadSize;
     int nDPs = sz / sizeof(DPCOM);
@@ -99,17 +110,51 @@ class DCSDataProcessor : public o2::framework::Task
     }
     s.Stop();
     LOG(INFO) << "TF: " << tfid << " -->  ...unordered_map built = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
+    // delta map
+    const auto* dhDelta = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("inputDelta").header);
+    auto szDelta = dhDelta->payloadSize;
+    int nDPsDelta = szDelta / sizeof(DPCOM);
+    LOG(INFO) << "Number of DPs received (delta map) = " << nDPsDelta;
+    std::unordered_map<DPID, DPVAL> dcsmapDelta;
+    LOG(INFO) << "TF: " << tfid << " -->  building (delta) unordered_map...";
+    s.Start();
+    for (int i = 0; i < nDPsDelta; i++) {
+      memcpy(&dptmp, rawcharDelta + i * sizeof(DPCOM), sizeof(DPCOM));
+      dcsmapDelta[dptmp.id] = dptmp.data;
+      LOG(DEBUG) << "Reading from generator: i = " << i << ", DPCOM = " << dptmp;
+      LOG(DEBUG) << "Reading from generator: i = " << i << ", DPID = " << dptmp.id;
+    }
+    s.Stop();
+    LOG(INFO) << "TF: " << tfid << " -->  ...unordered_map (delta) built = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
     LOG(INFO) << "TF: " << tfid << " -->  starting processing...";
     s.Start();
     mDCSproc.process(dcsmap);
     s.Stop();
     LOG(INFO) << "TF: " << tfid << " -->  ...processing done: realTime = " << s.RealTime() << ", cpuTime = " << s.CpuTime();
+
+    sendOutput(pc.outputs());
   }
 
  private:
   o2::dcs::DCSProcessor mDCSproc;
-};
 
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // copied from LHCClockCalibratorSpec.cxx
+    using clbUtils = o2::calibration::Utils;
+    const auto& payload = mDCSproc.getCCDBint();
+    auto& info = mDCSproc.getCCDBintInfo();
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+    LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size() << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+
+    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, 0}, *image.get()); // vector<char>
+    output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, 0}, info);
+  }
+}; // end class
 } // namespace dcs
 
 namespace framework
@@ -117,10 +162,17 @@ namespace framework
 
 DataProcessorSpec getDCSDataProcessorSpec()
 {
+
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
+  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+
   return DataProcessorSpec{
     "dcs-data-processor",
-    Inputs{{"input", "DCS", "DATAPOINTS"}},
-    Outputs{{}},
+    Inputs{{"input", "DCS", "DATAPOINTS"}, {"inputDelta", "DCS", "DATAPOINTSdelta"}},
+    outputs,
     AlgorithmSpec{adaptFromTask<o2::dcs::DCSDataProcessor>()},
     Options{}};
 }

--- a/Detectors/DCS/testWorkflow/dcs-data-workflow.cxx
+++ b/Detectors/DCS/testWorkflow/dcs-data-workflow.cxx
@@ -11,13 +11,13 @@
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
 #include "Framework/TypeTraits.h"
+#include <unordered_map>
 namespace o2::framework
 {
 template <>
 struct has_root_dictionary<std::unordered_map<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue>, void> : std::true_type {
 };
 } // namespace o2::framework
-#include <unordered_map>
 #include "Framework/DataProcessorSpec.h"
 #include "DCSDataGeneratorSpec.h"
 #include "DCSDataProcessorSpec.h"

--- a/Detectors/DCS/testWorkflow/dcs-data-workflow.cxx
+++ b/Detectors/DCS/testWorkflow/dcs-data-workflow.cxx
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "Framework/TypeTraits.h"
+namespace o2::framework
+{
+template <>
+struct has_root_dictionary<std::unordered_map<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue>, void> : std::true_type {
+};
+} // namespace o2::framework
+#include <unordered_map>
+#include "Framework/DataProcessorSpec.h"
+#include "DCSDataGeneratorSpec.h"
+#include "DCSDataProcessorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getDCSDataGeneratorSpec());
+  specs.emplace_back(getDCSDataProcessorSpec());
+  return specs;
+}

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -52,7 +52,8 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             macro/loadExtDepLib.C
             macro/load_all_libs.C
             macro/putCondition.C
-            macro/rootlogon.C)
+            macro/rootlogon.C
+	    Detectors/DCS/test/processor_dpcom_o2.C)
 
 if(NOT BUILD_SIMULATION)
   # some complete sub_directories are not added to the build when not building


### PR DESCRIPTION
This is an example of how to process the DCS data coming from DCS. For now, one should simulate the Data Points with a macro, and then process them from there. 
More discussions will be needed to understand how to interface the DCS FLP to the standard processing workflow (with DPL).

--> Workflow to simulate and process DCS data added.

--> update of CCDB added: o2-dcs-dcs-data-workflow --max-timeframes 100 -b | o2-calibration-ccdb-populator-workflow --ccdb-path localhost:8080 -b

--> default behaviour: first TF will process the full map with all DPs; from the 2nd TF on, only a delta map is processed, DP by DP, looping on detectors that "subscribed" to that DP. 
In order to process the full delta map, option "--process-full-delta-map" should be used

-------------------

DCS processor example

example macro

Update.

Fixes + check on entries in map

Using unordered_map find, adding other types.

Not yet complete.

Fix for string type (thanks to Ruben!) and adding binary type.

Implementing reading of flags plus other changes.

* new Init taking full map;
* function to check presence of alias.

Removing commented out line

Fix indentation

For the sake of clang happiness.