### PR TITLE
Eliminate mass argument from track mat.corrections and propagation interfaces

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
@@ -110,6 +110,7 @@ class PID
   GPUd() operator ID() const { return getID(); }
 
   GPUd() float getMass() const { return getMass(mID); }
+  GPUd() float getMass2() const { return getMass2(mID); }
   GPUd() float getMass2Z() const { return getMass2Z(mID); }
   GPUd() int getCharge() const { return getCharge(mID); }
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -197,7 +197,7 @@ class TrackParametrization
   GPUd() math_utils::Point3D<value_t> getXYZGloAt(value_t xk, value_t b, bool& ok) const;
 
   // parameters manipulation
-  GPUd() bool correctForELoss(value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
+  GPUd() bool correctForELoss(value_t xrho, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
   GPUd() bool rotateParam(value_t alpha);
   GPUd() bool propagateParamTo(value_t xk, value_t b);
   GPUd() bool propagateParamTo(value_t xk, const dim3_t& b);

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -102,7 +102,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   template <typename T>
   GPUd() bool update(const BaseCluster<T>& p);
 
-  GPUd() bool correctForMaterial(value_t x2x0, value_t xrho, value_t mass, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
+  GPUd() bool correctForMaterial(value_t x2x0, value_t xrho, bool anglecorr = false, value_t dedx = kCalcdEdxAuto);
 
   GPUd() void resetCovariance(value_t s2 = 0);
   GPUd() void checkCovariance();

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -59,39 +59,39 @@ class Propagator
   static constexpr float MAX_SIN_PHI = 0.85f;
   static constexpr float MAX_STEP = 2.0f;
 
-  bool PropagateToXBxByBz(o2::track::TrackParCov& track, float x, float mass = o2::constants::physics::MassPionCharged,
+  bool PropagateToXBxByBz(o2::track::TrackParCov& track, float x,
                           float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                           o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  bool PropagateToXBxByBz(o2::track::TrackPar& track, float x, float mass = o2::constants::physics::MassPionCharged,
+  bool PropagateToXBxByBz(o2::track::TrackPar& track, float x,
                           float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                           o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  bool propagateToX(o2::track::TrackParCov& track, float x, float bZ, float mass = o2::constants::physics::MassPionCharged,
+  bool propagateToX(o2::track::TrackParCov& track, float x, float bZ,
                     float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                     o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  bool propagateToX(o2::track::TrackPar& track, float x, float bZ, float mass = o2::constants::physics::MassPionCharged,
+  bool propagateToX(o2::track::TrackPar& track, float x, float bZ,
                     float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                     o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
   bool propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track, float bZ,
-                      float mass = o2::constants::physics::MassPionCharged, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
+                      float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                       o2::dataformats::DCA* dcaInfo = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
                       int signCorr = 0, float maxD = 999.f) const;
 
   bool propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track,
-                            float mass = o2::constants::physics::MassPionCharged, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
+                            float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                             o2::dataformats::DCA* dcaInfo = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
                             int signCorr = 0, float maxD = 999.f) const;
 
   bool propagateToDCA(const o2::math_utils::Point3D<float>& vtx, o2::track::TrackPar& track, float bZ,
-                      float mass = o2::constants::physics::MassPionCharged, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
+                      float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                       std::array<float, 2>* dca = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
                       int signCorr = 0, float maxD = 999.f) const;
 
   bool propagateToDCABxByBz(const o2::math_utils::Point3D<float>& vtx, o2::track::TrackPar& track,
-                            float mass = o2::constants::physics::MassPionCharged, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
+                            float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrTGeo,
                             std::array<float, 2>* dca = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
                             int signCorr = 0, float maxD = 999.f) const;
 

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -96,7 +96,7 @@ int Propagator::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verb
 #endif
 
 //_______________________________________________________________________
-bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, float mass, float maxSnp, float maxStep,
+bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, float maxSnp, float maxStep,
                                     Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
@@ -105,7 +105,6 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, 
   // taking into account all the three components of the magnetic field
   // and correcting for the crossed material.
   //
-  // mass     - mass used in propagation - used for energy loss correction (if <0 then q=2)
   // maxStep  - maximal step for propagation
   // tofInfo  - optional container for track length and PID-dependent TOF integration
   //
@@ -137,7 +136,7 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, 
     if (matCorr != MatCorrType::USEMatCorrNONE) {
       auto xyz1 = track.getXYZGlo();
       auto mb = getMatBudget(matCorr, xyz0, xyz1);
-      if (!track.correctForMaterial(mb.meanX2X0, ((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho, mass)) {
+      if (!track.correctForMaterial(mb.meanX2X0, ((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho)) {
         return false;
       }
 
@@ -156,7 +155,7 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, 
 }
 
 //_______________________________________________________________________
-bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, float mass, float maxSnp, float maxStep,
+bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, float maxSnp, float maxStep,
                                     Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
@@ -165,7 +164,6 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, flo
   // taking into account all the three components of the magnetic field
   // and optionally correcting for the e.loss crossed material.
   //
-  // mass     - mass used in propagation - used for energy loss correction (if <0 then q=2)
   // maxStep  - maximal step for propagation
   // tofInfo  - optional container for track length and PID-dependent TOF integration
   //
@@ -197,7 +195,7 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, flo
     if (matCorr != MatCorrType::USEMatCorrNONE) {
       auto xyz1 = track.getXYZGlo();
       auto mb = getMatBudget(matCorr, xyz0, xyz1);
-      if (!track.correctForELoss(((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho, mass)) {
+      if (!track.correctForELoss(((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho)) {
         return false;
       }
       if (tofInfo) {
@@ -215,7 +213,7 @@ bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, flo
 }
 
 //_______________________________________________________________________
-bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float bZ, float mass, float maxSnp, float maxStep,
+bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float bZ, float maxSnp, float maxStep,
                               Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
@@ -224,7 +222,6 @@ bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float 
   // taking into account all the three components of the magnetic field
   // and correcting for the crossed material.
   //
-  // mass     - mass used in propagation - used for energy loss correction (if <0 then q=2)
   // maxStep  - maximal step for propagation
   // tofInfo  - optional container for track length and PID-dependent TOF integration
   //
@@ -255,7 +252,7 @@ bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float 
       auto xyz1 = track.getXYZGlo();
       auto mb = getMatBudget(matCorr, xyz0, xyz1);
       //
-      if (!track.correctForMaterial(mb.meanX2X0, ((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho, mass)) {
+      if (!track.correctForMaterial(mb.meanX2X0, ((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho)) {
         return false;
       }
 
@@ -274,7 +271,7 @@ bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float 
 }
 
 //_______________________________________________________________________
-bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ, float mass, float maxSnp, float maxStep,
+bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ, float maxSnp, float maxStep,
                               Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
@@ -283,7 +280,6 @@ bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ,
   // taking into account all the three components of the magnetic field
   // and correcting for the crossed material.
   //
-  // mass     - mass used in propagation - used for energy loss correction (if <0 then q=2)
   // maxStep  - maximal step for propagation
   // tofInfo  - optional container for track length and PID-dependent TOF integration
   //
@@ -314,7 +310,7 @@ bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ,
       auto xyz1 = track.getXYZGlo();
       auto mb = getMatBudget(matCorr, xyz0, xyz1);
       //
-      if (!track.correctForELoss(((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho, mass)) {
+      if (!track.correctForELoss(((signCorr < 0) ? -mb.length : mb.length) * mb.meanRho)) {
         return false;
       }
 
@@ -334,7 +330,7 @@ bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ,
 
 //_______________________________________________________________________
 bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track, float bZ,
-                                float mass, float maxStep, Propagator::MatCorrType matCorr,
+                                float maxStep, Propagator::MatCorrType matCorr,
                                 o2::dataformats::DCA* dca, o2::track::TrackLTIntegral* tofInfo,
                                 int signCorr, float maxD) const
 {
@@ -362,7 +358,7 @@ bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::trac
 
   auto tmpT(track); // operate on the copy to recover after the failure
   alp += std::asin(sn);
-  if (!tmpT.rotate(alp) || !propagateToX(tmpT, xv, bZ, mass, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
+  if (!tmpT.rotate(alp) || !propagateToX(tmpT, xv, bZ, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: ";
     tmpT.print();
     return false;
@@ -379,7 +375,7 @@ bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::trac
 
 //_______________________________________________________________________
 bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track,
-                                      float mass, float maxStep, Propagator::MatCorrType matCorr,
+                                      float maxStep, Propagator::MatCorrType matCorr,
                                       o2::dataformats::DCA* dca, o2::track::TrackLTIntegral* tofInfo,
                                       int signCorr, float maxD) const
 {
@@ -407,7 +403,7 @@ bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2
 
   auto tmpT(track); // operate on the copy to recover after the failure
   alp += std::asin(sn);
-  if (!tmpT.rotate(alp) || !PropagateToXBxByBz(tmpT, xv, mass, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
+  if (!tmpT.rotate(alp) || !PropagateToXBxByBz(tmpT, xv, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: ";
     tmpT.print();
     return false;
@@ -424,7 +420,7 @@ bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2
 
 //_______________________________________________________________________
 bool Propagator::propagateToDCA(const math_utils::Point3D<float>& vtx, o2::track::TrackPar& track, float bZ,
-                                float mass, float maxStep, Propagator::MatCorrType matCorr,
+                                float maxStep, Propagator::MatCorrType matCorr,
                                 std::array<float, 2>* dca, o2::track::TrackLTIntegral* tofInfo,
                                 int signCorr, float maxD) const
 {
@@ -452,7 +448,7 @@ bool Propagator::propagateToDCA(const math_utils::Point3D<float>& vtx, o2::track
 
   auto tmpT(track); // operate on the copy to recover after the failure
   alp += std::asin(sn);
-  if (!tmpT.rotateParam(alp) || !propagateToX(tmpT, xv, bZ, mass, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
+  if (!tmpT.rotateParam(alp) || !propagateToX(tmpT, xv, bZ, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
     tmpT.printParam();
@@ -468,7 +464,7 @@ bool Propagator::propagateToDCA(const math_utils::Point3D<float>& vtx, o2::track
 
 //_______________________________________________________________________
 bool Propagator::propagateToDCABxByBz(const math_utils::Point3D<float>& vtx, o2::track::TrackPar& track,
-                                      float mass, float maxStep, Propagator::MatCorrType matCorr,
+                                      float maxStep, Propagator::MatCorrType matCorr,
                                       std::array<float, 2>* dca, o2::track::TrackLTIntegral* tofInfo,
                                       int signCorr, float maxD) const
 {
@@ -496,7 +492,7 @@ bool Propagator::propagateToDCABxByBz(const math_utils::Point3D<float>& vtx, o2:
 
   auto tmpT(track); // operate on the copy to recover after the failure
   alp += std::asin(sn);
-  if (!tmpT.rotateParam(alp) || !PropagateToXBxByBz(tmpT, xv, mass, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
+  if (!tmpT.rotateParam(alp) || !PropagateToXBxByBz(tmpT, xv, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
     tmpT.printParam();

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -507,7 +507,7 @@ class MatchTPCITS
   void refitWinners(bool loopInITS = false);
   bool refitTrackTPCITSloopITS(int iITS, int& iTPC);
   bool refitTrackTPCITSloopTPC(int iTPC, int& iITS);
-  bool refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, float xTgt, int trcID, float timeTB, float m = o2::constants::physics::MassPionCharged) const;
+  bool refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, float xTgt, int trcID, float timeTB) const;
 
   void selectBestMatches();
   bool validateTPCMatch(int iTPC);

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -885,7 +885,7 @@ void MatchTOF::doMatching(int sec)
     double reachedPoint = mXRef + istep * step;
 
     while (propagateToRefX(trefTrk, reachedPoint, step, intLT) && nStripsCrossedInPropagation <= 2 && reachedPoint < Geo::RMAX) {
-      // while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trefTrk,  mXRef + istep * step, o2::constants::physics::MassPionCharged, MAXSNP, step, 1, &intLT) && nStripsCrossedInPropagation <= 2 && mXRef + istep * step < Geo::RMAX) {
+      // while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trefTrk,  mXRef + istep * step, MAXSNP, step, 1, &intLT) && nStripsCrossedInPropagation <= 2 && mXRef + istep * step < Geo::RMAX) {
 
       trefTrk.getXYZGlo(pos);
       for (int ii = 0; ii < 3; ii++) { // we need to change the type...
@@ -1258,7 +1258,7 @@ void MatchTOF::doMatchingForTPC(int sec)
       }
     }
     while (propagateToRefX(trefTrk, reachedPoint, step, intLT) && reachedPoint < Geo::RMAX) {
-      // while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trefTrk,  mXRef + istep * step, o2::constants::physics::MassPionCharged, MAXSNP, step, 1, &intLT) && nStripsCrossedInPropagation <= 2 && mXRef + istep * step < Geo::RMAX) {
+      // while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trefTrk,  mXRef + istep * step, MAXSNP, step, 1, &intLT) && nStripsCrossedInPropagation <= 2 && mXRef + istep * step < Geo::RMAX) {
 
       trefTrk.getXYZGlo(pos);
       for (int ii = 0; ii < 3; ii++) { // we need to change the type...
@@ -1550,7 +1550,7 @@ bool MatchTOF::propagateToRefX(o2::track::TrackParCov& trc, float xRef, float st
     xStart = 50.;
   }
   int istep = 1;
-  bool hasPropagated = o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, xStart + istep * stepInCm, o2::constants::physics::MassPionCharged, MAXSNP, stepInCm, matCorr, &intLT);
+  bool hasPropagated = o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, xStart + istep * stepInCm, MAXSNP, stepInCm, matCorr, &intLT);
   while (hasPropagated) {
     if (trc.getX() > xRef) {
       refReached = true; // we reached the 371cm reference
@@ -1568,7 +1568,7 @@ bool MatchTOF::propagateToRefX(o2::track::TrackParCov& trc, float xRef, float st
     if (refReached) {
       break;
     }
-    hasPropagated = o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, xStart + istep * stepInCm, o2::constants::physics::MassPionCharged, MAXSNP, stepInCm, matCorr, &intLT);
+    hasPropagated = o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, xStart + istep * stepInCm, MAXSNP, stepInCm, matCorr, &intLT);
   }
 
   //  if (std::abs(trc.getSnp()) > MAXSNP) Printf("propagateToRefX: condition on snp not ok, returning false");

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1221,8 +1221,7 @@ void MatchTPCITS::addLastTrackCloneForNeighbourSector(int sector)
   mITSWork.push_back(mITSWork.back()); // clone the last track defined in given sector
   auto& trc = mITSWork.back();
   if (trc.rotate(o2::math_utils::sector2Angle(sector)) &&
-      o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, XMatchingRef, o2::constants::physics::MassPionCharged, MaxSnp,
-                                                           2., MatCorrType::USEMatCorrNONE)) {
+      o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, XMatchingRef, MaxSnp, 2., MatCorrType::USEMatCorrNONE)) {
     // TODO: use faster prop here, no 3d field, materials
     mITSSectIndexCache[sector].push_back(mITSWork.size() - 1); // register track CLONE
     if (mMCTruthON) {
@@ -1241,8 +1240,7 @@ bool MatchTPCITS::propagateToRefX(o2::track::TrackParCov& trc)
   bool refReached = false;
   refReached = XMatchingRef < 10.; // RS: tmp, to cover XMatchingRef~0
   int trialsLeft = 2;
-  while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, XMatchingRef, o2::constants::physics::MassPionCharged,
-                                                              MaxSnp, 2., mUseMatCorrFlag)) {
+  while (o2::base::Propagator::Instance()->PropagateToXBxByBz(trc, XMatchingRef, MaxSnp, 2., mUseMatCorrFlag)) {
     if (refReached) {
       break;
     }
@@ -1391,8 +1389,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
         // note: here we also calculate the L,T integral (in the inward direction, but this is irrelevant)
         // note: we should eventually use TPC pid in the refit (TODO)
         // note: since we are at small R, we can use field BZ component at origin rather than 3D field
-        // !propagator->PropagateToXBxByBz(trfit, x, o2::constants::physics::MassPionCharged,
-        !propagator->propagateToX(trfit, x, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+        !propagator->propagateToX(trfit, x, propagator->getNominalBz(),
                                   MaxSnp, maxStep, mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
       break;
     }
@@ -1414,7 +1411,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
 
   // we need to update the LTOF integral by the distance to the "primary vertex"
   const o2::dataformats::VertexBase vtxDummy; // at the moment using dummy vertex: TODO use MeanVertex constraint instead
-  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(),
                                   maxStep, mUseMatCorrFlag, nullptr, &trfit.getLTIntegralOut())) {
     LOG(ERROR) << "LTOF integral might be incorrect";
   }
@@ -1451,7 +1448,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
     // TODO: consider propagating in empty space till TPC entrance in large step, and then in more detailed propagation with mat. corrections
 
     // propagate to 1st cluster X
-    if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp, 10., mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
+    if (!propagator->PropagateToXBxByBz(tracOut, clsX, MaxSnp, 10., mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
       LOG(DEBUG) << "Propagation to 1st cluster at X=" << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp();
       mMatchedTracks.pop_back(); // destroy failed track
       return false;
@@ -1489,7 +1486,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
           return false;
         }
       }
-      if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp,
+      if (!propagator->PropagateToXBxByBz(tracOut, clsX, MaxSnp,
                                           10., MatCorrType::USEMatCorrNONE, &trfit.getLTIntegralOut())) { // no material correction!
         LOG(DEBUG) << "Propagation to cluster " << icl << " (of " << tpcTrOrig.getNClusterReferences() << ") at X="
                    << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp() << " pT=" << tracOut.getPt();
@@ -1505,7 +1502,7 @@ bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
     }
     // propagate to the outer edge of the TPC, TODO: check outer radius
     // Note: it is allowed to not reach the requested radius
-    propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, o2::constants::physics::MassPionCharged, MaxSnp,
+    propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, MaxSnp,
                                    10., mUseMatCorrFlag, &trfit.getLTIntegralOut());
 
     //    LOG(INFO) << "Refitted with chi2 = " << chi2Out;
@@ -1577,8 +1574,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
         // note: here we also calculate the L,T integral (in the inward direction, but this is irrelevant)
         // note: we should eventually use TPC pid in the refit (TODO)
         // note: since we are at small R, we can use field BZ component at origin rather than 3D field
-        // !propagator->PropagateToXBxByBz(trfit, x, o2::constants::physics::MassPionCharged,
-        !propagator->propagateToX(trfit, x, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+        !propagator->propagateToX(trfit, x, propagator->getNominalBz(),
                                   MaxSnp, maxStep, mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
       break;
     }
@@ -1600,7 +1596,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
 
   // we need to update the LTOF integral by the distance to the "primary vertex"
   const o2::dataformats::VertexBase vtxDummy; // at the moment using dummy vertex: TODO use MeanVertex constraint instead
-  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(),
                                   maxStep, mUseMatCorrFlag, nullptr, &trfit.getLTIntegralOut())) {
     LOG(ERROR) << "LTOF integral might be incorrect";
   }
@@ -1644,7 +1640,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
     // TODO: consider propagating in empty space till TPC entrance in large step, and then in more detailed propagation with mat. corrections
 
     // propagate to 1st cluster X
-    if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp, 10., mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
+    if (!propagator->PropagateToXBxByBz(tracOut, clsX, MaxSnp, 10., mUseMatCorrFlag, &trfit.getLTIntegralOut())) {
       LOG(DEBUG) << "Propagation to 1st cluster at X=" << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp();
       mMatchedTracks.pop_back(); // destroy failed track
       return false;
@@ -1682,7 +1678,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
           return false;
         }
       }
-      if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp,
+      if (!propagator->PropagateToXBxByBz(tracOut, clsX, MaxSnp,
                                           10., MatCorrType::USEMatCorrNONE, &trfit.getLTIntegralOut())) { // no material correction!
         LOG(DEBUG) << "Propagation to cluster " << icl << " (of " << tpcTrOrig.getNClusterReferences() << ") at X="
                    << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp() << " pT=" << tracOut.getPt();
@@ -1698,7 +1694,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
     }
     // propagate to the outer edge of the TPC, TODO: check outer radius
     // Note: it is allowed to not reach the requested radius
-    propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, o2::constants::physics::MassPionCharged, MaxSnp,
+    propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, MaxSnp,
                                    10., mUseMatCorrFlag, &trfit.getLTIntegralOut());
 
     //    LOG(INFO) << "Refitted with chi2 = " << chi2Out;
@@ -1729,7 +1725,7 @@ bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
 }
 
 //______________________________________________
-bool MatchTPCITS::refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, float xTgt, int trcID, float timeTB, float m) const
+bool MatchTPCITS::refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, float xTgt, int trcID, float timeTB) const
 {
   // inward refit
   constexpr float TolSNP = 0.99;
@@ -1793,7 +1789,7 @@ bool MatchTPCITS::refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, flo
     }
     mTPCTransform->Transform(sectArr[icl], rowArr[icl], clsArr[icl]->getPad(), clsArr[icl]->getTime(), clsX, clsYZ[0], clsYZ[1], timeTB);
     mTPCClusterParam->GetClusterErrors2(rowArr[icl], clsYZ[1], trcIn.getSnp(), trcIn.getTgl(), clsCov[0], clsCov[2]);
-    if (!propagator->PropagateToXBxByBz(trcIn, clsX, m, TolSNP, 10., MatCorrType::USEMatCorrNONE)) { // no material correction!
+    if (!propagator->PropagateToXBxByBz(trcIn, clsX, TolSNP, 10., MatCorrType::USEMatCorrNONE)) { // no material correction!
       LOG(DEBUG) << "Propagation to cluster at X="
                  << clsX << " failed, Xtr=" << trcIn.getX() << " snp=" << trcIn.getSnp() << " pT=" << trcIn.getPt();
       LOG(DEBUG) << trcIn.asString();
@@ -1808,7 +1804,7 @@ bool MatchTPCITS::refitTPCInward(o2::track::TrackParCov& trcIn, float& chi2, flo
   }
   // propagate to the inner edge of the TPC
   // Note: it is allowed to not reach the requested radius
-  if (!propagator->PropagateToXBxByBz(trcIn, xTgt, m, MaxSnp, 2., mUseMatCorrFlag)) {
+  if (!propagator->PropagateToXBxByBz(trcIn, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
     LOG(DEBUG) << "Propagation to target X=" << xTgt << " failed, Xtr=" << trcIn.getX() << " snp=" << trcIn.getSnp() << " pT=" << trcIn.getPt();
     LOG(DEBUG) << trcIn.asString();
     return false;
@@ -1837,7 +1833,7 @@ int MatchTPCITS::prepareTPCTracksAfterBurner()
       // which should be good assumption....
       float xTgt;
       if (!tTPC.getXatLabR(ROuter, xTgt, propagator->getNominalBz(), o2::track::DirInward) ||
-          !propagator->PropagateToXBxByBz(tTPC, xTgt, o2::constants::physics::MassPionCharged, MaxSnp, 2., mUseMatCorrFlag)) {
+          !propagator->PropagateToXBxByBz(tTPC, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
         continue;
       }
       mTPCABIndexCache.push_back(iTPC);
@@ -2031,7 +2027,7 @@ int MatchTPCITS::checkABSeedFromLr(int lrSeed, int seedID, ABTrackLinksList& lli
   float xTgt;
   const auto& lr = mRGHelper.layers[lrTgt];
   if (!seed.getXatLabR(lr.rRange.getMax(), xTgt, propagator->getNominalBz(), o2::track::DirInward) ||
-      !propagator->PropagateToXBxByBz(seed, xTgt, o2::constants::physics::MassPionCharged, MaxSnp, 2., mUseMatCorrFlag)) {
+      !propagator->PropagateToXBxByBz(seed, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
     return 0;
   }
   auto icCandID = seedLink.icCandID;
@@ -2399,7 +2395,7 @@ float MatchTPCITS::correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTP
     float xTgt;
     auto propagator = o2::base::Propagator::Instance();
     if (!trc.getXatLabR(r, xTgt, propagator->getNominalBz(), o2::track::DirInward) ||
-	!propagator->PropagateToXBxByBz(trc, xTgt, o2::constants::physics::MassPionCharged, MaxSnp, 2., mUseMatCorrFlag)) {
+	!propagator->PropagateToXBxByBz(trc, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
       return -1;
     }
   }
@@ -2680,8 +2676,7 @@ void MatchTPCITS::refitABTrack(int ibest) const
   while (ibest > MinusOne) {
     const auto& lnk = mABTrackLinks[ibest];
     if (!trc.rotate(lnk.getAlpha()) ||
-        !propagator->propagateToX(trc, lnk.getX(), propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
-                                  MaxSnp, maxStep, mUseMatCorrFlag, nullptr)) {
+        !propagator->propagateToX(trc, lnk.getX(), propagator->getNominalBz(), MaxSnp, maxStep, mUseMatCorrFlag, nullptr)) {
       LOG(WARNING) << "Failed to rotate to " << lnk.getAlpha() << " or propagate to " << lnk.getX();
       LOG(WARNING) << trc.asString();
       break;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -439,7 +439,7 @@ bool Tracker::fitTrack(const ROframe& event, TrackITSExt& track, int start, int 
     // The correctForMaterial should be called with anglecorr==true if the material budget is the "mean budget in vertical direction" and with false if the the estimated budget already accounts for the track inclination.
     // Here using !mMatLayerCylSet as its presence triggers update of parameters
 
-    if (!track.correctForMaterial(xx0, ((start < end) ? -1. : 1.) * distance * density, 0.14, !mMatLayerCylSet)) { // ~0.14 GeV: mass of charged pion is used by default
+    if (!track.correctForMaterial(xx0, ((start < end) ? -1. : 1.) * distance * density, !mMatLayerCylSet)) { // ~0.14 GeV: mass of charged pion is used by default
       return false;
     }
   }

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -192,7 +192,7 @@ bool TrackInterpolation::interpolateTrackITSTOF(const o2::dataformats::MatchInfo
       LOG(DEBUG) << "Failed to rotate track during first extrapolation";
       return false;
     }
-    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], mMaxSnp, mMaxStep, mMatCorr)) {
       LOG(DEBUG) << "Failed on first extrapolation";
       return false;
     }
@@ -218,7 +218,7 @@ bool TrackInterpolation::interpolateTrackITSTOF(const o2::dataformats::MatchInfo
   float clTOFX = clTOF.getX();
   std::array<float, 2> clTOFYZ{clTOF.getY(), clTOF.getZ()};
   std::array<float, 3> clTOFCov{mSigYZ2TOF, 0.f, mSigYZ2TOF}; // assume no correlation between y and z and equal cluster error sigma^2 = (3cm)^2 / 12
-  if (!propagator->PropagateToXBxByBz(trkWork, clTOFX, o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+  if (!propagator->PropagateToXBxByBz(trkWork, clTOFX, mMaxSnp, mMaxStep, mMatCorr)) {
     LOG(DEBUG) << "Failed final propagation to TOF radius";
     return false;
   }
@@ -236,7 +236,7 @@ bool TrackInterpolation::interpolateTrackITSTOF(const o2::dataformats::MatchInfo
       LOG(DEBUG) << "Failed to rotate track during back propagation";
       return false;
     }
-    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], mMaxSnp, mMaxStep, mMatCorr)) {
       LOG(DEBUG) << "Failed on back propagation";
       //printf("trkX(%.2f), clX(%.2f), clY(%.2f), clZ(%.2f), alphaTOF(%.2f)\n", trkWork.getX(), param::RowX[iRow], clTOFYZ[0], clTOFYZ[1], clTOFAlpha);
       return false;
@@ -315,7 +315,7 @@ bool TrackInterpolation::extrapolateTrackITS(const o2::its::TrackITS& trkITS, co
     if (!trk.rotate(o2::math_utils::sector2Angle(sector))) {
       return false;
     }
-    if (!propagator->PropagateToXBxByBz(trk, x, o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+    if (!propagator->PropagateToXBxByBz(trk, x, mMaxSnp, mMaxStep, mMatCorr)) {
       return false;
     }
     TPCClusterResiduals res;

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.cxx
@@ -345,7 +345,7 @@ GPUd() int GPUTrackingRefit::RefitTrack(T& trkX, bool outward, bool resetCov)
         IgnoreErrors(trk.getSnp());
         return -1;
       }
-      if (!prop->PropagateToXBxByBz(trk, x, o2::constants::physics::MassPionCharged, GPUCA_MAX_SIN_PHI_LOW)) {
+      if (!prop->PropagateToXBxByBz(trk, x, GPUCA_MAX_SIN_PHI_LOW)) {
         IgnoreErrors(trk.getSnp());
         return -2;
       }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -200,7 +200,7 @@ class propagatorInterface<o2::base::Propagator>
   propagatorInterface<o2::base::Propagator>(const propagatorInterface<o2::base::Propagator>&) = delete;
   propagatorInterface<o2::base::Propagator>& operator=(const propagatorInterface<o2::base::Propagator>&) = delete;
 
-  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep); }
+  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, maxSnp, maxStep); }
   int getPropagatedYZ(float x, float& projY, float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
 
   void setTrack(trackInterface<o2::dataformats::TrackTPCITS>* trk) { mParam = trk; }


### PR DESCRIPTION
Since the TrackPar provides its mass via getPID().getMass(), we don't need to pass the mass argument explicitly
to track.correctFor... and Propagator.propagetTo... methods. The correctFor... methods will query the mass internally.