### PR TITLE
DPL: Adds Variant JSON helpers

### DIFF
--- a/Framework/Core/include/Framework/Array2D.h
+++ b/Framework/Core/include/Framework/Array2D.h
@@ -20,6 +20,13 @@ template <typename T>
 struct Array2D {
   using element_t = T;
 
+  Array2D()
+    : data{nullptr},
+      rows{0},
+      cols{0}
+  {
+  }
+
   Array2D(T const* data_, uint32_t r, uint32_t c)
     : rows{r}, cols{c}
   {
@@ -103,9 +110,9 @@ struct Array2D {
     return data + y * cols;
   }
 
-  T* data = nullptr;
-  uint32_t rows = 0;
-  uint32_t cols = 0;
+  T* data;
+  uint32_t rows;
+  uint32_t cols;
 };
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -120,9 +120,9 @@ struct ConfigParamsHelper {
                          V == VariantType::ArrayDouble ||
                          V == VariantType::ArrayBool ||
                          V == VariantType::ArrayString ||
-                         V == VariantType::MatrixInt ||
-                         V == VariantType::MatrixFloat ||
-                         V == VariantType::MatrixDouble) {
+                         V == VariantType::Array2DInt ||
+                         V == VariantType::Array2DFloat ||
+                         V == VariantType::Array2DDouble) {
       auto value = boost::program_options::value<std::string>();
       value = value->default_value(spec.defaultValue.asString());
       if constexpr (V != VariantType::String) {

--- a/Framework/Core/include/Framework/VariantJSONHelpers.h
+++ b/Framework/Core/include/Framework/VariantJSONHelpers.h
@@ -12,9 +12,371 @@
 
 #include "Framework/Variant.h"
 
+#include <rapidjson/reader.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/error/en.h>
+
+#include <stack>
+#include <iostream>
+#include <sstream>
+
 namespace o2::framework
 {
+namespace
+{
+template <VariantType V>
+struct VariantReader : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, VariantReader<V>> {
+  using Ch = rapidjson::UTF8<>::Ch;
+  using SizeType = rapidjson::SizeType;
 
+  enum struct State {
+    IN_START,
+    IN_STOP,
+    IN_DATA,
+    IN_KEY,
+    IN_ARRAY,
+    IN_ROW,
+    IN_ERROR
+  };
+
+  VariantReader()
+    : states{}
+  {
+    debug << "Start" << std::endl;
+    states.push(State::IN_START);
+  }
+
+  bool Null()
+  {
+    debug << "Null value encountered" << std::endl;
+    return true;
+  }
+
+  bool Int(int i)
+  {
+    debug << "Int(" << i << ")" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if constexpr (!(V == VariantType::ArrayInt || V == VariantType::Array2DInt)) {
+      debug << "Integer value in non-integer variant" << std::endl;
+      states.push(State::IN_ERROR);
+      return true;
+    } else {
+      if (states.top() == State::IN_ARRAY || states.top() == State::IN_ROW) {
+        debug << "added to array" << std::endl;
+        accumulatedData.push_back(i);
+        return true;
+      }
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool Uint(unsigned i)
+  {
+    debug << "Uint -> Int" << std::endl;
+    return Int(static_cast<int>(i));
+  }
+
+  bool Int64(int64_t i)
+  {
+    debug << "Int64 -> Int" << std::endl;
+    return Int(static_cast<int>(i));
+  }
+
+  bool Uint64(uint64_t i)
+  {
+    debug << "Uint64 -> Int" << std::endl;
+    return Int(static_cast<int>(i));
+  }
+
+  bool Double(double d)
+  {
+    debug << "Double(" << d << ")" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if constexpr (!(V == VariantType::ArrayDouble || V == VariantType::Array2DDouble || V == VariantType::ArrayFloat || V == VariantType::Array2DFloat)) {
+      states.push(State::IN_ERROR);
+      return true;
+    }
+    if (states.top() == State::IN_ARRAY || states.top() == State::IN_ROW) {
+      if constexpr (V == VariantType::ArrayDouble || V == VariantType::Array2DDouble) {
+        debug << "added to array as double" << std::endl;
+        accumulatedData.push_back(d);
+        return true;
+      } else if constexpr (V == VariantType::ArrayFloat || V == VariantType::Array2DFloat) {
+        debug << "added to array as float" << std::endl;
+        accumulatedData.push_back(static_cast<float>(d));
+        return true;
+      }
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool Bool(bool b)
+  {
+    debug << "Bool(" << b << ")" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if constexpr (V != VariantType::ArrayBool) {
+      states.push(State::IN_ERROR);
+      return false;
+    } else {
+      if (states.top() == State::IN_ARRAY || states.top() == State::IN_ROW) {
+        debug << "added to array" << std::endl;
+        accumulatedData.push_back(b);
+        return true;
+      }
+    }
+  }
+
+  bool String(const Ch* str, SizeType, bool)
+  {
+    debug << "String(" << str << ")" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if constexpr (V != VariantType::ArrayString) {
+      states.push(State::IN_ERROR);
+      return true;
+    } else {
+      if (states.top() == State::IN_ARRAY || states.top() == State::IN_ROW) {
+        debug << "added to array" << std::endl;
+        accumulatedData.push_back(str);
+        return true;
+      }
+      states.push(State::IN_ERROR);
+      return true;
+    }
+  }
+
+  bool StartObject()
+  {
+    debug << "StartObject()" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if (states.top() == State::IN_START) {
+      states.push(State::IN_DATA);
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool Key(const Ch* str, SizeType, bool)
+  {
+    debug << "Key(" << str << ")" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if (states.top() == State::IN_DATA || states.top() == State::IN_KEY) {
+      states.push(State::IN_KEY);
+      currentKey = str;
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool EndObject(SizeType)
+  {
+    debug << "EndObject()" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if (states.top() == State::IN_KEY) {
+      // finish up key
+      if constexpr (isArray<V>()) {
+        debug << "creating 1d-array variant" << std::endl;
+        result = Variant(accumulatedData);
+      } else if constexpr (isArray2D<V>()) {
+        debug << "creating 2d-array variant" << std::endl;
+        result = Variant(Array2D{accumulatedData, rows, cols});
+      }
+      states.push(State::IN_STOP);
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool StartArray()
+  {
+    debug << "StartArray()" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if (states.top() == State::IN_KEY) {
+      states.push(State::IN_ARRAY);
+      rows = 1;
+      return true;
+    } else if (states.top() == State::IN_ARRAY) {
+      if constexpr (isArray2D<V>()) {
+        states.push(State::IN_ROW);
+        ++rows;
+        return true;
+      }
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  bool EndArray(SizeType elementCount)
+  {
+    debug << "EndArray()" << std::endl;
+    if (states.top() == State::IN_ERROR) {
+      debug << "In ERROR state" << std::endl;
+      return false;
+    }
+    if (states.top() == State::IN_ARRAY) {
+      //finish up array
+      states.pop();
+      if constexpr (isArray<V>()) {
+        cols = elementCount;
+      } else if constexpr (isArray2D<V>()) {
+        rows = elementCount;
+      }
+      return true;
+    } else if (states.top() == State::IN_ROW) {
+      if constexpr (isArray2D<V>()) {
+        cols = elementCount;
+      }
+      //finish up row
+      states.pop();
+      return true;
+    }
+    states.push(State::IN_ERROR);
+    return true;
+  }
+
+  std::stack<State> states;
+  std::ostringstream debug;
+
+  uint32_t rows;
+  uint32_t cols;
+  std::string currentKey;
+  std::vector<typename variant_array_element_type<V>::type> accumulatedData;
+  Variant result;
+};
+
+template <VariantType V>
+void writeVariant(std::ostream& o, Variant const& v)
+{
+  if constexpr (isArray<V>() || isArray2D<V>()) {
+    using type = typename variant_array_element_type<V>::type;
+    rapidjson::OStreamWrapper osw(o);
+    rapidjson::Writer<rapidjson::OStreamWrapper> w(osw);
+
+    auto writeArray = [&](auto* values, size_t size) {
+      using T = std::remove_pointer_t<decltype(values)>;
+      w.StartArray();
+      for (auto i = 0u; i < size; ++i) {
+        if constexpr (std::is_same_v<int, T>) {
+          w.Int(values[i]);
+        } else if constexpr (std::is_same_v<float, T> || std::is_same_v<double, T>) {
+          w.Double(values[i]);
+        } else if constexpr (std::is_same_v<int, bool>) {
+          w.Bool(values[i]);
+        } else if constexpr (std::is_same_v<std::string, T>) {
+          w.String(values[i].c_str());
+        }
+      }
+      w.EndArray();
+    };
+
+    auto writeArray2D = [&](auto&& array2d) {
+      using T = typename std::decay_t<decltype(array2d)>::element_t;
+      w.StartArray();
+      for (auto i = 0u; i < array2d.rows; ++i) {
+        w.StartArray();
+        for (auto j = 0u; j < array2d.cols; ++j) {
+          if constexpr (std::is_same_v<int, T>) {
+            w.Int(array2d(i, j));
+          } else if constexpr (std::is_same_v<float, T> || std::is_same_v<double, T>) {
+            w.Double(array2d(i, j));
+          }
+        }
+        w.EndArray();
+      }
+      w.EndArray();
+    };
+
+    w.StartObject();
+    w.Key("values");
+    if constexpr (isArray<V>()) {
+      writeArray(v.get<type*>(), v.size());
+    } else if constexpr (isArray2D<V>()) {
+      writeArray2D(v.get<Array2D<type>>());
+    }
+    w.EndObject();
+  }
+}
+} // namespace
+
+struct VariantJSONHelpers {
+  template <VariantType V>
+  static Variant read(std::istream& s)
+  {
+    rapidjson::Reader reader;
+    rapidjson::IStreamWrapper isw(s);
+    VariantReader<V> vreader;
+    bool ok = reader.Parse(isw, vreader);
+    if (ok == false) {
+      std::stringstream error;
+      error << "Cannot parse serialized Variant, error: " << rapidjson::GetParseError_En(reader.GetParseErrorCode()) << " at offset: " << reader.GetErrorOffset();
+      throw std::runtime_error(error.str());
+    }
+    return vreader.result;
+  }
+
+  static void write(std::ostream& o, Variant const& v)
+  {
+    switch (v.type()) {
+      case VariantType::ArrayInt:
+        writeVariant<VariantType::ArrayInt>(o, v);
+        break;
+      case VariantType::ArrayFloat:
+        writeVariant<VariantType::ArrayFloat>(o, v);
+        break;
+      case VariantType::ArrayDouble:
+        writeVariant<VariantType::ArrayDouble>(o, v);
+        break;
+      case VariantType::ArrayBool:
+        throw std::runtime_error("Bool vectors not implemented yet");
+        //        writeVariant<VariantType::ArrayBool>(o, v);
+        break;
+      case VariantType::ArrayString:
+        writeVariant<VariantType::ArrayString>(o, v);
+        break;
+      case VariantType::Array2DInt:
+        writeVariant<VariantType::Array2DInt>(o, v);
+        break;
+      case VariantType::Array2DFloat:
+        writeVariant<VariantType::Array2DFloat>(o, v);
+        break;
+      case VariantType::Array2DDouble:
+        writeVariant<VariantType::Array2DDouble>(o, v);
+        break;
+      default:
+        break;
+    }
+  }
+};
 }
 
 #endif // FRAMEWORK_VARIANTJSONHELPERS_H

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -69,9 +69,9 @@ void BoostOptionsRetriever::update(std::vector<ConfigParamSpec> const& specs,
       case VariantType::ArrayDouble:
       case VariantType::ArrayBool:
       case VariantType::ArrayString:
-      case VariantType::MatrixInt:
-      case VariantType::MatrixFloat:
-      case VariantType::MatrixDouble:
+      case VariantType::Array2DInt:
+      case VariantType::Array2DFloat:
+      case VariantType::Array2DDouble:
         options = options(name, bpo::value<std::string>()->default_value(spec.defaultValue.asString()), help);
         break;
       case VariantType::Unknown:

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -70,14 +70,14 @@ void ConfigParamsHelper::populateBoostProgramOptions(
       case VariantType::ArrayString:
         addConfigSpecOption<VariantType::ArrayString>(spec, options);
         break;
-      case VariantType::MatrixInt:
-        addConfigSpecOption<VariantType::MatrixInt>(spec, options);
+      case VariantType::Array2DInt:
+        addConfigSpecOption<VariantType::Array2DInt>(spec, options);
         break;
-      case VariantType::MatrixFloat:
-        addConfigSpecOption<VariantType::MatrixFloat>(spec, options);
+      case VariantType::Array2DFloat:
+        addConfigSpecOption<VariantType::Array2DFloat>(spec, options);
         break;
-      case VariantType::MatrixDouble:
-        addConfigSpecOption<VariantType::MatrixDouble>(spec, options);
+      case VariantType::Array2DDouble:
+        addConfigSpecOption<VariantType::Array2DDouble>(spec, options);
         break;
       case VariantType::Unknown:
       case VariantType::Empty:

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -65,13 +65,13 @@ void PropertyTreeHelpers::populateDefaults(std::vector<ConfigParamSpec> const& s
         case VariantType::ArrayString:
           pt.put_child(key, vectorToBranch(spec.defaultValue.get<std::string*>(), spec.defaultValue.size()));
           break;
-        case VariantType::MatrixInt:
+        case VariantType::Array2DInt:
           pt.put_child(key, array2DToBranch(spec.defaultValue.get<Array2D<int>>()));
           break;
-        case VariantType::MatrixFloat:
+        case VariantType::Array2DFloat:
           pt.put_child(key, array2DToBranch(spec.defaultValue.get<Array2D<float>>()));
           break;
-        case VariantType::MatrixDouble:
+        case VariantType::Array2DDouble:
           pt.put_child(key, array2DToBranch(spec.defaultValue.get<Array2D<double>>()));
           break;
         case VariantType::Unknown:
@@ -143,13 +143,13 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
         case VariantType::ArrayString:
           pt.put_child(key, vectorToBranch<std::string>(stringToVector<std::string>(vmap[key].as<std::string>())));
           break;
-        case VariantType::MatrixInt:
+        case VariantType::Array2DInt:
           pt.put_child(key, array2DToBranch<int>(stringToArray2D<int>(vmap[key].as<std::string>())));
           break;
-        case VariantType::MatrixFloat:
+        case VariantType::Array2DFloat:
           pt.put_child(key, array2DToBranch<float>(stringToArray2D<float>(vmap[key].as<std::string>())));
           break;
-        case VariantType::MatrixDouble:
+        case VariantType::Array2DDouble:
           pt.put_child(key, array2DToBranch<double>(stringToArray2D<double>(vmap[key].as<std::string>())));
           break;
         case VariantType::Unknown:
@@ -206,9 +206,9 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
         case VariantType::ArrayDouble:
         case VariantType::ArrayBool:
         case VariantType::ArrayString:
-        case VariantType::MatrixInt:
-        case VariantType::MatrixFloat:
-        case VariantType::MatrixDouble:
+        case VariantType::Array2DInt:
+        case VariantType::Array2DFloat:
+        case VariantType::Array2DDouble:
           pt.put_child(key, *it);
           break;
         case VariantType::Unknown:

--- a/Framework/Core/src/RootConfigParamHelpers.cxx
+++ b/Framework/Core/src/RootConfigParamHelpers.cxx
@@ -218,11 +218,11 @@ ConfigParamSpec memberToConfigParamSpec(const char* tname, TDataMember* dm, void
   } else {
     switch (typehash) {
       case compile_time_hash("o2::framework::Array2D<int>"):
-        return ConfigParamSpec{tname, VariantType::MatrixInt, *static_cast<Array2D<int>*>(ptr), {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Array2DInt, *static_cast<Array2D<int>*>(ptr), {"No help"}};
       case compile_time_hash("o2::framework::Array2D<float>"):
-        return ConfigParamSpec{tname, VariantType::MatrixFloat, *static_cast<Array2D<float>*>(ptr), {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Array2DFloat, *static_cast<Array2D<float>*>(ptr), {"No help"}};
       case compile_time_hash("o2::framework::Array2D<double>"):
-        return ConfigParamSpec{tname, VariantType::MatrixDouble, *static_cast<Array2D<double>*>(ptr), {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Array2DDouble, *static_cast<Array2D<double>*>(ptr), {"No help"}};
     }
   }
   auto* dt = dm->GetDataType();

--- a/Framework/Core/src/Variant.cxx
+++ b/Framework/Core/src/Variant.cxx
@@ -84,13 +84,13 @@ std::ostream& operator<<(std::ostream& oss, Variant const& val)
     case VariantType::ArrayString:
       printArray<std::string>(oss, val.get<std::string*>(), val.size());
       break;
-    case VariantType::MatrixInt:
+    case VariantType::Array2DInt:
       printMatrix<int>(oss, val.get<Array2D<int>>());
       break;
-    case VariantType::MatrixFloat:
+    case VariantType::Array2DFloat:
       printMatrix<float>(oss, val.get<Array2D<float>>());
       break;
-    case VariantType::MatrixDouble:
+    case VariantType::Array2DDouble:
       printMatrix<double>(oss, val.get<Array2D<double>>());
       break;
     case VariantType::Empty:

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -12,6 +12,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataDescriptorQueryBuilder.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/VariantJSONHelpers.h"
 
 #include <rapidjson/reader.h>
 #include <rapidjson/prettywriter.h>
@@ -265,6 +266,8 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       std::unique_ptr<ConfigParamSpec> opt{nullptr};
 
       using HelpString = ConfigParamSpec::HelpString;
+      std::stringstream is;
+      is.str(optionDefault);
       switch (optionType) {
         case VariantType::String:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault.c_str(), HelpString{optionHelp});
@@ -283,6 +286,30 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
           break;
         case VariantType::Bool:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, (bool)std::stoi(optionDefault, nullptr), HelpString{optionHelp});
+          break;
+        case VariantType::ArrayInt:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayInt>(is), HelpString{optionHelp});
+          break;
+        case VariantType::ArrayFloat:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayFloat>(is), HelpString{optionHelp});
+          break;
+        case VariantType::ArrayDouble:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayDouble>(is), HelpString{optionHelp});
+          break;
+          //        case VariantType::ArrayBool:
+          //          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayBool>(is), HelpString{optionHelp});
+          //          break;
+        case VariantType::ArrayString:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayString>(is), HelpString{optionHelp});
+          break;
+        case VariantType::Array2DInt:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DInt>(is), HelpString{optionHelp});
+          break;
+        case VariantType::Array2DFloat:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DFloat>(is), HelpString{optionHelp});
+          break;
+        case VariantType::Array2DDouble:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DDouble>(is), HelpString{optionHelp});
           break;
         default:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault, HelpString{optionHelp});
@@ -692,7 +719,21 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       w.Key("type");
       w.String(s.c_str());
       std::ostringstream oss;
-      oss << option.defaultValue;
+      switch (option.type) {
+        case VariantType::ArrayInt:
+        case VariantType::ArrayFloat:
+        case VariantType::ArrayDouble:
+        case VariantType::ArrayBool:
+        case VariantType::ArrayString:
+        case VariantType::Array2DInt:
+        case VariantType::Array2DFloat:
+        case VariantType::Array2DDouble:
+          VariantJSONHelpers::write(oss, option.defaultValue);
+          break;
+        default:
+          oss << option.defaultValue;
+          break;
+      }
       w.Key("defaultValue");
       w.String(oss.str().c_str());
       w.Key("help");

--- a/Framework/Core/test/test_Variants.cxx
+++ b/Framework/Core/test/test_Variants.cxx
@@ -13,6 +13,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include "Framework/Variant.h"
+#include "Framework/VariantStringHelpers.h"
+#include "Framework/VariantPropertyTreeHelpers.h"
+#include "Framework/VariantJSONHelpers.h"
 #include <sstream>
 #include <cstring>
 
@@ -24,23 +27,23 @@ bool unknown_type(RuntimeErrorRef const& ref)
   return strcmp(err.what, "Mismatch between types") == 0;
 }
 
-BOOST_AUTO_TEST_CASE(MatrixTest)
+BOOST_AUTO_TEST_CASE(Array2DTest)
 {
   float m[3][4] = {{0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7, 0.8}, {0.9, 1.0, 1.1, 1.2}};
   Array2D mm(&m[0][0], 3, 4);
-  for (auto i = 0U; i < 3; ++i) {
-    for (auto j = 0U; j < 4; ++j) {
+  for (auto i = 0u; i < 3; ++i) {
+    for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(mm(i, j) == m[i][j]);
     }
   }
   std::vector<float> v = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2};
   Array2D mv(v, 3, 4);
-  for (auto i = 0U; i < 3; ++i) {
-    for (auto j = 0U; j < 4; ++j) {
+  for (auto i = 0u; i < 3; ++i) {
+    for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(mm(i, j) == v[i * 4 + j]);
     }
   }
-  for (auto i = 0U; i < 3; ++i) {
+  for (auto i = 0u; i < 3; ++i) {
     auto const& vv = mm[i];
     for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(vv[j] == mm(i, j));
@@ -95,19 +98,19 @@ BOOST_AUTO_TEST_CASE(VariantTest)
 
   BOOST_CHECK(viarr.size() == 5);
   BOOST_CHECK(viarr.get<int*>() != iarr);
-  for (auto i = 0U; i < viarr.size(); ++i) {
+  for (auto i = 0u; i < viarr.size(); ++i) {
     BOOST_CHECK(iarr[i] == (viarr.get<int*>())[i]);
   }
 
   BOOST_CHECK(vfarr.size() == 6);
   BOOST_CHECK(vfarr.get<float*>() != farr);
-  for (auto i = 0U; i < vfarr.size(); ++i) {
+  for (auto i = 0u; i < vfarr.size(); ++i) {
     BOOST_CHECK(farr[i] == (vfarr.get<float*>())[i]);
   }
 
   BOOST_CHECK(vdvec.size() == dvec.size());
   BOOST_CHECK(vdvec.get<double*>() != dvec.data());
-  for (auto i = 0U; i < dvec.size(); ++i) {
+  for (auto i = 0u; i < dvec.size(); ++i) {
     BOOST_CHECK(dvec[i] == (vdvec.get<double*>())[i]);
   }
 
@@ -118,15 +121,15 @@ BOOST_AUTO_TEST_CASE(VariantTest)
   BOOST_CHECK(vfarr.get<float*>() == nullptr);
 
   BOOST_CHECK(fb.get<float*>() != farr);
-  for (auto i = 0U; i < fb.size(); ++i) {
+  for (auto i = 0u; i < fb.size(); ++i) {
     BOOST_CHECK(farr[i] == (fb.get<float*>())[i]);
   }
   BOOST_CHECK(fc.get<float*>() != farr);
-  for (auto i = 0U; i < fc.size(); ++i) {
+  for (auto i = 0u; i < fc.size(); ++i) {
     BOOST_CHECK(farr[i] == (fc.get<float*>())[i]);
   }
   BOOST_CHECK(fd.get<float*>() != farr);
-  for (auto i = 0U; i < fd.size(); ++i) {
+  for (auto i = 0u; i < fd.size(); ++i) {
     BOOST_CHECK(farr[i] == (fd.get<float*>())[i]);
   }
 
@@ -137,20 +140,20 @@ BOOST_AUTO_TEST_CASE(VariantTest)
 
   BOOST_CHECK(vstr.size() == 3);
   BOOST_CHECK(vvstr.size() == 3);
-  for (auto i = 0U; i < vstr.size(); ++i) {
+  for (auto i = 0u; i < vstr.size(); ++i) {
     BOOST_CHECK(strings[i] == (vstr.get<std::string*>())[i]);
   }
-  for (auto i = 0U; i < vvstr.size(); ++i) {
+  for (auto i = 0u; i < vvstr.size(); ++i) {
     BOOST_CHECK(vstrings[i] == (vvstr.get<std::string*>())[i]);
   }
 
   Variant vsc(vstr);            // Copy constructor
   Variant vsm(std::move(vstr)); // Move constructor
   Variant vscc = vsm;           // Copy assignment
-  for (auto i = 0U; i < vsm.size(); ++i) {
+  for (auto i = 0u; i < vsm.size(); ++i) {
     BOOST_CHECK(strings[i] == (vsm.get<std::string*>())[i]);
   }
-  for (auto i = 0U; i < vscc.size(); ++i) {
+  for (auto i = 0u; i < vscc.size(); ++i) {
     BOOST_CHECK(strings[i] == (vscc.get<std::string*>())[i]);
   }
 
@@ -158,8 +161,8 @@ BOOST_AUTO_TEST_CASE(VariantTest)
   Array2D mm(&m[0][0], 3, 4);
   Variant vmm(mm);
   auto const& mmc = vmm.get<Array2D<float>>();
-  for (auto i = 0U; i < 3; ++i) {
-    for (auto j = 0U; j < 4; ++j) {
+  for (auto i = 0u; i < 3; ++i) {
+    for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(mmc(i, j) == mm(i, j));
     }
   }
@@ -168,18 +171,49 @@ BOOST_AUTO_TEST_CASE(VariantTest)
   Variant vmmm(std::move(vmm)); // Move constructor
   Variant vmma = vmmm;          // Copy assignment
   auto const& mmc2 = vmmc.get<Array2D<float>>();
-  for (auto i = 0U; i < 3; ++i) {
-    for (auto j = 0U; j < 4; ++j) {
+  for (auto i = 0u; i < 3; ++i) {
+    for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(mmc2(i, j) == mm(i, j));
     }
   }
   auto const& mmc3 = vmma.get<Array2D<float>>();
-  for (auto i = 0U; i < 3; ++i) {
-    for (auto j = 0U; j < 4; ++j) {
+  for (auto i = 0u; i < 3; ++i) {
+    for (auto j = 0u; j < 4; ++j) {
       BOOST_CHECK(mmc3(i, j) == mm(i, j));
     }
   }
   std::stringstream ssm;
   ssm << vmma;
   BOOST_CHECK(ssm.str() == "f[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1, 1.1, 1.2]]");
+}
+
+BOOST_AUTO_TEST_CASE(VariantConversionsTest)
+{
+  int iarr[] = {1, 2, 3, 4, 5};
+  Variant viarr(iarr, 5);
+  std::stringstream os;
+  VariantJSONHelpers::write(os, viarr);
+
+  std::stringstream is;
+  is.str(os.str());
+  auto v = VariantJSONHelpers::read<VariantType::ArrayInt>(is);
+  for (auto i = 0u; i < viarr.size(); ++i) {
+    BOOST_CHECK_EQUAL(v.get<int*>()[i], viarr.get<int*>()[i]);
+  }
+  os.str("");
+
+  float m[3][4] = {{0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7, 0.8}, {0.9, 1.0, 1.1, 1.2}};
+  Array2D mm(&m[0][0], 3, 4);
+  Variant vmm(mm);
+  std::stringstream osm;
+  VariantJSONHelpers::write(osm, vmm);
+  std::stringstream ism;
+  ism.str(osm.str());
+  auto vm = VariantJSONHelpers::read<VariantType::Array2DFloat>(ism);
+
+  for (auto i = 0u; i < mm.rows; ++i) {
+    for (auto j = 0u; j < mm.cols; ++j) {
+      BOOST_CHECK_EQUAL(vmm.get<Array2D<float>>()(i, j), vm.get<Array2D<float>>()(i, j));
+    }
+  }
 }


### PR DESCRIPTION
* read/write array variants from/to JSON
* use Variant JSON representation when serializing/deserializing workflow
* Variant now correctly does copy/move assignments (including initializing an empty assignment target, allowing to use non-trivial types as possible Variant content)
