### PR TITLE
o2-sim kinematics as event generator

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -15,6 +15,7 @@
 #ifndef ALICEO2_DATA_MCTRACK_H_
 #define ALICEO2_DATA_MCTRACK_H_
 
+#include "SimulationDataFormat/ParticleStatus.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "Rtypes.h"
 #include "TDatabasePDG.h"
@@ -184,6 +185,14 @@ class MCTrackT
   /// get the production process (id) of this track
   int getProcess() const { return ((PropEncoding)mProp).process; }
 
+  void setToBeDone(bool f)
+  {
+    auto prop = ((PropEncoding)mProp);
+    prop.toBeDone = f;
+    mProp = prop.i;
+  }
+  bool getToBeDone() const { return ((PropEncoding)mProp).toBeDone; }
+
   /// get the string representation of the production process
   const char* getProdProcessAsString() const;
 
@@ -216,7 +225,8 @@ class MCTrackT
     struct {
       int storage : 1;  // encoding whether to store this track to the output
       int process : 6;  // encoding process that created this track (enough to store TMCProcess from ROOT)
-      int hitmask : 25; // encoding hits per detector
+      int hitmask : 24; // encoding hits per detector
+      int toBeDone : 1; // whether this (still) needs tracking --> we might more complete information to cover full ParticleStatus space
     };
   };
 
@@ -305,6 +315,8 @@ inline MCTrackT<T>::MCTrackT(const TParticle& part)
 {
   // our convention is to communicate the process as (part) of the unique ID
   setProcess(part.GetUniqueID());
+  // extract toBeDone flag
+  setToBeDone(part.TestBit(ParticleStatus::kToBeDone));
 }
 
 template <typename T>

--- a/DataFormats/simulation/include/SimulationDataFormat/ParticleStatus.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/ParticleStatus.h
@@ -1,0 +1,23 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_SIMDATA_PARTICLESTATUS_H_
+#define ALICEO2_SIMDATA_PARTICLESTATUS_H_
+
+#include "TParticle.h"
+
+/// enumeration to define status bits for particles in simulation
+enum ParticleStatus { kKeep = BIT(14),
+                      kDaughters = BIT(15),
+                      kToBeDone = BIT(16),
+                      kPrimary = BIT(17),
+                      kTransport = BIT(18) };
+
+#endif

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -20,6 +20,7 @@
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "SimulationDataFormat/MCEventStats.h"
+#include "SimulationDataFormat/ParticleStatus.h"
 #include "Rtypes.h"
 #include "TParticle.h"
 
@@ -54,11 +55,6 @@ namespace data
 /// The storage of secondaries can be switched off.
 /// The storage of all mothers can be switched off.
 /// By default, the minimal number of hits is 1 and the energy cut is 0.
-enum ParticleStatus { kKeep = BIT(14),
-                      kDaughters = BIT(15),
-                      kToBeDone = BIT(16),
-                      kPrimary = BIT(17),
-                      kTransport = BIT(18) };
 class Stack : public FairGenericStack
 {
  public:

--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -58,6 +58,34 @@ class GeneratorFromFile : public FairGenerator
   ClassDefOverride(GeneratorFromFile, 1);
 };
 
+/// This class implements a generic FairGenerator which
+/// reads the particles from an external O2 sim kinematics file.
+class GeneratorFromO2Kine : public FairGenerator
+{
+ public:
+  GeneratorFromO2Kine() = default;
+  GeneratorFromO2Kine(const char* name);
+
+  // the FairGenerator interface methods
+
+  /** Generates (or reads) one event and adds the tracks to the
+   ** injected primary generator instance.
+   ** @param primGen  pointer to the primary FairPrimaryGenerator
+   **/
+  bool ReadEvent(FairPrimaryGenerator* primGen) override;
+
+  // Set from which event to start
+  void SetStartEvent(int start);
+
+ private:
+  TFile* mEventFile = nullptr;     //! the file containing the persistent events
+  TBranch* mEventBranch = nullptr; //! the branch containing the persistent events
+  int mEventCounter = 0;
+  int mEventsAvailable = 0;
+  bool mSkipNonTrackable = true; //! whether to pass non-trackable (decayed particles) to the MC stack
+  ClassDefOverride(GeneratorFromO2Kine, 1);
+};
+
 } // end namespace eventgen
 } // end namespace o2
 

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -136,6 +136,12 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     extGen->SetStartEvent(conf.getStartEvent());
     primGen->AddGenerator(extGen);
     LOG(INFO) << "using external kinematics";
+  } else if (genconfig.compare("extkinO2") == 0) {
+    // external kinematics from previous O2 output
+    auto extGen = new o2::eventgen::GeneratorFromO2Kine(conf.getExtKinematicsFileName().c_str());
+    extGen->SetStartEvent(conf.getStartEvent());
+    primGen->AddGenerator(extGen);
+    LOG(INFO) << "using external O2 kinematics";
 #ifdef GENERATORS_WITH_HEPMC3
   } else if (genconfig.compare("hepmc") == 0) {
     // external HepMC file

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -47,6 +47,7 @@
 #pragma link C++ class o2::eventgen::GeneratorFactory + ;
 #endif
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;
+#pragma link C++ class o2::eventgen::GeneratorFromO2Kine + ;
 #pragma link C++ class o2::PDG + ;
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
 


### PR DESCRIPTION
Allows reading events from existing O2 kinematics.

Here, foremost, this achieves a possibility to split
event generation and transport into
different stages (using the same tool), in the following sense:

```
o2-sim -n 100 -g pythia8 + no-transport options // generate 100 pythia8 events

o2-sim -g extgenO2 -n 100 --extKinFile o2sim_Kine.root // continue transport on these events.
```

A possible use case is embedding: Signal simulation could continue based
on background events without having to wait for full background transport.

Later on, the same mechanism -- with some modification and careful state
handling -- might achieve a stop/go at a more general level
(for example splitting the transport in multiple stages)