### PR TITLE
AOD tables for forward tracks

### DIFF
--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -107,12 +107,12 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
       return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
     } else if (description == "TRACK:EXTRA") {
       return columnNamesTrait(typename TracksExtraMetadata::table_t::persistent_columns_t{});
-    } else if (description == "TRACKFWD:PAR") {
-      return columnNamesTrait(typename StoredTracksFwdMetadata::table_t::persistent_columns_t{});
-    } else if (description == "TRACKFWD:PARCOV") {
-      return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
-    } else if (description == "TRACKFWD:EXTRA") {
-      return columnNamesTrait(typename TracksExtraFwdMetadata::table_t::persistent_columns_t{});
+    } else if (description == "FWDTRACK:PAR") {
+      return columnNamesTrait(typename StoredFwdTracksMetadata::table_t::persistent_columns_t{});
+    } else if (description == "FWDTRACK:PARCOV") {
+      return columnNamesTrait(typename StoredFwdTracksCovMetadata::table_t::persistent_columns_t{});
+    } else if (description == "FWDTRACK:MFTPAR") {
+      return columnNamesTrait(typename MFTTracksMetadata::table_t::persistent_columns_t{});
     }
   }
 

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -111,8 +111,6 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
       return columnNamesTrait(typename StoredFwdTracksMetadata::table_t::persistent_columns_t{});
     } else if (description == "FWDTRACK:PARCOV") {
       return columnNamesTrait(typename StoredFwdTracksCovMetadata::table_t::persistent_columns_t{});
-    } else if (description == "FWDTRACK:MFTPAR") {
-      return columnNamesTrait(typename MFTTracksMetadata::table_t::persistent_columns_t{});
     }
   }
 

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -111,6 +111,8 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
       return columnNamesTrait(typename StoredTracksFwdMetadata::table_t::persistent_columns_t{});
     } else if (description == "TRACKFWD:PARCOV") {
       return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
+    } else if (description == "TRACKFWD:EXTRA") {
+      return columnNamesTrait(typename TracksExtraFwdMetadata::table_t::persistent_columns_t{});
     }
   }
 

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -107,6 +107,10 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
       return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
     } else if (description == "TRACK:EXTRA") {
       return columnNamesTrait(typename TracksExtraMetadata::table_t::persistent_columns_t{});
+    } else if (description == "TRACKFWD:PAR") {
+      return columnNamesTrait(typename StoredTracksFwdMetadata::table_t::persistent_columns_t{});
+    } else if (description == "TRACKFWD:PARCOV") {
+      return columnNamesTrait(typename StoredTracksCovMetadata::table_t::persistent_columns_t{});
     }
   }
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -337,7 +337,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::fwdtrack::sigma1
 } // namespace fwdtrack
 
 //Table for MFTStandalone tracks
-DECLARE_SOA_TABLE_FULL(MFTTracks, "MFTTracks", "AOD", "FWDTRACK:MFTPAR",
+DECLARE_SOA_TABLE_FULL(MFTTracks, "MFTTracks", "AOD", "MFTTRACK",
                        o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::BCId, fwdtrack::TrackType,
                        fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
                        fwdtrack::Signed1Pt,
@@ -386,7 +386,7 @@ DECLARE_SOA_EXTENDED_TABLE(FwdTracksCov, StoredFwdTracksCov, "FWDTRACK:PARCOV",
                            aod::fwdtrack::C1Pt21Pt2);
 
 using FwdTrack = FwdTracks::iterator;
-using FwdTrackCov = FwdTracksCov::iterator;
+using FwdTrackCovFwd = FwdTracksCov::iterator;
 
 using FullFwdTracks = soa::Join<FwdTracks, FwdTracksCov>;
 using FullFwdTrack = FullFwdTracks::iterator;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -267,7 +267,7 @@ using FullTrack = FullTracks::iterator;
 
 namespace fwdtrack
 {
-// FWDTRACKPAR and MFTTrack TABLE definition
+// FwdTracks and MFTTracks Columns definitions
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_INDEX_COLUMN(BC, bc);
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); // TODO change to ForwardTrackTypeEnum when enums are supported
@@ -301,7 +301,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, [](float pt, float tgl) -> float {
 });
 DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, 0.5f * (ntan(0.25f * static_cast<float>(M_PI) - 0.5f * natan(aod::fwdtrack::tgl)) + 1.f / ntan(0.25f * static_cast<float>(M_PI) - 0.5f * natan(aod::fwdtrack::tgl))) / nabs(aod::fwdtrack::signed1Pt));
 
