### PR TITLE
TableMaker task updated to use configurables for system type, event and track selections

### DIFF
--- a/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
@@ -18,7 +18,6 @@ namespace o2::aod
 {
 namespace dqhistograms
 {
-void DefineDataPeriod(const char* dataPeriod);
 void DefineHistograms(HistogramManager* hm, const char* histClass, const char* groupName, const char* subGroupName = "");
 }
 } // namespace o2::aod
@@ -84,7 +83,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     }
     if (subGroupStr.Contains("tpc")) {
       hm->AddHistogram(histClass, "TPCncls", "Number of cluster in TPC", false, 160, -0.5, 159.5, VarManager::kTPCncls);
-      hm->AddHistogram(histClass, "TPCncls_Run", "Number of cluster in TPC", true, VarManager::GetNRuns(), 0.5, 0.5 + VarManager::GetNRuns(), VarManager::kRunId,
+      hm->AddHistogram(histClass, "TPCncls_Run", "Number of cluster in TPC", true, (VarManager::GetNRuns() > 0 ? VarManager::GetNRuns() : 1), 0.5, 0.5 + VarManager::GetNRuns(), VarManager::kRunId,
                        10, -0.5, 159.5, VarManager::kTPCncls, 10, 0., 1., VarManager::kNothing, VarManager::GetRunStr().Data());
       hm->AddHistogram(histClass, "IsTPCrefit", "", false, 2, -0.5, 1.5, VarManager::kIsTPCrefit);
       hm->AddHistogram(histClass, "TPCchi2", "TPC chi2", false, 100, 0.0, 10.0, VarManager::kTPCchi2);
@@ -124,39 +123,5 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
   if (groupStr.Contains("pair-hadron-correlation")) {
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
-  }
-}
-
-void o2::aod::dqhistograms::DefineDataPeriod(const char* dataPeriod)
-{
-  //
-  // Define the list of runs to be used for histogramming.
-  //
-  TString periodStr = dataPeriod;
-  periodStr.ToLower();
-  if (periodStr.Contains("lhc18b")) {
-    std::vector<int> runs = {
-      285009, 285011, 285012, 285013, 285014, 285015, 285064, 285065, 285066, 285106,
-      285108, 285125, 285127, 285165, 285200, 285202, 285203, 285222, 285224, 285327,
-      285328, 285347, 285364, 285365, 285396};
-    VarManager::SetRunNumbers(runs);
-  }
-  if (periodStr.Contains("lhc15o")) {
-    std::vector<int> runs = {
-      244917, 244918, 244975, 244980, 244982, 244983, 245064, 245066, 245068, 245145,
-      245146, 245151, 245152, 245231, 245232, 245259, 245343, 245345, 245346, 245347,
-      245349, 245353, 245396, 245397, 245401, 245407, 245409, 245411, 245439, 245441,
-      245446, 245450, 245452, 245454, 245496, 245497, 245501, 245504, 245505, 245507,
-      245535, 245540, 245542, 245543, 245544, 245545, 245554, 245683, 245692, 245700,
-      245702, 245705, 245829, 245831, 245833, 245923, 245949, 245952, 245954, 245963,
-      246001, 246003, 246012, 246036, 246037, 246042, 246048, 246049, 246052, 246053,
-      246087, 246089, 246113, 246115, 246148, 246151, 246152, 246153, 246178, 246180,
-      246181, 246182, 246185, 246217, 246222, 246225, 246271, 246272, 246275, 246276,
-      246391, 246392, 246424, 246428, 246431, 246434, 246487, 246488, 246493, 246495,
-      246675, 246676, 246750, 246751, 246757, 246758, 246759, 246760, 246763, 246765,
-      246766, 246804, 246805, 246807, 246808, 246809, 246810, 246844, 246845, 246846,
-      246847, 246851, 246865, 246867, 246870, 246871, 246928, 246945, 246948, 246980,
-      246982, 246984, 246989, 246991, 246994};
-    VarManager::SetRunNumbers(runs);
   }
 }

--- a/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
@@ -10,6 +10,7 @@
 //
 // Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
 //
+#include <TString.h>
 #include "PWGDQCore/HistogramManager.h"
 #include "PWGDQCore/VarManager.h"
 
@@ -17,6 +18,7 @@ namespace o2::aod
 {
 namespace dqhistograms
 {
+void DefineDataPeriod(const char* dataPeriod);
 void DefineHistograms(HistogramManager* hm, const char* histClass, const char* groupName, const char* subGroupName = "");
 }
 } // namespace o2::aod
@@ -122,5 +124,39 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
   if (groupStr.Contains("pair-hadron-correlation")) {
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
+  }
+}
+
+void o2::aod::dqhistograms::DefineDataPeriod(const char* dataPeriod)
+{
+  //
+  // Define the list of runs to be used for histogramming.
+  //
+  TString periodStr = dataPeriod;
+  periodStr.ToLower();
+  if (periodStr.Contains("lhc18b")) {
+    std::vector<int> runs = {
+      285009, 285011, 285012, 285013, 285014, 285015, 285064, 285065, 285066, 285106,
+      285108, 285125, 285127, 285165, 285200, 285202, 285203, 285222, 285224, 285327,
+      285328, 285347, 285364, 285365, 285396};
+    VarManager::SetRunNumbers(runs);
+  }
+  if (periodStr.Contains("lhc15o")) {
+    std::vector<int> runs = {
+      244917, 244918, 244975, 244980, 244982, 244983, 245064, 245066, 245068, 245145,
+      245146, 245151, 245152, 245231, 245232, 245259, 245343, 245345, 245346, 245347,
+      245349, 245353, 245396, 245397, 245401, 245407, 245409, 245411, 245439, 245441,
+      245446, 245450, 245452, 245454, 245496, 245497, 245501, 245504, 245505, 245507,
+      245535, 245540, 245542, 245543, 245544, 245545, 245554, 245683, 245692, 245700,
+      245702, 245705, 245829, 245831, 245833, 245923, 245949, 245952, 245954, 245963,
+      246001, 246003, 246012, 246036, 246037, 246042, 246048, 246049, 246052, 246053,
+      246087, 246089, 246113, 246115, 246148, 246151, 246152, 246153, 246178, 246180,
+      246181, 246182, 246185, 246217, 246222, 246225, 246271, 246272, 246275, 246276,
+      246391, 246392, 246424, 246428, 246431, 246434, 246487, 246488, 246493, 246495,
+      246675, 246676, 246750, 246751, 246757, 246758, 246759, 246760, 246763, 246765,
+      246766, 246804, 246805, 246807, 246808, 246809, 246810, 246844, 246845, 246846,
+      246847, 246851, 246865, 246867, 246870, 246871, 246928, 246945, 246948, 246980,
+      246982, 246984, 246989, 246991, 246994};
+    VarManager::SetRunNumbers(runs);
   }
 }

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -215,6 +215,7 @@ class VarManager : public TObject
   }
 
   static void SetRunNumbers(int n, int* runs);
