### PR TITLE
Use global track indices for cross-detector matches

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackID.h
@@ -55,7 +55,7 @@ class GlobalTrackID : public AbstractRef<25, 4, 3>
   void print() const;
   std::string asString() const;
 
-  operator auto() const { return AbstractRef<25, 4, 3>(); }
+  operator int() const { return int(getIndex()); }
 
   ClassDefNV(GlobalTrackID, 1);
 };

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -15,6 +15,7 @@
 #define ALICEO2_MATCHINFOTOF_H
 
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonDataFormat/EvIndex.h"
 
 namespace o2
@@ -23,15 +24,16 @@ namespace dataformats
 {
 class MatchInfoTOF
 {
+  using evGIdx = o2::dataformats::EvIndex<int, o2::dataformats::GlobalTrackID>;
   using evIdx = o2::dataformats::EvIndex<int, int>;
 
  public:
-  MatchInfoTOF(evIdx evIdxTOFCl, float chi2, o2::track::TrackLTIntegral trkIntLT, evIdx evIdxTrack = evIdx(0, 0)) : mEvIdxTOFCl(evIdxTOFCl), mChi2(chi2), mIntLT(trkIntLT), mEvIdxTrack(evIdxTrack){};
+  MatchInfoTOF(evIdx evIdxTOFCl, float chi2, o2::track::TrackLTIntegral trkIntLT, evGIdx evIdxTrack) : mEvIdxTOFCl(evIdxTOFCl), mChi2(chi2), mIntLT(trkIntLT), mEvIdxTrack(evIdxTrack){};
   MatchInfoTOF() = default;
   void setEvIdxTOFCl(evIdx index) { mEvIdxTOFCl = index; }
-  void setEvIdxTrack(evIdx index) { mEvIdxTrack = index; }
+  void setEvIdxTrack(evGIdx index) { mEvIdxTrack = index; }
   evIdx getEvIdxTOFCl() const { return mEvIdxTOFCl; }
-  evIdx getEvIdxTrack() const { return mEvIdxTrack; }
+  evGIdx getEvIdxTrack() const { return mEvIdxTrack; }
   int getEventTOFClIndex() const { return mEvIdxTOFCl.getEvent(); }
   int getTOFClIndex() const { return mEvIdxTOFCl.getIndex(); }
   int getEventTrackIndex() const { return mEvIdxTrack.getEvent(); }
@@ -47,7 +49,7 @@ class MatchInfoTOF
   float mChi2;                       // chi2 of the pair track-TOFcluster
   o2::track::TrackLTIntegral mIntLT; ///< L,TOF integral calculated during the propagation
   evIdx mEvIdxTOFCl;                 ///< EvIdx for TOF cluster (first: ev index; second: cluster index)
-  evIdx mEvIdxTrack;                 ///< EvIdx for track (first: ev index; second: cluster index)
+  evGIdx mEvIdxTrack;                ///< EvIdx for track (first: ev index; second: track global index)
 
   ClassDefNV(MatchInfoTOF, 1);
 };

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackTPCITS.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackTPCITS.h
@@ -17,6 +17,7 @@
 
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonDataFormat/TimeStamp.h"
 
 namespace o2
@@ -35,10 +36,10 @@ class TrackTPCITS : public o2::track::TrackParCov
   TrackTPCITS(const o2::track::TrackParCov& src) : o2::track::TrackParCov(src) {}
   TrackTPCITS(const o2::track::TrackParCov& srcIn, const o2::track::TrackParCov& srcOut) : o2::track::TrackParCov(srcIn), mParamOut(srcOut) {}
 
-  int getRefTPC() const { return mRefTPC; }
-  int getRefITS() const { return mRefITS; }
-  void setRefTPC(int id) { mRefTPC = id; }
-  void setRefITS(int id) { mRefITS = id; }
+  GlobalTrackID getRefTPC() const { return mRefTPC; }
+  GlobalTrackID getRefITS() const { return mRefITS; }
+  void setRefTPC(GlobalTrackID id) { mRefTPC = id; }
+  void setRefITS(GlobalTrackID id) { mRefITS = id; }
 
   const timeEst& getTimeMUS() const { return mTimeMUS; }
   timeEst& getTimeMUS() { return mTimeMUS; }
@@ -64,14 +65,14 @@ class TrackTPCITS : public o2::track::TrackParCov
   void print() const;
 
  private:
-  int mRefTPC = -1;                  ///< reference on ITS track entry in its original container
-  int mRefITS = -1;                  ///< reference on TPC track entry in its original container
+  GlobalTrackID mRefTPC;             ///< reference on ITS track entry in its original container
+  GlobalTrackID mRefITS;             ///< reference on TPC track entry in its original container
   float mChi2Refit = 0.f;            ///< chi2 of the refit
   float mChi2Match = 0.f;            ///< chi2 of the match
   timeEst mTimeMUS;                  ///< time estimate in ns
   o2::track::TrackParCov mParamOut;  ///< refitted outer parameter
   o2::track::TrackLTIntegral mLTOut; ///< L,TOF integral calculated during the outward refit
-  ClassDefNV(TrackTPCITS, 2);
+  ClassDefNV(TrackTPCITS, 3);
 };
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -47,6 +47,7 @@
 
 #pragma link C++ class o2::dataformats::GlobalTrackID + ;
 #pragma link C++ class std::vector < o2::dataformats::GlobalTrackID> + ;
