### PR TITLE
DPL Analysis: remove old workaround for nullptr in Table constructor

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -909,10 +909,10 @@ class Table
 
   Table(std::shared_ptr<arrow::Table> table, uint64_t offset = 0)
     : mTable(table),
-      mEnd{table == nullptr ? 0 : static_cast<uint64_t>(table->num_rows())},
+      mEnd{static_cast<uint64_t>(table->num_rows())},
       mOffset(offset)
   {
-    if ((mTable == nullptr) or (mTable->num_rows() == 0)) {
+    if (mTable->num_rows() == 0) {
       for (size_t ci = 0; ci < sizeof...(C); ++ci) {
         mColumnChunks[ci] = nullptr;
       }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -110,7 +110,11 @@ struct AnalysisDataProcessorBuilder {
   static auto extractTableFromRecord(InputRecord& record)
   {
     if constexpr (soa::is_type_with_metadata_v<aod::MetadataTrait<T>>) {
-      return record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::tableLabel())->asArrowTable();
+      auto table = record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::tableLabel())->asArrowTable();
+      if (table->num_rows() == 0) {
+        table = makeEmptyTable<T>();
+      }
+      return table;
     } else if constexpr (soa::is_type_with_originals_v<T>) {
       return extractFromRecord<T>(record, typename T::originals{});
     }


### PR DESCRIPTION
Use `makeEmptyTable` on input record extraction instead of protecting Table constructor from nullptr/empty table.