### PR TITLE
DPL Analysis: workaround for arrow not serializing empty tables

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1753,47 +1753,6 @@ auto filter(T&& t, framework::expressions::Filter const& expr)
   return Filtered<T>(t.asArrowTable(), expr);
 }
 
-/// Expression-based column generator to materialize columns
-template <typename... C>
-auto spawner(framework::pack<C...> columns, arrow::Table* atable)
-{
-  static auto new_schema = o2::soa::createSchemaFromColumns(columns);
-  static auto projectors = framework::expressions::createProjectors(columns, atable->schema());
-
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> arrays;
-
-  if (atable->num_rows() == 0) {
-    return arrow::Table::Make(new_schema, arrays);
-  }
-
-  arrow::TableBatchReader reader(*atable);
-  std::shared_ptr<arrow::RecordBatch> batch;
-  arrow::ArrayVector v;
-  std::array<arrow::ArrayVector, sizeof...(C)> chunks;
-
-  while (true) {
-    auto s = reader.ReadNext(&batch);
-    if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot read batches from table: {}", s.ToString()));
-    }
-    if (batch == nullptr) {
-      break;
-    }
-    s = projectors->Evaluate(*batch, arrow::default_memory_pool(), &v);
-    if (!s.ok()) {
-      throw std::runtime_error(fmt::format("Cannot apply projector: {}", s.ToString()));
-    }
-    for (auto i = 0u; i < sizeof...(C); ++i) {
-      chunks[i].emplace_back(v.at(i));
-    }
-  }
-
-  for (auto i = 0u; i < sizeof...(C); ++i) {
-    arrays.push_back(std::make_shared<arrow::ChunkedArray>(chunks[i]));
-  }
-  return arrow::Table::Make(new_schema, arrays);
-}
-
 /// Template for building an index table to access matching rows from non-
 /// joinable, but compatible tables, e.g. Collisions and ZDCs.
 /// First argument is the key table (BCs for the Collisions+ZDCs case), the rest
@@ -1822,26 +1781,6 @@ struct IndexTable : Table<soa::Index<>, H, Ts...> {
 
 template <typename T>
 using is_soa_index_table_t = typename framework::is_base_of_template<soa::IndexTable, T>;
-
-/// On-the-fly adding of expression columns
-template <typename T, typename... Cs>
-auto Extend(T const& table)
-{
-  static_assert((soa::is_type_spawnable_v<Cs> && ...), "You can only extend a table with expression columns");
-  using output_t = Join<T, soa::Table<Cs...>>;
-  return output_t{{spawner(framework::pack<Cs...>{}, table.asArrowTable().get()), table.asArrowTable()}, 0};
-}
-
-/// Template function to attach dynamic columns on-the-fly (e.g. inside
-/// process() function). Dynamic columns need to be compatible with the table.
-template <typename T, typename... Cs>
-auto Attach(T const& table)
-{
-  static_assert((framework::is_base_of_template<o2::soa::DynamicColumn, Cs>::value && ...), "You can only attach dynamic columns");
-  using output_t = Join<T, o2::soa::Table<Cs...>>;
-  return output_t{{table.asArrowTable()}, table.offset()};
-}
-
 } // namespace o2::soa
 
 #endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -169,6 +169,7 @@ struct TableTransform {
 template <typename T>
 struct Spawns : TableTransform<typename aod::MetadataTrait<framework::pack_head_t<typename T::originals>>::metadata> {
   using extension_t = framework::pack_head_t<typename T::originals>;
+  using base_table_t = typename aod::MetadataTrait<extension_t>::metadata::base_table_t;
   using expression_pack_t = typename aod::MetadataTrait<extension_t>::metadata::expression_pack_t;
 
   constexpr auto pack()
@@ -540,5 +541,27 @@ struct Partition {
 };
 
 } // namespace o2::framework
+
+namespace o2::soa
+{
+/// On-the-fly adding of expression columns
+template <typename T, typename... Cs>
+auto Extend(T const& table)
+{
+  static_assert((soa::is_type_spawnable_v<Cs> && ...), "You can only extend a table with expression columns");
+  using output_t = Join<T, soa::Table<Cs...>>;
+  return output_t{{o2::framework::spawner(framework::pack<Cs...>{}, table.asArrowTable().get()), table.asArrowTable()}, 0};
+}
+
+/// Template function to attach dynamic columns on-the-fly (e.g. inside
+/// process() function). Dynamic columns need to be compatible with the table.
+template <typename T, typename... Cs>
+auto Attach(T const& table)
+{
+  static_assert((framework::is_base_of_template<o2::soa::DynamicColumn, Cs>::value && ...), "You can only attach dynamic columns");
+  using output_t = Join<T, o2::soa::Table<Cs...>>;
+  return output_t{{table.asArrowTable()}, table.offset()};
+}
+} // namespace o2::soa
 
 #endif // o2_framework_AnalysisHelpers_H_DEFINED

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -15,7 +15,6 @@
 #include "Framework/StructToTuple.h"
 #include "Framework/FunctionalHelpers.h"
 #include "Framework/VariantHelpers.h"
