### PR TITLE
Bugfix in chamber search for TRD tracking

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -1161,7 +1161,7 @@ GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::FindChambersInRoad(const TRDTRK* t, c
     const GPUTRDpadPlane* pp = mGeo->GetPadPlane(iLayer, currStack);
     int lastPadRow = mGeo->GetRowMax(iLayer, currStack, 0);
     float zCenter = pp->GetRowPos(lastPadRow / 2);
-    if ((t->getZ() + roadZ) > pp->GetRowPos(0) || (t->getZ() - roadZ) < pp->GetRowPos(lastPadRow)) {
+    if ((t->getZ() + roadZ) > pp->GetRow0() || (t->getZ() - roadZ) < pp->GetRowEnd()) {
       int addStack = t->getZ() > zCenter ? currStack - 1 : currStack + 1;
       if (addStack < kNStacks && addStack > -1) {
         det[nDets++] = mGeo->GetDetector(iLayer, addStack, currSec);


### PR DESCRIPTION
The variable lastPadRow actually contains the number of pad rows in the given TRD chamber. The `AliTRDpadPlane::GetRowPos(Int_t row)` method is defined for row = 0..**lastPadRow-1** only, therefore this call is undefined behavior.
I don't know why I did not see this earlier, it crashed for me in the HLT framework with an FPE (no segfault), but not in the standalone framework.
Asche auf mein Haupt...