### PR TITLE
Fix missing TPC split task in CMakeFile

### DIFF
--- a/Analysis/Tasks/CMakeLists.txt
+++ b/Analysis/Tasks/CMakeLists.txt
@@ -54,7 +54,7 @@ o2_add_dpl_workflow(pid-tpc
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(pid-tpc-split
-                    SOURCES pidTPC.cxx
+                    SOURCES pidTPC_split.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/Analysis/Tasks/PWGLF/spectraTOF_split.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF_split.cxx
@@ -36,12 +36,6 @@ struct TOFSpectraTaskSplit {
       histos.add(hp[i].data(), Form("%s;#it{p} (GeV/#it{c})", pT[i]), kTH1F, {{100, 0, 20}});
       histos.add(hpt[i].data(), Form("%s;#it{p}_{T} (GeV/#it{c})", pT[i]), kTH1F, {{100, 0, 20}});
     }
-    histos.add("electronbeta/hp_El", ";#it{p} (GeV/#it{c})", kTH1F, {{100, 0, 20}});
-    histos.add("electronbeta/hpt_El", ";#it{p}_{T} (GeV/#it{c})", kTH1F, {{100, 0, 20}});
-    histos.add("electronbeta/hlength_El", ";Track Length (cm);Tracks", kTH1D, {{100, 0, 1000}});
-    histos.add("electronbeta/htime_El", ";TOF Time (ns);Tracks", kTH1D, {{1000, 0, 600}});
-    histos.add("electronbeta/hp_beta_El", ";#it{p} (GeV/#it{c});#beta - #beta_{e};Tracks", kTH2D, {{100, 0, 20}, {100, -0.01, 0.01}});
-    histos.add("electronbeta/hp_betasigma_El", ";#it{p} (GeV/#it{c});(#beta - #beta_{e})/#sigma;Tracks", kTH2D, {{100, 0, 20}, {100, -5, 5}});
   }
 
   template <std::size_t i, typename T>
@@ -64,7 +58,7 @@ struct TOFSpectraTaskSplit {
                                                   aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
                                                   aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
                                                   aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
-                                                  aod::pidRespTOFbeta, aod::TrackSelection>>;
+                                                  aod::TrackSelection>>;
   void process(TrackCandidates::iterator const& track)
   {
     histos.fill(HIST("p/Unselected"), track.p());
@@ -79,16 +73,6 @@ struct TOFSpectraTaskSplit {
     fillParticleHistos<6>(track, track.tofNSigmaTr());
     fillParticleHistos<7>(track, track.tofNSigmaHe());
     fillParticleHistos<8>(track, track.tofNSigmaAl());
-
-    //
-    if (TMath::Abs(track.separationbetael() < 1.f)) {
-      histos.fill(HIST("electronbeta/hp_El"), track.p());
-      histos.fill(HIST("electronbeta/hpt_El"), track.pt());
-      histos.fill(HIST("electronbeta/hlength_El"), track.length());
-      histos.fill(HIST("electronbeta/htime_El"), track.tofSignal() / 1000);
-      histos.fill(HIST("electronbeta/hp_beta_El"), track.p(), track.diffbetael());
-      histos.fill(HIST("electronbeta/hp_betasigma_El"), track.p(), track.separationbetael());
-    }
   }
 };
 

--- a/Analysis/Tasks/PWGLF/spectraTOF_tiny.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF_tiny.cxx
@@ -51,13 +51,15 @@ struct TOFSpectraTaskTiny {
   Configurable<float> cfgCutVertex{"cfgCutVertex", 10.0f, "Accepted z-vertex range"};
   Configurable<float> cfgCutEta{"cfgCutEta", 0.8f, "Eta range for tracks"};
   Configurable<float> nsigmacut{"nsigmacut", 3, "Value of the Nsigma cut"};
+
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true) && (aod::track::tofSignal > 0.f);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
                                                   aod::pidRespTOFTEl, aod::pidRespTOFTMu, aod::pidRespTOFTPi,
                                                   aod::pidRespTOFTKa, aod::pidRespTOFTPr, aod::pidRespTOFTDe,
                                                   aod::pidRespTOFTTr, aod::pidRespTOFTHe, aod::pidRespTOFTAl,
-                                                  aod::pidRespTOFbeta, aod::TrackSelection>>;
+                                                  aod::TrackSelection>>;
+
   void process(TrackCandidates::iterator const& track)
   {
     histos.fill(HIST("p/Unselected"), track.p());
@@ -77,6 +79,6 @@ struct TOFSpectraTaskTiny {
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskTiny>("tofspectra-split-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskTiny>("tofspectra-tiny-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPC_split.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPC_split.cxx
@@ -10,6 +10,7 @@
 
 // O2 includes
 #include "ReconstructionDataFormats/Track.h"
+#include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
@@ -20,43 +21,8 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  std::vector<ConfigParamSpec> options{
-    {"add-tof-histos", VariantType::Int, 0, {"Generate TPC with TOF histograms"}}};
-  std::swap(workflowOptions, options);
-}
-
-#include "Framework/runDataProcessing.h"
-
-#define CANDIDATE_SELECTION                                                           \
-  Configurable<float> cfgCutVertex{"cfgCutVertex", 10.0f, "Accepted z-vertex range"}; \
-  Configurable<float> cfgCutEta{"cfgCutEta", 0.8f, "Eta range for tracks"};           \
-  Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;                 \
-  Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
-
-// FIXME: we should put this function in some common header so it has to be defined only once
-template <typename T>
-void makelogaxis(T h)
-{
-  const int nbins = h->GetNbinsX();
-  double binp[nbins + 1];
-  double max = h->GetXaxis()->GetBinUpEdge(nbins);
-  double min = h->GetXaxis()->GetBinLowEdge(1);
-  if (min <= 0) {
-    min = 0.00001;
-  }
-  double lmin = TMath::Log10(min);
-  double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins);
-  for (int i = 0; i < nbins; i++) {
-    binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta));
-  }
-  binp[nbins] = max + 1;
-  h->GetXaxis()->Set(nbins, binp);
-}
-
-constexpr int Np = 9;
 struct TPCSpectraTaskSplit {
+  static constexpr int Np = 9;
   static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
   static constexpr std::string_view hp[Np] = {"p/El", "p/Mu", "p/Pi", "p/Ka", "p/Pr", "p/De", "p/Tr", "p/He", "p/Al"};
   static constexpr std::string_view hpt[Np] = {"pt/El", "pt/Mu", "pt/Pi", "pt/Ka", "pt/Pr", "pt/De", "pt/Tr", "pt/He", "pt/Al"};
@@ -72,11 +38,6 @@ struct TPCSpectraTaskSplit {
     }
   }
 
-  //Defining filters and input
-  CANDIDATE_SELECTION
-
-  Configurable<float> nsigmacut{"nsigmacut", 3, "Value of the Nsigma cut"};
-
   template <std::size_t i, typename T>
   void fillParticleHistos(const T& track, const float& nsigma)
   {
@@ -87,6 +48,12 @@ struct TPCSpectraTaskSplit {
     histos.fill(HIST(hpt[i]), track.pt());
   }
 
+  Configurable<float> cfgCutVertex{"cfgCutVertex", 10.0f, "Accepted z-vertex range"};
+  Configurable<float> cfgCutEta{"cfgCutEta", 0.8f, "Eta range for tracks"};
+  Configurable<float> nsigmacut{"nsigmacut", 3, "Value of the Nsigma cut"};
+
+  Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
+  Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
                                                   aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
                                                   aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
@@ -110,68 +77,8 @@ struct TPCSpectraTaskSplit {
   }
 };
 
-struct TPCPIDQASignalwTOFTaskSplit {
-  static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
-  static constexpr std::string_view htpcsignal[Np] = {"tpcsignal/El", "tpcsignal/Mu", "tpcsignal/Pi",
-                                                      "tpcsignal/Ka", "tpcsignal/Pr", "tpcsignal/De",
-                                                      "tpcsignal/Tr", "tpcsignal/He", "tpcsignal/Al"};
-  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
-
-  template <uint8_t i>
-  void addParticleHistos()
-  {
-    histos.add(htpcsignal[i].data(), Form(";#it{p} (GeV/#it{c});TPC Signal;N_{#sigma}^{TPC}(%s)", pT[i]), kTH3D, {{1000, 0.001, 20}, {1000, 0, 1000}, {20, -10, 10}});
-    makelogaxis(histos.get<TH3>(HIST(htpcsignal[i])));
-  }
-
-  void init(o2::framework::InitContext&)
-  {
-    addParticleHistos<0>();
-    addParticleHistos<1>();
-    addParticleHistos<2>();
-    addParticleHistos<3>();
-    addParticleHistos<4>();
-    addParticleHistos<5>();
-    addParticleHistos<6>();
-    addParticleHistos<7>();
-    addParticleHistos<8>();
-  }
-
-  // Filters
-  CANDIDATE_SELECTION
-
-  Filter trackFilterTOF = (aod::track::tofSignal > 0.f); // Skip tracks without TOF
-  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                  aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                  aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
-                                                  aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                                  aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                                                  aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
-                                                  aod::TrackSelection>>;
-
-  void process(TrackCandidates::iterator const& track)
-  {
-    // const float mom = track.p();
-    const float mom = track.tpcInnerParam();
-    histos.fill(HIST(htpcsignal[0]), mom, track.tpcSignal(), track.tofNSigmaEl());
-    histos.fill(HIST(htpcsignal[1]), mom, track.tpcSignal(), track.tofNSigmaMu());
-    histos.fill(HIST(htpcsignal[2]), mom, track.tpcSignal(), track.tofNSigmaPi());
-    histos.fill(HIST(htpcsignal[3]), mom, track.tpcSignal(), track.tofNSigmaKa());
-    histos.fill(HIST(htpcsignal[4]), mom, track.tpcSignal(), track.tofNSigmaPr());
-    histos.fill(HIST(htpcsignal[5]), mom, track.tpcSignal(), track.tofNSigmaDe());
-    histos.fill(HIST(htpcsignal[6]), mom, track.tpcSignal(), track.tofNSigmaTr());
-    histos.fill(HIST(htpcsignal[7]), mom, track.tpcSignal(), track.tofNSigmaHe());
-    histos.fill(HIST(htpcsignal[8]), mom, track.tpcSignal(), track.tofNSigmaAl());
-  }
-};
-
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  int TPCwTOF = cfgc.options().get<int>("add-tof-histos");
   WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskSplit>("tpcspectra-split-task")};
