### PR TITLE
GPU: Add option to tpc-reco-workflow to ship shared cluster map created during tracking

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -42,6 +42,7 @@ enum struct Operation {
   OutputCompClusters,     // publish CompClusters container
   OutputCompClustersFlat, // publish CompClusters container
   OutputQA,               // Ship QA histograms to QC
+  OutputSharedClusterMap, // Ship optional shared cluster map
   ProcessMC,              // process MC labels
   SendClustersPerSector,  // Send clusters and clusters mc labels per sector
   Noop,                   // skip argument on the constructor
@@ -92,6 +93,9 @@ struct Config {
       case Operation::OutputQA:
         outputQA = true;
         break;
+      case Operation::OutputSharedClusterMap:
+        outputSharedClusterMap = true;
+        break;
       case Operation::ProcessMC:
         processMC = true;
         break;
@@ -121,6 +125,7 @@ struct Config {
   bool outputCompClustersFlat = false;
   bool outputCAClusters = false;
   bool outputQA = false;
+  bool outputSharedClusterMap = false;
   bool processMC = false;
   bool sendClustersPerSector = false;
 };

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -61,6 +61,7 @@ enum struct OutputType { Digits,
                          SendClustersPerSector,
                          ZSRaw,
                          QA,
+                         NoSharedClusterMap,
 };
 
 using CompletionPolicyData = std::vector<framework::InputSpec>;

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -85,7 +85,8 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"disable-writer", OutputType::DisableWriter},
   {"send-clusters-per-sector", OutputType::SendClustersPerSector},
   {"zsraw", OutputType::ZSRaw},
-  {"qa", OutputType::QA}};
+  {"qa", OutputType::QA},
+  {"no-shared-cluster-map", OutputType::NoSharedClusterMap}};
 
 framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, std::vector<int> const& laneConfiguration,
                                     bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput,
@@ -444,6 +445,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
                                                                isEnabled(OutputType::SendClustersPerSector) ? ca::Operation::SendClustersPerSector : ca::Operation::Noop,
                                                                isEnabled(OutputType::QA) ? ca::Operation::OutputQA : ca::Operation::Noop,
                                                                isEnabled(OutputType::Clusters) && (caClusterer || decompressTPC) ? ca::Operation::OutputCAClusters : ca::Operation::Noop,
