### PR TITLE
[CMake] Fix for ENABLE_UPGRADES=OFF

### DIFF
--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -107,6 +107,10 @@ o2_add_test_root_macro(analyzeOriginHits.C
                        PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat
                                              O2::DetectorsCommonDataFormats)
 
+if(ENABLE_UPGRADES)
+  set(upgradeTargets O2::Alice3DetectorsPassive O2::ITS3Simulation O2::TRKSimulation)
+endif()
+
 o2_add_test_root_macro(build_geometry.C
                        PUBLIC_LINK_LIBRARIES O2::DetectorsPassive
                                              O2::Field
@@ -125,9 +129,7 @@ o2_add_test_root_macro(build_geometry.C
                                              O2::PHOSSimulation
                                              O2::CPVSimulation
                                              O2::ZDCSimulation
-                                             $<$<BOOL:${ENABLE_UPGRADES}>:O2::Alice3DetectorsPassive>
-                                             $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Simulation>
-                                             $<$<BOOL:${ENABLE_UPGRADES}>:O2::TRKSimulation>)
+                                             ${upgradeTargets})
 
 o2_add_test_root_macro(checkTOFMatching.C
                        PUBLIC_LINK_LIBRARIES O2::GlobalTracking


### PR DESCRIPTION
Without this PR cmake -DENABLE_UPGRADES=OFF ... fails with :
```
2021-01-31@16:35:34:DEBUG:O2:O2:0: -- Configuring done
2021-01-31@16:35:58:DEBUG:O2:O2:0: CMake Error at cmake/O2AddTestWrapper.cmake:130 (add_test):
2021-01-31@16:35:58:DEBUG:O2:O2:0:   Error evaluating generator expression:
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:     $<TARGET_PROPERTY:$<$<BOOL:OFF>:O2::Alice3DetectorsPassive>,INTERFACE_INCLUDE_DIRECTORIES>
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:   $<TARGET_PROPERTY:tgt,prop> expression requires a non-empty target name.
2021-01-31@16:35:58:DEBUG:O2:O2:0: Call Stack (most recent call first):
2021-01-31@16:35:58:DEBUG:O2:O2:0:   cmake/O2AddTestRootMacro.cmake:103 (o2_add_test_wrapper)
2021-01-31@16:35:58:DEBUG:O2:O2:0:   macro/CMakeLists.txt:110 (o2_add_test_root_macro)
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0: CMake Error at cmake/O2AddTestWrapper.cmake:130 (add_test):
2021-01-31@16:35:58:DEBUG:O2:O2:0:   Error evaluating generator expression:
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:     $<TARGET_PROPERTY:$<$<BOOL:OFF>:O2::Alice3DetectorsPassive>,INTERFACE_LINK_DIRECTORIES>
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:   $<TARGET_PROPERTY:tgt,prop> expression requires a non-empty target name.
2021-01-31@16:35:58:DEBUG:O2:O2:0: Call Stack (most recent call first):
2021-01-31@16:35:58:DEBUG:O2:O2:0:   cmake/O2AddTestRootMacro.cmake:103 (o2_add_test_wrapper)
2021-01-31@16:35:58:DEBUG:O2:O2:0:   macro/CMakeLists.txt:110 (o2_add_test_root_macro)
2021-01-31@16:35:58:DEBUG:O2:O2:0:
2021-01-31@16:35:58:DEBUG:O2:O2:0:
``` 