### PR TITLE
Make TrackPar(Cov) compatible to GPU

### DIFF
--- a/Common/MathUtils/include/MathUtils/CartesianGPU.h
+++ b/Common/MathUtils/include/MathUtils/CartesianGPU.h
@@ -14,6 +14,8 @@
 #ifndef ALICEO2_CARTESIANGPU_H
 #define ALICEO2_CARTESIANGPU_H
 
+#include "GPUCommonDef.h"
+
 namespace o2::math_utils
 {
 
@@ -21,25 +23,25 @@ namespace detail
 {
 template <typename T, int I>
 struct GPUPoint2D {
-  GPUPoint2D() = default;
-  GPUPoint2D(T a, T b) : xx(a), yy(b) {}
+  GPUdDefault() GPUPoint2D() = default;
+  GPUd() GPUPoint2D(T a, T b) : xx(a), yy(b) {}
+  GPUd() float X() const { return xx; }
+  GPUd() float Y() const { return yy; }
+  GPUd() float R() const { return o2::gpu::CAMath::Sqrt(xx * xx + yy * yy); }
+  GPUd() void SetX(float v) { xx = v; }
+  GPUd() void SetY(float v) { yy = v; }
   T xx;
   T yy;
-  float X() const { return xx; }
-  float Y() const { return yy; }
-  float R() const { return o2::gpu::CAMath::Sqrt(xx * xx + yy * yy); }
-  void SetX(float v) { xx = v; }
-  void SetY(float v) { yy = v; }
 };
 
 template <typename T, int I>
 struct GPUPoint3D : public GPUPoint2D<T, I> {
-  GPUPoint3D() = default;
-  GPUPoint3D(T a, T b, T c) : GPUPoint2D<T, I>(a, b), zz(c) {}
+  GPUdDefault() GPUPoint3D() = default;
+  GPUd() GPUPoint3D(T a, T b, T c) : GPUPoint2D<T, I>(a, b), zz(c) {}
+  GPUd() float Z() const { return zz; }
+  GPUd() float R() const { return o2::gpu::CAMath::Sqrt(GPUPoint2D<T, I>::xx * GPUPoint2D<T, I>::xx + GPUPoint2D<T, I>::yy * GPUPoint2D<T, I>::yy + zz * zz); }
+  GPUd() void SetZ(float v) { zz = v; }
   T zz;
-  float Z() const { return zz; }
-  float R() const { return o2::gpu::CAMath::Sqrt(GPUPoint2D<T, I>::xx * GPUPoint2D<T, I>::xx + GPUPoint2D<T, I>::yy * GPUPoint2D<T, I>::yy + zz * zz); }
-  void SetZ(float v) { zz = v; }
 };
 } // namespace detail
 

--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -114,17 +114,17 @@ GPUdi() void sincosd(double ang, double& s, double& c)
   detail::sincos<double>(ang, s, c);
 }
 
-#ifndef GPUCA_GPUCODE_DEVICE
-inline void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
+GPUdi() void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
 {
   return detail::rotateZ<float>(xL, yL, xG, yG, snAlp, csAlp);
 }
 