-// FWDTRACKPARCOV TABLE definition
+// FwdTracksCov columns definitions
 DECLARE_SOA_COLUMN(SigmaX, sigmaX, float);
 DECLARE_SOA_COLUMN(SigmaY, sigmaY, float);
 DECLARE_SOA_COLUMN(SigmaPhi, sigmaPhi, float);
@@ -336,9 +336,9 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::fwdtrack::sigma1
 
 } // namespace fwdtrack
 
-//Table for MFTStandalone tracks
-DECLARE_SOA_TABLE_FULL(MFTTracks, "MFTTracks", "AOD", "MFTTRACK",
-                       o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::BCId, fwdtrack::TrackType,
+//Tables for MFTStandalone tracks
+DECLARE_SOA_TABLE_FULL(StoredMFTTracks, "MFTTracks", "AOD", "MFTTRACK",
+                       o2::soa::Index<>, fwdtrack::CollisionId,
                        fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
                        fwdtrack::Signed1Pt,
                        fwdtrack::Px<fwdtrack::Pt, fwdtrack::Phi>,
@@ -346,7 +346,12 @@ DECLARE_SOA_TABLE_FULL(MFTTracks, "MFTTracks", "AOD", "MFTTRACK",
                        fwdtrack::Pz<fwdtrack::Pt, fwdtrack::Tgl>,
                        fwdtrack::Charge<fwdtrack::Signed1Pt>, fwdtrack::Chi2);
 
-//Tables for MUONStandalone and GlobalForwardTracks
+DECLARE_SOA_EXTENDED_TABLE(MFTTracks, StoredMFTTracks, "MFTTRACK",
+                           aod::fwdtrack::Eta,
+                           aod::fwdtrack::Pt,
+                           aod::fwdtrack::P);
+
+//Tables for GlobalMuonTrack, MUONStandalone, MCHStandalone, and GlobalForwardTracks
 DECLARE_SOA_TABLE_FULL(StoredFwdTracks, "FwdTracks", "AOD", "FWDTRACK:PAR",
                        o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::BCId, fwdtrack::TrackType,
                        fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
@@ -404,16 +409,16 @@ DECLARE_SOA_TABLE(UnassignedTracks, "AOD", "UNASSIGNEDTRACK",
 
 using UnassignedTrack = UnassignedTracks::iterator;
 
-namespace unassignedfwdtracks
+namespace unassignedmfttracks
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);
-} // namespace unassignedfwdtracks
+DECLARE_SOA_INDEX_COLUMN(MFTTrack, mfttrack);
+} // namespace unassignedmfttracks
 
-DECLARE_SOA_TABLE(UnassignedFwdTracks, "AOD", "UNASSIGNEDFWDTR",
-                  unassignedfwdtracks::CollisionId, unassignedfwdtracks::FwdTrackId);
+DECLARE_SOA_TABLE(UnassignedMFTTracks, "AOD", "UNASSIGNEDMFTTR",
+                  unassignedmfttracks::CollisionId, unassignedmfttracks::MFTTrackId);
 
-using UnassignedFwdTrack = UnassignedFwdTracks::iterator;
+using UnassignedMFTTrack = UnassignedMFTTracks::iterator;
 
 namespace calo
 {

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -325,13 +325,15 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, (aod::trackfwd::rho1PtTgl
 DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::trackfwd::sigma1Pt* aod::trackfwd::sigma1Pt);
 
 // TRACKFWDEXTRA TABLE definition
+DECLARE_SOA_COLUMN(NClusters, nClusters, int8_t);
 DECLARE_SOA_COLUMN(Chi2, chi2, float);
 DECLARE_SOA_COLUMN(PDca, pDca, float);                         // PDca for MUONStandalone tracks
 DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);     // RAtAbsorberEnd for MUONStandalone tracks
-DECLARE_SOA_COLUMN(Chi2MatchMCHMID, chi2matchmchmid, float);   // MCH-MID Match Chi2 for MUONStandalone tracks
-DECLARE_SOA_COLUMN(Chi2MatchMCHMFT, chi2matchmchmft, float);   // MCH-MFT Match Chi2 for GlobalMuonTracks
-DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchscoremchmft, float); // MCH-MFT ML Matching Score for GlobalMuonTracks
-DECLARE_SOA_COLUMN(MatchingTrackID, MatchingTrackID, int32_t); // ID(s) of matching track(s).
+DECLARE_SOA_COLUMN(Chi2MatchMCHMID, chi2MatchMCHMID, float);   // MCH-MID Match Chi2 for MUONStandalone tracks
+DECLARE_SOA_COLUMN(Chi2MatchMCHMFT, chi2MatchMCHMFT, float);   // MCH-MFT Match Chi2 for GlobalMuonTracks
+DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchScoreMCHMFT, float); // MCH-MFT Machine Learning Matching Score for GlobalMuonTracks
+DECLARE_SOA_COLUMN(MatchMFTTrackID, matchMFTTrackID, int16_t); // ID of matching MFT track for GlobalMuonTracks
+DECLARE_SOA_COLUMN(MatchMCHTrackID, matchMCHTrackID, int8_t);  // ID of matching MCH track for GlobalMuonTracks
 } // namespace trackfwd
 
 DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -327,7 +327,11 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::trackfwd::sigma1
 // TRACKFWDEXTRA TABLE definition
 DECLARE_SOA_COLUMN(Chi2, chi2, float);
 DECLARE_SOA_COLUMN(Chi2Match, chi2Match, float);
