### PR TITLE
Swap Y coordinate of MB/OB half staves to match their actual position

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
@@ -491,8 +491,8 @@ TGeoVolume* V3Layer::createStave(const TGeoManager* /*mgr*/)
       xpos = (static_cast<TGeoBBox*>(hstaveVol->GetShape()))->GetDX() - sOBHalfStaveXOverlap / 2;
       // ypos is now a parameter to avoid HS displacement wrt nominal radii
       ypos = sOBHalfStaveYPos;
-      staveVol->AddNode(hstaveVol, 0, new TGeoTranslation(-xpos, ypos, 0));
-      staveVol->AddNode(hstaveVol, 1, new TGeoTranslation(xpos, ypos + sOBHalfStaveYTrans, 0));
+      staveVol->AddNode(hstaveVol, 0, new TGeoTranslation(-xpos, ypos + sOBHalfStaveYTrans, 0));
+      staveVol->AddNode(hstaveVol, 1, new TGeoTranslation(xpos, ypos, 0));
       mHierarchy[kHalfStave] = 2; // RS
       mechStaveVol = createSpaceFrameOuterB();
 


### PR DESCRIPTION
The two half staves of a MB/OB stave were erroneously placed in Y position (probably I misunderstood the orientation of the blueprints). Their Y position is now swapped so they appear in the correct orientation while keeping the match of modules with real hardware.