+#pragma link C++ class o2::dataformats::EvIndex < int, o2::dataformats::GlobalTrackID> + ;
 
 #pragma link C++ class o2::dataformats::VtxTrackIndex + ;
 #pragma link C++ class std::vector < o2::dataformats::VtxTrackIndex> + ;

--- a/DataFormats/Reconstruction/src/TrackTPCITS.cxx
+++ b/DataFormats/Reconstruction/src/TrackTPCITS.cxx
@@ -16,7 +16,7 @@ using namespace o2::dataformats;
 void TrackTPCITS::print() const
 {
   printf("TPCref: %6d ITSref: %6d\nChi2Refit: %6.2f Chi2Matc: %6.2f Time: %10.4f+-%10.4f mus\n",
-         mRefTPC, mRefITS, getChi2Refit(), getChi2Match(),
+         mRefTPC.getIndex(), mRefITS.getIndex(), getChi2Refit(), getChi2Match(),
          mTimeMUS.getTimeStamp(), mTimeMUS.getTimeStampError());
   printf("Inner param: ");
   o2::track::TrackParCov::print();

--- a/DataFormats/common/include/CommonDataFormat/AbstractRef.h
+++ b/DataFormats/common/include/CommonDataFormat/AbstractRef.h
@@ -70,8 +70,6 @@ class AbstractRef
 
   Base_t getRaw() const { return mRef; }
 
-  operator Base_t() const { return mRef; }
-
  protected:
   Base_t mRef = 0; // packed reference
 

--- a/DataFormats/common/test/testAbstractRefAccessor.cxx
+++ b/DataFormats/common/test/testAbstractRefAccessor.cxx
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(AbstractRefAccess)
     auto gid = vid[i];
     const auto& obj = acc.get(gid);
     int expect = gid.getSource() * 100 + i / GloIdx::NSources;
-    LOG(INFO) << i << " ? " << obj.b << " == " << expect << " for " << gid;
+    LOG(INFO) << i << " ? " << obj.b << " == " << expect << " for " << gid.getRaw();
     BOOST_CHECK(obj.b == expect);
   }
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -24,6 +24,7 @@
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DataFormatsTOF/CalibInfoTOF.h"
 #include "CommonDataFormat/EvIndex.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -72,6 +73,7 @@ class MatchTOF
 {
   using Geo = o2::tof::Geo;
   using Cluster = o2::tof::Cluster;
+  using evGIdx = o2::dataformats::EvIndex<int, o2::dataformats::GlobalTrackID>;
   using evIdx = o2::dataformats::EvIndex<int, int>;
   using timeEst = o2::dataformats::TimeStampWithError<float, float>;
   using matchTrack = std::pair<o2::track::TrackParCov, timeEst>;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -30,6 +30,7 @@
 #include "DetectorsBase/Propagator.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "MathUtils/Primitive2D.h"
 #include "CommonDataFormat/EvIndex.h"
 #include "CommonDataFormat/InteractionRecord.h"
@@ -551,7 +552,7 @@ class MatchTPCITS
     }
     int rof = tbin > 0 ? tbin * mTPCBin2ITSROFrame : 0;
     // the rof is estimated continuous counter but the actual bins might have gaps (e.g. HB rejects etc)-> use mapping
