### PR TITLE
DPL Analysis: use index-builder similar to aod-spawner for predefined index tables

### DIFF
--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -65,6 +65,7 @@ struct RuntimeWatchdog {
 struct AODReaderHelpers {
   static AlgorithmSpec rootFileReaderCallback();
   static AlgorithmSpec aodSpawnerCallback(std::vector<InputSpec> requested);
+  static AlgorithmSpec indexBuilderCallback(std::vector<InputSpec> requested);
 };
 
 } // namespace o2::framework::readers

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -25,6 +25,7 @@
 #include <arrow/compute/kernel.h>
 #include <gandiva/selection_vector.h>
 #include <cassert>
+#include <fmt/format.h>
 
 using o2::framework::runtime_error_f;
 
@@ -1050,6 +1051,7 @@ class TableMetadata
   static constexpr char const* tableLabel() { return INHERIT::mLabel; }
   static constexpr char const (&origin())[4] { return INHERIT::mOrigin; }
   static constexpr char const (&description())[16] { return INHERIT::mDescription; }
+  static std::string sourceSpec() { return fmt::format("{}/{}/{}", INHERIT::mLabel, INHERIT::mOrigin, INHERIT::mDescription); };
 };
 
 template <typename... C1, typename... C2>
@@ -1377,7 +1379,7 @@ constexpr auto is_binding_compatible_v()
 #define DECLARE_SOA_EXTENDED_TABLE_USER(_Name_, _Table_, _Description_, ...) \
   DECLARE_SOA_EXTENDED_TABLE_FULL(_Name_, _Table_, "AOD", _Description_, __VA_ARGS__)
 
-#define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Description_, ...)                                                \
+#define DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, _Origin_, _Description_, _Exclusive_, ...)                                   \
   struct _Name_ : o2::soa::IndexTable<_Key_, __VA_ARGS__> {                                                                      \
     _Name_(std::shared_ptr<arrow::Table> table, uint64_t offset = 0) : o2::soa::IndexTable<_Key_, __VA_ARGS__>(table, offset){}; \
     _Name_(_Name_ const&) = default;                                                                                             \
@@ -1393,6 +1395,7 @@ constexpr auto is_binding_compatible_v()
     static constexpr char const* mLabel = #_Name_;                                                                               \
     static constexpr char const mOrigin[4] = _Origin_;                                                                           \
     static constexpr char const mDescription[16] = _Description_;                                                                \
+    static constexpr bool exclusive = _Exclusive_;                                                                               \
   };                                                                                                                             \
                                                                                                                                  \
   template <>                                                                                                                    \
@@ -1406,7 +1409,16 @@ constexpr auto is_binding_compatible_v()
   };
 
 #define DECLARE_SOA_INDEX_TABLE(_Name_, _Key_, _Description_, ...) \
-  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "AOD", _Description_, __VA_ARGS__)
+  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "IDX", _Description_, false, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "IDX", _Description_, true, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_USER(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "AOD", _Description_, false, __VA_ARGS__)
+
+#define DECLARE_SOA_INDEX_TABLE_EXCLUSIVE_USER(_Name_, _Key_, _Description_, ...) \
+  DECLARE_SOA_INDEX_TABLE_FULL(_Name_, _Key_, "AOD", _Description_, true, __VA_ARGS__)
 
 namespace o2::soa
 {
@@ -1767,6 +1779,7 @@ struct IndexTable : Table<soa::Index<>, H, Ts...> {
   using indexing_t = Key;
   using first_t = typename H::binding_t;
   using rest_t = framework::pack<typename Ts::binding_t...>;
+  using sources_t = framework::pack<Key, typename H::binding_t, typename Ts::binding_t...>;
 
   IndexTable(std::shared_ptr<arrow::Table> table, uint64_t offset = 0)
     : base_t{table, offset}

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -608,14 +608,14 @@ DECLARE_SOA_INDEX_COLUMN(FDD, fdd);
 } // namespace indices
 
 #define INDEX_LIST_RUN2 indices::CollisionId, indices::ZdcId, indices::BCId, indices::FT0Id, indices::FV0AId, indices::FV0CId, indices::FDDId
-DECLARE_SOA_INDEX_TABLE(Run2MatchedExclusive, BCs, "MA_RN2_EX", INDEX_LIST_RUN2);
+DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run2MatchedExclusive, BCs, "MA_RN2_EX", INDEX_LIST_RUN2);
 DECLARE_SOA_INDEX_TABLE(Run2MatchedSparse, BCs, "MA_RN2_SP", INDEX_LIST_RUN2);
 
 #define INDEX_LIST_RUN3 indices::CollisionId, indices::ZdcId, indices::BCId, indices::FT0Id, indices::FV0AId, indices::FDDId
-DECLARE_SOA_INDEX_TABLE(Run3MatchedExclusive, BCs, "MA_RN3_EX", INDEX_LIST_RUN3);
+DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run3MatchedExclusive, BCs, "MA_RN3_EX", INDEX_LIST_RUN3);
 DECLARE_SOA_INDEX_TABLE(Run3MatchedSparse, BCs, "MA_RN3_SP", INDEX_LIST_RUN3);
 
