### PR TITLE
Make more parts of TrackParCov and Propagator compatible to GPU

### DIFF
--- a/Common/Field/include/Field/MagFieldFast.h
+++ b/Common/Field/include/Field/MagFieldFast.h
@@ -14,10 +14,12 @@
 #ifndef ALICEO2_FIELD_MAGFIELDFAST_H_
 #define ALICEO2_FIELD_MAGFIELDFAST_H_
 
-#include <Rtypes.h>
-#include <string>
-
+#include <GPUCommonRtypes.h>
 #include "MathUtils/Cartesian.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <string>
+#endif
 
 namespace o2
 {

--- a/Common/Field/src/MagFieldFast.cxx
+++ b/Common/Field/src/MagFieldFast.cxx
@@ -240,7 +240,7 @@ bool MagFieldFast::GetSegment(float x, float y, float z, int& zSeg, int& rSeg, i
     }
   }
   if (rSeg == kNSolRRanges) {
-    return kFALSE;
+    return false;
   }
   quadrant = GetQuadrant(x, y);
   return true;

--- a/Common/Field/src/MagFieldFast.cxx
+++ b/Common/Field/src/MagFieldFast.cxx
@@ -13,15 +13,16 @@
 /// \author ruben.shahoyan@cern.ch
 //
 #include "Field/MagFieldFast.h"
-#include <FairLogger.h>
-#include <TString.h>
-#include <TSystem.h>
+#include <GPUCommonLogger.h>
+
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <cmath>
 #include <fstream>
 #include <sstream>
+using namespace std;
+#endif
 
 using namespace o2::field;
-using namespace std;
 
 ClassImp(o2::field::MagFieldFast);
 
@@ -29,6 +30,10 @@ const float MagFieldFast::kSolR2Max[MagFieldFast::kNSolRRanges] = {80.f * 80.f, 
                                                                    423.f * 423.f, 500.f * 500.f};
 
 const float MagFieldFast::kSolZMax = 550.0f;
+
+#ifndef GPUCA_STANDALONE
+#include <TString.h>
+#include <TSystem.h>
 
 //_______________________________________________________________________
 MagFieldFast::MagFieldFast(const string inpFName) : mFactorSol(1.f)
@@ -106,6 +111,7 @@ bool MagFieldFast::LoadData(const string inpFName)
   }
   return true;
 }
+#endif // GPUCA_STANDALONE
 
 //_______________________________________________________________________
 bool MagFieldFast::Field(const double xyz[3], double bxyz[3]) const

--- a/Common/MathUtils/CMakeLists.txt
+++ b/Common/MathUtils/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_target_root_dictionary(
           include/MathUtils/Chebyshev3DCalc.h
           include/MathUtils/fit.h
           include/MathUtils/Cartesian.h
+          include/MathUtils/CartesianGPU.h
           include/MathUtils/CachingTF1.h
           include/MathUtils/RandomRing.h
           include/MathUtils/Primitive2D.h)

--- a/Common/MathUtils/include/MathUtils/Cartesian.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian.h
@@ -15,6 +15,9 @@
 #ifndef ALICEO2_CARTESIAN3D_H
 #define ALICEO2_CARTESIAN3D_H
 
+#include "GPUCommonDef.h"
+#include "GPUCommonRtypes.h"
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
 #include <Math/GenVector/DisplacementVector3D.h>
 #include <Math/GenVector/PositionVector3D.h>
 #include <Math/GenVector/Rotation3D.h>
@@ -22,25 +25,19 @@
 #include <Math/GenVector/Translation3D.h>
 #include <Math/GenVector/DisplacementVector2D.h>
 #include <Math/GenVector/PositionVector2D.h>
-#include <Rtypes.h>
 #include <TGeoMatrix.h>
 #include <iosfwd>
