### PR TITLE
DPL Analysis: disable TTreeCache

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -283,6 +283,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
             throw std::runtime_error("Processing is stopped!");
           }
         }
+        tr->SetCacheSize(0);
         if (first) {
           timeFrameNumber = didir->getTimeFrameNumber(dh, fcnt, ntf);
           auto o = Output(TFNumberHeader);


### PR DESCRIPTION
Seems to save around 30MB of RSS with the same number of reads.