### PR TITLE
(O2-1203) [rANS] Iterators for tranforming rANS input/Output 

### DIFF
--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -27,6 +27,13 @@ o2_add_test(FrequencyTable
             COMPONENT_NAME rANS
             LABELS utils)
             
+o2_add_test(CombinedIterator
+            NAME CombinedIterator
+            SOURCES test/test_ransCombinedIterator.cxx
+            PUBLIC_LINK_LIBRARIES O2::rANS
+            COMPONENT_NAME rANS
+            LABELS utils)
+            
 o2_add_executable(rans-encode-decode-8
                   TARGETVARNAME targetName
                   SOURCES run/bin-encode-decode.cxx

--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(rANS
                        src/FrequencyTable.cxx
                PUBLIC_LINK_LIBRARIES FairLogger::FairLogger)
 
+
 o2_add_test(EncodeDecode
             NAME EncodeDecode
             SOURCES test/test_ransEncodeDecode.cxx
@@ -33,6 +34,12 @@ o2_add_test(CombinedIterator
             PUBLIC_LINK_LIBRARIES O2::rANS
             COMPONENT_NAME rANS
             LABELS utils)
+            
+o2_add_executable(CombinedIterator
+                    SOURCES benchmarks/bench_ransCombinedIterator.cxx
+                    COMPONENT_NAME rANS
+              IS_BENCHMARK
+                    PUBLIC_LINK_LIBRARIES O2::rANS benchmark::benchmark)
             
 o2_add_executable(rans-encode-decode-8
                   TARGETVARNAME targetName

--- a/Utilities/rANS/benchmarks/bench_ransCombinedIterator.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransCombinedIterator.cxx
@@ -1,0 +1,113 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   bench_ransCombinedIterator.cxx
+/// @author Michael Lettrich
+/// @since  Nov 18, 2020
+/// @brief
+
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include "rANS/utils.h"
+
+static void BM_Array_Read_Copy(benchmark::State& state)
+{
+  std::vector<uint32_t> a(state.range(0), 0x0);
+  std::vector<uint32_t> b(state.range(0), 0x1);
+  std::vector<uint32_t> c(state.range(0), 0x0);
+  for (auto _ : state) {
+    std::vector<uint32_t> tmp(state.range(0));
+
+    for (size_t i = 0; i < a.size(); ++i) {
+      tmp[i] = b[i] + (a[i] << 16);
+    }
+
+    for (size_t i = 0; i < tmp.size(); ++i) {
+      c[i] = tmp[i] + 1;
+    }
+  }
+}
+
+BENCHMARK(BM_Array_Read_Copy)->RangeMultiplier(2)->Range(10e4, 2 * 10e6);
+
+static void BM_Array_Read_Iterator(benchmark::State& state)
+{
+  std::vector<uint32_t> a(state.range(0), 0x0);
+  std::vector<uint32_t> b(state.range(0), 0x1);
+  std::vector<uint32_t> c(state.range(0), 0x0);
+
+  for (auto _ : state) {
+    auto readOP = [](auto iterA, auto iterB) -> uint32_t {
+      return *iterB + (*iterA << 16);
+    };
+
+    const o2::rans::utils::CombinedInputIterator begin(a.begin(), b.begin(), readOP);
+    const o2::rans::utils::CombinedInputIterator end(a.end(), b.end(), readOP);
+
+    auto cIter = c.begin();
+
+    for (auto iter = begin; iter != end; ++iter) {
+      *cIter = *iter + 1;
+      ++cIter;
+    }
+  }
+}
+
+BENCHMARK(BM_Array_Read_Iterator)->RangeMultiplier(2)->Range(10e4, 2 * 10e6);
+
+static void BM_Array_Write_Copy(benchmark::State& state)
+{
+  std::vector<uint32_t> a(state.range(0), 0x0);
+  std::vector<uint32_t> b(state.range(0), 0x0);
+  std::vector<uint32_t> c(state.range(0), 0x0001000f);
+  for (auto _ : state) {
+    std::vector<uint32_t> tmp(state.range(0));
+
+    for (size_t i = 0; i < c.size(); ++i) {
+      tmp[i] = c[i] + 1;
+    }
+
+    for (size_t i = 0; i < a.size(); ++i) {
+      const uint32_t shift = 16;
+      a[i] = tmp[i] >> shift;
+      b[i] = tmp[i] & ((1 << shift) - 1);
+    }
+  }
+}
+
+BENCHMARK(BM_Array_Write_Copy)->RangeMultiplier(2)->Range(10e4, 2 * 10e6);
+
+static void BM_Array_Write_Iterator(benchmark::State& state)
+{
+  std::vector<uint32_t> a(state.range(0), 0x0);
+  std::vector<uint32_t> b(state.range(0), 0x0);
+  std::vector<uint32_t> c(state.range(0), 0x0001000f);
+
+  for (auto _ : state) {
+    auto writeOP = [](auto iterA, auto iterB, uint32_t value) -> void {
+      const uint32_t shift = 16;
+      *iterA = value >> shift;
+      *iterB = value & ((1 << shift) - 1);
+    };
+
+    o2::rans::utils::CombinedOutputIterator out(a.begin(), b.begin(), writeOP);
+
+    for (auto iter = c.begin(); iter != c.end(); ++iter) {
+      *out = *iter + 1;
+      ++out;
+    }
+  }
+}
+
+BENCHMARK(BM_Array_Write_Iterator)->RangeMultiplier(2)->Range(10e4, 2 * 10e6);
+
+BENCHMARK_MAIN();

--- a/Utilities/rANS/include/rANS/utils.h
+++ b/Utilities/rANS/include/rANS/utils.h
@@ -1,0 +1,16 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   utils.h
+/// @author Michael Lettrich
+/// @since  2020-11-18
+/// @brief  header for utils
+
+#include "utils/CombinedIterator.h"

--- a/Utilities/rANS/include/rANS/utils/CombinedIterator.h
+++ b/Utilities/rANS/include/rANS/utils/CombinedIterator.h
@@ -1,0 +1,220 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CombinedIterator.h
+/// \brief
+/// \author michael.lettrich@cern.ch
+
+#ifndef INCLUDE_RANS_UTILS_COMBINEDITERATOR_H_
+#define INCLUDE_RANS_UTILS_COMBINEDITERATOR_H_
+
+#include <cstddef>
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+#include <iostream>
+#include <iterator>
+
+namespace o2
+{
+namespace rans
+{
+namespace utils
+{
+
+template <class iterA_T, class iterB_T, class F>
+class CombinedInputIterator
+{
+  using difference_type = std::ptrdiff_t;
+  using value_type = std::result_of<F(iterA_T, iterB_T)>;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category = std::input_iterator_tag;
+
+ public:
+  CombinedInputIterator(iterA_T iterA, iterB_T iterB, F functor);
+  CombinedInputIterator(const CombinedInputIterator& iter) = default;
+  CombinedInputIterator(CombinedInputIterator&& iter) = default;
+  CombinedInputIterator& operator=(const CombinedInputIterator& other);
+  CombinedInputIterator& operator=(CombinedInputIterator&& other) = default;
+  ~CombinedInputIterator() = default;
+
+  //comparison
+  bool operator==(const CombinedInputIterator& other) const;
+  bool operator!=(const CombinedInputIterator& other) const;
+
+  //pointer arithmetics
+  CombinedInputIterator& operator++();
+  CombinedInputIterator operator++(int);
+
+  // dereference
+  auto operator*() const;
+
+ private:
+  iterA_T mIterA;
+  iterB_T mIterB;
+  F mFunctor;
+
+ public:
+  friend std::ostream& operator<<(std::ostream& o, const CombinedInputIterator& iter)
+  {
+    o << "CombinedInputIterator{iterA: " << &(iter.mIterA) << ", iterB: " << &(iter.mIterB) << "}";
+    return o;
+  }
+};
+
+template <class iterA_T, class iterB_T, class F>
+class CombinedOutputIterator
+{
+
+  class Proxy
+  {
+   public:
+    Proxy(CombinedOutputIterator& iter);
+
+    template <typename value_T>
+    Proxy& operator=(value_T value);
+
+   private:
+    CombinedOutputIterator& mIter;
+  };
+
+  using difference_type = std::ptrdiff_t;
+  using value_type = Proxy;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category = std::input_iterator_tag;
+
+ public:
+  CombinedOutputIterator(iterA_T iterA, iterB_T iterB, F functor);
+  CombinedOutputIterator(const CombinedOutputIterator& iter) = default;
+  CombinedOutputIterator(CombinedOutputIterator&& iter) = default;
+  CombinedOutputIterator& operator=(const CombinedOutputIterator& other);
+  CombinedOutputIterator& operator=(CombinedOutputIterator&& other) = default;
+  ~CombinedOutputIterator() = default;
+
+  //pointer arithmetics
+  CombinedOutputIterator& operator++();
+  CombinedOutputIterator operator++(int);
+
+  // dereference
+  value_type operator*();
+
+ private:
+  iterA_T mIterA;
+  iterB_T mIterB;
+  F mFunctor;
+
+ public:
+  friend std::ostream& operator<<(std::ostream& o, const CombinedOutputIterator& iter)
+  {
+    o << "CombinedOutputIterator{iterA: " << &(iter.mIterA) << ", iterB: " << &(iter.mIterB) << "}";
+    return o;
+  }
+};
+
+template <class iterA_T, class iterB_T, class F>
+CombinedInputIterator<iterA_T, iterB_T, F>::CombinedInputIterator(iterA_T iterA, iterB_T iterB, F functor) : mIterA(iterA), mIterB(iterB), mFunctor(functor)
+{
+}
+
+template <class iterA_T, class iterB_T, class F>
+auto CombinedInputIterator<iterA_T, iterB_T, F>::operator=(const CombinedInputIterator& other) -> CombinedInputIterator&
+{
+  mIterA = other.mIterA;
+  mIterB = other.mIterB;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline bool CombinedInputIterator<iterA_T, iterB_T, F>::operator==(const CombinedInputIterator& other) const
+{
+  return (mIterA == other.mIterA) && (mIterB == other.mIterB);
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline bool CombinedInputIterator<iterA_T, iterB_T, F>::operator!=(const CombinedInputIterator& other) const
+{
+  return !(*this == other);
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator++() -> CombinedInputIterator&
+{
+  ++mIterA;
+  ++mIterB;
+  return *this;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator++(int) -> CombinedInputIterator
+{
+  auto res = *this;
+  ++(*this);
+  return res;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator*() const
+{
+  return mFunctor(mIterA, mIterB);
+}
+
+template <class iterA_T, class iterB_T, class F>
+CombinedOutputIterator<iterA_T, iterB_T, F>::CombinedOutputIterator(iterA_T iterA, iterB_T iterB, F functor) : mIterA(iterA), mIterB(iterB), mFunctor(functor)
+{
+}
+
+template <class iterA_T, class iterB_T, class F>
+auto CombinedOutputIterator<iterA_T, iterB_T, F>::operator=(const CombinedOutputIterator& other) -> CombinedOutputIterator&
+{
+  mIterA = other.mIterA;
+  mIterB = other.mIterB;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedOutputIterator<iterA_T, iterB_T, F>::operator++() -> CombinedOutputIterator&
+{
+  ++mIterA;
+  ++mIterB;
+  return *this;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedOutputIterator<iterA_T, iterB_T, F>::operator++(int) -> CombinedOutputIterator
+{
+  auto res = *this;
+  ++(*this);
+  return res;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedOutputIterator<iterA_T, iterB_T, F>::operator*() -> value_type
+{
+  return Proxy(*this);
+}
+
+template <class iterA_T, class iterB_T, class F>
+CombinedOutputIterator<iterA_T, iterB_T, F>::Proxy::Proxy(CombinedOutputIterator& iter) : mIter(iter)
+{
+}
+
+template <class iterA_T, class iterB_T, class F>
+template <typename value_T>
+inline auto CombinedOutputIterator<iterA_T, iterB_T, F>::Proxy::operator=(value_T value) -> CombinedOutputIterator::Proxy&
+{
+  mIter.mFunctor(mIter.mIterA, mIter.mIterB, value);
+  return *this;
+}
+
+} // namespace utils
+} // namespace rans
+} // namespace o2
+
+#endif /* INCLUDE_RANS_UTILS_COMBINEDITERATOR_H_ */

--- a/Utilities/rANS/test/test_ransCombinedIterator.cxx
+++ b/Utilities/rANS/test/test_ransCombinedIterator.cxx
@@ -1,0 +1,164 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   test_ransCombinedIterator.cxx
+/// @author michael.lettrich@cern.ch
+/// @since  2020-10-28
+/// @brief
+
+#define BOOST_TEST_MODULE Utility test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "rANS/utils.h"
+
+struct test_CombninedIteratorFixture {
+  std::vector<uint16_t> a{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
+  std::vector<uint16_t> b{a.rbegin(), a.rend()};
+  size_t shift = 16;
+  std::vector<uint32_t> aAndB{0x0001000f, 0x0002000e, 0x0003000d, 0x0004000c, 0x0005000b,
+                              0x0006000a, 0x00070009, 0x00080008, 0x00090007, 0x000a0006,
+                              0x000b0005, 0x000c0004, 0x000d0003, 0x000e0002, 0x000f0001};
+};
+
+class ReadShiftFunctor
+{
+ public:
+  ReadShiftFunctor(size_t shift) : mShift(shift){};
+
+  template <typename iterA_T, typename iterB_T>
+  inline uint32_t operator()(iterA_T iterA, iterB_T iterB) const
+  {
+    return *iterB + (static_cast<uint32_t>(*iterA) << mShift);
+  };
+
+ private:
+  size_t mShift;
+};
+
+class WriteShiftFunctor
+{
+ public:
+  WriteShiftFunctor(size_t shift) : mShift(shift){};
+
+  template <typename iterA_T, typename iterB_T>
+  inline void operator()(iterA_T iterA, iterB_T iterB, uint32_t value) const
+  {
+    *iterA = value >> mShift;
+    *iterB = value & ((1 << mShift) - 1);
+  };
+
+ private:
+  size_t mShift;
+};
+
+BOOST_FIXTURE_TEST_CASE(test_CombinedInputIteratorBase, test_CombninedIteratorFixture)
+{
+
+  //  auto readOP = [](auto iterA, auto iterB) -> uint32_t {
+  //    return *iterB + (static_cast<uint32_t>(*iterA) << 16);
+  //  };
+
+  ReadShiftFunctor f(shift);
+
+  o2::rans::utils::CombinedInputIterator iter(a.begin(), b.begin(), f);
+  // test equal
+  const o2::rans::utils::CombinedInputIterator first(a.begin(), b.begin(), f);
+  BOOST_CHECK_EQUAL(iter, first);
+  // test not equal
+  const o2::rans::utils::CombinedInputIterator second(++(a.begin()), ++(b.begin()), f);
+  BOOST_CHECK_NE(iter, second);
+  // test pre increment
+  ++iter;
+  BOOST_CHECK_EQUAL(iter, second);
+  //test postIncrement
+  iter = first;
+  BOOST_CHECK_EQUAL(iter++, first);
+  BOOST_CHECK_EQUAL(iter, second);
+  //test deref
+  const uint32_t val = first.operator*();
+  BOOST_CHECK_EQUAL(val, aAndB.front());
+}
+
+BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorFixture)
+{
+  std::vector<uint16_t> aOut(2, 0x0);
+  std::vector<uint16_t> bOut(2, 0x0);
+
+  //  auto writeOP = [](auto iterA, auto iterB, uint32_t value) -> void {
+  //    const uint32_t shift = 16;
+  //    *iterA = value >> shift;
+  //    *iterB = value & ((1 << shift) - 1);
+  //  };
+
+  WriteShiftFunctor f(shift);
+
+  o2::rans::utils::CombinedOutputIterator iter(aOut.begin(), bOut.begin(), f);
+
+  // test deref:
+  *iter = aAndB[0];
+  BOOST_CHECK_EQUAL(aOut[0], a[0]);
+  BOOST_CHECK_EQUAL(bOut[0], b[0]);
+  aOut[0] = 0x0;
+  bOut[0] = 0x0;
+
+  // test pre increment
+  *(++iter) = aAndB[1];
+  BOOST_CHECK_EQUAL(aOut[0], 0);
+  BOOST_CHECK_EQUAL(bOut[0], 0);
+  BOOST_CHECK_EQUAL(aOut[1], a[1]);
+  BOOST_CHECK_EQUAL(bOut[1], b[1]);
+  aOut.assign(2, 0x0);
+  bOut.assign(2, 0x0);
+  iter = o2::rans::utils::CombinedOutputIterator(aOut.begin(), bOut.begin(), f);
+
+  // test post increment
+  auto preInc = iter++;
+  *preInc = aAndB[0];
+  BOOST_CHECK_EQUAL(aOut[0], a[0]);
+  BOOST_CHECK_EQUAL(bOut[0], b[0]);
+  BOOST_CHECK_EQUAL(aOut[1], 0x0);
+  BOOST_CHECK_EQUAL(bOut[1], 0x0);
+  aOut.assign(2, 0x0);
+  bOut.assign(2, 0x0);
+  *iter = aAndB[1];
+  BOOST_CHECK_EQUAL(aOut[0], 0);
+  BOOST_CHECK_EQUAL(bOut[0], 0);
+  BOOST_CHECK_EQUAL(aOut[1], a[1]);
+  BOOST_CHECK_EQUAL(bOut[1], b[1]);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_CombinedInputIteratorReadArray, test_CombninedIteratorFixture)
+{
+  //  auto readOP = [](auto iterA, auto iterB) -> uint32_t {
+  //    return *iterB + (static_cast<uint32_t>(*iterA) << 16);
+  //  };
+  ReadShiftFunctor f(shift);
+
+  const o2::rans::utils::CombinedInputIterator begin(a.begin(), b.begin(), f);
+  const o2::rans::utils::CombinedInputIterator end(a.end(), b.end(), f);
+  BOOST_CHECK_EQUAL_COLLECTIONS(begin, end, aAndB.begin(), aAndB.end());
+}
+
+BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorWriteArray, test_CombninedIteratorFixture)
+{
+  std::vector<uint16_t> aRes(a.size(), 0);
+  std::vector<uint16_t> bRes(b.size(), 0);
+
+  o2::rans::utils::CombinedOutputIterator iter(aRes.begin(), bRes.begin(), WriteShiftFunctor(shift));
+  for (auto input : aAndB) {
+    *iter++ = input;
+  }
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(aRes.begin(), aRes.end(), a.begin(), a.end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(bRes.begin(), bRes.end(), b.begin(), b.end());
+}


### PR DESCRIPTION
Implementat, test and benchmark a pair of input/output iterators that allow to merge or split the values of two iterators efficiently via a user defined transformation function. The flexible desing allows for nesting.

These iterators are designed as utility classes for the iterator based rANS encode/decode interfaces to allow transformation of input/output data on the fly during encoding and decoding.
    
* `CombinedInputIterator` is an iterator class respecting the STLs type trait of an `InputIterator`. It takes two arbitrary input iterators and a user defined transformation function (FP, Functor or lambda). The transformation function is applied when dereferencing the iterator and the result is returned by value.
* `CombinedOutputIterator` is an iterator class respecting the STLs type trait of an `OutputIterator`. It takes two arbitrary output iterators and a user defined transformation function (FP, Functor or lambda). The transformation function is applied during assignment to the dereferenced iterator.  
* Both iterators allow nesting, i.e. it is possible to use a `CombinedInputIterator` as the input for another `CombinedInputIterator`.
* In the planed usecase of rANS encoding/deconding these iterators replace a copy of the data and prove to be memory and computationaly efficient (see benchmarks).

For usage examples see unittests and benchmarks.
