### PR TITLE
Use value_t instead of double

### DIFF
--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -369,7 +369,7 @@ bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils::Point3
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  Double_t d = std::abs(x * snp - y * csp);
+  value_t d = std::abs(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -229,7 +229,7 @@ bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dataformat
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  Double_t d = std::abs(x * snp - y * csp);
+  value_t d = std::abs(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }


### PR DESCRIPTION
@shahor02 @MichaelLettrich : Is this supposed to be double, or was it an oversight when introducing the templates?
If it is supposed to be double, I'd change it to standard double instead of the ROOT Double_t instead.