### PR TITLE
revert temporary changes that were required to keep new math_utils compatible to QC

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -224,12 +224,4 @@ using detail::numberOfBitsSet;
 } // namespace math_utils
 } // namespace o2
 
-namespace o2
-{
-namespace utils
-{
-using namespace math_utils;
-} // namespace utils
-} // namespace o2
-
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -27,7 +27,6 @@
 #include "ITSMFTReconstruction/GBTLink.h"
 #include "ITSMFTReconstruction/RUDecodeData.h"
 #include "DetectorsRaw/RDHUtils.h"
-#include "MathUtils/Cartesian.h"
 
 #include <TTree.h>
 #include <TStopwatch.h>
@@ -48,13 +47,8 @@
 
 #define OUTHEX(v, l) "0x" << std::hex << std::setfill('0') << std::setw(l) << v << std::dec
 
-template <typename T>
-using Point3D = o2::math_utils::Point3D<T>;
-
 namespace o2
 {
-using TransformType = o2::math_utils::TransformType;
-
 namespace itsmft
 {
 


### PR DESCRIPTION
@Barthelemy @JianLIUhep 
Could you check and update AliceO2Group/QualityControl#518 such that it compiles with this PR which removes the compatibility part.