### PR TITLE
IndexedTrackref changes

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
@@ -97,7 +97,7 @@ class SimTraits
 
   // branches that are related to kinematics and general event information
   static inline const std::vector<std::string> KINEMATICSBRANCHES =
-    {"MCTrack", "MCEventHeader", "TrackRefs", "IndexedTrackRefs"};
+    {"MCTrack", "MCEventHeader", "TrackRefs"};
 
   ClassDefNV(SimTraits, 1);
 };

--- a/DataFormats/Detectors/FIT/FT0/src/DataFormatsFT0LinkDef.h
+++ b/DataFormats/Detectors/FIT/FT0/src/DataFormatsFT0LinkDef.h
@@ -33,6 +33,7 @@
 #pragma link C++ class vector < o2::ft0::ChannelDataFloat> + ;
 
 #pragma link C++ class o2::ft0::MCLabel + ;
+#include "SimulationDataFormat/MCTruthContainer.h"
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::ft0::MCLabel> + ;
 
 #pragma link C++ class o2::ft0::HitType + ;

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -18,7 +18,6 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "FairGenericStack.h"
 #include "SimulationDataFormat/MCTrack.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "SimulationDataFormat/MCEventStats.h"
 #include "Rtypes.h"
@@ -283,8 +282,6 @@ class Stack : public FairGenericStack
 
   // storage for track references
   std::vector<o2::TrackReference>* mTrackRefs = nullptr; //!
-
-  o2::dataformats::MCTruthContainer<o2::TrackReference>* mIndexedTrackRefs = nullptr; //!
 
   /// a pointer to the current MCEventStats object
   o2::dataformats::MCEventStats* mMCEventStats = nullptr; //!

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -72,7 +72,6 @@ Stack::Stack(Int_t size)
     mMinHits(1),
     mEnergyCut(0.),
     mTrackRefs(new std::vector<o2::TrackReference>),
-    mIndexedTrackRefs(new typename std::remove_pointer<decltype(mIndexedTrackRefs)>::type),
     mIsG4Like(false)
 {
   auto vmc = TVirtualMC::GetMC();
@@ -518,14 +517,6 @@ void Stack::UpdateTrackIndex(TRefArray* detList)
     return a.getTrackID() < b.getTrackID();
   });
 
-  // make final indexed container for track references
-  // fill empty
-  for (auto& ref : *mTrackRefs) {
-    if (ref.getTrackID() >= 0) {
-      mIndexedTrackRefs->addElement(ref.getTrackID(), ref);
-    }
-  }
-
   for (auto det : mActiveDetectors) {
     // update the track indices by delegating to specialized detector functions
     det->updateHitTrackIndices(mIndexMap);
@@ -553,7 +544,6 @@ void Stack::Reset()
   mNumberOfPrimariesPopped = 0;
   mPrimaryParticles.clear();
   mTrackRefs->clear();
-  mIndexedTrackRefs->clear();
   mTrackIDtoParticlesEntry.clear();
   mHitCounter = 0;
 }
@@ -562,7 +552,6 @@ void Stack::Register()
 {
   FairRootManager::Instance()->RegisterAny("MCTrack", mTracks, kTRUE);
   FairRootManager::Instance()->RegisterAny("TrackRefs", mTrackRefs, kTRUE);
-  FairRootManager::Instance()->RegisterAny("IndexedTrackRefs", mIndexedTrackRefs, kTRUE);
 }
 
 void Stack::Print(Int_t iVerbose) const

--- a/Steer/include/Steer/MCKinematicsReader.h
+++ b/Steer/include/Steer/MCKinematicsReader.h
@@ -106,6 +106,7 @@ class MCKinematicsReader
   void loadTracksForSource(int source) const;
   void loadHeadersForSource(int source) const;
   void loadTrackRefsForSource(int source) const;
+  void initIndexedTrackRefs(std::vector<o2::TrackReference>& refs, o2::dataformats::MCTruthContainer<o2::TrackReference>& indexedrefs) const;
 
   DigitizationContext const* mDigitizationContext = nullptr;
 
@@ -115,7 +116,7 @@ class MCKinematicsReader
   // a vector of tracks foreach source and each collision
   mutable std::vector<std::vector<std::vector<o2::MCTrack>>> mTracks; // the in-memory track container
   mutable std::vector<std::vector<o2::dataformats::MCEventHeader>> mHeaders; // the in-memory header container
-  mutable std::vector<std::vector<o2::dataformats::MCTruthContainer<o2::TrackReference>>> mTrackRefs; // the in-memory track ref container
+  mutable std::vector<std::vector<o2::dataformats::MCTruthContainer<o2::TrackReference>>> mIndexedTrackRefs; // the in-memory track ref container
 
   bool mInitialized = false; // whether initialized
 };
