### PR TITLE
Changes to strangeness tables: filter at producer level

### DIFF
--- a/Analysis/DataModel/include/Analysis/StrangenessTables.h
+++ b/Analysis/DataModel/include/Analysis/StrangenessTables.h
@@ -17,6 +17,11 @@ namespace o2::aod
 {
 namespace v0data
 {
+//Needed to have shorter table that does not rely on existing one (filtering!)
+DECLARE_SOA_INDEX_COLUMN_FULL(PosTrack, posTrack, int, FullTracks, "fPosTrackID");
+DECLARE_SOA_INDEX_COLUMN_FULL(NegTrack, negTrack, int, FullTracks, "fNegTrackID");
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+
 //General V0 properties: position, momentum
 DECLARE_SOA_COLUMN(PxPos, pxpos, float);
 DECLARE_SOA_COLUMN(PyPos, pypos, float);
@@ -62,6 +67,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, float, 1.f * aod::v0data::pzpos + 1.f * ao
 } // namespace v0dataext
 
 DECLARE_SOA_TABLE(V0Data, "AOD", "V0DATA",
+                  o2::soa::Index<>, v0data::PosTrackId, v0data::NegTrackId, v0data::CollisionId,
                   v0data::X, v0data::Y, v0data::Z,
                   v0data::PxPos, v0data::PyPos, v0data::PzPos,
                   v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
@@ -91,16 +97,12 @@ DECLARE_SOA_EXTENDED_TABLE_USER(V0DataExt, V0DataOrigin, "V0DATAEXT",
 
 using V0DataFull = V0DataExt;
 
-namespace v0finderdata
-{
-DECLARE_SOA_INDEX_COLUMN_FULL(PosTrack, posTrack, int, FullTracks, "fPosTrackID");
-DECLARE_SOA_INDEX_COLUMN_FULL(NegTrack, negTrack, int, FullTracks, "fNegTrackID");
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-} // namespace v0finderdata
-DECLARE_SOA_TABLE(V0FinderData, "AOD", "V0FINDERDATA", o2::soa::Index<>, v0finderdata::PosTrackId, v0finderdata::NegTrackId, v0finderdata::CollisionId);
-
 namespace cascdata
 {
+//Necessary for full filtering functionality
+DECLARE_SOA_INDEX_COLUMN_FULL(V0, v0, int, V0DataExt, "fV0ID");
+DECLARE_SOA_INDEX_COLUMN_FULL(BachTrack, bachTrack, int, FullTracks, "fBachTrackID");
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 //General V0 properties: position, momentum
 DECLARE_SOA_COLUMN(Charge, charge, int);
 DECLARE_SOA_COLUMN(PxPos, pxpos, float);
@@ -163,6 +165,8 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, float, 1.f * aod::cascdata::pzpos + 1.f * 
 } // namespace cascdataext
 
 DECLARE_SOA_TABLE(CascData, "AOD", "CASCDATA",
+                  o2::soa::Index<>, cascdata::V0Id, cascdata::BachTrackId, cascdata::CollisionId,
+
                   cascdata::Charge,
                   cascdata::X, cascdata::Y, cascdata::Z,
                   cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda,
@@ -198,14 +202,6 @@ DECLARE_SOA_EXTENDED_TABLE_USER(CascDataExt, CascDataOrigin, "CascDATAEXT",
                                 cascdataext::Px, cascdataext::Py, cascdataext::Pz);
 
 using CascDataFull = CascDataExt;
-
-namespace cascfinderdata
-{
-DECLARE_SOA_INDEX_COLUMN_FULL(V0, v0, int, V0FinderData, "fV0ID");
-DECLARE_SOA_INDEX_COLUMN_FULL(BachTrack, bachTrack, int, FullTracks, "fBachTrackID");
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-} // namespace cascfinderdata
-DECLARE_SOA_TABLE(CascFinderData, "AOD", "CASCFINDERDATA", o2::soa::Index<>, cascfinderdata::V0Id, cascfinderdata::BachTrackId, cascfinderdata::CollisionId);
 } // namespace o2::aod
 
 #endif // O2_ANALYSIS_STRANGENESSTABLES_H_

--- a/Analysis/DataModel/src/aodDataModelGraph.cxx
+++ b/Analysis/DataModel/src/aodDataModelGraph.cxx
@@ -262,7 +262,6 @@ int main(int, char**)
   displayEntity<JetConstituents>();
 
   displayEntities<V0s, V0DataFull>();
-  displayEntity<V0FinderData>();
 
   displayEntities<Cascades, CascDataFull>();
 

--- a/Analysis/Tasks/PWGLF/cascadeconsumer.cxx
+++ b/Analysis/Tasks/PWGLF/cascadeconsumer.cxx
@@ -7,6 +7,20 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+//
+// Example cascade analysis task
+// =============================
+//
+// This code loops over a CascData table and produces some
+// standard analysis output. It requires either
+// the cascadefinder or the cascadeproducer tasks
+// to have been executed in the workflow (before).
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -57,7 +71,7 @@ struct cascadeQA {
   OutputObj<TH1F> hDCACascDau{TH1F("hDCACascDau", "", 1000, 0.0, 10.0)};
   OutputObj<TH1F> hLambdaMass{TH1F("hLambdaMass", "", 1000, 0.0, 10.0)};
 
-  void process(aod::Collision const& collision, soa::Join<aod::Cascades, aod::CascDataExt> const& Cascades)
+  void process(aod::Collision const& collision, aod::CascDataExt const& Cascades)
   {
     for (auto& casc : Cascades) {
       if (casc.charge() < 0) { //FIXME: could be done better...
@@ -107,7 +121,7 @@ struct cascadeconsumer {
                                                                            aod::cascdata::dcabachtopv > dcabachtopv&&
                                                                                                           aod::cascdata::dcaV0daughters < dcav0dau&& aod::cascdata::dcacascdaughters < dcacascdau;
 
-  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& collision, soa::Filtered<soa::Join<aod::Cascades, aod::CascDataExt>> const& Cascades)
+  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades)
   {
     if (!collision.alias()[kINT7]) {
       return;

--- a/Analysis/Tasks/PWGLF/cascadeproducer.cxx
+++ b/Analysis/Tasks/PWGLF/cascadeproducer.cxx
@@ -6,7 +6,7 @@
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction
+// or submit itself to any jurisdiction.
 //
 // Cascade Producer task
 // =====================

--- a/Analysis/Tasks/PWGLF/cascadeproducer.cxx
+++ b/Analysis/Tasks/PWGLF/cascadeproducer.cxx
@@ -6,7 +6,22 @@
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.
+// or submit itself to any jurisdiction
+//
+// Cascade Producer task
+// =====================
+//
+// This task loops over an *existing* list of cascades (V0+bachelor track
+// indices) and calculates the corresponding full cascade information
+//
+// Any analysis should loop over the "CascData"
+// table as that table contains all information
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -152,7 +167,8 @@ struct cascadeproducer {
         } //end if cascade recoed
       }   //end if v0 recoed
       //Fill table, please
-      cascdata(charge, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
+      cascdata(casc.v0().globalIndex(), casc.bachelor().globalIndex(), casc.bachelor().collisionId(),
+               charge, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                pvecpos[0], pvecpos[1], pvecpos[2],
                pvecneg[0], pvecneg[1], pvecneg[2],
                pvecbach[0], pvecbach[1], pvecbach[2],

--- a/Analysis/Tasks/PWGLF/lambdakzeroconsumer.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzeroconsumer.cxx
@@ -7,6 +7,19 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+//
+// Example V0 analysis task
+// ========================
+//
+// This code loops over a V0Data table and produces some
+// standard analysis output. It requires either
+// the lambdakzerofinder or the lambdakzeroproducer tasks
+// to have been executed in the workflow (before).
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -50,7 +63,7 @@ struct lambdakzeroQA {
   OutputObj<TH1F> hDCANegToPV{TH1F("hDCANegToPV", "", 1000, 0.0, 10.0)};
   OutputObj<TH1F> hDCAV0Dau{TH1F("hDCAV0Dau", "", 1000, 0.0, 10.0)};
 
-  void process(aod::Collision const& collision, soa::Join<aod::V0s, aod::V0DataExt> const& fullV0s)
+  void process(aod::Collision const& collision, aod::V0DataExt const& fullV0s)
   {
     for (auto& v0 : fullV0s) {
       hMassLambda->Fill(v0.mLambda());
@@ -82,7 +95,7 @@ struct lambdakzeroconsumer {
   Filter preFilterV0 = aod::v0data::dcapostopv > dcapostopv&&
                                                    aod::v0data::dcanegtopv > dcanegtopv&& aod::v0data::dcaV0daughters < dcav0dau;
 
-  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& collision, soa::Filtered<soa::Join<aod::V0s, aod::V0DataExt>> const& fullV0s)
+  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& collision, soa::Filtered<aod::V0DataExt> const& fullV0s)
   {
     if (!collision.alias()[kINT7]) {
       return;

--- a/Analysis/Tasks/PWGLF/lambdakzerofinder.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzerofinder.cxx
@@ -8,7 +8,24 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 //
-// This task re-reconstructs the V0s and cascades
+// V0 Finder task
+// ==============
+//
+// This code loops over positive and negative tracks and finds
+// valid V0 candidates from scratch using a certain set of
+// minimum (configurable) selection criteria.
+//
+// It is different than the producer: the producer merely
+// loops over an *existing* list of V0s (pos+neg track
+// indices) and calculates the corresponding full V0 information
+//
+// In both cases, any analysis should loop over the "V0Data"
+// table as that table contains all information.
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -99,7 +116,6 @@ struct lambdakzeroprefilter {
 
 struct lambdakzerofinder {
   Produces<aod::V0Data> v0data;
-  Produces<aod::V0FinderData> v0finderdata;
 
   OutputObj<TH1F> hCandPerEvent{TH1F("hCandPerEvent", "", 1000, 0, 1000)};
 
@@ -172,8 +188,8 @@ struct lambdakzerofinder {
         }
 
         lNCand++;
-        v0finderdata(t0.globalIndex(), t1.globalIndex(), t0.collisionId());
-        v0data(pos[0], pos[1], pos[2],
+        v0data(t0.globalIndex(), t1.globalIndex(), t0.collisionId(),
+               pos[0], pos[1], pos[2],
                pvec0[0], pvec0[1], pvec0[2],
                pvec1[0], pvec1[1], pvec1[2],
                fitter.getChi2AtPCACandidate(),
@@ -210,10 +226,9 @@ struct lambdakzerofinderQA {
   //Filter preFilter2 = aod::v0data::dcanegtopv > dcanegtopv;
   //Filter preFilter3 = aod::v0data::dcaV0daughters < dcav0dau;
 
-  ///Connect to V0FinderData: newly indexed, note: V0DataExt table incompatible with standard V0 table!
+  ///Connect to V0Data: newly indexed, note: V0DataExt table incompatible with standard V0 table!
   void process(soa::Join<aod::Collisions, aod::EvSels, aod::Cents>::iterator const& collision,
-               //             soa::Filtered<soa::Join<aod::V0FinderData, aod::V0DataExt>> const& fullV0s)
-               soa::Join<aod::V0FinderData, aod::V0DataExt> const& fullV0s)
+               aod::V0DataExt const& fullV0s)
   {
     if (!collision.alias()[kINT7]) {
       return;

--- a/Analysis/Tasks/PWGLF/lambdakzeroproducer.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzeroproducer.cxx
@@ -7,6 +7,21 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+//
+// V0 Producer task
+// ================
+//
+// This task loops over an *existing* list of V0s (neg/pos track
+// indices) and calculates the corresponding full V0 information
+//
+// Any analysis should loop over the "V0Data"
+// table as that table contains all information
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -17,6 +32,8 @@
 #include "Analysis/RecoDecay.h"
 #include "Analysis/trackUtilities.h"
 #include "Analysis/StrangenessTables.h"
+#include "Analysis/TrackSelection.h"
+#include "Analysis/TrackSelectionTables.h"
 
 #include <TFile.h>
 #include <TH2F.h>
@@ -36,6 +53,57 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
 
+//This table stores a filtered list of valid V0 indices
+namespace o2::aod
+{
+namespace v0goodindices
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(PosTrack, posTrack, int, FullTracks, "fPositiveTrackID");
+DECLARE_SOA_INDEX_COLUMN_FULL(NegTrack, negTrack, int, FullTracks, "fNegativeTrackID");
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+} // namespace v0goodindices
+DECLARE_SOA_TABLE(V0GoodIndices, "AOD", "V0GOODINDICES", o2::soa::Index<>,
+                  v0goodindices::PosTrackId, v0goodindices::NegTrackId, v0goodindices::CollisionId);
+} // namespace o2::aod
+
+using FullTracksExt = soa::Join<aod::FullTracks, aod::TracksExtended>;
+
+//This prefilter creates a skimmed list of good V0s to re-reconstruct so that
+//CPU is saved in case there are specific selections that are to be done
+//Note: more configurables, more options to be added as needed
+struct lambdakzeroprefilterpairs {
+  Configurable<float> dcanegtopv{"dcanegtopv", .1, "DCA Neg To PV"};
+  Configurable<float> dcapostopv{"dcapostopv", .1, "DCA Pos To PV"};
+  Configurable<int> mincrossedrows{"mincrossedrows", 70, "min crossed rows"};
+  Configurable<bool> tpcrefit{"tpcrefit", 1, "demand TPC refit"};
+
+  Produces<aod::V0GoodIndices> v0goodindices;
+
+  void process(aod::Collision const& collision, aod::V0s const& V0s,
+               soa::Join<aod::FullTracks, aod::TracksExtended> const& tracks)
+  {
+    for (auto& V0 : V0s) {
+      if (tpcrefit) {
+        if (!(V0.posTrack().flags() & 0x40))
+          continue; //TPC refit
+        if (!(V0.negTrack().flags() & 0x40))
+          continue; //TPC refit
+      }
+      if (V0.posTrack().tpcNClsCrossedRows() < mincrossedrows)
+        continue;
+      if (V0.negTrack().tpcNClsCrossedRows() < mincrossedrows)
+        continue;
+
+      if (V0.posTrack_as<FullTracksExt>().dcaXY() < dcapostopv)
+        continue;
+      if (V0.negTrack_as<FullTracksExt>().dcaXY() < dcanegtopv)
+        continue;
+
+      v0goodindices(V0.posTrack().globalIndex(), V0.negTrack().globalIndex(), V0.posTrack().collisionId());
+    }
+  }
+};
+
 /// Cascade builder task: rebuilds cascades
 struct lambdakzeroproducer {
 
@@ -48,25 +116,18 @@ struct lambdakzeroproducer {
   Configurable<double> d_bz{"d_bz", -5.0, "bz field"};
   Configurable<double> d_UseAbsDCA{"d_UseAbsDCA", kTRUE, "Use Abs DCAs"};
 
+  //Selection criteria
+  Configurable<double> v0cospa{"v0cospa", 0.995, "V0 CosPA"}; //double -> N.B. dcos(x)/dx = 0 at x=0)
+  Configurable<float> dcav0dau{"dcav0dau", 1.0, "DCA V0 Daughters"};
+  Configurable<float> v0radius{"v0radius", 5.0, "v0radius"};
+
   double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();
   double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();
   double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass();
 
-  /// Extracts dca in the XY plane
-  /// \return dcaXY
-  template <typename T, typename U>
-  auto getdcaXY(const T& track, const U& coll)
-  {
-    //Calculate DCAs
-    auto sinAlpha = sin(track.alpha());
-    auto cosAlpha = cos(track.alpha());
-    auto globalX = track.x() * cosAlpha - track.y() * sinAlpha;
-    auto globalY = track.x() * sinAlpha + track.y() * cosAlpha;
-    return sqrt(pow((globalX - coll[0]), 2) +
-                pow((globalY - coll[1]), 2));
-  }
+  using FullTracksExt = soa::Join<aod::FullTracks, aod::TracksExtended>;
 
-  void process(aod::Collision const& collision, aod::V0s const& V0s, aod::FullTracks const& tracks)
+  void process(aod::Collision const& collision, aod::V0GoodIndices const& V0s, soa::Join<aod::FullTracks, aod::TracksExtended> const& tracks)
   {
     //Define o2 fitter, 2-prong
     o2::vertexing::DCAFitterN<2> fitter;
@@ -102,12 +163,22 @@ struct lambdakzeroproducer {
         fitter.getTrack(1).getPxPyPzGlo(pvec1);
       }
 
-      v0data(pos[0], pos[1], pos[2],
+      //Apply selections so a skimmed table is created only
+      if (fitter.getChi2AtPCACandidate() < dcav0dau)
+        continue;
+
+      auto V0CosinePA = RecoDecay::CPA(array{collision.posX(), collision.posY(), collision.posZ()}, array{pos[0], pos[1], pos[2]}, array{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]});
+
+      if (V0CosinePA < v0cospa)
+        continue;
+
+      v0data(V0.posTrack().globalIndex(), V0.negTrack().globalIndex(), V0.negTrack().collisionId(),
+             pos[0], pos[1], pos[2],
              pvec0[0], pvec0[1], pvec0[2],
              pvec1[0], pvec1[1], pvec1[2],
              fitter.getChi2AtPCACandidate(),
-             getdcaXY(V0.posTrack(), pVtx),
-             getdcaXY(V0.negTrack(), pVtx));
+             V0.posTrack_as<FullTracksExt>().dcaXY(),
+             V0.negTrack_as<FullTracksExt>().dcaXY());
     }
   }
 };

--- a/Analysis/Tasks/PWGLF/lambdakzeroproducer.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzeroproducer.cxx
@@ -84,20 +84,26 @@ struct lambdakzeroprefilterpairs {
   {
     for (auto& V0 : V0s) {
       if (tpcrefit) {
-        if (!(V0.posTrack().flags() & 0x40))
+        if (!(V0.posTrack().flags() & 0x40)) {
           continue; //TPC refit
-        if (!(V0.negTrack().flags() & 0x40))
+        }
+        if (!(V0.negTrack().flags() & 0x40)) {
           continue; //TPC refit
+        }
       }
-      if (V0.posTrack().tpcNClsCrossedRows() < mincrossedrows)
+      if (V0.posTrack().tpcNClsCrossedRows() < mincrossedrows) {
         continue;
-      if (V0.negTrack().tpcNClsCrossedRows() < mincrossedrows)
+      }
+      if (V0.negTrack().tpcNClsCrossedRows() < mincrossedrows) {
         continue;
+      }
 
-      if (V0.posTrack_as<FullTracksExt>().dcaXY() < dcapostopv)
+      if (V0.posTrack_as<FullTracksExt>().dcaXY() < dcapostopv) {
         continue;
-      if (V0.negTrack_as<FullTracksExt>().dcaXY() < dcanegtopv)
+      }
+      if (V0.negTrack_as<FullTracksExt>().dcaXY() < dcanegtopv) {
         continue;
+      }
 
       v0goodindices(V0.posTrack().globalIndex(), V0.negTrack().globalIndex(), V0.posTrack().collisionId());
     }
@@ -164,13 +170,15 @@ struct lambdakzeroproducer {
       }
 
       //Apply selections so a skimmed table is created only
-      if (fitter.getChi2AtPCACandidate() < dcav0dau)
+      if (fitter.getChi2AtPCACandidate() < dcav0dau) {
         continue;
+      }
 
       auto V0CosinePA = RecoDecay::CPA(array{collision.posX(), collision.posY(), collision.posZ()}, array{pos[0], pos[1], pos[2]}, array{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]});
 
-      if (V0CosinePA < v0cospa)
+      if (V0CosinePA < v0cospa) {
         continue;
+      }
 
       v0data(V0.posTrack().globalIndex(), V0.negTrack().globalIndex(), V0.negTrack().collisionId(),
              pos[0], pos[1], pos[2],


### PR DESCRIPTION
-> This commit makes the V0Data and the CascData tables fully self-contained and potentially smaller than the base aod::V0 and aod::Cascade tables. In this way, they can also be smaller, and they will always be the tables to analyse by any analysis task - regardless of if they were generated with the finder or the producer. 

-> Also added some comments at the top of all 6 base cxx files for helping people who are trying to find out what's what. 