### PR TITLE
refactor TRD digit class

### DIFF
--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -13,10 +13,10 @@ o2_add_library(TRDBase
                        src/Geometry.cxx
                        src/GeometryFlat.cxx
                        src/CommonParam.cxx
+                       src/Digit.cxx
                        src/DiffAndTimeStructEstimator.cxx
                        src/SimParam.cxx
                        src/PadResponse.cxx
-                       src/Digit.cxx
                        src/CalDet.cxx
                        src/CalROC.cxx
                        src/FeeParam.cxx
@@ -47,8 +47,8 @@ o2_target_root_dictionary(TRDBase
                                   include/TRDBase/GeometryFlat.h
                                   include/TRDBase/SimParam.h
                                   include/TRDBase/CommonParam.h
-                                  include/TRDBase/PadResponse.h
                                   include/TRDBase/Digit.h
+                                  include/TRDBase/PadResponse.h
                                   include/TRDBase/MCLabel.h
                                   include/TRDBase/CalDet.h
                                   include/TRDBase/CalROC.h

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -18,8 +18,7 @@
 #include <numeric>
 #include "Rtypes.h" // for ClassDef
 
-#include "CommonDataFormat/TimeStamp.h"
-#include "TRDBase/CommonParam.h"
+#include "TRDBase/FeeParam.h"
 #include "DataFormatsTRD/Constants.h"
 
 namespace o2
@@ -30,37 +29,56 @@ namespace trd
 using ADC_t = std::uint16_t;
 using ArrayADC = std::array<ADC_t, constants::TIMEBINS>;
 
-using TimeStamp = o2::dataformats::TimeStamp<double>;
-
-class Digit : public TimeStamp
+// Digit class for TRD
+// Notes:
+//    Shared pads:
+//        the lowe mcm and rob is chosen for a given shared pad.
+//        this negates the need for need alternate indexing strategies.
+//        it does however mean that if you are trying to go from pad/row to mcm/rob you need to remember to manually do the shared ones.
+//        TODO we could change the get methods to return the value in negaitve to indicate a shared pad, but I feel this is just added complexity? Comments?
+//        if you are going to have to check for negative you may as well check for it being shared.
+class Digit
 {
  public:
   Digit() = default;
   ~Digit() = default;
-  Digit(const int det, const int row, const int pad, const ArrayADC adc, double t)
-    : mDetector(det), mRow(row), mPad(pad), mADC(adc), TimeStamp(t) {}
+  Digit(const int det, const int row, const int pad, const ArrayADC adc);
+  Digit(const int det, const int row, const int pad); // add adc data in a seperate step
+  Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc);
+  Digit(const int det, const int rob, const int mcm, const int channel); // add adc data in a seperate step
+
   // Copy
   Digit(const Digit&) = default;
   // Assignment
   Digit& operator=(const Digit&) = default;
   // Modifiers
+  void setROB(int rob) { mROB = rob; }
+  void setROB(int row, int pad) { mROB = FeeParam::getROBfromPad(row, pad); }
+  void setMCM(int mcm) { mMCM = mcm; }
+  void setMCM(int row, int pad) { mMCM = FeeParam::getMCMfromPad(row, pad); }
+  void setChannel(int channel) { mChannel = channel; }
   void setDetector(int det) { mDetector = det; }
-  void setRow(int row) { mRow = row; }
-  void setPad(int pad) { mPad = pad; }
   void setADC(ArrayADC const& adc) { mADC = adc; }
   // Get methods
-  int getDetector() const { return mDetector; }
-  int getRow() const { return mRow; }
-  int getPad() const { return mPad; }
+  int getDetector() const { return mROB; }
+  int getRow() const { return FeeParam::getPadRowFromMCM(mROB, mMCM); }
+  int getPad() const { return FeeParam::getPadColFromADC(mROB, mMCM, mChannel); }
+  int getROB() const { return mROB; }
+  int getMCM() const { return mMCM; }
+  int getChannel() const { return mChannel; }
+  int isSharedDigit();
+
   ArrayADC const& getADC() const { return mADC; }
   ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }
 
  private:
-  std::uint16_t mDetector{0}; // TRD detector number, 0-539
-  std::uint8_t mRow{0};       // pad row, 0-15
-  std::uint8_t mPad{0};       // pad within pad row, 0-143
-  ArrayADC mADC{};            // ADC vector (30 time-bins)
-  ClassDefNV(Digit, 2);
+  std::uint16_t mDetector{0}; // detector, the chamber
+  std::uint8_t mROB{0};       // read out board with in chamber
+  std::uint8_t mMCM{0};       // MCM chip this digit is attached to
+  std::uint8_t mChannel{0};   // channel of this chip the digit is attached to.
+
+  ArrayADC mADC{}; // ADC vector (30 time-bins)
+  ClassDefNV(Digit, 3);
 };
 
 } // namespace trd

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -53,15 +53,15 @@ class FeeParam
   static void terminate();
 
   // Translation from MCM to Pad and vice versa
