### PR TITLE
Prototype for background-on-signal filtering for ITS digitization (WIP)

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -36,7 +36,7 @@ struct EventPart {
   // the sourceID should correspond to the chain ID
   int entryID = 0; // the event/entry ID inside the chain corresponding to sourceID
 
-  static bool isSignal(EventPart e) { return e.sourceID > 1 && e.sourceID != QEDSOURCEID; }
+  static bool isSignal(EventPart e) { return e.sourceID >= 1 && e.sourceID != QEDSOURCEID; }
   static bool isBackGround(EventPart e) { return !isSignal(e); }
   static bool isQED(EventPart e) { return e.sourceID == QEDSOURCEID; }
   ClassDefNV(EventPart, 1);

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -53,7 +53,7 @@ o2_add_executable(digitizer-workflow
                                         O2::TRDSimulation
                                         O2::TRDWorkflow
                                         O2::DataFormatsTRD
-                                        O2::ZDCSimulation)
+                                        O2::ZDCSimulation VecGeom::vecgeom)
 
 
 o2_add_executable(mctruth-testworkflow

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -158,4 +158,6 @@ find_package(O2GPU)
 
 find_package(FastJet)
 
+find_package(VecGeom)
+
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)


### PR DESCRIPTION
Fast filtering of background hits in the vicinity of signals for ITS.
Mechanism based on a voxel (hash) map keeping indexed information about signal hits.

The voxels avoid an O(NsignalsHits * NbackgroundHits) neighbour checking of hits
and reduce the problem to ~O(NsignalHits + NbackgroundHits).

One could also use the ALIPDE chip ID diretly as index if ITS hits stored this information.

**THIS SHOULD NOT BE MERGED AT THE MOMENT**