### PR TITLE
DPL Analysis: tweak ROOT caching and prefetching

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -33,6 +33,8 @@
 #include <ROOT/RDataFrame.hxx>
 #include <TGrid.h>
 #include <TFile.h>
+#include <TTreeCache.h>
+#include <TTreePerfStats.h>
 
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/writer.h>
@@ -283,7 +285,8 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
             throw std::runtime_error("Processing is stopped!");
           }
         }
-        tr->SetCacheSize(0);
+        TTreePerfStats ps("ioperf", tr);
+
         if (first) {
           timeFrameNumber = didir->getTimeFrameNumber(dh, fcnt, ntf);
           auto o = Output(TFNumberHeader);
@@ -314,6 +317,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         if (info.file) {
           totalReadCalls += info.file->GetReadCalls() - before;
         }
+        monitoring.send(Metric{(double)ps.GetReadCalls(), "aod-tree-read-calls"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
         delete tr;
 
         first = false;

--- a/Framework/Core/src/DataInputDirector.cxx
+++ b/Framework/Core/src/DataInputDirector.cxx
@@ -102,6 +102,7 @@ bool DataInputDescriptor::setFile(int counter)
   if (!mcurrentFile) {
     throw std::runtime_error(fmt::format("Couldn't open file \"{}\"!", filename));
   }
+  mcurrentFile->SetReadaheadSize(50 * 1024 * 1024);
 
   // get the directory names
   if (mfilenames[counter]->numberOfTimeFrames <= 0) {

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -863,7 +863,10 @@ void TreeToTable::fill(TTree* tree)
   std::vector<std::unique_ptr<ColumnIterator>> columnIterators;
   TTreeReader treeReader{tree};
 
+  tree->SetCacheSize(50000000);
+  tree->SetClusterPrefetch(true);
   for (auto&& columnName : mColumnNames) {
+    tree->AddBranchToCache(columnName.c_str(), true);
     auto colit = std::make_unique<ColumnIterator>(treeReader, columnName.c_str());
     auto stat = colit->getStatus();
     if (!stat) {
@@ -871,6 +874,7 @@ void TreeToTable::fill(TTree* tree)
     }
     columnIterators.push_back(std::move(colit));
   }
+  tree->StopCacheLearningPhase();
   auto numEntries = treeReader.GetEntries(true);
 
   for (auto&& column : columnIterators) {


### PR DESCRIPTION
This tweaks the cache and Readahead buffer of ROOT to minimize the
number of ReadCalls.