### PR TITLE
Compressor out one part for input subspec, regardless input struct

### DIFF
--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -60,6 +60,11 @@ void CompressorTask<RDH, verbose>::run(ProcessingContext& pc)
   auto device = pc.services().get<o2::framework::RawDeviceService>().device();
   auto outputRoutes = pc.services().get<o2::framework::RawDeviceService>().spec().outputs;
   auto fairMQChannel = outputRoutes.at(0).channel;
+  FairMQParts partsOut;
+
+  /** to store data sorted by subspec id **/
+  std::map<int, std::vector<o2::framework::DataRef>> subspecPartMap;
+  std::map<int, int> subspecBufferSize;
 
   /** loop over inputs routes **/
   for (auto iit = pc.inputs().begin(), iend = pc.inputs().end(); iit != iend; ++iit) {
@@ -67,11 +72,42 @@ void CompressorTask<RDH, verbose>::run(ProcessingContext& pc)
       continue;
     }
 
-    /** prepare output parts **/
-    FairMQParts parts;
-
     /** loop over input parts **/
     for (auto const& ref : iit) {
+
+      /** store parts in map **/
+      auto headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      auto subspec = headerIn->subSpecification;
+      subspecPartMap[subspec].push_back(ref);
+
+      /** increase subspec buffer size **/
+      if (!subspecBufferSize.count(subspec)) {
+        subspecBufferSize[subspec] = 0;
+      }
+      subspecBufferSize[subspec] += headerIn->payloadSize;
+    }
+  }
+
+  /** loop over subspecs **/
+  for (auto& subspecPartEntry : subspecPartMap) {
+
+    auto subspec = subspecPartEntry.first;
+    auto parts = subspecPartEntry.second;
+    auto& firstPart = parts.at(0);
+
+    /** use the first part to define output headers **/
+    auto headerOut = *DataRefUtils::getHeader<o2::header::DataHeader*>(firstPart);
+    auto dataProcessingHeaderOut = *DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(firstPart);
+    headerOut.dataDescription = "CRAWDATA";
+    headerOut.payloadSize = 0;
+
+    /** initialise output message **/
+    auto bufferSize = mOutputBufferSize > 0 ? mOutputBufferSize : subspecBufferSize[subspec];
+    auto payloadMessage = device->NewMessage(bufferSize);
+    auto bufferPointer = (char*)payloadMessage->GetData();
+
+    /** loop over subspec parts **/
+    for (const auto& ref : parts) {
 
       /** input **/
       auto headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
@@ -79,36 +115,33 @@ void CompressorTask<RDH, verbose>::run(ProcessingContext& pc)
       auto payloadIn = ref.payload;
       auto payloadInSize = headerIn->payloadSize;
 
-      /** prepare **/
-      auto bufferSize = mOutputBufferSize > 0 ? mOutputBufferSize : payloadInSize;
-      auto payloadMessage = device->NewMessage(bufferSize);
+      /** prepare compressor **/
       mCompressor.setDecoderBuffer(payloadIn);
       mCompressor.setDecoderBufferSize(payloadInSize);
-      mCompressor.setEncoderBuffer((char*)payloadMessage->GetData());
+      mCompressor.setEncoderBuffer(bufferPointer);
       mCompressor.setEncoderBufferSize(bufferSize);
 
       /** run **/
       mCompressor.run();
       auto payloadOutSize = mCompressor.getEncoderByteCounter();
-      payloadMessage->SetUsedSize(payloadOutSize);
-
-      /** output **/
-      auto headerOut = *headerIn;
-      auto dataProcessingHeaderOut = *dataProcessingHeaderIn;
-      headerOut.dataDescription = "CRAWDATA";
-      headerOut.payloadSize = payloadOutSize;
-      o2::header::Stack headerStack{headerOut, dataProcessingHeaderOut};
-      auto headerMessage = device->NewMessage(headerStack.size());
-      std::memcpy(headerMessage->GetData(), headerStack.data(), headerStack.size());
-
-      /** add parts **/
-      parts.AddPart(std::move(headerMessage));
-      parts.AddPart(std::move(payloadMessage));
+      bufferPointer += payloadOutSize;
+      bufferSize -= payloadOutSize;
+      headerOut.payloadSize += payloadOutSize;
     }
 
-    /** send message **/
-    device->Send(parts, fairMQChannel);
+    /** finalise output message **/
+    payloadMessage->SetUsedSize(headerOut.payloadSize);
+    o2::header::Stack headerStack{headerOut, dataProcessingHeaderOut};
+    auto headerMessage = device->NewMessage(headerStack.size());
+    std::memcpy(headerMessage->GetData(), headerStack.data(), headerStack.size());
+
+    /** add parts **/
+    partsOut.AddPart(std::move(headerMessage));
+    partsOut.AddPart(std::move(payloadMessage));
   }
+
+  /** send message **/
+  device->Send(partsOut, fairMQChannel);
 }
 
 template class CompressorTask<o2::header::RAWDataHeaderV4, true>;


### PR DESCRIPTION
This PR modifies the behaviour of the TOF compressor devices.
Previously, the structure of the output stream was designed to be identical to the one of the input stream: multi-part structure was copied.

In this PR we force to write only one output message whose multi-part structure is defined by the number of input subspecs.
That means, regardless the structure of the input, the output will always be one message containing a number of multi-parts messages, one for each input subspec.