-DECLARE_SOA_INDEX_TABLE(BCCollisionsExclusive, BCs, "MA_BCCOL_EX", indices::BCId, indices::CollisionId);
+DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(BCCollisionsExclusive, BCs, "MA_BCCOL_EX", indices::BCId, indices::CollisionId);
 DECLARE_SOA_INDEX_TABLE(BCCollisionsSparse, BCs, "MA_BCCOL_SP", indices::BCId, indices::CollisionId);
 
 } // namespace aod

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -8,8 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "Framework/TableTreeHelpers.h"
 #include "Framework/AODReaderHelpers.h"
+#include "Framework/TableTreeHelpers.h"
+#include "Framework/AnalysisHelpers.h"
 #include "AnalysisDataModelHelpers.h"
 #include "DataProcessingHelpers.h"
 #include "ExpressionHelpers.h"
@@ -41,16 +42,90 @@
 
 namespace o2::framework::readers
 {
+auto setEOSCallback(InitContext& ic)
+{
+  ic.services().get<CallbackService>().set(CallbackService::Id::EndOfStream,
+                                           [](EndOfStreamContext& eosc) {
+                                             auto& control = eosc.services().get<ControlService>();
+                                             control.endOfStream();
+                                             control.readyToQuit(QuitRequest::Me);
+                                           });
+}
+
+template <typename O>
+static inline auto extractTypedOriginal(ProcessingContext& pc)
+{
+  ///FIXME: this should be done in invokeProcess() as some of the originals may be compound tables
+  return O{pc.inputs().get<TableConsumer>(aod::MetadataTrait<O>::metadata::tableLabel())->asArrowTable()};
+}
+
+template <typename... Os>
+static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
+{
+  return std::make_tuple(extractTypedOriginal<Os>(pc)...);
+}
+
+AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requested)
+{
+  return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
+    setEOSCallback(ic);
+
+    return [requested](ProcessingContext& pc) {
+      auto outputs = pc.outputs();
+      // spawn tables
+      for (auto& input : requested) {
+        auto description = std::visit(
+          overloaded{
+            [](ConcreteDataMatcher const& matcher) { return matcher.description; },
+            [](auto&&) { return header::DataDescription{""}; }},
+          input.matcher);
+
+        auto origin = std::visit(
+          overloaded{
+            [](ConcreteDataMatcher const& matcher) { return matcher.origin; },
+            [](auto&&) { return header::DataOrigin{""}; }},
+          input.matcher);
+
+        auto maker = [&](auto metadata) {
+          using metadata_t = decltype(metadata);
+          using Key = typename metadata_t::Key;
+          using index_pack_t = typename metadata_t::index_pack_t;
+          using sources = typename metadata_t::originals;
+          if constexpr (metadata_t::exclusive == true) {
+            return o2::framework::IndexExclusive::indexBuilder(index_pack_t{},
+                                                               extractTypedOriginal<Key>(pc),
+                                                               extractOriginalsTuple(sources{}, pc));
+          } else {
+            return o2::framework::IndexSparse::indexBuilder(index_pack_t{},
+                                                            extractTypedOriginal<Key>(pc),
+                                                            extractOriginalsTuple(sources{}, pc));
+          }
+        };
+
+        if (description == header::DataDescription{"MA_RN2_EX"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::Run2MatchedExclusiveMetadata{}));
+        } else if (description == header::DataDescription{"MA_RN2_SP"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::Run2MatchedSparseMetadata{}));
+        } else if (description == header::DataDescription{"MA_RN3_EX"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::Run3MatchedExclusiveMetadata{}));
+        } else if (description == header::DataDescription{"MA_RN3_SP"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::Run3MatchedSparseMetadata{}));
+        } else if (description == header::DataDescription{"MA_BCCOL_EX"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::BCCollisionsExclusiveMetadata{}));
+        } else if (description == header::DataDescription{"MA_BCCOL_SP"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::BCCollisionsSparseMetadata{}));
+        } else {
+          throw std::runtime_error("Not an index table");
+        }
+      }
+    };
+  }};
+}
+
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
-    auto& callbacks = ic.services().get<CallbackService>();
-    auto endofdatacb = [](EndOfStreamContext& eosc) {
-      auto& control = eosc.services().get<ControlService>();
-      control.endOfStream();
-      control.readyToQuit(QuitRequest::Me);
-    };
-    callbacks.set(CallbackService::Id::EndOfStream, endofdatacb);
+    setEOSCallback(ic);
 
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -260,14 +260,14 @@ struct OutputManager<Spawns<T>> {
 
 /// Builds specialization
 template <typename O>
-static auto extractTypedOriginal(ProcessingContext& pc)
+static inline auto extractTypedOriginal(ProcessingContext& pc)
 {
   ///FIXME: this should be done in invokeProcess() as some of the originals may be compound tables
   return O{pc.inputs().get<TableConsumer>(aod::MetadataTrait<O>::metadata::tableLabel())->asArrowTable()};
 }
 
 template <typename... Os>
-static auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
+static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
 {
   return std::make_tuple(extractTypedOriginal<Os>(pc)...);
 }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -161,6 +161,41 @@ void addMissingOutputsToSpawner(std::vector<InputSpec>&& requestedDYNs,
   }
 }
 
