### PR TITLE
Update shaping time of electronics

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/ParameterElectronics.h
+++ b/Detectors/TPC/base/include/TPCBase/ParameterElectronics.h
@@ -45,6 +45,13 @@ struct ParameterElectronics : public o2::conf::ConfigurableParamHelper<Parameter
   float ElectronCharge = 1.602e-19f;                            ///< Electron charge [C]
   DigitzationMode DigiMode = DigitzationMode::SubtractPedestal; ///< Digitization mode [full / ... ]
 
+  /// Average time from the start of the signal shaping to the COG of the sampled distribution
+  ///
+  /// Since the shaping of the electronic starts when the signals arrive, the cluster finder
+  /// reconstructs signals later in time. Due to the asymmetry of the signal, the average
+  /// shaping time is somewhat larger then the PeakingTime
+  float getAverageShapingTime() const { return PeakingTime + 35e-3f; }
+
   O2ParamDef(ParameterElectronics, "TPCEleParam");
 };
 } // namespace tpc

--- a/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
@@ -245,7 +245,7 @@ int TPCFastTransformHelperO2::updateCalibration(TPCFastTransform& fastTransform,
   // spline corrections for xyz
   // Time-of-flight correction: ldrift += dist-to-vtx*tofCorr
 
-  const double t0 = elParam.PeakingTime / elParam.ZbinWidth;
+  const double t0 = elParam.getAverageShapingTime() / elParam.ZbinWidth;
 
   const double vdCorrY = 0.;
   const double ldCorr = 0.;


### PR DESCRIPTION
A time offset between TPC and ITS tracks is observed. The reason is that
the peaking time of the electronics and the average shaping time has a
slight offset due to the tail of the gamma4 function. This fixes this
issue.