### PR TITLE
Move ConfigurableMacroHelper plugin service helper in CommonUtils

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -27,7 +27,8 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/ValueMonitor.h
 				  include/CommonUtils/MemFileHelper.h
                                   include/CommonUtils/ConfigurableParam.h
-                                  include/CommonUtils/ConfigurableParamHelper.h)
+                                  include/CommonUtils/ConfigurableParamHelper.h
+                                  include/CommonUtils/ConfigurationMacroHelper.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils

--- a/Common/Utils/include/CommonUtils/ConfigurationMacroHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurationMacroHelper.h
@@ -10,8 +10,8 @@
 
 /// \author R+Preghenella - February 2020
 
-#ifndef ALICEO2_EVENTGEN_CONFIGURATIONMACRO_H_
-#define ALICEO2_EVENTGEN_CONFIGURATIONMACRO_H_
+#ifndef ALICEO2_CONF_CONFIGURATIONMACRO_H_
+#define ALICEO2_CONF_CONFIGURATIONMACRO_H_
 
 #include "FairLogger.h"
 #include "TROOT.h"
@@ -22,7 +22,7 @@
 
 namespace o2
 {
-namespace eventgen
+namespace conf
 {
 
 template <typename T>
@@ -67,7 +67,7 @@ T GetFromMacro(const std::string& file, const std::string& funcname, const std::
   return *ptr;
 }
 
-} // namespace eventgen
+} // namespace conf
 } // namespace o2
 
-#endif /* ALICEO2_EVENTGEN_CONFIGURATIONMACRO_H_ */
+#endif /* ALICEO2_CONF_CONFIGURATIONMACRO_H_ */

--- a/DataFormats/simulation/include/SimulationDataFormat/ParticleStatus.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ParticleStatus.h
@@ -18,6 +18,7 @@ enum ParticleStatus { kKeep = BIT(14),
                       kDaughters = BIT(15),
                       kToBeDone = BIT(16),
                       kPrimary = BIT(17),
-                      kTransport = BIT(18) };
+                      kTransport = BIT(18),
+                      kInhibited = BIT(19) };
 
 #endif

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <stack>
 #include <utility>
+#include <functional>
 
 class TClonesArray;
 class TRefArray;
@@ -220,6 +221,8 @@ class Stack : public FairGenericStack
   /// update values in the current event header
   void updateEventStats();
 
+  typedef std::function<bool(const TParticle& p)> TransportFcn;
+
  private:
   /// STL stack (FILO) used to handle the TParticles for tracking
   /// stack entries refer to
@@ -275,6 +278,8 @@ class Stack : public FairGenericStack
   bool mIsG4Like = false; //! flag indicating if the stack is used in a manner done by Geant4
 
   bool mIsExternalMode = false; // is stack an external factory or directly used inside simulation?
+
+  TransportFcn mTransportPrimary = [](const TParticle& p) { return false; }; //! a function to inhibit the tracking of a particle
 
   // storage for track references
   std::vector<o2::TrackReference>* mTrackRefs = nullptr; //!

