### PR TITLE
DPL: drop unneeded include statements

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingHeader.h
+++ b/Framework/Core/include/Framework/DataProcessingHeader.h
@@ -13,7 +13,6 @@
 #include "Headers/DataHeader.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <memory>
 #include <cassert>
 #include <chrono>

--- a/Framework/Core/include/Framework/SourceInfoHeader.h
+++ b/Framework/Core/include/Framework/SourceInfoHeader.h
@@ -14,7 +14,6 @@
 #include "Framework/ChannelInfo.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <memory>
 #include <cassert>
 

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -12,7 +12,6 @@
 
 #include <cstddef>
 #include <utility>
-#include <cstdio>
 
 namespace o2::framework
 {


### PR DESCRIPTION
cstdio should never be exposed in headers as it bloats.