### PR TITLE
[ITS-ntracker] Add material budget fix and chi2 selection

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -72,6 +72,9 @@ struct TrackingParameters {
   /// Neighbour finding cuts
   std::vector<float> NeighbourMaxDeltaCurvature = {0.008f, 0.0025f, 0.003f, 0.0035f};
   std::vector<float> NeighbourMaxDeltaN = {0.002f, 0.0090f, 0.002f, 0.005f};
+  /// Fitter parameters
+  bool UseMatBudLUT = false;
+  std::array<float, 2> FitIterationMaxChi2 = {o2::constants::math::VeryBig, o2::constants::math::VeryBig};
 };
 
 struct MemoryParameters {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "ITStracking/Definitions.h"
+#include "CommonConstants/MathConstants.h"
 #include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -25,6 +25,8 @@
 #include <utility>
 
 #include "ITStracking/Configuration.h"
+#include "DetectorsBase/MatLayerCylSet.h"
+#include "CommonConstants/MathConstants.h"
 #include "ITStracking/Definitions.h"
 #include "ITStracking/ROframe.h"
 #include "ITStracking/MathUtils.h"
@@ -80,7 +82,8 @@ class Tracker
   void findCellsNeighbours(int& iteration);
   void findRoads(int& iteration);
   void findTracks(const ROframe& ev);
-  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step);
+  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step,
+                const float chi2cut = o2::constants::math::VeryBig);
   void traverseCellsTree(const int, const int);
   void computeRoadsMClabels(const ROframe&);
   void computeTracksMClabels(const ROframe&);
@@ -100,6 +103,7 @@ class Tracker
   std::uint32_t mROFrame = 0;
   std::vector<TrackITSExt> mTracks;
   std::vector<MCCompLabel> mTrackLabels;
+  o2::base::MatLayerCylSet* mMatLayerCylSet;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -103,7 +103,7 @@ class Tracker
   std::uint32_t mROFrame = 0;
   std::vector<TrackITSExt> mTracks;
   std::vector<MCCompLabel> mTrackLabels;
-  o2::base::MatLayerCylSet* mMatLayerCylSet;
+  o2::base::MatLayerCylSet* mMatLayerCylSet = nullptr;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
 };
 
@@ -111,6 +111,9 @@ inline void Tracker::setParameters(const std::vector<MemoryParameters>& memPars,
 {
   mMemParams = memPars;
   mTrkParams = trkPars;
+  if (mTrkParams[0].UseMatBudLUT) {
+    mMatLayerCylSet = o2::base::MatLayerCylSet::loadFromFile();
+  }
 }
 
 inline float Tracker::getBz() const


### PR DESCRIPTION
Added usage of LUT for material budeget correction is togglable. Might consider in the future to implement a query to the actual mat. budget crossed in a given geometry, for comparisons.
A consequence of this addition is that **we will need to produce a dedicated LUT for each possible geometry considered**.
For ITS2 I've been provided a file with corresponding geom, so we should be fine.
@shahor02: do you have, perhaps, a macro that generates a LUT given a generic geometry? This would allow us to benefit from the feature also in upgrades.

@mpuccio for review, @qgp for knowledge  