### PR TITLE
Some improvements to TPC standalone visualization

### DIFF
--- a/GPU/GPUTracking/Base/GPUSettingsList.h
+++ b/GPU/GPUTracking/Base/GPUSettingsList.h
@@ -120,6 +120,7 @@ AddOption(registerStandaloneInputMemory, bool, false, "registerInputMemory", 0, 
 AddOption(memoryScalingFactor, float, 1.f, "", 0, "Factor to apply to all memory scalers")
 AddOption(alternateBorderSort, int, -1, "", 0, "Alternative implementation for sorting of border tracks")
 AddOption(enableRTC, bool, false, "", 0, "Use RTC to optimize GPU code")
+AddOption(showOutputStat, bool, false, "", 0, "Print some track output statistics")
 AddVariable(eventDisplay, GPUCA_NAMESPACE::gpu::GPUDisplayBackend*, nullptr)
 AddHelp("help", 'h')
 EndConfig()

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -2276,16 +2276,15 @@ int GPUChainTracking::RunTRDTracking()
 
   for (unsigned int i = 0; i < mIOPtrs.nMergedTracks; i++) {
     const GPUTPCGMMergedTrack& trk = mIOPtrs.mergedTracks[i];
-    if (!trk.OK()) {
+    if (!Tracker.PreCheckTrackTRDCandidate(trk)) {
       continue;
     }
-    if (trk.Looper()) {
-      continue;
-    }
-
     const GPUTRDTrackGPU& trktrd = param().rec.NWaysOuter ? (GPUTRDTrackGPU)trk.OuterParam() : (GPUTRDTrackGPU)trk;
+    if (!Tracker.CheckTrackTRDCandidate(trktrd)) {
+      continue;
+    }
 
-    if (Tracker.LoadTrack(trktrd, -1, nullptr, -1, i)) {
+    if (Tracker.LoadTrack(trktrd, -1, nullptr, -1, i, false)) {
       return 1;
     }
   }

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -2445,6 +2445,14 @@ int GPUChainTracking::RunChainFinalize()
     mRec->getGeneralStepTimer(GeneralStep::QA).Stop();
   }
 
+  if (GetProcessingSettings().showOutputStat) {
+    PrintOutputStat();
+  }
+
+  PrintDebugOutput();
+
+  //PrintMemoryRelations();
+
   if (GetProcessingSettings().eventDisplay) {
     if (!mDisplayRunning) {
       if (mEventDisplay->StartDisplay()) {
@@ -2491,9 +2499,6 @@ int GPUChainTracking::RunChainFinalize()
     mEventDisplay->WaitForNextEvent();
   }
 
-  PrintDebugOutput();
-
-  //PrintMemoryRelations();
   return 0;
 }
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -211,6 +211,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void PrintMemoryStatistics() override;
   void PrepareDebugOutput();
   void PrintDebugOutput();
+  void PrintOutputStat();
 
   bool ValidateSteps();
   bool ValidateSettings();

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -884,7 +884,10 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
       bool drawing = false;
 
       if (mTrackFilter) {
-        if (mTrackFilter && mTRDTrackIds[i] == -1) {
+        if (mTrackFilter == 2 && !trdTracker().CheckTrackTRDCandidate((GPUTRDTrackGPU)*track)) {
+          break;
+        }
+        if (mTrackFilter == 1 && mTRDTrackIds[i] == -1) {
           break;
         }
       }

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -884,7 +884,7 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
       bool drawing = false;
 
       if (mTrackFilter) {
-        if (mTrackFilter == 2 && !trdTracker().CheckTrackTRDCandidate((GPUTRDTrackGPU)*track)) {
+        if (mTrackFilter == 2 && (!trdTracker().PreCheckTrackTRDCandidate(*track) || !trdTracker().CheckTrackTRDCandidate((GPUTRDTrackGPU)*track))) {
           break;
         }
         if (mTrackFilter == 1 && mTRDTrackIds[i] == -1) {

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -882,7 +882,14 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
 
       size_t startCountInner = mVertexBuffer[iSlice].size();
       bool drawing = false;
-      if (mTRDTrackIds[i]) {
+      
+      if (mTrackFilter) {
+        if (mTrackFilter && mTRDTrackIds[i] == -1) {
+          break;
+        }
+      }
+      
+      if (mTRDTrackIds[i] != -1) {
         auto& trk = trdTracker().Tracks()[mTRDTrackIds[i]];
         for (int k = 5; k >= 0; k--) {
           int cid = trk.GetTrackletIndex(k);
@@ -1155,7 +1162,9 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
     if ((size_t)mMerger.GetConstantMem()->ioPtrs.nMergedTracks > mTRDTrackIds.size()) {
       mTRDTrackIds.resize(mMerger.GetConstantMem()->ioPtrs.nMergedTracks);
     }
-    memset(mTRDTrackIds.data(), 0, sizeof(mTRDTrackIds[0]) * mMerger.GetConstantMem()->ioPtrs.nMergedTracks);
+    for (unsigned int i = 0;i < mMerger.GetConstantMem()->ioPtrs.nMergedTracks;i++) {
+      mTRDTrackIds[i] = -1;
+    }
     for (int i = 0; i < trdTracker().NTracks(); i++) {
       if (trdTracker().Tracks()[i].GetNtracklets()) {
         mTRDTrackIds[trdTracker().Tracks()[i].GetTPCtrackId()] = i;

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -882,13 +882,13 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
 
       size_t startCountInner = mVertexBuffer[iSlice].size();
       bool drawing = false;
-      
+
       if (mTrackFilter) {
         if (mTrackFilter && mTRDTrackIds[i] == -1) {
           break;
         }
       }
-      
+
       if (mTRDTrackIds[i] != -1) {
         auto& trk = trdTracker().Tracks()[mTRDTrackIds[i]];
         for (int k = 5; k >= 0; k--) {
@@ -1162,7 +1162,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
     if ((size_t)mMerger.GetConstantMem()->ioPtrs.nMergedTracks > mTRDTrackIds.size()) {
       mTRDTrackIds.resize(mMerger.GetConstantMem()->ioPtrs.nMergedTracks);
     }
-    for (unsigned int i = 0;i < mMerger.GetConstantMem()->ioPtrs.nMergedTracks;i++) {
+    for (unsigned int i = 0; i < mMerger.GetConstantMem()->ioPtrs.nMergedTracks; i++) {
       mTRDTrackIds[i] = -1;
     }
     for (int i = 0; i < trdTracker().NTracks(); i++) {

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.h
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.h
@@ -238,6 +238,7 @@ class GPUDisplay
   void SetInfo(Args... args)
   {
     snprintf(mInfoText2, 1024, args...);
+    GPUInfo("%s", mInfoText2);
     mInfoText2Timer.ResetStart();
   }
   void PrintGLHelpText(float colorValue);
@@ -354,6 +355,7 @@ class GPUDisplay
   int mHideRejectedTracks = 1;
   int mMarkAdjacentClusters = 0;
   int mMarkFakeClusters = 0;
+  int mTrackFilter = 0;
 
   vecpod<std::array<int, 37>> mCollisionClusters;
   int mNCollissions = 1;

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
@@ -357,9 +357,9 @@ void GPUDisplay::HandleKeyRelease(unsigned char key)
       SetInfo("Animation mode %d - Position: %s, Direction: %s", mCfg.animationMode, (mCfg.animationMode & 2) ? "Spherical (spherical rotation)" : (mCfg.animationMode & 4) ? "Spherical (Euler angles)" : "Cartesian", (mCfg.animationMode & 1) ? "Euler angles" : "Quaternion");
     }
   } else if (key == 'u') {
-    mTrackFilter = (mTrackFilter + 1) % 2;
+    mTrackFilter = (mTrackFilter + 1) % 3;
     mUpdateDLList = true;
-    SetInfo("Track filter: %s", mTrackFilter ? "TRD Tracks only" : "None");
+    SetInfo("Track filter: %s", mTrackFilter == 2 ? "TRD Track candidates" : mTrackFilter ? "TRD Tracks only" : "None");
   } else if (key == 'o') {
     FILE* ftmp = fopen("glpos.tmp", "w+b");
     if (ftmp) {

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
@@ -35,8 +35,9 @@ const char* HelpText[] = {
   "[L] / [K]                     Draw single collisions (next / previous)",
   "[C]                           Colorcode clusters of different collisions",
   "[v]                           Hide rejected clusters from tracks",
-  "[b]                           Hide all clusters not belonging or related to matched tracks",
+  "[b]                           Hide all clusters not belonging or related to matched tracks in QA",
   "[j]                           Show global tracks as additional segments of final tracks",
+  "[u]                           Cycle through track filter",
   "[E] / [G]                     Extrapolate tracks / loopers",
   "[t] / [T]                     Take Screenshot / Record Animation to pictures",
   "[Z]                           Change screenshot resolution (scaling factor)",
@@ -355,6 +356,10 @@ void GPUDisplay::HandleKeyRelease(unsigned char key)
     } else {
       SetInfo("Animation mode %d - Position: %s, Direction: %s", mCfg.animationMode, (mCfg.animationMode & 2) ? "Spherical (spherical rotation)" : (mCfg.animationMode & 4) ? "Spherical (Euler angles)" : "Cartesian", (mCfg.animationMode & 1) ? "Euler angles" : "Quaternion");
     }
+  } else if (key == 'u') {
+    mTrackFilter = (mTrackFilter + 1) % 2;
+    mUpdateDLList = true;
+    SetInfo("Track filter: %s", mTrackFilter ? "TRD Tracks only" : "None");
   } else if (key == 'o') {
     FILE* ftmp = fopen("glpos.tmp", "w+b");
     if (ftmp) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -427,6 +427,21 @@ GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackRefs(const int trackID, boo
 #endif //! GPUCA_GPUCODE
 
 template <class TRDTRK, class PROP>
+GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackTRDCandidate(const TRDTRK& trk) const
+{
+  if (!trk.CheckNumericalQuality()) {
+    return false;
+  }
+  if (CAMath::Abs(trk.getEta()) > mMaxEta) {
+    return false;
+  }
+  if (trk.getPt() < mMinPt) {
+    return false;
+  }
+  return true;
+}
+
+template <class TRDTRK, class PROP>
 GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels)
 {
   //--------------------------------------------------------------------

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -442,7 +442,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackTRDCandidate(const TRDTRK& 
 }
 
 template <class TRDTRK, class PROP>
-GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTrack(const TRDTRK& trk, const int label, const int* nTrkltsOffline, const int labelOffline, int tpcTrackId)
+GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTrack(const TRDTRK& trk, const int label, const int* nTrkltsOffline, const int labelOffline, int tpcTrackId, bool checkTrack)
 {
   if (mNTracks >= mNMaxTracks) {
 #ifndef GPUCA_GPUCODE
@@ -450,7 +450,7 @@ GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTrack(const TRDTRK& trk, const int
 #endif
     return (1);
   }
-  if (!CheckTrackTRDCandidate(trk)) {
+  if (checkTrack && !CheckTrackTRDCandidate(trk)) {
     return 0;
   }
 #ifdef GPUCA_ALIROOT_LIB

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -442,6 +442,37 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackTRDCandidate(const TRDTRK& 
 }
 
 template <class TRDTRK, class PROP>
+GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTrack(const TRDTRK& trk, const int label, const int* nTrkltsOffline, const int labelOffline, int tpcTrackId)
+{
+  if (mNTracks >= mNMaxTracks) {
+#ifndef GPUCA_GPUCODE
+    GPUError("Error: Track dropped (no memory available) -> must not happen");
+#endif
+    return (1);
+  }
+  if (!CheckTrackTRDCandidate(trk)) {
+    return 0;
+  }
+#ifdef GPUCA_ALIROOT_LIB
+  new (&mTracks[mNTracks]) TRDTRK(trk); // We need placement new, since the class is virtual
+#else
+  mTracks[mNTracks] = trk;
+#endif
+  mTracks[mNTracks].SetTPCtrackId(tpcTrackId >= 0 ? tpcTrackId : mNTracks);
+  if (label >= 0) {
+    mTracks[mNTracks].SetLabel(label);
+  }
+  if (nTrkltsOffline) {
+    for (int i = 0; i < 4; ++i) {
+      mTracks[mNTracks].SetNtrackletsOffline(i, nTrkltsOffline[i]); // see GPUTRDTrack.h for information on the index
+    }
+  }
+  mTracks[mNTracks].SetLabelOffline(labelOffline);
+  mNTracks++;
+  return (0);
+}
+
+template <class TRDTRK, class PROP>
 GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels)
 {
   //--------------------------------------------------------------------

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -109,35 +109,8 @@ class GPUTRDTracker_t : public GPUProcessor
   void Reset();
   GPUd() int LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels = nullptr);
   GPUd() bool CheckTrackTRDCandidate(const TRDTRK& trk) const;
-  GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1)
-  {
-    if (mNTracks >= mNMaxTracks) {
-#ifndef GPUCA_GPUCODE
-      GPUError("Error: Track dropped (no memory available) -> must not happen");
-#endif
-      return (1);
-    }
-    if (!CheckTrackTRDCandidate(trk)) {
-      return 0;
-    }
-#ifdef GPUCA_ALIROOT_LIB
-    new (&mTracks[mNTracks]) TRDTRK(trk); // We need placement new, since the class is virtual
-#else
-    mTracks[mNTracks] = trk;
-#endif
-    mTracks[mNTracks].SetTPCtrackId(tpcTrackId >= 0 ? tpcTrackId : mNTracks);
-    if (label >= 0) {
-      mTracks[mNTracks].SetLabel(label);
-    }
-    if (nTrkltsOffline) {
-      for (int i = 0; i < 4; ++i) {
-        mTracks[mNTracks].SetNtrackletsOffline(i, nTrkltsOffline[i]); // see GPUTRDTrack.h for information on the index
-      }
-    }
-    mTracks[mNTracks].SetLabelOffline(labelOffline);
-    mNTracks++;
-    return (0);
-  }
+  GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1);
+
   GPUd() int GetCollisionID(float trkTime) const;
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);
   GPUd() bool CalculateSpacePoints(int iCollision = 0);

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -108,7 +108,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUhd() void OverrideGPUGeometry(TRD_GEOMETRY_CONST GPUTRDGeometry* geo) { mGeo = geo; }
   void Reset();
   GPUd() int LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels = nullptr);
-  //template <class T>
+  GPUd() bool CheckTrackTRDCandidate(const TRDTRK& trk) const;
   GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1)
   {
     if (mNTracks >= mNMaxTracks) {
@@ -117,14 +117,8 @@ class GPUTRDTracker_t : public GPUProcessor
 #endif
       return (1);
     }
-    if (!trk.CheckNumericalQuality()) {
-      return (0);
-    }
-    if (CAMath::Abs(trk.getEta()) > mMaxEta) {
-      return (0);
-    }
-    if (trk.getPt() < mMinPt) {
-      return (0);
+    if (!CheckTrackTRDCandidate(trk)) {
+      return 0;
     }
 #ifdef GPUCA_ALIROOT_LIB
     new (&mTracks[mNTracks]) TRDTRK(trk); // We need placement new, since the class is virtual

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -108,8 +108,14 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUhd() void OverrideGPUGeometry(TRD_GEOMETRY_CONST GPUTRDGeometry* geo) { mGeo = geo; }
   void Reset();
   GPUd() int LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels = nullptr);
+  template <class T>
+  GPUd() bool PreCheckTrackTRDCandidate(const T& trk) const
+  {
+    return true;
+  }
+  GPUd() bool PreCheckTrackTRDCandidate(const GPUTPCGMMergedTrack& trk) const { return trk.OK() && !trk.Looper(); }
   GPUd() bool CheckTrackTRDCandidate(const TRDTRK& trk) const;
-  GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1);
+  GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1, bool checkTrack = true);
 
   GPUd() int GetCollisionID(float trkTime) const;
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);


### PR DESCRIPTION
@martenole : This implements what you have requested:
- All text output is written before the display is started.
- I added a track filter to the visualization (cycle through with 'u').

However, the filter is applied during the visualization, so it can only query properties available at that time.
For now there is a filter for TRD tracks. I am having a quick check whether I can do that also for TRD candidates, which is a property that is not stored. Or you can just stick to the hack we discussed yesterday.