### PR TITLE
DPL Analysis: rework TableToTree

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -154,12 +154,12 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         }
 
         auto o = Output(dh);
-        auto& t2t = outputs.make<TreeToTable>(o, tr);
+        auto& t2t = outputs.make<TreeToTable>(o);
 
         // add branches to read
         auto colnames = aod::datamodel::getColumnNames(dh);
         if (colnames.size() == 0) {
-          t2t.addAllColumns();
+          t2t.addAllColumns(tr);
         } else {
           for (auto colname : colnames) {
             t2t.addColumn(colname.c_str());
@@ -167,7 +167,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         }
 
         // fill the table
-        t2t.fill();
+        t2t.fill(tr);
       }
     });
   })};

--- a/Framework/Core/test/benchmark_TreeToTable.cxx
+++ b/Framework/Core/test/benchmark_TreeToTable.cxx
@@ -72,9 +72,10 @@ static void BM_TreeToTable(benchmark::State& state)
 
     // benchmark TreeToTable
     if (tr) {
-      tr2ta = new TreeToTable(tr);
-      if (tr2ta->addAllColumns()) {
-        auto ta = tr2ta->process();
+      tr2ta = new TreeToTable;
+      if (tr2ta->addAllColumns(tr)) {
+        tr2ta->fill(tr);
+        auto ta = tr2ta->finalize();
       }
 
     } else {

--- a/Framework/Core/test/test_TreeToTable.cxx
+++ b/Framework/Core/test/test_TreeToTable.cxx
@@ -74,13 +74,15 @@ BOOST_AUTO_TEST_CASE(TreeToTableConversion)
   t1.Write();
 
   // Create an arrow table from this.
-  TreeToTable tr2ta(&t1);
-  auto stat = tr2ta.addAllColumns();
+  TreeToTable tr2ta;
+  auto stat = tr2ta.addAllColumns(&t1);
   if (!stat) {
     LOG(ERROR) << "Table was not created!";
     return;
   }
-  auto table = tr2ta.process();
+
+  tr2ta.fill(&t1);
+  auto table = tr2ta.finalize();
   f1.Close();
 
   // test result


### PR DESCRIPTION
* Hide internal details of the conversion.
* Attempt at freeing the memory as soon as possible.