### PR TITLE
Fix daughter labels when running parallel merger

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -202,6 +202,8 @@ class MCTrackT
   }
   bool getInhibited() const { return ((PropEncoding)mProp).inhibited; }
 
+  bool isTransported() const { return getToBeDone() && !getInhibited(); };
+
   /// get the string representation of the production process
   const char* getProdProcessAsString() const;
 

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -343,7 +343,10 @@ class O2HitMerger : public FairMQDevice
       originbr->GetEntry(index);
       for (Int_t i = 0; i < nprimaries[index]; i++) {
         auto& track = incomingdata->at(i);
-        track.SetFirstDaughterTrackId(-1);
+        if (track.isTransported()) { // reset daughters only if track was transported, it will be fixed below
+          track.SetFirstDaughterTrackId(-1);
+          track.SetLastDaughterTrackId(-1);
+        }
         targetdata->push_back(track);
       }
       incomingdata->clear();


### PR DESCRIPTION
This PR fixes the daughter labels when running parallel simulation.
The merger code was resetting the `firstDaughterLabel` of all tracks, which caused the information for the generator history to be lost.
The fix now resets the `firstDaughterLabel` *ONLY* if the tracks was actually transported.
Eventually, if the track has generated secondaries the labels of the daughters will be set in the following loop, as it was previously.