### PR TITLE
A ROOT serializable key-value store

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -12,7 +12,7 @@ o2_add_library(CommonUtils
                SOURCES src/TreeStream.cxx src/TreeStreamRedirector.cxx
                        src/RootChain.cxx src/CompStream.cxx src/ShmManager.cxx
 	               src/ValueMonitor.cxx
-                       src/ConfigurableParamHelper.cxx src/ConfigurableParam.cxx
+                       src/ConfigurableParamHelper.cxx src/ConfigurableParam.cxx src/RootSerializableKeyValueStore.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
@@ -28,7 +28,8 @@ o2_target_root_dictionary(CommonUtils
 				  include/CommonUtils/MemFileHelper.h
                                   include/CommonUtils/ConfigurableParam.h
                                   include/CommonUtils/ConfigurableParamHelper.h
-                                  include/CommonUtils/ConfigurationMacroHelper.h)
+                                  include/CommonUtils/ConfigurationMacroHelper.h
+				  include/CommonUtils/RootSerializableKeyValueStore.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils
@@ -52,6 +53,12 @@ o2_add_test(ValueMonitor
             COMPONENT_NAME CommonUtils
             LABELS utils
             SOURCES test/testValueMonitor.cxx
+            PUBLIC_LINK_LIBRARIES O2::CommonUtils)
+
+o2_add_test(PropertyMapIO
+            COMPONENT_NAME CommonUtils
+            LABELS utils
+            SOURCES test/testRootSerializableKeyValueStore.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonUtils)
 
 o2_add_test(MemFileHelper

--- a/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
+++ b/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
@@ -1,0 +1,225 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_ROOTSERKEYVALUESTORE_H
+#define ALICEO2_ROOTSERKEYVALUESTORE_H
+
+#include <map>
+#include <string>
+#include <TClass.h>
+#include <Rtypes.h>
+#include <typeinfo>
+#include <typeindex>
+#include <TBufferFile.h>
+#include <type_traits>
+
+namespace o2
+{
+namespace utils
+{
+
+/// A ROOT serializable container mapping a key (string) to an object of arbitrary type.
+///
+/// The container allows to group objects in heterogeneous type in a key-value container.
+/// The container can be ROOT serialized which adds on-top of existing solutions such as boost::property_tree.
+/// This may be useful in various circumenstances, for
+/// instance to assemble various CCDB objects into a single aggregate to reduce the number of CCDB files/entries.
+class RootSerializableKeyValueStore
+{
+ public:
+  /// Structure encapsulating the stored information: raw buffers and attached type information (combination of type_index_hash and TClass information)
+  struct SerializedInfo {
+    void* objptr = nullptr; //! pointer to existing object in memory
+    Int_t N = 0;
+    char* bufferptr = nullptr; //[N]  pointer to serialized buffer
+
+    // we use the TClass and/or the type_index_hash for type idendification
+    TClass* cl = nullptr;
+    std::string typeinfo_name; // typeinfo name that can be used to store type if TClass not available (for PODs!)
+    ClassDefNV(SerializedInfo, 1);
+  };
+
+  enum class GetState {
+    kOK,
+    kNOSUCHKEY,
+    kWRONGTYPE,
+    kNOTCLASS
+  };
+
+  RootSerializableKeyValueStore() = default;
+
+  /// Putting a value (and overrides previous entries)
+  /// T needs to be trivial non-pointer type or a type having a ROOT TClass instance
+  template <typename T>
+  void put(std::string const& key, T const& value)
+  {
+    remove_entry(key);
+    GetState s;
+    return put_impl(key, value, s, int{});
+  }
+
+  /// returns object pointer for this key or nullptr if error or does not exist.
+  template <typename T>
+  const T* get(std::string const& key) const
+  {
+    GetState s;
+    return get_impl<T>(key, s, int{});
+  }
+
+  /// returns object pointer for this key or nullptr if error or does not exist; state is set with meaningful error code
+  template <typename T>
+  const T* get(std::string const& key, GetState& state) const
+  {
+    return get_impl<T>(key, state, int{});
+  }
+
+  /// get interface returning a const reference instead of pointer; Error handling/detection is done via the state argument;
+  /// Beware: In case of errors, a default object is returned.
+  template <typename T>
+  const T& getRef(std::string const& key, GetState& state) const
+  {
+    auto ptr = get_impl<T>(key, state, int{});
+    if (ptr) {
+      return *ptr;
+    } else {
+      static T t = T();
+      // in case of error we return a default object
+      return t;
+    }
+  }
+
+  /// checks if a key exists
+  bool has(std::string const& key) const
+  {
+    return mStore.find(key) != mStore.end();
+  }
+
+  /// clear the store
+  void clear()
+  {
+    mStore.clear();
+  }
+
+ private:
+  std::map<std::string, SerializedInfo*> mStore;
+
+  // generic implementation for put relying on TClass
+  template <typename T>
+  void put_impl(std::string const& key, T const& value, GetState& state, ...)
+  {
+    // make sure we have a TClass for this
+    // if there is a TClass, we'll use ROOT serialization to encode into the buffer
+    auto ptr = new T(value);
+    auto cl = TClass::GetClass(typeid(value));
+    if (!cl) {
+      state = GetState::kNOTCLASS;
+      return;
+    }
+    char* bufferptr = nullptr;
+    TBufferFile buff(TBuffer::kWrite);
+    buff.WriteObjectAny(ptr, cl);
+    int N = buff.Length();
+    bufferptr = new char[N];
+    memcpy(bufferptr, buff.Buffer(), sizeof(char) * N);
+
+    auto name = std::type_index(typeid(value)).name();
+    mStore.insert(std::pair<std::string, SerializedInfo*>(key, new SerializedInfo{(void*)ptr, N, (char*)bufferptr, cl, name}));
+  }
+
+  // implementation for put for trivial types
+  template <typename T, typename std::enable_if<std::is_trivial<T>::value, T>::type* = nullptr>
+  void put_impl(std::string const& key, T const& value, GetState& state, int)
+  {
+    // we forbid pointers
+    static_assert(!std::is_pointer<T>::value);
+    // serialization of trivial types is easy (not based on ROOT)
+    auto ptr = new T(value);
+    int N = sizeof(T);
+    auto bufferptr = new char[N];
+    memcpy(bufferptr, (char*)ptr, sizeof(char) * N);
+
+    auto name = std::type_index(typeid(value)).name();
+    mStore.insert(std::pair<std::string, SerializedInfo*>(key, new SerializedInfo{(void*)ptr, N, (char*)bufferptr, nullptr, name}));
+  }
+
+  // generic implementation for get relying on TClass
+  template <typename T>
+  const T* get_impl(std::string const& key, GetState& state, ...) const
+  {
+    state = GetState::kOK;
+    auto iter = mStore.find(key);
+    if (iter != mStore.end()) {
+      auto value = iter->second;
+      auto cl = TClass::GetClass(typeid(T));
+      if (!cl) {
+        state = GetState::kNOTCLASS;
+        return nullptr;
+      }
+      if (value->cl && strcmp(cl->GetName(), value->cl->GetName()) == 0) {
+        // if there is a (cached) object pointer ... we return it
+        if (value->objptr) {
+          return (T*)value->objptr;
+        }
+        // do this only once and cache instance into value.objptr
+        TBufferFile buff(TBuffer::kRead, value->N, value->bufferptr, false, nullptr);
+        buff.Reset();
+        auto instance = (T*)buff.ReadObjectAny(cl);
+        value->objptr = instance;
+        return (T*)value->objptr;
+      } else {
+        state = GetState::kWRONGTYPE;
+        return nullptr;
+      }
+    }
+    state = GetState::kNOSUCHKEY;
+    return nullptr;
+  }
+
+  // implementation for standard POD types
+  template <typename T, typename std::enable_if<std::is_trivial<T>::value, T>::type* = nullptr>
+  const T* get_impl(std::string const& key, GetState& state, int) const
+  {
+    state = GetState::kOK;
+    auto iter = mStore.find(key);
+    if (iter != mStore.end()) {
+      auto value = iter->second;
+      if (strcmp(std::type_index(typeid(T)).name(), value->typeinfo_name.c_str()) == 0) {
+        // if there is a (cached) object pointer ... we return it
+        if (value->objptr) {
+          return (T*)value->objptr;
+        }
+        value->objptr = (T*)value->bufferptr;
+        return (T*)value->objptr;
+      } else {
+        state = GetState::kWRONGTYPE;
+        return nullptr;
+      }
+    }
+    state = GetState::kNOSUCHKEY;
+    return nullptr;
+  }
+
+  // removes a previous entry
+  void remove_entry(std::string const& key)
+  {
+    auto iter = mStore.find(key);
+    if (iter != mStore.end()) {
+      delete iter->second;
+      mStore.erase(iter);
+    }
+  }
+
+  ClassDefNV(RootSerializableKeyValueStore, 1);
+};
+
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -19,5 +19,8 @@
 #pragma link C++ class o2::utils::RootChain + ;
 #pragma link C++ class o2::utils::RngHelper;
 #pragma link C++ class o2::utils::MemFileHelper + ;
+#pragma link C++ class o2::utils::RootSerializableKeyValueStore::SerializedInfo + ;
+#pragma link C++ class map < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo*> + ;
+#pragma link C++ class o2::utils::RootSerializableKeyValueStore + ;
 
 #endif

--- a/Common/Utils/src/RootSerializableKeyValueStore.cxx
+++ b/Common/Utils/src/RootSerializableKeyValueStore.cxx
@@ -1,0 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/RootSerializableKeyValueStore.h"
+
+using namespace o2::utils;

--- a/Common/Utils/test/testRootSerializableKeyValueStore.cxx
+++ b/Common/Utils/test/testRootSerializableKeyValueStore.cxx
@@ -1,0 +1,116 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test RootSerKeyValueStore
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "CommonUtils/RootSerializableKeyValueStore.h"
+#include <TMemFile.h>
+#include <TH1F.h>
+#include <vector>
+#include <iostream>
+#include <TClass.h>
+
+using namespace o2;
+using namespace o2::utils;
+
+BOOST_AUTO_TEST_CASE(write_read_test)
+{
+  RootSerializableKeyValueStore s;
+
+  // put POD some stuff
+  double x = 1.1;
+  s.put("x", x);
+  s.put("i", 110);
+
+  // put some complex classes (need dictionary)
+  std::string str = "hello";
+  s.put("str", str);
+
+  // this should fail compiling:
+  // const char* text = "foo";
+  // s.put("cstr", text);
+
+  TH1F h1("th1name", "th1name", 100, 0, 99);
+  h1.FillRandom("gaus", 10000);
+  s.put("h1", h1);
+
+  // check basic assumption that typeinfo name is unique for basic types
+  BOOST_CHECK(strcmp(std::type_index(typeid(double*)).name(), "Pd") == 0);
+  BOOST_CHECK(strcmp(std::type_index(typeid(int)).name(), "i") == 0);
+  BOOST_CHECK(strcmp(std::type_index(typeid(unsigned int)).name(), "j") == 0);
+  BOOST_CHECK(strcmp(std::type_index(typeid(char)).name(), "c") == 0);
+  BOOST_CHECK(strcmp(std::type_index(typeid(char*)).name(), "Pc") == 0);
+  BOOST_CHECK(strcmp(std::type_index(typeid(unsigned char)).name(), "h") == 0);
+
+  // check assumption that for more complicated types the TClass name is unique
+  // (the std::type_index is not standardized)
+  BOOST_CHECK(strcmp(TClass::GetClass(typeid(std::vector<double>))->GetName(), "vector<double>") == 0);
+
+  // retrieve
+  BOOST_CHECK(s.get<std::string>("str")->compare(str) == 0);
+  BOOST_CHECK(*(s.get<double>("x")) == x);
+  BOOST_CHECK(s.has("x"));
+  BOOST_CHECK(!s.has("x_does_not_exist"));
+
+  // retrieve with state/error information
+  using ErrorState = RootSerializableKeyValueStore::GetState;
+  ErrorState state;
+  {
+    auto r1 = s.get<std::string>("str", state);
+    BOOST_CHECK(state == ErrorState::kOK);
+    auto returnedstring = s.getRef<std::string>("str", state);
+    BOOST_CHECK(state == ErrorState::kOK);
+    BOOST_CHECK(returnedstring.compare(str) == 0);
+
+    auto r2 = s.get<int>("str", state);
+    BOOST_CHECK(r2 == nullptr);
+    BOOST_CHECK(state == ErrorState::kWRONGTYPE);
+    auto r3 = s.get<int>("str2", state);
+    BOOST_CHECK(state == ErrorState::kNOSUCHKEY);
+    BOOST_CHECK(r3 == nullptr);
+
+    auto r4 = s.get<TH1F>("non-existend-histogram", state);
+    BOOST_CHECK(state == ErrorState::kNOSUCHKEY);
+  }
+
+  // put something twice
+  s.put<int>("twice", 10);
+  s.put<int>("twice", 7);
+  BOOST_CHECK(*(s.get<int>("twice")) == 7);
+
+  std::cerr << "TESTING FILE IO\n";
+  TMemFile f("tmp.root", "RECREATE");
+  f.WriteObject(&s, "map");
+
+  RootSerializableKeyValueStore* s2 = nullptr;
+  f.GetObject("map", s2);
+  BOOST_CHECK(s2 != nullptr);
+  if (s2) {
+    auto t1 = s2->get<double>("x");
+    BOOST_CHECK(t1 != nullptr);
+    BOOST_CHECK(t1 && *(t1) == x);
+
+    auto i1 = s2->get<int>("i");
+    BOOST_CHECK(i1 != nullptr);
+    BOOST_CHECK(i1 && *(i1) == 110);
+
+    auto t2 = s2->get<std::string>("str");
+    BOOST_CHECK(t2 && t2->compare(str) == 0);
+
+    auto t3 = s2->get<std::string>("str");
+    BOOST_CHECK(t3 && t3->compare(str) == 0);
+
+    auto histo = s2->get<TH1F>("h1");
+    BOOST_CHECK(histo);
+  }
+  f.Close();
+}


### PR DESCRIPTION
Basically a container mapping a string key to arbitrary values.
A bit like boost-property (tree) but ROOT serializable.

This may be useful in various circumenstances, for
instance to assemble various CCDB objects into a single aggregate
to reduce the number of CCDB files/entries.

A new quality is that one can serialize ordinary POD types under a key
which is not possible in ROOT by default (hard to serialize
a simple double under a file key).