+                                                               isEnabled(OutputType::Clusters) && isEnabled(OutputType::Tracks) && !isEnabled(OutputType::NoSharedClusterMap) ? ca::Operation::OutputSharedClusterMap : ca::Operation::Noop,
                                                              },
                                                  tpcSectors));
   }

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -46,7 +46,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   std::vector<ConfigParamSpec> options{
     {"input-type", VariantType::String, "digits", {"digitizer, digits, zsraw, clustershw, clustersnative, compressed-clusters, compressed-clusters-ctf"}},
-    {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer, send-clusters-per-sector, qa"}},
+    {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer, send-clusters-per-sector, qa, no-shared-cluster-map"}},
     {"no-ca-clusterer", VariantType::Bool, false, {"Use HardwareClusterer instead of clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     //{"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},

--- a/GPU/GPUTracking/Base/GPUSettingsList.h
+++ b/GPU/GPUTracking/Base/GPUSettingsList.h
@@ -138,6 +138,7 @@ AddOption(alternateBorderSort, int, -1, "", 0, "Alternative implementation for s
 AddOption(enableRTC, bool, false, "", 0, "Use RTC to optimize GPU code")
 AddOption(rtcConstexpr, bool, true, "", 0, "Replace constant variables by static constexpr expressions")
 AddOption(showOutputStat, bool, false, "", 0, "Print some track output statistics")
+AddOption(outputSharedClusterMap, bool, false, "", 0, "Ship optional shared cluster map as output for further use")
 AddVariable(eventDisplay, GPUCA_NAMESPACE::gpu::GPUDisplayBackend*, nullptr)
 AddHelp("help", 'h')
 EndConfig()

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -351,6 +351,12 @@ int GPUChainTracking::Init()
   if (mOutputTPCTracks == nullptr) {
     mOutputTPCTracks = &mRec->OutputControl();
   }
+  if (mOutputSharedClusterMap == nullptr) {
+    mOutputSharedClusterMap = &mRec->OutputControl();
+  }
+  if (mOutputClusterLabels == nullptr) {
+    mOutputClusterLabels = &mRec->OutputControl();
+  }
 
   if (!ValidateSettings()) {
     return 1;
@@ -1951,6 +1957,7 @@ int GPUChainTracking::RunTPCTrackingMerger(bool synchronizeOutput)
   SynchronizeGPU(); // Need to know the full number of slice tracks
   SetupGPUProcessor(&Merger, true);
   AllocateRegisteredMemory(Merger.MemoryResOutput(), mOutputTPCTracks);
+  AllocateRegisteredMemory(Merger.MemoryResOutputState(), mOutputSharedClusterMap);
 
   if (Merger.CheckSlices()) {
     return 1;

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -173,6 +173,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetOutputControlClustersNative(GPUOutputControl* v) { mOutputClustersNative = v; }
   void SetOutputControlTPCTracks(GPUOutputControl* v) { mOutputTPCTracks = v; }
   void SetOutputControlClusterLabels(GPUOutputControl* v) { mOutputClusterLabels = v; }
+  void SetOutputControlSharedClusterMap(GPUOutputControl* v) { mOutputSharedClusterMap = v; }
 
   const GPUSettingsDisplay* mConfigDisplay = nullptr; // Abstract pointer to Standalone Display Configuration Structure
   const GPUSettingsQA* mConfigQA = nullptr;           // Abstract pointer to Standalone QA Configuration Structure
@@ -245,6 +246,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   GPUOutputControl* mOutputClustersNative = nullptr;
   GPUOutputControl* mOutputTPCTracks = nullptr;
   GPUOutputControl* mOutputClusterLabels = nullptr;
+  GPUOutputControl* mOutputSharedClusterMap = nullptr;
 
   std::unique_ptr<GPUTPCCFChainContext> mCFContext;
 

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -65,6 +65,8 @@ int GPUTPCO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
     mChain->SetOutputControlClustersNative(mOutputClustersNative.get());
     mOutputTPCTracks.reset(new GPUOutputControl);
     mChain->SetOutputControlTPCTracks(mOutputTPCTracks.get());
+    mOutputSharedClusterMap.reset(new GPUOutputControl);
+    mChain->SetOutputControlSharedClusterMap(mOutputSharedClusterMap.get());
     GPUOutputControl dummy;
     dummy.set([](size_t size) -> void* {throw std::runtime_error("invalid output memory request, no common output buffer set"); return nullptr; });
     mRec->SetOutputControl(dummy);
@@ -140,6 +142,13 @@ int GPUTPCO2Interface::RunTracking(GPUTrackingInOutPointers* data, GPUInterfaceO
       mOutputTPCTracks->set(outputs->tpcTracks.ptr, outputs->tpcTracks.size);
     } else {
       mOutputTPCTracks->reset();
+    }
+    if (outputs->sharedClusterMap.allocator) {
+      mOutputSharedClusterMap->set(outputs->sharedClusterMap.allocator);
+    } else if (outputs->sharedClusterMap.ptr) {
+      mOutputSharedClusterMap->set(outputs->sharedClusterMap.ptr, outputs->sharedClusterMap.size);
+    } else {
+      mOutputSharedClusterMap->reset();
     }
   }
   if (mConfig->configProcessing.runMC) {

--- a/GPU/GPUTracking/Interface/GPUO2Interface.h
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.h
@@ -76,6 +76,7 @@ class GPUTPCO2Interface
   std::unique_ptr<GPUOutputControl> mOutputClustersNative;
   std::unique_ptr<GPUOutputControl> mOutputTPCTracks;
   std::unique_ptr<GPUOutputControl> mOutputTPCClusterLabels;
+  std::unique_ptr<GPUOutputControl> mOutputSharedClusterMap;
 };
 } // namespace o2::gpu
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -72,6 +72,7 @@ struct GPUInterfaceOutputs {
   GPUInterfaceOutputRegion clustersNative;
   GPUInterfaceOutputRegion tpcTracks;
   GPUInterfaceOutputRegion clusterLabels;
+  GPUInterfaceOutputRegion sharedClusterMap;
   GPUInterfaceQAOutputs qa;
 };
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -297,12 +297,16 @@ void* GPUTPCGMMerger::SetPointersOutput(void* mem)
   if (!mRec->GetProcessingSettings().fullMergerOnGPU) {
     mem = SetPointersRefitScratch2(mem);
   }
-  if (mRec->GetRecoSteps() & GPUDataTypes::RecoStep::Refit) {
+  return mem;
+}
+
+void* GPUTPCGMMerger::SetPointersOutputState(void* mem)
+{
+  if ((mRec->GetRecoSteps() & GPUDataTypes::RecoStep::Refit) || mRec->GetProcessingSettings().outputSharedClusterMap) {
     computePointerWithAlignment(mem, mClusterStateExt, mNMaxClusters);
   } else {
     mClusterStateExt = nullptr;
   }
-
   return mem;
 }
 
@@ -312,6 +316,7 @@ void GPUTPCGMMerger::RegisterMemoryAllocation()
   mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersMerger, (mRec->GetProcessingSettings().fullMergerOnGPU ? 0 : GPUMemoryResource::MEMORY_HOST) | GPUMemoryResource::MEMORY_SCRATCH | GPUMemoryResource::MEMORY_STACK, "TPCMerger");
   mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersRefitScratch, GPUMemoryResource::MEMORY_SCRATCH | GPUMemoryResource::MEMORY_STACK, "TPCMergerRefitScratch");
   mMemoryResOutput = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersOutput, (mRec->GetProcessingSettings().fullMergerOnGPU ? GPUMemoryResource::MEMORY_OUTPUT : GPUMemoryResource::MEMORY_INOUT) | GPUMemoryResource::MEMORY_CUSTOM, "TPCMergerOutput");
+  mMemoryResOutputState = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersOutputState, (mRec->GetProcessingSettings().fullMergerOnGPU ? GPUMemoryResource::MEMORY_OUTPUT : GPUMemoryResource::MEMORY_HOST) | GPUMemoryResource::MEMORY_CUSTOM, "TPCMergerOutputState");
   mMemoryResMemory = mRec->RegisterMemoryAllocation(this, &GPUTPCGMMerger::SetPointersMemory, GPUMemoryResource::MEMORY_PERMANENT, "TPCMergerMemory");
 }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -86,6 +86,7 @@ class GPUTPCGMMerger : public GPUProcessor
   void* SetPointersRefitScratch(void* mem);
   void* SetPointersRefitScratch2(void* mem);
   void* SetPointersOutput(void* mem);