@@ -164,18 +165,18 @@ inline o2::dataformats::MCEventHeader const& MCKinematicsReader::getMCEventHeade
 
 inline gsl::span<o2::TrackReference> MCKinematicsReader::getTrackRefs(int source, int event, int track) const
 {
-  if (mTrackRefs[source].size() == 0) {
+  if (mIndexedTrackRefs[source].size() == 0) {
     loadTrackRefsForSource(source);
   }
-  return mTrackRefs[source][event].getLabels(track);
+  return mIndexedTrackRefs[source][event].getLabels(track);
 }
 
 inline const std::vector<o2::TrackReference>& MCKinematicsReader::getTrackRefsByEvent(int source, int event) const
 {
-  if (mTrackRefs[source].size() == 0) {
+  if (mIndexedTrackRefs[source].size() == 0) {
     loadTrackRefsForSource(source);
   }
-  return mTrackRefs[source][event].getTruthArray();
+  return mIndexedTrackRefs[source][event].getTruthArray();
 }
 
 inline gsl::span<o2::TrackReference> MCKinematicsReader::getTrackRefs(int event, int track) const

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -248,7 +248,6 @@ void O2MCApplication::SendData()
   attachSubEventInfo(simdataparts, *mSubEventInfo);
   auto tracks = attachBranch<std::vector<o2::MCTrack>>("MCTrack", *mSimDataChannel, simdataparts);
   attachBranch<std::vector<o2::TrackReference>>("TrackRefs", *mSimDataChannel, simdataparts);
-  attachBranch<o2::dataformats::MCTruthContainer<o2::TrackReference>>("IndexedTrackRefs", *mSimDataChannel, simdataparts);
   assert(tracks->size() == mSubEventInfo->npersistenttracks);
 
   for (auto det : listActiveDetectors) {

--- a/macro/duplicateHits.C
+++ b/macro/duplicateHits.C
@@ -172,7 +172,6 @@ void duplicateHits(const char* filebase = "o2sim", const char* newfilebase = "o2
   duplicate<o2::dataformats::MCEventHeader>(kintree, "MCEventHeader.", newkintree, factor);
   // TODO: fix EventIDs in the newly created MCEventHeaders
   duplicate<o2::TrackReference>(kintree, "TrackRefs", newkintree, factor);
-  duplicate<o2::dataformats::MCTruthContainer<o2::TrackReference>>(kintree, "IndexedTrackRefs", newkintree, factor);
   newkintree->Write();
 
   // duplicating hits

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -167,7 +167,7 @@ o2_add_test(CheckStackG4
   NAME o2sim_checksimkinematics_G4
   WORKING_DIRECTORY ${SIMTESTDIR}
   COMMAND_LINE_ARGS o2simG4
-  PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat
+  PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::Steer
   NO_BOOST_TEST
   LABELS "g4;sim;long")
 
@@ -206,7 +206,7 @@ o2_add_test(CheckStackG3
   NAME o2sim_checksimkinematics_G3
   WORKING_DIRECTORY ${SIMTESTDIR}
   COMMAND_LINE_ARGS o2simG3
-  PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat
+  PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::Steer
   NO_BOOST_TEST
   LABELS "g3;sim;long")
 

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -262,7 +262,6 @@ class O2HitMerger : public FairMQDevice
     fillSubEventInfoEntry(info);
     consumeData<std::vector<o2::MCTrack>>(info.eventID, "MCTrack", data, index);
     consumeData<std::vector<o2::TrackReference>>(info.eventID, "TrackRefs", data, index);
-    consumeData<o2::dataformats::MCTruthContainer<o2::TrackReference>>(info.eventID, "IndexedTrackRefs", data, index);
     while (index < data.Size()) {
       consumeHits(info.eventID, data, index);
     }
@@ -324,13 +323,6 @@ class O2HitMerger : public FairMQDevice
   void backInsert(T const& from, T& to)
   {
     std::copy(from.begin(), from.end(), std::back_inserter(to));
-  }
-  // specialization for o2::MCTruthContainer<S>
-  template <typename S>
-  void backInsert(o2::dataformats::MCTruthContainer<S> const& from,
-                  o2::dataformats::MCTruthContainer<S>& to)
-  {
-    to.mergeAtBack(from);
   }
 
   void reorderAndMergeMCTRacks(TTree& origin, TTree& target, const std::vector<int>& nprimaries, const std::vector<int>& nsubevents)
@@ -610,7 +602,6 @@ class O2HitMerger : public FairMQDevice
     reorderAndMergeMCTRacks(*tree, *mOutTree, nprimaries, subevOrdered);
     Int_t ioffset = 0;
     remapTrackIdsAndMerge<std::vector<o2::TrackReference>>("TrackRefs", *tree, *mOutTree, trackoffsets, nprimaries, subevOrdered);
-    merge<o2::dataformats::MCTruthContainer<o2::TrackReference>>("IndexedTrackRefs", *tree, *mOutTree);
 
     // c) do the merge procedure for all hits ... delegate this to detector specific functions
     // since they know about types; number of branches; etc.


### PR DESCRIPTION
Simplify processing of track references during transport simulation
with benefit of less storage/less IO/less merging logic.

Instead, build indexed access to track references
in the background of MCKinematicsReader which should be the default path
to read such information anyway.