### PR TITLE
Initial concept of tracking inhibit with configurable param settings

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -59,7 +59,8 @@ enum ParticleStatus { kKeep = BIT(14),
                       kDaughters = BIT(15),
                       kToBeDone = BIT(16),
                       kPrimary = BIT(17),
-                      kTransport = BIT(18) };
+                      kTransport = BIT(18),
+                      kInhibited = BIT(19) };
 class Stack : public FairGenericStack
 {
  public:
@@ -280,6 +281,8 @@ class Stack : public FairGenericStack
   bool mIsG4Like = false; //! flag indicating if the stack is used in a manner done by Geant4
 
   bool mIsExternalMode = false; // is stack an external factory or directly used inside simulation?
+
+  std::function<bool(const TParticle& p)> mInhibitPrimary = [](const TParticle& p) { return false; }; // a function to inhibit the tracking of a particle
 
   // storage for track references
   std::vector<o2::TrackReference>* mTrackRefs = nullptr; //!

--- a/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
@@ -23,6 +23,7 @@ namespace sim
 struct StackParam : public o2::conf::ConfigurableParamHelper<StackParam> {
   bool storeSecondaries = true;
   bool pruneKine = true;
+  std::string inhibitPrimary = "none";
 
   // boilerplate stuff + make principal key "Stack"
   O2ParamDef(StackParam, "Stack");


### PR DESCRIPTION
This PR brings into the O2 simulation the concept of tracking vetoes.
A inhibit function is defined to veto the tracking of primary particles, depending of the requests.
Inhibited particles are flagged with a specific `ParticleStatus::kInhibited` bit.

This is configured via 
```
--configKeyValues "Stack.inhibitPrimary"
```

For the time being, only `none`, `all` and `forward` are supported and hardcoded.
Future developments will allow one to provide a fully-customised function to select which particles to veto according to the needs.

A similar functionality will be put in place to veto secondary particles.

