### PR TITLE
Use ConstMCTruthContainer in TPC workflow

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -16,6 +16,7 @@
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <cstdint>
 #include <cstddef> // for size_t
+#include <utility>
 #endif
 #include "DataFormatsTPC/Constants.h"
 #include "GPUCommonDef.h"
@@ -26,7 +27,9 @@ class MCCompLabel;
 namespace dataformats
 {
 template <class T>
-class MCTruthContainer;
+class ConstMCTruthContainer;
+template <class T>
+class ConstMCTruthContainerView;
 }
 } // namespace o2
 
@@ -157,13 +160,19 @@ struct ClusterNative {
 struct ClusterNativeAccess {
   const ClusterNative* clustersLinear;
   const ClusterNative* clusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth;
+  const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>* clustersMCTruth;
   unsigned int nClusters[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   unsigned int nClustersSector[constants::MAXSECTOR];
   unsigned int clusterOffset[constants::MAXSECTOR][constants::MAXGLOBALPADROW];
   unsigned int nClustersTotal;
 
   void setOffsetPtrs();
+
+#ifndef GPUCA_GPUCODE
+  using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
+  using ConstMCLabelContainerViewWithBuffer = std::pair<ConstMCLabelContainer, ConstMCLabelContainerView>;
+#endif
 };
 
 inline void ClusterNativeAccess::setOffsetPtrs()

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -18,7 +18,6 @@
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/ClusterGroupAttribute.h"
 #include "DataFormatsTPC/Constants.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include <gsl/gsl>

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -131,9 +131,8 @@ struct alignas(64) ClusterIndexBuffer {
 class ClusterNativeHelper
 {
  public:
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-  using ConstMCLabelContainer = ClusterNativeAccess::ConstMCLabelContainer;
-  using ConstMCLabelContainerView = ClusterNativeAccess::ConstMCLabelContainerView;
+  using MCLabelContainer = o2::dataformats::MCLabelContainer;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCLabelContainerView;
   using ConstMCLabelContainerViewWithBuffer = ClusterNativeAccess::ConstMCLabelContainerViewWithBuffer;
 
   ClusterNativeHelper() = default;

--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -31,7 +31,7 @@ void ClusterNativeHelper::convert(const char* fromFile, const char* toFile, cons
   size_t nEntries = reader.getTreeSize();
   ClusterNativeAccess clusterIndex;
   std::unique_ptr<ClusterNative[]> clusterBuffer;
-  MCLabelContainer mcBuffer;
+  ConstMCLabelContainerViewWithBuffer mcBuffer;
 
   int result = 0;
   int nClusters = 0;
@@ -161,7 +161,7 @@ void ClusterNativeHelper::Reader::clear()
 }
 
 int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex, std::unique_ptr<ClusterNative[]>& clusterBuffer,
-                                           MCLabelContainer& mcBuffer)
+                                           ConstMCLabelContainerViewWithBuffer& mcBuffer)
 {
   for (size_t index = 0; index < mSectorRaw.size(); ++index) {
     if (mSectorRaw[index] && mSectorRaw[index]->size() != mSectorRawSize[index]) {
@@ -177,8 +177,8 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex, st
   return 0;
 }
 
-int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, gsl::span<MCLabelContainer const> const& mcinput, ClusterNativeAccess& clusterIndex,
-                                             const MCLabelContainer* (&clustersMCTruth)[MAXSECTOR])
+int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, gsl::span<ConstMCLabelContainerView const> const& mcinput, ClusterNativeAccess& clusterIndex,
+                                             const ConstMCLabelContainerView* (&clustersMCTruth)[MAXSECTOR])
 {
   if (!buffer || size < sizeof(ClusterCountIndex)) {
     return 0;

--- a/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
@@ -127,7 +127,7 @@ class ConstMCTruthContainerView
  public:
   ConstMCTruthContainerView(gsl::span<const char> const bufferview) : mStorage(bufferview){};
   ConstMCTruthContainerView(ConstMCTruthContainer<TruthElement> const& cont) : mStorage(gsl::span<const char>(cont)){};
-  ConstMCTruthContainerView() = default;
+  ConstMCTruthContainerView() : mStorage(nullptr, (gsl::span<const char>::index_type)0){}; // be explicit that we want nullptr / 0 for an uninitialized container
   ConstMCTruthContainerView(const ConstMCTruthContainerView&) = default;
 
   // const data access
@@ -151,8 +151,11 @@ class ConstMCTruthContainerView
   // return the number of original data indexed here
   size_t getIndexedSize() const { return mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofHeaderElements : 0; }
 
-  // return the number of labels  managed in this container
+  // return the number of labels managed in this container
   size_t getNElements() const { return mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofTruthElements : 0; }
+
+  // return underlying buffer
+  const gsl::span<const char>& getBuffer() const { return mStorage; }
 
  private:
   gsl::span<const char> mStorage;

--- a/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
@@ -16,7 +16,9 @@
 #define O2_CONSTMCTRUTHCONTAINER_H
 
 #include <SimulationDataFormat/MCTruthContainer.h>
+#ifndef GPUCA_STANDALONE
 #include <Framework/Traits.h>
+#endif
 
 namespace o2
 {
@@ -77,7 +79,7 @@ class ConstMCTruthContainer : public std::vector<char>
   /// Restore internal vectors from a raw buffer
   /// The two vectors are resized according to the information in the \a FlatHeader
   /// struct at the beginning of the buffer. Data is copied to the vectors.
-  TruthElement const* const getLabelStart() const
+  TruthElement const* getLabelStart() const
   {
     auto* source = &(*this)[0];
     auto flatheader = getHeader();
@@ -94,7 +96,7 @@ class ConstMCTruthContainer : public std::vector<char>
     return flatheader;
   }
 
-  MCTruthHeaderElement const* const getHeaderStart() const
+  MCTruthHeaderElement const* getHeaderStart() const
   {
     auto* source = &(*this)[0];
     source += sizeof(FlatHeader);
@@ -108,12 +110,14 @@ class ConstMCTruthContainer : public std::vector<char>
 // In particular in enables
 // a) --> snapshot without ROOT dictionary (as a flat buffer)
 // b) --> requesting the resource in shared mem using make<T>
+#ifndef GPUCA_STANDALONE
 namespace o2::framework
 {
 template <typename T>
 struct is_specialization<o2::dataformats::ConstMCTruthContainer<T>, std::vector> : std::true_type {
 };
 } // namespace o2::framework
+#endif
 
 namespace o2
 {
@@ -149,10 +153,10 @@ class ConstMCTruthContainerView
   }
 
   // return the number of original data indexed here
-  size_t getIndexedSize() const { return mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofHeaderElements : 0; }
+  size_t getIndexedSize() const { return (size_t)mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofHeaderElements : 0; }
 
   // return the number of labels managed in this container
-  size_t getNElements() const { return mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofTruthElements : 0; }
+  size_t getNElements() const { return (size_t)mStorage.size() >= sizeof(FlatHeader) ? getHeader().nofTruthElements : 0; }
 
   // return underlying buffer
   const gsl::span<const char>& getBuffer() const { return mStorage; }
@@ -174,7 +178,7 @@ class ConstMCTruthContainerView
   /// Restore internal vectors from a raw buffer
   /// The two vectors are resized according to the information in the \a FlatHeader
   /// struct at the beginning of the buffer. Data is copied to the vectors.
-  TruthElement const* const getLabelStart() const
+  TruthElement const* getLabelStart() const
   {
     auto* source = &(mStorage)[0];
     auto flatheader = getHeader();
@@ -191,7 +195,7 @@ class ConstMCTruthContainerView
     return flatheader;
   }
 
-  MCTruthHeaderElement const* const getHeaderStart() const
+  MCTruthHeaderElement const* getHeaderStart() const
   {
     auto* source = &(mStorage)[0];
     source += sizeof(FlatHeader);

--- a/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ConstMCTruthContainer.h
@@ -203,6 +203,9 @@ class ConstMCTruthContainerView
   }
 };
 
+using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
+using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
+
 } // namespace dataformats
 } // namespace o2
 

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -30,8 +30,10 @@
 
 namespace o2
 {
+class MCCompLabel;
 namespace dataformats
 {
+
 /// @struct MCTruthHeaderElement
 /// @brief Simple struct having information about truth elements for particular indices:
 /// how many associations we have and where they start in the storage
@@ -414,6 +416,8 @@ class MCTruthContainer
 
   ClassDefNV(MCTruthContainer, 2);
 }; // end class
+
+using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -12,7 +12,6 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/LabelContainer.h"

--- a/Detectors/CPV/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CPV/workflow/src/RecoWorkflow.cxx
@@ -30,6 +30,8 @@
 #include "Framework/DataSpecUtils.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
+using namespace o2::dataformats;
+
 namespace o2
 {
 
@@ -163,7 +165,6 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
 
   // if (isEnabled(OutputType::Raw)) {
   //   using RawOutputType = std::vector<o2::cpv::Raw>;
-  //   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   //   specs.push_back(makeWriterSpec("cpv-raw-writer",
   //                                  inputType == InputType::Digits ? "cpv-raw.root" : "cpvrawcells.root",
   //                                  "o2sim",
@@ -178,7 +179,6 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Digits)) {
     using DigitOutputType = std::vector<o2::cpv::Digit>;
     using DTROutputType = std::vector<o2::cpv::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
     specs.emplace_back(o2::framework::MakeRootTreeWriterSpec("cpv-digits-writer", "cpvdigits.root", "o2sim",
                                                              -1,

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -248,7 +248,6 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Digits) && !disableRootOutput) {
     using DigitOutputType = std::vector<o2::emcal::Digit>;
     using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>;
     specs.push_back(makeWriterSpec("emcal-digits-writer",
                                    inputType == InputType::Digits ? "emc-filtered-digits.root" : "emcdigits.root",
                                    "o2sim",
@@ -258,7 +257,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                    BranchDefinition<TriggerOutputType>{o2::framework::InputSpec{"trigger", "EMC", "DIGITSTRGR", 0},
                                                                        "EMCALDigitTRGR",
                                                                        "digittrigger-branch-name"},
-                                   BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "EMC", "DIGITSMCTR", 0},
+                                   BranchDefinition<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>>{o2::framework::InputSpec{"mc", "EMC", "DIGITSMCTR", 0},
                                                                       "EMCDigitMCTruth",
                                                                       "digitmc-branch-name"})());
   }
@@ -267,7 +266,6 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
     if (inputType == InputType::Digits) {
       using DigitOutputType = std::vector<o2::emcal::Cell>;
       using TriggerOutputType = std::vector<o2::emcal::TriggerRecord>;
-      using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>;
       specs.push_back(makeWriterSpec("emcal-cells-writer", "emccells.root", "o2sim",
                                      BranchDefinition<DigitOutputType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
                                                                        "EMCALCell",
@@ -275,9 +273,9 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                      BranchDefinition<TriggerOutputType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
                                                                          "EMCALCellTRGR",
                                                                          "celltrigger-branch-name"},
-                                     BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "EMC", "CELLSMCTR", 0},
-                                                                        "EMCALCellMCTruth",
-                                                                        "cellmc-branch-name"})());
+                                     BranchDefinition<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>>{o2::framework::InputSpec{"mc", "EMC", "CELLSMCTR", 0},
+                                                                                                             "EMCALCellMCTruth",
+                                                                                                             "cellmc-branch-name"})());
     } else {
       using CellsDataType = std::vector<o2::emcal::Cell>;
       using TriggerRecordDataType = std::vector<o2::emcal::TriggerRecord>;

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -202,7 +202,9 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   o2::tpc::ClusterNativeAccess clusterIndex;
   std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC);
