### PR TITLE
PHOS CTF writing/reading

### DIFF
--- a/DataFormats/Detectors/PHOS/CMakeLists.txt
+++ b/DataFormats/Detectors/PHOS/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DataFormatsPHOS
                        src/Cluster.cxx 
                        src/MCLabel.cxx 
                        src/TriggerRecord.cxx
+		       src/CTF.cxx
                 PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
                                      O2::Headers 
                                      O2::MathUtils 
@@ -29,7 +30,9 @@ o2_target_root_dictionary(DataFormatsPHOS
                                   include/DataFormatsPHOS/Digit.h
                                   include/DataFormatsPHOS/Cluster.h
                                   include/DataFormatsPHOS/MCLabel.h
-                                  include/DataFormatsPHOS/TriggerRecord.h)
+                                  include/DataFormatsPHOS/TriggerRecord.h
+				  include/DataFormatsPHOS/CTF.h
+				  )
 o2_add_test(Cell
             SOURCES test/testCell.cxx
             COMPONENT_NAME DataFormats-PHOS

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/CTF.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/CTF.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for PHOS CTF data
+
+#ifndef O2_PHS_CTF_H
+#define O2_PHS_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+#include "DataFormatsPHOS/TriggerRecord.h"
+#include "DataFormatsPHOS/Cell.h"
+
+namespace o2
+{
+namespace phos
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nTriggers = 0;  /// number of triggers
+  uint32_t nCells = 0;     /// number of referred cells
+  uint32_t firstOrbit = 0; /// orbit of 1st trigger
+  uint16_t firstBC = 0;    /// bc of 1st trigger
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded triggers and cells of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 7, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncTrig,
+               BLC_orbitIncTrig,
+               BLC_entriesTrig,
+               BLC_packedID,
+               BLC_time,
+               BLC_energy,
+               BLC_status
+  };
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace phos
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/Cell.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/Cell.h
@@ -71,6 +71,24 @@ class Cell
 
   void PrintStream(std::ostream& stream) const;
 
+  // raw access for CTF encoding
+  uint16_t getPackedID() const { return getLong() & 0x3fff; }
+  void setPackedID(uint16_t v) { mBits = (getLong() & 0xffffffc000) + (v & 0x3fff); }
+
+  uint16_t getPackedTime() const { return (getLong() >> 14) & 0x3ff; }
+  void setPackedTime(uint16_t v) { mBits = (getLong() & 0xffff003fff) + (uint64_t(v & 0x3ff) << 14); }
+
+  uint16_t getPackedEnergy() const { return (getLong() >> 24) & 0x7fff; }
+  void setPackedEnergy(uint16_t v) { mBits = (getLong() & 0x8000ffffff) + (uint64_t(v & 0x7fff) << 24); }
+
+  uint8_t getPackedCellStatus() const { return mBits[39]; }
+  void setPackedCellStatus(uint8_t v) { mBits[39] = v ? true : false; }
+
+  void setPacked(uint16_t id, uint16_t t, uint16_t en, uint16_t status)
+  {
+    mBits = uint64_t(id & 0x3fff) + (uint64_t(t & 0x3ff) << 14) + (uint64_t(en & 0x7fff) << 24) + (uint64_t(status & 0x1) << 39);
+  }
+
  private:
   std::bitset<40> mBits;
 

--- a/DataFormats/Detectors/PHOS/src/CTF.cxx
+++ b/DataFormats/Detectors/PHOS/src/CTF.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsPHOS/CTF.h"
+
+using namespace o2::phos;

--- a/DataFormats/Detectors/PHOS/src/DataFormatsPHOSLinkDef.h
+++ b/DataFormats/Detectors/PHOS/src/DataFormatsPHOSLinkDef.h
@@ -29,4 +29,8 @@
 // For channel type in digits and cells
 #pragma link C++ enum o2::phos::ChannelType_t + ;
 
+#pragma link C++ struct o2::phos::CTFHeader + ;
+#pragma link C++ struct o2::phos::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::phos::CTFHeader, 7, uint32_t> + ;
+
 #endif

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -73,3 +73,11 @@ o2_add_test(emcal
             SOURCES test/test_ctf_io_emcal.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
+	  
+o2_add_test(phos
+            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                                  O2::DataFormatsEMCAL
+                                  O2::PHOSReconstruction
+            SOURCES test/test_ctf_io_phos.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf)

--- a/Detectors/CTF/test/test_ctf_io_phos.cxx
+++ b/Detectors/CTF/test/test_ctf_io_phos.cxx
@@ -1,0 +1,119 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test PHSCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "PHOSReconstruction/CTFCoder.h"
+#include "DataFormatsPHOS/CTF.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::phos;
+
+BOOST_AUTO_TEST_CASE(CTFTest)
+{
+  std::vector<TriggerRecord> triggers;
+  std::vector<Cell> cells;
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir(0, 0);
+  for (int irof = 0; irof < 1000; irof++) {
+    ir += 1 + gRandom->Integer(200);
+
+    auto start = cells.size();
+    int n = 1 + gRandom->Poisson(100);
+    for (int i = n; i--;) {
+      ChannelType_t tp = gRandom->Rndm() > 0.5 ? TRU : (gRandom->Rndm() > 0.5 ? HIGH_GAIN : LOW_GAIN);
+      uint16_t id = tp == TRU ? 3000 : gRandom->Integer(kNmaxCell);
+      float timeCell = gRandom->Rndm() * 3.00e-07 - 0.3e-9;
+      float en = gRandom->Rndm() * 160.;
+      cells.emplace_back(id, en, timeCell, tp);
+    }
+    triggers.emplace_back(ir, start, cells.size() - start);
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, triggers, cells); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::phos::CTF::get(vec.data());
+    TFile flOut("test_ctf_phos.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "PHS");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  {
+    sw.Start();
+    TFile flIn("test_ctf_phos.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::phos::CTF::readFromTree(vec, *(tree.get()), "PHS");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<TriggerRecord> triggersD;
+  std::vector<Cell> cellsD;
+
+  sw.Start();
+  const auto ctfImage = o2::phos::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, triggersD, cellsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  BOOST_CHECK(triggersD.size() == triggers.size());
+  BOOST_CHECK(cellsD.size() == cells.size());
+  LOG(INFO) << " BOOST_CHECK triggersD.size() " << triggersD.size() << " triggers.size() " << triggers.size()
+            << " BOOST_CHECK(cellsD.size() " << cellsD.size() << " cells.size()) " << cells.size();
+
+  for (size_t i = 0; i < triggers.size(); i++) {
+    const auto& dor = triggers[i];
+    const auto& ddc = triggersD[i];
+    LOG(DEBUG) << " Orig.TriggerRecord " << i << " " << dor.getBCData() << " " << dor.getFirstEntry() << " " << dor.getNumberOfObjects();
+    LOG(DEBUG) << " Deco.TriggerRecord " << i << " " << ddc.getBCData() << " " << ddc.getFirstEntry() << " " << ddc.getNumberOfObjects();
+
+    BOOST_CHECK(dor.getBCData() == ddc.getBCData());
+    BOOST_CHECK(dor.getNumberOfObjects() == ddc.getNumberOfObjects());
+    BOOST_CHECK(dor.getFirstEntry() == dor.getFirstEntry());
+  }
+
+  for (size_t i = 0; i < cells.size(); i++) {
+    const auto& cor = cells[i];
+    const auto& cdc = cellsD[i];
+    BOOST_CHECK(cor.getPackedID() == cdc.getPackedID());
+    BOOST_CHECK(cor.getPackedTime() == cdc.getPackedTime());
+    BOOST_CHECK(cor.getPackedEnergy() == cdc.getPackedEnergy());
+    BOOST_CHECK(cor.getPackedCellStatus() == cdc.getPackedCellStatus());
+  }
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -29,6 +29,7 @@ o2_add_library(CTFWorkflow
                                      O2::TOFWorkflow
                                      O2::MIDWorkflow
                                      O2::EMCALWorkflow
+				     O2::PHOSWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -31,6 +31,7 @@
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
+#include "DataFormatsPHOS/CTF.h"
 #include "Algorithm/RangeTokenizer.h"
 
 using namespace o2::framework;
@@ -170,6 +171,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::emcal::CTF));
     o2::emcal::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::PHS;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::phos::CTF));
+    o2::phos::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -28,6 +28,7 @@
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
+#include "DataFormatsPHOS/CTF.h"
 
 using namespace o2::framework;
 
@@ -104,6 +105,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::fdd::CTF>(pc, DetID::FDD, header, treeOut.get());
   processDet<o2::mid::CTF>(pc, DetID::MID, header, treeOut.get());
   processDet<o2::emcal::CTF>(pc, DetID::EMC, header, treeOut.get());
+  processDet<o2::phos::CTF>(pc, DetID::PHS, header, treeOut.get());
 
   mTimer.Stop();
 
@@ -174,6 +176,7 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::fdd::CTF>(DetID::FDD, header);
   storeDictionary<o2::mid::CTF>(DetID::MID, header);
   storeDictionary<o2::emcal::CTF>(DetID::EMC, header);
+  storeDictionary<o2::phos::CTF>(DetID::PHS, header);
   // close remnants
   if (mDictTreeOut) {
     closeDictionaryTreeAndFile(header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -28,6 +28,7 @@
 #include "TOFWorkflowUtils/EntropyDecoderSpec.h"
 #include "MIDWorkflow/EntropyDecoderSpec.h"
 #include "EMCALWorkflow/EntropyDecoderSpec.h"
+#include "PHOSWorkflow/EntropyDecoderSpec.h"
 
 using namespace o2::framework;
 using DetID = o2::detectors::DetID;
@@ -95,6 +96,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (dets[DetID::EMC]) {
     specs.push_back(o2::emcal::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::PHS]) {
+    specs.push_back(o2::phos::getEntropyDecoderSpec());
   }
 
   return std::move(specs);

--- a/Detectors/PHOS/reconstruction/CMakeLists.txt
+++ b/Detectors/PHOS/reconstruction/CMakeLists.txt
@@ -19,11 +19,15 @@ o2_add_library(PHOSReconstruction
                        src/Bunch.cxx
                        src/Channel.cxx
                        src/CaloRawFitter.cxx
+		       src/CTFCoder.cxx
+		       src/CTFHelper.cxx
                PUBLIC_LINK_LIBRARIES O2::PHOSBase
                                      O2::PHOSCalib
                                      O2::DataFormatsPHOS
                                      O2::DetectorsRaw
-                                     AliceO2::InfoLogger)
+                                     AliceO2::InfoLogger
+				     O2::rANS
+				     ms_gsl::ms_gsl)
 
 o2_target_root_dictionary(PHOSReconstruction
                           HEADERS include/PHOSReconstruction/RawReaderMemory.h

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
@@ -1,0 +1,153 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of PHOS data
+
+#ifndef O2_PHOS_CTFCODER_H
+#define O2_PHOS_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsPHOS/CTF.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "rANS/rans.h"
+#include "PHOSReconstruction/CTFHelper.h"
+
+class TTree;
+
+namespace o2
+{
+namespace phos
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::PHS) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VTRG, typename VCELL>
+  void decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Cell>& cellVec);
+};
+
+/// entropy-encode clusters to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncTrig
+    MD::EENCODE, // BLC_orbitIncTrig
+    MD::EENCODE, // BLC_entriesTrig
+    MD::EENCODE, // BLC_packedID
+    MD::EENCODE, // BLC_time
+    MD::EENCODE, // BLC_energy
+    MD::EENCODE  // BLC_status
+  };
+
+  CTFHelper helper(trigData, cellData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() / 4; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODEPHS(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODEPHS(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  ENCODEPHS(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  ENCODEPHS(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
+  
+  ENCODEPHS(helper.begin_packedID(),    helper.end_packedID(),     CTF::BLC_packedID,    0);
+  ENCODEPHS(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
+  ENCODEPHS(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
+  ENCODEPHS(helper.begin_status(),      helper.end_status(),       CTF::BLC_status,      0);
+  // clang-format on
+  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded clusters to standard compact clusters
+template <typename VTRG, typename VCELL>
+void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+  std::vector<uint16_t> bcInc, entries, energy, cellTime, packedID;
+  std::vector<uint32_t> orbitInc;
+  std::vector<uint8_t> status;
+
+#define DECODEPHOS(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODEPHOS(bcInc,       CTF::BLC_bcIncTrig);
+  DECODEPHOS(orbitInc,    CTF::BLC_orbitIncTrig);
+  DECODEPHOS(entries,     CTF::BLC_entriesTrig);
+  DECODEPHOS(packedID,    CTF::BLC_packedID);
+
+  DECODEPHOS(cellTime,    CTF::BLC_time);
+  DECODEPHOS(energy,      CTF::BLC_energy);
+  DECODEPHOS(status,      CTF::BLC_status);
+  // clang-format on
+  //
+  trigVec.clear();
+  cellVec.clear();
+  trigVec.reserve(header.nTriggers);
+  status.reserve(header.nCells);
+
+  uint32_t firstEntry = 0, cellCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  Cell cell;
+  for (uint32_t itrig = 0; itrig < header.nTriggers; itrig++) {
+    // restore TrigRecord
+    if (orbitInc[itrig]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[itrig]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[itrig];
+    } else {
+      ir.bc += bcInc[itrig];
+    }
+
+    firstEntry = cellVec.size();
+    for (uint16_t ic = 0; ic < entries[itrig]; ic++) {
+      cell.setPacked(packedID[cellCount], cellTime[cellCount], energy[cellCount], status[cellCount]);
+      cellVec.emplace_back(cell);
+      cellCount++;
+    }
+    trigVec.emplace_back(ir, firstEntry, entries[itrig]);
+  }
+  assert(cellCount == header.nCells);
+}
+
+} // namespace phos
+} // namespace o2
+
+#endif // O2_PHOS_CTFCODER_H

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
@@ -1,0 +1,193 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for PHOS CTF creation
+
+#ifndef O2_PHOS_CTF_HELPER_H
+#define O2_PHOS_CTF_HELPER_H
+
+#include "DataFormatsPHOS/CTF.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace phos
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const TriggerRecord>& trgData, const gsl::span<const Cell>& cellData)
+    : mTrigData(trgData), mCellData(cellData) {}
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
+    if (mTrigData.size()) {
+      h.firstOrbit = mTrigData[0].getBCData().orbit;
+      h.firstBC = mTrigData[0].getBCData().bc;
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mTrigData.size() * sizeof(TriggerRecord) + mCellData.size() * sizeof(Cell); }
+
+  //>>> =========================== ITERATORS ========================================
+
+  template <typename I, typename D, typename T>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncTrig : public _Iter<Iter_bcIncTrig, TriggerRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncTrig, TriggerRecord, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].getBCData().orbit == mData[mIndex - 1].getBCData().orbit) {
+          return mData[mIndex].getBCData().bc - mData[mIndex - 1].getBCData().bc;
+        } else {
+          return mData[mIndex].getBCData().bc;
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncTrig : public _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].getBCData().orbit - mData[mIndex - 1].getBCData().orbit : 0; }
+  };
+
+  //_______________________________________________
+  // Number of cells for trigger
+  class Iter_entriesTrig : public _Iter<Iter_entriesTrig, TriggerRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_entriesTrig, TriggerRecord, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNumberOfObjects(); }
+  };
+
+  //_______________________________________________
+  class Iter_packedID : public _Iter<Iter_packedID, Cell, uint16_t>
+  {
+   public:
+    using _Iter<Iter_packedID, Cell, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPackedID(); }
+  };
+
+  //_______________________________________________
+  class Iter_time : public _Iter<Iter_time, Cell, uint16_t>
+  {
+   public:
+    using _Iter<Iter_time, Cell, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPackedTime(); }
+  };
+
+  //_______________________________________________
+  class Iter_energy : public _Iter<Iter_energy, Cell, uint16_t>
+  {
+   public:
+    using _Iter<Iter_energy, Cell, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPackedEnergy(); }
+  };
+
+  //_______________________________________________
+  class Iter_status : public _Iter<Iter_status, Cell, uint8_t>
+  {
+   public:
+    using _Iter<Iter_status, Cell, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPackedCellStatus(); }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncTrig begin_bcIncTrig() const { return Iter_bcIncTrig(mTrigData, false); }
+  Iter_bcIncTrig end_bcIncTrig() const { return Iter_bcIncTrig(mTrigData, true); }
+
+  Iter_orbitIncTrig begin_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigData, false); }
+  Iter_orbitIncTrig end_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigData, true); }
+
+  Iter_entriesTrig begin_entriesTrig() const { return Iter_entriesTrig(mTrigData, false); }
+  Iter_entriesTrig end_entriesTrig() const { return Iter_entriesTrig(mTrigData, true); }
+
+  Iter_packedID begin_packedID() const { return Iter_packedID(mCellData, false); }
+  Iter_packedID end_packedID() const { return Iter_packedID(mCellData, true); }
+
+  Iter_time begin_time() const { return Iter_time(mCellData, false); }
+  Iter_time end_time() const { return Iter_time(mCellData, true); }
+
+  Iter_energy begin_energy() const { return Iter_energy(mCellData, false); }
+  Iter_energy end_energy() const { return Iter_energy(mCellData, true); }
+
+  Iter_status begin_status() const { return Iter_status(mCellData, false); }
+  Iter_status end_status() const { return Iter_status(mCellData, true); }
+
+ private:
+  const gsl::span<const o2::phos::TriggerRecord> mTrigData;
+  const gsl::span<const o2::phos::Cell> mCellData;
+};
+
+} // namespace phos
+} // namespace o2
+
+#endif

