### PR TITLE
TOF-TPC matching creates TOF-constrained TPC tracks, optionally refit 

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/WorkflowHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/WorkflowHelper.h
@@ -62,6 +62,21 @@ struct getWorkflowTPCInput_ret {
 };
 } // namespace internal
 
+static auto getWorkflowTPCInputEmpryPtr()
+{
+  /*
+  In case the need of TPCInput is conditional, this will allow to define an empty unique_ptr to this complex structure outside 
+  of the "if" scope, i.e. 
+  auto inp = getWorkflowTPCInputEmpryPtr();
+  if (want_TPCInput) {
+    inp = getWorkflowTPCInput(...);
+    consumer->setInp(inp);
+  }
+*/
+  std::unique_ptr<internal::getWorkflowTPCInput_ret> ptr;
+  return ptr;
+}
+
 static auto getWorkflowTPCInput(o2::framework::ProcessingContext& pc, int verbosity = 0, bool do_mcLabels = false, bool do_clusters = true, unsigned long tpcSectorMask = 0xFFFFFFFFF, bool do_digits = false)
 {
   auto retVal = std::make_unique<internal::getWorkflowTPCInput_ret>();

--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(ReconstructionDataFormats
                        src/GlobalTrackID.cxx
                        src/VtxTrackIndex.cxx
                        src/VtxTrackRef.cxx
+                       src/TrackTPCTOF.cxx
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                      O2::FrameworkLogger
                                      O2::DetectorsCommonDataFormats
@@ -44,7 +45,8 @@ o2_target_root_dictionary(
           include/ReconstructionDataFormats/V0.h
           include/ReconstructionDataFormats/GlobalTrackID.h
           include/ReconstructionDataFormats/VtxTrackIndex.h
-          include/ReconstructionDataFormats/VtxTrackRef.h)
+          include/ReconstructionDataFormats/VtxTrackRef.h
+          include/ReconstructionDataFormats/TrackTPCTOF.h)
 
 o2_add_test(Vertex
             SOURCES test/testVertex.cxx

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOF.h
@@ -44,6 +44,7 @@ class MatchInfoTOF
 
   o2::track::TrackLTIntegral& getLTIntegralOut() { return mIntLT; }
   const o2::track::TrackLTIntegral& getLTIntegralOut() const { return mIntLT; }
+  void print() const;
 
  private:
   float mChi2;                       // chi2 of the pair track-TOFcluster

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackTPCTOF.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackTPCTOF.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackTPCTOF.h
+/// \brief Result of refitting TPC with TOF match constraint
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_TRACKTPCTOF_H
+#define ALICEO2_TRACKTPCTOF_H
+
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackLTIntegral.h"
+#include "CommonDataFormat/TimeStamp.h"
+
+namespace o2
+{
+namespace dataformats
+{
+
+class TrackTPCTOF : public o2::track::TrackParCov
+{
+  using timeEst = o2::dataformats::TimeStampWithError<float, float>;
+
+ public:
+  TrackTPCTOF() = default;
+  ~TrackTPCTOF() = default;
+  TrackTPCTOF(const TrackTPCTOF& src) = default;
+  TrackTPCTOF(const o2::track::TrackParCov& src) : o2::track::TrackParCov(src) {}
+
+  int getRefMatch() const { return mRefMatch; }
+  void setRefMatch(int id) { mRefMatch = id; }
+
+  const timeEst& getTimeMUS() const { return mTimeMUS; }
+  timeEst& getTimeMUS() { return mTimeMUS; }
+  void setTimeMUS(const timeEst& t) { mTimeMUS = t; }
+  void setTimeMUS(float t, float te)
+  {
+    mTimeMUS.setTimeStamp(t);
+    mTimeMUS.setTimeStampError(te);
+  }
+
+  void setChi2Refit(float v) { mChi2Refit = v; }
+  float getChi2Refit() const { return mChi2Refit; }
+
+  void print() const;
+
+ private:
+  int mRefMatch = -1;     ///< reference on track-TOF match in its original container
+  float mChi2Refit = 0.f; ///< chi2 of the refit
+  timeEst mTimeMUS;       ///< time estimate in ns
+
+  ClassDefNV(TrackTPCTOF, 1);
+};
+} // namespace dataformats
+} // namespace o2
+
+#endif

--- a/DataFormats/Reconstruction/src/MatchInfoTOF.cxx
+++ b/DataFormats/Reconstruction/src/MatchInfoTOF.cxx
@@ -16,3 +16,10 @@
 using namespace o2::dataformats;
 
 ClassImp(o2::dataformats::MatchInfoTOF);
+
+void MatchInfoTOF::print() const
+{
+  printf("Match of GlobalID %s and TOF cl %d with chi2 = %.3f\n", getEvIdxTrack().getIndex().asString().c_str(),
+         getTOFClIndex(), mChi2);
+  mIntLT.print();
+}

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -28,8 +28,12 @@
 #pragma link C++ class o2::BaseCluster < float> + ;
 #pragma link C++ class o2::dataformats::TrackTPCITS + ;
 #pragma link C++ class std::vector < o2::dataformats::TrackTPCITS> + ;
+
 #pragma link C++ class o2::dataformats::MatchInfoTOF + ;
 #pragma link C++ class std::vector < o2::dataformats::MatchInfoTOF> + ;
+
+#pragma link C++ class o2::dataformats::TrackTPCTOF + ;
+#pragma link C++ class std::vector < o2::dataformats::TrackTPCTOF> + ;
 
 #pragma link C++ class std::vector < std::pair < float, float>> + ;
 #pragma link C++ class std::vector < std::pair < int, float>> + ;

--- a/DataFormats/Reconstruction/src/TrackTPCTOF.cxx
+++ b/DataFormats/Reconstruction/src/TrackTPCTOF.cxx
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ReconstructionDataFormats/TrackTPCTOF.h"
+
+using namespace o2::dataformats;
+
+//__________________________________________________
+void TrackTPCTOF::print() const
+{
+  printf("TPC-TOC MatchRef: %6d Chi2Refit: %6.2f Time: %10.4f+-%10.4f mus\n",
+         mRefMatch, getChi2Refit(), mTimeMUS.getTimeStamp(), mTimeMUS.getTimeStampError());
+  o2::track::TrackParCov::print();
+}

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/CalibInfoReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/CalibInfoReaderSpec.h
@@ -31,7 +31,7 @@ namespace tof
 class CalibInfoReader : public Task
 {
  public:
-  CalibInfoReader(int instance, int ninstances, const char* filename) : mInstance(instance), mNinstances(ninstances), mFileName(filename) {}
+  CalibInfoReader(int instance, int ninstances, const char* filename, bool toftpc = false) : mInstance(instance), mNinstances(ninstances), mFileName(filename), mTOFTPC(toftpc) {}
   ~CalibInfoReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -43,6 +43,7 @@ class CalibInfoReader : public Task
   const char* mFileName = nullptr;
   FILE* mFile = nullptr;
   TTree* mTree = nullptr;
+  bool mTOFTPC = false;
   int mCurrentEntry = 0;
   int mGlobalEntry = 0;
   std::vector<o2::dataformats::CalibInfoTOF> mVect, *mPvect = &mVect;
@@ -50,7 +51,7 @@ class CalibInfoReader : public Task
 
 /// create a processor spec
 /// read simulated TOF digits from a root file
-framework::DataProcessorSpec getCalibInfoReaderSpec(int instance, int ninstances, const char* filename);
+framework::DataProcessorSpec getCalibInfoReaderSpec(int instance, int ninstances, const char* filename, bool toftpc = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/RecoWorkflowWithTPCSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/RecoWorkflowWithTPCSpec.h
@@ -19,7 +19,7 @@ namespace o2
 namespace tof
 {
 
-o2::framework::DataProcessorSpec getTOFRecoWorkflowWithTPCSpec(bool useMC, bool useFIT);
+o2::framework::DataProcessorSpec getTOFRecoWorkflowWithTPCSpec(bool useMC, bool useFIT, bool doTPCRefit);
 
 } // end namespace tof
 } // end namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFCalibWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFCalibWriterSpec.h
@@ -24,7 +24,7 @@ namespace tof
 
 /// create a processor spec
 /// write TOF calbi info in a root file
-o2::framework::DataProcessorSpec getTOFCalibWriterSpec(const char* outdef = "o2calib_tof.root");
+o2::framework::DataProcessorSpec getTOFCalibWriterSpec(const char* outdef = "o2calib_tof.root", bool toftpc = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedReaderSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "ReconstructionDataFormats/TrackTPCTOF.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 namespace o2
@@ -29,7 +30,7 @@ namespace tof
 class TOFMatchedReader : public o2::framework::Task
 {
  public:
-  TOFMatchedReader(bool useMC) : mUseMC(useMC) {}
+  TOFMatchedReader(bool useMC, bool tpcmatch, bool readTracks) : mUseMC(useMC), mTPCMatch(tpcmatch), mReadTracks(readTracks) {}
   ~TOFMatchedReader() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
@@ -38,11 +39,15 @@ class TOFMatchedReader : public o2::framework::Task
   void connectTree(const std::string& filename);
 
   bool mUseMC = false;
+  bool mTPCMatch = false;
+  bool mReadTracks = false;
+
   std::string mInFileName{"o2match_tof.root"};
   std::string mInTreeName{"matchTOF"};
   std::unique_ptr<TFile> mFile = nullptr;
   std::unique_ptr<TTree> mTree = nullptr;
   std::vector<o2::dataformats::MatchInfoTOF> mMatches, *mMatchesPtr = &mMatches;
+  std::vector<o2::dataformats::TrackTPCTOF> mTracks, *mTracksPtr = &mTracks;
   std::vector<o2::MCCompLabel> mLabelTOF, *mLabelTOFPtr = &mLabelTOF;
   std::vector<o2::MCCompLabel> mLabelTPC, *mLabelTPCPtr = &mLabelTPC;
   std::vector<o2::MCCompLabel> mLabelITS, *mLabelITSPtr = &mLabelITS;
@@ -50,7 +55,7 @@ class TOFMatchedReader : public o2::framework::Task
 
 /// create a processor spec
 /// read matched TOF clusters from a ROOT file
-framework::DataProcessorSpec getTOFMatchedReaderSpec(bool useMC);
+framework::DataProcessorSpec getTOFMatchedReaderSpec(bool useMC, bool tpcmatch = false, bool readTracks = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedWriterSpec.h
@@ -24,7 +24,7 @@ namespace tof
 
 /// create a processor spec
 /// write TOF matching info in a root file
-o2::framework::DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef = "o2match_tof.root");
+o2::framework::DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef = "o2match_tof.root", bool writeTracks = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -123,9 +123,9 @@ class TOFDPLRecoWorkflowTask
     // send matching-info
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTPCLabelsVector());
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedITSLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTPCLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHITS", 0, Lifetime::Timeframe}, mMatcher.getMatchedITSLabelsVector());
     }
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
     mTimer.Stop();
@@ -160,9 +160,9 @@ o2::framework::DataProcessorSpec getTOFRecoWorkflowSpec(bool useMC, bool useFIT)
 
   outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
   if (useMC) {
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHITS", 0, Lifetime::Timeframe);
   }
   outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe);
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowWithTPCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowWithTPCSpec.cxx
@@ -123,13 +123,13 @@ class TOFDPLRecoWorkflowWithTPCTask
     //           << " DIGITS TO " << mClustersArray.size() << " CLUSTERS";
 
     // send matching-info
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS_TPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
     if (mUseMC) {
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTPCLabelsVector());
-      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe}, mMatcher.getMatchedITSLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTOF_TPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTPC_TPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTPCLabelsVector());
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHITS_TPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedITSLabelsVector());
     }
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "CALIBDATA_TPC", 0, Lifetime::Timeframe}, mMatcher.getCalibVector());
     mTimer.Stop();
   }
 
