### PR TITLE
[EMCAL-677] Propagate trigger bits from RDH to TriggerRecord

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
@@ -11,6 +11,7 @@
 #ifndef ALICEO2_EMCAL_TRIGGERRECORD_H
 #define ALICEO2_EMCAL_TRIGGERRECORD_H
 
+#include <cstdint>
 #include <iosfwd>
 #include "Rtypes.h"
 #include "CommonDataFormat/InteractionRecord.h"
@@ -35,24 +36,28 @@ class TriggerRecord
 
  public:
   TriggerRecord() = default;
-  TriggerRecord(const BCData& bunchcrossing, int firstentry, int nentries) : mBCData(bunchcrossing), mDataRange(firstentry, nentries) {}
+  TriggerRecord(const BCData& bunchcrossing, int firstentry, int nentries) : mBCData(bunchcrossing), mDataRange(firstentry, nentries), mTriggerBits(0) {}
+  TriggerRecord(const BCData& bunchcrossing, uint32_t triggerbits, int firstentry, int nentries) : TriggerRecord(bunchcrossing, firstentry, nentries) { mTriggerBits = triggerbits; }
   ~TriggerRecord() = default;
 
   void setBCData(const BCData& data) { mBCData = data; }
+  void setTriggerBits(uint32_t triggerbits) { mTriggerBits = triggerbits; }
   void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
   void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
 
   const BCData& getBCData() const { return mBCData; }
   BCData& getBCData() { return mBCData; }
+  uint32_t getTriggerBits() const { return mTriggerBits; }
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
 
   void printStream(std::ostream& stream) const;
 
  private:
-  BCData mBCData;       /// Bunch crossing data of the trigger
-  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
+  BCData mBCData;        /// Bunch crossing data of the trigger
+  DataRange mDataRange;  /// Index of the triggering event (event index and first entry in the container)
+  uint32_t mTriggerBits; /// Trigger bits as from the Raw Data Header
 
   ClassDefNV(TriggerRecord, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <bitset>
 #include <iostream>
 #include "DataFormatsEMCAL/TriggerRecord.h"
 
@@ -19,7 +20,7 @@ namespace emcal
 
 void TriggerRecord::printStream(std::ostream& stream) const
 {
-  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
+  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit << ", Triggers " << std::bitset<sizeof(mTriggerBits) * 8>(mTriggerBits) << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
 }
 
 std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg)

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -168,7 +168,7 @@ bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
     auto ddlid = srucont.mSRUid;
     auto [crorc, link] = getLinkAssignment(ddlid);
     LOG(DEBUG1) << "Adding payload with size " << payload.size() << " (" << payload.size() / 4 << " ALTRO words)";
-    mRawWriter->addData(ddlid, crorc, link, 0, trg.getBCData(), payload);
+    mRawWriter->addData(ddlid, crorc, link, 0, trg.getBCData(), payload, false, trg.getTriggerBits());
   }
   std::cout << "Done" << std::endl;
   return true;

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -31,6 +31,7 @@ o2_add_executable(digitizer-workflow
                           src/TOFDigitizerSpec.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                                         O2::Steer
+                                        O2::CommonConstants
                                         O2::EMCALSimulation
                                         O2::FT0Simulation
                                         O2::FV0Simulation

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include "EMCALDigitizerSpec.h"
+#include "CommonConstants/Triggers.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
@@ -128,7 +129,7 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
     std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(mAccumulatedDigits));
     labelAccum.mergeAtBack(mLabels);
     LOG(INFO) << "Have " << mAccumulatedDigits.size() << " digits ";
-    triggers.emplace_back(timesview[trigID], indexStart, mDigits.size());
+    triggers.emplace_back(timesview[trigID], o2::trigger::PhT, indexStart, mDigits.size());
     indexStart = mAccumulatedDigits.size();
     mDigits.clear();
     mLabels.clear();


### PR DESCRIPTION
- Add field for trigger bits in trigger record
- Propagate trigger bits from from RDH to new field in
  TriggerRecord
- Set trigger bits to physics trigger in simulation
- Propagate trigger bits from TriggerRecord to raw data in
  RawWriter