+  static void SetRunNumbers(std::vector<int> runs);
   static int GetNRuns()
   {
     return fgRunMap.size();

--- a/Analysis/PWGDQ/src/VarManager.cxx
+++ b/Analysis/PWGDQ/src/VarManager.cxx
@@ -72,6 +72,18 @@ void VarManager::SetRunNumbers(int n, int* runs)
 }
 
 //__________________________________________________________________
+void VarManager::SetRunNumbers(std::vector<int> runs)
+{
+  //
+  // maps the list of runs such that one can plot the list of runs nicely in a histogram axis
+  //
+  for (int i = 0; i < runs.size(); ++i) {
+    fgRunMap[runs.at(i)] = i + 1;
+    fgRunStr += Form("%d;", runs.at(i));
+  }
+}
+
+//__________________________________________________________________
 void VarManager::FillEventDerived(float* values)
 {
   //

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -232,10 +232,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow;
   const bool isPbPb = cfgc.options().get<bool>("isPbPb");
-  if (isPbPb)
+  if (isPbPb) {
     workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>("table-maker"));
-  else
+  }
+  else {
     workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>("table-maker"));
+  }
 
   return workflow;
 }

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -79,7 +79,6 @@ struct TableMaker {
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
-  Configurable<std::string> fConfigDataPeriod{"cfgDataPeriod", "LHC15o", "Data period to be analyzed"};
   Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};
   Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
   Configurable<float> fConfigBarrelTrackPtLow{"cfgBarrelLowPt", 1.0f, "Low pt cut for tracks in the barrel"};
