### PR TITLE
introduce MCH ROFRecord.h + modify tracking workflows to process several ROF per TF

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -10,7 +10,8 @@
 
 o2_add_library(DataFormatsMCH
                SOURCES src/TrackMCH.cxx
-	       PUBLIC_LINK_LIBRARIES O2::CommonDataFormat)
+	           PUBLIC_LINK_LIBRARIES O2::CommonDataFormat)
 
 o2_target_root_dictionary(DataFormatsMCH
-                          HEADERS include/DataFormatsMCH/TrackMCH.h)
+                          HEADERS include/DataFormatsMCH/ROFRecord.h
+                                  include/DataFormatsMCH/TrackMCH.h)

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ROFRecord.h
+/// \brief Definition of the MCH ROFrame record
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MCH_ROFRECORD_H
+#define ALICEO2_MCH_ROFRECORD_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+
+namespace o2
+{
+namespace mch
+{
+
+/// ROFRecord class encodes the trigger interaction record of a given ROF and
+/// the location of the associated objects (digit, cluster, etc) in the data container
+class ROFRecord
+{
+  using BCData = o2::InteractionRecord;
+  using DataRef = o2::dataformats::RangeReference<int, int>;
+
+ public:
+  ROFRecord() = default;
+  ROFRecord(const BCData& bc, int firstIdx, int nEntries) : mBCData(bc), mDataRef(firstIdx, nEntries) {}
+
+  /// get the interaction record
+  const BCData& getBCData() const { return mBCData; }
+  /// get the interaction record
+  BCData& getBCData() { return mBCData; }
+  /// set the interaction record
+  void setBCData(const BCData& bc) { mBCData = bc; }
+
+  /// get the number of associated objects
+  int getNEntries() const { return mDataRef.getEntries(); }
+  /// get the index of the first associated object
+  int getFirstIdx() const { return mDataRef.getFirstEntry(); }
+  /// get the index of the last associated object
+  int getLastIdx() const { return mDataRef.getFirstEntry() + mDataRef.getEntries() - 1; }
+  /// set the number of associated objects and the index of the first one
+  void setDataRef(int firstIdx, int nEntries) { mDataRef.set(firstIdx, nEntries); }
+
+ private:
+  BCData mBCData{};   ///< interaction record
+  DataRef mDataRef{}; ///< reference to the associated objects
+
+  ClassDefNV(ROFRecord, 1);
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif // ALICEO2_MCH_ROFRECORD_H

--- a/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
+++ b/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
@@ -14,5 +14,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::mch::ROFRecord + ;
 #pragma link C++ class o2::mch::TrackMCH + ;
 #endif

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -74,7 +74,7 @@ o2_add_executable(
         clusters-sampler-workflow
         SOURCES src/ClusterSamplerSpec.cxx src/clusters-sampler-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::MCHBase)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase)
 
 o2_add_executable(
         clusters-to-tracks-original-workflow
@@ -92,7 +92,7 @@ o2_add_executable(
         vertex-sampler-workflow
         SOURCES src/VertexSamplerSpec.cxx src/vertex-sampler-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH)
 
 o2_add_executable(
         tracks-to-tracks-at-vertex-workflow

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -55,7 +55,7 @@ filePath = /home/data/data-de819-ped-raw.raw
 
 `o2-mch-clusters-to-tracks-original-workflow`
 
-Take as input the list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "CLUSTERS" and send the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in two separate messages with the data description "TRACKS" and "TRACKCLUSTERS", respectively.
+Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
@@ -73,7 +73,7 @@ Same behavior and options as [Original track finder](#original-track-finder)
 
 `o2-mch-tracks-to-tracks-at-vertex-workflow`
 
-Take as input the vertex position (`Point3D<double>`) and the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) of the current event with the data description "VERTEX" and "TRACKS", respectively, and send the list of tracks at vertex (`TrackAtVtxStruct` as described below) with the data description "TRACKSATVERTEX".
+Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of ROF records pointing to the tracks associated to each interaction and their vertex position (`Point3D<double>`), with the data description "TRACKS", "TRACKROFS" and "VERTICES", respectively. Send the list of all tracks at vertex (`TrackAtVtxStruct` as described below) in the time frame with the data description "TRACKSATVERTEX".
 
 ```c++
 struct TrackAtVtxStruct {
@@ -90,7 +90,7 @@ Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current
 
 `o2-mch-tracks-to-tracks-workflow`
 
-Take as input the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "TRACKSIN" and "TRACKCLUSTERSIN", respectively, and send the list of refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in two separate messages with the data description "TRACKS" and "TRACKCLUSTERS", respectively.
+Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction, with the data description "TRACKSIN", "TRACKCLUSTERSIN" and "TRACKROFSIN", respectively. Send the list of all refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
@@ -109,7 +109,9 @@ where `clusters.in` is a binary file containing for each event:
 * list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
 * list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))
 
-Send the list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "CLUSTERS".
+Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+
+Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1)
 
 ### Track sampler
 
@@ -117,15 +119,17 @@ Send the list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.
 
 where `tracks.in` is a binary file with the same format as the one written by the workflow [o2-mch-tracks-sink-workflow](#track-sink)
 
-Send the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in two separate messages with the data description "TRACKS" and "TRACKCLUSTERS", respectively.
+Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
-Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN" and "TRACKCLUSTERSIN", respectively, as expected by the workflow [o2-mch-tracks-to-tracks-workflow](#track-fitter).
+Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN", "TRACKCLUSTERSIN" and TRACKROFSIN, respectively, as expected by the workflow [o2-mch-tracks-to-tracks-workflow](#track-fitter).
+
+Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1)
 
 ### Vertex sampler
 
 `o2-mch-vertex-sampler-workflow`
 
-Send the vertex position (`Point3D<double>`) of the current event with the data description "VERTEX".
+Take as input the list of ROF records in the current time frame, with the data description "TRACKROFS". Send the list of all vertex positions (`Point3D<double>`) in the time frame, one per interaction, with the data description "VERTICES".
 
 Option `--infile "vertices.in"` allows to read the position of the vertex from the binary file `vertices.in` containing for each event:
 
@@ -146,7 +150,7 @@ If no binary file is provided, the vertex is always set to (0,0,0).
 
 `o2-mch-tracks-sink-workflow --outfile "tracks.out"`
 
-Take as input the list of tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)), the list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) and the list of associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) of the current event with the data description "TRACKSATVERTEX", "TRACKS" and "TRACKCLUSTERS", respectively, and write them in the binary file `tracks.out` with the following format:
+Take as input the list of all tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)) in the current time frame, the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the MCH tracks associated to each interaction, with the data description "TRACKSATVERTEX", "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively, and write them event-by-event in the binary file `tracks.out` with the following format for each event:
 
 * number of tracks at vertex (int)
 * number of MCH tracks (int)

--- a/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
@@ -17,8 +17,8 @@
 
 #include <iostream>
 #include <fstream>
-
 #include <stdexcept>
+#include <vector>
 
 #include "Framework/CallbackService.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -29,6 +29,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "DataFormatsMCH/ROFRecord.h"
 #include "MCHBase/ClusterBlock.h"
 #include "MCHBase/Digit.h"
 
@@ -52,7 +53,15 @@ class ClusterSamplerTask
     auto inputFileName = ic.options().get<std::string>("infile");
     mInputFile.open(inputFileName, ios::binary);
     if (!mInputFile.is_open()) {
-      throw invalid_argument("Cannot open input file" + inputFileName);
+      throw invalid_argument("cannot open input file" + inputFileName);
+    }
+    if (mInputFile.peek() == EOF) {
+      throw length_error("input file is empty");
+    }
+
+    mNEventsPerTF = ic.options().get<int>("nEventsPerTF");
+    if (mNEventsPerTF < 1) {
+      throw invalid_argument("number of events per time frame must be >= 1");
     }
 
     auto stop = [this]() {
@@ -66,28 +75,60 @@ class ClusterSamplerTask
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
-    /// send the clusters of the current event
+    /// send the clusters of the next events in the current TF
 
-    // get the number of clusters and associated digits
-    int nClusters(0);
+    static uint32_t event(-1);
+
+    // reached eof
+    if (mInputFile.peek() == EOF) {
+      pc.services().get<ControlService>().endOfStream();
+      //pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      return;
+    }
+
+    // create the output messages
+    auto& rofs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"rofs"});
+    auto& clusters = pc.outputs().make<std::vector<ClusterStruct>>(OutputRef{"clusters"});
+
+    // loop over the requested number of events (or until eof) and fill the messages
+    for (int iEvt = 0; iEvt < mNEventsPerTF && mInputFile.peek() != EOF; ++iEvt) {
+      int nClusters = readOneEvent(clusters);
+      rofs.emplace_back(o2::InteractionRecord{0, ++event}, clusters.size() - nClusters, nClusters);
+    }
+  }
+
+ private:
+  //_________________________________________________________________________________________________
+  int readOneEvent(std::vector<ClusterStruct, o2::pmr::polymorphic_allocator<ClusterStruct>>& clusters)
+  {
+    /// fill the internal buffer with the clusters of the current event
+
+    // get the number of clusters
+    int nClusters(-1);
     mInputFile.read(reinterpret_cast<char*>(&nClusters), sizeof(int));
     if (mInputFile.fail()) {
-      pc.services().get<ControlService>().endOfStream();
-      return; // probably reached eof
+      throw length_error("invalid input");
     }
-    int nDigits(0);
+
+    // get the number of associated digits
+    int nDigits(-1);
     mInputFile.read(reinterpret_cast<char*>(&nDigits), sizeof(int));
+    if (mInputFile.fail()) {
+      throw length_error("invalid input");
+    }
 
     if (nClusters < 0 || nDigits < 0) {
-      throw length_error("incorrect message payload");
+      throw length_error("invalid input");
     }
-
-    // create the output message
-    auto clusters = pc.outputs().make<ClusterStruct>(Output{"MCH", "CLUSTERS", 0, Lifetime::Timeframe}, nClusters);
 
     // fill clusters in O2 format, if any
     if (nClusters > 0) {
-      mInputFile.read(reinterpret_cast<char*>(clusters.data()), clusters.size_bytes());
+      int clusterOffset = clusters.size();
+      clusters.resize(clusterOffset + nClusters);
+      mInputFile.read(reinterpret_cast<char*>(&clusters[clusterOffset]), nClusters * sizeof(ClusterStruct));
+      if (mInputFile.fail()) {
+        throw length_error("invalid input");
+      }
     } else {
       LOG(INFO) << "event is empty";
     }
@@ -95,11 +136,16 @@ class ClusterSamplerTask
     // skip the digits if any
     if (nDigits > 0) {
       mInputFile.seekg(nDigits * sizeof(Digit), std::ios::cur);
+      if (mInputFile.fail()) {
+        throw length_error("invalid input");
+      }
     }
+
+    return nClusters;
   }
 
- private:
   std::ifstream mInputFile{}; ///< input file
+  int mNEventsPerTF = 1;      ///< number of events per time frame
 };
 
 //_________________________________________________________________________________________________
@@ -108,9 +154,11 @@ o2::framework::DataProcessorSpec getClusterSamplerSpec()
   return DataProcessorSpec{
     "ClusterSampler",
     Inputs{},
-    Outputs{OutputSpec{"MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"rofs"}, "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
+            OutputSpec{{"clusters"}, "MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<ClusterSamplerTask>()},
-    Options{{"infile", VariantType::String, "", {"input filename"}}}};
+    Options{{"infile", VariantType::String, "", {"input filename"}},
+            {"nEventsPerTF", VariantType::Int, 1, {"number of events per time frame"}}}};
 }
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterSamplerSpec.cxx
@@ -77,7 +77,7 @@ class ClusterSamplerTask
   {
     /// send the clusters of the next events in the current TF
 
-    static uint32_t event(-1);
+    static uint32_t event(0);
 
     // reached eof
     if (mInputFile.peek() == EOF) {
@@ -93,7 +93,7 @@ class ClusterSamplerTask
     // loop over the requested number of events (or until eof) and fill the messages
     for (int iEvt = 0; iEvt < mNEventsPerTF && mInputFile.peek() != EOF; ++iEvt) {
       int nClusters = readOneEvent(clusters);
-      rofs.emplace_back(o2::InteractionRecord{0, ++event}, clusters.size() - nClusters, nClusters);
+      rofs.emplace_back(o2::InteractionRecord{0, event++}, clusters.size() - nClusters, nClusters);
     }
   }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -31,6 +31,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/ClusterBlock.h"
 #include "MCHTracking/TrackParam.h"
@@ -80,27 +81,38 @@ class TrackFinderTask
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
-    /// read the clusters of the current event, find tracks and send them
+    /// for each event in the current TF, read the clusters and find tracks, then send them all
 
-    // get the input clusters
+    // get the input messages with clusters
+    auto clusterROFs = pc.inputs().get<gsl::span<ROFRecord>>("clusterrofs");
     auto clustersIn = pc.inputs().get<gsl::span<ClusterStruct>>("clusters");
-    std::unordered_map<int, std::list<Cluster>> clusters{};
-    for (const auto& cluster : clustersIn) {
-      clusters[cluster.getDEId()].emplace_back(cluster);
-    }
 
-    // run the track finder
-    auto tStart = std::chrono::high_resolution_clock::now();
-    const auto& tracks = mTrackFinder.findTracks(clusters);
-    auto tEnd = std::chrono::high_resolution_clock::now();
-    mElapsedTime += tEnd - tStart;
+    //LOG(INFO) << "received time frame with " << clusterROFs.size() << " interactions";
 
     // create the output messages for tracks and attached clusters
-    auto& mchTracks = pc.outputs().make<std::vector<TrackMCH>>(Output{"MCH", "TRACKS", 0, Lifetime::Timeframe});
-    auto& usedClusters = pc.outputs().make<std::vector<ClusterStruct>>(Output{"MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe});
+    auto& trackROFs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"trackrofs"});
+    auto& mchTracks = pc.outputs().make<std::vector<TrackMCH>>(OutputRef{"tracks"});
+    auto& usedClusters = pc.outputs().make<std::vector<ClusterStruct>>(OutputRef{"trackclusters"});
 
-    // write the messages
-    if (tracks.size() > 0) {
+    trackROFs.reserve(clusterROFs.size());
+    for (const auto& clusterROF : clusterROFs) {
+
+      //LOG(INFO) << "processing interaction: " << clusterROF.getBCData() << "...";
+
+      // get the input clusters of the current event
+      std::unordered_map<int, std::list<Cluster>> clusters{};
+      for (const auto& cluster : clustersIn.subspan(clusterROF.getFirstIdx(), clusterROF.getNEntries())) {
+        clusters[cluster.getDEId()].emplace_back(cluster);
+      }
+
+      // run the track finder
+      auto tStart = std::chrono::high_resolution_clock::now();
+      const auto& tracks = mTrackFinder.findTracks(clusters);
+      auto tEnd = std::chrono::high_resolution_clock::now();
+      mElapsedTime += tEnd - tStart;
+
+      // fill the ouput messages
+      trackROFs.emplace_back(clusterROF.getBCData(), mchTracks.size(), tracks.size());
       writeTracks(tracks, mchTracks, usedClusters);
     }
   }
@@ -112,10 +124,6 @@ class TrackFinderTask
                    std::vector<ClusterStruct, o2::pmr::polymorphic_allocator<ClusterStruct>>& usedClusters) const
   {
     /// fill the output messages with tracks and attached clusters
-
-    // avoid memory reallocation
-    mchTracks.reserve(tracks.size());
-    usedClusters.reserve(20. * tracks.size());
 
     for (const auto& track : tracks) {
 
@@ -138,9 +146,11 @@ o2::framework::DataProcessorSpec getTrackFinderSpec()
 {
   return DataProcessorSpec{
     "TrackFinder",
-    Inputs{InputSpec{"clusters", "MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
-    Outputs{OutputSpec{"MCH", "TRACKS", 0, Lifetime::Timeframe},
-            OutputSpec{"MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe}},
+    Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
+           InputSpec{"clusters", "MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
+            OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe},
+            OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<TrackFinderTask>()},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},

--- a/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
@@ -78,7 +78,7 @@ class TrackSamplerTask
   {
     /// send the tracks with attached clusters of the next events in the current TF
 
-    static uint32_t event(-1);
+    static uint32_t event(0);
 
     // reached eof
     if (mInputFile.peek() == EOF) {
@@ -95,7 +95,7 @@ class TrackSamplerTask
     // loop over the requested number of events (or until eof) and fill the messages
     for (int iEvt = 0; iEvt < mNEventsPerTF && mInputFile.peek() != EOF; ++iEvt) {
       int nTracks = readOneEvent(tracks, clusters);
-      rofs.emplace_back(o2::InteractionRecord{0, ++event}, tracks.size() - nTracks, nTracks);
+      rofs.emplace_back(o2::InteractionRecord{0, event++}, tracks.size() - nTracks, nTracks);
     }
   }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
@@ -29,6 +29,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/ClusterBlock.h"
 #include "MCHBase/TrackBlock.h"
@@ -53,7 +54,15 @@ class TrackSamplerTask
     auto inputFileName = ic.options().get<std::string>("infile");
     mInputFile.open(inputFileName, ios::binary);
     if (!mInputFile.is_open()) {
-      throw invalid_argument("Cannot open input file" + inputFileName);
+      throw invalid_argument("cannot open input file" + inputFileName);
+    }
+    if (mInputFile.peek() == EOF) {
+      throw length_error("input file is empty");
+    }
+
+    mNEventsPerTF = ic.options().get<int>("nEventsPerTF");
+    if (mNEventsPerTF < 1) {
+      throw invalid_argument("number of events per time frame must be >= 1");
     }
 
     auto stop = [this]() {
@@ -67,40 +76,26 @@ class TrackSamplerTask
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
-    /// send the tracks with attached clusters of the current event
+    /// send the tracks with attached clusters of the next events in the current TF
 
-    // read the number of tracks at vertex, MCH tracks and attached clusters
-    int nTracksAtVtx(-1);
-    mInputFile.read(reinterpret_cast<char*>(&nTracksAtVtx), sizeof(int));
-    if (mInputFile.fail()) {
+    static uint32_t event(-1);
+
+    // reached eof
+    if (mInputFile.peek() == EOF) {
       pc.services().get<ControlService>().endOfStream();
-      return; // probably reached eof
-    }
-    int nMCHTracks(-1);
-    mInputFile.read(reinterpret_cast<char*>(&nMCHTracks), sizeof(int));
-    int nClusters(-1);
-    mInputFile.read(reinterpret_cast<char*>(&nClusters), sizeof(int));
-
-    if (nTracksAtVtx < 0 || nMCHTracks < 0 || nClusters < 0) {
-      throw length_error("invalid data input");
-    }
-    if (nMCHTracks > 0 && nClusters == 0) {
-      throw out_of_range("clusters are missing");
+      //pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+      return;
     }
 
     // create the output messages
-    auto tracks = pc.outputs().make<TrackMCH>(OutputRef{"tracks"}, nMCHTracks);
-    auto clusters = pc.outputs().make<ClusterStruct>(OutputRef{"clusters"}, nClusters);
+    auto& rofs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"rofs"});
+    auto& tracks = pc.outputs().make<std::vector<TrackMCH>>(OutputRef{"tracks"});
+    auto& clusters = pc.outputs().make<std::vector<ClusterStruct>>(OutputRef{"clusters"});
 
-    // skip the tracks at vertex if any
-    if (nTracksAtVtx > 0) {
-      mInputFile.seekg(nTracksAtVtx * sizeof(TrackAtVtxStruct), std::ios::cur);
-    }
-
-    // read the MCH tracks and the attached clusters
-    if (nMCHTracks > 0) {
-      mInputFile.read(reinterpret_cast<char*>(tracks.data()), tracks.size_bytes());
-      mInputFile.read(reinterpret_cast<char*>(clusters.data()), clusters.size_bytes());
+    // loop over the requested number of events (or until eof) and fill the messages
+    for (int iEvt = 0; iEvt < mNEventsPerTF && mInputFile.peek() != EOF; ++iEvt) {
+      int nTracks = readOneEvent(tracks, clusters);
+      rofs.emplace_back(o2::InteractionRecord{0, ++event}, tracks.size() - nTracks, nTracks);
     }
   }
 
@@ -112,7 +107,78 @@ class TrackSamplerTask
     int mchTrackIdx = 0;
   };
 
+  //_________________________________________________________________________________________________
+  int readOneEvent(std::vector<TrackMCH, o2::pmr::polymorphic_allocator<TrackMCH>>& tracks,
+                   std::vector<ClusterStruct, o2::pmr::polymorphic_allocator<ClusterStruct>>& clusters)
+  {
+    /// fill the output messages with the tracks and attached clusters of the current event
+    /// modify the references to the attached clusters according to their position in the global vector
+
+    // read the number of tracks at vertex, MCH tracks and attached clusters
+    int nTracksAtVtx(-1);
+    mInputFile.read(reinterpret_cast<char*>(&nTracksAtVtx), sizeof(int));
+    if (mInputFile.fail()) {
+      throw length_error("invalid input");
+    }
+    int nMCHTracks(-1);
+    mInputFile.read(reinterpret_cast<char*>(&nMCHTracks), sizeof(int));
+    if (mInputFile.fail()) {
+      throw length_error("invalid input");
+    }
+    int nClusters(-1);
+    mInputFile.read(reinterpret_cast<char*>(&nClusters), sizeof(int));
+    if (mInputFile.fail()) {
+      throw length_error("invalid input");
+    }
+
+    if (nTracksAtVtx < 0 || nMCHTracks < 0 || nClusters < 0) {
+      throw length_error("invalid input");
+    }
+    if (nMCHTracks > 0 && nClusters == 0) {
+      throw length_error("clusters are missing");
+    }
+
+    // skip the tracks at vertex if any
+    if (nTracksAtVtx > 0) {
+      mInputFile.seekg(nTracksAtVtx * sizeof(TrackAtVtxStruct), std::ios::cur);
+      if (mInputFile.fail()) {
+        throw length_error("invalid input");
+      }
+    }
+
+    if (nMCHTracks > 0) {
+
+      // read the MCH tracks
+      int trackOffset = tracks.size();
+      tracks.resize(trackOffset + nMCHTracks);
+      mInputFile.read(reinterpret_cast<char*>(&tracks[trackOffset]), nMCHTracks * sizeof(TrackMCH));
+      if (mInputFile.fail()) {
+        throw length_error("invalid input");
+      }
+
+      // read the attached clusters
+      int clusterOffset = clusters.size();
+      clusters.resize(clusterOffset + nClusters);
+      mInputFile.read(reinterpret_cast<char*>(&clusters[clusterOffset]), nClusters * sizeof(ClusterStruct));
+      if (mInputFile.fail()) {
+        throw length_error("invalid input");
+      }
+
+      // modify the cluster references
+      for (auto itTrack = tracks.begin() + trackOffset; itTrack < tracks.end(); ++itTrack) {
+        itTrack->setClusterRef(clusterOffset, itTrack->getNClusters());
+        clusterOffset += itTrack->getNClusters();
+      }
+      if (clusterOffset != clusters.size()) {
+        throw length_error("inconsistent cluster references");
+      }
+    }
+
+    return nMCHTracks;
+  }
+
   std::ifstream mInputFile{}; ///< input file
+  int mNEventsPerTF = 1;      ///< number of events per time frame
 };
 
 //_________________________________________________________________________________________________
@@ -120,9 +186,11 @@ o2::framework::DataProcessorSpec getTrackSamplerSpec(bool forTrackFitter)
 {
   Outputs outputs{};
   if (forTrackFitter) {
+    outputs.emplace_back(OutputLabel{"rofs"}, "MCH", "TRACKROFSIN", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"tracks"}, "MCH", "TRACKSIN", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"clusters"}, "MCH", "TRACKCLUSTERSIN", 0, Lifetime::Timeframe);
   } else {
+    outputs.emplace_back(OutputLabel{"rofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"clusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe);
   }
@@ -132,7 +200,8 @@ o2::framework::DataProcessorSpec getTrackSamplerSpec(bool forTrackFitter)
     Inputs{},
     outputs,
     AlgorithmSpec{adaptFromTask<TrackSamplerTask>()},
-    Options{{"infile", VariantType::String, "", {"input filename"}}}};
+    Options{{"infile", VariantType::String, "", {"input filename"}},
+            {"nEventsPerTF", VariantType::Int, 1, {"number of events per time frame"}}}};
 }
 
 } // end namespace mch


### PR DESCRIPTION
These modifications allows to send and process several events per time frame. Each individual interaction in the time frame is identified by an MCH ROF record, which contains the interaction record and the location of the associated objects (e.g. tracks) in the overall list. For the moment I only modified the tracking devices.