### PR TITLE
Small Updates for dimuon analysis

### DIFF
--- a/Analysis/Core/include/Analysis/VarManager.h
+++ b/Analysis/Core/include/Analysis/VarManager.h
@@ -150,6 +150,7 @@ class VarManager : public TObject
     kMuonBendingCoor,
     kMuonNonBendingCoor,
     kMuonRAtAbsorberEnd,
+    kMuonPDca,
     kMuonChi2,
     kMuonChi2MatchTrigger,
     kNMuonTrackVariables,
@@ -440,6 +441,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonBendingCoor] = track.bendingCoor();
     values[kMuonNonBendingCoor] = track.nonBendingCoor();
     values[kMuonRAtAbsorberEnd] = track.rAtAbsorberEnd();
+    values[kMuonPDca] = track.pDca();
     values[kMuonChi2] = track.chi2();
     values[kMuonChi2MatchTrigger] = track.chi2MatchTrigger();
   }

--- a/Analysis/Core/src/VarManager.cxx
+++ b/Analysis/Core/src/VarManager.cxx
@@ -216,6 +216,8 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kMuonNonBendingCoor] = "";
   fgVariableNames[kMuonRAtAbsorberEnd] = "R at the end of the absorber";
   fgVariableUnits[kMuonRAtAbsorberEnd] = "";
+  fgVariableNames[kMuonPDca] = "p x dca";
+  fgVariableUnits[kMuonPDca] = "cm x GeV/c";
   fgVariableNames[kMuonChi2] = "#chi 2";
   fgVariableUnits[kMuonChi2] = "";
   fgVariableNames[kMuonChi2MatchTrigger] = "#chi 2 trigger match";

--- a/Analysis/DataModel/include/Analysis/ReducedInfoTables.h
+++ b/Analysis/DataModel/include/Analysis/ReducedInfoTables.h
@@ -135,7 +135,8 @@ DECLARE_SOA_TABLE(ReducedMuonsExtended, "AOD", "RTMUONEXTENDED",
                   muon::ThetaX, muon::ThetaY, muon::ZMu,
                   muon::BendingCoor, muon::NonBendingCoor,
                   muon::Chi2, muon::Chi2MatchTrigger,
-                  muon::RAtAbsorberEnd<muon::BendingCoor, muon::NonBendingCoor, muon::ThetaX, muon::ThetaY, muon::ZMu>);
+                  muon::RAtAbsorberEnd<muon::BendingCoor, muon::NonBendingCoor, muon::ThetaX, muon::ThetaY, muon::ZMu>,
+                  muon::PDca<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY, muon::BendingCoor, muon::NonBendingCoor, muon::ZMu>);
 
 // iterators
 using ReducedTrack = ReducedTracks::iterator;

--- a/Analysis/Tasks/PWGDQ/tableMaker_pp.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker_pp.cxx
@@ -21,7 +21,10 @@
 #include "Analysis/ReducedInfoTables.h"
 #include "Analysis/VarManager.h"
 #include "Analysis/HistogramManager.h"
+#include "Analysis/AnalysisCut.h"
+#include "Analysis/AnalysisCompositeCut.h"
 #include "PID/PIDResponse.h"
+#include "Analysis/TrackSelectionTables.h"
 #include <iostream>
 
 using std::cout;
@@ -31,6 +34,19 @@ using namespace o2;
 using namespace o2::framework;
 //using namespace o2::framework::expressions;
 using namespace o2::aod;
