### PR TITLE
Add EMCAL / PHOS to full system test, use less memory and disable GPU by default (configurable), add some more options to the test

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -26,7 +26,7 @@ else
 fi
 
 if [ $CREATECTFDICT == 1 ]; then
-  CMD_DICT="o2-ctf-writer-workflow $ARGS_ALL --output-type dict --save-dict-after 1 --onlyDet ITS,MFT,TPC,TOF,FT0,MID"
+  CMD_DICT="o2-ctf-writer-workflow $ARGS_ALL --output-type dict --save-dict-after 1 --onlyDet ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS"
 else
   CMD_DICT=cat
 fi
@@ -91,6 +91,10 @@ o2-ft0-entropy-encoder-workflow $ARGS_ALL | \
 o2-mid-raw-to-digits-workflow $ARGS_ALL | \
 o2-mid-reco-workflow $ARGS_ALL --disable-root-output $DISABLE_MC $MID_CONFIG | \
 o2-mid-entropy-encoder-workflow $ARGS_ALL | \
+o2-phos-reco-workflow $ARGS_ALL --input-type raw --output-type cells | \
+o2-phos-entropy-encoder-workflow $ARGS_ALL |\
+o2-emcal-reco-workflow $ARGS_ALL --input-type raw --output-type cells | \
+o2-emcal-entropy-encoder-workflow $ARGS_ALL |\
 o2-tof-compressor $ARGS_ALL | \
 o2-tof-reco-workflow $ARGS_ALL --configKeyValues "HBFUtils.nHBFPerTF=$NHBPERTF" --input-type raw --output-type ctf,clusters,matching-info --disable-root-output $DISABLE_MC | \
 o2-tpc-scdcalib-interpolation-workflow $ARGS_ALL --disable-root-output --disable-root-input | \

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -35,9 +35,11 @@ if [ $SYNCMODE == 1 ]; then
   CFG_X="fastMultConfig.cutMultClusLow=30;fastMultConfig.cutMultClusHigh=2000;fastMultConfig.cutMultVtxHigh=500"
   ITS_CONFIG="--configKeyValues $CFG_X"
   TPC_CONFIG="GPU_global.synchronousProcessing=1;"
+  MID_CONFIG="--disable-tracking"
 else
   ITS_CONFIG=
   TPC_CONFIG=
+  MID_CONFIG=
 fi
 TPC_CONFIG2=
 
@@ -87,7 +89,7 @@ o2-ft0-flp-dpl-workflow $ARGS_ALL --disable-root-output | \
 o2-ft0-reco-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC | \
 o2-ft0-entropy-encoder-workflow $ARGS_ALL | \
 o2-mid-raw-to-digits-workflow $ARGS_ALL | \
-o2-mid-reco-workflow $ARGS_ALL --disable-root-output $DISABLE_MC | \
+o2-mid-reco-workflow $ARGS_ALL --disable-root-output $DISABLE_MC $MID_CONFIG | \
 o2-mid-entropy-encoder-workflow $ARGS_ALL | \
 o2-tof-compressor $ARGS_ALL | \
 o2-tof-reco-workflow $ARGS_ALL --configKeyValues "HBFUtils.nHBFPerTF=$NHBPERTF" --input-type raw --output-type ctf,clusters,matching-info --disable-root-output $DISABLE_MC | \

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -8,10 +8,12 @@ if [ "0$ALIENVLVL" == "0" ]; then
   alienv --no-refresh load O2/latest
 fi
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-throw-bad-alloc 0 --shm-segment-size $SHMSIZE"
-
+ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-segment-size $SHMSIZE"
 if [ $EXTINPUT == 1 ] || [ $NUMAGPUIDS == 1 ]; then
   ARGS_ALL+=" --no-cleanup"
+fi
+if [ $SHMTHROW == 0 ]; then
+  ARGS_ALL+=" --shm-throw-bad-alloc 0"
 fi
 
 if [ $EXTINPUT == 1 ]; then

--- a/prodtests/full-system-test/setenv.sh
+++ b/prodtests/full-system-test/setenv.sh
@@ -24,6 +24,7 @@ if [ -z "$NHBPERTF" ];      then export NHBPERTF=128; fi               # Time fr
 if [ -z "$GLOBALDPLOPT" ];  then export GLOBALDPLOPT=; fi              # Global DPL workflow options appended at the end
 if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=0; fi             # Set default EPN pipeline multiplicities
 if [ -z "$SEVERITY" ];      then export SEVERITY="info"; fi            # Log verbosity
+if [ -z "$SHMTHROW" ];      then export SHMTHROW=1; fi                 # Throw exception when running out of SHM
 
 SEVERITY_TPC="info" # overrides severity for the tpc workflow
 DISABLE_MC="--disable-mc"

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -16,6 +16,7 @@ export NUMAGPUIDS=1
 export EXTINPUT=1
 export EPNPIPELINES=1
 export SYNCMODE=1
+export SHMTHROW=0
 
 if [ $1 == "dd" ]; then
   export CMD=datadistribution.sh

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -63,6 +63,8 @@ taskwrapper ft0raw.log o2-ft0-digi2raw --file-per-link --configKeyValues '"HBFUt
 taskwrapper tpcraw.log o2-tpc-digits-to-rawzs  --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -i tpcdigits.root -o raw/TPC
 taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --tof-raw-file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' --output-type raw --tof-raw-outdir raw/TOF
 taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --mid-raw-perlink  --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"'
