### PR TITLE
small improvement in fake track rejection

### DIFF
--- a/Detectors/MUON/MCH/Tracking/README.md
+++ b/Detectors/MUON/MCH/Tracking/README.md
@@ -97,9 +97,11 @@ attached to the new track. Clusters that drive the track parameters outside of a
 are discarded.
 - Improve the tracks: run the smoother to recompute the local chi2 at each cluster, remove the worst cluster if it does
 not pass a stricter chi2 cut, refit the track and repeat the procedure until all clusters pass the cut or one of them
-cannot be removed (the track must contain at least 1 cluster per station), in which case the track is removed.
+cannot be removed without violating the tracking conditions (by default, the track must contain at least 1 cluster per
+station and both chambers fired on station 4 or 5), in which case the track is removed.
 - Remove connected tracks in station 3, 4 and 5. If two tracks share at least one cluster in these stations, remove the
-one with the smallest number of clusters or with the highest chi2 in case of equality, assuming it is a fake track.
+one with the smallest number of fired chambers or with the highest chi2/(ndf-1) in case of equality, assuming it is a 
+fake track.
 
 In all stations, the search for compatible clusters is done in a way to consider every possibilities, i.e. every
 combinations of 1 to 4 clusters, while skipping the already tested combinations. This includes subsets of previously

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/Track.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/Track.h
@@ -39,9 +39,6 @@ class Track
   Track(Track&&) = delete;
   Track& operator=(Track&&) = delete;
 
-  /// Return a reference to the track parameters at vertex
-  const TrackParam& getParamAtVertex() const { return mParamAtVertex; }
-
   /// Return the number of attached clusters
   int getNClusters() const { return mParamAtClusters.size(); }
 
@@ -101,7 +98,6 @@ class Track
   void print() const;
 
  private:
-  TrackParam mParamAtVertex{};                 ///< track parameters at vertex
   std::list<TrackParam> mParamAtClusters{};    ///< list of track parameters at each cluster
   std::unique_ptr<TrackParam> mCurrentParam{}; ///< current track parameters used during tracking
   int mCurrentChamber = -1;                    ///< current chamber on which the current parameters are given

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/Track.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/Track.h
@@ -45,6 +45,9 @@ class Track
   /// Return the number of attached clusters
   int getNClusters() const { return mParamAtClusters.size(); }
 
+  /// Return the number of degrees of freedom of the track
+  int getNDF() const { return 2 * getNClusters() - 5; }
+
   /// Return a reference to the track parameters at first cluster
   const TrackParam& first() const { return mParamAtClusters.front(); }
   /// Return a reference to the track parameters at last cluster
@@ -72,7 +75,7 @@ class Track
 
   bool isBetter(const Track& track) const;
 
-  void tagRemovableClusters(uint8_t requestedStationMask);
+  void tagRemovableClusters(uint8_t requestedStationMask, bool request2ChInSameSt45);
 
   void setCurrentParam(const TrackParam& param, int chamber);
   TrackParam& getCurrentParam();

--- a/Detectors/MUON/MCH/Tracking/src/Track.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/Track.cxx
@@ -133,63 +133,61 @@ bool Track::isBetter(const Track& track) const
 }
 
 //__________________________________________________________________________
