### PR TITLE
DPL: improve metrics for arrow messages

### DIFF
--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -107,14 +107,18 @@ o2::framework::ServiceSpec CommonMessageBackends::arrowBackendSpec()
                            continue;
                          }
                          auto dh = o2::header::get<DataHeader*>(input.header);
+                         if (dh->serialization != o2::header::gSerializationMethodArrow) {
+                           continue;
+                         }
                          auto dph = o2::header::get<DataProcessingHeader*>(input.header);
                          for (auto const& forward : ctx.services().get<DeviceSpec const>().forwards) {
-                           if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification) == true && (dph->startTime % forward.maxTimeslices) == forward.timeslice) {
+                           if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification) == true
+                               && (dph->startTime % forward.maxTimeslices) == forward.timeslice) {
                              continue;
                            }
-                           arrow->updateBytesDestroyed(dh->payloadSize);
-                           arrow->updateMessagesDestroyed(1);
                          }
+                         arrow->updateBytesDestroyed(dh->payloadSize);
+                         arrow->updateMessagesDestroyed(1);
                        }
                        ctx.services().get<Monitoring>().send(Metric{(uint64_t)arrow->bytesDestroyed(), "arrow-bytes-destroyed"}.addTag(Key::Subsystem, Value::DPL));
                        ctx.services().get<Monitoring>().send(Metric{(uint64_t)arrow->messagesDestroyed(), "arrow-messages-destroyed"}.addTag(Key::Subsystem, Value::DPL));

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -112,8 +112,7 @@ o2::framework::ServiceSpec CommonMessageBackends::arrowBackendSpec()
                          }
                          auto dph = o2::header::get<DataProcessingHeader*>(input.header);
                          for (auto const& forward : ctx.services().get<DeviceSpec const>().forwards) {
-                           if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification) == true
-                               && (dph->startTime % forward.maxTimeslices) == forward.timeslice) {
+                           if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification) == true && (dph->startTime % forward.maxTimeslices) == forward.timeslice) {
                              continue;
                            }
                          }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -955,8 +955,8 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
       context.registry->preProcessingCallbacks(processContext);
     }
     if (action.op == CompletionPolicy::CompletionOp::Discard) {
+      context.registry->postDispatchingCallbacks(processContext);
       if (context.spec->forwards.empty() == false) {
-        context.registry->postDispatchingCallbacks(processContext);
         forwardInputs(action.slot, record);
         continue;
       }

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -94,6 +94,7 @@ void DataProcessor::doSend(FairMQDevice& device, ArrowContext& context, ServiceR
     // exposing it to the user in the first place.
     DataHeader* dh = const_cast<DataHeader*>(cdh);
     dh->payloadSize = payload->GetSize();
+    dh->serialization = o2::header::gSerializationMethodArrow;
     context.updateBytesSent(payload->GetSize());
     context.updateMessagesSent(1);
     registry.get<Monitoring>().send(Metric{(uint64_t)context.bytesSent(), "arrow-bytes-created"}.addTag(Key::Subsystem, Value::DPL));


### PR DESCRIPTION
* Correctly account for the case in which there are no forwards.
* Only count Arrow serialized messages.