### PR TITLE
Revert "Exclude testCcdbApi_alien.cxx (#4941)"

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -51,11 +51,11 @@ o2_add_test(CcdbApi
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
 
-#o2_add_test(CcdbApi-Alien
-#		SOURCES test/testCcdbApi_alien.cxx
-#		COMPONENT_NAME ccdb
-#		PUBLIC_LINK_LIBRARIES O2::CCDB
-#		LABELS ccdb)
+o2_add_test(CcdbApi-Alien
+		SOURCES test/testCcdbApi_alien.cxx
+		COMPONENT_NAME ccdb
+		PUBLIC_LINK_LIBRARIES O2::CCDB
+		LABELS ccdb)
 
 o2_add_test(BasicCCDBManager
             SOURCES test/testBasicCCDBManager.cxx


### PR DESCRIPTION
This reverts commit 71f34092d1fc30cf831ca5986fc203f3840b447a.

The CCDB is back and this test should not fail anymore.