-void Track::tagRemovableClusters(uint8_t requestedStationMask)
+void Track::tagRemovableClusters(uint8_t requestedStationMask, bool request2ChInSameSt45)
 {
-  /// Identify clusters that can be removed from the track,
-  /// with the only requirements to have at least 1 cluster per requested station
-  /// and at least 2 chambers over 4 in stations 4 & 5 that contain cluster(s)
+  /// Identify clusters that can be removed from the track, with the requirement
+  /// to have enough chambers fired to fulfill the tracking criteria
 
-  int previousCh(-1), previousSt(-1), nChHitInSt45(0);
-  TrackParam* previousParam(nullptr);
-
+  // count the number of clusters in each chamber and the number of chambers fired on stations 4 and 5
+  int nClusters[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (auto& param : *this) {
+    ++nClusters[param.getClusterPtr()->getChamberId()];
+  }
+  int nChFiredInSt4 = (nClusters[6] > 0) ? 1 : 0;
+  if (nClusters[7] > 0) {
+    ++nChFiredInSt4;
+  }
+  int nChFiredInSt5 = (nClusters[8] > 0) ? 1 : 0;
+  if (nClusters[9] > 0) {
+    ++nChFiredInSt5;
+  }
+  int nChFiredInSt45 = nChFiredInSt4 + nChFiredInSt5;
 
-    int currentCh = param.getClusterPtr()->getChamberId();
-    int currentSt = currentCh / 2;
+  bool removable[10] = {false, false, false, false, false, false, false, false, false, false};
 
-    // set the cluster as removable if the station is not requested or if it is not alone in the station
-    if (((1 << currentSt) & requestedStationMask) == 0) {
-      param.setRemovable(true);
-    } else if (currentSt == previousSt) {
-      previousParam->setRemovable(true);
-      param.setRemovable(true);
-    } else {
-      param.setRemovable(false);
-      previousSt = currentSt;
-      previousParam = &param;
-    }
-
-    // count the number of chambers in station 4 & 5 that contain cluster(s)
-    if (currentCh > 5 && currentCh != previousCh) {
-      ++nChHitInSt45;
-      previousCh = currentCh;
+  // for station 1, 2 and 3, there must be at least one cluster per requested station
+  for (int iCh = 0; iCh < 6; iCh += 2) {
+    if (nClusters[iCh] + nClusters[iCh + 1] > 1 || (requestedStationMask & (1 << (iCh / 2))) == 0) {
+      removable[iCh] = removable[iCh + 1] = true;
     }
   }
 
-  // if there are less than 3 chambers containing cluster(s) in station 4 & 5
-  if (nChHitInSt45 < 3) {
-
-    previousCh = -1;
-    previousParam = nullptr;
-
-    for (auto itParam = this->rbegin(); itParam != this->rend(); ++itParam) {
-
-      int currentCh = itParam->getClusterPtr()->getChamberId();
-
-      if (currentCh < 6) {
-        break;
-      }
-
-      // set the cluster as not removable unless it is not alone in the chamber
-      if (currentCh == previousCh) {
-        previousParam->setRemovable(true);
-        itParam->setRemovable(true);
-      } else {
-        itParam->setRemovable(false);
-        previousCh = currentCh;
-        previousParam = &*itParam;
-      }
+  // for station 4 and 5, there must be at least one cluster per requested station and
+  // at least 2 chambers fired (on the same station or not depending on the requirement)
+  if (nChFiredInSt45 == 4) {
+    removable[6] = removable[7] = removable[8] = removable[9] = true;
+  } else if (nChFiredInSt45 == 3) {
+    if (nChFiredInSt4 == 2 && request2ChInSameSt45) {
+      removable[6] = (nClusters[6] > 1);
+      removable[7] = (nClusters[7] > 1);
+    } else if (nClusters[6] + nClusters[7] > 1 || (requestedStationMask & 0x8) == 0) {
+      removable[6] = removable[7] = true;
     }
+    if (nChFiredInSt5 == 2 && request2ChInSameSt45) {
+      removable[8] = (nClusters[8] > 1);
+      removable[9] = (nClusters[9] > 1);
+    } else if (nClusters[8] + nClusters[9] > 1 || (requestedStationMask & 0x10) == 0) {
+      removable[8] = removable[9] = true;
+    }
+  } else {
+    for (int iCh = 6; iCh < 10; ++iCh) {
+      removable[iCh] = (nClusters[iCh] > 1);
+    }
+  }
+
+  // tag the removable clusters
+  for (auto& param : *this) {
+    param.setRemovable(removable[param.getClusterPtr()->getChamberId()]);
   }
 }
 

--- a/Detectors/MUON/MCH/Tracking/src/Track.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/Track.cxx
@@ -28,8 +28,7 @@ using namespace std;
 
 //__________________________________________________________________________
 Track::Track(const Track& track)
-  : mParamAtVertex(track.mParamAtVertex),
-    mParamAtClusters(track.mParamAtClusters),
+  : mParamAtClusters(track.mParamAtClusters),
     mCurrentParam(nullptr),
     mCurrentChamber(-1),
     mConnected(track.mConnected),

--- a/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginal.cxx
@@ -1221,7 +1221,7 @@ void TrackFinderOriginal::improveTracks()
       }
 
       // Identify removable clusters
-      itTrack->tagRemovableClusters(requestedStationMask());
+      itTrack->tagRemovableClusters(requestedStationMask(), false);
 
       // Look for the cluster with the worst local chi2
       double worstLocalChi2(-1.);


### PR DESCRIPTION
This contains 2 little modifications of the algorithm that allow to slightly improve the track selection in the end of the tracking:
- enforce the same tracking requirements during track improvement as during the tracking itself (e.g. the default requirement to have at least 3/4 chambers fired in stations 4&5 was soften to 2/4)
- select in priority tracks with more chambers fired (instead of more clusters) when cleaning connected tracks to account for DE overlaps within chambers

Unrelated to that, a small left over in the track data members from the initial porting from AliRoot as been removed (separate commit).