+#else
+#include "GPUCommonMath.h"
+#include "CartesianGPU.h"
+#endif
+#include "GPUROOTCartesianFwd.h"
 
 namespace o2
 {
 
 namespace math_utils
 {
-
-template <typename T>
-using Point2D = ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
-template <typename T>
-using Vector2D = ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
-
-template <typename T>
-using Point3D = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
-template <typename T>
-using Vector3D = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
 
 // more typedefs can follow
 

--- a/Common/MathUtils/include/MathUtils/Cartesian.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian.h
@@ -148,6 +148,8 @@ class Rotation2D
 using Rotation2Df_t = Rotation2D<float>;
 using Rotation2Dd_t = Rotation2D<double>;
 
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIGPUCODE)
+
 class Transform3D : public ROOT::Math::Transform3D
 {
   //
@@ -241,11 +243,12 @@ class Transform3D : public ROOT::Math::Transform3D
 
   ClassDefNV(Transform3D, 1);
 };
+#endif // Disable for GPU
 } // namespace math_utils
 } // namespace o2
 
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIGPUCODE)
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Df_t& t);
-
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Dd_t& t);
 
 namespace std
@@ -266,4 +269,6 @@ template <typename T>
 struct is_trivially_copyable<o2::math_utils::Point3D<T>> : std::true_type {
 };
 } // namespace std
+#endif // Disable for GPU
+
 #endif

--- a/Common/MathUtils/include/MathUtils/CartesianGPU.h
+++ b/Common/MathUtils/include/MathUtils/CartesianGPU.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CartesianGPU.h
+/// @author David Rohr
+
+#ifndef ALICEO2_CARTESIANGPU_H
+#define ALICEO2_CARTESIANGPU_H
+
+namespace o2::math_utils
+{
+
+namespace detail
+{
+template <typename T, int I>
+struct GPUPoint2D {
+  GPUPoint2D() = default;
+  GPUPoint2D(T a, T b) : xx(a), yy(b) {}
+  T xx;
+  T yy;
+  float X() const { return xx; }
+  float Y() const { return yy; }
+  float R() const { return o2::gpu::CAMath::Sqrt(xx * xx + yy * yy); }
+  void SetX(float v) { xx = v; }
+  void SetY(float v) { yy = v; }
+};
+
+template <typename T, int I>
+struct GPUPoint3D : public GPUPoint2D<T, I> {
+  GPUPoint3D() = default;
+  GPUPoint3D(T a, T b, T c) : GPUPoint2D<T, I>(a, b), zz(c) {}
+  T zz;
+  float Z() const { return zz; }
+  float R() const { return o2::gpu::CAMath::Sqrt(GPUPoint2D<T, I>::xx * GPUPoint2D<T, I>::xx + GPUPoint2D<T, I>::yy * GPUPoint2D<T, I>::yy + zz * zz); }
+  void SetZ(float v) { zz = v; }
+};
+} // namespace detail
+
+} // end namespace o2::math_utils
+
+#endif

--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(ReconstructionDataFormats
                        src/VtxTrackIndex.cxx
                        src/VtxTrackRef.cxx
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
+                                     O2::FrameworkLogger
                                      O2::DetectorsCommonDataFormats
                                      O2::CommonDataFormat)
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -71,8 +71,8 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
 
   bool getCovXYZPxPyPzGlo(std::array<value_t, kLabCovMatSize>& c) const;
 
-#ifndef GPUCA_ALIGPUCODE
   void print() const;
+#ifndef GPUCA_ALIGPUCODE
   std::string asString() const;
 #endif
 

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -488,15 +488,17 @@ std::string TrackParametrization<value_T>::asString() const
   return fmt::format("X:{:+.4e} Alp:{:+.3e} Par: {:+.4e} {:+.4e} {:+.4e} {:+.4e} {:+.4e} |Q|:{:d} {:s}",
                      getX(), getAlpha(), getY(), getZ(), getSnp(), getTgl(), getQ2Pt(), getAbsCharge(), getPID().getName());
 }
+#endif
 
 //______________________________________________________________
 template <typename value_T>
 void TrackParametrization<value_T>::printParam() const
 {
   // print parameters
+#ifndef GPUCA_ALIGPUCODE
   printf("%s\n", asString().c_str());
-}
 #endif
