### PR TITLE
RecoDecay: getDaughters: Skip PDG check for the original particle.

### DIFF
--- a/Analysis/Core/include/AnalysisCore/RecoDecay.h
+++ b/Analysis/Core/include/AnalysisCore/RecoDecay.h
@@ -557,12 +557,13 @@ class RecoDecay
   /// \param depthMax  maximum decay tree level; Daughters at this level (or beyond) will be considered final. If -1, all levels are considered.
   /// \param stage  decay tree level; If different from 0, the particle itself will be added in the list in case it has no daughters.
   /// \note Final state is defined as particles from arrPDGFinal plus final daughters of any other decay branch.
+  /// \note Antiparticles of particles in arrPDGFinal are accepted as well.
   template <std::size_t N, typename T>
   static void getDaughters(const T& particlesMC,
                            int index,
                            std::vector<int>* list,
                            const array<int, N>& arrPDGFinal,
-                           int depthMax = -1,
+                           int8_t depthMax = -1,
                            int8_t stage = 0)
   {
     if (index <= -1) {
@@ -592,11 +593,12 @@ class RecoDecay
       // If this is not the original particle, we are at the end of this branch and this particle is final.
       isFinal = true;
     }
-    // If the particle has daughters but is considered to be final, we label it as final.
-    auto PDGParticle = particle.pdgCode();
-    if (!isFinal) {
+    auto PDGParticle = std::abs(particle.pdgCode());
+    // If this is not the original particle, check its PDG code.
+    if (!isFinal && stage > 0) {
+      // If the particle has daughters but is considered to be final, we label it as final.
       for (auto PDGi : arrPDGFinal) {
-        if (std::abs(PDGParticle) == std::abs(PDGi)) { // Accept antiparticles.
+        if (PDGParticle == std::abs(PDGi)) { // Accept antiparticles.
           isFinal = true;
           break;
         }
@@ -739,12 +741,13 @@ class RecoDecay
   /// \param candidate  candidate MC particle
   /// \param PDGParticle  expected particle PDG code
   /// \param acceptAntiParticles  switch to accept the antiparticle
+  /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
   /// \return true if PDG code of the particle is correct, false otherwise
   template <typename T, typename U>
-  static int isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false)
+  static int isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false, int8_t* sign = nullptr)
   {
     array<int, 0> arrPDGDaughters;
-    return isMatchedMCGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles);
+    return isMatchedMCGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles, sign);
   }
 
   /// Check whether the MC particle is the expected one and whether it decayed via the expected decay channel.
@@ -771,8 +774,7 @@ class RecoDecay
       sgn = 1;
     } else if (acceptAntiParticles && PDGCandidate == -PDGParticle) { // antiparticle PDG match
       sgn = -1;
-    }
-    if (sgn == 0) {
+    } else {
       //Printf("MC Gen: Rejected: bad particle PDG: %s%d != %d", acceptAntiParticles ? "abs " : "", PDGCandidate, std::abs(PDGParticle));
       return false;
     }


### PR DESCRIPTION
Do not label the original particle as final, when its species matches the expected species of its daughter.
This could happen when calling this function for a quark that radiates a gluon and becomes its own daughter.
In general, there is no reason to check the PDG code of the original particle against the codes of the expected daughters, so skipping it speeds up this function.