### PR TITLE
Decouple VMC libs from o2-sim

### DIFF
--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -8,20 +8,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+o2_add_library(G3Setup
+               SOURCES src/G3Config.cxx
+               PUBLIC_LINK_LIBRARIES MC::Geant3 FairRoot::Base O2::SimulationDataFormat O2::Generators
+)
+
+o2_add_library(G4Setup
+               SOURCES src/G4Config.cxx
+               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6
+)
+
 o2_add_library(SimSetup
-               SOURCES src/G3Config.cxx src/G4Config.cxx
-                       src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx
-               PUBLIC_LINK_LIBRARIES MC::Geant3
-                                     MC::Geant4VMC
-                                     MC::Geant4
-                                     O2::SimulationDataFormat
-                                     O2::DetectorsPassive
-				     O2::Generators
-                                     MC::Pythia6 # this is needed by Geant3 and
-                                                 # EGPythia6
-                                     ROOT::EGPythia6 # this is needed by Geant4
-                                                     # (TPythia6Decayer)
-               )
+               SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx
+	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase
+              )
 
 o2_target_root_dictionary(SimSetup
                           HEADERS include/SimSetup/SimSetup.h

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -17,18 +17,10 @@
 #include "TG4RunConfiguration.h"
 #include "TPythia6Decayer.h"
 #include "FairModule.h"
-#include <DetectorsPassive/Cave.h>
-#include "DetectorsBase/MaterialManager.h"
-#include "SimSetup/GlobalProcessCutSimParam.h"
 #include "SimConfig/G4Params.h"
 #include "Generators/DecayerPythia8.h"
 
 //using declarations here since SetCuts.C and g4Config.C are included within namespace
-// these are needed for SetCuts.C inclusion
-using o2::GlobalProcessCutSimParam;
-using o2::base::ECut;
-using o2::base::EProc;
-using o2::base::MaterialManager;
 // these are used in g4Config.C
 using std::cout;
 using std::endl;
@@ -40,13 +32,11 @@ namespace o2
 namespace g4config
 {
 #include "../g4Config.C"
-#include "../SetCuts.h"
 
 void G4Config()
 {
   LOG(INFO) << "Setting up G4 sim from library code";
   Config();
-  SetCuts();
 }
 } // namespace g4config
 } // namespace o2

--- a/Detectors/gconfig/src/SetCuts.cxx
+++ b/Detectors/gconfig/src/SetCuts.cxx
@@ -8,22 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
- *                                                                              *
- *              This software is distributed under the terms of the             *
- *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
- *                  copied verbatim in the file "LICENSE"                       *
- ********************************************************************************/
+#include "SetCuts.h"
+#include "SimSetup/GlobalProcessCutSimParam.h"
+#include "DetectorsBase/MaterialManager.h"
+#include "FairLogger.h"
 
-/** Configuration macro for setting common cuts and processes for G3, G4 and Fluka (M. Al-Turany 27.03.2008)
-    specific cuts and processes to g3 or g4 should be set in the g3Config.C, g4Config.C or flConfig.C
+using namespace o2::base;
 
-*/
+namespace o2
+{
 
 void SetCuts()
 {
-  cout << "SetCuts Macro: Setting Processes.." << endl;
+  LOG(INFO) << "Setup global cuts and processes";
 
   // ------>>>> IMPORTANT!!!!
   // For a correct comparison between GEANE and MC (pull distributions)
@@ -38,8 +35,8 @@ void SetCuts()
 
   // \note All following settings could also be set in Cave since it is always loaded.
   // Use MaterialManager to set processes and cuts
-  auto& mgr = MaterialManager::Instance();
-  auto& params = GlobalProcessCutSimParam::Instance();
+  auto& mgr = o2::base::MaterialManager::Instance();
+  auto& params = o2::GlobalProcessCutSimParam::Instance();
 
   LOG(INFO) << "Set default settings for processes and cuts.";
   mgr.DefaultProcesses({{EProc::kPAIR, params.PAIR},   /** pair production */
@@ -73,3 +70,5 @@ void SetCuts()
   LOG(INFO) << "Special process settings are " << settingProc << ".";
   LOG(INFO) << "Special cut settings are " << settingCut << ".";
 }
+
+} // namespace o2

--- a/Detectors/gconfig/src/SetCuts.h
+++ b/Detectors/gconfig/src/SetCuts.h
@@ -8,28 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "FairRunSim.h"
-#include "TGeant3.h"
-#include "TGeant3TGeo.h"
-#include "SimulationDataFormat/Stack.h"
-#include "SimulationDataFormat/StackParam.h"
-#include "FairLogger.h"
-#include "FairModule.h"
-#include "Generators/DecayerPythia8.h"
-
-// these are used in commonConfig.C
-using o2::eventgen::DecayerPythia8;
+#ifndef O2_SIMSETUP_SETCUTS_H
+#define O2_SIMSETUP_SETCUTS_H
 
 namespace o2
 {
-namespace g3config
-{
-#include "../g3Config.C"
-
-void G3Config()
-{
-  LOG(INFO) << "Setting up G3 sim from library code";
-  Config();
+void SetCuts();
 }
-} // namespace g3config
-} // namespace o2
+
+#endif

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -11,27 +11,51 @@
 #include <cstring>
 #include "SimSetup/SimSetup.h"
 #include "FairLogger.h"
+#include "SetCuts.h"
+#include <dlfcn.h>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include <sstream>
 
 namespace o2
 {
-// forward declarations of functions
-namespace g3config
+
+typedef void (*setup_fnc)();
+
+void setupFromPlugin(const char* libname, const char* setupfuncname)
 {
-void G3Config();
-}
-namespace g4config
-{
-void G4Config();
+  LOG(INFO) << "Loading simulation plugin " << libname;
+  auto libHandle = dlopen(libname, RTLD_NOW);
+  // try to make the library loading a bit more portable:
+  if (!libHandle) {
+    // try appending *.so
+    std::stringstream stream;
+    stream << libname << ".so";
+    libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
+  }
+  if (!libHandle) {
+    // try appending *.dylib
+    std::stringstream stream;
+    stream << libname << ".dylib";
+    libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
+  }
+  assert(libHandle);
+  auto setup = (setup_fnc)dlsym(libHandle, setupfuncname);
+  assert(setup);
+  setup();
 }
 
 void SimSetup::setup(const char* engine)
 {
   if (strcmp(engine, "TGeant3") == 0) {
-    g3config::G3Config();
+    setupFromPlugin("libO2G3Setup", "_ZN2o28g3config8G3ConfigEv");
   } else if (strcmp(engine, "TGeant4") == 0) {
-    g4config::G4Config();
+    setupFromPlugin("libO2G4Setup", "_ZN2o28g4config8G4ConfigEv");
   } else {
     LOG(FATAL) << "Unsupported engine " << engine;
   }
+  o2::SetCuts();
 }
 } // namespace o2


### PR DESCRIPTION
This is going back to loading VMC engines as real plugins **while**
retaining the advantage of compiling the configuration templates
and avoiding ROOT macros execution during startup.

This brings the advantage that not all engine libs are loaded at
startup simultaneously.