### PR TITLE
Implementation of simulation inhibit-pause-trigger-continue features

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -329,6 +329,8 @@ inline MCTrackT<T>::MCTrackT(const TParticle& part)
 {
   // our convention is to communicate the process as (part) of the unique ID
   setProcess(part.GetUniqueID());
+  // extract storage flag
+  setStore(part.TestBit(ParticleStatus::kKeep));
   // extract toBeDone flag
   setToBeDone(part.TestBit(ParticleStatus::kToBeDone));
   // extract inhibited flag

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -90,7 +90,8 @@ class Stack : public FairGenericStack
 
   void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz, Double_t e,
                  Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
-                 TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondParentId, Int_t daughter1Id, Int_t daughter2Id);
+                 TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondParentId, Int_t daughter1Id, Int_t daughter2Id,
+                 TMCProcess proc2);
 
   // similar function taking a particle
   void PushTrack(Int_t toBeDone, TParticle&);

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -103,6 +103,7 @@ Stack::Stack(Int_t size)
     if (!mTransportPrimary) {
       LOG(FATAL) << "Failed to retrieve external \'transportPrimary\' function: problem with configuration ";
     }
+    LOG(INFO) << "Successfully retrieve external \'transportPrimary\' frunction: " << param.transportPrimaryFileName;
   } else {
     LOG(FATAL) << "unsupported \'trasportPrimary\' mode: " << param.transportPrimary;
   }
@@ -183,12 +184,13 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
                       Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
                       TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondparentId)
 {
-  PushTrack(toBeDone, parentId, pdgCode, px, py, pz, e, vx, vy, vz, time, polx, poly, polz, proc, ntr, weight, is, secondparentId, -1, -1);
+  PushTrack(toBeDone, parentId, pdgCode, px, py, pz, e, vx, vy, vz, time, polx, poly, polz, proc, ntr, weight, is, secondparentId, -1, -1, proc);
 }
 
 void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px, Double_t py, Double_t pz, Double_t e,
                       Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
