### PR TITLE
Fix TString::Tokenize-related memleaks

### DIFF
--- a/Analysis/Core/src/HistogramManager.cxx
+++ b/Analysis/Core/src/HistogramManager.cxx
@@ -149,7 +149,7 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
 
   // tokenize the title string; the user may include in it axis titles which will overwrite the defaults
   TString titleStr(title);
-  TObjArray* arr = titleStr.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(titleStr.Tokenize(";"));
   // mark required variables as being used
   if (varX > kNothing) {
     fUsedVars[varX] = kTRUE;
@@ -364,7 +364,7 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
 
   // tokenize the title string; the user may include in it axis titles which will overwrite the defaults
   TString titleStr(title);
-  TObjArray* arr = titleStr.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(titleStr.Tokenize(";"));
 
   // encode needed variable identifiers in a vector and push it to the std::list corresponding to the current histogram list
   std::vector<int> varVector;
@@ -529,7 +529,7 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
 
   // tokenize the title string; the user may include in it axis titles which will overwrite the defaults
   TString titleStr(title);
-  TObjArray* arr = titleStr.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(titleStr.Tokenize(";"));
 
   if (varW > kNothing) {
     fUsedVars[varW] = kTRUE;
@@ -608,7 +608,7 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
 
   // tokenize the title string; the user may include in it axis titles which will overwrite the defaults
   TString titleStr(title);
-  TObjArray* arr = titleStr.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(titleStr.Tokenize(";"));
 
   if (varW > kNothing) {
     fUsedVars[varW] = kTRUE;
@@ -811,7 +811,7 @@ void HistogramManager::MakeAxisLabels(TAxis* ax, const char* labels)
   // add bin labels to an axis
   //
   TString labelsStr(labels);
-  TObjArray* arr = labelsStr.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(labelsStr.Tokenize(";"));
   for (int ib = 1; ib <= ax->GetNbins(); ++ib) {
     if (ib >= arr->GetEntries() + 1) {
       break;

--- a/Analysis/Tasks/PWGDQ/dileptonEE.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonEE.cxx
@@ -277,7 +277,7 @@ void DefineHistograms(o2::framework::OutputObj<HistogramManager> histMan, TStrin
   }
   VarManager::SetRunNumbers(kNRuns, runs);
 
-  TObjArray* arr = histClasses.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
   for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
     TString classStr = arr->At(iclass)->GetName();
 

--- a/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
@@ -306,7 +306,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
   }
   VarManager::SetRunNumbers(kNRuns, runs);
 
-  TObjArray* arr = histClasses.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
   for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
     TString classStr = arr->At(iclass)->GetName();
 

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -210,7 +210,7 @@ struct TableMaker {
     }
     VarManager::SetRunNumbers(kNRuns, runs);
 
-    TObjArray* arr = histClasses.Tokenize(";");
+    std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
       TString classStr = arr->At(iclass)->GetName();
 

--- a/Analysis/Tasks/PWGDQ/tableMaker_pp.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker_pp.cxx
@@ -210,7 +210,7 @@ struct TableMaker_pp {
     }
     VarManager::SetRunNumbers(kNRuns, runs);
 
-    TObjArray* arr = histClasses.Tokenize(";");
+    std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
       TString classStr = arr->At(iclass)->GetName();
 

--- a/Analysis/Tasks/PWGDQ/tableReader.cxx
+++ b/Analysis/Tasks/PWGDQ/tableReader.cxx
@@ -537,7 +537,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
   }
   VarManager::SetRunNumbers(kNRuns, runs);
 
-  TObjArray* arr = histClasses.Tokenize(";");
+  std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
   for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
     TString classStr = arr->At(iclass)->GetName();
 


### PR DESCRIPTION
I've noticed that ~~only 3 out of 30 (!!!)~~ _some of_ `TObjArrays*` produced by `TString::Tokenize` are freed, so I decided to fix this (fortunately, it is doable by a single regexp).

https://root.cern.ch/doc/v622/classTString.html#a689ddf39f10539c879dcee0c5f4113ec:
> `TObjArray * TString::Tokenize ( const TString & delim ) const`
> **The returned array** is the owner of the objects, and **must be deleted by the user**. 