### PR TITLE
MFT: eliminate sqrt where possible

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -117,7 +117,7 @@ inline const Float_t Tracker::getDistanceToSeed(const Cluster& cluster1, const C
 {
   // the seed is between "cluster1" and "cluster2" and cuts the plane
   // of the "cluster" at a distance dR from it
-  Float_t dxSeed, dySeed, dzSeed, invdzSeed, dz, dR, xSeed, ySeed;
+  Float_t dxSeed, dySeed, dzSeed, invdzSeed, dz, dR2, xSeed, ySeed;
   dxSeed = cluster2.getX() - cluster1.getX();
   dySeed = cluster2.getY() - cluster1.getY();
   dzSeed = cluster2.getZ() - cluster1.getZ();
@@ -125,8 +125,8 @@ inline const Float_t Tracker::getDistanceToSeed(const Cluster& cluster1, const C
   invdzSeed = dz / dzSeed;
   xSeed = cluster1.getX() + dxSeed * invdzSeed;
   ySeed = cluster1.getY() + dySeed * invdzSeed;
-  dR = std::sqrt((cluster.getX() - xSeed) * (cluster.getX() - xSeed) + (cluster.getY() - ySeed) * (cluster.getY() - ySeed));
-  return dR;
+  dR2 = (cluster.getX() - xSeed) * (cluster.getX() - xSeed) + (cluster.getY() - ySeed) * (cluster.getY() - ySeed);
+  return dR2;
 }
 
 //_________________________________________________________________________________________________
@@ -165,9 +165,9 @@ inline const Bool_t Tracker::getCellsConnect(const Cell& cell1, const Cell& cell
   Float_t cell2y1 = cell2.getY1();
   Float_t dx = cell1x2 - cell2x1;
   Float_t dy = cell1y2 - cell2y1;
-  Float_t dr = std::sqrt(dx * dx + dy * dy);
+  Float_t dr2 = dx * dx + dy * dy;
 
-  if (dr > constants::mft::Resolution) {
+  if (dr2 > (constants::mft::Resolution * constants::mft::Resolution)) {
     return kFALSE;
   }
   return kTRUE;

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
@@ -41,7 +41,9 @@ class TrackerConfig
   Int_t mMinTrackStationsLTF = 4;
   Int_t mMinTrackStationsCA = 4;
   Float_t mLTFclsRCut = 0.0100;
+  Float_t mLTFclsR2Cut = 0.0100 * 0.0100;
   Float_t mROADclsRCut = 0.0400;
+  Float_t mROADclsR2Cut = 0.0400 * 0.0400;
   Int_t mLTFseed2BinWin = 3;
   Int_t mLTFinterBinWin = 3;
   Int_t mRBins = 50;

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -188,7 +188,7 @@ void Tracker::findTracksLTF(ROframe& event)
   Int_t binR_proj, binPhi_proj, bin;
   Int_t binIndex, clsMinIndex, clsMaxIndex, clsMinIndexS, clsMaxIndexS;
   Int_t extClsIndex;
-  Float_t dR, dRmin, dRcut = mLTFclsRCut;
+  Float_t dR2, dR2min, dR2cut = mLTFclsR2Cut;
   Bool_t hasDisk[constants::mft::DisksNumber], newPoint, seed;
 
   Int_t clsInLayer1, clsInLayer2, clsInLayer;
@@ -247,7 +247,7 @@ void Tracker::findTracksLTF(ROframe& event)
             newPoint = kTRUE;
 
             // loop over the bins in the search window
-            dRmin = dRcut;
+            dR2min = dR2cut;
             for (auto& bin : mBins[layer1][layer - 1][cluster1.indexTableBin]) {
 
               getBinClusterRange(event, layer, bin, clsMinIndex, clsMaxIndex);
@@ -259,12 +259,12 @@ void Tracker::findTracksLTF(ROframe& event)
                 }
                 clsInLayer = it - event.getClustersInLayer(layer).begin();
 
-                dR = getDistanceToSeed(cluster1, cluster2, cluster);
-                // retain the closest point within a radius dRcut
-                if (dR >= dRmin) {
+                dR2 = getDistanceToSeed(cluster1, cluster2, cluster);
+                // retain the closest point within a radius dR2cut
+                if (dR2 >= dR2min) {
                   continue;
                 }
-                dRmin = dR;
+                dR2min = dR2;
 
                 if (newPoint) {
                   trackPoints[nPoints].layer = layer;
@@ -339,7 +339,7 @@ void Tracker::findTracksCA(ROframe& event)
   Int_t roadId, nPointDisks;
   Int_t binR_proj, binPhi_proj, bin;
   Int_t binIndex, clsMinIndex, clsMaxIndex, clsMinIndexS, clsMaxIndexS;
-  Float_t dR, dRcut = mROADclsRCut;
+  Float_t dR2, dR2cut = mROADclsR2Cut;
   Bool_t hasDisk[constants::mft::DisksNumber];
 
   Int_t clsInLayer1, clsInLayer2, clsInLayer;
@@ -392,9 +392,9 @@ void Tracker::findTracksCA(ROframe& event)
                   }
                   clsInLayer = it - event.getClustersInLayer(layer).begin();
 
-                  dR = getDistanceToSeed(cluster1, cluster2, cluster);
-                  // add all points within a radius dRcut
-                  if (dR >= dRcut) {
+                  dR2 = getDistanceToSeed(cluster1, cluster2, cluster);
+                  // add all points within a radius dR2cut
+                  if (dR2 >= dR2cut) {
                     continue;
                   }
 

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
@@ -23,7 +23,9 @@ o2::mft::TrackerConfig::TrackerConfig()
     mMinTrackStationsLTF{4},
     mMinTrackStationsCA{4},
     mLTFclsRCut{0.0100},
+    mLTFclsR2Cut{0.0100 * 0.0100},
     mROADclsRCut{0.0400},
+    mROADclsR2Cut{0.0400 * 0.0400},
     mLTFseed2BinWin{3},
     mLTFinterBinWin{3},
     mRBins{50},
@@ -47,7 +49,9 @@ void o2::mft::TrackerConfig::initialize(const MFTTrackingParam& trkParam)
   mMinTrackStationsLTF = trkParam.MinTrackStationsLTF;
   mMinTrackStationsCA = trkParam.MinTrackStationsCA;
   mLTFclsRCut = trkParam.LTFclsRCut;
+  mLTFclsR2Cut = mLTFclsRCut * mLTFclsRCut;
   mROADclsRCut = trkParam.ROADclsRCut;
+  mROADclsR2Cut = mROADclsRCut * mROADclsRCut;
   mLTFseed2BinWin = trkParam.LTFseed2BinWin;
   mLTFinterBinWin = trkParam.LTFinterBinWin;
 


### PR DESCRIPTION
More (small) improvement in track finding, by eliminating the sqrt where it is possible to consider directly the square values.