### PR TITLE
TRD tracking as a DPL workflow

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -50,7 +50,7 @@ class Tracklet64
  public:
   Tracklet64() = default;
   Tracklet64(uint64_t trackletword) { mtrackletWord = trackletword; }
-  Tracklet64(const Tracklet64& rhs) { mtrackletWord = rhs.getTrackletWord(); };
+  Tracklet64(const Tracklet64&) = default;
   Tracklet64(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position,
              uint64_t slope, uint64_t Q0, uint64_t Q1, uint64_t Q2)
   {
@@ -58,7 +58,6 @@ class Tracklet64
   }
 
   ~Tracklet64() = default;
-  Tracklet64& operator=(const Tracklet64& o) { return *this; }
 
   //TODO convert to the actual number  regarding compliments.
   // ----- Getters for contents of tracklet word -----
@@ -149,7 +148,6 @@ class Tracklet64
  protected:
   uint64_t mtrackletWord; // the 64 bit word holding all the tracklet information for run3.
  private:
-  //  Tracklet& operator=(const Tracklet &rhs);   // not implemented
   ClassDefNV(Tracklet64, 1);
 };
 

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -8,7 +8,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-#add_compile_options(-O0 -pg -fPIC) 
+#add_compile_options(-O0 -pg -fPIC)
 
 o2_add_library(TRDWorkflow
                TARGETVARNAME targetName
@@ -16,9 +16,13 @@ o2_add_library(TRDWorkflow
                        src/TRDDigitWriterSpec.cxx
                        src/TRDDigitReaderSpec.cxx
                        src/TRDTrackletWriterSpec.cxx
+                       src/TRDTrackletReaderSpec.cxx
                        src/TRDTrapRawWriterSpec.cxx
                        src/TRDTrapSimulatorSpec.cxx
-                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
+                       src/TRDGlobalTrackingSpec.cxx
+                       src/TRDTrackWriterSpec.cxx
+                       src/TRDTrackingWorkflow.cxx
+                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::GPUTracking O2::GlobalTrackingWorkflow)
 
                    #o2_target_root_dictionary(TRDWorkflow
                    # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)
@@ -33,8 +37,13 @@ o2_add_executable(trap-sim
                                         O2::DataFormatsTRD
                                         O2::TRDWorkflow)
 
+o2_add_executable(global-tracking
+                  COMPONENT_NAME trd
+                  SOURCES src/trd-tracking-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
+
+
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
     target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
 endif()
-

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TRDGlobalTrackingSpec.h
+
+#ifndef O2_TRD_GLOBALTRACKING
+#define O2_TRD_GLOBALTRACKING
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "TStopwatch.h"
+
+#include "GPUO2Interface.h"
+#include "GPUTRDTracker.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDGlobalTracking : public o2::framework::Task
+{
+ public:
+  TRDGlobalTracking(bool useMC) : mUseMC(useMC) {}
+  ~TRDGlobalTracking() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::gpu::GPUTRDTracker* mTracker{nullptr};          ///< TRD tracking engine
+  o2::gpu::GPUReconstruction* mRec{nullptr};          ///< GPU reconstruction pointer, handles memory for the tracker
+  o2::gpu::GPUChainTracking* mChainTracking{nullptr}; ///< TRD tracker is run in the tracking chain
+  bool mUseMC{false};                                 ///< MC flag
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC);
+
+} // namespace trd
+} // namespace o2
+
+#endif /* O2_TRD_TRACKLETREADER */

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -16,7 +16,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "TStopwatch.h"
-
+#include "TRDBase/GeometryFlat.h"
 #include "GPUO2Interface.h"
 #include "GPUTRDTracker.h"
 
@@ -38,6 +38,7 @@ class TRDGlobalTracking : public o2::framework::Task
   o2::gpu::GPUTRDTracker* mTracker{nullptr};          ///< TRD tracking engine
   o2::gpu::GPUReconstruction* mRec{nullptr};          ///< GPU reconstruction pointer, handles memory for the tracker
   o2::gpu::GPUChainTracking* mChainTracking{nullptr}; ///< TRD tracker is run in the tracking chain
