### PR TITLE
TRD: Remove labels that do not have a digit

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -40,10 +40,11 @@ class TRDArraySignal;
 class PadResponse;
 
 struct SignalArray {
-  double firstTBtime;                     // first TB time
+  double firstTBtime;                               // first TB time
   std::array<float, constants::TIMEBINS> signals{}; // signals
-  std::unordered_map<int, int> trackIds;  // tracks Ids associated to the signal
-  std::vector<MCLabel> labels;            // labels associated to the signal
+  std::unordered_map<int, int> trackIds;            // tracks Ids associated to the signal
+  std::vector<MCLabel> labels;                      // labels associated to the signal
+  bool isDigit = false;                             // flag a signal converted to a digit
 };
 
 using DigitContainer = std::vector<Digit>;
@@ -114,8 +115,8 @@ class Digitizer
   int mMaxTimeBinsTRAP = 30;                               // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
   // Digitization containers
-  std::vector<HitType> mHitContainer;                            // the container of hits in a given detector
-  std::vector<MCLabel> mMergedLabels;                            // temporary label container
+  std::vector<HitType> mHitContainer;                                            // the container of hits in a given detector
+  std::vector<MCLabel> mMergedLabels;                                            // temporary label container
   std::array<SignalContainer, constants::MAXCHAMBER> mSignalsMapCollection;      // container for caching signals over a timeframe
   std::deque<std::array<SignalContainer, constants::MAXCHAMBER>> mPileupSignals; // container for piled up signals
 
@@ -128,7 +129,7 @@ class Digitizer
   SignalContainer addSignalsFromPileup();
   void clearContainers();
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToADC(const SignalContainer&, DigitContainer&, int thread = 0);          // True if signal-to-ADC conversion is successful
+  bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                // True if signal-to-ADC conversion is successful
   void addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -96,19 +96,21 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
         LOG(WARN) << "TRD conversion of signals to digits failed";
       }
       for (const auto& iter : smc) {
-        labels.addElements(labels.getIndexedSize(), iter.second.labels);
+        if (iter.second.isDigit)
+          labels.addElements(labels.getIndexedSize(), iter.second.labels);
       }
     }
   } else {
     // since we don't have any pileup signals just flush the signals for each chamber
     // we avoid flattening the array<map, ndets> to a single map
-    for (const auto& smc : mSignalsMapCollection) {
+    for (auto& smc : mSignalsMapCollection) {
       bool status = convertSignalsToADC(smc, digits);
       if (!status) {
         LOG(WARN) << "TRD conversion of signals to digits failed";
       }
       for (const auto& iter : smc) {
-        labels.addElements(labels.getIndexedSize(), iter.second.labels);
+        if (iter.second.isDigit)
+          labels.addElements(labels.getIndexedSize(), iter.second.labels);
       }
     }
   }
@@ -482,7 +484,7 @@ float drawGaus(o2::math_utils::RandomRing<>& normaldistRing, float mu, float sig
   return mu + sigma * normaldistRing.getNextValue();
 }
 
-bool Digitizer::convertSignalsToADC(const SignalContainer& signalMapCont, DigitContainer& digits, int thread)
+bool Digitizer::convertSignalsToADC(SignalContainer& signalMapCont, DigitContainer& digits, int thread)
 {
   //
   // Converts the sampled electron signals to ADC values for a given chamber
@@ -495,7 +497,7 @@ bool Digitizer::convertSignalsToADC(const SignalContainer& signalMapCont, DigitC
   double baseline = mSimParam->GetADCbaseline() / adcConvert;                   // The electronics baseline in mV
   double baselineEl = baseline / convert;                                       // The electronics baseline in electrons
 
-  for (const auto& signalMapIter : signalMapCont) {
+  for (auto& signalMapIter : signalMapCont) {
     const auto key = signalMapIter.first;
     const int det = getDetectorFromKey(key);
     const int row = getRowFromKey(key);
@@ -522,6 +524,7 @@ bool Digitizer::convertSignalsToADC(const SignalContainer& signalMapCont, DigitC
       LOG(FATAL) << "Not a valid gain " << padgain << ", " << det << ", " << col << ", " << row;
     }
 
+    signalMapIter.second.isDigit = true; // flag the signal as digit
     // Loop over the all timebins in the ADC array
     const auto& signalArray = signalMapIter.second.signals;
     ArrayADC adcs{};

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -100,6 +100,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         LOG(INFO) << "For collision " << collID << " eventID " << part.entryID << " found TRD " << hits.size() << " hits ";
 
         mDigitizer.process(hits, digits, labels);
+        assert(digits.size() == labels.getIndexedSize());
 
         // Add trigger record
         triggers.emplace_back(irecords[collID], digitsAccum.size(), digits.size());
@@ -114,6 +115,8 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     }
     // Force flush of the digits that remain in the digitizer cache
     mDigitizer.flush(digits, labels);
+    assert(digits.size() == labels.getIndexedSize());
+
     triggers.emplace_back(irecords[irecords.size() - 1], digitsAccum.size(), digits.size());
     std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
     if (mctruth) {


### PR DESCRIPTION
@bazinski, you should check this pull request. These changes should fix the problem you described and find now that the size of the MC header array is the same as the digits container.