### PR TITLE
TPC-ITS matching will use tpc-reco-workflow or on-the-fly created shared cl.map 

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -406,6 +406,12 @@ class MatchTPCITS
     mTPCTrackClusIdx = inp;
   }
 
+  ///< set input TPC cluster sharing map
+  void setTPCClustersSharingMap(const gsl::span<const unsigned char> inp)
+  {
+    mTPCRefitterShMap = inp;
+  }
+
   ///< set input TPC clusters
   void setTPCClustersInp(const o2::tpc::ClusterNativeAccess* inp)
   {
@@ -653,7 +659,6 @@ class MatchTPCITS
   std::unique_ptr<TPCTransform> mTPCTransform;         ///< TPC cluster transformation
   std::unique_ptr<o2::gpu::GPUParam> mTPCClusterParam; ///< TPC clusters error param
   std::unique_ptr<o2::gpu::GPUTPCO2InterfaceRefit> mTPCRefitter; ///< TPC refitter used for TPC tracks refit during the reconstruction
-  std::vector<unsigned char> mTPCRefitterShMap;
 
   o2::BunchFilling mBunchFilling;
   std::array<int16_t, o2::constants::lhc::LHCMaxBunches> mClosestBunchAbove; // closest filled bunch from above
@@ -669,6 +674,8 @@ class MatchTPCITS
   gsl::span<const ITSCluster> mITSClustersArray;            ///< input ITS clusters span
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec; ///< input ITS clusters ROFRecord span
   gsl::span<const o2::ft0::RecPoints> mFITInfo;             ///< optional input FIT info span
+
+  gsl::span<const unsigned char> mTPCRefitterShMap; ///< externally set TPC clusters sharing map
 
   const o2::tpc::ClusterNativeAccess* mTPCClusterIdxStruct = nullptr; ///< struct holding the TPC cluster indices
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -403,9 +403,6 @@ void MatchTPCITS::updateTimeDependentParams()
   mMinTPCTrackPtInv = (mFieldON && mParams->minTPCTrackR > 0) ? 1. / std::abs(mParams->minTPCTrackR * mBz * o2::constants::math::B2C) : 999.;
   mMinITSTrackPtInv = (mFieldON && mParams->minITSTrackR > 0) ? 1. / std::abs(mParams->minITSTrackR * mBz * o2::constants::math::B2C) : 999.;
 
-  // RSTODO: do we need to recreate it? It should be enough to add/use setters in GPUTPCO2InterfaceRefit
-  mTPCRefitterShMap.resize(mTPCClusterIdxStruct->nClustersTotal);
-  o2::gpu::GPUTPCO2InterfaceRefit::fillSharedClustersMap(mTPCClusterIdxStruct, mTPCTracksArray, mTPCTrackClusIdx.data(), mTPCRefitterShMap.data());
   mTPCRefitter = std::make_unique<o2::gpu::GPUTPCO2InterfaceRefit>(mTPCClusterIdxStruct, mTPCTransform.get(), mBz, mTPCTrackClusIdx.data(), mTPCRefitterShMap.data(), nullptr, o2::base::Propagator::Instance());
 
   o2::math_utils::Point3D<float> p0(90., 1., 1), p1(90., 100., 100.);

--- a/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
@@ -14,6 +14,7 @@
 #include "ITSWorkflow/TrackReaderSpec.h"
 #include "TPCWorkflow/TrackReaderSpec.h"
 #include "TPCWorkflow/PublisherSpec.h"
+#include "TPCWorkflow/ClusterSharingMapSpec.h"
 #include "FT0Workflow/RecPointReaderSpec.h"
 #include "GlobalTrackingWorkflow/TPCITSMatchingSpec.h"
 #include "GlobalTrackingWorkflow/MatchTPCITSWorkflow.h"
@@ -52,11 +53,13 @@ framework::WorkflowSpec getMatchTPCITSWorkflow(bool useFT0, bool useMC, bool dis
                                                    tpcClusSectors,
                                                    tpcClusLanes},
                                                  useMC));
+    specs.emplace_back(o2::tpc::getClusterSharingMapSpec());
 
     if (useFT0) {
       specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
     }
   }
