### PR TITLE
(O2-1203) [CTF] use merging/splitting iterators during CTF ecoding/decoding for TPC  

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -27,6 +27,25 @@ namespace o2
 {
 namespace ctf
 {
+
+namespace detail
+{
+
+template <class, class Enable = void>
+struct is_iterator : std::false_type {
+};
+
+template <class T>
+struct is_iterator<T, std::enable_if_t<
+                        std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<T>::iterator_category> ||
+                        std::is_same_v<std::output_iterator_tag, typename std::iterator_traits<T>::iterator_category>>>
+  : std::true_type {
+};
+
+template <class T>
+inline constexpr bool is_iterator_v = is_iterator<T>::value;
+} // namespace detail
+
 using namespace o2::rans;
 constexpr size_t Alignment = 16;
 
@@ -384,12 +403,12 @@ class EncodedBlocks
   void encode(const S_IT srcBegin, const S_IT srcEnd, int slot, uint8_t probabilityBits, Metadata::OptStore opt, VB* buffer = nullptr, const void* encoderExt = nullptr);
 
   /// decode block at provided slot to destination vector (will be resized as needed)
-  template <typename VD>
-  void decode(VD& dest, int slot, const void* decoderExt = nullptr) const;
+  template <class container_T, class container_IT = typename container_T::iterator>
+  void decode(container_T& dest, int slot, const void* decoderExt = nullptr) const;
 
   /// decode block at provided slot to destination pointer, the needed space assumed to be available
-  template <typename D>
-  void decode(D* dest, int slot, const void* decoderExt = nullptr) const;
+  template <typename D_IT, std::enable_if_t<detail::is_iterator_v<D_IT>, bool> = true>
+  void decode(D_IT dest, int slot, const void* decoderExt = nullptr) const;
 
   /// create a special EncodedBlocks containing only dictionaries made from provided vector of frequency tables
   static std::vector<char> createDictionaryBlocks(const std::vector<o2::rans::FrequencyTable>& vfreq, const std::vector<Metadata>& prbits);
@@ -666,25 +685,27 @@ void EncodedBlocks<H, N, W>::print(const std::string& prefix) const
 
 ///_____________________________________________________________________________
 template <typename H, int N, typename W>
-template <typename VD>
-inline void EncodedBlocks<H, N, W>::decode(VD& dest,                     // destination container
+template <class container_T, class container_IT>
+inline void EncodedBlocks<H, N, W>::decode(container_T& dest,            // destination container
                                            int slot,                     // slot of the block to decode
                                            const void* decoderExt) const // optional externally provided decoder
 {
   dest.resize(mMetadata[slot].messageLength); // allocate output buffer
-  decode(dest.data(), slot, decoderExt);
+  decode(std::begin(dest), slot, decoderExt);
 }
 
 ///_____________________________________________________________________________
 template <typename H, int N, typename W>
-template <typename D>
-void EncodedBlocks<H, N, W>::decode(D* dest,                      // destination pointer
+template <typename D_IT, std::enable_if_t<detail::is_iterator_v<D_IT>, bool>>
+void EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to destination
                                     int slot,                     // slot of the block to decode
                                     const void* decoderExt) const // optional externally provided decoder
 {
   // get references to the right data
   const auto& block = mBlocks[slot];
   const auto& md = mMetadata[slot];
+
+  using dest_t = typename std::iterator_traits<D_IT>::value_type;
 
   // decode
   if (block.getNStored()) {
@@ -693,12 +714,12 @@ void EncodedBlocks<H, N, W>::decode(D* dest,                      // destination
         LOG(ERROR) << "Dictionaty is not saved for slot " << slot << " and no external decoder is provided";
         throw std::runtime_error("Dictionary is not saved and no external decoder provided");
       }
-      const o2::rans::LiteralDecoder64<D>* decoder = reinterpret_cast<const o2::rans::LiteralDecoder64<D>*>(decoderExt);
-      std::unique_ptr<o2::rans::LiteralDecoder64<D>> decoderLoc;
+      const o2::rans::LiteralDecoder64<dest_t>* decoder = reinterpret_cast<const o2::rans::LiteralDecoder64<dest_t>*>(decoderExt);
+      std::unique_ptr<o2::rans::LiteralDecoder64<dest_t>> decoderLoc;
       if (block.getNDict()) { // if dictionaty is saved, prefer it
         o2::rans::FrequencyTable frequencies;
         frequencies.addFrequencies(block.getDict(), block.getDict() + block.getNDict(), md.min, md.max);
-        decoderLoc = std::make_unique<o2::rans::LiteralDecoder64<D>>(frequencies, md.probabilityBits);
+        decoderLoc = std::make_unique<o2::rans::LiteralDecoder64<dest_t>>(frequencies, md.probabilityBits);
         decoder = decoderLoc.get();
       } else { // verify that decoded corresponds to stored metadata
         if (md.min != decoder->getMinSymbol() || md.max != decoder->getMaxSymbol()) {
@@ -708,16 +729,20 @@ void EncodedBlocks<H, N, W>::decode(D* dest,                      // destination
         }
       }
       // load incompressible symbols if they existed
-      std::vector<D> literals;
+      std::vector<dest_t> literals;
       if (block.getNLiterals()) {
         // note: here we have to use md.nLiterals (original number of literal words) rather than md.nLiteralWords == block.getNLiterals()
         // (number of W-words in the EncodedBlock occupied by literals) as we cast literals stored in W-word array
         // to D-word array
-        literals = std::vector<D>{reinterpret_cast<const D*>(block.getLiterals()), reinterpret_cast<const D*>(block.getLiterals()) + md.nLiterals};
+        literals = std::vector<dest_t>{reinterpret_cast<const dest_t*>(block.getLiterals()), reinterpret_cast<const dest_t*>(block.getLiterals()) + md.nLiterals};
       }
       decoder->process(dest, block.getData() + block.getNData(), md.messageLength, literals);
     } else { // data was stored as is
-      std::memcpy(dest, block.payload, md.messageLength * sizeof(D));
+      using destPtr_t = typename std::iterator_traits<D_IT>::pointer;
+      destPtr_t srcBegin = reinterpret_cast<destPtr_t>(block.payload);
+      destPtr_t srcEnd = srcBegin + md.messageLength * sizeof(dest_t);
+      std::copy(srcBegin, srcEnd, dest);
+      //std::memcpy(dest, block.payload, md.messageLength * sizeof(dest_t));
     }
   }
 }
@@ -738,7 +763,7 @@ void EncodedBlocks<H, N, W>::encode(const S_IT srcBegin,     // iterator begin o
   mRegistry.nFilledBlocks++;
   using STYP = typename std::iterator_traits<S_IT>::value_type;
   using stream_t = typename o2::rans::Encoder64<STYP>::stream_t;
-  ;
+
   const size_t messageLength = std::distance(srcBegin, srcEnd);
   // cover three cases:
   // * empty source message: no entropy coding
@@ -825,6 +850,7 @@ void EncodedBlocks<H, N, W>::encode(const S_IT srcBegin,     // iterator begin o
     // no dictionary needed
     expandStorage(dataSize);
     *meta = Metadata{messageLength, 0, sizeof(uint64_t), sizeof(stream_t), probabilityBits, opt, 0, 0, 0, dataSize, 0};
+    //FIXME: no we don't need an intermediate vector.
     // provided iterator is not necessarily pointer, need to use intermediate vector!!!
     std::vector<STYP> vtmp(srcBegin, srcEnd);
     bl->storeData(meta->nDataWords, reinterpret_cast<const W*>(vtmp.data()));

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -376,7 +376,7 @@ class EncodedBlocks
   template <typename VE, typename VB>
   inline void encode(const VE& src, int slot, uint8_t probabilityBits, Metadata::OptStore opt, VB* buffer = nullptr, const void* encoderExt = nullptr)
   {
-    encode(&(*src.begin()), &(*src.end()), slot, probabilityBits, opt, buffer, encoderExt);
+    encode(std::begin(src), std::end(src), slot, probabilityBits, opt, buffer, encoderExt);
   }
 
   /// encode vector src to bloc at provided slot

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
@@ -33,6 +33,8 @@ struct CTFHeader : public CompressedClustersCounters {
 /// wrapper for the Entropy-encoded clusters of the TF
 struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t> {
 
+  using container_t = o2::ctf::EncodedBlocks<CTFHeader, 23, uint32_t>;
+
   static constexpr size_t N = getNBlocks();
   static constexpr int NBitsQTot = 16;
   static constexpr int NBitsQMax = 10;

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -59,10 +59,13 @@ class CTFCoderBase
   template <typename S>
   void createCoder(OpType op, const o2::rans::FrequencyTable& freq, uint8_t probabilityBits, int slot)
   {
-    if (op == OpType::Encoder) {
-      mCoders[slot].reset(new o2::rans::LiteralEncoder64<S>(freq, probabilityBits));
-    } else {
-      mCoders[slot].reset(new o2::rans::LiteralDecoder64<S>(freq, probabilityBits));
+    switch (op) {
+      case OpType::Encoder:
+        mCoders[slot].reset(new o2::rans::LiteralEncoder64<S>(freq, probabilityBits));
+        break;
+      case OpType::Decoder:
+        mCoders[slot].reset(new o2::rans::LiteralDecoder64<S>(freq, probabilityBits));
+        break;
     }
   }
 

--- a/Detectors/CTF/test/test_ctf_io_tpc.cxx
+++ b/Detectors/CTF/test/test_ctf_io_tpc.cxx
@@ -42,6 +42,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   {
     CTFCoder coder;
     coder.setCompClusAddresses(c, buff);
+    coder.setCombineColumns(true);
   }
   ccFlat->set(sz, c);
 
@@ -85,6 +86,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   std::vector<o2::ctf::BufferType> vecIO;
   {
     CTFCoder coder;
+    coder.setCombineColumns(true);
     coder.encode(vecIO, c); // compress
   }
   sw.Stop();
@@ -120,6 +122,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   const auto ctfImage = o2::tpc::CTF::getImage(vecIO.data());
   {
     CTFCoder coder;
+    coder.setCombineColumns(true);
     coder.decode(ctfImage, vecIn); // decompress
   }
   sw.Stop();

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -160,8 +160,10 @@ void CTFCoder::splitColumns(const std::vector<detail::combinedType_t<NU, NL>>& v
 {
   static_assert(NU <= sizeof(CU) * 8 && NL <= sizeof(CL) * 8, "output columns bit count is wrong");
 
-  detail::ShiftFunctor<detail::combinedType_t<NU, NL>, NL> f;
-  o2::rans::utils::CombinedOutputIterator iter(vu, vl, f);
+  using combined_t = detail::combinedType_t<NU, NL>;
+
+  detail::ShiftFunctor<combined_t, NL> f;
+  auto iter = rans::utils::CombinedOutputIteratorFactory<combined_t>::makeIter(vu, vl, f);
 
   for (auto value : vm) {
     *iter = value;

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <string>
 #include <cassert>
+#include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
@@ -27,6 +28,7 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/CTFCoderBase.h"
 #include "rANS/rans.h"
+#include "rANS/utils.h"
 
 class TTree;
 
@@ -35,11 +37,56 @@ namespace o2
 namespace tpc
 {
 
+namespace detail
+{
+
+template <int A, int B>
+struct combinedType {
+  using type = std::conditional_t<(A + B > 16), uint32_t, std::conditional_t<(A + B > 8), uint16_t, uint8_t>>;
+};
+
+template <int A, int B>
+using combinedType_t = typename combinedType<A, B>::type;
+
+template <typename value_T, size_t shift>
+class ShiftFunctor
+{
+ public:
+  template <typename iterA_T, typename iterB_T>
+  inline value_T operator()(iterA_T iterA, iterB_T iterB) const
+  {
+    return *iterB + (static_cast<value_T>(*iterA) << shift);
+  };
+
+  template <typename iterA_T, typename iterB_T>
+  inline void operator()(iterA_T iterA, iterB_T iterB, value_T value) const
+  {
+    *iterA = value >> shift;
+    *iterB = value & ((0x1 << shift) - 0x1);
+  };
+};
+
+template <typename iterA_T, typename iterB_T, typename F>
+auto makeInputIterators(iterA_T iterA, iterB_T iterB, size_t nElements, F functor)
+{
+  using namespace o2::rans::utils;
+
+  auto advanceIter = [](auto iter, size_t nElements) {
+    auto tmp = iter;
+    std::advance(tmp, nElements);
+    return tmp;
+  };
+
+  return std::make_tuple(CombinedInputIterator{iterA, iterB, functor},
+                         CombinedInputIterator{advanceIter(iterA, nElements), advanceIter(iterB, nElements), functor});
+};
+
+} // namespace detail
+
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TPC) {}
-  ~CTFCoder() = default;
 
   /// entropy-encode compressed clusters to flat buffer
   template <typename VEC>
@@ -79,55 +126,47 @@ class CTFCoder : public o2::ctf::CTFCoderBase
  private:
   void checkDataDictionaryConsistency(const CTFHeader& h);
 
-  template <int NU, int NL>
-  static constexpr auto MVAR()
-  {
-    typename std::conditional<(NU + NL > 16), uint32_t, typename std::conditional<(NU + NL > 8), uint16_t, uint8_t>::type>::type tp = 0;
-    return tp;
-  }
-  template <int NU, int NL>
-  static constexpr auto MPTR()
-  {
-    typename std::conditional<(NU + NL > 16), uint32_t, typename std::conditional<(NU + NL > 8), uint16_t, uint8_t>::type>::type* tp = nullptr;
-    return tp;
-  }
-#define MTYPE(A, B) decltype(CTFCoder::MVAR<A, B>())
-
   template <int NU, int NL, typename CU, typename CL>
-  static void splitColumns(const std::vector<MTYPE(NU, NL)>& vm, CU*& vu, CL*& vl);
+  static void splitColumns(const std::vector<detail::combinedType_t<NU, NL>>& vm, CU*& vu, CL*& vl);
 
-  template <int NU, int NL, typename CU, typename CL>
-  static auto mergeColumns(const CU* vu, const CL* vl, size_t nelem);
+  template <typename source_T>
+  void buildCoder(ctf::CTFCoderBase::OpType coderType, const CTF::container_t& ctf, CTF::Slots slot);
 
   bool mCombineColumns = false; // combine correlated columns
 
   ClassDefNV(CTFCoder, 1);
 };
 
-/// split words of input vector to columns assigned to provided pointers (memory must be allocated in advance)
-template <int NU, int NL, typename CU, typename CL>
-void CTFCoder::splitColumns(const std::vector<MTYPE(NU, NL)>& vm, CU*& vu, CL*& vl)
+template <typename source_T>
+void CTFCoder::buildCoder(ctf::CTFCoderBase::OpType coderType, const CTF::container_t& ctf, CTF::Slots slot)
 {
-  static_assert(NU <= sizeof(CU) * 8 && NL <= sizeof(CL) * 8, "output columns bit count is wrong");
-  size_t n = vm.size();
-  for (size_t i = 0; i < n; i++) {
-    vu[i] = static_cast<CU>(vm[i] >> NL);
-    vl[i] = static_cast<CL>(vm[i] & ((0x1 << NL) - 1));
-  }
+  auto buildFrequencyTable = [](const CTF::container_t& ctf, CTF::Slots slot) -> rans::FrequencyTable {
+    rans::FrequencyTable frequencyTable;
+    auto block = ctf.getBlock(slot);
+    auto metaData = ctf.getMetadata(slot);
+    frequencyTable.addFrequencies(block.getDict(), block.getDict() + block.getNDict(), metaData.min, metaData.max);
+    return frequencyTable;
+  };
+  auto getProbabilityBits = [](const CTF::container_t& ctf, CTF::Slots slot) -> int {
+    return ctf.getMetadata(slot).probabilityBits;
+  };
+
+  this->createCoder<source_T>(coderType, buildFrequencyTable(ctf, slot), getProbabilityBits(ctf, slot), static_cast<int>(slot));
 }
 
-/// merge elements of 2 columns pointed by vu and vl to a single vector with wider field
+/// split words of input vector to columns assigned to provided pointers (memory must be allocated in advance)
 template <int NU, int NL, typename CU, typename CL>
-auto CTFCoder::mergeColumns(const CU* vu, const CL* vl, size_t nelem)
+void CTFCoder::splitColumns(const std::vector<detail::combinedType_t<NU, NL>>& vm, CU*& vu, CL*& vl)
 {
-  // merge 2 columns to 1
-  static_assert(NU <= sizeof(NU) * 8 && NL <= sizeof(NL) * 8, "input columns bit count is wrong");
-  std::vector<MTYPE(NU, NL)> outv;
-  outv.reserve(nelem);
-  for (size_t i = 0; i < nelem; i++) {
-    outv.push_back((static_cast<MTYPE(NU, NL)>(vu[i]) << NL) | static_cast<MTYPE(NU, NL)>(vl[i]));
+  static_assert(NU <= sizeof(CU) * 8 && NL <= sizeof(CL) * 8, "output columns bit count is wrong");
+
+  detail::ShiftFunctor<detail::combinedType_t<NU, NL>, NL> f;
+  o2::rans::utils::CombinedOutputIterator iter(vu, vl, f);
+
+  for (auto value : vm) {
+    *iter = value;
+    ++iter;
   }
-  return std::move(outv);
 }
 
 /// entropy-encode clusters to buffer with CTF
@@ -135,6 +174,7 @@ template <typename VEC>
 void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
 {
   using MD = o2::ctf::Metadata::OptStore;
+  using namespace detail;
   // what to do which each field: see o2::ctf::Metadata explanation
   constexpr MD optField[CTF::getNBlocks()] = {
     MD::EENCODE, //qTotA
@@ -174,73 +214,75 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   ec->setHeader(CTFHeader{reinterpret_cast<const CompressedClustersCounters&>(ccl), flags});
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
-  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
-#define ENCODETPC(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
-  // clang-format off
+
+  auto encodeTPC = [&buff, &optField, &coders = mCoders](auto begin, auto end, CTF::Slots slot, size_t probabilityBits) {
+    // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+    const auto slotVal = static_cast<int>(slot);
+    CTF::get(buff.data())->encode(begin, end, slotVal, probabilityBits, optField[slotVal], &buff, coders[slotVal].get());
+  };
 
   if (mCombineColumns) {
-    auto mrg = mergeColumns<CTF::NBitsQTot, CTF::NBitsQMax>(ccl.qTotA, ccl.qMaxA, ccl.nAttachedClusters);
-    ENCODETPC(&mrg[0],             (&mrg[0]) + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
+    const auto [begin, end] = makeInputIterators(ccl.qTotA, ccl.qMaxA, ccl.nAttachedClusters,
+                                                 ShiftFunctor<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>, CTF::NBitsQMax>{});
+    encodeTPC(begin, end, CTF::BLCqTotA, 0);
+  } else {
+    encodeTPC(ccl.qTotA, ccl.qTotA + ccl.nAttachedClusters, CTF::BLCqTotA, 0);
   }
-  else {
-    ENCODETPC(ccl.qTotA,           ccl.qTotA + ccl.nAttachedClusters,                CTF::BLCqTotA,             0);
-  }
-  ENCODETPC(ccl.qMaxA,             ccl.qMaxA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCqMaxA,    0);
-  
-  ENCODETPC(ccl.flagsA,            ccl.flagsA + ccl.nAttachedClusters,               CTF::BLCflagsA,            0);
-  
-  if (mCombineColumns) {
-    auto mrg = mergeColumns<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>(ccl.rowDiffA, ccl.sliceLegDiffA, ccl.nAttachedClustersReduced);    
-    ENCODETPC(&mrg[0],             (&mrg[0]) + ccl.nAttachedClustersReduced,         CTF::BLCrowDiffA,          0);
-  }
-  else {
-    ENCODETPC(ccl.rowDiffA,        ccl.rowDiffA + ccl.nAttachedClustersReduced,      CTF::BLCrowDiffA,          0);
-  }
-  ENCODETPC(ccl.sliceLegDiffA,     ccl.sliceLegDiffA + (mCombineColumns ? 0 : ccl.nAttachedClustersReduced), CTF::BLCsliceLegDiffA, 0);
+  encodeTPC(ccl.qMaxA, ccl.qMaxA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCqMaxA, 0);
 
-  ENCODETPC(ccl.padResA,           ccl.padResA + ccl.nAttachedClustersReduced,       CTF::BLCpadResA,           0);
-  ENCODETPC(ccl.timeResA,          ccl.timeResA + ccl.nAttachedClustersReduced,      CTF::BLCtimeResA,          0);
+  encodeTPC(ccl.flagsA, ccl.flagsA + ccl.nAttachedClusters, CTF::BLCflagsA, 0);
 
   if (mCombineColumns) {
-    auto mrg = mergeColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(ccl.sigmaPadA, ccl.sigmaTimeA, ccl.nAttachedClusters);
-    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nAttachedClusters,                  CTF::BLCsigmaPadA,         0);
+    const auto [begin, end] = makeInputIterators(ccl.rowDiffA, ccl.sliceLegDiffA, ccl.nAttachedClustersReduced,
+                                                 ShiftFunctor<combinedType_t<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>, CTF::NBitsSliceLegDiff>{});
+    encodeTPC(begin, end, CTF::BLCrowDiffA, 0);
+  } else {
+    encodeTPC(ccl.rowDiffA, ccl.rowDiffA + ccl.nAttachedClustersReduced, CTF::BLCrowDiffA, 0);
   }
-  else {
-    ENCODETPC(ccl.sigmaPadA,       ccl.sigmaPadA + ccl.nAttachedClusters,            CTF::BLCsigmaPadA,         0);
-  }
-  ENCODETPC(ccl.sigmaTimeA,        ccl.sigmaTimeA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCsigmaTimeA, 0);  
+  encodeTPC(ccl.sliceLegDiffA, ccl.sliceLegDiffA + (mCombineColumns ? 0 : ccl.nAttachedClustersReduced), CTF::BLCsliceLegDiffA, 0);
 
-  ENCODETPC(ccl.qPtA,              ccl.qPtA + ccl.nTracks,                           CTF::BLCqPtA,              0);
-  ENCODETPC(ccl.rowA,              ccl.rowA + ccl.nTracks,                           CTF::BLCrowA,              0);
-  ENCODETPC(ccl.sliceA,            ccl.sliceA + ccl.nTracks,                         CTF::BLCsliceA,            0);
-  ENCODETPC(ccl.timeA,             ccl.timeA + ccl.nTracks,                          CTF::BLCtimeA,             0);
-  ENCODETPC(ccl.padA,              ccl.padA + ccl.nTracks,                           CTF::BLCpadA,              0);
+  encodeTPC(ccl.padResA, ccl.padResA + ccl.nAttachedClustersReduced, CTF::BLCpadResA, 0);
+  encodeTPC(ccl.timeResA, ccl.timeResA + ccl.nAttachedClustersReduced, CTF::BLCtimeResA, 0);
 
   if (mCombineColumns) {
-    auto mrg = mergeColumns<CTF::NBitsQTot, CTF::NBitsQMax>(ccl.qTotU,ccl.qMaxU,ccl.nUnattachedClusters);
-    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nUnattachedClusters,                CTF::BLCqTotU,             0);
+    const auto [begin, end] = makeInputIterators(ccl.sigmaPadA, ccl.sigmaTimeA, ccl.nAttachedClusters,
+                                                 ShiftFunctor<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>, CTF::NBitsSigmaTime>{});
+    encodeTPC(begin, end, CTF::BLCsigmaPadA, 0);
+  } else {
+    encodeTPC(ccl.sigmaPadA, ccl.sigmaPadA + ccl.nAttachedClusters, CTF::BLCsigmaPadA, 0);
   }
-  else {    
-    ENCODETPC(ccl.qTotU,           ccl.qTotU + ccl.nUnattachedClusters,              CTF::BLCqTotU,             0);
-  }
-  ENCODETPC(ccl.qMaxU,             ccl.qMaxU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCqMaxU,  0);
+  encodeTPC(ccl.sigmaTimeA, ccl.sigmaTimeA + (mCombineColumns ? 0 : ccl.nAttachedClusters), CTF::BLCsigmaTimeA, 0);
 
-  ENCODETPC(ccl.flagsU,            ccl.flagsU + ccl.nUnattachedClusters,             CTF::BLCflagsU,            0);
-  ENCODETPC(ccl.padDiffU,          ccl.padDiffU + ccl.nUnattachedClusters,           CTF::BLCpadDiffU,          0);
-  ENCODETPC(ccl.timeDiffU,         ccl.timeDiffU + ccl.nUnattachedClusters,          CTF::BLCtimeDiffU,         0);
+  encodeTPC(ccl.qPtA, ccl.qPtA + ccl.nTracks, CTF::BLCqPtA, 0);
+  encodeTPC(ccl.rowA, ccl.rowA + ccl.nTracks, CTF::BLCrowA, 0);
+  encodeTPC(ccl.sliceA, ccl.sliceA + ccl.nTracks, CTF::BLCsliceA, 0);
+  encodeTPC(ccl.timeA, ccl.timeA + ccl.nTracks, CTF::BLCtimeA, 0);
+  encodeTPC(ccl.padA, ccl.padA + ccl.nTracks, CTF::BLCpadA, 0);
 
   if (mCombineColumns) {
-    auto mrg = mergeColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(ccl.sigmaPadU, ccl.sigmaTimeU, ccl.nUnattachedClusters);
-    ENCODETPC(&mrg[0],             &mrg[0] + ccl.nUnattachedClusters,                CTF::BLCsigmaPadU,         0);
+    const auto [begin, end] = makeInputIterators(ccl.qTotU, ccl.qMaxU, ccl.nUnattachedClusters,
+                                                 ShiftFunctor<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>, CTF::NBitsQMax>{});
+    encodeTPC(begin, end, CTF::BLCqTotU, 0);
+  } else {
+    encodeTPC(ccl.qTotU, ccl.qTotU + ccl.nUnattachedClusters, CTF::BLCqTotU, 0);
   }
-  else {
-    ENCODETPC(ccl.sigmaPadU,       ccl.sigmaPadU + ccl.nUnattachedClusters,          CTF::BLCsigmaPadU,         0);
-  }
-  ENCODETPC(ccl.sigmaTimeU,        ccl.sigmaTimeU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCsigmaTimeU, 0);
+  encodeTPC(ccl.qMaxU, ccl.qMaxU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCqMaxU, 0);
 
-  ENCODETPC(ccl.nTrackClusters,    ccl.nTrackClusters + ccl.nTracks,                 CTF::BLCnTrackClusters,    0);
-  ENCODETPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows,           CTF::BLCnSliceRowClusters, 0);
-  // clang-format on
+  encodeTPC(ccl.flagsU, ccl.flagsU + ccl.nUnattachedClusters, CTF::BLCflagsU, 0);
+  encodeTPC(ccl.padDiffU, ccl.padDiffU + ccl.nUnattachedClusters, CTF::BLCpadDiffU, 0);
+  encodeTPC(ccl.timeDiffU, ccl.timeDiffU + ccl.nUnattachedClusters, CTF::BLCtimeDiffU, 0);
+
+  if (mCombineColumns) {
+    const auto [begin, end] = makeInputIterators(ccl.sigmaPadU, ccl.sigmaTimeU, ccl.nUnattachedClusters,
+                                                 ShiftFunctor<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>, CTF::NBitsSigmaTime>{});
+    encodeTPC(begin, end, CTF::BLCsigmaPadU, 0);
+  } else {
+    encodeTPC(ccl.sigmaPadU, ccl.sigmaPadU + ccl.nUnattachedClusters, CTF::BLCsigmaPadU, 0);
+  }
+  encodeTPC(ccl.sigmaTimeU, ccl.sigmaTimeU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCsigmaTimeU, 0);
+
+  encodeTPC(ccl.nTrackClusters, ccl.nTrackClusters + ccl.nTracks, CTF::BLCnTrackClusters, 0);
+  encodeTPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows, CTF::BLCnSliceRowClusters, 0);
   CTF::get(buff.data())->print(getPrefix());
 }
 
@@ -248,6 +290,7 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
 template <typename VEC>
 void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
 {
+  using namespace detail;
   CompressedClusters cc;
   CompressedClustersCounters& ccCount = cc;
   auto& header = ec.getHeader();
@@ -269,7 +312,7 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
 #define DECODETPC(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
   if (mCombineColumns) {
-    std::vector<MTYPE(CTF::NBitsQTot, CTF::NBitsQMax)> mrg;
+    std::vector<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>> mrg;
     DECODETPC(mrg,                  CTF::BLCqTotA);
     splitColumns<CTF::NBitsQTot, CTF::NBitsQMax>(mrg, cc.qTotA, cc.qMaxA);
   }
@@ -281,7 +324,7 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   DECODETPC(cc.flagsA,              CTF::BLCflagsA);
   
   if (mCombineColumns) {
-    std::vector<MTYPE(CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff)> mrg;
+    std::vector<combinedType_t<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>> mrg;
     DECODETPC(mrg,                  CTF::BLCrowDiffA);
     splitColumns<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>(mrg, cc.rowDiffA, cc.sliceLegDiffA);
   }
@@ -294,7 +337,7 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   DECODETPC(cc.timeResA,            CTF::BLCtimeResA);
 
   if (mCombineColumns) {
-    std::vector<MTYPE(CTF::NBitsSigmaPad, CTF::NBitsSigmaTime)> mrg;
+    std::vector<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>> mrg;
     DECODETPC(mrg,                  CTF::BLCsigmaPadA);
     splitColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(mrg, cc.sigmaPadA, cc.sigmaTimeA);
   }
@@ -310,7 +353,7 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   DECODETPC(cc.padA,                CTF::BLCpadA);
 
   if (mCombineColumns) {
-    std::vector<MTYPE(CTF::NBitsQTot, CTF::NBitsQMax)> mrg;
+    std::vector<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>> mrg;
     DECODETPC(mrg,                  CTF::BLCqTotU);
     splitColumns<CTF::NBitsQTot, CTF::NBitsQMax>(mrg, cc.qTotU, cc.qMaxU);
   }
@@ -324,7 +367,7 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   DECODETPC(cc.timeDiffU,           CTF::BLCtimeDiffU);
 
   if (mCombineColumns) {
-    std::vector<MTYPE(CTF::NBitsSigmaPad, CTF::NBitsSigmaTime)> mrg;
+    std::vector<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>> mrg;
     DECODETPC(mrg,                  CTF::BLCsigmaPadU);
     splitColumns<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>(mrg, cc.sigmaPadU, cc.sigmaTimeU);
   }
@@ -337,7 +380,6 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   DECODETPC(cc.nSliceRowClusters,   CTF::BLCnSliceRowClusters);
   // clang-format on
 }
-#undef MTYPE
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TPC/reconstruction/src/CTFCoder.cxx
@@ -91,6 +91,8 @@ void CTFCoder::setCompClusAddresses(CompressedClusters& c, void*& buff)
 ///________________________________
 void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
 {
+  using namespace detail;
+
   bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
   auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
   if (!buff.size()) {
@@ -99,73 +101,55 @@ void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::
     }
     throw std::runtime_error("Failed to create CTF dictionaty");
   }
-  const auto* ctf = CTF::get(buff.data());
+  const CTF::container_t* ctf = CTF::get(buff.data());
   mCombineColumns = ctf->getHeader().flags & CTFHeader::CombinedColumns;
   LOG(INFO) << "TPC CTF Columns Combining " << (mCombineColumns ? "ON" : "OFF");
 
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
+  const CompressedClusters cc; // just to get member types
+  if (mCombineColumns) {
+    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, *ctf, CTF::BLCqTotA);
+  } else {
+    buildCoder<std::remove_pointer_t<decltype(cc.qTotA)>>(op, *ctf, CTF::BLCqTotA);
+  }
+  buildCoder<std::remove_pointer_t<decltype(cc.qMaxA)>>(op, *ctf, CTF::BLCqMaxA);
+  buildCoder<std::remove_pointer_t<decltype(cc.flagsA)>>(op, *ctf, CTF::BLCflagsA);
+  if (mCombineColumns) {
+    buildCoder<combinedType_t<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>>(op, *ctf, CTF::BLCrowDiffA); // merged rowDiffA and sliceLegDiffA
 
-  CompressedClusters cc; // just to get member types
-#define MAKECODER(part, slot) createCoder<std::remove_pointer<decltype(part)>::type>(op, getFreq(slot), getProbBits(slot), int(slot))
-  // clang-format off
+  } else {
+    buildCoder<std::remove_pointer_t<decltype(cc.rowDiffA)>>(op, *ctf, CTF::BLCrowDiffA);
+  }
+  buildCoder<std::remove_pointer_t<decltype(cc.sliceLegDiffA)>>(op, *ctf, CTF::BLCsliceLegDiffA);
+  buildCoder<std::remove_pointer_t<decltype(cc.padResA)>>(op, *ctf, CTF::BLCpadResA);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeResA)>>(op, *ctf, CTF::BLCtimeResA);
   if (mCombineColumns) {
-    MAKECODER( (MPTR<CTF::NBitsQTot, CTF::NBitsQMax>()),             CTF::BLCqTotA); //  merged qTotA and qMaxA
+    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, *ctf, CTF::BLCsigmaPadA); // merged sigmaPadA and sigmaTimeA
+  } else {
+    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadA)>>(op, *ctf, CTF::BLCsigmaPadA);
   }
-  else {
-    MAKECODER(cc.qTotA,           CTF::BLCqTotA);
-  }
-  MAKECODER(cc.qMaxA,             CTF::BLCqMaxA);
-  MAKECODER(cc.flagsA,            CTF::BLCflagsA);
+  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeA)>>(op, *ctf, CTF::BLCsigmaTimeA);
+  buildCoder<std::remove_pointer_t<decltype(cc.qPtA)>>(op, *ctf, CTF::BLCqPtA);
+  buildCoder<std::remove_pointer_t<decltype(cc.rowA)>>(op, *ctf, CTF::BLCrowA);
+  buildCoder<std::remove_pointer_t<decltype(cc.sliceA)>>(op, *ctf, CTF::BLCsliceA);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeA)>>(op, *ctf, CTF::BLCtimeA);
+  buildCoder<std::remove_pointer_t<decltype(cc.padA)>>(op, *ctf, CTF::BLCpadA);
   if (mCombineColumns) {
-    MAKECODER( (MPTR<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>()),  CTF::BLCrowDiffA); // merged rowDiffA and sliceLegDiffA
+    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, *ctf, CTF::BLCqTotU); // merged qTotU and qMaxU
+  } else {
+    buildCoder<std::remove_pointer_t<decltype(cc.qTotU)>>(op, *ctf, CTF::BLCqTotU);
   }
-  else {
-    MAKECODER(cc.rowDiffA,        CTF::BLCrowDiffA);
-  }
-  MAKECODER(cc.sliceLegDiffA,     CTF::BLCsliceLegDiffA);
-  MAKECODER(cc.padResA,           CTF::BLCpadResA);
-  MAKECODER(cc.timeResA,          CTF::BLCtimeResA);
+  buildCoder<std::remove_pointer_t<decltype(cc.qMaxU)>>(op, *ctf, CTF::BLCqMaxU);
+  buildCoder<std::remove_pointer_t<decltype(cc.flagsU)>>(op, *ctf, CTF::BLCflagsU);
+  buildCoder<std::remove_pointer_t<decltype(cc.padDiffU)>>(op, *ctf, CTF::BLCpadDiffU);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeDiffU)>>(op, *ctf, CTF::BLCtimeDiffU);
   if (mCombineColumns) {
-    MAKECODER( (MPTR<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>()),    CTF::BLCsigmaPadA); // merged sigmaPadA and sigmaTimeA
+    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, *ctf, CTF::BLCsigmaPadU); // merged sigmaPadU and sigmaTimeU
+  } else {
+    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadU)>>(op, *ctf, CTF::BLCsigmaPadU);
   }
