### PR TITLE
DPL: avoid busy looping when in Idle state

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -427,7 +427,7 @@ bool DataProcessingDevice::ConditionalRun()
   if (mState.loop) {
     ZoneScopedN("uv idle");
     TracyPlot("past activity", (int64_t)mWasActive);
-    uv_run(mState.loop, mWasActive ? UV_RUN_NOWAIT : UV_RUN_ONCE);
+    uv_run(mState.loop, mWasActive && (mDataProcessorContexes.at(0).state->streaming != StreamingState::Idle) ? UV_RUN_NOWAIT : UV_RUN_ONCE);
   }
 
   // Notify on the main thread the new region callbacks, making sure


### PR DESCRIPTION
Under certain conditions (most notably when an enumeration was provided and
the device switched to "Idle" state) the libuv integration mistaken 
considered as activity any further enumeration, resulting in a busy loop. This
makes sure we always UV_ONCE (i.e. wait for an external event) when in
StreamingState::Idle.