### PR TITLE
Keep tracking frame rotation angle between -pi and +pi

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -685,8 +685,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         }
         int currSec = mGeo->GetSector(currDet);
         if (currSec != GetSector(prop->getAlpha())) {
-          float currAlpha = GetAlphaOfSector(currSec);
-          if (!prop->rotate(currAlpha)) {
+          if (!prop->rotate(GetAlphaOfSector(currSec))) {
             if (ENABLE_WARNING) {
               Warning("FollowProlongation", "Track could not be rotated in tracklet coordinate system");
             }
@@ -1075,7 +1074,13 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::AdjustSector(PROP* prop, TRDTRK* t, c
       return false;
     }
     int sign = (y > 0) ? 1 : -1;
-    if (!prop->rotate(alphaCurr + alpha * sign)) {
+    float alphaNew = alphaCurr + alpha * sign;
+    if (alphaNew > M_PI) {
+      alphaNew -= 2 * M_PI;
+    } else if (alphaNew < -M_PI) {
+      alphaNew += 2 * M_PI;
+    }
+    if (!prop->rotate(alphaNew)) {
       return false;
     }
     if (!prop->propagateToX(xTmp, .8f, 2.f)) {
@@ -1107,7 +1112,11 @@ GPUd() float GPUTRDTracker_t<TRDTRK, PROP>::GetAlphaOfSector(const int sec) cons
   //--------------------------------------------------------------------
   // rotation angle for TRD sector sec
   //--------------------------------------------------------------------
-  return (2.0f * M_PI / (float)kNSectors * ((float)sec + 0.5f));
+  float alpha = 2.0f * M_PI / (float)kNSectors * ((float)sec + 0.5f);
+  if (alpha > M_PI) {
+    alpha -= 2 * M_PI;
+  }
+  return alpha;
 }
 
 template <class TRDTRK, class PROP>


### PR DESCRIPTION
Hi @davidrohr 
I found another mistake in the standalone version. When rotating the track parameters both `TrackParCov` of O2 and `AliExternalTrackParam` of AliRoot ensure that the rotation angle remains between -PI and +PI. Thus I did not check that in the TRD tracker.
For the `GPUTPCGMPropagator::RotateToAlpha()` method this is not the case, therefore I implemented the check now directly in the TRD tracker.
Could you please check if this fixes the issue in your event display with the attached tracklets from different sectors?

Overall I still see less tracklets attached in the standalone framework compared to the HLT. I dumped all the tracks to a file for both frameworks before and after the TRD tracking and am looking now what differences I can find. The total number of tracks is rather similar (3496 SA vs 3491 HLT).

A few things I noticed so far:

- Overall track quality seems to be better in SA than in the HLT (sigmaY2 ~ 0.001 (SA) vs 0.002 (HLT), for sigmaZ2 it's similar). This leads to a narrower search road which in combination with the ideal geometry without alignment correction could explain efficiency losses
- The track propagation stops in SA quite often in the first or second layer (20% of tracks, in the HLT its below 2%), without a tracklet being attached and although pt > 2GeV

Cheers,
Ole
