### PR TITLE
A ROOT serializable key-value store

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -12,7 +12,7 @@ o2_add_library(CommonUtils
                SOURCES src/TreeStream.cxx src/TreeStreamRedirector.cxx
                        src/RootChain.cxx src/CompStream.cxx src/ShmManager.cxx
 	               src/ValueMonitor.cxx
-                       src/ConfigurableParamHelper.cxx src/ConfigurableParam.cxx
+                       src/ConfigurableParamHelper.cxx src/ConfigurableParam.cxx src/RootSerializableKeyValueStore.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
@@ -28,7 +28,8 @@ o2_target_root_dictionary(CommonUtils
 				  include/CommonUtils/MemFileHelper.h
                                   include/CommonUtils/ConfigurableParam.h
                                   include/CommonUtils/ConfigurableParamHelper.h
-                                  include/CommonUtils/ConfigurationMacroHelper.h)
+                                  include/CommonUtils/ConfigurationMacroHelper.h
+				  include/CommonUtils/RootSerializableKeyValueStore.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils
@@ -52,6 +53,12 @@ o2_add_test(ValueMonitor
             COMPONENT_NAME CommonUtils
             LABELS utils
             SOURCES test/testValueMonitor.cxx
+            PUBLIC_LINK_LIBRARIES O2::CommonUtils)
+
+o2_add_test(PropertyMapIO
+            COMPONENT_NAME CommonUtils
+            LABELS utils
+            SOURCES test/testRootSerializableKeyValueStore.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonUtils)
 
 o2_add_test(MemFileHelper

--- a/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
+++ b/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
@@ -1,0 +1,132 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_ROOTSERKEYVALUESTORE_H
+#define ALICEO2_ROOTSERKEYVALUESTORE_H
+
+#include <map>
+#include <string>
+#include <TClass.h>
+#include <Rtypes.h>
+#include <typeinfo>
+#include <typeindex>
+#include <iostream>
+#include <TBufferFile.h>
+
+namespace o2
+{
+namespace utils
+{
+
+/// A ROOT serializable container mapping a key (string) to an object of arbitrary type.
+///
+/// The container allows to group objects in heterogeneous type in a key-value container.
+/// The container can be ROOT serialized which adds on-top of existing solutions such as boost::property_tree.
+/// This may be useful in various circumenstances, for
+/// instance to assemble various CCDB objects into a single aggregate to reduce the number of CCDB files/entries.
+class RootSerializableKeyValueStore
+{
+ public:
+  /// Structure encapsulating the stored information: raw buffers and attached type information (combination of type_index_hash and TClass information)
+  struct SerializedInfo {
+    void* objptr = nullptr; //! pointer to existing object in memory
+    Int_t N = 0;
+    char* bufferptr = nullptr; //[N]  pointer to serialized buffer
+
+    // we use the TClass and/or the type_index_hash for type idendification
+    TClass* cl = nullptr;
+    size_t type_index_hash = 0;
+    ClassDefNV(SerializedInfo, 1);
+  };
+
+  RootSerializableKeyValueStore() = default;
+
+  /// putting a value
+  /// TODO: list the constraints on T
+  template <typename T>
+  void put(std::string const& key, T const& value);
+
+  /// returns object for this key or nullptr if error or does not exist
+  /// TODO: error handling/info via some enum?
+  template <typename T>
+  const T* get(std::string const& key) const;
+
+ private:
+  std::map<std::string, SerializedInfo*> mStore;
+
+  ClassDefNV(RootSerializableKeyValueStore, 1);
+};
+
+template <typename T>
+inline void RootSerializableKeyValueStore::put(std::string const& key, T const& value)
+{
+  auto ptr = new T(value);
+  auto cl = TClass::GetClass(typeid(value));
+
+  // if there is a TClass, we'll use ROOT serialization to encode into the buffer
+  // TODO: do this only upon streaming (in a custom streamer)
+  int N = 0;
+  char* bufferptr = nullptr;
+  if (cl) {
+    TBufferFile buff(TBuffer::kWrite);
+    buff.WriteObjectAny(ptr, cl);
+    N = buff.Length();
+    bufferptr = new char[N];
+    memcpy(bufferptr, buff.Buffer(), sizeof(char) * N);
+  } else {
+    // TODO: static assert that this is a pod
+    N = sizeof(T);
+    bufferptr = new char[N];
+    memcpy(bufferptr, (char*)ptr, sizeof(char) * N);
+  }
+
+  auto hash = std::type_index(typeid(value)).hash_code();
+  mStore.insert(std::pair<std::string, SerializedInfo*>(key, new SerializedInfo{(void*)ptr, N, (char*)bufferptr, cl, hash}));
+}
+
+template <typename T>
+inline const T* RootSerializableKeyValueStore::get(std::string const& key) const
+{
+  auto iter = mStore.find(key);
+  if (iter != mStore.end()) {
+    auto value = iter->second;
+    std::cerr << "{" << value->objptr << " , " << value->N << " , " << (void*)value->bufferptr << " , " << value->cl << " , " << value->type_index_hash << "}\n";
+    auto cl = TClass::GetClass(typeid(T));
+    if (std::type_index(typeid(T)).hash_code() == value->type_index_hash) {
+      // if there is a (cached) object pointer ... we return it
+      if (value->objptr) {
+        return (T*)value->objptr;
+      }
+
+      // if we have TClass ... unpack first of all
+      if (value->cl) {
+        // do this only once and cache instance into value.objptr
+        TBufferFile buff(TBuffer::kRead, value->N, value->bufferptr, false, nullptr);
+        buff.Reset();
+        auto instance = (T*)buff.ReadObjectAny(cl);
+        value->objptr = instance;
+        return (T*)value->objptr;
+      } else {
+        value->objptr = (T*)value->bufferptr;
+        return (T*)value->objptr;
+      }
+    } else {
+      std::cerr << "type does not match\n";
+      return nullptr;
+    }
+  }
+  std::cerr << "no such key " << key << "\n";
+  return nullptr;
+}
+
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -19,5 +19,8 @@
 #pragma link C++ class o2::utils::RootChain + ;
 #pragma link C++ class o2::utils::RngHelper;
 #pragma link C++ class o2::utils::MemFileHelper + ;
+#pragma link C++ class o2::utils::RootSerializableKeyValueStore::SerializedInfo + ;
+#pragma link C++ class map < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo*> + ;
+#pragma link C++ class o2::utils::RootSerializableKeyValueStore + ;
 
 #endif

--- a/Common/Utils/src/RootSerializableKeyValueStore.cxx
+++ b/Common/Utils/src/RootSerializableKeyValueStore.cxx
@@ -1,0 +1,3 @@
+#include "CommonUtils/RootSerializableKeyValueStore.h"
+
+using namespace o2::utils;

--- a/Common/Utils/test/testRootSerializableKeyValueStore.cxx
+++ b/Common/Utils/test/testRootSerializableKeyValueStore.cxx
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test RootSerKeyValueStore
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "CommonUtils/RootSerializableKeyValueStore.h"
+#include <TMemFile.h>
+#include <TH1F.h>
+#include <vector>
+#include <iostream>
+
+using namespace o2;
+using namespace o2::utils;
+
+BOOST_AUTO_TEST_CASE(write_read_test)
+{
+  RootSerializableKeyValueStore s;
+
+  // put POD some stuff
+  double x = 1.1;
+  s.put("x", x);
+  s.put("i", 110);
+
+  // put some complex classes (need dictionary)
+  std::string str = "hello";
+  s.put("str", str);
+
+  TH1F h1("th1name", "th1name", 100, 0, 99);
+  h1.FillRandom("gaus", 10000);
+  s.put("h1", h1);
+
+  // check basic assumption that hash_code is unique (encouraged by standard)
+  BOOST_CHECK(std::type_index(typeid(std::vector<double>*)).hash_code() == 10319097832066014690UL);
+
+  // retrieve
+  BOOST_CHECK(s.get<std::string>("str")->compare(str) == 0);
+  BOOST_CHECK(*(s.get<double>("x")) == x);
+
+  std::cerr << "TESTING FILE IO\n";
+  TMemFile f("tmp.root", "RECREATE");
+  f.WriteObject(&s, "map");
+
+  RootSerializableKeyValueStore* s2 = nullptr;
+  f.GetObject("map", s2);
+  BOOST_CHECK(s2 != nullptr);
+  if (s2) {
+    auto t1 = s2->get<double>("x");
+    BOOST_CHECK(t1 != nullptr);
+    BOOST_CHECK(t1 && *(t1) == x);
+
+    auto i1 = s2->get<int>("i");
+    BOOST_CHECK(i1 != nullptr);
+    BOOST_CHECK(i1 && *(i1) == 110);
+
+    auto t2 = s2->get<std::string>("str");
+    BOOST_CHECK(t2 && t2->compare(str) == 0);
+
+    auto t3 = s2->get<std::string>("str");
+    BOOST_CHECK(t3 && t3->compare(str) == 0);
+
+    auto histo = s2->get<TH1F>("h1");
+    BOOST_CHECK(histo);
+  }
+  f.Close();
+}


### PR DESCRIPTION
Basically a container mapping a string key to arbitrary values.
A bit like boost-property (tree) but ROOT serializable.

This may be useful in various circumenstances, for
instance to assemble various CCDB objects into a single aggregate
to reduce the number of CCDB files/entries.