-  else {
-    MAKECODER(cc.sigmaPadA,       CTF::BLCsigmaPadA);
-  }
-  MAKECODER(cc.sigmaTimeA,        CTF::BLCsigmaTimeA);  
-  MAKECODER(cc.qPtA,              CTF::BLCqPtA);
-  MAKECODER(cc.rowA,              CTF::BLCrowA);
-  MAKECODER(cc.sliceA,            CTF::BLCsliceA);
-  MAKECODER(cc.timeA,             CTF::BLCtimeA);
-  MAKECODER(cc.padA,              CTF::BLCpadA);
-  if (mCombineColumns) {
-    MAKECODER( (MPTR<CTF::NBitsQTot, CTF::NBitsQMax>()),             CTF::BLCqTotU); // merged qTotU and qMaxU
-  }
-  else {
-    MAKECODER(cc.qTotU,           CTF::BLCqTotU);
-  }
-  MAKECODER(cc.qMaxU,             CTF::BLCqMaxU);
-  MAKECODER(cc.flagsU,            CTF::BLCflagsU);
-  MAKECODER(cc.padDiffU,          CTF::BLCpadDiffU);
-  MAKECODER(cc.timeDiffU,         CTF::BLCtimeDiffU);
-  if (mCombineColumns) {
-    MAKECODER( (MPTR<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>()),    CTF::BLCsigmaPadU); // merged sigmaPadA and sigmaTimeA
-  }
-  else {
-    MAKECODER(cc.sigmaPadU,       CTF::BLCsigmaPadU);
-  }
-  MAKECODER(cc.sigmaTimeU,        CTF::BLCsigmaTimeU);
-  MAKECODER(cc.nTrackClusters,    CTF::BLCnTrackClusters);
-  MAKECODER(cc.nSliceRowClusters, CTF::BLCnSliceRowClusters);
-  // clang-format on
+  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeU)>>(op, *ctf, CTF::BLCsigmaTimeU);
+  buildCoder<std::remove_pointer_t<decltype(cc.nTrackClusters)>>(op, *ctf, CTF::BLCnTrackClusters);
+  buildCoder<std::remove_pointer_t<decltype(cc.nSliceRowClusters)>>(op, *ctf, CTF::BLCnSliceRowClusters);
 }
 
 /// make sure loaded dictionaries (if any) are consistent with data

