### PR TITLE
Populate MC event header with information from current Pythia8 event

### DIFF
--- a/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
+++ b/Common/Utils/include/CommonUtils/RootSerializableKeyValueStore.h
@@ -47,10 +47,23 @@ class RootSerializableKeyValueStore
   };
 
   enum class GetState {
-    kOK,
-    kNOSUCHKEY,
-    kWRONGTYPE,
-    kNOTCLASS
+    kOK = 0,
+    kNOSUCHKEY = 1,
+    kWRONGTYPE = 2,
+    kNOTCLASS = 3
+  };
+
+ private:
+  static constexpr const char* GetStateString[4] = {
+    "ok",
+    "no such key",
+    "wrong type",
+    "no TClass"};
+
+ public:
+  static const char* getStateString(GetState state)
+  {
+    return (int)state < 4 ? GetStateString[(int)state] : nullptr;
   };
 
   RootSerializableKeyValueStore() = default;

--- a/DataFormats/simulation/src/MCEventHeader.cxx
+++ b/DataFormats/simulation/src/MCEventHeader.cxx
@@ -25,9 +25,11 @@ void MCEventHeader::Reset()
 {
   /** reset **/
 
+  FairMCEventHeader::Reset();
+
+  clearInfo();
   mEmbeddingFileName.clear();
   mEmbeddingEventIndex = 0;
-  FairMCEventHeader::Reset();
 }
 
 /*****************************************************************/

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -18,7 +18,13 @@
 #include "Generators/Trigger.h"
 #include <vector>
 
-class FairMCEventHeader;
+namespace o2
+{
+namespace dataformats
+{
+class MCEventHeader;
+}
+} // namespace o2
 
 namespace o2
 {
@@ -82,7 +88,7 @@ class Generator : public FairGenerator
   void clearParticles() { mParticles.clear(); };
 
   /** notification methods **/
-  virtual void notifyEmbedding(const FairMCEventHeader* mcHeader){};
+  virtual void notifyEmbedding(const o2::dataformats::MCEventHeader* eventHeader){};
 
  protected:
   /** copy constructor **/
@@ -91,7 +97,7 @@ class Generator : public FairGenerator
   Generator& operator=(const Generator&);
 
   /** methods that can be overridded **/
-  virtual void updateHeader(FairMCEventHeader* eventHeader){};
+  virtual void updateHeader(o2::dataformats::MCEventHeader* eventHeader){};
 
   /** internal methods **/
   Bool_t addTracks(FairPrimaryGenerator* primGen);

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -84,7 +84,7 @@ class GeneratorPythia8 : public Generator
   GeneratorPythia8& operator=(const GeneratorPythia8&);
 
   /** methods that can be overridded **/
-  void updateHeader(FairMCEventHeader* eventHeader) override;
+  void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override;
 
   /** internal methods **/
   Bool_t importParticles(Pythia8::Event& event);

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -13,6 +13,7 @@
 #include "Generators/Generator.h"
 #include "Generators/Trigger.h"
 #include "Generators/PrimaryGenerator.h"
+#include "SimulationDataFormat/MCEventHeader.h"
 #include "FairPrimaryGenerator.h"
 #include "FairLogger.h"
 #include <cmath>
@@ -89,7 +90,13 @@ Bool_t
   }
 
   /** update header **/
-  updateHeader(primGen->GetEvent());
+  auto header = primGen->GetEvent();
+  auto o2header = dynamic_cast<o2::dataformats::MCEventHeader*>(header);
+  if (!header) {
+    LOG(FATAL) << "MC event header is not a 'o2::dataformats::MCEventHeader' object";
+    return kFALSE;
+  }
+  updateHeader(o2header);
 
   /** success **/
   return kTRUE;

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -15,7 +15,7 @@
 #include "CommonUtils/ConfigurationMacroHelper.h"
 #include "FairLogger.h"
 #include "TParticle.h"