+  void* SetPointersOutputState(void* mem);
   void* SetPointersMemory(void* mem);
 
   void SetSliceData(int index, const GPUTPCSliceOutput* sliceData) { mkSlices[index] = sliceData; }
@@ -119,6 +120,7 @@ class GPUTPCGMMerger : public GPUProcessor
 
   GPUd() unsigned short MemoryResMemory() { return mMemoryResMemory; }
   GPUd() unsigned short MemoryResOutput() const { return mMemoryResOutput; }
+  GPUd() unsigned short MemoryResOutputState() const { return mMemoryResOutputState; }
 
   GPUd() int RefitSliceTrack(GPUTPCGMSliceTrack& sliceTrack, const GPUTPCTrack* inTrack, float alpha, int slice);
   GPUd() void SetTrackClusterZT(GPUTPCGMSliceTrack& track, int iSlice, const GPUTPCTrack* sliceTr);
@@ -211,6 +213,7 @@ class GPUTPCGMMerger : public GPUProcessor
 
   unsigned short mMemoryResMemory;
   unsigned short mMemoryResOutput;
+  unsigned short mMemoryResOutputState;
 
   int mNClusters;                     // Total number of incoming clusters (from slice tracks)
   GPUTPCGMMergedTrack* mOutputTracks; //* array of output merged tracks


### PR DESCRIPTION
@shahor02 : This adds the option to the tpc-reco-workflow to shop also the shared cluster map, just add shared-cluster-map to the output type. It is not stored to a ROOT file, I assume compared to ROOT IO the recreation is pretty much irrelevant. It will ship as datatype `TPC` `CLSHAREDMAP` and just a a plain char array. I checked the correctness of the map before shipping, didn't yet try to receive it but I don't see how I could have messed up the sending part ... :)

Do you want to adapt the its/tpc matching workflow, or shall I have a look?