-    return rof < mITSTrackROFContMapping.size() ? mITSTrackROFContMapping[rof] : mITSTrackROFContMapping.back();
+    return rof < int(mITSTrackROFContMapping.size()) ? mITSTrackROFContMapping[rof] : mITSTrackROFContMapping.back();
   }
 
   ///< convert ITS ROFrame to TPC time bin units // TOREMOVE

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -40,6 +40,7 @@
 #include "TPCBase/ParameterElectronics.h"
 
 using namespace o2::globaltracking;
+using evGIdx = o2::dataformats::EvIndex<int, o2::dataformats::GlobalTrackID>;
 using evIdx = o2::dataformats::EvIndex<int, int>;
 
 ClassImp(MatchTOF);
@@ -1107,8 +1108,8 @@ void MatchTOF::doMatching(int sec)
           foundCluster = true;
           // set event indexes (to be checked)
           evIdx eventIndexTOFCluster(trefTOF.getEntryInTree(), mTOFClusSectIndexCache[indices[0]][itof]);
-          evIdx eventIndexTracks(mCurrTracksTreeEntry, mTracksSectIndexCache[indices[0]][itrk]);
-          mMatchedTracksPairs.emplace_back(o2::dataformats::MatchInfoTOF(eventIndexTOFCluster, chi2, trkLTInt[iPropagation], eventIndexTracks)); // TODO: check if this is correct!
+          evGIdx eventIndexTracks(mCurrTracksTreeEntry, {uint32_t(mTracksSectIndexCache[indices[0]][itrk]), o2::dataformats::GlobalTrackID::ITSTPC});
+          mMatchedTracksPairs.emplace_back(eventIndexTOFCluster, chi2, trkLTInt[iPropagation], eventIndexTracks); // TODO: check if this is correct!
 
 #ifdef _ALLOW_TOF_DEBUG_
           if (mMCTruthON) {
@@ -1426,8 +1427,8 @@ void MatchTOF::doMatchingForTPC(int sec)
             foundCluster = true;
             // set event indexes (to be checked)
             evIdx eventIndexTOFCluster(trefTOF.getEntryInTree(), mTOFClusSectIndexCache[indices[0]][itof]);
-            evIdx eventIndexTracks(mCurrTracksTreeEntry, mTracksSectIndexCache[indices[0]][itrk]);
-            mMatchedTracksPairs.emplace_back(o2::dataformats::MatchInfoTOF(eventIndexTOFCluster, chi2, trkLTInt[ibc][iPropagation], eventIndexTracks)); // TODO: check if this is correct!
+            evGIdx eventIndexTracks(mCurrTracksTreeEntry, {uint32_t(mTracksSectIndexCache[indices[0]][itrk]), o2::dataformats::GlobalTrackID::TPC});
+            mMatchedTracksPairs.emplace_back(eventIndexTOFCluster, chi2, trkLTInt[ibc][iPropagation], eventIndexTracks); // TODO: check if this is correct!
           }
         }
       }

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1472,8 +1472,8 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
   trfit.setChi2Match(tpcMatchRec.chi2);
   trfit.setChi2Refit(chi2);
   trfit.setTimeMUS(time, timeErr);
