### PR TITLE
DPL Foundation: add own runtime_error.

### DIFF
--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -8,7 +8,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_header_only_library(FrameworkFoundation)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/Framework
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+o2_add_library(FrameworkFoundation
+               SOURCES src/RuntimeError.cxx)
 
 o2_add_test(test_FunctionalHelpers NAME test_FrameworkFoundation_test_FunctionalHelpers
             COMPONENT_NAME FrameworkFoundation
@@ -33,4 +37,9 @@ o2_add_test(test_CompilerBuiltins NAME test_FrameworkFoundation_CompilerBuiltins
 o2_add_test(test_Signpost NAME test_FrameworkFoundation_Signpost
             COMPONENT_NAME FrameworkFoundation
             SOURCES test/test_Signpost.cxx
+            PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation)
+
+o2_add_test(test_RuntimeError NAME test_FrameworkFoundation_RuntimeError
+            COMPONENT_NAME FrameworkFoundation
+            SOURCES test/test_RuntimeError.cxx
             PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation)

--- a/Framework/Foundation/include/Framework/RuntimeError.h
+++ b/Framework/Foundation/include/Framework/RuntimeError.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_RUNTIMEERROR_H_
+#define O2_FRAMEWORK_RUNTIMEERROR_H_
+
+namespace o2::framework
+{
+
+struct RuntimeError {
+  static constexpr unsigned int MAX_RUNTIME_ERRORS = 64;
+  static constexpr unsigned int MAX_RUNTIME_ERROR_SIZE = 1024;
+  static constexpr unsigned int MAX_BACKTRACE_SIZE = 100;
+  char what[MAX_RUNTIME_ERROR_SIZE];
+  void* backtrace[MAX_BACKTRACE_SIZE];
+  int maxBacktrace = 0;
+};
+
+struct RuntimeErrorRef {
+  int index = 0;
+};
+
+RuntimeErrorRef runtime_error(const char*);
+RuntimeErrorRef runtime_error_f(const char*, ...);
+RuntimeError& error_from_ref(RuntimeErrorRef);
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_RUNTIMEERROR_H_

--- a/Framework/Foundation/src/RuntimeError.cxx
+++ b/Framework/Foundation/src/RuntimeError.cxx
@@ -1,0 +1,80 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/RuntimeError.h"
+
+#include <cstdio>
+#include <atomic>
+#include <cstdarg>
+#include <execinfo.h>
+#include <cstring>
+
+namespace o2::framework
+{
+
+namespace
+{
+static RuntimeError gError[RuntimeError::MAX_RUNTIME_ERRORS];
+static std::atomic<bool> gErrorBooking[RuntimeError::MAX_RUNTIME_ERRORS];
+
+bool canDumpBacktrace()
+{
+#ifdef DPL_ENABLE_BACKTRACE
+  return true;
+#else
+  return false;
+#endif
+}
+} // namespace
+
+void clean_all_runtime_errors()
+{
+  for (size_t i = 0; i < RuntimeError::MAX_RUNTIME_ERRORS; ++i) {
+    gErrorBooking[i].store(false);
+  }
+}
+
+void clean_runtime_error(int i)
+{
+  gErrorBooking[i].store(false);
+}
+
+RuntimeError& error_from_ref(RuntimeErrorRef ref)
+{
+  return gError[ref.index];
+}
+
+RuntimeErrorRef runtime_error_f(const char* format, ...)
+{
+  int i = 0;
+  bool expected = false;
+  while (gErrorBooking[i].compare_exchange_strong(expected, true) == false) {
+    ++i;
+  }
+  va_list args;
+  va_start(args, format);
+  vsnprintf(gError[i].what, RuntimeError::MAX_RUNTIME_ERROR_SIZE, format, args);
+  gError[i].maxBacktrace = canDumpBacktrace() ? backtrace(gError[i].backtrace, RuntimeError::MAX_BACKTRACE_SIZE) : 0;
+  return RuntimeErrorRef{i};
+}
+
+RuntimeErrorRef runtime_error(const char* s)
+{
+  int i = 0;
+  bool expected = false;
+  while (gErrorBooking[i].compare_exchange_strong(expected, true) == false) {
+    ++i;
+  }
+  strncpy(gError[i].what, s, RuntimeError::MAX_RUNTIME_ERROR_SIZE);
+  gError[i].maxBacktrace = canDumpBacktrace() ? backtrace(gError[i].backtrace, RuntimeError::MAX_BACKTRACE_SIZE) : 0;
+  return RuntimeErrorRef{i};
+}
+
+} // namespace o2::framework

--- a/Framework/Foundation/test/test_RuntimeError.cxx
+++ b/Framework/Foundation/test/test_RuntimeError.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework RuntimeError
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/RuntimeError.h"
+#include <execinfo.h>
+
+BOOST_AUTO_TEST_CASE(TestRuntimeError)
+{
+  try {
+    throw o2::framework::runtime_error("foo");
+  } catch (o2::framework::RuntimeErrorRef ref) {
+    auto& err = o2::framework::error_from_ref(ref);
+    BOOST_CHECK_EQUAL(strncmp(err.what, "foo", 3), 0);
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+#endif
+  }
+
+  try {
+    throw o2::framework::runtime_error_f("foo %d", 1);
+  } catch (o2::framework::RuntimeErrorRef ref) {
+    auto& err = o2::framework::error_from_ref(ref);
+    BOOST_CHECK_EQUAL(strncmp(err.what, "foo", 3), 0);
+#ifdef DPL_ENABLE_BACKTRACE
+    backtrace_symbols_fd(err.backtrace, err.maxBacktrace, STDERR_FILENO);
+#endif
+  }
+}


### PR DESCRIPTION
A few features:

* No need to include <stdexcept> hopefully reducing bload.
* No allocation on throw.
* Includes backtrace.

We should use this to remove all the runtime_error from at least the framework.