### PR TITLE
Don't enforce line length restrictions since this should be handled by common sense

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -41,7 +41,7 @@ jobs:
 
         for x in $COMMIT_FILES; do
           case $x in
-            *.h|*.cxx)
+            #*.h|*.cxx)
               # We remove the header from the diff as it contains +++ then
               # we only select the added lines to check for the long ones.
               # We do not need to check for the lines which have been removed
@@ -49,7 +49,7 @@ jobs:
               # to avoid extra work.
               # 120 characters are allowed, meaning the error should start with 122,
               # to allow for the starting + at the end of the line.
-              git diff $BASE_COMMIT $x | tail -n +6 | grep -e '^+' | grep '.\{122,\}' && { echo "Line longer than 120 chars in $x." && exit 1; } || true ;;
+              #git diff $BASE_COMMIT $x | tail -n +6 | grep -e '^+' | grep '.\{122,\}' && { echo "Line longer than 120 chars in $x." && exit 1; } || true ;;
             *.hxx|*.cc|*.hpp) echo "$x uses non-allowed extension." && exit 1 ;;
             *) ;;
           esac


### PR DESCRIPTION
Was disabled in the clang-format file but was reenabled when we switched from travis to the github workflow.
@ktf 