### PR TITLE
ITS tracking works on generic N layers

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -37,7 +37,7 @@ class TrackITS : public o2::track::TrackParCov
 
  public:
   using o2::track::TrackParCov::TrackParCov; // inherit base constructors
-  static constexpr int MaxClusters = 7;
+  static constexpr int MaxClusters = 16;
 
   TrackITS() = default;
   TrackITS(const TrackITS& t) = default;
@@ -87,7 +87,7 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov& getParamOut() { return mParamOut; }
   const o2::track::TrackParCov& getParamOut() const { return mParamOut; }
 
-  void setPattern(uint8_t p) { mPattern = p; }
+  void setPattern(uint16_t p) { mPattern = p; }
   int getPattern() const { return mPattern; }
   bool hasHitOnLayer(int i) { return mPattern & (0x1 << i); }
 
@@ -95,7 +95,7 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov mParamOut; ///< parameter at largest radius
   ClusRefs mClusRef;                ///< references on clusters
   float mChi2 = 0.;                 ///< Chi2 for this track
-  uint8_t mPattern = 0;             ///< layers pattern
+  uint16_t mPattern = 0;             ///< layers pattern
 
   ClassDefNV(TrackITS, 4);
 };
@@ -104,7 +104,7 @@ class TrackITSExt : public TrackITS
 {
   ///< heavy version of TrackITS, with clusters embedded
  public:
-  static constexpr int MaxClusters = 7;
+  static constexpr int MaxClusters = 16; /// Prepare for overlaps and new detector configurations
   using TrackITS::TrackITS; // inherit base constructors
 
   TrackITSExt(o2::track::TrackParCov&& parCov, short ncl, float chi2,
@@ -132,7 +132,7 @@ class TrackITSExt : public TrackITS
   }
 
  private:
-  std::array<int, MaxClusters> mIndex = {-1}; ///< Indices of associated clusters
+  std::array<int, MaxClusters> mIndex = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}; ///< Indices of associated clusters
   ClassDefNV(TrackITSExt, 2);
 };
 } // namespace its

--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -95,7 +95,7 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov mParamOut; ///< parameter at largest radius
   ClusRefs mClusRef;                ///< references on clusters
   float mChi2 = 0.;                 ///< Chi2 for this track
-  uint16_t mPattern = 0;             ///< layers pattern
+  uint16_t mPattern = 0;            ///< layers pattern
 
   ClassDefNV(TrackITS, 4);
 };

--- a/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
@@ -19,7 +19,7 @@ o2_add_library(ITStracking
                        src/Label.cxx
                        src/PrimaryVertexContext.cxx
                        src/Road.cxx
-                       src/StandaloneDebugger.cxx
+                      #  src/StandaloneDebugger.cxx
                        src/Tracker.cxx
                        src/TrackerTraitsCPU.cxx
                        src/TrackingConfigParam.cxx

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreNV.h
@@ -29,6 +29,7 @@ namespace o2
 {
 namespace its
 {
+
 namespace GPU
 {
 
@@ -38,83 +39,83 @@ class DeviceStoreNV final
   DeviceStoreNV();
 
   UniquePointer<DeviceStoreNV> initialise(const float3&,
-                                          const std::array<std::vector<Cluster>, constants::its::LayersNumber>&,
-                                          const std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad>&,
-                                          const std::array<std::vector<Cell>, constants::its::CellsPerRoad>&,
-                                          const std::array<std::vector<int>, constants::its::CellsPerRoad - 1>&,
-                                          const std::array<float, constants::its::LayersNumber>&,
-                                          const std::array<float, constants::its::LayersNumber>&);
+                                          const std::array<std::vector<Cluster>, constants::its2::LayersNumber>&,
+                                          const std::array<std::vector<Tracklet>, constants::its2::TrackletsPerRoad>&,
+                                          const std::array<std::vector<Cell>, constants::its2::CellsPerRoad>&,
+                                          const std::array<std::vector<int>, constants::its2::CellsPerRoad - 1>&,
+                                          const std::array<float, constants::its2::LayersNumber>&,
+                                          const std::array<float, constants::its2::LayersNumber>&);
   GPU_DEVICE const float3& getPrimaryVertex();
-  GPU_HOST_DEVICE Array<Vector<Cluster>, constants::its::LayersNumber>& getClusters();
-  GPU_DEVICE Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
-                   constants::its::TrackletsPerRoad>&
+  GPU_HOST_DEVICE Array<Vector<Cluster>, constants::its2::LayersNumber>& getClusters();
+  GPU_DEVICE Array<Array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>,
+                   constants::its2::TrackletsPerRoad>&
     getIndexTables();
-  GPU_HOST_DEVICE Array<Vector<Tracklet>, constants::its::TrackletsPerRoad>& getTracklets();
-  GPU_HOST_DEVICE Array<Vector<int>, constants::its::CellsPerRoad>& getTrackletsLookupTable();
-  GPU_HOST_DEVICE Array<Vector<int>, constants::its::CellsPerRoad>& getTrackletsPerClusterTable();
-  GPU_HOST_DEVICE Array<Vector<Cell>, constants::its::CellsPerRoad>& getCells();
-  GPU_HOST_DEVICE Array<Vector<int>, constants::its::CellsPerRoad - 1>& getCellsLookupTable();
-  GPU_HOST_DEVICE Array<Vector<int>, constants::its::CellsPerRoad - 1>& getCellsPerTrackletTable();
-  Array<Vector<int>, constants::its::CellsPerRoad>& getTempTableArray();
+  GPU_HOST_DEVICE Array<Vector<Tracklet>, constants::its2::TrackletsPerRoad>& getTracklets();
+  GPU_HOST_DEVICE Array<Vector<int>, constants::its2::CellsPerRoad>& getTrackletsLookupTable();
+  GPU_HOST_DEVICE Array<Vector<int>, constants::its2::CellsPerRoad>& getTrackletsPerClusterTable();
+  GPU_HOST_DEVICE Array<Vector<Cell>, constants::its2::CellsPerRoad>& getCells();
+  GPU_HOST_DEVICE Array<Vector<int>, constants::its2::CellsPerRoad - 1>& getCellsLookupTable();
+  GPU_HOST_DEVICE Array<Vector<int>, constants::its2::CellsPerRoad - 1>& getCellsPerTrackletTable();
+  Array<Vector<int>, constants::its2::CellsPerRoad>& getTempTableArray();
 
   GPU_HOST_DEVICE float getRmin(int layer);
   GPU_HOST_DEVICE float getRmax(int layer);
 
  private:
   UniquePointer<float3> mPrimaryVertex;
-  Array<Vector<Cluster>, constants::its::LayersNumber> mClusters;
-  Array<float, constants::its::LayersNumber> mRmin;
-  Array<float, constants::its::LayersNumber> mRmax;
-  Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>, constants::its::TrackletsPerRoad>
+  Array<Vector<Cluster>, constants::its2::LayersNumber> mClusters;
+  Array<float, constants::its2::LayersNumber> mRmin;
+  Array<float, constants::its2::LayersNumber> mRmax;
+  Array<Array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>, constants::its2::TrackletsPerRoad>
     mIndexTables;
-  Array<Vector<Tracklet>, constants::its::TrackletsPerRoad> mTracklets;
-  Array<Vector<int>, constants::its::CellsPerRoad> mTrackletsLookupTable;
-  Array<Vector<int>, constants::its::CellsPerRoad> mTrackletsPerClusterTable;
-  Array<Vector<Cell>, constants::its::CellsPerRoad> mCells;
-  Array<Vector<int>, constants::its::CellsPerRoad - 1> mCellsLookupTable;
-  Array<Vector<int>, constants::its::CellsPerRoad - 1> mCellsPerTrackletTable;
+  Array<Vector<Tracklet>, constants::its2::TrackletsPerRoad> mTracklets;
+  Array<Vector<int>, constants::its2::CellsPerRoad> mTrackletsLookupTable;
+  Array<Vector<int>, constants::its2::CellsPerRoad> mTrackletsPerClusterTable;
+  Array<Vector<Cell>, constants::its2::CellsPerRoad> mCells;
+  Array<Vector<int>, constants::its2::CellsPerRoad - 1> mCellsLookupTable;
+  Array<Vector<int>, constants::its2::CellsPerRoad - 1> mCellsPerTrackletTable;
 };
 
 GPU_DEVICE inline const float3& DeviceStoreNV::getPrimaryVertex() { return *mPrimaryVertex; }
 
-GPU_HOST_DEVICE inline Array<Vector<Cluster>, constants::its::LayersNumber>& DeviceStoreNV::getClusters()
+GPU_HOST_DEVICE inline Array<Vector<Cluster>, constants::its2::LayersNumber>& DeviceStoreNV::getClusters()
 {
   return mClusters;
 }
 
-GPU_DEVICE inline Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
-                        constants::its::TrackletsPerRoad>&
+GPU_DEVICE inline Array<Array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>,
+                        constants::its2::TrackletsPerRoad>&
   DeviceStoreNV::getIndexTables()
 {
   return mIndexTables;
 }
 
-GPU_DEVICE inline Array<Vector<Tracklet>, constants::its::TrackletsPerRoad>& DeviceStoreNV::getTracklets()
+GPU_DEVICE inline Array<Vector<Tracklet>, constants::its2::TrackletsPerRoad>& DeviceStoreNV::getTracklets()
 {
   return mTracklets;
 }
 
-GPU_DEVICE inline Array<Vector<int>, constants::its::CellsPerRoad>& DeviceStoreNV::getTrackletsLookupTable()
+GPU_DEVICE inline Array<Vector<int>, constants::its2::CellsPerRoad>& DeviceStoreNV::getTrackletsLookupTable()
 {
   return mTrackletsLookupTable;
 }
 
-GPU_DEVICE inline Array<Vector<int>, constants::its::CellsPerRoad>& DeviceStoreNV::getTrackletsPerClusterTable()
+GPU_DEVICE inline Array<Vector<int>, constants::its2::CellsPerRoad>& DeviceStoreNV::getTrackletsPerClusterTable()
 {
   return mTrackletsPerClusterTable;
 }
 
-GPU_HOST_DEVICE inline Array<Vector<Cell>, constants::its::CellsPerRoad>& DeviceStoreNV::getCells()
+GPU_HOST_DEVICE inline Array<Vector<Cell>, constants::its2::CellsPerRoad>& DeviceStoreNV::getCells()
 {
   return mCells;
 }
 
-GPU_HOST_DEVICE inline Array<Vector<int>, constants::its::CellsPerRoad - 1>& DeviceStoreNV::getCellsLookupTable()
+GPU_HOST_DEVICE inline Array<Vector<int>, constants::its2::CellsPerRoad - 1>& DeviceStoreNV::getCellsLookupTable()
 {
   return mCellsLookupTable;
 }
 
-GPU_HOST_DEVICE inline Array<Vector<int>, constants::its::CellsPerRoad - 1>&
+GPU_HOST_DEVICE inline Array<Vector<int>, constants::its2::CellsPerRoad - 1>&
   DeviceStoreNV::getCellsPerTrackletTable()
 {
   return mCellsPerTrackletTable;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
@@ -56,12 +56,12 @@ class DeviceStoreVertexerGPU final
   DeviceStoreVertexerGPU();
   ~DeviceStoreVertexerGPU() = default;
 
-  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>&,
-                                                   const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
-                                                                    constants::its::LayersNumberVertexer>&);
+  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its2::LayersNumberVertexer>&,
+                                                   const std::array<std::array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>,
+                                                                    constants::its2::LayersNumberVertexer>&);
 
   // RO APIs
-  GPUd() const Array<Vector<Cluster>, constants::its::LayersNumberVertexer>& getClusters()
+  GPUd() const Array<Vector<Cluster>, constants::its2::LayersNumberVertexer>& getClusters()
   {
     return mClusters;
   }
@@ -111,7 +111,7 @@ class DeviceStoreVertexerGPU final
 
  private:
   VertexerStoreConfigurationGPU mGPUConf;
-  Array<Vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
+  Array<Vector<Cluster>, constants::its2::LayersNumberVertexer> mClusters;
   Vector<Line> mTracklets;
   Array<Vector<int>, 2> mIndexTables;
   Vector<GPUVertex> mGPUVertices;
@@ -121,7 +121,7 @@ class DeviceStoreVertexerGPU final
   Vector<int> mNExclusiveFoundLines;
   Vector<Tracklet> mDuplets01;
   Vector<Tracklet> mDuplets12;
-  Array<Vector<int>, constants::its::LayersNumberVertexer - 1> mNFoundDuplets;
+  Array<Vector<int>, constants::its2::LayersNumberVertexer - 1> mNFoundDuplets;
   Vector<int> mCUBTmpBuffer;
   Vector<float> mXYCentroids;
   Vector<float> mZCentroids;
@@ -140,7 +140,7 @@ inline std::vector<int> DeviceStoreVertexerGPU::getNFoundTrackletsFromGPU(const 
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its::LayersNumberVertexer);
+  sizes.resize(constants::its2::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<int> nFoundDuplets;
   nFoundDuplets.resize(sizes[1]);
@@ -158,7 +158,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getRawDupletsFromGPU(const 
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its::LayersNumberVertexer);
+  sizes.resize(constants::its2::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<Tracklet> tmpDuplets;
   tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));
@@ -180,7 +180,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getDupletsFromGPU(const Ord
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its::LayersNumberVertexer);
+  sizes.resize(constants::its2::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<Tracklet> tmpDuplets;
   tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
@@ -56,12 +56,12 @@ class DeviceStoreVertexerGPU final
   DeviceStoreVertexerGPU();
   ~DeviceStoreVertexerGPU() = default;
 
-  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its2::LayersNumberVertexer>&,
+  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>&,
                                                    const std::array<std::array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>,
-                                                                    constants::its2::LayersNumberVertexer>&);
+                                                                    constants::its::LayersNumberVertexer>&);
 
   // RO APIs
-  GPUd() const Array<Vector<Cluster>, constants::its2::LayersNumberVertexer>& getClusters()
+  GPUd() const Array<Vector<Cluster>, constants::its::LayersNumberVertexer>& getClusters()
   {
     return mClusters;
   }
@@ -111,7 +111,7 @@ class DeviceStoreVertexerGPU final
 
  private:
   VertexerStoreConfigurationGPU mGPUConf;
-  Array<Vector<Cluster>, constants::its2::LayersNumberVertexer> mClusters;
+  Array<Vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
   Vector<Line> mTracklets;
   Array<Vector<int>, 2> mIndexTables;
   Vector<GPUVertex> mGPUVertices;
@@ -121,7 +121,7 @@ class DeviceStoreVertexerGPU final
   Vector<int> mNExclusiveFoundLines;
   Vector<Tracklet> mDuplets01;
   Vector<Tracklet> mDuplets12;
-  Array<Vector<int>, constants::its2::LayersNumberVertexer - 1> mNFoundDuplets;
+  Array<Vector<int>, constants::its::LayersNumberVertexer - 1> mNFoundDuplets;
   Vector<int> mCUBTmpBuffer;
   Vector<float> mXYCentroids;
   Vector<float> mZCentroids;
@@ -140,7 +140,7 @@ inline std::vector<int> DeviceStoreVertexerGPU::getNFoundTrackletsFromGPU(const 
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its2::LayersNumberVertexer);
+  sizes.resize(constants::its::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<int> nFoundDuplets;
   nFoundDuplets.resize(sizes[1]);
@@ -158,7 +158,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getRawDupletsFromGPU(const 
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its2::LayersNumberVertexer);
+  sizes.resize(constants::its::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<Tracklet> tmpDuplets;
   tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));
@@ -180,7 +180,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getDupletsFromGPU(const Ord
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
-  sizes.resize(constants::its2::LayersNumberVertexer);
+  sizes.resize(constants::its::LayersNumberVertexer);
   mSizes.copyIntoSizedVector(sizes);
   std::vector<Tracklet> tmpDuplets;
   tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
@@ -39,7 +39,7 @@ class PrimaryVertexContextNV final : public PrimaryVertexContext
   virtual ~PrimaryVertexContextNV() = default;
 
   void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& cl,
-                          const std::array<float, 3>& pv, const int iteration);
+                  const std::array<float, 3>& pv, const int iteration);
 
   GPU::DeviceStoreNV& getDeviceContext();
   GPU::Array<GPU::Vector<Cluster>, constants::its2::LayersNumber>& getDeviceClusters();

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
@@ -38,28 +38,28 @@ class PrimaryVertexContextNV final : public PrimaryVertexContext
   PrimaryVertexContextNV() = default;
   virtual ~PrimaryVertexContextNV() = default;
 
-  virtual void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
+  virtual void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& cl,
                           const std::array<float, 3>& pv, const int iteration);
 
   GPU::DeviceStoreNV& getDeviceContext();