+
   specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(useFT0, calib, useMC, tpcClusLanes));
 
   if (!disableRootOut) {

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -113,6 +113,8 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   const auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
   const auto tracksTPCClRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
 
+  const auto clusTPCShmap = pc.inputs().get<gsl::span<unsigned char>>("clusTPCshmap");
+
   //---------------------------->> TPC Clusters loading >>------------------------------------------
   int operation = 0;
   uint64_t activeSectors = 0;
@@ -242,6 +244,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   mMatching.setTPCTracksInp(tracksTPC);
   mMatching.setTPCTrackClusIdxInp(tracksTPCClRefs);
   mMatching.setTPCClustersInp(&clusterIndex);
+  mMatching.setTPCClustersSharingMap(clusTPCShmap);
 
   if (mUseMC) {
     mMatching.setITSTrkLabelsInp(lblITS);
@@ -302,6 +305,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useFT0, bool calib, bool useMC, con
   inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
 
   inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
+  inputs.emplace_back("clusTPCshmap", "TPC", "CLSHAREDMAP", 0, Lifetime::Timeframe);
 
   if (useFT0) {
     inputs.emplace_back("fitInfo", "FT0", "RECPOINTS", 0, Lifetime::Timeframe);

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(TPCWorkflow
                        src/TPCSectorCompletionPolicy.cxx
                        src/ZSSpec.cxx
                        src/CalibProcessingHelper.cxx
+                       src/ClusterSharingMapSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ClusterSharingMapSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ClusterSharingMapSpec.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  ClusterSharingMapSpec.h
+/// @brief Device to produce TPC clusters sharing map
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef O2_TPC_CLUSTERSHARINGMAP_SPEC
+#define O2_TPC_CLUSTERSHARINGMAP_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+class ClusterSharingMapSpec : public o2::framework::Task
+{
+ public:
+  ~ClusterSharingMapSpec() override = default;
+  void run(framework::ProcessingContext& pc) final;
+};
+
+o2::framework::DataProcessorSpec getClusterSharingMapSpec()
+{
+
+  std::vector<o2::framework::InputSpec> inputs;
+  std::vector<o2::framework::OutputSpec> outputs;
+  inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, o2::framework::Lifetime::Timeframe);
+  inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, o2::framework::Lifetime::Timeframe);
+  inputs.emplace_back("clusTPC", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back("TPC", "CLSHAREDMAP", 0, o2::framework::Lifetime::Timeframe);
+
+  return o2::framework::DataProcessorSpec{
+    "tpc-clusters-sharing-map-producer",
+    inputs,
+    outputs,
+    o2::framework::AlgorithmSpec{o2::framework::adaptFromTask<ClusterSharingMapSpec>()},
+    o2::framework::Options{}};
+}
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/workflow/src/ClusterSharingMapSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterSharingMapSpec.cxx
@@ -1,0 +1,140 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ClusterSharingMapSpec.cxx
+/// @brief Device to produce TPC clusters sharing map
+/// \author ruben.shahoyan@cern.ch
+
+#include <gsl/span>
+#include <TStopwatch.h>
+#include <vector>
+#include "Framework/InputRecordWalker.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "GPUO2InterfaceRefit.h"
+#include "TPCWorkflow/ClusterSharingMapSpec.h"
+
+using namespace o2::framework;
+using namespace o2::tpc;
+
+void ClusterSharingMapSpec::run(ProcessingContext& pc)
+{
+  TStopwatch timer;
+
+  const auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
+  const auto tracksTPCClRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
+
+  //---------------------------->> TPC Clusters loading >>------------------------------------------
+  // FIXME: this is a copy-paste from TPCITSMatchingSpec version of TPC cluster reading, later to be organized in a better way
+  int operation = 0;
+  uint64_t activeSectors = 0;
+  std::bitset<o2::tpc::constants::MAXSECTOR> validSectors = 0;
+  std::map<int, DataRef> datarefs;
+  std::vector<InputSpec> filter = {
+    {"check", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe},
+  };
+  for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+    auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+    if (sectorHeader == nullptr) {
+      // FIXME: think about error policy
+      LOG(ERROR) << "sector header missing on header stack";
+      throw std::runtime_error("sector header missing on header stack");
+    }
+    int sector = sectorHeader->sector();
+    std::bitset<o2::tpc::constants::MAXSECTOR> sectorMask(sectorHeader->sectorBits);
+    LOG(INFO) << "Reading TPC cluster data, sector mask is " << sectorMask;
+    if ((validSectors & sectorMask).any()) {
+      // have already data for this sector, this should not happen in the current
+      // sequential implementation, for parallel path merged at the tracker stage
+      // multiple buffers need to be handled
+      throw std::runtime_error("can only have one data set per sector");
+    }
+    activeSectors |= sectorHeader->activeSectors;
+    validSectors |= sectorMask;
+    datarefs[sector] = ref;
+  }
+
+  auto printInputLog = [&validSectors, &activeSectors](auto& r, const char* comment, auto& s) {
+    LOG(INFO) << comment << " " << *(r.spec) << ", size " << DataRefUtils::getPayloadSize(r) //
+              << " for sector " << s                                                         //
+              << std::endl                                                                   //
+              << "  input status:   " << validSectors                                        //
+              << std::endl                                                                   //
+              << "  active sectors: " << std::bitset<o2::tpc::constants::MAXSECTOR>(activeSectors);
+  };
+
+  if (activeSectors == 0 || (activeSectors & validSectors.to_ulong()) != activeSectors) {
+    // not all sectors available
+    // Since we expect complete input, this should not happen (why does the bufferization considered for TPC CA tracker? Ask Matthias)
+    throw std::runtime_error("Did not receive TPC clusters data for all sectors");
+  }
+  //------------------------------------------------------------------------------
+  std::vector<gsl::span<const char>> clustersTPC;
+
+  for (auto const& refentry : datarefs) {
+    auto& sector = refentry.first;
+    auto& ref = refentry.second;
+    clustersTPC.emplace_back(ref.payload, DataRefUtils::getPayloadSize(ref));
+    printInputLog(ref, "received", sector);
+  }
+
+  // Just print TPC clusters status
+  {
+    // make human readable information from the bitfield
+    std::string bitInfo;
+    auto nActiveBits = validSectors.count();
+    if (((uint64_t)0x1 << nActiveBits) == validSectors.to_ulong() + 1) {
+      // sectors 0 to some upper bound are active
+      bitInfo = "0-" + std::to_string(nActiveBits - 1);
+    } else {
+      int rangeStart = -1;
+      int rangeEnd = -1;
+      for (size_t sector = 0; sector < validSectors.size(); sector++) {
+        if (validSectors.test(sector)) {
+          if (rangeStart < 0) {
+            if (rangeEnd >= 0) {
+              bitInfo += ",";
+            }
+            bitInfo += std::to_string(sector);
+            if (nActiveBits == 1) {
+              break;
+            }
+            rangeStart = sector;
+          }
+          rangeEnd = sector;
+        } else {
+          if (rangeStart >= 0 && rangeEnd > rangeStart) {
+            bitInfo += "-" + std::to_string(rangeEnd);
+          }
+          rangeStart = -1;
+        }
+      }
+      if (rangeStart >= 0 && rangeEnd > rangeStart) {
+        bitInfo += "-" + std::to_string(rangeEnd);
+      }
+    }
+    LOG(INFO) << "running matching for sector(s) " << bitInfo;
+  }
+
+  o2::tpc::ClusterNativeAccess clusterIndex;
+  std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
+  memset(&clusterIndex, 0, sizeof(clusterIndex));
+  o2::tpc::ClusterNativeHelper::ConstMCLabelContainerViewWithBuffer dummyMCOutput;
+  std::vector<o2::tpc::ClusterNativeHelper::ConstMCLabelContainerView> dummyMCInput;
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, dummyMCOutput, clustersTPC, dummyMCInput);
+  //----------------------------<< TPC Clusters loading <<------------------------------------------
+
+  auto& bufVec = pc.outputs().make<std::vector<unsigned char>>(Output{o2::header::gDataOriginTPC, "CLSHAREDMAP", 0}, clusterIndex.nClustersTotal);
+  o2::gpu::GPUTPCO2InterfaceRefit::fillSharedClustersMap(&clusterIndex, tracksTPC, tracksTPCClRefs.data(), bufVec.data());
+
+  timer.Stop();
+  LOGF(INFO, "Timing for TPC clusters sharing map creation: Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
+}


### PR DESCRIPTION
When getting inputs from the tpc-reco-workflow, the TPC-ITS matching will use shared clusters map info provided by TPC tracking.
In the workflow using the TPC input from root trees, the shared clusters map will be created on the fly by dedicated device.