### PR TITLE
Rdev evgen updates

### DIFF
--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -61,6 +61,10 @@ class Generator : public FairGenerator
 	**/
   Bool_t ReadEvent(FairPrimaryGenerator* primGen) final;
 
+  /** methods to override **/
+  virtual Bool_t generateEvent() = 0;
+  virtual Bool_t importParticles() = 0;
+
   /** setters **/
   void setMomentumUnit(double val) { mMomentumUnit = val; };
   void setEnergyUnit(double val) { mEnergyUnit = val; };
@@ -71,6 +75,12 @@ class Generator : public FairGenerator
   void addTrigger(Trigger trigger) { mTriggers.push_back(trigger); };
   void addDeepTrigger(DeepTrigger trigger) { mDeepTriggers.push_back(trigger); };
 
+  /** getters **/
+  const std::vector<TParticle>& getParticles() const { return mParticles; }; //!
+
+  /** other **/
+  void clearParticles() { mParticles.clear(); };
+
   /** notification methods **/
   virtual void notifyEmbedding(const FairMCEventHeader* mcHeader){};
 
@@ -79,10 +89,6 @@ class Generator : public FairGenerator
   Generator(const Generator&);
   /** operator= **/
   Generator& operator=(const Generator&);
-
-  /** methods to override **/
-  virtual Bool_t generateEvent() = 0;
-  virtual Bool_t importParticles() = 0;
 
   /** methods that can be overridded **/
   virtual void updateHeader(FairMCEventHeader* eventHeader){};

--- a/Generators/include/Generators/GeneratorHepMC.h
+++ b/Generators/include/Generators/GeneratorHepMC.h
@@ -54,6 +54,10 @@ class GeneratorHepMC : public Generator
   /** Initialize the generator if needed **/
   Bool_t Init() override;
 
+  /** methods to override **/
+  Bool_t generateEvent() override;
+  Bool_t importParticles() override;
+
   /** setters **/
   void setVersion(Int_t val) { mVersion = val; };
   void setFileName(std::string val) { mFileName = val; };
@@ -63,10 +67,6 @@ class GeneratorHepMC : public Generator
   GeneratorHepMC(const GeneratorHepMC&);
   /** operator= **/
   GeneratorHepMC& operator=(const GeneratorHepMC&);
-
-  /** methods to override **/
-  Bool_t generateEvent() override;
-  Bool_t importParticles() override;
 
   /** methods **/
 #ifdef GENERATORS_WITH_HEPMC3_DEPRECATED

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -59,6 +59,24 @@ class GeneratorPythia8 : public Generator
   bool readString(std::string val) { return mPythia.readString(val, true); };
   bool readFile(std::string val) { return mPythia.readFile(val, true); };
 
+  /** utilities **/
+  void getNcoll(int& nColl)
+  {
+    getNcoll(mPythia.info, nColl);
+  };
+  void getNpart(int& nPart)
+  {
+    getNpart(mPythia.info, nPart);
+  };
+  void getNpart(int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg)
+  {
+    getNpart(mPythia.info, nProtonProj, nNeutronProj, nProtonTarg, nNeutronTarg);
+  };
+  void getNremn(int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg)
+  {
+    getNremn(mPythia.event, nProtonProj, nNeutronProj, nProtonTarg, nNeutronTarg);
+  };
+
  protected:
   /** copy constructor **/
   GeneratorPythia8(const GeneratorPythia8&);
@@ -73,6 +91,10 @@ class GeneratorPythia8 : public Generator
 
   /** utilities **/
   void selectFromAncestor(int ancestor, Pythia8::Event& inputEvent, Pythia8::Event& outputEvent);
+  void getNcoll(const Pythia8::Info& info, int& nColl);
+  void getNpart(const Pythia8::Info& info, int& nPart);
+  void getNpart(const Pythia8::Info& info, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
+  void getNremn(const Pythia8::Event& event, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
 
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -38,6 +38,10 @@ class GeneratorPythia8 : public Generator
   /** Initialize the generator if needed **/
   Bool_t Init() override;
 
+  /** methods to override **/
+  Bool_t generateEvent() override;
+  Bool_t importParticles() override { return importParticles(mPythia.event); };
+
   /** setters **/
   void setConfig(std::string val) { mConfig = val; };
   void setHooksFileName(std::string val) { mHooksFileName = val; };
@@ -60,10 +64,6 @@ class GeneratorPythia8 : public Generator
   GeneratorPythia8(const GeneratorPythia8&);
   /** operator= **/
   GeneratorPythia8& operator=(const GeneratorPythia8&);
-
-  /** methods to override **/
-  Bool_t generateEvent() override;
-  Bool_t importParticles() override { return importParticles(mPythia.event); };
 
   /** methods that can be overridded **/
   void updateHeader(FairMCEventHeader* eventHeader) override;

--- a/Generators/include/Generators/GeneratorTGenerator.h
+++ b/Generators/include/Generators/GeneratorTGenerator.h
@@ -37,6 +37,10 @@ class GeneratorTGenerator : public Generator
   /** destructor **/
   ~GeneratorTGenerator() override;
 
+  /** methods to override **/
+  Bool_t generateEvent() override;
+  Bool_t importParticles() override;
+
   /** setters **/
   void setTGenerator(TGenerator* val) { mTGenerator = val; };
   const TGenerator* getTGenerator() const { return mTGenerator; }
@@ -48,10 +52,6 @@ class GeneratorTGenerator : public Generator
   GeneratorTGenerator(const GeneratorTGenerator&);
   /** operator= **/
   GeneratorTGenerator& operator=(const GeneratorTGenerator&);
-
-  /** methods to override **/
-  Bool_t generateEvent() override;
-  Bool_t importParticles() override;
 
   /** TGenerator interface **/
   TGenerator* mTGenerator;


### PR DESCRIPTION
This PR brings two functionalities with the corresponding commits (please, do not merge).

1. the routines used by event generators to generate the event and import the particles are moved to `public` to allow users to use them. Also, access to the internal particle vector is provided. This enables people to run the event generator in standalone mode in a simple macro to do analysis of the output, without the need of running the full O2 simulation machinery.
2. a few functions are provided to Pythia8 event generator to compute the number of binary collisions, the number of participating nucleons and the number of nucleons in the outgoing nuclear beam fragments. Information about number of participating nucleons (as well as number of nucleons in the beam fragments) is provided separately for the projectile and the target, where protons and neutrons are counted separately.