@@ -164,15 +164,15 @@ o2::framework::DataProcessorSpec getTOFRecoWorkflowWithTPCSpec(bool useMC, bool 
     inputs.emplace_back("fitrecpoints", o2::header::gDataOriginFT0, "RECPOINTS", 0, Lifetime::Timeframe);
   }
 
-  outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
-  outputs.emplace_back(OutputLabel{"tpctofTracks"}, o2::header::gDataOriginTOF, "TPCTOFTRACKS", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS_TPC", 0, Lifetime::Timeframe);
+  outputs.emplace_back(OutputLabel{"tpctofTracks"}, o2::header::gDataOriginTOF, "TOFTRACKS_TPC", 0, Lifetime::Timeframe);
 
   if (useMC) {
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTOF_TPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTPC_TPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHITS_TPC", 0, Lifetime::Timeframe);
   }
-  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA_TPC", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "TOFRecoWorkflowWithTPC",

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFCalibWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFCalibWriterSpec.cxx
@@ -34,16 +34,17 @@ namespace tof
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 using CalibInfosType = std::vector<o2::dataformats::CalibInfoTOF>;
-DataProcessorSpec getTOFCalibWriterSpec(const char* outdef)
+DataProcessorSpec getTOFCalibWriterSpec(const char* outdef, bool toftpc)
 {
   // A spectator for logging
   auto logger = [](CalibInfosType const& indata) {
     LOG(INFO) << "RECEIVED MATCHED SIZE " << indata.size();
   };
+  o2::header::DataDescription ddCalib{"CALIBDATA"}, ddCalib_tpc{"CALIBDATA_TPC"};
   return MakeRootTreeWriterSpec("TOFCalibWriter",
                                 outdef,
                                 "calibTOF",
-                                BranchDefinition<CalibInfosType>{InputSpec{"input", o2::header::gDataOriginTOF, "CALIBDATA", 0},
+                                BranchDefinition<CalibInfosType>{InputSpec{"input", o2::header::gDataOriginTOF, toftpc ? ddCalib_tpc : ddCalib, 0},
                                                                  "TOFCalibInfo",
                                                                  "calibinfo-branch-name",
                                                                  1,

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedReaderSpec.cxx
@@ -22,6 +22,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "CommonUtils/StringUtils.h"
 
 using namespace o2::framework;
 
@@ -29,6 +30,10 @@ namespace o2
 {
 namespace tof
 {
+o2::header::DataDescription ddMatchInfo{"MATCHINFOS"}, ddMatchInfo_tpc{"MATCHINFOS_TPC"},
+  ddMCMatchTOF{"MCMATCHTOF"}, ddMCMatchTOF_tpc{"MCMATCHTOF_TPC"},
+  ddMCMatchTPC{"MCMATCHTPC"}, ddMCMatchTPC_tpc{"MCMATCHTPC_TPC"},
+  ddMCMatchITS{"MCMATCHITS"}, ddMCMatchITS_tpc{"MCMATCHITS_TPC"};
 
 void TOFMatchedReader::init(InitContext& ic)
 {
@@ -51,7 +56,7 @@ void TOFMatchedReader::connectTree(const std::string& filename)
     if (!mTree->GetBranch("TPCTOFTracks")) {
       throw std::runtime_error("TPC-TOF tracks are requested but not found in the tree");
     }
-    mTree->SetBranchAddress("TPCTOFTracks", &mMatchesPtr);
+    mTree->SetBranchAddress("TPCTOFTracks", &mTracksPtr);
   }
   if (mUseMC) {
     mTree->SetBranchAddress("MatchTOFMCTruth", &mLabelTOFPtr);
@@ -68,14 +73,14 @@ void TOFMatchedReader::run(ProcessingContext& pc)
   mTree->GetEntry(currEntry);
   LOG(INFO) << "Pushing " << mMatches.size() << " TOF matchings at entry " << currEntry;
 
-  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe}, mMatches);
-  if (mReadTracks) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "TPCTOFTRACKS", 0, Lifetime::Timeframe}, mTracks);
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTPCMatch ? ddMatchInfo_tpc : ddMatchInfo, 0, Lifetime::Timeframe}, mMatches);
+  if (mReadTracks && mTPCMatch) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "TOFTRACKS_TPC", 0, Lifetime::Timeframe}, mTracks);
   }
   if (mUseMC) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe}, mLabelTOF);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe}, mLabelTPC);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe}, mLabelITS);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTPCMatch ? ddMCMatchTOF_tpc : ddMCMatchTOF, 0, Lifetime::Timeframe}, mLabelTOF);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTPCMatch ? ddMCMatchTPC_tpc : ddMCMatchTPC, 0, Lifetime::Timeframe}, mLabelTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, mTPCMatch ? ddMCMatchITS_tpc : ddMCMatchITS, 0, Lifetime::Timeframe}, mLabelITS);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
