### PR TITLE
TRD tracklet calculation in TrapSimulator

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -128,9 +128,9 @@ class Tracklet64
   static constexpr uint64_t formatmask = 0xf000000000000000;
   static constexpr uint64_t hcidmask = 0x0ffe000000000000;
   static constexpr uint64_t padrowmask = 0x0001e00000000000;
-  static constexpr uint64_t colmask = 0x0000180000000000;
-  static constexpr uint64_t posmask = 0x000007ff00000000;
-  static constexpr uint64_t slopemask = 0x00000000ff000000;
+  static constexpr uint64_t colmask = 0x0000000000000000;
+  static constexpr uint64_t posmask = 0x00001fff00000000;
+  static constexpr uint64_t slopemask = 0x000000007f000000;
   static constexpr uint64_t Q2mask = 0x0000000000ff0000;
   static constexpr uint64_t Q1mask = 0x000000000000ff00;
   static constexpr uint64_t Q0mask = 0x00000000000000ff;
@@ -139,7 +139,7 @@ class Tracklet64
   static constexpr uint64_t formatbs = 60;
   static constexpr uint64_t hcidbs = 49;
   static constexpr uint64_t padrowbs = 45;
-  static constexpr uint64_t colbs = 43;
+  static constexpr uint64_t colbs = 45;
   static constexpr uint64_t posbs = 32;
   static constexpr uint64_t slopebs = 24;
   static constexpr uint64_t PIDbs = 0;

--- a/Detectors/TRD/macros/convertRun2ToRun3Digits.C
+++ b/Detectors/TRD/macros/convertRun2ToRun3Digits.C
@@ -1,26 +1,36 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
-#include <TClonesArray.h>
 
+// ROOT
+#include "TClonesArray.h"
+#include "TH1F.h"
+#include "TCanvas.h"
+#include "TFile.h"
+
+// AliRoot
 #include <AliRunLoader.h>
 #include <AliLoader.h>
 #include <AliDataLoader.h>
 #include <AliTreeLoader.h>
 #include <AliTRDarrayADC.h>
-
-#include <iostream>
-
-#include "TH1F.h"
-#include "TRDBase/Digit.h"
-#include "TRDBase/Tracklet.h"
-
 #include <AliRawReaderRoot.h>
 #include <AliRawReaderDateOnline.h>
 #include <AliTRDrawStream.h>
 #include <AliRawReader.h>
+#include <AliTRDdigitsManager.h>
+#include <AliTRDCommonParam.h>
+#include <AliTRDSignalIndex.h>
+#include <AliTRDfeeParam.h>
+
+// O2
+#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+
+// other
+#include <iostream>
+
 #endif
 
-using namespace o2;
-using namespace trd;
+
 using namespace std;
 
 // qa.root
