### PR TITLE
[WIP][ITS-tracking] Add track dumping in standalone debugger

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
@@ -17,7 +17,7 @@ o2_add_library(ITStracking
                        src/Label.cxx
                        src/PrimaryVertexContext.cxx
                        src/Road.cxx
-                      #  src/StandaloneDebugger.cxx
+                       src/StandaloneDebugger.cxx
                        src/Tracker.cxx
                        src/TrackerTraitsCPU.cxx
                        src/TrackingConfigParam.cxx
@@ -36,6 +36,7 @@ o2_target_root_dictionary(ITStracking
                           HEADERS include/ITStracking/ClusterLines.h
                                   include/ITStracking/Tracklet.h
                                   include/ITStracking/TrackingConfigParam.h
+                                  include/ITStracking/StandaloneDebugger.h
                           LINKDEF src/TrackingLinkDef.h)
 
 if(CUDA_ENABLED)

--- a/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
@@ -35,6 +35,7 @@ o2_add_library(ITStracking
 o2_target_root_dictionary(ITStracking
                           HEADERS include/ITStracking/ClusterLines.h
                                   include/ITStracking/Tracklet.h
+                                  include/ITStracking/Cluster.h
                                   include/ITStracking/TrackingConfigParam.h
                                   include/ITStracking/StandaloneDebugger.h
                           LINKDEF src/TrackingLinkDef.h)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -59,6 +59,8 @@ struct TrackingFrameInfo {
   float alphaTrackingFrame;
   GPUArray<float, 2> positionTrackingFrame = {-1., -1.};
   GPUArray<float, 3> covarianceTrackingFrame = {999., 999., 999.};
+
+  ClassDefNV(TrackingFrameInfo, 1);
 };
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -19,6 +19,7 @@
 #include <array>
 #endif
 
+#include "GPUCommonRtypes.h"
 #include "ITStracking/Definitions.h"
 #include "ITStracking/MathUtils.h"
 
@@ -43,6 +44,8 @@ struct Cluster final {
   float rCoordinate;      // = -999.f;
   int clusterId;          // = -1;
   int indexTableBinIndex; // = -1;
+
+  ClassDefNV(Cluster, 1);
 };
 
 struct TrackingFrameInfo {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
@@ -21,7 +21,7 @@
 #include <array>
 #endif
 
-#define CA_DEBUG
+// #define CA_DEBUG
 
 #ifdef CA_DEBUG
 #define CA_DEBUGGER(x) x

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
@@ -21,7 +21,7 @@
 #include <array>
 #endif
 
-//#define CA_DEBUG
+#define CA_DEBUG
 
 #ifdef CA_DEBUG
 #define CA_DEBUGGER(x) x

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
@@ -21,7 +21,7 @@
 #include <array>
 #endif
 
-// #define CA_DEBUG
+#define CA_DEBUG
 
 #ifdef CA_DEBUG
 #define CA_DEBUGGER(x) x

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
@@ -70,7 +70,7 @@ struct FakeTrackInfo {
         occurrences.emplace_back(mcLabel, 1);
       }
     }
-    // LOG(WARN) << "Qui 1";
+
     if (occurrences.size() > 1) {
       isFake = true;
     }
@@ -78,14 +78,14 @@ struct FakeTrackInfo {
       return e1.second > e2.second;
     });
     mainLabel = occurrences[0].first;
-    // LOG(WARN) << "Qui 2";
+
     for (size_t iOcc{1}; iOcc < occurrences.size(); ++iOcc) {
       if (occurrences[iOcc].second == occurrences[0].second) {
         isAmbiguousId = true;
         break;
       }
     }
-    // LOG(WARN) << "Qui 3";
+
     for (size_t iCluster{0}; iCluster < numClusters; ++iCluster) {
       int extIndex = track.getClusterIndex(iCluster);
       if (extIndex == -1) {
@@ -99,20 +99,15 @@ struct FakeTrackInfo {
         ++nFakeClusters;
       }
     }
-    // LOG(WARN) << "Qui 3.5";
     if (storeClusters) {
       for (auto iCluster{0}; iCluster < numClusters; ++iCluster) {
         const int index = track.getClusterIndex(iCluster);
         if (index != constants::its::UnusedIndex) {
-          clusters[iCluster] = pvc->getClusters()[iCluster][track.getClusterIndex(iCluster)];
+          clusters[iCluster] = pvc->getClusters()[iCluster][index];
+          trackingFrameInfos[iCluster] = event.getTrackingFrameInfoOnLayer(iCluster).at(index);
         }
-        // LOG(WARN) << "Qui 3.5.1";
-        // LOG(WARN) << "\t iCLuster " << iCluster;
-        // LOG(WARN) << "\t getClusterIndex(iCluster) " << track.getClusterIndex(iCluster);
-        // LOG(WARN) << "\t externalIndex " << event.getClusterExternalIndex(iCluster, track.getClusterIndex(iCluster));
       }
     }
-    // LOG(WARN) << "Qui 4";
   }
 
   // Data
@@ -121,6 +116,8 @@ struct FakeTrackInfo {
   MCCompLabel mainLabel;
   std::array<int, numClusters> clusStatuses;
   std::array<o2::its::Cluster, numClusters> clusters;
+  std::array<o2::its::TrackingFrameInfo, numClusters> trackingFrameInfos;
+
   bool isFake;
   bool isAmbiguousId;
   int nFakeClusters = 0;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
@@ -15,21 +15,91 @@
 #ifndef O2_ITS_STANDALONE_DEBUGGER_H_
 #define O2_ITS_STANDALONE_DEBUGGER_H_
 
+#include <string>
+#include <iterator>
+
+// Tracker
+#include "DataFormatsITS/TrackITS.h"
+#include "ITStracking/ROframe.h"
+
 namespace o2
 {
 
-class MCCompLabel;
+// class MCCompLabel;
 
 namespace utils
 {
 class TreeStreamRedirector;
 }
 
+// namespace its
+// {
+// class TrackITSExt;
+// }
+
 namespace its
 {
 class Tracklet;
 class Line;
 class ROframe;
+class ClusterLines;
+
+using constants::its::UnusedIndex;
+
+struct FakeTrackInfo {
+ public:
+  FakeTrackInfo();
+  FakeTrackInfo(const ROframe& event, TrackITSExt& track) : isFake{false}, isAmbiguousId{false}, mainLabel{UnusedIndex, UnusedIndex, UnusedIndex, false}
+  {
+    occurrences.clear();
+    for (size_t iCluster{0}; iCluster < 7; ++iCluster) {
+      int extIndex = track.getClusterIndex(iCluster);
+      o2::MCCompLabel mcLabel = event.getClusterLabels(iCluster, extIndex);
+      bool found = false;
+
+      for (size_t iOcc{0}; iOcc < occurrences.size(); ++iOcc) {
+        std::pair<o2::MCCompLabel, int>& occurrence = occurrences[iOcc];
+        if (mcLabel == occurrence.first) {
+          ++occurrence.second;
+          found = true;
+        }
+      }
+      if (!found) {
+        occurrences.emplace_back(mcLabel, 1);
+      }
+    }
+    if (occurrences.size() > 1) {
+      isFake = true;
+    }
+    std::sort(std::begin(occurrences), std::end(occurrences), [](auto e1, auto e2) {
+      return e1.second > e2.second;
+    });
+    mainLabel = occurrences[0].first;
+
+    for (auto iOcc{1}; iOcc < occurrences.size(); ++iOcc) {
+      if (occurrences[iOcc].second == occurrences[0].second) {
+        isAmbiguousId = true;
+        break;
+      }
+    }
+    for (auto iCluster{0}; iCluster < TrackITSExt::MaxClusters; ++iCluster) {
+      int extIndex = track.getClusterIndex(iCluster);
+      o2::MCCompLabel lbl = event.getClusterLabels(iCluster, extIndex);
+      if (lbl == mainLabel && occurrences[0].second > 1 && !lbl.isNoise()) { // if 7 fake clusters -> occurrences[0].second = 1
+        clusStatuses[iCluster] = 1;
+      } else {
+        clusStatuses[iCluster] = 0;
+        ++nFakeClusters;
+      }
+    }
+  }
+  std::vector<std::pair<MCCompLabel, int>> occurrences;
+  MCCompLabel mainLabel;
+  std::array<int, 7> clusStatuses = {-1, -1, -1, -1, -1, -1, -1};
+  bool isFake;
+  bool isAmbiguousId;
+  int nFakeClusters = 0;
+};
 
 class StandaloneDebugger
 {
@@ -58,6 +128,9 @@ class StandaloneDebugger
   void fillLineClustersTree(std::vector<ClusterLines> clusters, const ROframe* event);
   void fillXYZHistogramTree(std::array<std::vector<int>, 3>, const std::array<int, 3>);
   void fillVerticesInfoTree(float x, float y, float z, int size, int rId, int eId, float pur);
+
+  // Tracker debug utilities
+  void dumpTrackToBranchWithInfo(const ROframe event, o2::its::TrackITSExt track, std::string branchName);
 
   static int getBinIndex(const float, const int, const float, const float);
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -38,6 +38,10 @@
 
 #include "Framework/Logger.h"
 
+#ifdef CA_DEBUG
+#include "ITStracking/StandaloneDebugger.h"
+#endif
+
 namespace o2
 {
 namespace gpu
@@ -105,6 +109,10 @@ class Tracker
   std::vector<MCCompLabel> mTrackLabels;
   o2::base::MatLayerCylSet* mMatLayerCylSet = nullptr;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
+
+#ifdef CA_DEBUG
+  StandaloneDebugger* mDebugger;
+#endif
 };
 
 inline void Tracker::setParameters(const std::vector<MemoryParameters>& memPars, const std::vector<TrackingParameters>& trkPars)

--- a/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
@@ -12,14 +12,11 @@
 /// \brief
 /// \author matteo.concas@cern.ch
 
-
 #include "ITStracking/Cluster.h"
 #include "ITStracking/Tracklet.h"
 #include "ITStracking/ClusterLines.h"
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "ITStracking/StandaloneDebugger.h"
-
-
 
 #include "TH1I.h"
 #include "TMath.h"
@@ -259,20 +256,19 @@ int StandaloneDebugger::getBinIndex(const float value, const int size, const flo
 }
 
 // Tracker
-void StandaloneDebugger::dumpTrackToBranchWithInfo(ROframe event, o2::its::TrackITSExt track,
-                                                   std::string branchName)
+void StandaloneDebugger::dumpTrackToBranchWithInfo(std::string branchName, o2::its::TrackITSExt track, const ROframe event, PrimaryVertexContext* pvc, const bool dumpClusters)
 {
-  // FakeTrackInfo t{event, track};
+  FakeTrackInfo<7> t{pvc, event, track, dumpClusters};
 
   (*mTreeStream)
     << branchName.data()
     << track
     << "\n";
-  
-  // (*mTreeStream)
-  //   << "TracksInfo" 
-  //   << tInfo
-  //   << "\n";
+
+  (*mTreeStream)
+    << "TracksInfo"
+    << t
+    << "\n";
 }
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
@@ -12,14 +12,15 @@
 /// \brief
 /// \author matteo.concas@cern.ch
 
-#include <string>
-#include <iterator>
+
 #include "ITStracking/Cluster.h"
 #include "ITStracking/Tracklet.h"
 #include "ITStracking/ClusterLines.h"
 #include "CommonUtils/TreeStreamRedirector.h"
-#include "ITStracking/ROframe.h"
 #include "ITStracking/StandaloneDebugger.h"
+
+
+
 #include "TH1I.h"
 #include "TMath.h"
 
@@ -257,5 +258,21 @@ int StandaloneDebugger::getBinIndex(const float value, const int size, const flo
   return std::distance(divisions.begin(), TMath::BinarySearch(divisions.begin(), divisions.end(), value));
 }
 
+// Tracker
+void StandaloneDebugger::dumpTrackToBranchWithInfo(ROframe event, o2::its::TrackITSExt track,
+                                                   std::string branchName)
+{
+  // FakeTrackInfo t{event, track};
+
+  (*mTreeStream)
+    << branchName.data()
+    << track
+    << "\n";
+  
+  // (*mTreeStream)
+  //   << "TracksInfo" 
+  //   << tInfo
+  //   << "\n";
+}
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -38,12 +38,21 @@ Tracker::Tracker(o2::its::TrackerTraits* traits)
   /// Initialise standard configuration with 1 iteration
   mTrkParams.resize(1);
   mMemParams.resize(1);
-  assert(traits != nullptr);
+  assert(mTracks != nullptr);
   mTraits = traits;
   mPrimaryVertexContext = mTraits->getPrimaryVertexContext();
+#ifdef CA_DEBUG
+  mDebugger = new StandaloneDebugger("dbg_ITSTrackerCPU.root");
+#endif
 }
-
+#ifdef CA_DEBUG
+Tracker::~Tracker()
+{
+  delete mDebugger;
+}
+#else
 Tracker::~Tracker() = default;
+#endif
 
 void Tracker::clustersToTracks(const ROframe& event, std::ostream& timeBenchmarkOutputStream)
 {
@@ -292,6 +301,9 @@ void Tracker::findTracks(const ROframe& event)
     temporaryTrack.getParamOut() = temporaryTrack;
     temporaryTrack.resetCovariance();
     fitSuccess = fitTrack(event, temporaryTrack, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].FitIterationMaxChi2[1]);
+#ifdef CA_DEBUG
+    mDebugger->dumpTrackToBranchWithInfo(event, temporaryTrack, "testBranch");
+#endif
     if (!fitSuccess) {
       continue;
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -302,7 +302,7 @@ void Tracker::findTracks(const ROframe& event)
     temporaryTrack.resetCovariance();
     fitSuccess = fitTrack(event, temporaryTrack, mTrkParams[0].NLayers - 1, -1, -1, mTrkParams[0].FitIterationMaxChi2[1]);
 #ifdef CA_DEBUG
-    mDebugger->dumpTrackToBranchWithInfo(event, temporaryTrack, "testBranch");
+    mDebugger->dumpTrackToBranchWithInfo("testBranch", temporaryTrack, event, mPrimaryVertexContext, true);
 #endif
     if (!fitSuccess) {
       continue;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
@@ -18,6 +18,6 @@
 #pragma link C++ class o2::its::Tracklet + ;
 
 #pragma link C++ class o2::its::VertexerParamConfig + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::VertexerParamConfig> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::VertexerParamConfig> + ;
 
 #endif


### PR DESCRIPTION
Hi @shahor02,
this pr adds the possibility to dump a `o2::its::TrackITSExt` on file.
By enabling `CA_DEBUG` in `Definitions.h` it creates automatically the file. I tested with the macro, should work also on workflow.

I also have a previously developed `FakeTrackInfo` class that performs some checks on the labels given a track to decide whether it is fake and other details.
My goal is to stream also this struct on file, coupled to the actual track.

This last class still does not work for some reason, tomorrow I'll fix it. In the meanwhile if you want to have a look, the track dumping works (i randomly put it in some point in the code, for today).

Cheers   