### PR TITLE
Prefer BUILD dir libs to installed ones in LD_LIBRARY_PATH 

### DIFF
--- a/cmake/O2AddWorkflow.cmake
+++ b/cmake/O2AddWorkflow.cmake
@@ -49,7 +49,7 @@ function(o2_add_dpl_workflow baseTargetName)
 
   add_custom_command(
     TARGET ${targetExeName} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" $<TARGET_FILE:${targetExeName}> -b --dump-workflow --dump-workflow-file ${jsonFile})
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$$LD_LIBRARY_PATH" $<TARGET_FILE:${targetExeName}> -b --dump-workflow --dump-workflow-file ${jsonFile})
   add_dependencies(${targetExeName} O2::FrameworkAnalysisSupport)
 
   install(


### PR DESCRIPTION
@ktf @aphecetche 
after pulling dev and doing ``make`` from BUILD/O2-latest/O2 I again got lot of errors like
````
[ 36%] Linking CXX executable ../../stage/bin/o2-analysistutorial-outputs
/home/shahoian/alice/sw/BUILD/O2-latest/O2/stage/bin/o2-analysistutorial-outputs: symbol lookup error: /home/shahoian/alice/sw/BUILD/O2-latest/O2/stage/bin/o2-analysistutorial-outputs: undefined symbol: _Z32doDefaultWorkflowTerminationHookv
Analysis/Tutorials/CMakeFiles/O2exe-analysistutorial-outputs.dir/build.make:152: recipe for target 'stage/bin/o2-analysistutorial-outputs' failed
````
This fixes the problem of preference of old installed libs to freshly compiled ones.