@@ -208,9 +207,6 @@ struct TableMaker {
 
   void DefineHistograms(TString histClasses)
   {
-    TString periodStr = fConfigDataPeriod.value;
-    dqhistograms::DefineDataPeriod(periodStr.Data());
-
     std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
       TString classStr = objArray->At(iclass)->GetName();

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -234,8 +234,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   const bool isPbPb = cfgc.options().get<bool>("isPbPb");
   if (isPbPb) {
     workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>("table-maker"));
-  }
-  else {
+  } else {
     workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>("table-maker"));
   }
 

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -10,10 +10,10 @@
 //
 // Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
 //
-#include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
+#include "Framework/DataTypes.h"
 #include "AnalysisDataModel/Multiplicity.h"
 #include "AnalysisDataModel/EventSelection.h"
 #include "AnalysisDataModel/Centrality.h"
@@ -23,6 +23,8 @@
 #include "PWGDQCore/HistogramManager.h"
 #include "PWGDQCore/AnalysisCut.h"
 #include "PWGDQCore/AnalysisCompositeCut.h"
+#include "PWGDQCore/HistogramsLibrary.h"
+#include "PWGDQCore/CutsLibrary.h"
 #include "AnalysisDataModel/PID/PIDResponse.h"
 #include "AnalysisDataModel/TrackSelectionTables.h"
 #include <iostream>
@@ -32,11 +34,19 @@ using std::endl;
 
 using namespace o2;
 using namespace o2::framework;
-//using namespace o2::framework::expressions;
 using namespace o2::aod;
 
-using MyEvents = soa::Join<aod::Collisions, aod::EvSels, aod::Cents>;
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  ConfigParamSpec optionDataType{"isPbPb", VariantType::Bool, false, {"Data type"}};
+  workflowOptions.push_back(optionDataType);
+}
+
+#include "Framework/runDataProcessing.h"
+
 using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection, aod::pidRespTPC, aod::pidRespTOF, aod::pidRespTOFbeta>;
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels, aod::Cents>;
+using MyEventsNoCent = soa::Join<aod::Collisions, aod::EvSels>;
 
 // HACK: In order to be able to deduce which kind of aod object is transmitted to the templated VarManager::Fill functions
 //         a constexpr static bit map must be defined and sent as template argument
@@ -46,9 +56,13 @@ using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, 
 //        This is a temporary fix until the arrow/ROOT issues are solved, at which point it will be possible
 //           to automatically detect the object types transmitted to the VarManager
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCent;
+constexpr static uint32_t gkEventFillMapNoCent = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
 