+  o2::tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer dummyMCOutput;
+  std::vector<o2::tpc::ClusterNativeHelper::ConstMCLabelContainerView> dummyMCInput;
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, dummyMCOutput, clustersTPC, dummyMCInput);
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   //

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -145,7 +145,9 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   o2::tpc::ClusterNativeAccess clusterIndex;
   std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clustersTPC);
+  o2::tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer dummyMCOutput;
+  std::vector<o2::tpc::ClusterNativeHelper::ConstMCLabelContainerView> dummyMCInput;
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, dummyMCOutput, clustersTPC, dummyMCInput);
   //----------------------------<< TPC Clusters loading <<------------------------------------------
 
   // pass input data to TrackInterpolation object

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -21,7 +21,6 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "ITSMFTReconstruction/DigitPixelReader.h"

--- a/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
@@ -11,7 +11,6 @@
 /// @file   DigitReaderSpec.cxx
 
 #include <vector>
-#include <SimulationDataFormat/ConstMCTruthContainer.h>
 
 #include "TTree.h"
 

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -19,7 +19,6 @@
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsParameters/GRPObject.h"

--- a/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
@@ -192,14 +192,13 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
 
   // if (isEnabled(OutputType::Raw)) {
   //   using RawOutputType = std::vector<o2::phos::Raw>;
-  //   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::phos::MCLabel>;
   //   specs.push_back(makeWriterSpec("phos-raw-writer",
   //                                  inputType == InputType::Digits ? "phos-raw.root" : "phosrawcells.root",
   //                                  "o2sim",
   //                                  BranchDefinition<DigitOutputType>{o2::framework::InputSpec{"data", "PHS", "RAW", 0},
   //                                                                    "PHSRaw",
   //                                                                    "raw-branch-name"},
