### PR TITLE
HistogramRegistry: several new features

### DIFF
--- a/Analysis/Tasks/trackqa.cxx
+++ b/Analysis/Tasks/trackqa.cxx
@@ -40,25 +40,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 //****************************************************************************************
 struct TrackQATask {
 
-  HistogramRegistry kine{"Kine", true, {}, OutputObjHandlingPolicy::QAObject};
-  HistogramRegistry trackpar{"TrackPar", true, {}, OutputObjHandlingPolicy::QAObject};
-  HistogramRegistry its{"ITS", true, {}, OutputObjHandlingPolicy::QAObject};
-  HistogramRegistry tpc{"TPC", true, {}, OutputObjHandlingPolicy::QAObject};
-
-  //HistogramRegistry trd{"TRD", true, {}, OutputObjHandlingPolicy::QAObject};
-  //HistogramRegistry tof{"TOF", true, {}, OutputObjHandlingPolicy::QAObject};
-  //HistogramRegistry emcal{"EMCAL", true, {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry histos{"Histos", true, {}, OutputObjHandlingPolicy::QAObject};
 
   Configurable<int> selectedTracks{"select", 1, "Choice of track selection. 0 = no selection, 1 = globalTracks, 2 = globalTracksSDD"};
 
   Filter trackFilter = aod::track::isGlobalTrack == true;
-  /*
-  //Function float castFLOAT4(uint8) not supported yet
-  Filter trackFilter = ((0 * aod::track::isGlobalTrack == (float)selectedTracks) ||
-                        (1 * aod::track::isGlobalTrack == (float)selectedTracks) ||
-                        (2 * aod::track::isGlobalTrackSDD == (float)selectedTracks) ||
-                        (3 * aod::track::isGlobalTrackwTOF == (float)selectedTracks));
-  */
 
   void init(o2::framework::InitContext&)
   {
@@ -66,83 +52,77 @@ struct TrackQATask {
                                      1.1, 1.2, 1.3, 1.4, 1.5, 2.0, 5.0, 10.0, 20.0, 50.0};
 
     // kine histograms
-    kine.add("pt", "#it{p}_{T};#it{p}_{T} [GeV/c]", kTH1D, {{ptBinning}});
-    kine.add("eta", "#eta;#eta", kTH1D, {{180, -0.9, 0.9}});
-    kine.add("phi", "#phi;#phi [rad]", kTH1D, {{180, 0., 2 * M_PI}});
+    histos.add("Kine/pt", "#it{p}_{T};#it{p}_{T} [GeV/c]", kTH1D, {{ptBinning}});
+    histos.add("Kine/eta", "#eta;#eta", kTH1D, {{180, -0.9, 0.9}});
+    histos.add("Kine/phi", "#phi;#phi [rad]", kTH1D, {{180, 0., 2 * M_PI}});
 
     // track histograms
-    trackpar.add("x", "track #it{x} position at dca in local coordinate system;#it{x} [cm]", kTH1D, {{200, -0.36, 0.36}});
-    trackpar.add("y", "track #it{y} position at dca in local coordinate system;#it{y} [cm]", kTH1D, {{200, -0.5, 0.5}});
-    trackpar.add("z", "track #it{z} position at dca in local coordinate system;#it{z} [cm]", kTH1D, {{200, -11., 11.}});
-    trackpar.add("alpha", "rotation angle of local wrt. global coordinate system;#alpha [rad]", kTH1D, {{36, -M_PI, M_PI}});
-    trackpar.add("signed1Pt", "track signed 1/#it{p}_{T};#it{q}/#it{p}_{T}", kTH1D, {{200, -8, 8}});
-    trackpar.add("snp", "sinus of track momentum azimuthal angle;snp", kTH1D, {{11, -0.1, 0.1}});
-    trackpar.add("tgl", "tangent of the track momentum dip angle;tgl;", kTH1D, {{200, -1., 1.}});
-    trackpar.add("flags", "track flag;flag bit", kTH1D, {{64, -0.5, 63.5}});
-    trackpar.add("dcaXY", "distance of closest approach in #it{xy} plane;#it{dcaXY} [cm];", kTH1D, {{200, -0.15, 0.15}});
-    trackpar.add("dcaZ", "distance of closest approach in #it{z};#it{dcaZ} [cm];", kTH1D, {{200, -0.15, 0.15}});
+    histos.add("TrackPar/x", "track #it{x} position at dca in local coordinate system;#it{x} [cm]", kTH1D, {{200, -0.36, 0.36}});
+    histos.add("TrackPar/y", "track #it{y} position at dca in local coordinate system;#it{y} [cm]", kTH1D, {{200, -0.5, 0.5}});
+    histos.add("TrackPar/z", "track #it{z} position at dca in local coordinate system;#it{z} [cm]", kTH1D, {{200, -11., 11.}});
+    histos.add("TrackPar/alpha", "rotation angle of local wrt. global coordinate system;#alpha [rad]", kTH1D, {{36, -M_PI, M_PI}});
+    histos.add("TrackPar/signed1Pt", "track signed 1/#it{p}_{T};#it{q}/#it{p}_{T}", kTH1D, {{200, -8, 8}});
+    histos.add("TrackPar/snp", "sinus of track momentum azimuthal angle;snp", kTH1D, {{11, -0.1, 0.1}});
+    histos.add("TrackPar/tgl", "tangent of the track momentum dip angle;tgl;", kTH1D, {{200, -1., 1.}});
+    histos.add("TrackPar/flags", "track flag;flag bit", kTH1D, {{64, -0.5, 63.5}});
+    histos.add("TrackPar/dcaXY", "distance of closest approach in #it{xy} plane;#it{dcaXY} [cm];", kTH1D, {{200, -0.15, 0.15}});
+    histos.add("TrackPar/dcaZ", "distance of closest approach in #it{z};#it{dcaZ} [cm];", kTH1D, {{200, -0.15, 0.15}});
 
     // its histograms
-    its.add("itsNCls", "number of found ITS clusters;# clusters ITS", kTH1D, {{8, -0.5, 7.5}});
-    its.add("itsChi2NCl", "chi2 per ITS cluster;chi2 / cluster ITS", kTH1D, {{100, 0, 40}});
-    its.add("itsHits", "hitmap ITS;layer ITS", kTH1D, {{7, -0.5, 6.5}});
+    histos.add("ITS/itsNCls", "number of found ITS clusters;# clusters ITS", kTH1D, {{8, -0.5, 7.5}});
+    histos.add("ITS/itsChi2NCl", "chi2 per ITS cluster;chi2 / cluster ITS", kTH1D, {{100, 0, 40}});
+    histos.add("ITS/itsHits", "hitmap ITS;layer ITS", kTH1D, {{7, -0.5, 6.5}});
 
     // tpc histograms
-    tpc.add("tpcNClsFindable", "number of findable TPC clusters;# findable clusters TPC", kTH1D, {{165, -0.5, 164.5}});
-    tpc.add("tpcNClsFound", "number of found TPC clusters;# clusters TPC", kTH1D, {{165, -0.5, 164.5}});
-    tpc.add("tpcNClsShared", "number of shared TPC clusters;# shared clusters TPC", kTH1D, {{165, -0.5, 164.5}});
-    tpc.add("tpcNClsCrossedRows", "number of crossed TPC rows;# crossed rows TPC", kTH1D, {{165, -0.5, 164.5}});
-    tpc.add("tpcFractionSharedCls", "fraction of shared TPC clusters;fraction shared clusters TPC", kTH1D, {{100, 0., 1.}});
-    tpc.add("tpcCrossedRowsOverFindableCls", "crossed TPC rows over findable clusters;crossed rows / findable clusters TPC", kTH1D, {{120, 0.0, 1.2}});
-    tpc.add("tpcChi2NCl", "chi2 per cluster in TPC;chi2 / cluster TPC", kTH1D, {{100, 0, 10}});
+    histos.add("TPC/tpcNClsFindable", "number of findable TPC clusters;# findable clusters TPC", kTH1D, {{165, -0.5, 164.5}});
+    histos.add("TPC/tpcNClsFound", "number of found TPC clusters;# clusters TPC", kTH1D, {{165, -0.5, 164.5}});
+    histos.add("TPC/tpcNClsShared", "number of shared TPC clusters;# shared clusters TPC", kTH1D, {{165, -0.5, 164.5}});
+    histos.add("TPC/tpcNClsCrossedRows", "number of crossed TPC rows;# crossed rows TPC", kTH1D, {{165, -0.5, 164.5}});
+    histos.add("TPC/tpcFractionSharedCls", "fraction of shared TPC clusters;fraction shared clusters TPC", kTH1D, {{100, 0., 1.}});
+    histos.add("TPC/tpcCrossedRowsOverFindableCls", "crossed TPC rows over findable clusters;crossed rows / findable clusters TPC", kTH1D, {{120, 0.0, 1.2}});
+    histos.add("TPC/tpcChi2NCl", "chi2 per cluster in TPC;chi2 / cluster TPC", kTH1D, {{100, 0, 10}});
   }
 
   void process(soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::TrackSelection>>::iterator const& track)
   {
     // fill kinematic variables
-    kine.fill("pt", track.pt());
-    kine.fill("eta", track.eta());
-    kine.fill("phi", track.phi());
+    histos.fill("Kine/pt", track.pt());
+    histos.fill("Kine/eta", track.eta());
+    histos.fill("Kine/phi", track.phi());
 
     // fill track parameters
-    trackpar.fill("alpha", track.alpha());
-    trackpar.fill("x", track.x());
-    trackpar.fill("y", track.y());
-    trackpar.fill("z", track.z());
-    trackpar.fill("signed1Pt", track.signed1Pt());
-    trackpar.fill("snp", track.snp());
-    trackpar.fill("tgl", track.tgl());
+    histos.fill("TrackPar/alpha", track.alpha());
+    histos.fill("TrackPar/x", track.x());
+    histos.fill("TrackPar/y", track.y());
+    histos.fill("TrackPar/z", track.z());
+    histos.fill("TrackPar/signed1Pt", track.signed1Pt());
+    histos.fill("TrackPar/snp", track.snp());
+    histos.fill("TrackPar/tgl", track.tgl());
     for (unsigned int i = 0; i < 64; i++) {
       if (track.flags() & (1 << i)) {
-        trackpar.fill("flags", i);
+        histos.fill("TrackPar/flags", i);
       }
     }
-    trackpar.fill("dcaXY", track.dcaXY());
-    trackpar.fill("dcaZ", track.dcaZ());
+    histos.fill("TrackPar/dcaXY", track.dcaXY());
+    histos.fill("TrackPar/dcaZ", track.dcaZ());
 
     // fill ITS variables
-    its.fill("itsNCls", track.itsNCls());
-    its.fill("itsChi2NCl", track.itsChi2NCl());
+    histos.fill("ITS/itsNCls", track.itsNCls());
+    histos.fill("ITS/itsChi2NCl", track.itsChi2NCl());
     for (unsigned int i = 0; i < 7; i++) {
       if (track.itsClusterMap() & (1 << i)) {
-        its.fill("itsHits", i);
+        histos.fill("ITS/itsHits", i);
       }
     }
 
     // fill TPC variables
-    tpc.fill("tpcNClsFindable", track.tpcNClsFindable());
-    tpc.fill("tpcNClsFound", track.tpcNClsFound());
-    tpc.fill("tpcNClsShared", track.tpcNClsShared());
-    tpc.fill("tpcNClsCrossedRows", track.tpcNClsCrossedRows());
-    tpc.fill("tpcCrossedRowsOverFindableCls", track.tpcCrossedRowsOverFindableCls());
-    tpc.fill("tpcFractionSharedCls", track.tpcFractionSharedCls());
-    tpc.fill("tpcChi2NCl", track.tpcChi2NCl());
-
-    // fill TRD variables
-
-    // fill TOF variables
-
-    // fill EMCAL variables
+    histos.fill("TPC/tpcNClsFindable", track.tpcNClsFindable());
+    histos.fill("TPC/tpcNClsFound", track.tpcNClsFound());
+    histos.fill("TPC/tpcNClsShared", track.tpcNClsShared());
+    histos.fill("TPC/tpcNClsCrossedRows", track.tpcNClsCrossedRows());
+    histos.fill("TPC/tpcCrossedRowsOverFindableCls", track.tpcCrossedRowsOverFindableCls());
+    histos.fill("TPC/tpcFractionSharedCls", track.tpcFractionSharedCls());
+    histos.fill("TPC/tpcChi2NCl", track.tpcChi2NCl());
   }
 };
 

