### PR TITLE
[DPL Analysis] Helper to create partitions in process() + extended expressions to int64_t

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -486,6 +486,13 @@ struct Partition {
   {
   }
 
+  void bindTable(T& table)
+  {
+    mFiltered.reset(getTableFromFilter(table, filter));
+    bindExternalIndices(&table);
+    getBoundToExternalIndices(table);
+  }
+
   void setTable(const T& table)
   {
     mFiltered.reset(getTableFromFilter(table, filter));

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -56,7 +56,7 @@ struct LiteralStorage {
   using stored_pack = framework::pack<T...>;
 };
 
-using LiteralValue = LiteralStorage<int, bool, float, double, uint8_t>;
+using LiteralValue = LiteralStorage<int, bool, float, double, uint8_t, int64_t>;
 
 template <typename T>
 constexpr auto selectArrowType()
@@ -73,6 +73,8 @@ constexpr auto selectArrowType()
     return atype::INT8;
   } else if constexpr (std::is_same_v<T, uint16_t>) {
     return atype::INT16;
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return atype::INT64;
   } else if constexpr (std::is_same_v<T, uint8_t>) {
     return atype::UINT8;
   } else {

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -67,6 +67,8 @@ std::shared_ptr<arrow::DataType> concreteArrowType(atype::type type)
       return arrow::int16();
     case atype::INT32:
       return arrow::int32();
+    case atype::INT64:
+      return arrow::int64();
     case atype::FLOAT:
       return arrow::float32();
     case atype::DOUBLE:
@@ -268,8 +270,8 @@ Operations createOperations(Filter const& expression)
       return t1;
     }
 
-    if (t1 == atype::INT32 || t1 == atype::INT8 || t1 == atype::INT16 || t1 == atype::UINT8) {
-      if (t2 == atype::INT32 || t2 == atype::INT8 || t2 == atype::INT16 || t2 == atype::UINT8) {
+    if (t1 == atype::INT32 || t1 == atype::INT8 || t1 == atype::INT16 || t1 == atype::INT64 || t1 == atype::UINT8) {
+      if (t2 == atype::INT32 || t2 == atype::INT8 || t2 == atype::INT16 || t2 == atype::INT64 || t2 == atype::UINT8) {
         return atype::FLOAT;
       }
       if (t2 == atype::FLOAT) {
@@ -280,7 +282,7 @@ Operations createOperations(Filter const& expression)
       }
     }
     if (t1 == atype::FLOAT) {
-      if (t2 == atype::INT32 || t2 == atype::INT8 || t2 == atype::INT16 || t2 == atype::UINT8) {
+      if (t2 == atype::INT32 || t2 == atype::INT8 || t2 == atype::INT16 || t2 == atype::INT64 || t2 == atype::UINT8) {
         return atype::FLOAT;
       }
       if (t2 == atype::DOUBLE) {
@@ -450,6 +452,9 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
       }
       if (content.index() == 4) {
         return gandiva::TreeExprBuilder::MakeLiteral(std::get<uint8_t>(content));
+      }
+      if (content.index() == 5) {
+        return gandiva::TreeExprBuilder::MakeLiteral(std::get<int64_t>(content));
       }
       throw runtime_error("Malformed LiteralNode");
     }


### PR DESCRIPTION
Hi @jgrosseo , this is the example for partitions. `groupedTracks.bindTable(tracks);` does the actual job.

For comparison with index columns I extended expression nodes to accept int64_t - @aalkin , is that OK for you?