### PR TITLE
DPL Analysis: protect grouping from empty tables

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -237,7 +237,7 @@ struct AnalysisDataProcessorBuilder {
         auto splitter = [&](auto&& x) {
           using xt = std::decay_t<decltype(x)>;
           constexpr auto index = framework::has_type_at_v<std::decay_t<decltype(x)>>(associated_pack_t{});
-          if (hasIndexTo<std::decay_t<G>>(typename xt::persistent_columns_t{})) {
+          if (x.size() != 0 && hasIndexTo<std::decay_t<G>>(typename xt::persistent_columns_t{})) {
             auto result = o2::framework::sliceByColumn(indexColumnName.c_str(),
                                                        x.asArrowTable(),
                                                        static_cast<int32_t>(gt.tableSize()),
@@ -342,7 +342,7 @@ struct AnalysisDataProcessorBuilder {
       auto prepareArgument()
       {
         constexpr auto index = framework::has_type_at_v<A1>(associated_pack_t{});
-        if (hasIndexTo<G>(typename std::decay_t<A1>::persistent_columns_t{})) {
+        if (std::get<A1>(*mAt).size() != 0 && hasIndexTo<G>(typename std::decay_t<A1>::persistent_columns_t{})) {
           uint64_t pos;
           if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
             pos = (*groupSelection)[position];

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -290,6 +290,38 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedFilteredGroups)
   }
 }
 
+BOOST_AUTO_TEST_CASE(EmptySliceables)
+{
+  TableBuilder builderE;
+  auto evtsWriter = builderE.cursor<aod::Events>();
+  for (auto i = 0; i < 20; ++i) {
+    evtsWriter(0, i, 0.5f * i, 2.f * i, 3.f * i);
+  }
+  auto evtTable = builderE.finalize();
+
+  TableBuilder builderT;
+  auto trksWriter = builderT.cursor<aod::TrksX>();
+  auto trkTable = builderT.finalize();
+
+  aod::Events e{evtTable};
+  aod::TrksX t{trkTable};
+  BOOST_CHECK_EQUAL(e.size(), 20);
+  BOOST_CHECK_EQUAL(t.size(), 0);
+
+  auto tt = std::make_tuple(t);
+  o2::framework::AnalysisDataProcessorBuilder::GroupSlicer g(e, tt);
+
+  unsigned int count = 0;
+  for (auto& slice : g) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    auto trks = std::get<aod::TrksX>(as);
+    BOOST_CHECK_EQUAL(gg.globalIndex(), count);
+    BOOST_CHECK_EQUAL(trks.size(), 0);
+    ++count;
+  }
+}
+
 BOOST_AUTO_TEST_CASE(ArrowDirectSlicing)
 {
   int counts[] = {5, 5, 5, 4, 1};


### PR DESCRIPTION
* Prevent GroupSlicer from trying to slice empty tables (+test)
* Demote 'empty table' warning to debug message
* Correctly use arrow return status for batch writer