### PR TITLE
Change Tau0 max to 10 mm in Pythia8 configurations

### DIFF
--- a/Generators/share/egconfig/pythia8_hf.cfg
+++ b/Generators/share/egconfig/pythia8_hf.cfg
@@ -9,4 +9,4 @@ HardQCD:hardbbbar on		# scatterings g-g / q-qbar -> b-bbar
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/Generators/share/egconfig/pythia8_hi.cfg
+++ b/Generators/share/egconfig/pythia8_hi.cfg
@@ -12,4 +12,4 @@ HeavyIon:bWidth	15.		# impact parameter from 0-x [fm]
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/Generators/share/egconfig/pythia8_inel.cfg
+++ b/Generators/share/egconfig/pythia8_inel.cfg
@@ -8,4 +8,4 @@ SoftQCD:inelastic on		# all inelastic processes
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/run/SimExamples/Adaptive_Pythia8/pythia8_inel.cfg
+++ b/run/SimExamples/Adaptive_Pythia8/pythia8_inel.cfg
@@ -8,4 +8,4 @@ SoftQCD:inelastic on		# all inelastic processes
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/run/SimExamples/Custom_EventInfo/pythia8_inel.cfg
+++ b/run/SimExamples/Custom_EventInfo/pythia8_inel.cfg
@@ -8,4 +8,4 @@ SoftQCD:inelastic on		# all inelastic processes
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/run/SimExamples/HF_Embedding_Pythia8/pythia8_ccbar.template
+++ b/run/SimExamples/HF_Embedding_Pythia8/pythia8_ccbar.template
@@ -16,4 +16,4 @@ PhaseSpace:pTHatMax ${pTHatMax}	# the maximum invariant pT
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	

--- a/run/SimExamples/Jet_Embedding_Pythia8/pythia8_hard.cfg
+++ b/run/SimExamples/Jet_Embedding_Pythia8/pythia8_hard.cfg
@@ -10,4 +10,4 @@ PhaseSpace:pTHatMin 500.	# min pT hat
 
 ### decays
 ParticleDecays:limitTau0 on	
-ParticleDecays:tau0Max 0.001	
+ParticleDecays:tau0Max 10.	


### PR DESCRIPTION
This PR changes the settings for decays in the Pythia8 configurations that are kept in the `O2`.
This is moved to 10 mm, which means that *charm and beauty hadrons will decay at the generator level*.
Strange decays will still happen at the simulation level.

@shahor02 , please complain if this is not ok with you.
People from the HF groups still have to give back a clear feedback about whether it makes sense (i.e. we have resolution to observe differences) to transport charm and beauty hadrons before decay.