--- a/Utilities/rANS/benchmarks/bench_ransCombinedIterator.cxx
+++ b/Utilities/rANS/benchmarks/bench_ransCombinedIterator.cxx
@@ -99,7 +99,7 @@ static void BM_Array_Write_Iterator(benchmark::State& state)
       *iterB = value & ((1 << shift) - 1);
     };
 
-    o2::rans::utils::CombinedOutputIterator out(a.begin(), b.begin(), writeOP);
+    auto out = o2::rans::utils::CombinedOutputIteratorFactory<uint32_t>::makeIter(a.begin(), b.begin(), writeOP);
 
     for (auto iter = c.begin(); iter != c.end(); ++iter) {
       *out = *iter + 1;

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -31,6 +31,7 @@
 #include "internal/SymbolTable.h"
 #include "internal/Decoder.h"
 #include "internal/SymbolStatistics.h"
+#include "internal/helper.h"
 
 namespace o2
 {
@@ -54,7 +55,7 @@ class Decoder
   ~Decoder() = default;
   Decoder(const FrequencyTable& stats, size_t probabilityBits);
 
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   void process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength) const;
 
   size_t getAlphabetRangeBits() const { return mSymbolTable->getAlphabetRangeBits(); }
@@ -107,15 +108,13 @@ Decoder<coder_T, stream_T, source_T>::Decoder(const FrequencyTable& frequencies,
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 void Decoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength) const
 {
   using namespace internal;
   LOG(trace) << "start decoding";
   RANSTimer t;
   t.start();
-  static_assert(std::is_same<typename std::iterator_traits<source_IT>::value_type, source_T>::value);
-  static_assert(std::is_same<typename std::iterator_traits<stream_IT>::value_type, stream_T>::value);
 
   if (messageLength == 0) {
     LOG(warning) << "Empty message passed to decoder, skipping decode process";

--- a/Utilities/rANS/include/rANS/DedupDecoder.h
+++ b/Utilities/rANS/include/rANS/DedupDecoder.h
@@ -44,12 +44,12 @@ class DedupDecoder : public Decoder<coder_T, stream_T, source_T>
  public:
   using duplicatesMap_t = std::map<uint32_t, uint32_t>;
 
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   void process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength, duplicatesMap_t& duplicates) const;
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 void DedupDecoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength, duplicatesMap_t& duplicates) const
 {
   using namespace internal;

--- a/Utilities/rANS/include/rANS/DedupEncoder.h
+++ b/Utilities/rANS/include/rANS/DedupEncoder.h
@@ -107,7 +107,7 @@ const stream_IT DedupEncoder<coder_T, stream_T, source_T>::process(const stream_
     return std::tuple(++dedupIT, coder.putSymbol(outputIter, encoderSymbol, this->mProbabilityBits));
   };
 
-  while (inputIT > inputBegin) { // NB: working in reverse!
+  while (inputIT != inputBegin) { // NB: working in reverse!
     std::tie(inputIT, outputIter) = encode(--inputIT, outputIter, rans);
     assert(outputIter < outputEnd);
   }

--- a/Utilities/rANS/include/rANS/DedupEncoder.h
+++ b/Utilities/rANS/include/rANS/DedupEncoder.h
@@ -46,13 +46,13 @@ class DedupEncoder : public Encoder<coder_T, stream_T, source_T>
  public:
   using duplicatesMap_t = std::map<uint32_t, uint32_t>;
 
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   const stream_IT process(const stream_IT outputBegin, const stream_IT outputEnd,
                           const source_IT inputBegin, source_IT inputEnd, duplicatesMap_t& duplicates) const;
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 const stream_IT DedupEncoder<coder_T, stream_T, source_T>::process(const stream_IT outputBegin, const stream_IT outputEnd, const source_IT inputBegin, const source_IT inputEnd, duplicatesMap_t& duplicates) const
 {
   using namespace internal;

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -53,7 +53,7 @@ class Encoder
   Encoder(encoderSymbolTable_t&& e, size_t probabilityBits);
   Encoder(const FrequencyTable& frequencies, size_t probabilityBits);
 
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   const stream_IT process(const stream_IT outputBegin, const stream_IT outputEnd,
                           const source_IT inputBegin, const source_IT inputEnd) const;
 
@@ -113,7 +113,7 @@ Encoder<coder_T, stream_T, source_T>::Encoder(const FrequencyTable& frequencies,
 }
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(const stream_IT outputBegin, const stream_IT outputEnd, const source_IT inputBegin, const source_IT inputEnd) const
 {
   using namespace internal;

--- a/Utilities/rANS/include/rANS/Encoder.h
+++ b/Utilities/rANS/include/rANS/Encoder.h
@@ -154,7 +154,7 @@ const stream_IT Encoder<coder_T, stream_T, source_T>::Encoder::process(const str
     assert(outputIter < outputEnd);
   }
 
-  while (inputIT > inputBegin) { // NB: working in reverse!
+  while (inputIT != inputBegin) { // NB: working in reverse!
     std::tie(inputIT, outputIter) = encode(--inputIT, outputIter, rans1);
     std::tie(inputIT, outputIter) = encode(--inputIT, outputIter, rans0);
     assert(outputIter < outputEnd);

--- a/Utilities/rANS/include/rANS/LiteralDecoder.h
+++ b/Utilities/rANS/include/rANS/LiteralDecoder.h
@@ -42,12 +42,12 @@ class LiteralDecoder : public Decoder<coder_T, stream_T, source_T>
   using Decoder<coder_T, stream_T, source_T>::Decoder;
 
  public:
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   void process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength, std::vector<source_T>& literals) const;
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 void LiteralDecoder<coder_T, stream_T, source_T>::process(const source_IT outputBegin, const stream_IT inputEnd, size_t messageLength, std::vector<source_T>& literals) const
 {
   using namespace internal;

--- a/Utilities/rANS/include/rANS/LiteralEncoder.h
+++ b/Utilities/rANS/include/rANS/LiteralEncoder.h
@@ -41,13 +41,13 @@ class LiteralEncoder : public Encoder<coder_T, stream_T, source_T>
   using Encoder<coder_T, stream_T, source_T>::Encoder;
 
  public:
-  template <typename stream_IT, typename source_IT>
+  template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool> = true>
   const stream_IT process(const stream_IT outputBegin, const stream_IT outputEnd,
                           const source_IT inputBegin, source_IT inputEnd, std::vector<source_T>& literals) const;
 };
 
 template <typename coder_T, typename stream_T, typename source_T>
-template <typename stream_IT, typename source_IT>
+template <typename stream_IT, typename source_IT, std::enable_if_t<internal::isCompatibleIter_v<stream_T, stream_IT> && internal::isCompatibleIter_v<source_T, source_IT>, bool>>
 const stream_IT LiteralEncoder<coder_T, stream_T, source_T>::process(const stream_IT outputBegin, const stream_IT outputEnd, const source_IT inputBegin, const source_IT inputEnd, std::vector<source_T>& literals) const
 {
   using namespace internal;

--- a/Utilities/rANS/include/rANS/LiteralEncoder.h
+++ b/Utilities/rANS/include/rANS/LiteralEncoder.h
@@ -92,7 +92,7 @@ const stream_IT LiteralEncoder<coder_T, stream_T, source_T>::process(const strea
     assert(outputIter < outputEnd);
   }
 
-  while (inputIT > inputBegin) { // NB: working in reverse!
+  while (inputIT != inputBegin) { // NB: working in reverse!
     std::tie(inputIT, outputIter) = encode(--inputIT, outputIter, rans1);
     std::tie(inputIT, outputIter) = encode(--inputIT, outputIter, rans0);
     assert(outputIter < outputEnd);

--- a/Utilities/rANS/include/rANS/internal/Decoder.h
+++ b/Utilities/rANS/include/rANS/internal/Decoder.h
@@ -49,21 +49,21 @@ class Decoder
 
   // Initializes a rANS decoder.
   // Unlike the encoder, the decoder works forwards as you'd expect.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   Stream_IT init(Stream_IT iter);
 
   // Returns the current cumulative frequency (map it to a symbol yourself!)
   uint32_t get(uint32_t scale_bits);
 
   // Equivalent to Rans32DecAdvance that takes a symbol.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   Stream_IT advanceSymbol(Stream_IT iter, const DecoderSymbol& sym, uint32_t scale_bits);
 
  private:
   State_T mState;
 
   // Renormalize.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   std::tuple<State_T, Stream_IT> renorm(State_T x, Stream_IT iter);
 
   // L ('l' in the paper) is the lower bound of our normalization interval.
@@ -79,10 +79,9 @@ template <typename State_T, typename Stream_T>
 Decoder<State_T, Stream_T>::Decoder() : mState(0){};
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 Stream_IT Decoder<State_T, Stream_T>::init(Stream_IT iter)
 {
-  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
 
   State_T x = 0;
   Stream_IT streamPos = iter;
@@ -116,7 +115,7 @@ uint32_t Decoder<State_T, Stream_T>::get(uint32_t scale_bits)
 };
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 Stream_IT Decoder<State_T, Stream_T>::advanceSymbol(Stream_IT iter, const DecoderSymbol& sym, uint32_t scale_bits)
 {
   static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
@@ -134,7 +133,7 @@ Stream_IT Decoder<State_T, Stream_T>::advanceSymbol(Stream_IT iter, const Decode
 };
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 inline std::tuple<State_T, Stream_IT> Decoder<State_T, Stream_T>::renorm(State_T x, Stream_IT iter)
 {
   static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);

--- a/Utilities/rANS/include/rANS/internal/Encoder.h
+++ b/Utilities/rANS/include/rANS/internal/Encoder.h
@@ -55,25 +55,25 @@ class Encoder
   // NOTE: With rANS, you need to encode symbols in *reverse order*, i.e. from
   // beginning to end! Likewise, the output bytestream is written *backwards*:
   // ptr starts pointing at the end of the output buffer and keeps decrementing.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   Stream_IT put(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits);
 
   // Flushes the rANS encoder.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   Stream_IT flush(Stream_IT iter);
 
   // Encodes a given symbol. This is faster than straight RansEnc since we can do
   // multiplications instead of a divide.
   //
   // See Rans32EncSymbolInit for a description of how this works.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   Stream_IT putSymbol(Stream_IT iter, const EncoderSymbol<State_T>& sym, uint32_t scale_bits);
 
  private:
   State_T mState;
 
   // Renormalize the encoder.
-  template <typename Stream_IT>
+  template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool> = true>
   std::tuple<State_T, Stream_IT> renorm(State_T x, Stream_IT iter, uint32_t freq, uint32_t scale_bits);
 
   // L ('l' in the paper) is the lower bound of our normalization interval.
@@ -89,10 +89,9 @@ template <typename State_T, typename Stream_T>
 Encoder<State_T, Stream_T>::Encoder() : mState(LOWER_BOUND){};
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 Stream_IT Encoder<State_T, Stream_T>::put(Stream_IT iter, uint32_t start, uint32_t freq, uint32_t scale_bits)
 {
-  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
   // renormalize
   Stream_IT streamPos;
   State_T x;
@@ -104,10 +103,9 @@ Stream_IT Encoder<State_T, Stream_T>::put(Stream_IT iter, uint32_t start, uint32
 };
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 Stream_IT Encoder<State_T, Stream_T>::flush(Stream_IT iter)
 {
-  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
 
   Stream_IT streamPos = iter;
 
@@ -134,10 +132,9 @@ Stream_IT Encoder<State_T, Stream_T>::flush(Stream_IT iter)
 };
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 Stream_IT Encoder<State_T, Stream_T>::putSymbol(Stream_IT iter, const EncoderSymbol<State_T>& sym, uint32_t scale_bits)
 {
-  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
 
   assert(sym.freq != 0); // can't encode symbol with freq=0
 
@@ -163,11 +160,9 @@ Stream_IT Encoder<State_T, Stream_T>::putSymbol(Stream_IT iter, const EncoderSym
 };
 
 template <typename State_T, typename Stream_T>
-template <typename Stream_IT>
+template <typename Stream_IT, std::enable_if_t<isCompatibleIter_v<Stream_T, Stream_IT>, bool>>
 inline std::tuple<State_T, Stream_IT> Encoder<State_T, Stream_T>::renorm(State_T x, Stream_IT iter, uint32_t freq, uint32_t scale_bits)
 {
-  static_assert(std::is_same<typename std::iterator_traits<Stream_IT>::value_type, Stream_T>::value);
-
   Stream_IT streamPos = iter;
 
   State_T x_max = ((LOWER_BOUND >> scale_bits) << STREAM_BITS) * freq; // this turns into a shift.

--- a/Utilities/rANS/include/rANS/internal/helper.h
+++ b/Utilities/rANS/include/rANS/internal/helper.h
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <cmath>
 #include <chrono>
+#include <type_traits>
+#include <iterator>
 
 namespace o2
 {
@@ -59,6 +61,9 @@ class RANSTimer
   std::chrono::time_point<std::chrono::high_resolution_clock> mStart;
   std::chrono::time_point<std::chrono::high_resolution_clock> mStop;
 };
+
+template <typename T, typename IT>
+inline constexpr bool isCompatibleIter_v = std::is_same_v<typename std::iterator_traits<IT>::value_type, T>;
 
 } // namespace internal
 } // namespace rans

--- a/Utilities/rANS/include/rANS/utils/CombinedIterator.h
+++ b/Utilities/rANS/include/rANS/utils/CombinedIterator.h
@@ -32,13 +32,15 @@ namespace utils
 template <class iterA_T, class iterB_T, class F>
 class CombinedInputIterator
 {
-  using difference_type = std::ptrdiff_t;
-  using value_type = std::result_of<F(iterA_T, iterB_T)>;
-  using pointer = value_type*;
-  using reference = value_type&;
-  using iterator_category = std::input_iterator_tag;
 
  public:
+  using difference_type = std::ptrdiff_t;
+  using value_type = std::invoke_result_t<F, iterA_T, iterB_T>;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category = std::bidirectional_iterator_tag;
+
+  CombinedInputIterator();
   CombinedInputIterator(iterA_T iterA, iterB_T iterB, F functor);
   CombinedInputIterator(const CombinedInputIterator& iter) = default;
   CombinedInputIterator(CombinedInputIterator&& iter) = default;
@@ -53,6 +55,8 @@ class CombinedInputIterator
   //pointer arithmetics
   CombinedInputIterator& operator++();
   CombinedInputIterator operator++(int);
+  CombinedInputIterator& operator--();
+  CombinedInputIterator operator--(int);
 
   // dereference
   auto operator*() const;
@@ -86,13 +90,13 @@ class CombinedOutputIterator
     CombinedOutputIterator& mIter;
   };
 
+ public:
   using difference_type = std::ptrdiff_t;
   using value_type = Proxy;
   using pointer = value_type*;
   using reference = value_type&;
   using iterator_category = std::input_iterator_tag;
 
- public:
   CombinedOutputIterator(iterA_T iterA, iterB_T iterB, F functor);
   CombinedOutputIterator(const CombinedOutputIterator& iter) = default;
   CombinedOutputIterator(CombinedOutputIterator&& iter) = default;
@@ -119,6 +123,9 @@ class CombinedOutputIterator
     return o;
   }
 };
+
+template <class iterA_T, class iterB_T, class F>
+CombinedInputIterator<iterA_T, iterB_T, F>::CombinedInputIterator() : mIterA{}, mIterB{}, mFunctor{} {};
 
 template <class iterA_T, class iterB_T, class F>
 CombinedInputIterator<iterA_T, iterB_T, F>::CombinedInputIterator(iterA_T iterA, iterB_T iterB, F functor) : mIterA(iterA), mIterB(iterB), mFunctor(functor)
@@ -158,6 +165,22 @@ inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator++(int) -> Combi
 {
   auto res = *this;
   ++(*this);
+  return res;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator--() -> CombinedInputIterator&
+{
+  --mIterA;
+  --mIterB;
+  return *this;
+}
+
+template <class iterA_T, class iterB_T, class F>
+inline auto CombinedInputIterator<iterA_T, iterB_T, F>::operator--(int) -> CombinedInputIterator
+{
+  auto res = *this;
+  --(*this);
   return res;
 }
 

--- a/Utilities/rANS/test/test_ransCombinedIterator.cxx
+++ b/Utilities/rANS/test/test_ransCombinedIterator.cxx
@@ -21,34 +21,16 @@
 
 #include "rANS/utils.h"
 
-struct test_CombninedIteratorFixture {
-  std::vector<uint16_t> a{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
-  std::vector<uint16_t> b{a.rbegin(), a.rend()};
-  size_t shift = 16;
-  std::vector<uint32_t> aAndB{0x0001000f, 0x0002000e, 0x0003000d, 0x0004000c, 0x0005000b,
-                              0x0006000a, 0x00070009, 0x00080008, 0x00090007, 0x000a0006,
-                              0x000b0005, 0x000c0004, 0x000d0003, 0x000e0002, 0x000f0001};
-};
-
-class ReadShiftFunctor
+class ShiftFunctor
 {
  public:
-  ReadShiftFunctor(size_t shift) : mShift(shift){};
+  ShiftFunctor(size_t shift) : mShift{shift} {};
 
   template <typename iterA_T, typename iterB_T>
   inline uint32_t operator()(iterA_T iterA, iterB_T iterB) const
   {
     return *iterB + (static_cast<uint32_t>(*iterA) << mShift);
   };
-
- private:
-  size_t mShift;
-};
-
-class WriteShiftFunctor
-{
- public:
-  WriteShiftFunctor(size_t shift) : mShift(shift){};
 
   template <typename iterA_T, typename iterB_T>
   inline void operator()(iterA_T iterA, iterB_T iterB, uint32_t value) const
@@ -61,14 +43,17 @@ class WriteShiftFunctor
   size_t mShift;
 };
 
+struct test_CombninedIteratorFixture {
+  const std::vector<uint16_t> a{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
+  const std::vector<uint16_t> b{a.rbegin(), a.rend()};
+  const ShiftFunctor f{16};
+  const std::vector<uint32_t> aAndB{0x0001000f, 0x0002000e, 0x0003000d, 0x0004000c, 0x0005000b,
+                                    0x0006000a, 0x00070009, 0x00080008, 0x00090007, 0x000a0006,
+                                    0x000b0005, 0x000c0004, 0x000d0003, 0x000e0002, 0x000f0001};
+};
+
 BOOST_FIXTURE_TEST_CASE(test_CombinedInputIteratorBase, test_CombninedIteratorFixture)
 {
-
-  //  auto readOP = [](auto iterA, auto iterB) -> uint32_t {
-  //    return *iterB + (static_cast<uint32_t>(*iterA) << 16);
-  //  };
-
-  ReadShiftFunctor f(shift);
 
   o2::rans::utils::CombinedInputIterator iter(a.begin(), b.begin(), f);
   // test equal
@@ -77,13 +62,22 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedInputIteratorBase, test_CombninedIteratorFi
   // test not equal
   const o2::rans::utils::CombinedInputIterator second(++(a.begin()), ++(b.begin()), f);
   BOOST_CHECK_NE(iter, second);
-  // test pre increment
+  // test pre-increment
   ++iter;
   BOOST_CHECK_EQUAL(iter, second);
-  //test postIncrement
+  //test post-increment
   iter = first;
   BOOST_CHECK_EQUAL(iter++, first);
   BOOST_CHECK_EQUAL(iter, second);
+  // test pre-decrement
+  iter = second;
+  --iter;
+  BOOST_CHECK_EQUAL(iter, first);
+  // test post-decrement
+  iter = second;
+  BOOST_CHECK_EQUAL(iter--, second);
+  BOOST_CHECK_EQUAL(iter, first);
+
   //test deref
   const uint32_t val = first.operator*();
   BOOST_CHECK_EQUAL(val, aAndB.front());
@@ -94,14 +88,6 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
   std::vector<uint16_t> aOut(2, 0x0);
   std::vector<uint16_t> bOut(2, 0x0);
 
-  //  auto writeOP = [](auto iterA, auto iterB, uint32_t value) -> void {
-  //    const uint32_t shift = 16;
-  //    *iterA = value >> shift;
-  //    *iterB = value & ((1 << shift) - 1);
-  //  };
-
-  WriteShiftFunctor f(shift);
-
   o2::rans::utils::CombinedOutputIterator iter(aOut.begin(), bOut.begin(), f);
 
   // test deref:
@@ -111,7 +97,7 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
   aOut[0] = 0x0;
   bOut[0] = 0x0;
 
-  // test pre increment
+  // test pre-increment
   *(++iter) = aAndB[1];
   BOOST_CHECK_EQUAL(aOut[0], 0);
   BOOST_CHECK_EQUAL(bOut[0], 0);
@@ -121,7 +107,7 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
   bOut.assign(2, 0x0);
   iter = o2::rans::utils::CombinedOutputIterator(aOut.begin(), bOut.begin(), f);
 
-  // test post increment
+  // test post-increment
   auto preInc = iter++;
   *preInc = aAndB[0];
   BOOST_CHECK_EQUAL(aOut[0], a[0]);
@@ -139,10 +125,6 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
 
 BOOST_FIXTURE_TEST_CASE(test_CombinedInputIteratorReadArray, test_CombninedIteratorFixture)
 {
-  //  auto readOP = [](auto iterA, auto iterB) -> uint32_t {
-  //    return *iterB + (static_cast<uint32_t>(*iterA) << 16);
-  //  };
-  ReadShiftFunctor f(shift);
 
   const o2::rans::utils::CombinedInputIterator begin(a.begin(), b.begin(), f);
   const o2::rans::utils::CombinedInputIterator end(a.end(), b.end(), f);
@@ -154,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorWriteArray, test_CombninedIte
   std::vector<uint16_t> aRes(a.size(), 0);
   std::vector<uint16_t> bRes(b.size(), 0);
 
-  o2::rans::utils::CombinedOutputIterator iter(aRes.begin(), bRes.begin(), WriteShiftFunctor(shift));
+  o2::rans::utils::CombinedOutputIterator iter(aRes.begin(), bRes.begin(), f);
   for (auto input : aAndB) {
     *iter++ = input;
   }

--- a/Utilities/rANS/test/test_ransCombinedIterator.cxx
+++ b/Utilities/rANS/test/test_ransCombinedIterator.cxx
@@ -88,7 +88,8 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
   std::vector<uint16_t> aOut(2, 0x0);
   std::vector<uint16_t> bOut(2, 0x0);
 
-  o2::rans::utils::CombinedOutputIterator iter(aOut.begin(), bOut.begin(), f);
+  o2::rans::utils::CombinedOutputIteratorFactory<uint32_t> iterFactory;
+  auto iter = iterFactory.makeIter(aOut.begin(), bOut.begin(), f);
 
   // test deref:
   *iter = aAndB[0];
@@ -105,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorBase, test_CombninedIteratorF
   BOOST_CHECK_EQUAL(bOut[1], b[1]);
   aOut.assign(2, 0x0);
   bOut.assign(2, 0x0);
-  iter = o2::rans::utils::CombinedOutputIterator(aOut.begin(), bOut.begin(), f);
+  iter = iterFactory.makeIter(aOut.begin(), bOut.begin(), f);
 
   // test post-increment
   auto preInc = iter++;
@@ -136,7 +137,7 @@ BOOST_FIXTURE_TEST_CASE(test_CombinedOutputIteratorWriteArray, test_CombninedIte
   std::vector<uint16_t> aRes(a.size(), 0);
   std::vector<uint16_t> bRes(b.size(), 0);
 
-  o2::rans::utils::CombinedOutputIterator iter(aRes.begin(), bRes.begin(), f);
+  auto iter = o2::rans::utils::CombinedOutputIteratorFactory<uint32_t>::makeIter(aRes.begin(), bRes.begin(), f);
   for (auto input : aAndB) {
     *iter++ = input;
   }


### PR DESCRIPTION
* Refactor `o2::tpc::CTFCoder` to use merging/splitting iterators from `o2::rans::utils`. This avoids storing intermediate vectors and removes two copy operations per merged/ splitted element and should visibly improve performance in CTF creation. 
* Refactor `EncodedBlocks` to remove artificial restriction to pointers and use iterators instead
* Refactor `CombinedInputIterator` and `CombinedOutputIterator` to make it usable in real world applications
* Small bugfixes and improvements wherever appropriate