### PR TITLE
Correctly use object passed to MID decoder constructor

### DIFF
--- a/Detectors/MUON/MID/Raw/src/Decoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Decoder.cxx
@@ -73,7 +73,7 @@ std::unique_ptr<Decoder> createDecoder(const o2::header::RDHAny& rdh, bool isDeb
 {
   /// Creates the decoder from the RDH info
   bool isBare = (o2::raw::RDHUtils::getLinkID(rdh) != raw::sUserLogicLinkID);
-  return std::make_unique<Decoder>(isDebugMode, isBare, electronicsDelay, crateMasks);
+  return std::make_unique<Decoder>(isDebugMode, isBare, electronicsDelay, crateMasks, feeIdConfig);
 }
 std::unique_ptr<Decoder> createDecoder(const o2::header::RDHAny& rdh, bool isDebugMode, const char* electronicsDelayFile, const char* crateMasksFile, const char* feeIdConfigFile)
 {


### PR DESCRIPTION
The object was passed as an argument, but not used in the end.
This PR fixes it.