### PR TITLE
TPC Workflow: Fix TPC Completion Policy

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -14,6 +14,7 @@
 /// @brief  Processor spec for running TPC CA tracking
 
 #include "Framework/DataProcessorSpec.h"
+#include "RecoWorkflow.h"
 #include <utility> // std::forward
 
 namespace o2
@@ -132,7 +133,7 @@ struct Config {
 ///
 /// @param specconfig configuration options for the processor spec
 /// @param tpcsectors list of sector numbers
-framework::DataProcessorSpec getCATrackerSpec(ca::Config const& specconfig, std::vector<int> const& tpcsectors);
+framework::DataProcessorSpec getCATrackerSpec(o2::tpc::reco_workflow::CompletionPolicyData* policyData, ca::Config const& specconfig, std::vector<int> const& tpcsectors);
 
 o2::framework::CompletionPolicy getCATrackerCompletionPolicy();
 } // end namespace tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -17,11 +17,16 @@
 
 #include "Framework/WorkflowSpec.h"
 #include <vector>
+#include <array>
 #include <string>
 #include <numeric> // std::iota
 
 namespace o2
 {
+namespace framework
+{
+struct InputSpec;
+}
 namespace tpc
 {
 
@@ -56,8 +61,11 @@ enum struct OutputType { Digits,
                          ZSRaw,
 };
 
+using CompletionPolicyData = std::vector<framework::InputSpec>;
+
 /// create the workflow for TPC reconstruction
-framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,           //
+framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
+                                    std::vector<int> const& tpcSectors,           //
                                     std::vector<int> const& laneConfiguration,    //
                                     bool propagateMC = true, unsigned nLanes = 1, //
                                     std::string const& cfgInput = "digitizer",    //
@@ -67,7 +75,8 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,         
                                     int zs10bit = 0,
                                     float zsThreshold = 2.0f);
 
-static inline framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,           //
+static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
+                                                  std::vector<int> const& tpcSectors,           //
                                                   bool propagateMC = true, unsigned nLanes = 1, //
                                                   std::string const& cfgInput = "digitizer",    //
                                                   std::string const& cfgOutput = "tracks",      //
@@ -79,10 +88,11 @@ static inline framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSec
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
+  return getWorkflow(policyData, tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
 }
 
-static inline framework::WorkflowSpec getWorkflow(bool propagateMC = true, unsigned nLanes = 1, //
+static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
+                                                  bool propagateMC = true, unsigned nLanes = 1, //
                                                   std::string const& cfgInput = "digitizer",    //
                                                   std::string const& cfgOutput = "tracks",      //
                                                   int caClusterer = 0,                          //
@@ -93,7 +103,7 @@ static inline framework::WorkflowSpec getWorkflow(bool propagateMC = true, unsig
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow({}, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
+  return getWorkflow(policyData, {}, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold);
 }
 
 } // end namespace reco_workflow

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -86,7 +86,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"zsraw", OutputType::ZSRaw},
 };
 
-framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vector<int> const& laneConfiguration,
+framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, std::vector<int> const& laneConfiguration,
                                     bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput,
                                     int caClusterer, int zsOnTheFly, int zs10bit, float zsThreshold)
 {
@@ -430,18 +430,18 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   //
   // selected by output type 'tracks'
   if (runTracker) {
-    specs.emplace_back(o2::tpc::getCATrackerSpec(ca::Config{
-                                                   propagateMC ? ca::Operation::ProcessMC : ca::Operation::Noop,
-                                                   decompressTPC ? ca::Operation::DecompressTPC : ca::Operation::Noop,
-                                                   decompressTPC && inputType == InputType::CompClusters ? ca::Operation::DecompressTPCFromROOT : ca::Operation::Noop,
-                                                   caClusterer ? ca::Operation::CAClusterer : ca::Operation::Noop,
-                                                   zsDecoder ? ca::Operation::ZSDecoder : ca::Operation::Noop,
-                                                   zsOnTheFly ? ca::Operation::ZSOnTheFly : ca::Operation::Noop,
-                                                   produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
-                                                   produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
-                                                   runClusterEncoder ? ca::Operation::OutputCompClustersFlat : ca::Operation::Noop,
-                                                   isEnabled(OutputType::Clusters) && (caClusterer || decompressTPC) ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
-                                                 },
+    specs.emplace_back(o2::tpc::getCATrackerSpec(policyData, ca::Config{
+                                                               propagateMC ? ca::Operation::ProcessMC : ca::Operation::Noop,
+                                                               decompressTPC ? ca::Operation::DecompressTPC : ca::Operation::Noop,
+                                                               decompressTPC && inputType == InputType::CompClusters ? ca::Operation::DecompressTPCFromROOT : ca::Operation::Noop,
+                                                               caClusterer ? ca::Operation::CAClusterer : ca::Operation::Noop,
+                                                               zsDecoder ? ca::Operation::ZSDecoder : ca::Operation::Noop,
+                                                               zsOnTheFly ? ca::Operation::ZSOnTheFly : ca::Operation::Noop,
+                                                               produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
+                                                               produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
+                                                               runClusterEncoder ? ca::Operation::OutputCompClustersFlat : ca::Operation::Noop,
+                                                               isEnabled(OutputType::Clusters) && (caClusterer || decompressTPC) ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
+                                                             },
                                                  tpcSectors));
   }
 

--- a/Detectors/TPC/workflow/src/tpc-raw-to-digits-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-raw-to-digits-workflow.cxx
@@ -126,7 +126,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     recoOuput = tpcRecoOutputType.c_str();
   }
 
-  auto tpcRecoWorkflow = o2::tpc::reco_workflow::getWorkflow(tpcSectors, tpcSectors, false, lanes, "digitizer", recoOuput.data());
+  auto tpcRecoWorkflow = o2::tpc::reco_workflow::getWorkflow(nullptr, tpcSectors, tpcSectors, false, lanes, "digitizer", recoOuput.data());
   specs.insert(specs.end(), tpcRecoWorkflow.begin(), tpcRecoWorkflow.end());
 
   return specs;


### PR DESCRIPTION
This is an attempt to fix the TPC completion policy. There was actually a comment left by @matthiasrichter mentioning that it will not work if the TPC has both per-sector inputs that go through the policy and single-inputs that are not covered in the policy due to some general limitations of the policy.
Unfortunately, this was exactly what was happening when using zero-suppression together with MC labels.
This PR passes an additional object to the policy that can be adjusted later after command line parsing to add all required inputs to the policy.
It is not the nicest solution, but at least for the current TPC workflow it should cover all cases.
Since I was not really familiar with the completion policies, I am not fully sure if I don't break something with this. @wiechula @shahor02 would be cool if you could double-check :)