### PR TITLE
Fix code-formatting workflow

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -45,7 +45,7 @@ jobs:
               # to avoid extra work.
               # 120 characters are allowed, meaning the error should start with 122,
               # to allow for the starting + at the end of the line.
-              git diff $x | tail -n +5 | grep -e '^+' | grep '.\{122,\}' && { echo "Line longer than 120 chars in $x." && exit 1; } || true ;;
+              git diff $BASE_COMMIT $x | tail -n +6 | grep -e '^+' | grep '.\{122,\}' && { echo "Line longer than 120 chars in $x." && exit 1; } || true ;;
             *.hxx|*.cc|*.hpp) echo "$x uses non-allowed extension." && exit 1 ;;
             *) ;;
           esac

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -26,7 +26,11 @@ jobs:
         git config --global user.name "ALICE Action Bot"
         git checkout -b alibot-cleanup-${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.sha }}
 
-        BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+        # github.event.pull_request.base.sha is the latest commit on the branch
+        # the PR will be merged into, NOT the commit this PR derives from! For
+        # that, we need to find the latest common ancestor between the PR and
+        # the branch we are merging into.
+        BASE_COMMIT=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
         echo "Running clang-format-8 against branch ${{ github.event.pull_request.base.ref }} , with hash ${{ github.event.pull_request.base.sha }}"
         COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -ivE 'LinkDef|Utilities/PCG/')
         RESULT_OUTPUT="$(git-clang-format-8 --commit $BASE_COMMIT --diff --binary `which clang-format-8` $COMMIT_FILES)"


### PR DESCRIPTION
This picks the correct commit to compare against.

Also includes a fix for line length detection.

This should fix the issues seen in #4471.