-  GPU::Array<GPU::Vector<Cluster>, constants::its::LayersNumber>& getDeviceClusters();
-  GPU::Array<GPU::Vector<Tracklet>, constants::its::TrackletsPerRoad>& getDeviceTracklets();
-  GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad>& getDeviceTrackletsLookupTable();
-  GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad>& getDeviceTrackletsPerClustersTable();
-  GPU::Array<GPU::Vector<Cell>, constants::its::CellsPerRoad>& getDeviceCells();
-  GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad - 1>& getDeviceCellsLookupTable();
-  GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad - 1>& getDeviceCellsPerTrackletTable();
-  std::array<GPU::Vector<int>, constants::its::CellsPerRoad>& getTempTableArray();
-  std::array<GPU::Vector<Tracklet>, constants::its::CellsPerRoad>& getTempTrackletArray();
-  std::array<GPU::Vector<Cell>, constants::its::CellsPerRoad - 1>& getTempCellArray();
+  GPU::Array<GPU::Vector<Cluster>, constants::its2::LayersNumber>& getDeviceClusters();
+  GPU::Array<GPU::Vector<Tracklet>, constants::its2::TrackletsPerRoad>& getDeviceTracklets();
+  GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad>& getDeviceTrackletsLookupTable();
+  GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad>& getDeviceTrackletsPerClustersTable();
+  GPU::Array<GPU::Vector<Cell>, constants::its2::CellsPerRoad>& getDeviceCells();
+  GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad - 1>& getDeviceCellsLookupTable();
+  GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad - 1>& getDeviceCellsPerTrackletTable();
+  std::array<GPU::Vector<int>, constants::its2::CellsPerRoad>& getTempTableArray();
+  std::array<GPU::Vector<Tracklet>, constants::its2::CellsPerRoad>& getTempTrackletArray();
+  std::array<GPU::Vector<Cell>, constants::its2::CellsPerRoad - 1>& getTempCellArray();
   void updateDeviceContext();
 
  private:
   GPU::DeviceStoreNV mGPUContext;
   GPU::UniquePointer<GPU::DeviceStoreNV> mGPUContextDevicePointer;
-  std::array<GPU::Vector<int>, constants::its::CellsPerRoad> mTempTableArray;
-  std::array<GPU::Vector<Tracklet>, constants::its::CellsPerRoad> mTempTrackletArray;
-  std::array<GPU::Vector<Cell>, constants::its::CellsPerRoad - 1> mTempCellArray;
+  std::array<GPU::Vector<int>, constants::its2::CellsPerRoad> mTempTableArray;
+  std::array<GPU::Vector<Tracklet>, constants::its2::CellsPerRoad> mTempTrackletArray;
+  std::array<GPU::Vector<Cell>, constants::its2::CellsPerRoad - 1> mTempCellArray;
 };
 
 inline GPU::DeviceStoreNV& PrimaryVertexContextNV::getDeviceContext()
@@ -67,54 +67,54 @@ inline GPU::DeviceStoreNV& PrimaryVertexContextNV::getDeviceContext()
   return *mGPUContextDevicePointer;
 }
 
-inline GPU::Array<GPU::Vector<Cluster>, constants::its::LayersNumber>& PrimaryVertexContextNV::getDeviceClusters()
+inline GPU::Array<GPU::Vector<Cluster>, constants::its2::LayersNumber>& PrimaryVertexContextNV::getDeviceClusters()
 {
   return mGPUContext.getClusters();
 }
 
-inline GPU::Array<GPU::Vector<Tracklet>, constants::its::TrackletsPerRoad>& PrimaryVertexContextNV::getDeviceTracklets()
+inline GPU::Array<GPU::Vector<Tracklet>, constants::its2::TrackletsPerRoad>& PrimaryVertexContextNV::getDeviceTracklets()
 {
   return mGPUContext.getTracklets();
 }
 
-inline GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad>& PrimaryVertexContextNV::getDeviceTrackletsLookupTable()
+inline GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad>& PrimaryVertexContextNV::getDeviceTrackletsLookupTable()
 {
   return mGPUContext.getTrackletsLookupTable();
 }
 
-inline GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad>&
+inline GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad>&
   PrimaryVertexContextNV::getDeviceTrackletsPerClustersTable()
 {
   return mGPUContext.getTrackletsPerClusterTable();
 }
 
-inline GPU::Array<GPU::Vector<Cell>, constants::its::CellsPerRoad>& PrimaryVertexContextNV::getDeviceCells()
+inline GPU::Array<GPU::Vector<Cell>, constants::its2::CellsPerRoad>& PrimaryVertexContextNV::getDeviceCells()
 {
   return mGPUContext.getCells();
 }
 
-inline GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad - 1>& PrimaryVertexContextNV::getDeviceCellsLookupTable()
+inline GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad - 1>& PrimaryVertexContextNV::getDeviceCellsLookupTable()
 {
   return mGPUContext.getCellsLookupTable();
 }
 
-inline GPU::Array<GPU::Vector<int>, constants::its::CellsPerRoad - 1>&
+inline GPU::Array<GPU::Vector<int>, constants::its2::CellsPerRoad - 1>&
   PrimaryVertexContextNV::getDeviceCellsPerTrackletTable()
 {
   return mGPUContext.getCellsPerTrackletTable();
 }
 
-inline std::array<GPU::Vector<int>, constants::its::CellsPerRoad>& PrimaryVertexContextNV::getTempTableArray()
+inline std::array<GPU::Vector<int>, constants::its2::CellsPerRoad>& PrimaryVertexContextNV::getTempTableArray()
 {
   return mTempTableArray;
 }
 
-inline std::array<GPU::Vector<Tracklet>, constants::its::CellsPerRoad>& PrimaryVertexContextNV::getTempTrackletArray()
+inline std::array<GPU::Vector<Tracklet>, constants::its2::CellsPerRoad>& PrimaryVertexContextNV::getTempTrackletArray()
 {
   return mTempTrackletArray;
 }
 
-inline std::array<GPU::Vector<Cell>, constants::its::CellsPerRoad - 1>& PrimaryVertexContextNV::getTempCellArray()
+inline std::array<GPU::Vector<Cell>, constants::its2::CellsPerRoad - 1>& PrimaryVertexContextNV::getTempCellArray()
 {
   return mTempCellArray;
 }
@@ -124,11 +124,12 @@ inline void PrimaryVertexContextNV::updateDeviceContext()
   mGPUContextDevicePointer = GPU::UniquePointer<GPU::DeviceStoreNV>{mGPUContext};
 }
 
-inline void PrimaryVertexContextNV::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
+inline void PrimaryVertexContextNV::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& cl,
                                                const std::array<float, 3>& pv, const int iteration)
 {
-  this->PrimaryVertexContext::initialise(memParam, cl, pv, iteration);
-  mGPUContextDevicePointer = mGPUContext.initialise(mPrimaryVertex, mClusters, mTracklets, mCells, mCellsLookupTable, mMinR, mMaxR);
+  ///TODO: to be re-enabled in the future
+  // this->PrimaryVertexContext::initialise(memParam, cl, pv, iteration);
+  // mGPUContextDevicePointer = mGPUContext.initialise(mPrimaryVertex, mClusters, mTracklets, mCells, mCellsLookupTable, mMinR, mMaxR);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/PrimaryVertexContextNV.h
@@ -38,7 +38,7 @@ class PrimaryVertexContextNV final : public PrimaryVertexContext
   PrimaryVertexContextNV() = default;
   virtual ~PrimaryVertexContextNV() = default;
 
-  virtual void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& cl,
+  void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& cl,
                           const std::array<float, 3>& pv, const int iteration);
 
   GPU::DeviceStoreNV& getDeviceContext();

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/TrackerTraitsNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/TrackerTraitsNV.h
@@ -34,7 +34,7 @@ class TrackerTraitsNV : public TrackerTraits
 
   void computeLayerCells() final;
   void computeLayerTracklets() final;
