### PR TITLE
[EMCAL-630] Store result of the raw fit as energy

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -64,6 +64,7 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
 void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(DEBUG) << "[EMCALRawToCellConverter - run] called";
+  const double CONVADCGEV = 0.016; // Conversion from ADC counts to energy: E = 16 MeV / ADC
 
   // Cache cells from for bunch crossings as the component reads timeframes from many links consecutively
   std::map<o2::InteractionRecord, std::shared_ptr<std::vector<o2::emcal::Cell>>> cellBuffer; // Internal cell buffer
@@ -138,7 +139,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         if (fitResults.getTime() < 0) {
           fitResults.setTime(0.);
         }
-        currentCellContainer->emplace_back(CellID, amp, time, chantype);
+        currentCellContainer->emplace_back(CellID, amp * CONVADCGEV, time, chantype);
       }
     }
   }


### PR DESCRIPTION
As the range of the cell object is truncated and
designed for storing energy values from 0 to
250 GeV the ADC counts must be converted to
energy with the standard ADC to GeV conversion
1 ADC count = 16 MeV. Energy calibration will be
done relative to this.