### PR TITLE
EMC fix: check bunchIndex validity before using it

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
@@ -62,7 +62,7 @@ CaloFitResults CaloRawFitterStandard::evaluate(const std::vector<Bunch>& bunchli
   auto [nsamples, bunchIndex, ampEstimate,
         maxADC, timeEstimate, pedEstimate, first, last] = preFitEvaluateSamples(bunchlist, altrocfg1, altrocfg2, mAmpCut);
 
-  if (ampEstimate >= mAmpCut) {
+  if (bunchIndex >= 0 && ampEstimate >= mAmpCut) {
     time = timeEstimate;
     int timebinOffset = bunchlist.at(bunchIndex).getStartTime() - (bunchlist.at(bunchIndex).getBunchLength() - 1);
     amp = ampEstimate;


### PR DESCRIPTION
@mfasDa this fixes the crash I've reported in https://github.com/AliceO2Group/AliceO2/pull/4909#issuecomment-735405247
Please check that the behaviour in case of invalid bunchIndex is correct.
BTW, I see that you are routinely use ``vector.at(i)`` instead of ``vector[i]``. This is a wast of time, could you change it to ``[]`` everywhere?