### PR TITLE
Fix clean-test.yml: need apt update

### DIFF
--- a/.github/workflows/clean-test.yml
+++ b/.github/workflows/clean-test.yml
@@ -28,6 +28,7 @@ jobs:
           python-version: 3.7
       - name: Install ali-bot
         run: |
+          sudo apt-get update
           sudo apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev
           python -m pip install --upgrade pip
           pip install git+https://github.com/alisw/ali-bot@master

--- a/.github/workflows/clean-test.yml
+++ b/.github/workflows/clean-test.yml
@@ -28,8 +28,8 @@ jobs:
           python-version: 3.7
       - name: Install ali-bot
         run: |
-          sudo apt-get update
-          sudo apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev
+          sudo apt-get update -y
+          sudo apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev
           python -m pip install --upgrade pip
           pip install git+https://github.com/alisw/ali-bot@master
       - uses: octokit/graphql-action@v2.x


### PR DESCRIPTION
This solves the 404 errors in `apt-get install`, seen in e.g. <https://github.com/AliceO2Group/AliceO2/runs/1484842279?check_suite_focus=true>.