### PR TITLE
GPU: Initialize GPU settings from configKeyValues if compiled in O2 and not set externally

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -45,6 +45,10 @@
 #define GPUCA_LOGGING_PRINTF
 #include "GPULogging.h"
 
+#ifdef GPUCA_O2_LIB
+#include "GPUO2InterfaceConfiguration.h"
+#endif
+
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
@@ -954,10 +958,18 @@ int GPUReconstruction::ReadSettings(const char* dir)
 
 void GPUReconstruction::SetSettings(float solenoidBz, const GPURecoStepConfiguration* workflow)
 {
+#ifdef GPUCA_O2_LIB
+  GPUO2InterfaceConfiguration config;
+  config.ReadConfigurableParam();
+  if (config.configEvent.solenoidBz <= -1e6f) {
+    config.configEvent.solenoidBz = solenoidBz;
+  }
+  SetSettings(&config.configEvent, &config.configReconstruction, &config.configProcessing, workflow);
+#else
   GPUSettingsEvent ev;
-  new (&ev) GPUSettingsEvent;
   ev.solenoidBz = solenoidBz;
   SetSettings(&ev, nullptr, nullptr, workflow);
+#endif
 }
 
 void GPUReconstruction::SetSettings(const GPUSettingsEvent* settings, const GPUSettingsRec* rec, const GPUSettingsProcessing* proc, const GPURecoStepConfiguration* workflow)

--- a/GPU/GPUTracking/Base/GPUSettingsList.h
+++ b/GPU/GPUTracking/Base/GPUSettingsList.h
@@ -266,7 +266,7 @@ AddSubConfig(GPUSettingsEG, EG)
 EndConfig()
 #elif defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE) // GPUCA_STANDALONE
 BeginSubConfig(GPUSettingsO2, global, configStandalone, "O2", 0, "O2 workflow settings")
-AddOption(solenoidBz, float, -1000.f, "", 0, "solenoid field strength")
+AddOption(solenoidBz, float, -1e6f, "", 0, "solenoid field strength")
 AddOption(constBz, bool, false, "", 0, "force constant Bz for tests")
 AddOption(continuousMaxTimeBin, int, 0, "", 0, "maximum time bin of continuous data, 0 for triggered events, -1 for default of 23ms")
 AddOption(deviceType, std::string, "CPU", "", 0, "Device type, CPU | CUDA | HIP | OCL1 | OCL2")

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
@@ -100,7 +100,7 @@ GPUSettingsO2 GPUO2InterfaceConfiguration::ReadConfigurableParam()
   if (global.continuousMaxTimeBin) {
     configEvent.continuousMaxTimeBin = global.continuousMaxTimeBin;
   }
-  if (global.solenoidBz > -1000.f) {
+  if (global.solenoidBz > -1e6f) {
     configEvent.solenoidBz = global.solenoidBz;
   }
   if (global.constBz) {


### PR DESCRIPTION
@martenole : This makes the configKeyValues setting for the GPUReconstruction in DPL workflows generally available.
You can basically use the simple method SetSettings providing only the bz field and the recoSteps.
All other settings are initialized to their defaults and can be overridden on the command line via:
```
--configKeyValues "GPU_proc.debugLevel=1;GPU_global.solenoidBz=10.f;GPU_rec.MinNTrackClusters=20"
```
for example, also the solenoid field can be overridden on the command line which takes precedence. List of all settings is in `GPUSettingsList.h`. Could you have a look if this works for you? I am afraid it will not work in the macro, because to my knowledge you cannot set the configKeyValues there.