@@ -97,7 +107,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
         int row, col;
         while (idx->NextRCIndex(row, col)) {
           int tbsum = 0;
-          ArrayADC adctimes;
+          o2::trd::ArrayADC adctimes;
           for (int timebin = 0; timebin < digitMan->GetDigits(det)->GetNtime(); timebin++) {
             int adc = digitMan->GetDigits(det)->GetData(row, col, timebin);
             hAdc->Fill(adc);
@@ -169,7 +179,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
         for (int row = 0; row < nrows; row++) {
           for (int col = 0; col < AliTRDfeeParam::GetNcol(); col++) {
             int tbsum = 0;
-            ArrayADC adctimes;
+            o2::trd::ArrayADC adctimes;
 
             for (int timebin = 0; timebin < digitMan->GetDigits(det)->GetNtime(); timebin++) {
 

--- a/Detectors/TRD/macros/convertRun2ToRun3Digits.C
+++ b/Detectors/TRD/macros/convertRun2ToRun3Digits.C
@@ -24,12 +24,14 @@
 // O2
 #include "TRDBase/Digit.h"
 #include "DataFormatsTRD/TriggerRecord.h"
+#include "TRDBase/MCLabel.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 
 // other
 #include <iostream>
 
 #endif
-
 
 using namespace std;
 
@@ -44,6 +46,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
 {
   vector<o2::trd::Digit> run3Digits;
   vector<o2::trd::TriggerRecord> triggerRecords;
+  o2::dataformats::MCTruthContainer<o2::trd::MCLabel> mcLabels;
 
   TH1F* hAdc = new TH1F("hADC", "ADC spectrum", 1024, -0.5, 1023.5);
   TH1F* hTBsum = new TH1F("hTBsum", "TBsum", 3000, -0.5, 2999.5);
@@ -242,6 +245,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
     std::vector<o2::trd::Digit>* run3pdigits = &run3Digits;
     digitTree->Branch("TRDDigit", &run3pdigits);
     digitTree->Branch("TriggerRecord", &triggerRecords);
+    digitTree->Branch("TRDMCLabels", &mcLabels);
     digitTree->Fill();
     cout << run3Digits.size() << " run3 digits written to: " << run3DigitsOutPath << endl;
     digitTree->Write();

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -1603,10 +1603,10 @@ void TrapSimulator::calcFitreg()
     fitreg.ClearReg();
   }
 
-  //  mFitReg.clear();
   for (int i = 0; i < mNHits; i++) {
     mHits[i].ClearHits(); // do it this way as we dont want to zero 150 members if we only used 3 ....
   }
+  mNHits = 0;
 
   for (timebin = timebin1; timebin < timebin2; timebin++) {
     // first find the hit candidates and store the total cluster charge in qTotal array
@@ -1663,7 +1663,6 @@ void TrapSimulator::calcFitreg()
     marked[4] = 19; // invalid channel
     marked[5] = 19; // invalid channel
     qTotal[19] = 0;
-    int loopcount = 0;
     while ((adcch < 16) && (found < 3)) {
       if (qTotal[adcch] > 0) {
         fromLeft = adcch;
@@ -1772,11 +1771,9 @@ void TrapSimulator::calcFitreg()
         LOG(debug) << "ypos before lut correction : " << ypos;
         ypos = ypos + mTrapConfig->getTrapReg((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + (ypos & 0x7F)),
                                               mDetector, mRobPos, mMcmPos);
+        LOG(debug) << "ypos after lut correction : " << ypos;
         if (adcLeft > adcRight) {
-          LOG(debug) << "ypos after lut correction : " << ypos;
-          if (adcLeft > adcRight) {
-            ypos = -ypos;
-          }
+          ypos = -ypos;
         }
         /*   TODO this is left in here as a ref for what was done with labels, its stored externally now figure something out.
                 */
@@ -1808,8 +1805,8 @@ void TrapSimulator::trackletSelection()
   // and assign them to the CPUs.
   LOG(debug) << "ENTERING : " << __FILE__ << ":" << __func__ << ":" << __LINE__ << " :: " << getDetector() << ":" << getRobPos() << ":" << getMcmPos();
   unsigned short adcIdx, i, j, ntracks, tmp;
-  std::array<unsigned short, 18> trackletCandch{};   // store the adcch[0] and number of hits[1] for all tracklet candidates
-  std::array<unsigned short, 18> trackletCandhits{}; // store the adcch[0] and number of hits[1] for all tracklet candidates
+  std::array<unsigned short, 18> trackletCandch{};   // store the adcch for all tracklet candidates
+  std::array<unsigned short, 18> trackletCandhits{}; // store the number of hits for all tracklet candidates
 
   ntracks = 0;
   for (adcIdx = 0; adcIdx < 18; adcIdx++) { // ADCs


### PR DESCRIPTION
New try...
This does not modify the code too much as it did before.
It fixes first the MCM column number which is written to the tracklet word. Furthermore the scaling factors for offset and slope are adjusted. For the offset our TDP quotes a granularity of 1/75 pad widths. In Jochens thesis I found that the calculations in the TRAP are done with 1/256 pad width granularity. Therefore I set scaleY to 256/75 for instance. Do we have the granularity for the new tracklet format confirmed?
I think it would be best to first update the TDP such that we can refer to the document in the implementation. @tdietel what do you think? Without having a reference of what is done in the actual TRAP it is very hard for me to debug this code.