### PR TITLE
FT0 LUT prepared as Singleton for DigitBlockFT0 usage

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
@@ -215,6 +215,19 @@ class LookUpTable
   ClassDefNV(LookUpTable, 2);
 };
 
+//Singleton for LookUpTable
+class SingleLUT:public LookUpTable
+{
+ private:
+  SingleLUT():LookUpTable(LookUpTable::readTable()) {}
+  SingleLUT(const SingleLUT&) = delete;
+  SingleLUT& operator=(SingleLUT&) = delete;
+ public:
+  static SingleLUT& Instance() {
+    static SingleLUT instanceLUT;
+    return instanceLUT;
+  }
+};
 } // namespace ft0
 } // namespace o2
 #endif

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
@@ -216,14 +216,16 @@ class LookUpTable
 };
 
 //Singleton for LookUpTable
-class SingleLUT:public LookUpTable
+class SingleLUT : public LookUpTable
 {
  private:
-  SingleLUT():LookUpTable(LookUpTable::readTable()) {}
+  SingleLUT() : LookUpTable(LookUpTable::readTable()) {}
   SingleLUT(const SingleLUT&) = delete;
   SingleLUT& operator=(SingleLUT&) = delete;
+
  public:
-  static SingleLUT& Instance() {
+  static SingleLUT& Instance()
+  {
     static SingleLUT instanceLUT;
     return instanceLUT;
   }

--- a/Detectors/FIT/FT0/raw/include/FT0Raw/DigitBlockFT0.h
+++ b/Detectors/FIT/FT0/raw/include/FT0Raw/DigitBlockFT0.h
@@ -53,7 +53,6 @@ class DigitBlockFT0 : public DigitBlockBase<DigitBlockFT0>
   void setIntRec(o2::InteractionRecord intRec) { mDigit.mIntRecord = intRec; }
   Digit mDigit;
   std::vector<ChannelData> mVecChannelData;
-  static o2::ft0::LookUpTable sLookupTable;
   static int sEventID;
 
   template <class DataBlockType>
@@ -61,7 +60,7 @@ class DigitBlockFT0 : public DigitBlockBase<DigitBlockFT0>
   {
     if constexpr (std::is_same<DataBlockType, DataBlockPM>::value) { //Filling data from PM
       for (int iEventData = 0; iEventData < dataBlock.DataBlockWrapper<RawDataPM>::mNelements; iEventData++) {
-        mVecChannelData.emplace_back(uint8_t(sLookupTable.getChannel(linkID, dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].channelID)),
+        mVecChannelData.emplace_back(uint8_t(o2::ft0::SingleLUT::Instance().getChannel(linkID, dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].channelID)),
                                      int(dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].time),
                                      int(dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].charge),
                                      dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].getFlagWord());
@@ -141,8 +140,6 @@ class DigitBlockFT0ext : public DigitBlockBase<DigitBlockFT0ext>
   DigitExt mDigit;
   std::vector<ChannelData> mVecChannelData;
   std::vector<TriggersExt> mVecTriggersExt;
-
-  static o2::ft0::LookUpTable sLookupTable;
   static int sEventID;
 
   template <class DataBlockType>
@@ -150,7 +147,7 @@ class DigitBlockFT0ext : public DigitBlockBase<DigitBlockFT0ext>
   {
     if constexpr (std::is_same<DataBlockType, DataBlockPM>::value) { //Filling data from PM
       for (int iEventData = 0; iEventData < dataBlock.DataBlockWrapper<RawDataPM>::mNelements; iEventData++) {
-        mVecChannelData.emplace_back(uint8_t(sLookupTable.getChannel(linkID, dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].channelID)),
+        mVecChannelData.emplace_back(uint8_t(o2::ft0::SingleLUT::Instance().getChannel(linkID, dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].channelID)),
                                      int(dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].time),
                                      int(dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].charge),
                                      dataBlock.DataBlockWrapper<RawDataPM>::mData[iEventData].getFlagWord());

--- a/Detectors/FIT/FT0/raw/src/DigitBlockFT0.cxx
+++ b/Detectors/FIT/FT0/raw/src/DigitBlockFT0.cxx
@@ -12,6 +12,4 @@
 using namespace o2::ft0;
 
 int DigitBlockFT0::sEventID = 0;
-o2::ft0::LookUpTable DigitBlockFT0::sLookupTable = o2::ft0::LookUpTable::readTable();
 int DigitBlockFT0ext::sEventID = 0;
-o2::ft0::LookUpTable DigitBlockFT0ext::sLookupTable = o2::ft0::LookUpTable::readTable();


### PR DESCRIPTION
Static member (o2::ft0::LookUpTable) in DigitBlockFT0 changed to simple Singleton(o2::ft0::SingleLUT)