### PR TITLE
TPC Tracking: Workaround for 0-cluster tracks

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -164,6 +164,16 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
   for (char cside = 0; cside < 2; cside++) {
     for (int i = 0; i < nTracks; i++) {
       if (tracks[i].OK() && tracks[i].CSide() == cside) {
+        bool hasCl = false;
+        for (int j = 0; j < tracks[i].NClusters(); j++) {
+          if (!((trackClusters[tracks[i].FirstClusterRef() + j].state & flagsReject) || (ptrs.mergedTrackHitAttachment[trackClusters[tracks[i].FirstClusterRef() + j].num] & flagsRequired) != flagsRequired)) {
+            hasCl = true;
+            break;
+          }
+        }
+        if (!hasCl) {
+          continue;
+        }
         trackSort[tmp++] = {i, tracks[i].GetParam().GetTZOffset()};
         auto ncl = tracks[i].NClusters();
         clBuff += ncl + (ncl + 1) / 2; // actual N clusters to store will be less

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -329,6 +329,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* GPUrestrict() merger, 
   if (!(N + NTolerated >= GPUCA_TRACKLET_SELECTOR_MIN_HITS(mP[4]) && 2 * NTolerated <= CAMath::Max(10, N) && CheckNumericalQuality(covYYUpd))) {
     return (false); // TODO: NTolerated should never become that large, check what is going wrong!
   }
+  // TODO: we have looping tracks here with 0 accepted clusters in the primary leg. In that case we should refit the track using only the primary leg.
 
   if (dEdxOut) {
     dEdx.computedEdx(*dEdxOut, param);


### PR DESCRIPTION
@shahor02 @sawenzel : This should fix (work around) the problem with the 0-cluster tracks you reported.
I could not verify on @sawenzel 's data, since it is no longer present in the tmp folder on lxplus, but this is certainly a but that can cause such behavior.
The background is: By default we drop all secondary legs of looping tracks. If during the refit all hits of the primary leg are rejected, but not of the secondary, it is still a healthy track. When the track is stored discarding all secondary legs, it becomes a 0-cluster track. This is suppressed with this PR.
I think for the future this should be done better, by refitting the track using only the primary leg in such case, in order not to loose the track.