### PR TITLE
DPL: fix naming for internal-dpl-***aod***-index-builder

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -382,7 +382,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {}};
 
   DataProcessorSpec indexBuilder{
-    "internal-dpl-index-builder",
+    "internal-dpl-aod-index-builder",
     {},
     {},
     readers::AODReaderHelpers::indexBuilderCallback(requestedIDXs),


### PR DESCRIPTION
We treat `internal-dpl-***aod***` in a special manner when handling socket polling compared to `internal-dpl` which are considered non pollable. This fully explains the recent locking issues.