### PR TITLE
(O2-1813)[GPU] Rename double overloads for math functions

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -106,12 +106,12 @@ inline void bringToPMPid(double& phi)
 
 GPUdi() void sincos(float ang, float& s, float& c)
 {
-  detail::sincos(ang, s, c);
+  detail::sincos<float>(ang, s, c);
 }
 
 GPUdi() void sincosd(double ang, double& s, double& c)
 {
-  detail::sincos(ang, s, c);
+  detail::sincos<double>(ang, s, c);
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -108,24 +108,16 @@ inline void bringToPMPiGen(T& phi)
 }
 
 template <typename T>
-GPUdi() void sincos(T ang, T& s, T& c)
+GPUdi() void sincos(T ang, GPUgeneric() T& s, GPUgeneric() T& c)
 {
   return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
 
 template <>
-GPUdi() void sincos(double ang, double& s, double& c)
-{
-  return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
-}
-
-#ifdef __OPENCLCPP__
-template <>
 GPUdi() void sincos(double ang, GPUgeneric() double& s, GPUgeneric() double& c)
 {
   return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
 }
-#endif
 
 #ifndef GPUCA_GPUCODE_DEVICE
 

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -107,14 +107,16 @@ inline void bringToPMPiGen(T& phi)
   phi = toPMPiGen<T>(phi);
 }
 
-GPUdi() void sincos(float ang, float& s, float& c)
+template <typename T>
+GPUdi() void sincos(T ang, T& s, T& c)
 {
-  o2::gpu::GPUCommonMath::SinCos(ang, s, c);
+  return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
 
+template <>
 GPUdi() void sincos(double ang, double& s, double& c)
 {
-  o2::gpu::GPUCommonMath::SinCos(ang, s, c);
+  return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE
@@ -124,7 +126,7 @@ GPUhdi() std::tuple<T, T> sincos(T ang)
 {
   T sin = 0;
   T cos = 0;
-  o2::gpu::GPUCommonMath::SinCos(ang, sin, cos);
+  sincos<T>(ang, sin, cos);
   return std::make_tuple(sin, cos);
 }
 
@@ -195,6 +197,18 @@ inline T angle2Alpha(T phi)
 }
 
 template <typename T>
+GPUhdi() T copysign(T x, T y)
+{
+  return o2::gpu::GPUCommonMath::Copysign(x, y);
+}
+
+template <>
+GPUhdi() double copysign(double x, double y)
+{
+  return o2::gpu::GPUCommonMath::Copysignd(x, y);
+}
+
+template <typename T>
 GPUhdi() T fastATan2(T y, T x)
 {
   // Fast atan2(y,x) for any angle [-Pi,Pi]
@@ -233,7 +247,7 @@ GPUhdi() T fastATan2(T y, T x)
   };
 
   // fast atan2(y,x) for any angle [-Pi,Pi]
-  return o2::gpu::GPUCommonMath::Copysign(atan2P(o2::gpu::GPUCommonMath::Abs(y), x), y);
+  return copysign<T>(atan2P(o2::gpu::GPUCommonMath::Abs(y), x), y);
 }
 
 } // namespace detail

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -119,6 +119,14 @@ GPUdi() void sincos(double ang, double& s, double& c)
   return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
 }
 
+#ifdef __OPENCLCPP__
+template <>
+GPUdi() void sincos(double ang, GPUgeneric() double& s, GPUgeneric() double& c)
+{
+  return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
+}
+#endif
+
 #ifndef GPUCA_GPUCODE_DEVICE
 
 template <typename T>

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -62,10 +62,10 @@ class GPUCommonMath
   GPUd() static float Sin(float x);
   GPUd() static float Cos(float x);
   GPUhdni() static void SinCos(float x, float& s, float& c);
-  GPUhdni() static void SinCos(double x, double& s, double& c);
+  GPUhdni() static void SinCosd(double x, double& s, double& c);
   GPUd() static float Tan(float x);
   GPUhdni() static float Copysign(float x, float y);
