### PR TITLE
Fix find_package for MS GSL

### DIFF
--- a/dependencies/Findms_gsl.cmake
+++ b/dependencies/Findms_gsl.cmake
@@ -9,7 +9,7 @@
 # submit itself to any jurisdiction.
 
 find_path(MS_GSL_INCLUDE_DIR gsl/gsl PATH_SUFFIXES ms_gsl/include include
-        PATHS $ENV{MS_GSL_ROOT})
+        HINTS $ENV{MS_GSL_ROOT})
 
 if(NOT MS_GSL_INCLUDE_DIR)
   set(MS_GSL_FOUND FALSE)


### PR DESCRIPTION
Pass `$MS_GSL_ROOT` as `HINTS` in order to take precedence over system  paths, using `PATHS` it is searched after the system paths resulting in a system installation being picked up despite an aliBuild installation of it.