### PR TITLE
enable track refinement with different cluster resolution

### DIFF
--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
@@ -46,7 +46,7 @@ class TrackExtrap
   static bool isFieldON() { return sFieldON; }
 
   /// Switch to Runge-Kutta extrapolation v2
-  static void useExtrapV2() { sExtrapV2 = true; }
+  static void useExtrapV2(bool extrapV2 = true) { sExtrapV2 = extrapV2; }
 
   static double getImpactParamFromBendingMomentum(double bendingMomentum);
   static double getBendingMomentumFromImpactParam(double impactParam);

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
@@ -52,6 +52,9 @@ class TrackFinder
   /// set the flag to try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
   void findMoreTrackCandidates(bool moreCandidates) { mMoreCandidates = moreCandidates; }
 
+  /// set the flag to refine the tracks in the end using cluster resolution
+  void refineTracks(bool refine) { mRefineTracks = refine; }
+
   /// set the debug level defining the verbosity
   void debug(int debugLevel) { mDebugLevel = debugLevel; }
 
@@ -79,6 +82,8 @@ class TrackFinder
   void improveTracks();
 
   void removeConnectedTracks(int stMin, int stMax);
+
+  void refineTracks();
 
   void finalize();
 
@@ -113,6 +118,15 @@ class TrackFinder
   /// return the chamber to which this plane belong to
   int getChamberId(int plane) { return (plane < 8) ? plane / 2 : 4 + (plane - 8) / 4; }
 
+  /// return the chamber resolution square in x direction
+  static constexpr double chamberResolutionX2() { return SChamberResolutionX * SChamberResolutionX; }
+  /// return the chamber resolution square in y direction
+  static constexpr double chamberResolutionY2() { return SChamberResolutionY * SChamberResolutionY; }
+
+  /// chamber resolution in x direction used as cluster resolution during tracking
+  static constexpr double SChamberResolutionX = 0.2;
+  /// chamber resolution in y direction used as cluster resolution during tracking
+  static constexpr double SChamberResolutionY = 0.2;
   /// sigma cut to select clusters (local chi2) and tracks (global chi2) during tracking
   static constexpr double SSigmaCutForTracking = 5.;
   /// sigma cut to select clusters (local chi2) and tracks (global chi2) during improvement
@@ -125,8 +139,8 @@ class TrackFinder
   static constexpr double SBendingVertexDispersion = 70.;    ///< vertex dispersion (cm) in bending plane
   static constexpr double SMinBendingMomentum = 0.8;         ///< minimum value (GeV/c) of momentum in bending plane
   /// z position of the chambers
-  static constexpr float SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
-                                                 -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
+  static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
+                                                  -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
@@ -142,7 +156,8 @@ class TrackFinder
 
   double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
 
-  bool mMoreCandidates = false; ///< try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
+  bool mMoreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
+  bool mRefineTracks = true;    ///< refine the tracks in the end using cluster resolution
 
   int mDebugLevel = 0; ///< debug level defining the verbosity
 
@@ -155,6 +170,7 @@ class TrackFinder
   std::chrono::duration<double> mTimeFollowTracks{};       ///< timer
   std::chrono::duration<double> mTimeImproveTracks{};      ///< timer
   std::chrono::duration<double> mTimeCleanTracks{};        ///< timer
+  std::chrono::duration<double> mTimeRefineTracks{};       ///< timer
 };
 
 } // namespace mch

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
@@ -45,6 +45,9 @@ class TrackFinderOriginal
   /// set the flag to try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
   void findMoreTrackCandidates(bool moreCandidates) { mMoreCandidates = moreCandidates; }
 
+  /// set the flag to refine the tracks in the end using cluster resolution
+  void refineTracks(bool refine) { mRefineTracks = refine; }
+
   /// set the debug level defining the verbosity
   void debug(int debugLevel) { mDebugLevel = debugLevel; }
 
@@ -70,6 +73,7 @@ class TrackFinderOriginal
   std::list<Track>::iterator recoverTrack(std::list<Track>::iterator& itTrack, int nextStation);
   bool completeTracks();
   void improveTracks();
+  void refineTracks();
   void finalize();
   uint8_t requestedStationMask() const;
   int getTrackIndex(const std::list<Track>::iterator& itCurrentTrack) const;
@@ -78,24 +82,33 @@ class TrackFinderOriginal
   template <class... Args>
   void print(Args... args) const;
 
