### PR TITLE
GPU: Add chi2 output to refit

### DIFF
--- a/GPU/GPUTracking/Interface/GPUO2InterfaceRefit.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceRefit.h
@@ -50,8 +50,8 @@ class GPUTPCO2InterfaceRefit
 
   int RefitTrackAsGPU(o2::tpc::TrackTPC& trk, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsGPU(trk, outward, resetCov); }
   int RefitTrackAsTrackParCov(o2::tpc::TrackTPC& trk, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsTrackParCov(trk, outward, resetCov); }
-  int RefitTrackAsGPU(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsGPU(trk, clusRef, time0, outward, resetCov); }
-  int RefitTrackAsTrackParCov(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsTrackParCov(trk, clusRef, time0, outward, resetCov); }
+  int RefitTrackAsGPU(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, float* chi2 = nullptr, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsGPU(trk, clusRef, time0, chi2, outward, resetCov); }
+  int RefitTrackAsTrackParCov(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, float* chi2 = nullptr, bool outward = false, bool resetCov = false) { return mRefit.RefitTrackAsTrackParCov(trk, clusRef, time0, chi2, outward, resetCov); }
   void setGPUTrackFitInProjections(bool v = true);
   void setTrackReferenceX(float v);
   void setIgnoreErrorsAtTrackEnds(bool v) { mRefit.mIgnoreErrorsOnTrackEnds = v; }

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.h
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.h
@@ -72,15 +72,16 @@ class GPUTrackingRefit
     o2::track::TrackParCov& trk;
     const o2::tpc::TrackTPCClusRef& clusRef;
     float time0;
+    float* chi2;
   };
-  GPUd() int RefitTrackAsGPU(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, bool outward = false, bool resetCov = false)
+  GPUd() int RefitTrackAsGPU(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, float* chi2 = nullptr, bool outward = false, bool resetCov = false)
   {
-    TrackParCovWithArgs x{trk, clusRef, time0};
+    TrackParCovWithArgs x{trk, clusRef, time0, chi2};
     return RefitTrack<TrackParCovWithArgs, GPUTPCGMTrackParam>(x, outward, resetCov);
   }
-  GPUd() int RefitTrackAsTrackParCov(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, bool outward = false, bool resetCov = false)
+  GPUd() int RefitTrackAsTrackParCov(o2::track::TrackParCov& trk, const o2::tpc::TrackTPCClusRef& clusRef, float time0, float* chi2 = nullptr, bool outward = false, bool resetCov = false)
   {
-    TrackParCovWithArgs x{trk, clusRef, time0};
+    TrackParCovWithArgs x{trk, clusRef, time0, chi2};
     return RefitTrack<TrackParCovWithArgs, o2::track::TrackParCov>(x, outward, resetCov);
   }
 
@@ -97,7 +98,7 @@ class GPUTrackingRefit
   template <class T, class S>
   GPUd() int RefitTrack(T& trk, bool outward, bool resetCov);
   template <class T, class S, class U>
-  void convertTrack(T& trk, const S& trkX, U& prop);
+  void convertTrack(T& trk, const S& trkX, U& prop, float* chi2);
   template <class U>
   void initProp(U& prop);
 };

--- a/macro/runTPCRefit.C
+++ b/macro/runTPCRefit.C
@@ -94,7 +94,7 @@ int runTPCRefit(TString trackFile = "tpctracks.root", TString clusterFile = "tpc
       if (retval < 0) {
         std::cout << "Refit as GPU track failed " << retval << "\n";
       } else {
-        std::cout << "Succeeded using " << retval << " hits\n";
+        std::cout << "Succeeded using " << retval << " hits (chi2 = " << trk.getChi2() << ")\n";
         trk.print();
       }
       trk = (*tracks)[i];
@@ -103,17 +103,18 @@ int runTPCRefit(TString trackFile = "tpctracks.root", TString clusterFile = "tpc
       if (retval < 0) {
         std::cout << "Refit as TrackParCov track failed " << retval << "\n";
       } else {
-        std::cout << "Succeeded using " << retval << " hits\n";
+        std::cout << "Succeeded using " << retval << " hits (chi2 = " << trk.getChi2() << ")\n";
         trk.print();
       }
       trk = (*tracks)[i];
       TrackParCov trkX = trk;
+      float chi2 = trk.getChi2();
       std::cout << "Refitting as TrackParCov track with TrackParCov input\n";
-      retval = refit.RefitTrackAsTrackParCov(trkX, trk.getClusterRef(), trk.getTime0(), false, true);
+      retval = refit.RefitTrackAsTrackParCov(trkX, trk.getClusterRef(), trk.getTime0(), &chi2, false, true);
       if (retval < 0) {
         std::cout << "Refit as TrackParCov track failed " << retval << "\n";
       } else {
-        std::cout << "Succeeded using " << retval << " hits\n";
+        std::cout << "Succeeded using " << retval << " hits (chi2 = " << chi2 << ")\n";
         trkX.print();
       }
     }


### PR DESCRIPTION
@shahor02 : This adds the chi2 output to the refit. Please not that the interface for the TrackParCov input changed because the chi2 ptr must be transported. You can pass in nullptr in which case no chi2 is returned optionally.