-  trfit.setRefTPC(tTPC.sourceID);
-  trfit.setRefITS(tITS.sourceID);
+  trfit.setRefTPC({unsigned(tTPC.sourceID), o2::dataformats::GlobalTrackID::TPC});
+  trfit.setRefITS({unsigned(tITS.sourceID), o2::dataformats::GlobalTrackID::ITS});
 
   if (mMCTruthON) { // store MC info
     mOutITSLabels.emplace_back(mITSLblWork[iITS]);

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -18,6 +18,7 @@
 #include "TPCBase/ParameterElectronics.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/Defs.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 
 #include <fairlogger/Logger.h>
 #include <set>

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -70,7 +70,7 @@ class PVertexer
   }
   float getTukey() const;
 
-  void finalizeVertex(const VertexingInput& input, const PVertex& vtx, std::vector<PVertex>& vertices, std::vector<V2TRef>& v2tRefs, std::vector<int>& vertexTrackIDs, SeedHisto& histo);
+  void finalizeVertex(const VertexingInput& input, const PVertex& vtx, std::vector<PVertex>& vertices, std::vector<V2TRef>& v2tRefs, std::vector<GTrackID>& vertexTrackIDs, SeedHisto& histo);
   bool setCompatibleIR(PVertex& vtx);
 
   void setBunchFilling(const o2::BunchFilling& bf);
@@ -107,7 +107,7 @@ class PVertexer
   void applyConstraint(VertexSeed& vtxSeed) const;
   bool upscaleSigma(VertexSeed& vtxSeed) const;
   void createTracksPool(gsl::span<const o2d::TrackTPCITS> tracksITSTPC);