+  /// return the chamber resolution square in x direction
+  static constexpr double chamberResolutionX2() { return SChamberResolutionX * SChamberResolutionX; }
+  /// return the chamber resolution square in y direction
+  static constexpr double chamberResolutionY2() { return SChamberResolutionY * SChamberResolutionY; }
+
+  /// chamber resolution in x direction used as cluster resolution during tracking
+  static constexpr double SChamberResolutionX = 0.2;
+  /// chamber resolution in y direction used as cluster resolution during tracking
+  static constexpr double SChamberResolutionY = 0.2;
   /// sigma cut to select clusters (local chi2) and tracks (global chi2) during tracking
   static constexpr double SSigmaCutForTracking = 5.;
   /// sigma cut to select clusters (local chi2) and tracks (global chi2) during improvement
   static constexpr double SSigmaCutForImprovement = 4.;
-  ///< maximum distance to the track to search for compatible cluster(s) in non bending direction
+  /// maximum distance to the track to search for compatible cluster(s) in non bending direction
   static constexpr double SMaxNonBendingDistanceToTrack = 1.;
-  ///< maximum distance to the track to search for compatible cluster(s) in bending direction
+  /// maximum distance to the track to search for compatible cluster(s) in bending direction
   static constexpr double SMaxBendingDistanceToTrack = 1.;
   static constexpr double SNonBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in non bending plane
   static constexpr double SBendingVertexDispersion = 70.;    ///< vertex dispersion (cm) in bending plane
   static constexpr double SMinBendingMomentum = 0.8;         ///< minimum value (GeV/c) of momentum in bending plane
   /// z position of the chambers
-  static constexpr float SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
-                                                 -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
+  static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
+                                                  -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
-  ///< if true, at least one cluster in the station is requested to validate the track
+  /// if true, at least one cluster in the station is requested to validate the track
   static constexpr bool SRequestStation[5] = {true, true, true, true, true};
 
   TrackFitter mTrackFitter{}; /// track fitter
@@ -105,7 +118,8 @@ class TrackFinderOriginal
 
   double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
 
-  bool mMoreCandidates = false; ///< try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
+  bool mMoreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
+  bool mRefineTracks = true;    ///< refine the tracks in the end using cluster resolution
 
   int mDebugLevel = 0; ///< debug level defining the verbosity
 
@@ -119,6 +133,7 @@ class TrackFinderOriginal
   std::chrono::duration<double> mTimeCompleteTracks{};     ///< timer
   std::chrono::duration<double> mTimeImproveTracks{};      ///< timer
   std::chrono::duration<double> mTimeCleanTracks{};        ///< timer
+  std::chrono::duration<double> mTimeRefineTracks{};       ///< timer
 };
 
 } // namespace mch

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
@@ -44,6 +44,13 @@ class TrackFitter
   /// Return the smoother enable/disable flag
   bool isSmootherEnabled() { return mSmooth; }
 
+  /// Use the own resolution of each cluster during the fit (default)
+  void useClusterResolution() { mUseChamberResolution = false; }
+  /// Use the chamber resolution instead of cluster resolution during the fit
+  void useChamberResolution() { mUseChamberResolution = true; }
+  // Set the chamber resolution in x and y directions
+  void setChamberResolution(double ex, double ey);
+
   void fit(Track& track, bool smooth = true, bool finalize = true,
            std::list<TrackParam>::reverse_iterator* itStartingParam = nullptr);
 
@@ -61,14 +68,26 @@ class TrackFitter
   static constexpr double SMaxChi2 = 2.e10;               ///< maximum chi2 above which the track can be considered as abnormal
   static constexpr double SBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in bending plane
   /// z position of the chambers
-  static constexpr float SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
-                                                 -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
+  static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
+                                                  -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
 
   bool mSmooth = false; ///< switch ON/OFF the smoother
+
+  bool mUseChamberResolution = false; ///< switch between using chamber or cluster resolution
+  double mChamberResolutionX2 = 0.04; ///< chamber resolution square in x direction
+  double mChamberResolutionY2 = 0.04; ///< chamber resolution square in y direction
 };
+
+//_________________________________________________________________________________________________
+inline void TrackFitter::setChamberResolution(double ex, double ey)
+{
+  /// Set the chamber resolution in x and y directions
+  mChamberResolutionX2 = ex * ex;
+  mChamberResolutionY2 = ey * ey;
+}
 
 } // namespace mch
 } // namespace o2

