### PR TITLE
Fix missing reference, speed up trap sim by ~100x for Pb-Pb

### DIFF
--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -336,7 +336,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
       LOG(debug) << "i:" << msgDigitsIndex[i];
     }
     std::stable_sort(std::begin(msgDigitsIndex) + trig.getFirstEntry(), std::begin(msgDigitsIndex) + trig.getNumberOfObjects() + trig.getFirstEntry(),
-                     [msgDigits](auto&& PH1, auto&& PH2) { return digitindexcompare(PH1, PH2, msgDigits); });
+                     [&msgDigits](auto&& PH1, auto&& PH2) { return digitindexcompare(PH1, PH2, msgDigits); });
     LOG(debug) << "post sort";
     for (int i = msgDigitsIndex[trig.getFirstEntry()]; i < trig.getNumberOfObjects() + trig.getFirstEntry(); i++) {
       LOG(debug) << "i:" << i << " = " << msgDigitsIndex[i];


### PR DESCRIPTION
@bazinski : This fixes the problem I mentioned today.
@martenole : I have tried your TRD tracking workflow with 10 Pb-Pb events after this fix and it seems to work well.