-
+//DECLARE_SOA_COLUMN(PDca, pDca, float);
+//DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);
+// Expression columns for PDca and RAtAbsorberEnd will be replaced by SOA columns
+DECLARE_SOA_EXPRESSION_COLUMN(PDca, pDca, float, (aod::trackfwd::p)*nsqrt((aod::trackfwd::x * aod::trackfwd::x) + (aod::trackfwd::y * aod::trackfwd::y) + (aod::trackfwd::z * aod::trackfwd::z)));
+DECLARE_SOA_EXPRESSION_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float, nsqrt((aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) + (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl)));
 } // namespace trackfwd
 
 DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",
@@ -368,7 +372,7 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovFwd, StoredTracksCovFwd, "TRACKFWD:PARCOV",
                            aod::trackfwd::C1Pt21Pt2);
 
 DECLARE_SOA_TABLE(TracksExtraFwd, "AOD", "TRACKFWD:EXTRA",
-                  trackfwd::Chi2, trackfwd::Chi2Match);
+                  trackfwd::Chi2, trackfwd::Chi2Match, trackfwd::PDca, trackfwd::RAtAbsorberEnd);
 
 using TrackFwd = TracksFwd::iterator;
 using TrackCovFwd = TracksCovFwd::iterator;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -270,7 +270,7 @@ namespace trackfwd
 // TRACKPARFWD TABLE definition
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); // TODO change to ForwardTrackTypeEnum when enums are supported
-DECLARE_SOA_COLUMN(X, x, float);
+DECLARE_SOA_COLUMN(X, x, float);                   // TrackParFwd parameters: x, y, z, phi, tan(lamba), q/pt
 DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);
 DECLARE_SOA_COLUMN(Phi, phi, float);
@@ -309,7 +309,7 @@ DECLARE_SOA_COLUMN(Rho1PtPhi, rho1PtPhi, int8_t);
 DECLARE_SOA_COLUMN(Rho1PtTgl, rho1PtTgl, int8_t);
 
 DECLARE_SOA_EXPRESSION_COLUMN(CXX, cXX, float, aod::trackfwd::sigmaX* aod::trackfwd::sigmaX);
-DECLARE_SOA_EXPRESSION_COLUMN(CXY, cXY, float, (aod::trackfwd::rhoXY / 128.f) * (aod::trackfwd::sigmaX * aod::trackfwd::sigmaY)); //Why /128.f ?
+DECLARE_SOA_EXPRESSION_COLUMN(CXY, cXY, float, (aod::trackfwd::rhoXY / 128.f) * (aod::trackfwd::sigmaX * aod::trackfwd::sigmaY));
 DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, aod::trackfwd::sigmaY* aod::trackfwd::sigmaY);
 DECLARE_SOA_EXPRESSION_COLUMN(CPhiX, cPhiX, float, (aod::trackfwd::rhoPhiX / 128.f) * (aod::trackfwd::sigmaPhi * aod::trackfwd::sigmaX));
 DECLARE_SOA_EXPRESSION_COLUMN(CPhiY, cPhiY, float, (aod::trackfwd::rhoPhiY / 128.f) * (aod::trackfwd::sigmaPhi * aod::trackfwd::sigmaY));