-  //                                  BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "PHS", "RAWMCTR", 0},
+  //                                  BranchDefinition<o2::dataformats::MCTruthContainer<o2::phos::MCLabel>>{o2::framework::InputSpec{"mc", "PHS", "RAWMCTR", 0},
   //                                                                     "PHSRawMCTruth",
   //                                                                     "rawmc-branch-name"})());
   // }
@@ -207,7 +206,6 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Digits)) {
     using DigitOutputType = std::vector<o2::phos::Digit>;
     using DTROutputType = std::vector<o2::phos::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::phos::MCLabel>;
 
     specs.emplace_back(o2::framework::MakeRootTreeWriterSpec("phos-digits-writer", "phosdigits.root", "o2sim",
                                                              -1,
@@ -218,15 +216,14 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                              BranchDefinition<DTROutputType>{o2::framework::InputSpec{"data", "PHS", "DIGITTRIGREC", 0},
                                                                                              "PHSDigTR",
                                                                                              "digittr-branch-name"},
-                                                             BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "PHS", "DIGITSMCTR", 0},
-                                                                                                "PHSDigitMCTruth",
-                                                                                                "digitmc-branch-name"})());
+                                                             BranchDefinition<o2::dataformats::MCTruthContainer<o2::phos::MCLabel>>{o2::framework::InputSpec{"mc", "PHS", "DIGITSMCTR", 0},
+                                                                                                                                    "PHSDigitMCTruth",
+                                                                                                                                    "digitmc-branch-name"})());
   }
 
   if (isEnabled(OutputType::Cells)) {
     using CellOutputType = std::vector<o2::phos::Cell>;
     using CTROutputType = std::vector<o2::phos::TriggerRecord>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::phos::MCLabel>;
     specs.emplace_back(o2::framework::MakeRootTreeWriterSpec("phos-cells-writer", "phoscells.root", "o2sim", -1,
                                                              o2::framework::MakeRootTreeWriterSpec::TerminationCondition{checkReady},
                                                              BranchDefinition<CellOutputType>{o2::framework::InputSpec{"data", "PHS", "CELLS", 0},
@@ -235,9 +232,9 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                              BranchDefinition<CTROutputType>{o2::framework::InputSpec{"data", "PHS", "CELLTRIGREC", 0},
                                                                                              "PHSCellTR",
                                                                                              "celltr-branch-name"},
-                                                             BranchDefinition<MCLabelContainer>{o2::framework::InputSpec{"mc", "PHS", "CELLSMCTR", 0},
-                                                                                                "PHSCellMCTruth",
-                                                                                                "cellmc-branch-name"},
+                                                             BranchDefinition<o2::dataformats::MCTruthContainer<o2::phos::MCLabel>>{o2::framework::InputSpec{"mc", "PHS", "CELLSMCTR", 0},
+                                                                                                                                    "PHSCellMCTruth",
+                                                                                                                                    "cellmc-branch-name"},
                                                              BranchDefinition<std::vector<uint>>{o2::framework::InputSpec{"mcmap", "PHS", "CELLSMCMAP", 0},
                                                                                                  "PHSCellMCMAP",
                                                                                                  "cellmcmap-branch-name"})());

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
@@ -29,7 +29,7 @@ namespace tof
 {
 class Clusterer
 {
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using MCLabelContainer = o2::dataformats::MCLabelContainer;
   using Cluster = o2::tof::Cluster;
   using StripData = o2::tof::DataReader::StripData;
   using Digit = o2::tof::Digit;

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/ClustererTask.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/ClustererTask.h
@@ -32,9 +32,6 @@ namespace tof
 
 class ClustererTask : public FairTask
 {
-
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-
  public:
   ClustererTask(Bool_t useMCTruth = kTRUE);
   ~ClustererTask() override;
@@ -46,9 +43,9 @@ class ClustererTask : public FairTask
   DigitDataReader mReader; ///< Digit reader
   Clusterer mClusterer;    ///< Cluster finder
 
-  std::vector<Cluster>* mClustersArray = nullptr;                           ///< Array of clusters
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; ///< MC labels for output
-  MCLabelContainer const* mDigitMCTruth;                                    ///< Array for MCTruth information associated to digits
+  std::vector<Cluster>* mClustersArray = nullptr;          ///< Array of clusters
+  o2::dataformats::MCLabelContainer* mClsLabels = nullptr; ///< MC labels for output
+  o2::dataformats::MCLabelContainer const* mDigitMCTruth;  ///< Array for MCTruth information associated to digits
 
   ClassDefOverride(ClustererTask, 1);
 };

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -32,6 +32,7 @@
 #include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
+using namespace o2::dataformats;
 
 namespace o2
 {
@@ -42,7 +43,6 @@ namespace tof
 // just need to implement 2 special methods init + run (there is no need to inherit from anything)
 class TOFDPLClustererTask
 {
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   bool mUseMC = true;
   bool mUseCCDB = false;
 

--- a/Detectors/TPC/calibration/macro/extractGainMap.C
+++ b/Detectors/TPC/calibration/macro/extractGainMap.C
@@ -107,7 +107,7 @@ void calibGainMacroTrk(const float momMin, const float momMax, const std::string
 
   ClusterNativeAccess clusterIndex{};
   std::unique_ptr<ClusterNative[]> clusterBuffer{};
-  MCLabelContainer clusterMCBuffer;
+  o2::tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer clusterMCBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
 
   CalibPadGainTracks cGain{};

--- a/Detectors/TPC/qc/macro/runClusters.C
+++ b/Detectors/TPC/qc/macro/runClusters.C
@@ -29,7 +29,7 @@ void runClusters(std::string_view outputFile = "ClusterQC.root", std::string_vie
   ClusterNativeAccess clusterIndex;
   std::unique_ptr<ClusterNative[]> clusterBuffer;
   memset(&clusterIndex, 0, sizeof(clusterIndex));
-  MCLabelContainer clusterMCBuffer;
+  o2::tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer clusterMCBuffer;
 
   qc::Clusters clusters;
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 #include "TPCBase/CalDet.h"
@@ -34,7 +35,7 @@ class Digit;
 class Clusterer
 {
  protected:
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
 
  public:
   /// Default Constructor
@@ -49,8 +50,8 @@ class Clusterer
   /// Processing all digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
-  virtual void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
-  virtual void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
+  virtual void process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) = 0;
+  virtual void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) = 0;
 
   /// Setter for noise object, noise will be added before cluster finding
   /// \param noiseObject CalDet object, containing noise simulation

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
@@ -17,7 +17,6 @@
 #include <vector>
 #include <memory>
 
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
@@ -33,9 +33,6 @@ class Digit;
 /// \brief Base Class for TPC clusterer
 class Clusterer
 {
- protected:
-  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
-
  public:
   /// Default Constructor
   Clusterer() = default;
@@ -49,8 +46,8 @@ class Clusterer
   /// Processing all digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
-  virtual void process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) = 0;
-  virtual void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) = 0;
+  virtual void process(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::ConstMCLabelContainerView const& mcDigitTruth) = 0;
+  virtual void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::ConstMCLabelContainerView const& mcDigitTruth) = 0;
 
   /// Setter for noise object, noise will be added before cluster finding
   /// \param noiseObject CalDet object, containing noise simulation

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -21,6 +21,7 @@
 #include "DataFormatsTPC/Digit.h"
 #include "TPCReconstruction/HwClusterer.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsTPC/Helpers.h"
 #include "DataFormatsTPC/ClusterHardware.h"
@@ -36,6 +37,8 @@ class ClustererTask : public FairTask
 {
 
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
   using OutputType = ClusterHardwareContainer8kb;
 
  public:
@@ -68,7 +71,7 @@ class ClustererTask : public FairTask
 
   // Digit arrays
   std::unique_ptr<const std::vector<Digit>> mDigitsArray;     ///< Array of TPC digits
-  std::unique_ptr<const MCLabelContainer> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
+  std::unique_ptr<const ConstMCLabelContainerView> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
 
   // Cluster arrays
   std::unique_ptr<std::vector<OutputType>> mHwClustersArray; ///< Array of clusters found by Hw Clusterfinder

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -34,10 +34,6 @@ namespace tpc
 
 class ClustererTask : public FairTask
 {
-
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-  using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
-  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
   using OutputType = ClusterHardwareContainer8kb;
 
  public:
@@ -70,11 +66,11 @@ class ClustererTask : public FairTask
 
   // Digit arrays
   std::unique_ptr<const std::vector<Digit>> mDigitsArray;     ///< Array of TPC digits
-  std::unique_ptr<const ConstMCLabelContainerView> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
+  std::unique_ptr<const o2::dataformats::ConstMCLabelContainerView> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
 
   // Cluster arrays
   std::unique_ptr<std::vector<OutputType>> mHwClustersArray; ///< Array of clusters found by Hw Clusterfinder
-  std::unique_ptr<MCLabelContainer> mHwClustersMCTruthArray; ///< Array for MCTruth information associated to cluster in mHwClustersArrays
+  std::unique_ptr<o2::dataformats::MCLabelContainer> mHwClustersMCTruthArray; ///< Array for MCTruth information associated to cluster in mHwClustersArrays
 
   ClassDefOverride(ClustererTask, 1);
 };

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -20,7 +20,6 @@
 
 #include "DataFormatsTPC/Digit.h"
 #include "TPCReconstruction/HwClusterer.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsTPC/Helpers.h"

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -30,6 +30,8 @@ namespace dataformats
 {
 template <typename TruthElement>
 class MCTruthContainer;
+template <typename TruthElement>
+class ConstMCTruthContainerView;
 }
 
 /// @class HardwareClusterDecoder
@@ -76,7 +78,7 @@ class HardwareClusterDecoder
   /// @param outMCLabels     optional pointer to MC output container
   int decodeClusters(std::vector<std::pair<const o2::tpc::ClusterHardwareContainer*, std::size_t>>& inputClusters,
                      OutputAllocator outputAllocator,
-                     const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr,
+                     const std::vector<o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>>* inMCLabels = nullptr,
                      o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outMCLabels = nullptr);
 
   /// @brief Sort clusters and MC labels in place

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -20,7 +20,6 @@
 #include "TPCReconstruction/Clusterer.h"
 #include "DataFormatsTPC/Helpers.h"
 
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -39,12 +39,9 @@ class ClusterHardware;
 /// \brief Class for TPC HW cluster finding
 class HwClusterer : public Clusterer
 {
-
  private:
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-  using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
-  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
-
+  using MCLabelContainer = o2::dataformats::MCLabelContainer;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCLabelContainerView;
   /// Main Constructor
   HwClusterer(
     std::vector<ClusterHardwareContainer8kb>* clusterOutputContainer,

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -21,6 +21,7 @@
 #include "DataFormatsTPC/Helpers.h"
 
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 #include <vector>
@@ -42,6 +43,8 @@ class HwClusterer : public Clusterer
 
  private:
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
+  using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
 
   /// Main Constructor
   HwClusterer(
@@ -71,15 +74,15 @@ class HwClusterer : public Clusterer
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
-  void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) override;
-  void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
+  void process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) override;
+  void process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth, bool clearContainerFirst);
 
   /// Finish processing digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
-  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) override;
-  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
+  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth) override;
+  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth, bool clearContainerFirst);
 
   /// Switch for triggered / continuous readout
   /// \param isContinuous - false for triggered readout, true for continuous readout
@@ -218,12 +221,12 @@ class HwClusterer : public Clusterer
   MCLabelContainer* mClusterMcLabelArray;                  ///< Pointer to MC Label container
 };
 
-inline void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+inline void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth)
 {
   process(digits, mcDigitTruth, true);
 }
 
-inline void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+inline void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth)
 {
   finishProcess(digits, mcDigitTruth, true);
 }