+  std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
   TStopwatch mTimer;
 };

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackWriterSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackWriterSpec.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRACK_WRITER_H
+#define O2_TRD_TRACK_WRITER_H
+
+/// @file   TRDTrackWriterSpec.h
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getTRDTrackWriterSpec(bool useMC);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRACKING_WORKFLOW_H
+#define O2_TRD_TRACKING_WORKFLOW_H
+
+/// @file   TRDTrackingWorkflow.h
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletReaderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletReaderSpec.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TRDTrackletReaderSpec.h
+
+#ifndef O2_TRD_TRACKLETREADER
+#define O2_TRD_TRACKLETREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDTrackletReader : public o2::framework::Task
+{
+ public:
+  TRDTrackletReader(bool useMC) : mUseMC(useMC) {}
+  ~TRDTrackletReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ private:
+  void connectTree(const std::string& filename);
+  bool mUseMC{false};
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInFileName{"trdtracklets.root"};
+  std::string mInTreeName{"o2sim"};
+  std::vector<o2::trd::Tracklet64> mTracklets, *mTrackletsPtr = &mTracklets;
+  std::vector<o2::trd::TriggerRecord> mTriggerRecords, *mTriggerRecordsPtr = &mTriggerRecords;
+  std::vector<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
+};
+
+/// create a processor spec
+/// read TRD tracklets from a root file
+framework::DataProcessorSpec getTRDTrackletReaderSpec(bool useMC);
+
+} // namespace trd
+} // namespace o2
+
+#endif /* O2_TRD_TRACKLETREADER */

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -114,7 +114,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     int64_t evTime = trg.getBCData().toLong() * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
     trdTriggerTimes.push_back(evTime / 1000.);
     trdTriggerIndices.push_back(iFirstTracklet);
-    LOGF(INFO, "Event %i: Occured at %li us after SOR, contains %i tracklets, index of first tracklet is %i", iEv, evTime / 1000, nTrackletsCurrent, iFirstTracklet);
+    LOGF(DEBUG, "Event %i: Occured at %li us after SOR, contains %i tracklets, index of first tracklet is %i", iEv, evTime / 1000, nTrackletsCurrent, iFirstTracklet);
   }
 
   mTracker->Reset();
@@ -125,7 +125,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   mRec->PrepareEvent();
   mRec->SetupGPUProcessor(mTracker, true);
 
-  LOG(INFO) << "Start loading input into TRD tracker";
+  LOG(DEBUG) << "Start loading input into TRD tracker";
   // load everything into the tracker
   int nTracksLoaded = 0;
   for (int iTrk = 0; iTrk < nTracks; ++iTrk) {
@@ -145,7 +145,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
       continue;
     }
     ++nTracksLoaded;
-    LOGF(INFO, "Loaded track %i with time %f", nTracksLoaded, trkLoad.getTime());
+    LOGF(DEBUG, "Loaded track %i with time %f", nTracksLoaded, trkLoad.getTime());
   }
 
   for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
@@ -162,9 +162,9 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   mTracker->SetTriggerRecordTimes(&(trdTriggerTimes[0]));
   mTracker->SetTriggerRecordIndices(&(trdTriggerIndices[0]));
   mTracker->SetNCollisions(nCollisions);
-  mTracker->DumpTracks();
+  //mTracker->DumpTracks();
   mTracker->DoTracking(mChainTracking);