--- a/Detectors/MUON/MCH/Tracking/src/TrackFitter.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFitter.cxx
@@ -30,7 +30,7 @@ namespace mch
 
 using namespace std;
 
-constexpr float TrackFitter::SDefaultChamberZ[10];
+constexpr double TrackFitter::SDefaultChamberZ[10];
 constexpr double TrackFitter::SChamberThicknessInX0[10];
 
 //_________________________________________________________________________________________________
@@ -117,14 +117,26 @@ void TrackFitter::initTrack(const Cluster& cl1, const Cluster& cl2, TrackParam& 
   // compute the track parameter covariances at the last cluster (as if the other clusters did not exist)
   TMatrixD lastParamCov(5, 5);
   lastParamCov.Zero();
+  double cl1Ey2(0.);
+  if (mUseChamberResolution) {
+    // Non bending plane
+    lastParamCov(0, 0) = mChamberResolutionX2;
+    lastParamCov(1, 1) = (1000. * mChamberResolutionX2 + lastParamCov(0, 0)) / dZ / dZ;
+    // Bending plane
+    lastParamCov(2, 2) = mChamberResolutionY2;
+    cl1Ey2 = mChamberResolutionY2;
+  } else {
+    // Non bending plane
+    lastParamCov(0, 0) = cl2.getEx2();
+    lastParamCov(1, 1) = (1000. * cl1.getEx2() + lastParamCov(0, 0)) / dZ / dZ;
+    // Bending plane
+    lastParamCov(2, 2) = cl2.getEy2();
+    cl1Ey2 = cl1.getEy2();
+  }
   // Non bending plane
-  lastParamCov(0, 0) = cl2.getEx2();
   lastParamCov(0, 1) = -lastParamCov(0, 0) / dZ;
   lastParamCov(1, 0) = lastParamCov(0, 1);
-  lastParamCov(1, 1) = (1000. * cl1.getEx2() + lastParamCov(0, 0)) / dZ / dZ;
   // Bending plane
-  double cl1Ey2 = cl1.getEy2();
-  lastParamCov(2, 2) = cl2.getEy2();
   lastParamCov(2, 3) = -lastParamCov(2, 2) / dZ;
   lastParamCov(3, 2) = lastParamCov(2, 3);
   lastParamCov(3, 3) = (1000. * cl1Ey2 + lastParamCov(2, 2)) / dZ / dZ;
@@ -267,8 +279,13 @@ void TrackFitter::runKalmanFilter(TrackParam& trackParam)
   // compute the new cluster weight (U)
   TMatrixD clusterWeight(5, 5);
   clusterWeight.Zero();
-  clusterWeight(0, 0) = 1. / cluster->getEx2();
-  clusterWeight(2, 2) = 1. / cluster->getEy2();
+  if (mUseChamberResolution) {
+    clusterWeight(0, 0) = 1. / mChamberResolutionX2;
+    clusterWeight(2, 2) = 1. / mChamberResolutionY2;
+  } else {
+    clusterWeight(0, 0) = 1. / cluster->getEx2();
+    clusterWeight(2, 2) = 1. / cluster->getEy2();
+  }
 
   // compute the new parameters covariance matrix ((W+U)^-1)
   TMatrixD newParamCov(paramWeight, TMatrixD::kPlus, clusterWeight);
@@ -345,10 +362,15 @@ void TrackFitter::runSmoother(const TrackParam& previousParam, TrackParam& param
 
   // compute weight of smoothed residual: W(k n) = (clusterCov - C(k n))^-1
   TMatrixD smoothResidualWeight(2, 2);
-  smoothResidualWeight(0, 0) = cluster->getEx2() - smoothCovariances(0, 0);
+  if (mUseChamberResolution) {
+    smoothResidualWeight(0, 0) = mChamberResolutionX2 - smoothCovariances(0, 0);
+    smoothResidualWeight(1, 1) = mChamberResolutionY2 - smoothCovariances(2, 2);
+  } else {
+    smoothResidualWeight(0, 0) = cluster->getEx2() - smoothCovariances(0, 0);
+    smoothResidualWeight(1, 1) = cluster->getEy2() - smoothCovariances(2, 2);
+  }
   smoothResidualWeight(0, 1) = -smoothCovariances(0, 2);
   smoothResidualWeight(1, 0) = -smoothCovariances(2, 0);
-  smoothResidualWeight(1, 1) = cluster->getEy2() - smoothCovariances(2, 2);
   if (smoothResidualWeight.Determinant() != 0) {
     smoothResidualWeight.Invert();
   } else {

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -119,7 +119,7 @@ where `tracks.in` is a binary file with the same format as the one written by th
 
 Send the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in two separate messages with the data description "TRACKS" and "TRACKCLUSTERS", respectively.
 
-Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN" and "TRACKCLUSTERSIN", respectively, as expected by the workflow `o2-mch-tracks-to-tracks-workflow` described below.
+Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN" and "TRACKCLUSTERSIN", respectively, as expected by the workflow [o2-mch-tracks-to-tracks-workflow](#track-fitter).
 
 ### Vertex sampler
 
@@ -146,12 +146,12 @@ If no binary file is provided, the vertex is always set to (0,0,0).
 
 `o2-mch-tracks-sink-workflow --outfile "tracks.out"`
 
-Take as input the list of tracks at vertex (`TrackAtVtxStruct` as described above), the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "TRACKSATVERTEX", "TRACKS" and "TRACKCLUSTERS", respectively, and write them in the binary file `tracks.out` with the following format:
+Take as input the list of tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)), the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "TRACKSATVERTEX", "TRACKS" and "TRACKCLUSTERS", respectively, and write them in the binary file `tracks.out` with the following format:
 
 * number of tracks at vertex (int)
 * number of MCH tracks (int)
 * number of associated clusters (int)
-* list of tracks at vertex (`TrackAtVtxStruct` as described above)
+* list of tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex))
 * list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h))
 * list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
 

