### PR TITLE
Workflow: use existing PR if creation fails

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -131,4 +131,7 @@ jobs:
           hub pull-request -f -b dev -h changelog \
               --no-edit --no-maintainer-edits     \
               'Auto-generated changelog'          \
-              -m 'The following changelog has been automatically generated.'
+              -m 'The following changelog has been automatically generated.' ||
+            # If the PR already exists, the force-push will have updated it.
+            # It's fine if this step fails.
+            true


### PR DESCRIPTION
If the pull request already exists, creating it with `hub` will fail. We can ignore the error, as the previous force-push will have already added the commit to the existing pull request.