### PR TITLE
TRD trapsim clean up

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -30,19 +30,6 @@ class LinkRecord
 {
   using DataRange = o2::dataformats::RangeReference<int>;
 
-  struct LinkId {
-    union {
-      uint16_t word;
-      struct {
-        uint16_t spare : 4;
-        uint16_t side : 1;
-        uint16_t layer : 3;
-        uint16_t stack : 3;
-        uint16_t supermodule : 5;
-      };
-    };
-  };
-
  public:
   LinkRecord() = default;
   LinkRecord(const uint32_t linkid, int firstentry, int nentries) : mDataRange(firstentry, nentries) { mLinkId = linkid; }
@@ -52,24 +39,40 @@ class LinkRecord
   ~LinkRecord() = default;
 
   void setLinkId(const uint32_t linkid) { mLinkId = linkid; }
-  //  void setLinkId(const LinkId linkid) { mLinkId = linkid; }
   void setLinkId(const uint32_t sector, const uint32_t stack, const uint32_t layer, const uint32_t side);
   void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
   void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
+  void setSector(const int sector) { mLinkId |= ((sector << supermodulebs) & supermodulemask); }
+  void setStack(const int stack) { mLinkId |= ((stack << stackbs) & stackmask); }
+  void setLayer(const int layer) { mLinkId |= ((layer << layerbs) & layermask); }
+  void setSide(const int side) { mLinkId |= ((side << sidebs) & sidemask); }
+  void setSpare(const int spare = 0) { mLinkId |= ((spare << sparebs) & sparemask); }
 
   const uint32_t getLinkId() { return mLinkId; }
   //TODO come backwith a ccdb lookup.  const uint32_t getLinkHCID() { return mLinkId & 0x7ff; } // the last 11 bits.
-  const uint32_t getSector() { return (mLinkId & 0xf800) >> 11; }
-  const uint32_t getStack() { return (mLinkId & 0x700) >> 8; }
-  const uint32_t getLayer() { return (mLinkId & 0xe0) >> 5; }
-  const uint32_t getSide() { return (mLinkId & 0x10) >> 4; }
+  const uint32_t getSector() { return (mLinkId & supermodulemask) >> supermodulebs; }
+  const uint32_t getStack() { return (mLinkId & stackmask) >> stackbs; }
+  const uint32_t getLayer() { return (mLinkId & layermask) >> layerbs; }
+  const uint32_t getSide() { return (mLinkId & sidemask) >> sidebs; }
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
   static uint32_t getHalfChamberLinkId(uint32_t detector, uint32_t rob);
   static uint32_t getHalfChamberLinkId(uint32_t sector, uint32_t stack, uint32_t layer, uint32_t side);
 
   void printStream(std::ostream& stream);
+  // bit masks for the above raw data;
+  static constexpr uint64_t sparemask = 0x000f;
+  static constexpr uint64_t sidemask = 0x0010;
+  static constexpr uint64_t layermask = 0x00e0;
+  static constexpr uint64_t stackmask = 0x0700;
+  static constexpr uint64_t supermodulemask = 0xf800;
+  //bit shifts for the above raw data
+  static constexpr uint64_t sparebs = 0;
+  static constexpr uint64_t sidebs = 4;
+  static constexpr uint64_t layerbs = 5;
+  static constexpr uint64_t stackbs = 8;
+  static constexpr uint64_t supermodulebs = 11;
 
  private:
   uint16_t mLinkId;
@@ -81,10 +84,8 @@ std::ostream& operator<<(std::ostream& stream, LinkRecord& trg);
 
 extern void buildTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format);
 extern void buildTrakcletHCHeader(TrackletHCHeader& header, int detector, int rob, int chipclock, int format);
-} // namespace trd
 
+} // namespace trd
 } // namespace o2
 
 #endif
-//extern void buildTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format)
-//extern void buildTrakcletlHCHeader(TrackletHCHeader& header, int detector, int rob, int chipclock, int format)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -182,7 +182,7 @@ struct TrackletMCMHeader {
 //  \structure TrackletMCMData.
 //  \brief Raw Data of a tracklet, part is how ever in the MCM Header hence both are grouped together in the same file
 
