### PR TITLE
code-formatting workflow: fetch all history

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -11,6 +11,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
+        # We need the history of the dev branch all the way back to where the PR
+        # diverged. We're fetching everything here, as we don't know how many
+        # commits back that point is.
+        fetch-depth: 0
     - name: Run clang format
       id: clang_format
       env:


### PR DESCRIPTION
We don't know how far back the last common ancestor commit between dev and the
PR is, so fetch everything.