+void addMissingOutputsToBuilder(std::vector<InputSpec>&& requestedIDXs,
+                                std::vector<InputSpec>& requestedAODs,
+                                DataProcessorSpec& publisher)
+{
+  auto inputSpecFromString = [](std::string s) {
+    std::regex word_regex("(\\w+)");
+    auto words = std::sregex_iterator(s.begin(), s.end(), word_regex);
+    if (std::distance(words, std::sregex_iterator()) != 3) {
+      throw runtime_error_f("Malformed spec: %s", s.c_str());
+    }
+    std::vector<std::string> data;
+    for (auto i = words; i != std::sregex_iterator(); ++i) {
+      data.emplace_back(i->str());
+    }
+    char origin[4];
+    char description[16];
+    std::memcpy(&origin, data[1].c_str(), 4);
+    std::memcpy(&description, data[2].c_str(), 16);
+    return InputSpec{data[0], header::DataOrigin{origin}, header::DataDescription{description}};
+  };
+
+  for (auto& input : requestedIDXs) {
+    auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
+    publisher.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec});
+    for (auto& i : input.metadata) {
+      auto spec = inputSpecFromString(i.defaultValue.get<std::string>());
+      auto j = std::find_if(publisher.inputs.begin(), publisher.inputs.end(), [&](auto x) { return x.binding == spec.binding; });
+      if (j == publisher.inputs.end()) {
+        publisher.inputs.push_back(spec);
+      }
+      requestedAODs.push_back(spec);
+    }
+  }
+}
+
 void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext const& ctx)
 {
   auto fakeCallback = AlgorithmSpec{[](InitContext& ic) {
@@ -218,6 +253,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::vector<InputSpec> requestedAODs;
   std::vector<OutputSpec> providedAODs;
   std::vector<InputSpec> requestedDYNs;
+  std::vector<InputSpec> requestedIDXs;
 
   std::vector<InputSpec> requestedCCDBs;
   std::vector<OutputSpec> providedCCDBs;
@@ -281,6 +317,11 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
           requestedDYNs.emplace_back(input);
         }
       }
+      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"IDX"})) {
+        if (std::find_if(requestedIDXs.begin(), requestedIDXs.end(), [&](InputSpec const& spec) { return input.binding == spec.binding; }) == requestedIDXs.end()) {
+          requestedIDXs.emplace_back(input);
+        }
+      }
     }
     std::stable_sort(timer.outputs.begin(), timer.outputs.end(), [](OutputSpec const& a, OutputSpec const& b) { return *DataSpecUtils::getOptionalSubSpec(a) < *DataSpecUtils::getOptionalSubSpec(b); });
 
@@ -316,6 +357,9 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   auto last = std::unique(requestedDYNs.begin(), requestedDYNs.end());
   requestedDYNs.erase(last, requestedDYNs.end());
 
+  last = std::unique(requestedIDXs.begin(), requestedIDXs.end());
+  requestedIDXs.erase(last, requestedIDXs.end());
+
   DataProcessorSpec aodSpawner{
     "internal-dpl-aod-spawner",
     {},
@@ -323,7 +367,16 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     readers::AODReaderHelpers::aodSpawnerCallback(requestedDYNs),
     {}};
 
+  DataProcessorSpec indexBuilder{
+    "internal-dpl-index-builder",
+    {},
+    {},
+    readers::AODReaderHelpers::indexBuilderCallback(requestedIDXs),
+    {}};
+
   addMissingOutputsToSpawner(std::move(requestedDYNs), requestedAODs, aodSpawner);
+  addMissingOutputsToBuilder(std::move(requestedIDXs), requestedAODs, indexBuilder);
+
   addMissingOutputsToReader(providedAODs, requestedAODs, aodReader);
   addMissingOutputsToReader(providedCCDBs, requestedCCDBs, ccdbBackend);
 
@@ -341,6 +394,10 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   if (aodSpawner.outputs.empty() == false) {
     extraSpecs.push_back(aodSpawner);
+  }
+
+  if (indexBuilder.outputs.empty() == false) {
+    extraSpecs.push_back(indexBuilder);
   }
 
   if (aodReader.outputs.empty() == false) {


### PR DESCRIPTION
Using the new ability to store metadata in input specs, it is now possible to automatically create requested index tables by a dedicated devices in the same way how it is already done for extended tables.
Introduced `DECLARE_SOA_INDEX_TABLE(_USER)` and `DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(_USER)` macros:
* user-defined index tables use `AOD` origin and need to be created by `Builds<>`
* predefined index tables use `IDX` origin and are created on demand.