### PR TITLE
TPC Workflow: Add option to split clusters per sector when writing to ROOT file

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -42,6 +42,7 @@ enum struct Operation {
   OutputCompClusters,     // publish CompClusters container
   OutputCompClustersFlat, // publish CompClusters container
   ProcessMC,              // process MC labels
+  SendClustersPerSector,  // Send clusters and clusters mc labels per sector
   Noop,                   // skip argument on the constructor
 };
 
@@ -90,6 +91,9 @@ struct Config {
       case Operation::ProcessMC:
         processMC = true;
         break;
+      case Operation::SendClustersPerSector:
+        sendClustersPerSector = true;
+        break;
       case Operation::Noop:
         break;
       default:
@@ -113,6 +117,7 @@ struct Config {
   bool outputCompClustersFlat = false;
   bool outputCAClusters = false;
   bool processMC = false;
+  bool sendClustersPerSector = false;
 };
 
 } // namespace ca

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -58,6 +58,7 @@ enum struct OutputType { Digits,
                          CompClusters,
                          EncodedClusters,
                          DisableWriter,
+                         SendClustersPerSector,
                          ZSRaw,
 };
 

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -83,6 +83,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"compressed-clusters", OutputType::CompClusters},
   {"encoded-clusters", OutputType::EncodedClusters},
   {"disable-writer", OutputType::DisableWriter},
+  {"send-clusters-per-sector", OutputType::SendClustersPerSector},
   {"zsraw", OutputType::ZSRaw},
 };
 
@@ -413,7 +414,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
                                    BranchDefinition<std::vector<char>>{InputSpec{"mc", ConcreteDataTypeMatcher{"TPC", "CLNATIVEMCLBL"}},
                                                                        "TPCClusterNativeMCTruth",
                                                                        "mcbranch", fillLabels},
-                                   caClusterer || decompressTPC));
+                                   (caClusterer || decompressTPC) && !isEnabled(OutputType::SendClustersPerSector)));
   }
 
   if (zsOnTheFly) {
@@ -440,6 +441,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
                                                                produceTracks ? ca::Operation::OutputTracks : ca::Operation::Noop,
                                                                produceCompClusters ? ca::Operation::OutputCompClusters : ca::Operation::Noop,
                                                                runClusterEncoder ? ca::Operation::OutputCompClustersFlat : ca::Operation::Noop,
+                                                               isEnabled(OutputType::SendClustersPerSector) ? ca::Operation::SendClustersPerSector : ca::Operation::Noop,
                                                                isEnabled(OutputType::Clusters) && (caClusterer || decompressTPC) ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
                                                              },
                                                  tpcSectors));

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -46,7 +46,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   std::vector<ConfigParamSpec> options{
     {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters, compressed-clusters-ctf"}},
-    {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer"}},
+    {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer, send-clusters-per-sector"}},
     {"no-ca-clusterer", VariantType::Bool, false, {"Use HardwareClusterer instead of clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     //{"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},


### PR DESCRIPTION
There is a new "tpc workflow output type" called `send-clusters-per-sector` which will split the cluster native by sector, to be used together with the `clusters` output type.

Implementation is quite stupid and involves yet another copy but probably doesn't matter much performance-wise since we anyway have ROOT IO. However it blows up the memory size to some extent.

Tried this in the TPC workflow with MC labels and with running the workflow afterwards with `clusters` as input. Should be transparent to the usage since the TPC cluster reading already supports the split reading in all places.