### PR TITLE
Fix geometry with ENABLE_UPGRADES

### DIFF
--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -127,7 +127,11 @@ void build_geometry(FairRunSim* run = nullptr)
   // beam pipe
   if (isActivated("PIPE")) {
 #ifdef ENABLE_UPGRADES
-    run->AddModule(new o2::passive::Pipe("PIPE", "Beam pipe", 1.6f, 0.05));
+    if (isActivated("IT3") || isActivated("IT4")) {
+      run->AddModule(new o2::passive::Pipe("PIPE", "Beam pipe", 1.6f, 0.05));
+    } else {
+      run->AddModule(new o2::passive::Pipe("PIPE", "Beam pipe"));
+    }
 #else
     run->AddModule(new o2::passive::Pipe("PIPE", "Beam pipe"));
 #endif


### PR DESCRIPTION
- use new beampipe only when IT3 or IT4 are activated

FYI: @mpuccio @mconcas 