### PR TITLE
[EMCAL-630] Fix assignment of energy and time

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -131,15 +131,14 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         int CellID = mGeometry->GetAbsCellIdFromCellIndexes(iSM, iRow, iCol);
 
         // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
-        double amp = 0., time = 0.;
         o2::emcal::CaloFitResults fitResults = mRawFitter->evaluate(chan.getBunches(), 0, 0);
-        if (fitResults.getAmp() > 0) {
+        if (fitResults.getAmp() < 0) {
           fitResults.setAmp(0.);
         }
         if (fitResults.getTime() < 0) {
           fitResults.setTime(0.);
         }
-        currentCellContainer->emplace_back(CellID, amp * CONVADCGEV, time, chantype);
+        currentCellContainer->emplace_back(CellID, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), chantype);
       }
     }
   }


### PR DESCRIPTION
- Energy must be protected only against negative energies
- Time from the raw fit also only protected against negative entries
- Cell converter needs to store amplitued and time from the
  raw fit results.