-                      TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondparentId, Int_t daughter1Id, Int_t daughter2Id)
+                      TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondparentId, Int_t daughter1Id, Int_t daughter2Id,
+                      TMCProcess proc2)
 {
   //  printf("Pushing %s toBeDone %5d parentId %5d pdgCode %5d is %5d entries %5d \n",
   //	 proc == kPPrimary ? "Primary:   " : "Secondary: ",
@@ -214,36 +216,38 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
   p.SetPolarisation(polx, poly, polz);
   p.SetWeight(weight);
   p.SetUniqueID(proc); // using the unique ID to transfer process ID
+  p.SetBit(ParticleStatus::kPrimary, proc == kPPrimary ? 1 : 0); // set primary bit
+  p.SetBit(ParticleStatus::kToBeDone, toBeDone == 1 ? 1 : 0);    // set to be done bit
   mNumberOfEntriesInParticles++;
 
   insertInVector(mTrackIDtoParticlesEntry, trackId, (int)(mParticles.size()));
 
+  handleTransportPrimary(p); // handle selective transport of primary particles
+
   // Push particle on the stack if toBeDone is set
-  if (proc == kPPrimary) {
+  if (p.TestBit(ParticleStatus::kPrimary)) {
     // This is a particle from the primary particle generator
     //
     // SetBit is used to pass information about the primary particle to the stack during transport.
     // Sime particles have already decayed or are partons from a shower. They are needed for the
     // event history in the stack, but not for transport.
     //
+
+    // primary particles might have been pushed with a second creation process
+    // in case we pushed a secondary track of a previous simulation to be continued.
+    // We save therefore in the UniqueID the correct process
+    // while the particle will still be treated as a primary given its bit settings
+    p.SetUniqueID(proc2);
+
     mIndexMap[trackId] = trackId;
-    p.SetBit(ParticleStatus::kKeep);
-    p.SetBit(ParticleStatus::kPrimary);
-    if (toBeDone == 1) {
-      handleTransportPrimary(p);
-    } else {
-      p.SetBit(ParticleStatus::kToBeDone, 0);
+    p.SetBit(ParticleStatus::kKeep, 1);
+    if (p.TestBit(ParticleStatus::kToBeDone)) {
+      mNumberOfPrimariesforTracking++;
     }
     mNumberOfPrimaryParticles++;
     mPrimaryParticles.push_back(p);
     mTracks->emplace_back(p);
   } else {
-    p.SetBit(ParticleStatus::kPrimary, 0);
-    if (toBeDone == 1) {
-      p.SetBit(ParticleStatus::kToBeDone, 1);
-    } else {
-      p.SetBit(ParticleStatus::kToBeDone, 0);
-    }
     mParticles.emplace_back(p);
     mCurrentParticle0 = p;
   }
@@ -255,10 +259,11 @@ void Stack::handleTransportPrimary(TParticle& p)
   // this function tests whether we really want to transport
   // this particle and sets the relevant bits accordingly
 
-  if (mTransportPrimary(p, mPrimaryParticles)) {
-    p.SetBit(ParticleStatus::kToBeDone, 1);
-    mNumberOfPrimariesforTracking++;
-  } else {
+  if (!p.TestBit(ParticleStatus::kToBeDone) || !p.TestBit(ParticleStatus::kPrimary)) {
+    return;
+  }
+
+  if (!mTransportPrimary(p, mPrimaryParticles)) {
     p.SetBit(ParticleStatus::kToBeDone, 0);
     p.SetBit(ParticleStatus::kInhibited, 1);
   }
@@ -271,15 +276,15 @@ void Stack::PushTrack(int toBeDone, TParticle& p)
   // This method is called
   //
   // - during parallel simulation to push primary particles (called by the stack itself)
-  if (p.GetUniqueID() == 0) {
+  if (p.TestBit(ParticleStatus::kPrimary)) {
     // one to one mapping for primaries
     mIndexMap[mNumberOfPrimaryParticles] = mNumberOfPrimaryParticles;
-    // Push particle on the stack
-    if (p.TestBit(ParticleStatus::kPrimary) && p.TestBit(ParticleStatus::kToBeDone)) {
-      handleTransportPrimary(p);
-    }
     mNumberOfPrimaryParticles++;
     mPrimaryParticles.push_back(p);
+    // Push particle on the stack
+    if (p.TestBit(ParticleStatus::kToBeDone)) {
+      mNumberOfPrimariesforTracking++;
+    }
     mStack.push(p);
     mTracks->emplace_back(p);
   }

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(Generators
                        src/GeneratorTGenerator.cxx
                        src/GeneratorExternalParam.cxx
                        src/GeneratorFromFile.cxx
+                       src/GeneratorFromO2KineParam.cxx
                        src/PDG.cxx
                        src/PrimaryGenerator.cxx
                        src/InteractionDiamondParam.cxx
@@ -68,6 +69,7 @@ set(headers
     include/Generators/GeneratorTGenerator.h
     include/Generators/GeneratorExternalParam.h
     include/Generators/GeneratorFromFile.h
+    include/Generators/GeneratorFromO2KineParam.h
     include/Generators/PDG.h
     include/Generators/PrimaryGenerator.h
     include/Generators/InteractionDiamondParam.h

--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -78,11 +78,15 @@ class GeneratorFromO2Kine : public o2::eventgen::Generator
   void SetStartEvent(int start);
 
  private:
+  /** methods that can be overridden **/
+  void updateHeader(o2::dataformats::MCEventHeader* eventHeader) override;
+
   TFile* mEventFile = nullptr;     //! the file containing the persistent events
   TBranch* mEventBranch = nullptr; //! the branch containing the persistent events
   int mEventCounter = 0;
   int mEventsAvailable = 0;
   bool mSkipNonTrackable = true; //! whether to pass non-trackable (decayed particles) to the MC stack
+  bool mContinueMode = false;    //! whether we want to continue simulation of previously inhibited tracks
   ClassDefOverride(GeneratorFromO2Kine, 1);
 };
 

--- a/Generators/include/Generators/GeneratorFromO2KineParam.h
+++ b/Generators/include/Generators/GeneratorFromO2KineParam.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2021
+
+#ifndef ALICEO2_EVENTGEN_GENERATORFROMO2KINEPARAM_H_
+#define ALICEO2_EVENTGEN_GENERATORFROMO2KINEPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the FromO2Kine event generator and
+ ** allow the user to modify them 
+ **/
+
+struct GeneratorFromO2KineParam : public o2::conf::ConfigurableParamHelper<GeneratorFromO2KineParam> {
+  bool skipNonTrackable = true;
+  bool continueMode = false;
+  O2ParamDef(GeneratorFromO2KineParam, "GeneratorFromO2Kine");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_GENERATORFROMO2KINEPARAM_H_

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -131,7 +131,8 @@ Bool_t
                         particle.GetStatusCode() == 1,
                         particle.Energy() * mEnergyUnit,
                         particle.T() * mTimeUnit,
-                        particle.GetWeight());
+                        particle.GetWeight(),
+                        (TMCProcess)particle.GetUniqueID());
   }
 
   /** success **/

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -9,7 +9,9 @@
 // or submit itself to any jurisdiction.
 
 #include "Generators/GeneratorFromFile.h"
+#include "Generators/GeneratorFromO2KineParam.h"
 #include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/MCEventHeader.h"
 #include <FairLogger.h>
 #include <FairPrimaryGenerator.h>
 #include <TBranch.h>
@@ -176,6 +178,13 @@ GeneratorFromO2Kine::GeneratorFromO2Kine(const char* name)
     }
   }
   LOG(ERROR) << "Problem reading events from file " << name;
+
+  // read and set params
+  auto& param = GeneratorFromO2KineParam::Instance();
+  LOG(INFO) << "Instance \'FromO2Kine\' generator with following parameters";
+  LOG(INFO) << param;
+  mSkipNonTrackable = param.skipNonTrackable;
+  mContinueMode = param.continueMode;
 }
 
 void GeneratorFromO2Kine::SetStartEvent(int start)
@@ -201,8 +210,9 @@ bool GeneratorFromO2Kine::importParticles()
     mEventBranch->GetEntry(mEventCounter);
 
     for (auto& t : *tracks) {
-      // I guess we only want primaries (unless later on we continue a simulation)
-      if (!t.isPrimary()) {
+
+      // in case we do not want to continue, take only primaries
+      if (!mContinueMode && !t.isPrimary()) {
         continue;
       }
 
@@ -221,9 +231,16 @@ bool GeneratorFromO2Kine::importParticles()
       auto vt = t.T();
       auto weight = 1.; // p.GetWeight() ??
       auto wanttracking = t.getToBeDone();
+
+      if (mContinueMode) { // in case we want to continue, do only inhibited tracks
+        wanttracking &= t.getInhibited();
+      }
+
       LOG(DEBUG) << "Putting primary " << pdg;
 
       mParticles.push_back(TParticle(pdg, wanttracking, m1, m2, d1, d2, px, py, pz, e, vx, vy, vz, vt));
+      mParticles.back().SetUniqueID((unsigned int)t.getProcess()); // we should propagate the process ID
+
       particlecounter++;
     }
     mEventCounter++;
@@ -238,6 +255,17 @@ bool GeneratorFromO2Kine::importParticles()
     LOG(ERROR) << "GeneratorFromO2Kine: Ran out of events\n";
   }
   return false;
+}
+
+void GeneratorFromO2Kine::updateHeader(o2::dataformats::MCEventHeader* eventHeader)
+{
+  /** update header **/
+
+  // put information about input file and event number of the current event
+
+  eventHeader->putInfo<std::string>("generator", "generatorFromO2Kine");
+  eventHeader->putInfo<std::string>("inputFile", mEventFile->GetName());
+  eventHeader->putInfo<int>("inputEventNumber", mEventCounter - 1);
 }
 
 } // namespace eventgen