+taskwrapper emcraw.log o2-emcal-rawcreator --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -o raw/EMC
+taskwrapper phsraw.log o2-phos-digi2raw  --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -o raw/PHS
 cat raw/*/*.cfg > rawAll.cfg
 
 # We run the workflow in both CPU-only and With-GPU mode
@@ -102,7 +104,7 @@ for STAGE in "NOGPU" "WITHGPU"; do
     walltime=`grep "#walltime" ${logfile}_time | awk '//{print $2}'`
     echo "walltime_${STAGE},${TAG} value=${walltime}" >> ${METRICFILE}
 
-    # memory 
+    # memory
     maxmem=`awk '/PROCESS MAX MEM/{print $5}' ${logfile}`  # in MB
     avgmem=`awk '/PROCESS AVG MEM/{print $5}' ${logfile}`  # in MB
     echo "maxmem_${STAGE},${TAG} value=${maxmem}" >> ${METRICFILE}

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -7,7 +7,7 @@
 #
 # Note that this might require a production server to run.
 #
-# This script needs some binary objects (for the moment):
+# This script can use additional binary objects which can be optionally provided:
 # - matbud.root + ITSdictionary.bin
 #
 # authors: D. Rohr / S. Wenzel
@@ -83,6 +83,7 @@ for STAGE in "NOGPU" "WITHGPU"; do
     export GPUTYPE=CPU
     export SYNCMODE=0
     export HOSTMEMSIZE=$TPCTRACKERSCRATCHMEMORY
+    rm -f ctf_dictionary.root
   fi
   export SHMSIZE
   export NTIMEFRAMES

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -24,8 +24,9 @@ NEventsQED=${NEventsQED:-1000} #35000 for full TF
 NCPUS=$(getNumberOfPhysicalCPUCores)
 echo "Found ${NCPUS} physical CPU cores"
 NJOBS=${NJOBS:-"${NCPUS}"}
-SHMSIZE=128000000000 # 128000000000  # Size of shared memory for messages
-TPCTRACKERSCRATCHMEMORY=22000000000
+SHMSIZE=${SHMSIZE:-8000000000} # Size of shared memory for messages (use 128 GB for 550 event full TF)
+TPCTRACKERSCRATCHMEMORY=${SHMSIZE:-4000000000} # Size of memory allocated by TPC tracker. (Use 24 GB for 550 event full TF)
+ENABLE_GPU_TEST=${ENABLE_GPU_TEST:-0} # Run the full system test also on the GPU
 NTIMEFRAMES=${NTIMEFRAMES:-1} # Number of time frames to process
 TFDELAY=100 # Delay in seconds between publishing time frames
 NOMCLABELS="--disable-mc"
@@ -68,7 +69,11 @@ taskwrapper phsraw.log o2-phos-digi2raw  --file-for link --configKeyValues '"HBF
 cat raw/*/*.cfg > rawAll.cfg
 
 # We run the workflow in both CPU-only and With-GPU mode
-for STAGE in "NOGPU" "WITHGPU"; do
+STAGES="NOGPU"
+if [ $ENABLE_GPU_TEST != "0" ]; then
+  STAGES+=" WITHGPU"
+fi
+for STAGE in $STAGES; do
 
   ARGS_ALL="--session default"
   DICTCREATION=""

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -52,7 +52,7 @@ cd qed
 taskwrapper qedsim.log o2-sim -j $NJOBS -n$NEventsQED -m PIPE ITS MFT FT0 FV0 -g extgen --configKeyValues '"GeneratorExternal.fileName=$O2_ROOT/share/Generators/external/QEDLoader.C;QEDGenParam.yMin=-5;QEDGenParam.yMax=6;QEDGenParam.ptMin=0.001;QEDGenParam.ptMax=1.;Diamond.width[2]=6."'
 cd ..
 
-GLOBALDPLOPT="-b --monitoring-backend no-op://"
+GLOBALDPLOPT="-b" #  --monitoring-backend no-op:// is currently removed due to https://alice.its.cern.ch/jira/browse/O2-1887
 taskwrapper sim.log o2-sim -n $NEvents --skipModules ZDC --configKeyValues "Diamond.width[2]=6." -g pythia8hi -j $NJOBS
 taskwrapper digi.log o2-sim-digitizer-workflow -n $NEvents --simPrefixQED qed/o2sim --qed-x-section-ratio 3735  ${NOMCLABELS} --firstOrbit 0 --firstBC 0 --skipDet TRD --tpc-lanes $((NJOBS < 36 ? NJOBS : 36)) --shm-segment-size $SHMSIZE ${GLOBALDPLOPT}
 taskwrapper digiTRD.log o2-sim-digitizer-workflow -n $NEvents --simPrefixQED qed/o2sim --qed-x-section-ratio 3735  ${NOMCLABELS} --firstOrbit 0 --firstBC 0 --onlyDet TRD --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} --incontext collisioncontext.root --configKeyValues "TRDSimParams.digithreads=${NJOBS}"


### PR DESCRIPTION
@sawenzel : This adds EMCAL/PHOS + some features + some cleanup. Changes for alibi are:
- The daily short test should run:
```
ENABLE_GPU_TEST=1 $O2_ROOT/prodtests/full_system_test.sh
```
- The weekly large test should run:
```
NEvents=550 NEventsQED=35000 SHMSIZE=128000000000 TPCTRACKERSCRATCHMEMORY=24000000000 $O2_ROOT/O2/prodtests/full_system_test.sh 
```