### PR TITLE
Add CPV raw generation, reco, entropy encoding to full system test scripts

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -105,8 +105,8 @@ WORKFLOW+="o2-tof-reco-workflow $ARGS_ALL --configKeyValues \"HBFUtils.nHBFPerTF
 # Workflows disabled in sync mode
 if [ $SYNCMODE == 0 ]; then
   WORKFLOW+="o2-mid-reco-workflow $ARGS_ALL --disable-root-output $DISABLE_MC | "
-  # WORKFLOW+="o2-mft-reco-workflow $ARGS_ALL --clusters-from-upstream --disable-mc --disable-root-output --configKeyValues \"HBFUtils.nHBFPerTF=128;\" | " # Disabled since currently crashing
-  WORKFLOW+="o2-primary-vertexing-workflow $ARGS_ALL --disable-mc --disable-root-input --disable-root-output --validate-with-ft0 | "
+  WORKFLOW+="o2-mft-reco-workflow $ARGS_ALL --clusters-from-upstream $DISABLE_MC --disable-root-output --configKeyValues \"HBFUtils.nHBFPerTF=128;\" | "
+  WORKFLOW+="o2-primary-vertexing-workflow $ARGS_ALL $DISABLE_MC --disable-root-input --disable-root-output --validate-with-ft0 | "
   WORKFLOW+="o2-secondary-vertexing-workflow $ARGS_ALL --disable-root-input --disable-root-output | "
 fi
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -81,7 +81,7 @@ if [ $CTFINPUT == 1 ]; then
   TOF_INPUT=digits
   WORKFLOW="o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root $ARGS_ALL | "
 elif [ $EXTINPUT == 1 ]; then
-  WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"B:TPC/RAWDATA;C:ITS/RAWDATA;D:TOF/RAWDATA;D:MFT/RAWDATA;E:FT0/RAWDATA;F:MID/RAWDATA;G:EMC/RAWDATA;H:PHS/RAWDATA\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@stfb-to-dpl,transport=shmem,rateLogging=0\" | "
+  WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"B:TPC/RAWDATA;C:ITS/RAWDATA;D:TOF/RAWDATA;D:MFT/RAWDATA;E:FT0/RAWDATA;F:MID/RAWDATA;G:EMC/RAWDATA;H:PHS/RAWDATA;I:CPV/RAWDATA\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@stfb-to-dpl,transport=shmem,rateLogging=0\" | "
 else
   WORKFLOW="o2-raw-file-reader-workflow $ARGS_ALL --configKeyValues \"HBFUtils.nHBFPerTF=$NHBPERTF;\" --delay $TFDELAY --loop $NTIMEFRAMES --max-tf 0 --input-conf rawAll.cfg | "
 fi
@@ -112,13 +112,16 @@ fi
 
 # Workflows disabled in async mode
 if [ $CTFINPUT == 0 ]; then
-  WORKFLOW+="o2-phos-reco-workflow $ARGS_ALL --input-type raw --output-type cells | "
-  WORKFLOW+="o2-emcal-reco-workflow $ARGS_ALL --input-type raw --output-type cells --disable-root-output | "
+  WORKFLOW+="o2-phos-reco-workflow $ARGS_ALL --input-type raw --output-type cells $DISABLE_MC  | "
+  WORKFLOW+="o2-cpv-reco-workflow $ARGS_ALL --input-type raw --output-type digits $DISABLE_MC  | "
+  WORKFLOW+="o2-cpv-reco-workflow $ARGS_ALL --input-type digits --output-type clusters $DISABLE_MC | "
+  WORKFLOW+="o2-emcal-reco-workflow $ARGS_ALL --input-type raw --output-type cells --disable-root-output $DISABLE_MC  | "
 
   WORKFLOW+="o2-itsmft-entropy-encoder-workflow $ARGS_ALL --runmft true | "
   WORKFLOW+="o2-ft0-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-mid-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-phos-entropy-encoder-workflow $ARGS_ALL | "
+  WORKFLOW+="o2-cpv-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-emcal-entropy-encoder-workflow $ARGS_ALL | "
 
   WORKFLOW+="o2-tpc-scdcalib-interpolation-workflow $ARGS_ALL --disable-root-output --disable-root-input | "
@@ -128,7 +131,7 @@ if [ $CTFINPUT == 0 ]; then
   if [ $CREATECTFDICT == 1 ] && [ $SAVECTF == 1 ]; then CTF_OUTPUT_TYPE="both"; fi
   if [ $CREATECTFDICT == 1 ] && [ $SAVECTF == 0 ]; then CTF_OUTPUT_TYPE="dict"; fi
   if [ $CREATECTFDICT == 0 ] && [ $SAVECTF == 1 ]; then CTF_OUTPUT_TYPE="ctf"; fi
-  CMD_CTF="o2-ctf-writer-workflow $ARGS_ALL --output-type $CTF_OUTPUT_TYPE --onlyDet ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS"
+  CMD_CTF="o2-ctf-writer-workflow $ARGS_ALL --output-type $CTF_OUTPUT_TYPE --onlyDet ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV"
   if [ $CREATECTFDICT == 1 ] && [ $; then
     CMD_CTF+=" --save-dict-after 1"
   fi

--- a/prodtests/full-system-test/setenv.sh
+++ b/prodtests/full-system-test/setenv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Make sure we can open sufficiently many files / allocate enough memory
-ulimit -n 4096 || ulimit -l unlimited || ulimit -m unlimited || ulimit -l unlimited
+ulimit -n 4096 && ulimit -l unlimited && ulimit -m unlimited && ulimit -l unlimited
 if [ $? != 0 ]; then
   echo Error setting ulimits
   exit 1

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -66,6 +66,7 @@ taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --tof-raw-file-for l
 taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --mid-raw-perlink  --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"'
 taskwrapper emcraw.log o2-emcal-rawcreator --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -o raw/EMC
 taskwrapper phsraw.log o2-phos-digi2raw  --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -o raw/PHS
+taskwrapper cpvraw.log o2-cpv-digi2raw  --file-for link --configKeyValues '"HBFUtils.nHBFPerTF=128;HBFUtils.orbitFirst=0"' -o raw/CPV
 cat raw/*/*.cfg > rawAll.cfg
 
 # We run the workflow in both CPU-only and With-GPU mode


### PR DESCRIPTION
@peressounko @shahor02 : It seems that the cpv-rec-workflow cannot go directly from raw to clusters. Is this intended? I have to use
```
o2-raw-file-reader-workflow --configKeyValues "HBFUtils.nHBFPerTF=128" --delay 10 --loop 1 --max-tf 0 --input-conf rawAll.cfg | o2-cpv-reco-workflow --input-type raw --output-type digits --disable-mc | o2-cpv-reco-workflow --input-type digits --output-type clusters --disable-mc | o2-cpv-entropy-encoder-workflow
```
so basically running the workflow twice, raw-->digits and digits-->clusters. This works, but I think it would be more convenient if it would work directly.