### PR TITLE
Add option to create an o2 propagator instance uninitialized to be used with external matLut / gpuFieldMap

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -114,9 +114,9 @@ class Propagator
   GPUd() void setBz(float bz) { mBz = bz; }
 
 #ifndef GPUCA_GPUCODE
-  static Propagator* Instance()
+  static Propagator* Instance(bool uninitialized = false)
   {
-    static Propagator instance;
+    static Propagator instance(uninitialized);
     return &instance;
   }
 
@@ -129,7 +129,7 @@ class Propagator
 
  private:
 #ifndef GPUCA_GPUCODE
-  Propagator();
+  Propagator(bool uninitialized = false);
   ~Propagator() = default;
 #endif
 

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -29,8 +29,11 @@ using namespace o2::gpu;
 #include <FairRunAna.h> // eventually will get rid of it
 #include <TGeoGlobalMagField.h>
 
-Propagator::Propagator()
+Propagator::Propagator(bool uninitialized)
 {
+  if (uninitialized) {
+    return;
+  }
   ///< construct checking if needed components were initialized
 
   // we need the geoemtry loaded
@@ -99,7 +102,7 @@ int Propagator::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verb
   return 0;
 }
 #elif !defined(GPUCA_GPUCODE)
-Propagator::Propagator()
+Propagator::Propagator(bool uninitialized)
 {
 } // empty dummy constructor for standalone benchmark
 #endif

--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -257,7 +257,7 @@ o2::base::Propagator* GPUParam::GetDefaultO2Propagator(bool useGPUField) const
   if (useGPUField == false) {
     throw std::runtime_error("o2 propagator withouzt gpu field unsupported");
   }
-  prop = o2::base::Propagator::Instance();
+  prop = o2::base::Propagator::Instance(useGPUField);
   if (useGPUField) {
     prop->setGPUField(&polynomialField);
     prop->setBz(polynomialField.GetNominalBz());


### PR DESCRIPTION
@shahor02 : Is this ok for you?
It is a bit ugly, since if someone else requires an initialized propagator later, he won't get it.
On the other hand, 2 users requesting the propagator share the same instance anyway, and if one alter the settings, that affects the other user as well, so I think my patch does not introduce an additionall problem.