### PR TITLE
Update to TPC spectra task and added PID QA plots to PID tasks

### DIFF
--- a/Analysis/Tasks/CMakeLists.txt
+++ b/Analysis/Tasks/CMakeLists.txt
@@ -31,12 +31,12 @@ o2_add_dpl_workflow(qatask
 
 o2_add_dpl_workflow(pid-tof
                     SOURCES pidTOF.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(pid-tpc
                     SOURCES pidTPC.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(validation

--- a/Analysis/Tasks/pidTOF.cxx
+++ b/Analysis/Tasks/pidTOF.cxx
@@ -9,19 +9,36 @@
 // or submit itself to any jurisdiction.
 
 // O2 includes
-#include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "PID/PIDResponse.h"
-#include "Framework/ASoAHelpers.h"
 #include <CCDB/BasicCCDBManager.h>
+#include "Analysis/HistHelpers.h"
+
+// #define USE_REGISTRY
+#ifdef USE_REGISTRY
+#include "Framework/HistogramRegistry.h"
+#endif
+
+// ROOT includes
+#include <TH1F.h>
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"add-qa", VariantType::Int, 0, {"Produce TOF PID QA histograms"}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
 
 struct pidTOFTask {
   Produces<aod::pidRespTOF> tofpid;
@@ -102,7 +119,218 @@ struct pidTOFTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+struct pidTOFTaskQA {
+  enum event_histo : uint8_t { vertexz,
+                               signal,
+                               tofbeta };
+  enum Particle : uint8_t { El,
+                            Mu,
+                            Pi,
+                            Ka,
+                            Pr,
+                            De,
+                            Tr,
+                            He,
+                            Al };
+
+#ifdef USE_REGISTRY
+  // Event
+  HistogramRegistry event{
+    "event",
+    true,
+    {
+      {"hvertexz", ";Vtx_{z} (cm);Entries", {HistogramType::kTH1F, {{100, -20, 20}}}},
+      {"htofsignal", ";#it{p} (GeV/#it{c});TOF Signal", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}} //
+      {"htofbeta", ";#it{p} (GeV/#it{c});TOF #beta", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 2}}}}        //
+    }                                                                                                           //
+  };
+  // Exp signal
+  HistogramRegistry expected{
+    "expected",
+    true,
+    {
+      {"hexpectedEl", ";#it{p} (GeV/#it{c});t_{exp e}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedMu", ";#it{p} (GeV/#it{c});t_{exp #mu}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedPi", ";#it{p} (GeV/#it{c});t_{exp #pi}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedKa", ";#it{p} (GeV/#it{c});t_{exp K}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedPr", ";#it{p} (GeV/#it{c});t_{exp p}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedDe", ";#it{p} (GeV/#it{c});t_{exp d}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedTr", ";#it{p} (GeV/#it{c});t_{exp t}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedHe", ";#it{p} (GeV/#it{c});t_{exp ^{3}He}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}},
+      {"hexpectedAl", ";#it{p} (GeV/#it{c});t_{exp #alpha}", {HistogramType::kTH2F, {{100, 0, 5}, {100, 0, 10000}}}} //
+    }                                                                                                                //
+  };
+  // T-Texp
+  HistogramRegistry timediff{
+    "timediff",
+    true,
+    {
+      {"htimediffEl", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp e})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffMu", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #mu})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffPi", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #pi})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffKa", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp K})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffPr", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp p})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffDe", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp d})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffTr", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp t})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffHe", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp ^{3}He})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}},
+      {"htimediffAl", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #alpha})", {HistogramType::kTH2F, {{100, 0, 5}, {100, -1000, 1000}}}} //
+    }                                                                                                                               //
+  };
+
+  // NSigma
+  HistogramRegistry nsigma{
+    "nsigma",
+    true,
+    {
+      {"hnsigmaEl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(e)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaMu", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#mu)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaPi", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#pi)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaKa", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(K)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaPr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(p)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaDe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(d)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaTr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(t)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaHe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(^{3}He)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}},
+      {"hnsigmaAl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#alpha)", {HistogramType::kTH2F, {{1000, 0.001, 20}, {200, -10, 10}}}} //
+    }                                                                                                                             //
+  };
+#else
+  // Event
+  OutputObj<experimental::histhelpers::HistFolder> event{experimental::histhelpers::HistFolder("event"), OutputObjHandlingPolicy::QAObject};
+  // Exp signal
+  OutputObj<experimental::histhelpers::HistFolder> expected{experimental::histhelpers::HistFolder("expected"), OutputObjHandlingPolicy::QAObject};
+  // T-Texp
+  OutputObj<experimental::histhelpers::HistFolder> timediff{experimental::histhelpers::HistFolder("timediff"), OutputObjHandlingPolicy::QAObject};
+  // NSigma
+  OutputObj<experimental::histhelpers::HistFolder> nsigma{experimental::histhelpers::HistFolder("nsigma"), OutputObjHandlingPolicy::QAObject};
+#endif
+
+  void init(o2::framework::InitContext&)
+  {
+#ifndef USE_REGISTRY
+    event->Add<vertexz>(new TH1F("hvertexz", ";Vtx_{z} (cm);Entries", 100, -20, 20));
+    event->Add<signal>(new TH2F("htofsignal", ";#it{p} (GeV/#it{c});TOF Signal", 100, 0, 5, 100, 0, 10000));
+    event->Add<tofbeta>(new TH2F("htofbeta", ";#it{p} (GeV/#it{c});TOF #beta", 100, 0, 5, 100, 0, 2));
+    //
+    expected->Add<El>(new TH2F("hexpectedEl", ";#it{p} (GeV/#it{c});t_{exp e}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Mu>(new TH2F("hexpectedMu", ";#it{p} (GeV/#it{c});t_{exp #mu}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Pi>(new TH2F("hexpectedPi", ";#it{p} (GeV/#it{c});t_{exp #pi}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Ka>(new TH2F("hexpectedKa", ";#it{p} (GeV/#it{c});t_{exp K}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Pr>(new TH2F("hexpectedPr", ";#it{p} (GeV/#it{c});t_{exp p}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<De>(new TH2F("hexpectedDe", ";#it{p} (GeV/#it{c});t_{exp d}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Tr>(new TH2F("hexpectedTr", ";#it{p} (GeV/#it{c});t_{exp t}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<He>(new TH2F("hexpectedHe", ";#it{p} (GeV/#it{c});t_{exp ^{3}He}", 100, 0, 5, 100, 0, 10000));
+    expected->Add<Al>(new TH2F("hexpectedAl", ";#it{p} (GeV/#it{c});t_{exp #alpha}", 100, 0, 5, 100, 0, 10000));
+    //
+    timediff->Add<El>(new TH2F("htimediffEl", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp e})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Mu>(new TH2F("htimediffMu", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #mu})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Pi>(new TH2F("htimediffPi", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #pi})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Ka>(new TH2F("htimediffKa", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp K})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Pr>(new TH2F("htimediffPr", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp p})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<De>(new TH2F("htimediffDe", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp d})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Tr>(new TH2F("htimediffTr", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp t})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<He>(new TH2F("htimediffHe", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp ^{3}He})", 100, 0, 5, 100, -1000, 1000));
+    timediff->Add<Al>(new TH2F("htimediffAl", ";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp #alpha})", 100, 0, 5, 100, -1000, 1000));
+    //
+    nsigma->Add<El>(new TH2F("nsigmaEl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(e)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Mu>(new TH2F("nsigmaMu", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#mu)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Pi>(new TH2F("nsigmaPi", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#pi)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Ka>(new TH2F("nsigmaKa", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(K)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Pr>(new TH2F("nsigmaPr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(p)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<De>(new TH2F("nsigmaDe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(d)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Tr>(new TH2F("nsigmaTr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(t)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<He>(new TH2F("nsigmaHe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(^{3}He)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Al>(new TH2F("nsigmaAl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(#alpha)", 1000, 0.001, 20, 200, -10, 10));
+#endif
+  }
+
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTOF, aod::pidRespTOFbeta> const& tracks)
+  {
+#ifdef USE_REGISTRY
+    event("vertexz")->Fill(collision.posZ());
+#else
+    event->Fill<vertexz>(collision.posZ());
+#endif
+
+    for (auto i : tracks) {
+      //
+      const float tof = i.tofSignal() - collision.collisionTime();
+#ifdef USE_REGISTRY
+      event("htofsignal")->Fill(i.p(), i.tofSignal());
+      event("htofbeta")->Fill(i.p(), i.beta());
+      //
+      expected("hexpectedEl")->Fill(i.p(), i.tofExpSignalEl());
+      expected("hexpectedEl")->Fill(i.p(), i.tofExpSignalEl());
+      expected("hexpectedMu")->Fill(i.p(), i.tofExpSignalMu());
+      expected("hexpectedPi")->Fill(i.p(), i.tofExpSignalPi());
+      expected("hexpectedKa")->Fill(i.p(), i.tofExpSignalKa());
+      expected("hexpectedPr")->Fill(i.p(), i.tofExpSignalPr());
+      expected("hexpectedDe")->Fill(i.p(), i.tofExpSignalDe());
+      expected("hexpectedTr")->Fill(i.p(), i.tofExpSignalTr());
+      expected("hexpectedHe")->Fill(i.p(), i.tofExpSignalHe());
+      expected("hexpectedAl")->Fill(i.p(), i.tofExpSignalAl());
+      //
+      timediff("htimediffEl")->Fill(i.p(), tof - i.tofExpSignalEl());
+      timediff("htimediffMu")->Fill(i.p(), tof - i.tofExpSignalMu());
+      timediff("htimediffPi")->Fill(i.p(), tof - i.tofExpSignalPi());
+      timediff("htimediffKa")->Fill(i.p(), tof - i.tofExpSignalKa());
+      timediff("htimediffPr")->Fill(i.p(), tof - i.tofExpSignalPr());
+      timediff("htimediffDe")->Fill(i.p(), tof - i.tofExpSignalDe());
+      timediff("htimediffTr")->Fill(i.p(), tof - i.tofExpSignalTr());
+      timediff("htimediffHe")->Fill(i.p(), tof - i.tofExpSignalHe());
+      timediff("htimediffAl")->Fill(i.p(), tof - i.tofExpSignalAl());
+      //
+      nsigma("hnsigmaEl")->Fill(i.p(), i.tofNSigmaEl());
+      nsigma("hnsigmaMu")->Fill(i.p(), i.tofNSigmaMu());
+      nsigma("hnsigmaPi")->Fill(i.p(), i.tofNSigmaPi());
+      nsigma("hnsigmaKa")->Fill(i.p(), i.tofNSigmaKa());
+      nsigma("hnsigmaPr")->Fill(i.p(), i.tofNSigmaPr());
+      nsigma("hnsigmaDe")->Fill(i.p(), i.tofNSigmaDe());
+      nsigma("hnsigmaTr")->Fill(i.p(), i.tofNSigmaTr());
+      nsigma("hnsigmaHe")->Fill(i.p(), i.tofNSigmaHe());
+      nsigma("hnsigmaAl")->Fill(i.p(), i.tofNSigmaAl());
+#else
+      event->Fill<signal>(i.p(), i.tofSignal());
+      event->Fill<tofbeta>(i.p(), i.beta());
+      //
+      expected->Fill<El>(i.p(), i.tofExpSignalEl());
+      expected->Fill<Mu>(i.p(), i.tofExpSignalMu());
+      expected->Fill<Pi>(i.p(), i.tofExpSignalPi());
+      expected->Fill<Ka>(i.p(), i.tofExpSignalKa());
+      expected->Fill<Pr>(i.p(), i.tofExpSignalPr());
+      expected->Fill<De>(i.p(), i.tofExpSignalDe());
+      expected->Fill<Tr>(i.p(), i.tofExpSignalTr());
+      expected->Fill<He>(i.p(), i.tofExpSignalHe());
+      expected->Fill<Al>(i.p(), i.tofExpSignalAl());
+      //
+      timediff->Fill<El>(i.p(), tof - i.tofExpSignalEl());
+      timediff->Fill<Mu>(i.p(), tof - i.tofExpSignalMu());
+      timediff->Fill<Pi>(i.p(), tof - i.tofExpSignalPi());
+      timediff->Fill<Ka>(i.p(), tof - i.tofExpSignalKa());
+      timediff->Fill<Pr>(i.p(), tof - i.tofExpSignalPr());
+      timediff->Fill<De>(i.p(), tof - i.tofExpSignalDe());
+      timediff->Fill<Tr>(i.p(), tof - i.tofExpSignalTr());
+      timediff->Fill<He>(i.p(), tof - i.tofExpSignalHe());
+      timediff->Fill<Al>(i.p(), tof - i.tofExpSignalAl());
+      //
+      nsigma->Fill<El>(i.p(), i.tofNSigmaEl());
+      nsigma->Fill<Mu>(i.p(), i.tofNSigmaMu());
+      nsigma->Fill<Pi>(i.p(), i.tofNSigmaPi());
+      nsigma->Fill<Ka>(i.p(), i.tofNSigmaKa());
+      nsigma->Fill<Pr>(i.p(), i.tofNSigmaPr());
+      nsigma->Fill<De>(i.p(), i.tofNSigmaDe());
+      nsigma->Fill<Tr>(i.p(), i.tofNSigmaTr());
+      nsigma->Fill<He>(i.p(), i.tofNSigmaHe());
+      nsigma->Fill<Al>(i.p(), i.tofNSigmaAl());
+#endif
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTOFTask>("pidTOF-task")};
+  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTOFTask>("pidTOF-task")};
+  if (cfgc.options().get<int>("add-qa")) {
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA>("pidTOFQA-task"));
+  }
+  return workflow;
 }

--- a/Analysis/Tasks/pidTPC.cxx
+++ b/Analysis/Tasks/pidTPC.cxx
@@ -9,19 +9,28 @@
 // or submit itself to any jurisdiction.
 
 // O2 includes
-#include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "PID/PIDResponse.h"
-#include "Framework/ASoAHelpers.h"
 #include <CCDB/BasicCCDBManager.h>
+#include "Analysis/HistHelpers.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"add-qa", VariantType::Int, 0, {"Produce TOF PID QA histograms"}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
 
 struct pidTPCTask {
   Produces<aod::pidRespTPC> tpcpid;
@@ -90,7 +99,154 @@ struct pidTPCTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+struct pidTPCTaskQA {
+  enum event_histo : uint8_t { vertexz,
+                               signal };
+  enum Particle : uint8_t { El,
+                            Mu,
+                            Pi,
+                            Ka,
+                            Pr,
+                            De,
+                            Tr,
+                            He,
+                            Al
+  };
+
+  // Event
+  OutputObj<experimental::histhelpers::HistFolder> event{experimental::histhelpers::HistFolder("event"), OutputObjHandlingPolicy::QAObject};
+  // Exp signal
+  OutputObj<experimental::histhelpers::HistFolder> expected{experimental::histhelpers::HistFolder("expected"), OutputObjHandlingPolicy::QAObject};
+  // Exp signal difference
+  OutputObj<experimental::histhelpers::HistFolder> expected_diff{experimental::histhelpers::HistFolder("expected_diff"), OutputObjHandlingPolicy::QAObject};
+  // NSigma
+  OutputObj<experimental::histhelpers::HistFolder> nsigma{experimental::histhelpers::HistFolder("nsigma"), OutputObjHandlingPolicy::QAObject};
+  void init(o2::framework::InitContext&)
+  {
+
+#define makelogaxis(h)                                            \
+  {                                                               \
+    const Int_t nbins = h->GetNbinsX();                           \
+    double binp[nbins + 1];                                       \
+    double max = h->GetXaxis()->GetBinUpEdge(nbins);              \
+    double min = h->GetXaxis()->GetBinLowEdge(1);                 \
+    double lmin = TMath::Log10(min);                              \
+    double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins); \
+    for (int i = 0; i < nbins; i++) {                             \
+      binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta)); \
+    }                                                             \
+    binp[nbins] = max + 1;                                        \
+    h->GetXaxis()->Set(nbins, binp);                              \
+  }
+
+    event->Add<vertexz>(new TH1F("hvertexz", ";Vtx_{z} (cm);Entries", 100, -20, 20));
+    event->Add<signal>(new TH2F("htpcsignal", ";#it{p} (GeV/#it{c});TPC Signal", 1000, 0.001, 20, 1000, 0, 1000));
+    makelogaxis(event->Get<TH2>(signal));
+    //
+    expected->Add<El>(new TH2F("hexpectedEl", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{e}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Mu>(new TH2F("hexpectedMu", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{#mu}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Pi>(new TH2F("hexpectedPi", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{#pi}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Ka>(new TH2F("hexpectedKa", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{K}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Pr>(new TH2F("hexpectedPr", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{p}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<De>(new TH2F("hexpectedDe", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{d}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Tr>(new TH2F("hexpectedTr", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{t}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<He>(new TH2F("hexpectedHe", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{^{3}He}", 1000, 0.001, 20, 1000, 0, 1000));
+    expected->Add<Al>(new TH2F("hexpectedAl", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_{#alpha}", 1000, 0.001, 20, 1000, 0, 1000));
+    makelogaxis(expected->Get<TH2>(El));
+    makelogaxis(expected->Get<TH2>(Mu));
+    makelogaxis(expected->Get<TH2>(Pi));
+    makelogaxis(expected->Get<TH2>(Ka));
+    makelogaxis(expected->Get<TH2>(Pr));
+    makelogaxis(expected->Get<TH2>(De));
+    makelogaxis(expected->Get<TH2>(Tr));
+    makelogaxis(expected->Get<TH2>(He));
+    makelogaxis(expected->Get<TH2>(Al));
+    //
+    expected_diff->Add<El>(new TH2F("hexpdiffEl", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{e}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Mu>(new TH2F("hexpdiffMu", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{#mu}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Pi>(new TH2F("hexpdiffPi", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{#pi}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Ka>(new TH2F("hexpdiffKa", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{K}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Pr>(new TH2F("hexpdiffPr", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{p}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<De>(new TH2F("hexpdiffDe", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{d}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Tr>(new TH2F("hexpdiffTr", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{t}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<He>(new TH2F("hexpdiffHe", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{^{3}He}", 1000, 0.001, 20, 1000, -500, 500));
+    expected_diff->Add<Al>(new TH2F("hexpdiffAl", ";#it{p} (GeV/#it{c});d#it{E}/d#it{x} - d#it{E}/d#it{x}_{#alpha}", 1000, 0.001, 20, 1000, -500, 500));
+    makelogaxis(expected_diff->Get<TH2>(El));
+    makelogaxis(expected_diff->Get<TH2>(Mu));
+    makelogaxis(expected_diff->Get<TH2>(Pi));
+    makelogaxis(expected_diff->Get<TH2>(Ka));
+    makelogaxis(expected_diff->Get<TH2>(Pr));
+    makelogaxis(expected_diff->Get<TH2>(De));
+    makelogaxis(expected_diff->Get<TH2>(Tr));
+    makelogaxis(expected_diff->Get<TH2>(He));
+    makelogaxis(expected_diff->Get<TH2>(Al));
+    //
+    nsigma->Add<El>(new TH2F("hnsigmaEl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(e)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Mu>(new TH2F("hnsigmaMu", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(#mu)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Pi>(new TH2F("hnsigmaPi", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(#pi)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Ka>(new TH2F("hnsigmaKa", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(K)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Pr>(new TH2F("hnsigmaPr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(p)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<De>(new TH2F("hnsigmaDe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(d)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Tr>(new TH2F("hnsigmaTr", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(t)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<He>(new TH2F("hnsigmaHe", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(^{3}He)", 1000, 0.001, 20, 200, -10, 10));
+    nsigma->Add<Al>(new TH2F("hnsigmaAl", ";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(#alpha)", 1000, 0.001, 20, 200, -10, 10));
+    makelogaxis(nsigma->Get<TH2>(El));
+    makelogaxis(nsigma->Get<TH2>(Mu));
+    makelogaxis(nsigma->Get<TH2>(Pi));
+    makelogaxis(nsigma->Get<TH2>(Ka));
+    makelogaxis(nsigma->Get<TH2>(Pr));
+    makelogaxis(nsigma->Get<TH2>(De));
+    makelogaxis(nsigma->Get<TH2>(Tr));
+    makelogaxis(nsigma->Get<TH2>(He));
+    makelogaxis(nsigma->Get<TH2>(Al));
+#undef makelogaxis
+  }
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC> const& tracks)
+  {
+    event->Fill<vertexz>(collision.posZ());
+    for (auto i : tracks) {
+      // const float mom = i.p();
+      const float mom = i.tpcInnerParam();
+      event->Fill<signal>(mom, i.tpcSignal());
+      //
+      expected->Fill<El>(mom, i.tpcExpSignalEl());
+      expected->Fill<Mu>(mom, i.tpcExpSignalMu());
+      expected->Fill<Pi>(mom, i.tpcExpSignalPi());
+      expected->Fill<Ka>(mom, i.tpcExpSignalKa());
+      expected->Fill<Pr>(mom, i.tpcExpSignalPr());
+      expected->Fill<De>(mom, i.tpcExpSignalDe());
+      expected->Fill<Tr>(mom, i.tpcExpSignalTr());
+      expected->Fill<He>(mom, i.tpcExpSignalHe());
+      expected->Fill<Al>(mom, i.tpcExpSignalAl());
+      //
+      expected_diff->Fill<El>(mom, i.tpcSignal() - i.tpcExpSignalEl());
+      expected_diff->Fill<Mu>(mom, i.tpcSignal() - i.tpcExpSignalMu());
+      expected_diff->Fill<Pi>(mom, i.tpcSignal() - i.tpcExpSignalPi());
+      expected_diff->Fill<Ka>(mom, i.tpcSignal() - i.tpcExpSignalKa());
+      expected_diff->Fill<Pr>(mom, i.tpcSignal() - i.tpcExpSignalPr());
+      expected_diff->Fill<De>(mom, i.tpcSignal() - i.tpcExpSignalDe());
+      expected_diff->Fill<Tr>(mom, i.tpcSignal() - i.tpcExpSignalTr());
+      expected_diff->Fill<He>(mom, i.tpcSignal() - i.tpcExpSignalHe());
+      expected_diff->Fill<Al>(mom, i.tpcSignal() - i.tpcExpSignalAl());
+      //
+      nsigma->Fill<El>(mom, i.tpcNSigmaEl());
+      nsigma->Fill<Mu>(mom, i.tpcNSigmaMu());
+      nsigma->Fill<Pi>(mom, i.tpcNSigmaPi());
+      nsigma->Fill<Ka>(mom, i.tpcNSigmaKa());
+      nsigma->Fill<Pr>(mom, i.tpcNSigmaPr());
+      nsigma->Fill<De>(mom, i.tpcNSigmaDe());
+      nsigma->Fill<Tr>(mom, i.tpcNSigmaTr());
+      nsigma->Fill<He>(mom, i.tpcNSigmaHe());
+      nsigma->Fill<Al>(mom, i.tpcNSigmaAl());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTPCTask>("pidTPC-task")};
+  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTPCTask>("pidTPC-task")};
+  if (cfgc.options().get<int>("add-qa")) {
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskQA>("pidTPCQA-task"));
+  }
+  return workflow;
 }


### PR DESCRIPTION
Update to TPC spectra task and added PID QA plots to PID tasks

- Update TPC spectra task
-- Use common configuration
-- Use same filtering in all sub tasks
-- Add histograms for event and unselected tracks

- Add QA histograms for TOF PID in TOF PID task
 -- QA histograms are now optionally added

 - Add QA histograms for TPC PID in TPC PID task
  -- QA histograms are now optionally added

@jgrosseo I have ready the delegation of PID to tasks but I will wait to merge this so as to avoid having a very large commit, but of course I can add it as well if needed
