### PR TITLE
TRD fix digit sorting

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -31,39 +31,39 @@ class LinkRecord
   using DataRange = o2::dataformats::RangeReference<int>;
 
   struct LinkId {
-      union {
-          uint16_t word;
-          struct {
-              uint16_t spare : 4;
-              uint16_t side : 1;
-              uint16_t layer : 3;
-              uint16_t stack : 3;
-              uint16_t supermodule : 5;
-          };
+    union {
+      uint16_t word;
+      struct {
+        uint16_t spare : 4;
+        uint16_t side : 1;
+        uint16_t layer : 3;
+        uint16_t stack : 3;
+        uint16_t supermodule : 5;
       };
+    };
   };
 
-    public:
+ public:
   LinkRecord() = default;
-  LinkRecord(const uint32_t linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) { mLinkId.word = linkid; }
+  LinkRecord(const uint32_t linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) { mLinkId = linkid; }
   // LinkRecord(const LinkRecord::LinkId linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) {mLinkId.word=linkid.word;}
   LinkRecord(uint32_t sector, int stack, int layer, int side, int firstentry, int nentries) : mDataRange(firstentry, nentries) { setLinkId(sector, stack, layer, side); }
 
   ~LinkRecord() = default;
 
-  void setLinkId(const uint32_t linkid) { mLinkId.word = linkid; }
-  void setLinkId(const LinkId linkid) { mLinkId.word = linkid.word; }
+  void setLinkId(const uint32_t linkid) { mLinkId = linkid; }
+  //  void setLinkId(const LinkId linkid) { mLinkId = linkid; }
   void setLinkId(const uint32_t sector, const uint32_t stack, const uint32_t layer, const uint32_t side);
   void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
   void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
 
-  const uint32_t getLinkId() { return mLinkId.word; }
+  const uint32_t getLinkId() { return mLinkId; }
   //TODO come backwith a ccdb lookup.  const uint32_t getLinkHCID() { return mLinkId & 0x7ff; } // the last 11 bits.
-  const uint32_t getSector() { return mLinkId.supermodule; }
-  const uint32_t getStack() { return mLinkId.stack; }
-  const uint32_t getLayer() { return mLinkId.layer; }
-  const uint32_t getSide() { return mLinkId.side; }
+  const uint32_t getSector() { return (mLinkId & 0xf800) >> 11; }
+  const uint32_t getStack() { return (mLinkId & 0x700) >> 8; }
+  const uint32_t getLayer() { return (mLinkId & 0xe0) >> 5; }
+  const uint32_t getSide() { return (mLinkId & 0x10) >> 4; }
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
   static uint32_t getHalfChamberLinkId(uint32_t detector, uint32_t rob);
@@ -71,8 +71,8 @@ class LinkRecord
 
   void printStream(std::ostream& stream);
 
-    private:
-  LinkId mLinkId;
+ private:
+  uint16_t mLinkId;
   DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
   ClassDefNV(LinkRecord, 3);
 };

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -23,19 +23,6 @@ namespace o2
 namespace trd
 {
 
-struct LinkId {
- public:
-  union {
-    uint16_t word;
-    struct {
-      uint16_t spare : 4;
-      uint16_t side : 1;
-      uint16_t layer : 3;
-      uint16_t stack : 3;
-      uint16_t supermodule : 5;
-    };
-  };
-};
 /// \class LinkRecord
 /// \brief Header for data corresponding to the indexing of the links in the raw data output
 /// adapted from DataFormatsTRD/TriggerRecord
@@ -43,7 +30,20 @@ class LinkRecord
 {
   using DataRange = o2::dataformats::RangeReference<int>;
 
- public:
+  struct LinkId {
+      union {
+          uint16_t word;
+          struct {
+              uint16_t spare : 4;
+              uint16_t side : 1;
+              uint16_t layer : 3;
+              uint16_t stack : 3;
+              uint16_t supermodule : 5;
+          };
+      };
+  };
+
+    public:
   LinkRecord() = default;
   LinkRecord(const uint32_t linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) { mLinkId.word = linkid; }
   // LinkRecord(const LinkRecord::LinkId linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) {mLinkId.word=linkid.word;}
@@ -71,10 +71,10 @@ class LinkRecord
 
   void printStream(std::ostream& stream);
 
- private:
+    private:
   LinkId mLinkId;
   DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
-  ClassDefNV(LinkRecord, 2);
+  ClassDefNV(LinkRecord, 3);
 };
 
 std::ostream& operator<<(std::ostream& stream, LinkRecord& trg);

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -16,6 +16,7 @@
 
 #pragma link C++ class o2::trd::TriggerRecord + ;
 #pragma link C++ class o2::trd::LinkRecord + ;
+#pragma link C++ struct o2::trd::LinkRecord::LinkId + ;
 #pragma link C++ struct o2::trd::HalfCRUHeader + ;
 #pragma link C++ struct o2::trd::TrackletHCHeader + ;
 #pragma link C++ struct o2::trd::TrackletMCMHeader + ;

--- a/DataFormats/Detectors/TRD/src/LinkRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/LinkRecord.cxx
@@ -24,27 +24,22 @@ uint32_t LinkRecord::getHalfChamberLinkId(uint32_t detector, uint32_t rob)
   int stack = (detector % constants::NLAYER);
   int layer = ((detector % (constants::NLAYER * constants::NSTACK)) / constants::NLAYER);
   int side = rob % 2;
-  return getHalfChamberLinkId(sector, stack, layer, side);
+  return LinkRecord::getHalfChamberLinkId(sector, stack, layer, side);
 }
 
 uint32_t LinkRecord::getHalfChamberLinkId(uint32_t sector, uint32_t stack, uint32_t layer, uint32_t side)
 {
-  LinkId tmplinkid;
-  tmplinkid.supermodule = sector;
-  tmplinkid.stack = stack;
-  tmplinkid.layer = layer;
-  ;
-  tmplinkid.side = side;
-  return tmplinkid.word;
+  LinkRecord tmplinkid;
+  tmplinkid.setLinkId(sector, stack, layer, side);
+  return tmplinkid.getLinkId();
 }
 
 void LinkRecord::setLinkId(const uint32_t sector, const uint32_t stack, const uint32_t layer, const uint32_t side)
 {
-  mLinkId.supermodule = sector;
-  mLinkId.stack = stack;
-  mLinkId.layer = layer;
-  ;
-  mLinkId.side = side;
+  mLinkId |= sector << 11;
+  mLinkId |= stack << 8;
+  mLinkId |= layer << 5;
+  mLinkId |= side << 4;
 }
 
 void LinkRecord::printStream(std::ostream& stream)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -65,6 +65,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mEnableOnlineGainCorrection{false};
   bool mEnableTrapConfigDump{false};
   bool mFixTriggerRecords{false};   // shift the trigger record due to its being corrupt on coming in.
+  bool mDumpTriggerRecords{false};  // display the trigger records.
   std::vector<Tracklet64> mTracklets; // store of found tracklets
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";


### PR DESCRIPTION
- Redo sorting of incoming digits by index. Some digits were assigned to wrong mcm.
- fix linkrecord, remove struct to enable root streaming.
- some other sundry fixes.
sorting by index is needed for removal of timestamp from digits.
It also fixes some wrongly assigned hardware link ID's