### PR TITLE
DPL: generalise option merging

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -7,8 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_DEVICESPECHELPERS_H
-#define FRAMEWORK_DEVICESPECHELPERS_H
+#ifndef O2_FRAMEWORK_DEVICESPECHELPERS_H_
+#define O2_FRAMEWORK_DEVICESPECHELPERS_H_
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ChannelConfigurationPolicy.h"
@@ -30,10 +30,9 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <functional>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 struct InputChannelSpec;
 struct OutputChannelSpec;
@@ -75,7 +74,26 @@ struct DeviceSpecHelpers {
   /// Helper to provide the channel configuration string for an output channel
   static std::string outputChannel2String(const OutputChannelSpec& channel);
 
-  /// Rework the infos so that they have a consisten --shm-section-size
+  /// Rework a given command line option so that all the sub workflows
+  /// either have the same value, or they leave it unspecified.
+  /// @a infos the DataProcessorInfos to modify
+  /// @a name of the option to modify, including --
+  /// @a defaultValue the default value for the option. If default is nullptr, not finding the
+  ///    option will not not add a default value.
+  static void reworkHomogeneousOption(std::vector<DataProcessorInfo>& infos,
+                                      char const* name, char const* defaultValue);
+
+  /// Rework a given command line option so that we pick the largest value
+  /// which has been specified or a default one.
+  /// @a defaultValueCallback a callback which returns the default value, if nullptr, the option
+  ///    will not be added.
+  /// @a bestValue given to possible values of the option, return the one which should be used.
+  static void reworkIntegerOption(std::vector<DataProcessorInfo>& infos,
+                                  char const* name,
+                                  std::function<long long()> defaultValueCallback,
+                                  long long startValue,
+                                  std::function<long long(long long, long long)> bestValue);
+  /// Rework the infos so that they have a consistent --shm-section-size
   /// which is the maximum of the specified value.
   static void reworkShmSegmentSize(std::vector<DataProcessorInfo>& infos);
   /// Helper to prepare the arguments which will be used to
@@ -130,6 +148,5 @@ struct DeviceSpecHelpers {
   static boost::program_options::options_description getForwardedDeviceOptions();
 };
 
-} // namespace framework
-} // namespace o2
-#endif // FRAMEWORK_DEVICESPECHELPERS_H
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DEVICESPECHELPERS_H_

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1184,6 +1184,11 @@ int runStateMachine(DataProcessorSpecs const& workflow,
           controls.resize(deviceSpecs.size());
           deviceExecutions.resize(deviceSpecs.size());
 
+          DeviceSpecHelpers::reworkHomogeneousOption(dataProcessorInfos, "--resources-monitoring", nullptr);
+          DeviceSpecHelpers::reworkHomogeneousOption(dataProcessorInfos, "--readers", nullptr);
+          DeviceSpecHelpers::reworkHomogeneousOption(dataProcessorInfos, "--aod-memory-rate-limit", nullptr);
+          DeviceSpecHelpers::reworkHomogeneousOption(dataProcessorInfos, "--time-limit", nullptr);
+          DeviceSpecHelpers::reworkHomogeneousOption(dataProcessorInfos, "--driver-client-backend", nullptr);
           DeviceSpecHelpers::reworkShmSegmentSize(dataProcessorInfos);
           DeviceSpecHelpers::prepareArguments(driverControl.defaultQuiet,
                                               driverControl.defaultStopped,

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -23,12 +23,11 @@
 #include <cstring>
 #include <vector>
 #include <map>
+#include <cstring>
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 using CheckMatrix = std::map<std::string, std::vector<std::pair<std::string, std::string>>>;
@@ -64,7 +63,6 @@ void check(const std::vector<std::string>& arguments,
   for (auto const& arg : arguments) {
     output << " " << arg;
   }
-  std::cout << "checking for arguments: " << output.str() << std::endl;
 
   std::vector<DeviceExecution> deviceExecutions(deviceSpecs.size());
   std::vector<DeviceControl> deviceControls(deviceSpecs.size());
@@ -84,12 +82,10 @@ void check(const std::vector<std::string>& arguments,
                                       deviceControls,
                                       "workflow-id");
 
-  std::cout << "created execution for " << deviceSpecs.size() << " device(s)" << std::endl;
 
   for (size_t index = 0; index < deviceSpecs.size(); index++) {
     const auto& deviceSpec = deviceSpecs[index];
     const auto& deviceExecution = deviceExecutions[index];
-    std::cout << deviceSpec.name << std::endl;
     std::stringstream execArgs;
     for (const auto& arg : deviceExecution.args) {
       if (arg == nullptr) {
@@ -98,7 +94,6 @@ void check(const std::vector<std::string>& arguments,
       }
       execArgs << "  " << arg;
     }
-    std::cout << execArgs.str() << std::endl;
     for (auto const& testCase : matrix[deviceSpec.name]) {
       BOOST_TEST_INFO(std::string("can not find option: ") + testCase.first + " " + testCase.second);
       BOOST_CHECK(search(deviceExecution, testCase.first, testCase.second));
@@ -182,5 +177,113 @@ BOOST_AUTO_TEST_CASE(test_prepareArguments)
   matrix["processor1"] = {{"--depth", "2"}, {"--foo", "bar"}, {"--mode", "default"}};
   check({"--depth", "2", "--processor0", "--mode silly"}, workflowOptions, deviceSpecs, matrix);
 }
-} // namespace framework
-} // namespace o2
+
+BOOST_AUTO_TEST_CASE(CheckOptionReworking)
+{
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--driver-client-backend", "foo"}},
+      {}};
+    DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
+    BOOST_REQUIRE_EQUAL(infos[0].cmdLineArgs[1], "foo");
+    BOOST_REQUIRE_EQUAL(infos[1].cmdLineArgs[1], "foo");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--driver-client-backend", "foo"}},
+      {{}, {}, {"--driver-client-backend", "bar"}}};
+    BOOST_CHECK_THROW(
+      DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://"), o2::framework::RuntimeErrorRef);
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--driver-client-backend", "foo"}},
+      {{}, {}, {"--driver-client-backend", "foo"}}};
+    DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
+    BOOST_REQUIRE_EQUAL(infos[0].cmdLineArgs[1], "foo");
+    BOOST_REQUIRE_EQUAL(infos[1].cmdLineArgs[1], "foo");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"foo", "bar"}},
+      {{}, {}, {"fnjcnak", "foo"}}};
+    DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
+    BOOST_REQUIRE_EQUAL(infos[0].cmdLineArgs[3], "stdout://");
+    BOOST_REQUIRE_EQUAL(infos[1].cmdLineArgs[3], "stdout://");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"foo", "bar", "--driver-client-backend", "bar"}},
+      {{}, {}, {"fnjcnak", "foo"}}};
+    DeviceSpecHelpers::reworkHomogeneousOption(infos, "--driver-client-backend", "stdout://");
+    BOOST_REQUIRE_EQUAL(infos[0].cmdLineArgs[3], "bar");
+    BOOST_REQUIRE_EQUAL(infos[1].cmdLineArgs[3], "bar");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckIntegerReworking)
+{
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--readers", "2"}},
+      {}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", nullptr, 1, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs[1], "2");
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs[1], "2");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {},
+      {}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", nullptr, 1, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs.size(), 0);
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs.size(), 0);
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {},
+      {}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", []() { return 1; }, 3, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs[1], "1");
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs[1], "1");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--readers", "2"}},
+      {{}, {}, {"--readers", "3"}}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", []() { return 1; }, 1, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs[1], "3");
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs[1], "3");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"--readers", "3"}},
+      {{}, {}, {"--readers", "2"}}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", []() { return 1; }, 1, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs[1], "3");
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs[1], "3");
+  }
+  {
+    std::vector<DataProcessorInfo> infos = {
+      {{}, {}, {"foo", "bar", "--readers", "3"}},
+      {{}, {}, {"--readers", "2"}}};
+    DeviceSpecHelpers::reworkIntegerOption(
+      infos, "--readers", []() { return 1; }, 1, [](long long x, long long y) { return x > y ? x : y; });
+    BOOST_REQUIRE_EQUAL(infos[0].cmdLineArgs.size(), 4);
+    BOOST_REQUIRE_EQUAL(infos[1].cmdLineArgs.size(), 2);
+    BOOST_CHECK_EQUAL(infos[0].cmdLineArgs[3], "3");
+    BOOST_CHECK_EQUAL(infos[1].cmdLineArgs[1], "3");
+  }
+}
+} // namespace o2::framework


### PR DESCRIPTION
The following options:

*  --resources-monitoring
*  --readers
*  --aod-memory-rate-limit
*  --time-limit
*  --driver-client-backend

can now be specified anywhere in the chain of workflows and DPL
will complain if different values are given.

Helper methods to achieve this with a single statement are now provided.