### PR TITLE
DPL Analysis: do not write to disk TFN output.

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -434,11 +434,13 @@ DataProcessorSpec
 
   std::vector<InputSpec> validBinaryInputs;
   auto onlyTimeframe = [](InputSpec const& input) {
-    return input.lifetime == Lifetime::Timeframe;
+    return (DataSpecUtils::partialMatch(input, o2::header::DataOrigin("TFN")) == false) &&
+           input.lifetime == Lifetime::Timeframe;
   };
 
   auto noTimeframe = [](InputSpec const& input) {
-    return input.lifetime != Lifetime::Timeframe;
+    return (DataSpecUtils::partialMatch(input, o2::header::DataOrigin("TFN")) == true) ||
+          input.lifetime != Lifetime::Timeframe;
   };
 
   std::copy_if(danglingOutputInputs.begin(), danglingOutputInputs.end(),

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -440,7 +440,7 @@ DataProcessorSpec
 
   auto noTimeframe = [](InputSpec const& input) {
     return (DataSpecUtils::partialMatch(input, o2::header::DataOrigin("TFN")) == true) ||
-          input.lifetime != Lifetime::Timeframe;
+           input.lifetime != Lifetime::Timeframe;
   };
 
   std::copy_if(danglingOutputInputs.begin(), danglingOutputInputs.end(),


### PR DESCRIPTION
This is really some internal data which should never be serialised when dangling.