+}
 
 //______________________________________________________________
 template <typename value_T>

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -159,7 +159,7 @@ bool TrackParametrization<value_T>::rotateParam(value_t alpha)
 {
   // rotate to alpha frame
   if (std::fabs(getSnp()) > constants::math::Almost1) {
-    LOGF(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", getSnp());
+    LOGP(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", getSnp());
     return false;
   }
   //
@@ -177,7 +177,7 @@ bool TrackParametrization<value_T>::rotateParam(value_t alpha)
   //
   value_t tmp = snp * ca - csp * sa;
   if (std::fabs(tmp) > constants::math::Almost1) {
-    LOGF(WARNING, "Rotation failed: new snp {:.2f}", tmp);
+    LOGP(WARNING, "Rotation failed: new snp {:.2f}", tmp);
     return false;
   }
   value_t xold = getX(), yold = getY();
@@ -205,7 +205,7 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
   }
   // Do not propagate tracks outside the ALICE detector
   if (std::fabs(dx) > 1e5 || std::fabs(getY()) > 1e5 || std::fabs(getZ()) > 1e5) {
-    LOGF(WARNING, "Anomalous track, target X:{:f}", xk);
+    LOGP(WARNING, "Anomalous track, target X:{:f}", xk);
     //    print();
     return false;
   }

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -26,11 +26,16 @@
 #include "ReconstructionDataFormats/TrackParametrization.h"
 #include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/DCA.h"
-#include <FairLogger.h>
-#include <iostream>
+#include <GPUCommonLogger.h>
 #include "Math/SMatrix.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <iostream>
+#endif
+
+#ifndef GPUCA_ALIGPUCODE
 #include <fmt/printf.h>
-#include "Framework/Logger.h"
+#endif
 
 namespace o2
 {

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -168,7 +168,7 @@ bool TrackParametrizationWithError<value_T>::rotate(value_t alpha)
 {
   // rotate to alpha frame
   if (std::fabs(this->getSnp()) > constants::math::Almost1) {
-    LOGF(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", this->getSnp());
+    LOGP(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", this->getSnp());
     return false;
   }
   //
@@ -180,14 +180,14 @@ bool TrackParametrizationWithError<value_T>::rotate(value_t alpha)
   // RS: check if rotation does no invalidate track model (cos(local_phi)>=0, i.e. particle
   // direction in local frame is along the X axis
   if ((csp * ca + snp * sa) < 0) {
-    //LOGF(WARNING,"Rotation failed: local cos(phi) would become {:.2f}", csp * ca + snp * sa);
+    //LOGP(WARNING,"Rotation failed: local cos(phi) would become {:.2f}", csp * ca + snp * sa);
     return false;
   }
   //
 
   value_t updSnp = snp * ca - csp * sa;
   if (std::fabs(updSnp) > constants::math::Almost1) {
-    LOGF(WARNING, "Rotation failed: new snp {:.2f}", updSnp);
+    LOGP(WARNING, "Rotation failed: new snp {:.2f}", updSnp);
     return false;
   }
   value_t xold = this->getX(), yold = this->getY();
@@ -197,7 +197,7 @@ bool TrackParametrizationWithError<value_T>::rotate(value_t alpha)
   this->setSnp(updSnp);
 
   if (std::fabs(csp) < constants::math::Almost0) {
-    LOGF(WARNING, "Too small cosine value {:f}", csp);
+    LOGP(WARNING, "Too small cosine value {:f}", csp);
     csp = constants::math::Almost0;
   }
 
@@ -429,7 +429,7 @@ bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, const dim3_
   }
   // Do not propagate tracks outside the ALICE detector
   if (std::fabs(dx) > 1e5 || std::fabs(this->getY()) > 1e5 || std::fabs(this->getZ()) > 1e5) {
-    LOGF(WARNING, "Anomalous track, target X:{:f}", xk);
+    LOGP(WARNING, "Anomalous track, target X:{:f}", xk);
     //    print();
     return false;
   }

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -1076,13 +1076,16 @@ std::string TrackParametrizationWithError<value_T>::asString() const
            mC[kSigTglZ], mC[kSigTglSnp], mC[kSigTgl2], "", mC[kSigQ2PtY], mC[kSigQ2PtZ], mC[kSigQ2PtSnp], mC[kSigQ2PtTgl],
            mC[kSigQ2Pt2]);
 }
+#endif
 
 //______________________________________________________________
 template <typename value_T>
 void TrackParametrizationWithError<value_T>::print() const
 {
   // print parameters
+#ifndef GPUCA_ALIGPUCODE
   printf("%s\n", asString().c_str());
+#endif
 }
 
 template class TrackParametrizationWithError<float>;
@@ -1090,4 +1093,3 @@ template class TrackParametrizationWithError<double>;
 
 } // namespace track
 } // namespace o2
-#endif

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -26,11 +26,16 @@
 #include "ReconstructionDataFormats/TrackParametrizationWithError.h"
 #include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/DCA.h"
-#include <FairLogger.h>
-#include <iostream>
+#include <GPUCommonLogger.h>
 #include "Math/SMatrix.h"
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <iostream>
+#endif
+
+#ifndef GPUCA_ALIGPUCODE
 #include <fmt/printf.h>
-#include "Framework/Logger.h"
+#endif
 
 namespace o2
 {

--- a/Detectors/TPC/simulation/macro/createResidualDistortionObject.C
+++ b/Detectors/TPC/simulation/macro/createResidualDistortionObject.C
@@ -23,6 +23,7 @@
 #include "CommonConstants/MathConstants.h"
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "TPCSimulation/SpaceCharge.h"
+#include "MathUtils/Cartesian.h"
 
 using namespace o2::tpc;
 

--- a/Detectors/TPC/simulation/test/testTPCSimulation.cxx
+++ b/Detectors/TPC/simulation/test/testTPCSimulation.cxx
@@ -18,9 +18,10 @@
 #include <boost/test/unit_test.hpp>
 #include "TPCSimulation/Point.h"
 #include "TPCSimulation/DigitMCMetaData.h"
+#include "MathUtils/Cartesian.h"
 
 template <typename T>
-using Point3D = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+using Point3D = o2::math_utils::Point3D<T>;
 
 namespace o2
 {

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -17,12 +17,17 @@
 #if defined(__OPENCL__)
 #define LOG(...)
 #define LOGF(...)
+#define LOGP(...)
 
 #elif defined(GPUCA_GPUCODE_DEVICE)
-#define LOG(...)
+#define LOG(...) static_assert("LOG(...) << ... unsupported in GPU code");
 #define LOGF(type, string, ...)         \
   {                                     \
     printf(string "\n", ##__VA_ARGS__); \
+  }
+#define LOGP(type, string, ...) \
+  {                             \
+    printf(string "\n");        \
   }
 
 #elif defined(GPUCA_STANDALONE) ||                    \
@@ -35,6 +40,10 @@
 #define LOGF(type, string, ...)         \
   {                                     \
     printf(string "\n", ##__VA_ARGS__); \
+  }
+#define LOGP(type, string, ...) \
+  {                             \
+    printf(string "\n");        \
   }
 
 #else

--- a/GPU/Common/GPUROOTCartesianFwd.h
+++ b/GPU/Common/GPUROOTCartesianFwd.h
@@ -17,6 +17,8 @@
 // Standalone forward declarations for Cartesian2D / Cartesian3D / Point2D / Point3D etc.
 // To be used on GPU where ROOT is not available.
 
+#include "GPUCommonDef.h"
+
 namespace ROOT
 {
 namespace Math
@@ -31,6 +33,10 @@ template <class CoordSystem, class Tag>
 class PositionVector2D;
 template <class CoordSystem, class Tag>
 class PositionVector3D;
+template <class CoordSystem, class Tag>
+class DisplacementVector2D;
+template <class CoordSystem, class Tag>
+class DisplacementVector3D;
 template <class T>
 class Cartesian2D;
 template <class T>
@@ -44,10 +50,33 @@ namespace o2
 namespace math_utils
 {
 
+namespace detail
+{
+template <typename T, int I>
+struct GPUPoint2D;
+template <typename T, int I>
+struct GPUPoint3D;
+} // namespace detail
+
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
 template <typename T>
 using Point2D = ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
 template <typename T>
+using Vector2D = ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
 using Point3D = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+using Vector3D = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+#else
+template <typename T>
+using Point2D = detail::GPUPoint2D<T, 0>;
+template <typename T>
+using Vector2D = detail::GPUPoint2D<T, 1>;
+template <typename T>
+using Point3D = detail::GPUPoint3D<T, 0>;
+template <typename T>
+using Vector3D = detail::GPUPoint3D<T, 1>;
+#endif
 
 } // namespace math_utils
 } // namespace o2

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
@@ -252,11 +252,11 @@ GPUd() int GPUTrackingRefit::RefitTrack(T& trkX, bool outward, bool resetCov)
   int start = outward ? count - 1 : begin;
   int stop = outward ? begin - 1 : count;
   const ClusterNative* cl = nullptr;
-  uint8_t sector, row, currentSector, currentRow;
-  short clusterState, nextState;
+  uint8_t sector, row = 0, currentSector = 0, currentRow = 0;
+  short clusterState = 0, nextState;
   int nFitted = 0;
   for (int i = start; i != stop; i += cl ? 0 : direction) {
-    float x, y, z, charge;
+    float x, y, z, charge = 0.f;
     int clusters = 0;
     while (true) {
       if (!cl) {

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -121,6 +121,7 @@ if(CONFIG_O2_EXTENSIONS)
 include_directories(${CMAKE_SOURCE_DIR}/TPCClusterFinder
                     ${CMAKE_SOURCE_DIR}/ITS
                     ${CMAKE_SOURCE_DIR}/DataCompression
+                    ${CMAKE_SOURCE_DIR}/../../../Common/Field/include
                     ${CMAKE_SOURCE_DIR}/../../../Common/Constants/include
                     ${CMAKE_SOURCE_DIR}/../../../Common/MathUtils/include
                     ${CMAKE_SOURCE_DIR}/../../../DataFormats/common/include
@@ -160,21 +161,27 @@ target_compile_definitions(standalone_support PUBLIC $<TARGET_PROPERTY:O2::GPUTr
 # Add all sources and dependencies to to support based on Config File
 if(CONFIG_O2_EXTENSIONS)
   target_sources(standalone_support PRIVATE
-               ../../..//DataFormats/Detectors/TPC/src/CompressedClusters.cxx
-               ../../..//DataFormats/simulation/src/MCCompLabel.cxx
-               ../../..//Detectors/TRD/base/src/TRDGeometryBase.cxx
-               ../../..//Detectors/Base/src/MatLayerCylSet.cxx
-               ../../..//Detectors/Base/src/MatLayerCyl.cxx
-               ../../..//Detectors/Base/src/Ray.cxx
-               ../../..//Detectors/ITSMFT/ITS/tracking/src/Road.cxx)
+               ../../../Common/Field/src/MagFieldFast.cxx
+               ../../../DataFormats/Detectors/TPC/src/CompressedClusters.cxx
+               ../../../DataFormats/simulation/src/MCCompLabel.cxx
+               ../../../DataFormats/Reconstruction/src/TrackParametrization.cxx
+               ../../../DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+               ../../../DataFormats/Reconstruction/src/Vertex.cxx
+               ../../../DataFormats/Reconstruction/src/TrackLTIntegral.cxx
+               ../../../Detectors/TRD/base/src/TRDGeometryBase.cxx
+               ../../../Detectors/Base/src/MatLayerCylSet.cxx
+               ../../../Detectors/Base/src/MatLayerCyl.cxx
+               ../../../Detectors/Base/src/Ray.cxx
+               ../../../Detectors/Base/src/Propagator.cxx
+               ../../../Detectors/ITSMFT/ITS/tracking/src/Road.cxx)
   if(CONFIG_O2_ITS_TRAITS)
     target_sources(standalone_support PRIVATE
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
-        ../../..//Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx)
+        ../../../Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+        ../../../Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+        ../../../Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
+        ../../../Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+        ../../../Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+        ../../../Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx)
     target_link_libraries(standalone_support PUBLIC Boost::boost)
   endif()
 endif()


### PR DESCRIPTION
@shahor02 : I am trying to make TrackParCov and Propagator compatible to GPU. This PR does several adjustments.
Besides some actual fixes, it mostly hides code from compilation on GPU.

The only significant change I need is with Poind2D/Point3D, which was coming from ROOT. I have put a small mockup there that provides the required functionality for TrackParCov and Propagator and makes them work on GPU. I'll still simplify this a bit, but I guess if we want to be portable, we cannot fully rely on ROOT in this place. I assume in the way it is done now, it should be transparent, as long as no other ROOT functionality is used in TrackParCov / Propagator.

Another small change is that I use a manual rotation in `getXYZGlo` to avoid ROOT as well. I guess if these are the only changes, we can live with it.

Let me know in case you have any comments.
Still, it doesn't fully compile yet, but I think the changes in here will be in any case mandatory to make it run on GPU, or we stick only to Sergey's GPU track model for GPU.