### PR TITLE
TPCClusterFinder: Rename TPCCalibration class to TPCPadGainCalib.

### DIFF
--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -27,7 +27,7 @@
 #include "TPCFastTransform.h"
 #include "TPCdEdxCalibrationSplines.h"
 #include "GPUO2InterfaceConfiguration.h"
-#include "TPCCFCalibration.h"
+#include "TPCPadGainCalib.h"
 
 using namespace o2::gpu;
 
@@ -77,8 +77,8 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
   config.configCalib.fastTransform = fastTransform.get();
   std::unique_ptr<o2::gpu::TPCdEdxCalibrationSplines> dEdxSplines(new TPCdEdxCalibrationSplines);
   config.configCalib.dEdxSplines = dEdxSplines.get();
-  std::unique_ptr<TPCCFCalibration> tpcCalibration(new TPCCFCalibration{});
-  config.configCalib.tpcCalibration = tpcCalibration.get();
+  std::unique_ptr<TPCPadGainCalib> gainCalib(new TPCPadGainCalib{});
+  config.configCalib.tpcPadGain = gainCalib.get();
 
   tracker.initialize(config);
   std::vector<ClusterNativeContainer> cont(constants::MAXGLOBALPADROW);

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -43,7 +43,7 @@
 #include "TPCBase/RDHUtils.h"
 #include "GPUO2InterfaceConfiguration.h"
 #include "GPUO2InterfaceQA.h"
-#include "TPCCFCalibration.h"
+#include "TPCPadGainCalib.h"
 #include "GPUDisplayBackend.h"
 #ifdef GPUCA_BUILD_EVENT_DISPLAY
 #include "GPUDisplayBackendGlfw.h"
@@ -100,7 +100,7 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
     std::unique_ptr<GPUDisplayBackend> displayBackend;
     std::unique_ptr<TPCFastTransform> fastTransform;
     std::unique_ptr<TPCdEdxCalibrationSplines> dEdxSplines;
-    std::unique_ptr<TPCCFCalibration> tpcCalibration;
+    std::unique_ptr<TPCPadGainCalib> tpcPadGainCalib;
     std::unique_ptr<GPUSettingsQA> qaConfig;
     int qaTaskMask = 0;
     std::unique_ptr<GPUO2InterfaceQA> qa;
@@ -230,14 +230,14 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
       if (boost::filesystem::exists(confParam.gainCalibFile)) {
         LOG(INFO) << "Loading tpc gain correction from file " << confParam.gainCalibFile;
         const auto* gainMap = o2::tpc::utils::readCalPads(confParam.gainCalibFile, "GainMap")[0];
-        processAttributes->tpcCalibration.reset(new TPCCFCalibration{*gainMap});
+        processAttributes->tpcPadGainCalib.reset(new TPCPadGainCalib{*gainMap});
       } else {
         if (not confParam.gainCalibFile.empty()) {
           LOG(WARN) << "Couldn't find tpc gain correction file " << confParam.gainCalibFile << ". Not applying any gain correction.";
         }
-        processAttributes->tpcCalibration.reset(new TPCCFCalibration{});
+        processAttributes->tpcPadGainCalib.reset(new TPCPadGainCalib{});
       }
