### PR TITLE
Support for FLUKA VMC backend in O2

### DIFF
--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -77,8 +77,8 @@ Stack::Stack(Int_t size)
     mIsG4Like(false)
 {
   auto vmc = TVirtualMC::GetMC();
-  if (vmc && strcmp(vmc->GetName(), "TGeant4") == 0) {
-    mIsG4Like = true;
+  if (vmc) {
+    mIsG4Like = !(vmc->SecondariesAreOrdered());
   }
 
   auto& param = o2::sim::StackParam::Instance();

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -18,6 +18,16 @@ o2_add_library(G4Setup
                PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6
 )
 
+if (FlukaVMC_FOUND)
+  message(STATUS "BUILDING WITH FLUKA")
+  o2_add_library(FLUKASetup
+                 SOURCES src/FlukaConfig.cxx
+       	         PUBLIC_LINK_LIBRARIES MC::FlukaVMC FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6
+	        )
+else()
+  message(STATUS "BUILDING WITHOUT FLUKA")
+endif (FlukaVMC_FOUND)
+	      
 o2_add_library(SimSetup
                SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx
 	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase
@@ -49,3 +59,5 @@ o2_add_test_root_macro(g3Config.C
 o2_add_test_root_macro(g4Config.C
                        PUBLIC_LINK_LIBRARIES O2::SimSetup
                        LABELS simsetup)
+
+o2_data_file(COPY data  DESTINATION Detectors/gconfig/)

--- a/Detectors/gconfig/data/coreFlukaVmc.inp
+++ b/Detectors/gconfig/data/coreFlukaVmc.inp
@@ -1,0 +1,29 @@
+GLOBAL        50000.                           4.0
+DEFAULTS                                                              NEW-DEFA
+OPEN              1.                                                  OLD
+random.dat
+GEOBEGIN                                                              COMBINAT
+GEOEND
+*
+*...+....1....+....2....+....3....+....4....+....5....+....6....+....7....+ 
+*
+EVENTYPE                             1.0
+BEAM          7000.0                                                  MUON-
+MGNFIELD        10.0     0.001
+SOURCE
+*...+....1....+....2....+....3....+....4....+....5....+....6....+....7....+ 
+USERDUMP        200.      37.0      -2.0       1.0                    TRAKFILE
+START         42000.99999999.0       2.0               
+STOP                                                                           
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Detectors/gconfig/src/FlukaConfig.cxx
+++ b/Detectors/gconfig/src/FlukaConfig.cxx
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairRunSim.h"
+#include "TFluka.h"
+#include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
+#include <iostream>
+#include "FairLogger.h"
+#include "FairModule.h"
+#include "Generators/DecayerPythia8.h"
+#include "../commonConfig.C"
+
+// these are used in commonConfig.C
+using o2::eventgen::DecayerPythia8;
+
+namespace o2
+{
+namespace flukaconfig
+{
+
+void linkFlukaFiles()
+{
+  // Link here some special Fluka files needed
+  gSystem->Exec("ln -s $FLUKADATA/neuxsc.bin  .");
+  gSystem->Exec("ln -s $FLUKADATA/elasct.bin  .");
+  gSystem->Exec("ln -s $FLUKADATA/gxsect.bin  .");
+  gSystem->Exec("ln -s $FLUKADATA/nuclear.bin .");
+  gSystem->Exec("ln -s $FLUKADATA/sigmapi.bin .");
+  gSystem->Exec("ln -s $FLUKADATA/brems_fin.bin .");
+  gSystem->Exec("ln -s $FLUKADATA/cohff.bin .");
+  gSystem->Exec("ln -s $FLUKADATA/fluodt.dat  .");
+  gSystem->Exec("ln -s $FLUKADATA/random.dat  .");
+  // Copy the random seed
+  gSystem->Exec("cp $FLUKADATA/random.dat old.seed");
+  // Give some meaningfull name to the output
+  gSystem->Exec("ln -s fluka.out fort.11");
+  gSystem->Exec("ln -s fluka.err fort.15");
+  gSystem->Exec("ln -fs $ALICE_ROOT/TFluka/macro/FlukaConfig.C Config.C");
+  gSystem->Exec("ln -fs $O2_ROOT/share/Detectors/gconfig/data/coreFlukaVmc.inp .");
+}
+
+void Config()
+{
+  linkFlukaFiles();
+  FairRunSim* run = FairRunSim::Instance();
+  TString* gModel = run->GetGeoModel();
+  TFluka* fluka = new TFluka("C++ Interface to Fluka", 0);
+  stackSetup(fluka, run);
+
+  // setup decayer
+  decayerSetup(fluka);
+
+  // ******* FLUKA  specific configuration for simulated Runs  *******
+}
+
+void FlukaConfig()
+{
+  LOG(INFO) << "Setting up FLUKA sim from library code";
+  Config();
+}
+} // namespace flukaconfig
+} // namespace o2

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -53,6 +53,8 @@ void SimSetup::setup(const char* engine)
     setupFromPlugin("libO2G3Setup", "_ZN2o28g3config8G3ConfigEv");
   } else if (strcmp(engine, "TGeant4") == 0) {
     setupFromPlugin("libO2G4Setup", "_ZN2o28g4config8G4ConfigEv");
+  } else if (strcmp(engine, "TFluka") == 0) {
+    setupFromPlugin("libO2FLUKASetup", "_ZN2o211flukaconfig11FlukaConfigEv");
   } else {
     LOG(FATAL) << "Unsupported engine " << engine;
   }

--- a/dependencies/FindFlukaVMC.cmake
+++ b/dependencies/FindFlukaVMC.cmake
@@ -1,0 +1,29 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+# use the GEANT4_VMCConfig.cmake provided by the Geant4VMC installation but
+# amend the target geant4vmc with the include directories
+
+find_package(FlukaVMC NO_MODULE)
+if(NOT FlukaVMC_FOUND)
+return()
+endif()
+
+set_target_properties(flukavmc
+                      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                "${FlukaVMC_INCLUDE_DIRS}"
+                      		INTERFACE_LINK_DIRECTORIES
+                                $<TARGET_FILE_DIR:flukavmc>)
+
+# Promote the imported target to global visibility
+# (so we can alias it)
+set_target_properties(flukavmc PROPERTIES IMPORTED_GLOBAL TRUE)
+
+add_library(MC::FlukaVMC ALIAS flukavmc)

--- a/dependencies/O2FindDependenciesFromAliBuild.cmake
+++ b/dependencies/O2FindDependenciesFromAliBuild.cmake
@@ -154,6 +154,7 @@ function(o2_find_dependencies_from_alibuild)
   protected_set_root(Geant3 GEANT3)
   protected_set_root(Geant4 GEANT4)
   protected_set_root(Geant4VMC GEANT4_VMC)
+  protected_set_root(FlukaVMC FLUKA_VMC)	
   protected_set_root(VGM vgm)
   protected_set_root(HepMC HepMC3)
 

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -63,6 +63,9 @@ set_package_properties(Geant4
 find_package(Geant4VMC MODULE)
 set_package_properties(Geant4VMC PROPERTIES TYPE ${mcPackageRequirement})
 
+find_package(FlukaVMC MODULE)
+set_package_properties(FlukaVMC PROPERTIES TYPE OPTIONAL)
+
 find_package(VGM MODULE)
 set_package_properties(VGM PROPERTIES TYPE ${mcPackageRequirement})
 

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -188,14 +188,8 @@ class O2SimDevice final : public FairMQDevice
                     << "part " << info.part << "/" << info.nparts;
           gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
-          auto& conf = o2::conf::SimConfig::Instance();
-          if (strcmp(conf.getMCEngine().c_str(), "TGeant4") == 0) {
-            mVMC->ProcessEvent();
-          } else {
-            // for Geant3 at least calling ProcessEvent is not enough
-            // as some hooks are not called
-            mVMC->ProcessRun(1);
-          }
+          // Process one event
+          mVMC->ProcessRun(1);
 
           FairSystemInfo sysinfo;
           LOG(INFO) << "TIME-STAMP " << mTimer.RealTime() << "\t";


### PR DESCRIPTION
This commit provides support for FLUKA in O2.
FLUKA compilation is optional for the moment.

This backend can be selected via:

```
o2-sim -e TFluka ...
```

Work provided by @amorsch.