### PR TITLE
[WIP] Sketching AOD tables for forward tracks

### DIFF
--- a/Framework/Core/src/AnalysisDataModelHelpers.cxx
+++ b/Framework/Core/src/AnalysisDataModelHelpers.cxx
@@ -60,6 +60,10 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
       return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
     } else if (description == "TRACK:EXTRA") {
       return columnNamesTrait(typename TracksExtraMetadata::table_t::persistent_columns_t{});
+    } else if (description == "TRACKFWD:PAR") {
+      return columnNamesTrait(typename StoredTracksFwdMetadata::table_t::persistent_columns_t{});
+    } else if (description == "TRACKFWD:PARCOV") {
+      return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
     }
   }
 


### PR DESCRIPTION
This is to start a discussion about the representation of forward tracks on AOD tables. 

Columns corresponding to the native forward tracking coordinate system and covariances have been added to the `trackfwd` namespace. 