@@ -326,15 +326,12 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::trackfwd::sigma1
 
 // TRACKFWDEXTRA TABLE definition
 DECLARE_SOA_COLUMN(Chi2, chi2, float);
-//DECLARE_SOA_COLUMN(PDca, pDca, float);
-//DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);
-// Expression columns for PDca and RAtAbsorberEnd will be replaced by SOA columns
-DECLARE_SOA_EXPRESSION_COLUMN(PDca, pDca, float, (aod::trackfwd::p)*nsqrt((aod::trackfwd::x * aod::trackfwd::x) + (aod::trackfwd::y * aod::trackfwd::y) + (aod::trackfwd::z * aod::trackfwd::z)));
-DECLARE_SOA_EXPRESSION_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float, nsqrt((aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) + (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl)));
-DECLARE_SOA_COLUMN(Chi2MatchMCHMID, chi2matchmchmid, float);
-DECLARE_SOA_COLUMN(Chi2MatchMCHMFT, chi2matchmchmft, float);
-DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchscoremchmft, float);
-DECLARE_SOA_COLUMN(GlobalMuonTrackRank, globalmuontrackrank, uint8_t);
+DECLARE_SOA_COLUMN(PDca, pDca, float);                         // PDca for MUONStandalone tracks
+DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);     // RAtAbsorberEnd for MUONStandalone tracks
+DECLARE_SOA_COLUMN(Chi2MatchMCHMID, chi2matchmchmid, float);   // MCH-MID Match Chi2 for MUONStandalone tracks
+DECLARE_SOA_COLUMN(Chi2MatchMCHMFT, chi2matchmchmft, float);   // MCH-MFT Match Chi2 for GlobalMuonTracks
+DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchscoremchmft, float); // MCH-MFT ML Matching Score for GlobalMuonTracks
+DECLARE_SOA_COLUMN(MatchingTrackID, MatchingTrackID, int32_t); // ID(s) of matching track(s).
 } // namespace trackfwd
 
 DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -326,12 +326,15 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::trackfwd::sigma1
 
 // TRACKFWDEXTRA TABLE definition
 DECLARE_SOA_COLUMN(Chi2, chi2, float);
-DECLARE_SOA_COLUMN(Chi2Match, chi2Match, float);
 //DECLARE_SOA_COLUMN(PDca, pDca, float);
 //DECLARE_SOA_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float);
 // Expression columns for PDca and RAtAbsorberEnd will be replaced by SOA columns
 DECLARE_SOA_EXPRESSION_COLUMN(PDca, pDca, float, (aod::trackfwd::p)*nsqrt((aod::trackfwd::x * aod::trackfwd::x) + (aod::trackfwd::y * aod::trackfwd::y) + (aod::trackfwd::z * aod::trackfwd::z)));
 DECLARE_SOA_EXPRESSION_COLUMN(RAtAbsorberEnd, rAtAbsorberEnd, float, nsqrt((aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::x + (-505. - aod::trackfwd::z) * ncos(aod::trackfwd::phi) / aod::trackfwd::tgl) + (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl) * (aod::trackfwd::y + (-505. - aod::trackfwd::z) * nsin(aod::trackfwd::phi) / aod::trackfwd::tgl)));
+DECLARE_SOA_COLUMN(Chi2MatchMCHMID, chi2matchmchmid, float);
+DECLARE_SOA_COLUMN(Chi2MatchMCHMFT, chi2matchmchmft, float);
+DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchscoremchmft, float);
+DECLARE_SOA_COLUMN(GlobalMuonTrackRank, globalmuontrackrank, uint8_t);
 } // namespace trackfwd
 
 DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",
