### PR TITLE
DPL: improve ability to forward messages to an output

### DIFF
--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -127,7 +127,6 @@ int main(int argc, char** argv)
     UserCustomizationsHelper::userDefinedCustomization(workflowOptions, 0);
     workflowOptions.push_back(ConfigParamSpec{"readers", VariantType::Int64, 1ll, {"number of parallel readers to use"}});
     workflowOptions.push_back(ConfigParamSpec{"pipeline", VariantType::String, "", {"override default pipeline size"}});
-    workflowOptions.push_back(ConfigParamSpec{"dangling-outputs-policy", VariantType::String, "file", {"what to do with dangling outputs. file: write to file, fairmq: send to output proxy"}});
 
     // options for AOD rate limiting
     workflowOptions.push_back(ConfigParamSpec{"aod-memory-rate-limit", VariantType::Int64, 0LL, {"Rate limit AOD processing based on memory"}});
@@ -139,6 +138,18 @@ int main(int argc, char** argv)
     workflowOptions.push_back(ConfigParamSpec{"aod-writer-ntfmerge", VariantType::Int, -1, {"Number of time frames to merge into one file"}});
     workflowOptions.push_back(ConfigParamSpec{"aod-writer-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}});
 
+    workflowOptions.push_back(ConfigParamSpec{"forwarding-policy",
+                                              VariantType::String,
+                                              "dangling",
+                                              {"Which messages to forward."
+                                               " dangling: dangling outputs,"
+                                               " all: all messages"}});
+    workflowOptions.push_back(ConfigParamSpec{"forwarding-destination",
+                                              VariantType::String,
+                                              "file",
+                                              {"Destination for forwarded messages."
+                                               " file: write to file,"
+                                               " fairmq: send to output proxy"}});
     std::vector<ChannelConfigurationPolicy> channelPolicies;
     UserCustomizationsHelper::userDefinedCustomization(channelPolicies, 0);
     auto defaultChannelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -480,7 +480,7 @@ DataProcessorSpec CommonDataProcessors::getGlobalFairMQSink(std::vector<InputSpe
   externalChannelSpec.protocol = ChannelProtocol::IPC;
   std::string defaultChannelConfig = formatExternalChannelConfiguration(externalChannelSpec);
   // at some point the formatting tool might add the transport as well so we have to check
-  return specifyFairMQDeviceOutputProxy("internal-dpl-output-proxy", danglingOutputInputs, defaultChannelConfig.c_str());
+  return specifyFairMQDeviceOutputProxy("internal-dpl-injected-output-proxy", danglingOutputInputs, defaultChannelConfig.c_str());
 }
 
 DataProcessorSpec CommonDataProcessors::getDummySink(std::vector<InputSpec> const& danglingOutputInputs)

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -29,8 +29,16 @@ std::unique_ptr<ConfigContext> makeEmptyConfigContext()
   // FIXME: Ugly... We need to fix ownership and make sure the ConfigContext
   //        either owns or shares ownership of the registry.
   std::vector<std::unique_ptr<ParamRetriever>> retrievers;
-  static std::vector<ConfigParamSpec> specs;
-  specs.push_back(ConfigParamSpec{"dangling-outputs-policy", VariantType::String, "file", {"what to do with dangling outputs. file: write to file, fairmq: send to output proxy"}});
+  static std::vector<ConfigParamSpec> specs = {
+    ConfigParamSpec{"forwarding-policy",
+                    VariantType::String,
+                    "dangling",
+                    {""}},
+    ConfigParamSpec{"forwarding-destination",
+                    VariantType::String,
+                    "file",
+                    {"what to do with dangling outputs. file: write to file, fairmq: send to output proxy"}},
+  };
   specs.push_back(ConfigParamSpec{"aod-memory-rate-limit", VariantType::String, "0", {"rate"}});
   auto store = std::make_unique<ConfigParamStore>(specs, std::move(retrievers));
   store->preload();


### PR DESCRIPTION
* Old dangling-outputs-policy renamed to forwarding-destination.
* Introduced "forwarding-policy" to decide which kind of messages to forward.
* Use enums rather than integers.