### PR TITLE
Workaround for readability-braces-around-statements bug

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -87,7 +87,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     InOutMemory();
     ~InOutMemory();
     InOutMemory(InOutMemory&&);
-    InOutMemory& operator=(InOutMemory&&);
+    InOutMemory& operator=(InOutMemory&&) = default;
 
     std::unique_ptr<unsigned long long int[]> tpcZSpages;
     std::unique_ptr<char[]> tpcZSpagesChar; // Same as above, but as char (needed for reading dumps, but deprecated, since alignment can be wrong)

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -65,7 +65,6 @@ static constexpr char DUMP_HEADER[DUMP_HEADER_SIZE + 1] = "CAv1";
 GPUChainTracking::InOutMemory::InOutMemory() = default;
 GPUChainTracking::InOutMemory::~InOutMemory() = default;
 GPUChainTracking::InOutMemory::InOutMemory(GPUChainTracking::InOutMemory&&) = default;
-GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default;
 
 void GPUChainTracking::DumpData(const char* filename)
 {


### PR DESCRIPTION
codechecker aggroes at `GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default;`:
```
GPU/GPUTracking/Global/GPUChainTrackingIO.cxx:68:105: error: statement should be inside braces [readability-braces-around-statements]
GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default;
                                                                                                        ^
                                                                                                         {
```
(Should I move all `= default`ed constructors/operators to the `.h` file?)