@@ -372,7 +375,9 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovFwd, StoredTracksCovFwd, "TRACKFWD:PARCOV",
                            aod::trackfwd::C1Pt21Pt2);
 
 DECLARE_SOA_TABLE(TracksExtraFwd, "AOD", "TRACKFWD:EXTRA",
-                  trackfwd::Chi2, trackfwd::Chi2Match, trackfwd::PDca, trackfwd::RAtAbsorberEnd);
+                  trackfwd::Chi2, trackfwd::Chi2MatchMCHMID, trackfwd::Chi2MatchMCHMFT,
+                  trackfwd::MatchScoreMCHMFT, trackfwd::GlobalMuonTrackRank, trackfwd::PDca,
+                  trackfwd::RAtAbsorberEnd);
 
 using TrackFwd = TracksFwd::iterator;
 using TrackCovFwd = TracksCovFwd::iterator;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -269,7 +269,7 @@ namespace trackfwd
 {
 // TRACKPARFWD TABLE definition
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
-DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); // TODO change to TrackTypeEnum when enums are supported
+DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); // TODO change to ForwardTrackTypeEnum when enums are supported
 DECLARE_SOA_COLUMN(X, x, float);
 DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -280,6 +280,15 @@ DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float);
 DECLARE_SOA_DYNAMIC_COLUMN(Charge, charge, [](float signed1Pt) -> short { return (signed1Pt > 0) ? 1 : -1; });
 DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, -1.f * nlog(ntan(0.25f * static_cast<float>(M_PI) - 0.5f * natan(aod::trackfwd::tgl))));
 DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, nabs(1.f / aod::trackfwd::signed1Pt));
+DECLARE_SOA_DYNAMIC_COLUMN(Px, px, [](float pt, float phi) -> float {
+  return pt * std::cos(phi);
+});
+DECLARE_SOA_DYNAMIC_COLUMN(Py, py, [](float pt, float phi) -> float {
+  return pt * std::sin(phi);
+});
+DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, [](float pt, float tgl) -> float {
+  return pt * tgl;
+});
 DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, 0.5f * (ntan(0.25f * static_cast<float>(M_PI) - 0.5f * natan(aod::trackfwd::tgl)) + 1.f / ntan(0.25f * static_cast<float>(M_PI) - 0.5f * natan(aod::trackfwd::tgl))) / nabs(aod::trackfwd::signed1Pt));
 
 // TRACKPARCOVFWD TABLE definition
@@ -314,6 +323,11 @@ DECLARE_SOA_EXPRESSION_COLUMN(C1PtX, c1PtX, float, (aod::trackfwd::rho1PtX / 128
 DECLARE_SOA_EXPRESSION_COLUMN(C1PtPhi, c1PtPhi, float, (aod::trackfwd::rho1PtPhi / 128.f) * (aod::trackfwd::sigma1Pt * aod::trackfwd::sigmaPhi));
 DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, (aod::trackfwd::rho1PtTgl / 128.f) * (aod::trackfwd::sigma1Pt * aod::trackfwd::sigmaTgl));
 DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, aod::trackfwd::sigma1Pt* aod::trackfwd::sigma1Pt);
+
+// TRACKFWDEXTRA TABLE definition
+DECLARE_SOA_COLUMN(Chi2, chi2, float);
+DECLARE_SOA_COLUMN(Chi2Match, chi2Match, float);
+
 } // namespace trackfwd
 
 DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",
@@ -321,9 +335,9 @@ DECLARE_SOA_TABLE_FULL(StoredTracksFwd, "TracksFwd", "AOD", "TRACKFWD:PAR",
                        trackfwd::X,
                        trackfwd::Y, trackfwd::Z, trackfwd::Phi, trackfwd::Tgl,
                        trackfwd::Signed1Pt,
-                       // trackfwd::Px<trackfwd::Signed1Pt, trackfwd::Phi>,
-                       // trackfwd::Py<trackfwd::Signed1Pt, trackfwd::Phi>,
-                       // trackfwd::Pz<trackfwd::Signed1Pt, trackfwd::Tgl>,
+                       trackfwd::Px<trackfwd::Pt, trackfwd::Phi>,
+                       trackfwd::Py<trackfwd::Pt, trackfwd::Phi>,
+                       trackfwd::Pz<trackfwd::Pt, trackfwd::Tgl>,
                        trackfwd::Charge<trackfwd::Signed1Pt>);
 
 DECLARE_SOA_EXTENDED_TABLE(TracksFwd, StoredTracksFwd, "TRACKFWD:PAR",
@@ -353,10 +367,14 @@ DECLARE_SOA_EXTENDED_TABLE(TracksCovFwd, StoredTracksCovFwd, "TRACKFWD:PARCOV",
                            aod::trackfwd::C1PtTgl,
                            aod::trackfwd::C1Pt21Pt2);
 
+DECLARE_SOA_TABLE(TracksExtraFwd, "AOD", "TRACKFWD:EXTRA",
+                  trackfwd::Chi2, trackfwd::Chi2Match);
+
 using TrackFwd = TracksFwd::iterator;
 using TrackCovFwd = TracksCovFwd::iterator;
+using TrackExtraFwd = TracksExtraFwd::iterator;
 
-using FullTracksFwd = soa::Join<TracksFwd, TracksCovFwd>;
+using FullTracksFwd = soa::Join<TracksFwd, TracksCovFwd, TracksExtraFwd>;
 using FullTrackFwd = FullTracksFwd::iterator;
 
 namespace unassignedtracks

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -27,13 +27,16 @@ enum TrackFlagsRun2Enum {
 };
 } // namespace o2::aod::track
 
