### PR TITLE
A helper workflow to write clusters to a file

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 o2_add_library(ITSWorkflow
                SOURCES src/RecoWorkflow.cxx
+                       src/ClusterWriterWorkflow.cxx
                        src/DigitReaderSpec.cxx
                        src/ClustererSpec.cxx
                        src/ClusterWriterSpec.cxx
@@ -30,6 +31,11 @@ o2_add_library(ITSWorkflow
 
 o2_add_executable(reco-workflow
                   SOURCES src/its-reco-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
+o2_add_executable(cluster-writer-workflow
+                  SOURCES src/its-cluster-writer-workflow.cxx
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterWorkflow.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_ITS_CLUSTER_WRITER_WORKFLOW_H
+#define O2_ITS_CLUSTER_WRITER_WORKFLOW_H
+
+/// @file   ClusterWriterWorkflow.h
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+namespace cluster_writer_workflow
+{
+framework::WorkflowSpec getWorkflow(bool useMC);
+}
+
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterWorkflow.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ClusterWriterWorkflow.cxx
+
+#include "ITSWorkflow/ClusterWriterWorkflow.h"
+#include "ITSWorkflow/ClusterWriterSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+namespace cluster_writer_workflow
+{
+
+framework::WorkflowSpec getWorkflow(bool useMC)
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
+
+  return specs;
+}
+
+} // namespace cluster_writer_workflow
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
@@ -1,0 +1,33 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/ClusterWriterWorkflow.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "disable-mc",
+      o2::framework::VariantType::Bool,
+      false,
+      {"disable MC propagation even if available"}});
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  return std::move(o2::its::cluster_writer_workflow::getWorkflow(useMC));
+}


### PR DESCRIPTION
This helper workflow is quite useful at the end of the ITS commissioning data reconstruction pipe 
o2-raw-file-reader-workflow ... | o2-itsmft-stf-decoder-workflow ... |  o2-its-cluster-writer-workflow