### PR TITLE
DPL: drop check of InputSpec.h in dictionaries

### DIFF
--- a/Framework/Core/test/TestClasses.h
+++ b/Framework/Core/test/TestClasses.h
@@ -11,7 +11,6 @@
 #define O2_FRAMEWORK_TEST_CLASSES_H_
 
 #include <Rtypes.h>
-#include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
 
 namespace o2::test


### PR DESCRIPTION
This seems to break the o2-test-framework-TMessageSerializer test. Not sure why.