### PR TITLE
PWGHF: Fix MC matching flags.

### DIFF
--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -67,7 +67,7 @@ struct HFCandidateCreator2Prong {
     df.setMinRelChi2Change(d_minrelchi2change);
     df.setUseAbsDCA(true);
 
-    // loop over pairs of track indeces
+    // loop over pairs of track indices
     for (const auto& rowTrackIndexProng2 : rowsTrackIndexProng2) {
       auto trackParVarPos1 = getTrackParCov(rowTrackIndexProng2.index0());
       auto trackParVarNeg1 = getTrackParCov(rowTrackIndexProng2.index1());
@@ -147,51 +147,51 @@ struct HFCandidateCreator2ProngMC {
                aod::McParticles const& particlesMC)
   {
     int8_t sign = 0;
-    int8_t result = N2ProngDecays;
+    int8_t flag = 0;
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
-      result = N2ProngDecays;
+      flag = 0;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()};
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
       if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 421, array{+kPiPlus, -kKPlus}, true, &sign) > -1) {
-        result = sign * D0ToPiK;
+        flag = sign * (1 << D0ToPiK);
       }
 
       // J/ψ → e+ e-
-      if (result == N2ProngDecays) {
+      if (flag == 0) {
         //Printf("Checking J/ψ → e+ e-");
         if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 443, array{+kElectron, -kElectron}, true) > -1) {
-          result = JpsiToEE;
+          flag = 1 << JpsiToEE;
         }
       }
 
-      rowMCMatchRec(result);
+      rowMCMatchRec(flag);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
-      result = N2ProngDecays;
+      flag = 0;
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
       if (RecoDecay::isMatchedMCGen(particlesMC, particle, 421, array{+kPiPlus, -kKPlus}, true, &sign)) {
-        result = sign * D0ToPiK;
+        flag = sign * (1 << D0ToPiK);
       }
 
       // J/ψ → e+ e-
-      if (result == N2ProngDecays) {
+      if (flag == 0) {
         //Printf("Checking J/ψ → e+ e-");
         if (RecoDecay::isMatchedMCGen(particlesMC, particle, 443, array{+kElectron, -kElectron}, true)) {
-          result = JpsiToEE;
+          flag = 1 << JpsiToEE;
         }
       }
 
-      rowMCMatchGen(result);
+      rowMCMatchGen(flag);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -66,7 +66,7 @@ struct HFCandidateCreator3Prong {
     df.setMinRelChi2Change(d_minrelchi2change);
     df.setUseAbsDCA(true);
 
-    // loop over pairs of track indeces
+    // loop over triplets of track indices
     for (const auto& rowTrackIndexProng3 : rowsTrackIndexProng3) {
       auto trackParVar0 = getTrackParCov(rowTrackIndexProng3.index0());
       auto trackParVar1 = getTrackParCov(rowTrackIndexProng3.index1());
@@ -151,51 +151,51 @@ struct HFCandidateCreator3ProngMC {
                aod::McParticles const& particlesMC)
   {
     int8_t sign = 0;
-    int8_t result = N3ProngDecays;
+    int8_t flag = 0;
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
-      result = N3ProngDecays;
+      flag = 0;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
 
       // D± → π± K∓ π±
       //Printf("Checking D± → π± K∓ π±");
       if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign) > -1) {
-        result = sign * DPlusToPiKPi;
+        flag = sign * (1 << DPlusToPiKPi);
       }
 
       // Λc± → p± K∓ π±
-      if (result == N3ProngDecays) {
+      if (flag == 0) {
         //Printf("Checking Λc± → p± K∓ π±");
         if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign) > -1) {
-          result = sign * LcToPKPi;
+          flag = sign * (1 << LcToPKPi);
         }
       }
 
-      rowMCMatchRec(result);
+      rowMCMatchRec(flag);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
-      result = N3ProngDecays;
+      flag = 0;
 
       // D± → π± K∓ π±
       //Printf("Checking D± → π± K∓ π±");
       if (RecoDecay::isMatchedMCGen(particlesMC, particle, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign)) {
-        result = sign * DPlusToPiKPi;
+        flag = sign * (1 << DPlusToPiKPi);
       }
 
       // Λc± → p± K∓ π±
-      if (result == N3ProngDecays) {
+      if (flag == 0) {
         //Printf("Checking Λc± → p± K∓ π±");
         if (RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
-          result = sign * LcToPKPi;
+          flag = sign * (1 << LcToPKPi);
         }
       }
 
-      rowMCMatchGen(result);
+      rowMCMatchGen(flag);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/taskD0.cxx
+++ b/Analysis/Tasks/PWGHF/taskD0.cxx
@@ -131,7 +131,7 @@ struct TaskD0MC {
         //Printf("MC Rec.: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (std::abs(candidate.flagMCMatchRec()) == D0ToPiK) {
+      if (std::abs(candidate.flagMCMatchRec()) == 1 << D0ToPiK) {
         // Get the corresponding MC particle.
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().label_as<soa::Join<aod::McParticles, aod::HfCandProng2MCGen>>(), 421, true);
         auto particleMother = particlesMC.iteratorAt(indexMother);
@@ -152,7 +152,7 @@ struct TaskD0MC {
         //Printf("MC Gen.: eta rejection: %g", particle.eta());
         continue;
       }
-      if (std::abs(particle.flagMCMatchGen()) == D0ToPiK) {
+      if (std::abs(particle.flagMCMatchGen()) == 1 << D0ToPiK) {
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
       }

--- a/Analysis/Tasks/PWGHF/taskJpsi.cxx
+++ b/Analysis/Tasks/PWGHF/taskJpsi.cxx
@@ -118,7 +118,7 @@ struct TaskJpsiMC {
         //Printf("MC Rec.: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (candidate.flagMCMatchRec() == JpsiToEE) {
+      if (candidate.flagMCMatchRec() == 1 << JpsiToEE) {
         registry.fill(HIST("hPtRecSig"), candidate.pt());
         registry.fill(HIST("hCPARecSig"), candidate.cpa());
         registry.fill(HIST("hEtaRecSig"), candidate.eta());
@@ -135,7 +135,7 @@ struct TaskJpsiMC {
         //Printf("MC Gen.: eta rejection: %g", particle.eta());
         continue;
       }
-      if (std::abs(particle.flagMCMatchGen()) == JpsiToEE) {
+      if (particle.flagMCMatchGen() == 1 << JpsiToEE) {
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
       }

--- a/Analysis/Tasks/PWGHF/taskLc.cxx
+++ b/Analysis/Tasks/PWGHF/taskLc.cxx
@@ -130,7 +130,7 @@ struct TaskLcMC {
         //Printf("MC Rec.: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (std::abs(candidate.flagMCMatchRec()) == LcToPKPi) {
+      if (std::abs(candidate.flagMCMatchRec()) == 1 << LcToPKPi) {
         registry.fill(HIST("hPtRecSig"), candidate.pt());
         registry.fill(HIST("hCPARecSig"), candidate.cpa());
         registry.fill(HIST("hEtaRecSig"), candidate.eta());
@@ -147,7 +147,7 @@ struct TaskLcMC {
         //Printf("MC Gen.: eta rejection: %g", particle.eta());
         continue;
       }
-      if (std::abs(particle.flagMCMatchGen()) == LcToPKPi) {
+      if (std::abs(particle.flagMCMatchGen()) == 1 << LcToPKPi) {
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
       }


### PR DESCRIPTION
Use the DecayType values as bit numbers in MC matching as well.
This fixes the issue where one cannot distinguish particles and antiparticles for decays with decay type 0.