-namespace o2::aod::trackfwd
+namespace o2::aod::fwdtrack
 {
 enum ForwardTrackTypeEnum : uint8_t {
-  GlobalMuonTrack = 0,
-  MUONStandalone,
+  MUONStandalone = 0,
   MFTStandalone,
+  GlobalMuonTrack,
+  GlobalMuonTrackBestMatch,
+  MCHStandalone,
+  GlobalForwardTrack
 };
-} // namespace o2::aod::trackfwd
+} // namespace o2::aod::fwdtrack
 
 #endif // O2_FRAMEWORK_DATATYPES_H_

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -31,9 +31,8 @@ namespace o2::aod::fwdtrack
 {
 enum ForwardTrackTypeEnum : uint8_t {
   MUONStandalone = 0,
-  MFTStandalone,
   GlobalMuonTrack,
-  GlobalMuonTrackBestMatch,
+  GlobalMuonTrackOtherMatch,
   MCHStandalone,
   GlobalForwardTrack
 };

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -30,11 +30,11 @@ enum TrackFlagsRun2Enum {
 namespace o2::aod::fwdtrack
 {
 enum ForwardTrackTypeEnum : uint8_t {
-  MUONStandalone = 0,
-  GlobalMuonTrack,
-  GlobalMuonTrackOtherMatch,
+  GlobalMuonTrack = 0,
+  MUONStandalone,
   MCHStandalone,
-  GlobalForwardTrack
+  GlobalForwardTrack,
+  GlobalMuonTrackOtherMatch
 };
 } // namespace o2::aod::fwdtrack
 

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -31,7 +31,7 @@ namespace o2::aod::trackfwd
 {
 enum ForwardTrackTypeEnum : uint8_t {
   GlobalMuonTrack = 0,
-  MCHStandalone,
+  MUONStandalone,
   MFTStandalone,
 };
 } // namespace o2::aod::trackfwd

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -17,7 +17,6 @@ namespace o2::aod::track
 enum TrackTypeEnum : uint8_t {
   GlobalTrack = 0,
   ITSStandalone,
-  MFTStandalone,
   Run2GlobalTrack = 254,
   Run2Tracklet = 255
 };
@@ -27,5 +26,14 @@ enum TrackFlagsRun2Enum {
   GoldenChi2 = 0x4
 };
 } // namespace o2::aod::track
+
+namespace o2::aod::trackfwd
+{
+enum ForwardTrackTypeEnum : uint8_t {
+  GlobalMuonTrack = 0,
+  MCHStandalone,
+  MFTStandalone,
+};
+} // namespace o2::aod::trackfwd
 
 #endif // O2_FRAMEWORK_DATATYPES_H_


### PR DESCRIPTION
This PR summarizes the discussions around AOD tables for forward tracks held up to now. It aims at a single table for all forward tracks in O2. The new forward track tables are mimicking the style of central barrel tracks tables: 
 * The main table contains physics parameters. 
 * Covariances table (not final - further performance and optimization studies pending)
 * Extra table for tracking and detector specific data. This table brings chi2 and matchchi2 from the MUON table. It is not obvious if we should have a single chi2 column for all track types of a dedicated column for each. 
 
@iarsene @vfeuilla , please notice that I did not bring the `RAtAbsorberEnd` and `PDca` colums since these are very specific to MUON and perhaps these should be evaluated at the analysis level. Please take a look and let me know if is there anything else needed to drop the `muon` tables in favor of the `trackfwd` tables.

Ping @jgrosseo @javierecc @ginnocen @aphecetche @pillot @shahor02 