--- a/Detectors/TPC/reconstruction/macro/readClusters.C
+++ b/Detectors/TPC/reconstruction/macro/readClusters.C
@@ -47,7 +47,7 @@ void readClusters(std::string clusterFilename, std::string digitFilename, int se
   std::vector<o2::tpc::Digit>* digits = nullptr;
   digitBranch->SetAddress(&digits);
 
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using MCLabelContainer = o2::dataformats::MCLabelContainer;
   MCLabelContainer* mcClusterTruth = nullptr;
   clusterTree->SetBranchAddress(Form("TPCClusterHWMCTruth%i", sectorid), &mcClusterTruth);
   MCLabelContainer* mcDigitTruth = nullptr;

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -62,8 +62,8 @@ InitStatus ClustererTask::Init()
   }
   std::stringstream mcsectornamestr;
   mcsectornamestr << "TPCDigitMCTruth" << mClusterSector;
-  mDigitMCTruthArray = std::unique_ptr<const MCLabelContainer>(
-    mgr->InitObjectAs<const MCLabelContainer*>(mcsectornamestr.str().c_str()));
+  mDigitMCTruthArray = std::unique_ptr<const ConstMCLabelContainerView>(
+    mgr->InitObjectAs<const ConstMCLabelContainerView*>(mcsectornamestr.str().c_str()));
   if (!mDigitMCTruthArray) {
     LOG(ERROR) << "TPC MC Truth not registered in the FairRootManager. Exiting ...";
     return kERROR;
@@ -102,7 +102,7 @@ void ClustererTask::Exec(Option_t* option)
   if (mHwClustersMCTruthArray)
     mHwClustersMCTruthArray->clear();
 
-  mHwClusterer->process(gsl::span<o2::tpc::Digit const>(mDigitsArray->data(), mDigitsArray->size()), mDigitMCTruthArray.get());
+  mHwClusterer->process(gsl::span<o2::tpc::Digit const>(mDigitsArray->data(), mDigitsArray->size()), *mDigitMCTruthArray.get());
   LOG(DEBUG) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container";
 
   ++mEventCount;
@@ -118,7 +118,7 @@ void ClustererTask::FinishTask()
   if (mHwClustersMCTruthArray)
     mHwClustersMCTruthArray->clear();
 
-  mHwClusterer->finishProcess(*mDigitsArray.get(), mDigitMCTruthArray.get());
+  mHwClusterer->finishProcess(*mDigitsArray.get(), *mDigitMCTruthArray.get());
   LOG(DEBUG) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container";
 
   ++mEventCount;

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -19,6 +19,7 @@
 ClassImp(o2::tpc::ClustererTask);
 
 using namespace o2::tpc;
+using namespace o2::dataformats;
 
 //_____________________________________________________________________
 ClustererTask::ClustererTask(int sectorid)

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -45,8 +45,6 @@ using namespace o2::tpc;
 using namespace o2;
 using namespace o2::dataformats;
 
-using MCLabelContainer = MCTruthContainer<MCCompLabel>;
-
 GPUCATracking::GPUCATracking() = default;
 GPUCATracking::~GPUCATracking() { deinitialize(); }
 

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -16,7 +16,6 @@
 #include "FairLogger.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "TChain.h"
 #include "TClonesArray.h"

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -17,6 +17,7 @@
 #include "ReconstructionDataFormats/Track.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "TChain.h"
 #include "TClonesArray.h"
 #include "TPCBase/Mapper.h"
@@ -26,6 +27,7 @@
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/Sector.h"
 #include "DataFormatsTPC/Digit.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
 #include "DetectorsRaw/HBFUtils.h"
 
 #include "GPUO2Interface.h"
@@ -87,6 +89,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
 
   std::vector<o2::tpc::Digit> gpuDigits[Sector::MAXSECTOR];
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> gpuDigitsMC[Sector::MAXSECTOR];
+  ClusterNativeAccess::ConstMCLabelContainerViewWithBuffer gpuDigitsMCConst[Sector::MAXSECTOR];
 
   GPUTrackingInOutDigits gpuDigitsMap;
   GPUTPCDigitsMCInput gpuDigitsMapMC;
@@ -121,7 +124,9 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
         gpuDigitsMap.tpcDigits[i] = gpuDigits[i].data();
         gpuDigitsMap.nTPCDigits[i] = gpuDigits[i].size();
         if (data->o2DigitsMC) {
-          gpuDigitsMapMC.v[i] = &gpuDigitsMC[i];
+          gpuDigitsMC[i].flatten_to(gpuDigitsMCConst[i].first);
+          gpuDigitsMCConst[i].second = gpuDigitsMCConst[i].first;
+          gpuDigitsMapMC.v[i] = &gpuDigitsMCConst[i].second;
         }
       } else {
         gpuDigitsMap.tpcDigits[i] = (*(data->o2Digits))[i].data();

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -34,7 +34,7 @@ using namespace o2::dataformats;
 
 int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>>& inputClusters,
                                            HardwareClusterDecoder::OutputAllocator outputAllocator,
-                                           const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels,
+                                           const std::vector<o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>>* inMCLabels,
                                            o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outMCLabels)
 {
   if (mIntegrator == nullptr)
@@ -176,7 +176,7 @@ void HardwareClusterDecoder::sortClustersAndMC(ClusterNative* clusters, size_t n
     return clusters[a] < clusters[b];
   });
   std::vector<ClusterNative> buffer(clusters, clusters + nClusters);
