### PR TITLE
Only run reports.yml in AliceO2Group/AliceO2

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     runs-on: macOS-latest
+    if: github.repository == 'AliceO2Group/AliceO2'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Don't create pointless errors in forks.

Works in my fork -- https://github.com/TimoWilken/AliceO2/actions/runs/493227278 shows up as "this workflow run was skipped" and doesn't send me an email.