+
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection, aod::pidRespTPC, aod::pidRespTOF, aod::pidRespTOFbeta>;
+
+// HACK: In order to be able to deduce which kind of aod object is transmitted to the templated VarManager::Fill functions
+//         a constexpr static bit map must be defined and sent as template argument
+//        The user has to include in this bit map all the tables needed in analysis, as defined in VarManager::ObjTypes
+//        Additionally, one should make sure that the requested tables are actually provided in the process() function,
+//       otherwise a compile time error will be thrown.
+//        This is a temporary fix until the arrow/ROOT issues are solved, at which point it will be possible
+//           to automatically detect the object types transmitted to the VarManager
+constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
 
 struct TableMaker_pp {
 
@@ -44,31 +60,71 @@ struct TableMaker_pp {
   Produces<ReducedMuons> muonBasic;
   Produces<ReducedMuonsExtended> muonExtended;
 
-  OutputObj<HistogramManager> fHistMan{"output"};
+  float* fValues;
 
-  // HACK: In order to be able to deduce which kind of aod object is transmitted to the templated VarManager::Fill functions
-  //         a constexpr static bit map must be defined and sent as template argument
-  //        The user has to include in this bit map all the tables needed in analysis, as defined in VarManager::ObjTypes
-  //        Additionally, one should make sure that the requested tables are actually provided in the process() function,
-  //       otherwise a compile time error will be thrown.
-  //        This is a temporary fix until the arrow/ROOT issues are solved, at which point it will be possible
-  //           to automatically detect the object types transmitted to the VarManager
-  constexpr static uint32_t fgEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
-  constexpr static uint32_t fgTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackCov;
+  OutputObj<THashList> fOutputList{"output"};
+  HistogramManager* fHistMan;
+
+  // TODO: Filters should be used to make lowest level selection. The additional more restrictive cuts should be defined via the AnalysisCuts
+  // TODO: Multiple event selections can be applied and decisions stored in the reducedevent::tag
+  AnalysisCompositeCut* fEventCut;
+  // TODO: Multiple track selections can be applied and decisions stored in the reducedtrack::filteringFlags
+  //  Cuts should be defined using Configurables (prepare cut libraries, as discussed in O2 DQ meetings)
+  AnalysisCompositeCut* fTrackCut;
+
+  // Partition will select fast a group of tracks with basic requirements
+  //   If some of the cuts cannot be included in the Partition expression, add them via AnalysisCut(s)
+  Partition<MyBarrelTracks> barrelSelectedTracks = o2::aod::track::pt >= 1.0f && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
+
+  // TODO a few of the important muon variables in the central data model are dynamic columns so not usable in expressions (e.g. eta, phi)
+  //        Update the data model to have them as expression columns
+  Partition<aod::Muons> muonSelectedTracks = o2::aod::muon::pt >= 0.5f; // For pp collisions a 0.5 GeV/c pp cuts is defined
 
   void init(o2::framework::InitContext&)
   {
+    fValues = new float[VarManager::kNVars];
     VarManager::SetDefaultVarNames();
-    fHistMan.setObject(new HistogramManager("analysisHistos", "aa", VarManager::kNVars));
-
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
     fHistMan->SetUseDefaultVariableNames(kTRUE);
     fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
 
-    DefineHistograms("Event;");                      // define all histograms
-    VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+    DefineHistograms("Event_BeforeCuts;Event_AfterCuts;TrackBarrel_BeforeCuts;TrackBarrel_AfterCuts"); // define all histograms
+    VarManager::SetUseVars(fHistMan->GetUsedVars());                                                   // provide the list of required variables so that VarManager knows what to fill
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+    DefineCuts();
   }
 
-  void process(soa::Join<aod::Collisions, aod::EvSels>::iterator collision, aod::MuonClusters const& clustersMuon, aod::Muons const& tracksMuon, aod::BCs const& bcs, soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov /*, aod::pidRespTPC, aod::pidRespTOF, aod::pidRespTOFbeta*/> const& tracksBarrel)
+  void DefineCuts()
+  {
+    fEventCut = new AnalysisCompositeCut(true);
+    AnalysisCut* eventVarCut = new AnalysisCut();
+    eventVarCut->AddCut(VarManager::kVtxZ, -10.0, 10.0);
+    eventVarCut->AddCut(VarManager::kIsINT7, 0.5, 1.5); // require kINT7
+    fEventCut->AddCut(eventVarCut);
+
+    fTrackCut = new AnalysisCompositeCut(true);
+    AnalysisCut* trackVarCut = new AnalysisCut();
+    //trackVarCut->AddCut(VarManager::kPt, 1.0, 1000.0);
+    //trackVarCut->AddCut(VarManager::kEta, -0.9, 0.9);
+    //trackVarCut->AddCut(VarManager::kTPCsignal, 70.0, 100.0);
+    trackVarCut->AddCut(VarManager::kIsITSrefit, 0.5, 1.5);
+    trackVarCut->AddCut(VarManager::kIsTPCrefit, 0.5, 1.5);
+    //trackVarCut->AddCut(VarManager::kTPCchi2, 0.0, 4.0);
+    //trackVarCut->AddCut(VarManager::kITSchi2, 0.1, 36.0);
+    trackVarCut->AddCut(VarManager::kTPCncls, 100.0, 161.);
+
+    AnalysisCut* pidCut1 = new AnalysisCut();
+    TF1* cutLow1 = new TF1("cutLow1", "pol1", 0., 10.);
+    cutLow1->SetParameters(130., -40.0);
+    pidCut1->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
+
+    fTrackCut->AddCut(trackVarCut);
+    fTrackCut->AddCut(pidCut1);
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+  }
+
+  void process(MyEvents::iterator const& collision, aod::MuonClusters const& clustersMuon, aod::Muons const& tracksMuon, aod::BCs const& bcs, MyBarrelTracks const& tracksBarrel)
   {
     uint64_t tag = 0;
     uint32_t triggerAliases = 0;
@@ -78,66 +134,68 @@ struct TableMaker_pp {
       }
     }
 
-    VarManager::ResetValues();
-    VarManager::FillEvent<fgEventFillMap>(collision);       // extract event information and place it in the fgValues array
-    fHistMan->FillHistClass("Event", VarManager::fgValues); // automatically fill all the histograms in the class Event
+    VarManager::ResetValues(0, VarManager::kNEventWiseVariables, fValues);
+    VarManager::FillEvent<gkEventFillMap>(collision, fValues); // extract event information and place it in the fgValues array
+    fHistMan->FillHistClass("Event_BeforeCuts", fValues);      // automatically fill all the histograms in the class Event
+
+    if (!fEventCut->IsSelected(fValues)) {
+      return;
+    }
+
+    fHistMan->FillHistClass("Event_AfterCuts", fValues);
 
     event(tag, collision.bc().runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib());
     eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), triggerAliases, 0.0f);
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
     uint64_t trackFilteringTag = 0;
