### PR TITLE
Remove std::memcpy while processing data in compressor task

### DIFF
--- a/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
+++ b/Detectors/TOF/compression/include/TOFCompression/CompressorTask.h
@@ -32,16 +32,14 @@ template <typename RDH, bool verbose>
 class CompressorTask : public Task
 {
  public:
-  CompressorTask() { mBufferOut = new char[mBufferOutSize]; };
-  ~CompressorTask() override { delete[] mBufferOut; };
+  CompressorTask() = default;
+  ~CompressorTask() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   Compressor<RDH, verbose> mCompressor;
-
-  char* mBufferOut = nullptr;
-  const int mBufferOutSize = 33554432;
+  int mOutputBufferSize;
 };
 
 } // namespace tof

--- a/Detectors/TOF/compression/src/tof-compressor.cxx
+++ b/Detectors/TOF/compression/src/tof-compressor.cxx
@@ -93,6 +93,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       outputs,
       algoSpec,
       Options{
+        {"tof-compressor-output-buffer-size", VariantType::Int, 0, {"Encoder output buffer size (in bytes). Zero = automatic (careful)."}},
         {"tof-compressor-conet-mode", VariantType::Bool, false, {"Decoder CONET flag"}},
         {"tof-compressor-decoder-verbose", VariantType::Bool, false, {"Decoder verbose flag"}},
         {"tof-compressor-encoder-verbose", VariantType::Bool, false, {"Encoder verbose flag"}},


### PR DESCRIPTION
This PR removes an unnecessary `std::memcpy` while running the TOF compressor device.
The buffer for the message is created before hand and used size adjusted according to the output to be forwarded downstream.