-  virtual int getPadRowFromMCM(int irob, int imcm) const;
-  virtual int getPadColFromADC(int irob, int imcm, int iadc) const;
-  virtual int getExtendedPadColFromADC(int irob, int imcm, int iadc) const;
-  virtual int getMCMfromPad(int irow, int icol) const;
-  virtual int getMCMfromSharedPad(int irow, int icol) const;
-  virtual int getROBfromPad(int irow, int icol) const;
-  virtual int getROBfromSharedPad(int irow, int icol) const;
-  virtual int getRobSide(int irob) const;
-  virtual int getColSide(int icol) const;
+  static int getPadRowFromMCM(int irob, int imcm);
+  static int getPadColFromADC(int irob, int imcm, int iadc);
+  static int getExtendedPadColFromADC(int irob, int imcm, int iadc);
+  static int getMCMfromPad(int irow, int icol);
+  static int getMCMfromSharedPad(int irow, int icol);
+  static int getROBfromPad(int irow, int icol);
+  static int getROBfromSharedPad(int irow, int icol);
+  static int getRobSide(int irob);
+  static int getColSide(int icol);
 
   // SCSN-related
   static unsigned int aliToExtAli(int rob, int aliid);                                                                 // Converts the MCM-ROB combination to the extended MCM ALICE ID (used to address MCMs on the SCSN Bus)
@@ -70,11 +70,11 @@ class FeeParam
   static short getRobAB(unsigned short robsel, unsigned short linkpair); // Returns the chamber side (A=0, B=0) of a ROB
 
   // wiring
-  virtual int getORI(int detector, int readoutboard) const;
-  virtual int getORIinSM(int detector, int readoutboard) const;
-  //  virtual void createORILookUpTable();
-  virtual int getORIfromHCID(int hcid) const;
-  virtual int getHCIDfromORI(int ori, int readoutboard) const; // TODO we need more info than just ori, for now readoutboard is there ... might change
+  static int getORI(int detector, int readoutboard);
+  static int getORIinSM(int detector, int readoutboard);
+  //  static void createORILookUpTable();
+  static int getORIfromHCID(int hcid);
+  static int getHCIDfromORI(int ori, int readoutboard); // TODO we need more info than just ori, for now readoutboard is there ... might change
 
   // tracklet simulation
   bool getTracklet() const { return mgTracklet; }

--- a/Detectors/TRD/base/src/Digit.cxx
+++ b/Detectors/TRD/base/src/Digit.cxx
@@ -9,3 +9,41 @@
 // or submit itself to any jurisdiction.
 
 #include "TRDBase/Digit.h"
