### PR TITLE
Add DAQ SystemID Unloaded [O2-1918]

### DIFF
--- a/DataFormats/Headers/include/Headers/DAQID.h
+++ b/DataFormats/Headers/include/Headers/DAQID.h
@@ -22,6 +22,9 @@ namespace header
 {
 /// Source IDs used by DAQ
 
+constexpr o2::header::DataOrigin gDataOriginUnloaded{"UNL"};
+constexpr o2::header::DataOrigin gDataOriginTST{"TST"};
+
 class DAQID
 {
 
@@ -48,6 +51,7 @@ class DAQID
   static constexpr ID MID = 37;
   static constexpr ID DCS = 38;
   static constexpr ID FOC = 39;
+  static constexpr ID UNLOADED = 255;
   static constexpr ID MINDAQ = TPC;
   static constexpr ID MAXDAQ = FOC;
 
@@ -60,7 +64,7 @@ class DAQID
 
   static constexpr o2::header::DataOrigin DAQtoO2(ID daq)
   {
-    return (daq < MAXDAQ + 1) ? MAP_DAQtoO2[daq] : MAP_DAQtoO2[INVALID];
+    return (daq < MAXDAQ + 1) ? MAP_DAQtoO2[daq] : (daq == UNLOADED ? gDataOriginUnloaded : MAP_DAQtoO2[INVALID]);
   }
 
   static constexpr ID O2toDAQ(o2::header::DataOrigin o2orig)
@@ -71,7 +75,7 @@ class DAQID
  private:
   ID mID = INVALID;
 
-  static constexpr o2::header::DataOrigin MAP_DAQtoO2[] = {
+  static constexpr o2::header::DataOrigin MAP_DAQtoO2[0xff + 1] = {
     "NIL", "NIL", "NIL",
     "TPC", "TRD", "TOF", "HMP", "PHS", "CPV",
     "NIL",
@@ -81,11 +85,44 @@ class DAQID
     "NIL",
     "TRG", "EMC", "TST",
     "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL",
-    "ITS", "FDD", "FT0", "FV0", "MFT", "MID", "DCS", "FOC"};
+    "ITS", "FDD", "FT0", "FV0", "MFT", "MID", "DCS", "FOC",               // 39
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 49
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 59
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 69
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 79
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 89
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 99
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 109
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 119
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 129
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 139
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 149
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 159
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 169
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 179
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 189
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 199
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 209
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 219
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 229
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 239
+    "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", "NIL", // 249
+    "NIL", "NIL", "NIL", "NIL", "NIL", "UNL"                              // 255
+  };
+
+  static constexpr bool isSameOrigin(o2::header::DataOrigin origin, ID id)
+  {
+    for (auto i = sizeof(o2::header::DataOrigin); i--;) {
+      if (MAP_DAQtoO2[id].str[i] != origin.str[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   static constexpr ID or2daq(o2::header::DataOrigin origin, ID id)
   {
-    return id > MAXDAQ ? INVALID : (origin == MAP_DAQtoO2[id] ? id : or2daq(origin, id + 1));
+    return (id > MAXDAQ) ? (isSameOrigin(origin, UNLOADED) ? UNLOADED : INVALID) : (isSameOrigin(origin, id) ? id : or2daq(origin, id + 1));
   }
 };
 

--- a/DataFormats/Headers/test/testDAQID.cxx
+++ b/DataFormats/Headers/test/testDAQID.cxx
@@ -23,6 +23,7 @@ using namespace o2::header;
 
 BOOST_AUTO_TEST_CASE(DAQIDTEST)
 {
+
   for (int i = 0; i < DAQID::MAXDAQ + 5; i++) {
     auto vo2 = DAQID::DAQtoO2(i);
     auto daq = DAQID::O2toDAQ(vo2);
@@ -32,4 +33,7 @@ BOOST_AUTO_TEST_CASE(DAQIDTEST)
     BOOST_CHECK(i == daq || vo2 == DAQID::DAQtoO2(DAQID::INVALID));
   }
   std::cout << "DAQ INVALID  " << int(DAQID::INVALID) << " <-> " << DAQID::DAQtoO2(DAQID::INVALID).str << std::endl;
+  std::cout << "DAQ UNLOADED " << int(DAQID::UNLOADED) << " <-> " << DAQID::DAQtoO2(DAQID::UNLOADED).str << std::endl;
+  BOOST_CHECK(DAQID::DAQtoO2(DAQID::UNLOADED) == o2::header::gDataOriginUnloaded);
+  BOOST_CHECK(DAQID::O2toDAQ(o2::header::gDataOriginUnloaded) == DAQID::UNLOADED);
 }


### PR DESCRIPTION
The DAQ SystemIDs 19 (TST) and 255 (UNLOADED) are mapped on ``gDataOriginTST`` and ``gDataOriginUnloaded`` respectively, so that they can end up in formally valid RDH.