### PR TITLE
[MFT] Improved track seed for low pt tracks & MCS effects evaluation

### DIFF
--- a/DataFormats/Reconstruction/src/TrackFwd.cxx
+++ b/DataFormats/Reconstruction/src/TrackFwd.cxx
@@ -325,7 +325,7 @@ void TrackParCovFwd::addMCSEffect(double dZ, double x_over_X0)
   auto pathLengthOverX0 = x_over_X0 * csclambda; //
 
   // Angular dispersion square of the track (variance) in a plane perpendicular to the trajectory
-  auto sigmathetasq = 0.0136 * getInverseMomentum() * (1 + 0.038 * TMath::Log(pathLengthOverX0));
+  auto sigmathetasq = 0.0136 * getInverseMomentum();
   sigmathetasq *= sigmathetasq * pathLengthOverX0;
 
   // Get covariance matrix

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Cluster.h
@@ -26,6 +26,7 @@ namespace mft
 {
 
 struct Cluster : public o2::BaseCluster<float> {
+  Cluster() = default;
   Cluster(const Float_t x, const Float_t y, const Float_t z, const Float_t phi, const Float_t r, const Int_t id, const Int_t bin, const Float_t sigX2, const Float_t sigY2, const Int_t sensorID)
     : BaseCluster(sensorID, x, y, z),
       phiCoordinate{phi},

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -21,11 +21,6 @@ namespace o2
 namespace mft
 {
 
-enum MFTTrackingSeed {
-  AB, //
-  DH
-};
-
 enum MFTTrackModel {
   Helix,
   Quadratic,
@@ -36,11 +31,8 @@ enum MFTTrackModel {
 // ** Parameters for MFT tracking configuration
 // **
 struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingParam> {
-  Int_t seed = MFTTrackingSeed::DH;
   Int_t trackmodel = MFTTrackModel::Helix;
-  double sigmaboost = 1e3;
-  double seedH_k = 1.0;
-  double MFTRadLenghts = 0.041; // MFT average material budget within acceptance
+  double MFTRadLength = 1.0; // MFT average material budget within acceptance. Should be 0.041
   bool verbose = false;
 
   O2ParamDef(MFTTrackingParam, "MFTTracking");

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -98,127 +98,123 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
   auto& mftTrackingParam = MFTTrackingParam::Instance();
 
   // initialize the starting track parameters and cluster
-	double sigmainvQPtsq;
+  double sigmainvQPtsq;
   double chi2invqptquad;
-  double invQPtSeed;
+  auto invQPt0 = invQPtFromFCF(track, mBZField, sigmainvQPtsq);
   auto nPoints = track.getNumberOfPoints();
   auto k = TMath::Abs(o2::constants::math::B2C * mBZField);
   auto Hz = std::copysign(1, mBZField);
-  invQPtSeed = invQPtFromFCF(track, mBZField, sigmainvQPtsq);
 
   if (mftTrackingParam.verbose) {
     std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
     std::cout << "N Clusters = " << nPoints << std::endl;
   }
 
-  track.setInvQPtSeed(invQPtSeed);
+  track.setInvQPtSeed(invQPt0);
   track.setChi2QPtSeed(chi2invqptquad);
-  track.setInvQPt(invQPtSeed);
+  track.setInvQPt(invQPt0);
 
   /// Compute the initial track parameters to seed the Kalman filter
 
-  int start; // Start fitting by the first or the last cluster
-  if (outward)
-    start = 0;
-  else
-    start = nPoints - 1;
+  int first_cls, last_cls;
+  if (outward) { // MCH matching
+    first_cls = 0;
+    last_cls = nPoints - 1;
+  } else { // Vertexing
+    first_cls = nPoints - 1;
+    last_cls = 0;
+  }
 
-  double x0 = track.getXCoordinates()[start];
-  double y0 = track.getYCoordinates()[start];
-  double z0 = track.getZCoordinates()[start];
-  double deltaX = track.getXCoordinates()[nPoints - 1] - track.getXCoordinates()[0];
-  double deltaY = track.getYCoordinates()[nPoints - 1] - track.getYCoordinates()[0];
-  double deltaZ = track.getZCoordinates()[nPoints - 1] - track.getZCoordinates()[0];
-  double deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
-  double tanl = 0.5 * TMath::Sqrt(2) * (deltaZ / deltaR) *
-                TMath::Sqrt(TMath::Sqrt((invQPtSeed * deltaR * k) * (invQPtSeed * deltaR * k) + 1) + 1);
-  double phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPtSeed * deltaZ * k / tanl;
-  double r0sq = x0 * x0 + y0 * y0;
-  double r0cu = r0sq * TMath::Sqrt(r0sq);
-  double invr0sq = 1.0 / r0sq;
-  double invr0cu = 1.0 / r0cu;
-  double sigmax0sq = track.getSigmasX2()[start];
-  double sigmay0sq = track.getSigmasY2()[start];
-  double sigmaDeltaZsq = 5.0;                      // Primary vertex distribution: beam interaction diamond
-  double sigmaboost = mftTrackingParam.sigmaboost; // Boost q/pt seed covariances
-  double seedH_k = mftTrackingParam.seedH_k;       // SeedH constant
+  auto x0 = track.getXCoordinates()[first_cls];
+  auto y0 = track.getYCoordinates()[first_cls];
+  auto z0 = track.getZCoordinates()[first_cls];
+
+  auto deltaX = track.getXCoordinates()[nPoints - 1] - track.getXCoordinates()[0];
+  auto deltaY = track.getYCoordinates()[nPoints - 1] - track.getYCoordinates()[0];
+  auto deltaZ = track.getZCoordinates()[nPoints - 1] - track.getZCoordinates()[0];
+  auto deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
+  auto tanl0 = 0.5 * TMath::Sqrt2() * (deltaZ / deltaR) *
+               TMath::Sqrt(TMath::Sqrt((invQPt0 * deltaR * k) * (invQPt0 * deltaR * k) + 1) + 1);
+  auto phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPt0 * deltaZ * k / tanl0;
+  auto sigmax0sq = track.getSigmasX2()[first_cls];
+  auto sigmay0sq = track.getSigmasY2()[first_cls];
+  auto sigmax1sq = track.getSigmasX2()[last_cls];
+  auto sigmay1sq = track.getSigmasY2()[last_cls];
+  auto sigmaDeltaXsq = sigmax0sq + sigmax1sq;
+  auto sigmaDeltaYsq = sigmay0sq + sigmay1sq;
 
   track.setX(x0);
   track.setY(y0);
   track.setZ(z0);
   track.setPhi(phi0);
-  track.setTanl(tanl);
+  track.setTanl(tanl0);
 
-  // Configure the track seed
-  switch (mftTrackingParam.seed) {
-    case AB:
-      if (mftTrackingParam.verbose)
-        std::cout << " Init track with Seed A / B; sigmaboost = " << sigmaboost << (track.isCA() ? " CA Track " : " LTF Track") << std::endl;
-      track.setInvQPt(1.0 / TMath::Sqrt(x0 * x0 + y0 * y0)); // Seeds A & B
-      break;
-    case DH:
-      if (mftTrackingParam.verbose)
-        std::cout << " Init track with Seed H; (k = " << seedH_k << "); sigmaboost = " << sigmaboost << (track.isCA() ? " CA Track " : " LTF Track") << std::endl;
-      track.setInvQPt(track.getInvQPt() / seedH_k); // SeedH
-      break;
-    default:
-      LOG(ERROR) << "Invalid MFT tracking seed";
-      return false;
-      break;
-  }
   if (mftTrackingParam.verbose) {
+    std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
     auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
     std::cout << "Track Model: " << model << std::endl;
-    std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << track.getTanl() << "  Phi = " << track.getPhi() << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
-    std::cout << " Variances: sigma_x0 = " << TMath::Sqrt(sigmax0sq) << " sigma_y0 = " << TMath::Sqrt(sigmay0sq) << " sigma_q/pt = " << TMath::Sqrt(sigmainvQPtsq) << std::endl;
+    std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
+    std::cout << " Variances: sigma2_x0 = " << TMath::Sqrt(sigmax0sq) << " sigma2_y0 = " << TMath::Sqrt(sigmay0sq) << " sigma2_q/pt = " << TMath::Sqrt(sigmainvQPtsq) << std::endl;
   }
 
-  auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
+  auto deltaR2 = deltaR * deltaR;
+  auto deltaR3 = deltaR2 * deltaR;
+  auto deltaR4 = deltaR2 * deltaR2;
+  auto k2 = k * k;
+  auto A = TMath::Sqrt(track.getInvQPt() * track.getInvQPt() * deltaR2 * k2 + 1);
+  auto A2 = A * A;
+  auto B = A + 1.0;
+  auto B2 = B * B;
+  auto B3 = B * B * B;
+  auto B12 = TMath::Sqrt(B);
+  auto B32 = B * B12;
+  auto B52 = B * B32;
+  auto C = invQPt0 * k;
+  auto C2 = C * C;
+  auto C3 = C * C2;
+  auto D = 1.0 / (A2 * B2 * B2 * deltaR4);
+  auto E = D * deltaZ / (B * deltaR);
+  auto F = deltaR * deltaX * C3 * Hz / (A * B32);
+  auto G = 0.5 * TMath::Sqrt2() * A * B32 * C * Hz * deltaR;
+  auto Gx = G * deltaX;
+  auto Gy = G * deltaY;
+  auto H = -0.25 * TMath::Sqrt2() * B12 * C3 * Hz * deltaR3;
+  auto Hx = H * deltaX;
+  auto Hy = H * deltaY;
+  auto I = A * B2;
+  auto Ix = I * deltaX;
+  auto Iy = I * deltaY;
+  auto J = 2 * B * deltaR3 * deltaR3 * k2;
+  auto K = 0.5 * A * B - 0.25 * C2 * deltaR2;
+  auto L0 = Gx + Hx + Iy;
+  auto M0 = -Gy - Hy + Ix;
+  auto N = -0.5 * B3 * C * Hz * deltaR3 * deltaR4 * k2;
+  auto O = 0.125 * C2 * deltaR4 * deltaR4 * k2;
+  auto P = -K * k * Hz * deltaR / A;
+  auto Q = deltaZ * deltaZ / (A2 * B * deltaR3 * deltaR3);
+  auto R = 0.25 * C * deltaZ * TMath::Sqrt2() * deltaR * k / (A * B12);
 
-
-  double C1 = track.getInvQPt() * k * deltaR;
-  double D1 = TMath::Sqrt(C1 * C1 + 1);
-  double invD1 = 1. / D1;
-  double D2 = 1. / TMath::Sqrt(D1 + 1);
-  double E1 = deltaR * D2 * D2 * invD1;
-  double F1 = Hz * k * D2;
-  double G1 = deltaZ * k * D2 / D1;
-  double invDr2 = 1. / (deltaR * deltaR);
-  double J1 = G1 * invDr2 / (k*deltaR);
-  double L1 = C1 * C1 - 2 * D1 * (D1 + 1);
-  double inv2rt2 = 0.25 * TMath::Sqrt(2);
-  double Mx = invDr2 * (inv2rt2 * track.getInvQPt() * E1 * F1 * L1 * deltaX - deltaY);
-  double My = invDr2 * (inv2rt2 * track.getInvQPt() * E1 * F1 * L1 * deltaY + deltaX);
-
-  double sigmax1sq = track.getSigmasX2()[0];
-  double sigmay1sq = track.getSigmasY2()[0];
-  double sigmaDeltaX = sigmax0sq + sigmax1sq;
-  double sigmaDeltaY = sigmay0sq + sigmay1sq;
-
-  // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)
   SMatrix55 lastParamCov;
-  lastParamCov(0, 0) = sigmax0sq;                   // <X,X>
-  lastParamCov(0, 1) = 0;                           // <Y,X>
-  lastParamCov(0, 2) = sigmax0sq * Mx;	// <PHI,X>
-  lastParamCov(0, 3) = sigmax0sq * inv2rt2 * J1 * L1 * deltaX; 	// <TANL,X>
-  lastParamCov(0, 4) = 0;    	// <INVQPT,X>
+  lastParamCov(0, 0) = sigmax0sq; // <X,X>
+  lastParamCov(0, 1) = 0;         // <Y,X>
+  lastParamCov(0, 2) = 0;         // <PHI,X>
+  lastParamCov(0, 3) = 0;         // <TANL,X>
+  lastParamCov(0, 4) = 0;         // <INVQPT,X>
 
-  lastParamCov(1, 1) = sigmay0sq;	// <Y,Y>
-  lastParamCov(1, 2) = sigmay0sq * My;       // <PHI,Y>
-  lastParamCov(1, 3) = sigmay0sq * inv2rt2 * J1 * L1 * deltaY; 	// <TANL,Y>
-  lastParamCov(1, 4) = 0;       // <INVQPT,Y>
+  lastParamCov(1, 1) = sigmay0sq; // <Y,Y>
+  lastParamCov(1, 2) = 0;         // <PHI,Y>
+  lastParamCov(1, 3) = 0;         // <TANL,Y>
+  lastParamCov(1, 4) = 0;         // <INVQPT,Y>
 
-  lastParamCov(2, 2) = sigmainvQPtsq * 0.125 * E1 * E1 * F1 * F1 * L1 * L1 + sigmaDeltaX * Mx * Mx + sigmaDeltaY * My * My; // <PHI,PHI>
+  lastParamCov(2, 2) = D * (J * K * K * sigmainvQPtsq + L0 * L0 * sigmaDeltaXsq + M0 * M0 * sigmaDeltaYsq); // <PHI,PHI>
+  lastParamCov(2, 3) = E * K * (TMath::Sqrt2() * B52 * (L0 * deltaX * sigmaDeltaXsq - deltaY * sigmaDeltaYsq * M0) + N * sigmainvQPtsq); //  <TANL,PHI>
+  lastParamCov(2, 4) = P * sigmainvQPtsq * TMath::Sqrt2() / B32; //  <INVQPT,PHI>
 
-  lastParamCov(2, 3) = sigmainvQPtsq * 0.125 * C1 * E1 * F1 * G1 * L1 + inv2rt2 * J1 * L1 * (sigmaDeltaX * Mx + sigmaDeltaY * My);      //  <TANL,PHI>
-
-  lastParamCov(2, 4) = sigmainvQPtsq * inv2rt2 * E1 * F1 * L1;           //  <INVQPT,PHI>
-
-  lastParamCov(3, 3) = sigmainvQPtsq * 0.125 * C1 * C1 * G1 * G1 + 0.125 * J1 * J1 * L1 * L1 * (sigmaDeltaX * deltaX * deltaX + sigmaDeltaY * deltaY * deltaY); // <TANL,TANL>
-
-  lastParamCov(3, 4) = sigmainvQPtsq * inv2rt2 * C1 * G1;                                // <INVQPT,TANL>
+  lastParamCov(3, 3) = Q * (2 * K * K * (deltaX * deltaX * sigmaDeltaXsq + deltaY * deltaY * sigmaDeltaYsq) + O * sigmainvQPtsq); // <TANL,TANL>
+  lastParamCov(3, 4) = R * sigmainvQPtsq; // <INVQPT,TANL>
 
   lastParamCov(4, 4) = sigmainvQPtsq; // <INVQPT,INVQPT>
+
   track.setCovariances(lastParamCov);
   track.setTrackChi2(0.);
 
@@ -252,7 +248,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
   using o2::mft::constants::LayerZPosition;
   int startingLayerID, newLayerID;
 
-  double dZ = clz - track.getZ();
+  auto dZ = clz - track.getZ();
   //LayerID of each cluster from ZPosition // TODO: Use ChipMapping
   for (auto layer = 10; layer--;)
     if (track.getZ() < LayerZPosition[layer] + .3 & track.getZ() > LayerZPosition[layer] - .3)
@@ -267,7 +263,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
   else
     NDisksMS = (startingLayerID % 2 == 0) ? (newLayerID - startingLayerID + 1) / 2 : (newLayerID - startingLayerID) / 2;
 
-  double MFTDiskThicknessInX0 = mftTrackingParam.MFTRadLenghts / 5.0;
+  auto MFTDiskThicknessInX0 = mftTrackingParam.MFTRadLenghts / 5.0;
   if (mftTrackingParam.verbose) {
     std::cout << "startingLayerID = " << startingLayerID << " ; "
               << "newLayerID = " << newLayerID << " ; ";
@@ -343,9 +339,9 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
   Double_t* Rn = new Double_t[nPoints - 1];
   Double_t* Pn = new Double_t[nPoints - 1];
   Double_t A, Aerr, B, Berr, x2, y2, invx2y2, a, b, r, sigmaRsq, u2, sigma;
-  Double_t F0,F1,F2,F3,F4, SumSRn, SumSPn, SumRn, SumUPn, SumRP;
+  Double_t F0, F1, F2, F3, F4, SumSRn, SumSPn, SumRn, SumUPn, SumRP;
 
-	SumSRn = SumSPn = SumRn = SumUPn = SumRP = 0.0;
+  SumSRn = SumSPn = SumRn = SumUPn = SumRP = 0.0;
   F0 = F1 = F2 = F3 = F4 = 0.0;
 
   for (auto np = 0; np < nPoints; np++) {
@@ -362,7 +358,7 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
     }
     zVal[np] = zPositions[np];
   }
-	for (int i = 0; i < (nPoints - 1); i++) {
+  for (int i = 0; i < (nPoints - 1); i++) {
     x2 = xVal[i + 1] * xVal[i + 1];
     y2 = yVal[i + 1] * yVal[i + 1];
     invx2y2 = 1. / (x2 + y2);
@@ -370,46 +366,46 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
     vVal[i] = yVal[i + 1] * invx2y2;
     vErr[i] = std::sqrt(8. * xErr[i + 1] * xErr[i + 1] * x2 * y2 + 2. * yErr[i + 1] * yErr[i + 1] * (x2 - y2) * (x2 - y2)) * invx2y2 * invx2y2;
     u2 = uVal[i] * uVal[i];
-    fweight[i] = 1. / vErr[i];  
-    F0 += fweight[i];   // f = fn(Hansroul) que é o peso de cada ponto Vn...inverso da incerteza? 
+    fweight[i] = 1. / vErr[i];
+    F0 += fweight[i]; // f = fn(Hansroul) que é o peso de cada ponto Vn...inverso da incerteza?
     F1 += fweight[i] * uVal[i];
     F2 += fweight[i] * u2;
     F3 += fweight[i] * uVal[i] * u2;
     F4 += fweight[i] * u2 * u2;
   }
 
-	double Rn_det1 = F2 * F4 - F3 * F3; 
+  double Rn_det1 = F2 * F4 - F3 * F3;
   double Rn_det2 = F1 * F4 - F2 * F3;
   double Rn_det3 = F1 * F3 - F2 * F2;
   double Pn_det1 = Rn_det2;
   double Pn_det2 = F0 * F4 - F2 * F2;
   double Pn_det3 = F0 * F3 - F1 * F2;
 
-	for (int j = 0; j < (nPoints - 1); j++) {
-    Rn[j] = fweight[j] * (Rn_det1 - uVal[j]*Rn_det2 + uVal[j]*uVal[j]*Rn_det3);
+  for (int j = 0; j < (nPoints - 1); j++) {
+    Rn[j] = fweight[j] * (Rn_det1 - uVal[j] * Rn_det2 + uVal[j] * uVal[j] * Rn_det3);
     SumSRn += Rn[j] * Rn[j] * vErr[j] * vErr[j];
     SumRn += Rn[j];
 
-    Pn[j] = fweight[j] * (-Pn_det1 + uVal[j]*Pn_det2 - uVal[j]*uVal[j]*Pn_det3);
+    Pn[j] = fweight[j] * (-Pn_det1 + uVal[j] * Pn_det2 - uVal[j] * uVal[j] * Pn_det3);
     SumSPn += Pn[j] * Pn[j] * vErr[j] * vErr[j];
     SumUPn += uVal[j] * Pn[j];
-  
+
     SumRP += Rn[j] * Pn[j] * vErr[j] * vErr[j] * vErr[j];
   }
- 
+
   Double_t invqpt_fcf;
   Int_t qfcf;
-//  chi2 = 0.;
+  //  chi2 = 0.;
   if (LinearRegression((nPoints - 1), uVal, vVal, vErr, B, Berr, A, Aerr)) {
     // v = a * u + b
     // circle passing through (0,0):
     // (x - rx)^2 + (y - ry)^2 = r^2
     // ---> a = - rx / ry;
     // ---> b = 1 / (2 * ry)
-    b =  1. / (2. * A);
+    b = 1. / (2. * A);
     a = -B * b;
     r = std::sqrt(a * a + b * b);
-    double_t invR = 1./r;
+    double_t invR = 1. / r;
 
     // pt --->
     Double_t invpt = 1. / (o2::constants::math::B2C * bFieldZ * r);
@@ -445,15 +441,14 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
     double sigmaBsq = SumSPn / (SumUPn * SumUPn);
     double sigmaAB = SumRP / (SumRn * SumUPn);
 
-		double sigmaasq_FCF = TMath::Abs (0.25 * invA2 * invA2 * (B * B * sigmaAsq + A * A * sigmaBsq - A * B * sigmaAB));
-    double sigmabsq_FCF = TMath::Abs (0.25 * invA2 * invA2 * sigmaAsq);
+    double sigmaasq_FCF = TMath::Abs(0.25 * invA2 * invA2 * (B * B * sigmaAsq + A * A * sigmaBsq - A * B * sigmaAB));
+    double sigmabsq_FCF = TMath::Abs(0.25 * invA2 * invA2 * sigmaAsq);
     double sigma2R = invR * invR * (b * b * sigmaasq_FCF + a * a * sigmabsq_FCF + 2 * a * b * TMath::Sqrt(sigmaasq_FCF) * TMath::Sqrt(sigmabsq_FCF));
 
-		sigmainvqptsq = sigma2R * invpt * invpt * invR * invR;
+    sigmainvqptsq = sigma2R * invpt * invpt * invR * invR;
 
-		std::cout << " Sigma^2_A " << sigmaAsq <<" Sigma^2_B " << sigmaBsq <<" Sigma_AB " << sigmaAB << std::endl;
-		std::cout << " Sigma^2_a " << sigmaasq_FCF <<" Sigma^2_b " << sigmabsq_FCF <<" Sigma^2_R " << sigma2R << std::endl;
-		
+    std::cout << " Sigma^2_A " << sigmaAsq << " Sigma^2_B " << sigmaBsq << " Sigma_AB " << sigmaAB << std::endl;
+    std::cout << " Sigma^2_a " << sigmaasq_FCF << " Sigma^2_b " << sigmabsq_FCF << " Sigma^2_R " << sigma2R << std::endl;
 
   } else { // the linear regression failed...
     LOG(WARN) << "LinearRegression failed!";
@@ -512,7 +507,6 @@ Bool_t LinearRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t* yE
   }
   return kTRUE;
 }
-
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -206,12 +206,12 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
   lastParamCov(1, 3) = 0;         // <TANL,Y>
   lastParamCov(1, 4) = 0;         // <INVQPT,Y>
 
-  lastParamCov(2, 2) = D * (J * K * K * sigmainvQPtsq + L0 * L0 * sigmaDeltaXsq + M0 * M0 * sigmaDeltaYsq); // <PHI,PHI>
+  lastParamCov(2, 2) = D * (J * K * K * sigmainvQPtsq + L0 * L0 * sigmaDeltaXsq + M0 * M0 * sigmaDeltaYsq);                              // <PHI,PHI>
   lastParamCov(2, 3) = E * K * (TMath::Sqrt2() * B52 * (L0 * deltaX * sigmaDeltaXsq - deltaY * sigmaDeltaYsq * M0) + N * sigmainvQPtsq); //  <TANL,PHI>
-  lastParamCov(2, 4) = P * sigmainvQPtsq * TMath::Sqrt2() / B32; //  <INVQPT,PHI>
+  lastParamCov(2, 4) = P * sigmainvQPtsq * TMath::Sqrt2() / B32;                                                                         //  <INVQPT,PHI>
 
   lastParamCov(3, 3) = Q * (2 * K * K * (deltaX * deltaX * sigmaDeltaXsq + deltaY * deltaY * sigmaDeltaYsq) + O * sigmainvQPtsq); // <TANL,TANL>
-  lastParamCov(3, 4) = R * sigmainvQPtsq; // <INVQPT,TANL>
+  lastParamCov(3, 4) = R * sigmainvQPtsq;                                                                                         // <INVQPT,TANL>
 
   lastParamCov(4, 4) = sigmainvQPtsq; // <INVQPT,INVQPT>
 
@@ -263,7 +263,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
   else
     NDisksMS = (startingLayerID % 2 == 0) ? (newLayerID - startingLayerID + 1) / 2 : (newLayerID - startingLayerID) / 2;
 
-  auto MFTDiskThicknessInX0 = mftTrackingParam.MFTRadLenghts / 5.0;
+  auto MFTDiskThicknessInX0 = mftTrackingParam.MFTRadLength / 5.0;
   if (mftTrackingParam.verbose) {
     std::cout << "startingLayerID = " << startingLayerID << " ; "
               << "newLayerID = " << newLayerID << " ; ";
@@ -367,7 +367,7 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
     vErr[i] = std::sqrt(8. * xErr[i + 1] * xErr[i + 1] * x2 * y2 + 2. * yErr[i + 1] * yErr[i + 1] * (x2 - y2) * (x2 - y2)) * invx2y2 * invx2y2;
     u2 = uVal[i] * uVal[i];
     fweight[i] = 1. / vErr[i];
-    F0 += fweight[i]; // f = fn(Hansroul) que é o peso de cada ponto Vn...inverso da incerteza?
+    F0 += fweight[i];
     F1 += fweight[i] * uVal[i];
     F2 += fweight[i] * u2;
     F3 += fweight[i] * uVal[i] * u2;
@@ -446,9 +446,6 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmai
     double sigma2R = invR * invR * (b * b * sigmaasq_FCF + a * a * sigmabsq_FCF + 2 * a * b * TMath::Sqrt(sigmaasq_FCF) * TMath::Sqrt(sigmabsq_FCF));
 
     sigmainvqptsq = sigma2R * invpt * invpt * invR * invR;
-
-    std::cout << " Sigma^2_A " << sigmaAsq << " Sigma^2_B " << sigmaBsq << " Sigma_AB " << sigmaAB << std::endl;
-    std::cout << " Sigma^2_a " << sigmaasq_FCF << " Sigma^2_b " << sigmabsq_FCF << " Sigma^2_R " << sigma2R << std::endl;
 
   } else { // the linear regression failed...
     LOG(WARN) << "LinearRegression failed!";

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -98,12 +98,13 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
   auto& mftTrackingParam = MFTTrackingParam::Instance();
 
   // initialize the starting track parameters and cluster
+	double sigmainvQPtsq;
   double chi2invqptquad;
   double invQPtSeed;
   auto nPoints = track.getNumberOfPoints();
   auto k = TMath::Abs(o2::constants::math::B2C * mBZField);
   auto Hz = std::copysign(1, mBZField);
-  invQPtSeed = invQPtFromFCF(track, mBZField, chi2invqptquad);
+  invQPtSeed = invQPtFromFCF(track, mBZField, sigmainvQPtsq);
 
   if (mftTrackingParam.verbose) {
     std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
@@ -169,32 +170,48 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
     auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
     std::cout << "Track Model: " << model << std::endl;
     std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << track.getTanl() << "  Phi = " << track.getPhi() << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
+    std::cout << " Variances: sigma_x0 = " << TMath::Sqrt(sigmax0sq) << " sigma_y0 = " << TMath::Sqrt(sigmay0sq) << " sigma_q/pt = " << TMath::Sqrt(sigmainvQPtsq) << std::endl;
   }
 
   auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
 
+
+  double C1 = track.getInvQPt() * k * deltaR;
+  double D1 = TMath::Sqrt(C1 * C1 + 1);
+  double invD1 = 1. / D1;
+  double D2 = 1. / TMath::Sqrt(D1 + 1);
+  double E1 = deltaR * D2 * D2 * invD1;
+  double F1 = Hz * k * D2;
+  double G1 = deltaZ * k * D2 / D1;
+  double invDr2 = 1. / (deltaR * deltaR);
+  double J1 = G1 * invDr2 / (k*deltaR);
+  double L1 = C1 * C1 - 2 * D1 * (D1 + 1);
+  double inv2rt2 = 0.25 * TMath::Sqrt(2);
+
   // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)
   SMatrix55 lastParamCov;
-  lastParamCov(0, 0) = sigmax0sq;                                   // <X,X>
-  lastParamCov(0, 1) = 0;                                           // <Y,X>
-  lastParamCov(0, 2) = sigmaboost * -sigmax0sq * y0 * invr0sq;      // <PHI,X>
-  lastParamCov(0, 3) = sigmaboost * -z0 * sigmax0sq * x0 * invr0cu; // <TANL,X>
-  lastParamCov(0, 4) = sigmaboost * -x0 * sigmax0sq * invr0cu;      // <INVQPT,X>
+  lastParamCov(0, 0) = sigmax0sq;                   // <X,X>
+  lastParamCov(0, 1) = 0;                           // <Y,X>
+  lastParamCov(0, 2) = sigmax0sq * invDr2 * (inv2rt2 * track.getInvQPt() * F1 * E1 * L1 * deltaX - deltaY);	// <PHI,X>
+  lastParamCov(0, 3) = sigmax0sq * inv2rt2 * J1 * L1 * deltaX; 	// <TANL,X>
+  lastParamCov(0, 4) = 0;    	// <INVQPT,X>
 
-  lastParamCov(1, 1) = sigmay0sq;                                   // <Y,Y>
-  lastParamCov(1, 2) = sigmaboost * sigmay0sq * x0 * invr0sq;       // <PHI,Y>
-  lastParamCov(1, 3) = sigmaboost * -z0 * sigmay0sq * y0 * invr0cu; // <TANL,Y>
-  lastParamCov(1, 4) = sigmaboost * y0 * sigmay0sq * invr0cu;       //1e-2; // <INVQPT,Y>
+  lastParamCov(1, 1) = sigmay0sq;	// <Y,Y>
+  lastParamCov(1, 2) = sigmay0sq * invDr2 * (inv2rt2 * track.getInvQPt() * F1 * E1 * L1 * deltaY - deltaX);       // <PHI,Y>
+  lastParamCov(1, 3) = sigmay0sq * inv2rt2 * J1 * L1 * deltaY; 	// <TANL,Y>
+  lastParamCov(1, 4) = 0;       // <INVQPT,Y>
 
-  lastParamCov(2, 2) = sigmaboost * (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) * invr0sq * invr0sq; // <PHI,PHI>
-  lastParamCov(2, 3) = sigmaboost * z0 * x0 * y0 * (sigmax0sq - sigmay0sq) * invr0sq * invr0cu;      //  <TANL,PHI>
-  lastParamCov(2, 4) = sigmaboost * y0 * x0 * invr0cu * invr0sq * (sigmax0sq - sigmay0sq);           //  <INVQPT,PHI>
+  lastParamCov(2, 2) = sigmainvQPtsq * 0.125 * E1 * E1 * F1 * F1 * L1 * L1; // <PHI,PHI>
 
-  lastParamCov(3, 3) = sigmaboost * z0 * z0 * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) * invr0cu * invr0cu + sigmaDeltaZsq * invr0sq; // <TANL,TANL>
-  lastParamCov(3, 4) = sigmaboost * z0 * invr0cu * invr0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);                                // <INVQPT,TANL>
+  lastParamCov(2, 3) = sigmainvQPtsq * 0.125 * C1 * E1 * F1 * G1 * L1;      //  <TANL,PHI>
 
-  lastParamCov(4, 4) = sigmaboost * sigmaboost * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) * invr0cu * invr0cu; // <INVQPT,INVQPT>
+  lastParamCov(2, 4) = sigmainvQPtsq * inv2rt2 * E1 * F1 * L1;           //  <INVQPT,PHI>
 
+  lastParamCov(3, 3) = sigmainvQPtsq * 0.125 * C1 * C1 * G1 * G1; // <TANL,TANL>
+
+  lastParamCov(3, 4) = sigmainvQPtsq * inv2rt2 * C1 * G1;                                // <INVQPT,TANL>
+
+  lastParamCov(4, 4) = sigmainvQPtsq; // <INVQPT,INVQPT>
   track.setCovariances(lastParamCov);
   track.setTrackChi2(0.);
 
@@ -296,7 +313,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
 }
 
 //_________________________________________________________________________________________________
-Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
+Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmainvqptsq)
 {
 
   const std::array<Float_t, constants::mft::LayersNumber>& xPositions = track.getXCoordinates();
@@ -315,7 +332,14 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
   Double_t* uVal = new Double_t[nPoints - 1];
   Double_t* vVal = new Double_t[nPoints - 1];
   Double_t* vErr = new Double_t[nPoints - 1];
-  Double_t a, ae, b, be, x2, y2, invx2y2, rx, ry, r;
+  Double_t* fweight = new Double_t[nPoints - 1];
+  Double_t* Rn = new Double_t[nPoints - 1];
+  Double_t* Pn = new Double_t[nPoints - 1];
+  Double_t A, Aerr, B, Berr, x2, y2, invx2y2, a, b, r, sigmaRsq, u2, sigma;
+  Double_t F0,F1,F2,F3,F4, SumSRn, SumSPn, SumRn, SumUPn, SumRP;
+
+	SumSRn = SumSPn = SumRn = SumUPn = SumRP = 0.0;
+  F0 = F1 = F2 = F3 = F4 = 0.0;
 
   for (auto np = 0; np < nPoints; np++) {
     xErr[np] = SigmasX2[np];
@@ -331,27 +355,55 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
     }
     zVal[np] = zPositions[np];
   }
-  for (int i = 0; i < (nPoints - 1); i++) {
+	for (int i = 0; i < (nPoints - 1); i++) {
     x2 = xVal[i + 1] * xVal[i + 1];
     y2 = yVal[i + 1] * yVal[i + 1];
     invx2y2 = 1. / (x2 + y2);
     uVal[i] = xVal[i + 1] * invx2y2;
     vVal[i] = yVal[i + 1] * invx2y2;
     vErr[i] = std::sqrt(8. * xErr[i + 1] * xErr[i + 1] * x2 * y2 + 2. * yErr[i + 1] * yErr[i + 1] * (x2 - y2) * (x2 - y2)) * invx2y2 * invx2y2;
+    u2 = uVal[i] * uVal[i];
+    fweight[i] = 1;//. / vErr[i];
+    F0 += fweight[i];   // f = fn(Hansroul) que é o peso de cada ponto Vn...inverso da incerteza? 
+    F1 += fweight[i] * uVal[i];
+    F2 += fweight[i] * u2;
+    F3 += fweight[i] * uVal[i] * u2;
+    F4 += fweight[i] * u2 * u2;
   }
 
+	double Rn_det1 = F2 * F4 - F3 * F3; 
+  double Rn_det2 = F1 * F4 - F2 * F3;
+  double Rn_det3 = F1 * F3 - F2 * F2;
+  double Pn_det1 = Rn_det2;
+  double Pn_det2 = F0 * F4 - F2 * F2;
+  double Pn_det3 = F0 * F3 - F1 * F2;
+
+	for (int j = 0; j < (nPoints - 1); j++) {
+    Rn[j] = fweight[j] * (Rn_det1 - uVal[j]*Rn_det2 + uVal[j]*uVal[j]*Rn_det3);
+    SumSRn += Rn[j] * Rn[j] * vErr[j];
+    SumRn += Rn[j];
+
+    Pn[j] = fweight[j] * (-Pn_det1 + uVal[j]*Pn_det2 - uVal[j]*uVal[j]*Pn_det3);
+    SumSPn += Pn[j] * Pn[j] * vErr[j];
+    SumUPn += uVal[j] * Pn[j];
+  
+    SumRP += Rn[j] * Pn[j] * vErr[j] * vErr[j]; //falta um vErr?
+  }
+ 
   Double_t invqpt_fcf;
   Int_t qfcf;
-  chi2 = 0.;
-  if (LinearRegression((nPoints - 1), uVal, vVal, vErr, a, ae, b, be)) {
+//  chi2 = 0.;
+  if (LinearRegression((nPoints - 1), uVal, vVal, vErr, B, Berr, A, Aerr)) {
     // v = a * u + b
     // circle passing through (0,0):
     // (x - rx)^2 + (y - ry)^2 = r^2
     // ---> a = - rx / ry;
     // ---> b = 1 / (2 * ry)
-    ry = 1. / (2. * b);
-    rx = -a * ry;
-    r = std::sqrt(rx * rx + ry * ry);
+    b =  1. / (2. * A);
+    a = -B * b;
+    r = std::sqrt(a * a + b * b);
+    double_t invR = 1./r;
+
     // pt --->
     Double_t invpt = 1. / (o2::constants::math::B2C * bFieldZ * r);
 
@@ -363,8 +415,8 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
     Double_t slope = TMath::ATan2(y, x);
     Double_t cosSlope = TMath::Cos(slope);
     Double_t sinSlope = TMath::Sin(slope);
-    Double_t rxRot = rx * cosSlope + ry * sinSlope;
-    Double_t ryRot = rx * sinSlope - ry * cosSlope;
+    Double_t rxRot = a * cosSlope + b * sinSlope;
+    Double_t ryRot = a * sinSlope - b * cosSlope;
     qfcf = (ryRot > 0.) ? -1 : +1;
 
     Double_t alpha = 2.0 * std::abs(TMath::ATan2(rxRot, ryRot));
@@ -378,6 +430,24 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
     pz = std::sqrt(p * p - pt * pt);
 
     invqpt_fcf = qfcf * invpt;
+
+    //error calculations:
+    double invA2 = 1. / (A * A);
+
+    double sigmaAsq = SumSRn / (SumRn * SumRn);
+    double sigmaBsq = SumSPn / (SumUPn * SumUPn);
+    double sigmaAB = SumRP / (SumRn * SumUPn);
+
+		double sigmaasq_FCF = TMath::Abs (0.25 * invA2 * invA2 * (B * B * sigmaAsq + A * A * sigmaBsq - A * B * sigmaAB));
+    double sigmabsq_FCF = TMath::Abs (0.25 * invA2 * invA2 * sigmaAsq);
+    double sigma2R = invR * invR * (b * b * sigmaasq_FCF + a * a * sigmabsq_FCF + 2 * a * b * TMath::Sqrt(sigmaasq_FCF) * TMath::Sqrt(sigmabsq_FCF));
+
+		sigmainvqptsq = sigma2R * invpt * invpt * invR * invR;
+
+		std::cout << " Sigma^2_A " << sigmaAsq <<" Sigma^2_B " << sigmaBsq <<" Sigma_AB " << sigmaAB << std::endl;
+		std::cout << " Sigma^2_a " << sigmaasq_FCF <<" Sigma^2_b " << sigmabsq_FCF <<" Sigma^2_R " << sigma2R << std::endl;
+		
+
   } else { // the linear regression failed...
     LOG(WARN) << "LinearRegression failed!";
     invqpt_fcf = 1. / 100.;
@@ -387,9 +457,9 @@ Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2)
 }
 
 ////_________________________________________________________________________________________________
-Bool_t LinearRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t* yErr, Double_t& a, Double_t& ae, Double_t& b, Double_t& be)
+Bool_t LinearRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t* yErr, Double_t& B, Double_t& Berr, Double_t& A, Double_t& Aerr)
 {
-  // linear regression y = a * x + b
+  // linear regression y = B * x + A
 
   Double_t S1, SXY, SX, SY, SXX, SsXY, SsXX, SsYY, Xm, Ym, s, delta, difx;
   Double_t invYErr2;
@@ -416,8 +486,8 @@ Bool_t LinearRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t* yE
   if (delta == 0.) {
     return kFALSE;
   }
-  a = (SXY * S1 - SX * SY) / delta;
-  b = (SY * SXX - SX * SXY) / delta;
+  B = (SXY * S1 - SX * SY) / delta;
+  A = (SY * SXX - SX * SXY) / delta;
 
   Ym /= (Double_t)nVal;
   Xm /= (Double_t)nVal;
@@ -427,14 +497,15 @@ Bool_t LinearRegression(Int_t nVal, Double_t* xVal, Double_t* yVal, Double_t* yE
   Double_t eps = 1.E-24;
   if ((nVal > 2) && (TMath::Abs(difx) > eps) && ((SsYY - (SsXY * SsXY) / SsXX) > 0.)) {
     s = TMath::Sqrt((SsYY - (SsXY * SsXY) / SsXX) / (nVal - 2));
-    be = s * TMath::Sqrt(1. / (Double_t)nVal + (Xm * Xm) / SsXX);
-    ae = s / TMath::Sqrt(SsXX);
+    Aerr = s * TMath::Sqrt(1. / (Double_t)nVal + (Xm * Xm) / SsXX);
+    Berr = s / TMath::Sqrt(SsXX);
   } else {
-    be = 0.;
-    ae = 0.;
+    Aerr = 0.;
+    Berr = 0.;
   }
   return kTRUE;
 }
+
 
 } // namespace mft
 } // namespace o2


### PR DESCRIPTION
This PR improves the seed configuration for low Pt MFT standalone tracks. 

The simplified calculation of MCS effects improve results, but the MFT radiation length evaluated during track fitting has to be doubled with respect to design values in order to match fitting covariances and simulation (positions and angles). 

The fitted covariances for inverse charged momentum remains way smaller than the dispersion observed (factor of 20). MCS effects on q/pt may need to be added after fitting, or perhaps we should remove q/pt from Kalman filter fitting given that the initial estimate of q/pt from track curvature is better than the ones obtained by Kalman filter.