### PR TITLE
Cosmic tracking mode added for ITS

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -27,7 +27,7 @@ namespace its
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, bool async, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
+framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
                                     bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool eencode = false);
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -38,7 +38,7 @@ namespace its
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(bool isMC, bool async, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
+  TrackerDPL(bool isMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -46,7 +46,7 @@ class TrackerDPL : public framework::Task
 
  private:
   bool mIsMC = false;
-  bool mAsyncMode = false;
+  std::string mMode = "sync";
   o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
   std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
@@ -57,7 +57,7 @@ class TrackerDPL : public framework::Task
 
 /// create a processor spec
 /// run ITS CA tracker
-framework::DataProcessorSpec getTrackerSpec(bool useMC, bool async, o2::gpu::GPUDataTypes::DeviceType dType);
+framework::DataProcessorSpec getTrackerSpec(bool useMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -28,7 +28,7 @@ namespace its
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, bool async, o2::gpu::GPUDataTypes::DeviceType dtype,
+framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dtype,
                                     bool upstreamDigits, bool upstreamClusters, bool disableRootOutput,
                                     bool eencode)
 {
@@ -45,7 +45,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, bool async, o
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
   }
   if (useCAtracker) {
-    specs.emplace_back(o2::its::getTrackerSpec(useMC, async, dtype));
+    specs.emplace_back(o2::its::getTrackerSpec(useMC, trmode, dtype));
   } else {
     specs.emplace_back(o2::its::getCookedTrackerSpec(useMC));
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -31,7 +31,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (default: trackerCM)"}},
-    {"async-phase", o2::framework::VariantType::Bool, false, {"perform multiple passes for async. phase reconstruction"}},
+    {"tracking-mode", o2::framework::VariantType::String, "sync", {"sync,async,cosmics"}},
     {"entropy-encoding", o2::framework::VariantType::Bool, false, {"produce entropy encoded data"}},
     {"gpuDevice", o2::framework::VariantType::Int, 1, {"use gpu device: CPU=1,CUDA=2,HIP=3 (default: CPU)"}}};
 
@@ -55,16 +55,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto useCAtracker = configcontext.options().get<bool>("trackerCA");
-  auto async = configcontext.options().get<bool>("async-phase");
+  auto trmode = configcontext.options().get<std::string>("tracking-mode");
   auto gpuDevice = static_cast<o2::gpu::GPUDataTypes::DeviceType>(configcontext.options().get<int>("gpuDevice"));
   auto extDigits = configcontext.options().get<bool>("digits-from-upstream");
   auto extClusters = configcontext.options().get<bool>("clusters-from-upstream");
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto eencode = configcontext.options().get<bool>("entropy-encoding");
 
-  if (async && !useCAtracker) {
-    LOG(ERROR) << "Async.mode is not supported by CookedTracker, use --trackerCA";
+  std::transform(trmode.begin(), trmode.end(), trmode.begin(), [](unsigned char c) { return std::tolower(c); });
+  if (trmode != "sync" && !useCAtracker) {
+    LOG(ERROR) << "requested CookedTracker supports only sync tracking-mode, use --trackerCA";
     throw std::runtime_error("incompatible options provided");
   }
-  return std::move(o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, async, gpuDevice, extDigits, extClusters, disableRootOutput, eencode));
+  return std::move(o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, trmode, gpuDevice, extDigits, extClusters, disableRootOutput, eencode));
 }

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -53,7 +53,8 @@ using o2::its::TrackingParameters;
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 using MCLabCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
-void run_trac_ca_its(std::string path = "./",
+void run_trac_ca_its(bool cosmics = false,
+                     std::string path = "./",
                      std::string outputfile = "o2trac_its.root",
                      std::string inputClustersITS = "o2clus_its.root",
                      std::string dictfile = "",
@@ -183,13 +184,29 @@ void run_trac_ca_its(std::string path = "./",
   std::vector<double> ncls;
   std::vector<double> time;
 
-  std::vector<TrackingParameters> trackParams(3);
-  trackParams[0].TrackletMaxDeltaPhi = 0.05f;
-  trackParams[1].TrackletMaxDeltaPhi = 0.1f;
-  trackParams[2].MinTrackLength = 4;
-  trackParams[2].TrackletMaxDeltaPhi = 0.3;
-
-  std::vector<MemoryParameters> memParams(3);
+  std::vector<TrackingParameters> trackParams(1);
+  std::vector<MemoryParameters> memParams(1);
+  if (cosmics) {
+    trackParams[0].MinTrackLength = 3;
+    trackParams[0].TrackletMaxDeltaPhi = o2::its::constants::math::Pi * 0.5f;
+    for (int iLayer = 0; iLayer < o2::its::constants::its2::TrackletsPerRoad; iLayer++) {
+      trackParams[0].TrackletMaxDeltaZ[iLayer] = o2::its::constants::its2::LayersZCoordinate()[iLayer + 1];
+      memParams[0].TrackletsMemoryCoefficients[iLayer] = 0.5f;
+      // trackParams[0].TrackletMaxDeltaZ[iLayer] = 10.f;
+    }
+    for (int iLayer = 0; iLayer < o2::its::constants::its2::CellsPerRoad; iLayer++) {
+      trackParams[0].CellMaxDCA[iLayer] = 10000.f;    //cm
+      trackParams[0].CellMaxDeltaZ[iLayer] = 10000.f; //cm
+      memParams[0].CellsMemoryCoefficients[iLayer] = 0.001f;
+    }
+  } else {
+    trackParams.resize(3);
+    memParams.resize(3);
+    trackParams[0].TrackletMaxDeltaPhi = 0.05f;
+    trackParams[1].TrackletMaxDeltaPhi = 0.1f;
+    trackParams[2].MinTrackLength = 4;
+    trackParams[2].TrackletMaxDeltaPhi = 0.3;
+  }
 
   tracker.setParameters(memParams, trackParams);
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -34,7 +34,7 @@ if [ $SYNCMODE == 1 ]; then
   TPC_CONFIG_KEY+=" GPU_global.synchronousProcessing=1;"
 fi
 if [ $CTFINPUT == 1 ]; then
-  ITS_CONFIG+=" --async-phase"
+  ITS_CONFIG+=" --tracking-mode async"
 else
   ITS_CONFIG+=" --entropy-encoding"
   TOF_OUTPUT+=",ctf"

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -115,7 +115,7 @@ if [ "$doreco" == "1" ]; then
   echo "Return status of tpcreco: $?"
 
   echo "Running ITS reco flow"
-  taskwrapper itsreco.log  o2-its-reco-workflow --trackerCA --async-phase $gloOpt
+  taskwrapper itsreco.log  o2-its-reco-workflow --trackerCA --tracking-mode async $gloOpt
   echo "Return status of itsreco: $?"
 
   # existing checks


### PR DESCRIPTION
@davidrohr note, that I've substituted  the isolated ``--async-phase`` option of  ``o2-its-reco-workflow`` by 
``{"tracking-mode", o2::framework::VariantType::String, "sync", {"sync,async,cosmics"}}``. The scripts are corrected.