### PR TITLE
avoid non constexpr string lookups

### DIFF
--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -176,12 +176,16 @@ struct CorrelationTask {
       }
     }
 
+    // NOTE remove when HistogramRegistry uses constexpr strings for lookup
+    auto& yields = registry.get<TH3>("yields");
+    auto& etaphi = registry.get<TH3>("etaphi");
+
     for (auto& track1 : tracks) {
 
       // LOGF(info, "Track %f | %f | %f  %d %d", track1.eta(), track1.phi(), track1.pt(), track1.isGlobalTrack(), track1.isGlobalTrackSDD());
 
-      registry.fill("yields", centrality, track1.pt(), track1.eta());
-      registry.fill("etaphi", centrality, track1.eta(), track1.phi());
+      yields->Fill(centrality, track1.pt(), track1.eta());
+      etaphi->Fill(centrality, track1.eta(), track1.phi());
 
       if (cfgTriggerCharge != 0 && cfgTriggerCharge * track1.charge() < 0) {
         continue;


### PR DESCRIPTION
only needed for current version of histogram registry