### PR TITLE
GPU: Fix memory buffer scaling factor when memory allocation strategy is auto

### DIFF
--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -77,7 +77,7 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
   if (mRec->Init()) {
     return (1);
   }
-  if (!mRec->IsGPU() && mConfig->configProcessing.memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {
+  if (!mRec->IsGPU() && mRec->GetProcessingSettings().memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {
     mRec->MemoryScalers()->factor *= 2;
   }
   mRec->MemoryScalers()->factor *= mConfig->configInterface.memoryBufferScaleFactor;


### PR DESCRIPTION
Check was looking at the cached value, which can be auto, and not yet set to individual.

@shahor02 : This fixes your buffer overflow issue.

Merging since trivial and currently broken.