### PR TITLE
TRD: Fix trigger records (digitizer), and MC step size (hits)

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <array>
 #include <unordered_map>
+#include <numeric>
 #include "Rtypes.h" // for ClassDef
 
 #include "CommonDataFormat/TimeStamp.h"
@@ -52,6 +53,7 @@ class Digit : public TimeStamp
   int getRow() const { return mRow; }
   int getPad() const { return mPad; }
   ArrayADC const& getADC() const { return mADC; }
+  ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }
 
  private:
   std::uint16_t mDetector{0}; // TRD detector number, 0-539

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -59,6 +59,7 @@ class Digitizer
 
   void process(std::vector<HitType> const&, DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void flush(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
+  void pileup();
   void setEventTime(double timeNS) { mTime = timeNS; }
   void setEventID(int entryID) { mEventID = entryID; }
   void setSrcID(int sourceID) { mSrcID = sourceID; }
@@ -66,6 +67,11 @@ class Digitizer
   int getEventTime() const { return mTime; }
   int getEventID() const { return mEventID; }
   int getSrcID() const { return mSrcID; }
+
+  // Trigger parameters
+  static constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.
+  static constexpr double DEAD_TIME = 200;                      // trigger deadtime, 2 micro-s
+  static constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no new trigger can be received in nanoseconds
 
  private:
   TRDGeometry* mGeo = nullptr;            // access to TRDGeometry
@@ -96,12 +102,6 @@ class Digitizer
     kEmbeddingEvent
   };
 
-  // Trigger parameters
-  bool mTriggeredEvent = false;
-  static constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.
-  static constexpr double DEAD_TIME = 200;                      // trigger deadtime, 2 micro-s
-  static constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no new trigger can be received in nanoseconds
-
   // Digitization parameters
   static constexpr float AmWidth = TRDGeometry::amThick(); // Width of the amplification region
   static constexpr float DrWidth = TRDGeometry::drThick(); // Width of the drift retion
@@ -125,7 +125,6 @@ class Digitizer
 
   // Digitization chain methods
   int triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
-  void pileup();
   SignalContainer addSignalsFromPileup();
   void clearContainers();
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -92,6 +92,7 @@ bool Detector::ProcessHits(FairVolume* v)
   if ((!fMC->TrackCharge()) || fMC->IsTrackDisappeared()) {
     return false;
   }
+  fMC->SetMaxStep(0.1); // Should we optimize this value?
 
   // Inside sensitive volume ?
   bool drRegion = false;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -188,41 +188,12 @@ void Digitizer::clearContainers()
   }
 }
 