-inline void rotateZd(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
+GPUdi() void rotateZd(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
 {
   return detail::rotateZ<double>(xL, yL, xG, yG, snAlp, csAlp);
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE
 inline void rotateZInv(float xG, float yG, float& xL, float& yL, float snAlp, float csAlp)
 {
   detail::rotateZInv<float>(xG, yG, xL, yL, snAlp, csAlp);

--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -108,11 +108,12 @@ GPUdi() void sincos(float ang, float& s, float& c)
 {
   detail::sincos<float>(ang, s, c);
 }
-
+#ifndef __OPENCL__
 GPUdi() void sincosd(double ang, double& s, double& c)
 {
   detail::sincos<double>(ang, s, c);
 }
+#endif
 
 GPUdi() void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
 {

--- a/Common/MathUtils/include/MathUtils/detail/CircleXY.h
+++ b/Common/MathUtils/include/MathUtils/detail/CircleXY.h
@@ -16,6 +16,7 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_CIRCLEXY_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_CIRCLEXY_H_
 
+#include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 
 namespace o2
@@ -32,18 +33,18 @@ struct CircleXY {
   T rC; // circle radius
   T xC; // x-center
   T yC; // y-center
-  CircleXY(T r = T(), T x = T(), T y = T());
-  T getCenterD2() const;
+  GPUd() CircleXY(T r = T(), T x = T(), T y = T());
+  GPUd() T getCenterD2() const;
   ClassDefNV(CircleXY, 2);
 };
 
 template <typename T>
-CircleXY<T>::CircleXY(T r, T x, T y) : rC(std::move(r)), xC(std::move(x)), yC(std::move(y))
+GPUdi() CircleXY<T>::CircleXY(T r, T x, T y) : rC(r), xC(x), yC(y)
 {
 }
 
 template <typename T>
-inline T CircleXY<T>::getCenterD2() const
+GPUdi() T CircleXY<T>::getCenterD2() const
 {
   return xC * xC + yC * yC;
 }

--- a/Common/MathUtils/include/MathUtils/detail/IntervalXY.h
+++ b/Common/MathUtils/include/MathUtils/detail/IntervalXY.h
@@ -16,9 +16,12 @@
 #ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_INTERVALXY_H_
 #define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_INTERVALXY_H_
 
+#include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <cmath>
 #include <tuple>
+#endif
 
 #include "MathUtils/detail/CircleXY.h"
 
@@ -36,30 +39,32 @@ class IntervalXY
   using value_t = T;
 
   ///< 2D interval in lab frame defined by its one edge and signed projection lengths on X,Y axes
-  IntervalXY(T x = T(), T y = T(), T dx = T(), T dy = T());
-  T getX0() const;
-  T getY0() const;
-  T& getX0();
-  T& getY0();
-  T getX1() const;
-  T getY1() const;
-  T getDX() const;
-  T getDY() const;
-  T& getDX();
-  T& getDY();
+  GPUd() IntervalXY(T x = T(), T y = T(), T dx = T(), T dy = T());
+  GPUd() T getX0() const;
+  GPUd() T getY0() const;
+  GPUd() T& getX0();
+  GPUd() T& getY0();
+  GPUd() T getX1() const;
+  GPUd() T getY1() const;
+  GPUd() T getDX() const;
+  GPUd() T getDY() const;
+  GPUd() T& getDX();
+  GPUd() T& getDY();
 
-  void setX0(T x0);
-  void setY0(T y0);
-  void setX1(T x1);
-  void setY1(T y1);
-  void setDX(T dx);
-  void setDY(T dy);
-  void setEdges(T x0, T y0, T x1, T y1);
+  GPUd() void setX0(T x0);
+  GPUd() void setY0(T y0);
+  GPUd() void setX1(T x1);
+  GPUd() void setY1(T y1);
+  GPUd() void setDX(T dx);
+  GPUd() void setDY(T dy);
+  GPUd() void setEdges(T x0, T y0, T x1, T y1);
 
-  void eval(T t, T& x, T& y) const;
+  GPUd() void eval(T t, T& x, T& y) const;
+#ifndef GPUCA_GPUCODE_DEVICE
   std::tuple<T, T> eval(T t) const;
+#endif
 
-  void getLineCoefs(T& a, T& b, T& c) const;
+  GPUd() void getLineCoefs(T& a, T& b, T& c) const;
 
   /** check if XY interval is seen by the circle.
   * The tolerance parameter eps is interpreted as a fraction of the interval
@@ -69,9 +74,9 @@ class IntervalXY
   * y = yc + dy*t
   * with 0<t<1., we acctually check the interval for -eps<t<1+eps
   */
-  bool seenByCircle(const CircleXY<T>& circle, T eps) const;
+  GPUd() bool seenByCircle(const CircleXY<T>& circle, T eps) const;
 
-  bool circleCrossParam(const CircleXY<T>& circle, T& t) const;
+  GPUd() bool circleCrossParam(const CircleXY<T>& circle, T& t) const;
 
   /**
   * check if XY interval is seen by the line defined by other interval
@@ -82,12 +87,12 @@ class IntervalXY
   * y = yc + dy*t
   * with 0<t<1., we acctually check the interval for -eps<t<1+eps
   */
-  bool seenByLine(const IntervalXY<T>& other, T eps) const;
+  GPUd() bool seenByLine(const IntervalXY<T>& other, T eps) const;
 
   /**
    * get crossing parameter of 2 intervals
    */
-  bool lineCrossParam(const IntervalXY<T>& other, T& t) const;
+  GPUd() bool lineCrossParam(const IntervalXY<T>& other, T& t) const;
 
  private:
   T mX, mY;   ///< one of edges
@@ -97,100 +102,100 @@ class IntervalXY
 };
 
 template <typename T>
-IntervalXY<T>::IntervalXY(T x, T y, T dx, T dy) : mX(std::move(x)), mY(std::move(y)), mDx(std::move(dx)), mDY(std::move(dy))
+GPUdi() IntervalXY<T>::IntervalXY(T x, T y, T dx, T dy) : mX(x), mY(y), mDx(dx), mDY(dy)
 {
 }
 
 template <typename T>
-inline T IntervalXY<T>::getX0() const
-{
-  return mX;
-}
-
-template <typename T>
-inline T IntervalXY<T>::getY0() const
-{
-  return mY;
-}
-
-template <typename T>
-inline T& IntervalXY<T>::getX0()
+GPUdi() T IntervalXY<T>::getX0() const
 {
   return mX;
 }
 
 template <typename T>
-inline T& IntervalXY<T>::getY0()
+GPUdi() T IntervalXY<T>::getY0() const
 {
   return mY;
 }
 
 template <typename T>
-inline T IntervalXY<T>::getX1() const
+GPUdi() T& IntervalXY<T>::getX0()
+{
+  return mX;
+}
+
+template <typename T>
+GPUdi() T& IntervalXY<T>::getY0()
+{
+  return mY;
+}
+
+template <typename T>
+GPUdi() T IntervalXY<T>::getX1() const
 {
   return mX + mDx;
 }
 template <typename T>
-inline T IntervalXY<T>::getY1() const
+GPUdi() T IntervalXY<T>::getY1() const
 {
   return mY + mDY;
 }
 template <typename T>
-inline T IntervalXY<T>::getDX() const
+GPUdi() T IntervalXY<T>::getDX() const
 {
   return mDx;
 }
 template <typename T>
-inline T IntervalXY<T>::getDY() const
+GPUdi() T IntervalXY<T>::getDY() const
 {
   return mDY;
 }
 
 template <typename T>
-inline T& IntervalXY<T>::getDX()
+GPUdi() T& IntervalXY<T>::getDX()
 {
   return mDx;
 }
 template <typename T>
-inline T& IntervalXY<T>::getDY()
+GPUdi() T& IntervalXY<T>::getDY()
 {
   return mDY;
 }
 
 template <typename T>
-inline void IntervalXY<T>::setX0(T x0)
+GPUdi() void IntervalXY<T>::setX0(T x0)
 {
   mX = x0;
 }
 
 template <typename T>
-inline void IntervalXY<T>::setY0(T y0)
+GPUdi() void IntervalXY<T>::setY0(T y0)
 {
   mY = y0;
 }
 template <typename T>
-inline void IntervalXY<T>::setX1(T x1)
+GPUdi() void IntervalXY<T>::setX1(T x1)
 {
   mDx = x1 - mX;
 }
 template <typename T>
-inline void IntervalXY<T>::setY1(T y1)
+GPUdi() void IntervalXY<T>::setY1(T y1)
 {
   mDY = y1 - mY;
 }
 template <typename T>
-inline void IntervalXY<T>::setDX(T dx)
+GPUdi() void IntervalXY<T>::setDX(T dx)
 {
   mDx = dx;
 }
 template <typename T>
-inline void IntervalXY<T>::setDY(T dy)
+GPUdi() void IntervalXY<T>::setDY(T dy)
 {
   mDY = dy;
 }
 
 template <typename T>
-inline void IntervalXY<T>::setEdges(T x0, T y0, T x1, T y1)
+GPUdi() void IntervalXY<T>::setEdges(T x0, T y0, T x1, T y1)
 {
   mX = x0;
   mY = y0;
@@ -198,20 +203,22 @@ inline void IntervalXY<T>::setEdges(T x0, T y0, T x1, T y1)
   mDY = y1 - y0;
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE
 template <typename T>
-inline std::tuple<T, T> IntervalXY<T>::eval(T t) const
+GPUdi() std::tuple<T, T> IntervalXY<T>::eval(T t) const
 {
   return {mX + t * mDx, mY + t * mDY};
 }
+#endif
 
 template <typename T>
-inline void IntervalXY<T>::eval(T t, T& x, T& y) const
+GPUdi() void IntervalXY<T>::eval(T t, T& x, T& y) const
 {
   std::tie(x, y) = eval(t);
 }
 
 template <typename T>
-void IntervalXY<T>::getLineCoefs(T& a, T& b, T& c) const
+GPUdi() void IntervalXY<T>::getLineCoefs(T& a, T& b, T& c) const
 {
   // convert to line parameters in canonical form: a*x+b*y+c = 0
   c = mX * mDY - mY * mDx;
@@ -230,7 +237,7 @@ void IntervalXY<T>::getLineCoefs(T& a, T& b, T& c) const
 }
 
 template <typename T>
-bool IntervalXY<T>::seenByCircle(const CircleXY<T>& circle, T eps) const
+GPUdi() bool IntervalXY<T>::seenByCircle(const CircleXY<T>& circle, T eps) const
 {
   T dx0 = mX - circle.xC;
   T dy0 = mY - circle.yC;
@@ -251,7 +258,7 @@ bool IntervalXY<T>::seenByCircle(const CircleXY<T>& circle, T eps) const
   return (d02 - rC2) * (d12 - rC2) < 0;
 }
 template <typename T>
-bool IntervalXY<T>::circleCrossParam(const CircleXY<T>& circle, T& t) const
+GPUdi() bool IntervalXY<T>::circleCrossParam(const CircleXY<T>& circle, T& t) const
 {
   const T dx = mX - circle.xC;
   const T dy = mY - circle.yC;
@@ -271,7 +278,7 @@ bool IntervalXY<T>::circleCrossParam(const CircleXY<T>& circle, T& t) const
 }
 
 template <typename T>
-bool IntervalXY<T>::seenByLine(const IntervalXY<T>& other, T eps) const
+GPUdi() bool IntervalXY<T>::seenByLine(const IntervalXY<T>& other, T eps) const
 {
   T a, b, c; // find equation of the line a*x+b*y+c = 0
   other.getLineCoefs(a, b, c);
@@ -282,7 +289,7 @@ bool IntervalXY<T>::seenByLine(const IntervalXY<T>& other, T eps) const
 }
 
 template <typename T>
-bool IntervalXY<T>::lineCrossParam(const IntervalXY<T>& other, T& t) const
+GPUdi() bool IntervalXY<T>::lineCrossParam(const IntervalXY<T>& other, T& t) const
 {
   // tolerance
   constexpr float eps = 1.e-9f;

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -107,17 +107,24 @@ inline void bringToPMPiGen(T& phi)
   phi = toPMPiGen<T>(phi);
 }
 
+#ifdef __OPENCL__ // TODO: get rid of that stupid workaround for OpenCL template address spaces
 template <typename T>
-GPUhdi() void sincos(T ang, GPUgeneric() T& s, GPUgeneric() T& c)
+GPUhdi() void sincos(T ang, float& s, float& c)
 {
   return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
-
+#else
+template <typename T>
+GPUhdi() void sincos(T ang, T& s, T& c)
+{
+  return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
+}
 template <>
-GPUhdi() void sincos(double ang, GPUgeneric() double& s, GPUgeneric() double& c)
+GPUhdi() void sincos(double ang, double& s, double& c)
 {
   return o2::gpu::GPUCommonMath::SinCosd(ang, s, c);
 }
+#endif
 
 #ifndef GPUCA_GPUCODE_DEVICE
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
@@ -11,12 +11,11 @@
 #ifndef ALICEO2_DCA_H
 #define ALICEO2_DCA_H
 
+#include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
+#include "GPUCommonArray.h"
 
-#ifndef __OPENCL__
-#include <array>
-#endif
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <iosfwd>
 #endif
 
@@ -32,14 +31,14 @@ class DCA
 {
 
  public:
-  DCA() = default;
+  GPUdDefault() DCA() = default;
 
-  DCA(float y, float z, float syy = 0.f, float syz = 0.f, float szz = 0.f)
+  GPUd() DCA(float y, float z, float syy = 0.f, float syz = 0.f, float szz = 0.f)
   {
     set(y, z, syy, syz, szz);
   }
 
-  void set(float y, float z, float syy, float syz, float szz)
+  GPUd() void set(float y, float z, float syy, float syz, float szz)
   {
     mY = y;
     mZ = z;
@@ -48,30 +47,32 @@ class DCA
     mCov[2] = szz;
   }
 
-  void set(float y, float z)
+  GPUd() void set(float y, float z)
   {
     mY = y;
     mZ = z;
   }
 
-  auto getY() const { return mY; }
-  auto getZ() const { return mZ; }
-  auto getSigmaY2() const { return mCov[0]; }
-  auto getSigmaYZ() const { return mCov[1]; }
-  auto getSigmaZ2() const { return mCov[2]; }
-  const auto& getCovariance() const { return mCov; }
+  GPUd() auto getY() const { return mY; }
+  GPUd() auto getZ() const { return mZ; }
+  GPUd() auto getSigmaY2() const { return mCov[0]; }
+  GPUd() auto getSigmaYZ() const { return mCov[1]; }
+  GPUd() auto getSigmaZ2() const { return mCov[2]; }
+  GPUd() const auto& getCovariance() const { return mCov; }
 
   void print() const;
 
  private:
   float mY = 0.f;
   float mZ = 0.f;
-  std::array<float, 3> mCov; ///< s2y, syz, s2z
+  gpu::gpustd::array<float, 3> mCov; ///< s2y, syz, s2z
 
   ClassDefNV(DCA, 1);
 };
 
+#ifndef GPUCA_GPUCODE_DEVICE
 std::ostream& operator<<(std::ostream& os, const DCA& d);
+#endif
 
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
@@ -16,7 +16,7 @@
 #ifndef __OPENCL__
 #include <array>
 #endif
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 #include <iosfwd>
 #endif
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
@@ -15,6 +15,7 @@
 #ifndef ALICEO2_track_PID_H_
 #define ALICEO2_track_PID_H_
 
+#include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "CommonConstants/PhysicsConstants.h"
 
@@ -99,44 +100,46 @@ class PID
   static constexpr ID NIDsTot = pid_constants::NIDsTot; ///< total number of defined IDs
   static_assert(NIDsTot == LastExt + 1, "Incorrect NIDsTot, please update!");
 
-  PID() = default;
-  PID(ID id) : mID(id) {}
-  PID(const char* name);
-  PID(const PID& src) = default;
-  PID& operator=(const PID& src) = default;
+  GPUdDefault() PID() = default;
+  GPUd() PID(ID id) : mID(id) {}
+  GPUd() PID(const char* name);
+  GPUdDefault() PID(const PID& src) = default;
+  GPUdDefault() PID& operator=(const PID& src) = default;
 
-  ID getID() const { return mID; }
-  operator ID() const { return getID(); }
+  GPUd() ID getID() const { return mID; }
+  GPUd() operator ID() const { return getID(); }
 
-  float getMass() const { return getMass(mID); }
-  float getMass2Z() const { return getMass2Z(mID); }
-  int getCharge() const { return getCharge(mID); }
+  GPUd() float getMass() const { return getMass(mID); }
+  GPUd() float getMass2Z() const { return getMass2Z(mID); }
+  GPUd() int getCharge() const { return getCharge(mID); }
 
-  static float getMass(ID id) { return pid_constants::sMasses[id]; }
-  static float getMass2(ID id) { return pid_constants::sMasses2[id]; }
-  static float getMass2Z(ID id) { return pid_constants::sMasses2Z[id]; }
-  static int getCharge(ID id) { return pid_constants::sCharges[id]; }
+  GPUd() static float getMass(ID id) { return pid_constants::sMasses[id]; }
+  GPUd() static float getMass2(ID id) { return pid_constants::sMasses2[id]; }
+  GPUd() static float getMass2Z(ID id) { return pid_constants::sMasses2Z[id]; }
+  GPUd() static int getCharge(ID id) { return pid_constants::sCharges[id]; }
 #ifndef GPUCA_GPUCODE_DEVICE
-  const char* getName() const
+  GPUd() const char* getName() const
   {
     return getName(mID);
   }
-  static const char* getName(ID id) { return pid_constants::sNames[id]; }
+  GPUd() static const char* getName(ID id) { return pid_constants::sNames[id]; }
 #endif
 
  private:
   ID mID = Pion;
 
   // are 2 strings equal ? (trick from Giulio)
-  inline static constexpr bool sameStr(char const* x, char const* y)
+  GPUdi() static constexpr bool sameStr(char const* x, char const* y)
   {
     return !*x && !*y ? true : /* default */ (*x == *y && sameStr(x + 1, y + 1));
   }
 
-  inline static constexpr ID nameToID(char const* name, ID id)
+#ifndef GPUCA_GPUCODE_DEVICE
+  GPUdi() static constexpr ID nameToID(char const* name, ID id)
   {
-    return id > LastExt ? id : sameStr(name, sNames[id]) ? id : nameToID(name, id + 1);
+    return id > LastExt ? id : sameStr(name, pid_constants::sNames[id]) ? id : nameToID(name, id + 1);
   }
+#endif
 
   ClassDefNV(PID, 2);
 };

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PrimaryVertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PrimaryVertex.h
@@ -36,7 +36,7 @@ class PrimaryVertex : public Vertex<TimeStampWithError<float, float>>
   void setIR(const InteractionRecord& ir) { mIRMin = mIRMax = ir; }
   bool hasUniqueIR() const { return !mIRMin.isDummy() && (mIRMin == mIRMax); }
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
   void print() const;
   std::string asString() const;
 #endif
@@ -48,7 +48,7 @@ class PrimaryVertex : public Vertex<TimeStampWithError<float, float>>
   ClassDefNV(PrimaryVertex, 1);
 };
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::PrimaryVertex& v);
 #endif
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -103,14 +103,14 @@ constexpr float kCY2max = 100 * 100, // SigmaY<=100cm
   kCalcdEdxAuto = -999.f;            // value indicating request for dedx calculation
 
 // access to covariance matrix by row and column
-constexpr int CovarMap[kNParams][kNParams] = {{0, 1, 3, 6, 10},
-                                              {1, 2, 4, 7, 11},
-                                              {3, 4, 5, 8, 12},
-                                              {6, 7, 8, 9, 13},
-                                              {10, 11, 12, 13, 14}};
+GPUconstexpr() int CovarMap[kNParams][kNParams] = {{0, 1, 3, 6, 10},
+                                                   {1, 2, 4, 7, 11},
+                                                   {3, 4, 5, 8, 12},
+                                                   {6, 7, 8, 9, 13},
+                                                   {10, 11, 12, 13, 14}};
 
 // access to covariance matrix diagonal elements
-constexpr int DiagMap[kNParams] = {0, 2, 5, 9, 14};
+GPUconstexpr() int DiagMap[kNParams] = {0, 2, 5, 9, 14};
 
 constexpr float HugeF = o2::constants::math::VeryBig;
 
@@ -124,100 +124,102 @@ class TrackParametrization
   using dim3_t = gpu::gpustd::array<value_t, 3>;
   using params_t = gpu::gpustd::array<value_t, kNParams>;
 
+#ifndef GPUCA_GPUCODE_DEVICE
   static_assert(std::is_floating_point_v<value_t>);
+#endif
 
-  TrackParametrization() = default;
-  TrackParametrization(value_t x, value_t alpha, const params_t& par, int charge = 1);
-  TrackParametrization(const dim3_t& xyz, const dim3_t& pxpypz, int charge, bool sectorAlpha = true);
-  TrackParametrization(const TrackParametrization&) = default;
-  TrackParametrization(TrackParametrization&&) = default;
-  TrackParametrization& operator=(const TrackParametrization& src) = default;
-  TrackParametrization& operator=(TrackParametrization&& src) = default;
-  ~TrackParametrization() = default;
+  GPUdDefault() TrackParametrization() = default;
+  GPUd() TrackParametrization(value_t x, value_t alpha, const params_t& par, int charge = 1);
+  GPUd() TrackParametrization(const dim3_t& xyz, const dim3_t& pxpypz, int charge, bool sectorAlpha = true);
+  GPUdDefault() TrackParametrization(const TrackParametrization&) = default;
+  GPUdDefault() TrackParametrization(TrackParametrization&&) = default;
+  GPUdDefault() TrackParametrization& operator=(const TrackParametrization& src) = default;
+  GPUdDefault() TrackParametrization& operator=(TrackParametrization&& src) = default;
+  GPUdDefault() ~TrackParametrization() = default;
 
-  const value_t* getParams() const;
-  value_t getParam(int i) const;
-  value_t getX() const;
-  value_t getAlpha() const;
-  value_t getY() const;
-  value_t getZ() const;
-  value_t getSnp() const;
-  value_t getTgl() const;
-  value_t getQ2Pt() const;
-  value_t getCharge2Pt() const;
-  int getAbsCharge() const;
-  PID getPID() const;
-  void setPID(const PID pid);
+  GPUd() const value_t* getParams() const;
+  GPUd() value_t getParam(int i) const;
+  GPUd() value_t getX() const;
+  GPUd() value_t getAlpha() const;
+  GPUd() value_t getY() const;
+  GPUd() value_t getZ() const;
+  GPUd() value_t getSnp() const;
+  GPUd() value_t getTgl() const;
+  GPUd() value_t getQ2Pt() const;
+  GPUd() value_t getCharge2Pt() const;
+  GPUd() int getAbsCharge() const;
+  GPUd() PID getPID() const;
+  GPUd() void setPID(const PID pid);
 
   /// calculate cos^2 and cos of track direction in rphi-tracking
-  value_t getCsp2() const;
-  value_t getCsp() const;
+  GPUd() value_t getCsp2() const;
+  GPUd() value_t getCsp() const;
 
-  void setX(value_t v);
-  void setParam(value_t v, int i);
-  void setAlpha(value_t v);
-  void setY(value_t v);
-  void setZ(value_t v);
-  void setSnp(value_t v);
-  void setTgl(value_t v);
-  void setQ2Pt(value_t v);
-  void setAbsCharge(int q);
+  GPUd() void setX(value_t v);
+  GPUd() void setParam(value_t v, int i);
+  GPUd() void setAlpha(value_t v);
+  GPUd() void setY(value_t v);
+  GPUd() void setZ(value_t v);
+  GPUd() void setSnp(value_t v);
+  GPUd() void setTgl(value_t v);
+  GPUd() void setQ2Pt(value_t v);
+  GPUd() void setAbsCharge(int q);
 
   // derived getters
-  bool getXatLabR(value_t r, value_t& x, value_t bz, DirType dir = DirAuto) const;
-  void getCircleParamsLoc(value_t bz, o2::math_utils::CircleXY<value_t>& circle) const;
-  void getCircleParams(value_t bz, o2::math_utils::CircleXY<value_t>& circle, value_t& sna, value_t& csa) const;
-  void getLineParams(o2::math_utils::IntervalXY<value_t>& line, value_t& sna, value_t& csa) const;
-  value_t getCurvature(value_t b) const;
-  int getCharge() const;
-  int getSign() const;
-  value_t getPhi() const;
-  value_t getPhiPos() const;
+  GPUd() bool getXatLabR(value_t r, value_t& x, value_t bz, DirType dir = DirAuto) const;
+  GPUd() void getCircleParamsLoc(value_t bz, o2::math_utils::CircleXY<value_t>& circle) const;
+  GPUd() void getCircleParams(value_t bz, o2::math_utils::CircleXY<value_t>& circle, value_t& sna, value_t& csa) const;
+  GPUd() void getLineParams(o2::math_utils::IntervalXY<value_t>& line, value_t& sna, value_t& csa) const;
+  GPUd() value_t getCurvature(value_t b) const;
+  GPUd() int getCharge() const;
+  GPUd() int getSign() const;
+  GPUd() value_t getPhi() const;
+  GPUd() value_t getPhiPos() const;
 
-  value_t getPtInv() const;
-  value_t getP2Inv() const;
-  value_t getP2() const;
-  value_t getPInv() const;
-  value_t getP() const;
-  value_t getPt() const;
+  GPUd() value_t getPtInv() const;
+  GPUd() value_t getP2Inv() const;
+  GPUd() value_t getP2() const;
+  GPUd() value_t getPInv() const;
+  GPUd() value_t getP() const;
+  GPUd() value_t getPt() const;
 
-  value_t getTheta() const;
-  value_t getEta() const;
-  math_utils::Point3D<value_t> getXYZGlo() const;
-  void getXYZGlo(dim3_t& xyz) const;
-  bool getPxPyPzGlo(dim3_t& pxyz) const;
-  bool getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const;
+  GPUd() value_t getTheta() const;
+  GPUd() value_t getEta() const;
+  GPUd() math_utils::Point3D<value_t> getXYZGlo() const;
+  GPUd() void getXYZGlo(dim3_t& xyz) const;
+  GPUd() bool getPxPyPzGlo(dim3_t& pxyz) const;
+  GPUd() bool getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const;
 
   // methods for track params estimate at other point
-  bool getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const;
-  value_t getZAt(value_t xk, value_t b) const;
-  value_t getYAt(value_t xk, value_t b) const;
-  math_utils::Point3D<value_t> getXYZGloAt(value_t xk, value_t b, bool& ok) const;
+  GPUd() bool getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const;
+  GPUd() value_t getZAt(value_t xk, value_t b) const;
+  GPUd() value_t getYAt(value_t xk, value_t b) const;
+  GPUd() math_utils::Point3D<value_t> getXYZGloAt(value_t xk, value_t b, bool& ok) const;
 
   // parameters manipulation
-  bool correctForELoss(value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
-  bool rotateParam(value_t alpha);
-  bool propagateParamTo(value_t xk, value_t b);
-  bool propagateParamTo(value_t xk, const dim3_t& b);
+  GPUd() bool correctForELoss(value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
+  GPUd() bool rotateParam(value_t alpha);
+  GPUd() bool propagateParamTo(value_t xk, value_t b);
+  GPUd() bool propagateParamTo(value_t xk, const dim3_t& b);
 
-  bool propagateParamToDCA(const math_utils::Point3D<value_t>& vtx, value_t b, dim2_t* dca = nullptr, value_t maxD = 999.f);
+  GPUd() bool propagateParamToDCA(const math_utils::Point3D<value_t>& vtx, value_t b, dim2_t* dca = nullptr, value_t maxD = 999.f);
 
-  void invertParam();
+  GPUd() void invertParam();
 
-  bool isValid() const;
-  void invalidate();
+  GPUd() bool isValid() const;
+  GPUd() void invalidate();
 
-  uint16_t getUserField() const;
-  void setUserField(uint16_t v);
+  GPUd() uint16_t getUserField() const;
+  GPUd() void setUserField(uint16_t v);
 
-  void printParam() const;
+  GPUd() void printParam() const;
 #ifndef GPUCA_ALIGPUCODE
   std::string asString() const;
 #endif
 
  protected:
-  void updateParam(value_t delta, int i);
-  void updateParams(const value_t delta[kNParams]);
+  GPUd() void updateParam(value_t delta, int i);
+  GPUd() void updateParams(const value_t delta[kNParams]);
 
  private:
   //
@@ -234,100 +236,102 @@ class TrackParametrization
 
 //____________________________________________________________
 template <typename value_T>
-inline TrackParametrization<value_T>::TrackParametrization(value_t x, value_t alpha, const params_t& par, int charge)
-  : mX{x}, mAlpha{alpha}, mAbsCharge{char(std::abs(charge))}
+GPUdi() TrackParametrization<value_T>::TrackParametrization(value_t x, value_t alpha, const params_t& par, int charge)
+  : mX{x}, mAlpha{alpha}, mAbsCharge{char(gpu::CAMath::Abs(charge))}
 {
   // explicit constructor
-  std::copy(par.begin(), par.end(), mP);
+  for (int i = 0; i < kNParams; i++) {
+    mP[i] = par[i];
+  }
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline const typename TrackParametrization<value_T>::value_t* TrackParametrization<value_T>::getParams() const
+GPUdi() const typename TrackParametrization<value_T>::value_t* TrackParametrization<value_T>::getParams() const
 {
   return mP;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getParam(int i) const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getParam(int i) const
 {
   return mP[i];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getX() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getX() const
 {
   return mX;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getAlpha() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getAlpha() const
 {
   return mAlpha;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getY() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getY() const
 {
   return mP[kY];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getZ() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getZ() const
 {
   return mP[kZ];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getSnp() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getSnp() const
 {
   return mP[kSnp];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTgl() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTgl() const
 {
   return mP[kTgl];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getQ2Pt() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getQ2Pt() const
 {
   return mP[kQ2Pt];
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCharge2Pt() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCharge2Pt() const
 {
   return mAbsCharge ? mP[kQ2Pt] : 0.f;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline int TrackParametrization<value_T>::getAbsCharge() const
+GPUdi() int TrackParametrization<value_T>::getAbsCharge() const
 {
   return mAbsCharge;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline PID TrackParametrization<value_T>::getPID() const
+GPUdi() PID TrackParametrization<value_T>::getPID() const
 {
   return mPID;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setPID(const PID pid)
+GPUdi() void TrackParametrization<value_T>::setPID(const PID pid)
 {
   mPID = pid;
   setAbsCharge(pid.getCharge());
@@ -335,7 +339,7 @@ inline void TrackParametrization<value_T>::setPID(const PID pid)
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp2() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp2() const
 {
   const value_t csp2 = (1.f - mP[kSnp]) * (1.f + mP[kSnp]);
   return csp2 > o2::constants::math::Almost0 ? csp2 : o2::constants::math::Almost0;
@@ -343,88 +347,88 @@ inline typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp() const
 {
-  return std::sqrt(getCsp2());
+  return gpu::CAMath::Sqrt(getCsp2());
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setX(value_t v)
+GPUdi() void TrackParametrization<value_T>::setX(value_t v)
 {
   mX = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setParam(value_t v, int i)
+GPUdi() void TrackParametrization<value_T>::setParam(value_t v, int i)
 {
   mP[i] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setAlpha(value_t v)
+GPUdi() void TrackParametrization<value_T>::setAlpha(value_t v)
 {
   mAlpha = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setY(value_t v)
+GPUdi() void TrackParametrization<value_T>::setY(value_t v)
 {
   mP[kY] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setZ(value_t v)
+GPUdi() void TrackParametrization<value_T>::setZ(value_t v)
 {
   mP[kZ] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setSnp(value_t v)
+GPUdi() void TrackParametrization<value_T>::setSnp(value_t v)
 {
   mP[kSnp] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setTgl(value_t v)
+GPUdi() void TrackParametrization<value_T>::setTgl(value_t v)
 {
   mP[kTgl] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setQ2Pt(value_t v)
+GPUdi() void TrackParametrization<value_T>::setQ2Pt(value_t v)
 {
   mP[kQ2Pt] = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::setAbsCharge(int q)
+GPUdi() void TrackParametrization<value_T>::setAbsCharge(int q)
 {
-  mAbsCharge = std::abs(q);
+  mAbsCharge = gpu::CAMath::Abs(q);
 }
 
 //_______________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::getCircleParamsLoc(value_t bz, o2::math_utils::CircleXY<value_t>& c) const
+GPUdi() void TrackParametrization<value_T>::getCircleParamsLoc(value_t bz, o2::math_utils::CircleXY<value_t>& c) const
 {
   // get circle params in track local frame, for straight line just set to local coordinates
   c.rC = getCurvature(bz);
   // treat as straight track if sagitta between the vertex and middle of TPC is below 0.01 cm
   constexpr value_t MinSagitta = 0.01f, TPCMidR = 160.f, MinCurv = 8 * MinSagitta / (TPCMidR * TPCMidR);
-  if (std::abs(c.rC) > MinCurv) {
+  if (gpu::CAMath::Abs(c.rC) > MinCurv) {
     c.rC = 1.f / getCurvature(bz);
-    value_t sn = getSnp(), cs = std::sqrt((1.f - sn) * (1.f + sn));
+    value_t sn = getSnp(), cs = gpu::CAMath::Sqrt((1.f - sn) * (1.f + sn));
     c.xC = getX() - sn * c.rC; // center in tracking
     c.yC = getY() + cs * c.rC; // frame. Note: r is signed!!!
-    c.rC = std::abs(c.rC);
+    c.rC = gpu::CAMath::Abs(c.rC);
   } else {
     c.rC = 0.f; // signal straight line
     c.xC = getX();
@@ -434,7 +438,7 @@ inline void TrackParametrization<value_T>::getCircleParamsLoc(value_t bz, o2::ma
 
 //_______________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::getCircleParams(value_t bz, o2::math_utils::CircleXY<value_t>& c, value_t& sna, value_t& csa) const
+GPUdi() void TrackParametrization<value_T>::getCircleParams(value_t bz, o2::math_utils::CircleXY<value_t>& c, value_t& sna, value_t& csa) const
 {
   // get circle params in loc and lab frame, for straight line just set to global coordinates
   getCircleParamsLoc(bz, c);
@@ -444,69 +448,69 @@ inline void TrackParametrization<value_T>::getCircleParams(value_t bz, o2::math_
 
 //_______________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::getLineParams(o2::math_utils::IntervalXY<value_t>& ln, value_t& sna, value_t& csa) const
+GPUdi() void TrackParametrization<value_T>::getLineParams(o2::math_utils::IntervalXY<value_t>& ln, value_t& sna, value_t& csa) const
 {
   // get line parameterization as { x = x0 + xSlp*t, y = y0 + ySlp*t }
   o2::math_utils::detail::sincos(getAlpha(), sna, csa);
   o2::math_utils::detail::rotateZ<value_t>(getX(), getY(), ln.getX0(), ln.getY0(), sna, csa); // reference point in global frame
-  value_t snp = getSnp(), csp = std::sqrt((1.f - snp) * (1.f + snp));
+  value_t snp = getSnp(), csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp));
   ln.setDX(csp * csa - snp * sna);
   ln.setDY(snp * csa + csp * sna);
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCurvature(value_t b) const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCurvature(value_t b) const
 {
   return mAbsCharge ? mP[kQ2Pt] * b * o2::constants::math::B2C : 0.;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline int TrackParametrization<value_T>::getCharge() const
+GPUdi() int TrackParametrization<value_T>::getCharge() const
 {
   return getSign() > 0 ? mAbsCharge : -mAbsCharge;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline int TrackParametrization<value_T>::getSign() const
+GPUdi() int TrackParametrization<value_T>::getSign() const
 {
   return mAbsCharge ? (mP[kQ2Pt] > 0.f ? 1 : -1) : 0;
 }
 
 //_______________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhi() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhi() const
 {
   // track pt direction phi (in 0:2pi range)
-  value_t phi = std::asin(getSnp()) + getAlpha();
+  value_t phi = gpu::CAMath::ASin(getSnp()) + getAlpha();
   math_utils::detail::bringTo02Pi<value_t>(phi);
   return phi;
 }
 
 //_______________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhiPos() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhiPos() const
 {
   // angle of track position (in -pi:pi range)
-  value_t phi = std::atan2(getY(), getX()) + getAlpha();
+  value_t phi = gpu::CAMath::ATan2(getY(), getX()) + getAlpha();
   math_utils::detail::bringTo02Pi<value_t>(phi);
   return phi;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPtInv() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPtInv() const
 {
   // return the inverted track pT
-  const value_t ptInv = std::fabs(mP[kQ2Pt]);
+  const value_t ptInv = gpu::CAMath::Abs(mP[kQ2Pt]);
   return (mAbsCharge > 1) ? ptInv / mAbsCharge : ptInv;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2Inv() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2Inv() const
 {
   // return the inverted track momentum^2
   const value_t p2 = mP[kQ2Pt] * mP[kQ2Pt] / (1.f + getTgl() * getTgl());
@@ -515,7 +519,7 @@ inline typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2() const
 {
   // return the track momentum^2
   const value_t p2inv = getP2Inv();
@@ -524,16 +528,16 @@ inline typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPInv() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPInv() const
 {
   // return the inverted track momentum^2
-  const value_t pInv = std::fabs(mP[kQ2Pt]) / std::sqrt(1.f + getTgl() * getTgl());
+  const value_t pInv = gpu::CAMath::Abs(mP[kQ2Pt]) / gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
   return (mAbsCharge > 1) ? pInv / mAbsCharge : pInv;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP() const
 {
   // return the track momentum
   const value_t pInv = getPInv();
@@ -542,10 +546,10 @@ inline typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPt() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPt() const
 {
   // return the track transverse momentum
-  value_t ptI = std::fabs(mP[kQ2Pt]);
+  value_t ptI = gpu::CAMath::Abs(mP[kQ2Pt]);
   if (mAbsCharge > 1) {
     ptI /= mAbsCharge;
   }
@@ -554,34 +558,34 @@ inline typename TrackParametrization<value_T>::value_t TrackParametrization<valu
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTheta() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTheta() const
 {
-  return constants::math::PIHalf - std::atan(mP[3]);
+  return constants::math::PIHalf - gpu::CAMath::ATan(mP[3]);
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getEta() const
+GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getEta() const
 {
-  return -std::log(std::tan(0.5f * getTheta()));
+  return -gpu::CAMath::Log(gpu::CAMath::Tan(0.5f * getTheta()));
 }
 
 //_______________________________________________________
 template <typename value_T>
-inline math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGlo() const
+GPUdi() math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGlo() const
 {
 #ifndef GPUCA_ALIGPUCODE
   return math_utils::Rotation2D<value_t>(getAlpha())(math_utils::Point3D<value_t>(getX(), getY(), getZ()));
 #else // mockup on GPU without ROOT
   float sina, cosa;
-  o2::gpu::CAMath::SinCos(getAlpha(), sina, cosa);
+  gpu::CAMath::SinCos(getAlpha(), sina, cosa);
   return math_utils::Point3D<value_t>(cosa * getX() + sina * getY(), cosa * getY() - sina * getX(), getZ());
 #endif
 }
 
 //_______________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::getXYZGlo(dim3_t& xyz) const
+GPUdi() void TrackParametrization<value_T>::getXYZGlo(dim3_t& xyz) const
 {
   // track coordinates in lab frame
   xyz[0] = getX();
@@ -592,7 +596,7 @@ inline void TrackParametrization<value_T>::getXYZGlo(dim3_t& xyz) const
 
 //_______________________________________________________
 template <typename value_T>
-inline math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGloAt(value_t xk, value_t b, bool& ok) const
+GPUdi() math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGloAt(value_t xk, value_t b, bool& ok) const
 {
   //----------------------------------------------------------------
   // estimate global X,Y,Z in global frame at given X
@@ -604,7 +608,7 @@ inline math_utils::Point3D<typename TrackParametrization<value_T>::value_t> Trac
     return math_utils::Rotation2D<value_t>(getAlpha())(math_utils::Point3D<value_t>(xk, y, z));
 #else // mockup on GPU without ROOT
     float sina, cosa;
-    o2::gpu::CAMath::SinCos(getAlpha(), sina, cosa);
+    gpu::CAMath::SinCos(getAlpha(), sina, cosa);
     return math_utils::Point3D<value_t>(cosa * xk + sina * y, cosa * y - sina * xk, z);
 #endif
   } else {
@@ -614,40 +618,40 @@ inline math_utils::Point3D<typename TrackParametrization<value_T>::value_t> Trac
 
 //____________________________________________________________
 template <typename value_T>
-inline bool TrackParametrization<value_T>::isValid() const
+GPUdi() bool TrackParametrization<value_T>::isValid() const
 {
   return mX != InvalidX;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::invalidate()
+GPUdi() void TrackParametrization<value_T>::invalidate()
 {
   mX = InvalidX;
 }
 
 template <typename value_T>
-inline uint16_t TrackParametrization<value_T>::getUserField() const
+GPUdi() uint16_t TrackParametrization<value_T>::getUserField() const
 {
   return mUserField;
 }
 
 template <typename value_T>
-inline void TrackParametrization<value_T>::setUserField(uint16_t v)
+GPUdi() void TrackParametrization<value_T>::setUserField(uint16_t v)
 {
   mUserField = v;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::updateParam(value_t delta, int i)
+GPUdi() void TrackParametrization<value_T>::updateParam(value_t delta, int i)
 {
   mP[i] += delta;
 }
 
 //____________________________________________________________
 template <typename value_T>
-inline void TrackParametrization<value_T>::updateParams(const value_t delta[kNParams])
+GPUdi() void TrackParametrization<value_T>::updateParams(const value_t delta[kNParams])
 {
   for (int i = kNParams; i--;) {
     mP[i] += delta[i];

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -28,10 +28,11 @@
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
 #include "GPUCommonMath.h"
+#include "GPUCommonArray.h"
+#include "GPUROOTCartesianFwd.h"
 
 #ifndef __OPENCL__
 #include <algorithm>
-#include <array>
 #include <cfloat>
 #include <cmath>
 #include <cstring>
@@ -49,9 +50,6 @@
 #include "ReconstructionDataFormats/PID.h"
 
 #include "ReconstructionDataFormats/TrackUtils.h"
-
-//Forward declarations, since we cannot include the headers if we eventually want to use track.h on GPU
-#include "GPUROOTCartesianFwd.h"
 
 namespace o2
 {
@@ -122,9 +120,9 @@ class TrackParametrization
 
  public:
   using value_t = value_T;
-  using dim2_t = std::array<value_t, 2>;
-  using dim3_t = std::array<value_t, 3>;
-  using params_t = std::array<value_t, kNParams>;
+  using dim2_t = gpu::gpustd::array<value_t, 2>;
+  using dim3_t = gpu::gpustd::array<value_t, 3>;
+  using params_t = gpu::gpustd::array<value_t, kNParams>;
 
   static_assert(std::is_floating_point_v<value_t>);
 
@@ -188,7 +186,7 @@ class TrackParametrization
   math_utils::Point3D<value_t> getXYZGlo() const;
   void getXYZGlo(dim3_t& xyz) const;
   bool getPxPyPzGlo(dim3_t& pxyz) const;
-  bool getPosDirGlo(std::array<value_t, 9>& posdirp) const;
+  bool getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const;
 
   // methods for track params estimate at other point
   bool getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const;

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -37,12 +37,12 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   static_assert(std::is_floating_point_v<value_t>);
 
  public:
-  using covMat_t = std::array<value_t, kCovMatSize>;
+  using covMat_t = gpu::gpustd::array<value_t, kCovMatSize>;
 
   TrackParametrizationWithError();
-  TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par, const std::array<value_t, kCovMatSize>& cov, int charge = 1);
+  TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1);
   TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
-                                const std::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true);
+                                       const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true);
 
   TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
   TrackParametrizationWithError(TrackParametrizationWithError&& src) = default;
@@ -70,7 +70,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   value_t getCovarElem(int i, int j) const;
   value_t getDiagError2(int i) const;
 
-  bool getCovXYZPxPyPzGlo(std::array<value_t, kLabCovMatSize>& c) const;
+  bool getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& c) const;
 
   void print() const;
 #ifndef GPUCA_ALIGPUCODE

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -34,82 +34,82 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   using typename TrackParametrization<value_T>::dim2_t;
   using typename TrackParametrization<value_T>::params_t;
 
+#ifndef GPUCA_GPUCODE_DEVICE
   static_assert(std::is_floating_point_v<value_t>);
+#endif
 
  public:
   using covMat_t = gpu::gpustd::array<value_t, kCovMatSize>;
 
-  TrackParametrizationWithError();
-  TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1);
-  TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
+  GPUd() TrackParametrizationWithError();
+  GPUd() TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1);
+  GPUd() TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
                                        const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true);
 
-  TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
-  TrackParametrizationWithError(TrackParametrizationWithError&& src) = default;
-  TrackParametrizationWithError& operator=(const TrackParametrizationWithError& src) = default;
-  TrackParametrizationWithError& operator=(TrackParametrizationWithError&& src) = default;
-  ~TrackParametrizationWithError() = default;
+  GPUdDefault() TrackParametrizationWithError(const TrackParametrizationWithError& src) = default;
+  GPUdDefault() TrackParametrizationWithError(TrackParametrizationWithError&& src) = default;
+  GPUdDefault() TrackParametrizationWithError& operator=(const TrackParametrizationWithError& src) = default;
+  GPUdDefault() TrackParametrizationWithError& operator=(TrackParametrizationWithError&& src) = default;
+  GPUdDefault() ~TrackParametrizationWithError() = default;
   using TrackParametrization<value_T>::TrackParametrization;
 
-  const value_t* getCov() const;
-  value_t getSigmaY2() const;
-  value_t getSigmaZY() const;
-  value_t getSigmaZ2() const;
-  value_t getSigmaSnpY() const;
-  value_t getSigmaSnpZ() const;
-  value_t getSigmaSnp2() const;
-  value_t getSigmaTglY() const;
-  value_t getSigmaTglZ() const;
-  value_t getSigmaTglSnp() const;
-  value_t getSigmaTgl2() const;
-  value_t getSigma1PtY() const;
-  value_t getSigma1PtZ() const;
-  value_t getSigma1PtSnp() const;
-  value_t getSigma1PtTgl() const;
-  value_t getSigma1Pt2() const;
-  value_t getCovarElem(int i, int j) const;
-  value_t getDiagError2(int i) const;
+  GPUd() const value_t* getCov() const;
+  GPUd() value_t getSigmaY2() const;
+  GPUd() value_t getSigmaZY() const;
+  GPUd() value_t getSigmaZ2() const;
+  GPUd() value_t getSigmaSnpY() const;
+  GPUd() value_t getSigmaSnpZ() const;
+  GPUd() value_t getSigmaSnp2() const;
+  GPUd() value_t getSigmaTglY() const;
+  GPUd() value_t getSigmaTglZ() const;
+  GPUd() value_t getSigmaTglSnp() const;
+  GPUd() value_t getSigmaTgl2() const;
+  GPUd() value_t getSigma1PtY() const;
+  GPUd() value_t getSigma1PtZ() const;
+  GPUd() value_t getSigma1PtSnp() const;
+  GPUd() value_t getSigma1PtTgl() const;
+  GPUd() value_t getSigma1Pt2() const;
+  GPUd() value_t getCovarElem(int i, int j) const;
+  GPUd() value_t getDiagError2(int i) const;
 
-  bool getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& c) const;
+  GPUd() bool getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& c) const;
 
-  void print() const;
+  GPUd() void print() const;
 #ifndef GPUCA_ALIGPUCODE
   std::string asString() const;
 #endif
 
   // parameters + covmat manipulation
-  bool rotate(value_t alpha);
-  bool propagateTo(value_t xk, value_t b);
-  bool propagateTo(value_t xk, const dim3_t& b);
-  bool propagateToDCA(const o2::dataformats::VertexBase& vtx, value_t b, o2::dataformats::DCA* dca = nullptr, value_t maxD = 999.f);
-  void invert();
+  GPUd() bool rotate(value_t alpha);
+  GPUd() bool propagateTo(value_t xk, value_t b);
+  GPUd() bool propagateTo(value_t xk, const dim3_t& b);
+  GPUd() bool propagateToDCA(const o2::dataformats::VertexBase& vtx, value_t b, o2::dataformats::DCA* dca = nullptr, value_t maxD = 999.f);
+  GPUd() void invert();
 
-  value_t getPredictedChi2(const dim2_t& p, const dim3_t& cov) const;
+  GPUd() value_t getPredictedChi2(const dim2_t& p, const dim3_t& cov) const;
 
   template <typename T>
-  value_t getPredictedChi2(const BaseCluster<T>& p) const;
-
-  value_t getPredictedChi2(const TrackParametrizationWithError& rhs) const;
+  GPUd() value_t getPredictedChi2(const BaseCluster<T>& p) const;
 
   void buildCombinedCovMatrix(const TrackParametrizationWithError& rhs, MatrixDSym5& cov) const;
   value_t getPredictedChi2(const TrackParametrizationWithError& rhs, MatrixDSym5& covToSet) const;
+  value_t getPredictedChi2(const TrackParametrizationWithError& rhs) const;
   bool update(const TrackParametrizationWithError& rhs, const MatrixDSym5& covInv);
-
-  bool update(const dim2_t& p, const dim3_t& cov);
-
-  template <typename T>
-  bool update(const BaseCluster<T>& p);
-
   bool update(const TrackParametrizationWithError& rhs);
 
-  bool correctForMaterial(value_t x2x0, value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
+  GPUd() bool update(const dim2_t& p, const dim3_t& cov);
 
-  void resetCovariance(value_t s2 = 0);
-  void checkCovariance();
-  void setCov(value_t v, int i);
+  template <typename T>
+  GPUd() bool update(const BaseCluster<T>& p);
 
-  void updateCov(const value_t delta[kCovMatSize]);
-  void updateCov(value_t delta, int i);
+  GPUd() bool correctForMaterial(value_t x2x0, value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
+
+  GPUd() void resetCovariance(value_t s2 = 0);
+  GPUd() void checkCovariance();
+  GPUd() void setCov(value_t v, int i);
+
+  GPUd() void updateCov(const value_t delta[kCovMatSize]);
+  GPUd() void updateCov(value_t delta, int i);
 
  protected:
   value_t mC[kCovMatSize] = {0.f}; // 15 covariance matrix elements
@@ -119,142 +119,144 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
 
 //__________________________________________________________________________
 template <typename value_T>
-inline TrackParametrizationWithError<value_T>::TrackParametrizationWithError() : TrackParametrization<value_T>{}
+GPUdi() TrackParametrizationWithError<value_T>::TrackParametrizationWithError() : TrackParametrization<value_T>{}
 {
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline TrackParametrizationWithError<value_T>::TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par,
-                                                                             const std::array<value_t, kCovMatSize>& cov, int charge)
+GPUdi() TrackParametrizationWithError<value_T>::TrackParametrizationWithError(value_t x, value_t alpha, const params_t& par,
+                                                                              const covMat_t& cov, int charge)
   : TrackParametrization<value_T>{x, alpha, par, charge}
 {
   // explicit constructor
-  std::copy(cov.begin(), cov.end(), mC);
+  for (int i = 0; i < kCovMatSize; i++) {
+    mC[i] = cov[i];
+  }
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline const typename TrackParametrizationWithError<value_T>::value_t* TrackParametrizationWithError<value_T>::getCov() const
+GPUdi() const typename TrackParametrizationWithError<value_T>::value_t* TrackParametrizationWithError<value_T>::getCov() const
 {
   return mC;
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaY2() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaY2() const
 {
   return mC[kSigY2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZY() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZY() const
 {
   return mC[kSigZY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZ2() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZ2() const
 {
   return mC[kSigZ2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpY() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpY() const
 {
   return mC[kSigSnpY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpZ() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpZ() const
 {
   return mC[kSigSnpZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnp2() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnp2() const
 {
   return mC[kSigSnp2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglY() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglY() const
 {
   return mC[kSigTglY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglZ() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglZ() const
 {
   return mC[kSigTglZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglSnp() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglSnp() const
 {
   return mC[kSigTglSnp];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTgl2() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTgl2() const
 {
   return mC[kSigTgl2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtY() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtY() const
 {
   return mC[kSigQ2PtY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtZ() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtZ() const
 {
   return mC[kSigQ2PtZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtSnp() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtSnp() const
 {
   return mC[kSigQ2PtSnp];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtTgl() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtTgl() const
 {
   return mC[kSigQ2PtTgl];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1Pt2() const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1Pt2() const
 {
   return mC[kSigQ2Pt2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getCovarElem(int i, int j) const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getCovarElem(int i, int j) const
 {
   return mC[CovarMap[i][j]];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getDiagError2(int i) const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getDiagError2(int i) const
 {
   return mC[DiagMap[i]];
 }
@@ -262,7 +264,7 @@ inline typename TrackParametrizationWithError<value_T>::value_t TrackParametriza
 //__________________________________________________________________________
 template <typename value_T>
 template <typename T>
-typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const BaseCluster<T>& p) const
+GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const BaseCluster<T>& p) const
 {
   const dim2_t pyz = {p.getY(), p.getZ()};
   const dim3_t cov = {p.getSigmaY2(), p.getSigmaYZ(), p.getSigmaZ2()};
@@ -272,7 +274,7 @@ typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWit
 //__________________________________________________________________________
 template <typename value_T>
 template <typename T>
-bool TrackParametrizationWithError<value_T>::update(const BaseCluster<T>& p)
+GPUdi() bool TrackParametrizationWithError<value_T>::update(const BaseCluster<T>& p)
 {
   const dim2_t pyz = {p.getY(), p.getZ()};
   const dim3_t cov = {p.getSigmaY2(), p.getSigmaYZ(), p.getSigmaZ2()};
@@ -281,21 +283,21 @@ bool TrackParametrizationWithError<value_T>::update(const BaseCluster<T>& p)
 
 //__________________________________________________________________________
 template <typename value_T>
-inline void TrackParametrizationWithError<value_T>::setCov(value_t v, int i)
+GPUdi() void TrackParametrizationWithError<value_T>::setCov(value_t v, int i)
 {
   mC[i] = v;
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline void TrackParametrizationWithError<value_T>::updateCov(value_t delta, int i)
+GPUdi() void TrackParametrizationWithError<value_T>::updateCov(value_t delta, int i)
 {
   mC[i] += delta;
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-inline void TrackParametrizationWithError<value_T>::updateCov(const value_t delta[kCovMatSize])
+GPUdi() void TrackParametrizationWithError<value_T>::updateCov(const value_t delta[kCovMatSize])
 {
   for (int i = kCovMatSize; i--;) {
     mC[i] += delta[i];

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackUtils.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackUtils.h
@@ -17,9 +17,9 @@
 #define INCLUDE_RECONSTRUCTIONDATAFORMATS_TRACKUTILS_H_
 
 #include "GPUCommonRtypes.h"
+#include "GPUCommonArray.h"
 
 #ifndef __OPENCL__
-#include <array>
 #include <cmath>
 #endif
 
@@ -33,13 +33,13 @@ namespace track
 // helper function
 template <typename value_T = float>
 value_T BetheBlochSolid(value_T bg, value_T rho = 2.33, value_T kp1 = 0.20, value_T kp2 = 3.00, value_T meanI = 173e-9,
-                        value_T meanZA = 0.49848);
+                               value_T meanZA = 0.49848);
 template <typename value_T = float>
-void g3helx3(value_T qfield, value_T step, std::array<value_T, 7>& vect);
+void g3helx3(value_T qfield, value_T step, gpu::gpustd::array<value_T, 7>& vect);
 
 //____________________________________________________
 template <typename value_T>
-void g3helx3(value_T qfield, value_T step, std::array<value_T, 7>& vect)
+void g3helx3(value_T qfield, value_T step, gpu::gpustd::array<value_T, 7>& vect)
 {
   /******************************************************************
    *                                                                *

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -11,12 +11,15 @@
 #ifndef ALICEO2_VERTEX_H
 #define ALICEO2_VERTEX_H
 
+#include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
 #include <MathUtils/Cartesian.h>
+
 #include "CommonDataFormat/TimeStamp.h"
 #ifndef __OPENCL__
 #include <array>
 #endif
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 #include <iosfwd>
 #endif
 
@@ -42,7 +45,7 @@ class VertexBase
   {
   }
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
   void print() const;
   std::string asString() const;
 #endif
@@ -144,7 +147,7 @@ class Vertex : public VertexBase
   ClassDefNV(Vertex, 3);
 };
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::VertexBase& v);
 #endif
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -13,13 +13,11 @@
 
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
+#include "GPUCommonArray.h"
 #include <MathUtils/Cartesian.h>
 
 #include "CommonDataFormat/TimeStamp.h"
-#ifndef __OPENCL__
-#include <array>
-#endif
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 #include <iosfwd>
 #endif
 
@@ -39,51 +37,51 @@ class VertexBase
                         kCovYZ,
                         kCovZZ };
   static constexpr int kNCov = 6;
-  VertexBase() = default;
-  ~VertexBase() = default;
-  VertexBase(const math_utils::Point3D<float>& pos, const std::array<float, kNCov>& cov) : mPos(pos), mCov(cov)
+  GPUdDefault() VertexBase() = default;
+  GPUdDefault() ~VertexBase() = default;
+  GPUd() VertexBase(const math_utils::Point3D<float>& pos, const gpu::gpustd::array<float, kNCov>& cov) : mPos(pos), mCov(cov)
   {
   }
 
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
   void print() const;
   std::string asString() const;
 #endif
 
   // getting the cartesian coordinates and errors
-  float getX() const { return mPos.X(); }
-  float getY() const { return mPos.Y(); }
-  float getZ() const { return mPos.Z(); }
-  float getSigmaX2() const { return mCov[kCovXX]; }
-  float getSigmaY2() const { return mCov[kCovYY]; }
-  float getSigmaZ2() const { return mCov[kCovZZ]; }
-  float getSigmaXY() const { return mCov[kCovXY]; }
-  float getSigmaXZ() const { return mCov[kCovXZ]; }
-  float getSigmaYZ() const { return mCov[kCovYZ]; }
-  const std::array<float, kNCov>& getCov() const { return mCov; }
+  GPUd() float getX() const { return mPos.X(); }
+  GPUd() float getY() const { return mPos.Y(); }
+  GPUd() float getZ() const { return mPos.Z(); }
+  GPUd() float getSigmaX2() const { return mCov[kCovXX]; }
+  GPUd() float getSigmaY2() const { return mCov[kCovYY]; }
+  GPUd() float getSigmaZ2() const { return mCov[kCovZZ]; }
+  GPUd() float getSigmaXY() const { return mCov[kCovXY]; }
+  GPUd() float getSigmaXZ() const { return mCov[kCovXZ]; }
+  GPUd() float getSigmaYZ() const { return mCov[kCovYZ]; }
+  GPUd() const gpu::gpustd::array<float, kNCov>& getCov() const { return mCov; }
 
-  math_utils::Point3D<float> getXYZ() const { return mPos; }
-  math_utils::Point3D<float>& getXYZ() { return mPos; }
+  GPUd() math_utils::Point3D<float> getXYZ() const { return mPos; }
+  GPUd() math_utils::Point3D<float>& getXYZ() { return mPos; }
 
-  void setX(float x) { mPos.SetX(x); }
-  void setY(float y) { mPos.SetY(y); }
-  void setZ(float z) { mPos.SetZ(z); }
+  GPUd() void setX(float x) { mPos.SetX(x); }
+  GPUd() void setY(float y) { mPos.SetY(y); }
+  GPUd() void setZ(float z) { mPos.SetZ(z); }
 
-  void setXYZ(float x, float y, float z)
+  GPUd() void setXYZ(float x, float y, float z)
   {
     setX(x);
     setY(y);
     setZ(z);
   }
-  void setPos(const math_utils::Point3D<float>& p) { mPos = p; }
+  GPUd() void setPos(const math_utils::Point3D<float>& p) { mPos = p; }
 
-  void setSigmaX2(float v) { mCov[kCovXX] = v; }
-  void setSigmaY2(float v) { mCov[kCovYY] = v; }
-  void setSigmaZ2(float v) { mCov[kCovZZ] = v; }
-  void setSigmaXY(float v) { mCov[kCovXY] = v; }
-  void setSigmaXZ(float v) { mCov[kCovXZ] = v; }
-  void setSigmaYZ(float v) { mCov[kCovYZ] = v; }
-  void setCov(float sxx, float sxy, float syy, float sxz, float syz, float szz)
+  GPUd() void setSigmaX2(float v) { mCov[kCovXX] = v; }
+  GPUd() void setSigmaY2(float v) { mCov[kCovYY] = v; }
+  GPUd() void setSigmaZ2(float v) { mCov[kCovZZ] = v; }
+  GPUd() void setSigmaXY(float v) { mCov[kCovXY] = v; }
+  GPUd() void setSigmaXZ(float v) { mCov[kCovXZ] = v; }
+  GPUd() void setSigmaYZ(float v) { mCov[kCovYZ] = v; }
+  GPUd() void setCov(float sxx, float sxy, float syy, float sxz, float syz, float szz)
   {
     setSigmaX2(sxx);
     setSigmaY2(syy);
@@ -92,11 +90,11 @@ class VertexBase
     setSigmaXZ(sxz);
     setSigmaYZ(syz);
   }
-  void setCov(const std::array<float, kNCov>& cov) { mCov = cov; }
+  GPUd() void setCov(const gpu::gpustd::array<float, kNCov>& cov) { mCov = cov; }
 
  protected:
   math_utils::Point3D<float> mPos{0., 0., 0.}; ///< cartesian position
-  std::array<float, kNCov> mCov{};             ///< errors, see CovElems enum
+  gpu::gpustd::array<float, kNCov> mCov{};     ///< errors, see CovElems enum
 
   ClassDefNV(VertexBase, 1);
 };
@@ -115,28 +113,28 @@ class Vertex : public VertexBase
     FlagsMask = 0xffff
   };
 
-  Vertex() = default;
-  ~Vertex() = default;
-  Vertex(const math_utils::Point3D<float>& pos, const std::array<float, kNCov>& cov, ushort nCont, float chi2)
+  GPUdDefault() Vertex() = default;
+  GPUdDefault() ~Vertex() = default;
+  GPUd() Vertex(const math_utils::Point3D<float>& pos, const gpu::gpustd::array<float, kNCov>& cov, ushort nCont, float chi2)
     : VertexBase(pos, cov), mNContributors(nCont), mChi2(chi2)
   {
   }
 
-  ushort getNContributors() const { return mNContributors; }
-  void setNContributors(ushort v) { mNContributors = v; }
-  void addContributor() { mNContributors++; }
+  GPUd() ushort getNContributors() const { return mNContributors; }
+  GPUd() void setNContributors(ushort v) { mNContributors = v; }
+  GPUd() void addContributor() { mNContributors++; }
 
-  ushort getFlags() const { return mBits; }
-  bool isFlagSet(uint f) const { return mBits & (FlagsMask & f); }
-  void setFlags(ushort f) { mBits |= FlagsMask & f; }
-  void resetFrags(ushort f = FlagsMask) { mBits &= ~(FlagsMask & f); }
+  GPUd() ushort getFlags() const { return mBits; }
+  GPUd() bool isFlagSet(uint f) const { return mBits & (FlagsMask & f); }
+  GPUd() void setFlags(ushort f) { mBits |= FlagsMask & f; }
+  GPUd() void resetFrags(ushort f = FlagsMask) { mBits &= ~(FlagsMask & f); }
 
-  void setChi2(float v) { mChi2 = v; }
-  float getChi2() const { return mChi2; }
+  GPUd() void setChi2(float v) { mChi2 = v; }
+  GPUd() float getChi2() const { return mChi2; }
 
-  const Stamp& getTimeStamp() const { return mTimeStamp; }
-  Stamp& getTimeStamp() { return mTimeStamp; }
-  void setTimeStamp(const Stamp& v) { mTimeStamp = v; }
+  GPUd() const Stamp& getTimeStamp() const { return mTimeStamp; }
+  GPUd() Stamp& getTimeStamp() { return mTimeStamp; }
+  GPUd() void setTimeStamp(const Stamp& v) { mTimeStamp = v; }
 
  protected:
   float mChi2 = 0;           ///< chi2 or quality of tracks to vertex attachment
@@ -147,7 +145,7 @@ class Vertex : public VertexBase
   ClassDefNV(Vertex, 3);
 };
 
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::VertexBase& v);
 #endif
 

--- a/DataFormats/Reconstruction/src/DCA.cxx
+++ b/DataFormats/Reconstruction/src/DCA.cxx
@@ -19,7 +19,7 @@ namespace o2
 namespace dataformats
 {
 
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::DCA& d)
 {
   // stream itself
@@ -30,7 +30,7 @@ std::ostream& operator<<(std::ostream& os, const o2::dataformats::DCA& d)
 
 void DCA::print() const
 {
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
   std::cout << *this << '\n';
 #endif
 }

--- a/DataFormats/Reconstruction/src/DCA.cxx
+++ b/DataFormats/Reconstruction/src/DCA.cxx
@@ -19,7 +19,7 @@ namespace o2
 namespace dataformats
 {
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::DCA& d)
 {
   // stream itself
@@ -30,7 +30,7 @@ std::ostream& operator<<(std::ostream& os, const o2::dataformats::DCA& d)
 
 void DCA::print() const
 {
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
   std::cout << *this << '\n';
 #endif
 }

--- a/DataFormats/Reconstruction/src/PID.cxx
+++ b/DataFormats/Reconstruction/src/PID.cxx
@@ -18,11 +18,6 @@
 
 using namespace o2::track;
 
-constexpr const char* PID::sNames[NIDsTot + 1];
-constexpr const float PID::sMasses[NIDsTot];
-constexpr const float PID::sMasses2Z[NIDsTot];
-constexpr const int PID::sCharges[NIDsTot];
-
 //_______________________________
 PID::PID(const char* name) : mID(nameToID(name, First))
 {

--- a/DataFormats/Reconstruction/src/PrimaryVertex.cxx
+++ b/DataFormats/Reconstruction/src/PrimaryVertex.cxx
@@ -18,7 +18,7 @@ namespace o2
 namespace dataformats
 {
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 
 std::string PrimaryVertex::asString() const
 {

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -26,8 +26,8 @@
 #include "ReconstructionDataFormats/TrackParametrization.h"
 #include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/DCA.h"
+#include <MathUtils/Cartesian.h>
 #include <GPUCommonLogger.h>
-#include "Math/SMatrix.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <iostream>
@@ -37,14 +37,12 @@
 #include <fmt/printf.h>
 #endif
 
-namespace o2
-{
-namespace track
-{
+using namespace o2::gpu;
+using namespace o2::track;
 
 //______________________________________________________________
 template <typename value_T>
-TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim3_t& pxpypz, int charge, bool sectorAlpha)
+GPUd() TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim3_t& pxpypz, int charge, bool sectorAlpha)
   : mX{0.f}, mAlpha{0.f}, mP{0.f}
 {
   // construct track param from kinematics
@@ -59,9 +57,9 @@ TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim
   value_t radPos2 = xyz[0] * xyz[0] + xyz[1] * xyz[1];
   value_t alp = 0;
   if (sectorAlpha || radPos2 < 1) {
-    alp = std::atan2(pxpypz[1], pxpypz[0]);
+    alp = gpu::CAMath::ATan2(pxpypz[1], pxpypz[0]);
   } else {
-    alp = std::atan2(xyz[1], xyz[0]);
+    alp = gpu::CAMath::ATan2(xyz[1], xyz[0]);
   }
   if (sectorAlpha) {
     alp = math_utils::detail::angle2Alpha<value_t>(alp);
@@ -70,14 +68,14 @@ TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim
   value_t sn, cs;
   math_utils::detail::sincos(alp, sn, cs);
   // protection:  avoid alpha being too close to 0 or +-pi/2
-  if (std::fabs(sn) < 2 * kSafe) {
+  if (gpu::CAMath::Abs(sn) < 2 * kSafe) {
     if (alp > 0) {
       alp += alp < constants::math::PIHalf ? 2 * kSafe : -2 * kSafe;
     } else {
       alp += alp > -constants::math::PIHalf ? -2 * kSafe : 2 * kSafe;
     }
     math_utils::detail::sincos(alp, sn, cs);
-  } else if (std::fabs(cs) < 2 * kSafe) {
+  } else if (gpu::CAMath::Abs(cs) < 2 * kSafe) {
     if (alp > 0) {
       alp += alp > constants::math::PIHalf ? 2 * kSafe : -2 * kSafe;
     } else {
@@ -100,12 +98,12 @@ TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim
   mP[kZ] = ver[2];
   mP[kSnp] = mom[1] * ptI;
   mP[kTgl] = mom[2] * ptI;
-  mAbsCharge = std::abs(charge);
+  mAbsCharge = gpu::CAMath::Abs(charge);
   mP[kQ2Pt] = charge ? ptI * charge : ptI;
   //
-  if (std::fabs(1 - getSnp()) < kSafe) {
+  if (gpu::CAMath::Abs(1 - getSnp()) < kSafe) {
     mP[kSnp] = 1.f - kSafe; // Protection
-  } else if (std::fabs(-1 - getSnp()) < kSafe) {
+  } else if (gpu::CAMath::Abs(-1 - getSnp()) < kSafe) {
     mP[kSnp] = -1.f + kSafe; // Protection
   }
   //
@@ -113,14 +111,14 @@ TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, const dim
 
 //_______________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
+GPUd() bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
 {
   // track momentum
-  if (std::fabs(getQ2Pt()) < constants::math::Almost0 || std::fabs(getSnp()) > constants::math::Almost1) {
+  if (gpu::CAMath::Abs(getQ2Pt()) < constants::math::Almost0 || gpu::CAMath::Abs(getSnp()) > constants::math::Almost1) {
     return false;
   }
   value_t cs, sn, pt = getPt();
-  value_t r = std::sqrt((1.f - getSnp()) * (1.f + getSnp()));
+  value_t r = gpu::CAMath::Sqrt((1.f - getSnp()) * (1.f + getSnp()));
   math_utils::detail::sincos(getAlpha(), sn, cs);
   pxyz[0] = pt * (r * cs - getSnp() * sn);
   pxyz[1] = pt * (getSnp() * cs + r * sn);
@@ -130,17 +128,17 @@ bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
 
 //____________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const
+GPUd() bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const
 {
   // fill vector with lab x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha
-  value_t ptI = std::fabs(getQ2Pt());
+  value_t ptI = gpu::CAMath::Abs(getQ2Pt());
   value_t snp = getSnp();
-  if (ptI < constants::math::Almost0 || std::fabs(snp) > constants::math::Almost1) {
+  if (ptI < constants::math::Almost0 || gpu::CAMath::Abs(snp) > constants::math::Almost1) {
     return false;
   }
   value_t &sn = posdirp[7], &cs = posdirp[8];
-  value_t csp = std::sqrt((1.f - snp) * (1.f + snp));
-  value_t cstht = std::sqrt(1.f + getTgl() * getTgl());
+  value_t csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp));
+  value_t cstht = gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
   value_t csthti = 1.f / cstht;
   math_utils::detail::sincos(getAlpha(), sn, cs);
   posdirp[0] = getX() * cs - getY() * sn;
@@ -155,10 +153,10 @@ bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>&
 
 //______________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::rotateParam(value_t alpha)
+GPUd() bool TrackParametrization<value_T>::rotateParam(value_t alpha)
 {
   // rotate to alpha frame
-  if (std::fabs(getSnp()) > constants::math::Almost1) {
+  if (gpu::CAMath::Abs(getSnp()) > constants::math::Almost1) {
     LOGP(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", getSnp());
     return false;
   }
@@ -167,7 +165,7 @@ bool TrackParametrization<value_T>::rotateParam(value_t alpha)
   //
   value_t ca = 0, sa = 0;
   math_utils::detail::sincos(alpha - getAlpha(), sa, ca);
-  value_t snp = getSnp(), csp = std::sqrt((1.f - snp) * (1.f + snp)); // Improve precision
+  value_t snp = getSnp(), csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp)); // Improve precision
   // RS: check if rotation does no invalidate track model (cos(local_phi)>=0, i.e. particle
   // direction in local frame is along the X axis
   if ((csp * ca + snp * sa) < 0) {
@@ -176,7 +174,7 @@ bool TrackParametrization<value_T>::rotateParam(value_t alpha)
   }
   //
   value_t tmp = snp * ca - csp * sa;
-  if (std::fabs(tmp) > constants::math::Almost1) {
+  if (gpu::CAMath::Abs(tmp) > constants::math::Almost1) {
     LOGP(WARNING, "Rotation failed: new snp {:.2f}", tmp);
     return false;
   }
@@ -190,7 +188,7 @@ bool TrackParametrization<value_T>::rotateParam(value_t alpha)
 
 //____________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b)
+GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b)
 {
   //----------------------------------------------------------------
   // Extrapolate this track params (w/o cov matrix) to the plane X=xk in the field b[].
@@ -200,11 +198,11 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
   //----------------------------------------------------------------
 
   value_t dx = xk - getX();
-  if (std::fabs(dx) < constants::math::Almost0) {
+  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
     return true;
   }
   // Do not propagate tracks outside the ALICE detector
-  if (std::fabs(dx) > 1e5 || std::fabs(getY()) > 1e5 || std::fabs(getZ()) > 1e5) {
+  if (gpu::CAMath::Abs(dx) > 1e5 || gpu::CAMath::Abs(getY()) > 1e5 || gpu::CAMath::Abs(getZ()) > 1e5) {
     LOGP(WARNING, "Anomalous track, target X:{:f}", xk);
     //    print();
     return false;
@@ -212,21 +210,21 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
   value_t crv = getCurvature(b[2]);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if (std::fabs(f1) > constants::math::Almost1 || std::fabs(f2) > constants::math::Almost1) {
+  if (gpu::CAMath::Abs(f1) > constants::math::Almost1 || gpu::CAMath::Abs(f2) > constants::math::Almost1) {
     return false;
   }
-  value_t r1 = std::sqrt((1.f - f1) * (1.f + f1));
-  if (std::fabs(r1) < constants::math::Almost0) {
+  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
+  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = std::sqrt((1.f - f2) * (1.f + f2));
-  if (std::fabs(r2) < constants::math::Almost0) {
+  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
+  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
     return false;
   }
   value_t dy2dx = (f1 + f2) / (r1 + r2);
-  value_t step = (std::fabs(x2r) < 0.05f) ? dx * std::fabs(r2 + f2 * dy2dx)                                      // chord
-                                          : 2.f * asinf(0.5f * dx * std::sqrt(1.f + dy2dx * dy2dx) * crv) / crv; // arc
-  step *= std::sqrt(1.f + getTgl() * getTgl());
+  value_t step = (gpu::CAMath::Abs(x2r) < 0.05f) ? dx * gpu::CAMath::Abs(r2 + f2 * dy2dx)                                              // chord
+                                                 : 2.f * CAMath::ASin(0.5f * dx * gpu::CAMath::Sqrt(1.f + dy2dx * dy2dx) * crv) / crv; // arc
+  step *= gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
   gpu::gpustd::array<value_t, 9> vecLab{0.f};
@@ -236,13 +234,13 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
 
   // rotate to the system where Bx=By=0.
   value_t bxy2 = b[0] * b[0] + b[1] * b[1];
-  value_t bt = std::sqrt(bxy2);
+  value_t bt = gpu::CAMath::Sqrt(bxy2);
   value_t cosphi = 1.f, sinphi = 0.f;
   if (bt > constants::math::Almost0) {
     cosphi = b[0] / bt;
     sinphi = b[1] / bt;
   }
-  value_t bb = std::sqrt(bxy2 + b[2] * b[2]);
+  value_t bb = gpu::CAMath::Sqrt(bxy2 + b[2] * b[2]);
   value_t costet = 1.f, sintet = 0.f;
   if (bb > constants::math::Almost0) {
     costet = b[2] / bb;
@@ -280,8 +278,8 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
 
   // Do the final correcting step to the target plane (linear approximation)
   value_t x = vecLab[0], y = vecLab[1], z = vecLab[2];
-  if (std::fabs(dx) > constants::math::Almost0) {
-    if (std::fabs(vecLab[3]) < constants::math::Almost0) {
+  if (gpu::CAMath::Abs(dx) > constants::math::Almost0) {
+    if (gpu::CAMath::Abs(vecLab[3]) < constants::math::Almost0) {
       return false;
     }
     dx = xk - vecLab[0];
@@ -291,7 +289,7 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
   }
 
   // Calculate the track parameters
-  t = 1.f / std::sqrt(vecLab[3] * vecLab[3] + vecLab[4] * vecLab[4]);
+  t = 1.f / gpu::CAMath::Sqrt(vecLab[3] * vecLab[3] + vecLab[4] * vecLab[4]);
   mX = x;
   mP[kY] = y;
   mP[kZ] = z;
@@ -304,7 +302,7 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
 
 //____________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t b)
+GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t b)
 {
   //----------------------------------------------------------------
   // propagate this track to the plane X=xk (cm) in the field "b" (kG)
@@ -312,28 +310,28 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t b)
   // distances only (<mm, i.e. misalignment)
   //----------------------------------------------------------------
   value_t dx = xk - getX();
-  if (std::fabs(dx) < constants::math::Almost0) {
+  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
     return true;
   }
-  value_t crv = (std::fabs(b) < constants::math::Almost0) ? 0.f : getCurvature(b);
+  value_t crv = (gpu::CAMath::Abs(b) < constants::math::Almost0) ? 0.f : getCurvature(b);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if ((std::fabs(f1) > constants::math::Almost1) || (std::fabs(f2) > constants::math::Almost1)) {
+  if ((gpu::CAMath::Abs(f1) > constants::math::Almost1) || (gpu::CAMath::Abs(f2) > constants::math::Almost1)) {
     return false;
   }
-  value_t r1 = std::sqrt((1.f - f1) * (1.f + f1));
-  if (std::fabs(r1) < constants::math::Almost0) {
+  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
+  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = std::sqrt((1.f - f2) * (1.f + f2));
-  if (std::fabs(r2) < constants::math::Almost0) {
+  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
+  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
     return false;
   }
   mX = xk;
   double dy2dx = (f1 + f2) / (r1 + r2);
   mP[kY] += dx * dy2dx;
   mP[kSnp] += x2r;
-  if (std::fabs(x2r) < 0.05f) {
+  if (gpu::CAMath::Abs(x2r) < 0.05f) {
     mP[kZ] += dx * (r2 + f2 * dy2dx) * getTgl();
   } else {
     // for small dx/R the linear apporximation of the arc by the segment is OK,
@@ -344,7 +342,7 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t b)
     //    double rot = 2*TMath::ASin(0.5*chord*crv); // angular difference seen from the circle center
     //    track1 += rot/crv*track3;
     //
-    value_t rot = asinf(r1 * f2 - r2 * f1);         // more economic version from Yura.
+    value_t rot = CAMath::ASin(r1 * f2 - r2 * f1);  // more economic version from Yura.
     if (f1 * f1 + f2 * f2 > 1.f && f1 * f2 < 0.f) { // special cases of large rotations or large abs angles
       if (f2 > 0.f) {
         rot = constants::math::PI - rot; //
@@ -359,32 +357,32 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t b)
 
 //_______________________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils::Point3D<value_t>& vtx, value_t b, dim2_t* dca, value_t maxD)
+GPUd() bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils::Point3D<value_t>& vtx, value_t b, dim2_t* dca, value_t maxD)
 {
   // propagate track to DCA to the vertex
   value_t sn, cs, alp = getAlpha();
   math_utils::detail::sincos(alp, sn, cs);
-  value_t x = getX(), y = getY(), snp = getSnp(), csp = std::sqrt((1.f - snp) * (1.f + snp));
+  value_t x = getX(), y = getY(), snp = getSnp(), csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp));
   value_t xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  value_t d = std::abs(x * snp - y * csp);
+  value_t d = gpu::CAMath::Abs(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
   value_t crv = getCurvature(b);
   value_t tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / std::sqrt(1.f + tgfv * tgfv);
-  cs = std::sqrt((1.f - sn) * (1.f + sn));
-  cs = (std::abs(tgfv) > constants::math::Almost0) ? sn / tgfv : constants::math::Almost1;
+  sn = tgfv / gpu::CAMath::Sqrt(1.f + tgfv * tgfv);
+  cs = gpu::CAMath::Sqrt((1.f - sn) * (1.f + sn));
+  cs = (gpu::CAMath::Abs(tgfv) > constants::math::Almost0) ? sn / tgfv : constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(*this); // operate on the copy to recover after the failure
-  alp += std::asin(sn);
+  alp += gpu::CAMath::ASin(sn);
   if (!tmpT.rotateParam(alp) || !tmpT.propagateParamTo(xv, b)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
@@ -401,33 +399,33 @@ bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils::Point3
 
 //____________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const
+GPUd() bool TrackParametrization<value_T>::getYZAt(value_t xk, value_t b, value_t& y, value_t& z) const
 {
   //----------------------------------------------------------------
   // estimate Y,Z in tracking frame at given X
   //----------------------------------------------------------------
   value_t dx = xk - getX();
-  if (std::fabs(dx) < constants::math::Almost0) {
+  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
     return true;
   }
   value_t crv = getCurvature(b);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if ((std::fabs(f1) > constants::math::Almost1) || (std::fabs(f2) > constants::math::Almost1)) {
+  if ((gpu::CAMath::Abs(f1) > constants::math::Almost1) || (gpu::CAMath::Abs(f2) > constants::math::Almost1)) {
     return false;
   }
-  value_t r1 = std::sqrt((1.f - f1) * (1.f + f1));
-  if (std::fabs(r1) < constants::math::Almost0) {
+  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
+  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = std::sqrt((1.f - f2) * (1.f + f2));
-  if (std::fabs(r2) < constants::math::Almost0) {
+  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
+  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
     return false;
   }
   double dy2dx = (f1 + f2) / (r1 + r2);
   y = mP[kY] + dx * dy2dx;
   z = mP[kZ];
-  if (std::fabs(x2r) < 0.05f) {
+  if (gpu::CAMath::Abs(x2r) < 0.05f) {
     z += dx * (r2 + f2 * dy2dx) * getTgl();
   } else {
     // for small dx/R the linear apporximation of the arc by the segment is OK,
@@ -438,7 +436,7 @@ bool TrackParametrization<value_T>::getYZAt(value_t xk, value_t b, value_t& y, v
     //    double rot = 2*TMath::ASin(0.5*chord*crv); // angular difference seen from the circle center
     //    track1 += rot/crv*track3;
     //
-    value_t rot = asinf(r1 * f2 - r2 * f1);         // more economic version from Yura.
+    value_t rot = CAMath::ASin(r1 * f2 - r2 * f1);  // more economic version from Yura.
     if (f1 * f1 + f2 * f2 > 1.f && f1 * f2 < 0.f) { // special cases of large rotations or large abs angles
       if (f2 > 0.f) {
         rot = constants::math::PI - rot; //
@@ -453,7 +451,7 @@ bool TrackParametrization<value_T>::getYZAt(value_t xk, value_t b, value_t& y, v
 
 //______________________________________________________________
 template <typename value_T>
-void TrackParametrization<value_T>::invertParam()
+GPUd() void TrackParametrization<value_T>::invertParam()
 {
   // Transform this track to the local coord. system rotated by 180 deg.
   mX = -mX;
@@ -468,7 +466,7 @@ void TrackParametrization<value_T>::invertParam()
 
 //______________________________________________________________
 template <typename value_T>
-typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getZAt(value_t xk, value_t b) const
+GPUd() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getZAt(value_t xk, value_t b) const
 {
   ///< this method is just an alias for obtaining Z @ X in the tree->Draw()
   value_t y, z;
@@ -477,7 +475,7 @@ typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::g
 
 //______________________________________________________________
 template <typename value_T>
-typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getYAt(value_t xk, value_t b) const
+GPUd() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getYAt(value_t xk, value_t b) const
 {
   ///< this method is just an alias for obtaining Z @ X in the tree->Draw()
   value_t y, z;
@@ -497,7 +495,7 @@ std::string TrackParametrization<value_T>::asString() const
 
 //______________________________________________________________
 template <typename value_T>
-void TrackParametrization<value_T>::printParam() const
+GPUd() void TrackParametrization<value_T>::printParam() const
 {
   // print parameters
 #ifndef GPUCA_ALIGPUCODE
@@ -507,7 +505,7 @@ void TrackParametrization<value_T>::printParam() const
 
 //______________________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz, track::DirType dir) const
+GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz, track::DirType dir) const
 {
   // Get local X of the track position estimated at the radius lab radius r.
   // The track curvature is accounted exactly
@@ -521,16 +519,16 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
   const value_t kEps = 1.e-6;
   //
   auto crv = getCurvature(bz);
-  if (std::fabs(crv) > constants::math::Almost0) { // helix
+  if (gpu::CAMath::Abs(crv) > constants::math::Almost0) { // helix
     // get center of the track circle
     math_utils::CircleXY<value_t> circle;
     getCircleParamsLoc(bz, circle);
-    value_t r0 = std::sqrt(circle.getCenterD2());
+    value_t r0 = gpu::CAMath::Sqrt(circle.getCenterD2());
     if (r0 <= constants::math::Almost0) {
       return false; // the track is concentric to circle
     }
     value_t tR2r0 = 1.f, g = 0.f, tmp = 0.f;
-    if (std::fabs(circle.rC - r0) > kEps) {
+    if (gpu::CAMath::Abs(circle.rC - r0) > kEps) {
       tR2r0 = circle.rC / r0;
       g = 0.5f * (r * r / (r0 * circle.rC) - tR2r0 - 1.f / tR2r0);
       tmp = 1.f + g * tR2r0;
@@ -543,7 +541,7 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
     if (det < 0.f) {
       return false; // does not reach raduis r
     }
-    det = std::sqrt(det);
+    det = gpu::CAMath::Sqrt(det);
     //
     // the intersection happens in 2 points: {circle.xC+tR*C,circle.yC+tR*S}
     // with C=f*c0+-|s0|*det and S=f*s0-+c0 sign(s0)*det
@@ -551,8 +549,8 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
     //
     x = circle.xC * tmp;
     value_t y = circle.yC * tmp;
-    if (std::fabs(circle.yC) > constants::math::Almost0) { // when circle.yC==0 the x,y is unique
-      value_t dfx = tR2r0 * std::fabs(circle.yC) * det;
+    if (gpu::CAMath::Abs(circle.yC) > constants::math::Almost0) { // when circle.yC==0 the x,y is unique
+      value_t dfx = tR2r0 * gpu::CAMath::Abs(circle.yC) * det;
       value_t dfy = tR2r0 * circle.xC * (circle.yC > 0.f ? det : -det);
       if (dir == DirAuto) {                              // chose the one which corresponds to smallest step
         value_t delta = (x - mX) * dfx - (y - fy) * dfy; // the choice of + in C will lead to smaller step if delta<0
@@ -563,7 +561,7 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
         if (dfeps < -kEps) {
           return true;
         }
-        if (std::fabs(dfeps) < kEps && std::fabs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+        if (gpu::CAMath::Abs(dfeps) < kEps && gpu::CAMath::Abs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
           return mX;
         }
         x += dfx + dfx;
@@ -580,7 +578,7 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
         if (dfeps < -kEps) {
           return true;
         }
-        if (std::fabs(dfeps) < kEps && std::fabs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+        if (gpu::CAMath::Abs(dfeps) < kEps && gpu::CAMath::Abs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
           return mX;
         }
         x -= dfx + dfx;
@@ -598,8 +596,8 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
         return false;
       }
     }
-  } else {                                           // this is a straight track
-    if (std::fabs(sn) >= constants::math::Almost1) { // || to Y axis
+  } else {                                                  // this is a straight track
+    if (gpu::CAMath::Abs(sn) >= constants::math::Almost1) { // || to Y axis
       value_t det = (r - mX) * (r + mX);
       if (det < 0.f) {
         return false; // does not reach raduis r
@@ -608,7 +606,7 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
       if (dir == DirAuto) {
         return true;
       }
-      det = std::sqrt(det);
+      det = gpu::CAMath::Sqrt(det);
       if (dir == DirOutward) { // along the track direction
         if (sn > 0.f) {
           if (fy > det) {
@@ -628,12 +626,12 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
           return false; // track is against Y axis
         }
       }
-    } else if (std::fabs(sn) <= constants::math::Almost0) { // || to X axis
+    } else if (gpu::CAMath::Abs(sn) <= constants::math::Almost0) { // || to X axis
       value_t det = (r - fy) * (r + fy);
       if (det < 0.f) {
         return false; // does not reach raduis r
       }
-      det = std::sqrt(det);
+      det = gpu::CAMath::Sqrt(det);
       if (dir == DirAuto) {
         x = mX > 0.f ? det : -det; // choose the solution requiring the smalest step
         return true;
@@ -651,13 +649,13 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
         }
       }
     } else { // general case of straight line
-      value_t cs = std::sqrt((1.f - sn) * (1.f + sn));
+      value_t cs = gpu::CAMath::Sqrt((1.f - sn) * (1.f + sn));
       value_t xsyc = mX * sn - fy * cs;
       value_t det = (r - xsyc) * (r + xsyc);
       if (det < 0.f) {
         return false; // does not reach raduis r
       }
-      det = std::sqrt(det);
+      det = gpu::CAMath::Sqrt(det);
       value_t xcys = mX * cs + fy * sn;
       value_t t = -xcys;
       if (dir == DirAuto) {
@@ -684,7 +682,7 @@ bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, value_t bz
 
 //______________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::correctForELoss(value_t xrho, value_t mass, bool anglecorr, value_t dedx)
+GPUd() bool TrackParametrization<value_T>::correctForELoss(value_t xrho, value_t mass, bool anglecorr, value_t dedx)
 {
   //------------------------------------------------------------------
   // This function corrects the track parameters for the energy loss in crossed material.
@@ -702,7 +700,7 @@ bool TrackParametrization<value_T>::correctForELoss(value_t xrho, value_t mass, 
   if (anglecorr) {
     value_t csp2 = (1.f - getSnp()) * (1.f + getSnp()); // cos(phi)^2
     value_t cst2I = (1.f + getTgl() * getTgl());        // 1/cos(lambda)^2
-    value_t angle = std::sqrt(cst2I / (csp2));
+    value_t angle = gpu::CAMath::Sqrt(cst2I / (csp2));
     xrho *= angle;
   }
 
@@ -717,15 +715,15 @@ bool TrackParametrization<value_T>::correctForELoss(value_t xrho, value_t mass, 
   // Calculating the energy loss corrections************************
   if ((xrho != 0.f) && (beta2 < 1.f)) {
     if (dedx < kCalcdEdxAuto + constants::math::Almost1) { // request to calculate dedx on the fly
-      dedx = BetheBlochSolid(p / std::fabs(mass));
+      dedx = BetheBlochSolid(p / gpu::CAMath::Abs(mass));
       if (mAbsCharge != 1) {
         dedx *= mAbsCharge * mAbsCharge;
       }
     }
 
     value_t dE = dedx * xrho;
-    value_t e = std::sqrt(e2);
-    if (std::fabs(dE) > kMaxELossFrac * e) {
+    value_t e = gpu::CAMath::Sqrt(e2);
+    if (gpu::CAMath::Abs(dE) > kMaxELossFrac * e) {
       return false; // 30% energy loss is too much!
     }
     value_t eupd = e + dE;
@@ -733,14 +731,16 @@ bool TrackParametrization<value_T>::correctForELoss(value_t xrho, value_t mass, 
     if (pupd2 < kMinP * kMinP) {
       return false;
     }
-    setQ2Pt(getQ2Pt() * p / std::sqrt(pupd2));
+    setQ2Pt(getQ2Pt() * p / gpu::CAMath::Sqrt(pupd2));
   }
 
   return true;
 }
 
+namespace o2::track
+{
 template class TrackParametrization<float>;
+#ifndef GPUCA_GPUCODE_DEVICE
 template class TrackParametrization<double>;
-
-} // namespace track
-} // namespace o2
+#endif
+} // namespace o2::track

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -130,7 +130,7 @@ bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
 
 //____________________________________________________
 template <typename value_T>
-bool TrackParametrization<value_T>::getPosDirGlo(std::array<value_t, 9>& posdirp) const
+bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const
 {
   // fill vector with lab x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha
   value_t ptI = std::fabs(getQ2Pt());
@@ -229,7 +229,7 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
   step *= std::sqrt(1.f + getTgl() * getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
-  std::array<value_t, 9> vecLab{0.f};
+  gpu::gpustd::array<value_t, 9> vecLab{0.f};
   if (!getPosDirGlo(vecLab)) {
     return false;
   }
@@ -248,13 +248,13 @@ bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const dim3_t& b
     costet = b[2] / bb;
     sintet = bt / bb;
   }
-  std::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
-                              -sinphi * vecLab[0] + cosphi * vecLab[1],
-                              sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
-                              costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],
-                              -sinphi * vecLab[3] + cosphi * vecLab[4],
-                              sintet * cosphi * vecLab[3] + sintet * sinphi * vecLab[4] + costet * vecLab[5],
-                              vecLab[6]};
+  gpu::gpustd::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
+                                      -sinphi * vecLab[0] + cosphi * vecLab[1],
+                                      sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
+                                      costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],
+                                      -sinphi * vecLab[3] + cosphi * vecLab[4],
+                                      sintet * cosphi * vecLab[3] + sintet * sinphi * vecLab[4] + costet * vecLab[5],
+                                      vecLab[6]};
 
   // Do the helix step
   value_t q = getCharge();

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -27,10 +27,10 @@
 #include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include <GPUCommonLogger.h>
-#include "Math/SMatrix.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <iostream>
+#include "Math/SMatrix.h"
 #endif
 
 #ifndef GPUCA_ALIGPUCODE
@@ -686,6 +686,8 @@ typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWit
   return (d * (szz * d - sdz * z) + z * (sdd * z - d * sdz)) / det;
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE // Disable function relying on ROOT SMatrix on GPU
+
 //______________________________________________
 template <typename value_T>
 void TrackParametrizationWithError<value_T>::buildCombinedCovMatrix(const TrackParametrizationWithError<value_T>& rhs, MatrixDSym5& cov) const
@@ -830,6 +832,8 @@ bool TrackParametrizationWithError<value_T>::update(const TrackParametrizationWi
   }
   return update(rhs, covI);
 }
+
+#endif
 
 //______________________________________________
 template <typename value_T>

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -262,7 +262,7 @@ bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dataformat
 //______________________________________________________________
 template <typename value_T>
 TrackParametrizationWithError<value_T>::TrackParametrizationWithError(const dim3_t& xyz, const dim3_t& pxpypz,
-                                                                      const std::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha)
+                                                                             const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha)
 {
   // construct track param and covariance from kinematics and lab errors
 
@@ -454,7 +454,7 @@ bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, const dim3_
   step *= std::sqrt(1.f + this->getTgl() * this->getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
-  std::array<value_t, 9> vecLab{0.f};
+  gpu::gpustd::array<value_t, 9> vecLab{0.f};
   if (!this->getPosDirGlo(vecLab)) {
     return false;
   }
@@ -521,13 +521,13 @@ bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, const dim3_
     costet = b[2] / bb;
     sintet = bt / bb;
   }
-  std::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
-                              -sinphi * vecLab[0] + cosphi * vecLab[1],
-                              sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
-                              costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],
-                              -sinphi * vecLab[3] + cosphi * vecLab[4],
-                              sintet * cosphi * vecLab[3] + sintet * sinphi * vecLab[4] + costet * vecLab[5],
-                              vecLab[6]};
+  gpu::gpustd::array<value_t, 7> vect{costet * cosphi * vecLab[0] + costet * sinphi * vecLab[1] - sintet * vecLab[2],
+                                      -sinphi * vecLab[0] + cosphi * vecLab[1],
+                                      sintet * cosphi * vecLab[0] + sintet * sinphi * vecLab[1] + costet * vecLab[2],
+                                      costet * cosphi * vecLab[3] + costet * sinphi * vecLab[4] - sintet * vecLab[5],
+                                      -sinphi * vecLab[3] + cosphi * vecLab[4],
+                                      sintet * cosphi * vecLab[3] + sintet * sinphi * vecLab[4] + costet * vecLab[5],
+                                      vecLab[6]};
 
   // Do the helix step
   value_t sgn = this->getSign();
@@ -1004,7 +1004,7 @@ bool TrackParametrizationWithError<value_T>::correctForMaterial(value_t x2x0, va
 
 //______________________________________________________________
 template <typename value_T>
-bool TrackParametrizationWithError<value_T>::getCovXYZPxPyPzGlo(std::array<value_t, kLabCovMatSize>& cv) const
+bool TrackParametrizationWithError<value_T>::getCovXYZPxPyPzGlo(gpu::gpustd::array<value_t, kLabCovMatSize>& cv) const
 {
   //---------------------------------------------------------------------
   // This function returns the global covariance matrix of the track params

--- a/DataFormats/Reconstruction/src/Vertex.cxx
+++ b/DataFormats/Reconstruction/src/Vertex.cxx
@@ -17,7 +17,7 @@ namespace o2
 namespace dataformats
 {
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 
 std::string VertexBase::asString() const
 {

--- a/DataFormats/Reconstruction/src/Vertex.cxx
+++ b/DataFormats/Reconstruction/src/Vertex.cxx
@@ -17,7 +17,7 @@ namespace o2
 namespace dataformats
 {
 
-#ifndef GPUCA_ALIGPUCODE
+#ifndef GPUCA_GPUCODE_DEVICE
 
 std::string VertexBase::asString() const
 {

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -14,7 +14,7 @@
 #define ALICEO2_INTERACTIONRECORD_H
 
 #include "GPUCommonRtypes.h"
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 #include <iosfwd>
 #include <cstdint>
 #endif
@@ -246,7 +246,7 @@ struct InteractionRecord {
     return InteractionRecord(l % o2::constants::lhc::LHCMaxBunches, l / o2::constants::lhc::LHCMaxBunches);
   }
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
   void print() const;
   std::string asString() const;
   friend std::ostream& operator<<(std::ostream& stream, InteractionRecord const& ir);
@@ -324,7 +324,7 @@ struct InteractionTimeRecord : public InteractionRecord {
     return !((*this) > other);
   }
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
   void print() const;
   std::string asString() const;
   friend std::ostream& operator<<(std::ostream& stream, InteractionTimeRecord const& ir);

--- a/DataFormats/common/src/InteractionRecord.cxx
+++ b/DataFormats/common/src/InteractionRecord.cxx
@@ -14,7 +14,7 @@
 namespace o2
 {
 
-#ifndef ALIGPU_GPUCODE
+#ifndef GPUCA_ALIGPUCODE
 
 std::string InteractionRecord::asString() const
 {

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DetectorsBase/Propagator.h"
-#include <GPUCommonLogger.h>
+#include "GPUCommonLogger.h"
 #include "Field/MagFieldFast.h"
 #include "MathUtils/Utils.h"
 #include "ReconstructionDataFormats/Vertex.h"

--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HDRS_INSTALL
     GPUCommonLogger.h
     GPUCommonMath.h
     GPUCommonRtypes.h
+    GPUCommonArray.h
     GPUCommonTransform3D.h
     GPUDef.h
     GPUDefConstantsAndSettings.h

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUCommonArray.h
+/// \author David Rohr
+
+#ifndef GPUCOMMONFAIRARRAY_H
+#define GPUCOMMONFAIRARRAY_H
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <array>
+#endif
+
+#include "GPUCommonDef.h"
+namespace o2::gpu::gpustd
+{
+#ifdef GPUCA_GPUCODE_DEVICE
+template <typename T, size_t N>
+struct array {
+  GPUd() T& operator[](size_t i) { return m_internal_V__[i]; }
+  GPUd() const T& operator[](size_t i) const { return m_internal_V__[i]; }
+  T m_internal_V__[N];
+};
+#else
+template <typename T, size_t N>
+using array = std::array<T, N>;
+#endif
+} // namespace o2::gpu::gpustd
+
+#endif

--- a/GPU/Common/GPUCommonDef.h
+++ b/GPU/Common/GPUCommonDef.h
@@ -74,7 +74,7 @@
 #endif
 
 //Set AliRoot / O2 namespace
-#if defined(GPUCA_STANDALONE) || (defined(GPUCA_O2_LIB) && !defined(GPUCA_O2_INTERFACE)) || defined(GPUCA_ALIROOT_LIB) || defined(GPUCA_GPULIBRARY)
+#if defined(GPUCA_STANDALONE) || (defined(GPUCA_O2_LIB) && !defined(GPUCA_O2_INTERFACE)) || defined(GPUCA_ALIROOT_LIB) || defined(GPUCA_GPULIBRARY) || defined (GPUCA_GPUCODE)
   #define GPUCA_ALIGPUCODE
 #endif
 #ifdef GPUCA_ALIROOT_LIB

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -20,7 +20,19 @@
 #define LOGP(...)
 
 #elif defined(GPUCA_GPUCODE_DEVICE)
-#define LOG(...) static_assert("LOG(...) << ... unsupported in GPU code");
+#include "GPUCommonDef.h"
+namespace o2::gpu::detail
+{
+struct DummyLogger {
+  template <typename... Args>
+  GPUd() DummyLogger& operator<<(Args... args)
+  {
+    return *this;
+  }
+};
+} // namespace o2::gpu::detail
+#define LOG(...) o2::gpu::detail::DummyLogger()
+//#define LOG(...) static_assert(false, "LOG(...) << ... unsupported in GPU code");
 #define LOGF(type, string, ...)         \
   {                                     \
     printf(string "\n", ##__VA_ARGS__); \

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -14,13 +14,9 @@
 #ifndef GPUCOMMONFAIRLOGGER_H
 #define GPUCOMMONFAIRLOGGER_H
 
-#if defined(__OPENCL__)
-#define LOG(...)
-#define LOGF(...)
-#define LOGP(...)
-
-#elif defined(GPUCA_GPUCODE_DEVICE)
 #include "GPUCommonDef.h"
+
+#if defined(GPUCA_GPUCODE_DEVICE)
 namespace o2::gpu::detail
 {
 struct DummyLogger {
@@ -31,6 +27,14 @@ struct DummyLogger {
   }
 };
 } // namespace o2::gpu::detail
+#endif
+
+#if defined(__OPENCL__)
+#define LOG(...) o2::gpu::detail::DummyLogger()
+#define LOGF(...)
+#define LOGP(...)
+
+#elif defined(GPUCA_GPUCODE_DEVICE)
 #define LOG(...) o2::gpu::detail::DummyLogger()
 //#define LOG(...) static_assert(false, "LOG(...) << ... unsupported in GPU code");
 #define LOGF(type, string, ...)         \

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -16,12 +16,12 @@
 
 #include "GPUCommonDef.h"
 
-#if defined(GPUCA_GPUCODE_DEVICE)
+#if defined(GPUCA_GPUCODE_DEVICE) || defined(__HIPCC__)
 namespace o2::gpu::detail
 {
 struct DummyLogger {
   template <typename... Args>
-  GPUd() DummyLogger& operator<<(Args... args)
+  GPUhd() DummyLogger& operator<<(Args... args)
   {
     return *this;
   }
@@ -34,7 +34,7 @@ struct DummyLogger {
 #define LOGF(...)
 #define LOGP(...)
 
-#elif defined(GPUCA_GPUCODE_DEVICE)
+#elif defined(GPUCA_GPUCODE_DEVICE) || defined(__HIPCC__)
 #define LOG(...) o2::gpu::detail::DummyLogger()
 //#define LOG(...) static_assert(false, "LOG(...) << ... unsupported in GPU code");
 #define LOGF(type, string, ...)         \

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -58,6 +58,10 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "MatLayerCyl.cxx"
 #include "Ray.cxx"
 
+// O2 track model
+#include "TrackParametrization.cxx"
+#include "TrackParametrizationWithError.cxx"
+
 // Files for GPU dEdx
 #include "GPUdEdx.cxx"
 

--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -115,6 +115,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     PRIVATE_INCLUDE_DIRECTORIES
       ${CMAKE_SOURCE_DIR}/Detectors/Base/src
       ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
+      ${CMAKE_SOURCE_DIR}/DataFormats/Reconstruction/src
     PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingCUDA
     TARGETVARNAME targetName)
 

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -31,6 +31,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingHIP hip::host hip::device hip::hipcub roc::rocthrust
     PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
                                ${CMAKE_SOURCE_DIR}/Detectors/Base/src
+                               ${CMAKE_SOURCE_DIR}/DataFormats/Reconstruction/src
     TARGETVARNAME targetName)
 
   target_compile_definitions(

--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -30,6 +30,7 @@ set(OCL_DEFINECL "-D$<JOIN:$<TARGET_PROPERTY:O2::GPUTracking,COMPILE_DEFINITIONS
             "-I$<JOIN:$<TARGET_PROPERTY:O2::GPUTracking,INCLUDE_DIRECTORIES>,$<SEMICOLON>-I>"
             -I${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
             -I${CMAKE_SOURCE_DIR}/Detectors/Base/src
+            -I${CMAKE_SOURCE_DIR}/DataFormats/Reconstruction/src
             -I${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/tracking/cuda/include
             -DGPUCA_GPULIBRARY=OCL2
             -D__OPENCLCPP__

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -147,6 +147,7 @@ include_directories(${CMAKE_SOURCE_DIR}/TPCClusterFinder
                     ${CMAKE_SOURCE_DIR}/../../../DataFormats/Headers/include
                     ${CMAKE_SOURCE_DIR}/../../../DataFormats/MemoryResources/include
                     ${CMAKE_SOURCE_DIR}/../../../DataFormats/Reconstruction/include
+                    ${CMAKE_SOURCE_DIR}/../../../DataFormats/Reconstruction/src
                     ${CMAKE_SOURCE_DIR}/../../../DataFormats/simulation/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/Base/include
                     ${CMAKE_SOURCE_DIR}/../../../Detectors/Base/src
@@ -183,6 +184,8 @@ if(CONFIG_O2_EXTENSIONS)
                ../../../DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
                ../../../DataFormats/Reconstruction/src/Vertex.cxx
                ../../../DataFormats/Reconstruction/src/TrackLTIntegral.cxx
+               ../../../DataFormats/Reconstruction/src/TrackParametrization.cxx
+               ../../../DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
                ../../../Detectors/TRD/base/src/GeometryBase.cxx
                ../../../Detectors/Base/src/MatLayerCylSet.cxx
                ../../../Detectors/Base/src/MatLayerCyl.cxx


### PR DESCRIPTION
@mconcas : This is my current state. It still fails compilation on HIP, but that should not bother your. Let's see if this passes the CI without AMD.
It is so far only TrackPar and TrackParCov, the Propagator will come next.
But I didn't test it yet, just compiled it with CUDA in Standalone mode, will become more mature the next days.

In order to use it:
The TPC GPU code works a bit differently compared to what you do in ITS. There is no separate compilation, but all files are included in the CU files. If you want to keep going with separate compilation, that should not be a problem. Just create a CU file that includes `TrackParametrization.cxx` and `TrackParametrizationWithErrors.cxx` (and later the propagator) and link that together with whatever code you write in your library. Symbols should not collide in theory. Let's see :)