-  mTracker->DumpTracks();
+  //mTracker->DumpTracks();
 
   std::vector<GPUTRDTrack> tracksOut(mTracker->NTracks());
   std::copy(mTracker->Tracks(), mTracker->Tracks() + mTracker->NTracks(), tracksOut.begin());

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -178,7 +178,7 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC)
   std::vector<OutputSpec> outputs;
   inputs.emplace_back("tpcitstrack", "GLO", "TPCITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trdtracklets", o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("trdtriggerrec", o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trdtriggerrec", o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
 
   if (useMC) {
     LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -1,0 +1,201 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TRDGlobalTrackingSpec.cxx
+
+#include "TRDWorkflow/TRDGlobalTrackingSpec.h"
+
+#include "TRDBase/Geometry.h"
+
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "CommonConstants/LHCConstants.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+
+// GPU header
+#include "GPUReconstruction.h"
+#include "GPUChainTracking.h"
+#include "GPUSettings.h"
+#include "GPUDataTypes.h"
+#include "GPUTRDDef.h"
+#include "GPUTRDTrack.h"
+#include "GPUTRDTrackletWord.h"
+#include "GPUTRDInterfaces.h"
+#include "GPUTRDGeometry.h"
+
+using namespace o2::framework;
+using namespace o2::gpu;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDGlobalTracking::init(InitContext& ic)
+{
+  //-------- init geometry and field --------//
+  o2::base::GeometryManager::loadGeometry();
+  o2::base::Propagator::initFieldFromGRP(o2::base::NameConf::getGRPFileName());
+  auto geo = Geometry::instance();
+  geo->createPadPlaneArray();
+  geo->createClusterMatrixArray();
+  const GeometryFlat geoFlat(*geo);
+
+  //-------- init GPU reconstruction --------//
+  GPUSettingsEvent cfgEvent;                 // defaults should be ok
+  GPUSettingsRec cfgRec;                     // don't care for now, NWaysOuter is set in here for instance
+  GPUSettingsProcessing cfgDeviceProcessing; // also keep defaults here, or adjust debug level
+  cfgDeviceProcessing.debugLevel = 5;
+  GPURecoStepConfiguration cfgRecoStep;
+  cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
+  cfgRecoStep.inputs.clear();
+  cfgRecoStep.outputs.clear();
+  mRec = GPUReconstruction::CreateInstance("CPU", true);
+  mRec->SetSettings(&cfgEvent, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
+
+  mChainTracking = mRec->AddChain<GPUChainTracking>();
+
+  mTracker = new GPUTRDTracker();
+  mTracker->SetNCandidates(1); // must be set before initialization
+  mTracker->SetProcessPerTimeFrame();
+  mTracker->SetNMaxCollisions(1000); // max number of collisions within a time frame which can be processed
+
+  mRec->RegisterGPUProcessor(mTracker, false);
+  mChainTracking->SetTRDGeometry(&geoFlat);
+  if (mRec->Init()) {
+    LOG(FATAL) << "GPUReconstruction could not be initialized";
+  }
+
+  // configure the tracker
+  //mTracker->EnableDebugOutput();
+  //mTracker->StartDebugging();
+  mTracker->SetPtThreshold(0.5);
+  mTracker->SetChi2Threshold(15);
+  mTracker->SetChi2Penalty(12);
+  mTracker->SetMaxMissingLayers(6);
+  mTracker->PrintSettings();
+
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void TRDGlobalTracking::run(ProcessingContext& pc)
+{
+  mTimer.Start(false);
+  const auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("tpcitstrack");
+  const auto trackletsTRD = pc.inputs().get<std::vector<o2::trd::Tracklet64>>("trdtracklets");
+  const auto triggerRecords = pc.inputs().get<std::vector<o2::trd::TriggerRecord>>("trdtriggerrec");
+
+  int nTracks = tracksITSTPC.size();
+  int nCollisions = triggerRecords.size();
+  int nTracklets = trackletsTRD.size();
+  LOGF(INFO, "There are %i tracklets in total from %i trigger records", nTracklets, nCollisions);
+
+  std::vector<float> trdTriggerTimes;
+  std::vector<int> trdTriggerIndices;
+
+  for (int iEv = 0; iEv < nCollisions; ++iEv) {
+    const auto& trg = triggerRecords.at(iEv);
+    int nTrackletsCurrent = trg.getNumberOfObjects();
+    int iFirstTracklet = trg.getFirstEntry();
+    int64_t evTime = trg.getBCData().toLong() * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
+    trdTriggerTimes.push_back(evTime / 1000.);
+    trdTriggerIndices.push_back(iFirstTracklet);
+    LOGF(INFO, "Event %i: Occured at %li us after SOR, contains %i tracklets, index of first tracklet is %i", iEv, evTime / 1000, nTrackletsCurrent, iFirstTracklet);
+  }
+
+  mTracker->Reset();
+
+  mChainTracking->mIOPtrs.nMergedTracks = nTracks;
+  mChainTracking->mIOPtrs.nTRDTracklets = nTracklets;
+  mChainTracking->AllocateIOMemory();
+  mRec->PrepareEvent();
+  mRec->SetupGPUProcessor(mTracker, true);
+
+  LOG(INFO) << "Start loading input into TRD tracker";
+  // load everything into the tracker
+  for (int iTrk = 0; iTrk < nTracks; ++iTrk) {
+    const auto& match = tracksITSTPC[iTrk];
+    const auto& trk = match.getParamOut();
+    GPUTRDTrack trkLoad;
+    trkLoad.setX(trk.getX());
+    trkLoad.setAlpha(trk.getAlpha());
+    for (int i = 0; i < 5; ++i) {
+      trkLoad.setParam(trk.getParam(i), i);
+    }
+    for (int i = 0; i < 15; ++i) {
+      trkLoad.setCov(trk.getCov()[i], i);
+    }
+    trkLoad.setTime(match.getTimeMUS().getTimeStamp());
+    mTracker->LoadTrack(trkLoad);
+    LOGF(INFO, "Loaded track %i with time %f", iTrk, trkLoad.getTime());
+  }
+
+  for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
+    auto trklt = trackletsTRD[iTrklt];
+    unsigned int trkltWord = 0; // DUMMY
+    GPUTRDTrackletWord trkltLoad;
+    trkltLoad.SetId(iTrklt);
+    trkltLoad.SetHCId(trklt.getHCID());
+    trkltLoad.SetTrackletWord(trkltWord);
+    if (mTracker->LoadTracklet(trkltLoad) > 0) {
+      LOG(WARNING) << "Could not load tracklet " << iTrklt;
+    }
+  }
+  mTracker->SetTriggerRecordTimes(&(trdTriggerTimes[0]));
+  mTracker->SetTriggerRecordIndices(&(trdTriggerIndices[0]));
+  mTracker->SetNCollisions(nCollisions);
+  mTracker->DumpTracks();
+  mTracker->DoTracking(mChainTracking);
+  mTracker->DumpTracks();
+
+  std::vector<GPUTRDTrack> tracksOut;
+  //tracksOut.resize(mTracker->NTracks());
+  std::copy(mTracker->Tracks(), mTracker->Tracks() + mTracker->NTracks(), tracksOut.begin());
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCHTRD", 0, Lifetime::Timeframe}, tracksOut);
+
+  mTimer.Stop();
+}
+
+void TRDGlobalTracking::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "TRD global tracking total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC)
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+  inputs.emplace_back("tpcitstrack", "GLO", "TPCITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trdtracklets", o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trdtriggerrec", o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe);
+
+  if (useMC) {
+    LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";
+    //inputs.emplace_back("itstracklabel", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
+    //inputs.emplace_back("tpctracklabel", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
+  }
+
+  outputs.emplace_back(o2::header::gDataOriginTRD, "MATCHTRD", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "trd-globaltracking",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDGlobalTracking>(useMC)},
+    Options{}};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -93,8 +93,8 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
 {
   mTimer.Start(false);
   const auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("tpcitstrack");
-  const auto trackletsTRD = pc.inputs().get<std::vector<o2::trd::Tracklet64>>("trdtracklets");
-  const auto triggerRecords = pc.inputs().get<std::vector<o2::trd::TriggerRecord>>("trdtriggerrec");
+  const auto trackletsTRD = pc.inputs().get<gsl::span<o2::trd::Tracklet64>>("trdtracklets");
+  const auto triggerRecords = pc.inputs().get<gsl::span<o2::trd::TriggerRecord>>("trdtriggerrec");
 
   int nTracks = tracksITSTPC.size();
   int nCollisions = triggerRecords.size();

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -159,8 +159,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   mTracker->DoTracking(mChainTracking);
   mTracker->DumpTracks();
 
-  std::vector<GPUTRDTrack> tracksOut;
-  //tracksOut.resize(mTracker->NTracks());
+  std::vector<GPUTRDTrack> tracksOut(mTracker->NTracks());
   std::copy(mTracker->Tracks(), mTracker->Tracks() + mTracker->NTracks(), tracksOut.begin());
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCHTRD", 0, Lifetime::Timeframe}, tracksOut);
 

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -82,7 +82,7 @@ void TRDGlobalTracking::init(InitContext& ic)
   mTracker->SetPtThreshold(0.5);
   mTracker->SetChi2Threshold(15);
   mTracker->SetChi2Penalty(12);
-  mTracker->SetMaxMissingLayers(6);
+  mTracker->SetStopTrkFollowingAfterNMissingLayers(6);
   mTracker->PrintSettings();
 
   mTimer.Stop();

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -52,10 +52,12 @@ void TRDGlobalTracking::init(InitContext& ic)
   mFlatGeo = std::make_unique<GeometryFlat>(*geo);
 
   //-------- init GPU reconstruction --------//
-  GPUSettingsEvent cfgEvent;                 // defaults should be ok
-  GPUSettingsRec cfgRec;                     // don't care for now, NWaysOuter is set in here for instance
-  GPUSettingsProcessing cfgDeviceProcessing; // also keep defaults here, or adjust debug level
-  cfgDeviceProcessing.debugLevel = 5;
+  GPUSettingsEvent cfgEvent;
+  cfgEvent.solenoidBz = o2::base::Propagator::Instance()->getNominalBz();
+  GPUSettingsRec cfgRec;
+  cfgRec.NWaysOuter = 1;
+  GPUSettingsProcessing cfgDeviceProcessing;
+  cfgDeviceProcessing.debugLevel = -1; // -1 : silent
   GPURecoStepConfiguration cfgRecoStep;
   cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
   cfgRecoStep.inputs.clear();
@@ -77,6 +79,7 @@ void TRDGlobalTracking::init(InitContext& ic)
   }
 
   // configure the tracker
+  // TODO: these settings will eventually be moved to GPUSettingsRec to be configurable via --configKeyValues
   //mTracker->EnableDebugOutput();
   //mTracker->StartDebugging();
   mTracker->SetPtThreshold(0.5);

--- a/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TRDTrackWriterSpec.cxx
+
+#include <vector>
+#include "GPUO2Interface.h"
+#include "GPUTRDDef.h"
+#include "GPUTRDTrack.h"
+
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+
+using namespace o2::framework;
+using namespace o2::gpu;
+
+namespace o2
+{
+namespace trd
+{
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getTRDTrackWriterSpec(bool useMC)
+{
+  // TODO: not clear if the writer is supposed to write MC labels at some point
+  // this is just a dummy definition for the template branch definition below
+  // define the correct type and the input specs
+  using LabelsType = std::vector<int>;
+  // force, this will disable the branch for now, can be adjusted in the future
+  useMC = false;
+
+  // A spectator to store the size of the data array for the logger below
+  auto tracksSize = std::make_shared<int>();
+  auto tracksLogger = [tracksSize](std::vector<GPUTRDTrack> const& tracks) {
+    *tracksSize = tracks.size();
+  };
+
+  return MakeRootTreeWriterSpec("trd-track-writer",
+                                "trdtracks.root",
+                                "tracksTRD",
+                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD", 0},
+                                                                           "tracks",
+                                                                           "tracks-branch-name",
+                                                                           1,
+                                                                           tracksLogger},
+                                // NOTE: this branch template is to show how the conditional MC labels can
+                                // be defined, the '0' disables the branch for the moment
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},
+                                                             "labels",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "labels-branch-name"})();
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TRDTrackingWorkflow.cxx
+
+#include <vector>
+
+#include "Framework/WorkflowSpec.h"
+#include "GlobalTrackingWorkflow/TrackTPCITSReaderSpec.h"
+#include "TRDWorkflow/TRDTrackletReaderSpec.h"
+#include "TRDWorkflow/TRDGlobalTrackingSpec.h"
+#include "TRDWorkflow/TRDTrackWriterSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut)
+{
+  framework::WorkflowSpec specs;
+  bool useMC = false;
+  if (!disableRootInp) {
+    specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    specs.emplace_back(o2::trd::getTRDTrackletReaderSpec(useMC));
+  }
+
+  specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC));
+
+  if (!disableRootOut) {
+    specs.emplace_back(o2::trd::getTRDTrackWriterSpec(useMC));
+  }
+  return specs;
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
@@ -56,7 +56,7 @@ void TRDTrackletReader::run(ProcessingContext& pc)
   LOG(INFO) << "Pushing " << mTracklets.size() << " TRD tracklets for these trigger records";
 
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe}, mTracklets);
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe}, mTriggerRecords);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe}, mTriggerRecords);
   if (mUseMC) {
     LOG(FATAL) << "MC information not yet included for TRD tracklets";
   }
