### PR TITLE
DCS proxy to retrieve DCS DPs from ADAPOS

### DIFF
--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -8,6 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+# add_compile_options(-O0 -g -fPIC)
+
 o2_add_library(
   DetectorsDCS
   TARGETVARNAME targetName
@@ -43,6 +45,19 @@ o2_add_executable(
   COMPONENT_NAME dcs
   SOURCES testWorkflow/dcs-random-data-workflow.cxx
   PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsDCS)
+
+o2_add_executable(
+  proxy
+  COMPONENT_NAME dcs
+  SOURCES testWorkflow/dcs-proxy.cxx
+  PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::DetectorsDCS)
+
+o2_add_executable(
+  data-client
+  COMPONENT_NAME dcs
+  SOURCES testWorkflow/dcs-data-client-workflow.cxx
+  PUBLIC_LINK_LIBRARIES O2::Framework
+  O2::DetectorsDCS)
 
 if(OpenMP_CXX_FOUND)
   target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/DCS/testWorkflow/DCSConsumerSpec.h
+++ b/Detectors/DCS/testWorkflow/DCSConsumerSpec.h
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DCS_CONSUMER_H
+#define O2_DCS_CONSUMER_H
+
+/// @file   DCSConsumerSpec.h
+/// @brief  Consumer of DPs coming from DCS server; it is just
+/// to check that we receive and pack the data correctly
+
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "Framework/DataSpecUtils.h"
+
+using namespace o2::framework;
+namespace o2h = o2::header;
+
+namespace o2
+{
+namespace dcs
+{
+class DCSConsumer : public o2::framework::Task
+{
+
+  using DPCOM = o2::dcs::DataPointCompositeObject;
+
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+
+    uint64_t tfid;
+    for (auto& input : pc.inputs()) {
+      tfid = header::get<o2::framework::DataProcessingHeader*>(input.header)->startTime;
+      LOG(DEBUG) << "tfid = " << tfid;
+      break; // we break because one input is enough to get the TF ID
+    }
+
+    LOG(DEBUG) << "TF: " << tfid << " --> reading binary blob...";
+    mTFs++;
+    auto vect = pc.inputs().get<gsl::span<DPCOM>>("COMMONDPs");
+    LOG(INFO) << "vector has " << vect.size() << " Data Points inside";
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+
+    LOG(INFO) << "Number of processed TFs = " << mTFs;
+  }
+
+ private:
+  uint64_t mTFs = 0;
+};
+
+} // namespace dcs
+
+namespace framework
+{
+
+DataProcessorSpec getDCSConsumerSpec()
+{
+  return DataProcessorSpec{
+    "dcs-consumer",
+    Inputs{{"COMMONDPs", "DCS", "COMMON", 0, Lifetime::Timeframe}},
+    Outputs{},
+    AlgorithmSpec{adaptFromTask<o2::dcs::DCSConsumer>()},
+    Options{}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/DCS/testWorkflow/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/DCStoDPLconverter.h
@@ -1,0 +1,140 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DCS_TO_DPL_CONVERTER
+#define O2_DCS_TO_DPL_CONVERTER
+
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include <fairmq/FairMQParts.h>
+#include <fairmq/FairMQDevice.h>
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include <unordered_map>
+#include <functional>
+#include <string_view>
+
+namespace o2h = o2::header;
+namespace o2f = o2::framework;
+
+// we need to provide hash function for the DataDescription
+namespace std
+{
+template <>
+struct hash<o2h::DataDescription> {
+  std::size_t operator()(const o2h::DataDescription& d) const noexcept
+  {
+    return std::hash<std::string_view>{}({d.str, size_t(d.size)});
+  }
+};
+} // namespace std
+
+namespace o2
+{
+namespace dcs
+{
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPCOM = o2::dcs::DataPointCompositeObject;
+
+/// A callback function to retrieve the FairMQChannel name to be used for sending
+/// messages of the specified OutputSpec
+
+o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dpid2group, uint64_t startTime, uint64_t step, bool verbose = false)
+{
+
+  auto timesliceId = std::make_shared<size_t>(startTime);
+  return [dpid2group, timesliceId, step, verbose](FairMQDevice& device, FairMQParts& parts, o2f::ChannelRetriever channelRetriever) {
+    static std::unordered_map<DPID, DPCOM> cache; // will keep only the latest measurement in the 1-second wide window for each DPID
+    static auto timer = std::chrono::high_resolution_clock::now();
+
+    LOG(DEBUG) << "In lambda function: ********* Size of unordered_map (--> number of defined groups) = " << dpid2group.size();
+    // We first iterate over the parts of the received message
+    for (size_t i = 0; i < parts.Size(); ++i) {             // DCS sends only 1 part, but we should be able to receive more
+      auto nDPCOM = parts.At(i)->GetSize() / sizeof(DPCOM); // number of DPCOM in current part
+      for (size_t j = 0; j < nDPCOM; j++) {
+        DPCOM src;
+        memcpy(&src, reinterpret_cast<char*>(parts.At(i)->GetData()) + j * sizeof(DPCOM), sizeof(DPCOM));
+        // const auto* src = reinterpret_cast<const DPCOM*>(parts.At(i)->GetData()) + j;
+        // do we want to check if this DP was requested ?
+        auto mapEl = dpid2group.find(src.id);
+        if (verbose) {
+          LOG(INFO) << "Received DP " << src.id << " (data = " << src.data << "), matched to output-> " << (mapEl == dpid2group.end() ? "none " : mapEl->second.as<std::string>());
+        }
+        if (mapEl != dpid2group.end()) {
+          auto& dst = cache[src.id]; // this is needed in case in the 1s window we get a new value for the same DP
+          memcpy(&dst, &src, sizeof(DPCOM));
+        }
+      }
+    }
+
+    auto timerNow = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::ratio<1>> duration = timerNow - timer;
+    if (duration.count() > 1) { //did we accumulate for 1 sec?
+      *timesliceId += step;     // we increment only if we send something
+      std::unordered_map<o2h::DataDescription, vector<DPCOM>, std::hash<o2h::DataDescription>> outputs;
+      // in the cache we have the final values of the DPs that we should put in the output
+      // distribute DPs over the vectors for each requested output
+      for (auto& it : cache) {
+        auto mapEl = dpid2group.find(it.first);
+        if (mapEl != dpid2group.end()) {
+          outputs[mapEl->second].push_back(it.second);
+        }
+      }
+
+      // create and send output messages
+      for (auto& it : outputs) {
+        o2h::DataHeader hdr(it.first, "DCS", 0);
+        o2f::OutputSpec outsp{hdr.dataOrigin, hdr.dataDescription, hdr.subSpecification};
+        if (it.second.empty()) {
+          LOG(WARNING) << "No data for OutputSpec " << outsp;
+          continue;
+        }
+        auto channel = channelRetriever(outsp, *timesliceId);
+        if (channel.empty()) {
+          LOG(WARNING) << "No output channel found for OutputSpec " << outsp << ", discarding its data";
+          it.second.clear();
+          continue;
+        }
+
+        hdr.tfCounter = *timesliceId; // this also
+        hdr.payloadSerializationMethod = o2h::gSerializationMethodNone;
+        hdr.splitPayloadParts = 1;
+        hdr.splitPayloadIndex = 1;
+        hdr.payloadSize = it.second.size() * sizeof(DPCOM);
+        hdr.firstTForbit = 0; // this should be irrelevant for DCS
+        o2h::Stack headerStack{hdr, o2::framework::DataProcessingHeader{*timesliceId, 0}};
+        auto fmqFactory = device.GetChannel(channel).Transport();
+        auto hdMessage = fmqFactory->CreateMessage(headerStack.size(), fair::mq::Alignment{64});
+        auto plMessage = fmqFactory->CreateMessage(hdr.payloadSize, fair::mq::Alignment{64});
+        memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
+        memcpy(plMessage->GetData(), it.second.data(), hdr.payloadSize);
+        if (verbose) {
+          LOG(INFO) << "Pushing " << it.second.size() << " DPs to output " << it.first.as<std::string>() << " for TimeSlice " << *timesliceId;
+          hdr.print();
+        }
+        it.second.clear();
+        FairMQParts outParts;
+        outParts.AddPart(std::move(hdMessage));
+        outParts.AddPart(std::move(plMessage));
+        o2f::sendOnChannel(device, outParts, channel);
+      }
+
+      timer = timerNow;
+      cache.clear();
+    }
+  };
+}
+
+} // namespace dcs
+} // namespace o2
+
+#endif /* O2_DCS_TO_DPL_CONVERTER_H */

--- a/Detectors/DCS/testWorkflow/dcs-data-client-workflow.cxx
+++ b/Detectors/DCS/testWorkflow/dcs-data-client-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/TypeTraits.h"
+#include "Framework/DataSpecUtils.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "DCSConsumerSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getDCSConsumerSpec());
+  return specs;
+}

--- a/Detectors/DCS/testWorkflow/dcs-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/dcs-proxy.cxx
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// example to run:
+// o2-dcs-proxy --dcs-proxy '--channel-config "name=dcs-proxy,type=pull,method=connect,address=tcp://10.11.28.22:60000,rateLogging=1,transport=zeromq"' -b
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/Lifetime.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "DCStoDPLconverter.h"
+#include <vector>
+#include <unordered_map>
+
+using namespace o2::framework;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DeliveryType = o2::dcs::DeliveryType;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{"verbose", VariantType::Bool, false, {"verbose output"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+
+  bool verbose = config.options().get<bool>("verbose");
+  DPID dpidtmp;
+
+  std::unordered_map<DPID, o2h::DataDescription> dpid2DataDesc;
+  DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000100", DeliveryType::RAW_STRING);
+  dpid2DataDesc[dpidtmp] = "COMMON"; // i.e. this will go to {DCS/COMMON/0} OutputSpec
+  DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000110", DeliveryType::RAW_STRING);
+  dpid2DataDesc[dpidtmp] = "COMMON";
+  DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000200", DeliveryType::RAW_STRING);
+  dpid2DataDesc[dpidtmp] = "COMMON1";
+  DPID::FILL(dpidtmp, "ADAPOS_LG/TEST_000240", DeliveryType::RAW_INT);
+  dpid2DataDesc[dpidtmp] = "COMMON1";
+
+  // RS: here we should complete the attribution of different DPs to different outputs
+  // ...
+
+  // now collect all required outputs to define OutputSpecs for specifyExternalFairMQDeviceProxy
+  std::unordered_map<o2h::DataDescription, int, std::hash<o2h::DataDescription>> outMap;
+  for (auto itdp : dpid2DataDesc) {
+    outMap[itdp.second]++;
+  }
+
+  Outputs dcsOutputs;
+  for (auto itout : outMap) {
+    dcsOutputs.emplace_back("DCS", itout.first, 0, Lifetime::Timeframe);
+  }
+
+  DataProcessorSpec dcsProxy = specifyExternalFairMQDeviceProxy(
+    "dcs-proxy",
+    std::move(dcsOutputs),
+    "type=pull,method=connect,address=tcp://aldcsadaposactor:60000,rateLogging=1,transport=zeromq",
+    dcs2dpl(dpid2DataDesc, 0, 1, verbose));
+
+  WorkflowSpec workflow;
+  workflow.emplace_back(dcsProxy);
+  return workflow;
+}


### PR DESCRIPTION
PR to introduce the dcs-proxy to get the data from the DCS server. Work done with @shahor02 .

The  o2-dcs-data-client is a very simple data processor that consumes the output (as a check). 

o2-dcs-proxy --dcs-proxy '--channel-config "name=dcs-proxy,type=pull,method=connect,address=tcp://10.11.28.22:60000,rateLogging=1,transport=zeromq"' --verbose -b | o2-dcs-data-client -b
