### PR TITLE
Add possibility to use the GPUPolynomialField in the O2 propagator and make the O2 propagator compile on GPU

### DIFF
--- a/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
+++ b/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
@@ -10,12 +10,10 @@
 
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
 #include "CommonConstants/PhysicsConstants.h"
-
-#ifndef GPUCA_GPUCODE_DEVICE
-#include <cmath>
-#endif
+#include "GPUCommonMath.h"
 
 using namespace o2::track;
+using namespace o2::gpu;
 
 //_____________________________________________________
 GPUd() void TrackLTIntegral::print() const
@@ -38,7 +36,7 @@ GPUd() void TrackLTIntegral::addStep(float dL, const TrackPar& track)
   float dTns = dL * 1000.f / o2::constants::physics::LightSpeedCm2NS; // time change in ps for beta = 1 particle
   for (int id = 0; id < getNTOFs(); id++) {
     float m2z = o2::track::PID::getMass2Z(id);
-    float betaInv = std::sqrt(1.f + m2z * m2z * p2);
+    float betaInv = CAMath::Sqrt(1.f + m2z * m2z * p2);
     mT[id] += dTns * betaInv;
   }
 }

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -16,7 +16,7 @@ o2_add_library(DetectorsBase
                        src/MatLayerCyl.cxx
                        src/MatLayerCylSet.cxx
                        src/Ray.cxx
-		       src/DCAFitter.cxx
+                       src/DCAFitter.cxx
                        src/BaseDPLDigitizer.cxx
                        src/CTFCoderBase.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
@@ -29,8 +29,10 @@ o2_add_library(DetectorsBase
                                      O2::Framework
                                      FairMQ::FairMQ
                                      O2::DataFormatsParameters
-				     O2::SimConfig
-                                     ROOT::VMC)
+                                     O2::SimConfig
+                                     ROOT::VMC
+               PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/GPU/GPUTracking/Merger # Must not link to avoid cyclic dependency
+                             )
 
 o2_target_root_dictionary(DetectorsBase
                           HEADERS include/DetectorsBase/Detector.h

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -44,6 +44,11 @@ namespace field
 class MagFieldFast;
 }
 
+namespace gpu
+{
+class GPUTPCGMPolynomialField;
+}
+
 namespace base
 {
 class Propagator
@@ -104,6 +109,8 @@ class Propagator
 
   GPUd() void setMatLUT(const o2::base::MatLayerCylSet* lut) { mMatLUT = lut; }
   GPUd() const o2::base::MatLayerCylSet* getMatLUT() const { return mMatLUT; }
+  GPUd() void setGPUField(const o2::gpu::GPUTPCGMPolynomialField* field) { mGPUField = field; }
+  GPUd() const o2::gpu::GPUTPCGMPolynomialField* getGPUField() const { return mGPUField; }
 
 #ifndef GPUCA_GPUCODE
   static Propagator* Instance()
@@ -123,11 +130,13 @@ class Propagator
 #endif
 
   GPUd() MatBudget getMatBudget(MatCorrType corrType, const o2::math_utils::Point3D<float>& p0, const o2::math_utils::Point3D<float>& p1) const;
+  GPUd() void getFiedXYZ(const math_utils::Point3D<float> xyz, float* bxyz) const;
 
   const o2::field::MagFieldFast* mField = nullptr; ///< External fast field (barrel only for the moment)
   float mBz = 0;                                   // nominal field
 
-  const o2::base::MatLayerCylSet* mMatLUT = nullptr; // externally set LUT
+  const o2::base::MatLayerCylSet* mMatLUT = nullptr;           // externally set LUT
+  const o2::gpu::GPUTPCGMPolynomialField* mGPUField = nullptr; // externally set GPU Field
 
   ClassDef(Propagator, 0);
 };

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -61,6 +61,8 @@ using namespace GPUCA_NAMESPACE::gpu;
 // O2 track model
 #include "TrackParametrization.cxx"
 #include "TrackParametrizationWithError.cxx"
+#include "Propagator.cxx"
+#include "TrackLTIntegral.cxx"
 
 // Files for GPU dEdx
 #include "GPUdEdx.cxx"

--- a/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.h
@@ -14,7 +14,7 @@
 #ifndef GPUTPCGMPOLYNOMIALFIELD_H
 #define GPUTPCGMPOLYNOMIALFIELD_H
 
-#include "GPUTPCDef.h"
+#include "GPUCommonDef.h"
 
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.h
@@ -44,13 +44,13 @@ class GPUTPCGMPolynomialField
 
   GPUdi() float GetNominalBz() const { return mNominalBz; }
 
-  GPUd() void GetField(float x, float y, float z, float B[3]) const;
+  GPUd() void GetField(float x, float y, float z, float* B) const;
   GPUd() float GetFieldBz(float x, float y, float z) const;
 
-  GPUd() void GetFieldTrd(float x, float y, float z, float B[3]) const;
+  GPUd() void GetFieldTrd(float x, float y, float z, float* B) const;
   GPUd() float GetFieldTrdBz(float x, float y, float z) const;
 
-  GPUd() void GetFieldIts(float x, float y, float z, float B[3]) const;
+  GPUd() void GetFieldIts(float x, float y, float z, float* B) const;
   GPUd() float GetFieldItsBz(float x, float y, float z) const;
 
   void Print() const;
@@ -164,7 +164,7 @@ GPUdi() void GPUTPCGMPolynomialField::GetPolynomsTpc(float x, float y, float z, 
   f[9] = z * z;
 }
 
-GPUdi() void GPUTPCGMPolynomialField::GetField(float x, float y, float z, float B[3]) const
+GPUdi() void GPUTPCGMPolynomialField::GetField(float x, float y, float z, float* B) const
 {
   const float* fBxS = &mTpcBx[1];
   const float* fByS = &mTpcBy[1];
@@ -220,7 +220,7 @@ GPUdi() void GPUTPCGMPolynomialField::GetPolynomsTrd(float x, float y, float z, 
   f[19] = z * zz;
 }
 
-GPUdi() void GPUTPCGMPolynomialField::GetFieldTrd(float x, float y, float z, float B[3]) const
+GPUdi() void GPUTPCGMPolynomialField::GetFieldTrd(float x, float y, float z, float* B) const
 {
   float f[NTRDM];
   GetPolynomsTrd(x, y, z, f);
@@ -266,7 +266,7 @@ GPUdi() void GPUTPCGMPolynomialField::GetPolynomsIts(float x, float y, float z, 
    */
 }
 
-GPUdi() void GPUTPCGMPolynomialField::GetFieldIts(float x, float y, float z, float B[3]) const
+GPUdi() void GPUTPCGMPolynomialField::GetFieldIts(float x, float y, float z, float* B) const
 {
   const float* fBxS = &mItsBx[1];
   const float* fByS = &mItsBy[1];


### PR DESCRIPTION
This finally makes the o2 propagator compile fully on GPU, even though using the GPUPolynomialField instead of MagFieldFast.
So far, only tested the compilation. This is not yet used. Next step is to port the TPC Refit onto the GPU, using optionally either the GPU track param / propagator or the o2 TrackParCov / propagator.

@mconcas : This should finally bring also the propagator on the GPU, but as is you cannot use it in the ITS code etc out of the box, since it relies on the setup of the polynomial field in the constant memory of the GPUTPCTracking. Working on providing a functional setup for you as well...