### PR TITLE
Allow skipping MC in MID ditis reader and do this in DigitsToRawWorkflow

### DIFF
--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DigitReaderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DigitReaderSpec.h
@@ -22,7 +22,7 @@ namespace o2
 {
 namespace mid
 {
-framework::DataProcessorSpec getDigitReaderSpec();
+framework::DataProcessorSpec getDigitReaderSpec(bool useMC);
 }
 } // namespace o2
 

--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -38,6 +38,8 @@ namespace mid
 class DigitsReaderDeviceDPL
 {
  public:
+  DigitsReaderDeviceDPL(bool useMC = true) : mUseMC(useMC) {}
+
   void init(o2::framework::InitContext& ic)
   {
     auto filename = ic.options().get<std::string>("mid-digit-infile");
@@ -54,7 +56,9 @@ class DigitsReaderDeviceDPL
       return;
     }
     mTree->SetBranchAddress("MIDDigit", &mDigits);
-    mTree->SetBranchAddress("MIDDigitMCLabels", &mMCContainer);
+    if (mUseMC) {
+      mTree->SetBranchAddress("MIDDigitMCLabels", &mMCContainer);
+    }
     mTree->SetBranchAddress("MIDROFRecords", &mROFRecords);
     mState = 0;
   }
@@ -72,16 +76,19 @@ class DigitsReaderDeviceDPL
     for (auto ientry = 0; ientry < mTree->GetEntries(); ++ientry) {
       mTree->GetEntry(ientry);
       digits.insert(digits.end(), mDigits->begin(), mDigits->end());
-      mcContainer.mergeAtBack(*mMCContainer);
       rofRecords.insert(rofRecords.end(), mROFRecords->begin(), mROFRecords->end());
+      if (mUseMC) {
+        mcContainer.mergeAtBack(*mMCContainer);
+      }
     }
 
     LOG(DEBUG) << "MIDDigitsReader pushed " << digits.size() << " merged digits";
     pc.outputs().snapshot(of::Output{"MID", "DATA", 0, of::Lifetime::Timeframe}, digits);
     pc.outputs().snapshot(of::Output{"MID", "DATAROF", 0, of::Lifetime::Timeframe}, rofRecords);
-    LOG(DEBUG) << "MIDDigitsReader pushed " << mcContainer.getIndexedSize() << " indexed digits";
-    pc.outputs().snapshot(of::Output{"MID", "DATALABELS", 0, of::Lifetime::Timeframe}, mcContainer);
-
+    LOG(DEBUG) << "MIDDigitsReader pushed " << digits.size() << " indexed digits";
+    if (mUseMC) {
+      pc.outputs().snapshot(of::Output{"MID", "DATALABELS", 0, of::Lifetime::Timeframe}, mcContainer);
+    }
     mState = 2;
     pc.services().get<of::ControlService>().endOfStream();
   }
@@ -93,18 +100,23 @@ class DigitsReaderDeviceDPL
   o2::dataformats::MCTruthContainer<MCLabel>* mMCContainer{nullptr}; // not owner
   std::vector<o2::mid::ROFRecord>* mROFRecords{nullptr};             // not owner
   int mState = 0;
+  bool mUseMC = true;
 };
 
-framework::DataProcessorSpec getDigitReaderSpec()
+framework::DataProcessorSpec getDigitReaderSpec(bool useMC)
 {
+  std::vector<of::OutputSpec> outputs;
+  outputs.emplace_back("MID", "DATA", o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back("MID", "DATAROF", o2::framework::Lifetime::Timeframe);
+  if (useMC) {
+    outputs.emplace_back("MID", "DATALABELS", o2::framework::Lifetime::Timeframe);
+  }
+
   return of::DataProcessorSpec{
     "MIDDigitsReader",
     of::Inputs{},
-    of::Outputs{
-      of::OutputSpec{"MID", "DATA"},
-      of::OutputSpec{"MID", "DATAROF"},
-      of::OutputSpec{"MID", "DATALABELS"}},
-    of::AlgorithmSpec{of::adaptFromTask<o2::mid::DigitsReaderDeviceDPL>()},
+    outputs,
+    of::AlgorithmSpec{of::adaptFromTask<o2::mid::DigitsReaderDeviceDPL>(useMC)},
     of::Options{
       {"mid-digit-infile", of::VariantType::String, "middigits.root", {"Name of the input file"}}}};
 }

--- a/Detectors/MUON/MID/Workflow/src/DigitsToRawWorkflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitsToRawWorkflow.cxx
@@ -30,7 +30,7 @@ of::WorkflowSpec getDigitsToRawWorkflow()
 {
   of::WorkflowSpec specs;
 
-  specs.emplace_back(getDigitReaderSpec());
+  specs.emplace_back(getDigitReaderSpec(false));
   specs.emplace_back(getRawWriterSpec());
   return specs;
 }

--- a/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
@@ -89,7 +89,7 @@ class RawWriterDeviceDPL
 
 framework::DataProcessorSpec getRawWriterSpec()
 {
-  std::vector<of::InputSpec> inputSpecs{of::InputSpec{"mid_data", header::gDataOriginMID, "DATA"}, of::InputSpec{"mid_data_rof", header::gDataOriginMID, "DATAROF"}, of::InputSpec{"mid_data_labels", header::gDataOriginMID, "DATALABELS"}};
+  std::vector<of::InputSpec> inputSpecs{of::InputSpec{"mid_data", header::gDataOriginMID, "DATA"}, of::InputSpec{"mid_data_rof", header::gDataOriginMID, "DATAROF"}};
 
   return of::DataProcessorSpec{
     "MIDRawWriter",

--- a/Detectors/MUON/MID/Workflow/src/RecoWorkflowMC.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RecoWorkflowMC.cxx
@@ -47,7 +47,7 @@ of::WorkflowSpec getRecoWorkflowMC()
 
   of::WorkflowSpec specs;
 
-  specs.emplace_back(getDigitReaderSpec());
+  specs.emplace_back(getDigitReaderSpec(true));
   specs.emplace_back(getClusterizerMCSpec());
   specs.emplace_back(getTrackerMCSpec());
   specs.emplace_back(of::MakeRootTreeWriterSpec("MIDTrackLabelsWriter",


### PR DESCRIPTION
@dstocco I've added to DigitReaderSpec an option to skip MC labels (default is to read them) and hardcoded it to false in its invocation in digits->raw converter. 