--- a/Detectors/PHOS/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/CTFCoder.cxx
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of PHOS data
+
+#include "PHOSReconstruction/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::phos;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Cell>& cellVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, trigVec, cellVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, packedid = 0;
+  uint32_t orbitInc = 0;
+  uint8_t status = 0;
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+  // clang-format off
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
+  MAKECODER(entries,    CTF::BLC_entriesTrig);
+  MAKECODER(packedid,   CTF::BLC_packedID);
+  MAKECODER(cellTime,   CTF::BLC_time);
+  MAKECODER(energy,     CTF::BLC_energy);
+  MAKECODER(status,     CTF::BLC_status);
+  // clang-format on
+}

--- a/Detectors/PHOS/reconstruction/src/CTFHelper.cxx
+++ b/Detectors/PHOS/reconstruction/src/CTFHelper.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for PHOS CTF creation
+
+#include "PHOSReconstruction/CTFHelper.h"

--- a/Detectors/PHOS/simulation/src/RawCreator.cxx
+++ b/Detectors/PHOS/simulation/src/RawCreator.cxx
@@ -45,7 +45,7 @@ int main(int argc, const char** argv)
     add_option("help,h", "Print this help message");
     add_option("verbose,v", bpo::value<uint32_t>()->default_value(0), "Select verbosity level [0 = no output]");
     add_option("input-file,i", bpo::value<std::string>()->default_value("phosdigits.root"), "Specifies digit input file.");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,subdet,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");

