### PR TITLE
[QC-338] Facilitate creating a Dispatcher without configuration files

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSamplingCondition.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSamplingCondition.h
@@ -24,7 +24,7 @@
 namespace o2::utilities
 {
 
-/// A standarised data sampling condition, to decide if given data sample should be passed forward.
+/// A standardised data sampling condition, to decide if given data sample should be passed forward.
 class DataSamplingCondition
 {
  public:

--- a/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
@@ -39,8 +39,8 @@ class DataSamplingPolicy
   class PathMap : public PathVectorBase
   {
    public:
-    ~PathMap() = default;
     PathMap() = default;
+    ~PathMap() = default;
     const PathVectorBase::const_iterator find(const framework::ConcreteDataMatcher& input) const
     {
       return std::find_if(begin(), end(), [input](const auto& el) {
@@ -50,21 +50,33 @@ class DataSamplingPolicy
   };
 
  public:
-  /// \brief Constructor.
-  DataSamplingPolicy();
-  /// \brief Constructor.
-  DataSamplingPolicy(const boost::property_tree::ptree&);
-  /// \brief Destructor
-  ~DataSamplingPolicy();
-
   /// \brief Configures a policy using structured configuration entry.
-  void configure(const boost::property_tree::ptree&);
+  static DataSamplingPolicy fromConfiguration(const boost::property_tree::ptree&);
+
+  /// \brief Constructor.
+  DataSamplingPolicy(std::string name);
+  /// \brief Destructor
+  ~DataSamplingPolicy() = default;
+  /// \brief Move constructor
+  DataSamplingPolicy(DataSamplingPolicy&&) = default;
+  /// \brief Move assignment
+  DataSamplingPolicy& operator=(DataSamplingPolicy&&) = default;
+
+  /// \brief Adds a new association between inputs and outputs.
+  void registerPath(const framework::InputSpec&, const framework::OutputSpec&);
+  /// \brief Adds a new association between inputs and outputs.
+  //  void registerPolicy(framework::InputSpec&&, framework::OutputSpec&&);
+  /// \brief Adds a new sampling condition.
+  void registerCondition(std::unique_ptr<DataSamplingCondition>&&);
+  /// \brief Sets a raw FairMQChannel. Deprecated, do not use.
+  void setFairMQOutputChannel(std::string);
+
   /// \brief Returns true if this policy requires data with given InputSpec.
   bool match(const framework::ConcreteDataMatcher& input) const;
   /// \brief Returns true if user-defined conditions of sampling are fulfilled.
   bool decide(const o2::framework::DataRef&);
   /// \brief Returns Output for given InputSpec to pass data forward.
-  const framework::Output prepareOutput(const framework::ConcreteDataMatcher& input, framework::Lifetime lifetime = framework::Lifetime::Timeframe) const;
+  framework::Output prepareOutput(const framework::ConcreteDataMatcher& input, framework::Lifetime lifetime = framework::Lifetime::Timeframe) const;
 
   const std::string& getName() const;
   const PathMap& getPathMap() const;

--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -50,12 +50,14 @@ class Dispatcher : public framework::Task
   /// \brief Dispatcher process callback
   void run(framework::ProcessingContext& ctx) override;
 
-  /// \brief Create appropriate inputSpecs and outputSpecs for sampled data during the workflow declaration phase.
-  void registerPath(const std::pair<framework::InputSpec, framework::OutputSpec>&);
+  /// \brief Register a Data Sampling Policy
+  void registerPolicy(std::unique_ptr<DataSamplingPolicy>&&);
 
   const std::string& getName();
+  /// \brief Assembles InputSpecs of all registered policies in a single vector, removing overlapping entries.
   framework::Inputs getInputSpecs();
   framework::Outputs getOutputSpecs();
+  framework::Options getOptions();
 
  private:
   DataSamplingHeader prepareDataSamplingHeader(const DataSamplingPolicy& policy, const framework::DeviceSpec& spec);
@@ -67,8 +69,6 @@ class Dispatcher : public framework::Task
 
   std::string mName;
   std::string mReconfigurationSource;
-  framework::Inputs inputs;
-  framework::Outputs outputs;
   // policies should be shared between all pipeline threads
   std::vector<std::shared_ptr<DataSamplingPolicy>> mPolicies;
 };

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -134,7 +134,7 @@ std::vector<InputSpec> DataSampling::InputSpecsForPolicy(std::shared_ptr<configu
 
   for (auto&& policyConfig : policiesTree) {
     if (policyConfig.second.get<std::string>("id") == policyName) {
-      DataSamplingPolicy policy(policyConfig.second);
+      auto policy = DataSamplingPolicy::fromConfiguration(policyConfig.second);
       for (const auto& path : policy.getPathMap()) {
         InputSpec input = DataSpecUtils::matchingInput(path.second);
         inputs.push_back(input);

--- a/Utilities/DataSampling/src/Dispatcher.cxx
+++ b/Utilities/DataSampling/src/Dispatcher.cxx
@@ -202,12 +202,11 @@ Inputs Dispatcher::getInputSpecs()
 
   // Add data inputs. Avoid duplicates and inputs which include others (e.g. "TST/DATA" includes "TST/DATA/1".
   for (const auto& policy : mPolicies) {
-    for (const auto& [potentiallyNewInput, _policyOutput] : policy->getPathMap()) {
-      (void)_policyOutput;
+    for (const auto& path : policy->getPathMap()) {
+      auto& potentiallyNewInput = path.first;
 
       // The idea is that we remove all existing inputs which are covered by the potentially new input.
       // If there are none which are broader than the new one, then we add it.
-      // I hope this is enough for all corner cases, but I am not 100% sure.
       auto newInputIsBroader = [&potentiallyNewInput](const InputSpec& other) {
         return DataSpecUtils::includes(potentiallyNewInput, other);
       };

--- a/Utilities/DataSampling/test/test_DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/test/test_DataSamplingPolicy.cxx
@@ -14,12 +14,14 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include "DataSampling/DataSamplingConditionFactory.h"
 #include "DataSampling/DataSamplingPolicy.h"
 #include "Framework/DataRef.h"
 #include "Framework/DataProcessingHeader.h"
 
 using namespace o2::framework;
 using namespace o2::utilities;
+using namespace o2::header;
 
 // an example of DataSamplingPolicy JSON object
 // {
@@ -29,19 +31,7 @@ using namespace o2::utilities;
 //     "aidlalala1",
 //     "aidlalala2"
 //   ]
-//   "dataHeaders" : [
-//     {
-//       "binding" : "clusters",
-//       "dataOrigin" : "TPC",
-//       "dataDescription" : "CLUSTERS"
-//     },
-//     {
-//       "binding" : "tracks",
-//       "dataOrigin" : "TPC",
-//       "dataDescription" : "TRACKS"
-//     }
-//   ],
-//   "subSpec" : "*",
+//   "query" : "c:TST/CHLEB/33;m:TST/MLEKO/33",
 //   "samplingConditions" : [
 //     {
 //       "condition" : "random",
@@ -52,10 +42,9 @@ using namespace o2::utilities;
 //   "blocking" : "false"
 // }
 
-BOOST_AUTO_TEST_CASE(DataSamplingPolicyConfiguration)
+BOOST_AUTO_TEST_CASE(DataSamplingPolicyFromConfiguration)
 {
   using boost::property_tree::ptree;
-  DataSamplingPolicy policy;
 
   ptree config;
   config.put("id", "my_policy");
@@ -70,28 +59,57 @@ BOOST_AUTO_TEST_CASE(DataSamplingPolicyConfiguration)
   config.add_child("samplingConditions", samplingConditions);
   config.put("blocking", "false");
 
-  policy.configure(config);
+  {
+    auto policy = std::move(DataSamplingPolicy::fromConfiguration(config));
 
-  BOOST_CHECK_EQUAL(policy.getName(), "my_policy");
-  BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"DS", "my_policy0", 33}));
-  BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"DS", "my_policy1", 33}));
-  const auto& map = policy.getPathMap();
-  BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second == (OutputSpec{"DS", "my_policy0", 33}));
-  BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second == (OutputSpec{"DS", "my_policy1", 33}));
-  BOOST_CHECK_EQUAL(map.size(), 2);
+    BOOST_CHECK_EQUAL(policy.getName(), "my_policy");
+    BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"DS", "my_policy0", 33}));
+    BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"DS", "my_policy1", 33}));
+    const auto& map = policy.getPathMap();
+    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second == (OutputSpec{"DS", "my_policy0", 33}));
+    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second == (OutputSpec{"DS", "my_policy1", 33}));
+    BOOST_CHECK_EQUAL(map.size(), 2);
 