+template <uint32_t eventFillMap, typename T>
 struct TableMaker {
+
+  using MyEvent = typename T::iterator;
 
   Produces<ReducedEvents> event;
   Produces<ReducedEventsExtended> eventExtended;
@@ -65,6 +79,11 @@ struct TableMaker {
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
+  Configurable<std::string> fConfigDataPeriod{"cfgDataPeriod", "LHC15o", "Data period to be analyzed"};
+  Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};
+  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<float> fConfigBarrelTrackPtLow{"cfgBarrelLowPt", 1.0f, "Low pt cut for tracks in the barrel"};
+
   // TODO: Filters should be used to make lowest level selection. The additional more restrictive cuts should be defined via the AnalysisCuts
   // TODO: Multiple event selections can be applied and decisions stored in the reducedevent::tag
   AnalysisCompositeCut* fEventCut;
@@ -74,7 +93,7 @@ struct TableMaker {
 
   // Partition will select fast a group of tracks with basic requirements
   //   If some of the cuts cannot be included in the Partition expression, add them via AnalysisCut(s)
-  Partition<MyBarrelTracks> barrelSelectedTracks = o2::aod::track::pt >= 1.0f && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
+  Partition<MyBarrelTracks> barrelSelectedTracks = o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
 
   // TODO a few of the important muon variables in the central data model are dynamic columns so not usable in expressions (e.g. eta, phi)
   //        Update the data model to have them as expression columns
@@ -97,34 +116,21 @@ struct TableMaker {
   void DefineCuts()
   {
     fEventCut = new AnalysisCompositeCut(true);
-    AnalysisCut* eventVarCut = new AnalysisCut();
-    eventVarCut->AddCut(VarManager::kVtxZ, -10.0, 10.0);
-    eventVarCut->AddCut(VarManager::kIsINT7, 0.5, 1.5); // require kINT7
-    fEventCut->AddCut(eventVarCut);
+    TString eventCutStr = fConfigEventCuts.value;
+    fEventCut->AddCut(dqcuts::GetAnalysisCut(eventCutStr.Data()));
 
+    // available cuts: jpsiKineAndQuality, jpsiPID1, jpsiPID2
+    // NOTE: for now, the model of this task is that just one track cut is applied; multiple parallel cuts should be enabled in the future
     fTrackCut = new AnalysisCompositeCut(true);
-    AnalysisCut* trackVarCut = new AnalysisCut();
-    //trackVarCut->AddCut(VarManager::kPt, 1.0, 1000.0);
-    //trackVarCut->AddCut(VarManager::kEta, -0.9, 0.9);
-    //trackVarCut->AddCut(VarManager::kTPCsignal, 70.0, 100.0);
-    trackVarCut->AddCut(VarManager::kIsITSrefit, 0.5, 1.5);
-    trackVarCut->AddCut(VarManager::kIsTPCrefit, 0.5, 1.5);
-    //trackVarCut->AddCut(VarManager::kTPCchi2, 0.0, 4.0);
-    //trackVarCut->AddCut(VarManager::kITSchi2, 0.1, 36.0);
-    trackVarCut->AddCut(VarManager::kTPCncls, 100.0, 161.);
+    TString trackCutStr = fConfigTrackCuts.value;
+    fTrackCut->AddCut(dqcuts::GetCompositeCut(trackCutStr.Data()));
 
-    AnalysisCut* pidCut1 = new AnalysisCut();
-    TF1* cutLow1 = new TF1("cutLow1", "pol1", 0., 10.);
-    cutLow1->SetParameters(130., -40.0);
-    pidCut1->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
-
-    fTrackCut->AddCut(trackVarCut);
-    fTrackCut->AddCut(pidCut1);
+    // NOTE: Additional cuts to those specified via the Configurable may still be added
 
     VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
   }
 
-  void process(MyEvents::iterator const& collision, aod::MuonClusters const& clustersMuon, aod::Muons const& tracksMuon, aod::BCs const& bcs, MyBarrelTracks const& tracksBarrel)
+  void process(MyEvent const& collision, aod::MuonClusters const& clustersMuon, aod::Muons const& tracksMuon, aod::BCs const& bcs, MyBarrelTracks const& tracksBarrel)
   {
     uint64_t tag = 0;
     uint32_t triggerAliases = 0;
@@ -135,7 +141,7 @@ struct TableMaker {
     }
 
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables, fValues);
-    VarManager::FillEvent<gkEventFillMap>(collision, fValues); // extract event information and place it in the fgValues array
+    VarManager::FillEvent<eventFillMap>(collision, fValues);   // extract event information and place it in the fgValues array
     fHistMan->FillHistClass("Event_BeforeCuts", fValues);      // automatically fill all the histograms in the class Event
 
     if (!fEventCut->IsSelected(fValues)) {
@@ -145,7 +151,7 @@ struct TableMaker {
     fHistMan->FillHistClass("Event_AfterCuts", fValues);
 
     event(tag, collision.bc().runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib());
-    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), triggerAliases, collision.centV0M());
+    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), triggerAliases, fValues[VarManager::kCentVZERO]);
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
     uint64_t trackFilteringTag = 0;
@@ -202,51 +208,34 @@ struct TableMaker {
 
   void DefineHistograms(TString histClasses)
   {
-    const int kNRuns = 2;
-    int runs[kNRuns] = {244918, 244919};
-    TString runsStr;
-    for (int i = 0; i < kNRuns; i++) {
-      runsStr += Form("%d;", runs[i]);
-    }
-    VarManager::SetRunNumbers(kNRuns, runs);
+    TString periodStr = fConfigDataPeriod.value;
+    dqhistograms::DefineDataPeriod(periodStr.Data());
 
-    std::unique_ptr<TObjArray> arr(histClasses.Tokenize(";"));
-    for (Int_t iclass = 0; iclass < arr->GetEntries(); ++iclass) {
-      TString classStr = arr->At(iclass)->GetName();
+    std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+    for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+      TString classStr = objArray->At(iclass)->GetName();
+      fHistMan->AddHistClass(classStr.Data());
 
+      // NOTE: The level of detail for histogramming can be controlled via configurables
       if (classStr.Contains("Event")) {
-        fHistMan->AddHistClass(classStr.Data());
-        fHistMan->AddHistogram(classStr.Data(), "VtxZ", "Vtx Z", false, 60, -15.0, 15.0, VarManager::kVtxZ); // TH1F histogram
-        fHistMan->AddHistogram(classStr.Data(), "VtxZ_Run", "Vtx Z", true,
-                               kNRuns, 0.5, 0.5 + kNRuns, VarManager::kRunId, 60, -15.0, 15.0, VarManager::kVtxZ, 10, 0., 0., VarManager::kNothing, runsStr.Data());
-        fHistMan->AddHistogram(classStr.Data(), "CentVZERO", "Centrality VZERO", false, 100, 0.0, 100.0, VarManager::kCentVZERO); // TH1F histogram
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "event", "trigger,cent");
       }
 
       if (classStr.Contains("Track")) {
-        fHistMan->AddHistClass(classStr.Data());
-        fHistMan->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kPt);                                                // TH1F histogram
-        fHistMan->AddHistogram(classStr.Data(), "Eta", "#eta distribution", false, 500, -5.0, 5.0, VarManager::kEta);                                               // TH1F histogram
-        fHistMan->AddHistogram(classStr.Data(), "Phi_Eta", "#phi vs #eta distribution", false, 200, -5.0, 5.0, VarManager::kEta, 200, -6.3, 6.3, VarManager::kPhi); // TH2F histogram
-
-        if (classStr.Contains("Barrel")) {
-          fHistMan->AddHistogram(classStr.Data(), "TPCncls", "Number of cluster in TPC", false, 160, -0.5, 159.5, VarManager::kTPCncls); // TH1F histogram
-          fHistMan->AddHistogram(classStr.Data(), "TPCncls_Run", "Number of cluster in TPC", true, kNRuns, 0.5, 0.5 + kNRuns, VarManager::kRunId,
-                                 10, -0.5, 159.5, VarManager::kTPCncls, 10, 0., 1., VarManager::kNothing, runsStr.Data());           // TH1F histogram
-          fHistMan->AddHistogram(classStr.Data(), "ITSncls", "Number of cluster in ITS", false, 8, -0.5, 7.5, VarManager::kITSncls); // TH1F histogram
-          //for TPC PID
-          fHistMan->AddHistogram(classStr.Data(), "TPCdedx_pIN", "TPC dE/dx vs pIN", false, 200, 0.0, 20.0, VarManager::kPin, 200, 0.0, 200., VarManager::kTPCsignal); // TH2F histogram
-          fHistMan->AddHistogram(classStr.Data(), "DCAxy", "DCAxy", false, 100, -3.0, 3.0, VarManager::kTrackDCAxy);                                                   // TH1F histogram
-          fHistMan->AddHistogram(classStr.Data(), "DCAz", "DCAz", false, 100, -5.0, 5.0, VarManager::kTrackDCAz);                                                      // TH1F histogram
-          fHistMan->AddHistogram(classStr.Data(), "IsGlobalTrack", "IsGlobalTrack", false, 2, -0.5, 1.5, VarManager::kIsGlobalTrack);                                  // TH1F histogram
-          fHistMan->AddHistogram(classStr.Data(), "IsGlobalTrackSDD", "IsGlobalTrackSDD", false, 2, -0.5, 1.5, VarManager::kIsGlobalTrackSDD);                         // TH1F histogram
-        }
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "tpcpid");
       }
-    } // end loop over histogram classes
+    }
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<TableMaker>("table-maker")};
+  WorkflowSpec workflow;
+  const bool isPbPb = cfgc.options().get<bool>("isPbPb");
+  if (isPbPb)
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>("table-maker"));
+  else
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>("table-maker"));
+
+  return workflow;
 }


### PR DESCRIPTION
TableMaker:
1) Event and track selections can be specified via configurables selecting predefined cuts in the CutsLibrary.
2) A special configurable for the minimum pt of the lepton is added to allow switching between the quarkonia and lmee analyses.
3) The task can now be run on either pp or PbPb by specifying the isPbPb parameter. In the case of pp, the centrality task has to be taken out from the pipe.
4) Histogram definition is now using the predefined histogram groups from the HistogramLibrary. Configurables should be added in the future to control the level of histogramming detail.