--- a/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
@@ -23,6 +23,10 @@ namespace sim
 struct StackParam : public o2::conf::ConfigurableParamHelper<StackParam> {
   bool storeSecondaries = true;
   bool pruneKine = true;
+  std::string transportPrimary = "all";
+  std::string transportPrimaryFileName = "";
+  std::string transportPrimaryFuncName = "";
+  bool transportPrimaryInvert = false;
 
   // boilerplate stuff + make principal key "Stack"
   O2ParamDef(StackParam, "Stack");

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -73,7 +73,6 @@ set(headers
     include/Generators/InteractionDiamondParam.h
     include/Generators/TriggerExternalParam.h
     include/Generators/TriggerParticleParam.h
-    include/Generators/ConfigurationMacroHelper.h
     include/Generators/BoxGunParam.h
     include/Generators/QEDGenParam.h
     include/Generators/GenCosmicsParam.h)

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -35,7 +35,7 @@
 #include <Generators/TriggerParticle.h>
 #include <Generators/TriggerExternalParam.h>
 #include <Generators/TriggerParticleParam.h>
-#include "Generators/ConfigurationMacroHelper.h"
+#include "CommonUtils/ConfigurationMacroHelper.h"
 
 #include "TRandom.h"
 
@@ -205,7 +205,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     LOG(INFO) << params;
     auto extgen_filename = params.fileName;
     auto extgen_func = params.funcName;
-    auto extgen = GetFromMacro<FairGenerator*>(extgen_filename, extgen_func, "FairGenerator*", "extgen");
+    auto extgen = o2::conf::GetFromMacro<FairGenerator*>(extgen_filename, extgen_func, "FairGenerator*", "extgen");
     if (!extgen) {
       LOG(FATAL) << "Failed to retrieve \'extgen\': problem with configuration ";
     }
@@ -243,10 +243,10 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     LOG(INFO) << params;
     auto external_trigger_filename = params.fileName;
     auto external_trigger_func = params.funcName;
-    trigger = GetFromMacro<o2::eventgen::Trigger>(external_trigger_filename, external_trigger_func, "o2::eventgen::Trigger", "trigger");
+    trigger = o2::conf::GetFromMacro<o2::eventgen::Trigger>(external_trigger_filename, external_trigger_func, "o2::eventgen::Trigger", "trigger");
     if (!trigger) {
       LOG(INFO) << "Trying to retrieve a \'o2::eventgen::DeepTrigger\' type" << std::endl;
-      deeptrigger = GetFromMacro<o2::eventgen::DeepTrigger>(external_trigger_filename, external_trigger_func, "o2::eventgen::DeepTrigger", "deeptrigger");
+      deeptrigger = o2::conf::GetFromMacro<o2::eventgen::DeepTrigger>(external_trigger_filename, external_trigger_func, "o2::eventgen::DeepTrigger", "deeptrigger");
     }
     if (!trigger && !deeptrigger) {
       LOG(FATAL) << "Failed to retrieve \'external trigger\': problem with configuration ";

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -12,7 +12,7 @@
 
 #include "Generators/GeneratorPythia8.h"
 #include "Generators/GeneratorPythia8Param.h"
-#include "Generators/ConfigurationMacroHelper.h"
+#include "CommonUtils/ConfigurationMacroHelper.h"
 #include "FairLogger.h"
 #include "TParticle.h"
 #include "FairMCEventHeader.h"
@@ -82,7 +82,7 @@ Bool_t GeneratorPythia8::Init()
   /** user hooks via configuration macro **/
   if (!mHooksFileName.empty()) {
     LOG(INFO) << "Applying \'Pythia8\' user hooks: " << mHooksFileName << " -> " << mHooksFuncName;
-    auto hooks = GetFromMacro<Pythia8::UserHooks*>(mHooksFileName, mHooksFuncName, "Pythia8::UserHooks*", "pythia8_user_hooks");
+    auto hooks = o2::conf::GetFromMacro<Pythia8::UserHooks*>(mHooksFileName, mHooksFuncName, "Pythia8::UserHooks*", "pythia8_user_hooks");
     if (!hooks) {
       LOG(FATAL) << "Failed to init \'Pythia8\': problem with user hooks configuration ";
       return false;

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -457,5 +457,6 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | [PrimaryKinematics](../run/SimExamples/JustPrimaryKinematics) | Example showing how to obtain only primary kinematics via transport configuration |
 | [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
+| [Selective_Transport](../run/SimExamples/Selective_Transport) | Simple example showing how to run simulation transporting only a custumisable set of particles |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -16,4 +16,5 @@
 * \subpage refrunSimExamplesStepMonitoringSimple1
 * \subpage refrunSimExamplesForceDecay_Lambda_Neutron_Dalitz
 * \subpage refrunSimExamplesJustPrimaryKinematics
+* \subpage refrunSimExamplesSelective_Transport
 /doxy -->

--- a/run/SimExamples/Selective_Tranport/run.sh
+++ b/run/SimExamples/Selective_Tranport/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# This is a simulation example showing how to run simulation and selectively
+# transport particles through the detector geometry according to configurable settings
+#
+# The simulation uses Pythia8 pp generator with default settings.
+# The specific settings of the simulation are defined in the sim.ini file.
+#
+# Only the parameters for the selective particle transport are adjusted, namely
+# ```
+# [Stack]
+# transportPrimary=external
+# transportPrimaryFileName=transportPDG.macro
+# transportPrimaryFuncName=transportPDG(321)
+# transportPrimaryInvert=false
+# ```
+#
+# `transportPrimary` defines the mode of selection, `external` means that the definition is loaded from a plugin macro
+# defined by the function call `transportPrimaryFuncName` from the file `transportPrimaryFileName`.
+# `transportPrimaryInvert` allows one to invert the definition, hence to inhibit transport for the selected particles.
+#
+
+set -x
+
+MODULES="PIPE ITS TPC"
+EVENTS=100
+NWORKERS=8
+
+o2-sim -j ${NWORKERS} -n ${EVENTS} -g pythia8 -m ${MODULES} -o step1 \
+       --configFile sim.ini \
+       > logstep1 2>&1
+

--- a/run/SimExamples/Selective_Tranport/sim.ini
+++ b/run/SimExamples/Selective_Tranport/sim.ini
@@ -1,0 +1,5 @@
+[Stack]
+transportPrimary=external
+transportPrimaryFileName=transportPDG.macro
+transportPrimaryFuncName=transportPDG(321)
+transportPrimaryInvert=false

--- a/run/SimExamples/Selective_Tranport/transportPDG.macro
+++ b/run/SimExamples/Selective_Tranport/transportPDG.macro
@@ -1,0 +1,7 @@
+o2::data::Stack::TransportFcn
+transportPDG(int pdg = 321)
+{
+  return [pdg](const TParticle& p) -> bool {
+	   return p.GetPdgCode() == pdg;
+	 };
+}


### PR DESCRIPTION
This PR moves the `ConfigurableMacroHelper` and contained functionalities to a scope that is more visible for common use, namely in `CommonUtils`