### PR TITLE
[ITS][ntracker-workflow] Add --configKeyValue for MB LUT

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -65,12 +65,15 @@ class Tracker
 
   std::vector<TrackITSExt>& getTracks();
   auto& getTrackLabels() { return mTrackLabels; }
+  bool isMatLUT();
 
   void clustersToTracks(const ROframe&, std::ostream& = std::cout);
 
   void setROFrame(std::uint32_t f) { mROFrame = f; }
   std::uint32_t getROFrame() const { return mROFrame; }
   void setParameters(const std::vector<MemoryParameters>&, const std::vector<TrackingParameters>&);
+  void initMatBudLUTFromFile();
+  void getGlobalConfiguration();
 
  private:
   track::TrackParCov buildTrackSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster3,
@@ -111,9 +114,6 @@ inline void Tracker::setParameters(const std::vector<MemoryParameters>& memPars,
 {
   mMemParams = memPars;
   mTrkParams = trkPars;
-  if (mTrkParams[0].UseMatBudLUT) {
-    mMatLayerCylSet = o2::base::MatLayerCylSet::loadFromFile();
-  }
 }
 
 inline float Tracker::getBz() const
@@ -124,6 +124,16 @@ inline float Tracker::getBz() const
 inline void Tracker::setBz(float bz)
 {
   mBz = bz;
+}
+
+inline void Tracker::initMatBudLUTFromFile()
+{
+  mMatLayerCylSet = o2::base::MatLayerCylSet::loadFromFile();
+}
+
+inline bool Tracker::isMatLUT()
+{
+  return mMatLayerCylSet;
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -19,7 +19,6 @@ namespace o2
 namespace its
 {
 
-class VertexingParameters;
 struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerParamConfig> {
 
   // geometrical cuts
@@ -36,7 +35,14 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   O2ParamDef(VertexerParamConfig, "ITSVertexerParam");
 };
 
-// VertexerParamConfig VertexerParamConfig::sInstance;
+struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerParamConfig> {
+
+  // Use lookup table for mat. budget
+  bool useMatBudLUT = false;
+
+  O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
+};
+
 } // namespace its
 } // namespace o2
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -20,6 +20,7 @@
 #include "ITStracking/Tracklet.h"
 #include "ITStracking/TrackerTraits.h"
 #include "ITStracking/TrackerTraitsCPU.h"
+#include "ITStracking/TrackingConfigParam.h"
 
 #include "ReconstructionDataFormats/Track.h"
 #include <cassert>
@@ -651,6 +652,15 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
                                                                               : crv / (getBz() * o2::constants::math::B2C)},
                             {s2, 0.f, s2, s2 * fy, 0.f, s2 * fy * fy, 0.f, s2 * tz, 0.f, s2 * tz * tz, s2 * cy, 0.f,
                              s2 * fy * cy, 0.f, s2 * cy * cy});
+}
+
+void Tracker::getGlobalConfiguration()
+{
+  auto& tc = o2::its::TrackerParamConfig::Instance();
+
+  if (tc.useMatBudLUT) {
+    initMatBudLUTFromFile();
+  }
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingConfigParam.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingConfigParam.cxx
@@ -16,7 +16,9 @@ namespace o2
 namespace its
 {
 static auto& sVertexerParamITS = o2::its::VertexerParamConfig::Instance();
+static auto& sCATrackerParamITS = o2::its::TrackerParamConfig::Instance();
 
-O2ParamImpl(o2::its::VertexerParamConfig)
+O2ParamImpl(o2::its::VertexerParamConfig);
+O2ParamImpl(o2::its::TrackerParamConfig);
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
@@ -20,4 +20,7 @@
 #pragma link C++ class o2::its::VertexerParamConfig + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::VertexerParamConfig> + ;
 
+#pragma link C++ class o2::its::TrackerParamConfig + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::TrackerParamConfig> + ;
+
 #endif

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -79,7 +79,9 @@ void TrackerDPL::init(InitContext& ic)
       LOG(INFO) << "Initializing tracker in async. phase reconstruction with " << trackParams.size() << " passes";
     }
     mVertexer->getGlobalConfiguration();
-    // mVertexer->dumpTraits();
+    mTracker->getGlobalConfiguration();
+    LOG(INFO) << Form("%ssing lookup table for material budget approximation", (mTracker->isMatLUT() ? "U" : "Not u"));
+
     double origD[3] = {0., 0., 0.};
     mTracker->setBz(field->getBz(origD));
   } else {


### PR DESCRIPTION
@shahor02 
I pulled out the loading of the matbud.root file from tracking parameters configuration, so this should also work independently from the `--async` mode. It is toggleable with:
```bash
--configKeyValues 'ITSCATrackerParam.useMatBudLUT=true'
``` 
This is a possible implementation, we can discuss on that.
Also ping @mpuccio for review.

For macro-based approach the tracker has explicit handle for file loading.
Cheers