### PR TITLE
Update of reader / writer

### DIFF
--- a/Framework/Core/include/Framework/CommonDataProcessors.h
+++ b/Framework/Core/include/Framework/CommonDataProcessors.h
@@ -43,8 +43,11 @@ struct CommonDataProcessors {
   static DataProcessorSpec getGlobalFairMQSink(std::vector<InputSpec> const& danglingInputs);
 
   /// writes inputs of kind AOD to file
-  static DataProcessorSpec getGlobalAODSink(std::vector<InputSpec> const& OutputInputs,
-                                            std::vector<bool> const& isdangling);
+  static DataProcessorSpec getGlobalAODSink(std::shared_ptr<DataOutputDirector> dod,
+                                           std::vector<InputSpec> const& OutputInputs);
+
+  //static DataProcessorSpec getGlobalAODSink(std::vector<InputSpec> const& OutputInputs,
+  //                                          std::vector<bool> const& isdangling);
   /// @return a dummy DataProcessorSpec which requires all the passed @a InputSpec
   /// and simply discards them.
   static DataProcessorSpec getDummySink(std::vector<InputSpec> const& danglingInputs);

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -63,7 +63,7 @@ struct DataInputDescriptor {
   int getNumberInputfiles() { return mfilenames.size(); }
   int getNumberTimeFrames() { return mtotalNumberTimeFrames; }
 
-  std::tuple<TFile*, std::string> getFileFolder(int counter);
+  std::tuple<TFile*, std::string> getFileFolder(int counter, int numTF);
 
   void closeInputFile();
   bool isAlienSupportOn() { return mAlienSupport; }
@@ -103,9 +103,9 @@ struct DataInputDirector {
 
   // getters
   DataInputDescriptor* getDataInputDescriptor(header::DataHeader dh);
-  std::unique_ptr<TTreeReader> getTreeReader(header::DataHeader dh, int counter, std::string treeName);
-  std::tuple<TFile*, std::string> getFileFolder(header::DataHeader dh, int counter);
-  TTree* getDataTree(header::DataHeader dh, int counter);
+  std::unique_ptr<TTreeReader> getTreeReader(header::DataHeader dh, int counter, int numTF, std::string treeName);
+  std::tuple<TFile*, std::string> getFileFolder(header::DataHeader dh, int counter, int numTF);
+  TTree* getDataTree(header::DataHeader dh, int counter, int numTF);
   int getNumberInputDescriptors() { return mdataInputDescriptors.size(); }
 
  private:

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -116,7 +116,7 @@ struct DataInputDirector {
   DataInputDescriptor* mdefaultDataInputDescriptor = nullptr;
   std::vector<FileNameHolder*> mdefaultInputFiles;
   std::vector<DataInputDescriptor*> mdataInputDescriptors;
-  
+
   bool mDebugMode = false;
   bool mAlienSupport = false;
 

--- a/Framework/Core/include/Framework/DataInputDirector.h
+++ b/Framework/Core/include/Framework/DataInputDirector.h
@@ -116,7 +116,7 @@ struct DataInputDirector {
   DataInputDescriptor* mdefaultDataInputDescriptor = nullptr;
   std::vector<FileNameHolder*> mdefaultInputFiles;
   std::vector<DataInputDescriptor*> mdataInputDescriptors;
-
+  
   bool mDebugMode = false;
   bool mAlienSupport = false;
 

--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -87,7 +87,7 @@ struct DataOutputDirector {
   std::vector<DataOutputDescriptor*> getDataOutputDescriptors(InputSpec spec);
 
   // get the matching TFile
-  std::tuple<TFile*, std::string> getFileFolder(DataOutputDescriptor* dodesc);
+  std::tuple<TFile*, std::string> getFileFolder(DataOutputDescriptor* dodesc, uint64_t folderNumber);
 
   void closeDataFiles();
 
@@ -101,7 +101,6 @@ struct DataOutputDirector {
   std::vector<DataOutputDescriptor*> mDataOutputDescriptors;
   std::vector<std::string> mtreeFilenames;
   std::vector<std::string> mfilenameBases;
-  std::vector<int> mfolderCounts;
   std::vector<TFile*> mfilePtrs;
   bool mdebugmode = false;
   int mnumberTimeFramesToMerge = 1;

--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -40,12 +40,18 @@ struct DataOutputDescriptor {
   void setFilenameBase(std::string fn) { mfilenameBase = fn; }
   void setFilenameBase(std::string* fnptr) { mfilenameBasePtr = fnptr; }
   std::string getFilenameBase();
+  int getNumberOfWrites() { return numberOfWrites; }
+  int incrementNumberOfWrites() {
+    numberOfWrites++;
+    return numberOfWrites;
+  }
 
   void printOut();
 
  private:
   std::string mfilenameBase;
   std::string* mfilenameBasePtr = nullptr;
+  int numberOfWrites = -1;
 
   std::string remove_ws(const std::string& s);
 };
@@ -70,14 +76,18 @@ struct DataOutputDirector {
   std::tuple<std::string, std::string, int> readJson(std::string const& fnjson);
   std::tuple<std::string, std::string, int> readJsonString(std::string const& stjson);
 
+  // read/write private members
+  int getNumberTimeFramesToMerge() { return mnumberTimeFramesToMerge; }
+  void setNumberTimeFramesToMerge(int ntfmerge) { mnumberTimeFramesToMerge = ntfmerge; }
+  std::string getFileMode() { return mfileMode; }
+  void setFileMode(std::string filemode) { mfileMode = filemode; }
+  
   // get matching DataOutputDescriptors
   std::vector<DataOutputDescriptor*> getDataOutputDescriptors(header::DataHeader dh);
   std::vector<DataOutputDescriptor*> getDataOutputDescriptors(InputSpec spec);
 
   // get the matching TFile
-  std::tuple<TFile*, std::string> getFileFolder(DataOutputDescriptor* dodesc,
-                                                int ntf, int ntfmerge,
-                                                std::string filemode);
+  std::tuple<TFile*, std::string> getFileFolder(DataOutputDescriptor* dodesc);
 
   void closeDataFiles();
 
@@ -94,6 +104,8 @@ struct DataOutputDirector {
   std::vector<int> mfolderCounts;
   std::vector<TFile*> mfilePtrs;
   bool mdebugmode = false;
+  int mnumberTimeFramesToMerge = 1;
+  std::string mfileMode = "RECREATE";
 
   std::tuple<std::string, std::string, int> readJsonDocument(Document* doc);
   const std::tuple<std::string, std::string, int> memptyanswer = std::make_tuple(std::string(""), std::string(""), -1);

--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -40,18 +40,12 @@ struct DataOutputDescriptor {
   void setFilenameBase(std::string fn) { mfilenameBase = fn; }
   void setFilenameBase(std::string* fnptr) { mfilenameBasePtr = fnptr; }
   std::string getFilenameBase();
-  int getNumberOfWrites() { return numberOfWrites; }
-  int incrementNumberOfWrites() {
-    numberOfWrites++;
-    return numberOfWrites;
-  }
 
   void printOut();
 
  private:
   std::string mfilenameBase;
   std::string* mfilenameBasePtr = nullptr;
-  int numberOfWrites = -1;
 
   std::string remove_ws(const std::string& s);
 };

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -130,7 +130,7 @@ int main(int argc, char** argv)
 
     // options for AOD writer
     workflowOptions.push_back(ConfigParamSpec{"aodw-json", VariantType::String, "", {"Name of the json configuration file"}});
-    workflowOptions.push_back(ConfigParamSpec{"aodw-resfile", VariantType::String, "", {"Default name of the output file"}});
+    workflowOptions.push_back(ConfigParamSpec{"aodw-resfile", VariantType::String, "AnalysisResults_trees", {"Default name of the output file"}});
     workflowOptions.push_back(ConfigParamSpec{"aodw-resmode", VariantType::String, "RECREATE", {"Creation mode of the result files: NEW, CREATE, RECREATE, UPDATE"}});
     workflowOptions.push_back(ConfigParamSpec{"aodw-ntfmerge", VariantType::Int, 1, {"Number of time frames to merge into one file"}});
     workflowOptions.push_back(ConfigParamSpec{"aodw-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}});

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -128,6 +128,13 @@ int main(int argc, char** argv)
     workflowOptions.push_back(ConfigParamSpec{"pipeline", VariantType::String, "", {"override default pipeline size"}});
     workflowOptions.push_back(ConfigParamSpec{"dangling-outputs-policy", VariantType::String, "file", {"what to do with dangling outputs. file: write to file, fairmq: send to output proxy"}});
 
+    // options for AOD writer
+    workflowOptions.push_back(ConfigParamSpec{"aodw-json", VariantType::String, "", {"Name of the json configuration file"}});
+    workflowOptions.push_back(ConfigParamSpec{"aodw-resfile", VariantType::String, "", {"Default name of the output file"}});
+    workflowOptions.push_back(ConfigParamSpec{"aodw-resmode", VariantType::String, "RECREATE", {"Creation mode of the result files: NEW, CREATE, RECREATE, UPDATE"}});
+    workflowOptions.push_back(ConfigParamSpec{"aodw-ntfmerge", VariantType::Int, 1, {"Number of time frames to merge into one file"}});
+    workflowOptions.push_back(ConfigParamSpec{"aodw-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}});
+
     std::vector<ChannelConfigurationPolicy> channelPolicies;
     UserCustomizationsHelper::userDefinedCustomization(channelPolicies, 0);
     auto defaultChannelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();

--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -495,7 +495,6 @@ TTree* DataInputDirector::getDataTree(header::DataHeader dh, int counter, int nu
     // if NOT match then use
     //  . filename from defaultDataInputDescriptor
     //  . treename from DataHeader
-    LOGP(INFO, "Using default DataInputDescriptor");
     didesc = mdefaultDataInputDescriptor;
     treename = aod::datamodel::getTreeName(dh);
   }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -209,7 +209,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {},
     readers::AODReaderHelpers::rootFileReaderCallback(),
     {ConfigParamSpec{"aod-file", VariantType::String, "aod.root", {"Input AOD file"}},
-     ConfigParamSpec{"aodr-jsonfile", VariantType::String, {"json configuration file"}},
+     ConfigParamSpec{"aodr-json", VariantType::String, {"json configuration file"}},
      ConfigParamSpec{"time-limit", VariantType::Int64, 0ll, {"Maximum run time limit in seconds"}},
      ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
      ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
@@ -386,24 +386,16 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // ATTENTION: if there are dangling outputs the getGlobalAODSink
   // has to be created in any case!
   std::vector<InputSpec> outputsInputsAOD;
-  std::vector<bool> isdangling;
-  LOGP(INFO, "OutputsInputs.size() {}", OutputsInputs.size());
   for (auto ii = 0u; ii < OutputsInputs.size(); ii++) {
     if ((outputTypes[ii] & 2) == 2) {
       auto ds = dod->getDataOutputDescriptors(OutputsInputs[ii]);
       if (ds.size() > 0 || (outputTypes[ii] & 1) == 1) {
         outputsInputsAOD.emplace_back(OutputsInputs[ii]);
-        // is this dangling ?
-        if ((outputTypes[ii] & 1) == 1) {
-          isdangling.emplace_back((outputTypes[ii] & 1) == 1);
-        }
       }
     }
   }
 
-  LOGP(INFO, "outputsInputsAOD.size() {}", outputsInputsAOD.size());
   if (outputsInputsAOD.size() > 0) {
-    LOGP(INFO, "Creating getGlobalAODSink");
     auto fileSink = CommonDataProcessors::getGlobalAODSink(dod,outputsInputsAOD);
     extraSpecs.push_back(fileSink);
   }

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -14,6 +14,7 @@
 #include "Framework/OutputSpec.h"
 #include "Framework/ForwardRoute.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/DataOutputDirector.h"
 #include "DataProcessorInfo.h"
 
 #include <cstddef>
@@ -172,6 +173,8 @@ struct WorkflowHelpers {
   static std::vector<EdgeAction> computeInEdgeActions(
     const std::vector<DeviceConnectionEdge>& edges,
     const std::vector<size_t>& index);
+
+  static std::shared_ptr<DataOutputDirector> getDataOutputDirector(ConfigParamRegistry const& options, std::vector<InputSpec> const& OutputsInputs, std::vector<unsigned char> const& outputTypes);
 
   /// Given @a workflow it gathers all the OutputSpec and in addition provides
   /// the information whether and output is dangling and/or of type AOD

--- a/Framework/Core/test/test_DataInputDirector.cxx
+++ b/Framework/Core/test/test_DataInputDirector.cxx
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(TestDatainputDirector)
   auto dh = DataHeader(DataDescription{"DUE"},
                        DataOrigin{"AOD"},
                        DataHeader::SubSpecificationType{0});
-  auto [file1, directory1] = didir1.getFileFolder(dh, 1);
+  auto [file1, directory1] = didir1.getFileFolder(dh, 1, 0);
   //BOOST_CHECK_EQUAL(file1->GetName(), "Bresults_1.root");
 
   auto didesc = didir1.getDataInputDescriptor(dh);
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(TestDatainputDirector)
   didir2.printOut(); printf("\n\n");
   BOOST_CHECK(didir2.readJson(jsonFile));
 
-  auto [file2, directory2] = didir2.getFileFolder(dh, 1);
+  auto [file2, directory2] = didir2.getFileFolder(dh, 1, 0);
   //BOOST_CHECK_EQUAL(file2->GetName(), "Bresults_1.root");
 
   didesc = didir2.getDataInputDescriptor(dh);


### PR DESCRIPTION
This update addresses some issues with the reader/writer. This is not final and needs discussion and further developments. Simple tasks like the o2-analysistutorial-aodwriter seem to work properly, more complicated queues of tasks fail.

. the reader has been changed to read an entire file instead of only a single TF. This guarantees that not more than one reader accesses a file simultaneously. The reader opens one file and loops over the folders TF_%d. In each folder it reads the requested trees and converts them to tables. The created tables of all TF are sequentially added to the output of the reader. In this scheme the created tables are forwarded to the consumers only at the very end, when all TF have been read. This is however, not exactly what we want. How can the reader announce that the tables of a given TF are ready or push them forward, such that they can be further processed while the next TF is read?

. the writer has been adapted to work with the completion policy "consume". Different versions of the same table are written to consecutive folders TF_%d as they arrive at the writer (FIFO), under consideration of the ntfmerge option.

. it is our intention to avoid that a writer is started when no outputs need to be saved. This is not implemented yet. In order to decide whether tables need to be saved to file the values of the command line options of the writer are needed. However, only when the writer is started its options become available. A solution could be to make the relevant command line options global. A first attempt to do so was not successful.