### PR TITLE
Improve class checkin handling

### DIFF
--- a/Common/Utils/include/CommonUtils/TreeStream.h
+++ b/Common/Utils/include/CommonUtils/TreeStream.h
@@ -178,7 +178,7 @@ Int_t TreeStream::CheckIn(T* obj)
   // check in arbitrary class having dictionary
   TClass* pClass = nullptr;
   if (obj) {
-    pClass = obj->IsA();
+    pClass = TClass::GetClass(typeid(*obj));
   }
 
   if (mCurrentIndex >= static_cast<int>(mElements.size())) {


### PR DESCRIPTION
Enable streaming of any class with a dictionary, not only classes with
IsA functionality.

@shahor02 with some simple testing it does not show side effects for me. 

This enables to e.g. directly stream std::vector without any wrapping. But I'm not sure if it can have other side effects. I tried with a custom class without ClassDef etc. using this macro:
```c++
#if !defined(__CLING__) || defined(__ROOTCLING__)
#include <vector>
#include <numeric>

#include "CommonUtils/TreeStreamRedirector.h"
#endif

struct dummy {
  int i;
};

void test() {

  o2::utils::TreeStreamRedirector stream("/tmp/test.root", "recreate");

  for (int i = 0; i < 10; ++i) {
    std::vector<float> v(i);
    std::iota(v.begin(), v.end(), i*10);

    dummy t{i * 10};
    stream << "t"
           << "i=" << i
           << "v=" << v
           << "test=" << t << "\n";
  }

  stream.Close();
}

int main() {
  test();
  return 0;
}
```

if I run the macro in cling, compiled or uncompiled, it even creates the dictionary for this class automatically, such that the class is written to the tree.
.x test.C
.x test.C+

If I compile the macro
```
g++ -o test $(root-config --cflags) $(root-config --libs) -I$O2_ROOT/include -L$O2_ROOT/lib -l O2CommonUtils test.C
```

no dictionary seems to be created. Therefore, the class does not enter in the tree, but there is also no crash. Simply no branch is created for the class.

Cheers,
Jens
