### PR TITLE
GPU: Reject tracks with too large fraction of ignored clusters

### DIFF
--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -326,8 +326,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* GPUrestrict() merger, 
   }
   ConstrainSinPhi();
 
-  bool ok = N + NTolerated >= GPUCA_TRACKLET_SELECTOR_MIN_HITS(mP[4]) && CheckNumericalQuality(covYYUpd);
-  if (!ok) {
+  if (!(N + NTolerated >= GPUCA_TRACKLET_SELECTOR_MIN_HITS(mP[4]) && 2 * NTolerated <= CAMath::Max(10, N) && CheckNumericalQuality(covYYUpd))) {
     return (false);
   }
 
@@ -338,7 +337,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* GPUrestrict() merger, 
   MoveToReference(prop, param, Alpha);
   NormalizeAlpha(Alpha);
 
-  return (ok);
+  return (true);
 }
 
 GPUd() void GPUTPCGMTrackParam::MoveToReference(GPUTPCGMPropagator& prop, const GPUParam& param, float& Alpha)


### PR DESCRIPTION
@shahor02 : I found a bug in the accounting of clusters ignored in the fit due to high sinPhi, which is leading to the tracks with 0 clusters you saw. Will need some time for a proper fix.

This PR is a quick fix that cuts them away and the cut here is useful anyway, so I'd merge this in any case.
I just believe some tracks are rejected incorrectly (already before), and I'll fix that in a follow-up PR.