### PR TITLE
Correct noise treatment for duplicated channels. Introduced geographical mapping of autotrigger bits

### DIFF
--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/BCData.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/BCData.h
@@ -31,17 +31,19 @@ struct BCData {
   /// we are going to refer to at most 26 channels, so 5 bits for the NChannels and 27 for the reference
   o2::dataformats::RangeRefComp<5> ref;
   o2::InteractionRecord ir;
-  uint32_t channels = 0; // pattern of channels it refers to
-  uint32_t triggers = 0; // pattern of triggered channels (not necessarily stored) in this BC
+  uint32_t channels = 0;    // pattern of channels it refers to
+  uint32_t triggers = 0;    // pattern of triggered channels (not necessarily stored) in this BC
+  uint8_t ext_triggers = 0; // pattern of ALICE triggers
 
   BCData() = default;
-  BCData(int first, int ne, o2::InteractionRecord iRec, uint32_t chSto, uint32_t chTrig)
+  BCData(int first, int ne, o2::InteractionRecord iRec, uint32_t chSto, uint32_t chTrig, uint8_t extTrig)
   {
     ref.setFirstEntry(first);
     ref.setEntries(ne);
     ir = iRec;
     channels = chSto;
     triggers = chTrig;
+    ext_triggers = extTrig;
   }
 
   gsl::span<const ChannelData> getBunchChannelData(const gsl::span<const ChannelData> tfdata) const;

--- a/DataFormats/Detectors/ZDC/src/BCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/BCData.cxx
@@ -18,16 +18,32 @@ void BCData::print() const
 {
   ir.print();
   printf("%d channels starting from %d\n", ref.getEntries(), ref.getFirstEntry());
-  printf("Read : [");
-  for (int ic = 0; ic < NChannels; ic++) {
+  printf("Read:");
+  for (int ic = 0; ic < NDigiChannels; ic++) {
+    if (ic % NChPerModule == 0) {
+      if (ic == 0)
+        printf(" %d[", ic / NChPerModule);
+      else
+        printf("] %d[", ic / NChPerModule);
+    }
     if (channels & (0x1 << ic)) {
-      printf("%s ", channelName(ic));
+      printf("R");
+    } else {
+      printf(" ");
     }
   }
-  printf("] Hits: [");
-  for (int ic = 0; ic < NChannels; ic++) {
+  printf("]\nHits:");
+  for (int ic = 0; ic < NDigiChannels; ic++) {
+    if (ic % NChPerModule == 0) {
+      if (ic == 0)
+        printf(" %d[", ic / NChPerModule);
+      else
+        printf("] %d[", ic / NChPerModule);
+    }
     if (triggers & (0x1 << ic)) {
-      printf("%s ", channelName(ic));
+      printf("H");
+    } else {
+      printf(" ");
     }
   }
   printf("]\n");

--- a/DataFormats/Detectors/ZDC/src/BCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/BCData.cxx
@@ -24,7 +24,7 @@ void BCData::print() const
       printf("%s ", channelName(ic));
     }
   }
-  printf("] Triggered: [");
+  printf("] Hits: [");
   for (int ic = 0; ic < NChannels; ic++) {
     if (triggers & (0x1 << ic)) {
       printf("%s ", channelName(ic));

--- a/DataFormats/Detectors/ZDC/src/ChannelData.cxx
+++ b/DataFormats/Detectors/ZDC/src/ChannelData.cxx
@@ -14,7 +14,7 @@ using namespace o2::zdc;
 
 void ChannelData::print() const
 {
-  printf("Ch%2d | ", id);
+  printf("Sig %2d | ", id);
   for (int i = 0; i < NTimeBinsPerBC; i++) {
     printf("%+5d ", data[i]);
   }

--- a/Detectors/ZDC/base/include/ZDCBase/Constants.h
+++ b/Detectors/ZDC/base/include/ZDCBase/Constants.h
@@ -39,8 +39,8 @@ enum ChannelTypeZNP { Common,
 enum ChannelTypeZEM { ZEMCh1,
                       ZEMCh2 }; //  channel IDs for ZEMs
 
-constexpr int NTimeBinsPerBC = 12;                   //< number of samples per BC
-constexpr int NBCReadOut = 4;                        // N BCs read out per trigger
+constexpr int NTimeBinsPerBC = 12; //< number of samples per BC
+constexpr int NBCReadOut = 4;      // N BCs read out per trigger
 constexpr int NTimeBinsReadout = NTimeBinsPerBC * NBCReadOut;
 
 constexpr int NChannelsZN = 6;  //< number of channels stored per ZN
@@ -51,10 +51,11 @@ constexpr float ChannelTimeBinNS = 2.; //< bin length in NS
 constexpr float SampleLenghtNS = NTimeBinsPerBC * ChannelTimeBinNS;
 
 constexpr int NChannels = 2 * (NChannelsZN + NChannelsZP) + NChannelsZEM;
-constexpr uint32_t AllChannelsMask = (0x1 << NChannels) - 1;
+constexpr uint8_t ALICETriggerMask = 0x1;
 
 constexpr int NModules = 8;
 constexpr int NChPerModule = 4;
+constexpr int NDigiChannels = NModules * NChPerModule;
 constexpr int NWPerBc = 3;
 constexpr int MaxTriggerChannels = NChannels;
 

--- a/Detectors/ZDC/base/include/ZDCBase/Constants.h
+++ b/Detectors/ZDC/base/include/ZDCBase/Constants.h
@@ -54,7 +54,9 @@ constexpr int NChannels = 2 * (NChannelsZN + NChannelsZP) + NChannelsZEM;
 constexpr uint32_t AllChannelsMask = (0x1 << NChannels) - 1;
 
 constexpr int NModules = 8;
-constexpr int MaxTriggerChannels = 10;
+constexpr int NChPerModule = 4;
+constexpr int NWPerBc = 3;
+constexpr int MaxTriggerChannels = NChannels;
 
 constexpr int MaxTDCValues = 5;  // max number of TDC values to store in reconstructed event
 constexpr int NTDCChannels = 10; // max number of TDC values to store in reconstructed event

--- a/Detectors/ZDC/base/include/ZDCBase/ModuleConfig.h
+++ b/Detectors/ZDC/base/include/ZDCBase/ModuleConfig.h
@@ -41,6 +41,8 @@ struct Module {
 
   void setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig = false, int tF = 0, int tL = 0, int tS = 0, int tT = 0);
   void print() const;
+  void printCh() const;
+  void printTrig() const;
   void check() const;
   ClassDefNV(Module, 1);
 };

--- a/Detectors/ZDC/base/src/ModuleConfig.cxx
+++ b/Detectors/ZDC/base/src/ModuleConfig.cxx
@@ -14,14 +14,18 @@
 
 using namespace o2::zdc;
 
-void Module::print() const
+void Module::printCh() const
 {
   printf("Module %d [ChID/LinkID R:T ]", id);
   for (int ic = 0; ic < MaxChannels; ic++) {
-    printf("[%s{%2d}/L%02d %c:%c ]", channelName(channelID[ic]), channelID[ic], linkID[ic], readChannel[ic] ? '+' : '-', trigChannel[ic] ? '+' : '-');
+    printf("[%s{%2d}/L%02d %c:%c ]", channelName(channelID[ic]), channelID[ic], linkID[ic], readChannel[ic] ? 'R' : ' ', trigChannel[ic] ? 'T' : ' ');
   }
   printf("\n");
-  printf("Trigger conf: ");
+}
+
+void Module::printTrig() const
+{
+  printf("Trigger conf %d: ", id);
   for (int ic = 0; ic < MaxChannels; ic++) {
     const auto& cnf = trigChannelConf[ic];
     if (trigChannel[ic]) {
@@ -33,12 +37,23 @@ void Module::print() const
   printf("\n");
 }
 
+void Module::print() const
+{
+  printCh();
+  printTrig();
+}
+
 void ModuleConfig::print() const
 {
   printf("Modules configuration:\n");
   for (const auto& md : modules) {
     if (md.id >= 0) {
-      md.print();
+      md.printCh();
+    }
+  }
+  for (const auto& md : modules) {
+    if (md.id >= 0) {
+      md.printTrig();
     }
   }
 }

--- a/Detectors/ZDC/base/src/ModuleConfig.cxx
+++ b/Detectors/ZDC/base/src/ModuleConfig.cxx
@@ -26,7 +26,7 @@ void Module::print() const
     const auto& cnf = trigChannelConf[ic];
     if (trigChannel[ic]) {
       printf("[TRIG %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
-    }else if (cnf.shift > 0 && cnf.threshold > 0){
+    } else if (cnf.shift > 0 && cnf.threshold > 0) {
       printf("[DISC %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
     }
   }
@@ -76,7 +76,7 @@ void Module::setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig
   // Therefore we put the trig flag just for the triggering channels
   // Discriminator parameters are stored for all modules
   trigChannel[slot] = trig;
-  if (tS>0 && tT>0) { 
+  if (tS > 0 && tT > 0) {
     if (tL + tS + 1 >= NTimeBinsPerBC) {
       LOG(FATAL) << "Sum of Last and Shift trigger parameters exceed allowed range";
     }

--- a/Detectors/ZDC/base/src/ModuleConfig.cxx
+++ b/Detectors/ZDC/base/src/ModuleConfig.cxx
@@ -23,9 +23,11 @@ void Module::print() const
   printf("\n");
   printf("Trigger conf: ");
   for (int ic = 0; ic < MaxChannels; ic++) {
+    const auto& cnf = trigChannelConf[ic];
     if (trigChannel[ic]) {
-      const auto& cnf = trigChannelConf[ic];
-      printf("[%s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
+      printf("[TRIG %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
+    }else if (cnf.shift > 0 && cnf.threshold > 0){
+      printf("[DISC %s: F:%2d L:%2d S:%2d T:%2d] ", channelName(channelID[ic]), cnf.first, cnf.last, cnf.shift, cnf.threshold);
     }
   }
   printf("\n");
@@ -70,8 +72,11 @@ void Module::setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig
   linkID[slot] = lID;
   channelID[slot] = chID;
   readChannel[slot] = read;
+  // In the 2020 firmware implementation, autotrigger bits are computed for each channel
+  // Therefore we put the trig flag just for the triggering channels
+  // Discriminator parameters are stored for all modules
   trigChannel[slot] = trig;
-  if (trig) {
+  if (tS>0 && tT>0) { 
     if (tL + tS + 1 >= NTimeBinsPerBC) {
       LOG(FATAL) << "Sum of Last and Shift trigger parameters exceed allowed range";
     }

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -38,10 +38,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 0;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZNAC, 0, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 1, false, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZNA1, 2, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZNA2, 3, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZNAC,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(1, IdZNASum, 2*modID,   false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA1,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA2,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -49,10 +49,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 1;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZNAC, 4, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 5, true, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZNA3, 6, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZNA4, 7, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZNAC,   2*modID,   false, true , -5, 6, 4, 12);
+    module.setChannel(1, IdZNASum, 2*modID,   true , false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA3,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA4,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -60,10 +60,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 2;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZNCC, 8, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 9, false, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZNC1, 10, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZNC2, 11, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZNCC,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(1, IdZNCSum, 2*modID,   false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC1,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC2,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -71,10 +71,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 3;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZNCC, 12, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 13, true, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZNC3, 14, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZNC4, 15, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZNCC,   2*modID,   false, true , -5, 6, 4, 12);
+    module.setChannel(1, IdZNCSum, 2*modID,   true , false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC3,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC4,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -82,10 +82,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 4;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZPAC, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZEM1, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPA1, 17, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPA2, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZPAC,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(1, IdZEM1,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(2, IdZPA1,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA2,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -93,10 +93,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 5;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZPAC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPASum, 18, true, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZPA3, 19, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPA4, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZPAC,   2*modID,   false, true , -5, 6, 4, 12);
+    module.setChannel(1, IdZPASum, 2*modID,   true , false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPA3,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA4,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -104,10 +104,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 6;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZPCC, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZEM2, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC1, 17, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPC2, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZPCC,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(1, IdZEM2,   2*modID,   true , true , -5, 6, 4, 12);
+    module.setChannel(2, IdZPC1,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC2,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -115,10 +115,10 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     modID = 7;
     auto& module = conf.modules[modID];
     module.id = modID;
-    module.setChannel(0, IdZPCC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPCSum, 18, true, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC3, 19, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPC4, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(0, IdZPCC,   2*modID,   false, true , -5, 6, 4, 12);
+    module.setChannel(1, IdZPCSum, 2*modID,   true , false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPC3,   2*modID+1, true , false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC4,   2*modID+1, true , false, -5, 6, 4, 12);
     //
   }
   conf.check();

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -32,14 +32,16 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
   int modID;
 
   //-------------------------------------------
+  // Up to 8 modules with four channels
+  // setChannel(int slot, int8_t chID, int16_t lID, bool read, bool trig = false, int tF = 0, int tL = 0, int tS = 0, int tT = 0)
   {
     modID = 0;
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNAC, 0, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 1, false, false);
-    module.setChannel(2, IdZNA1, 2, true, false);
-    module.setChannel(3, IdZNA2, 3, true, false);
+    module.setChannel(1, IdZNASum, 1, false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA1, 2, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA2, 3, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -48,9 +50,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNAC, 4, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNASum, 5, true, false);
-    module.setChannel(2, IdZNA3, 6, true, false);
-    module.setChannel(3, IdZNA4, 7, true, false);
+    module.setChannel(1, IdZNASum, 5, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNA3, 6, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNA4, 7, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -59,9 +61,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNCC, 8, true, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 9, false, false);
-    module.setChannel(2, IdZNC1, 10, true, false);
-    module.setChannel(3, IdZNC2, 11, true, false);
+    module.setChannel(1, IdZNCSum, 9, false, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC1, 10, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC2, 11, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -70,9 +72,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZNCC, 12, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZNCSum, 13, true, false);
-    module.setChannel(2, IdZNC3, 14, true, false);
-    module.setChannel(3, IdZNC4, 15, true, false);
+    module.setChannel(1, IdZNCSum, 13, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZNC3, 14, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZNC4, 15, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -82,8 +84,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPAC, 16, true, true, -5, 6, 4, 12);
     module.setChannel(1, IdZEM1, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPA1, 17, true, false);
-    module.setChannel(3, IdZPA2, 17, true, false);
+    module.setChannel(2, IdZPA1, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA2, 17, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -92,9 +94,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZPAC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPASum, 18, true, false);
-    module.setChannel(2, IdZPA3, 19, true, false);
-    module.setChannel(3, IdZPA4, 19, true, false);
+    module.setChannel(1, IdZPASum, 18, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPA3, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPA4, 19, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -104,8 +106,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPCC, 16, true, true, -5, 6, 4, 12);
     module.setChannel(1, IdZEM2, 16, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC1, 17, true, false);
-    module.setChannel(3, IdZPC2, 17, true, false);
+    module.setChannel(2, IdZPC1, 17, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC2, 17, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -114,9 +116,9 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     auto& module = conf.modules[modID];
     module.id = modID;
     module.setChannel(0, IdZPCC, 18, false, true, -5, 6, 4, 12);
-    module.setChannel(1, IdZPCSum, 18, true, false);
-    module.setChannel(2, IdZPC3, 19, true, false);
-    module.setChannel(3, IdZPC4, 19, true, false);
+    module.setChannel(1, IdZPCSum, 18, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPC3, 19, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC4, 19, true, false, -5, 6, 4, 12);
     //
   }
   conf.check();

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -49,8 +49,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZNAC, 4, false, true, -5, 6, 4, 12);
     module.setChannel(1, IdZNASum, 5, true, false);
-    module.setChannel(2, IdZNA1, 6, true, false);
-    module.setChannel(3, IdZNA2, 7, true, false);
+    module.setChannel(2, IdZNA3, 6, true, false);
+    module.setChannel(3, IdZNA4, 7, true, false);
     //
   }
   //-------------------------------------------
@@ -93,8 +93,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1,
     module.id = modID;
     module.setChannel(0, IdZPAC, 18, false, true, -5, 6, 4, 12);
     module.setChannel(1, IdZPASum, 18, true, false);
-    module.setChannel(2, IdZPA1, 19, true, false);
-    module.setChannel(3, IdZPA2, 19, true, false);
+    module.setChannel(2, IdZPA3, 19, true, false);
+    module.setChannel(3, IdZPA4, 19, true, false);
     //
   }
   //-------------------------------------------

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -40,11 +40,11 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
   std::string ShapeName[o2::zdc::NChannels] = {
     "znatc", "znatc", "znatc", "znatc", "znatc", "znatc", // ZNAC, ZNA1, ZNA2, ZNA3, ZNA4, ZNAS (shape not used)
     "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", // ZPAC, ZPA1, ZPA2, ZPA3, ZPA4, ZPAS (shape not used)
-    "zem2","zem2",					  // ZEM1, ZEM2
+    "zem2", "zem2",                                       // ZEM1, ZEM2
     "znctc", "znctc", "znctc", "znctc", "znctc", "znctc", // ZNCC, ZNC1, ZNC2, ZNC3, ZNC4, ZNCS (shape not used)
     "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc"  // ZPCC, ZPC1, ZPC2, ZPC3, ZPC4, ZPCS (shape not used)
   };
-  
+
   for (int ic = 0; ic < o2::zdc::NChannels; ic++) {
 
     auto& channel = conf.channels[ic];

--- a/Detectors/ZDC/macro/CreateSimCondition.C
+++ b/Detectors/ZDC/macro/CreateSimCondition.C
@@ -35,6 +35,16 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
   const float Gains[5] = {15.e-3, 30.e-3, 100.e-3, 15.e-3, 30.e-3}; // gain (response per photoelectron)
   const float fudgeFactor = 2.7;                                    // ad hoc factor to tune the gain in the MC
 
+  // Source of line shapes, pedestal and noise for each channel
+  // Missing histos for: towers 1-4 of all calorimeters, zem1, all towers of zpc
+  std::string ShapeName[o2::zdc::NChannels] = {
+    "znatc", "znatc", "znatc", "znatc", "znatc", "znatc", // ZNAC, ZNA1, ZNA2, ZNA3, ZNA4, ZNAS (shape not used)
+    "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", // ZPAC, ZPA1, ZPA2, ZPA3, ZPA4, ZPAS (shape not used)
+    "zem2","zem2",					  // ZEM1, ZEM2
+    "znctc", "znctc", "znctc", "znctc", "znctc", "znctc", // ZNCC, ZNC1, ZNC2, ZNC3, ZNC4, ZNCS (shape not used)
+    "zpatc", "zpatc", "zpatc", "zpatc", "zpatc", "zpatc"  // ZPCC, ZPC1, ZPC2, ZPC3, ZPC4, ZPCS (shape not used)
+  };
+  
   for (int ic = 0; ic < o2::zdc::NChannels; ic++) {
 
     auto& channel = conf.channels[ic];
@@ -43,9 +53,7 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
     //
     channel.gain = (tower != o2::zdc::Sum) ? fudgeFactor * Gains[det - 1] : 1.0;
     //
-    // at the moment we use wf_znatc histo for all channels, to be fixed when
-    // more histos are created. So, we read in the loop the same histo
-    std::string histoShapeName = "hw_znatc";
+    std::string histoShapeName = "hw_" + ShapeName[ic];
     TH1* histoShape = (TH1*)sourceData.GetObjectUnchecked(histoShapeName.c_str());
     if (!histoShape) {
       LOG(FATAL) << "Failed to extract the shape histogram  " << histoShapeName;
@@ -72,14 +80,14 @@ void CreateSimCondition(std::string sourceDataPath = "signal_shapes.root",
     //
     channel.pedestal = gRandom->Gaus(1800., 30.);
     //
-    std::string histoPedNoiseName = "hb_znatc"; // same comment here (at the moment the same histo used)
+    std::string histoPedNoiseName = "hb_" + ShapeName[ic];
     TH1* histoPedNoise = (TH1*)sourceData.GetObjectUnchecked(histoPedNoiseName.c_str());
     if (!histoPedNoise) {
       LOG(FATAL) << "Failed to extract the pedestal noise histogram  " << histoPedNoise;
     }
     channel.pedestalNoise = histoPedNoise->GetRMS();
     //
-    std::string histoPedFluctName = "hp_znatc"; // same comment here (at the moment the same histo used)
+    std::string histoPedFluctName = "hp_" + ShapeName[ic];
     TH1* histoPedFluct = (TH1*)sourceData.GetObjectUnchecked(histoPedFluctName.c_str());
     if (!histoPedFluct) {
       LOG(FATAL) << "Failed to extract the pedestal fluctuation histogram  " << histoPedFluct;

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -37,10 +37,12 @@ class Digitizer
  public:
   struct BCCache : public o2::InteractionRecord {
     std::array<ChannelBCDataF, NChannels> data = {};
+    std::array<ChannelBCDataF, NDigiChannels> digi = {};
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
-    uint32_t trigChanMask = 0; // mask of triggered channels IDs
+    uint32_t trigChanMask = 0; // mask of triggered channels
+    uint8_t extTrig = 0;       // external trigger
     static constexpr uint32_t AllChannelsMask = 0x80000000;
 
     BCCache();

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that can actually trigger a module
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -133,7 +133,7 @@ class Digitizer
   o2::InteractionTimeRecord mIR;
   std::deque<o2::InteractionRecord> mIRExternalTrigger; // IRs of externally provided triggered (at the moment MC sampled interactions)
 
-  std::deque<BCCache> mCache; // cached BCs data
+  std::deque<BCCache> mCache;                                    // cached BCs data
   std::array<std::vector<int16_t>, NChannels> mTrigChannelsData; // buffer for fast access to triggered channels data
   int mTrigBinMin = 0xffff;                                      // prefetched min and max
   int mTrigBinMax = -0xffff;                                     // bins to be checked for trigger
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that can actually trigger a module
+  uint32_t mTriggerableChanMask = 0;                ///< mask of digital discriminators that can actually trigger a module
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -41,7 +41,7 @@ class Digitizer
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
-    static constexpr uint32_t AllChannelsMask = 0x1 << NChannels;
+    static constexpr uint32_t AllChannelsMask = 0x80000000;
 
     BCCache();
 

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t triggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t mTriggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -35,12 +35,12 @@ class Digitizer
   using ChannelBCDataF = std::array<float, NTimeBinsPerBC>;
 
  public:
+  uint32_t triggerableChanMask = 0; // mask of triggerable channels IDs
   struct BCCache : public o2::InteractionRecord {
     std::array<ChannelBCDataF, NChannels> data = {};
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
-    uint32_t trigChanMask = 0; // mask of triggered channels IDs
     static constexpr uint32_t AllChannelsMask = 0x1 << NChannels;
 
     BCCache();
@@ -143,6 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
+  uint32_t trigChanMask = 0;			    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Digitizer.h
@@ -35,12 +35,12 @@ class Digitizer
   using ChannelBCDataF = std::array<float, NTimeBinsPerBC>;
 
  public:
-  uint32_t triggerableChanMask = 0; // mask of triggerable channels IDs
   struct BCCache : public o2::InteractionRecord {
     std::array<ChannelBCDataF, NChannels> data = {};
     std::vector<o2::zdc::MCLabel> labels;
     bool digitized = false;
     bool triggerChecked = false;
+    uint32_t trigChanMask = 0; // mask of triggered channels IDs
     static constexpr uint32_t AllChannelsMask = 0x80000000;
 
     BCCache();
@@ -143,7 +143,7 @@ class Digitizer
   const SimCondition* mSimCondition = nullptr;      ///< externally set SimCondition
   const ModuleConfig* mModuleConfig = nullptr;      ///< externally set ModuleConfig
   std::vector<TriggerChannelConfig> mTriggerConfig; ///< triggering channels
-  uint32_t trigChanMask = 0;			    ///< mask of digital discriminators that are actually flagged as triggers
+  uint32_t triggerableChanMask = 0;		    ///< mask of digital discriminators that are actually flagged as triggers
   std::vector<ModuleConfAux> mModConfAux;           ///< module check helper
   std::vector<BCCache*> mFastCache;                 ///< for the fast iteration over cached BCs + dummy
   std::vector<uint32_t> mStoreChanMask;             ///< pattern of channels to store

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -463,7 +463,6 @@ void Digitizer::refreshCCDB()
       }
     }
     mModuleConfig->print();
-    // TODO: Dove si mettono i readout channels?
   }
 
   if (!mSimCondition) { // load this only once

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -226,7 +226,7 @@ bool Digitizer::triggerBC(int ibc)
     for (int ic = mTriggerConfig.size(); ic--;) {
       const auto& trigCh = mTriggerConfig[ic];
       bool okPrev = false;
-      int last1 = trigCh.last + 2;
+      int last1 = trigCh.last + 2; // To be modified. The new requirement is 3 consecutive samples
       // look for 2 consecutive bins (the 1st one spanning trigCh.first : trigCh.last range) so that
       // signal[bin]-signal[bin+trigCh.shift] > trigCh.threshold
       for (int ib = trigCh.first; ib < last1; ib++) { // ib may be negative, so we shift by offs and look in the ADC cache
@@ -237,7 +237,7 @@ bool Digitizer::triggerBC(int ibc)
         bool ok = bcF.data[trigCh.id][binF] - bcL.data[trigCh.id][binL] > trigCh.threshold;
         if (ok && okPrev) {                          // trigger ok!
           bcCached.trigChanMask |= 0x1 << trigCh.id; // register trigger mask
-          LOG(DEBUG) << " triggering channel " << int(trigCh.id) << " => " << bcCached.trigChanMask;
+          LOG(DEBUG) << " triggering channel " << int(trigCh.id) << "(" << ChannelNames[trigCh.id] << ") => " << bcCached.trigChanMask;
           break;
         }
         okPrev = ok;
@@ -251,7 +251,7 @@ bool Digitizer::triggerBC(int ibc)
     }
   }
 
-  if (bcCached.trigChanMask) { // there are triggered channels, flag modules/channels to read
+  if (bcCached.trigChanMask & triggerableChanMask) { // there are triggered channels, flag modules/channels to read
     for (int ibcr = ibc - mNBCAHead; ibcr <= ibc; ibcr++) {
       auto& bcr = mStoreChanMask[ibcr + mNBCAHead];
       for (const auto& mdh : mModConfAux) {
@@ -398,11 +398,10 @@ void Digitizer::refreshCCDB()
     for (const auto& md : mModuleConfig->modules) {
       if (md.id >= 0) {
         mModConfAux.emplace_back(md);
-        //
         for (int ic = Module::MaxChannels; ic--;) {
-          if (md.trigChannel[ic]) { // check if this triggering channel was already registered
+          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift>0 && md.trigChannelConf[ic].threshold>0)) {
             bool skip = false;
-            for (int is = mTriggerConfig.size(); is--;) {
+            for (int is = mTriggerConfig.size(); is--;) {  // check if this triggering channel was already registered
               if (mTriggerConfig[is].id == md.channelID[ic]) {
                 skip = true;
                 break;
@@ -414,7 +413,12 @@ void Digitizer::refreshCCDB()
                 LOG(FATAL) << "Wrong trigger settings";
               }
               mTriggerConfig.emplace_back(trgChanConf);
-              LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+	      if(md.trigChannel[ic]){
+        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+		triggerableChanMask |= 0x1 << trgChanConf.id;
+	      }else{
+        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
+	      }
               if (trgChanConf.first < mTrigBinMin) {
                 mTrigBinMin = trgChanConf.first;
               }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -399,9 +399,9 @@ void Digitizer::refreshCCDB()
       if (md.id >= 0) {
         mModConfAux.emplace_back(md);
         for (int ic = Module::MaxChannels; ic--;) {
-          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift>0 && md.trigChannelConf[ic].threshold>0)) {
+          if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift > 0 && md.trigChannelConf[ic].threshold > 0)) {
             bool skip = false;
-            for (int is = mTriggerConfig.size(); is--;) {  // check if this triggering channel was already registered
+            for (int is = mTriggerConfig.size(); is--;) { // check if this triggering channel was already registered
               if (mTriggerConfig[is].id == md.channelID[ic]) {
                 skip = true;
                 break;
@@ -413,12 +413,12 @@ void Digitizer::refreshCCDB()
                 LOG(FATAL) << "Wrong trigger settings";
               }
               mTriggerConfig.emplace_back(trgChanConf);
-	      if(md.trigChannel[ic]){
-        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
-		mTriggerableChanMask |= 0x1 << trgChanConf.id;
-	      }else{
-        	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
-	      }
+              if (md.trigChannel[ic]) {
+                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+                mTriggerableChanMask |= 0x1 << trgChanConf.id;
+              } else {
+                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
+              }
               if (trgChanConf.first < mTrigBinMin) {
                 mTrigBinMin = trgChanConf.first;
               }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -26,14 +26,17 @@ Digitizer::BCCache::BCCache()
 
 Digitizer::ModuleConfAux::ModuleConfAux(const Module& md) : id(md.id)
 {
+  if (md.id < 0 || md.id >= NModules) {
+    LOG(FATAL) << "Module id = " << md.id << " not in allowed range [0:" << NModules << ")";
+  }
   // construct aux helper from full module description
   for (int ic = Module::MaxChannels; ic--;) {
     if (md.channelID[ic] >= IdDummy) {
       if (md.readChannel[ic]) {
-        readChannels |= 0x1 << md.channelID[ic];
+        readChannels |= 0x1 << (NChPerModule * md.id + ic);
       }
       if (md.trigChannel[ic]) {
-        trigChannels |= 0x1 << md.channelID[ic];
+        trigChannels |= 0x1 << (NChPerModule * md.id + ic);
       }
     }
   }
@@ -179,6 +182,7 @@ void Digitizer::generatePedestal()
 void Digitizer::digitizeBC(BCCache& bc)
 {
   auto& bcdata = bc.data;
+  auto& bcdigi = bc.digi;
   // apply gain
   for (int idet : {ZNA, ZPA, ZNC, ZPC}) {
     for (int ic : {Common, Ch1, Ch2, Ch3, Ch4}) {
@@ -193,7 +197,7 @@ void Digitizer::digitizeBC(BCCache& bc)
     bcdata[IdZEM1][ib] *= mSimCondition->channels[IdZEM1].gain;
     bcdata[IdZEM2][ib] *= mSimCondition->channels[IdZEM2].gain;
   }
-  //
+  // Prepare sum of towers before adding noise
   for (int ib = NTimeBinsPerBC; ib--;) {
     bcdata[IdZNASum][ib] = mSimCondition->channels[IdZNASum].gain *
                            (bcdata[IdZNA1][ib] + bcdata[IdZNA2][ib] + bcdata[IdZNA3][ib] + bcdata[IdZNA4][ib]);
@@ -204,15 +208,29 @@ void Digitizer::digitizeBC(BCCache& bc)
     bcdata[IdZPCSum][ib] = mSimCondition->channels[IdZPCSum].gain *
                            (bcdata[IdZPC1][ib] + bcdata[IdZPC2][ib] + bcdata[IdZPC3][ib] + bcdata[IdZPC4][ib]);
   }
-  for (int chan = NChannels; chan--;) {
-    const auto& chanConf = mSimCondition->channels[chan];
-    auto pedBaseLine = mSimCondition->channels[chan].pedestal;
-    for (int ib = NTimeBinsPerBC; ib--;) {
-      bcdata[chan][ib] += gRandom->Gaus(pedBaseLine + mPedestalBLFluct[chan], chanConf.pedestalNoise);
-      int adc = std::nearbyint(bcdata[chan][ib]);
-      bcdata[chan][ib] = adc < ADCMax ? (adc > ADCMin ? adc : ADCMin) : ADCMax;
+  // Digitize the signals connected to each channel of the different modules
+  for (const auto& md : mModuleConfig->modules) {
+    if (md.id >= 0 && md.id < NModules) {
+      for (int ic = Module::MaxChannels; ic--;) {
+        int id = md.channelID[ic];
+        if (id >= 0 && id < NChannels) {
+          const auto& chanConf = mSimCondition->channels[id];
+          auto pedBaseLine = mSimCondition->channels[id].pedestal;
+          // Geographical position of signal in the setup
+          auto ipos = NChPerModule * md.id + ic;
+          for (int ib = NTimeBinsPerBC; ib--;) {
+            bcdigi[ipos][ib] = bcdata[id][ib] + gRandom->Gaus(pedBaseLine + mPedestalBLFluct[id], chanConf.pedestalNoise);
+            int adc = std::nearbyint(bcdigi[ipos][ib]);
+            bcdigi[ipos][ib] = adc < ADCMax ? (adc > ADCMin ? adc : ADCMin) : ADCMax;
+          }
+          LOG(DEBUG) << "md " << md.id << " ch " << ic << " sig " << id << " " << ChannelNames[id]
+                     << bcdigi[ipos][0] << " " << bcdigi[ipos][1] << " " << bcdigi[ipos][2] << " " << bcdigi[ipos][3] << " " << bcdigi[ipos][4] << " " << bcdigi[ipos][5] << " "
+                     << bcdigi[ipos][6] << " " << bcdigi[ipos][7] << " " << bcdigi[ipos][8] << " " << bcdigi[ipos][9] << " " << bcdigi[ipos][10] << " " << bcdigi[ipos][11];
+        }
+      }
     }
   }
+
   bc.digitized = true;
 }
 
@@ -222,35 +240,45 @@ bool Digitizer::triggerBC(int ibc)
   auto& bcCached = *mFastCache[ibc];
 
   LOG(DEBUG) << "CHECK TRIGGER " << ibc << " IR=" << bcCached;
-  if (mIsContinuous) {
-    for (int ic = mTriggerConfig.size(); ic--;) {
-      const auto& trigCh = mTriggerConfig[ic];
-      bool okPrev = false;
-      int last1 = trigCh.last + 2; // To be modified. The new requirement is 3 consecutive samples
-      // look for 2 consecutive bins (the 1st one spanning trigCh.first : trigCh.last range) so that
-      // signal[bin]-signal[bin+trigCh.shift] > trigCh.threshold
-      for (int ib = trigCh.first; ib < last1; ib++) { // ib may be negative, so we shift by offs and look in the ADC cache
-        int binF, bcFidx = ibc + binHelper(ib, binF);
-        int binL, bcLidx = ibc + binHelper(ib + trigCh.shift, binL);
-        const auto& bcF = (bcFidx < 0 || !mFastCache[bcFidx]) ? mDummyBC : *mFastCache[bcFidx];
-        const auto& bcL = (bcLidx < 0 || !mFastCache[bcLidx]) ? mDummyBC : *mFastCache[bcLidx];
-        bool ok = bcF.data[trigCh.id][binF] - bcL.data[trigCh.id][binL] > trigCh.threshold;
-        if (ok && okPrev) {                          // trigger ok!
-          bcCached.trigChanMask |= 0x1 << trigCh.id; // register trigger mask
-          LOG(DEBUG) << " triggering channel " << int(trigCh.id) << "(" << ChannelNames[trigCh.id] << ") => " << bcCached.trigChanMask;
-          break;
+
+  // Check trigger condition regardless of run type, will apply later the trigger mask
+  for (const auto& md : mModuleConfig->modules) {
+    if (md.id >= 0 && md.id < NModules) {
+      for (int ic = Module::MaxChannels; ic--;) {
+        //int id=md.channelID[ic];
+        auto trigCh = md.trigChannelConf[ic];
+        int id = trigCh.id;
+        if (id >= 0 && id < NChannels) {
+          auto ipos = NChPerModule * md.id + ic;
+          bool okPrev = false;
+          int last1 = trigCh.last + 2; // To be modified. The new requirement is 3 consecutive samples
+          // look for 2 consecutive bins (the 1st one spanning trigCh.first : trigCh.last range) so that
+          // signal[bin]-signal[bin+trigCh.shift] > trigCh.threshold
+          for (int ib = trigCh.first; ib < last1; ib++) { // ib may be negative, so we shift by offs and look in the ADC cache
+            int binF, bcFidx = ibc + binHelper(ib, binF);
+            int binL, bcLidx = ibc + binHelper(ib + trigCh.shift, binL);
+            const auto& bcF = (bcFidx < 0 || !mFastCache[bcFidx]) ? mDummyBC : *mFastCache[bcFidx];
+            const auto& bcL = (bcLidx < 0 || !mFastCache[bcLidx]) ? mDummyBC : *mFastCache[bcLidx];
+            bool ok = bcF.digi[ipos][binF] - bcL.digi[ipos][binL] > trigCh.threshold;
+            if (ok && okPrev) {                                            // trigger ok!
+              bcCached.trigChanMask |= 0x1 << (NChPerModule * md.id + ic); // register trigger mask
+              LOG(DEBUG) << bcF.digi[ipos][binF] << " - " << bcL.digi[ipos][binL] << " = " << bcF.digi[ipos][binF] - bcL.digi[ipos][binL] << " > " << trigCh.threshold;
+              LOG(DEBUG) << " hit [" << md.id << "," << ic << "] " << int(id) << "(" << ChannelNames[id] << ") => " << bcCached.trigChanMask;
+              break;
+            }
+            okPrev = ok;
+          }
         }
-        okPrev = ok;
       }
-    } // loop over trigger channels
-  } else {
-    // just check if this BC IR corresponds to externall trigger
-    if (!mIRExternalTrigger.empty() && mIRExternalTrigger.front() == bcCached) {
-      bcCached.trigChanMask = AllChannelsMask;
-      mIRExternalTrigger.pop_front(); // suppress accounted external trigger
     }
   }
 
+  // just check if this BC IR corresponds to external trigger
+  if (!mIRExternalTrigger.empty() && mIRExternalTrigger.front() == bcCached) {
+    bcCached.extTrig = ALICETriggerMask;
+    mIRExternalTrigger.pop_front(); // suppress accounted external trigger
+  }
+  // This works in autotrigger mode, partially for triggered mode
   if (bcCached.trigChanMask & mTriggerableChanMask) { // there are triggered channels, flag modules/channels to read
     for (int ibcr = ibc - mNBCAHead; ibcr <= ibc; ibcr++) {
       auto& bcr = mStoreChanMask[ibcr + mNBCAHead];
@@ -276,14 +304,20 @@ void Digitizer::storeBC(const BCCache& bc, uint32_t chan2Store,
   LOG(DEBUG) << "Storing ch: " << chanPattern(chan2Store) << " trigger: " << chanPattern(bc.trigChanMask) << " for BC " << bc;
 
   int first = digitsCh.size(), nSto = 0;
-  for (int ic = 0; ic < NChannels; ic++) {
-    if (chan2Store & (0x1 << ic)) {
-      digitsCh.emplace_back(ic, bc.data[ic]);
-      nSto++;
+  for (const auto& md : mModuleConfig->modules) {
+    if (md.id >= 0 && md.id < NModules) {
+      for (int ic = 0; ic < Module::MaxChannels; ic++) {
+        auto ipos = NChPerModule * md.id + ic;
+        if (chan2Store & (0x1 << ipos)) {
+          digitsCh.emplace_back(md.channelID[ic], bc.digi[ipos]);
+          nSto++;
+        }
+      }
     }
   }
+
   int nBC = digitsBC.size();
-  digitsBC.emplace_back(first, nSto, bc, chan2Store, bc.trigChanMask);
+  digitsBC.emplace_back(first, nSto, bc, chan2Store, bc.trigChanMask, bc.extTrig);
   // TODO clarify if we want to store MC labels for all channels or only for stored ones
   for (const auto& lbl : bc.labels) {
     if (chan2Store & (0x1 << lbl.getChannel())) {
@@ -396,45 +430,40 @@ void Digitizer::refreshCCDB()
     mTriggerConfig.clear();
     mModConfAux.clear();
     for (const auto& md : mModuleConfig->modules) {
-      if (md.id >= 0) {
+      if (md.id >= 0 && md.id < NModules) {
         mModConfAux.emplace_back(md);
         for (int ic = Module::MaxChannels; ic--;) {
+          // We consider all channels that can produce a hit
           if (md.trigChannel[ic] || (md.trigChannelConf[ic].shift > 0 && md.trigChannelConf[ic].threshold > 0)) {
-            bool skip = false;
-            for (int is = mTriggerConfig.size(); is--;) { // check if this triggering channel was already registered
-              if (mTriggerConfig[is].id == md.channelID[ic]) {
-                skip = true;
-                break;
-              }
+            const auto& trgChanConf = md.trigChannelConf[ic];
+            if (trgChanConf.last + trgChanConf.shift + 1 >= NTimeBinsPerBC) {
+              LOG(FATAL) << "Wrong trigger settings";
             }
-            if (!skip) {
-              const auto& trgChanConf = md.trigChannelConf[ic];
-              if (trgChanConf.last + trgChanConf.shift + 1 >= NTimeBinsPerBC) {
-                LOG(FATAL) << "Wrong trigger settings";
-              }
-              mTriggerConfig.emplace_back(trgChanConf);
-              if (md.trigChannel[ic]) {
-                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
-                mTriggerableChanMask |= 0x1 << trgChanConf.id;
-              } else {
-                LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
-              }
-              if (trgChanConf.first < mTrigBinMin) {
-                mTrigBinMin = trgChanConf.first;
-              }
-              if (trgChanConf.last + trgChanConf.shift > mTrigBinMax) {
-                mTrigBinMax = trgChanConf.last + trgChanConf.shift;
-              }
+            mTriggerConfig.emplace_back(trgChanConf);
+            // We insert in the trigger mask only the channels that are actually triggering
+            // Trigger mask is geographical, bit position is relative to the module and channel
+            // where signal is connected
+            if (md.trigChannel[ic]) {
+              LOG(INFO) << "Adding channel [" << md.id << "," << ic << "] " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
+              // TODO insert check if bit is already used. Should never happen
+              mTriggerableChanMask |= 0x1 << (NChPerModule * md.id + ic);
+            } else {
+              LOG(INFO) << "Adding channel [" << md.id << "," << ic << "] " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
+            }
+            if (trgChanConf.first < mTrigBinMin) {
+              mTrigBinMin = trgChanConf.first;
+            }
+            if (trgChanConf.last + trgChanConf.shift > mTrigBinMax) {
+              mTrigBinMax = trgChanConf.last + trgChanConf.shift;
             }
           }
         }
+      } else {
+        LOG(FATAL) << "Module id: " << md.id << " is out of range";
       }
     }
-    if (int(mTriggerConfig.size()) > MaxTriggerChannels) {
-      LOG(FATAL) << "Too many triggering channels (" << mTriggerConfig.size() << ')';
-    }
     mModuleConfig->print();
-    //
+    // TODO: Dove si mettono i readout channels?
   }
 
   if (!mSimCondition) { // load this only once

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -181,7 +181,7 @@ void Digitizer::digitizeBC(BCCache& bc)
   auto& bcdata = bc.data;
   // apply gain
   for (int idet : {ZNA, ZPA, ZNC, ZPC}) {
-    for (int ic : {Ch1, Ch2, Ch3, Ch4}) {
+    for (int ic : {Common, Ch1, Ch2, Ch3, Ch4}) {
       int chan = toChannel(idet, ic);
       auto gain = mSimCondition->channels[chan].gain;
       for (int ib = NTimeBinsPerBC; ib--;) {
@@ -314,7 +314,7 @@ void Digitizer::phe2Sample(int nphe, int parID, double timeHit, std::array<o2::I
         break;
       }
       if (sample >= 0) {
-        auto signal = chanConfig.shape[sample] * nphe; // signal accounting for the gain
+        auto signal = chanConfig.shape[sample] * nphe; // signal not accounting for the gain
         (*bcCache).data[channel][ib] += signal;
         added = true;
       }

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -251,7 +251,7 @@ bool Digitizer::triggerBC(int ibc)
     }
   }
 
-  if (bcCached.trigChanMask & triggerableChanMask) { // there are triggered channels, flag modules/channels to read
+  if (bcCached.trigChanMask & mTriggerableChanMask) { // there are triggered channels, flag modules/channels to read
     for (int ibcr = ibc - mNBCAHead; ibcr <= ibc; ibcr++) {
       auto& bcr = mStoreChanMask[ibcr + mNBCAHead];
       for (const auto& mdh : mModConfAux) {
@@ -415,7 +415,7 @@ void Digitizer::refreshCCDB()
               mTriggerConfig.emplace_back(trgChanConf);
 	      if(md.trigChannel[ic]){
         	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as triggering one";
-		triggerableChanMask |= 0x1 << trgChanConf.id;
+		mTriggerableChanMask |= 0x1 << trgChanConf.id;
 	      }else{
         	LOG(INFO) << "Adding channel " << int(trgChanConf.id) << '(' << channelName(trgChanConf.id) << ") as discriminator";
 	      }


### PR DESCRIPTION
This update addresses the correct treatment of electronics noise for channels that are used as trigger on two modules and therefore for near threshold signals may trigger one module and not the other.
Moreover it changes the meaning of autotrigger bits from logical to geographical in order to save all information needed to write simulated raw data