-  GPUhdni() static double Copysign(double x, double y);
+  GPUhdni() static double Copysignd(double x, double y);
   GPUd() static float TwoPi() { return 6.28319f; }
   GPUd() static float Pi() { return 3.1415926535897f; }
   GPUd() static int Nint(float x);
@@ -250,7 +250,7 @@ GPUhdi() void GPUCommonMath::SinCos(float x, float& s, float& c)
 #endif
 }
 
-GPUhdi() void GPUCommonMath::SinCos(double x, double& s, double& c)
+GPUhdi() void GPUCommonMath::SinCosd(double x, double& s, double& c)
 {
 #if !defined(GPUCA_GPUCODE_DEVICE) && defined(__APPLE__)
   __sincos(x, &s, &c);
@@ -280,7 +280,8 @@ GPUdi() unsigned int GPUCommonMath::Clz(unsigned int x)
 GPUdi() unsigned int GPUCommonMath::Popcount(unsigned int x)
 {
 #if (defined(__GNUC__) || defined(__clang__) || defined(__CUDACC__) || defined(__HIPCC__)) && (!defined(__OPENCL__) /*|| defined(__OPENCLCPP__)*/) // TODO: remove OPENCLCPP workaround when reported SPIR-V bug is fixed
-  return CHOICE(__builtin_popcount(x), __popc(x), __builtin_popcount(x));                                                                          // use builtin if available
+  // use builtin if available
+  return CHOICE(__builtin_popcount(x), __popc(x), __builtin_popcount(x));
 #else
   unsigned int retVal = 0;
   for (int i = 0; i < 32; i++) {
@@ -400,7 +401,7 @@ GPUhdi() float GPUCommonMath::Copysign(float x, float y)
 #endif // GPUCA_GPUCODE
 }
 
-GPUhdi() double GPUCommonMath::Copysign(double x, double y)
+GPUhdi() double GPUCommonMath::Copysignd(double x, double y)
 {
 #if defined(__OPENCLCPP__)
   return copysign(x, y);

--- a/GPU/TPCFastTransformation/Spline1DHelper.cxx
+++ b/GPU/TPCFastTransformation/Spline1DHelper.cxx
@@ -501,7 +501,7 @@ int Spline1DHelper<DataT>::test(const bool draw, const bool drawDataPoints)
     double cosx[Fdegree + 1], sinx[Fdegree + 1];
     double xi = 0;
     for (int i = 0; i <= Fdegree; i++, xi += x) {
-      GPUCommonMath::SinCos(xi, sinx[i], cosx[i]);
+      GPUCommonMath::SinCosd(xi, sinx[i], cosx[i]);
     }
     for (int dim = 0; dim < Ndim; dim++) {
       f[dim] = 0; // Fcoeff[0]/2;

--- a/GPU/TPCFastTransformation/Spline2DHelper.cxx
+++ b/GPU/TPCFastTransformation/Spline2DHelper.cxx
@@ -245,8 +245,8 @@ int Spline2DHelper<DataT>::test(const bool draw, const bool drawDataPoints)
     double cosu[Fdegree + 1], sinu[Fdegree + 1], cosv[Fdegree + 1], sinv[Fdegree + 1];
     double ui = 0, vi = 0;
     for (int i = 0; i <= Fdegree; i++, ui += uu, vi += vv) {
-      GPUCommonMath::SinCos(ui, sinu[i], cosu[i]);
-      GPUCommonMath::SinCos(vi, sinv[i], cosv[i]);
+      GPUCommonMath::SinCosd(ui, sinu[i], cosu[i]);
+      GPUCommonMath::SinCosd(vi, sinv[i], cosv[i]);
     }
     for (int dim = 0; dim < Ndim; dim++) {
       double f = 0; // Fcoeff[dim][0]/2;


### PR DESCRIPTION
The double precision overloads for GPU functions (and the respective, calling functions) were renamed with a trailing `d` to ensure that they are not used by accident.