-#include "FairMCEventHeader.h"
+#include "SimulationDataFormat/MCEventHeader.h"
 #include "Pythia8/HIUserHooks.h"
 #include "TSystem.h"
 
@@ -192,7 +192,7 @@ Bool_t
 
 /*****************************************************************/
 
-void GeneratorPythia8::updateHeader(FairMCEventHeader* eventHeader)
+void GeneratorPythia8::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
 {
   /** update header **/
 

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -196,15 +196,37 @@ void GeneratorPythia8::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
 {
   /** update header **/
 
+  eventHeader->putInfo<std::string>("generator", "pythia8");
+  eventHeader->putInfo<int>("version", PYTHIA_VERSION_INTEGER);
+
 #if PYTHIA_VERSION_INTEGER < 8300
   auto hiinfo = mPythia.info.hiinfo;
 #else
   auto hiinfo = mPythia.info.hiInfo;
 #endif
 
-  /** set impact parameter if in heavy-ion mode **/
   if (hiinfo) {
+    /** set impact parameter **/
     eventHeader->SetB(hiinfo->b());
+    eventHeader->putInfo<double>("Bimpact", hiinfo->b());
+    /** set Ncoll, Npart and Nremn **/
+    int nColl, nPart;
+    int nPartProtonProj, nPartNeutronProj, nPartProtonTarg, nPartNeutronTarg;
+    int nRemnProtonProj, nRemnNeutronProj, nRemnProtonTarg, nRemnNeutronTarg;
+    getNcoll(nColl);
+    getNpart(nPart);
+    getNpart(nPartProtonProj, nPartNeutronProj, nPartProtonTarg, nPartNeutronTarg);
+    getNremn(nRemnProtonProj, nRemnNeutronProj, nRemnProtonTarg, nRemnNeutronTarg);
+    eventHeader->putInfo<int>("Ncoll", nColl);
+    eventHeader->putInfo<int>("Npart", nPart);
+    eventHeader->putInfo<int>("Npart_proj_p", nPartProtonProj);
+    eventHeader->putInfo<int>("Npart_proj_n", nPartNeutronProj);
+    eventHeader->putInfo<int>("Npart_targ_p", nPartProtonTarg);
+    eventHeader->putInfo<int>("Npart_targ_n", nPartNeutronTarg);
+    eventHeader->putInfo<int>("Nremn_proj_p", nRemnProtonProj);
+    eventHeader->putInfo<int>("Nremn_proj_n", nRemnNeutronProj);
+    eventHeader->putInfo<int>("Nremn_targ_p", nRemnProtonTarg);
+    eventHeader->putInfo<int>("Nremn_targ_n", nRemnNeutronTarg);
   }
 }
 

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -388,10 +388,12 @@ void GeneratorPythia8::getNremn(const Pythia8::Event& event, int& nProtonProj, i
     auto pdg = particle.id();
 
     // nuclear remnants have pdg code = ±10LZZZAAA9
-    if (pdg < 1000000000)
+    if (pdg < 1000000000) {
       continue; // must be nucleus
-    if (pdg % 10 != 9)
+    }
+    if (pdg % 10 != 9) {
       continue; // first digit must be 9
+    }
     nNucRem++;
 
     // extract A, Z and L from pdg code

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -460,5 +460,6 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [Selective_Transport](../run/SimExamples/Selective_Transport) | Simple example showing how to run simulation transporting only a custumisable set of particles |
+| [Custom_EventInfo](../run/SimExamples/Custom_EventInfo) | Simple example showing how to add custom information to the MC event header |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/Adaptive_Pythia8/adaptive_pythia8.macro
+++ b/run/SimExamples/Adaptive_Pythia8/adaptive_pythia8.macro
@@ -16,7 +16,7 @@ public:
 
   // update the number of events to be generated
   // according to background primaries and formula
-  void notifyEmbedding(const FairMCEventHeader *bkgHeader) override {
+  void notifyEmbedding(const o2::dataformats::MCEventHeader *bkgHeader) override {
     auto nPrimaries = bkgHeader->GetNPrim();
     mEvents = mFormula.Eval(nPrimaries);
   };

--- a/run/SimExamples/AliRoot_AMPT/aliroot_ampt.macro
+++ b/run/SimExamples/AliRoot_AMPT/aliroot_ampt.macro
@@ -76,7 +76,7 @@ public:
     return o2::eventgen::GeneratorTGenerator::generateEvent();
   }
 
-  void updateHeader(FairMCEventHeader* eventHeader) {
+  void updateHeader(o2::dataformats::MCEventHeader* eventHeader) {
     auto theAMPT = (TAmpt *)mGenAMPT->GetMC();
     auto impactB = theAMPT->GetHINT1(19);
     auto evPlane = theAMPT->GetReactionPlaneAngle();    

--- a/run/SimExamples/Custom_EventInfo/generator.macro
+++ b/run/SimExamples/Custom_EventInfo/generator.macro
@@ -1,0 +1,42 @@
+class Generator : public o2::eventgen::GeneratorPythia8 {
+
+public:
+  
+  Generator() = default;
+  ~Generator() = default;
+
+  /** static functions that define the information 
+      stored in the header (key and data type)
+      and provide a mean to retrieve it
+  **/
+  
+  static void setXsection(o2::dataformats::MCEventHeader* head, double val) { head->putInfo<double>("Xsection", val); };
+  static double getXsection(o2::dataformats::MCEventHeader* head, bool& isvalid) { return head->getInfo<double>("Xsection", isvalid); };
+
+  static void setXsectionErr(o2::dataformats::MCEventHeader* head, double val) { head->putInfo<double>("Xsection_err", val); };
+  static double getXsectionErr(o2::dataformats::MCEventHeader* head, bool& isvalid) { return head->getInfo<double>("Xsection_err", isvalid); };
+
+  static void setNmpi(o2::dataformats::MCEventHeader* head, int val) { head->putInfo<int>("Nmpi", val); };
+  static int getNmpi(o2::dataformats::MCEventHeader* head, bool& isvalid) { return head->getInfo<int>("Nmpi", isvalid); };
+
+private:
+
+  void updateHeader(o2::dataformats::MCEventHeader* head) final {
+
+    // call original function
+    o2::eventgen::GeneratorPythia8::updateHeader(head);
+
+    // store cross-section and Nmpi
+    setXsection(head, mPythia.info.sigmaGen());
+    setXsectionErr(head, mPythia.info.sigmaErr());
+    setNmpi(head, mPythia.info.nMPI());
+
+  };
+
+};
+
+FairGenerator*
+generator()
+{
+  return new Generator;
+}

--- a/run/SimExamples/Custom_EventInfo/pythia8_inel.cfg
+++ b/run/SimExamples/Custom_EventInfo/pythia8_inel.cfg
@@ -1,0 +1,11 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 14000. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 0.001	

--- a/run/SimExamples/Custom_EventInfo/read_event_info.macro
+++ b/run/SimExamples/Custom_EventInfo/read_event_info.macro
@@ -1,0 +1,31 @@
+#include "generator.macro"
+
+void
+read_event_info(const char *fname)
+{
+
+  auto fin = TFile::Open(fname);
+  auto tin = (TTree*)fin->Get("o2sim");
+  auto head = new o2::dataformats::MCEventHeader;
+  tin->SetBranchAddress("MCEventHeader.", &head);
+
+  bool isvalid;
+  
+  for (int iev = 0; iev < tin->GetEntries(); ++iev) {
+
+    tin->GetEntry(iev);
+
+    std::cout << " ---------------" << std::endl;
+    auto Xsection = Generator::getXsection(head, isvalid);
+    if (isvalid)
+      std::cout << "    Xsection = " << Xsection << std::endl;
+    auto XsectionErr = Generator::getXsectionErr(head, isvalid);
+    if (isvalid)
+      std::cout << " XsectionErr = " << XsectionErr << std::endl;
+    auto Nmpi = Generator::getNmpi(head, isvalid);
+    if (isvalid)
+      std::cout << "        Nmpi = " << Nmpi << std::endl;
+
+  }
+  
+}

--- a/run/SimExamples/Custom_EventInfo/run.sh
+++ b/run/SimExamples/Custom_EventInfo/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# This is a simulation example showing how to run simulation with Pythia8
+# with an external generator that adds custom information to the event header
+#
+#
+
+set -x
+
+MODULES="PIPE ITS TPC"
+EVENTS=100
+NWORKERS=8
+
+### generate some events with the external generator that will
+### provide some custom information in the event header
+
+o2-sim -j ${NWORKERS} -n ${EVENTS} -g external -m ${MODULES} \
+       --configFile sim.ini > log 2>&1
+
+### read the kinematics to print the custom information stored by
+### the external generator that we ran before
+
+root -b -q -l "read_event_info.macro(\"o2sim_Kine.root\")"

--- a/run/SimExamples/Custom_EventInfo/sim.ini
+++ b/run/SimExamples/Custom_EventInfo/sim.ini
@@ -1,0 +1,6 @@
+[GeneratorExternal]
+fileName=generator.macro
+funcName=generator()
+
+[GeneratorPythia8]
+config=pythia8_inel.cfg

--- a/run/SimExamples/HF_Embedding_Pythia8/GeneratorHF.macro
+++ b/run/SimExamples/HF_Embedding_Pythia8/GeneratorHF.macro
@@ -28,7 +28,7 @@ public:
   // for each event in case we are in embedding mode.
   // We use it to setup the number of signal events
   // to be generated and to be embedded on the background.
-  void notifyEmbedding(const FairMCEventHeader *bkgHeader) override {
+  void notifyEmbedding(const o2::dataformats::MCEventHeader *bkgHeader) override {
     mEvents = mFormula.Eval(bkgHeader->GetB());
     std::cout << " --- notify embedding: impact parameter is " << bkgHeader->GetB() << ", generating " << mEvents << " signal events " << std::endl;
   };

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -17,4 +17,5 @@
 * \subpage refrunSimExamplesForceDecay_Lambda_Neutron_Dalitz
 * \subpage refrunSimExamplesJustPrimaryKinematics
 * \subpage refrunSimExamplesSelective_Transport
+* \subpage refrunSimExamplesCustom_EventInfo
 /doxy -->

--- a/run/SimExamples/Signal_ImpactB/signal_impactb.macro
+++ b/run/SimExamples/Signal_ImpactB/signal_impactb.macro
@@ -28,7 +28,7 @@ public:
   
   // update the number of particles to be generated
   // according to impact parameter and formula
-  void notifyEmbedding(const FairMCEventHeader *bkgHeader) override {
+  void notifyEmbedding(const o2::dataformats::MCEventHeader *bkgHeader) override {
     auto b = bkgHeader->GetB();
     mNSignals = mFormula.Eval(b);
     std::cout << " --- notify embedding: b = " << b << ", nparticles = " << mNSignals << std::endl;


### PR DESCRIPTION
This PR provides a main addition to the information from event simulation.
The MCEventHeader stores arbitrary information in the form of a key-value storage that can be populated for each event, written in the kine files and retrieved at a later stage.

The example use of this comes also with this PR, where Pythia8 information about the current event is stored in the MC event header. The particular case of this PR takes care of information that can be computed in heavy-ion collisions with Pythia8 internal data. This information is stored in the event header.

This extension is generic and allow the user to define at run-time any type of information to be stored in the event header, without the need to developing and building new code.

There is the possibility to add information that was not previously foreseen in the following way, as an example for Pythia8:
- implement a custom external event generator that inherits from `GeneratorPythia8`
- override the `updateHeader` function and `putInfo<T>` information in the MC event header at wish.
An example of that will be provided with a commit that is coming soon.