-  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks) final;
+  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks);
 };
 
 extern "C" TrackerTraits* createTrackerTraitsNV();

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
@@ -37,7 +37,7 @@ namespace its
 {
 class ROframe;
 
-using constants::index_table::InversePhiBinSize;
+using constants::its2::InversePhiBinSize;
 
 class VertexerTraitsGPU : public VertexerTraits
 {
@@ -69,7 +69,7 @@ class VertexerTraitsGPU : public VertexerTraits
 inline GPUd() const int2 VertexerTraitsGPU::getBinsPhiRectWindow(const Cluster& currentCluster, float phiCut)
 {
   // This function returns the lowest PhiBin and the number of phi bins to be spanned, In the form int2{phiBinLow, PhiBinSpan}
-  const int phiBinMin{index_table_utils::getPhiBinIndex(
+  const int phiBinMin{constants::its2::getPhiBinIndex(
     math_utils::getNormalizedPhiCoordinate(currentCluster.phiCoordinate - phiCut))};
   const int phiBinSpan{static_cast<int>(MATH_CEIL(phiCut * InversePhiBinSize))};
   return int2{phiBinMin, phiBinSpan};

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
@@ -96,12 +96,12 @@ __global__ void fillDeviceStructures(GPU::DeviceStoreNV& primaryVertexContext, c
 {
   fillIndexTables(primaryVertexContext, layerIndex);
 
-  if (layerIndex < o2::its::constants::its::CellsPerRoad) {
+  if (layerIndex < o2::its::constants::its2::CellsPerRoad) {
 
     fillTrackletsPerClusterTables(primaryVertexContext, layerIndex);
   }
 
-  if (layerIndex < o2::its::constants::its::CellsPerRoad - 1) {
+  if (layerIndex < o2::its::constants::its2::CellsPerRoad - 1) {
 
     fillCellsPerClusterTables(primaryVertexContext, layerIndex);
   }
@@ -121,34 +121,34 @@ DeviceStoreNV::DeviceStoreNV()
 }
 
 UniquePointer<DeviceStoreNV> DeviceStoreNV::initialise(const float3& primaryVertex,
-                                                       const std::array<std::vector<Cluster>, constants::its::LayersNumber>& clusters,
-                                                       const std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad>& tracklets,
-                                                       const std::array<std::vector<Cell>, constants::its::CellsPerRoad>& cells,
-                                                       const std::array<std::vector<int>, constants::its::CellsPerRoad - 1>& cellsLookupTable,
-                                                       const std::array<float, constants::its::LayersNumber>& rmin,
-                                                       const std::array<float, constants::its::LayersNumber>& rmax)
+                                                       const std::array<std::vector<Cluster>, constants::its2::LayersNumber>& clusters,
+                                                       const std::array<std::vector<Tracklet>, constants::its2::TrackletsPerRoad>& tracklets,
+                                                       const std::array<std::vector<Cell>, constants::its2::CellsPerRoad>& cells,
+                                                       const std::array<std::vector<int>, constants::its2::CellsPerRoad - 1>& cellsLookupTable,
+                                                       const std::array<float, constants::its2::LayersNumber>& rmin,
+                                                       const std::array<float, constants::its2::LayersNumber>& rmax)
 {
   mPrimaryVertex = UniquePointer<float3>{primaryVertex};
 
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::LayersNumber; ++iLayer) {
     this->mRmin[iLayer] = rmin[iLayer];
     this->mRmax[iLayer] = rmax[iLayer];
 
     this->mClusters[iLayer] =
       Vector<Cluster>{&clusters[iLayer][0], static_cast<int>(clusters[iLayer].size())};
 
-    if (iLayer < constants::its::TrackletsPerRoad) {
+    if (iLayer < constants::its2::TrackletsPerRoad) {
       this->mTracklets[iLayer].reset(tracklets[iLayer].capacity());
     }
 
-    if (iLayer < constants::its::CellsPerRoad) {
+    if (iLayer < constants::its2::CellsPerRoad) {
 
       this->mTrackletsLookupTable[iLayer].reset(static_cast<int>(clusters[iLayer + 1].size()));
       this->mTrackletsPerClusterTable[iLayer].reset(static_cast<int>(clusters[iLayer + 1].size()));
       this->mCells[iLayer].reset(static_cast<int>(cells[iLayer].capacity()));
     }
 
-    if (iLayer < constants::its::CellsPerRoad - 1) {
+    if (iLayer < constants::its2::CellsPerRoad - 1) {
 
       this->mCellsLookupTable[iLayer].reset(static_cast<int>(cellsLookupTable[iLayer].size()));
       this->mCellsPerTrackletTable[iLayer].reset(static_cast<int>(cellsLookupTable[iLayer].size()));
@@ -157,9 +157,9 @@ UniquePointer<DeviceStoreNV> DeviceStoreNV::initialise(const float3& primaryVert
 
   UniquePointer<DeviceStoreNV> gpuContextDevicePointer{*this};
 
-  std::array<Stream, constants::its::LayersNumber> streamArray;
+  std::array<Stream, constants::its2::LayersNumber> streamArray;
 
-  for (int iLayer{0}; iLayer < constants::its::TrackletsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::TrackletsPerRoad; ++iLayer) {
 
     const int nextLayerClustersNum = static_cast<int>(clusters[iLayer + 1].size());
 

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
@@ -57,7 +57,7 @@ __device__ void fillIndexTables(GPU::DeviceStoreNV& primaryVertexContext, const 
 
     if (currentClusterIndex == nextLayerClustersNum - 1) {
 
-      for (int iBin{currentBinIndex + 1}; iBin <= o2::its::constants::index_table::ZBins * o2::its::constants::index_table::PhiBins;
+      for (int iBin{currentBinIndex + 1}; iBin <= o2::its::constants::its2::ZBins * o2::its::constants::its2::PhiBins;
            iBin++) {
 
         primaryVertexContext.getIndexTables()[layerIndex][iBin] = nextLayerClustersNum;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreVertexerGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreVertexerGPU.cu
@@ -47,7 +47,7 @@ DeviceStoreVertexerGPU::DeviceStoreVertexerGPU()
   mBeamPosition = Vector<float>{2, 2};
 
   for (int iTable{0}; iTable < 2; ++iTable) {
-    mIndexTables[iTable] = Vector<int>{constants::index_table::ZBins * constants::index_table::PhiBins + 1}; // 2*20*20+1 * sizeof(int) = 802B
+    mIndexTables[iTable] = Vector<int>{constants::its2::ZBins * constants::its2::PhiBins + 1}; // 2*20*20+1 * sizeof(int) = 802B
   }
   for (int iLayer{0}; iLayer < constants::its::LayersNumberVertexer; ++iLayer) { // 4e4 * 3 * sizof(Cluster) = 3.36MB
     mClusters[iLayer] = Vector<Cluster>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};
@@ -68,7 +68,7 @@ DeviceStoreVertexerGPU::DeviceStoreVertexerGPU()
 } // namespace GPU
 
 UniquePointer<DeviceStoreVertexerGPU> DeviceStoreVertexerGPU::initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>& clusters,
-                                                                         const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
+                                                                         const std::array<std::array<int, constants::its2::ZBins * constants::its2::PhiBins + 1>,
                                                                                           constants::its::LayersNumberVertexer>& indexTables)
 {
 #ifdef _ALLOW_DEBUG_TREES_ITS_

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
@@ -72,11 +72,11 @@ __device__ void computeLayerTracklets(DeviceStoreNV& devStore, const int layerIn
 
       if (phiBinsNum < 0) {
 
-        phiBinsNum += constants::index_table::PhiBins;
+        phiBinsNum += constants::its2::PhiBins;
       }
 
       for (int iPhiBin{selectedBinsRect.y}, iPhiCount{0}; iPhiCount < phiBinsNum;
-           iPhiBin = ++iPhiBin == constants::index_table::PhiBins ? 0 : iPhiBin, iPhiCount++) {
+           iPhiBin = ++iPhiBin == constants::its2::PhiBins ? 0 : iPhiBin, iPhiCount++) {
 
         const int firstBinIndex{index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin)};
         const int firstRowClusterIndex = devStore.getIndexTables()[layerIndex][firstBinIndex];
@@ -283,11 +283,11 @@ void TrackerTraitsNV::computeLayerTracklets()
   PrimaryVertexContextNV* primaryVertexContext = static_cast<PrimaryVertexContextNV*>(mPrimaryVertexContext);
 
   cudaMemcpyToSymbol(GPU::kTrkPar, &mTrkParams, sizeof(TrackingParameters));
-  std::array<size_t, constants::its::CellsPerRoad> tempSize;
-  std::array<int, constants::its::CellsPerRoad> trackletsNum;
-  std::array<GPU::Stream, constants::its::TrackletsPerRoad> streamArray;
+  std::array<size_t, constants::its2::CellsPerRoad> tempSize;
+  std::array<int, constants::its2::CellsPerRoad> trackletsNum;
+  std::array<GPU::Stream, constants::its2::TrackletsPerRoad> streamArray;
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad; ++iLayer) {
 
     tempSize[iLayer] = 0;
     primaryVertexContext->getTempTrackletArray()[iLayer].reset(
@@ -303,7 +303,7 @@ void TrackerTraitsNV::computeLayerTracklets()
 
   cudaDeviceSynchronize();
 
-  for (int iLayer{0}; iLayer < constants::its::TrackletsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::TrackletsPerRoad; ++iLayer) {
 
     const GPU::DeviceProperties& deviceProperties = GPU::Context::getInstance().getDeviceProperties();
     const int clustersNum{static_cast<int>(primaryVertexContext->getClusters()[iLayer].size())};
@@ -335,7 +335,7 @@ void TrackerTraitsNV::computeLayerTracklets()
 
   cudaDeviceSynchronize();
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad; ++iLayer) {
 
     trackletsNum[iLayer] = primaryVertexContext->getTempTrackletArray()[iLayer].getSizeFromDevice();
     if (trackletsNum[iLayer] == 0) {
@@ -371,12 +371,12 @@ void TrackerTraitsNV::computeLayerCells()
 {
 
   PrimaryVertexContextNV* primaryVertexContext = static_cast<PrimaryVertexContextNV*>(mPrimaryVertexContext);
-  std::array<size_t, constants::its::CellsPerRoad - 1> tempSize;
-  std::array<int, constants::its::CellsPerRoad - 1> trackletsNum;
-  std::array<int, constants::its::CellsPerRoad - 1> cellsNum;
-  std::array<GPU::Stream, constants::its::CellsPerRoad> streamArray;
+  std::array<size_t, constants::its2::CellsPerRoad - 1> tempSize;
+  std::array<int, constants::its2::CellsPerRoad - 1> trackletsNum;
+  std::array<int, constants::its2::CellsPerRoad - 1> cellsNum;
+  std::array<GPU::Stream, constants::its2::CellsPerRoad> streamArray;
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad - 1; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad - 1; ++iLayer) {
 
     tempSize[iLayer] = 0;
     trackletsNum[iLayer] = primaryVertexContext->getDeviceTracklets()[iLayer + 1].getSizeFromDevice();
@@ -394,7 +394,7 @@ void TrackerTraitsNV::computeLayerCells()
 
   cudaDeviceSynchronize();
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad; ++iLayer) {
     const GPU::DeviceProperties& deviceProperties = GPU::Context::getInstance().getDeviceProperties();
     const int trackletsSize = primaryVertexContext->getDeviceTracklets()[iLayer].getSizeFromDevice();
     if (trackletsSize == 0) {
@@ -428,7 +428,7 @@ void TrackerTraitsNV::computeLayerCells()
 
   cudaDeviceSynchronize();
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad - 1; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad - 1; ++iLayer) {
     cellsNum[iLayer] = primaryVertexContext->getTempCellArray()[iLayer].getSizeFromDevice();
     if (cellsNum[iLayer] == 0) {
       continue;
@@ -460,7 +460,7 @@ void TrackerTraitsNV::computeLayerCells()
 
   cudaDeviceSynchronize();
 
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its2::CellsPerRoad; ++iLayer) {
 
     int cellsSize = 0;
     if (iLayer == 0) {

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
@@ -62,7 +62,27 @@ GPU_DEVICE const int4 getBinsRect(const Cluster& currentCluster, const int layer
 namespace GPU
 {
 
-__constant__ TrackingParameters kTrkPar;
+struct StaticTrackingParameters {
+  StaticTrackingParameters& operator=(const StaticTrackingParameters& t);
+
+  int CellMinimumLevel();
+
+  /// General parameters
+  int ClusterSharing = 0;
+  int MinTrackLength = 7;
+  /// Trackleting cuts
+  float TrackletMaxDeltaPhi = 0.3f;
+  float TrackletMaxDeltaZ[constants::its2::TrackletsPerRoad] = {0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f};
+  /// Cell finding cuts
+  float CellMaxDeltaTanLambda = 0.025f;
+  float CellMaxDCA[constants::its2::CellsPerRoad] = {0.05f, 0.04f, 0.05f, 0.2f, 0.4f};
+  float CellMaxDeltaPhi = 0.14f;
+  float CellMaxDeltaZ[constants::its2::CellsPerRoad] = {0.2f, 0.4f, 0.5f, 0.6f, 3.0f};
+  /// Neighbour finding cuts
+  float NeighbourMaxDeltaCurvature[constants::its2::CellsPerRoad - 1] = {0.008f, 0.0025f, 0.003f, 0.0035f};
+  float NeighbourMaxDeltaN[constants::its2::CellsPerRoad - 1] = {0.002f, 0.0090f, 0.002f, 0.005f};
+};
+__constant__ StaticTrackingParameters kTrkPar;
 
 __device__ void computeLayerTracklets(DeviceStoreNV& devStore, const int layerIndex,
                                       Vector<Tracklet>& trackletsVector)
@@ -304,7 +324,7 @@ void TrackerTraitsNV::computeLayerTracklets()
 {
   PrimaryVertexContextNV* primaryVertexContext = static_cast<PrimaryVertexContextNV*>(mPrimaryVertexContext);
 
-  cudaMemcpyToSymbol(GPU::kTrkPar, &mTrkParams, sizeof(TrackingParameters));
+  // cudaMemcpyToSymbol(GPU::kTrkPar, &mTrkParams, sizeof(TrackingParameters));
   std::array<size_t, constants::its2::CellsPerRoad> tempSize;
   std::array<int, constants::its2::CellsPerRoad> trackletsNum;
   std::array<GPU::Stream, constants::its2::TrackletsPerRoad> streamArray;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
@@ -33,8 +33,12 @@
 #include "ITStrackingCUDA/Stream.h"
 #include "ITStrackingCUDA/Vector.h"
 
-namespace
+namespace o2
 {
+namespace its
+{
+
+using namespace constants::its2;
 GPU_DEVICE const int4 getBinsRect(const Cluster& currentCluster, const int layerIndex,
                                   const float z1, const float z2, float maxdeltaz, float maxdeltaphi)
 {
@@ -54,12 +58,7 @@ GPU_DEVICE const int4 getBinsRect(const Cluster& currentCluster, const int layer
               gpu::GPUCommonMath::Min(ZBins - 1, getZBinIndex(layerIndex + 1, zRangeMax)),
               getPhiBinIndex(phiRangeMax)};
 }
-} // namespace
 
-namespace o2
-{
-namespace its
-{
 namespace GPU
 {
 

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -37,14 +37,14 @@ namespace o2
 namespace its
 {
 
-using constants::its2::PhiBins;
-using constants::its2::ZBins;
-using constants::its2::LayersRCoordinate;
-using constants::its2::LayersZCoordinate;
-using constants::its2::VertexerHistogramVolume;
-using constants::math::TwoPi;
 using constants::its2::getPhiBinIndex;
 using constants::its2::getZBinIndex;
+using constants::its2::LayersRCoordinate;
+using constants::its2::LayersZCoordinate;
+using constants::its2::PhiBins;
+using constants::its2::VertexerHistogramVolume;
+using constants::its2::ZBins;
+using constants::math::TwoPi;
 using math_utils::getNormalizedPhiCoordinate;
 
 GPUh() void gpuThrowOnError()

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -37,14 +37,14 @@ namespace o2
 namespace its
 {
 
-using constants::index_table::PhiBins;
-using constants::index_table::ZBins;
-using constants::its::LayersRCoordinate;
-using constants::its::LayersZCoordinate;
-using constants::its::VertexerHistogramVolume;
+using constants::its2::PhiBins;
+using constants::its2::ZBins;
+using constants::its2::LayersRCoordinate;
+using constants::its2::LayersZCoordinate;
+using constants::its2::VertexerHistogramVolume;
 using constants::math::TwoPi;
-using index_table_utils::getPhiBinIndex;
-using index_table_utils::getZBinIndex;
+using constants::its2::getPhiBinIndex;
+using constants::its2::getZBinIndex;
 using math_utils::getNormalizedPhiCoordinate;
 
 GPUh() void gpuThrowOnError()
@@ -155,7 +155,7 @@ GPUg() void trackleterKernel(
         }
         const size_t nClustersAdjacentLayer = store.getClusters()[static_cast<int>(adjacentLayerIndex)].size();
         for (size_t iPhiBin{(size_t)selectedBinsRect.y}, iPhiCount{0}; iPhiCount < (size_t)phiBinsNum; iPhiBin = ++iPhiBin == PhiBins ? 0 : iPhiBin, iPhiCount++) {
-          const int firstBinIndex{index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin)};
+          const int firstBinIndex{constants::its2::getBinIndex(selectedBinsRect.x, iPhiBin)};
           const int firstRowClusterIndex{store.getIndexTable(adjacentLayerIndex)[firstBinIndex]};
           const int maxRowClusterIndex{store.getIndexTable(adjacentLayerIndex)[firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1]};
           for (size_t iAdjacentCluster{(size_t)firstRowClusterIndex}; iAdjacentCluster < (size_t)maxRowClusterIndex && iAdjacentCluster < nClustersAdjacentLayer; ++iAdjacentCluster) {

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -163,7 +163,7 @@ GPUg() void trackleterKernel(
       const size_t stride{currentClusterIndex * store.getConfig().maxTrackletsPerCluster};
       const Cluster& currentCluster = store.getClusters()[1][currentClusterIndex]; // assign-constructor may be a problem, check
       const VertexerLayerName adjacentLayerIndex{layerOrder == TrackletingLayerOrder::fromInnermostToMiddleLayer ? VertexerLayerName::innermostLayer : VertexerLayerName::outerLayer};
-      const int4 selectedBinsRect{getBinsRect(currentCluster, static_cast<int>(adjacentLayerIndex), 0.f, 50.f, phiCut / 2)};
+      const int4 selectedBinsRect{getBinsRect(currentCluster, static_cast<int>(adjacentLayerIndex), 0.f, 0.f, 50.f, phiCut / 2)};
       if (selectedBinsRect.x != 0 || selectedBinsRect.y != 0 || selectedBinsRect.z != 0 || selectedBinsRect.w != 0) {
         int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
         if (phiBinsNum < 0) {

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -43,11 +43,11 @@ using math_utils::getNormalizedPhiCoordinate;
 
 using namespace constants::its2;
 GPU_DEVICE const int4 getBinsRect(const Cluster& currentCluster, const int layerIndex,
-                                  const float z1, const float z2, float maxdeltaz, float maxdeltaphi)
+                                  const float z1, float maxdeltaz, float maxdeltaphi)
 {
-  const float zRangeMin = gpu::GPUCommonMath::Min(z1, z2) - maxdeltaz;
+  const float zRangeMin = z1 - maxdeltaz;
   const float phiRangeMin = currentCluster.phiCoordinate - maxdeltaphi;
-  const float zRangeMax = gpu::GPUCommonMath::Max(z1, z2) + maxdeltaz;
+  const float zRangeMax = z1 + maxdeltaz;
   const float phiRangeMax = currentCluster.phiCoordinate + maxdeltaphi;
 
   if (zRangeMax < -LayersZCoordinate()[layerIndex + 1] ||
@@ -163,7 +163,7 @@ GPUg() void trackleterKernel(
       const size_t stride{currentClusterIndex * store.getConfig().maxTrackletsPerCluster};
       const Cluster& currentCluster = store.getClusters()[1][currentClusterIndex]; // assign-constructor may be a problem, check
       const VertexerLayerName adjacentLayerIndex{layerOrder == TrackletingLayerOrder::fromInnermostToMiddleLayer ? VertexerLayerName::innermostLayer : VertexerLayerName::outerLayer};
-      const int4 selectedBinsRect{getBinsRect(currentCluster, static_cast<int>(adjacentLayerIndex), 0.f, 0.f, 50.f, phiCut / 2)};
+      const int4 selectedBinsRect{getBinsRect(currentCluster, static_cast<int>(adjacentLayerIndex), 0.f, 50.f, phiCut / 2)};
       if (selectedBinsRect.x != 0 || selectedBinsRect.y != 0 || selectedBinsRect.z != 0 || selectedBinsRect.w != 0) {
         int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
         if (phiBinsNum < 0) {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -31,9 +31,9 @@ namespace its
 struct Cluster final {
   Cluster() = default;
   Cluster(const float x, const float y, const float z, const int idx);
-  Cluster(const int, const Cluster&);
-  Cluster(const int, const float3&, const Cluster&);
-  void Init(const int, const float3&, const Cluster&);
+  Cluster(const int, const IndexTableUtils& utils, const Cluster&);
+  Cluster(const int, const float3&, const IndexTableUtils& utils, const Cluster&);
+  void Init(const int, const float3&, const IndexTableUtils& utils, const Cluster&);
 
   float xCoordinate;      // = -999.f;
   float yCoordinate;      // = -999.f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -21,12 +21,13 @@
 
 #include "ITStracking/Definitions.h"
 #include "ITStracking/MathUtils.h"
-#include "ITStracking/IndexTableUtils.h"
 
 namespace o2
 {
 namespace its
 {
+
+class IndexTableUtils;
 
 struct Cluster final {
   Cluster() = default;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -87,6 +87,12 @@ inline int TrackingParameters::CellMinimumLevel()
 
 inline TrackingParameters& TrackingParameters::operator=(const TrackingParameters& t)
 {
+  this->NLayers = t.NLayers;
+  this->LayerZ = t.LayerZ;
+  this->LayerRadii = t.LayerRadii;
+  this->ZBins = t.ZBins;
+  this->PhiBins = t.PhiBins;
+  /// General parameters
   this->ClusterSharing = t.ClusterSharing;
   this->MinTrackLength = t.MinTrackLength;
   /// Trackleting cuts

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -47,29 +47,37 @@ struct TrackingParameters {
   TrackingParameters& operator=(const TrackingParameters& t);
 
   int CellMinimumLevel();
+  int CellsPerRoad() const { return NLayers - 2; }
+  int TrackletsPerRoad() const { return NLayers - 1; }
+
+  int NLayers = 7;
+  std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};
+  std::vector<float> LayerRadii = {2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f};
+  int ZBins{256};
+  int PhiBins{128};
 
   /// General parameters
   int ClusterSharing = 0;
   int MinTrackLength = 7;
   /// Trackleting cuts
   float TrackletMaxDeltaPhi = 0.3f;
-  float TrackletMaxDeltaZ[constants::its::TrackletsPerRoad] = {0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f};
+  std::vector<float> TrackletMaxDeltaZ = {0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f};
   /// Cell finding cuts
   float CellMaxDeltaTanLambda = 0.025f;
-  float CellMaxDCA[constants::its::CellsPerRoad] = {0.05f, 0.04f, 0.05f, 0.2f, 0.4f};
+  std::vector<float> CellMaxDCA = {0.05f, 0.04f, 0.05f, 0.2f, 0.4f};
   float CellMaxDeltaPhi = 0.14f;
-  float CellMaxDeltaZ[constants::its::CellsPerRoad] = {0.2f, 0.4f, 0.5f, 0.6f, 3.0f};
+  std::vector<float> CellMaxDeltaZ = {0.2f, 0.4f, 0.5f, 0.6f, 3.0f};
   /// Neighbour finding cuts
-  float NeighbourMaxDeltaCurvature[constants::its::CellsPerRoad - 1] = {0.008f, 0.0025f, 0.003f, 0.0035f};
-  float NeighbourMaxDeltaN[constants::its::CellsPerRoad - 1] = {0.002f, 0.0090f, 0.002f, 0.005f};
+  std::vector<float> NeighbourMaxDeltaCurvature = {0.008f, 0.0025f, 0.003f, 0.0035f};
+  std::vector<float> NeighbourMaxDeltaN = {0.002f, 0.0090f, 0.002f, 0.005f};
 };
 
 struct MemoryParameters {
   /// Memory coefficients
   MemoryParameters& operator=(const MemoryParameters& t);
   int MemoryOffset = 256;
-  float CellsMemoryCoefficients[constants::its::CellsPerRoad] = {2.3208e-08f, 2.104e-08f, 1.6432e-08f, 1.2412e-08f, 1.3543e-08f};
-  float TrackletsMemoryCoefficients[constants::its::TrackletsPerRoad] = {0.0016353f, 0.0013627f, 0.000984f, 0.00078135f, 0.00057934f, 0.00052217f};
+  std::vector<float> CellsMemoryCoefficients = {2.3208e-08f, 2.104e-08f, 1.6432e-08f, 1.2412e-08f, 1.3543e-08f};
+  std::vector<float> TrackletsMemoryCoefficients = {0.0016353f, 0.0013627f, 0.000984f, 0.00078135f, 0.00057934f, 0.00052217f};
 };
 
 inline int TrackingParameters::CellMinimumLevel()
@@ -83,37 +91,32 @@ inline TrackingParameters& TrackingParameters::operator=(const TrackingParameter
   this->MinTrackLength = t.MinTrackLength;
   /// Trackleting cuts
   this->TrackletMaxDeltaPhi = t.TrackletMaxDeltaPhi;
-  for (int iT = 0; iT < constants::its::TrackletsPerRoad; ++iT) {
-    this->TrackletMaxDeltaZ[iT] = t.TrackletMaxDeltaZ[iT];
-  }
+  this->TrackletMaxDeltaZ = t.TrackletMaxDeltaZ;
   /// Cell finding cuts
   this->CellMaxDeltaTanLambda = t.CellMaxDeltaTanLambda;
   this->CellMaxDeltaPhi = t.CellMaxDeltaPhi;
-  for (int iC = 0; iC < constants::its::CellsPerRoad; ++iC) {
-    this->CellMaxDCA[iC] = t.CellMaxDCA[iC];
-    this->CellMaxDeltaZ[iC] = t.CellMaxDeltaZ[iC];
-  }
+  this->CellMaxDCA = t.CellMaxDCA;
+  this->CellMaxDeltaZ = t.CellMaxDeltaZ;
   /// Neighbour finding cuts
-  for (int iC = 0; iC < constants::its::CellsPerRoad - 1; ++iC) {
-    this->NeighbourMaxDeltaCurvature[iC] = t.NeighbourMaxDeltaCurvature[iC];
-    this->NeighbourMaxDeltaN[iC] = t.NeighbourMaxDeltaN[iC];
-  }
+  this->NeighbourMaxDeltaCurvature = t.NeighbourMaxDeltaCurvature;
+  this->NeighbourMaxDeltaN = t.NeighbourMaxDeltaN;
   return *this;
 }
 
 inline MemoryParameters& MemoryParameters::operator=(const MemoryParameters& t)
 {
   this->MemoryOffset = t.MemoryOffset;
-  for (int iC = 0; iC < constants::its::CellsPerRoad; ++iC) {
-    this->CellsMemoryCoefficients[iC] = t.CellsMemoryCoefficients[iC];
-  }
-  for (int iT = 0; iT < constants::its::TrackletsPerRoad; ++iT) {
-    this->TrackletsMemoryCoefficients[iT] = t.TrackletsMemoryCoefficients[iT];
-  }
+  this->CellsMemoryCoefficients = t.CellsMemoryCoefficients;
+  this->TrackletsMemoryCoefficients = t.TrackletsMemoryCoefficients;
   return *this;
 }
 
 struct VertexingParameters {
+  std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};
+  std::vector<float> LayerRadii = {2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f};
+  int ZBins{256};
+  int PhiBins{128};
+
   float zCut = 0.002f;   //0.002f
   float phiCut = 0.005f; //0.005f
   float pairCut = 0.04f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -15,10 +15,12 @@
 #ifndef TRACKINGITSU_INCLUDE_CONFIGURATION_H_
 #define TRACKINGITSU_INCLUDE_CONFIGURATION_H_
 
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <array>
 #include <climits>
 #include <vector>
 #include <cmath>
+#endif
 
 #include "ITStracking/Constants.h"
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -46,7 +46,7 @@ class Configuration : public Param
 };
 
 struct TrackingParameters {
-  TrackingParameters& operator=(const TrackingParameters& t);
+  TrackingParameters& operator=(const TrackingParameters& t) = default;
 
   int CellMinimumLevel();
   int CellsPerRoad() const { return NLayers - 2; }
@@ -76,7 +76,7 @@ struct TrackingParameters {
 
 struct MemoryParameters {
   /// Memory coefficients
-  MemoryParameters& operator=(const MemoryParameters& t);
+  MemoryParameters& operator=(const MemoryParameters& t) = default;
   int MemoryOffset = 256;
   std::vector<float> CellsMemoryCoefficients = {2.3208e-08f, 2.104e-08f, 1.6432e-08f, 1.2412e-08f, 1.3543e-08f};
   std::vector<float> TrackletsMemoryCoefficients = {0.0016353f, 0.0013627f, 0.000984f, 0.00078135f, 0.00057934f, 0.00052217f};
@@ -85,38 +85,6 @@ struct MemoryParameters {
 inline int TrackingParameters::CellMinimumLevel()
 {
   return MinTrackLength - constants::its::ClustersPerCell + 1;
-}
-
-inline TrackingParameters& TrackingParameters::operator=(const TrackingParameters& t)
-{
-  this->NLayers = t.NLayers;
-  this->LayerZ = t.LayerZ;
-  this->LayerRadii = t.LayerRadii;
-  this->ZBins = t.ZBins;
-  this->PhiBins = t.PhiBins;
-  /// General parameters
-  this->ClusterSharing = t.ClusterSharing;
-  this->MinTrackLength = t.MinTrackLength;
-  /// Trackleting cuts
-  this->TrackletMaxDeltaPhi = t.TrackletMaxDeltaPhi;
-  this->TrackletMaxDeltaZ = t.TrackletMaxDeltaZ;
-  /// Cell finding cuts
-  this->CellMaxDeltaTanLambda = t.CellMaxDeltaTanLambda;
-  this->CellMaxDeltaPhi = t.CellMaxDeltaPhi;
-  this->CellMaxDCA = t.CellMaxDCA;
-  this->CellMaxDeltaZ = t.CellMaxDeltaZ;
-  /// Neighbour finding cuts
-  this->NeighbourMaxDeltaCurvature = t.NeighbourMaxDeltaCurvature;
-  this->NeighbourMaxDeltaN = t.NeighbourMaxDeltaN;
-  return *this;
-}
-
-inline MemoryParameters& MemoryParameters::operator=(const MemoryParameters& t)
-{
-  this->MemoryOffset = t.MemoryOffset;
-  this->CellsMemoryCoefficients = t.CellsMemoryCoefficients;
-  this->TrackletsMemoryCoefficients = t.TrackletsMemoryCoefficients;
-  return *this;
 }
 
 struct VertexingParameters {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -54,32 +54,30 @@ GPU_HOST_DEVICE constexpr GPUArray<float, 3> VertexerHistogramVolume()
 
 namespace its2
 {
-constexpr int LayersNumber{7};	
-constexpr int TrackletsPerRoad{LayersNumber - 1};	
+constexpr int LayersNumber{7};
+constexpr int TrackletsPerRoad{LayersNumber - 1};
 constexpr int CellsPerRoad{LayersNumber - 2};
 
-
-GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersZCoordinate()	
-{	
-  constexpr double s = 1.; // safety margin	
-  return GPUArray<float, LayersNumber>{{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s}};	
-}	
-GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()	
-{	
-  return GPUArray<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};	
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersZCoordinate()
+{
+  constexpr double s = 1.; // safety margin
+  return GPUArray<float, LayersNumber>{{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s}};
+}
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()
+{
+  return GPUArray<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};
 }
 
-constexpr int ZBins{256};	
-constexpr int PhiBins{128};	
-constexpr float InversePhiBinSize{PhiBins / constants::math::TwoPi};	
-GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> InverseZBinSize()	
-{	
-  constexpr auto zSize = LayersZCoordinate();	
-  return GPUArray<float, LayersNumber>{{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),	
-                                             0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),	
-                                             0.5f * ZBins / (zSize[6])}};	
+constexpr int ZBins{256};
+constexpr int PhiBins{128};
+constexpr float InversePhiBinSize{PhiBins / constants::math::TwoPi};
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> InverseZBinSize()
+{
+  constexpr auto zSize = LayersZCoordinate();
+  return GPUArray<float, LayersNumber>{{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),
+                                        0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),
+                                        0.5f * ZBins / (zSize[6])}};
 }
-
 }
 
 namespace pdgcodes

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -78,7 +78,7 @@ GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> InverseZBinSize()
                                         0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),
                                         0.5f * ZBins / (zSize[6])}};
 }
-}
+} // namespace its2
 
 namespace pdgcodes
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "ITStracking/Definitions.h"
+#include "GPUCommonMath.h"
 
 namespace o2
 {
@@ -78,6 +79,30 @@ GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> InverseZBinSize()
                                         0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),
                                         0.5f * ZBins / (zSize[6])}};
 }
+inline float getInverseZCoordinate(const int layerIndex)
+{
+  return 0.5f * ZBins / LayersZCoordinate()[layerIndex];
+}
+
+GPU_HOST_DEVICE inline int getZBinIndex(const int layerIndex, const float zCoordinate)
+{
+  return (zCoordinate + LayersZCoordinate()[layerIndex]) *
+         InverseZBinSize()[layerIndex];
+}
+
+GPU_HOST_DEVICE inline int getPhiBinIndex(const float currentPhi)
+{
+  return (currentPhi * InversePhiBinSize);
+}
+
+GPU_HOST_DEVICE inline int getBinIndex(const int zIndex, const int phiIndex)
+{
+  return gpu::GPUCommonMath::Min(phiIndex * ZBins + zIndex,
+                                 ZBins * PhiBins - 1);
+}
+
+GPU_HOST_DEVICE constexpr int4 getEmptyBinsRect() { return int4{0, 0, 0, 0}; }
+
 } // namespace its2
 
 namespace pdgcodes

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -52,6 +52,36 @@ GPU_HOST_DEVICE constexpr GPUArray<float, 3> VertexerHistogramVolume()
 }
 } // namespace its
 
+namespace its2
+{
+constexpr int LayersNumber{7};	
+constexpr int TrackletsPerRoad{LayersNumber - 1};	
+constexpr int CellsPerRoad{LayersNumber - 2};
+
+
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersZCoordinate()	
+{	
+  constexpr double s = 1.; // safety margin	
+  return GPUArray<float, LayersNumber>{{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s}};	
+}	
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()	
+{	
+  return GPUArray<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};	
+}
+
+constexpr int ZBins{256};	
+constexpr int PhiBins{128};	
+constexpr float InversePhiBinSize{PhiBins / constants::math::TwoPi};	
+GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> InverseZBinSize()	
+{	
+  constexpr auto zSize = LayersZCoordinate();	
+  return GPUArray<float, LayersNumber>{{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),	
+                                             0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),	
+                                             0.5f * ZBins / (zSize[6])}};	
+}
+
+}
+
 namespace pdgcodes
 {
 constexpr int PionCode{211};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -41,42 +41,16 @@ constexpr float FloatMinThreshold{1e-20f};
 
 namespace its
 {
-constexpr int LayersNumber{7};
 constexpr int LayersNumberVertexer{3};
-constexpr int TrackletsPerRoad{LayersNumber - 1};
-constexpr int CellsPerRoad{LayersNumber - 2};
 constexpr int ClustersPerCell{3};
 constexpr int UnusedIndex{-1};
 constexpr float Resolution{0.0005f};
 
-GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersZCoordinate()
-{
-  constexpr double s = 1.; // safety margin
-  return GPUArray<float, LayersNumber>{{16.333f + s, 16.333f + s, 16.333f + s, 42.140f + s, 42.140f + s, 73.745f + s, 73.745f + s}};
-}
-GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()
-{
-  return GPUArray<float, LayersNumber>{{2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f}};
-}
 GPU_HOST_DEVICE constexpr GPUArray<float, 3> VertexerHistogramVolume()
 {
   return GPUArray<float, 3>{{1.98, 1.98, 40.f}};
 }
 } // namespace its
-
-namespace index_table
-{
-constexpr int ZBins{256};
-constexpr int PhiBins{128};
-constexpr float InversePhiBinSize{constants::index_table::PhiBins / constants::math::TwoPi};
-GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
-{
-  constexpr auto zSize = its::LayersZCoordinate();
-  return GPUArray<float, its::LayersNumber>{{0.5f * ZBins / (zSize[0]), 0.5f * ZBins / (zSize[1]), 0.5f * ZBins / (zSize[2]),
-                                             0.5f * ZBins / (zSize[3]), 0.5f * ZBins / (zSize[4]), 0.5f * ZBins / (zSize[5]),
-                                             0.5f * ZBins / (zSize[6])}};
-}
-} // namespace index_table
 
 namespace pdgcodes
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -55,7 +55,6 @@ constexpr float DefClusErrorCol = o2::itsmft::SegmentationAlpide::PitchCol * 0.5
 constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
 constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
 
-void loadConfigurations(const std::string&);
 std::vector<ROframe> loadEventData(const std::string&);
 void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
@@ -63,7 +62,7 @@ void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clus
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                     gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
-void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
+// void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
@@ -73,7 +73,6 @@ class PrimaryVertexContext
   float3 mPrimaryVertex;
   std::vector<float> mMinR;
   std::vector<float> mMaxR;
-  std::vector<std::vector<Cluster>> mUnsortedClusters;
   std::vector<std::vector<Cluster>> mClusters;
   std::vector<std::vector<bool>> mUsedClusters;
   std::vector<std::vector<Cell>> mCells;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -38,7 +38,7 @@ using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 class ROframe final
 {
  public:
-  ROframe(int ROframeId);
+  ROframe(int ROframeId, int nLayers);
   int getROFrameId() const;
   const float3& getPrimaryVertex(const int) const;
   int getPrimaryVerticesNum() const;
@@ -49,10 +49,10 @@ class ROframe final
   int getTotalClusters() const;
   bool empty() const;
 
-  const std::array<std::vector<Cluster>, constants::its::LayersNumber>& getClusters() const;
+  const auto& getClusters() const { return mClusters; }
   const std::vector<Cluster>& getClustersOnLayer(int layerId) const;
   const std::vector<TrackingFrameInfo>& getTrackingFrameInfoOnLayer(int layerId) const;
-  const std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber>& getTrackingFrameInfo() const;
+  const auto& getTrackingFrameInfo() const { return mTrackingFrameInfo; }
 
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
   const MCCompLabel& getClusterLabels(int layerId, const Cluster& cl) const;
@@ -73,10 +73,10 @@ class ROframe final
  private:
   const int mROframeId;
   std::vector<float3> mPrimaryVertices;
-  std::array<std::vector<Cluster>, constants::its::LayersNumber> mClusters;
-  std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber> mTrackingFrameInfo;
-  std::array<std::vector<MCCompLabel>, constants::its::LayersNumber> mClusterLabels;
-  std::array<std::vector<int>, constants::its::LayersNumber> mClusterExternalIndices;
+  std::vector<std::vector<Cluster>> mClusters;
+  std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
+  std::vector<std::vector<MCCompLabel>> mClusterLabels;
+  std::vector<std::vector<int>> mClusterExternalIndices;
 };
 
 inline int ROframe::getROFrameId() const { return mROframeId; }
@@ -87,11 +87,6 @@ inline int ROframe::getPrimaryVerticesNum() const { return mPrimaryVertices.size
 
 inline bool ROframe::empty() const { return getTotalClusters() == 0; }
 
-inline const std::array<std::vector<Cluster>, constants::its::LayersNumber>& ROframe::getClusters() const
-{
-  return mClusters;
-}
-
 inline const std::vector<Cluster>& ROframe::getClustersOnLayer(int layerId) const
 {
   return mClusters[layerId];
@@ -100,11 +95,6 @@ inline const std::vector<Cluster>& ROframe::getClustersOnLayer(int layerId) cons
 inline const std::vector<TrackingFrameInfo>& ROframe::getTrackingFrameInfoOnLayer(int layerId) const
 {
   return mTrackingFrameInfo[layerId];
-}
-
-inline const std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber>& ROframe::getTrackingFrameInfo() const
-{
-  return mTrackingFrameInfo;
 }
 
 inline const TrackingFrameInfo& ROframe::getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const
@@ -157,7 +147,7 @@ inline void ROframe::addClusterExternalIndexToLayer(int layer, const int idx)
 
 inline void ROframe::clear()
 {
-  for (int iL = 0; iL < constants::its::LayersNumber; ++iL) {
+  for (unsigned int iL = 0; iL < mClusters.size(); ++iL) {
     mClusters[iL].clear();
     mTrackingFrameInfo[iL].clear();
     mClusterLabels[iL].clear();

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
@@ -43,8 +43,10 @@ class Road final
   void resetRoad();
   void addCell(int, int);
 
+  static constexpr int mMaxRoadSize = 13;
+
  private:
-  int mCellIds[constants::its::CellsPerRoad];
+  int mCellIds[mMaxRoadSize];
   int mRoadSize;
   int mLabel;
   bool mIsFakeRoad;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraitsCPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraitsCPU.h
@@ -44,7 +44,7 @@ class TrackerTraitsCPU : public TrackerTraits
 
   void computeLayerCells() final;
   void computeLayerTracklets() final;
-  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks) final;
+  void refitTracks(const std::vector<std::vector<TrackingFrameInfo>>& tf, std::vector<TrackITSExt>& tracks) final;
 
  protected:
   std::vector<std::vector<Tracklet>> mTracklets;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -45,8 +45,6 @@ namespace its
 
 class ROframe;
 
-using constants::index_table::PhiBins;
-using constants::index_table::ZBins;
 using constants::its::LayersNumberVertexer;
 
 struct lightVertex {
@@ -106,8 +104,11 @@ class VertexerTraits
   {
     return int4{0, 0, 0, 0};
   }
-  GPUhd() static const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi);
-  GPUhd() static const int2 getPhiBins(float phi, float deltaPhi);
+  GPUhd() const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi);
+  GPUhd() const int2 getPhiBins(float phi, float deltaPhi);
+
+  GPUhd() static const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi, const IndexTableUtils&);
+  GPUhd() static const int2 getPhiBins(float phi, float deltaPhi, const IndexTableUtils&);
 
   // virtual vertexer interface
   virtual void reset();
@@ -128,8 +129,9 @@ class VertexerTraits
 
   void updateVertexingParameters(const VertexingParameters& vrtPar);
   VertexingParameters getVertexingParameters() const { return mVrtParams; }
-  static const std::vector<std::pair<int, int>> selectClusters(const std::array<int, ZBins * PhiBins + 1>& indexTable,
-                                                               const std::array<int, 4>& selectedBinsRect);
+  static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,
+                                                               const std::array<int, 4>& selectedBinsRect,
+                                                               const IndexTableUtils& utils);
   std::vector<lightVertex> getVertices() const { return mVertices; }
 
   // utils
@@ -160,7 +162,8 @@ class VertexerTraits
 #endif
 
   VertexingParameters mVrtParams;
-  std::array<std::array<int, ZBins * PhiBins + 1>, LayersNumberVertexer> mIndexTables;
+  IndexTableUtils mIndexTableUtils;
+  std::array<std::vector<int>, LayersNumberVertexer> mIndexTables;
   std::vector<lightVertex> mVertices;
 
   // Frame related quantities
@@ -177,6 +180,8 @@ class VertexerTraits
 inline void VertexerTraits::initialise(ROframe* event)
 {
   reset();
+  if (!mIndexTableUtils.getNzBins())
+    updateVertexingParameters(mVrtParams);
   arrangeClusters(event);
   setIsGPU(false);
 }
@@ -189,32 +194,51 @@ inline void VertexerTraits::setIsGPU(const unsigned char isgpu)
 inline void VertexerTraits::updateVertexingParameters(const VertexingParameters& vrtPar)
 {
   mVrtParams = vrtPar;
+  mIndexTableUtils.setTrackingParameters(vrtPar);
+  mVrtParams.phiSpan = static_cast<int>(std::ceil(mIndexTableUtils.getNphiBins() * mVrtParams.phiCut /
+                                                  constants::math::TwoPi));
+  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * mIndexTableUtils.getInverseZCoordinate(0)));
+  for (auto& table : mIndexTables) {
+    table.resize(mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1, 0);
+  }
 }
 
 GPUhdi() const int2 VertexerTraits::getPhiBins(float phi, float dPhi)
 {
-  return int2{index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi - dPhi)),
-              index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi + dPhi))};
+  return VertexerTraits::getPhiBins(phi, dPhi, mIndexTableUtils);
+}
+
+GPUhdi() const int2 VertexerTraits::getPhiBins(float phi, float dPhi, const IndexTableUtils& utils)
+{
+  return int2{utils.getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi - dPhi)),
+              utils.getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi + dPhi))};
 }
 
 GPUhdi() const int4 VertexerTraits::getBinsRect(const Cluster& currentCluster, const int layerIndex,
-                                                const float directionZIntersection, float maxdeltaz, float maxdeltaphi)
+                                                const float directionZIntersection, float maxdeltaz, float maxdeltaphi,
+                                                const IndexTableUtils& utils)
 {
   const float zRangeMin = directionZIntersection - 2 * maxdeltaz;
   const float phiRangeMin = currentCluster.phiCoordinate - maxdeltaphi;
   const float zRangeMax = directionZIntersection + 2 * maxdeltaz;
   const float phiRangeMax = currentCluster.phiCoordinate + maxdeltaphi;
 
-  if (zRangeMax < -constants::its::LayersZCoordinate()[layerIndex + 1] ||
-      zRangeMin > constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
+  if (zRangeMax < -utils.getLayerZ(layerIndex + 1) ||
+      zRangeMin > utils.getLayerZ(layerIndex + 1) || zRangeMin > zRangeMax) {
 
     return getEmptyBinsRect();
   }
 
-  return int4{gpu::GPUCommonMath::Max(0, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMin)),
-              index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMin)),
-              gpu::GPUCommonMath::Min(constants::index_table::ZBins - 1, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMax)),
-              index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMax))};
+  return int4{gpu::GPUCommonMath::Max(0, utils.getZBinIndex(layerIndex + 1, zRangeMin)),
+              utils.getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMin)),
+              gpu::GPUCommonMath::Min(utils.getNzBins() - 1, utils.getZBinIndex(layerIndex + 1, zRangeMax)),
+              utils.getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMax))};
+}
+
+GPUhdi() const int4 VertexerTraits::getBinsRect(const Cluster& currentCluster, const int layerIndex,
+                                                const float directionZIntersection, float maxdeltaz, float maxdeltaphi)
+{
+  return VertexerTraits::getBinsRect(currentCluster, layerIndex, directionZIntersection, maxdeltaz, maxdeltaphi, mIndexTableUtils);
 }
 
 // debug

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -181,8 +181,9 @@ class VertexerTraits
 inline void VertexerTraits::initialise(ROframe* event)
 {
   reset();
-  if (!mIndexTableUtils.getNzBins())
+  if (!mIndexTableUtils.getNzBins()) {
     updateVertexingParameters(mVrtParams);
+  }
   arrangeClusters(event);
   setIsGPU(false);
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -23,6 +23,7 @@
 #include "ITStracking/Configuration.h"
 #include "ITStracking/ClusterLines.h"
 #include "ITStracking/Definitions.h"
+#include "ITStracking/IndexTableUtils.h"
 #ifdef _ALLOW_DEBUG_TREES_ITS_
 #include "ITStracking/StandaloneDebugger.h"
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -13,8 +13,6 @@
 ///
 
 #include "ITStracking/Cluster.h"
-
-#include "ITStracking/IndexTableUtils.h"
 #include "ITStracking/MathUtils.h"
 
 namespace o2
@@ -38,21 +36,21 @@ Cluster::Cluster(const float x, const float y, const float z, const int index)
   // Nothing to do
 }
 
-Cluster::Cluster(const int layerIndex, const Cluster& other)
+Cluster::Cluster(const int layerIndex, const IndexTableUtils& utils, const Cluster& other)
   : xCoordinate{other.xCoordinate},
     yCoordinate{other.yCoordinate},
     zCoordinate{other.zCoordinate},
     phiCoordinate{getNormalizedPhiCoordinate(calculatePhiCoordinate(other.xCoordinate, other.yCoordinate))},
     rCoordinate{calculateRCoordinate(other.xCoordinate, other.yCoordinate)},
     clusterId{other.clusterId},
-    indexTableBinIndex{index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
-                                                      index_table_utils::getPhiBinIndex(phiCoordinate))}
+    indexTableBinIndex{utils.getBinIndex(utils.getZBinIndex(layerIndex, zCoordinate),
+                                         utils.getPhiBinIndex(phiCoordinate))}
 //, montecarloId{ other.montecarloId }
 {
   // Nothing to do
 }
 
-Cluster::Cluster(const int layerIndex, const float3& primaryVertex, const Cluster& other)
+Cluster::Cluster(const int layerIndex, const float3& primaryVertex, const IndexTableUtils& utils, const Cluster& other)
   : xCoordinate{other.xCoordinate},
     yCoordinate{other.yCoordinate},
     zCoordinate{other.zCoordinate},
@@ -60,13 +58,13 @@ Cluster::Cluster(const int layerIndex, const float3& primaryVertex, const Cluste
       calculatePhiCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y))},
     rCoordinate{calculateRCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y)},
     clusterId{other.clusterId},
-    indexTableBinIndex{index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
-                                                      index_table_utils::getPhiBinIndex(phiCoordinate))}
+    indexTableBinIndex{utils.getBinIndex(utils.getZBinIndex(layerIndex, zCoordinate),
+                                         utils.getPhiBinIndex(phiCoordinate))}
 {
   // Nothing to do
 }
 
-void Cluster::Init(const int layerIndex, const float3& primaryVertex, const Cluster& other)
+void Cluster::Init(const int layerIndex, const float3& primaryVertex, const IndexTableUtils& utils, const Cluster& other)
 {
   xCoordinate = other.xCoordinate;
   yCoordinate = other.yCoordinate;
@@ -75,8 +73,8 @@ void Cluster::Init(const int layerIndex, const float3& primaryVertex, const Clus
     calculatePhiCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y));
   rCoordinate = calculateRCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y);
   clusterId = other.clusterId;
-  indexTableBinIndex = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
-                                                      index_table_utils::getPhiBinIndex(phiCoordinate));
+  indexTableBinIndex = utils.getBinIndex(utils.getZBinIndex(layerIndex, zCoordinate),
+                                         utils.getPhiBinIndex(phiCoordinate));
 }
 
 TrackingFrameInfo::TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, GPUArray<float, 2>&& posTF,

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -14,6 +14,7 @@
 
 #include "ITStracking/Cluster.h"
 #include "ITStracking/MathUtils.h"
+#include "ITStracking/IndexTableUtils.h"
 
 namespace o2
 {

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -38,9 +38,6 @@ constexpr int PrimaryVertexLayerId{-1};
 constexpr int EventLabelsSeparator{-1};
 } // namespace
 
-using o2::its::constants::its::LayersRCoordinate;
-using o2::its::constants::its::LayersZCoordinate;
-
 namespace o2
 {
 namespace its
@@ -80,18 +77,6 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
   }
 }
 
-void ioutils::loadConfigurations(const std::string& fileName)
-{
-  if (!fileName.empty()) {
-    std::ifstream inputStream;
-    inputStream.open(fileName);
-    nlohmann::json j;
-    inputStream >> j;
-    static_cast<TrackingParameters&>(Configuration<TrackingParameters>::getInstance()) = j.at("TrackingParameters").get<TrackingParameters>();
-    //static_cast<IndexTableParameters&>(Configuration<IndexTableParameters>::getInstance()) = j.at("IndexTableParameters").get<IndexTableParameters>();
-  }
-}
-
 std::vector<ROframe> ioutils::loadEventData(const std::string& fileName)
 {
   std::vector<ROframe> events{};
@@ -114,7 +99,7 @@ std::vector<ROframe> ioutils::loadEventData(const std::string& fileName)
       if (layerId == PrimaryVertexLayerId) {
 
         if (clusterId != 0) {
-          events.emplace_back(events.size());
+          events.emplace_back(events.size(), 7);
         }
 
         events.back().addPrimaryVertex(xCoordinate, yCoordinate, zCoordinate);
@@ -244,33 +229,33 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
   return clusters_in_frame.size();
 }
 
-void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 1)
-{
-  const float angleOffset = constants::math::TwoPi / static_cast<float>(phiDivs);
-  // Maximum z allowed on innermost layer should be: ~9,75
-  const float zOffsetFirstLayer = (zDivs == 1) ? 0 : 1.5 * (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * (static_cast<float>(zDivs) - 1));
-  std::vector<float> x, y;
-  std::array<std::vector<float>, 7> z;
-  for (size_t j{0}; j < zDivs; ++j) {
-    for (size_t i{0}; i < phiDivs; ++i) {
-      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
-      y.emplace_back(sin(i * angleOffset + 0.001));
-      const float zFirstLayer{-static_cast<float>((zDivs - 1.) / 2.) * zOffsetFirstLayer + zOffsetFirstLayer * static_cast<float>(j)};
-      z[0].emplace_back(zFirstLayer);
-      for (size_t iLayer{1}; iLayer < constants::its::LayersNumber; ++iLayer) {
-        z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
-      }
-    }
-  }
+// void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 1)
+// {
+//   const float angleOffset = constants::math::TwoPi / static_cast<float>(phiDivs);
+//   // Maximum z allowed on innermost layer should be: ~9,75
+//   const float zOffsetFirstLayer = (zDivs == 1) ? 0 : 1.5 * (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * (static_cast<float>(zDivs) - 1));
+//   std::vector<float> x, y;
+//   std::array<std::vector<float>, 7> z;
+//   for (size_t j{0}; j < zDivs; ++j) {
+//     for (size_t i{0}; i < phiDivs; ++i) {
+//       x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
+//       y.emplace_back(sin(i * angleOffset + 0.001));
+//       const float zFirstLayer{-static_cast<float>((zDivs - 1.) / 2.) * zOffsetFirstLayer + zOffsetFirstLayer * static_cast<float>(j)};
+//       z[0].emplace_back(zFirstLayer);
+//       for (size_t iLayer{1}; iLayer < 7; ++iLayer) {
+//         z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
+//       }
+//     }
+//   }
 
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
-    for (int i = 0; i < phiDivs * zDivs; i++) {
-      o2::MCCompLabel label{i, 0, 0, false};
-      event.addClusterLabelToLayer(iLayer, label);                                                                              //last argument : label, goes into mClustersLabel
-      event.addClusterToLayer(iLayer, LayersRCoordinate()[iLayer] * x[i], LayersRCoordinate()[iLayer] * y[i], z[iLayer][i], i); //uses 1st constructor for clusters
-    }
-  }
-}
+//   for (int iLayer{0}; iLayer < 7; ++iLayer) {
+//     for (int i = 0; i < phiDivs * zDivs; i++) {
+//       o2::MCCompLabel label{i, 0, 0, false};
+//       event.addClusterLabelToLayer(iLayer, label);                                                                              //last argument : label, goes into mClustersLabel
+//       event.addClusterToLayer(iLayer, LayersRCoordinate()[iLayer] * x[i], LayersRCoordinate()[iLayer] * y[i], z[iLayer][i], i); //uses 1st constructor for clusters
+//     }
+//   }
+// }
 
 std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int eventsNum, const std::string& fileName)
 {
@@ -364,70 +349,7 @@ void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofs
   }
 }
 
-void to_json(nlohmann::json& j, const TrackingParameters& par)
-{
-  std::array<float, constants::its::TrackletsPerRoad> tmpTrackletMaxDeltaZ;
-  std::copy(par.TrackletMaxDeltaZ, par.TrackletMaxDeltaZ + tmpTrackletMaxDeltaZ.size(), tmpTrackletMaxDeltaZ.begin());
-  std::array<float, constants::its::CellsPerRoad> tmpCellMaxDCA;
-  std::copy(par.CellMaxDCA, par.CellMaxDCA + tmpCellMaxDCA.size(), tmpCellMaxDCA.begin());
-  std::array<float, constants::its::CellsPerRoad> tmpCellMaxDeltaZ;
-  std::copy(par.CellMaxDeltaZ, par.CellMaxDeltaZ + tmpCellMaxDeltaZ.size(), tmpCellMaxDeltaZ.begin());
-  std::array<float, constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaCurvature;
-  std::copy(par.NeighbourMaxDeltaCurvature, par.NeighbourMaxDeltaCurvature + tmpNeighbourMaxDeltaCurvature.size(), tmpNeighbourMaxDeltaCurvature.begin());
-  std::array<float, constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaN;
-  std::copy(par.NeighbourMaxDeltaN, par.NeighbourMaxDeltaN + tmpNeighbourMaxDeltaN.size(), tmpNeighbourMaxDeltaN.begin());
-  j = nlohmann::json{
-    {"ClusterSharing", par.ClusterSharing},
-    {"MinTrackLength", par.MinTrackLength},
-    {"TrackletMaxDeltaPhi", par.TrackletMaxDeltaPhi},
-    {"TrackletMaxDeltaZ", tmpTrackletMaxDeltaZ},
-    {"CellMaxDeltaTanLambda", par.CellMaxDeltaTanLambda},
-    {"CellMaxDCA", tmpCellMaxDCA},
-    {"CellMaxDeltaPhi", par.CellMaxDeltaPhi},
-    {"CellMaxDeltaZ", tmpCellMaxDeltaZ},
-    {"NeighbourMaxDeltaCurvature", tmpNeighbourMaxDeltaCurvature},
-    {"NeighbourMaxDeltaN", tmpNeighbourMaxDeltaN}};
-}
 
-void from_json(const nlohmann::json& j, TrackingParameters& par)
-{
-  par.ClusterSharing = j.at("ClusterSharing").get<int>();
-  par.MinTrackLength = j.at("MinTrackLength").get<int>();
-  par.TrackletMaxDeltaPhi = j.at("TrackletMaxDeltaPhi").get<float>();
-  par.CellMaxDeltaTanLambda = j.at("CellMaxDeltaTanLambda").get<float>();
-  par.CellMaxDeltaPhi = j.at("CellMaxDeltaPhi").get<float>();
-  auto tmpTrackletMaxDeltaZ = j.at("TrackletMaxDeltaZ").get<std::array<float, constants::its::TrackletsPerRoad>>();
-  std::copy(tmpTrackletMaxDeltaZ.begin(), tmpTrackletMaxDeltaZ.end(), par.TrackletMaxDeltaZ);
-  auto tmpCellMaxDCA = j.at("CellMaxDCA").get<std::array<float, constants::its::CellsPerRoad>>();
-  std::copy(tmpCellMaxDCA.begin(), tmpCellMaxDCA.end(), par.CellMaxDCA);
-  auto tmpCellMaxDeltaZ = j.at("CellMaxDeltaZ").get<std::array<float, constants::its::CellsPerRoad>>();
-  std::copy(tmpCellMaxDCA.begin(), tmpCellMaxDeltaZ.end(), par.CellMaxDeltaZ);
-  auto tmpNeighbourMaxDeltaCurvature = j.at("NeighbourMaxDeltaCurvature").get<std::array<float, constants::its::CellsPerRoad - 1>>();
-  std::copy(tmpNeighbourMaxDeltaCurvature.begin(), tmpNeighbourMaxDeltaCurvature.end(), par.NeighbourMaxDeltaCurvature);
-  auto tmpNeighbourMaxDeltaN = j.at("NeighbourMaxDeltaN").get<std::array<float, constants::its::CellsPerRoad - 1>>();
-  std::copy(tmpNeighbourMaxDeltaN.begin(), tmpNeighbourMaxDeltaN.end(), par.NeighbourMaxDeltaN);
-}
-
-void to_json(nlohmann::json& j, const MemoryParameters& par)
-{
-  std::array<float, constants::its::CellsPerRoad> tmpCellsMemoryCoefficients;
-  std::copy(par.CellsMemoryCoefficients, par.CellsMemoryCoefficients + tmpCellsMemoryCoefficients.size(), tmpCellsMemoryCoefficients.begin());
-  std::array<float, constants::its::TrackletsPerRoad> tmpTrackletsMemoryCoefficients;
-  std::copy(par.TrackletsMemoryCoefficients, par.TrackletsMemoryCoefficients + tmpTrackletsMemoryCoefficients.size(), tmpTrackletsMemoryCoefficients.begin());
-  j = nlohmann::json{
-    {"MemoryOffset", par.MemoryOffset},
-    {"CellsMemoryCoefficients", tmpCellsMemoryCoefficients},
-    {"TrackletsMemoryCoefficients", tmpTrackletsMemoryCoefficients}};
-}
-
-void from_json(const nlohmann::json& j, MemoryParameters& par)
-{
-  par.MemoryOffset = j.at("MemoryOffset").get<int>();
-  auto tmpCellsMemoryCoefficients = j.at("CellsMemoryCoefficients").get<std::array<float, constants::its::CellsPerRoad>>();
-  std::copy(tmpCellsMemoryCoefficients.begin(), tmpCellsMemoryCoefficients.end(), par.CellsMemoryCoefficients);
-  auto tmpTrackletsMemoryCoefficients = j.at("TrackletsMemoryCoefficients").get<std::array<float, constants::its::TrackletsPerRoad>>();
-  std::copy(tmpTrackletsMemoryCoefficients.begin(), tmpTrackletsMemoryCoefficients.end(), par.TrackletsMemoryCoefficients);
-}
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -21,8 +21,8 @@ namespace o2
 namespace its
 {
 
-void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
-                                      const std::array<float, 3>& pVtx, const int iteration)
+void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const TrackingParameters& trkParam,
+                                      const std::vector<std::vector<Cluster>>& cl, const std::array<float, 3>& pVtx, const int iteration)
 {
 
   struct ClusterHelper {
@@ -38,7 +38,20 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
 
     std::vector<ClusterHelper> cHelper;
 
-    for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
+    mMinR.resize(trkParam.LayerRadii.size(), 10000.);
+    mMaxR.resize(trkParam.LayerRadii.size(), -1.);
+    mUnsortedClusters.resize(trkParam.LayerRadii.size());
+    mClusters.resize(trkParam.NLayers);
+    mUsedClusters.resize(trkParam.NLayers);
+    mCells.resize(trkParam.NLayers - 2);
+    mCellsLookupTable.resize(trkParam.NLayers - 3);
+    mCellsNeighbours.resize(trkParam.NLayers - 3);
+    mIndexTables.resize(trkParam.NLayers - 1, std::vector<int>(trkParam.ZBins * trkParam.PhiBins + 1, 0));
+    mTracklets.resize(trkParam.NLayers - 1);
+    mTrackletsLookupTable.resize(trkParam.NLayers - 2);
+    mIndexTableUtils.setTrackingParameters(trkParam);
+
+    for (unsigned int iLayer{0}; iLayer < mClusters.size(); ++iLayer) {
 
       const auto& currentLayer{cl[iLayer]};
       const int clustersNum{static_cast<int>(currentLayer.size())};
@@ -48,11 +61,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       mUsedClusters[iLayer].clear();
       mUsedClusters[iLayer].resize(clustersNum, false);
 
-      constexpr int _size = constants::index_table::PhiBins * constants::index_table::ZBins;
-      std::array<int, _size> clsPerBin;
-      for (int iB{0}; iB < _size; ++iB) {
-        clsPerBin[iB] = 0;
-      }
+      std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);
 
       cHelper.clear();
       cHelper.resize(clustersNum);
@@ -66,8 +75,8 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
         float x = c.xCoordinate - mPrimaryVertex.x;
         float y = c.yCoordinate - mPrimaryVertex.y;
         float phi = math_utils::calculatePhiCoordinate(x, y);
-        int bin = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(iLayer, c.zCoordinate),
-                                                 index_table_utils::getPhiBinIndex(phi));
+        int bin = mIndexTableUtils.getBinIndex(mIndexTableUtils.getZBinIndex(iLayer, c.zCoordinate),
+                                               mIndexTableUtils.getPhiBinIndex(phi));
         h.phi = phi;
         h.r = math_utils::calculateRCoordinate(x, y);
         mMinR[iLayer] = gpu::GPUCommonMath::Min(h.r, mMinR[iLayer]);
@@ -76,9 +85,9 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
         h.ind = clsPerBin[bin]++;
       }
 
