### PR TITLE
Overload InputSpecsForPolicy with shared_ptr

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSampling.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSampling.h
@@ -94,7 +94,10 @@ class DataSampling
   /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
   static std::vector<framework::InputSpec> InputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName);
   /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
+  /// @deprecated
   static std::vector<framework::InputSpec> InputSpecsForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName);
+  /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
+  static std::vector<framework::InputSpec> InputSpecsForPolicy(std::shared_ptr<configuration::ConfigurationInterface> config, const std::string& policyName);
   /// \brief Provides OutputSpecs of given DataSamplingPolicy
   static std::vector<framework::OutputSpec> OutputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName);
   /// \brief Provides OutputSpecs of given DataSamplingPolicy

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -138,6 +138,24 @@ std::vector<InputSpec> DataSampling::InputSpecsForPolicy(ConfigurationInterface*
   return inputs;
 }
 
+std::vector<InputSpec> DataSampling::InputSpecsForPolicy(std::shared_ptr<configuration::ConfigurationInterface> config, const std::string& policyName)
+{
+  std::vector<InputSpec> inputs;
+  auto policiesTree = config->getRecursive("dataSamplingPolicies");
+
+  for (auto&& policyConfig : policiesTree) {
+    if (policyConfig.second.get<std::string>("id") == policyName) {
+      DataSamplingPolicy policy(policyConfig.second);
+      for (const auto& path : policy.getPathMap()) {
+        InputSpec input = DataSpecUtils::matchingInput(path.second);
+        inputs.push_back(input);
+      }
+      break;
+    }
+  }
+  return inputs;
+}
+
 std::vector<OutputSpec> DataSampling::OutputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName)
 {
   std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(policiesSource);


### PR DESCRIPTION
Add an overloaded version of InputSpecsForPolicy that takes a shared_ptr instead of a raw. The former version is marked as deprecated and should be removed as soon as we switch in QC.