+namespace o2::trd
+{
+Digit::Digit(const int det, const int row, const int pad, const ArrayADC adc)
+{
+  setDetector(det);
+  setROB(row, pad);
+  setMCM(row, pad);
+  setADC(adc);
+}
+Digit::Digit(const int det, const int row, const int pad) // add adc data in a seperate step
+{
+  setDetector(det);
+  setROB(row, pad);
+  setMCM(row, pad);
+}
+Digit::Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc)
+{
+  setROB(rob);
+  setMCM(mcm);
+  setChannel(channel);
+  setADC(adc);
+}
+Digit::Digit(const int det, const int rob, const int mcm, const int channel) // add adc data in a seperate step
+{
+  setROB(rob);
+  setMCM(mcm);
+  setChannel(channel);
+}
+int Digit::isSharedDigit()
+{
+  if (mChannel == 0 || mChannel == 19 || mChannel == 20) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -195,7 +195,7 @@ void FeeParam::Copy(FeeParam& p) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getPadRowFromMCM(int irob, int imcm) const
+int FeeParam::getPadRowFromMCM(int irob, int imcm)
 {
   //
   // Return on which pad row this mcm sits
@@ -205,7 +205,7 @@ int FeeParam::getPadRowFromMCM(int irob, int imcm) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getPadColFromADC(int irob, int imcm, int iadc) const
+int FeeParam::getPadColFromADC(int irob, int imcm, int iadc)
 {
   //
   // Return which pad is connected to this adc channel.
@@ -232,7 +232,7 @@ int FeeParam::getPadColFromADC(int irob, int imcm, int iadc) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getExtendedPadColFromADC(int irob, int imcm, int iadc) const
+int FeeParam::getExtendedPadColFromADC(int irob, int imcm, int iadc)
 {
   //
   // Return which pad coresponds to the extended digit container pad numbering
@@ -250,7 +250,7 @@ int FeeParam::getExtendedPadColFromADC(int irob, int imcm, int iadc) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getMCMfromPad(int irow, int icol) const
+int FeeParam::getMCMfromPad(int irow, int icol)
 {
   //
   // Return on which MCM this pad is directry connected.
@@ -264,7 +264,7 @@ int FeeParam::getMCMfromPad(int irow, int icol) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getMCMfromSharedPad(int irow, int icol) const
+int FeeParam::getMCMfromSharedPad(int irow, int icol)
 {
   //
   // Return on which MCM this pad is directry connected.
@@ -295,7 +295,7 @@ int FeeParam::getMCMfromSharedPad(int irow, int icol) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getROBfromPad(int irow, int icol) const
+int FeeParam::getROBfromPad(int irow, int icol)
 {
   //
   // Return on which rob this pad is
@@ -304,7 +304,7 @@ int FeeParam::getROBfromPad(int irow, int icol) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getROBfromSharedPad(int irow, int icol) const
+int FeeParam::getROBfromSharedPad(int irow, int icol)
 {
   //
   // Return on which rob this pad is for shared pads
@@ -318,7 +318,7 @@ int FeeParam::getROBfromSharedPad(int irow, int icol) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getRobSide(int irob) const
+int FeeParam::getRobSide(int irob)
 {
   //
   // Return on which side this rob sits (A side = 0, B side = 1)
@@ -332,7 +332,7 @@ int FeeParam::getRobSide(int irob) const
 }
 
 //_____________________________________________________________________________
-int FeeParam::getColSide(int icol) const
+int FeeParam::getColSide(int icol)
 {
   //
   // Return on which side this column sits (A side = 0, B side = 1)
@@ -511,14 +511,14 @@ void FeeParam::createORILookUpTable()
 }
 */
 
-int FeeParam::getORI(int detector, int readoutboard) const
+int FeeParam::getORI(int detector, int readoutboard)
 {
   int supermodule = detector / 30;
   LOG(debug3) << "getORI : " << detector << " :: " << readoutboard << getORIinSM(detector, readoutboard) + 60 * detector;
   return getORIinSM(detector, readoutboard) + 2 * detector; // 2 ORI per detector
 }
 
-int FeeParam::getORIinSM(int detector, int readoutboard) const
+int FeeParam::getORIinSM(int detector, int readoutboard)
 {
   int ori = -1;
   int chamberside = 0;
@@ -546,7 +546,7 @@ int FeeParam::getORIinSM(int detector, int readoutboard) const
   return ori;
 }
 
-int FeeParam::getORIfromHCID(int hcid) const
+int FeeParam::getORIfromHCID(int hcid)
 {
   int detector = hcid / 2;
   int side = hcid % 2; // 0 for side 0, 1 for side 1;
@@ -555,9 +555,8 @@ int FeeParam::getORIfromHCID(int hcid) const
   int trdstack = Geometry::getStack(detector);
   int trdlayer = Geometry::getLayer(detector);
   return getORIinSM(detector, side); // it takes readoutboard but only cares if its odd or even hence side here.
-  return 1;
 }
-int FeeParam::getHCIDfromORI(int ori, int readoutboard) const
+int FeeParam::getHCIDfromORI(int ori, int readoutboard)
 {
   // ori = 60*SM+offset[0-29 A, 30-59 C]
   // from the offset, we can derive the stack/layer/side combination giving the decector.

--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -18,9 +18,9 @@
 #pragma link C++ class o2::trd::Geometry + ;
 #pragma link C++ class o2::trd::GeometryBase + ;
 #pragma link C++ class o2::trd::CommonParam + ;
-#pragma link C++ class o2::trd::SimParam + ;
 #pragma link C++ class o2::trd::Digit + ;
-#pragma link C++ class std::vector < o2::trd::Digit> + ;
+#pragma link C++ class std::vector < o2::trd::Digit > +;
+#pragma link C++ class o2::trd::SimParam + ;
 #pragma link C++ class o2::trd::FeeParam + ;
 #pragma link C++ class o2::trd::CalDet + ;
 #pragma link C++ class o2::trd::CalROC + ;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -519,7 +519,7 @@ bool Digitizer::convertSignalsToADC(SignalContainer& signalMapCont, DigitContain
       adcs[tb] = adc;
     } // loop over timebins
     // Convert the map to digits here, and push them to the container
-    digits.emplace_back(det, row, col, adcs, getEventTime());
+    digits.emplace_back(det, row, col, adcs);
   } // loop over digits
   return true;
 }

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -211,7 +211,6 @@ bool digitindexcompare(unsigned int A, unsigned int B, const std::vector<o2::trd
   const o2::trd::Digit *a, *b;
   a = &originalDigits[A];
   b = &originalDigits[B];
-  // timestamps are equal
   if (a->getDetector() < b->getDetector()) {
     return 1;
   }
@@ -365,7 +364,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   //for (auto& digit : msgDigits) {
   for (auto& digitindex : msgDigitsIndex) {
     Digit digit = msgDigits[digitindex];
-    LOG(debug) << "sorted digit time:" << digit.getTimeStamp() << " detector:row:pad:rob:mcm ::"
+    LOG(debug) << "sorted digit detector:row:pad:rob:mcm ::"
                << digit.getDetector() << ":" << digit.getRow() << ":" << digit.getPad() << ":"
                << mFeeParam->getROBfromPad(digit.getRow(), digit.getPad()) << ":"
                << mFeeParam->getMCMfromPad(digit.getRow(), digit.getPad())
@@ -402,7 +401,6 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
     //  fireup trapsim, do its thing with each 18 sequence of pads data that already exists inside the class from previous iterations of the loop
     LOG(debug) << "Digit iterator is : " << *digititerator;
     Digit* digit = &msgDigits[*digititerator];
-    double digittime = digit->getTimeStamp();
     int pad = digit->getPad();
     int row = digit->getRow();
     int detector = digit->getDetector();
@@ -416,7 +414,6 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
                << detector << ":" << row << ":" << pad << ":" << rob << ":" << mcm
                << " LinkId:" << LinkRecord::getHalfChamberLinkId(detector, rob) << "\t\t  SM:stack:layer:side  " << detector / 30 << ":" << trdstack << ":" << trdlayer << ":" << fibreside
                << " with ORI : " << mFeeParam->getORI(detector, rob) << " and within supermodule ori index:" << mFeeParam->getORIinSM(detector, rob);
-    LOG(debug) << "digit time :  " << digittime;
     if (digititerator == msgDigitsIndex.begin()) { // first time in loop
       oldrow = row;
       olddetector = detector;


### PR DESCRIPTION
- Convert digits to store rob/mcm and not pad/row.
- The interface for pad row remains so code wont change.
- For shared pads the lower indexed mcm is returned. It is the users responsibility to check if its shared if needed for their purposes.
 - The plan was to move digit to DataFormats, but there is a circular library, so postponed to later.