### PR TITLE
Add some required getters to MCTruthContainer and MCKinematicsReader

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -140,6 +140,11 @@ class MCTruthContainer
   size_t getIndexedSize() const { return mHeaderArray.size(); }
   // return the number of elements managed in this container
   size_t getNElements() const { return mTruthArray.size(); }
+  // return unterlaying vector of elements
+  const std::vector<TruthElement>& getTruthArray() const
+  {
+    return mTruthArray;
+  }
 
   // get individual "view" container for a given data index
   // the caller can do modifications on this view (such as sorting)

--- a/Steer/include/Steer/MCKinematicsReader.h
+++ b/Steer/include/Steer/MCKinematicsReader.h
@@ -83,11 +83,19 @@ class MCKinematicsReader
 
   /// return all track references associated to a source/event/track
   gsl::span<o2::TrackReference> getTrackRefs(int source, int event, int track) const;
+  /// return all track references associated to a source/event
+  const std::vector<o2::TrackReference>& getTrackRefsByEvent(int source, int event) const;
   /// return all track references associated to a event/track (when initialized from kinematics directly)
   gsl::span<o2::TrackReference> getTrackRefs(int event, int track) const;
 
   /// retrieves the MCEventHeader for a given eventID and sourceID
   o2::dataformats::MCEventHeader const& getMCEventHeader(int source, int event) const;
+
+  /// Get number of sources
+  size_t getNSources() const;
+
+  /// Get number of events
+  size_t getNEvents(int source) const;
 
   DigitizationContext const* getDigitizationContext() const
   {
@@ -162,9 +170,30 @@ inline gsl::span<o2::TrackReference> MCKinematicsReader::getTrackRefs(int source
   return mTrackRefs[source][event].getLabels(track);
 }
 
+inline const std::vector<o2::TrackReference>& MCKinematicsReader::getTrackRefsByEvent(int source, int event) const
+{
+  if (mTrackRefs[source].size() == 0) {
+    loadTrackRefsForSource(source);
+  }
+  return mTrackRefs[source][event].getTruthArray();
+}
+
 inline gsl::span<o2::TrackReference> MCKinematicsReader::getTrackRefs(int event, int track) const
 {
   return getTrackRefs(0, event, track);
+}
+
+inline size_t MCKinematicsReader::getNSources() const
+{
+  return mTracks.size();
+}
+
+inline size_t MCKinematicsReader::getNEvents(int source) const
+{
+  if (mTracks[source].size() == 0) {
+    loadTracksForSource(source);
+  }
+  return mTracks[source].size();
 }
 
 } // namespace steer


### PR DESCRIPTION
@sawenzel : I think this contains all the interfaces I need. Perhaps we should clean it up a bit / homegenize a bit, but this can also be done at a later stage. In particular:
- Is the naming OK with you? In particular I had to use getTrackRefsByEvent(int, int) because getTrackRefs(int, int) exists already.
- We should add the array getter to the other versions of the MCTruthContainer.
- Perhaps we should change the MCKinematicsReader to retugn gsl::span in all cases instead of the std::vector reference, but perhaps that is a matter of taste.