-      config.configCalib.tpcCalibration = processAttributes->tpcCalibration.get();
+      config.configCalib.tpcPadGain = processAttributes->tpcPadGainCalib.get();
 
       // Sample code what needs to be done for the TRD Geometry, when we extend this to TRD tracking.
       /*o2::base::GeometryManager::loadGeometry();

--- a/GPU/GPUTracking/Base/GPUConstantMem.h
+++ b/GPU/GPUTracking/Base/GPUConstantMem.h
@@ -136,7 +136,7 @@ GPUdi() void GPUProcessor::raiseError(unsigned int code, unsigned int param1, un
 #if defined(GPUCA_NOCOMPAT_ALLCINT) && (!defined(GPUCA_GPULIBRARY) || !defined(GPUCA_ALIROOT_LIB)) && defined(HAVE_O2HEADERS)
 GPUd() float GPUTPCClusterFinder::getGainCorrection(tpccf::Row row, tpccf::Pad pad) const
 {
-  return GetConstantMem()->calibObjects.tpcCalibration->getGainCorrection(mISlice, row, pad);
+  return GetConstantMem()->calibObjects.tpcPadGain->getGainCorrection(mISlice, row, pad);
 }
 #endif
 

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -69,7 +69,7 @@ namespace gpu
 {
 class TPCFastTransform;
 class TPCdEdxCalibrationSplines;
-struct TPCCFCalibration;
+struct TPCPadGainCalib;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
@@ -175,7 +175,7 @@ struct GPUCalibObjectsTemplate {
   typename S<o2::base::MatLayerCylSet>::type* matLUT = nullptr;
   typename S<o2::trd::GeometryFlat>::type* trdGeometry = nullptr;
   typename S<TPCdEdxCalibrationSplines>::type* dEdxSplines = nullptr;
-  typename S<TPCCFCalibration>::type* tpcCalibration = nullptr;
+  typename S<TPCPadGainCalib>::type* tpcPadGain = nullptr;
 };
 typedef GPUCalibObjectsTemplate<DefaultPtr> GPUCalibObjects;
 typedef GPUCalibObjectsTemplate<ConstPtr> GPUCalibObjectsConst;

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -172,7 +172,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR CONFIG_O2_EXTENSIONS)
         TPCClusterFinder/GPUTPCCFMCLabelFlattener.cxx
         TPCClusterFinder/GPUTPCCFDecodeZS.cxx
         TPCClusterFinder/GPUTPCCFGather.cxx
-        TPCClusterFinder/TPCCFCalibration.cxx
+        TPCClusterFinder/TPCPadGainCalib.cxx
         dEdx/TPCdEdxCalibrationSplines.cxx
         Refit/GPUTrackingRefit.cxx)
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -255,7 +255,7 @@ bool GPUChainTracking::ValidateSteps()
     GPUError("Cannot run dE/dx without calibration splines");
     return false;
   }
-  if ((GetRecoSteps() & GPUDataTypes::RecoStep::TPCClusterFinding) && processors()->calibObjects.tpcCalibration == nullptr) {
+  if ((GetRecoSteps() & GPUDataTypes::RecoStep::TPCClusterFinding) && processors()->calibObjects.tpcPadGain == nullptr) {
     GPUError("Cannot run gain calibration without calibration object");
     return false;
   }
@@ -383,8 +383,8 @@ int GPUChainTracking::Init()
       memcpy((void*)mFlatObjectsShadow.mCalibObjects.trdGeometry, (const void*)processors()->calibObjects.trdGeometry, sizeof(*processors()->calibObjects.trdGeometry));
       mFlatObjectsShadow.mCalibObjects.trdGeometry->clearInternalBufferPtr();
     }
-    if (processors()->calibObjects.tpcCalibration) {
-      memcpy((void*)mFlatObjectsShadow.mCalibObjects.tpcCalibration, (const void*)processors()->calibObjects.tpcCalibration, sizeof(*processors()->calibObjects.tpcCalibration));
+    if (processors()->calibObjects.tpcPadGain) {
+      memcpy((void*)mFlatObjectsShadow.mCalibObjects.tpcPadGain, (const void*)processors()->calibObjects.tpcPadGain, sizeof(*processors()->calibObjects.tpcPadGain));
     }
 #endif
     TransferMemoryResourceLinkToGPU(RecoStep::NoRecoStep, mFlatObjectsShadow.mMemoryResFlat);
@@ -439,8 +439,8 @@ void* GPUChainTracking::GPUTrackingFlatObjects::SetPointersFlatObjects(void* mem
     computePointerWithAlignment(mem, mCalibObjects.fastTransform, 1);
     computePointerWithAlignment(mem, mTpcTransformBuffer, mChainTracking->GetTPCTransform()->getFlatBufferSize());
   }
-  if (mChainTracking->GetTPCCalibration()) {
-    computePointerWithAlignment(mem, mCalibObjects.tpcCalibration, 1);
+  if (mChainTracking->GetTPCPadGainCalib()) {
+    computePointerWithAlignment(mem, mCalibObjects.tpcPadGain, 1);
   }
 #ifdef HAVE_O2HEADERS
   if (mChainTracking->GetdEdxSplines()) {

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -152,7 +152,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   // Getters / setters for parameters
   const TPCFastTransform* GetTPCTransform() const { return processors()->calibObjects.fastTransform; }
-  const TPCCFCalibration* GetTPCCalibration() const { return processors()->calibObjects.tpcCalibration; }
+  const TPCPadGainCalib* GetTPCPadGainCalib() const { return processors()->calibObjects.tpcPadGain; }
   const TPCdEdxCalibrationSplines* GetdEdxSplines() const { return processors()->calibObjects.dEdxSplines; }
   const o2::base::MatLayerCylSet* GetMatLUT() const { return processors()->calibObjects.matLUT; }
   const GPUTRDGeometry* GetTRDGeometry() const { return (GPUTRDGeometry*)processors()->calibObjects.trdGeometry; }
@@ -161,7 +161,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetMatLUT(std::unique_ptr<o2::base::MatLayerCylSet>&& lut);
   void SetTRDGeometry(std::unique_ptr<o2::trd::GeometryFlat>&& geo);
   void SetTPCFastTransform(const TPCFastTransform* tpcFastTransform) { processors()->calibObjects.fastTransform = tpcFastTransform; }
-  void SetTPCCFCalibration(const TPCCFCalibration* tpcCalibration) { processors()->calibObjects.tpcCalibration = tpcCalibration; }
+  void SetTPCPadGainCalib(const TPCPadGainCalib* tpcPadGainCalib) { processors()->calibObjects.tpcPadGain = tpcPadGainCalib; }
   void SetdEdxSplines(const TPCdEdxCalibrationSplines* dEdxSplines) { processors()->calibObjects.dEdxSplines = dEdxSplines; }
   void SetMatLUT(const o2::base::MatLayerCylSet* lut) { processors()->calibObjects.matLUT = lut; }
   void SetTRDGeometry(const o2::trd::GeometryFlat* geo) { processors()->calibObjects.trdGeometry = geo; }
@@ -231,7 +231,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
 
   // Ptr to detector / calibration objects
   std::unique_ptr<TPCFastTransform> mTPCFastTransformU;               // Global TPC fast transformation object
-  std::unique_ptr<TPCCFCalibration> mTPCCalibrationU;                 // TPC gain calibration and cluster finder parameters
+  std::unique_ptr<TPCPadGainCalib> mTPCPadGainCalibU;                 // TPC gain calibration and cluster finder parameters
   std::unique_ptr<TPCdEdxCalibrationSplines> mdEdxSplinesU;           // TPC dEdx calibration splines
   std::unique_ptr<o2::base::MatLayerCylSet> mMatLUTU;                 // Material Lookup Table
   std::unique_ptr<o2::trd::GeometryFlat> mTRDGeometryU;               // TRD Geometry

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -223,10 +223,10 @@ void GPUChainTracking::DumpSettings(const char* dir)
     f += "tpctransform.dump";
     DumpFlatObjectToFile(processors()->calibObjects.fastTransform, f.c_str());
   }
-  if (processors()->calibObjects.tpcCalibration != nullptr) {
+  if (processors()->calibObjects.tpcPadGain != nullptr) {
     f = dir;
-    f += "tpccalibration.dump";
-    DumpStructToFile(processors()->calibObjects.tpcCalibration, f.c_str());
+    f += "tpcpadgaincalib.dump";
+    DumpStructToFile(processors()->calibObjects.tpcPadGain, f.c_str());
   }
 #ifdef HAVE_O2HEADERS
   if (processors()->calibObjects.dEdxSplines != nullptr) {
@@ -256,9 +256,9 @@ void GPUChainTracking::ReadSettings(const char* dir)
   mTPCFastTransformU = ReadFlatObjectFromFile<TPCFastTransform>(f.c_str());
   processors()->calibObjects.fastTransform = mTPCFastTransformU.get();
   f = dir;
-  f += "tpccalibration.dump";
-  mTPCCalibrationU = ReadStructFromFile<TPCCFCalibration>(f.c_str());
-  processors()->calibObjects.tpcCalibration = mTPCCalibrationU.get();
+  f += "tpcpadgaincalib.dump";
+  mTPCPadGainCalibU = ReadStructFromFile<TPCPadGainCalib>(f.c_str());
+  processors()->calibObjects.tpcPadGain = mTPCPadGainCalibU.get();
 #ifdef HAVE_O2HEADERS
   f = dir;
   f += "dedxsplines.dump";

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -53,7 +53,7 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
   }
   mRec->SetSettings(&mConfig->configEvent, &mConfig->configReconstruction, &mConfig->configProcessing, &mConfig->configWorkflow);
   mChain->SetTPCFastTransform(mConfig->configCalib.fastTransform);
-  mChain->SetTPCCFCalibration(mConfig->configCalib.tpcCalibration);
+  mChain->SetTPCPadGainCalib(mConfig->configCalib.tpcPadGain);
   mChain->SetdEdxSplines(mConfig->configCalib.dEdxSplines);
   mChain->SetMatLUT(mConfig->configCalib.matLUT);
   mChain->SetTRDGeometry(mConfig->configCalib.trdGeometry);

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
@@ -16,7 +16,7 @@
 #include "Array2D.h"
 #include "CfUtils.h"
 #include "PackedCharge.h"
-#include "TPCCFCalibration.h"
+#include "TPCPadGainCalib.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace GPUCA_NAMESPACE::gpu::tpccf;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
@@ -18,7 +18,7 @@
 #include "GPUProcessor.h"
 #include "GPUDataTypes.h"
 #include "CfFragment.h"
-#include "TPCCFCalibration.h"
+#include "TPCPadGainCalib.h"
 
 namespace o2
 {
@@ -44,7 +44,7 @@ class Digit;
 namespace GPUCA_NAMESPACE::gpu
 {
 struct GPUTPCClusterMCInterim;
-struct TPCCFCalibration;
+struct TPCPadGainCalib;
 
 struct ChargePos;
 

--- a/GPU/GPUTracking/TPCClusterFinder/TPCPadGainCalib.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/TPCPadGainCalib.cxx
@@ -8,10 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file TPCCFCalibration.cxx
+/// \file TPCPadGainCalib.cxx
 /// \author Felix Weiglhofer
 
-#include "TPCCFCalibration.h"
+#include "TPCPadGainCalib.h"
 
 #include "GPUTPCGeometry.h"
 #include "DataFormatsTPC/Constants.h"
@@ -19,7 +19,7 @@
 
 using namespace GPUCA_NAMESPACE::gpu;
 
-TPCCFCalibration::TPCCFCalibration()
+TPCPadGainCalib::TPCPadGainCalib()
 {
   GPUTPCGeometry geo{};
   int offset = 0;
@@ -29,7 +29,7 @@ TPCCFCalibration::TPCCFCalibration()
   }
 }
 
-TPCCFCalibration::TPCCFCalibration(const o2::tpc::CalDet<float>& gainMap) : TPCCFCalibration()
+TPCPadGainCalib::TPCPadGainCalib(const o2::tpc::CalDet<float>& gainMap) : TPCPadGainCalib()
 {
   for (int sector = 0; sector < o2::tpc::constants::MAXSECTOR; sector++) {
     for (int p = 0; p < TPC_PADS_IN_SECTOR; p++) {

--- a/GPU/GPUTracking/TPCClusterFinder/TPCPadGainCalib.h
+++ b/GPU/GPUTracking/TPCClusterFinder/TPCPadGainCalib.h
@@ -8,11 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file TPCCFCalibration.h
+/// \file TPCPadGainCalib.h
 /// \author Felix Weiglhofer
 
-#ifndef O2_GPU_TPC_CF_CALIBRATION_H
-#define O2_GPU_TPC_CF_CALIBRATION_H
+#ifndef O2_GPU_TPC_PAD_GAIN_CALIB_H
+#define O2_GPU_TPC_PAD_GAIN_CALIB_H
 
 #include "clusterFinderDefs.h"
 #include "GPUCommonMath.h"
@@ -40,11 +40,11 @@ struct TPCPadGainCorrectionStepNum<unsigned short> {
   static constexpr int value = 65534;
 };
 
-struct TPCCFCalibration {
+struct TPCPadGainCalib {
  public:
 #ifndef GPUCA_GPUCODE
-  TPCCFCalibration();
-  TPCCFCalibration(const o2::tpc::CalDet<float>&);
+  TPCPadGainCalib();
+  TPCPadGainCalib(const o2::tpc::CalDet<float>&);
 #endif
 
   // Deal with pad gain correction from here on
@@ -60,7 +60,7 @@ struct TPCCFCalibration {
 
  private:
   template <typename T = unsigned short>
-  class PadGainCorrection
+  class SectorPadGainCorrection
   {
 
    public:
@@ -68,7 +68,7 @@ struct TPCCFCalibration {
     constexpr static float MaxCorrectionFactor = 2.f;
     constexpr static int NumOfSteps = TPCPadGainCorrectionStepNum<T>::value;
 
-    GPUdi() PadGainCorrection()
+    GPUdi() SectorPadGainCorrection()
     {
       reset();
     }
@@ -119,7 +119,7 @@ struct TPCCFCalibration {
   };
 
   unsigned short mPadOffsetPerRow[TPC_NUM_OF_ROWS];
-  PadGainCorrection<unsigned short> mGainCorrection[TPC_SECTORS];
+  SectorPadGainCorrection<unsigned short> mGainCorrection[TPC_SECTORS];
 
   GPUdi() unsigned short globalPad(tpccf::Row row, tpccf::Pad pad) const
   {


### PR DESCRIPTION
@davidrohr Rename of the pad gain calibration class, as requested.

I think there is some issue with the dependency tracking of the cuda rtc. After renaming the files, i had to delete the entire O2 build folder to in order to get CMake to stop looking for the old file.