-  MCLabelContainer tmpMC = std::move(mcTruth);
+  ClusterNativeHelper::MCLabelContainer tmpMC = std::move(mcTruth);
   assert(mcTruth.getIndexedSize() == 0);
   for (int i = 0; i < nClusters; i++) {
     clusters[i] = buffer[indizes[i]];

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -129,7 +129,7 @@ void HwClusterer::init()
 }
 
 //______________________________________________________________________________
-void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
+void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth, bool clearContainerFirst)
 {
   if (clearContainerFirst) {
     if (mClusterArray)
@@ -226,9 +226,11 @@ void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, MCLabel
       // we have to copy the MC truth container because we need the information
       // maybe only in the next events (we store permanently 5 timebins), where
       // the original pointer could already point to the next container.
-      if (mcDigitTruth) {
+      if (mcDigitTruth.getBuffer().size()) {
         if (mCurrentMcContainerInBuffer == 0) {
-          mMCtruth[mapTimeInRange(timeBin)] = std::make_shared<MCLabelContainer const>(*mcDigitTruth);
+          auto tmp = std::make_shared<MCLabelContainer>();
+          tmp->restore_from(mcDigitTruth.getBuffer().data(), mcDigitTruth.getBuffer().size());
+          mMCtruth[mapTimeInRange(timeBin)] = tmp;
         } else {
           mMCtruth[mapTimeInRange(timeBin)] = std::shared_ptr<MCLabelContainer const>(mMCtruth[getFirstSetBitOfField()]);
         }
@@ -272,7 +274,7 @@ void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, MCLabel
 }
 
 //______________________________________________________________________________
-void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
+void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, ConstMCLabelContainerView const& mcDigitTruth, bool clearContainerFirst)
 {
   // Process the last digits (if there are any)
   process(digits, mcDigitTruth, clearContainerFirst);

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -21,7 +21,6 @@
 #include "TPCBase/Mapper.h"
 #include "TPCReconstruction/HwClusterer.h"
 
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -22,6 +22,7 @@
 #include "TPCReconstruction/HwClusterer.h"
 
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 #include <vector>
@@ -156,8 +157,10 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test1)
 
   auto digits = std::make_unique<const std::vector<Digit>>(digitVec);
   auto mcDigitTruth = std::make_unique<const MCLabelContainer>(labelContainer);
+  o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel> flatLabels;
+  mcDigitTruth->flatten_to(flatLabels);
 
-  clusterer.process(*digits.get(), mcDigitTruth.get());
+  clusterer.process(*digits.get(), flatLabels);
 
   // check if clusters were found
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
@@ -216,7 +219,8 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test2)
   std::sort(digits->begin(), digits->end(), sortTime());
 
   // Search clusters
-  clusterer.process(*digits.get(), nullptr);
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> flatLabelsViewEmpty;
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
 
   // Check result
   BOOST_CHECK_EQUAL(clusterArray->size(), 47);
@@ -314,7 +318,8 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test3)
   std::sort(digits->begin(), digits->end(), sortTime());
 
   // Search clusters
