### PR TITLE
Use InputRecordWalker to scan all EMC links

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -13,6 +13,7 @@
 
 #include "CommonDataFormat/InteractionRecord.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/InputRecordWalker.h"
 #include "Framework/ControlService.h"
 #include "Framework/WorkflowSpec.h"
 #include "DataFormatsEMCAL/EMCALBlockHeader.h"
@@ -68,8 +69,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   std::map<o2::InteractionRecord, std::shared_ptr<std::vector<o2::emcal::Cell>>> cellBuffer; // Internal cell buffer
 
   int firstEntry = 0;
-  for (const auto& rawData : ctx.inputs()) {
-
+  for (const auto& rawData : framework::InputRecordWalker(ctx.inputs())) {
     //o2::emcal::RawReaderMemory<o2::header::RAWDataHeaderV4> rawreader(gsl::span(rawData.payload, o2::framework::DataRefUtils::getPayloadSize(rawData)));
 
     o2::emcal::RawReaderMemory rawreader(o2::framework::DataRefUtils::as<const char>(rawData));


### PR DESCRIPTION
@mfasDa , with your current loop over ``ctx.inputs()`` you will visit just the 1st shipped link data (i.e. the 1st part of the raw data multipart). This PR fixes it by looping over all part. Once you fix the problem https://github.com/AliceO2Group/AliceO2/pull/4909#issuecomment-735405247, could you check that you see all links with both simulated and raw data?

@peressounko this was also the origin of the problem you've reported, could you try with the same lines as in this PR?