### PR TITLE
[EMCAL-515] Use signed type for time calib values

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
@@ -62,13 +62,13 @@ class TimeCalibrationParams
   /// \param cellID Absolute ID of cell
   /// \param time is the calibration coefficient
   /// \param isLowGain is flag whether this cell is LG or HG
-  void addTimeCalibParam(unsigned short cellID, unsigned short time, bool isLowGain);
+  void addTimeCalibParam(unsigned short cellID, short time, bool isLowGain);
 
   /// \brief Get the time calibration coefficient for a certain cell
   /// \param cellID Absolute ID of cell
   /// \param isLowGain is flag whether this cell is LG or HG
   /// \return time calibration coefficient of the cell
-  unsigned short getTimeCalibParam(unsigned short cellID, bool isLowGain) const;
+  short getTimeCalibParam(unsigned short cellID, bool isLowGain) const;
 
   /// \brief Convert the time calibration coefficient array to a histogram
   /// \param isLowGain is flag whether to draw for LG or HG
@@ -76,8 +76,8 @@ class TimeCalibrationParams
   TH1* getHistogramRepresentation(bool isLowGain) const;
 
  private:
-  std::array<unsigned short, 17664> mTimeCalibParamsHG; ///< Container for the time calibration coefficient for the High Gain cells
-  std::array<unsigned short, 17664> mTimeCalibParamsLG; ///< Container for the time calibration coefficient for the Low Gain cells
+  std::array<short, 17664> mTimeCalibParamsHG; ///< Container for the time calibration coefficient for the High Gain cells
+  std::array<short, 17664> mTimeCalibParamsLG; ///< Container for the time calibration coefficient for the Low Gain cells
 
   ClassDefNV(TimeCalibrationParams, 1);
 };

--- a/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
+++ b/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
@@ -18,7 +18,7 @@
 
 using namespace o2::emcal;
 
-void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, unsigned short time, bool isLowGain)
+void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, short time, bool isLowGain)
 {
   if (!isLowGain)
     mTimeCalibParamsHG[cellID] = time;
@@ -26,7 +26,7 @@ void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, unsigned sh
     mTimeCalibParamsLG[cellID] = time;
 }
 
-unsigned short TimeCalibrationParams::getTimeCalibParam(unsigned short cellID, bool isLowGain) const
+short TimeCalibrationParams::getTimeCalibParam(unsigned short cellID, bool isLowGain) const
 {
   if (isLowGain)
     return mTimeCalibParamsLG[cellID];


### PR DESCRIPTION
In run3 we will shift the time already during
reconstruction by 600 ns in order to center it around 0,
therefore the time calib will need to be done with respect
to the shifted time, meaing the time calib params can
become negative. Therefore a signed type is mandatory.