### PR TITLE
DPL: drop unneeded header

### DIFF
--- a/Framework/Core/src/WSDriverClient.cxx
+++ b/Framework/Core/src/WSDriverClient.cxx
@@ -14,7 +14,6 @@
 #include "Framework/DeviceSpec.h"
 #include "DPLWebSocket.h"
 #include <uv.h>
-#include <uv/unix.h>
 
 namespace o2::framework
 {


### PR DESCRIPTION
Not actually needed and actually non-existing when using some
old system installation of libuv (like on Ubuntu).