-    float sinAlpha = 0.f;
-    float cosAlpha = 0.f;
-    float globalX = 0.f;
-    float globalY = 0.f;
-    float dcaXY = 0.f;
-    float dcaZ = 0.f;
-    for (auto& track : tracksBarrel) {
+    trackBasic.reserve(barrelSelectedTracks.size());
+    trackBarrel.reserve(barrelSelectedTracks.size());
+    trackBarrelCov.reserve(barrelSelectedTracks.size());
+    trackBarrelPID.reserve(barrelSelectedTracks.size());
 
-      if (track.pt() < 0.15) {
+    for (auto& track : barrelSelectedTracks) {
+      VarManager::FillTrack<gkTrackFillMap>(track, fValues);
+      fHistMan->FillHistClass("TrackBarrel_BeforeCuts", fValues);
+      if (!fTrackCut->IsSelected(fValues)) {
         continue;
       }
-      if (TMath::Abs(track.eta()) > 0.9) {
-        continue;
+      fHistMan->FillHistClass("TrackBarrel_AfterCuts", fValues);
+
+      if (track.isGlobalTrack()) {
+        trackFilteringTag |= (uint64_t(1) << 0);
       }
-
-      sinAlpha = sin(track.alpha());
-      cosAlpha = cos(track.alpha());
-      globalX = track.x() * cosAlpha - track.y() * sinAlpha;
-      globalY = track.x() * sinAlpha + track.y() * cosAlpha;
-
-      dcaXY = sqrt(pow((globalX - collision.posX()), 2) +
-                   pow((globalY - collision.posY()), 2));
-      dcaZ = sqrt(pow(track.z() - collision.posZ(), 2));
-
-      trackBasic(collision, track.globalIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.charge());
+      if (track.isGlobalTrackSDD()) {
+        trackFilteringTag |= (uint64_t(1) << 1);
+      }
+      trackBasic(event.lastIndex(), track.globalIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.charge());
       trackBarrel(track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
                   track.tpcNClsFindable(), track.tpcNClsFindableMinusFound(), track.tpcNClsFindableMinusCrossedRows(),
                   track.tpcNClsShared(), track.tpcChi2NCl(),
                   track.trdChi2(), track.tofChi2(),
-                  track.length(), dcaXY, dcaZ);
+                  track.length(), track.dcaXY(), track.dcaZ());
       trackBarrelCov(track.cYY(), track.cZZ(), track.cSnpSnp(), track.cTglTgl(), track.c1Pt21Pt2());
       trackBarrelPID(track.tpcSignal(),
-                     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-      //track.tpcNSigmaEl(), track.tpcNSigmaMu(),
-      //track.tpcNSigmaPi(), track.tpcNSigmaKa(), track.tpcNSigmaPr(),
-      //track.tpcNSigmaDe(), track.tpcNSigmaTr(), track.tpcNSigmaHe(), track.tpcNSigmaAl(),
-      //track.tofSignal(), track.beta(),
-      //track.tofNSigmaEl(), track.tofNSigmaMu(),
-      //track.tofNSigmaPi(), track.tofNSigmaKa(), track.tofNSigmaPr(),
-      //track.tofNSigmaDe(), track.tofNSigmaTr(), track.tofNSigmaHe(), track.tofNSigmaAl(),
-      //track.trdSignal());
+                     track.tpcNSigmaEl(), track.tpcNSigmaMu(),
+                     track.tpcNSigmaPi(), track.tpcNSigmaKa(), track.tpcNSigmaPr(),
+                     track.tpcNSigmaDe(), track.tpcNSigmaTr(), track.tpcNSigmaHe(), track.tpcNSigmaAl(),
+                     track.tofSignal(), track.beta(),
+                     track.tofNSigmaEl(), track.tofNSigmaMu(),
+                     track.tofNSigmaPi(), track.tofNSigmaKa(), track.tofNSigmaPr(),
+                     track.tofNSigmaDe(), track.tofNSigmaTr(), track.tofNSigmaHe(), track.tofNSigmaAl(),
+                     track.trdSignal());
     }
 
-    for (auto& muon : tracksMuon) {
+    muonBasic.reserve(muonSelectedTracks.size());
+    muonExtended.reserve(muonSelectedTracks.size());
+    for (auto& muon : muonSelectedTracks) {
       // TODO: add proper information for muon tracks
-      if (muon.bc() != collision.bc()) {
+      if (muon.bcId() != collision.bcId()) {
         continue;
       }
+      // TODO: the trackFilteringTag will not be needed to encode whether the track is a muon since there is a dedicated table for muons
       trackFilteringTag |= (uint64_t(1) << 0); // this is a MUON arm track
-      muonBasic(collision, trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.charge());
+      muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.charge());
       muonExtended(muon.inverseBendingMomentum(), muon.thetaX(), muon.thetaY(), muon.zMu(), muon.bendingCoor(), muon.nonBendingCoor(), muon.chi2(), muon.chi2MatchTrigger());
     }
   }
@@ -168,6 +226,26 @@ struct TableMaker_pp {
         fHistMan->AddHistogram(classStr.Data(), "Ncontrib_vs_VtxZ_VtxX_VtxY_prof", "n-contrib vs (x,y,z)", true,
                                100, 0.055, 0.08, VarManager::kVtxX, 100, 0.31, 0.35, VarManager::kVtxY, 30, -15., 15., VarManager::kVtxZ,
                                "", "", "", VarManager::kVtxNcontrib); // TProfile3D
+      }
+
+      if (classStr.Contains("Track")) {
+        fHistMan->AddHistClass(classStr.Data());
+        fHistMan->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kPt);                                                // TH1F histogram
+        fHistMan->AddHistogram(classStr.Data(), "Eta", "#eta distribution", false, 500, -5.0, 5.0, VarManager::kEta);                                               // TH1F histogram
+        fHistMan->AddHistogram(classStr.Data(), "Phi_Eta", "#phi vs #eta distribution", false, 200, -5.0, 5.0, VarManager::kEta, 200, -6.3, 6.3, VarManager::kPhi); // TH2F histogram
+
+        if (classStr.Contains("Barrel")) {
+          fHistMan->AddHistogram(classStr.Data(), "TPCncls", "Number of cluster in TPC", false, 160, -0.5, 159.5, VarManager::kTPCncls); // TH1F histogram
+          fHistMan->AddHistogram(classStr.Data(), "TPCncls_Run", "Number of cluster in TPC", true, kNRuns, 0.5, 0.5 + kNRuns, VarManager::kRunId,
+                                 10, -0.5, 159.5, VarManager::kTPCncls, 10, 0., 1., VarManager::kNothing, runsStr.Data());           // TH1F histogram
+          fHistMan->AddHistogram(classStr.Data(), "ITSncls", "Number of cluster in ITS", false, 8, -0.5, 7.5, VarManager::kITSncls); // TH1F histogram
+          //for TPC PID
+          fHistMan->AddHistogram(classStr.Data(), "TPCdedx_pIN", "TPC dE/dx vs pIN", false, 200, 0.0, 20.0, VarManager::kPin, 200, 0.0, 200., VarManager::kTPCsignal); // TH2F histogram
+          fHistMan->AddHistogram(classStr.Data(), "DCAxy", "DCAxy", false, 100, -3.0, 3.0, VarManager::kTrackDCAxy);                                                   // TH1F histogram
+          fHistMan->AddHistogram(classStr.Data(), "DCAz", "DCAz", false, 100, -5.0, 5.0, VarManager::kTrackDCAz);                                                      // TH1F histogram
+          fHistMan->AddHistogram(classStr.Data(), "IsGlobalTrack", "IsGlobalTrack", false, 2, -0.5, 1.5, VarManager::kIsGlobalTrack);                                  // TH1F histogram
+          fHistMan->AddHistogram(classStr.Data(), "IsGlobalTrackSDD", "IsGlobalTrackSDD", false, 2, -0.5, 1.5, VarManager::kIsGlobalTrackSDD);                         // TH1F histogram
+        }
       }
     } // end loop over histogram classes
   }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -347,6 +347,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, [](float bendingCoor,
   float rAtAbsorberEnd = std::sqrt(xAbs * xAbs + yAbs * yAbs);
   return rAtAbsorberEnd;
 });