-  if (TPCwTOF) {
-    workflow.push_back(adaptAnalysisTask<TPCPIDQASignalwTOFTaskSplit>("TPCpidqa-signalwTOF-split-task"));
-  }
   return workflow;
 }

--- a/Analysis/Tasks/pidTOF_split.cxx
+++ b/Analysis/Tasks/pidTOF_split.cxx
@@ -27,7 +27,6 @@ using namespace o2::track;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"add-qa", VariantType::Int, 1, {"Produce TOF PID QA histograms"}},
     {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
     {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
     {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
@@ -81,123 +80,9 @@ struct pidTOFTaskPerParticle {
   }
 };
 
-struct pidTOFTaskQA {
-
-  static constexpr int Np = 9;
-  static constexpr std::string_view hexpected[Np] = {"expected/El", "expected/Mu", "expected/Pi",
-                                                     "expected/Ka", "expected/Pr", "expected/De",
-                                                     "expected/Tr", "expected/He", "expected/Al"};
-  static constexpr std::string_view hexpected_diff[Np] = {"expected_diff/El", "expected_diff/Mu", "expected_diff/Pi",
-                                                          "expected_diff/Ka", "expected_diff/Pr", "expected_diff/De",
-                                                          "expected_diff/Tr", "expected_diff/He", "expected_diff/Al"};
-  static constexpr std::string_view hnsigma[Np] = {"nsigma/El", "nsigma/Mu", "nsigma/Pi",
-                                                   "nsigma/Ka", "nsigma/Pr", "nsigma/De",
-                                                   "nsigma/Tr", "nsigma/He", "nsigma/Al"};
-  static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
-  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
-
-  Configurable<int> nBinsP{"nBinsP", 400, "Number of bins for the momentum"};
-  Configurable<float> MinP{"MinP", 0.1, "Minimum momentum in range"};
-  Configurable<float> MaxP{"MaxP", 5, "Maximum momentum in range"};
-
-  template <typename T>
-  void makelogaxis(T h)
-  {
-    const int nbins = h->GetNbinsX();
-    double binp[nbins + 1];
-    double max = h->GetXaxis()->GetBinUpEdge(nbins);
-    double min = h->GetXaxis()->GetBinLowEdge(1);
-    if (min <= 0) {
-      min = 0.00001;
-    }
-    double lmin = TMath::Log10(min);
-    double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins);
-    for (int i = 0; i < nbins; i++) {
-      binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta));
-    }
-    binp[nbins] = max + 1;
-    h->GetXaxis()->Set(nbins, binp);
-  }
-
-  template <uint8_t i>
-  void addParticleHistos()
-  {
-    // Exp signal
-    histos.add(hexpected[i].data(), Form(";#it{p} (GeV/#it{c});t_{exp}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 2e6}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected[i])));
-
-    // T-Texp
-    histos.add(hexpected_diff[i].data(), Form(";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp}(%s))", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {100, -1000, 1000}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected_diff[i])));
-
-    // NSigma
-    histos.add(hnsigma[i].data(), Form(";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {200, -10, 10}});
-    makelogaxis(histos.get<TH2>(HIST(hnsigma[i])));
-  }
-
-  void init(o2::framework::InitContext&)
-  {
-    // Event properties
-    histos.add("event/vertexz", ";Vtx_{z} (cm);Entries", HistType::kTH1F, {{100, -20, 20}});
-    histos.add("event/colltime", ";Collision time (ps);Entries", HistType::kTH1F, {{100, -2000, 2000}});
-    histos.add("event/tofsignal", ";#it{p} (GeV/#it{c});TOF Signal", HistType::kTH2F, {{nBinsP, MinP, MaxP}, {10000, 0, 2e6}});
-    makelogaxis(histos.get<TH2>(HIST("event/tofsignal")));
-    histos.add("event/tofbeta", ";#it{p} (GeV/#it{c});TOF #beta", HistType::kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 2}});
-    makelogaxis(histos.get<TH2>(HIST("event/tofbeta")));
-
-    addParticleHistos<0>();
-    addParticleHistos<1>();
-    addParticleHistos<2>();
-    addParticleHistos<3>();
-    addParticleHistos<4>();
-    addParticleHistos<5>();
-    addParticleHistos<6>();
-    addParticleHistos<7>();
-    addParticleHistos<8>();
-  }
-
-  template <uint8_t i, typename T>
-  void fillParticleHistos(const T& t, const float tof, const float exp_diff, const float nsigma)
-  {
-    histos.fill(HIST(hexpected[i]), t.p(), tof - exp_diff);
-    histos.fill(HIST(hexpected_diff[i]), t.p(), exp_diff);
-    histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
-  }
-
-  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTOF, aod::pidRespTOFbeta> const& tracks)
-  {
-    const float collisionTime_ps = collision.collisionTime() * 1000.f;
-    histos.fill(HIST("event/vertexz"), collision.posZ());
-    histos.fill(HIST("event/colltime"), collisionTime_ps);
-
-    for (auto t : tracks) {
-      //
-      if (t.tofSignal() < 0) { // Skipping tracks without TOF
-        continue;
-      }
-
-      const float tof = t.tofSignal() - collisionTime_ps;
-
-      //
-      histos.fill(HIST("event/tofsignal"), t.p(), t.tofSignal());
-      histos.fill(HIST("event/tofbeta"), t.p(), t.beta());
-      //
-      fillParticleHistos<0>(t, tof, t.tofExpSignalDiffEl(), t.tofNSigmaEl());
-      fillParticleHistos<1>(t, tof, t.tofExpSignalDiffMu(), t.tofNSigmaMu());
-      fillParticleHistos<2>(t, tof, t.tofExpSignalDiffPi(), t.tofNSigmaPi());
-      fillParticleHistos<3>(t, tof, t.tofExpSignalDiffKa(), t.tofNSigmaKa());
-      fillParticleHistos<4>(t, tof, t.tofExpSignalDiffPr(), t.tofNSigmaPr());
-      fillParticleHistos<5>(t, tof, t.tofExpSignalDiffDe(), t.tofNSigmaDe());
-      fillParticleHistos<6>(t, tof, t.tofExpSignalDiffTr(), t.tofNSigmaTr());
-      fillParticleHistos<7>(t, tof, t.tofExpSignalDiffHe(), t.tofNSigmaHe());
-      fillParticleHistos<8>(t, tof, t.tofExpSignalDiffAl(), t.tofNSigmaAl());
-    }
-  }
-};
-
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  auto workflow = WorkflowSpec{};
+  WorkflowSpec workflow;
   if (cfgc.options().get<int>("pid-el")) {
     workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Electron, o2::aod::pidRespTOFEl>>("pidTOFEl-task"));
   }