-#include "Framework/Logger.h"
 #include "arrow/type_traits.h"
 
 // Apparently needs to be on top of the arrow includes.

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -15,6 +15,7 @@
 #include "Framework/StructToTuple.h"
 #include "Framework/FunctionalHelpers.h"
 #include "Framework/VariantHelpers.h"
+#include "Framework/Logger.h"
 #include "arrow/type_traits.h"
 
 // Apparently needs to be on top of the arrow includes.
@@ -596,6 +597,55 @@ class TableBuilder
   std::shared_ptr<arrow::Schema> mSchema;
   std::vector<std::shared_ptr<arrow::Array>> mArrays;
 };
+
+template <typename T>
+auto makeEmptyTable()
+{
+  TableBuilder b;
+  auto writer = b.cursor<T>();
+  return b.finalize();
+}
+
+/// Expression-based column generator to materialize columns
+template <typename... C>
+auto spawner(framework::pack<C...> columns, arrow::Table* atable)
+{
+  static auto new_schema = o2::soa::createSchemaFromColumns(columns);
+  static auto projectors = framework::expressions::createProjectors(columns, atable->schema());
+
+  if (atable->num_rows() == 0) {
+    return makeEmptyTable<soa::Table<C...>>();
+  }
+
+  arrow::TableBatchReader reader(*atable);
+  std::shared_ptr<arrow::RecordBatch> batch;
+  arrow::ArrayVector v;
+  std::array<arrow::ArrayVector, sizeof...(C)> chunks;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> arrays;
+
+  while (true) {
+    auto s = reader.ReadNext(&batch);
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot read batches from table: {}", s.ToString()));
+    }
+    if (batch == nullptr) {
+      break;
+    }
+    s = projectors->Evaluate(*batch, arrow::default_memory_pool(), &v);
+    if (!s.ok()) {
+      throw std::runtime_error(fmt::format("Cannot apply projector: {}", s.ToString()));
+    }
+    for (auto i = 0u; i < sizeof...(C); ++i) {
+      chunks[i].emplace_back(v.at(i));
+    }
+  }
+
+  for (auto i = 0u; i < sizeof...(C); ++i) {
+    arrays.push_back(std::make_shared<arrow::ChunkedArray>(chunks[i]));
+  }
+
+  return arrow::Table::Make(new_schema, arrays);
+}
 
 /// Helper to get a tuple tail
 template <typename Head, typename... Tail>

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -72,7 +72,7 @@ AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> reques
           using metadata_t = decltype(metadata);
           using expressions = typename metadata_t::expression_pack_t;
           auto original_table = pc.inputs().get<TableConsumer>(input.binding)->asArrowTable();
-          return o2::soa::spawner(expressions{}, original_table.get());
+          return o2::framework::spawner(expressions{}, original_table.get());
         };
 
         if (description == header::DataDescription{"TRACK:PAR"}) {

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -236,7 +236,12 @@ struct OutputManager<Spawns<T>> {
   static bool prepare(ProcessingContext& pc, Spawns<T>& what)
   {
     auto original_table = soa::ArrowHelpers::joinTables(extractOriginals(what.sources_pack(), pc));
-    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::soa::spawner(what.pack(), original_table.get()));
+    if (original_table->schema()->fields().empty() == true) {
+      using base_table_t = typename Spawns<T>::base_table_t;
+      original_table = makeEmptyTable<base_table_t>();
+    }
+
+    what.extension = std::make_shared<typename Spawns<T>::extension_t>(o2::framework::spawner(what.pack(), original_table.get()));
     what.table = std::make_shared<typename T::table_t>(soa::ArrowHelpers::joinTables({what.extension->asArrowTable(), original_table}));
     return true;
   }

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -188,7 +188,6 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
     auto table = payload->finalize();
 
     auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
-    std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
     auto outBatch = arrow::ipc::NewStreamWriter(stream.get(), table->schema());
     if (outBatch.ok() == true) {
       auto outStatus = outBatch.ValueOrDie()->WriteTable(*table);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -15,6 +15,7 @@
 #include "Framework/ASoA.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/Expressions.h"
+#include "Framework/AnalysisHelpers.h"
 #include "../src/ExpressionHelpers.h"
 #include "gandiva/tree_expr_builder.h"
 #include "arrow/status.h"


### PR DESCRIPTION
Arrow does not serialize empty table, as a result the message extracted at the receiving end has no schema which results in exception. To solve it, the consumer creates a new empty table with a correct schema if incoming message for this table type is empty. Needs also to be handled in spawner, when the incoming empty message is the base for an extended table.

* Uses TableBuilder to create valid empty table for a given type
* spawner()/Attach()/Extend() moved to different headers to have access to TableBuilder