@@ -71,7 +71,7 @@ DataProcessorSpec getTRDTrackletReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe);
-  outputs.emplace_back(o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
   if (useMC) {
     LOG(FATAL) << "MC information not yet included for TRD tracklets";
   }

--- a/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TRDTrackletReaderSpec.cxx
+
+#include "TRDWorkflow/TRDTrackletReaderSpec.h"
+
+#include "Headers/DataHeader.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDTrackletReader::init(InitContext& ic)
+{
+  // get the option from the init context
+  LOG(INFO) << "Init TRD tracklet reader!";
+  mInFileName = ic.options().get<std::string>("trd-tracklet-infile");
+  mInTreeName = ic.options().get<std::string>("treename");
+  connectTree(mInFileName);
+}
+
+void TRDTrackletReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mInTreeName.c_str()));
+  assert(mTree);
+  mTree->SetBranchAddress("Tracklet", &mTrackletsPtr);
+  mTree->SetBranchAddress("TrackTrg", &mTriggerRecordsPtr);
+  if (mUseMC) {
+    LOG(FATAL) << "MC information not yet included for TRD tracklets";
+  }
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+void TRDTrackletReader::run(ProcessingContext& pc)
+{
+  auto currEntry = mTree->GetReadEntry() + 1;
+  assert(currEntry < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(currEntry);
+  LOG(INFO) << "Pushing " << mTriggerRecords.size() << " TRD trigger records at entry " << currEntry;
+  LOG(INFO) << "Pushing " << mTracklets.size() << " TRD tracklets for these trigger records";
+
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe}, mTracklets);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe}, mTriggerRecords);
+  if (mUseMC) {
+    LOG(FATAL) << "MC information not yet included for TRD tracklets";
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getTRDTrackletReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRIGGERREC", 0, Lifetime::Timeframe);
+  if (useMC) {
+    LOG(FATAL) << "MC information not yet included for TRD tracklets";
+  }
+
+  return DataProcessorSpec{
+    "TRDTrackletReader",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDTrackletReader>(useMC)},
+    Options{
+      {"trd-tracklet-infile", VariantType::String, "trdtracklets.root", {"Name of the input file"}},
+      {"treename", VariantType::String, "o2sim", {"Name of top-level TTree"}},
+    }};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDWorkflow/TRDTrackingWorkflow.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
+  std::string keyvaluehelp("Semicolon separated key=value strings ...");
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2trdtracking-workflow_configuration.ini");
+  auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
+  auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
+  return std::move(o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut));
+}

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -137,7 +137,7 @@ set(HDRS_INSTALL
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   set(SRCS ${SRCS} Interface/GPUO2Interface.cxx Interface/GPUO2InterfaceRefit.cxx Interface/GPUO2InterfaceQA.cxx Interface/GPUO2InterfaceConfigurableParam.cxx)
   set(HDRS_CINT_O2 ${HDRS_CINT_O2} Interface/GPUO2Interface.h Interface/GPUO2InterfaceRefit.h Interface/GPUO2InterfaceQA.h Interface/GPUO2InterfaceConfigurableParam.h dEdx/TPCdEdxCalibrationSplines.h)
-  set(HDRS_CINT_O2_ADDITIONAL Base/GPUSettings.h Base/GPUSettingsList.h) # Manual depencies for ROOT dictionary generation
+  set(HDRS_CINT_O2_ADDITIONAL Base/GPUSettings.h Base/GPUSettingsList.h TRDTracking/GPUTRDTrack.h) # Manual dependencies for ROOT dictionary generation
 endif()
 
 # Sources for O2 and for Standalone if requested in config file

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
@@ -26,5 +26,8 @@
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessing + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplay + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsQA + ;
+#pragma link C++ class o2::gpu::trackInterface < o2::dataformats::TrackTPCITS> + ;
+#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::dataformats::TrackTPCITS>> + ;
+#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::dataformats::TrackTPCITS>>> + ;
 
 #endif

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -238,7 +238,8 @@ void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking(GPUChainTracking* chainTracking)
     }
 
     if (!CalculateSpacePoints(iColl)) {
-      GPUError("Space points for at least one chamber could not be calculated");
+      GPUError("Space points for at least one chamber could not be calculated (for interaction %i)", iColl);
+      break;
     }
   }
 