--- a/Detectors/PHOS/workflow/CMakeLists.txt
+++ b/Detectors/PHOS/workflow/CMakeLists.txt
@@ -16,6 +16,8 @@ o2_add_library(PHOSWorkflow
                        src/ClusterizerSpec.cxx
                        src/DigitsPrinterSpec.cxx
                        src/RawWriterSpec.cxx
+                       src/EntropyEncoderSpec.cxx
+                       src/EntropyDecoderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsPHOS 
                                      O2::DPLUtils 
                                      O2::PHOSBase 
@@ -27,4 +29,9 @@ o2_add_library(PHOSWorkflow
 o2_add_executable(reco-workflow
                   COMPONENT_NAME phos
                   SOURCES src/phos-reco-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::PHOSWorkflow)
+
+o2_add_executable(entropy-encoder-workflow
+                  COMPONENT_NAME phos
+                  SOURCES src/entropy-encoder-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::PHOSWorkflow)

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to PHOS digit/channels strean
+
+#ifndef O2_PHOS_ENTROPYDECODER_SPEC
+#define O2_PHOS_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "PHOSReconstruction/CTFCoder.h"
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace phos
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::phos::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace phos
+} // namespace o2
+
+#endif

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert PHOS data to CTF (EncodedBlocks)
+
+#ifndef O2_PHOS_ENTROPYENCODER_SPEC
+#define O2_PHOS_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include <TStopwatch.h>
+#include "PHOSReconstruction/CTFCoder.h"
+
+namespace o2
+{
+namespace phos
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::phos::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace phos
+} // namespace o2
+
+#endif

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "PHOSWorkflow/EntropyDecoderSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace phos
+{
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("phos-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
+  auto& cells = pc.outputs().make<std::vector<Cell>>(OutputRef{"cells"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::phos::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, triggers, cells);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << cells.size() << " PHOS cells in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "PHOS Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"triggers"}, "PHS", "CELLTRIGREC", 0, Lifetime::Timeframe},
+    OutputSpec{{"cells"}, "PHS", "CELLS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "phos-entropy-decoder",
+    Inputs{InputSpec{"ctf", "PHS", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"phos-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace phos
+} // namespace o2

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "PHOSWorkflow/EntropyEncoderSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace phos
+{
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("phos-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
+  auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"PHS", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, triggers, cells);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for PHOS in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "PHOS Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("triggers", "PHS", "CELLTRIGREC", 0, Lifetime::Timeframe);
+  inputs.emplace_back("cells", "PHS", "CELLS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "phos-entropy-encoder",
+    inputs,
+    Outputs{{"PHS", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"phos-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+}
+
+} // namespace phos
+} // namespace o2

--- a/Detectors/PHOS/workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/PHOS/workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "PHOSWorkflow/EntropyEncoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::phos::getEntropyEncoderSpec());
+  return wf;
+}


### PR DESCRIPTION
@peressounko here is the CTF machinery for the PHOS. I've added only encoding of Cells and TriggerRecords, like for the EMCAL. I see that in the RawToCellConverter you create also the message for decoding errors. Should this also go to the CTF? In fact, I don't see any index which would allow relating the error struct to a particular trigger.

To test it:
````
o2-sim -n10 -g boxgen --configKeyValues 'BoxGun.pdg=22 ;BoxGun.phirange[0]=260; BoxGun.phirange[1]=280; BoxGun.number=50; BoxGun.eta[0]=-0.125 ; BoxGun.eta[1]=0.125; '
o2-sim-digitizer-workflow   --onlyDet PHS
o2-phos-digi2raw -o raw/PHS
# to encode
o2-raw-file-reader-workflow --input-conf raw/PHS/PHSraw.cfg | o2-phos-reco-workflow --input-type raw --output-type cells | o2-phos-entropy-encoder-workflow  | o2-ctf-writer-workflow --onlyDet PHS

# to decode:
o2-ctf-reader-workflow --ctf-input  o2_ctf_0000000000.root  --onlyDet PHS
````