### PR TITLE
Adding truncation + some minor changes

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -105,7 +105,42 @@ class AODProducerWorkflowDPL : public Task
   int mFillTracksTPC = 1;
   int mFillTracksITSTPC = 1;
   int mTFNumber = -1;
+  int mTruncate = 1;
   TStopwatch mTimer;
+
+  // truncation is enabled by default
+  uint32_t mCollisionPosition = 0xFFFFFFF0;    // 19 bits mantissa
+  uint32_t mCollisionPositionCov = 0xFFFFE000; // 10 bits mantissa
+  uint32_t mTrackX = 0xFFFFFFF0;               // 19 bits
+  uint32_t mTrackAlpha = 0xFFFFFFF0;           // 19 bits
+  uint32_t mTrackSnp = 0xFFFFFF00;             // 15 bits
+  uint32_t mTrackTgl = 0xFFFFFF00;             // 15 bits
+  uint32_t mTrack1Pt = 0xFFFFFC00;             // 13 bits
+  uint32_t mTrackCovDiag = 0xFFFFFF00;         // 15 bits
+  uint32_t mTrackCovOffDiag = 0xFFFF0000;      // 7 bits
+  uint32_t mTrackSignal = 0xFFFFFF00;          // 15 bits
+  uint32_t mTrackPosEMCAL = 0xFFFFFF00;        // 15 bits
+  uint32_t mTracklets = 0xFFFFFF00;            // 15 bits
+  uint32_t mMcParticleW = 0xFFFFFFF0;          // 19 bits
+  uint32_t mMcParticlePos = 0xFFFFFFF0;        // 19 bits
+  uint32_t mMcParticleMom = 0xFFFFFFF0;        // 19 bits
+  uint32_t mCaloAmp = 0xFFFFFF00;              // 15 bits
+  uint32_t mCaloTime = 0xFFFFFF00;             // 15 bits
+  uint32_t mMuonTr1P = 0xFFFFFC00;             // 13 bits
+  uint32_t mMuonTrThetaX = 0xFFFFFF00;         // 15 bits
+  uint32_t mMuonTrThetaY = 0xFFFFFF00;         // 15 bits
+  uint32_t mMuonTrZmu = 0xFFFFFFF0;            // 19 bits
+  uint32_t mMuonTrBend = 0xFFFFFFF0;           // 19 bits
+  uint32_t mMuonTrNonBend = 0xFFFFFFF0;        // 19 bits
+  uint32_t mMuonTrCov = 0xFFFF0000;            // 7 bits
+  uint32_t mMuonCl = 0xFFFFFF00;               // 15 bits
+  uint32_t mMuonClErr = 0xFFFF0000;            // 7 bits
+  uint32_t mV0Time = 0xFFFFF000;               // 11 bits
+  uint32_t mFDDTime = 0xFFFFF000;              // 11 bits
+  uint32_t mT0Time = 0xFFFFFF00;               // 15 bits
+  uint32_t mV0Amplitude = 0xFFFFF000;          // 11 bits
+  uint32_t mFDDAmplitude = 0xFFFFF000;         // 11 bits
+  uint32_t mT0Amplitude = 0xFFFFF000;          // 11 bits
 
   uint64_t maxGlBC = 0;
   uint64_t minGlBC = INT64_MAX;
@@ -115,6 +150,8 @@ class AODProducerWorkflowDPL : public Task
 
   template <typename TracksType, typename TracksCursorType>
   void fillTracksTable(const TracksType& tracks, std::vector<int>& vCollRefs, const TracksCursorType& tracksCursor, int trackType);
+
+  float TruncateFloatFraction(float x, uint32_t mask);
 };
 
 /// create a processor spec


### PR DESCRIPTION
*Truncation is identical to [AliAnalysisTaskAO2Dconverter](https://github.com/alisw/AliPhysics/blob/master/RUN3/AliAnalysisTaskAO2Dconverter.cxx)
*`TruncateFloatFraction` was ported from [AliMathBase.h](https://github.com/alisw/AliRoot/blob/master/STAT/AliMathBase.h)
*Truncation is enabled by default
*Dummy tables (FV0A, FV0C, FDD, ZDC) are skipped for now
*Truncation can be disabled with `--enable-truncation 0` flag