### PR TITLE
DPL Analysis: Fixed OutputObj sink to process custom TList correctly

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -367,18 +367,20 @@ template <typename T>
 struct OutputObj {
   using obj_t = T;
 
-  OutputObj(T&& t, OutputObjHandlingPolicy policy_ = OutputObjHandlingPolicy::AnalysisObject)
+  OutputObj(T&& t, OutputObjHandlingPolicy policy_ = OutputObjHandlingPolicy::AnalysisObject, OutputObjSourceType sourceType_ = OutputObjSourceType::OutputObjSource)
     : object(std::make_shared<T>(t)),
       label(t.GetName()),
       policy{policy_},
+      sourceType{sourceType_},
       mTaskHash{0}
   {
   }
 
-  OutputObj(std::string const& label_, OutputObjHandlingPolicy policy_ = OutputObjHandlingPolicy::AnalysisObject)
+  OutputObj(std::string const& label_, OutputObjHandlingPolicy policy_ = OutputObjHandlingPolicy::AnalysisObject, OutputObjSourceType sourceType_ = OutputObjSourceType::OutputObjSource)
     : object(nullptr),
       label(label_),
       policy{policy_},
+      sourceType{sourceType_},
       mTaskHash{0}
   {
   }
@@ -439,12 +441,13 @@ struct OutputObj {
   OutputRef ref()
   {
     return OutputRef{std::string{label}, 0,
-                     o2::header::Stack{OutputObjHeader{policy, mTaskHash}}};
+                     o2::header::Stack{OutputObjHeader{policy, sourceType, mTaskHash}}};
   }
 
   std::shared_ptr<T> object;
   std::string label;
   OutputObjHandlingPolicy policy;
+  OutputObjSourceType sourceType;
   uint32_t mTaskHash;
 };
 

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -539,7 +539,7 @@ class HistogramRegistry
 
   OutputRef ref()
   {
-    return OutputRef{std::string{mName}, 0, o2::header::Stack{OutputObjHeader{mPolicy, mTaskHash}}};
+    return OutputRef{std::string{mName}, 0, o2::header::Stack{OutputObjHeader{mPolicy, OutputObjSourceType::HistogramRegistrySource, mTaskHash}}};
   }
 
   void setHash(uint32_t hash)

--- a/Framework/Core/include/Framework/OutputObjHeader.h
+++ b/Framework/Core/include/Framework/OutputObjHeader.h
@@ -26,6 +26,12 @@ enum OutputObjHandlingPolicy : unsigned int {
   numPolicies
 };
 
+enum OutputObjSourceType : unsigned int {
+  OutputObjSource,
+  HistogramRegistrySource,
+  numTypes
+};
+
 /// @struct OutputObjHeader
 /// @brief O2 header for OutputObj metadata
 struct OutputObjHeader : public BaseHeader {
@@ -33,15 +39,18 @@ struct OutputObjHeader : public BaseHeader {
   constexpr static const o2::header::HeaderType sHeaderType = "OutObjMD";
   constexpr static const o2::header::SerializationMethod sSerializationMethod = o2::header::gSerializationMethodNone;
   OutputObjHandlingPolicy mPolicy;
+  OutputObjSourceType mSourceType;
   uint32_t mTaskHash;
 
   constexpr OutputObjHeader()
     : BaseHeader(sizeof(OutputObjHeader), sHeaderType, sSerializationMethod, sVersion),
       mPolicy{OutputObjHandlingPolicy::AnalysisObject},
+      mSourceType{OutputObjSourceType::OutputObjSource},
       mTaskHash{0} {}
-  constexpr OutputObjHeader(OutputObjHandlingPolicy policy, uint32_t hash)
+  constexpr OutputObjHeader(OutputObjHandlingPolicy policy, OutputObjSourceType sourceType, uint32_t hash)
     : BaseHeader(sizeof(OutputObjHeader), sHeaderType, sSerializationMethod, sVersion),
       mPolicy{policy},
+      mSourceType{sourceType},
       mTaskHash{hash} {}
   constexpr OutputObjHeader(OutputObjHeader const&) = default;
 };

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -60,6 +60,7 @@ struct InputObjectRoute {
   std::string directory;
   uint32_t taskHash;
   OutputObjHandlingPolicy policy;
+  OutputObjSourceType sourceType;
 };
 
 struct InputObject {
@@ -123,8 +124,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjHistSink(outputObjects const
           };
 
           TDirectory* currentDir = f[route.policy]->GetDirectory(currentDirectory.c_str());
-          TNamed* named = static_cast<TNamed*>(entry.obj);
-          if (named->InheritsFrom(TList::Class())) {
+          if (route.sourceType == OutputObjSourceType::HistogramRegistrySource) {
             TList* outputList = (TList*)entry.obj;
             outputList->SetOwner(false);
 
@@ -185,6 +185,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjHistSink(outputObjects const
       }
 
       auto policy = objh->mPolicy;
+      auto sourceType = objh->mSourceType;
       auto hash = objh->mTaskHash;
 
       obj.obj = tm.ReadObjectAny(obj.kind);
@@ -207,7 +208,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjHistSink(outputObjects const
         return;
       }
       auto nameHash = compile_time_hash(obj.name.c_str());
-      InputObjectRoute key{obj.name, nameHash, taskname, hash, policy};
+      InputObjectRoute key{obj.name, nameHash, taskname, hash, policy, sourceType};
       auto existing = std::find_if(inputObjects->begin(), inputObjects->end(), [&](auto&& x) { return (x.first.uniqueId == nameHash) && (x.first.taskHash == hash); });
       if (existing == inputObjects->end()) {
         inputObjects->push_back(std::make_pair(key, obj));


### PR DESCRIPTION
Added additional enum to recognize properly OutputObj vs HistogramRegistry in the output sink, so as one could use OutputObj<TList>.