### PR TITLE
Don't build cpulimit tool with glibc >= 2.32 since it will fail

### DIFF
--- a/Utilities/Tools/CMakeLists.txt
+++ b/Utilities/Tools/CMakeLists.txt
@@ -8,7 +8,17 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(cpulimit)
+EXECUTE_PROCESS (COMMAND ${CMAKE_C_COMPILER} -print-file-name=libc.so.6
+                 OUTPUT_VARIABLE GLIBC
+                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+GET_FILENAME_COMPONENT (GLIBC ${GLIBC} REALPATH)
+GET_FILENAME_COMPONENT (GLIBC_VERSION ${GLIBC} NAME)
+STRING (REPLACE "libc-" "" GLIBC_VERSION ${GLIBC_VERSION})
+STRING (REPLACE ".so" "" GLIBC_VERSION ${GLIBC_VERSION})
+if(${GLIBC_VERSION} VERSION_LESS 2.32)
+  add_subdirectory(cpulimit) # Incompatible to glibc >= 2.32
+endif()
 
 install(PROGRAMS monitor-mem.sh DESTINATION share/scripts/)
 install(PROGRAMS jobutils.sh DESTINATION share/scripts/)


### PR DESCRIPTION
@sawenzel : This works for me, and I checked that it builds the tool with the old glibc.
Not sure if this could be done in a more elegant way.
Please make sure to check the availability before using the tool, otherwise you'll break the full system test on my dev system :)