### PR TITLE
Fix: do not invoke FIT recpoints reader with --use-fit in raw data input mode

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -206,7 +206,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     }
   }
 
-  if (useFIT) {
+  if (useFIT && !disableRootInput) {
     specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
   }
 


### PR DESCRIPTION
since in raw mode the FT0 recpoints must be provided by upstream devices