### PR TITLE
Fixes for GPU compilation

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -114,6 +114,37 @@ GPUdi() void sincosd(double ang, double& s, double& c)
   detail::sincos(ang, s, c);
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE
+inline void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
+{
+  return detail::rotateZ<float>(xL, yL, xG, yG, snAlp, csAlp);
+}
+
+inline void rotateZd(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
+{
+  return detail::rotateZ<double>(xL, yL, xG, yG, snAlp, csAlp);
+}
+
+inline void rotateZInv(float xG, float yG, float& xL, float& yL, float snAlp, float csAlp)
+{
+  detail::rotateZInv<float>(xG, yG, xL, yL, snAlp, csAlp);
+}
+
+inline void rotateZInvd(double xG, double yG, double& xL, double& yL, double snAlp, double csAlp)
+{
+  detail::rotateZInv<double>(xG, yG, xL, yL, snAlp, csAlp);
+}
+
+inline std::tuple<float, float> rotateZInv(float xG, float yG, float snAlp, float csAlp)
+{
+  return detail::rotateZInv<float>(xG, yG, snAlp, csAlp);
+}
+
+inline std::tuple<double, double> rotateZInvd(double xG, double yG, double snAlp, double csAlp)
+{
+  return detail::rotateZInv<double>(xG, yG, snAlp, csAlp);
+}
+
 GPUdi() std::tuple<float, float> sincos(float ang)
 {
   return detail::sincos<float>(ang);
@@ -134,37 +165,6 @@ inline std::tuple<double, double> rotateZd(double xL, double yL, double snAlp, d
   return detail::rotateZ<double>(xL, yL, snAlp, csAlp);
 }
 
-inline void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
-{
-  return detail::rotateZ<float>(xL, yL, xG, yG, snAlp, csAlp);
-}
-
-inline void rotateZd(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
-{
-  return detail::rotateZ<double>(xL, yL, xG, yG, snAlp, csAlp);
-}
-
-inline std::tuple<float, float> rotateZInv(float xG, float yG, float snAlp, float csAlp)
-{
-  return detail::rotateZInv<float>(xG, yG, snAlp, csAlp);
-}
-
-inline std::tuple<double, double> rotateZInvd(double xG, double yG, double snAlp, double csAlp)
-{
-  return detail::rotateZInv<double>(xG, yG, snAlp, csAlp);
-}
-
-inline void rotateZInv(float xG, float yG, float& xL, float& yL, float snAlp, float csAlp)
-{
-  detail::rotateZInv<float>(xG, yG, xL, yL, snAlp, csAlp);
-}
-
-inline void rotateZInvd(double xG, double yG, double& xL, double& yL, double snAlp, double csAlp)
-{
-  detail::rotateZInv<double>(xG, yG, xL, yL, snAlp, csAlp);
-}
-
-#ifndef GPUCA_GPUCODE_DEVICE
 inline void rotateZ(std::array<float, 3>& xy, float alpha)
 {
   detail::rotateZ<float>(xy, alpha);

--- a/Common/MathUtils/include/MathUtils/detail/Bracket.h
+++ b/Common/MathUtils/include/MathUtils/detail/Bracket.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_BRACKET_H
 #define ALICEO2_BRACKET_H
 
-#include <Rtypes.h>
+#include <GPUCommonRtypes.h>
 
 namespace o2
 {

--- a/Common/MathUtils/include/MathUtils/detail/StatAccumulator.h
+++ b/Common/MathUtils/include/MathUtils/detail/StatAccumulator.h
@@ -15,7 +15,9 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_STATACCUMULATOR_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_STATACCUMULATOR_H_
 
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <tuple>
+#endif
 
 namespace o2
 {
@@ -41,6 +43,7 @@ struct StatAccumulator {
   }
   double getMean() const { return wsum > 0. ? sum / wsum : 0.; }
 
+#ifndef GPUCA_GPUCODE_DEVICE
   template <typename T = float>
   std::tuple<T, T> getMeanRMS2() const
   {
@@ -55,6 +58,7 @@ struct StatAccumulator {
 
     return {mean, rms2};
   }
+#endif
 
   StatAccumulator& operator+=(const StatAccumulator& other)
   {

--- a/Common/MathUtils/include/MathUtils/detail/bitOps.h
+++ b/Common/MathUtils/include/MathUtils/detail/bitOps.h
@@ -15,7 +15,9 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BITOPS_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BITOPS_H_
 
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <cstdint>
+#endif
 
 namespace o2
 {

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -18,11 +18,11 @@
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <array>
 #include <cmath>
+#include <tuple>
 #endif
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
 #include "CommonConstants/MathConstants.h"
-#include <tuple>
 
 namespace o2
 {
@@ -117,6 +117,8 @@ GPUdi() void sincos(double ang, double& s, double& c)
   o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE
+
 template <typename T>
 GPUdi() std::tuple<T, T> sincos(T ang)
 {
@@ -134,12 +136,6 @@ inline std::tuple<T, T> rotateZ(T xL, T yL, T snAlp, T csAlp)
 }
 
 template <typename T>
-inline void rotateZ(T xL, T yL, T& xG, T& yG, T snAlp, T csAlp)
-{
-  std::tie(xG, yG) = rotateZ<T>(xL, yL, snAlp, csAlp);
-}
-
-template <typename T>
 inline std::tuple<T, T> rotateZInv(T xG, T yG, T snAlp, T csAlp)
 {
   // inverse 2D rotation of the point by angle alpha (global to local)
@@ -147,13 +143,10 @@ inline std::tuple<T, T> rotateZInv(T xG, T yG, T snAlp, T csAlp)
 }
 
 template <typename T>
-inline void rotateZInv(T xG, T yG, T& xL, T& yL, T snAlp, T csAlp)
+inline void rotateZ(T xL, T yL, T& xG, T& yG, T snAlp, T csAlp)
 {
-  // inverse 2D rotation of the point by angle alpha (global to local)
-  rotateZ<T>(xG, yG, xL, yL, -snAlp, csAlp);
+  std::tie(xG, yG) = rotateZ<T>(xL, yL, snAlp, csAlp);
 }
-
-#ifndef GPUCA_GPUCODE_DEVICE
 
 template <typename T>
 inline void rotateZ(std::array<T, 3>& xy, T alpha)
@@ -163,6 +156,13 @@ inline void rotateZ(std::array<T, 3>& xy, T alpha)
   const T x = xy[0];
   xy[0] = x * cos - xy[1] * sin;
   xy[1] = x * sin + xy[1] * cos;
+}
+
+template <typename T>
+inline void rotateZInv(T xG, T yG, T& xL, T& yL, T snAlp, T csAlp)
+{
+  // inverse 2D rotation of the point by angle alpha (global to local)
+  rotateZ<T>(xG, yG, xL, yL, -snAlp, csAlp);
 }
 
 #endif


### PR DESCRIPTION
#4607 pulled in some std::tuple that failed standalone compilation on the GPU, perhaps just due to reorganisation of the headers?
@MichaelLettrich I assume it broke only the standalone benchmark, could be that the normal O2 compilation went through OK, that is probably why you didn't see it.