### PR TITLE
PWGHF: Shift decay type values to allow usage in arrays and bitmaps.

### DIFF
--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -155,7 +155,9 @@ DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction le
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
 // mapping of decay types
-enum DecayType { D0ToPiK = 1 };
+enum DecayType { D0ToPiK = 0,
+                 JpsiToEE,
+                 N2ProngDecays }; //always keep N2ProngDecays at the end
 
 // functions for specific particles
 
@@ -289,8 +291,10 @@ DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction le
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
 
 // mapping of decay types
-enum DecayType { DPlusToPiKPi = 1,
-                 LcToPKPi };
+enum DecayType { DPlusToPiKPi = 0,
+                 LcToPKPi,
+                 DsToPiKK,
+                 N3ProngDecays }; //always keep N3ProngDecays at the end
 
 // functions for specific particles
 

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -147,19 +147,19 @@ struct HFCandidateCreator2ProngMC {
                aod::McParticles const& particlesMC)
   {
     int8_t sign = 0;
-    int8_t result = 0;
+    int8_t result = N2ProngDecays;
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
-      result = 0;
+      result = N2ProngDecays;
+      auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()};
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
-      auto indexRecD0 = RecoDecay::getMatchedMCRec(
-        particlesMC, array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()},
-        421, array{+kPiPlus, -kKPlus}, true, &sign);
-      result += sign * D0ToPiK * int8_t(indexRecD0 > -1);
+      if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 421, array{+kPiPlus, -kKPlus}, true, &sign) > -1) {
+        result = sign * D0ToPiK;
+      }
 
       rowMCMatchRec(result);
     }
@@ -167,12 +167,13 @@ struct HFCandidateCreator2ProngMC {
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
-      result = 0;
+      result = N2ProngDecays;
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
-      auto isMatchedGenD0 = RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign);
-      result += sign * D0ToPiK * int8_t(isMatchedGenD0);
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign)) {
+        result = sign * D0ToPiK;
+      }
 
       rowMCMatchGen(result);
     }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -151,23 +151,27 @@ struct HFCandidateCreator3ProngMC {
                aod::McParticles const& particlesMC)
   {
     int8_t sign = 0;
-    int8_t result = 0;
+    int8_t result = N3ProngDecays;
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
-      result = 0;
+      result = N3ProngDecays;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
 
       // D± → π± K∓ π±
       //Printf("Checking D± → π± K∓ π±");
-      auto indexRecDPlus = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * DPlusToPiKPi * int8_t(indexRecDPlus > -1);
+      if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign) > -1) {
+        result = sign * DPlusToPiKPi;
+      }
 
       // Λc± → p± K∓ π±
-      //Printf("Checking Λc± → p± K∓ π±");
-      auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * LcToPKPi * int8_t(indexRecLc > -1);
+      if (result == N3ProngDecays) {
+        //Printf("Checking Λc± → p± K∓ π±");
+        if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign) > -1) {
+          result = sign * LcToPKPi;
+        }
+      }
 
       rowMCMatchRec(result);
     }
@@ -175,17 +179,21 @@ struct HFCandidateCreator3ProngMC {
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
-      result = 0;
+      result = N3ProngDecays;
 
       // D± → π± K∓ π±
       //Printf("Checking D± → π± K∓ π±");
-      auto isMatchedGenDPlus = RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * DPlusToPiKPi * int8_t(isMatchedGenDPlus);
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign)) {
+        result = sign * DPlusToPiKPi;
+      }
 
       // Λc± → p± K∓ π±
-      //Printf("Checking Λc± → p± K∓ π±");
-      auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign);
-      result += sign * LcToPKPi * int8_t(isMatchedGenLc);
+      if (result == N3ProngDecays) {
+        //Printf("Checking Λc± → p± K∓ π±");
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
+          result = sign * LcToPKPi;
+        }
+      }
 
       rowMCMatchGen(result);
     }


### PR DESCRIPTION
This allows to use the `enum` values of decay types as indices to access array elements and as bit positions in candidate selection bitwise operations.
Related PRs: https://github.com/AliceO2Group/AliceO2/pull/5218 https://github.com/AliceO2Group/AliceO2/pull/5223 