-      std::array<int, _size> lutPerBin;
+      std::vector<int> lutPerBin(clsPerBin.size());
       lutPerBin[0] = 0;
-      for (int iB{1}; iB < _size; ++iB) {
+      for (unsigned int iB{1}; iB < lutPerBin.size(); ++iB) {
         lutPerBin[iB] = lutPerBin[iB - 1] + clsPerBin[iB - 1];
       }
 
@@ -92,10 +101,10 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
 
       if (iLayer > 0) {
-        for (int iB{0}; iB < _size; ++iB) {
+        for (unsigned int iB{0}; iB < clsPerBin.size(); ++iB) {
           mIndexTables[iLayer - 1][iB] = lutPerBin[iB];
         }
-        for (int iB{_size}; iB < (int)mIndexTables[iLayer - 1].size(); iB++) {
+        for (auto iB{clsPerBin.size()}; iB < (int)mIndexTables[iLayer - 1].size(); iB++) {
           mIndexTables[iLayer - 1][iB] = clustersNum;
         }
       }
@@ -104,8 +113,8 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
 
   mRoads.clear();
 
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
-    if (iLayer < constants::its::CellsPerRoad) {
+  for (unsigned int iLayer{0}; iLayer < mClusters.size(); ++iLayer) {
+    if (iLayer < mCells.size()) {
       mCells[iLayer].clear();
       float cellsMemorySize =
         memParam.MemoryOffset +
@@ -118,7 +127,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
     }
 
-    if (iLayer < constants::its::CellsPerRoad - 1) {
+    if (iLayer < mCells.size() - 1) {
       mCellsLookupTable[iLayer].clear();
       mCellsLookupTable[iLayer].resize(
         std::max(cl[iLayer + 1].size(), cl[iLayer + 2].size()) +
@@ -130,8 +139,8 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
     }
   }
 
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
-    if (iLayer < constants::its::TrackletsPerRoad) {
+  for (unsigned int iLayer{0}; iLayer < mClusters.size(); ++iLayer) {
+    if (iLayer < mTracklets.size()) {
       mTracklets[iLayer].clear();
       float trackletsMemorySize =
         std::max(cl[iLayer].size(), cl[iLayer + 1].size()) +
@@ -143,7 +152,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
     }
 
-    if (iLayer < constants::its::CellsPerRoad) {
+    if (iLayer < mCells.size()) {
       mTrackletsLookupTable[iLayer].clear();
       mTrackletsLookupTable[iLayer].resize(cl[iLayer + 1].size(), constants::its::UnusedIndex);
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -40,7 +40,6 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const Tr
 
     mMinR.resize(trkParam.NLayers, 10000.);
     mMaxR.resize(trkParam.NLayers, -1.);
-    mUnsortedClusters.resize(trkParam.NLayers);
     mClusters.resize(trkParam.NLayers);
     mUsedClusters.resize(trkParam.NLayers);
     mCells.resize(trkParam.CellsPerRoad());

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -130,12 +130,12 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const Tr
 
     if (iLayer < mCells.size() - 1) {
       mCellsLookupTable[iLayer].clear();
-      mCellsLookupTable[iLayer].resize(
-        std::max(cl[iLayer + 1].size(), cl[iLayer + 2].size()) +
-          std::ceil((memParam.TrackletsMemoryCoefficients[iLayer + 1] *
-                     cl[iLayer + 1].size()) *
-                    cl[iLayer + 2].size()),
-        constants::its::UnusedIndex);
+      mCellsLookupTable[iLayer].resize(memParam.MemoryOffset +
+                                         std::max(cl[iLayer + 1].size(), cl[iLayer + 2].size()) +
+                                         std::ceil((memParam.TrackletsMemoryCoefficients[iLayer + 1] *
+                                                    cl[iLayer + 1].size()) *
+                                                   cl[iLayer + 2].size()),
+                                       constants::its::UnusedIndex);
       mCellsNeighbours[iLayer].clear();
     }
   }
@@ -143,10 +143,10 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const Tr
   for (unsigned int iLayer{0}; iLayer < mClusters.size(); ++iLayer) {
     if (iLayer < mTracklets.size()) {
       mTracklets[iLayer].clear();
-      float trackletsMemorySize =
-        std::max(cl[iLayer].size(), cl[iLayer + 1].size()) +
-        std::ceil((memParam.TrackletsMemoryCoefficients[iLayer] * cl[iLayer].size()) *
-                  cl[iLayer + 1].size());
+      float trackletsMemorySize = memParam.MemoryOffset +
+                                  std::max(cl[iLayer].size(), cl[iLayer + 1].size()) +
+                                  std::ceil((memParam.TrackletsMemoryCoefficients[iLayer] * cl[iLayer].size()) *
+                                            cl[iLayer + 1].size());
 
       if (trackletsMemorySize > mTracklets[iLayer].capacity()) {
         mTracklets[iLayer].reserve(trackletsMemorySize);

--- a/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
@@ -21,7 +21,11 @@ namespace o2
 namespace its
 {
 
-ROframe::ROframe(const int ROframeId) : mROframeId{ROframeId}
+ROframe::ROframe(int ROframeId, int nLayers) : mROframeId{ROframeId},
+                                               mClusters{nLayers},
+                                               mTrackingFrameInfo{nLayers},
+                                               mClusterLabels{nLayers},
+                                               mClusterExternalIndices{nLayers}
 {
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
@@ -21,12 +21,12 @@ namespace o2
 namespace its
 {
 
-ROframe::ROframe(int ROframeId, int nLayers) : mROframeId{ROframeId},
-                                               mClusters{nLayers},
-                                               mTrackingFrameInfo{nLayers},
-                                               mClusterLabels{nLayers},
-                                               mClusterExternalIndices{nLayers}
+ROframe::ROframe(int ROframeId, int nLayers) : mROframeId{ROframeId}
 {
+  mClusters.resize(nLayers);
+  mTrackingFrameInfo.resize(nLayers);
+  mClusterLabels.resize(nLayers);
+  mClusterExternalIndices.resize(nLayers);
 }
 
 void ROframe::addPrimaryVertex(const float xCoordinate, const float yCoordinate, const float zCoordinate)

--- a/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
@@ -13,6 +13,8 @@
 ///
 
 #include "ITStracking/Road.h"
+#include <cassert>
+#include <iostream>
 
 namespace o2
 {
@@ -25,7 +27,7 @@ Road::Road(int cellLayer, int cellId) : Road() { addCell(cellLayer, cellId); }
 
 void Road::resetRoad()
 {
-  for (int i = 0; i < constants::its::CellsPerRoad; i++) {
+  for (int i = 0; i < mMaxRoadSize; i++) {
     mCellIds[i] = constants::its::UnusedIndex;
   }
   mRoadSize = 0;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -57,6 +57,15 @@ void Tracker::clustersToTracks(const ROframe& event, std::ostream& timeBenchmark
     float total{0.f};
 
     for (int iteration = 0; iteration < mTrkParams.size(); ++iteration) {
+
+      int numCls = 0;
+      for (unsigned int iLayer{0}; iLayer < mTrkParams[iteration].NLayers; ++iLayer) {
+        numCls += event.getClusters()[iLayer].size();
+      }
+      if (numCls < mTrkParams[iteration].MinTrackLength) {
+        continue;
+      }
+
       mTraits->UpdateTrackingParameters(mTrkParams[iteration]);
       /// Ugly hack -> Unifiy float3 definition in CPU and CUDA/HIP code
       int pass = iteration + iVertex; /// Do not reinitialise the context if we analyse pile-up events

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -326,22 +326,22 @@ void Tracker::findTracks(const ROframe& event)
       CA_DEBUGGER(nClusters++);
     }
 
-// #ifdef CA_DEBUG
-//     assert(nClusters == track.getNumberOfClusters());
-//     xcheckCounters[nClusters - 4]++;
-//     assert(nShared <= nClusters);
-//     sharingMatrix[cumulativeIndex(nClusters) + nShared]++;
-// #endif
+    // #ifdef CA_DEBUG
+    //     assert(nClusters == track.getNumberOfClusters());
+    //     xcheckCounters[nClusters - 4]++;
+    //     assert(nShared <= nClusters);
+    //     sharingMatrix[cumulativeIndex(nClusters) + nShared]++;
+    // #endif
 
     if (nShared > mTrkParams[0].ClusterSharing) {
       continue;
     }
 
-// #ifdef CA_DEBUG
-//     nonsharingCounters[nClusters - 4]++;
-//     assert(nClusters <= prevNclusters);
-//     prevNclusters = nClusters;
-// #endif
+    // #ifdef CA_DEBUG
+    //     nonsharingCounters[nClusters - 4]++;
+    //     assert(nClusters <= prevNclusters);
+    //     prevNclusters = nClusters;
+    // #endif
 
     for (int iLayer{0}; iLayer < mTrkParams[0].NLayers; ++iLayer) {
       if (track.getClusterIndex(iLayer) == constants::its::UnusedIndex) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -34,7 +34,7 @@ namespace its
 void TrackerTraitsCPU::computeLayerTracklets()
 {
   PrimaryVertexContext* primaryVertexContext = mPrimaryVertexContext;
-  for (int iLayer{0}; iLayer < constants::its::TrackletsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < mTrkParams.TrackletsPerRoad(); ++iLayer) {
     if (primaryVertexContext->getClusters()[iLayer].empty() || primaryVertexContext->getClusters()[iLayer + 1].empty()) {
       return;
     }
@@ -67,12 +67,12 @@ void TrackerTraitsCPU::computeLayerTracklets()
       int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
 
       if (phiBinsNum < 0) {
-        phiBinsNum += constants::index_table::PhiBins;
+        phiBinsNum += mTrkParams.PhiBins;
       }
 
       for (int iPhiBin{selectedBinsRect.y}, iPhiCount{0}; iPhiCount < phiBinsNum;
-           iPhiBin = ++iPhiBin == constants::index_table::PhiBins ? 0 : iPhiBin, iPhiCount++) {
-        const int firstBinIndex{index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin)};
+           iPhiBin = ++iPhiBin == mTrkParams.PhiBins ? 0 : iPhiBin, iPhiCount++) {
+        const int firstBinIndex{primaryVertexContext->mIndexTableUtils.getBinIndex(selectedBinsRect.x, iPhiBin)};
         const int maxBinIndex{firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1};
         const int firstRowClusterIndex = primaryVertexContext->getIndexTables()[iLayer][firstBinIndex];
         const int maxRowClusterIndex = primaryVertexContext->getIndexTables()[iLayer][maxBinIndex];
@@ -113,7 +113,7 @@ void TrackerTraitsCPU::computeLayerTracklets()
 void TrackerTraitsCPU::computeLayerCells()
 {
   PrimaryVertexContext* primaryVertexContext = mPrimaryVertexContext;
-  for (int iLayer{0}; iLayer < constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{0}; iLayer < mTrkParams.CellsPerRoad(); ++iLayer) {
 
     if (primaryVertexContext->getTracklets()[iLayer + 1].empty() ||
         primaryVertexContext->getTracklets()[iLayer].empty()) {
@@ -231,15 +231,15 @@ void TrackerTraitsCPU::computeLayerCells()
   }
 }
 
-void TrackerTraitsCPU::refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
+void TrackerTraitsCPU::refitTracks(const std::vector<std::vector<TrackingFrameInfo>>& tf, std::vector<TrackITSExt>& tracks)
 {
-  std::array<const Cell*, 5> cells;
-  for (int iLayer = 0; iLayer < 5; iLayer++) {
-    cells[iLayer] = mPrimaryVertexContext->getCells()[iLayer].data();
+  std::vector<const Cell*> cells;
+  for (int iLayer = 0; iLayer < mTrkParams.CellsPerRoad(); iLayer++) {
+    cells.push_back(mPrimaryVertexContext->getCells()[iLayer].data());
   }
-  std::array<const Cluster*, 7> clusters;
-  for (int iLayer = 0; iLayer < 7; iLayer++) {
-    clusters[iLayer] = mPrimaryVertexContext->getClusters()[iLayer].data();
+  std::vector<const Cluster*> clusters;
+  for (int iLayer = 0; iLayer < mTrkParams.NLayers; iLayer++) {
+    clusters.push_back(mPrimaryVertexContext->getClusters()[iLayer].data());
   }
   mChainRunITSTrackFit(*mChain, mPrimaryVertexContext->getRoads(), clusters, cells, tf, tracks);
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -36,7 +36,7 @@ void TrackerTraitsCPU::computeLayerTracklets()
   PrimaryVertexContext* primaryVertexContext = mPrimaryVertexContext;
   for (int iLayer{0}; iLayer < mTrkParams.TrackletsPerRoad(); ++iLayer) {
     if (primaryVertexContext->getClusters()[iLayer].empty() || primaryVertexContext->getClusters()[iLayer + 1].empty()) {
-      return;
+      continue;
     }
 
     const float3& primaryVertex = primaryVertexContext->getPrimaryVertex();
@@ -107,7 +107,8 @@ void TrackerTraitsCPU::computeLayerTracklets()
         }
       }
     }
-    if (iLayer > 0 && primaryVertexContext->getTracklets()[iLayer].size() > primaryVertexContext->getCellsLookupTable()[iLayer - 1].size()) {
+    if (iLayer > 0 && iLayer < mTrkParams.TrackletsPerRoad() - 1 &&
+        primaryVertexContext->getTracklets()[iLayer].size() > primaryVertexContext->getCellsLookupTable()[iLayer - 1].size()) {
       std::cout << "**** FATAL: not enough memory in the CellsLookupTable, increase the tracklet memory coefficients ****" << std::endl;
       exit(1);
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -107,7 +107,18 @@ void TrackerTraitsCPU::computeLayerTracklets()
         }
       }
     }
+    if (iLayer > 0 && primaryVertexContext->getTracklets()[iLayer].size() > primaryVertexContext->getCellsLookupTable()[iLayer - 1].size()) {
+      std::cout << "**** FATAL: not enough memory in the CellsLookupTable, increase the tracklet memory coefficients ****" << std::endl;
+      exit(1);
+    }
   }
+#ifdef CA_DEBUG
+  std::cout << "+++ Number of tracklets per layer: ";
+  for (int iLayer{0}; iLayer < mTrkParams.TrackletsPerRoad(); ++iLayer) {
+    std::cout << primaryVertexContext->getTracklets()[iLayer].size() << "\t";
+  }
+  std::cout << std::endl;
+#endif
 }
 
 void TrackerTraitsCPU::computeLayerCells()
@@ -229,6 +240,13 @@ void TrackerTraitsCPU::computeLayerCells()
       }
     }
   }
+  #ifdef CA_DEBUG
+  std::cout << "+++ Number of cells per layer: ";
+  for (int iLayer{0}; iLayer < mTrkParams.CellsPerRoad(); ++iLayer) {
+    std::cout << primaryVertexContext->getCells()[iLayer].size() << "\t";
+  }
+  std::cout << std::endl;
+#endif
 }
 
 void TrackerTraitsCPU::refitTracks(const std::vector<std::vector<TrackingFrameInfo>>& tf, std::vector<TrackITSExt>& tracks)

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -80,6 +80,9 @@ void TrackerTraitsCPU::computeLayerTracklets()
         for (int iNextLayerCluster{firstRowClusterIndex}; iNextLayerCluster < maxRowClusterIndex;
              ++iNextLayerCluster) {
 
+          if (iNextLayerCluster >= primaryVertexContext->getClusters()[iLayer + 1].size())
+            break;
+
           const Cluster& nextCluster{primaryVertexContext->getClusters()[iLayer + 1][iNextLayerCluster]};
 
           if (primaryVertexContext->isClusterUsed(iLayer + 1, nextCluster.clusterId)) {
@@ -241,7 +244,7 @@ void TrackerTraitsCPU::computeLayerCells()
       }
     }
   }
-  #ifdef CA_DEBUG
+#ifdef CA_DEBUG
   std::cout << "+++ Number of cells per layer: ";
   for (int iLayer{0}; iLayer < mTrkParams.CellsPerRoad(); ++iLayer) {
     std::cout << primaryVertexContext->getCells()[iLayer].size() << "\t";

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -80,8 +80,9 @@ void TrackerTraitsCPU::computeLayerTracklets()
         for (int iNextLayerCluster{firstRowClusterIndex}; iNextLayerCluster < maxRowClusterIndex;
              ++iNextLayerCluster) {
 
-          if (iNextLayerCluster >= primaryVertexContext->getClusters()[iLayer + 1].size())
+          if (iNextLayerCluster >= primaryVertexContext->getClusters()[iLayer + 1].size()) {
             break;
+          }
 
           const Cluster& nextCluster{primaryVertexContext->getClusters()[iLayer + 1][iNextLayerCluster]};
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -119,7 +119,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
 
   o2::its::VertexerTraits vertexerTraits;
   o2::its::Vertexer vertexer(&vertexerTraits);
-  o2::its::ROframe event(0);
+  o2::its::ROframe event(0, 7);
 
   auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -130,7 +130,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
 
   std::uint32_t roFrame = 0;
-  ROframe event(0);
+  ROframe event(0, 7);
 
   bool continuous = mGRP->isDetContinuousReadOut("ITS");
   LOG(INFO) << "ITSTracker RO: continuous=" << continuous;

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -90,6 +90,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 // Files for ITS Track Fit
 #include "GPUITSFitterKernels.cxx"
 
+/*
 #if !defined(GPUCA_O2_LIB) && defined(__HIPCC__) && !defined(GPUCA_NO_ITS_TRAITS)
 #include "VertexerTraitsHIP.hip.cxx"
 #include "ContextHIP.hip.cxx"
@@ -97,7 +98,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "ClusterLinesHIP.hip.cxx"
 #include "UtilsHIP.hip.cxx"
 #elif !defined(GPUCA_O2_LIB) && defined(__CUDACC__) && !defined(GPUCA_NO_ITS_TRAITS)
-#include "TrackerTraitsNV.cu"
+// #include "TrackerTraitsNV.cu"
 #include "VertexerTraitsGPU.cu"
 #include "Context.cu"
 #include "Stream.cu"
@@ -106,7 +107,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "ClusterLinesGPU.cu"
 #include "Utils.cu"
 #endif // !defined(GPUCA_O2_LIB) && defined(__CUDACC__) && !defined(GPUCA_NO_ITS_TRAITS)
-
+*/
 #endif // HAVE_O2HEADERS
 #endif // (!defined(__OPENCL__) || defined(__OPENCLCPP__)) && !defined(GPUCA_ALIROOT_LIB)
 

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -90,7 +90,6 @@ using namespace GPUCA_NAMESPACE::gpu;
 // Files for ITS Track Fit
 #include "GPUITSFitterKernels.cxx"
 
-/*
 #if !defined(GPUCA_O2_LIB) && defined(__HIPCC__) && !defined(GPUCA_NO_ITS_TRAITS)
 #include "VertexerTraitsHIP.hip.cxx"
 #include "ContextHIP.hip.cxx"
@@ -98,7 +97,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "ClusterLinesHIP.hip.cxx"
 #include "UtilsHIP.hip.cxx"
 #elif !defined(GPUCA_O2_LIB) && defined(__CUDACC__) && !defined(GPUCA_NO_ITS_TRAITS)
-// #include "TrackerTraitsNV.cu"
+#include "TrackerTraitsNV.cu"
 #include "VertexerTraitsGPU.cu"
 #include "Context.cu"
 #include "Stream.cu"
@@ -107,7 +106,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "ClusterLinesGPU.cu"
 #include "Utils.cu"
 #endif // !defined(GPUCA_O2_LIB) && defined(__CUDACC__) && !defined(GPUCA_NO_ITS_TRAITS)
-*/
+
 #endif // HAVE_O2HEADERS
 #endif // (!defined(__OPENCL__) || defined(__OPENCLCPP__)) && !defined(GPUCA_ALIROOT_LIB)
 

--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -70,13 +70,13 @@ int GPUChainITS::Finalize() { return 0; }
 
 int GPUChainITS::RunChain() { return 0; }
 
-int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
+int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
 {
   mRec->PrepareEvent();
   return RunITSTrackFit(roads, clusters, cells, tf, tracks);
 }
 
-int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
+int GPUChainITS::RunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks)
 {
   auto threadContext = GetThreadContext();
   bool doGPU = GetRecoStepsGPU() & RecoStep::ITSTracking;
@@ -85,7 +85,7 @@ int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Clust
 
   Fitter.clearMemory();
   Fitter.SetNumberOfRoads(roads.size());
-  for (int i = 0; i < 7; i++) {
+  for (int i = 0; i < clusters.size(); i++) {
     Fitter.SetNumberTF(i, tf[i].size());
   }
   Fitter.SetMaxData(processors()->ioPtrs);
@@ -93,7 +93,7 @@ int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Clust
   std::copy(cells.begin(), cells.end(), Fitter.cells());
   SetupGPUProcessor(&Fitter, true);
   std::copy(roads.begin(), roads.end(), Fitter.roads());
-  for (int i = 0; i < 7; i++) {
+  for (int i = 0; i < clusters.size(); i++) {
     std::copy(tf[i].begin(), tf[i].end(), Fitter.trackingFrame()[i]);
   }
 

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -40,8 +40,8 @@ class GPUChainITS : public GPUChain
   int RunChain() override;
   void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) override;
 
-  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITSExt>& tracks);
-  int RunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITSExt>& tracks);
+  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
+  int RunITSTrackFit(std::vector<o2::its::Road>& roads, std::vector<const o2::its::Cluster*>& clusters, std::vector<const o2::its::Cell*>& cells, const std::vector<std::vector<o2::its::TrackingFrameInfo>>& tf, std::vector<o2::its::TrackITSExt>& tracks);
 
   o2::its::TrackerTraits* GetITSTrackerTraits();
   o2::its::VertexerTraits* GetITSVertexerTraits();

--- a/GPU/GPUTracking/ITS/GPUITSFitter.h
+++ b/GPU/GPUTracking/ITS/GPUITSFitter.h
@@ -56,6 +56,8 @@ class GPUITSFitter : public GPUProcessor
   {
     return mMemory->mNumberOfTracks;
   }
+  GPUd() void SetNumberOfLayers(int i) { mNumberOfLayers = i; }
+  GPUd() int NumberOfLayers() { return mNumberOfLayers; }
   GPUd() void SetNumberTF(int i, int v) { mNTF[i] = v; }
   GPUd() o2::its::TrackingFrameInfo** trackingFrame()
   {
@@ -77,16 +79,17 @@ class GPUITSFitter : public GPUProcessor
   };
 
  protected:
+  int mNumberOfLayers;
   int mNumberOfRoads = 0;
   int mNMaxTracks = 0;
-  int mNTF[7] = {};
+  int* mNTF = nullptr;
   Memory* mMemory = nullptr;
   o2::its::Road* mRoads = nullptr;
-  o2::its::TrackingFrameInfo* mTF[7] = {};
+  o2::its::TrackingFrameInfo** mTF = {nullptr};
   GPUITSTrack* mTracks = nullptr;
 
-  const o2::its::Cluster* mClusterPtrs[7];
-  const o2::its::Cell* mCellPtrs[5];
+  const o2::its::Cluster** mClusterPtrs;
+  const o2::its::Cell** mCellPtrs;
 
   short mMemoryResInput = -1;
   short mMemoryResTracks = -1;

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -78,7 +78,7 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
     int lastCellLevel = o2::its::constants::its::UnusedIndex;
     CA_DEBUGGER(int nClusters = 2);
 
-    for (int iCell{0}; iCell < o2::its::constants::its::CellsPerRoad; ++iCell) {
+    for (int iCell{0}; iCell < Fitter.NumberOfLayers() - 2; ++iCell) {
       const int cellIndex = road[iCell];
       if (cellIndex == o2::its::constants::its::UnusedIndex) {
         continue;
@@ -164,13 +164,13 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
     for (size_t iC = 0; iC < 7; ++iC) {
       temporaryTrack.mClusters[iC] = clusters[iC];
     }
-    bool fitSuccess = fitTrack(Fitter, prop, temporaryTrack, o2::its::constants::its::LayersNumber - 4, -1, -1);
+    bool fitSuccess = fitTrack(Fitter, prop, temporaryTrack, Fitter.NumberOfLayers() - 4, -1, -1);
     if (!fitSuccess) {
       continue;
     }
     CA_DEBUGGER(fitCounters[nClusters - 4]++);
     temporaryTrack.ResetCovariance();
-    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, 0, o2::its::constants::its::LayersNumber, 1);
+    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, 0, Fitter.NumberOfLayers(), 1);
     if (!fitSuccess) {
       continue;
     }
@@ -184,7 +184,7 @@ GPUdii() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBloc
     temporaryTrack.mOuterParam.X = temporaryTrack.X();
     temporaryTrack.mOuterParam.alpha = prop.GetAlpha();
     temporaryTrack.ResetCovariance();
-    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, o2::its::constants::its::LayersNumber - 1, -1, -1);
+    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, Fitter.NumberOfLayers() - 1, -1, -1);
     if (!fitSuccess) {
       continue;
     }

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -53,6 +53,7 @@ install(FILES CheckDigits_mft.C
               run_rawdecoding_mft.C
               run_trac_ca_its.C
               run_trac_its.C
+              run_trac_alice3.C
 	      CreateBCPattern.C
         DESTINATION share/macro/)
 
@@ -379,6 +380,11 @@ o2_add_test_root_macro(run_trac_its.C
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                         LABELS its)
+
+# FIXME: move to subsystem dir
+o2_add_test_root_macro(run_trac_alice3.C
+                       PUBLIC_LINK_LIBRARIES O2::GPUTracking
+                       LABELS its COMPILE_ONLY)
 
 #
 # NOTE: commented out until unit testing reenabled FIXME : re-enable or delete ?

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -170,7 +170,7 @@ int run_primary_vertexer_ITS(const GPUDataTypes::DeviceType dtype = GPUDataTypes
 
   for (size_t iROfCount{static_cast<size_t>(startAt)}; iROfCount < static_cast<size_t>(stopAt); ++iROfCount) {
     auto& rof = (*rofs)[iROfCount];
-    o2::its::ROframe frame(iROfCount); // to get meaningful roframeId
+    o2::its::ROframe frame(iROfCount, 7); // to get meaningful roframeId
     std::cout << "ROframe: " << iROfCount << std::endl;
 
     auto it = pattIt;

--- a/macro/run_trac_alice3.C
+++ b/macro/run_trac_alice3.C
@@ -3,11 +3,11 @@
 
 #include <TFile.h>
 #include <TChain.h>
+#include <TH2D.h>
 #include <TBranch.h>
 #include <TRandom3.h>
 #include <TGeoGlobalMagField.h>
 #include <vector>
-
 
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTSimulation/Hit.h"
@@ -17,28 +17,52 @@
 #include "ITStracking/TrackerTraitsCPU.h"
 #include "ITStracking/Vertexer.h"
 #include "DataFormatsITSMFT/Cluster.h"
-
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DetectorsCommonDataFormats/DetID.h"
-
+#include "SimulationDataFormat/MCTrack.h"
+#include "MathUtils/Cartesian3D.h"
+#include "ReconstructionDataFormats/DCA.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 #endif
 
-using o2::itsmft::Hit;
-using std::string;
 using o2::its::MemoryParameters;
 using o2::its::TrackingParameters;
+using o2::itsmft::Hit;
+using std::string;
 
 constexpr bool kUseSmearing{false};
+
+struct particle {
+  int pdg = 0;
+  int nLayers = 0;
+  float pt;
+  float eta;
+  float phi;
+  float recoPt;
+  float recoEta;
+  float energyFirst;
+  float energyLast;
+  int isReco = 0; // 0 = no, 1 = good, 2 = fake
+};
 
 float getDetLengthFromEta(const float eta, const float radius)
 {
   return 10. * (10. + radius * std::cos(2 * std::atan(std::exp(-eta))));
 }
 
-void run_vertexer(const string hitsFileName = "o2sim_HitsIT4.root")
+void run_trac_alice3(const string hitsFileName = "o2sim_HitsIT4.root")
 {
+
+  TChain mcTree("o2sim");
+  mcTree.AddFile("o2sim_Kine.root");
+  mcTree.SetBranchStatus("*", 0); //disable all branches
+  mcTree.SetBranchStatus("MCTrack*", 1);
+
+  std::vector<o2::MCTrack>* mcArr = nullptr;
+  mcTree.SetBranchAddress("MCTrack", &mcArr);
+
   o2::its::Vertexer vertexer(new o2::its::VertexerTraits());
   TChain itsHits("o2sim");
 
@@ -47,17 +71,15 @@ void run_vertexer(const string hitsFileName = "o2sim_HitsIT4.root")
   o2::its::Tracker tracker(new o2::its::TrackerTraitsCPU());
   tracker.setBz(5.f);
 
-
   std::uint32_t roFrame;
   std::vector<Hit>* hits = nullptr;
   itsHits.SetBranchAddress("IT4Hit", &hits);
 
-  std::vector<TrackingParameters> trackParams(1);
+  std::vector<TrackingParameters> trackParams(4);
   trackParams[0].NLayers = 10;
   trackParams[0].MinTrackLength = 10;
-  std::cout << "Trackparams: " << trackParams[0].CellsPerRoad() << std::endl;
 
-  std::vector<float> LayerRadii = {1.8f,2.4f,3.0f,4.0f,5.0f,6.0f,7.0f,8.0f,9.0f,10.0f};
+  std::vector<float> LayerRadii = {1.8f, 2.4f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
   std::vector<float> LayerZ(10);
   for (int i{0}; i < 10; ++i)
     LayerZ[i] = getDetLengthFromEta(1.44, LayerRadii[i]) + 1.;
@@ -69,30 +91,78 @@ void run_vertexer(const string hitsFileName = "o2sim_HitsIT4.root")
 
   trackParams[0].LayerRadii = LayerRadii;
   trackParams[0].LayerZ = LayerZ;
+  trackParams[0].TrackletMaxDeltaPhi = 0.3;
+  trackParams[0].CellMaxDeltaPhi = 0.15;
+  trackParams[0].CellMaxDeltaTanLambda = 0.03;
   trackParams[0].TrackletMaxDeltaZ = TrackletMaxDeltaZ;
   trackParams[0].CellMaxDCA = CellMaxDCA;
   trackParams[0].CellMaxDeltaZ = CellMaxDeltaZ;
   trackParams[0].NeighbourMaxDeltaCurvature = NeighbourMaxDeltaCurvature;
   trackParams[0].NeighbourMaxDeltaN = NeighbourMaxDeltaN;
 
-  std::vector<MemoryParameters> memParams(1);
-  std::vector<float> CellsMemoryCoefficients = {2.3208e-08f *20, 2.104e-08f*20, 1.6432e-08f*20, 1.2412e-08f*20, 1.3543e-08f*20, 1.5e-08f*20, 1.6e-08f*20, 1.7e-08f*20};
-  std::vector<float> TrackletsMemoryCoefficients = {0.0016353f * 10, 0.0013627f * 10, 0.000984f * 10, 0.00078135f * 10, 0.00057934f * 10, 0.00052217f * 10, 0.00052217f * 10, 0.00052217f * 10, 0.00052217f * 10};
+  std::vector<MemoryParameters> memParams(4);
+  std::vector<float> CellsMemoryCoefficients = {2.3208e-08f * 20, 2.104e-08f * 20, 1.6432e-08f * 20, 1.2412e-08f * 20, 1.3543e-08f * 20, 1.5e-08f * 20, 1.6e-08f * 20, 1.7e-08f * 20};
+  std::vector<float> TrackletsMemoryCoefficients = {0.0016353f * 1000, 0.0013627f * 1000, 0.000984f * 1000, 0.00078135f * 1000, 0.00057934f * 1000, 0.00052217f * 1000, 0.00052217f * 1000, 0.00052217f * 1000, 0.00052217f * 1000};
   memParams[0].CellsMemoryCoefficients = CellsMemoryCoefficients;
   memParams[0].TrackletsMemoryCoefficients = TrackletsMemoryCoefficients;
+  memParams[0].MemoryOffset = 8000;
+
+  for (int i = 1; i < 4; ++i) {
+    memParams[i] = memParams[i - 1];
+    trackParams[i] = trackParams[i - 1];
+    // trackParams[i].MinTrackLength -= 2;
+    trackParams[i].TrackletMaxDeltaPhi *= 3;
+    trackParams[i].CellMaxDeltaPhi *= 3;
+    trackParams[i].CellMaxDeltaTanLambda *= 3;
+    for (auto& val : trackParams[i].TrackletMaxDeltaZ)
+      val *= 3;
+    for (auto& val : trackParams[i].CellMaxDCA)
+      val *= 3;
+    for (auto& val : trackParams[i].CellMaxDeltaZ)
+      val *= 3;
+    for (auto& val : trackParams[i].NeighbourMaxDeltaCurvature)
+      val *= 3;
+    for (auto& val : trackParams[i].NeighbourMaxDeltaN)
+      val *= 3;
+  }
 
   tracker.setParameters(memParams, trackParams);
 
+  constexpr int nBins = 100;
+  constexpr float minPt = 0.01;
+  constexpr float maxPt = 10;
+  double newBins[nBins + 1];
+  newBins[0] = minPt;
+  double factor = pow(maxPt / minPt, 1. / nBins);
+  for (int i = 1; i <= nBins; i++) {
+    newBins[i] = factor * newBins[i - 1];
+  }
+
+  TH1D genH("gen", ";#it{p}_{T} (GeV/#it{c});", nBins, newBins);
+  TH1D recH("rec", "Efficiency;#it{p}_{T} (GeV/#it{c});", nBins, newBins);
+  TH1D fakH("fak", "Fake rate;#it{p}_{T} (GeV/#it{c});", nBins, newBins);
+  TH2D deltaPt("deltapt", ";#it{p}_{T} (GeV/#it{c});#Delta#it{p}_{T} (GeV/#it{c});", nBins, newBins, 100, -0.1, 0.1);
+  TH2D dcaxy("dcaxy", ";#it{p}_{T} (GeV/#it{c});DCA_{xy} (#mum);", nBins, newBins, 200, -200, 200);
+  TH2D dcaz("dcaz", ";#it{p}_{T} (GeV/#it{c});DCA_{z} (#mum);", nBins, newBins, 200, -200, 200);
+  TH2D deltaE("deltaE", ";#it{p}_{T} (GeV/#it{c});#DeltaE (MeV);", nBins, newBins, 200, 0, 100);
+
+  Point3D<float> pos{0.f, 0.f, 0.f};
+  const std::array<float, 6> cov{1.e-4, 0., 0., 1.e-4, 0., 1.e-4};
+  o2::dataformats::VertexBase vtx(pos, cov);
+  o2::dataformats::DCA dca;
+
   for (int iEvent{0}; iEvent < itsHits.GetEntriesFast(); ++iEvent) {
-    std::cout << "***** Event " << iEvent << " *****" << std::endl;
+    std::cout << "*************** Event " << iEvent << " ***************" << std::endl;
     itsHits.GetEntry(iEvent);
+    mcTree.GetEvent(iEvent);
     o2::its::ROframe event{iEvent, 10};
 
     int id{0};
+    std::map<int, particle> mapPDG;
     for (auto& hit : *hits) {
       const int layer{hit.GetDetectorID()};
       float xyz[3]{hit.GetX(), hit.GetY(), hit.GetZ()};
-      float r{std::hypot(xyz[0],xyz[1])};
+      float r{std::hypot(xyz[0], xyz[1])};
       float phi{std::atan2(-xyz[1], -xyz[0]) + o2::its::constants::math::Pi};
 
       if (kUseSmearing) {
@@ -107,13 +177,87 @@ void run_vertexer(const string hitsFileName = "o2sim_HitsIT4.root")
       event.addClusterToLayer(layer, xyz[0], xyz[1], xyz[2], event.getClustersOnLayer(layer).size());
       event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
       event.addClusterExternalIndexToLayer(layer, id++);
-
+      if (mapPDG.find(hit.GetTrackID()) == mapPDG.end()) {
+        mapPDG[hit.GetTrackID()] = particle();
+        mapPDG[hit.GetTrackID()].nLayers |= 1 << layer;
+        mapPDG[hit.GetTrackID()].pt = std::hypot(hit.GetPx(), hit.GetPy());
+        if (hit.GetTrackID() < mcArr->size()) {
+          auto part = mcArr->at(hit.GetTrackID());
+          mapPDG[hit.GetTrackID()].energyFirst = part.GetEnergy();
+          mapPDG[hit.GetTrackID()].pdg = part.GetPdgCode();
+          mapPDG[hit.GetTrackID()].pt = part.GetPt();
+          mapPDG[hit.GetTrackID()].eta = part.GetEta();
+          mapPDG[hit.GetTrackID()].phi = part.GetPhi();
+        }
+      } else {
+        mapPDG[hit.GetTrackID()].nLayers |= 1 << layer;
+        mapPDG[hit.GetTrackID()].energyLast = hit.GetE();
+      }
     }
     roFrame = iEvent;
 
     vertexer.clustersToVertices(event);
+    int nPart10layers{0};
+    for (auto& part : mapPDG) {
+      if (part.second.nLayers == 0x3FF) {
+        nPart10layers++;
+        genH.Fill(part.second.pt);
+        deltaE.Fill(part.second.pt, 1000 * (part.second.energyFirst - part.second.energyLast));
+      }
+    }
     tracker.clustersToTracks(event);
-
+    auto& tracks = tracker.getTracks();
+    auto& tracksLabels = tracker.getTrackLabels();
+    std::cout << "**** " << nPart10layers << " particles with 10 layers " << tracks.size() << " tracks" << std::endl;
+    int good{0};
+    for (unsigned int i{0}; i < tracks.size(); ++i) {
+      auto& lab = tracksLabels[i];
+      auto& track = tracks[i];
+      int trackID = std::abs(lab.getTrackID());
+      if (mapPDG.find(trackID) != mapPDG.end()) {
+        if (!mapPDG[trackID].pdg)
+          std::cout << "strange" << std::endl;
+        mapPDG[trackID].isReco = lab.isFake() ? 2 : 1;
+        mapPDG[trackID].recoPt = track.getPt();
+        mapPDG[trackID].recoEta = track.getEta();
+        (lab.isFake() ? fakH : recH).Fill(mapPDG[trackID].pt);
+        deltaPt.Fill(mapPDG[trackID].pt, (mapPDG[trackID].pt - mapPDG[trackID].recoPt) / mapPDG[trackID].pt);
+        if (!track.propagateToDCA(vtx, tracker.getBz(), &dca)) {
+          std::cout << "Propagation failed." << std::endl;
+        } else {
+          dcaxy.Fill(mapPDG[trackID].pt, dca.getY() * 1.e4);
+          dcaz.Fill(mapPDG[trackID].pt, dca.getZ() * 1.e4);
+        }
+      }
+    }
   }
 
+  TH1D dcaxy_res(recH);
+  dcaxy_res.Reset();
+  dcaxy_res.SetNameTitle("dcaxy_res", ";#it{p}_{T} (GeV/#it{c});#sigma(DCA_{xy}) (#mum);");
+  TH1D dcaz_res(recH);
+  dcaz_res.Reset();
+  dcaz_res.SetNameTitle("dcaz_res", ";#it{p}_{T} (GeV/#it{c});#sigma(DCA_{z}) (#mum);");
+  for (int i = 1; i <= nBins; ++i) {
+    auto proj = dcaxy.ProjectionY(Form("xy%i", i), i, i);
+    dcaxy_res.SetBinContent(i, proj->GetStdDev());
+    dcaxy_res.SetBinError(i, proj->GetStdDevError());
+    proj = dcaz.ProjectionY(Form("z%i", i), i, i);
+    dcaz_res.SetBinContent(i, proj->GetStdDev());
+    dcaz_res.SetBinError(i, proj->GetStdDevError());
+  }
+
+  TFile output("output.root", "recreate");
+  recH.Divide(&genH);
+  fakH.Divide(&genH);
+  recH.Write();
+  fakH.SetLineColor(kRed);
+  fakH.Write();
+  genH.Write();
+  deltaPt.Write();
+  dcaxy.Write();
+  dcaz.Write();
+  dcaz_res.Write();
+  dcaxy_res.Write();
+  deltaE.Write();
 }

--- a/macro/run_trac_alice3.C
+++ b/macro/run_trac_alice3.C
@@ -1,0 +1,119 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <string>
+
+#include <TFile.h>
+#include <TChain.h>
+#include <TBranch.h>
+#include <TRandom3.h>
+#include <TGeoGlobalMagField.h>
+#include <vector>
+
+
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITSMFTSimulation/Hit.h"
+#include "ITStracking/Configuration.h"
+#include "ITStracking/IOUtils.h"
+#include "ITStracking/Tracker.h"
+#include "ITStracking/TrackerTraitsCPU.h"
+#include "ITStracking/Vertexer.h"
+#include "DataFormatsITSMFT/Cluster.h"
+
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+
+#endif
+
+using o2::itsmft::Hit;
+using std::string;
+using o2::its::MemoryParameters;
+using o2::its::TrackingParameters;
+
+constexpr bool kUseSmearing{false};
+
+float getDetLengthFromEta(const float eta, const float radius)
+{
+  return 10. * (10. + radius * std::cos(2 * std::atan(std::exp(-eta))));
+}
+
+void run_vertexer(const string hitsFileName = "o2sim_HitsIT4.root")
+{
+  o2::its::Vertexer vertexer(new o2::its::VertexerTraits());
+  TChain itsHits("o2sim");
+
+  itsHits.AddFile(hitsFileName.data());
+
+  o2::its::Tracker tracker(new o2::its::TrackerTraitsCPU());
+  tracker.setBz(5.f);
+
+
+  std::uint32_t roFrame;
+  std::vector<Hit>* hits = nullptr;
+  itsHits.SetBranchAddress("IT4Hit", &hits);
+
+  std::vector<TrackingParameters> trackParams(1);
+  trackParams[0].NLayers = 10;
+  trackParams[0].MinTrackLength = 10;
+  std::cout << "Trackparams: " << trackParams[0].CellsPerRoad() << std::endl;
+
+  std::vector<float> LayerRadii = {1.8f,2.4f,3.0f,4.0f,5.0f,6.0f,7.0f,8.0f,9.0f,10.0f};
+  std::vector<float> LayerZ(10);
+  for (int i{0}; i < 10; ++i)
+    LayerZ[i] = getDetLengthFromEta(1.44, LayerRadii[i]) + 1.;
+  std::vector<float> TrackletMaxDeltaZ = {0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f, 0.5f, 0.5f, 0.5f};
+  std::vector<float> CellMaxDCA = {0.05f, 0.04f, 0.05f, 0.2f, 0.4f, 0.5f, 0.5f, 0.5f};
+  std::vector<float> CellMaxDeltaZ = {0.2f, 0.4f, 0.5f, 0.6f, 3.0f, 3.0f, 3.0f, 3.0f};
+  std::vector<float> NeighbourMaxDeltaCurvature = {0.008f, 0.0025f, 0.003f, 0.0035f, 0.004f, 0.004f, 0.005f};
+  std::vector<float> NeighbourMaxDeltaN = {0.002f, 0.0090f, 0.002f, 0.005f, 0.005f, 0.005f, 0.005f};
+
+  trackParams[0].LayerRadii = LayerRadii;
+  trackParams[0].LayerZ = LayerZ;
+  trackParams[0].TrackletMaxDeltaZ = TrackletMaxDeltaZ;
+  trackParams[0].CellMaxDCA = CellMaxDCA;
+  trackParams[0].CellMaxDeltaZ = CellMaxDeltaZ;
+  trackParams[0].NeighbourMaxDeltaCurvature = NeighbourMaxDeltaCurvature;
+  trackParams[0].NeighbourMaxDeltaN = NeighbourMaxDeltaN;
+
+  std::vector<MemoryParameters> memParams(1);
+  std::vector<float> CellsMemoryCoefficients = {2.3208e-08f *20, 2.104e-08f*20, 1.6432e-08f*20, 1.2412e-08f*20, 1.3543e-08f*20, 1.5e-08f*20, 1.6e-08f*20, 1.7e-08f*20};
+  std::vector<float> TrackletsMemoryCoefficients = {0.0016353f * 10, 0.0013627f * 10, 0.000984f * 10, 0.00078135f * 10, 0.00057934f * 10, 0.00052217f * 10, 0.00052217f * 10, 0.00052217f * 10, 0.00052217f * 10};
+  memParams[0].CellsMemoryCoefficients = CellsMemoryCoefficients;
+  memParams[0].TrackletsMemoryCoefficients = TrackletsMemoryCoefficients;
+
+  tracker.setParameters(memParams, trackParams);
+
+  for (int iEvent{0}; iEvent < itsHits.GetEntriesFast(); ++iEvent) {
+    std::cout << "***** Event " << iEvent << " *****" << std::endl;
+    itsHits.GetEntry(iEvent);
+    o2::its::ROframe event{iEvent, 10};
+
+    int id{0};
+    for (auto& hit : *hits) {
+      const int layer{hit.GetDetectorID()};
+      float xyz[3]{hit.GetX(), hit.GetY(), hit.GetZ()};
+      float r{std::hypot(xyz[0],xyz[1])};
+      float phi{std::atan2(-xyz[1], -xyz[0]) + o2::its::constants::math::Pi};
+
+      if (kUseSmearing) {
+        phi = gRandom->Gaus(phi, std::asin(0.0005f / r));
+        xyz[0] = r * std::cos(phi);
+        xyz[1] = r * std::sin(phi);
+        xyz[2] = gRandom->Gaus(xyz[2], 0.0005f);
+      }
+
+      event.addTrackingFrameInfoToLayer(layer, xyz[0], xyz[1], xyz[2], r, phi, std::array<float, 2>{0.f, xyz[2]},
+                                        std::array<float, 3>{0.0005f * 0.0005f, 0.f, 0.0005f * 0.0005f});
+      event.addClusterToLayer(layer, xyz[0], xyz[1], xyz[2], event.getClustersOnLayer(layer).size());
+      event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
+      event.addClusterExternalIndexToLayer(layer, id++);
+
+    }
+    roFrame = iEvent;
+
+    vertexer.clustersToVertices(event);
+    tracker.clustersToTracks(event);
+
+  }
+
+}

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -63,13 +63,13 @@ void run_trac_ca_its(std::string path = "./",
   gSystem->Load("libO2ITStracking.so");
 
   //std::unique_ptr<GPUReconstruction> rec(GPUReconstruction::CreateInstance());
-  std::unique_ptr<GPUReconstruction> rec(GPUReconstruction::CreateInstance("CUDA", true)); // for GPU with CUDA
-  auto* chainITS = rec->AddChain<GPUChainITS>();
-  rec->Init();
+  // std::unique_ptr<GPUReconstruction> rec(GPUReconstruction::CreateInstance("CUDA", true)); // for GPU with CUDA
+  // auto* chainITS = rec->AddChain<GPUChainITS>();
+  // rec->Init();
 
-  o2::its::Tracker tracker(chainITS->GetITSTrackerTraits());
-  //o2::its::Tracker tracker(new o2::its::TrackerTraitsCPU());
-  o2::its::ROframe event(0);
+  // o2::its::Tracker tracker(chainITS->GetITSTrackerTraits());
+  o2::its::Tracker tracker(new o2::its::TrackerTraitsCPU());
+  o2::its::ROframe event(0, 7);
 
   if (path.back() != '/') {
     path += '/';

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -166,7 +166,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
 
   o2::its::VertexerTraits vertexerTraits;
   o2::its::Vertexer vertexer(&vertexerTraits);
-  o2::its::ROframe event(0);
+  o2::its::ROframe event(0, 7);
 
   gsl::span<const unsigned char> patt(patterns->data(), patterns->size());
   auto pattIt = patt.begin();


### PR DESCRIPTION
This introduces the changes required to run the ITS tracking suite on dataset with a different number of layers (ITS3 with more than 3 layers in the IB, ALICE3...).
@mconcas please check that everything is fine with you.

@qgp FYI