-  BOOST_CHECK(policy.match(ConcreteDataMatcher{"TST", "CHLEB", 33}));
-  BOOST_CHECK(!policy.match(ConcreteDataMatcher{"TST", "SZYNKA", 33}));
+    BOOST_CHECK(policy.match(ConcreteDataMatcher{"TST", "CHLEB", 33}));
+    BOOST_CHECK(!policy.match(ConcreteDataMatcher{"TST", "SZYNKA", 33}));
 
-  DataProcessingHeader dph{555, 0};
-  o2::header::Stack headerStack{dph};
-  DataRef dr{nullptr, reinterpret_cast<const char*>(headerStack.data()), nullptr};
-  policy.decide(dr); // just make sure it does not crash
+    DataProcessingHeader dph{555, 0};
+    o2::header::Stack headerStack{dph};
+    DataRef dr{nullptr, reinterpret_cast<const char*>(headerStack.data()), nullptr};
+    policy.decide(dr); // just make sure it does not crash
+  }
 
   config.put("id", "too-long-policy-name");
-  policy.configure(config);
-  BOOST_CHECK_EQUAL(policy.getName(), "too-long-polic");
-  BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"DS", "too-long-polic0", 33}));
-  BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"DS", "too-long-polic1", 33}));
-  BOOST_CHECK_EQUAL(policy.getPathMap().size(), 2); // previous paths should be cleared
+
+  {
+    auto policy = std::move(DataSamplingPolicy::fromConfiguration(config));
+    BOOST_CHECK_EQUAL(policy.getName(), "too-long-policy-name");
+    BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"DS", "too-long-polic0", 33}));
+    BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"DS", "too-long-polic1", 33}));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(DataSamplingPolicyFromMethods)
+{
+  DataSamplingPolicy policy("my_policy");
+  auto conditionNConsecutive = DataSamplingConditionFactory::create("nConsecutive");
+  BOOST_REQUIRE(conditionNConsecutive);
+
+  boost::property_tree::ptree config;
+  config.put("samplesNumber", 3);
+  config.put("cycleSize", 10);
+  conditionNConsecutive->configure(config);
+
+  policy.registerCondition(std::move(conditionNConsecutive));
+
+  policy.registerPath({"tststs", {"TST", "CHLEB"}}, {{"asdf"}, "AA", "BBBB"});
+  BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"AA", "BBBB", 33}));
+}
+
+BOOST_AUTO_TEST_CASE(DataSamplingPolicyStaticMethods)
+{
+  BOOST_CHECK(DataSamplingPolicy::createPolicyDataOrigin() == DataOrigin("DS"));
+  BOOST_CHECK(DataSamplingPolicy::createPolicyDataDescription("asdf", 0) == DataDescription("asdf0"));
+  BOOST_CHECK(DataSamplingPolicy::createPolicyDataDescription("asdfasdfasdfasdf", 0) == DataDescription("asdfasdfasdfas0"));
+  BOOST_CHECK(DataSamplingPolicy::createPolicyDataDescription("asdfasdfasdfasdf", 10) == DataDescription("asdfasdfasdfas10"));
 }


### PR DESCRIPTION
This allows to generate a hard-coded Dispatcher without any configuration files. Additionally, thanks to the refactoring, responsibilities of the classes are better separated, and Dispatcher makes sure that does not require overlapping InputSpecs.