### PR TITLE
DPL: do not invoke end of stream for pipe devices

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -75,7 +75,6 @@ static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingConte
 AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
-    setEOSCallback(ic);
 
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();
@@ -132,7 +131,6 @@ AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requ
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
-    setEOSCallback(ic);
 
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();


### PR DESCRIPTION
EndOfStream + Quit should only be raised by devices which produce
data from no source. All the other devices should simply process all
the data the got in input.