--- a/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
@@ -88,10 +88,6 @@ class ClusterSamplerTask
     // fill clusters in O2 format, if any
     if (nClusters > 0) {
       mInputFile.read(reinterpret_cast<char*>(clusters.data()), clusters.size_bytes());
-      for (auto& cluster : clusters) {
-        cluster.ex = 0.2f;
-        cluster.ey = 0.2f;
-      }
     } else {
       LOG(INFO) << "event is empty";
     }

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -63,6 +63,9 @@ class TrackFinderTask
     auto moreCandidates = ic.options().get<bool>("moreCandidates");
     mTrackFinder.findMoreTrackCandidates(moreCandidates);
 
+    auto refineTracks = !ic.options().get<bool>("noRefinement");
+    mTrackFinder.refineTracks(refineTracks);
+
     auto debugLevel = ic.options().get<int>("debug");
     mTrackFinder.debug(debugLevel);
 
@@ -142,6 +145,7 @@ o2::framework::DataProcessorSpec getTrackFinderOriginalSpec()
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
             {"moreCandidates", VariantType::Bool, false, {"Find more track candidates"}},
+            {"noRefinement", VariantType::Bool, false, {"Disable the track refinement"}},
             {"debug", VariantType::Int, 0, {"debug level"}}}};
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -63,6 +63,9 @@ class TrackFinderTask
     auto moreCandidates = ic.options().get<bool>("moreCandidates");
     mTrackFinder.findMoreTrackCandidates(moreCandidates);
 
+    auto refineTracks = !ic.options().get<bool>("noRefinement");
+    mTrackFinder.refineTracks(refineTracks);
+
     auto debugLevel = ic.options().get<int>("debug");
     mTrackFinder.debug(debugLevel);
 
@@ -142,6 +145,7 @@ o2::framework::DataProcessorSpec getTrackFinderSpec()
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
             {"moreCandidates", VariantType::Bool, false, {"Find more track candidates"}},
+            {"noRefinement", VariantType::Bool, false, {"Disable the track refinement"}},
             {"debug", VariantType::Int, 0, {"debug level"}}}};
 }
 


### PR DESCRIPTION
Use different cluster resolution for tracking and final fit:
- During the tracking, a constant cluster resolution (higher than the true resolution to account for tails) is used. The problem with playing with different cluster resolution at this stage, appart from loosing the tails, is that clusters with poor resolution further away from the track can be preferred instead of the right clusters because they contribute less to the global chi2.
- After the tracking, the reconstructed tracks are refitted with the "true" resolution of each cluster to improve the precision.

This is what was done in run2, but only for the mono-cathode clusters, whose resolution was changed manually (still to be ported in the "original clustering" in O2). Hopefully the future clustering will be able to refine this.

PS: there is another unrelated commit just improving the documentation. So it would be nice to merge without squashing. ;-)