@@ -214,9 +99,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Triton, o2::aod::pidRespTOFTr>>("pidTOFTr-task"));
     workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Helium3, o2::aod::pidRespTOFHe>>("pidTOFHe-task"));
     workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Alpha, o2::aod::pidRespTOFAl>>("pidTOFAl-task"));
-  }
-  if (cfgc.options().get<int>("add-qa")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA>("pidTOFQA-task"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/pidTOF_tiny.cxx
+++ b/Analysis/Tasks/pidTOF_tiny.cxx
@@ -27,7 +27,6 @@ using namespace o2::track;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"add-qa", VariantType::Int, 1, {"Produce TOF PID QA histograms"}},
     {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
     {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
     {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
@@ -38,7 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 #include "Framework/runDataProcessing.h"
 
 template <o2::track::PID::ID pid_type, typename table>
-struct pidTOFTaskPerTiny {
+struct pidTOFTaskTiny {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
   Produces<table> tofpid;
@@ -94,21 +93,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow;
   if (cfgc.options().get<int>("pid-el")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Electron, o2::aod::pidRespTOFTEl>>("pidTOFEl-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Electron, o2::aod::pidRespTOFTEl>>("pidTOFEl-task-tiny"));
   }
   if (cfgc.options().get<int>("pid-mu")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Muon, o2::aod::pidRespTOFTMu>>("pidTOFMu-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Muon, o2::aod::pidRespTOFTMu>>("pidTOFMu-task-tiny"));
   }
   if (cfgc.options().get<int>("pid-pikapr")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Pion, o2::aod::pidRespTOFTPi>>("pidTOFPi-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Kaon, o2::aod::pidRespTOFTKa>>("pidTOFKa-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Proton, o2::aod::pidRespTOFTPr>>("pidTOFPr-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Pion, o2::aod::pidRespTOFTPi>>("pidTOFPi-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Kaon, o2::aod::pidRespTOFTKa>>("pidTOFKa-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Proton, o2::aod::pidRespTOFTPr>>("pidTOFPr-task-tiny"));
   }
   if (cfgc.options().get<int>("pid-nuclei")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Deuteron, o2::aod::pidRespTOFTDe>>("pidTOFDe-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Triton, o2::aod::pidRespTOFTTr>>("pidTOFTr-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Helium3, o2::aod::pidRespTOFTHe>>("pidTOFHe-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerTiny<PID::Alpha, o2::aod::pidRespTOFTAl>>("pidTOFAl-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Deuteron, o2::aod::pidRespTOFTDe>>("pidTOFDe-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Triton, o2::aod::pidRespTOFTTr>>("pidTOFTr-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Helium3, o2::aod::pidRespTOFTHe>>("pidTOFHe-task-tiny"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Alpha, o2::aod::pidRespTOFTAl>>("pidTOFAl-task-tiny"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/pidTPC_split.cxx
+++ b/Analysis/Tasks/pidTPC_split.cxx
@@ -27,11 +27,10 @@ using namespace o2::track;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"add-qa", VariantType::Int, 0, {"Produce TPC PID QA histograms"}},
-    {"pid-el", VariantType::Int, 0, {"Produce PID information for the electron mass hypothesis"}},
-    {"pid-mu", VariantType::Int, 0, {"Produce PID information for the muon mass hypothesis"}},
-    {"pid-pikapr", VariantType::Int, 0, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
-    {"pid-nuclei", VariantType::Int, 0, {"Produce PID information for the Deuteron, Triton, Alpha mass hypothesis"}}};
+    {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
+    {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
+    {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
+    {"pid-nuclei", VariantType::Int, 1, {"Produce PID information for the Deuteron, Triton, Alpha mass hypothesis"}}};
   std::swap(workflowOptions, options);
 }
 
@@ -82,110 +81,9 @@ struct pidTPCTaskPerParticle {
   }
 };
 
-struct pidTPCTaskQA {
-  static constexpr int Np = 9;
-  static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
-  static constexpr std::string_view hexpected[Np] = {"expected/El", "expected/Mu", "expected/Pi",
-                                                     "expected/Ka", "expected/Pr", "expected/De",
-                                                     "expected/Tr", "expected/He", "expected/Al"};
-  static constexpr std::string_view hexpected_diff[Np] = {"expected_diff/El", "expected_diff/Mu", "expected_diff/Pi",
-                                                          "expected_diff/Ka", "expected_diff/Pr", "expected_diff/De",
-                                                          "expected_diff/Tr", "expected_diff/He", "expected_diff/Al"};
-  static constexpr std::string_view hnsigma[Np] = {"nsigma/El", "nsigma/Mu", "nsigma/Pi",
-                                                   "nsigma/Ka", "nsigma/Pr", "nsigma/De",
-                                                   "nsigma/Tr", "nsigma/He", "nsigma/Al"};
-  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
-
-  Configurable<int> nBinsP{"nBinsP", 400, "Number of bins for the momentum"};
-  Configurable<float> MinP{"MinP", 0, "Minimum momentum in range"};
-  Configurable<float> MaxP{"MaxP", 20, "Maximum momentum in range"};
-
-  template <typename T>
-  void makelogaxis(T h)
-  {
-    const int nbins = h->GetNbinsX();
-    double binp[nbins + 1];
-    double max = h->GetXaxis()->GetBinUpEdge(nbins);
-    double min = h->GetXaxis()->GetBinLowEdge(1);
-    if (min <= 0) {
-      min = 0.00001;
-    }
-    double lmin = TMath::Log10(min);
-    double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins);
-    for (int i = 0; i < nbins; i++) {
-      binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta));
-    }
-    binp[nbins] = max + 1;
-    h->GetXaxis()->Set(nbins, binp);
-  }
-
-  template <uint8_t i>
-  void addParticleHistos()
-  {
-    // Exp signal
-    histos.add(hexpected[i].data(), Form(";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 1000}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected[i])));
-
-    // Signal - Expected signal
-    histos.add(hexpected_diff[i].data(), Form(";#it{p} (GeV/#it{c});;d#it{E}/d#it{x} - d#it{E}/d#it{x}(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {1000, -500, 500}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected_diff[i])));
-
-    // NSigma
-    histos.add(hnsigma[i].data(), Form(";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {200, -10, 10}});
-    makelogaxis(histos.get<TH2>(HIST(hnsigma[i])));
-  }
-
-  void init(o2::framework::InitContext&)
-  {
-    // Event properties
-    histos.add("event/vertexz", ";Vtx_{z} (cm);Entries", kTH1F, {{100, -20, 20}});
-    histos.add("event/tpcsignal", ";#it{p} (GeV/#it{c});TPC Signal", kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 1000}});
-    makelogaxis(histos.get<TH2>(HIST("event/tpcsignal")));
-
-    addParticleHistos<0>();
-    addParticleHistos<1>();
-    addParticleHistos<2>();
-    addParticleHistos<3>();
-    addParticleHistos<4>();
-    addParticleHistos<5>();
-    addParticleHistos<6>();
-    addParticleHistos<7>();
-    addParticleHistos<8>();
-  }
-
-  template <uint8_t i, typename T>
-  void fillParticleHistos(const T& t, const float mom, const float exp_diff, const float nsigma)
-  {
-    histos.fill(HIST(hexpected[i]), mom, t.tpcSignal() - exp_diff);
-    histos.fill(HIST(hexpected_diff[i]), mom, exp_diff);
-    histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
-  }
-
-  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPC> const& tracks)
-  {
-    histos.fill(HIST("event/vertexz"), collision.posZ());
-
-    for (auto t : tracks) {
-      // const float mom = t.p();
-      const float mom = t.tpcInnerParam();
-      histos.fill(HIST("event/tpcsignal"), mom, t.tpcSignal());
-      //
-      fillParticleHistos<0>(t, mom, t.tpcExpSignalDiffEl(), t.tpcNSigmaEl());
-      fillParticleHistos<1>(t, mom, t.tpcExpSignalDiffMu(), t.tpcNSigmaMu());
-      fillParticleHistos<2>(t, mom, t.tpcExpSignalDiffPi(), t.tpcNSigmaPi());
-      fillParticleHistos<3>(t, mom, t.tpcExpSignalDiffKa(), t.tpcNSigmaKa());
-      fillParticleHistos<4>(t, mom, t.tpcExpSignalDiffPr(), t.tpcNSigmaPr());
-      fillParticleHistos<5>(t, mom, t.tpcExpSignalDiffDe(), t.tpcNSigmaDe());
-      fillParticleHistos<6>(t, mom, t.tpcExpSignalDiffTr(), t.tpcNSigmaTr());
-      fillParticleHistos<7>(t, mom, t.tpcExpSignalDiffHe(), t.tpcNSigmaHe());
-      fillParticleHistos<8>(t, mom, t.tpcExpSignalDiffAl(), t.tpcNSigmaAl());
-    }
-  }
-};
-
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  auto workflow = WorkflowSpec{};
+  WorkflowSpec workflow;
   if (cfgc.options().get<int>("pid-el")) {
     workflow.push_back(adaptAnalysisTask<pidTPCTaskPerParticle<PID::Electron, o2::aod::pidRespTPCEl>>("pidTPCEl-task"));
   }
@@ -203,11 +101,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     workflow.push_back(adaptAnalysisTask<pidTPCTaskPerParticle<PID::Helium3, o2::aod::pidRespTPCHe>>("pidTPCHe-task"));
     workflow.push_back(adaptAnalysisTask<pidTPCTaskPerParticle<PID::Alpha, o2::aod::pidRespTPCAl>>("pidTPCAl-task"));
   }
-  if (cfgc.options().get<int>("add-qa")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskQA>("pidTPCQA-task"));
-  }
   return workflow;
-}
-
-return workflow;
 }

--- a/Analysis/Tasks/pidTPC_tiny.cxx
+++ b/Analysis/Tasks/pidTPC_tiny.cxx
@@ -27,7 +27,6 @@ using namespace o2::track;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"add-qa", VariantType::Int, 1, {"Produce TPC PID QA histograms"}},
     {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
     {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
     {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
@@ -38,7 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 #include "Framework/runDataProcessing.h"
 
 template <o2::track::PID::ID pid_type, typename table>
-struct pidTPCTaskPerTiny {
+struct pidTPCTaskTiny {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
   Produces<table> tpcpid;
@@ -95,21 +94,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow;
   if (cfgc.options().get<int>("pid-el")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Electron, o2::aod::pidRespTPCTEl>>("pidTPCEl-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Electron, o2::aod::pidRespTPCTEl>>("pidTPCEl-task"));
   }
   if (cfgc.options().get<int>("pid-mu")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Muon, o2::aod::pidRespTPCTMu>>("pidTPCMu-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Muon, o2::aod::pidRespTPCTMu>>("pidTPCMu-task"));
   }
   if (cfgc.options().get<int>("pid-pikapr")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Pion, o2::aod::pidRespTPCTPi>>("pidTPCPi-task"));
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Kaon, o2::aod::pidRespTPCTKa>>("pidTPCKa-task"));
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Proton, o2::aod::pidRespTPCTPr>>("pidTPCPr-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Pion, o2::aod::pidRespTPCTPi>>("pidTPCPi-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Kaon, o2::aod::pidRespTPCTKa>>("pidTPCKa-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Proton, o2::aod::pidRespTPCTPr>>("pidTPCPr-task"));
   }
   if (cfgc.options().get<int>("pid-nuclei")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Deuteron, o2::aod::pidRespTPCTDe>>("pidTPCDe-task"));
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Triton, o2::aod::pidRespTPCTTr>>("pidTPCTr-task"));
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Helium3, o2::aod::pidRespTPCTHe>>("pidTPCHe-task"));
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskPerTiny<PID::Alpha, o2::aod::pidRespTPCTAl>>("pidTPCAl-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Deuteron, o2::aod::pidRespTPCTDe>>("pidTPCDe-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Triton, o2::aod::pidRespTPCTTr>>("pidTPCTr-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Helium3, o2::aod::pidRespTPCTHe>>("pidTPCHe-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Alpha, o2::aod::pidRespTPCTAl>>("pidTPCAl-task"));
   }
   return workflow;
 }


### PR DESCRIPTION
- Replace spectraTPC.cxx with spectraTPC_split in CmakeFile
- Uniform pid and spectra tasks
- Remove QA from split and tiny tasks
- Use common nomenclature pid and spectra tasks