### PR TITLE
Add storing CTF / Reading input from CTF / Run asynchronous reconstruction to full system test

### DIFF
--- a/prodtests/full-system-test/README.md
+++ b/prodtests/full-system-test/README.md
@@ -46,6 +46,7 @@ The following options exist (some of the options are not used in all scripts, an
   * 0: Read `ctf_dictionary.root` as input.
   * 1: Create `ctf_dictionary.root`. Note that this was already done automatically if the raw data was simulated with `full_system_test.sh`.
 * `SYNCMODE`: Run only reconstruction steps of the synchronous reconstruction.
+  * Note that there is no `ASYNCMODE` but instead the `CTFINPUT` option already enforces asynchronous processing.
 * `NUMAGPUIDS`: NUMAID-aware GPU id selection. Needed for the full EPN configuration with 8 GPUs, 2 NUMA domains, 4 GPUs per domain.
   In this configuration, 2 instances of `dpl-workflow.sh` must run in parallel.
   To be used in combination with `NUMAID` to select the id per workflow.
@@ -56,6 +57,7 @@ The following options exist (some of the options are not used in all scripts, an
 * `EXTINPUT`: Receive input from raw FMQ channel instead of running o2-raw-file-reader.
   * 0: `dpl-workflow.sh` can run as standalone benchmark, and will read the input itself.
   * 1: To be used in combination with either `datadistribution.sh` or `raw-reader.sh` or with another DataDistribution instance.
+* `CTFINPUT`: Read input from CTF ROOT file. This option is incompatible to EXTINPUT=1. The CTF ROOT file can be stored via SAVECTF=1.
 * `NHBPERTF`: Time frame length (in HBF)
 * `GLOBALDPLOPT`: Global DPL workflow options appended to o2-dpl-run.
 * `EPNPIPELINES`: Set default EPN pipeline multiplicities.

--- a/prodtests/full-system-test/README.md
+++ b/prodtests/full-system-test/README.md
@@ -41,6 +41,7 @@ The following options exist (some of the options are not used in all scripts, an
 * `HOSTMEMSIZE`: Size of allocated host memory for GPU reconstruction (0 = default).
   * For `GPUTYPE = CPU`: TPC Tracking scratch memory size. (Default 0 -> dynamic allocation.)
   * Otherwise : Size of page-locked host memory for GPU processing. (Defauls 0 -> 1 GB.)
+* `SAVECTF`: Save the CTF to a root file.
 * `CREATECTFDICT`: Create CTF dictionary.
   * 0: Read `ctf_dictionary.root` as input.
   * 1: Create `ctf_dictionary.root`. Note that this was already done automatically if the raw data was simulated with `full_system_test.sh`.

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -96,7 +96,7 @@ $CMD_MID | \
 o2-mid-entropy-encoder-workflow $ARGS_ALL | \
 o2-phos-reco-workflow $ARGS_ALL --input-type raw --output-type cells | \
 o2-phos-entropy-encoder-workflow $ARGS_ALL |\
-o2-emcal-reco-workflow $ARGS_ALL --input-type raw --output-type cells | \
+o2-emcal-reco-workflow $ARGS_ALL --input-type raw --output-type cells --disable-root-output | \
 o2-emcal-entropy-encoder-workflow $ARGS_ALL |\
 o2-tof-compressor $ARGS_ALL | \
 o2-tof-reco-workflow $ARGS_ALL --configKeyValues "HBFUtils.nHBFPerTF=$NHBPERTF" --input-type raw --output-type ctf,clusters,matching-info --disable-root-output $DISABLE_MC | \

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -28,10 +28,13 @@ else
   CMD_INPUT="o2-raw-file-reader-workflow $ARGS_ALL --configKeyValues $CMD_X --delay $TFDELAY --loop $NTIMEFRAMES --max-tf 0 --input-conf rawAll.cfg"
 fi
 
-if [ $CREATECTFDICT == 1 ]; then
-  CMD_DICT="o2-ctf-writer-workflow $ARGS_ALL --output-type dict --save-dict-after 1 --onlyDet ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS"
-else
-  CMD_DICT=cat
+CMD_CTF_TYPE="none"
+if [ $CREATECTFDICT == 1 ] && [ $SAVECTF == 1 ]; then CMD_CTF_TYPE="both"; fi
+if [ $CREATECTFDICT == 1 ] && [ $SAVECTF == 0 ]; then CMD_CTF_TYPE="dict"; fi
+if [ $CREATECTFDICT == 0 ] && [ $SAVECTF == 1 ]; then CMD_CTF_TYPE="ctf"; fi
+CMD_CTF="o2-ctf-writer-workflow $ARGS_ALL --output-type $CMD_CTF_TYPE --onlyDet ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS"
+if [ $CREATECTFDICT == 1 ] && [ $; then
+  CMD_CTF+=" --save-dict-after 1"
 fi
 
 if [ $SYNCMODE == 1 ]; then
@@ -101,5 +104,5 @@ o2-emcal-entropy-encoder-workflow $ARGS_ALL |\
 o2-tof-compressor $ARGS_ALL | \
 o2-tof-reco-workflow $ARGS_ALL --configKeyValues "HBFUtils.nHBFPerTF=$NHBPERTF" --input-type raw --output-type ctf,clusters,matching-info --disable-root-output $DISABLE_MC | \
 o2-tpc-scdcalib-interpolation-workflow $ARGS_ALL --disable-root-output --disable-root-input | \
-$CMD_DICT | \
+$CMD_CTF | \
 o2-dpl-run $ARGS_ALL $GLOBALDPLOPT --run

--- a/prodtests/full-system-test/setenv.sh
+++ b/prodtests/full-system-test/setenv.sh
@@ -21,6 +21,7 @@ if [ -z "$SYNCMODE" ];      then export SYNCMODE=0; fi                 # Run onl
 if [ -z "$NUMAID" ];        then export NUMAID=0; fi                   # SHM segment id to use for shipping data as well as set of GPUs to use (use 0 / 1 for 2 NUMA domains)
 if [ -z "$NUMAGPUIDS" ];    then export NUMAGPUIDS=0; fi               # NUMAID-aware GPU id selection
 if [ -z "$EXTINPUT" ];      then export EXTINPUT=0; fi                 # Receive input from raw FMQ channel instead of running o2-raw-file-reader
+if [ -z "$CTFINPUT" ];      then export CTFINPUT=0; fi                 # Read input from CTF (incompatible to EXTINPUT=1)
 if [ -z "$NHBPERTF" ];      then export NHBPERTF=128; fi               # Time frame length (in HBF)
 if [ -z "$GLOBALDPLOPT" ];  then export GLOBALDPLOPT=; fi              # Global DPL workflow options appended at the end
 if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=0; fi             # Set default EPN pipeline multiplicities
@@ -30,3 +31,16 @@ if [ -z "$NORATELOG" ];     then export NORATELOG=1; fi                # Disable
 
 SEVERITY_TPC="info" # overrides severity for the tpc workflow
 DISABLE_MC="--disable-mc"
+
+if [ $EXTINPUT == 1 ] && [ $CTFINPUT == 1 ]; then
+  echo EXTINPUT and CTFINPUT are incompatible
+  exit 1
+fi
+if [ $SAVECTF == 1 ] && [ $CTFINPUT == 1 ]; then
+  echo SAVECTF and CTFINPUT are incompatible
+  exit 1
+fi
+if [ $SYNCMODE == 1 ] && [ $CTFINPUT == 1 ]; then
+  echo SYNCMODE and CTFINPUT are incompatible
+  exit 1
+fi

--- a/prodtests/full-system-test/setenv.sh
+++ b/prodtests/full-system-test/setenv.sh
@@ -16,6 +16,7 @@ if [ -z "$DDSHMSIZE" ];     then export DDSHMSIZE=$(( 32 << 10 )); fi  # Size of
 if [ -z "$GPUMEMSIZE" ];    then export GPUMEMSIZE=$(( 13 << 30 )); fi # Size of allocated GPU memory (if GPUTYPE != CPU)
 if [ -z "$HOSTMEMSIZE" ];   then export HOSTMEMSIZE=0; fi              # Size of allocated host memory for GPU reconstruction (0 = default)
 if [ -z "$CREATECTFDICT" ]; then export CREATECTFDICT=0; fi            # Create CTF dictionary
+if [ -z "$SAVECTF" ];       then export SAVECTF=0; fi                  # Save the CTF to a ROOT file
 if [ -z "$SYNCMODE" ];      then export SYNCMODE=0; fi                 # Run only reconstruction steps of the synchronous reconstruction
 if [ -z "$NUMAID" ];        then export NUMAID=0; fi                   # SHM segment id to use for shipping data as well as set of GPUs to use (use 0 / 1 for 2 NUMA domains)
 if [ -z "$NUMAGPUIDS" ];    then export NUMAGPUIDS=0; fi               # NUMAID-aware GPU id selection

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -28,7 +28,7 @@ SHMSIZE=${SHMSIZE:-8000000000} # Size of shared memory for messages (use 128 GB 
 TPCTRACKERSCRATCHMEMORY=${SHMSIZE:-4000000000} # Size of memory allocated by TPC tracker. (Use 24 GB for 550 event full TF)
 ENABLE_GPU_TEST=${ENABLE_GPU_TEST:-0} # Run the full system test also on the GPU
 NTIMEFRAMES=${NTIMEFRAMES:-1} # Number of time frames to process
-TFDELAY=100 # Delay in seconds between publishing time frames
+TFDELAY=${TFDELAY:-100} # Delay in seconds between publishing time frames
 NOMCLABELS="--disable-mc"
 
 # allow skipping
@@ -73,6 +73,7 @@ STAGES="NOGPU"
 if [ $ENABLE_GPU_TEST != "0" ]; then
   STAGES+=" WITHGPU"
 fi
+STAGES+=" ASYNC"
 for STAGE in $STAGES; do
 
   ARGS_ALL="--session default"
@@ -83,11 +84,22 @@ for STAGE in $STAGES; do
     export GPUMEMSIZE=6000000000
     export HOSTMEMSIZE=1000000000
     export SYNCMODE=1
+    export CTFINPUT=0
+    export SAVECTF=0
+  elif [[ "$STAGE" = "ASYNC" ]]; then
+    export CREATECTFDICT=1
+    export GPUTYPE=CPU
+    export SYNCMODE=0
+    export HOSTMEMSIZE=$TPCTRACKERSCRATCHMEMORY
+    export CTFINPUT=1
+    export SAVECTF=0
   else
     export CREATECTFDICT=1
     export GPUTYPE=CPU
     export SYNCMODE=0
     export HOSTMEMSIZE=$TPCTRACKERSCRATCHMEMORY
+    export CTFINPUT=0
+    export SAVECTF=1
     rm -f ctf_dictionary.root
   fi
   export SHMSIZE


### PR DESCRIPTION
@sawenzel : This adds another STAGE called `ASYNC` to your `full_system_test.sh` script. Could you update grafana to show its metrics :)

@shahor02 : The scripts should now contain everything to run the full system test simulation and both the sync and the async workflow. It have also updated the full system test JIRA (https://alice.its.cern.ch/jira/browse/O2-1492) to point to these scripts.

In case you want to use it to run the stages in the bat.sh you sent me:
```
NEvents=10 NEventsQED=1000 SHMSIZE=26000000000 $O2_ROOT/prodtests/full_system_test.sh
rm ctf_dictionary.root # Will already be created by the above script, but in case you want to run the stages one after another you have to remove it
SYNCMODE=1 CREATECTFDICT=1 SHMSIZE=26000000000 ~/alice/O2/prodtests/full-system-test/dpl-workflow.sh
SYNCMODE=1 SAVECTF=1 SHMSIZE=26000000000 ~/alice/O2/prodtests/full-system-test/dpl-workflow.sh
CTFINPUT=1 SHMSIZE=26000000000 ~/alice/O2/prodtests/full-system-test/dpl-workflow.sh

SHMSIZE=26000000000 ~/alice/O2/prodtests/full-system-test/dpl-workflow.sh # Will run a full combined workflow of sync and async processes to test everything at once (except for CTF decoding)
```