### PR TITLE
Improve O2 TPC Tracking QA to include secondary efficiencies and Z resolution

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -18,7 +18,7 @@
 #include "CommonDataFormat/BunchFilling.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include <FairLogger.h>
+#include <GPUCommonLogger.h>
 
 namespace o2
 {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCMCInfo.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCMCInfo.h
@@ -30,6 +30,9 @@ struct GPUTPCMCInfo {
   float pY;
   float pZ;
   float genRadius;
+#ifdef GPUCA_TPC_GEOMETRY_O2
+  float t0;
+#endif
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -994,7 +994,7 @@ void GPUQA::RunQA(bool matchOnly, const std::vector<o2::tpc::TrackTPC>* tracksEx
           const float& mcphi = mc2.phi;
           const float& mceta = mc2.eta;
 
-          if (info.prim && info.primDaughters) {
+          if (info.primDaughters) {
             continue;
           }
           if (mc2.nWeightCls < MIN_WEIGHT_CLS) {
@@ -1079,6 +1079,9 @@ void GPUQA::RunQA(bool matchOnly, const std::vector<o2::tpc::TrackTPC>* tracksEx
         const mcInfo_t& mc1 = GetMCTrack(mTrackMCLabels[i]);
         const additionalMCParameters& mc2 = GetMCTrackObj(mMCParam, mTrackMCLabels[i]);
 
+        if (mc1.primDaughters) {
+          continue;
+        }
         if (!tracksExternal) {
           if (!mTracking->mIOPtrs.mergedTracks[i].OK()) {
             continue;
@@ -1108,9 +1111,9 @@ void GPUQA::RunQA(bool matchOnly, const std::vector<o2::tpc::TrackTPC>* tracksEx
         if (mc2.nWeightCls < MIN_WEIGHT_CLS) {
           continue;
         }
-        if (mConfig.resPrimaries == 1 && (!mc1.prim || mc1.primDaughters)) {
+        if (mConfig.resPrimaries == 1 && !mc1.prim) {
           continue;
-        } else if (mConfig.resPrimaries == 2 && (mc1.prim || mc1.primDaughters)) {
+        } else if (mConfig.resPrimaries == 2 && mc1.prim) {
           continue;
         }
         if (GetMCTrackObj(mTrackMCLabelsReverse, mTrackMCLabels[i]) != (int)i) {


### PR DESCRIPTION
@wiechula @stheckel @tklemenz : This is the last ingredient on the O2 side I guess. It fixes the histograms that were broken / empty so far. I have also updated https://qcg-test.cern.ch/?page=objectTree with the latest versions.

Only missing part now is on thee QC side, as described in AliceO2Group/QualityControl#553