### PR TITLE
PWGHF: Little fix of the J/ψ → e+ e- code.

### DIFF
--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -159,14 +159,15 @@ struct HFCandidateCreator2ProngMC {
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
-      if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 421, array{+kPiPlus, -kKPlus}, true, &sign) > -1) {
+      if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 421, array{+kPiPlus, -kKPlus}, true, &sign) > -1) {
         result = sign * D0ToPiK;
       }
-      // Jpsi → e+e-
+
+      // J/ψ → e+ e-
       if (result == N2ProngDecays) {
-        //Printf("Checking Jpsi → e+e-");
-        if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 443, array{+kElectron, -kElectron}, true, &sign) > -1) {
-          result = sign * JpsiToEE;
+        //Printf("Checking J/ψ → e+ e-");
+        if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 443, array{+kElectron, -kElectron}, true) > -1) {
+          result = JpsiToEE;
         }
       }
 
@@ -183,11 +184,12 @@ struct HFCandidateCreator2ProngMC {
       if (RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign)) {
         result = sign * D0ToPiK;
       }
-      // Jpsi → e+e-
+
+      // J/ψ → e+ e-
       if (result == N2ProngDecays) {
-        //Printf("Checking Jpsi → e+e-");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, 443, array{+kElectron, -kElectron}, true, &sign)) {
-          result = sign * JpsiToEE;
+        //Printf("Checking J/ψ → e+ e-");
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, 443, array{+kElectron, -kElectron}, true)) {
+          result = JpsiToEE;
         }
       }
 

--- a/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
@@ -134,11 +134,9 @@ struct HFJpsiToEECandidateSelector {
     return true;
   }
 
-  /// Check if track is compatible with given TPC Nsigma cut for a given flavour hypothesis
+  /// Check if track is compatible with given TPC Nsigma cut for the electron hypothesis
   /// \param track is the track
-  /// \param nPDG is the flavour hypothesis PDG number
   /// \param nSigmaCut is the nsigma threshold to test against
-  /// \note nPDG=11 electron
   /// \return true if track satisfies TPC PID hypothesis for given Nsigma cut
   template <typename T>
   bool selectionPIDTPC(const T& track, int nSigmaCut)
@@ -148,8 +146,6 @@ struct HFJpsiToEECandidateSelector {
 
   /// PID selection on daughter track
   /// \param track is the daughter track
-  /// \param nPDG is the PDG code of the flavour hypothesis
-  /// \note nPDG=11 electron
   /// \return 1 if successful PID match, 0 if successful PID rejection, -1 if no PID info
   template <typename T>
   int selectionPID(const T& track)


### PR DESCRIPTION
- Fix usage of `std::move`.
- Use only positive match flag since J/ψ is its own antiparticle.
- Fix comments.