### PR TITLE
Don't use ROOTCLING -m on MacOS

### DIFF
--- a/cmake/rootcling_wrapper.sh.in
+++ b/cmake/rootcling_wrapper.sh.in
@@ -72,6 +72,14 @@ if [[ ! $ROOTMAP_FILE ]]; then
   exit 1
 fi
 
+case $OSTYPE in
+  darwin*)
+    unset PCMDEPS
+    ;;
+  *)
+    ;;
+esac
+
 LOGFILE=${DICTIONARY_FILE}.log
 
 @CMAKE_COMMAND@ -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} @ROOT_rootcling_CMD@ \


### PR DESCRIPTION
@shahor02 @sawenzel @ktf : #4477 causes a problem with rebuild from scratch on MacOS. Apparently, with the -m flag ROOTCLING does not create correct dictionaries. I didn't check what goes wrong in detail, but since it works on Linux, I guess it could be a ROOT problem.
This PR just removes the -m from rootcling if we are on MacOS, leaves it in on Linux where it seems to work.
Also the dependency resolving fir of #4477 is unaffected and still works, both on MacOS and Linux.
It is only the -m that should remove the duplicates in the dictionary that is causing trouble.
Don't know if we should follow this up and possibly file a bug report v.s. ROOT but personally I don't care enough for MacOS anyway.