-  int findVertices(const VertexingInput& input, std::vector<PVertex>& vertices, std::vector<int>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
+  int findVertices(const VertexingInput& input, std::vector<PVertex>& vertices, std::vector<GTrackID>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
   std::pair<int, int> getBestFT0Trigger(const PVertex& vtx, gsl::span<const o2::ft0::RecPoints> ft0Data, int& currEntry) const;
 
   int dbscan_RangeQuery(int idxs, std::vector<int>& cand, const std::vector<int>& status);

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
@@ -31,6 +31,7 @@ using PVertex = o2::dataformats::PrimaryVertex;
 using TimeEst = o2::dataformats::TimeStampWithError<float, float>;
 using V2TRef = o2::dataformats::VtxTrackRef;
 using GIndex = o2::dataformats::VtxTrackIndex;
+using GTrackID = o2::dataformats::GlobalTrackID;
 
 ///< weights and scaling params for current vertex
 struct VertexSeed : public PVertex {
@@ -96,9 +97,8 @@ struct TrackVF {
 
   TimeEst timeEst;
   float wgh = 0.; ///< track weight wrt current vertex seed
-  uint32_t entry = 0;
+  GTrackID entry;
   int16_t bin = -1; // seeds histo bin
-  uint8_t srcID = 0;
   uint8_t flags = 0;
   int vtxID = kNoVtx; ///< assigned vertex
 
@@ -143,8 +143,8 @@ struct TrackVF {
   }
 
   TrackVF() = default;
-  TrackVF(const o2::track::TrackParCov& src, const TimeEst& t_est, uint32_t _entry, uint8_t _srcID)
-    : x(src.getX()), y(src.getY()), z(src.getZ()), tgL(src.getTgl()), tgP(src.getSnp() / std::sqrt(1. - src.getSnp()) * (1. + src.getSnp())), timeEst(t_est), entry(_entry), srcID(_srcID)
+  TrackVF(const o2::track::TrackParCov& src, const TimeEst& t_est, GTrackID _entry)
+    : x(src.getX()), y(src.getY()), z(src.getZ()), tgL(src.getTgl()), tgP(src.getSnp() / std::sqrt(1. - src.getSnp()) * (1. + src.getSnp())), timeEst(t_est), entry(_entry)
   {
     o2::math_utils::sincos(src.getAlpha(), sinAlp, cosAlp);
     auto det = src.getSigmaY2() * src.getSigmaZ2() - src.getSigmaZY() * src.getSigmaZY();

--- a/Detectors/Vertexing/src/PVertexer.cxx
+++ b/Detectors/Vertexing/src/PVertexer.cxx
@@ -35,7 +35,7 @@ int PVertexer::process(gsl::span<const o2d::TrackTPCITS> tracksITSTPC, gsl::span
   dbscan_clusterize();
 
   std::vector<PVertex> verticesLoc;
-  std::vector<int> vertexTrackIDsLoc;
+  std::vector<GTrackID> vertexTrackIDsLoc;
   std::vector<V2TRef> v2tRefsLoc;
   std::vector<float> validationTimes;
 
@@ -87,7 +87,7 @@ int PVertexer::process(gsl::span<const o2d::TrackTPCITS> tracksITSTPC, gsl::span
     vertices.push_back(vtx);
     int it = v2tRefsLoc[i].getFirstEntry(), itEnd = it + v2tRefsLoc[i].getEntries(), dest0 = vertexTrackIDs.size();
     for (; it < itEnd; it++) {
-      auto& gid = vertexTrackIDs.emplace_back(vertexTrackIDsLoc[it], GIndex::ITSTPC);
+      auto& gid = vertexTrackIDs.emplace_back(vertexTrackIDsLoc[it]);
       gid.setPVContributor();
     }
     v2tRefs.emplace_back(dest0, v2tRefsLoc[i].getEntries());
@@ -110,7 +110,7 @@ int PVertexer::process(gsl::span<const o2d::TrackTPCITS> tracksITSTPC, gsl::span
 }
 
 //______________________________________________
-int PVertexer::findVertices(const VertexingInput& input, std::vector<PVertex>& vertices, std::vector<int>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs)
+int PVertexer::findVertices(const VertexingInput& input, std::vector<PVertex>& vertices, std::vector<GTrackID>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs)
 {
   // find vertices using tracks with indices (sorted in time) from idRange from "tracks" pool. The pool may containt arbitrary number of tracks,
   // only those which are in the idRange and have canUse()==true, will be used.
@@ -439,7 +439,7 @@ void PVertexer::init()
 
 //___________________________________________________________________
 void PVertexer::finalizeVertex(const VertexingInput& input, const PVertex& vtx,
-                               std::vector<PVertex>& vertices, std::vector<V2TRef>& v2tRefs, std::vector<int>& vertexTrackIDs,
+                               std::vector<PVertex>& vertices, std::vector<V2TRef>& v2tRefs, std::vector<GTrackID>& vertexTrackIDs,
                                SeedHisto& histo)
 {
   int lastID = vertices.size();
@@ -477,7 +477,7 @@ void PVertexer::createTracksPool(gsl::span<const o2d::TrackTPCITS> tracksITSTPC)
         dca.getY() * dca.getY() / (dca.getSigmaY2() + vtxErr2) > mPVParams->pullIniCut) {
       continue;
     }
-    auto& tvf = mTracksPool.emplace_back(trc, tracksITSTPC[i].getTimeMUS(), i, 0);
+    auto& tvf = mTracksPool.emplace_back(trc, tracksITSTPC[i].getTimeMUS(), GTrackID{i, o2::dataformats::GlobalTrackID::ITSTPC});
     mStatZErr.add(std::sqrt(trc.getSigmaZ2()));
     mStatTErr.add(tvf.timeEst.getTimeStampError());
   }

--- a/macro/checkTOFMatching.C
+++ b/macro/checkTOFMatching.C
@@ -13,6 +13,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsTOF/Cluster.h"
+#include "FairLogger.h"
 #endif
 
 //#define DEBUG
@@ -129,20 +130,20 @@ void checkTOFMatching(bool batchMode = true)
       int tofClIndex = infoTOF.getTOFClIndex();
       float chi2 = infoTOF.getChi2();
 #ifdef DEBUG
-      Printf("\nentry in tree %d, matching %d, indexITSTPCtrack = %d, tofClIndex = %d, chi2 = %f", ientry, imatch, indexITSTPCtrack, tofClIndex, chi2);
+      LOGF(INFO, "nentry in tree %d, matching %d, indexITSTPCtrack = %d, tofClIndex = %d, chi2 = %f", ientry, imatch, indexITSTPCtrack, tofClIndex, chi2);
 #endif
 
       float matBud = infoTOF.getLTIntegralOut().getX2X0();
 
       //      o2::MCCompLabel label = mcTOF->getElement(mcTOF->getMCTruthHeader(tofClIndex).index);
       const auto& labelsTOF = mcTOF->getLabels(tofClIndex);
-      int trackIdTOF;
-      int eventIdTOF;
-      int sourceIdTOF;
+      int trackIdTOF = -1;
+      int eventIdTOF = -1;
+      int sourceIdTOF = -1;
 
       for (uint ilabel = 0; ilabel < labelsTOF.size(); ilabel++) {
 #ifdef DEBUG
-        Printf("TOF label %d: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsTOF[ilabel].getTrackID(), labelsTOF[ilabel].getEventID(), labelsTOF[ilabel].getSourceID());
+        LOGF(INFO, "TOF label %d: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsTOF[ilabel].getTrackID(), labelsTOF[ilabel].getEventID(), labelsTOF[ilabel].getSourceID());
 #endif
         if (ilabel == 0) {
           trackIdTOF = labelsTOF[ilabel].getTrackID();
@@ -154,12 +155,12 @@ void checkTOFMatching(bool batchMode = true)
       int nContributingChannels = tofCluster.getNumOfContributingChannels();
       int mainContributingChannel = tofCluster.getMainContributingChannel();
 #ifdef DEBUG
-      Printf("The TOF cluster has %d contributing channels, and the main one is %d", nContributingChannels, mainContributingChannel);
+      LOGF(INFO, "The TOF cluster has %d contributing channels, and the main one is %d", nContributingChannels, mainContributingChannel);
 #endif
       int* indices = new int();
       o2::tof::Geo::getVolumeIndices(mainContributingChannel, indices);
 #ifdef DEBUG
-      Printf("Indices of main contributing channel are %d, %d, %d, %d, %d", indices[0], indices[1], indices[2], indices[3], indices[4]);
+      LOGF(INFO, "Indices of main contributing channel are %d, %d, %d, %d, %d", indices[0], indices[1], indices[2], indices[3], indices[4]);
 #endif
       bool isUpLeft = tofCluster.isAdditionalChannelSet(o2::tof::Cluster::kUpLeft);
       bool isUp = tofCluster.isAdditionalChannelSet(o2::tof::Cluster::kUp);
@@ -170,7 +171,7 @@ void checkTOFMatching(bool batchMode = true)
       bool isDownLeft = tofCluster.isAdditionalChannelSet(o2::tof::Cluster::kDownLeft);
       bool isLeft = tofCluster.isAdditionalChannelSet(o2::tof::Cluster::kLeft);
 #ifdef DEBUG
-      Printf("isUpLeft = %d, isUp = %d, isUpRight = %d, isRight = %d, isDownRight = %d, isDown = %d, isDownLeft = %d, isLeft = %d", isUpLeft, isUp, isUpRight, isRight, isDownRight, isDown, isDownLeft, isLeft);
+      LOGF(INFO, "isUpLeft = %d, isUp = %d, isUpRight = %d, isRight = %d, isDownRight = %d, isDown = %d, isDownLeft = %d, isLeft = %d", isUpLeft, isUp, isUpRight, isRight, isDownRight, isDown, isDownLeft, isLeft);
 #endif
       int* indexCont = new int();
       indexCont[0] = indices[0];
@@ -185,7 +186,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[down] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[down] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
       }
@@ -195,7 +196,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[downright] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[downright] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
         indexCont[4] = indices[4];
@@ -206,7 +207,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[downleft] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[downleft] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
         indexCont[4] = indices[4];
@@ -216,7 +217,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[up] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[up] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
       }
@@ -226,7 +227,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[upright] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[upright] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
         indexCont[4] = indices[4];
@@ -237,7 +238,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[upleft] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[upleft] = %d", secondaryContributingChannel);
 #endif
         indexCont[3] = indices[3];
         indexCont[4] = indices[4];
@@ -247,7 +248,7 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[right] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[right] = %d", secondaryContributingChannel);
 #endif
         indexCont[4] = indices[4];
       }
@@ -256,33 +257,33 @@ void checkTOFMatching(bool batchMode = true)
         numberOfSecondaryContributingChannels++;
         secondaryContributingChannel = o2::tof::Geo::getIndex(indexCont);
 #ifdef DEBUG
-        Printf("secondaryContributingChannel[left] = %d", secondaryContributingChannel);
+        LOGF(INFO, "secondaryContributingChannel[left] = %d", secondaryContributingChannel);
 #endif
         indexCont[4] = indices[4];
       }
 #ifdef DEBUG
-      Printf("Total number of secondary channels= %d", numberOfSecondaryContributingChannels);
+      LOGF(INFO, "Total number of secondary channels= %d", numberOfSecondaryContributingChannels);
 #endif
       o2::dataformats::TrackTPCITS trackITSTPC = mTracksArrayInp->at(indexITSTPCtrack);
 
       const auto evIdxTPC = trackITSTPC.getRefTPC();
 #ifdef DEBUG
-      Printf("matched TPCtrack index = %d", evIdxTPC);
+      LOG(INFO) << "matched TPCtrack index:", evIdxTPC;
 #endif
       const auto evIdxITS = trackITSTPC.getRefITS();
 #ifdef DEBUG
-      Printf("matched ITStrack index = %d", evIdxITS);
+      LOG(INFO) << "matched ITStrack index: ", evIdxITS;
 #endif
       // getting the TPC labels
       const auto& labelsTPC = (*mcTPC)[evIdxTPC];
 #ifdef DEBUG
-      Printf("TPC label: trackID = %d, eventID = %d, sourceID = %d", labelsTPC.getTrackID(), labelsTPC.getEventID(), labelsTPC.getSourceID());
+      LOGF(INFO, "TPC label: trackID = %d, eventID = %d, sourceID = %d", labelsTPC.getTrackID(), labelsTPC.getEventID(), labelsTPC.getSourceID());
 #endif
 
       // getting the ITS labels
       const auto& labelsITS = (*mcITS)[evIdxITS];
 #ifdef DEBUG
-      Printf("ITS label: trackID = %d, eventID = %d, sourceID = %d", ilabel, labelsITS.getTrackID(), labelsITS.getEventID(), labelsITS.getSourceID());
+      LOGF(INFO, "ITS label: trackID = %d, eventID = %d, sourceID = %d", labelsITS.getTrackID(), labelsITS.getEventID(), labelsITS.getSourceID());
 #endif
       bool bMatched = kFALSE;
       for (uint ilabel = 0; ilabel < labelsTOF.size(); ilabel++) {
@@ -346,37 +347,37 @@ void checkTOFMatching(bool batchMode = true)
       bool ITSfound = false;
       for (uint i = 0; i < mTracksArrayInp->size(); i++) {
         o2::dataformats::TrackTPCITS trackITSTPC = mTracksArrayInp->at(i);
-        const auto evIdxTPCcheck = trackITSTPC.getRefTPC();
-        const auto evIdxITScheck = trackITSTPC.getRefITS();
-        const auto& labelsTPCcheck = (*mcTPC)[evIdxTPCcheck];
+        const auto idxTPCcheck = trackITSTPC.getRefTPC();
+        const auto idxITScheck = trackITSTPC.getRefITS();
+        const auto& labelsTPCcheck = (*mcTPC)[idxTPCcheck.getIndex()];
         if (abs(labelsTPCcheck.getTrackID()) == trackIdTOF && labelsTPCcheck.getEventID() == eventIdTOF && labelsTPCcheck.getSourceID() == sourceIdTOF) {
 #ifdef DEBUG
-          Printf("The TPC track that should have been matched to TOF is number %d", i);
+          LOGF(INFO, "The TPC track that should have been matched to TOF is number %d", i);
 #endif
           TPCfound = true;
         }
-        const auto& labelsITScheck = (*mcITS)[evIdxITScheck];
+        const auto& labelsITScheck = (*mcITS)[idxITScheck.getIndex()];
         if (labelsITScheck.getTrackID() == trackIdTOF && labelsITScheck.getEventID() == eventIdTOF && labelsITScheck.getSourceID() == sourceIdTOF) {
 #ifdef DEBUG
-          Printf("The ITS track that should have been matched to TOF is number %d", i);
+          LOGF(INFO, "The ITS track that should have been matched to TOF is number %d", i);
 #endif
           ITSfound = true;
         }
       }
 #ifdef DEBUG
       if (!TPCfound)
-        Printf("There is no TPC track found that should have corresponded to this TOF cluster!");
+        LOGF(INFO, "There is no TPC track found that should have corresponded to this TOF cluster!");
       if (!ITSfound)
-        Printf("There is no ITS track found that should have corresponded to this TOF cluster!");
+        LOGF(INFO, "There is no ITS track found that should have corresponded to this TOF cluster!");
 #endif
     }
   }
 
   new TCanvas;
 
-  Printf("Number of      matches = %d", nMatches);
-  Printf("Number of GOOD matches = %d (%.2f)", nGoodMatches, (float)nGoodMatches / nMatches);
-  Printf("Number of BAD  matches = %d (%.2f)", nBadMatches, (float)nBadMatches / nMatches);
+  LOGF(INFO, "Number of      matches = %d", nMatches);
+  LOGF(INFO, "Number of GOOD matches = %d (%.2f)", nGoodMatches, (float)nGoodMatches / nMatches);
+  LOGF(INFO, "Number of BAD  matches = %d (%.2f)", nBadMatches, (float)nBadMatches / nMatches);
 
   TFile* fout = nullptr;
   if (batchMode)
@@ -489,7 +490,7 @@ void checkTOFMatching(bool batchMode = true)
 
   float fraction = hchi2dh->GetEntries() * 1. / hchi2->GetEntries();
   float fractionErr = TMath::Sqrt(fraction * (1 - fraction) / hchi2->GetEntries());
-  printf("Fraction of multiple hits = (%.1f +/- %.1f)%c\n", fraction * 100, fractionErr * 100, '%');
+  LOGF(INFO, "Fraction of multiple hits = (%.1f +/- %.1f)%c", fraction * 100, fractionErr * 100, '%');
 
   htof->Fit("pol0", "", "", 1, 5);
   float effMatch = 0;
@@ -498,7 +499,7 @@ void checkTOFMatching(bool batchMode = true)
   float effMatchErr = 0;
   if (htof->GetListOfFunctions()->At(0))
     effMatchErr = ((TF1*)htof->GetListOfFunctions()->At(0))->GetParError(0);
-  printf("TOF matching eff (pt > 1) = %f +/- %f\n", effMatch, effMatchErr);
+  LOGF(INFO, "TOF matching eff (pt > 1) = %f +/- %f", effMatch, effMatchErr);
 
   htofMism->Fit("pol0", "", "", 1, 5);
   float mismMatch = 0;
@@ -507,7 +508,7 @@ void checkTOFMatching(bool batchMode = true)
   float mismMatchErr = 0;
   if (htofMism->GetListOfFunctions()->At(0))
     mismMatchErr = ((TF1*)htofMism->GetListOfFunctions()->At(0))->GetParError(0);
-  printf("TOF-track mismatch (pt > 1) = %f +/- %f\n", mismMatch, mismMatchErr);
+  LOGF(INFO, "TOF-track mismatch (pt > 1) = %f +/- %f", mismMatch, mismMatchErr);
 
   if (fout)
     fout->Close();


### PR DESCRIPTION
All integer indices referring to entries of various tracks in their respective containers are
substituted by o2::dataformats::GlobalTrackID, providing both the index and its source container