### PR TITLE
[EMCAL-610] Fix channel header in payload encoding

### DIFF
--- a/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
+++ b/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
@@ -43,6 +43,7 @@ void RawFitterTESTs(const char* filename = "")
     inputDir += "/share/Detectors/EMC/files/";
     inputfile = inputDir + "emcal.raw";
   }
+  std::cout << "Using input file " << inputfile << std::endl;
 
   o2::raw::RawFileReader reader;
   reader.setDefaultDataOrigin(o2::header::gDataOriginEMC);
@@ -64,6 +65,7 @@ void RawFitterTESTs(const char* filename = "")
       break;
     }
     std::vector<char> dataBuffer; // where to put extracted data
+    std::cout << "Next iteration: Number of links: " << reader.getNLinks() << std::endl;
     for (int il = 0; il < reader.getNLinks(); il++) {
       auto& link = reader.getLink(il);
       std::cout << "Decoding link " << il << std::endl;
@@ -84,14 +86,17 @@ void RawFitterTESTs(const char* filename = "")
 
         // use the altro decoder to decode the raw data, and extract the RCU trailer
         o2::emcal::AltroDecoder decoder(parser);
+        std::cout << "Decoding" << std::endl;
         decoder.decode();
 
         std::cout << decoder.getRCUTrailer() << std::endl;
+        std::cout << "Found number of channels: " << decoder.getChannels().size() << std::endl;
 
         // Loop over all the channels
         for (auto& chan : decoder.getChannels()) {
-
+          std::cout << "processing next channel idx " << chan.getChannelIndex() << ", " << chan.getHardwareAddress() << std::endl;
           // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
+          continue;
           o2::emcal::CaloFitResults fitResults = RawFitter.evaluate(chan.getBunches(), 0, 0);
 
           // print the fit output

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -58,7 +58,7 @@ union ChannelHeader {
     uint32_t mPayloadSize : 10;     ///< Bits 16 - 25: Payload size
     uint32_t mZero1 : 3;            ///< Bits 26 - 28: zeroed
     uint32_t mBadChannel : 1;       ///< Bit  29: Bad channel status
-    uint32_t mZero2 : 2;            ///< Bits 30 - 31: zeroed
+    uint32_t mHeaderBits : 2;       ///< Bits 30 - 31: channel header bits (1)
   };
 };
 


### PR DESCRIPTION
- Channel header must be marked with bit 30, otherwise the
  decoder will not find any channel
- Swap fields for bunch size and start time (first bunch size,
  then start time)
- Add bunch header size (2) to bunch size
- Skip encoding of channels with no bunches
- Skip encoding of SRUs with no channels