### PR TITLE
MFT: fix lanes mapping for decoding commissionning data and for worki…

### DIFF
--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -228,7 +228,6 @@ void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, st
 
         int ruID = nRUtot++;
         bool accept = !(ruSW < m2r.getRUSWMin() || ruSW > m2r.getRUSWMax()); // ignored RUs ?
-        int accL = 0;
         if (accept) {
           m2r.getCreateRUDecode(ruSW); // create RU container
           nRU++;
@@ -237,12 +236,11 @@ void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, st
           uint32_t lanes = mp.getCablesOnRUType(ru.ruInfo->ruType); // lanes patter of this RU
           ru.links[0] = m2r.addGBTLink();
           auto link = m2r.getGBTLink(ru.links[0]);
-          link->lanes = lanes & ((0x1 << lnkAs) - 1) << (accL);
+          link->lanes = lanes;
           link->idInCRU = linkID;
           link->cruID = cruIDtmp * 100 + o2::detectors::DetID::MFT;
           link->feeID = mp.RUSW2FEEId(ruSW);
           link->endPointID = 0; // 0 or 1
-          accL += lnkAs;
           // register the link in the writer, if not done here, its data will be dumped to common default file
           //printf("Register link: FeeID 0x%02x , CRU ID 0x%x , link ID %2d \n", link->feeID, link->cruID, link->idInCRU);
           //printf("RU SW: %2d   HW: 0x%02x   Type: %2d   %s \n", ruSW, ruHW, ruType, outFileLink.data());

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -172,6 +172,9 @@ class ChipMappingITS
   ///< convert HW cable ID to SW ID for given RU type (see ChipOnRUInfo.cableSW explanation)
   uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
+  ///< convert cable iterator ID to the position on the ActiveLanes word in the GBT.header for given RU type; MFT lanes position compatible
+  uint8_t cablePos(uint8_t ruType, uint8_t id) const { return id; }
+
   ///< get number of chips served by single cable on given RU type
   int getNChipsPerCable(int ruType) { return NChipsPerCableSB[ruType]; }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -108,6 +108,9 @@ class ChipMappingMFT
   ///< convert HW cable ID to SW ID for give RU type
   uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
+  ///< convert cable iterator ID to its position on the ActiveLanes word in the GBT.header for given RU type
+  uint8_t cablePos(uint8_t ruType, uint8_t id) const { return mCablePos[ruType][id]; }
+
   ///< get chip global SW ID from chipID on module, cable SW ID and stave (RU) info
   uint16_t getGlobalChipID(uint16_t chOnModuleHW, int cableHW, const RUInfo& ruInfo) const
   {
@@ -198,8 +201,14 @@ class ChipMappingMFT
 
   static constexpr std::int16_t getRUDetectorField() { return 0x0; }
 
-  ///< get pattern of lanes on the RU served by a given RU type
-  Int_t getCablesOnRUType(Int_t ruType) const { return (0x1 << NChipsOnRUType[ruType]) - 1; }
+  uint32_t getCablesOnRUType(Int_t ruType) const
+  {
+    uint32_t pattern = 0;
+    for (Int_t i = 0; i < NRUCables; i++) {
+      pattern |= (0x1 << mCableHW2Pos[ruType][i]);
+    }
+    return pattern;
+  }
 
   ///< get info on sw RU
   const RUInfo* getRUInfoSW(int ruSW) const { return &mRUInfo[ruSW]; }
@@ -277,6 +286,7 @@ class ChipMappingMFT
 
   std::vector<uint8_t> mCableHW2SW[NRUs];       ///< table of cables HW to SW conversion for each RU type
   std::vector<uint8_t> mCableHW2Pos[NRUs];      ///< table of cables positions in the ActiveLanes mask for each RU type
+  std::vector<uint8_t> mCablePos[NRUs];         ///< reverse table of cables positions in the ActiveLanes mask for each RU type
   std::vector<uint8_t> mCableHWFirstChip[NRUs]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
 
   std::array<std::vector<uint16_t>, NRUs> mRUGlobalChipID;

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
@@ -1652,6 +1652,7 @@ ChipMappingMFT::ChipMappingMFT()
         mChipInfoEntryRU[iRU] = ctrChip;
         mCableHW2SW[iRU].resize(NRUCables, 0xff);
         mCableHW2Pos[iRU].resize(NRUCables, 0xff);
+        mCablePos[iRU].resize(NRUCables, 0xff);
         mCableHWFirstChip[iRU].resize(NRUCables, 0xff);
       } else {
         if ((layer != curLayer) || (zone != curZone) || (half != curHalf)) {
@@ -1676,10 +1677,11 @@ ChipMappingMFT::ChipMappingMFT()
 
       chInfo.cableHW = ChipConnectorCable[chInfo.moduleHW][chInfo.chipOnModuleSW];
       chInfo.cableSW = chipOnRU;
-      chInfo.cableHWPos = chipOnRU;
+      chInfo.cableHWPos = chInfo.cableHW;
 
       chInfo.chipOnCable = 0;
 
+      mCablePos[iRU][chInfo.id] = chInfo.cableHWPos;
       mCableHW2Pos[iRU][chInfo.cableHW] = chInfo.cableHWPos;
       mCableHW2SW[iRU][chInfo.cableHW] = chInfo.cableSW;
       mCableHWFirstChip[iRU][chInfo.cableHW] = 0;

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -180,8 +180,8 @@ void MC2RawEncoder<Mapping>::fillGBTLinks(RUDecodeData& ru)
     // estimate real payload size in GBT words
     int nPayLoadWordsNeeded = 0;           // number of payload words filled to link buffer (RDH not included) for current IR
     for (int icab = ru.nCables; icab--;) { // calculate number of GBT words per link
-      if ((link->lanes & (0x1 << icab))) {
-        int nb = ru.cableData[icab].getSize();
+      if ((link->lanes & (0x1 << mMAP.cablePos(ru.ruInfo->ruType, icab)))) {
+        int nb = ru.cableData[mMAP.cablePos(ru.ruInfo->ruType, icab)].getSize();
         nPayLoadWordsNeeded += nb ? 1 + (nb - 1) / 9 : 0; // single GBT word carries at most 9 payload bytes
       }
     }
@@ -195,8 +195,8 @@ void MC2RawEncoder<Mapping>::fillGBTLinks(RUDecodeData& ru)
     while (hasData) {
       hasData = false;
       for (int icab = 0; icab < ru.nCables; icab++) {
-        if ((link->lanes & (0x1 << icab))) {
-          auto& cableData = ru.cableData[icab];
+        if ((link->lanes & (0x1 << mMAP.cablePos(ru.ruInfo->ruType, icab)))) {
+          auto& cableData = ru.cableData[mMAP.cablePos(ru.ruInfo->ruType, icab)];
           int nb = cableData.getUnusedSize();
           if (!nb) {
             continue; // write 80b word only if there is something to write
@@ -204,10 +204,10 @@ void MC2RawEncoder<Mapping>::fillGBTLinks(RUDecodeData& ru)
           if (nb > 9) {
             nb = 9;
           }
-          int gbtWordStart = link->data.getSize();                                                       // beginning of the current GBT word in the link
-          link->data.addFast(cableData.getPtr(), nb);                                                    // fill payload of cable
-          link->data.addFast(zero16, GBTPaddedWordLength - nb);                                          // fill the rest of the GBT word by 0
-          link->data[gbtWordStart + 9] = mMAP.getGBTHeaderRUType(ru.ruInfo->ruType, ru.cableHWID[icab]); // set cable flag
+          int gbtWordStart = link->data.getSize();                                                                                         // beginning of the current GBT word in the link
+          link->data.addFast(cableData.getPtr(), nb);                                                                                      // fill payload of cable
+          link->data.addFast(zero16, GBTPaddedWordLength - nb);                                                                            // fill the rest of the GBT word by 0
+          link->data[gbtWordStart + 9] = mMAP.getGBTHeaderRUType(ru.ruInfo->ruType, ru.cableHWID[mMAP.cablePos(ru.ruInfo->ruType, icab)]); // set cable flag
           cableData.setPtr(cableData.getPtr() + nb);
           hasData = true;
         } // storing data of single cable


### PR DESCRIPTION
…ng also with MC, both MFT and ITS

with minimum invasion in the common code and the ITS code:

- in MC2RawEncoder treat the loop index "icab" as  mapping index "cablePos" (dummy identity in case of ITS)

- introduce the cable position for the "lanes" word which is given by the HW ID in the case of MFT

- consequently, the RU cable data array is filled with gaps in the case of the MFT

I have checked it for MC encoding/decoding ITS and MFT.