### PR TITLE
Update CompletionPolicy of internal-dpl-aod-writer

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -50,6 +50,8 @@ struct CompletionPolicyHelpers {
   }
   /// Attach a given @a op to a device matching @name.
   static CompletionPolicy defineByName(std::string const& name, CompletionPolicy::CompletionOp op);
+  /// Attach a given @a op to a device matching @name, check message of origin @origin is available
+  static CompletionPolicy defineByNameOrigin(std::string const& name, std::string const& origin, CompletionPolicy::CompletionOp op);
   /// Get a specific header from the input
   template <typename T, typename U>
   static auto getHeader(U const& input)

--- a/Framework/Core/src/CompletionPolicy.cxx
+++ b/Framework/Core/src/CompletionPolicy.cxx
@@ -23,7 +23,7 @@ std::vector<CompletionPolicy>
   CompletionPolicy::createDefaultPolicies()
 {
   return {
-    CompletionPolicyHelpers::defineByName("internal-dpl-aod-writer", CompletionOp::Consume),
+    CompletionPolicyHelpers::defineByNameOrigin("internal-dpl-aod-writer", "TFN", CompletionOp::Consume),
     CompletionPolicyHelpers::consumeWhenAll()};
 }
 


### PR DESCRIPTION
The aod-writer is supposed to save the tables as they arrive to file into folders TF_x, where x is the time frame number (TFN). The TFN is contained in a message which is created by the reader or any other process providing the input data. The TFN message thus has to be available to the writer before a table can be saved to file. This PR guarantees, that the CompletionPolicy of the writer is set to WAIT and only switched to CONSUME when the required TFN information is available to the writer.