### PR TITLE
Fix integer trancation of payload size to 32 bits

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -152,7 +152,7 @@ struct DataRefUtils {
     }
   }
 
-  static unsigned getPayloadSize(const DataRef& ref)
+  static o2::header::DataHeader::PayloadSizeType getPayloadSize(const DataRef& ref)
   {
     using DataHeader = o2::header::DataHeader;
     auto* header = o2::header::get<const DataHeader*>(ref.header);


### PR DESCRIPTION
@ktf : This was truncating the payload size to 4 GB, not sure if there are similar problems elsewhere, but at least in the TPC workflow cluster arrays > 4gb can be transmitted with this fix.