### PR TITLE
Update cpulimit.c

### DIFF
--- a/Utilities/Tools/cpulimit/cpulimit.c
+++ b/Utilities/Tools/cpulimit/cpulimit.c
@@ -38,7 +38,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#if defined(__APPLE__)
 #include <sys/sysctl.h>
+#endif
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
systcl header is deprecated on linux. Protect include since it's used on APPLE.