### PR TITLE
Check CTFdict existence before trying to load

### DIFF
--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -14,6 +14,7 @@
 
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "DetectorsBase/CTFCoderBase.h"
+#include "TSystem.h"
 
 using namespace o2::ctf;
 
@@ -34,7 +35,7 @@ bool readFromTree(TTree& tree, const std::string brname, T& dest, int ev = 0)
 std::unique_ptr<TFile> CTFCoderBase::loadDictionaryTreeFile(const std::string& dictPath, bool mayFail)
 {
   TDirectory* curd = gDirectory;
-  std::unique_ptr<TFile> fileDict(TFile::Open(dictPath.c_str()));
+  std::unique_ptr<TFile> fileDict(gSystem->AccessPathName(dictPath.c_str()) ? nullptr : TFile::Open(dictPath.c_str()));
   if (!fileDict || fileDict->IsZombie()) {
     if (mayFail) {
       LOG(INFO) << "CTF dictionary file " << dictPath << " for detector " << mDet.getName() << " is absent, will use dictionaries stored in CTF";


### PR DESCRIPTION
@davidrohr : the split log messages were caused by root ``Error in <TFile::TFile>`` by root error when requesting to load non-existing CTF dictionaries.