-struct TrackletMCMData { // This is a bad name as part of the tracklet data is in the MCMHeader.
+struct TrackletMCMData {
   union {
     uint32_t word;
     struct {
@@ -223,6 +223,7 @@ void buildTrackletHCHeaderd(TrackletHCHeader& header, int detector, int rob, int
 uint16_t buildTRDFeeID(int supermodule, int side, int endpoint);
 uint32_t setHalfCRUHeader(HalfCRUHeader& cruhead, int crurdhversion, int bunchcrossing, int stopbits, int endpoint, int eventtype, int feeid, int cruid);
 uint32_t setHalfCRUHeaderLinkData(HalfCRUHeader& cruhead, int link, int size, int errors);
+void buildTrackletMCMData(TrackletMCMData& trackletword, const uint slope, const uint pos, const uint q0, const uint q1, const uint q2);
 uint32_t unpacklinkinfo(const HalfCRUHeader& cruhead, const uint32_t link, const bool data);
 uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -58,6 +58,7 @@ class Tracklet64
   }
 
   ~Tracklet64() = default;
+  Tracklet64& operator=(const Tracklet64& rhs) = default;
 
   //TODO convert to the actual number  regarding compliments.
   // ----- Getters for contents of tracklet word -----
@@ -73,6 +74,7 @@ class Tracklet64
 
   uint64_t buildTrackletWord(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position, uint64_t slope, uint64_t Q2, uint64_t Q1, uint64_t Q0)
   {
+    LOG(debug) << "Build tracklet with format:" << format << " hcid:" << hcid << " padrow: " << padrow << " col:" << col << " position:" << position << " slope:" << slope << " Q0:1:2:: " << Q0 << ":" << Q1 << ":" << Q2;
     mtrackletWord = ((format << formatbs) & formatmask) + ((hcid << hcidbs) & hcidmask) + ((padrow << padrowbs) & padrowmask) + ((col << colbs) & colmask) + ((position << posbs) & posmask) + ((slope << slopebs) & slopemask) + ((Q2 << Q2bs) & Q2mask) + ((Q1 << Q1bs) & Q1mask) + ((Q0 << Q0bs) & Q0mask);
     return 0;
   }

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -16,7 +16,6 @@
 
 #pragma link C++ class o2::trd::TriggerRecord + ;
 #pragma link C++ class o2::trd::LinkRecord + ;
-#pragma link C++ struct o2::trd::LinkRecord::LinkId + ;
 #pragma link C++ struct o2::trd::HalfCRUHeader + ;
 #pragma link C++ struct o2::trd::TrackletHCHeader + ;
 #pragma link C++ struct o2::trd::TrackletMCMHeader + ;

--- a/DataFormats/Detectors/TRD/src/LinkRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/LinkRecord.cxx
@@ -29,17 +29,18 @@ uint32_t LinkRecord::getHalfChamberLinkId(uint32_t detector, uint32_t rob)
 
 uint32_t LinkRecord::getHalfChamberLinkId(uint32_t sector, uint32_t stack, uint32_t layer, uint32_t side)
 {
-  LinkRecord tmplinkid;
-  tmplinkid.setLinkId(sector, stack, layer, side);
-  return tmplinkid.getLinkId();
+  LinkRecord a;
+  a.setLinkId(sector, stack, layer, side);
+  return a.mLinkId;
 }
 
 void LinkRecord::setLinkId(const uint32_t sector, const uint32_t stack, const uint32_t layer, const uint32_t side)
 {
-  mLinkId |= sector << 11;
-  mLinkId |= stack << 8;
-  mLinkId |= layer << 5;
-  mLinkId |= side << 4;
+  setSector(sector);
+  setStack(stack);
+  setLayer(layer);
+  setSide(side);
+  setSpare();
 }
 
 void LinkRecord::printStream(std::ostream& stream)

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -50,6 +50,14 @@ uint16_t buildTRDFeeID(int supermodule, int side, int endpoint)
   return feeid.word;
 }
 
+void buildTrackletMCMData(TrackletMCMData& trackletword, const uint slope, const uint pos, const uint q0, const uint q1, const uint q2)
+{
+  trackletword.slope = slope;
+  trackletword.pos = pos;
+  trackletword.pid = q0 | ((q1 & 0xff) << 8); //q2 sits with a bit of q1 in the header pid word.
+  trackletword.checkbit = 1;
+}
+
 uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link)
 {
   // link is the link you are requesting information on, 0-14

--- a/Detectors/TRD/base/macros/OCDB2CCDB.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDB.C
@@ -25,7 +25,7 @@
 //    alienv enter VO_ALICE@O2::latest-O2-o2,VO_ALICE@AliRoot::latest-O2-o2
 //    according to my configs, modify as required of course.
 //
-
+#if !defined(__CINT__) || defined(__MAKECINT__)
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -78,11 +78,12 @@
 #include "TRDBase/CalOnlineGainTables.h"
 #include "TRDBase/FeeParam.h"
 #include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/Constants.h"
+#endif
 
 using namespace std;
 using namespace o2::ccdb;
 using namespace o2::trd;
-
 // global variables
 // histograms used for extracting the mean and RMS of calibration parameters
 

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -207,7 +207,7 @@ its all going here unfortunately ....
 */
 
   vector<std::string> run2confignames = {
-    /* "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5505",
+    "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5505",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b2p-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5585",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b5p-fs1e24-ht200-qs0e23s23e22-pidlhc11dv3en-pt100_ptrg.r5766",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e23s23e22-pidlhc11dv3en_ptrg.r5767",
@@ -261,7 +261,7 @@ its all going here unfortunately ....
     "cf_pg-fpnp32_zs-s16-deh_tb26_trkl-b2n-fs1e24-ht200-qs0e23s23e22-pidlhc11dv3en-pt100_ptrg.r5771",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b5n-fs1e24-ht200-qs0e23s23e22-pidlhc11dv1-pt100_ptrg.r5762",
     "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5505",
-    "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e23s23e22-pidlhc11dv1_ptrg.r5762",*/
+    "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e23s23e22-pidlhc11dv1_ptrg.r5762",
     "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549"};
 
   // now we loop over these extracting the trapconfing and dumping it into the ccdb.
@@ -270,10 +270,10 @@ its all going here unfortunately ....
   if ((entry = GetCDBentry("TRD/Calib/TrapConfig", 0))) {
     if ((run2caltrapconfig = (AliTRDCalTrapConfig*)entry->GetObject())) {
       for (auto const& run2trapconfigname : run2confignames) {
-        auto o2trapconfig = new TrapConfig(run2trapconfigname);
+        auto o2trapconfig = new TrapConfig();
         run2trapconfig = run2caltrapconfig->Get(run2trapconfigname.c_str());
         ParseTrapConfigs(o2trapconfig, run2trapconfig);
-        //   ccdb.storeAsTFileAny(o2trapconfig, "TRD_test/TrapConfig2020/c", metadata, 1, 1670700184549); //upper time chosen into the future else the server simply adds a year
+        ccdb.storeAsTFileAny(o2trapconfig, "TRD_test/TrapConfig", metadata, 1, 1670700184549); //upper time chosen into the future else the server simply adds a year
         //    cout << "ccdb.storeAsTFileAny(o2trapconfig, Form(\"" << TRDCalBase.c_str() << "/TrapConfig/" << run2trapconfigname.c_str()<< endl; //upper time chosen into the future else the server simply adds a year
         //AliTRDcalibDB *calibdb=AliTRDcalibDB::Instance();
       }

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -25,6 +25,11 @@
 #pragma link C++ class o2::trd::TrapConfig::TrapDmemWord + ;
 #pragma link C++ class o2::trd::TrapConfig::TrapRegister + ;
 #pragma link C++ class o2::trd::TrapSimulator + ;
+// dictionaries for the internal classes of TrapSimulator are needed for the debug output
+#pragma link C++ class o2::trd::TrapSimulator::TrackletDetail + ;
+#pragma link C++ class o2::trd::TrapSimulator::Hit + ;
+#pragma link C++ class o2::trd::TrapSimulator::FitReg + ;
+#pragma link C++ class o2::trd::TrapSimulator::FilterReg + ;
 #pragma link C++ class o2::trd::Trap2CRU + ;
 
 #pragma link C++ class o2::trd::TRDSimParams + ;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -64,8 +64,6 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mDebugRejectedTracklets{false};
   bool mEnableOnlineGainCorrection{false};
   bool mEnableTrapConfigDump{false};
-  bool mFixTriggerRecords{false};   // shift the trigger record due to its being corrupt on coming in.
-  bool mDumpTriggerRecords{false};  // display the trigger records.
   std::vector<Tracklet64> mTracklets; // store of found tracklets
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";
@@ -92,6 +90,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   TrackletHCHeader mTrackletHCHeader; // the current half chamber header, that will be written if a first tracklet is found for this halfchamber.
   TrapConfig* getTrapConfig();
   void loadTrapConfig();
+  void loadDefaultTrapConfig();
   void setOnlineGainTables();
 };
 


### PR DESCRIPTION
- Clean up trapsimulator code.
- Fix units.
- re do the generation of digits index.
- remove lots of output.
- remove a lot of debug statements.