@@ -84,26 +89,27 @@ void TOFMatchedReader::run(ProcessingContext& pc)
   }
 }
 
-DataProcessorSpec getTOFMatchedReaderSpec(bool useMC, bool readTracks)
+DataProcessorSpec getTOFMatchedReaderSpec(bool useMC, bool tpcmatch, bool readTracks)
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
-  if (readTracks) {
-    outputs.emplace_back(o2::header::gDataOriginTOF, "TPCTOFTRACKS", 0, Lifetime::Timeframe);
+
+  outputs.emplace_back(o2::header::gDataOriginTOF, tpcmatch ? ddMatchInfo_tpc : ddMatchInfo, 0, Lifetime::Timeframe);
+  if (tpcmatch && readTracks) {
+    outputs.emplace_back(o2::header::gDataOriginTOF, "TOFTRACKS_TPC", 0, Lifetime::Timeframe);
   }
   if (useMC) {
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, tpcmatch ? ddMCMatchTOF_tpc : ddMCMatchTOF, 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, tpcmatch ? ddMCMatchTPC_tpc : ddMCMatchTPC, 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, tpcmatch ? ddMCMatchITS_tpc : ddMCMatchITS, 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{
-    "TOFMatchedReader",
+    o2::utils::concat_string("TOFMatchedReader_", tpcmatch ? "tpc" : "glo"),
     Inputs{},
     outputs,
-    AlgorithmSpec{adaptFromTask<TOFMatchedReader>(useMC, readTracks)},
+    AlgorithmSpec{adaptFromTask<TOFMatchedReader>(useMC, tpcmatch, readTracks)},
     Options{
-      {"tof-matched-infile", VariantType::String, "o2match_tof.root", {"Name of the input file"}},
+      {"tof-matched-infile", VariantType::String, tpcmatch ? "o2match_toftpc.root" : "o2match_tof.root", {"Name of the input file"}},
       {"treename", VariantType::String, "matchTOF", {"Name of top-level TTree"}},
     }};
 }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
@@ -37,7 +37,7 @@ using TrackInfo = std::vector<o2::dataformats::TrackTPCTOF>;
 using LabelsType = std::vector<o2::MCCompLabel>;
 using namespace o2::header;
 
-DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef, bool writeTracks)
+DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef, bool writeTOFTPC)
 {
   // spectators for logging
   auto loggerMatched = [](MatchInfo const& indata) {
@@ -55,30 +55,34 @@ DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef, bool w
   // TODO: there was a comment in the original implementation:
   // RS why do we need to repeat ITS/TPC labels ?
   // They can be extracted from TPC-ITS matches
+  o2::header::DataDescription ddMatchInfo{"MATCHINFOS"}, ddMatchInfo_tpc{"MATCHINFOS_TPC"},
+    ddMCMatchTOF{"MCMATCHTOF"}, ddMCMatchTOF_tpc{"MCMATCHTOF_TPC"},
+    ddMCMatchTPC{"MCMATCHTPC"}, ddMCMatchTPC_tpc{"MCMATCHTPC_TPC"},
+    ddMCMatchITS{"MCMATCHITS"}, ddMCMatchITS_tpc{"MCMATCHITS_TPC"};
 
-  return MakeRootTreeWriterSpec("TOFMatchedWriter",
+  return MakeRootTreeWriterSpec(writeTOFTPC ? "TOFMatchedWriter_TPC" : "TOFMatchedWriter",
                                 outdef,
                                 "matchTOF",
-                                BranchDefinition<MatchInfo>{InputSpec{"tofmatching", gDataOriginTOF, "MATCHINFOS", 0},
+                                BranchDefinition<MatchInfo>{InputSpec{"tofmatching", gDataOriginTOF, writeTOFTPC ? ddMatchInfo_tpc : ddMatchInfo, 0},
                                                             "TOFMatchInfo",
                                                             "TOFMatchInfo-branch-name",
                                                             1,
                                                             loggerMatched},
-                                BranchDefinition<TrackInfo>{InputSpec{"tpctofTracks", gDataOriginTOF, "TPCTOFTRACKS", 0},
+                                BranchDefinition<TrackInfo>{InputSpec{"tpctofTracks", gDataOriginTOF, "TOFTRACKS_TPC", 0},
                                                             "TPCTOFTracks",
                                                             "TPCTOFTracks-branch-name",
-                                                            writeTracks},
-                                BranchDefinition<LabelsType>{InputSpec{"matchtoflabels", gDataOriginTOF, "MATCHTOFINFOSMC", 0},
+                                                            writeTOFTPC},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtoflabels", gDataOriginTOF, writeTOFTPC ? ddMCMatchTOF_tpc : ddMCMatchTOF, 0},
                                                              "MatchTOFMCTruth",
                                                              "MatchTOFMCTruth-branch-name",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              loggerTofLabels},
-                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", gDataOriginTOF, "MATCHTPCINFOSMC", 0},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", gDataOriginTOF, writeTOFTPC ? ddMCMatchTPC_tpc : ddMCMatchTPC, 0},
                                                              "MatchTPCMCTruth",
                                                              "MatchTPCMCTruth-branch-name",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              loggerTpcLabels},
-                                BranchDefinition<LabelsType>{InputSpec{"matchitslabels", gDataOriginTOF, "MATCHITSINFOSMC", 0},
+                                BranchDefinition<LabelsType>{InputSpec{"matchitslabels", gDataOriginTOF, writeTOFTPC ? ddMCMatchITS_tpc : ddMCMatchITS, 0},
                                                              "MatchITSMCTruth",
                                                              "MatchITSMCTruth-branch-name",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedWriterSpec.cxx
@@ -18,6 +18,7 @@
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "ReconstructionDataFormats/TrackTPCTOF.h"
 #include "DataFormatsTOF/CalibInfoTOF.h"
 #include "DataFormatsTOF/Cluster.h"
 #include "CommonUtils/StringUtils.h"
@@ -31,14 +32,15 @@ namespace tof
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
-using OutputType = std::vector<o2::dataformats::MatchInfoTOF>;
+using MatchInfo = std::vector<o2::dataformats::MatchInfoTOF>;
+using TrackInfo = std::vector<o2::dataformats::TrackTPCTOF>;
 using LabelsType = std::vector<o2::MCCompLabel>;
 using namespace o2::header;
 
-DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef)
+DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef, bool writeTracks)
 {
   // spectators for logging
-  auto loggerMatched = [](OutputType const& indata) {
+  auto loggerMatched = [](MatchInfo const& indata) {
     LOG(INFO) << "RECEIVED MATCHED SIZE " << indata.size();
   };
   auto loggerTofLabels = [](LabelsType const& labeltof) {
@@ -51,16 +53,21 @@ DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef)
     LOG(INFO) << "ITS LABELS GOT " << labelits.size() << " LABELS ";
   };
   // TODO: there was a comment in the original implementation:
-  // RS why do we need to repead ITS/TPC labels ?
+  // RS why do we need to repeat ITS/TPC labels ?
   // They can be extracted from TPC-ITS matches
+
   return MakeRootTreeWriterSpec("TOFMatchedWriter",
                                 outdef,
                                 "matchTOF",
-                                BranchDefinition<OutputType>{InputSpec{"tofmatching", gDataOriginTOF, "MATCHINFOS", 0},
-                                                             "TOFMatchInfo",
-                                                             "TOFMatchInfo-branch-name",
-                                                             1,
-                                                             loggerMatched},
+                                BranchDefinition<MatchInfo>{InputSpec{"tofmatching", gDataOriginTOF, "MATCHINFOS", 0},
+                                                            "TOFMatchInfo",
+                                                            "TOFMatchInfo-branch-name",
+                                                            1,
+                                                            loggerMatched},
+                                BranchDefinition<TrackInfo>{InputSpec{"tpctofTracks", gDataOriginTOF, "TPCTOFTRACKS", 0},
+                                                            "TPCTOFTracks",
+                                                            "TPCTOFTracks-branch-name",
+                                                            writeTracks},
                                 BranchDefinition<LabelsType>{InputSpec{"matchtoflabels", gDataOriginTOF, "MATCHTOFINFOSMC", 0},
                                                              "MatchTOFMCTruth",
                                                              "MatchTOFMCTruth-branch-name",

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-calibinfo-reader.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-calibinfo-reader.cxx
@@ -34,6 +34,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(ConfigParamSpec{"collection-infile", o2::framework::VariantType::String, "list-calibfile", {"Name of the collection input file"}});
   workflowOptions.push_back(ConfigParamSpec{"ninstances", o2::framework::VariantType::Int, 1, {"Number of reader instances"}});
+  workflowOptions.push_back(ConfigParamSpec{"tpc-matches", o2::framework::VariantType::Bool, false, {"Made from TOF-TPC matches"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
 }
 
@@ -65,6 +66,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   int ninstances = cfgc.options().get<int>("ninstances");
   auto listname = cfgc.options().get<std::string>("collection-infile");
+  auto toftpc = cfgc.options().get<bool>("tpc-matches");
 
   char* stringTBP = new char[listname.size()];
   sprintf(stringTBP, "%s", listname.c_str());
@@ -74,7 +76,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // std::vector<int> laneConfiguration = tofSectors;
 
   for (int i = 0; i < ninstances; i++) {
-    specs.emplace_back(o2::tof::getCalibInfoReaderSpec(i, ninstances, stringTBP));
+    specs.emplace_back(o2::tof::getCalibInfoReaderSpec(i, ninstances, stringTBP, toftpc));
   }
 
   LOG(INFO) << "Number of active devices = " << specs.size();

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
@@ -26,9 +26,6 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 
-// GRP
-#include "DataFormatsParameters/GRPObject.h"
-
 // FIT
 #include "FT0Workflow/RecPointReaderSpec.h"
 
@@ -75,20 +72,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec specs;
 
-  if (!cfgc.helpOnCommandLine()) {
-    std::string inputGRP = o2::base::NameConf::getGRPFileName();
-    o2::base::Propagator::initFieldFromGRP(inputGRP);
-    const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
-    if (!grp) {
-      LOG(ERROR) << "This workflow needs a valid GRP file to start";
-      return specs;
-    }
-    o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-    //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
-  }
   // the lane configuration defines the subspecification ids to be distributed among the lanes.
-  // auto tofSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tof-sectors"));
-  // std::vector<int> laneConfiguration = tofSectors;
   auto nLanes = cfgc.options().get<int>("tof-lanes");
   auto inputType = cfgc.options().get<std::string>("input-type");
   auto outputType = cfgc.options().get<std::string>("output-type");

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
@@ -119,32 +119,34 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   LOG(INFO) << "TOF disable-root-input = " << disableRootInput;
   LOG(INFO) << "TOF disable-root-output = " << disableRootOutput;
 
-  if (clusterinput) {
-    LOG(INFO) << "Insert TOF Cluster Reader";
-    specs.emplace_back(o2::tof::getClusterReaderSpec(useMC));
-  }
-  if (trackinput) {
-    LOG(INFO) << "Insert ITS-TPC Track Reader";
-    specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
-  }
+  if (!disableRootInput) { // input data loaded from root files
+    if (clusterinput) {
+      LOG(INFO) << "Insert TOF Cluster Reader";
+      specs.emplace_back(o2::tof::getClusterReaderSpec(useMC));
+    }
+    if (trackinput) {
+      LOG(INFO) << "Insert ITS-TPC Track Reader";
+      specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    }
 
-  if (fitinput) {
-    LOG(INFO) << "Insert FIT RecPoint Reader";
-    specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
+    if (fitinput) {
+      LOG(INFO) << "Insert FIT RecPoint Reader";
+      specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
+    }
   }
-
   LOG(INFO) << "Insert TOF Matching";
   specs.emplace_back(o2::tof::getTOFRecoWorkflowSpec(useMC, useFIT));
 
-  if (writematching && !disableRootOutput) {
-    LOG(INFO) << "Insert TOF Matched Info Writer";
-    specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC));
+  if (!disableRootOutput) {
+    if (writematching) {
+      LOG(INFO) << "Insert TOF Matched Info Writer";
+      specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC));
+    }
+    if (writecalib) {
+      LOG(INFO) << "Insert TOF Calib Info Writer";
+      specs.emplace_back(o2::tof::getTOFCalibWriterSpec());
+    }
   }
-  if (writecalib) {
-    LOG(INFO) << "Insert TOF Calib Info Writer";
-    specs.emplace_back(o2::tof::getTOFCalibWriterSpec());
-  }
-
   LOG(INFO) << "Number of active devices = " << specs.size();
 
   return std::move(specs);

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
@@ -25,6 +25,8 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "TPCWorkflow/TrackReaderSpec.h"
+#include "TPCWorkflow/PublisherSpec.h"
+#include "TPCWorkflow/ClusterSharingMapSpec.h"
 
 // GRP
 #include "DataFormatsParameters/GRPObject.h"
@@ -40,7 +42,6 @@
 // including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"input-type", o2::framework::VariantType::String, "clusters,tracks", {"clusters, tracks, fit"}});
   workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "matching-info", {"matching-info, calib-info"}});
   workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}});
   workflowOptions.push_back(ConfigParamSpec{"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}});
@@ -48,6 +49,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
   workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
   workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
+  workflowOptions.push_back(ConfigParamSpec{"tpc-refit", o2::framework::VariantType::Bool, false, {"refit matched TPC tracks"}});
   workflowOptions.push_back(ConfigParamSpec{"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
   workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
@@ -74,23 +76,8 @@ using namespace o2::framework;
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec specs;
-
-  if (!cfgc.helpOnCommandLine()) {
-    std::string inputGRP = o2::base::NameConf::getGRPFileName();
-    o2::base::Propagator::initFieldFromGRP(inputGRP);
-    const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
-    if (!grp) {
-      LOG(ERROR) << "This workflow needs a valid GRP file to start";
-      return specs;
-    }
-    o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-    //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
-  }
   // the lane configuration defines the subspecification ids to be distributed among the lanes.
-  // auto tofSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tof-sectors"));
-  // std::vector<int> laneConfiguration = tofSectors;
   auto nLanes = cfgc.options().get<int>("tof-lanes");
-  auto inputType = cfgc.options().get<std::string>("input-type");
   auto outputType = cfgc.options().get<std::string>("output-type");
 
   bool writematching = 0;
@@ -103,35 +90,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     writecalib = 1;
   }
 
-  bool clusterinput = 0;
-  bool trackinput = 0;
-  bool fitinput = 0;
-
-  if (inputType.rfind("clusters") < inputType.size()) {
-    clusterinput = 1;
-  }
-  if (inputType.rfind("tracks") < inputType.size()) {
-    trackinput = 1;
-  }
   auto useMC = !cfgc.options().get<bool>("disable-mc");
   auto useCCDB = cfgc.options().get<bool>("use-ccdb");
   auto useFIT = cfgc.options().get<bool>("use-fit");
+  auto doTPCRefit = cfgc.options().get<bool>("tpc-refit");
   bool disableRootInput = cfgc.options().get<bool>("disable-root-input");
   bool disableRootOutput = cfgc.options().get<bool>("disable-root-output");
 
-  if (inputType.rfind("fit") < inputType.size()) {
-    fitinput = 1;
-    useFIT = 1;
-  }
-
   LOG(INFO) << "TOF RECO WORKFLOW configuration";
-  LOG(INFO) << "TOF input = " << cfgc.options().get<std::string>("input-type");
   LOG(INFO) << "TOF output = " << cfgc.options().get<std::string>("output-type");
   LOG(INFO) << "TOF sectors = " << cfgc.options().get<std::string>("tof-sectors");
   LOG(INFO) << "TOF disable-mc = " << cfgc.options().get<std::string>("disable-mc");
   LOG(INFO) << "TOF lanes = " << cfgc.options().get<std::string>("tof-lanes");
   LOG(INFO) << "TOF use-ccdb = " << cfgc.options().get<std::string>("use-ccdb");
   LOG(INFO) << "TOF use-fit = " << cfgc.options().get<std::string>("use-fit");
+  LOG(INFO) << "TOF tpc-refit = " << cfgc.options().get<bool>("tpc-refit");
   LOG(INFO) << "TOF disable-root-input = " << disableRootInput;
   LOG(INFO) << "TOF disable-root-output = " << disableRootOutput;
 
@@ -140,30 +113,50 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // writecalib = false;
   // LOG(INFO) << "TOF CalibInfo disabled (forced)";
 
-  if (clusterinput) {
+  std::vector<int> tpcClusSectors = o2::RangeTokenizer::tokenize<int>("0-35");
+  std::vector<int> tpcClusLanes = tpcClusSectors;
+
+  if (!disableRootInput) { // input data loaded from root files
     LOG(INFO) << "Insert TOF Cluster Reader";
     specs.emplace_back(o2::tof::getClusterReaderSpec(useMC));
-  }
-  if (trackinput) {
+
     LOG(INFO) << "Insert TPC Track Reader";
     specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(useMC));
-  }
 
-  if (fitinput) {
-    LOG(INFO) << "Insert FIT RecPoint Reader";
-    specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
+    if (doTPCRefit) {
+      LOG(INFO) << "Insert TPC Cluster Reader";
+      specs.emplace_back(o2::tpc::getPublisherSpec(o2::tpc::PublisherConf{
+                                                     "tpc-native-cluster-reader",
+                                                     "tpc-native-clusters.root",
+                                                     "tpcrec",
+                                                     {"clusterbranch", "TPCClusterNative", "Branch with TPC native clusters"},
+                                                     {"clustermcbranch", "TPCClusterNativeMCTruth", "MC label branch"},
+                                                     OutputSpec{"TPC", "CLUSTERNATIVE"},
+                                                     OutputSpec{"TPC", "CLNATIVEMCLBL"},
+                                                     tpcClusSectors,
+                                                     tpcClusLanes},
+                                                   false));
+      specs.emplace_back(o2::tpc::getClusterSharingMapSpec());
+    }
+
+    if (useFIT) {
+      LOG(INFO) << "Insert FIT RecPoint Reader";
+      specs.emplace_back(o2::ft0::getRecPointReaderSpec(useMC));
+    }
   }
 
   LOG(INFO) << "Insert TOF Matching";
-  specs.emplace_back(o2::tof::getTOFRecoWorkflowWithTPCSpec(useMC, useFIT));
+  specs.emplace_back(o2::tof::getTOFRecoWorkflowWithTPCSpec(useMC, useFIT, doTPCRefit));
 
-  if (writematching && !disableRootOutput) {
-    LOG(INFO) << "Insert TOF Matched Info Writer";
-    specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_toftpc.root"));
-  }
-  if (writecalib) {
-    LOG(INFO) << "Insert TOF Calib Info Writer";
-    specs.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_toftpc.root"));
+  if (!disableRootOutput) {
+    if (writematching) {
+      LOG(INFO) << "Insert TOF Matched Info Writer";
+      specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_toftpc.root", true));
+    }
+    if (writecalib) {
+      LOG(INFO) << "Insert TOF Calib Info Writer";
+      specs.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_toftpc.root"));
+    }
   }
 
   LOG(INFO) << "Number of active devices = " << specs.size();

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
@@ -155,7 +155,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     }
     if (writecalib) {
       LOG(INFO) << "Insert TOF Calib Info Writer";
-      specs.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_toftpc.root"));
+      specs.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_toftpc.root", true));
     }
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -34,9 +34,6 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 
-// GRP
-#include "DataFormatsParameters/GRPObject.h"
-
 // FIT
 #include "FT0Workflow/RecPointReaderSpec.h"
 
@@ -88,11 +85,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   if (!cfgc.helpOnCommandLine()) {
     o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-    //  o2::conf::ConfigurableParam::writeINI("o2tofrecoflow_configuration.ini");
   }
   // the lane configuration defines the subspecification ids to be distributed among the lanes.
-  // auto tofSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tof-sectors"));
-  // std::vector<int> laneConfiguration = tofSectors;
   auto nLanes = cfgc.options().get<int>("tof-lanes");
   auto inputType = cfgc.options().get<std::string>("input-type");
   auto outputType = cfgc.options().get<std::string>("output-type");
@@ -134,19 +128,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   } else if (inputType == "raw") {
     rawinput = 1;
     writeerr = cfgc.options().get<bool>("write-decoding-errors");
-  }
-
-  if (rawinput) {
-  } else {
-    if (!cfgc.helpOnCommandLine()) {
-      std::string inputGRP = o2::base::NameConf::getGRPFileName();
-      o2::base::Propagator::initFieldFromGRP(inputGRP);
-      const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
-      if (!grp) {
-        LOG(ERROR) << "This workflow needs a valid GRP file to start";
-        return specs;
-      }
-    }
   }
 
   auto useMC = !cfgc.options().get<bool>("disable-mc");

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -98,10 +98,10 @@ DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tp
     LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";
     // are the MC inputs from ITS-TPC matching and TOF matching duplicates? if trackITSMCTR == matchTOFMCITS one of them should be removed
     inputs.emplace_back("trackITSMCTR", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("trackTPCMCTR", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMC", o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMCTPC", o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMCITS", o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("trackTPCMCTR", "GLO", "TPCITSMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMC", o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMCTPC", o2::header::gDataOriginTOF, "MCMATCHTPC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMCITS", o2::header::gDataOriginTOF, "MCMATCHITS", 0, Lifetime::Timeframe);
   }
 
   outputs.emplace_back("GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);


### PR DESCRIPTION
At the moment TOF-time-constrained track is created at inner TPC references, either by (1) shift in Z accounting for the TOF-time vs tpcTrack.getTime0 difference or (2) by additional inward refit with clusters accounting correct time.
The outward TrackParam is not created. 
The LTintegral of matches is also not modified, currently it accounts only for the integral from TPC outer track position to TOF match position. In case these TOF-TPC matches will be used as final tracks, these integrals need to be recalculated.