### PR TITLE
HistogramRegistry: add support for all root histogram types

### DIFF
--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -27,16 +27,16 @@ struct ATask {
     "registry",
     true,
     {
-      {"eta", "#eta", {HistogramType::kTH1F, {{102, -2.01, 2.01}}}},     //
-      {"phi", "#varphi", {HistogramType::kTH1F, {{100, 0., 2. * M_PI}}}} //
-    }                                                                    //
+      {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},     //
+      {"phi", "#varphi", {HistType::kTH1F, {{100, 0., 2. * M_PI}}}} //
+    }                                                               //
   };
 
   void process(aod::Tracks const& tracks)
   {
     for (auto& track : tracks) {
-      registry.get("eta")->Fill(track.eta());
-      registry.get("phi")->Fill(track.phi());
+      registry.get<TH1>("eta")->Fill(track.eta());
+      registry.get<TH1>("phi")->Fill(track.phi());
     }
   }
 };
@@ -47,9 +47,9 @@ struct BTask {
     "registry",
     true,
     {
-      {"eta", "#eta", {HistogramType::kTH1F, {{102, -2.01, 2.01}}}},                            //
-      {"ptToPt", "#ptToPt", {HistogramType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
-    }                                                                                           //
+      {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},                            //
+      {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
+    }                                                                                      //
   };
 
   void process(aod::Tracks const& tracks)
@@ -59,9 +59,128 @@ struct BTask {
   }
 };
 
+struct CTask {
+
+  HistogramRegistry registry{
+    "registry",
+    true,
+    {
+      {"1d", "test 1d", {HistType::kTH1I, {{100, -10.0f, 10.0f}}}},                                                                                               //
+      {"2d", "test 2d", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                                                                       //
+      {"3d", "test 3d", {HistType::kTH3D, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                                                //
+      {"4d", "test 4d", {HistType::kTHnC, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                         //
+      {"5d", "test 5d", {HistType::kTHnSparseL, {{10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}}}}, //
+    }                                                                                                                                                             //
+  };
+
+  void init(o2::framework::InitContext&)
+  {
+    registry.add({"7d", "test 7d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}}});
+
+    registry.add({"6d", "test 6d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}}});
+
+    registry.add({"1d-profile", "test 1d profile", {HistType::kTProfile, {{20, 0.0f, 10.01f}}}});
+    registry.add({"2d-profile", "test 2d profile", {HistType::kTProfile2D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}}});
+    registry.add({"3d-profile", "test 3d profile", {HistType::kTProfile3D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}}});
+
+    registry.add({"2d-weight", "test 2d weight", {HistType::kTH2C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+
+    registry.add({"3d-weight", "test 3d weight", {HistType::kTH3C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+
+    registry.add({"4d-weight", "test 4d weight", {HistType::kTHnC, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}, true});
+
+    registry.add({"1d-profile-weight", "test 1d profile weight", {HistType::kTProfile, {{2, -10.0f, 10.01f}}}, true});
+    registry.add({"2d-profile-weight", "test 2d profile weight", {HistType::kTProfile2D, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+  }
+
+  void process(aod::Tracks const& tracks)
+  {
+    using namespace aod::track;
+    // does not work with dynamic columns (e.g. Charge, NormalizedPhi)
+    registry.fill<Eta>("1d", tracks, eta > -0.7f);
+    registry.fill<Pt, Eta, RawPhi>("3d", tracks, eta > 0.f);
+    registry.fill<Pt, Eta, RawPhi, P, X>("5d", tracks, pt > 0.15f);
+    registry.fill<Pt, Eta, RawPhi, P, X, Y, Z>("7d", tracks, pt > 0.15f);
+    registry.fill<Pt, Eta, RawPhi>("2d-profile", tracks, eta > -0.5f);
+
+    // fill 4d histogram with weight (column X)
+    registry.fillWeight<Pt, Eta, RawPhi, Z, X>("4d-weight", tracks, eta > 0.f);
+
+    registry.fillWeight<Pt, Eta, RawPhi>("2d-weight", tracks, eta > 0.f);
+
+    registry.fillWeight<Pt, Eta, RawPhi>("1d-profile-weight", tracks, eta > 0.f);
+
+    for (auto& track : tracks) {
+      registry.fill("2d", track.eta(), track.pt());
+      registry.fill("4d", track.pt(), track.eta(), track.phi(), track.signed1Pt());
+      registry.fill("6d", track.pt(), track.eta(), track.phi(), track.snp(), track.tgl(), track.alpha());
+      registry.fill("1d-profile", track.pt(), track.eta());
+      registry.fill("3d-profile", track.pt(), track.eta(), track.phi(), track.snp());
+
+      // fill 3d histogram with weight (2.)
+      registry.fillWeight("3d-weight", track.pt(), track.eta(), track.phi(), 2.);
+
+      registry.fillWeight("2d-profile-weight", track.pt(), track.eta(), track.phi(), 5.);
+    }
+  }
+};
+
+struct DTask {
+  HistogramRegistry spectra{"spectra", true, {}};
+  HistogramRegistry etaStudy{"etaStudy", true, {}};
+
+  void init(o2::framework::InitContext&)
+  {
+    std::vector<double> ptBinning = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+                                     1.1, 1.2, 1.3, 1.4, 1.5, 2.0, 5.0, 10.0, 20.0, 50.0};
+    std::vector<double> centBinning = {0., 30., 60., 90.};
+
+    AxisSpec ptAxis = {ptBinning, "#it{p}_{T} (GeV/c)"};
+    AxisSpec centAxis = {centBinning, "centrality"};
+    AxisSpec etaAxis = {5, -0.8, 0.8, "#eta"};
+    AxisSpec phiAxis = {4, 0., 2. * M_PI, "#phi"};
+    const int nCuts = 5;
+    AxisSpec cutAxis = {nCuts, -0.5, nCuts - 0.5, "cut setting"};
+
+    HistogramConfigSpec defaultParticleHist({HistType::kTHnF, {ptAxis, etaAxis, centAxis, cutAxis}});
+
+    spectra.add({"myControlHist", "a", {HistType::kTH2F, {ptAxis, etaAxis}}});
+    spectra.get<TH2>("myControlHist")->GetYaxis()->SetTitle("my-y-axis");
+    spectra.get<TH2>("myControlHist")->SetTitle("something meaningful");
+
+    spectra.add({"pions", "Pions", defaultParticleHist});
+    spectra.add({"kaons", "Kaons", defaultParticleHist});
+    spectra.add({"sigmas", "Sigmas", defaultParticleHist});
+    spectra.add({"lambdas", "Lambd", defaultParticleHist});
+
+    spectra.get<THn>("lambdas")->SetTitle("Lambdas");
+
+    etaStudy.add({"positive", "A side spectra", {HistType::kTH1I, {ptAxis}}});
+    etaStudy.add({"negative", "C side spectra", {HistType::kTH1I, {ptAxis}}});
+  }
+
+  void process(aod::Tracks const& tracks)
+  {
+    using namespace aod::track;
+
+    etaStudy.fill<Pt>("positive", tracks, eta > 0.f);
+    etaStudy.fill<Pt>("negative", tracks, eta < 0.f);
+
+    for (auto& track : tracks) {
+      spectra.fill("myControlHist", track.pt(), track.eta());
+      spectra.fill("pions", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("kaons", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("sigmas", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("lambdas", track.pt(), track.eta(), 50., 0.);
+    }
+  }
+};
+
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
     adaptAnalysisTask<ATask>("eta-and-phi-histograms"),
-    adaptAnalysisTask<BTask>("filtered-histograms")};
+    adaptAnalysisTask<BTask>("filtered-histograms"),
+    adaptAnalysisTask<CTask>("dimension-test"),
+    adaptAnalysisTask<DTask>("realistic-example")};
 }

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -103,6 +103,7 @@ o2_add_library(Framework
                        src/WorkflowSpec.cxx
                        src/runDataProcessing.cxx
                        src/ExternalFairMQDeviceProxy.cxx
+                       src/HistogramRegistry.cxx
                        test/TestClasses.cxx
                PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/src
                PUBLIC_LINK_LIBRARIES ${DEBUGGUI_TARGET}

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/HistogramRegistry.h"
+
+namespace o2::framework
+{
+
+// define histogram callbacks for runtime histogram creation
+#define CALLB(HType)                                            \
+  {                                                             \
+    k##HType,                                                   \
+      [](HistogramSpec const& histSpec) {                       \
+        return HistFactory::createHistVariant<HType>(histSpec); \
+      }                                                         \
+  }
+
+const std::map<HistType, std::function<HistPtr(const HistogramSpec&)>> HistFactory::HistogramCreationCallbacks{
+  CALLB(TH1D), CALLB(TH1F), CALLB(TH1I), CALLB(TH1C), CALLB(TH1S),
+  CALLB(TH2D), CALLB(TH2F), CALLB(TH2I), CALLB(TH2C), CALLB(TH2S),
+  CALLB(TH3D), CALLB(TH3F), CALLB(TH3I), CALLB(TH3C), CALLB(TH3S),
+  CALLB(THnD), CALLB(THnF), CALLB(THnI), CALLB(THnC), CALLB(THnS), CALLB(THnL),
+  CALLB(THnSparseD), CALLB(THnSparseF), CALLB(THnSparseI), CALLB(THnSparseC), CALLB(THnSparseS), CALLB(THnSparseL),
+  CALLB(TProfile), CALLB(TProfile2D), CALLB(TProfile3D),
+  //CALLB(StepTHnF), CALLB(StepTHnD)
+};
+
+#undef CALLB
+
+} // namespace o2::framework

--- a/Framework/Core/test/benchmark_HistogramRegistry.cxx
+++ b/Framework/Core/test/benchmark_HistogramRegistry.cxx
@@ -28,15 +28,15 @@ static void BM_HashedNameLookup(benchmark::State& state)
 {
   for (auto _ : state) {
     state.PauseTiming();
-    std::vector<HistogramSpec> specs;
+    std::vector<HistogramSpec> histSpecs;
     for (auto i = 0; i < state.range(0); ++i) {
-      specs.push_back({fmt::format("histo{}", i + 1).c_str(), fmt::format("Histo {}", i + 1).c_str(), {HistogramType::kTH1F, {{100, 0, 1}}}});
+      histSpecs.push_back({fmt::format("histo{}", i + 1).c_str(), fmt::format("Histo {}", i + 1).c_str(), {HistType::kTH1F, {{100, 0, 1}}}});
     }
-    HistogramRegistry registry{"registry", true, specs};
+    HistogramRegistry registry{"registry", true, histSpecs};
     state.ResumeTiming();
 
     for (auto i = 0; i < nLookups; ++i) {
-      auto& x = registry.get("histo4");
+      auto& x = registry.get<TH1>("histo4");
       benchmark::DoNotOptimize(x);
     }
     state.counters["Average lookup distance"] = ((double)registry.lookup / (double)(state.range(0)));

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
   BOOST_REQUIRE_EQUAL(registry.get<TH1>("eta")->GetNbinsX(), 100);
   BOOST_REQUIRE_EQUAL(registry.get<TH1>("phi")->GetNbinsX(), 102);
   BOOST_REQUIRE_EQUAL(registry.get<TH1>("pt")->GetNbinsX(), 1002);
-  BOOST_REQUIRE_EQUAL(registry.get<TH1>("ptToPt")->GetNbinsX(), 100);
-  BOOST_REQUIRE_EQUAL(registry.get<TH1>("ptToPt")->GetNbinsY(), 100);
+  BOOST_REQUIRE_EQUAL(registry.get<TH2>("ptToPt")->GetNbinsX(), 100);
+  BOOST_REQUIRE_EQUAL(registry.get<TH2>("ptToPt")->GetNbinsY(), 100);
 
   /// Get a pointer to the histogram
   auto histo = registry.get<TH1>("pt").get();

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -25,7 +25,7 @@ DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
 
 HistogramRegistry foo()
 {
-  return {"r", true, {{"histo", "histo", {HistogramType::kTH1F, {{100, 0, 1}}}}}};
+  return {"r", true, {{"histo", "histo", {HistType::kTH1F, {{100, 0, 1}}}}}};
 }
 
 BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
@@ -33,27 +33,27 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry", true, {
-                        {"eta", "#Eta", {HistogramType::kTH1F, {{100, -2.0, 2.0}}}},                              //
-                        {"phi", "#Phi", {HistogramType::kTH1D, {{102, 0, 2 * M_PI}}}},                            //
-                        {"pt", "p_{T}", {HistogramType::kTH1D, {{1002, -0.01, 50.1}}}},                           //
-                        {"ptToPt", "#ptToPt", {HistogramType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
-                      }                                                                                           //
+                        {"eta", "#Eta", {HistType::kTH1F, {{100, -2.0, 2.0}}}},                              //
+                        {"phi", "#Phi", {HistType::kTH1D, {{102, 0, 2 * M_PI}}}},                            //
+                        {"pt", "p_{T}", {HistType::kTH1D, {{1002, -0.01, 50.1}}}},                           //
+                        {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
+                      }                                                                                      //
   };
 
   /// Get histograms by name
-  BOOST_REQUIRE_EQUAL(registry.get("eta")->GetNbinsX(), 100);
-  BOOST_REQUIRE_EQUAL(registry.get("phi")->GetNbinsX(), 102);
-  BOOST_REQUIRE_EQUAL(registry.get("pt")->GetNbinsX(), 1002);
-  BOOST_REQUIRE_EQUAL(registry.get("ptToPt")->GetNbinsX(), 100);
-  BOOST_REQUIRE_EQUAL(registry.get("ptToPt")->GetNbinsY(), 100);
+  BOOST_REQUIRE_EQUAL(registry.get<TH1>("eta")->GetNbinsX(), 100);
+  BOOST_REQUIRE_EQUAL(registry.get<TH1>("phi")->GetNbinsX(), 102);
+  BOOST_REQUIRE_EQUAL(registry.get<TH1>("pt")->GetNbinsX(), 1002);
+  BOOST_REQUIRE_EQUAL(registry.get<TH1>("ptToPt")->GetNbinsX(), 100);
+  BOOST_REQUIRE_EQUAL(registry.get<TH1>("ptToPt")->GetNbinsY(), 100);
 
   /// Get a pointer to the histogram
-  auto histo = registry.get("pt").get();
+  auto histo = registry.get<TH1>("pt").get();
   BOOST_REQUIRE_EQUAL(histo->GetNbinsX(), 1002);
 
   /// Get registry object from a function
   auto r = foo();
-  auto histo2 = r.get("histo").get();
+  auto histo2 = r.get<TH1>("histo").get();
   BOOST_REQUIRE_EQUAL(histo2->GetNbinsX(), 100);
 }
 
@@ -78,16 +78,16 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryExpressionFill)
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry", true, {
-                        {"x", "test x", {HistogramType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
-                        {"xy", "test xy", {HistogramType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
-                      }                                                                                           //
+                        {"x", "test x", {HistType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
+                        {"xy", "test xy", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
+                      }                                                                                      //
   };
 
   /// Fill histogram with expression and table
   registry.fill<test::X>("x", tests, test::x > 3.0f);
-  BOOST_CHECK_EQUAL(registry.get("x")->GetEntries(), 4);
+  BOOST_CHECK_EQUAL(registry.get<TH1>("x")->GetEntries(), 4);
 
   /// Fill histogram with expression and table
   registry.fill<test::X, test::Y>("xy", tests, test::x > 3.0f && test::y > -5.0f);
-  BOOST_CHECK_EQUAL(registry.get("xy")->GetEntries(), 2);
+  BOOST_CHECK_EQUAL(registry.get<TH2>("xy")->GetEntries(), 2);
 }


### PR DESCRIPTION
- renamed readableName to title (to be consistent with root naming conventions)
 - made nBins in AxisSpec std::optional to seamlessly distinguish between fixed and variable binning per axis -> removed binsEqual in AxisSpec and HistogramConfigSpec
 - added callSumw2 property to HistogramSpec
 - rename axis lable -> title (to be consistent with root naming conventions)
 - added optional name property to axis (this can be helpful in n dimensional histograms so they are not only called axis0, axis1, axis2...)
 - added possibility to insert axes also after ctor was called
 - store histograms in registry in form of a std::variant (HistPtr) that can take any root hist pointer type
 - added static HistFactory helper class that handles the creation of the actual root histograms
 - HistFactory provides createHist<>() function to instanciate arbitrary histogram based on the blueprint defined in HistogramSpec
 - HistFactory provides createHistVariant<>() function that creates the histogram and returns a properly casted HistPtr which can be stored in the registry
 - HistFactory provides a runtime version of the above, which creates the histogram based on the type information stored in HistogramConfigSpec
 - it was necessary to move from unique_ptrs to shared_ptrs because we must be able to 'downcast' the actual pointer to the few interface types stored in HistPtr (this can not be done with unique ptrs). As a beneficial side effect, this way the pointers created by the HistFactory can also be stored in OutputObj<> (which uses shared_ptrs)
 - extend HistogramCreationCallback to cover all root histogram types
 - moved HistogramCallbacks map to .cxx as it is now const static member variable in HistFactory that should be defined only once (otherwise linker will complain)
 - get() now also requires to specify the interface type (TH1, TH2, TH3, THn, THnSparse, TProfile, TProfile2D or TProfile3D) since type cannot be infered from the variant at compile time
 - allowed adding histograms to an existing registry
 - added HistFiller static helper class that contains functions to fill histogams of any type both simply via values or via filtered tables
 - extended existing fill-from-table functionality to arbitrary number of dimensions
 - added fill and fillWeight functions to registry that can fill the stored histograms (again providing a version to fill values and one to fill whole filtered table)
 - renamed HistogramType -> HistType to reduce code verbosity