-  clusterer.process(*digits.get(), nullptr);
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> flatLabelsViewEmpty;
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
 
   // Check outcome
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
@@ -416,7 +421,8 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   std::cout << "testing without thresholds..." << std::endl;
   clusterer.setRejectSinglePadClusters(false);
   clusterer.setRejectSingleTimeClusters(false);
-  clusterer.process(*digits.get(), nullptr);
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> flatLabelsViewEmpty;
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 4);
@@ -456,7 +462,7 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   std::cout << "testing with pad threshold..." << std::endl;
   clusterer.setRejectSinglePadClusters(true);
   clusterer.setRejectSingleTimeClusters(false);
-  clusterer.process(*digits.get(), nullptr);
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 2);
@@ -496,7 +502,7 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   std::cout << "testing with time threshold..." << std::endl;
   clusterer.setRejectSinglePadClusters(false);
   clusterer.setRejectSingleTimeClusters(true);
-  clusterer.process(*digits.get(), nullptr);
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 2);
@@ -536,7 +542,7 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   std::cout << "testing both thresholds..." << std::endl;
   clusterer.setRejectSinglePadClusters(true);
   clusterer.setRejectSingleTimeClusters(true);
-  clusterer.process(*digits.get(), nullptr);
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 1);
@@ -620,7 +626,8 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
   // Search clusters without rejection, all 4 clusters shoud be found
   std::cout << "testing without rejection..." << std::endl;
   clusterer.setRejectLaterTimebin(false);
-  clusterer.process(*digits.get(), nullptr);
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> flatLabelsViewEmpty;
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 4);
@@ -632,7 +639,7 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
   // Search clusters with rejection, cluster with peak charge 13 should be surpressed
   std::cout << "testing with with rejection..." << std::endl;
   clusterer.setRejectLaterTimebin(true);
-  clusterer.process(*digits.get(), nullptr);
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 3);
@@ -904,7 +911,8 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
   clustersToCompare.emplace_back();
   clustersToCompare.back().setCluster(2, 7 + 100, p_pre_fp(clustersMode0[10]), t_pre_fp(clustersMode0[10]), sigma_p_pre_fp(clustersMode0[10]), sigma_t_pre_fp(clustersMode0[10]), (clustersMode0[10][12] * 2), (std::accumulate(clustersMode0[10].begin(), clustersMode0[10].end(), 0.0) * 16), 0, 0);
   clusterer.setSplittingMode(0);
-  clusterer.process(*digits.get(), nullptr);
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> flatLabelsViewEmpty;
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);
@@ -962,7 +970,7 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
   clustersToCompare.emplace_back();
   clustersToCompare.back().setCluster(2, 7 + 100, p_pre_fp(clustersMode1[10]), t_pre_fp(clustersMode1[10]), sigma_p_pre_fp(clustersMode1[10]), sigma_t_pre_fp(clustersMode1[10]), (clustersMode1[10][12] * 2), (std::accumulate(clustersMode1[10].begin(), clustersMode1[10].end(), 0.0) * 16), 0, 0);
   clusterer.setSplittingMode(1);
-  clusterer.process(*digits.get(), nullptr);
+  clusterer.process(*digits.get(), flatLabelsViewEmpty);
   BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -28,6 +28,8 @@
 #include <memory>
 #include <iostream>
 
+using MCLabelContainer = o2::dataformats::MCLabelContainer;
+
 namespace o2
 {
 namespace tpc
@@ -133,7 +135,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test1)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 1, basic class tests." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<MCLabelContainer>();
 
@@ -188,7 +189,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test2)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 2, finding single pad clusters." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::tpc::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
 
@@ -263,7 +263,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test3)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 3, computing cluster properties." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::tpc::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
 
@@ -367,7 +366,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 4, rejecting single pad clusters." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::tpc::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
 
@@ -587,7 +585,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 5, rejecting peaks in subsequent." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::tpc::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
 
@@ -656,7 +653,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 6, split charge among nearby clusters." << std::endl;
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::tpc::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
 

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -48,12 +48,12 @@ namespace bpo = boost::program_options;
 
 using namespace o2::tpc;
 using namespace o2::gpu;
+using namespace o2::dataformats;
 using o2::MCCompLabel;
 
 constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
 constexpr static size_t NEndpoints = o2::gpu::GPUTrackingInOutZS::NENDPOINTS;
 using DigitArray = std::array<gsl::span<const o2::tpc::Digit>, Sector::MAXSECTOR>;
