### PR TITLE
Exclude testCcdbApi_alien.cxx

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -51,11 +51,11 @@ o2_add_test(CcdbApi
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
 
-o2_add_test(CcdbApi-Alien
-		SOURCES test/testCcdbApi_alien.cxx
-		COMPONENT_NAME ccdb
-		PUBLIC_LINK_LIBRARIES O2::CCDB
-		LABELS ccdb)
+#o2_add_test(CcdbApi-Alien
+#		SOURCES test/testCcdbApi_alien.cxx
+#		COMPONENT_NAME ccdb
+#		PUBLIC_LINK_LIBRARIES O2::CCDB
+#		LABELS ccdb)
 
 o2_add_test(BasicCCDBManager
             SOURCES test/testBasicCCDBManager.cxx


### PR DESCRIPTION
It breaks when an alien token is not found. We should probably have some failover logic for that case.