### PR TITLE
Do not encode TDC errors to compressed output stream

### DIFF
--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -418,7 +418,9 @@ bool Compressor<RDH, verbose>::processDRM()
       /** check event **/
       checkerCheck();
       *mEncoderPointer |= mCheckerSummary.nDiagnosticWords;
+#if ENCODE_TDC_ERRORS
       *mEncoderPointer |= (mCheckerSummary.nTDCErrors << 16);
+#endif
 
       if (verbose && mEncoderVerbose) {
         auto CrateTrailer = reinterpret_cast<compressed::CrateTrailer_t*>(mEncoderPointer);
@@ -445,6 +447,7 @@ bool Compressor<RDH, verbose>::processDRM()
       /** encode TDC errors **/
       for (int itrm = 0; itrm < 10; ++itrm) {
         for (int ichain = 0; ichain < 2; ++ichain) {
+#if ENCODE_TDC_ERRORS
           for (int ierror = 0; ierror < mDecoderSummary.trmErrors[itrm][ichain]; ++ierror) {
             *mEncoderPointer = *mDecoderSummary.trmError[itrm][ichain][ierror];
             *mEncoderPointer &= 0xFF07FFFF;
@@ -460,6 +463,7 @@ bool Compressor<RDH, verbose>::processDRM()
             }
             encoderNext();
           }
+#endif
           mDecoderSummary.trmErrors[itrm][ichain] = 0;
         }
       }


### PR DESCRIPTION
this PR disables the encoding of TDC errors in the compressed output stream.
The feature might be re-enabled in the future.