### PR TITLE
Do not track neutral particles for MID

### DIFF
--- a/Detectors/MUON/MID/Simulation/src/Stepper.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Stepper.cxx
@@ -29,6 +29,14 @@ Stepper::~Stepper()
 
 bool Stepper::process(const TVirtualMC& vmc)
 {
+
+  if (!(vmc.TrackCharge())) {
+    // Only charged particles
+    return false;
+  }
+
+  // TODO: Update basing on AliRoot
+
   o2::SimTrackStatus ts{vmc};
 
   int detElemId;


### PR DESCRIPTION
The neutral particles were wrongly tracked in simulations.
This fix should solve the issue seen here:
https://alice.its.cern.ch/jira/browse/O2-1800
A further fine tuning of the stepper will be done later on.