### PR TITLE
AlpideCoder: skip chips with all hits masked as noise

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -192,6 +192,12 @@ class AlpideCoder
             addHit(chipData, rightColHits[ihr], colDPrev);
           }
         }
+        if (!chipData.getData().size() && !chipData.isErrorSet()) {
+          nRightCHits = 0;
+          colDPrev = 0xffff;
+          chipData.clear();
+          continue;
+        }
         break;
       }
 


### PR DESCRIPTION
@iouribelikov this is slightly modified version of the code you proposed, mostly because even if the chip is empty we still want to return it to ``RUDecodeData::decodeROF`` in case errors were detected (this will not lead to skipping other cables).