-using MCLabelContainer = o2::dataformats::MCTruthContainer<MCCompLabel>;
 
 struct ProcessAttributes {
   std::unique_ptr<unsigned long long int[]> zsoutput;

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -50,7 +50,6 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "TPCBase/Sector.h"
 #include "TPCBase/Utils.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "Algorithm/Parser.h"

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -69,9 +69,7 @@ using namespace o2::framework;
 using namespace o2::header;
 using namespace o2::gpu;
 using namespace o2::base;
-
-using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
-using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
+using namespace o2::dataformats;
 
 namespace o2
 {

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -35,16 +35,12 @@
 
 using namespace o2::framework;
 using namespace o2::header;
+using namespace o2::dataformats;
 
 namespace o2
 {
 namespace tpc
 {
-
-using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
-using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
-
 /// create the processor spec for TPC raw cluster decoder converting TPC raw to native clusters
 /// Input: raw pages of TPC raw clusters
 /// Output: vector of containers with clusters in ClusterNative format, one container per

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -22,7 +22,6 @@
 #include "DataFormatsTPC/ClusterHardware.h"
 #include "DataFormatsTPC/Helpers.h"
 #include "TPCReconstruction/HardwareClusterDecoder.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include <FairMQLogger.h>

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -32,15 +32,12 @@
 
 using namespace o2::framework;
 using namespace o2::header;
+using namespace o2::dataformats;
 
 namespace o2
 {
 namespace tpc
 {
-
-using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-using ConstMCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
-using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
 
 /// create a processor spec
 /// runs the TPC HwClusterer in a DPL process with digits and mc as input

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -32,7 +32,6 @@
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "DataFormatsTPC/CompressedClusters.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/IOMCTruthContainerView.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -117,6 +117,9 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
     zsOnTheFly = false;
     propagateMC = false;
   }
+  if (inputType == InputType::ClustersHardware || inputType == InputType::Clusters) {
+    caClusterer = false;
+  }
   if (!caClusterer) {
     zsOnTheFly = false;
   }

--- a/Detectors/TPC/workflow/test/test_TPCWorkflow.cxx
+++ b/Detectors/TPC/workflow/test/test_TPCWorkflow.cxx
@@ -21,6 +21,7 @@
 #include <TTree.h>
 
 using namespace o2;
+using namespace o2::dataformats;
 
 BOOST_AUTO_TEST_CASE(TPCWorkflow_types)
 {
@@ -30,8 +31,7 @@ BOOST_AUTO_TEST_CASE(TPCWorkflow_types)
   // even though std::vector < o2::dataformats::MCTruthContainer < o2::MCCompLabel >>
   // has not been specified in the LinkDef file. But it can only e serialized to a
   // tree branch if it has been defined.
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-  MCLabelContainer labels;
+  dataformats::MCLabelContainer labels;
   std::vector<MCLabelContainer> containers;
   const char* filename = "testTPCWorkflowTypes.root";
   const char* treename = "testtree";

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -19,7 +19,6 @@
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "TChain.h"
 #include <SimulationDataFormat/MCCompLabel.h>
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -35,7 +35,6 @@
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "TChain.h"
 #include <SimulationDataFormat/MCCompLabel.h>
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include "fairlogger/Logger.h"
 #include "CCDB/BasicCCDBManager.h"

--- a/EventVisualisation/Detectors/src/DataInterpreterTPC.cxx
+++ b/EventVisualisation/Detectors/src/DataInterpreterTPC.cxx
@@ -60,7 +60,7 @@ std::unique_ptr<VisualisationEvent> DataInterpreterTPC::interpretDataForType(TOb
 
     auto access = std::make_unique<o2::tpc::ClusterNativeAccess>();
     std::unique_ptr<tpc::ClusterNative[]> clusterBuffer;
-    tpc::MCLabelContainer clusterMCBuffer;
+    tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer clusterMCBuffer;
 
     reader->fillIndex(*access, clusterBuffer, clusterMCBuffer);
 

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -58,6 +58,8 @@ namespace dataformats
 {
 template <class T>
 class MCTruthContainer;
+template <class T>
+class ConstMCTruthContainerView;
 } // namespace dataformats
 } // namespace o2
 

--- a/GPU/GPUTracking/Base/GPUHostDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUHostDataTypes.h
@@ -27,7 +27,6 @@
 #include <vector>
 #include <array>
 #include "DataFormatsTPC/Constants.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 

--- a/GPU/GPUTracking/Base/GPUHostDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUHostDataTypes.h
@@ -28,6 +28,7 @@
 #include <array>
 #include "DataFormatsTPC/Constants.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 namespace GPUCA_NAMESPACE
@@ -36,7 +37,7 @@ namespace gpu
 {
 
 struct GPUTPCDigitsMCInput {
-  std::array<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR> v;
+  std::array<const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR> v;
 };
 
 struct GPUTPCClusterMCInterim {

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -168,6 +168,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetOutputControlCompressedClusters(GPUOutputControl* v) { mOutputCompressedClusters = v; }
   void SetOutputControlClustersNative(GPUOutputControl* v) { mOutputClustersNative = v; }
   void SetOutputControlTPCTracks(GPUOutputControl* v) { mOutputTPCTracks = v; }
+  void SetOutputControlClusterLabels(GPUOutputControl* v) { mOutputClusterLabels = v; }
 
   const void* mConfigDisplay = nullptr; // Abstract pointer to Standalone Display Configuration Structure
   const void* mConfigQA = nullptr;      // Abstract pointer to Standalone QA Configuration Structure
@@ -238,6 +239,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   GPUOutputControl* mOutputCompressedClusters = nullptr;
   GPUOutputControl* mOutputClustersNative = nullptr;
   GPUOutputControl* mOutputTPCTracks = nullptr;
+  GPUOutputControl* mOutputClusterLabels = nullptr;
 
   std::unique_ptr<GPUTPCCFChainContext> mCFContext;
 

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -64,6 +64,10 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
     mOutputTPCTracks.reset(new GPUOutputControl);
     mChain->SetOutputControlTPCTracks(mOutputTPCTracks.get());
   }
+  if (mConfig->configProcessing.runMC) {
+    mOutputTPCClusterLabels.reset(new GPUOutputControl);
+    mChain->SetOutputControlClusterLabels(mOutputTPCClusterLabels.get());
+  }
 
   if (mRec->Init()) {
     return (1);
@@ -129,6 +133,13 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
       mOutputTPCTracks->set(outputs->tpcTracks.ptr, outputs->tpcTracks.size);
     } else {
       mOutputTPCTracks->reset();
+    }
+  }
+  if (mConfig->configProcessing.runMC) {
+    if (outputs->clusterLabels.allocator) {
+      mOutputTPCClusterLabels->set(outputs->clusterLabels.allocator);
+    } else {
+      mOutputTPCClusterLabels->reset();
     }
   }
   int retVal = mRec->RunChains();

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -75,6 +75,7 @@ class GPUTPCO2Interface
   std::unique_ptr<GPUOutputControl> mOutputCompressedClusters;
   std::unique_ptr<GPUOutputControl> mOutputClustersNative;
   std::unique_ptr<GPUOutputControl> mOutputTPCTracks;
+  std::unique_ptr<GPUOutputControl> mOutputTPCClusterLabels;
 };
 } // namespace o2::gpu
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -63,6 +63,7 @@ struct GPUInterfaceOutputs {
   GPUInterfaceOutputRegion compressedClusters;
   GPUInterfaceOutputRegion clustersNative;
   GPUInterfaceOutputRegion tpcTracks;
+  GPUInterfaceOutputRegion clusterLabels;
 };
 
 // Full configuration structure with all available settings of GPU...
@@ -108,7 +109,7 @@ struct GPUO2InterfaceIOPtrs {
   // Input: TPC clusters in cluster native format, or digits, or list of ZS pages -  const as it can only be input
   const o2::tpc::ClusterNativeAccess* clusters = nullptr;
   const std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::constants::MAXSECTOR>* o2Digits = nullptr;
-  std::array<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR>* o2DigitsMC = nullptr;
+  std::array<const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>*, o2::tpc::constants::MAXSECTOR>* o2DigitsMC = nullptr;
   const o2::gpu::GPUTrackingInOutZS* tpcZS = nullptr;
 
   // Input / Output for Merged TPC tracks, two ptrs, for the tracks themselves, and for the MC labels.

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -43,6 +43,7 @@
 #include "GPUParam.inc"
 #ifdef GPUCA_O2_LIB
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/TrackReference.h"
@@ -160,6 +161,7 @@ static const GPUQA::configQA& GPUQA_GetConfig(GPUChainTracking* rec)
 #ifdef GPUCA_TPC_GEOMETRY_O2
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 
 inline unsigned int GPUQA::GetNMCCollissions()
 {

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -42,7 +42,6 @@
 #include "GPUO2DataTypes.h"
 #include "GPUParam.inc"
 #ifdef GPUCA_O2_LIB
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTrack.h"
@@ -160,7 +159,6 @@ static const GPUQA::configQA& GPUQA_GetConfig(GPUChainTracking* rec)
 
 #ifdef GPUCA_TPC_GEOMETRY_O2
 #include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 
 inline unsigned int GPUQA::GetNMCCollissions()

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
@@ -29,6 +29,8 @@ namespace dataformats
 {
 template <typename TruthElement>
 class MCTruthContainer;
+template <typename TruthElement>
+class ConstMCTruthContainerView;
 } // namespace dataformats
 
 namespace tpc
@@ -111,7 +113,7 @@ class GPUTPCClusterFinder : public GPUProcessor
   int* mPbuf = nullptr;
   Memory* mPmemory = nullptr;
 
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mPinputLabels = nullptr;
+  o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> const* mPinputLabels = nullptr;
   uint* mPlabelsInRow = nullptr;
   uint mPlabelsHeaderGlobalOffset = 0;
   uint mPlabelsDataGlobalOffset = 0;

--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
@@ -33,7 +33,7 @@ void MCLabelAccumulator::collect(const ChargePos& pos, Charge q)
 
   uint index = mIndexMap[pos];
 
-  auto labels = mLabels->getLabels(index);
+  const auto& labels = mLabels->getLabels(index);
 
   for (const auto& label : labels) {
     int h = label.getRawValue() % mMaybeHasLabel.size();

--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
@@ -16,15 +16,20 @@
 
 #include "clusterFinderDefs.h"
 #include "Array2D.h"
-#include "SimulationDataFormat/MCCompLabel.h"
 #include <bitset>
 #include <vector>
 
-namespace o2::dataformats
+namespace o2
 {
+class MCCompLabel;
+namespace dataformats
+{
+class MCCompLabel;
 template <typename T>
 class ConstMCTruthContainerView;
-} // namespace o2::dataformats
+using ConstMCLabelContainerView = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
+} // namespace dataformats
+} // namespace o2
 
 namespace GPUCA_NAMESPACE::gpu
 {
@@ -45,10 +50,8 @@ class MCLabelAccumulator
   void commit(tpccf::Row, uint, uint);
 
  private:
-  using MCLabelContainer = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
-
   Array2D<const uint> mIndexMap;
-  const MCLabelContainer* mLabels = nullptr;
+  const o2::dataformats::ConstMCLabelContainerView* mLabels = nullptr;
   GPUTPCClusterMCInterim* mOutput = nullptr;
 
   std::bitset<64> mMaybeHasLabel;

--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
@@ -23,7 +23,7 @@
 namespace o2::dataformats
 {
 template <typename T>
-class MCTruthContainer;
+class ConstMCTruthContainerView;
 } // namespace o2::dataformats
 
 namespace GPUCA_NAMESPACE::gpu
@@ -45,7 +45,7 @@ class MCLabelAccumulator
   void commit(tpccf::Row, uint, uint);
 
  private:
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using MCLabelContainer = o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel>;
 
   Array2D<const uint> mIndexMap;
   const MCLabelContainer* mLabels = nullptr;

--- a/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
@@ -18,7 +18,6 @@
 #include "Headers/DataHeader.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "DetectorsBase/BaseDPLDigitizer.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -18,7 +18,6 @@
 #include "Headers/DataHeader.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "DataFormatsITSMFT/Digit.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "DetectorsBase/BaseDPLDigitizer.h"
 #include "DetectorsCommonDataFormats/DetID.h"

--- a/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/MCTruthReaderSpec.h
@@ -16,7 +16,6 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include <SimulationDataFormat/MCCompLabel.h>
 #include "SimulationDataFormat/IOMCTruthContainerView.h"

--- a/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthSourceSpec.cxx
@@ -13,7 +13,6 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include <SimulationDataFormat/MCCompLabel.h>
 #include "Framework/Task.h"

--- a/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCTruthWriterSpec.cxx
@@ -13,7 +13,6 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include <SimulationDataFormat/MCCompLabel.h>
 #include "SimulationDataFormat/IOMCTruthContainerView.h"

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -78,7 +78,6 @@ DataProcessorSpec getTPCDigitRootWriterSpec(std::vector<int> const& laneConfigur
 
   //branch definitions for RootTreeWriter spec
   using DigitsOutputType = std::vector<o2::tpc::Digit>;
-  using MCLabelContainer = o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>;
   using CommonModeOutputType = std::vector<o2::tpc::CommonMode>;
 
   // extracts the sector from header of an input

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -22,7 +22,6 @@
 #include "TChain.h"
 #include "TSystem.h"
 #include <SimulationDataFormat/MCCompLabel.h>
-#include <SimulationDataFormat/MCTruthContainer.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"

--- a/macro/readITSDigits.C
+++ b/macro/readITSDigits.C
@@ -9,7 +9,6 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "SimulationDataFormat/DigitizationContext.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "SimulationDataFormat/IOMCTruthContainerView.h"
 #include "SimulationDataFormat/MCCompLabel.h"

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -40,8 +40,6 @@ using namespace o2::tpc;
 using namespace o2::dataformats;
 using namespace std;
 
-using MCLabelContainer = MCTruthContainer<o2::MCCompLabel>;
-
 #if !defined(__CLING__) || defined(__ROOTCLING__) // Disable in interpreted mode due to missing rootmaps
 
 // This is a prototype of a macro to test running the HLT O2 CA Tracking library on a root input file containg


### PR DESCRIPTION
This switches from the MCTruthContainer to the ConstMCTruthContainer/ConstMCTruthContainerView for the digit labels and cluster labels in both TPC clusterizers and the TPC tracker. Tested with both clusterizers and with storing clusters to a ROOT file in between and without.

Todo in follow-up PRs:
- A bit of clean up. In particular I copy and pasted the `hook` and `fillLabels` functions. I guess eventually they should be moved to a header, or everything should happen automatically in the `RootTreeWriter`/`Reader`.
- Extend the splitting of TBuffer for large datasets to all std::vectors with a check if the buffer size would be exceeded when stored as single entry.
- Fix the reading of TPC clusters/labels in macros.

Ping @sawenzel @wiechula 