@@ -451,7 +452,7 @@ GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTrack(const TRDTRK& trk, const int
     return (1);
   }
   if (checkTrack && !CheckTrackTRDCandidate(trk)) {
-    return 0;
+    return 2;
   }
 #ifdef GPUCA_ALIROOT_LIB
   new (&mTracks[mNTracks]) TRDTRK(trk); // We need placement new, since the class is virtual

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -1310,6 +1310,19 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::IsGeoFindable(const TRDTRK* t, const 
   return true;
 }
 
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::SetNCollisions(int nColl)
+{
+  // Set the number of collisions for a given time frame.
+  // The number is taken from the TRD trigger records
+  if (nColl < mNMaxCollisions) {
+    mNCollisions = nColl;
+  } else {
+    GPUError("Cannot process more than %i collisions. The last %i collisions will be dropped", mNMaxCollisions, nColl - mNMaxCollisions);
+    mNCollisions = mNMaxCollisions;
+  }
+}
+
 #ifndef GPUCA_GPUCODE
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -405,8 +405,7 @@ GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackRefs(const int trackID, boo
       layer = 5;
     }
     if (layer < 0) {
-      Error("CheckTrackRefs", "No layer can be determined");
-      GPUError("x=%f, y=%f, z=%f, layer=%i", xLoc, trackReference->LocalY(), trackReference->Z(), layer);
+      GPUError("No layer can be determined for x=%f, y=%f, z=%f, layer=%i", xLoc, trackReference->LocalY(), trackReference->Z(), layer);
       continue;
     }
     if (trackReference->TestBits(0x1 << 18)) {
@@ -510,7 +509,9 @@ GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::GetCollisionID(float trkTime) const
 {
   for (int iColl = 0; iColl < mNCollisions; ++iColl) {
     if (CAMath::Abs(trkTime - mTriggerRecordTimes[iColl]) < mTimeWindow) {
-      GPUInfo("TRD info found from interaction %i at %f for track with time %f", iColl, mTriggerRecordTimes[iColl], trkTime);
+      if (ENABLE_INFO) {
+        GPUInfo("TRD info found from interaction %i at %f for track with time %f", iColl, mTriggerRecordTimes[iColl], trkTime);
+      }
       return iColl;
     }
   }
@@ -527,7 +528,9 @@ GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::DoTrackingThread(int iTrk, int thread
   if (mProcessPerTimeFrame) {
     collisionId = GetCollisionID(mTracks[iTrk].getTime());
     if (collisionId < 0) {
-      GPUInfo("Did not find TRD data for track with t=%f", mTracks[iTrk].getTime());
+      if (ENABLE_INFO) {
+        GPUInfo("Did not find TRD data for track with t=%f", mTracks[iTrk].getTime());
+      }
       // no TRD data available for the bunch crossing this track originates from
       return;
     }
@@ -689,7 +692,6 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         if (ENABLE_INFO) {
           GPUInfo("Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
         }
-        GPUInfo("Propagation failed");
         continue;
       }
 
@@ -698,7 +700,6 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         if (ENABLE_INFO) {
           GPUInfo("FollowProlongation: Adjusting sector failed for track %i candidate %i in layer %i", iTrack, iCandidate, iLayer);
         }
-        GPUInfo("Adjust sector failed");
         continue;
       }
 
@@ -716,7 +717,6 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         if (ENABLE_INFO) {
           GPUInfo("FollowProlongation: Track out of TRD acceptance with z=%f in layer %i (eta=%f)", trkWork->getZ(), iLayer, trkWork->getEta());
         }
-        GPUInfo("Out of z acceptance");
         continue;
       }
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -140,7 +140,7 @@ class GPUTRDTracker_t : public GPUProcessor
 
   // input from TRD trigger record
   GPUd() void SetNMaxCollisions(int nColl) { mNMaxCollisions = nColl; } // can this be fixed to a sufficiently large value?
-  GPUd() void SetNCollisions(int nColl) { mNCollisions = nColl; }
+  GPUd() void SetNCollisions(int nColl);
   GPUd() void SetTriggerRecordIndices(int* indices) { mTriggerRecordIndices = indices; }
   GPUd() void SetTriggerRecordTimes(float* times) { mTriggerRecordTimes = times; }
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -152,7 +152,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() void SetMaxEta(float maxEta) { mMaxEta = maxEta; }
   GPUd() void SetChi2Threshold(float chi2) { mMaxChi2 = chi2; }
   GPUd() void SetChi2Penalty(float chi2) { mChi2Penalty = chi2; }
-  GPUd() void SetMaxMissingLayers(int ly) { mMaxMissingLy = ly; }
+  GPUd() void SetStopTrkFollowingAfterNMissingLayers(int ly) { mMaxMissingLy = ly; }
   GPUd() void SetExtraRoadY(float extraRoadY) { mExtraRoadY = extraRoadY; }
   GPUd() void SetRoadZ(float roadZ) { mRoadZ = roadZ; }
 

--- a/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
+++ b/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
@@ -86,7 +86,7 @@ void run_trd_tracker(std::string path = "./",
   tracker->SetPtThreshold(0.5);
   tracker->SetChi2Threshold(15);
   tracker->SetChi2Penalty(12);
-  tracker->SetMaxMissingLayers(6);
+  tracker->SetStopTrkFollowingAfterNMissingLayers(6);
   tracker->PrintSettings();
 
   // load input tracks


### PR DESCRIPTION
Hello @shahor02 , @davidrohr  @tdietel  and @bazinski 

I created a first version of a TRD tracking workflow (currently based on ITS-TPC matched tracks as input). At the moment it has basically the same functionality as the macro I used before `run_trd_tracking.C`. Here is a list of what I would like to achieve in the end:

- The `TRDGlobalTrackingSpec` should get an option whether to use ITS-TPC matched tracks or TPC only tracks as input. The functionality to use TPC only tracks of course needs to be added to `GPUTRDTracker` first.
- At some point the TRD tracking shall receive calibrated tracklets which are available after the standalone TRD tracking. But since the development has just started I would like to take the "raw" online tracklets as a first step and start with those. I will simply transform them into the Run2 format and plug them into the tracker. This will be done as soon as the tracklets give reasonable results.
- I wonder what the output of the TRD tracking whould be for the synchronous reconstruction. For the TPC interpolation we will not need the tracks, but only the indices of the global tracks, which could be matched successfully to the TRD and for those tracks the up to 6 space points. For the TPC interpolation these space points will then be used for a refit from the outer radius. Maybe I need to add this to the `GPUTRDTracker` class.
- MC is completely disabled at the moment.

Open questions:
- In the `run` method of `TRDGlobalTrackingSpec.cxx` I cannot use `gsl::span` as input for the TRD data, but only `std::vector` since the data is not trivially copyable. I do not know why.

I wanted to ping also Jason. Does somebody know his github name?

Cheers,
Ole