+DECLARE_SOA_DYNAMIC_COLUMN(PDca, pDca, [](float inverseBendingMomentum, float thetaX, float thetaY, float bendingCoor, float nonBendingCoor, float zMu) -> float {
+  // linear extrapolation of the coordinates of the track to the position of the end of the absorber (-505 cm)
+  float dca = std::sqrt(bendingCoor * bendingCoor + nonBendingCoor * nonBendingCoor + zMu * zMu);
+  float pz = -std::sqrt(1.0 + std::tan(thetaY) * std::tan(thetaY)) / std::abs(inverseBendingMomentum);
+  float pt = std::abs(pz) * std::sqrt(std::tan(thetaX) * std::tan(thetaX) + std::tan(thetaY) * std::tan(thetaY));
+  float pTot = std::sqrt(pt * pt + pz * pz);
+  float pDca = pTot * dca;
+  return pDca;
+});
 DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, nsqrt(1.0f + ntan(aod::muon::thetaY) * ntan(aod::muon::thetaY)) * nsqrt(ntan(aod::muon::thetaX) * ntan(aod::muon::thetaX) + ntan(aod::muon::thetaY) * ntan(aod::muon::thetaY)) / nabs(aod::muon::inverseBendingMomentum));
 DECLARE_SOA_EXPRESSION_COLUMN(Px, px, float, -1.0f * ntan(aod::muon::thetaX) * nsqrt(1.0f + ntan(aod::muon::thetaY) * ntan(aod::muon::thetaY)) / nabs(aod::muon::inverseBendingMomentum));
 DECLARE_SOA_EXPRESSION_COLUMN(Py, py, float, -1.0f * ntan(aod::muon::thetaY) * nsqrt(1.0f + ntan(aod::muon::thetaY) * ntan(aod::muon::thetaY)) / nabs(aod::muon::inverseBendingMomentum));
@@ -362,6 +371,7 @@ DECLARE_SOA_TABLE_FULL(StoredMuons, "Muons", "AOD", "MUON",
                        muon::Eta<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY>,
                        muon::Phi<muon::ThetaX, muon::ThetaY>,
                        muon::RAtAbsorberEnd<muon::BendingCoor, muon::NonBendingCoor, muon::ThetaX, muon::ThetaY, muon::ZMu>,
+                       muon::PDca<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY, muon::BendingCoor, muon::NonBendingCoor, muon::ZMu>,
                        muon::Charge<muon::InverseBendingMomentum>);
 
 DECLARE_SOA_EXTENDED_TABLE(Muons, StoredMuons, "MUON",


### PR DESCRIPTION
Modification of:
- Analysis/Core/include/Analysis/VarManager.h
- Analysis/Core/src/VarManager.cxx
- Analysis/DataModel/include/Analysis/ReducedInfoTables.h
- Framework/Core/include/Framework/AnalysisDataModel.h
to include the pxdca variable, which is used in track selection in dimuon analysis

Modification of:
- Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
- Analysis/Tasks/PWGDQ/tableMaker_pp.cxx
to include the pxdca cut, and to have partitions for track selection 