### PR TITLE
Quick fix: change of trigger in dimuon task

### DIFF
--- a/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
@@ -116,7 +116,7 @@ struct EventSelection {
 
     AnalysisCut* varCut = new AnalysisCut();
     varCut->AddCut(VarManager::kVtxZ, -10.0, 10.0);
-    varCut->AddCut(VarManager::kIsMuonSingleLowPt7, 0.5, 1.5);
+    varCut->AddCut(VarManager::kIsMuonUnlikeLowPt7, 0.5, 1.5);
 
     fEventCut->AddCut(varCut);
     // TODO: Add more cuts, also enable cuts which are not easily possible via the VarManager (e.g. trigger selections)


### PR DESCRIPTION
Changing the trigger to kIsMuonUnlikeLowPt7, corresponding to CMUL7, which is the one used in dimuon analysis