### PR TITLE
Fix typo in full system test script

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -133,8 +133,8 @@ if [ $CTFINPUT == 0 ]; then
   if [ $CREATECTFDICT == 1 ] && [ $SAVECTF == 0 ]; then CTF_OUTPUT_TYPE="dict"; fi
   if [ $CREATECTFDICT == 0 ] && [ $SAVECTF == 1 ]; then CTF_OUTPUT_TYPE="ctf"; fi
   CMD_CTF="o2-ctf-writer-workflow $ARGS_ALL --output-type $CTF_OUTPUT_TYPE --onlyDet $CTF_DETECTORS"
-  if [ $CREATECTFDICT == 1 ] && [ $; then
-    CMD_CTF+=" --save-dict-after 1"
+  if [ $CREATECTFDICT == 1 ] && [ $EXTINPUT == 1]; then
+    CMD_CTF+=" --save-dict-after $NTIMEFRAMES"
   fi
   WORKFLOW+="$CMD_CTF | "
 fi


### PR DESCRIPTION
@sawenzel : This fixes the typo in the script you reported. No idea.., but was there for a while. Apparently I saved the file in the middle of typing and not at the end...