### PR TITLE
GPU: Set correct ASM language for assembler files during GPU compilation

### DIFF
--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HDRS GPUReconstructionCUDA.h GPUReconstructionCUDAInternals.h GPUReconstruct
 
 # -------------------------------- Prepare RTC -------------------------------------------------------
 if(NOT ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
+  enable_language(ASM)
   if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     set(defineIncludeSrc "O2::${MODULE}")
   else()
@@ -92,7 +93,7 @@ if(NOT ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
     ${CURTC_BIN}.src.S
     PROPERTIES
     LANGUAGE
-    CXX
+    ASM
     OBJECT_DEPENDS
     "${CURTC_BIN}.src;${GPUDIR}/Standalone/makefiles/include.S")
     
@@ -100,7 +101,7 @@ if(NOT ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
     ${CURTC_BIN}.command.S
     PROPERTIES
     LANGUAGE
-    CXX
+    ASM
   )
   
   set(SRCS ${SRCS} ${CURTC_BIN}.src.S ${CURTC_BIN}.command.S)

--- a/GPU/GPUTracking/Base/opencl/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl/CMakeLists.txt
@@ -9,6 +9,7 @@
 # submit itself to any jurisdiction.
 
 set(MODULE GPUTrackingOCL)
+enable_language(ASM)
 
 # AMD APP SDK required for OpenCL tracker as it's using specific extensions
 # (currently) not provided by other vendors
@@ -78,7 +79,7 @@ set_source_files_properties(
   ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionOCLCode.S
   PROPERTIES
   LANGUAGE
-  CXX
+  ASM
   OBJECT_DEPENDS
   "${CL_BIN};${GPUDIR}/Standalone/makefiles/include.S")
 

--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -9,6 +9,7 @@
 # submit itself to any jurisdiction.
 
 set(MODULE GPUTrackingOCL2)
+enable_language(ASM)
 
 if(DEFINED OCL2_GPUTARGET)
   set(TMP_TARGET "(AMDGPU Target ${OCL2_GPUTARGET})")
@@ -68,7 +69,7 @@ if(OPENCL2_ENABLED_AMD) # BUILD OpenCL2 binaries for AMD target
     ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionOCLCode.amd.S
     PROPERTIES
     LANGUAGE
-    CXX
+    ASM
     OBJECT_DEPENDS
     "${CL_BIN}.amd;${GPUDIR}/Standalone/makefiles/include.S")
 
@@ -108,7 +109,7 @@ if(OPENCL2_ENABLED_SPIRV) # BUILD OpenCL2 intermediate code for SPIR-V target
     ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionOCLCode.spirv.S
     PROPERTIES
     LANGUAGE
-    CXX
+    ASM
     OBJECT_DEPENDS
     "${CL_BIN}.spirv;${GPUDIR}/Standalone/makefiles/include.S")
 
@@ -140,7 +141,7 @@ if(OPENCL2_ENABLED) # BUILD OpenCL2 source code for runtime compilation target
     ${CMAKE_CURRENT_BINARY_DIR}/GPUReconstructionOCLCode.src.S
     PROPERTIES
     LANGUAGE
-    CXX
+    ASM
     OBJECT_DEPENDS
     "${CL_BIN}.src;${GPUDIR}/Standalone/makefiles/include.S")
 


### PR DESCRIPTION
This should fix one of the 2 problems mentioned in alisw/alidist#2628.
@fweig : This should fix the problem you reported.
The second CMake problem with include paths on some systems is still there and requires some more investigation.