### PR TITLE
GPU TPC QA: Use MCKinematicsReader to obtain MC truth

### DIFF
--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -259,6 +259,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
                                        O2::TPCFastTransformation
                                        O2::DetectorsRaw
                                        ${DEBUGGUI_TARGET}
+                                       O2::Steer
                  PUBLIC_INCLUDE_DIRECTORIES SliceTracker
                                             Base
                                             TPCConvert

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -60,6 +60,7 @@
 #include "SimulationDataFormat/DigitizationContext.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include "Steer/MCKinematicsReader.h"
 #include "TPDGCode.h"
 #include "TParticlePDG.h"
 #include "TDatabasePDG.h"
@@ -587,17 +588,8 @@ int GPUQA::InitQA(int tasks)
 #ifdef GPUCA_O2_LIB
   static constexpr float PRIM_MAX_T = 0.01f;
 
-  TFile fileSim(o2::base::NameConf::getMCKinematicsFileName("o2sim").c_str());
-  TTree* treeSim = (TTree*)fileSim.Get("o2sim");
-  std::vector<o2::MCTrack>* tracksX;
-  std::vector<o2::TrackReference>* trackRefsX;
-  if (treeSim == nullptr) {
-    throw std::runtime_error("Error reading o2sim tree");
-  }
-  treeSim->SetBranchAddress("MCTrack", &tracksX);
-  treeSim->SetBranchAddress("TrackRefs", &trackRefsX);
-
-  int nSimEvents = treeSim->GetEntries();
+  o2::steer::MCKinematicsReader mcReader("collisioncontext.root");
+  int nSimEvents = mcReader.getNEvents(0);
   mTrackMCLabelsReverse.resize(nSimEvents);
   mRecTracks.resize(nSimEvents);
   mFakeTracks.resize(nSimEvents);
@@ -614,9 +606,8 @@ int GPUQA::InitQA(int tasks)
     auto ir0 = o2::raw::HBFUtils::Instance().getFirstIRofTF(ir);
     float timebin = (float)ir.differenceInBC(ir0) / o2::tpc::constants::LHCBCPERTIMEBIN;
 
-    treeSim->GetEntry(i);
-    const std::vector<o2::MCTrack>& tracks = *tracksX;
-    const std::vector<o2::TrackReference>& trackRefs = *trackRefsX;
+    const std::vector<o2::MCTrack>& tracks = mcReader.getTracks(0, i);
+    const std::vector<o2::TrackReference>& trackRefs = mcReader.getTrackRefsByEvent(0, i);
 
     refId.resize(tracks.size());
     std::fill(refId.begin(), refId.end(), -1);
@@ -679,8 +670,6 @@ int GPUQA::InitQA(int tasks)
       }
     }
   }
-
-  fileSim.Close();
 #endif
 
   if (mConfig.matchMCLabels.size()) {


### PR DESCRIPTION
Don't read the file manually.
This will automatically pick the right files, uses the framework code instead of duplicating it, and provides support for multiple sources in the future.