-int Digitizer::triggerEventProcessing(DigitContainer& digits, o2::dataformats::MCTruthContainer<MCLabel>& labels)
-{
-  if (mCurrentTriggerTime < 0 && mLastTime < 0) {
-    // very first event
-    mCurrentTriggerTime = mTime;
-    mLastTime = mTime;
-    return EventType::kFirstEvent;
-  }
-  if (mTime > mLastTime) {
-    if ((mTime - mCurrentTriggerTime) < BUSY_TIME) {
-      // send the signal containers to the pileup container, and do not change the current trigger time.
-      pileup();
-      mLastTime = mTime;
-      return EventType::kPileupEvent;
-    } else {
-      // flush the digits: signals from the pileup container are converted to adcs
-      // digits and labels are produced, and the current trigger time is changed after the flush is completed
-      flush(digits, labels);
-      mCurrentTriggerTime = mTime;
-      mLastTime = mTime;
-      return EventType::kTriggerFired;
-    }
-  } else {
-    return EventType::kEmbeddingEvent;
-  }
-}
-
 void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits,
                         o2::dataformats::MCTruthContainer<MCLabel>& labels)
 {
   if (!mCalib) {
     LOG(FATAL) << "TRD Calibration database not available";
   }
-
-  int status = triggerEventProcessing(digits, labels);
 
   // Get the a hit container for all the hits in a given detector then call convertHits for a given detector (0 - 539)
   std::array<std::vector<HitType>, MAXCHAMBER> hitsPerDetector;

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -79,44 +79,67 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     std::vector<o2::trd::Digit> digits;                         // digits which get filled
     o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labels; // labels which get filled
 
+    o2::InteractionTimeRecord lastTime;    // the time of the previous event
+    o2::InteractionTimeRecord currentTime; // the current time
+    o2::InteractionTimeRecord triggerTime; // the time at which the TRD start reading out a signal
+    bool firstEvent = true;                // Flag for the first event processed
+
     TStopwatch timer;
     timer.Start();
-
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
-      mDigitizer.setEventTime(irecords[collID].getTimeNS());
+      currentTime = irecords[collID];
+      // Trigger logic implemented here
+      if (firstEvent) {
+        triggerTime = currentTime;
+        lastTime = currentTime;
+        firstEvent = false;
+      } else {
+        if (currentTime.getTimeNS() > lastTime.getTimeNS()) {
+          double dT = currentTime.getTimeNS() - triggerTime.getTimeNS();
+          if (dT < o2::trd::Digitizer::BUSY_TIME) {
+            // BUSY_TIME = READOUT_TIME + DEAD_TIME, if less than that, pile up the signals and update the last time
+            mDigitizer.pileup();
+            lastTime = currentTime;
+          } else {
+            // A new signal can be received, and the detector read it out:
+            // flush previous stored digits, labels and keep a trigger record
+            // then update the trigger time to the new one
+            mDigitizer.flush(digits, labels);
+            assert(digits.size() == labels.getIndexedSize());
+            // Add trigger record, and send digits to the accumulator
+            triggers.emplace_back(triggerTime, digitsAccum.size(), digits.size());
+            std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
+            if (mctruth) {
+              labelsAccum.mergeAtBack(labels);
+            }
+            lastTime = currentTime;
+            triggerTime = currentTime;
+            digits.clear();
+            labels.clear();
+          }
+        }
+      }
+
+      mDigitizer.setEventTime(triggerTime.getTimeNS()); // do we need this?
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)
       for (auto& part : eventParts[collID]) {
         mDigitizer.setEventID(part.entryID);
         mDigitizer.setSrcID(part.sourceID);
-
-        // get the hits for this event and this source
+        // get the hits for this event and this source and process them
         std::vector<o2::trd::HitType> hits;
         context->retrieveHits(mSimChains, "TRDHit", part.sourceID, part.entryID, &hits);
-        LOG(INFO) << "For collision " << collID << " eventID " << part.entryID << " found TRD " << hits.size() << " hits ";
-
         mDigitizer.process(hits, digits, labels);
-        assert(digits.size() == labels.getIndexedSize());
-
-        // Add trigger record
-        triggers.emplace_back(irecords[collID], digitsAccum.size(), digits.size());
-
-        std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
-        if (mctruth) {
-          labelsAccum.mergeAtBack(labels);
-        }
-        digits.clear();
-        labels.clear();
       }
     }
+
     // Force flush of the digits that remain in the digitizer cache
     mDigitizer.flush(digits, labels);
     assert(digits.size() == labels.getIndexedSize());
-
-    triggers.emplace_back(irecords[irecords.size() - 1], digitsAccum.size(), digits.size());
+    triggers.emplace_back(triggerTime, digitsAccum.size(), digits.size());
     std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
     if (mctruth) {
       labelsAccum.mergeAtBack(labels);

--- a/macro/analyzeDigitLabels.C
+++ b/macro/analyzeDigitLabels.C
@@ -79,14 +79,16 @@ void analyse(TTree* tr, const char* brname, Accumulator& prop)
     return;
   }
   auto entries = br->GetEntries();
-  o2::dataformats::MCTruthContainer<LabelType>* labels = nullptr;
-  br->SetAddress(&labels);
+  o2::dataformats::IOMCTruthContainerView* io2 = nullptr;
+  br->SetAddress(&io2);
 
   for (int i = 0; i < entries; ++i) {
     br->GetEntry(i);
+    o2::dataformats::ConstMCTruthContainer<LabelType> labels;
+    io2->copyandflatten(labels);
 
-    for (int i = 0; i < (int)labels->getIndexedSize(); ++i) {
-      prop.addLabels(labels->getLabels(i));
+    for (int i = 0; i < (int)labels.getIndexedSize(); ++i) {
+      prop.addLabels(labels.getLabels(i));
     }
   }
 };


### PR DESCRIPTION
- Fix the trigger records: move the TRD event trigger to the steering code with a bit improved trigger logic  (passing all checks of embedding and pileup).
- Fix a maximum MC step (see Detector.cxx) with a good empirical value for the moment.
- Fix analyze digit labels macro for new labels IO for having the embedding and pileup checker working again.