### PR TITLE
[EMCAL-675] Handling of pages without trailer

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
@@ -113,18 +113,30 @@ void RawReaderMemory::nextPage(bool doResetPayload)
   } else {
     mRawBuffer.readFromMemoryBuffer(gsl::span<const char>(mRawMemoryBuffer.data() + mCurrentPosition + RDHDecoder::getHeaderSize(mRawHeader), RDHDecoder::getMemorySize(mRawHeader) - RDHDecoder::getHeaderSize(mRawHeader)));
 
-    // Read off and chop trailer
+    // Read off and chop trailer (if required)
     //
-    // Every page gets a trailer. The trailers from the single pages need to be removed.
-    // There will be a combined trailer which keeps the sum of the payloads for all trailers.
-    // This will be appended to the chopped payload.
-    auto trailer = RCUTrailer::constructFromPayloadWords(mRawBuffer.getDataWords());
-    if (!mCurrentTrailer.isInitialized()) {
-      mCurrentTrailer = trailer;
+    // In case every page gets a trailer (intermediate format). The trailers from the single
+    // pages need to be removed. There will be a combined trailer which keeps the sum of the
+    // payloads for all trailers. This will be appended to the chopped payload.
+    //
+    // Trailer only at the last page (new format): Only last page gets trailer. The trailer is
+    // also chopped from the payload as it will be added later again.
+    auto lastword = *(mRawBuffer.getDataWords().rbegin());
+    gsl::span<const uint32_t> payloadWithoutTrailer;
+    if (lastword >> 30 == 3) {
+      // lastword is a trailer word
+      // decode trailer and chop
+      auto trailer = RCUTrailer::constructFromPayloadWords(mRawBuffer.getDataWords());
+      if (!mCurrentTrailer.isInitialized()) {
+        mCurrentTrailer = trailer;
+      } else {
+        mCurrentTrailer.setPayloadSize(mCurrentTrailer.getPayloadSize() + trailer.getPayloadSize());
+      }
+      payloadWithoutTrailer = gsl::span<const uint32_t>(mRawBuffer.getDataWords().data(), mRawBuffer.getDataWords().size() - trailer.getTrailerSize());
     } else {
-      mCurrentTrailer.setPayloadSize(mCurrentTrailer.getPayloadSize() + trailer.getPayloadSize());
+      // Not a trailer word = copy page as it is
+      payloadWithoutTrailer = mRawBuffer.getDataWords(); // No trailer to be chopped
     }
-    gsl::span<const uint32_t> payloadWithoutTrailer(mRawBuffer.getDataWords().data(), mRawBuffer.getDataWords().size() - trailer.getTrailerSize());
 
     mRawPayload.appendPayloadWords(payloadWithoutTrailer);
     mRawPayload.increasePageCount();


### PR DESCRIPTION
In the new version of the raw format the trailer will be only
on the last page. In order to be compatible with both version
the last trailer word is checked for bit 30 (trailer marker), in
case it found the trailer is decoded and chopped from the page
as it is re-encoded when the multi-page payload is combined.
Otherwise the full payload is added to the multi-page buffer. This
works for single and multi-page payload and therefore
consequently for the old and new raw format.