--- a/Analysis/Tasks/trackqa.cxx
+++ b/Analysis/Tasks/trackqa.cxx
@@ -40,7 +40,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 //****************************************************************************************
 struct TrackQATask {
 
-  HistogramRegistry histos{"Histos", true, {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
 
   Configurable<int> selectedTracks{"select", 1, "Choice of track selection. 0 = no selection, 1 = globalTracks, 2 = globalTracksSDD"};
 
@@ -127,7 +127,7 @@ struct TrackQATask {
 };
 
 struct TrackCutQATask {
-  HistogramRegistry cuts{"Cuts", true, {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry cuts{"Cuts", {}, OutputObjHandlingPolicy::QAObject};
   TrackSelection selectedTracks = getGlobalTrackSelection();
   static constexpr int ncuts = static_cast<int>(TrackSelection::TrackCuts::kNCuts);
   void init(InitContext&)
@@ -155,7 +155,7 @@ struct TrackCutQATask {
 //****************************************************************************************
 struct TrackQATaskMC {
 
-  HistogramRegistry resolution{"Resolution", true, {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry resolution{"Resolution", {}, OutputObjHandlingPolicy::QAObject};
 
   void init(o2::framework::InitContext&){
 

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -126,8 +126,8 @@ struct CTask {
 };
 
 struct DTask {
-  HistogramRegistry spectra{"spectra", true, {}};
-  HistogramRegistry etaStudy{"etaStudy", true, {}};
+  HistogramRegistry spectra{"spectra", true, {}, OutputObjHandlingPolicy::AnalysisObject, true};
+  HistogramRegistry etaStudy{"etaStudy", true, {}, OutputObjHandlingPolicy::AnalysisObject, true};
 
   void init(o2::framework::InitContext&)
   {

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -25,7 +25,6 @@ struct ATask {
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry",
-    true,
     {
       {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},     //
       {"phi", "#varphi", {HistType::kTH1F, {{100, 0., 2. * M_PI}}}} //
@@ -45,7 +44,6 @@ struct BTask {
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry",
-    true,
     {
       {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},                            //
       {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
@@ -63,34 +61,35 @@ struct CTask {
 
   HistogramRegistry registry{
     "registry",
-    true,
     {
       {"1d", "test 1d", {HistType::kTH1I, {{100, -10.0f, 10.0f}}}},                                                                                               //
       {"2d", "test 2d", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                                                                       //
       {"3d", "test 3d", {HistType::kTH3D, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                                                //
       {"4d", "test 4d", {HistType::kTHnC, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}},                         //
       {"5d", "test 5d", {HistType::kTHnSparseL, {{10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}, {10, -10.0f, 10.01f}}}}, //
-    }                                                                                                                                                             //
+    },
+    OutputObjHandlingPolicy::AnalysisObject,
+    true //
   };
 
   void init(o2::framework::InitContext&)
   {
-    registry.add({"7d", "test 7d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}}});
+    registry.add("7d", "test 7d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}});
 
-    registry.add({"6d", "test 6d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}}});
+    registry.add("6d", "test 6d", {HistType::kTHnC, {{3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}, {3, -10.0f, 10.01f}}});
 
-    registry.add({"1d-profile", "test 1d profile", {HistType::kTProfile, {{20, 0.0f, 10.01f}}}});
-    registry.add({"2d-profile", "test 2d profile", {HistType::kTProfile2D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}}});
-    registry.add({"3d-profile", "test 3d profile", {HistType::kTProfile3D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}}});
+    registry.add("1d-profile", "test 1d profile", {HistType::kTProfile, {{20, 0.0f, 10.01f}}});
+    registry.add("2d-profile", "test 2d profile", {HistType::kTProfile2D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}});
+    registry.add("3d-profile", "test 3d profile", {HistType::kTProfile3D, {{20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}, {20, 0.0f, 10.01f}}});
 
-    registry.add({"2d-weight", "test 2d weight", {HistType::kTH2C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+    registry.add("2d-weight", "test 2d weight", {HistType::kTH2C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true);
 
-    registry.add({"3d-weight", "test 3d weight", {HistType::kTH3C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+    registry.add("3d-weight", "test 3d weight", {HistType::kTH3C, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true);
 
-    registry.add({"4d-weight", "test 4d weight", {HistType::kTHnC, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}, true});
+    registry.add("4d-weight", "test 4d weight", {HistType::kTHnC, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}, true);
 
-    registry.add({"1d-profile-weight", "test 1d profile weight", {HistType::kTProfile, {{2, -10.0f, 10.01f}}}, true});
-    registry.add({"2d-profile-weight", "test 2d profile weight", {HistType::kTProfile2D, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true});
+    registry.add("1d-profile-weight", "test 1d profile weight", {HistType::kTProfile, {{2, -10.0f, 10.01f}}}, true);
+    registry.add("2d-profile-weight", "test 2d profile weight", {HistType::kTProfile2D, {{2, -10.0f, 10.01f}, {2, -10.0f, 10.01f}}}, true);
   }
 
   void process(aod::Tracks const& tracks)
@@ -126,8 +125,8 @@ struct CTask {
 };
 
 struct DTask {
-  HistogramRegistry spectra{"spectra", true, {}, OutputObjHandlingPolicy::AnalysisObject, true};
-  HistogramRegistry etaStudy{"etaStudy", true, {}, OutputObjHandlingPolicy::AnalysisObject, true};
+  HistogramRegistry spectra{"spectra", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+  HistogramRegistry etaStudy{"etaStudy", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
   void init(o2::framework::InitContext&)
   {
@@ -158,6 +157,19 @@ struct DTask {
 
     etaStudy.add("positive", "A side spectra", kTH1I, {ptAxis});
     etaStudy.add("negative", "C side spectra", kTH1I, {ptAxis});
+
+    spectra.add("before_cuts/hist1", "asdf", defaultParticleHist);
+    spectra.add("before_cuts/hist2", "asdf", defaultParticleHist);
+    spectra.add("before_cuts/hist3", "asdf", defaultParticleHist);
+    spectra.add("before_cuts/hist4", "asdf", defaultParticleHist);
+    spectra.add("before_cuts/hist5", "asdf", defaultParticleHist);
+
+    // clone whole category / group
+    spectra.addClone("before_cuts/", "after_cuts/");
+
+    // clone single histograms
+    spectra.addClone("sigmas", "cascades");
+    spectra.addClone("neutral/pions", "strange/funny/particles");
   }
 
   void process(aod::Tracks const& tracks)
@@ -175,6 +187,14 @@ struct DTask {
       spectra.fill("one/two/three/four/kaons", track.pt(), track.eta(), 50., 0.);
       spectra.fill("sigmas", track.pt(), track.eta(), 50., 0.);
       spectra.fill("lambdas", track.pt(), track.eta(), 50., 0.);
+
+      spectra.fill("before_cuts/hist2", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("before_cuts/hist2", track.pt(), track.eta(), 50., 0.);
+
+      spectra.fill("after_cuts/hist2", track.pt(), track.eta(), 50., 0.);
+
+      spectra.fill("cascades", track.pt(), track.eta(), 50., 0.);
+      spectra.fill("strange/funny/particles", track.pt(), track.eta(), 50., 0.);
     }
   }
 };

--- a/Framework/Core/test/benchmark_HistogramRegistry.cxx
+++ b/Framework/Core/test/benchmark_HistogramRegistry.cxx
@@ -32,7 +32,7 @@ static void BM_HashedNameLookup(benchmark::State& state)
     for (auto i = 0; i < state.range(0); ++i) {
       histSpecs.push_back({fmt::format("histo{}", i + 1).c_str(), fmt::format("Histo {}", i + 1).c_str(), {HistType::kTH1F, {{100, 0, 1}}}});
     }
-    HistogramRegistry registry{"registry", true, histSpecs};
+    HistogramRegistry registry{"registry", histSpecs};
     state.ResumeTiming();
 
     for (auto i = 0; i < nLookups; ++i) {

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -25,19 +25,19 @@ DECLARE_SOA_COLUMN_FULL(Y, y, float, "y");
 
 HistogramRegistry foo()
 {
-  return {"r", true, {{"histo", "histo", {HistType::kTH1F, {{100, 0, 1}}}}}};
+  return {"r", {{"histo", "histo", {HistType::kTH1F, {{100, 0, 1}}}}}};
 }
 
 BOOST_AUTO_TEST_CASE(HistogramRegistryLookup)
 {
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
-    "registry", true, {
-                        {"eta", "#Eta", {HistType::kTH1F, {{100, -2.0, 2.0}}}},                              //
-                        {"phi", "#Phi", {HistType::kTH1D, {{102, 0, 2 * M_PI}}}},                            //
-                        {"pt", "p_{T}", {HistType::kTH1D, {{1002, -0.01, 50.1}}}},                           //
-                        {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
-                      }                                                                                      //
+    "registry", {
+                  {"eta", "#Eta", {HistType::kTH1F, {{100, -2.0, 2.0}}}},                              //
+                  {"phi", "#Phi", {HistType::kTH1D, {{102, 0, 2 * M_PI}}}},                            //
+                  {"pt", "p_{T}", {HistType::kTH1D, {{1002, -0.01, 50.1}}}},                           //
+                  {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
+                }                                                                                      //
   };
 
   /// Get histograms by name
@@ -77,10 +77,10 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryExpressionFill)
 
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
-    "registry", true, {
-                        {"x", "test x", {HistType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
-                        {"xy", "test xy", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
-                      }                                                                                      //
+    "registry", {
+                  {"x", "test x", {HistType::kTH1F, {{100, 0.0f, 10.0f}}}},                            //
+                  {"xy", "test xy", {HistType::kTH2F, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}}} //
+                }                                                                                      //
   };
 
   /// Fill histogram with expression and table


### PR DESCRIPTION
- content of histogram registry can be stored in separate folder
- output histograms can be sorted alphabetically
- existing histograms or groups of histograms can be cloned and copies stored under different name
- track qa now uses grouping feature of registry