### PR TITLE
HistogramRegistry: allow for grouping of histograms in output file

### DIFF
--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -144,19 +144,20 @@ struct DTask {
 
     HistogramConfigSpec defaultParticleHist({HistType::kTHnF, {ptAxis, etaAxis, centAxis, cutAxis}});
 
-    spectra.add({"myControlHist", "a", {HistType::kTH2F, {ptAxis, etaAxis}}});
+    spectra.add("myControlHist", "a", kTH2F, {ptAxis, etaAxis});
     spectra.get<TH2>("myControlHist")->GetYaxis()->SetTitle("my-y-axis");
     spectra.get<TH2>("myControlHist")->SetTitle("something meaningful");
 
-    spectra.add({"pions", "Pions", defaultParticleHist});
-    spectra.add({"kaons", "Kaons", defaultParticleHist});
-    spectra.add({"sigmas", "Sigmas", defaultParticleHist});
-    spectra.add({"lambdas", "Lambd", defaultParticleHist});
+    spectra.add("charged/pions", "Pions", defaultParticleHist);
+    spectra.add("neutral/pions", "Pions", defaultParticleHist);
+    spectra.add("one/two/three/four/kaons", "Kaons", defaultParticleHist);
+    spectra.add("sigmas", "Sigmas", defaultParticleHist);
+    spectra.add("lambdas", "Lambd", defaultParticleHist);
 
     spectra.get<THn>("lambdas")->SetTitle("Lambdas");
 
-    etaStudy.add({"positive", "A side spectra", {HistType::kTH1I, {ptAxis}}});
-    etaStudy.add({"negative", "C side spectra", {HistType::kTH1I, {ptAxis}}});
+    etaStudy.add("positive", "A side spectra", kTH1I, {ptAxis});
+    etaStudy.add("negative", "C side spectra", kTH1I, {ptAxis});
   }
 
   void process(aod::Tracks const& tracks)
@@ -168,8 +169,10 @@ struct DTask {
 
     for (auto& track : tracks) {
       spectra.fill("myControlHist", track.pt(), track.eta());
-      spectra.fill("pions", track.pt(), track.eta(), 50., 0.);
-      spectra.fill("kaons", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("charged/pions", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("charged/pions", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("neutral/pions", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("one/two/three/four/kaons", track.pt(), track.eta(), 50., 0.);
       spectra.fill("sigmas", track.pt(), track.eta(), 50., 0.);
       spectra.fill("lambdas", track.pt(), track.eta(), 50., 0.);
     }

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <variant>
+#include <deque>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -30,10 +30,7 @@
 #include <TProfile.h>
 #include <TProfile2D.h>
 #include <TProfile3D.h>
-
-#include <TFolder.h>
-//#include <TObjArray.h>
-//#include <TList.h>
+#include <TList.h>
 
 #include <string>
 #include <variant>
@@ -472,19 +469,28 @@ class HistogramRegistry
     taskHash = hash;
   }
 
-  // TODO: maybe support also TDirectory,TList,TObjArray?, find a way to write to file in 'single key' mode (arg in WriteObjAny)
-  TFolder* operator*()
+  TList* operator*()
   {
-    TFolder* folder = new TFolder(this->name.c_str(), this->name.c_str());
+    TList* list = new TList();
+    list->SetName(this->name.data());
     for (auto j = 0u; j < MAX_REGISTRY_SIZE; ++j) {
-      TObject* rawPtr = nullptr;
-      std::visit([&](const auto& sharedPtr) { rawPtr = sharedPtr.get(); }, mRegistryValue[j]);
+      TNamed* rawPtr = nullptr;
+      std::visit([&](const auto& sharedPtr) { rawPtr = (TNamed*)sharedPtr.get(); }, mRegistryValue[j]);
       if (rawPtr) {
-        folder->Add(rawPtr);
+        std::deque<std::string> path = splitPath(rawPtr->GetName());
+        std::string name = path.back();
+        path.pop_back();
+        TList* targetList{getSubList(list, path)};
+        if (targetList) {
+          rawPtr->SetName(name.data());
+          targetList->Add(rawPtr);
+        } else {
+          LOGF(FATAL, "Specified subfolder could not be created.");
+        }
       }
     }
-    folder->SetOwner(false); // object deletion will be handled by shared_ptrs
-    return folder;
+    list->SetOwner(false); // object deletion will be handled by shared_ptrs
+    return list;
   }
 
   // fill hist with values
@@ -547,6 +553,7 @@ class HistogramRegistry
   mutable uint32_t lookup = 0;
 
  private:
+  // create histogram from specification and insert it into the registry
   void insert(const HistogramSpec& histSpec)
   {
     uint32_t i = imask(histSpec.id);
@@ -566,6 +573,40 @@ class HistogramRegistry
   inline constexpr uint32_t imask(uint32_t i) const
   {
     return i & mask;
+  }
+
+  // helper function to create resp. find the subList defined by path
+  TList* getSubList(TList* list, std::deque<std::string> path)
+  {
+    if (path.empty())
+      return list;
+    TList* targetList{nullptr};
+    std::string nextList = path[0];
+    path.pop_front();
+    if (auto subList = (TList*)list->FindObject(nextList.data())) {
+      if (subList->InheritsFrom(TList::Class()))
+        targetList = getSubList((TList*)subList, path);
+      else
+        return nullptr;
+    } else {
+      subList = new TList();
+      subList->SetName(nextList.data());
+      list->Add(subList);
+      targetList = getSubList(subList, path);
+    }
+    return targetList;
+  }
+
+  // helper function to split user defined path/to/hist/name string
+  std::deque<std::string> splitPath(std::string pathAndNameUser)
+  {
+    std::istringstream pathAndNameStream(pathAndNameUser);
+    std::deque<std::string> pathAndName;
+    std::string curDir;
+    while (std::getline(pathAndNameStream, curDir, '/')) {
+      pathAndName.push_back(curDir);
+    }
+    return pathAndName;
   }
 
   std::string name{};


### PR DESCRIPTION
- move from TFolders to TLists since TFolder is 'non-mergable'
- allow sub-grouping of output
- TODO: turn lists into directories in file sink