--- a/Generators/src/GeneratorFromO2KineParam.cxx
+++ b/Generators/src/GeneratorFromO2KineParam.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2021
+
+#include "Generators/GeneratorFromO2KineParam.h"
+O2ParamImpl(o2::eventgen::GeneratorFromO2KineParam);

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -48,6 +48,8 @@
 #endif
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;
 #pragma link C++ class o2::eventgen::GeneratorFromO2Kine + ;
+#pragma link C++ class o2::eventgen::GeneratorFromO2KineParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorFromO2KineParam> + ;
 #pragma link C++ class o2::PDG + ;
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
 

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -193,8 +193,8 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
     return; // must be the o2 stack
   }
   stack->PushTrack(doTracking, mother1, pdgid, px, py, pz,
-                   e, vx, vy, vz, tof, polx, poly, polz, proc, ntr,
-                   weight, status, mother2, daughter1, daughter2);
+                   e, vx, vy, vz, tof, polx, poly, polz, TMCProcess::kPPrimary, ntr,
+                   weight, status, mother2, daughter1, daughter2, proc);
 
   fNTracks++;
 }

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -460,6 +460,7 @@ Other helpful resources are the scripts used for regression testing in [prodtest
 | [HepMC_STARlight](../run/SimExamples/HepMC_STARlight) | Simple example showing **generator configuration** that runs a standalone `STARlight` generation that couples to the `o2` via a `HepMC` file |
 | [Jet_Embedding_Pythia](../run/SimExamples/Jet_Embedding_Pythia8) | Complex example showing **generator configuration**, **digitization embedding**, **MCTrack access** |
 | [Selective_Transport](../run/SimExamples/Selective_Transport) | Simple example showing how to run simulation transporting only a custumisable set of particles |
+| [Selective_Transport_pi0](../run/SimExamples/Selective_Transport_pi0) | Complex example showing how to run simulation within the inhibit-pause-trigger-continue approach |
 | [Custom_EventInfo](../run/SimExamples/Custom_EventInfo) | Simple example showing how to add custom information to the MC event header |
 | [sim_challenge.sh](../prodtests/sim_challenge.sh) | Basic example doing a **simple transport, digitization, reconstruction pipeline** on the full dectector. All stages use parallelism. |
 | [sim_performance.sh](../prodtests/sim_performance_test.sh) | Basic example for serial transport and linearized digitization sequence (one detector after the other). Serves as standard performance candle. |  

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -17,5 +17,6 @@
 * \subpage refrunSimExamplesForceDecay_Lambda_Neutron_Dalitz
 * \subpage refrunSimExamplesJustPrimaryKinematics
 * \subpage refrunSimExamplesSelective_Transport
+* \subpage refrunSimExamplesSelective_Transport_pi0
 * \subpage refrunSimExamplesCustom_EventInfo
 /doxy -->

--- a/run/SimExamples/Selective_Transport_pi0/check_kine.macro
+++ b/run/SimExamples/Selective_Transport_pi0/check_kine.macro
@@ -1,0 +1,83 @@
+void
+check_kine(const char *fname1, const char *fname2)
+{
+
+  auto fin1 = TFile::Open(fname1);
+  auto tin1 = (TTree*)fin1->Get("o2sim");
+  auto tracks1 = new vector<o2::MCTrack>;
+  tin1->SetBranchAddress("MCTrack", &tracks1);
+
+  auto fin2 = TFile::Open(fname2);
+  auto tin2 = (TTree*)fin2->Get("o2sim");
+  auto tracks2 = new vector<o2::MCTrack>;
+  auto head2 = new o2::dataformats::MCEventHeader;
+  tin2->SetBranchAddress("MCEventHeader.", &head2);
+  tin2->SetBranchAddress("MCTrack", &tracks2);
+
+  bool isvalid;
+  
+  for (int iev2 = 0; iev2 < tin2->GetEntries(); ++iev2) {
+
+    tin2->GetEntry(iev2);
+
+    auto iev1 = head2->getInfo<int>("inputEventNumber", isvalid);
+    tin1->GetEntry(iev1);
+    
+    std::cout << "--- event2 " << iev2 << ", event1 " << iev1 << ": "
+	      << tracks1->size() << " " << tracks2->size() << std::endl;
+    
+    std::cout << "itrk" << " "
+	      << "st1" << " "
+	      << "st2" << "\t"
+	      << "pdg" << "\t"
+	      << "M1" << "\t"
+	      << "M2" << "\t"
+	      << "D1" << "\t"
+	      << "D2" << "\t"
+	      << std::endl;
+    
+    for (int itr = 0; itr < tracks1->size(); ++itr) {
+
+      auto& t1 = tracks1->at(itr);
+      auto& t2 = tracks2->at(itr);
+      
+      // check that the two tracks are identical
+      if (t1.GetPdgCode() != t2.GetPdgCode() ||
+	  t1.getMotherTrackId() != t2.getMotherTrackId() ||
+	  t1.getSecondMotherTrackId() != t2.getSecondMotherTrackId()) {// ||
+	//	  t1.getFirstDaughterTrackId() != t2.getFirstDaughterTrackId() ||
+	//	  t1.getLastDaughterTrackId() != t2.getLastDaughterTrackId()) {
+	std::cout << itr << " tracks are not identical " << std::endl;
+      }
+      
+      std::cout << itr << " "
+		<< t1.isPrimary() << t1.getToBeDone() << t1.getInhibited() << " "
+		<< t2.isPrimary() << t2.getToBeDone() << t2.getInhibited() << "\t"
+		<< t2.GetPdgCode() << "\t"
+		<< t2.getMotherTrackId() << "\t"
+		<< t2.getSecondMotherTrackId() << "\t"
+		<< t2.getFirstDaughterTrackId() << "\t"
+		<< t2.getLastDaughterTrackId() << "\t"
+		<< std::endl;
+      
+    }
+    
+    for (int itr = tracks1->size(); itr < tracks2->size(); ++itr) {
+
+      auto& t2 = tracks2->at(itr);
+      
+      std::cout << itr << " "
+		<< "---" << " "
+		<< t2.isPrimary() << t2.getToBeDone() << t2.getInhibited() << "\t"
+		<< t2.GetPdgCode() << "\t"
+		<< t2.getMotherTrackId() << "\t"
+		<< t2.getSecondMotherTrackId() << "\t"
+		<< t2.getFirstDaughterTrackId() << "\t"
+		<< t2.getLastDaughterTrackId() << "\t"
+		<< std::endl;
+      
+    }
+    
+  }
+  
+}

--- a/run/SimExamples/Selective_Transport_pi0/check_kine_labels.macro
+++ b/run/SimExamples/Selective_Transport_pi0/check_kine_labels.macro
@@ -1,0 +1,79 @@
+void print(int itr, o2::MCTrack& t) {
+std::cout << itr << " "
+	      << t.isPrimary() << t.getToBeDone() << t.getInhibited() << " "
+	      << t.isPrimary() << t.getToBeDone() << t.getInhibited() << "\t"
+	      << t.GetPdgCode() << "\t"
+	      << t.getMotherTrackId() << "\t"
+	      << t.getSecondMotherTrackId() << "\t"
+	      << t.getFirstDaughterTrackId() << "\t"
+	      << t.getLastDaughterTrackId() << "\t"
+	      << std::endl;
+    }	   
+
+
+void
+check_kine_labels(const char *fname)
+{
+
+  auto fin = TFile::Open(fname);
+  auto tin = (TTree*)fin->Get("o2sim");
+  auto tracks = new vector<o2::MCTrack>;
+  tin->SetBranchAddress("MCTrack", &tracks);
+  auto nev = tin->GetEntries();
+  
+  // loop over events
+  for (int iev = 0; iev < nev; ++iev) {    
+    tin->GetEntry(iev);
+
+    // loop over tracks from the beginning
+    for (int itr = 0; itr < tracks->size(); ++itr) {
+      auto& t = tracks->at(itr);
+      //      print(itr, t);
+      auto id1 = t.getFirstDaughterTrackId();
+      auto id2 = t.getLastDaughterTrackId();
+      if (id1 == -1) continue; // track has no daughter
+
+      // loop over daughters
+      for (int jtr = id1; jtr <= id2; ++jtr) {
+	auto& d = tracks->at(jtr);
+
+	if (d.getSecondMotherTrackId() == -1) { // if it only has first mother, check label is the same
+	  if (itr != d.getMotherTrackId()) {
+	    std::cout << "THIS IS WRONG (looping forward)" << std::endl;
+	    std::cout << "mother:   "; print(itr, t);
+	    std::cout << "daughter: "; print(jtr, d);
+	  }
+	} else { // else if it has first and second mother, check that label is in between 
+	  if (itr < d.getMotherTrackId() || itr > d.getSecondMotherTrackId()) {
+	    std::cout << "THIS IS WRONG (looping forward)" << std::endl;
+	    std::cout << "mother:   "; print(itr, t);
+	    std::cout << "daughter: "; print(jtr, d);
+	  }
+	}	
+      }
+    }
+
+    // loop over tracks from the end
+    for (int itr = tracks->size() - 1; itr >= 0; --itr) {
+
+      auto& t = tracks->at(itr);
+      auto im1 = t.getMotherTrackId();
+      auto im2 = t.getSecondMotherTrackId();
+      if (im1 == -1) continue; // track has no mother
+      if (im2 == -1) { // track has only one mother
+	auto& m = tracks->at(im1);
+	if (itr < m.getFirstDaughterTrackId() || itr > m.getLastDaughterTrackId()) {
+	    std::cout << "THIS IS WRONG (looping backward)" << std::endl;
+	    std::cout << "mother:   "; print(im1, m);
+	    std::cout << "daughter: "; print(itr, t);
+	}
+      } else { // track has first and second mother
+	continue;
+	
+      }
+      
+    }
+    
+  }
+    
+}

--- a/run/SimExamples/Selective_Transport_pi0/read_kine.macro
+++ b/run/SimExamples/Selective_Transport_pi0/read_kine.macro
@@ -1,0 +1,38 @@
+void
+read_kine(const char *fname1, int iev1 = 0)
+{
+
+  auto fin1 = TFile::Open(fname1);
+  auto tin1 = (TTree*)fin1->Get("o2sim");
+  auto tracks1 = new vector<o2::MCTrack>;
+  tin1->SetBranchAddress("MCTrack", &tracks1);
+
+  tin1->GetEntry(iev1);
+  
+  std::cout << "itrk" << " "
+	    << "st1" << " "
+	    << "st2" << "\t"
+	    << "pdg" << "\t"
+	    << "M1" << "\t"
+	    << "M2" << "\t"
+	    << "D1" << "\t"
+	    << "D2" << "\t"
+	    << std::endl;
+  
+  for (int itr = 0; itr < tracks1->size(); ++itr) {
+    
+    auto& t1 = tracks1->at(itr);
+    
+    std::cout << itr << " "
+	      << t1.isPrimary() << t1.getToBeDone() << t1.getInhibited() << " "
+	      << t1.isPrimary() << t1.getToBeDone() << t1.getInhibited() << "\t"
+	      << t1.GetPdgCode() << "\t"
+	      << t1.getMotherTrackId() << "\t"
+	      << t1.getSecondMotherTrackId() << "\t"
+	      << t1.getFirstDaughterTrackId() << "\t"
+	      << t1.getLastDaughterTrackId() << "\t"
+	      << std::endl;
+    
+  }
+  
+}

--- a/run/SimExamples/Selective_Transport_pi0/run.sh
+++ b/run/SimExamples/Selective_Transport_pi0/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This is a simulation example showing how to run simulation and selectively
+# transport particles through the detector geometry according to configurable settings
+#
+# The simulation uses Pythia8 pp generator with default settings.
+# The specific settings of the simulation are defined in the sim.ini file.
+#
+# Only the parameters for the selective particle transport are adjusted, namely
+# ```
+# [Stack]
+# transportPrimary=external
+# transportPrimaryFileName=transportPDG.macro
+# transportPrimaryFuncName=transportPDG(321)
+# transportPrimaryInvert=false
+# ```
+#
+# `transportPrimary` defines the mode of selection, `external` means that the definition is loaded from a plugin macro
+# defined by the function call `transportPrimaryFuncName` from the file `transportPrimaryFileName`.
+# `transportPrimaryInvert` allows one to invert the definition, hence to inhibit transport for the selected particles.
+#
+#
+# The second step of this simulation examples shows how to continue the simulation from the first
+# step and propagate all the remaining tracks. The process is done only for events that pass a specific
+# trigger which requires that both photons from pi0 decay have converted within a given region.
+#
+
+set -x
+
+MODULES="PIPE ITS TPC"
+NEVENTS1=100
+NEVENTS2=1
+NWORKERS=1
+
+### step 1
+
+o2-sim -j ${NWORKERS} -n ${NEVENTS1} -g pythia8 -m ${MODULES} -o step1 \
+       --configFile sim_step1.ini --seed 73141128
+
+### step 2
+
+o2-sim -j ${NWORKERS} -n ${NEVENTS2} -g extkinO2 -m ${MODULES} -o step2 \
+       --extKinFile step1_Kine.root \
+       --configFile sim_step2.ini \
+       --trigger external
+

--- a/run/SimExamples/Selective_Transport_pi0/sim_step1.ini
+++ b/run/SimExamples/Selective_Transport_pi0/sim_step1.ini
@@ -1,0 +1,5 @@
+[Stack]
+transportPrimary=external
+transportPrimaryFileName=transport_pi0.macro
+transportPrimaryFuncName=transport_pi0()
+transportPrimaryInvert=false

--- a/run/SimExamples/Selective_Transport_pi0/sim_step2.ini
+++ b/run/SimExamples/Selective_Transport_pi0/sim_step2.ini
@@ -1,0 +1,6 @@
+[TriggerExternal]
+fileName=trigger_pi0.macro
+funcName=trigger_pi0()
+
+[GeneratorFromO2Kine]
+continueMode=true

--- a/run/SimExamples/Selective_Transport_pi0/transport_pi0.macro
+++ b/run/SimExamples/Selective_Transport_pi0/transport_pi0.macro
@@ -1,0 +1,28 @@
+o2::data::Stack::TransportFcn
+transport_pi0()
+{
+
+  /** this function returns true/false depending on whether the
+   ** current particle is either a pi0 produced at mid-rapidity 
+   ** or a daughter of a pi0 produced at mid-rapidity **/
+
+  o2::data::Stack::TransportFcn decision;
+  decision = [&decision](const TParticle& particle, const std::vector<TParticle>& particles) -> bool {
+//  std::cout << particles.size() << std::endl;
+//particle.Print();
+//return false;
+	       if (particle.GetPdgCode() == 111)         // if particle is a pi0
+		 return std::fabs(particle.Eta()) < 1.0; // decision is based on particle rapidity
+	       auto motherL = particle.GetFirstMother(); // if not a pi0, we look at the mother
+	       if (motherL == -1) return false;          // if particle has no mother, decision is false
+	       if (motherL >= particles.size()) {
+	       std::cout << "this makes no sense: " << motherL << " " << particles.size() << std::endl;
+	       return false;
+}
+auto mother = particles[motherL];         // if particle has mother
+	       return decision(mother, particles);       // decision is based on the mother
+	     };
+  
+  return decision;
+
+}

--- a/run/SimExamples/Selective_Transport_pi0/trigger_pi0.macro
+++ b/run/SimExamples/Selective_Transport_pi0/trigger_pi0.macro
@@ -1,0 +1,46 @@
+#include "Generators/Trigger.h"
+#include "TParticle.h"
+
+int counterAll = 0;
+int counterSel = 0;
+
+bool has_gamma_converted(const TParticle& gamma, const std::vector<TParticle>& particles)
+{
+  if (gamma.GetPdgCode() != 22) return false; // not a photon
+  if (gamma.GetNDaughters() != 2) return false; // did not produce 2 particles
+  auto& d1 = particles[gamma.GetFirstDaughter()];
+  auto& d2 = particles[gamma.GetLastDaughter()];
+  if (abs(d1.GetPdgCode()) != 11 || abs(d2.GetPdgCode()) != 11) return false; // not e+e- pair;
+  if (d1.R() > 100. || d2.R() > 100.) return false; // both at R < 100 cm
+  return true;
+};
+
+bool has_pi0_converted(const TParticle& pi0, const std::vector<TParticle>& particles)
+{  
+  if (pi0.GetPdgCode() != 111) return false;
+  if (std::fabs(pi0.Eta()) > 1.0) return false;
+  //  pi0.Print();
+  //  std::cout << "HERE: " << pi0.GetNDaughters() << std::endl;
+  if (pi0.GetNDaughters() != 2) return false;
+  auto& d1 = particles[pi0.GetFirstDaughter()];
+  auto& d2 = particles[pi0.GetLastDaughter()];
+  return ( has_gamma_converted(d1, particles) && has_gamma_converted(d2, particles) );
+};
+		     		     
+o2::eventgen::Trigger
+  trigger_pi0()
+{
+  auto trigger = [](const std::vector<TParticle>& particles) -> bool {		   
+		   counterAll++;
+		   for (const auto& particle : particles)
+		     if (has_pi0_converted(particle, particles)) {
+		       counterSel++;
+		       std::cout << " --- event selected: " << counterSel << " / " << counterAll << std::endl;
+		       return true;
+		     }
+		   std::cout << " --- event rejected: " << counterSel << " / " << counterAll << std::endl;
+		   return false;
+		 };
+  
+  return trigger;
+}


### PR DESCRIPTION
This PR brings changes that put together a new feature that allows one to continue a simulation in a second step.
The logic of the pause-trigger-continue approach is the following
* (step-1) run a simulation where only some particles are transported (pause)
* inspect the output of the simulation at step-1 to look for interesting events (trigger)
* (step-2) continue the interesting event transporting all remaining particles (continue)

