### PR TITLE
RecoDecay + PWGHF: Extend MC matching to support multi-stage decays and better particle origin tracking.

### DIFF
--- a/Analysis/Core/include/Analysis/RecoDecay.h
+++ b/Analysis/Core/include/Analysis/RecoDecay.h
@@ -433,10 +433,10 @@ class RecoDecay
   template <typename T, typename U>
   static int getMother(const T& particlesMC, const U& particle, int PDGMother, bool acceptAntiParticles = false, int8_t* sign = nullptr)
   {
-    int8_t sgn = 0;                     // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
-    int indexMother = -1; // index of the final matched mother, if found
+    int8_t sgn = 0;                 // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
+    int indexMother = -1;           // index of the final matched mother, if found
     auto particleMother = particle; // Initialise loop over mothers.
-    int stage = 0; // mother tree level (just for debugging)
+    int stage = 0;                  // mother tree level (just for debugging)
     if (sign) {
       *sign = sgn;
     }
@@ -447,14 +447,13 @@ class RecoDecay
       auto PDGParticleIMother = particleMother.pdgCode(); // PDG code of the mother
       //printf("getMother: ");
       //for (int i = stage; i < 0; i++) // Indent to make the tree look nice.
-        //printf(" ");
+      //  printf(" ");
       //printf("Stage %d: Mother PDG: %d\n", stage, PDGParticleIMother);
       if (PDGParticleIMother == PDGMother) { // exact PDG match
         sgn = 1;
         indexMother = indexMotherTmp;
         break;
-      }
-      else if (acceptAntiParticles && PDGParticleIMother == -PDGMother) { // antiparticle PDG match
+      } else if (acceptAntiParticles && PDGParticleIMother == -PDGMother) { // antiparticle PDG match
         sgn = -1;
         indexMother = indexMotherTmp;
         break;
@@ -493,7 +492,7 @@ class RecoDecay
     }
     // Get the particle.
     auto particle = particlesMC.iteratorAt(index);
-    bool isFinal = false; // Flag to indicate the end of recursion
+    bool isFinal = false;                     // Flag to indicate the end of recursion
     if (depthMax > -1 && stage >= depthMax) { // Maximum depth has been reached (or exceeded).
       isFinal = true;
     }
@@ -524,7 +523,7 @@ class RecoDecay
     if (isFinal) {
       //printf("getDaughters: ");
       //for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
-        //printf(" ");
+      //  printf(" ");
       //printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
       list->push_back(index);
       return;
@@ -532,7 +531,7 @@ class RecoDecay
     // If we are here, we have to follow the daughter tree.
     //printf("getDaughters: ");
     //for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
-      //printf(" ");
+    //  printf(" ");
     //printf("Stage %d: %d (PDG %d) -> %d-%d\n", stage, index, PDGParticle, indexDaughterFirst, indexDaughterLast);
     // Call itself to get daughters of daughters recursively.
     // Get daughters of the first daughter.
@@ -567,10 +566,10 @@ class RecoDecay
   static int getMatchedMCRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
   {
     //Printf("MC Rec: Expected mother PDG: %d", PDGMother);
-    int8_t sgn = 0;                     // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
+    int8_t sgn = 0;                  // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
     int indexMother = -1;            // index of the mother particle
     std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters of the mother of the first provided daughter
-    array<int, N> arrDaughtersIndex; // array of indices of provided daughters
+    array<int, N> arrDaughtersIndex;       // array of indices of provided daughters
     if (sign) {
       *sign = sgn;
     }
@@ -591,7 +590,7 @@ class RecoDecay
         //Printf("MC Rec: Good mother: %d", indexMother);
         auto particleMother = particlesMC.iteratorAt(indexMother);
         int indexDaughterFirst = particleMother.daughter0(); // index of the first direct daughter
-        int indexDaughterLast = particleMother.daughter1(); // index of the last direct daughter
+        int indexDaughterLast = particleMother.daughter1();  // index of the last direct daughter
         // Check the daughter indices.
         if (indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
           //Printf("MC Rec: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
@@ -606,7 +605,7 @@ class RecoDecay
         getDaughters(particlesMC, indexMother, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
         //printf("MC Rec: Mother %d has %d final daughters:", indexMother, arrAllDaughtersIndex.size());
         //for (auto i : arrAllDaughtersIndex) {
-          //printf(" %d", i);
+        //  printf(" %d", i);
         //}
         //printf("\n");
         // Check whether the number of actual final daughters is equal to the number of expected final daughters (i.e. the number of provided prongs).
@@ -678,7 +677,7 @@ class RecoDecay
   static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
   {
     //Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
-    int8_t sgn = 0;                // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
+    int8_t sgn = 0; // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
     if (sign) {
       *sign = sgn;
     }
@@ -687,8 +686,7 @@ class RecoDecay
     //Printf("MC Gen: Candidate PDG: %d", PDGCandidate);
     if (PDGCandidate == PDGParticle) { // exact PDG match
       sgn = 1;
-    }
-    else if (acceptAntiParticles && PDGCandidate == -PDGParticle) { // antiparticle PDG match
+    } else if (acceptAntiParticles && PDGCandidate == -PDGParticle) { // antiparticle PDG match
       sgn = -1;
     }
     if (sgn == 0) {
@@ -698,9 +696,9 @@ class RecoDecay
     // Check the PDG codes of the decay products.
     if (N > 0) {
       //Printf("MC Gen: Checking %d daughters", N);
-      std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters
+      std::vector<int> arrAllDaughtersIndex;          // vector of indices of all daughters
       int indexDaughterFirst = candidate.daughter0(); // index of the first direct daughter
-      int indexDaughterLast = candidate.daughter1(); // index of the last direct daughter
+      int indexDaughterLast = candidate.daughter1();  // index of the last direct daughter
       // Check the daughter indices.
       if (indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
         //Printf("MC Gen: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
@@ -715,7 +713,7 @@ class RecoDecay
       getDaughters(particlesMC, candidate.globalIndex(), &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
       //printf("MC Gen: Mother %d has %d final daughters:", candidate.globalIndex(), arrAllDaughtersIndex.size());
       //for (auto i : arrAllDaughtersIndex) {
-        //printf(" %d", i);
+      //  printf(" %d", i);
       //}
       //printf("\n");
       // Check whether the number of final daughters is equal to the required number.

--- a/Analysis/Core/include/Analysis/RecoDecay.h
+++ b/Analysis/Core/include/Analysis/RecoDecay.h
@@ -445,10 +445,10 @@ class RecoDecay
       particleMother = particlesMC.iteratorAt(indexMotherTmp);
       // Check mother's PDG code.
       auto PDGParticleIMother = particleMother.pdgCode(); // PDG code of the mother
-      printf("getMother: ");
-      for (int i = stage; i < 0; i++) // Indent to make the tree look nice.
-        printf(" ");
-      printf("Stage %d: Mother PDG: %d\n", stage, PDGParticleIMother);
+      //printf("getMother: ");
+      //for (int i = stage; i < 0; i++) // Indent to make the tree look nice.
+        //printf(" ");
+      //printf("Stage %d: Mother PDG: %d\n", stage, PDGParticleIMother);
       if (PDGParticleIMother == PDGMother) { // exact PDG match
         sgn = 1;
         indexMother = indexMotherTmp;
@@ -484,11 +484,11 @@ class RecoDecay
                            int8_t stage = 0)
   {
     if (index <= -1) {
-      Printf("getDaughters: Error: No particle: index %d", index);
+      //Printf("getDaughters: Error: No particle: index %d", index);
       return;
     }
     if (!list) {
-      Printf("getDaughters: Error: No list!");
+      //Printf("getDaughters: Error: No list!");
       return;
     }
     // Get the particle.
@@ -504,7 +504,7 @@ class RecoDecay
     if (!isFinal && indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
       // If the original particle has no daughters, we do nothing and exit.
       if (stage == 0) {
-        Printf("getDaughters: No daughters of %d", index);
+        //Printf("getDaughters: No daughters of %d", index);
         return;
       }
       // If this is not the original particle, we are at the end of this branch and this particle is final.
@@ -522,18 +522,18 @@ class RecoDecay
     }
     // If the particle is labelled as final, we add this particle in the list of final daughters and exit.
     if (isFinal) {
-      printf("getDaughters: ");
-      for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
-        printf(" ");
-      printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
+      //printf("getDaughters: ");
+      //for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
+        //printf(" ");
+      //printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
       list->push_back(index);
       return;
     }
     // If we are here, we have to follow the daughter tree.
-    printf("getDaughters: ");
-    for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
-      printf(" ");
-    printf("Stage %d: %d (PDG %d) -> %d-%d\n", stage, index, PDGParticle, indexDaughterFirst, indexDaughterLast);
+    //printf("getDaughters: ");
+    //for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
+      //printf(" ");
+    //printf("Stage %d: %d (PDG %d) -> %d-%d\n", stage, index, PDGParticle, indexDaughterFirst, indexDaughterLast);
     // Call itself to get daughters of daughters recursively.
     // Get daughters of the first daughter.
     if (indexDaughterFirst > -1) {
@@ -566,7 +566,7 @@ class RecoDecay
   template <std::size_t N, typename T, typename U>
   static int getMatchedMCRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
   {
-    Printf("MC Rec: Expected mother PDG: %d", PDGMother);
+    //Printf("MC Rec: Expected mother PDG: %d", PDGMother);
     int8_t sgn = 0;                     // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
     int indexMother = -1;            // index of the mother particle
     std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters of the mother of the first provided daughter
@@ -585,33 +585,33 @@ class RecoDecay
         indexMother = getMother(particlesMC, particleI, PDGMother, acceptAntiParticles, &sgn);
         // Check whether mother was found.
         if (indexMother <= -1) {
-          Printf("MC Rec: Rejected: bad mother index or PDG");
+          //Printf("MC Rec: Rejected: bad mother index or PDG");
           return -1;
         }
-        Printf("MC Rec: Good mother: %d", indexMother);
+        //Printf("MC Rec: Good mother: %d", indexMother);
         auto particleMother = particlesMC.iteratorAt(indexMother);
         int indexDaughterFirst = particleMother.daughter0(); // index of the first direct daughter
         int indexDaughterLast = particleMother.daughter1(); // index of the last direct daughter
         // Check the daughter indices.
         if (indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
-          Printf("MC Rec: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
+          //Printf("MC Rec: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
           return -1;
         }
         // Check that the number of direct daughters is not larger than the number of expected final daughters.
         if (indexDaughterFirst > -1 && indexDaughterLast > -1 && indexDaughterLast - indexDaughterFirst + 1 > N) {
-          Printf("MC Rec: Rejected: too many direct daughters: %d (expected %d final)", indexDaughterLast - indexDaughterFirst + 1, N);
+          //Printf("MC Rec: Rejected: too many direct daughters: %d (expected %d final)", indexDaughterLast - indexDaughterFirst + 1, N);
           return -1;
         }
         // Get the list of actual final daughters.
         getDaughters(particlesMC, indexMother, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
-        printf("MC Rec: Mother %d has %d final daughters:", indexMother, arrAllDaughtersIndex.size());
-        for (auto i : arrAllDaughtersIndex) {
-          printf(" %d", i);
-        }
-        printf("\n");
+        //printf("MC Rec: Mother %d has %d final daughters:", indexMother, arrAllDaughtersIndex.size());
+        //for (auto i : arrAllDaughtersIndex) {
+          //printf(" %d", i);
+        //}
+        //printf("\n");
         // Check whether the number of actual final daughters is equal to the number of expected final daughters (i.e. the number of provided prongs).
         if (arrAllDaughtersIndex.size() != N) {
-          Printf("MC Rec: Rejected: incorrect number of final daughters: %d (expected %d)", arrAllDaughtersIndex.size(), N);
+          //Printf("MC Rec: Rejected: incorrect number of final daughters: %d (expected %d)", arrAllDaughtersIndex.size(), N);
           return -1;
         }
       }
@@ -626,12 +626,12 @@ class RecoDecay
         }
       }
       if (!isDaughterFound) {
-        Printf("MC Rec: Rejected: bad daughter index: %d not in the list of final daughters", arrDaughtersIndex[iProng]);
+        //Printf("MC Rec: Rejected: bad daughter index: %d not in the list of final daughters", arrDaughtersIndex[iProng]);
         return -1;
       }
       // Check daughter's PDG code.
       auto PDGParticleI = particleI.pdgCode(); // PDG code of the ith daughter
-      Printf("MC Rec: Daughter %d PDG: %d", iProng, PDGParticleI);
+      //Printf("MC Rec: Daughter %d PDG: %d", iProng, PDGParticleI);
       bool isPDGFound = false; // Is the PDG code of this daughter among the remaining expected PDG codes?
       for (auto iProngCp = 0; iProngCp < N; ++iProngCp) {
         if (PDGParticleI == sgn * arrPDGDaughters[iProngCp]) {
@@ -641,11 +641,11 @@ class RecoDecay
         }
       }
       if (!isPDGFound) {
-        Printf("MC Rec: Rejected: bad daughter PDG: %d", PDGParticleI);
+        //Printf("MC Rec: Rejected: bad daughter PDG: %d", PDGParticleI);
         return -1;
       }
     }
-    Printf("MC Rec: Accepted: m: %d", indexMother);
+    //Printf("MC Rec: Accepted: m: %d", indexMother);
     if (sign) {
       *sign = sgn;
     }
@@ -677,14 +677,14 @@ class RecoDecay
   template <std::size_t N, typename T, typename U>
   static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
   {
-    Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
+    //Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
     int8_t sgn = 0;                // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
     if (sign) {
       *sign = sgn;
     }
     // Check the PDG code of the particle.
     auto PDGCandidate = candidate.pdgCode();
-    Printf("MC Gen: Candidate PDG: %d", PDGCandidate);
+    //Printf("MC Gen: Candidate PDG: %d", PDGCandidate);
     if (PDGCandidate == PDGParticle) { // exact PDG match
       sgn = 1;
     }
@@ -692,42 +692,42 @@ class RecoDecay
       sgn = -1;
     }
     if (sgn == 0) {
-      Printf("MC Gen: Rejected: bad particle PDG: %s%d != %d", acceptAntiParticles ? "abs " : "", PDGCandidate, std::abs(PDGParticle));
+      //Printf("MC Gen: Rejected: bad particle PDG: %s%d != %d", acceptAntiParticles ? "abs " : "", PDGCandidate, std::abs(PDGParticle));
       return false;
     }
     // Check the PDG codes of the decay products.
     if (N > 0) {
-      Printf("MC Gen: Checking %d daughters", N);
+      //Printf("MC Gen: Checking %d daughters", N);
       std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters
       int indexDaughterFirst = candidate.daughter0(); // index of the first direct daughter
       int indexDaughterLast = candidate.daughter1(); // index of the last direct daughter
       // Check the daughter indices.
       if (indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
-        Printf("MC Gen: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
+        //Printf("MC Gen: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
         return false;
       }
       // Check that the number of direct daughters is not larger than the number of expected final daughters.
       if (indexDaughterFirst > -1 && indexDaughterLast > -1 && indexDaughterLast - indexDaughterFirst + 1 > N) {
-        Printf("MC Gen: Rejected: too many direct daughters: %d (expected %d final)", indexDaughterLast - indexDaughterFirst + 1, N);
+        //Printf("MC Gen: Rejected: too many direct daughters: %d (expected %d final)", indexDaughterLast - indexDaughterFirst + 1, N);
         return false;
       }
       // Get the list of actual final daughters.
       getDaughters(particlesMC, candidate.globalIndex(), &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
-      printf("MC Gen: Mother %d has %d final daughters:", candidate.globalIndex(), arrAllDaughtersIndex.size());
-      for (auto i : arrAllDaughtersIndex) {
-        printf(" %d", i);
-      }
-      printf("\n");
+      //printf("MC Gen: Mother %d has %d final daughters:", candidate.globalIndex(), arrAllDaughtersIndex.size());
+      //for (auto i : arrAllDaughtersIndex) {
+        //printf(" %d", i);
+      //}
+      //printf("\n");
       // Check whether the number of final daughters is equal to the required number.
       if (arrAllDaughtersIndex.size() != N) {
-        Printf("MC Gen: Rejected: incorrect number of final daughters: %d (expected %d)", arrAllDaughtersIndex.size(), N);
+        //Printf("MC Gen: Rejected: incorrect number of final daughters: %d (expected %d)", arrAllDaughtersIndex.size(), N);
         return false;
       }
       // Check daughters' PDG codes.
       for (auto indexDaughterI : arrAllDaughtersIndex) {
         auto candidateDaughterI = particlesMC.iteratorAt(indexDaughterI); // ith daughter particle
         auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();        // PDG code of the ith daughter
-        Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);
+        //Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);
         bool isPDGFound = false; // Is the PDG code of this daughter among the remaining expected PDG codes?
         for (auto iProngCp = 0; iProngCp < N; ++iProngCp) {
           if (PDGCandidateDaughterI == sgn * arrPDGDaughters[iProngCp]) {
@@ -737,12 +737,12 @@ class RecoDecay
           }
         }
         if (!isPDGFound) {
-          Printf("MC Gen: Rejected: bad daughter PDG: %d", PDGCandidateDaughterI);
+          //Printf("MC Gen: Rejected: bad daughter PDG: %d", PDGCandidateDaughterI);
           return false;
         }
       }
     }
-    Printf("MC Gen: Accepted: m: %d", candidate.globalIndex());
+    //Printf("MC Gen: Accepted: m: %d", candidate.globalIndex());
     if (sign) {
       *sign = sgn;
     }

--- a/Analysis/Core/include/Analysis/RecoDecay.h
+++ b/Analysis/Core/include/Analysis/RecoDecay.h
@@ -558,9 +558,9 @@ class RecoDecay
   /// \param arrPDGDaughters  array of expected daughter PDG codes
   /// \param acceptAntiParticles  switch to accept the antiparticle version of the expected decay
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
-  /// \return true if PDG codes of the mother and daughters are correct, false otherwise
+  /// \return index of the mother particle if the mother and daughters are correct, -1 otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMCMatchedDecayRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
+  static int getMatchedMCRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
   {
     Printf("MC Rec: Expected mother PDG: %d", PDGMother);
     int8_t sgn = 0;                     // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
@@ -579,7 +579,7 @@ class RecoDecay
         // Check whether mother was found.
         if (indexMother <= -1) {
           Printf("MC Rec: Rejected: bad mother index or PDG");
-          return false;
+          return -1;
         }
         Printf("MC Rec: Good mother: %d", indexMother);
         auto particleMother = particlesMC.iteratorAt(indexMother);
@@ -588,12 +588,12 @@ class RecoDecay
         // Check the daughter indices.
         if (indexDaughterFirst <= -1 && indexDaughterLast <= -1) {
           Printf("MC Rec: Rejected: bad daughter index range: %d-%d", indexDaughterFirst, indexDaughterLast);
-          return false;
+          return -1;
         }
         // Check that the number of direct daughters is not larger than the number of expected final daughters.
         if (indexDaughterFirst > -1 && indexDaughterLast > -1 && indexDaughterLast - indexDaughterFirst + 1 > N) {
           Printf("MC Rec: Rejected: too many direct daughters: %d (expected %d final)", indexDaughterLast - indexDaughterFirst + 1, N);
-          return false;
+          return -1;
         }
         // Get the list of actual final daughters.
         getDaughters(particlesMC, indexMother, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
@@ -605,7 +605,7 @@ class RecoDecay
         // Check whether the number of actual final daughters is equal to the number of expected final daughters (i.e. the number of provided prongs).
         if (arrAllDaughtersIndex.size() != N) {
           Printf("MC Rec: Rejected: incorrect number of final daughters: %d (expected %d)", arrAllDaughtersIndex.size(), N);
-          return false;
+          return -1;
         }
       }
       // Check that the daughter is in the list of final daughters.
@@ -620,7 +620,7 @@ class RecoDecay
       }
       if (!isDaughterFound) {
         Printf("MC Rec: Rejected: bad daughter index: %d not in the list of final daughters", arrDaughtersIndex[iProng]);
-        return false;
+        return -1;
       }
       // Check daughter's PDG code.
       auto PDGParticleI = particleI.pdgCode(); // PDG code of the ith daughter
@@ -635,11 +635,11 @@ class RecoDecay
       }
       if (!isPDGFound) {
         Printf("MC Rec: Rejected: bad daughter PDG: %d", PDGParticleI);
-        return false;
+        return -1;
       }
     }
     Printf("MC Rec: Accepted: m: %d", indexMother);
-    return true;
+    return indexMother;
   }
 
   /// Checks whether the MC particle is the expected one.
@@ -649,10 +649,10 @@ class RecoDecay
   /// \param acceptAntiParticles  switch to accept the antiparticle
   /// \return true if PDG code of the particle is correct, false otherwise
   template <typename T, typename U>
-  static bool isMCMatchedDecayGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false)
+  static int isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false)
   {
     array<int, 0> arrPDGDaughters;
-    return isMCMatchedDecayGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles);
+    return isMatchedMCGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles);
   }
 
   /// Check whether the MC particle is the expected one and whether it decayed via the expected decay channel.
@@ -664,7 +664,7 @@ class RecoDecay
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMCMatchedDecayGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
+  static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
   {
     Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
     int sgn = 1;                // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)

--- a/Analysis/Core/include/Analysis/RecoDecay.h
+++ b/Analysis/Core/include/Analysis/RecoDecay.h
@@ -636,7 +636,8 @@ class RecoDecay
   template <typename T, typename U>
   static bool isMCMatchedDecayGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false)
   {
-    return isMCMatchedDecayGen(particlesMC, candidate, PDGParticle, array{0}, acceptAntiParticles);
+    array<int, 0> arrPDGDaughters;
+    return isMCMatchedDecayGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles);
   }
 
   /// Check whether the MC particle is the expected one and whether it decayed via the expected decay channel.
@@ -651,8 +652,6 @@ class RecoDecay
   {
     //Printf("MC Gen.: Expected particle PDG: %d", PDGParticle);
     int sgn = 1;                // 1 if the expected mother is particle, -1 if antiparticle
-    int indexDaughterFirst = 0; // index of the first daughter
-    int indexDaughterLast = 0;  // index of the last daughter
     // Check the PDG code of the particle.
     auto PDGCandidate = candidate.pdgCode();
     //Printf("MC Gen.: Candidate PDG: %d", PDGCandidate);
@@ -665,7 +664,10 @@ class RecoDecay
       }
     }
     // Check the PDG codes of the decay products.
-    if (N > 1) {
+    int indexDaughterFirst = 0; // index of the first daughter
+    int indexDaughterLast = 0;  // index of the last daughter
+    std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters of the mother of the first provided daughter
+    if (N > 0) {
       //Printf("MC Gen.: Checking %d daughters", N);
       // Set the range of expected daughter indices.
       indexDaughterFirst = candidate.daughter0();

--- a/Analysis/Core/include/Analysis/RecoDecay.h
+++ b/Analysis/Core/include/Analysis/RecoDecay.h
@@ -428,7 +428,7 @@ class RecoDecay
   /// \param index  index of the MC particle
   /// \param list  vector where the indices of final-state daughters will be added
   /// \param arrPDGFinal  array of PDG codes of particles to be considered final
-  /// \param depthMax  maximum decay tree level; Daughters at this level (or beyond) will be considered final.
+  /// \param depthMax  maximum decay tree level; Daughters at this level (or beyond) will be considered final. If -1, all levels are considered.
   /// \param stage  decay tree level; If different from 0, the particle itself will be added in the list in case it has no daughters.
   /// \note Final state is defined as particles from arrPDGFinal plus final daughters of any other decay branch.
   template <std::size_t N, typename T>
@@ -436,7 +436,7 @@ class RecoDecay
                            int index,
                            std::vector<int>* list,
                            const array<int, N>& arrPDGFinal,
-                           int depthMax = 1,
+                           int depthMax = -1,
                            int8_t stage = 0)
   {
     if (index == -1) {
@@ -450,7 +450,7 @@ class RecoDecay
     // Get the particle.
     auto particle = particlesMC.iteratorAt(index);
     bool isFinal = false; // Flag to indicate the end of recursion
-    if (stage >= depthMax) { // Maximum depth has been reached (or exceeded).
+    if (depthMax > -1 && stage >= depthMax) { // Maximum depth has been reached (or exceeded).
       isFinal = true;
     }
     // Get the range of daughter indices.
@@ -512,9 +512,10 @@ class RecoDecay
   /// \param PDGMother  expected mother PDG code
   /// \param arrPDGDaughters  array of expected daughter PDG codes
   /// \param acceptAntiParticles  switch to accept the antiparticle version of the expected decay
+  /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \return true if PDG codes of the mother and daughters are correct, false otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMCMatchedDecayRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false)
+  static bool isMCMatchedDecayRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
   {
     Printf("MC Rec.: Expected mother PDG: %d", PDGMother);
     int sgn = 1;                     // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
@@ -581,7 +582,7 @@ class RecoDecay
           return false;
         }
         // Get the list of final daughters.
-        getDaughters(particlesMC, indexMother, &arrAllDaughtersIndex, arrPDGDaughters);
+        getDaughters(particlesMC, indexMother, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
         printf("Mother %d has %d final daughters:", indexMother, arrAllDaughtersIndex.size());
         for (auto i : arrAllDaughtersIndex) {
           printf(" %d", i);
@@ -653,9 +654,10 @@ class RecoDecay
   /// \param PDGParticle  expected particle PDG code
   /// \param arrPDGDaughters  array of expected PDG codes of daughters
   /// \param acceptAntiParticles  switch to accept the antiparticle
+  /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMCMatchedDecayGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false)
+  static bool isMCMatchedDecayGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int depthMax = 1)
   {
     Printf("MC Gen.: Expected particle PDG: %d", PDGParticle);
     int sgn = 1;                // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
@@ -691,7 +693,7 @@ class RecoDecay
         return false;
       }
       // Get the list of final daughters.
-      getDaughters(particlesMC, candidate.globalIndex(), &arrAllDaughtersIndex, arrPDGDaughters);
+      getDaughters(particlesMC, candidate.globalIndex(), &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
       printf("Mother %d has %d final daughters:", candidate.globalIndex(), arrAllDaughtersIndex.size());
       for (auto i : arrAllDaughtersIndex) {
         printf(" %d", i);

--- a/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
@@ -137,6 +137,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, [](float px0, float py0, 
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
+enum DecayType { D0ToPiK = 1 };
+
 // functions for specific particles
 
 // D0(bar) → π± K∓
@@ -261,6 +263,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1
 // - bit 1: Λc± → p± K∓ π±
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
+
+enum DecayType { DPlusToPiKPi = 1, LcToPKPi };
 
 // functions for specific particles
 

--- a/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
@@ -134,8 +134,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1
 DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m, double mTot, int iProng) { return RecoDecay::CosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng); });
 // MC matching result:
 // - bit 0: D0(bar) → π± K∓
-DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, uint8_t); // reconstruction level
-DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, uint8_t); // generator level
+DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
+DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
 // functions for specific particles
 
@@ -258,9 +258,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(M, m, [](float px0, float py0, float pz0, float px1, 
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const array<double, 3>& m) { return RecoDecay::M2(array{array{px0, py0, pz0}, array{px1, py1, pz1}, array{px2, py2, pz2}}, m); });
 // MC matching result:
 // - bit 0: D± → π± K∓ π±
-// - bit 1: Lc± → p± K∓ π±
-DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, uint8_t); // reconstruction level
-DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, uint8_t); // generator level
+// - bit 1: Λc± → p± K∓ π±
+DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
+DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
 // functions for specific particles
 
@@ -290,7 +290,7 @@ auto InvMassDPlus(const T& candidate)
   return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
-// Lc± → p± K∓ π±
+// Λc± → p± K∓ π±
 
 template <typename T>
 auto CtLc(const T& candidate)

--- a/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/Analysis/HFSecondaryVertex.h
@@ -133,10 +133,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(M, m, [](float px0, float py0, float pz0, float px1, 
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) { return RecoDecay::M2(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m, double mTot, int iProng) { return RecoDecay::CosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng); });
 // MC matching result:
-// - bit 0: D0(bar) → π± K∓
+// - ±D0ToPiK: D0(bar) → π± K∓
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
+// mapping of decay types
 enum DecayType { D0ToPiK = 1 };
 
 // functions for specific particles
@@ -259,12 +260,14 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, float, 1.f * aod::hf_cand::pzProng0 + 1.f 
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const array<double, 3>& m) { return RecoDecay::M(array{array{px0, py0, pz0}, array{px1, py1, pz1}, array{px2, py2, pz2}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const array<double, 3>& m) { return RecoDecay::M2(array{array{px0, py0, pz0}, array{px1, py1, pz1}, array{px2, py2, pz2}}, m); });
 // MC matching result:
-// - bit 0: D± → π± K∓ π±
-// - bit 1: Λc± → p± K∓ π±
+// - ±DPlusToPiKPi: D± → π± K∓ π±
+// - ±LcToPKPi: Λc± → p± K∓ π±
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
-enum DecayType { DPlusToPiKPi = 1, LcToPKPi };
+// mapping of decay types
+enum DecayType { DPlusToPiKPi = 1,
+                 LcToPKPi };
 
 // functions for specific particles
 

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -146,7 +146,9 @@ struct HFCandidateCreator2ProngMC {
   {
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
+      Printf("New rec. candidate");
       // D0(bar) → π± K∓
+      Printf("Checking D0(bar) → π± K∓");
       auto isMatchedRecD0 = RecoDecay::isMCMatchedDecayRec(
         particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
         421, array{+kPiPlus, -kKPlus}, true);
@@ -155,7 +157,9 @@ struct HFCandidateCreator2ProngMC {
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
+      Printf("New gen. candidate");
       // D0(bar) → π± K∓
+      Printf("Checking D0(bar) → π± K∓");
       auto isMatchedGenD0 = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true);
       rowMCMatchGen(uint8_t(isMatchedGenD0));
     }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -149,10 +149,10 @@ struct HFCandidateCreator2ProngMC {
       Printf("New rec. candidate");
       // D0(bar) → π± K∓
       Printf("Checking D0(bar) → π± K∓");
-      auto isMatchedRecD0 = RecoDecay::isMCMatchedDecayRec(
+      auto indexRecD0 = RecoDecay::getMatchedMCRec(
         particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
         421, array{+kPiPlus, -kKPlus}, true);
-      rowMCMatchRec(uint8_t(isMatchedRecD0));
+      rowMCMatchRec(uint8_t(indexRecD0 > -1));
     }
 
     // Match generated particles.
@@ -160,7 +160,7 @@ struct HFCandidateCreator2ProngMC {
       Printf("New gen. candidate");
       // D0(bar) → π± K∓
       Printf("Checking D0(bar) → π± K∓");
-      auto isMatchedGenD0 = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true);
+      auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true);
       rowMCMatchGen(uint8_t(isMatchedGenD0));
     }
   }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -144,24 +144,35 @@ struct HFCandidateCreator2ProngMC {
                aod::BigTracksMC const& tracks,
                aod::McParticles const& particlesMC)
   {
+    int8_t sign = 0;
+    int8_t result = 0;
+
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       Printf("New rec. candidate");
+      result = 0;
+
       // D0(bar) → π± K∓
       Printf("Checking D0(bar) → π± K∓");
       auto indexRecD0 = RecoDecay::getMatchedMCRec(
         particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
-        421, array{+kPiPlus, -kKPlus}, true);
-      rowMCMatchRec(uint8_t(indexRecD0 > -1));
+        421, array{+kPiPlus, -kKPlus}, true, &sign);
+      result += sign * 1 * int8_t(indexRecD0 > -1);
+
+      rowMCMatchRec(result);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       Printf("New gen. candidate");
+      result = 0;
+
       // D0(bar) → π± K∓
       Printf("Checking D0(bar) → π± K∓");
-      auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true);
-      rowMCMatchGen(uint8_t(isMatchedGenD0));
+      auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign);
+      result += sign * 1 * int8_t(isMatchedGenD0);
+
+      rowMCMatchGen(result);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -150,11 +150,11 @@ struct HFCandidateCreator2ProngMC {
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
-      Printf("New rec. candidate");
+      //Printf("New rec. candidate");
       result = 0;
 
       // D0(bar) → π± K∓
-      Printf("Checking D0(bar) → π± K∓");
+      //Printf("Checking D0(bar) → π± K∓");
       auto indexRecD0 = RecoDecay::getMatchedMCRec(
         particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
         421, array{+kPiPlus, -kKPlus}, true, &sign);
@@ -165,11 +165,11 @@ struct HFCandidateCreator2ProngMC {
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
-      Printf("New gen. candidate");
+      //Printf("New gen. candidate");
       result = 0;
 
       // D0(bar) → π± K∓
-      Printf("Checking D0(bar) → π± K∓");
+      //Printf("Checking D0(bar) → π± K∓");
       auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign);
       result += sign * D0ToPiK * int8_t(isMatchedGenD0);
 

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -22,6 +22,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::aod::hf_cand_prong2;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
@@ -157,7 +158,7 @@ struct HFCandidateCreator2ProngMC {
       auto indexRecD0 = RecoDecay::getMatchedMCRec(
         particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
         421, array{+kPiPlus, -kKPlus}, true, &sign);
-      result += sign * 1 * int8_t(indexRecD0 > -1);
+      result += sign * D0ToPiK * int8_t(indexRecD0 > -1);
 
       rowMCMatchRec(result);
     }
@@ -170,7 +171,7 @@ struct HFCandidateCreator2ProngMC {
       // D0(bar) → π± K∓
       Printf("Checking D0(bar) → π± K∓");
       auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign);
-      result += sign * 1 * int8_t(isMatchedGenD0);
+      result += sign * D0ToPiK * int8_t(isMatchedGenD0);
 
       rowMCMatchGen(result);
     }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -150,19 +150,25 @@ struct HFCandidateCreator3ProngMC {
   {
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
+      Printf("New rec. candidate");
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
       // D± → π± K∓ π±
+      Printf("Checking D± → π± K∓ π±");
       auto isMatchedRecDPlus = RecoDecay::isMCMatchedDecayRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
       // Lc± → p± K∓ π±
+      Printf("Checking Lc± → p± K∓ π±");
       auto isMatchedRecLc = RecoDecay::isMCMatchedDecayRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
       rowMCMatchRec(uint8_t(isMatchedRecDPlus + 2 * isMatchedRecLc));
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
+      Printf("New gen. candidate");
       // D± → π± K∓ π±
+      Printf("Checking D± → π± K∓ π±");
       auto isMatchedGenDPlus = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
       // Lc± → p± K∓ π±
+      Printf("Checking Lc± → p± K∓ π±");
       auto isMatchedGenLc = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
       rowMCMatchGen(uint8_t(isMatchedGenDPlus + 2 * isMatchedGenLc));
     }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -154,17 +154,17 @@ struct HFCandidateCreator3ProngMC {
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
-      Printf("New rec. candidate");
+      //Printf("New rec. candidate");
       result = 0;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
 
       // D± → π± K∓ π±
-      Printf("Checking D± → π± K∓ π±");
+      //Printf("Checking D± → π± K∓ π±");
       auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
       result += sign * DPlusToPiKPi * int8_t(indexRecDPlus > -1);
 
       // Λc± → p± K∓ π±
-      Printf("Checking Λc± → p± K∓ π±");
+      //Printf("Checking Λc± → p± K∓ π±");
       auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
       result += sign * LcToPKPi * int8_t(indexRecLc > -1);
 
@@ -173,16 +173,16 @@ struct HFCandidateCreator3ProngMC {
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
-      Printf("New gen. candidate");
+      //Printf("New gen. candidate");
       result = 0;
 
       // D± → π± K∓ π±
-      Printf("Checking D± → π± K∓ π±");
+      //Printf("Checking D± → π± K∓ π±");
       auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
       result += sign * DPlusToPiKPi * int8_t(isMatchedGenDPlus);
 
       // Λc± → p± K∓ π±
-      Printf("Checking Λc± → p± K∓ π±");
+      //Printf("Checking Λc± → p± K∓ π±");
       auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
       result += sign * LcToPKPi * int8_t(isMatchedGenLc);
 

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -22,6 +22,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::aod::hf_cand_prong3;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
@@ -160,12 +161,12 @@ struct HFCandidateCreator3ProngMC {
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
       auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * 1 * int8_t(indexRecDPlus > -1);
+      result += sign * DPlusToPiKPi * int8_t(indexRecDPlus > -1);
 
       // Λc± → p± K∓ π±
       Printf("Checking Λc± → p± K∓ π±");
       auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * 2 * int8_t(indexRecLc > -1);
+      result += sign * LcToPKPi * int8_t(indexRecLc > -1);
 
       rowMCMatchRec(result);
     }
@@ -178,12 +179,12 @@ struct HFCandidateCreator3ProngMC {
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
       auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * 1 * int8_t(isMatchedGenDPlus);
+      result += sign * DPlusToPiKPi * int8_t(isMatchedGenDPlus);
 
       // Λc± → p± K∓ π±
       Printf("Checking Λc± → p± K∓ π±");
       auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * 2 * int8_t(isMatchedGenLc);
+      result += sign * LcToPKPi * int8_t(isMatchedGenLc);
 
       rowMCMatchGen(result);
     }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -154,11 +154,11 @@ struct HFCandidateCreator3ProngMC {
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
-      auto isMatchedRecDPlus = RecoDecay::isMCMatchedDecayRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
-      // Lc± → p± K∓ π±
-      Printf("Checking Lc± → p± K∓ π±");
-      auto isMatchedRecLc = RecoDecay::isMCMatchedDecayRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
-      rowMCMatchRec(uint8_t(isMatchedRecDPlus + 2 * isMatchedRecLc));
+      auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
+      // Λc± → p± K∓ π±
+      Printf("Checking Λc± → p± K∓ π±");
+      auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
+      rowMCMatchRec(uint8_t((indexRecDPlus > -1) + 2 * (indexRecLc > -1)));
     }
 
     // Match generated particles.
@@ -166,10 +166,10 @@ struct HFCandidateCreator3ProngMC {
       Printf("New gen. candidate");
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
-      auto isMatchedGenDPlus = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
-      // Lc± → p± K∓ π±
-      Printf("Checking Lc± → p± K∓ π±");
-      auto isMatchedGenLc = RecoDecay::isMCMatchedDecayGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
+      auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
+      // Λc± → p± K∓ π±
+      Printf("Checking Λc± → p± K∓ π±");
+      auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
       rowMCMatchGen(uint8_t(isMatchedGenDPlus + 2 * isMatchedGenLc));
     }
   }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -148,29 +148,44 @@ struct HFCandidateCreator3ProngMC {
                aod::BigTracksMC const& tracks,
                aod::McParticles const& particlesMC)
   {
+    int8_t sign = 0;
+    int8_t result = 0;
+
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       Printf("New rec. candidate");
+      result = 0;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
+
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
-      auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
+      auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
+      result += sign * 1 * int8_t(indexRecDPlus > -1);
+
       // Λc± → p± K∓ π±
       Printf("Checking Λc± → p± K∓ π±");
-      auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
-      rowMCMatchRec(uint8_t((indexRecDPlus > -1) + 2 * (indexRecLc > -1)));
+      auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
+      result += sign * 2 * int8_t(indexRecLc > -1);
+
+      rowMCMatchRec(result);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       Printf("New gen. candidate");
+      result = 0;
+
       // D± → π± K∓ π±
       Printf("Checking D± → π± K∓ π±");
-      auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true);
+      auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
+      result += sign * 1 * int8_t(isMatchedGenDPlus);
+
       // Λc± → p± K∓ π±
       Printf("Checking Λc± → p± K∓ π±");
-      auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true);
-      rowMCMatchGen(uint8_t(isMatchedGenDPlus + 2 * isMatchedGenLc));
+      auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
+      result += sign * 2 * int8_t(isMatchedGenLc);
+
+      rowMCMatchGen(result);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/taskD0.cxx
+++ b/Analysis/Tasks/PWGHF/taskD0.cxx
@@ -124,7 +124,7 @@ struct TaskD0MC {
         //Printf("MC Rec.: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (candidate.flagMCMatchRec() == 1) {
+      if (std::abs(candidate.flagMCMatchRec()) == D0ToPiK) {
         registry.get<TH1>("hPtRecSig")->Fill(candidate.pt());
         registry.get<TH1>("hCPARecSig")->Fill(candidate.cpa());
         registry.get<TH1>("hEtaRecSig")->Fill(candidate.eta());
@@ -141,7 +141,7 @@ struct TaskD0MC {
         //Printf("MC Gen.: eta rejection: %g", particle.eta());
         continue;
       }
-      if (particle.flagMCMatchGen() == 1) {
+      if (std::abs(particle.flagMCMatchGen()) == D0ToPiK) {
         registry.get<TH1>("hPtGen")->Fill(particle.pt());
         registry.get<TH1>("hEtaGen")->Fill(particle.eta());
       }


### PR DESCRIPTION
These changes add functionalities to allow for MC matching of multi-stage decays, tracking of particle origin, particle–antiparticle distinction at the analysis level, and retrieving of properties of the matched MC particle.
* Add iterative function `getMother()`.
* Add recursive function `getDaughters()`.
  * Allow to define final state using a list of expected PDG codes and maximum tree depth.
* Support matching of decays with any intermediate states and arbitrary number of stages.
* Support single-daughter conversions (e.g. K0 → K0S).
* Simplify the matching strategy using the lists of actual vs. expected final daughters.
* Return index of the matched mother particle in reconstruction level matching.
* Support and return the antiparticle indicator at all levels.
* Store antiparticle information in the table of HF candidates.
* Store information about the matched decay in the table of HF candidates using `enum` type values.