### PR TITLE
Different workaround for false codechecker error

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -87,7 +87,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     InOutMemory();
     ~InOutMemory();
     InOutMemory(InOutMemory&&);
-    InOutMemory& operator=(InOutMemory&&) = default;
+    InOutMemory& operator=(InOutMemory&&);
 
     std::unique_ptr<unsigned long long int[]> tpcZSpages;
     std::unique_ptr<char[]> tpcZSpagesChar; // Same as above, but as char (needed for reading dumps, but deprecated, since alignment can be wrong)

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -65,7 +65,7 @@ static constexpr char DUMP_HEADER[DUMP_HEADER_SIZE + 1] = "CAv1";
 GPUChainTracking::InOutMemory::InOutMemory() = default;
 GPUChainTracking::InOutMemory::~InOutMemory() = default;
 GPUChainTracking::InOutMemory::InOutMemory(GPUChainTracking::InOutMemory&&) = default;
-GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default;
+GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default; // NOLINT: False positive in clang-tidy
 
 void GPUChainTracking::DumpData(const char* filename)
 {

--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -65,6 +65,7 @@ static constexpr char DUMP_HEADER[DUMP_HEADER_SIZE + 1] = "CAv1";
 GPUChainTracking::InOutMemory::InOutMemory() = default;
 GPUChainTracking::InOutMemory::~InOutMemory() = default;
 GPUChainTracking::InOutMemory::InOutMemory(GPUChainTracking::InOutMemory&&) = default;
+GPUChainTracking::InOutMemory& GPUChainTracking::InOutMemory::operator=(GPUChainTracking::InOutMemory&&) = default;
 
 void GPUChainTracking::DumpData(const char* filename)
 {


### PR DESCRIPTION
@anerokhi : Your workaround turned out to break GPU compilation in some cases, since some types might be only forward-declared in the header, so the implementation of the constructors etc. must be moved to the CXX. I have thus disabled the linter on this line.