### PR TITLE
[ITS EVE] Fix typo in geometry list

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/EVE/geom_list_ITS.txt
+++ b/Detectors/ITSMFT/ITS/macros/EVE/geom_list_ITS.txt
@@ -4,7 +4,7 @@
 #/cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1
 #
 #/cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_0
-/cave_1/barrel_1/barel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_0/ITSUHalfStave0_0
+/cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_0/ITSUHalfStave0_0
 #/cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_1
 /cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_1/ITSUHalfStave0_0
 #/cave_1/barrel_1/ITSV_2/ITSUWrapVol0_1/ITSULayer0_1/ITSUStave0_2


### PR DESCRIPTION
I was playing a bit with the event display and I saw a missing stave not being displayed.
Before:
![photo_2020-10-26_18-00-44](https://user-images.githubusercontent.com/4990252/97203641-653dcb00-17b5-11eb-86d9-dcdb1bbfa8bf.jpg)

After:
![photo_2020-10-26_18-04-51](https://user-images.githubusercontent.com/4990252/97203931-c4034480-17b5-11eb-8151-393086f33378.jpg)
