### PR TITLE
PWGHF : Cleaning selectors

### DIFF
--- a/Analysis/DataModel/include/AnalysisDataModel/HFCandidateSelectionTables.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFCandidateSelectionTables.h
@@ -15,20 +15,31 @@ namespace o2::aod
 {
 namespace hf_selcandidate_d0
 {
-DECLARE_SOA_COLUMN(IsSelD0, isSelD0, int);
-DECLARE_SOA_COLUMN(IsSelD0bar, isSelD0bar, int);
+DECLARE_SOA_COLUMN(IsSelD0ToPiK, isSelD0ToPiK, int);
+DECLARE_SOA_COLUMN(IsSelD0ToPiKbar, isSelD0ToPiKbar, int);
+DECLARE_SOA_COLUMN(SelectionTopol, selectionTopol, int);
+DECLARE_SOA_COLUMN(SelectionTopolConjugate, selectionTopolConjugate, int);
+DECLARE_SOA_COLUMN(SelectionPID, selectionPID, int);
 } // namespace hf_selcandidate_d0
-DECLARE_SOA_TABLE(HFSelD0Candidate, "AOD", "HFSELD0CAND", hf_selcandidate_d0::IsSelD0, hf_selcandidate_d0::IsSelD0bar);
+DECLARE_SOA_TABLE(HFSelD0ToPiKCandidate, "AOD", "HFSELD0ToPiK", hf_selcandidate_d0::IsSelD0ToPiK, hf_selcandidate_d0::IsSelD0ToPiKbar);
+DECLARE_SOA_TABLE(HFSelD0ToPiKCuts, "AOD", "HFCutD0ToPiK", hf_selcandidate_d0::SelectionTopol,
+                  hf_selcandidate_d0::SelectionTopolConjugate, hf_selcandidate_d0::SelectionPID);
 } // namespace o2::aod
 
 namespace o2::aod
 {
 namespace hf_selcandidate_lc
 {
-DECLARE_SOA_COLUMN(IsSelLcpKpi, isSelLcpKpi, int);
-DECLARE_SOA_COLUMN(IsSelLcpiKp, isSelLcpiKp, int);
+DECLARE_SOA_COLUMN(IsSelLcToPKPi, isSelLcToPKPi, int);
+DECLARE_SOA_COLUMN(IsSelLcToPiKP, isSelLcToPiKP, int);
+DECLARE_SOA_COLUMN(SelectionTopol, selectionTopol, int);
+DECLARE_SOA_COLUMN(SelectionTopolConjugate, selectionTopolConjugate, int);
+DECLARE_SOA_COLUMN(SelectionPID, selectionPID, int);
 } // namespace hf_selcandidate_lc
-DECLARE_SOA_TABLE(HFSelLcCandidate, "AOD", "HFSELLCCAND", hf_selcandidate_lc::IsSelLcpKpi, hf_selcandidate_lc::IsSelLcpiKp);
+DECLARE_SOA_TABLE(HFSelLcToPKPiCandidate, "AOD", "HFSELLCToPKPi", hf_selcandidate_lc::IsSelLcToPKPi, hf_selcandidate_lc::IsSelLcToPiKP);
+DECLARE_SOA_TABLE(HFSelLcToPKPiCuts, "AOD", "HFCutLCToPKPi", hf_selcandidate_lc::SelectionTopol,
+                  hf_selcandidate_lc::SelectionTopolConjugate, hf_selcandidate_lc::SelectionPID);
+
 } // namespace o2::aod
 
 namespace o2::aod
@@ -36,7 +47,11 @@ namespace o2::aod
 namespace hf_selcandidate_jpsi
 {
 DECLARE_SOA_COLUMN(IsSelJpsiToEE, isSelJpsiToEE, int);
+DECLARE_SOA_COLUMN(SelectionTopol, selectionTopol, int);
+DECLARE_SOA_COLUMN(SelectionPID, selectionPID, int);
 } // namespace hf_selcandidate_jpsi
-DECLARE_SOA_TABLE(HFSelJpsiToEECandidate, "AOD", "HFSELJPSICAND", hf_selcandidate_jpsi::IsSelJpsiToEE);
+DECLARE_SOA_TABLE(HFSelJpsiToEECandidate, "AOD", "HFSELJPSIToEE", hf_selcandidate_jpsi::IsSelJpsiToEE);
+DECLARE_SOA_TABLE(HFSelJpsiToEECuts, "AOD", "HFCutJpsiToEE", hf_selcandidate_jpsi::SelectionTopol,
+                  hf_selcandidate_jpsi::SelectionPID);
 } // namespace o2::aod
 #endif // O2_ANALYSIS_HFCANDIDATESELECTIONTABLES_H_

--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -35,6 +35,14 @@ DECLARE_SOA_TABLE(HFSelTrack, "AOD", "HFSELTRACK",
                   hf_seltrack::DCAPrim0,
                   hf_seltrack::DCAPrim1);
 
+namespace hf_trackquality
+{
+DECLARE_SOA_COLUMN(TrackQuality, trackQuality, int);
+} // namespace hf_trackquality
+
+DECLARE_SOA_TABLE(HFTrackQuality, "AOD", "HFTRACKQUALITY",
+                  hf_trackquality::TrackQuality);
+
 using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra, HFSelTrack>;
 using BigTracksMC = soa::Join<BigTracks, McTrackLabels>;
 using BigTracksPID = soa::Join<BigTracks, pidRespTPC, pidRespTOF>;

--- a/Analysis/Tasks/PWGHF/CMakeLists.txt
+++ b/Analysis/Tasks/PWGHF/CMakeLists.txt
@@ -23,6 +23,11 @@ o2_add_dpl_workflow(qa-simple
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2_add_dpl_workflow(hf-track-quality-selector
+                    SOURCES HFTrackQualitySelector.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing ROOT::EG
+                    COMPONENT_NAME Analysis)
+
 o2_add_dpl_workflow(hf-track-index-skims-creator
                     SOURCES HFTrackIndexSkimsCreator.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing ROOT::EG
@@ -38,18 +43,18 @@ o2_add_dpl_workflow(hf-candidate-creator-3prong
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2_add_dpl_workflow(hf-d0-candidate-selector
-                    SOURCES HFD0CandidateSelector.cxx
+o2_add_dpl_workflow(hf-candidate-selector-d0topik
+                    SOURCES HFCandidateSelectorD0ToPiK.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2_add_dpl_workflow(hf-lc-candidate-selector
-                    SOURCES HFLcCandidateSelector.cxx
+o2_add_dpl_workflow(hf-candidate-selector-lctopkpi
+                    SOURCES HFCandidateSelectorLcToPKPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2_add_dpl_workflow(hf-jpsi-toee-candidate-selector   
-                    SOURCES HFJpsiToEECandidateSelector.cxx
+o2_add_dpl_workflow(hf-candidate-selector-jpsitoee  
+                    SOURCES HFCandidateSelectorJpsiToEE.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -39,7 +39,7 @@ struct SelectTracks {
   Configurable<double> d_bz{"d_bz", 5., "bz field"};
   // quality cut
   Configurable<bool> doCutQuality{"doCutQuality", true, "apply quality cuts"};
-  Configurable<int> d_tpcnclsfound{"d_tpcnclsfound", 70, ">= min. number of TPC clusters needed"};
+  Configurable<int> trackQualityVal{"trackQualityVal", 1, "value of track quality cut"};
   // 2-prong cuts
   Configurable<double> ptmintrack_2prong{"ptmintrack_2prong", -1., "min. track pT for 2 prong candidate"};
   Configurable<double> dcatoprimxy_2prong_maxpt{"dcatoprimxy_2prong_maxpt", 2., "max pt cut for min. DCAXY to prim. vtx. for 2 prong candidate"};
@@ -66,7 +66,7 @@ struct SelectTracks {
      {"heta_cuts_3prong", "tracks selected for 3-prong vertexing;#it{#eta};entries", {HistType::kTH1F, {{static_cast<int>(1.2 * etamax_3prong * 100), -1.2 * etamax_3prong, 1.2 * etamax_3prong}}}}}};
 
   void process(aod::Collision const& collision,
-               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra> const& tracks)
+               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::HFTrackQuality> const& tracks)
   {
     math_utils::Point3D<float> vtxXYZ(collision.posX(), collision.posY(), collision.posZ());
     for (auto& track : tracks) {
@@ -96,11 +96,8 @@ struct SelectTracks {
       }
 
       // quality cut
-      if (doCutQuality && status_prong > 0) { // FIXME to make a more complete selection e.g track.flags() & o2::aod::track::TPCrefit && track.flags() & o2::aod::track::GoldenChi2 &&
-        UChar_t clustermap = track.itsClusterMap();
-        if (!(track.tpcNClsFound() >= d_tpcnclsfound &&
-              track.flags() & o2::aod::track::ITSrefit &&
-              (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
+      if (doCutQuality && status_prong > 0) {
+        if (track.trackQuality() != trackQualityVal) {
           status_prong = 0;
         }
       }

--- a/Analysis/Tasks/PWGHF/HFTrackQualitySelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackQualitySelector.cxx
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HFTrackQualitySelector.cxx
+/// \brief Tagging of track quality for HF studies
+///
+/// \author Nima Zardoshti <nima.zardoshti@cern.ch>, CERN
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "AnalysisDataModel/HFSecondaryVertex.h"
+#include "AnalysisCore/trackUtilities.h"
+#include "AnalysisDataModel/TrackSelectionTables.h"
+//#include "AnalysisDataModel/Centrality.h"
+#include "Framework/HistogramRegistry.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+/// Track selection
+struct HFTrackQualitySelector {
+  Produces<aod::HFTrackQuality> trackQualityTable;
+
+  Configurable<bool> b_doPlots{"b_doPlots", true, "fill histograms"};
+  Configurable<int> d_tpcnclsfound{"d_tpcnclsfound", 70, ">= min. number of TPC clusters needed"};
+
+  HistogramRegistry registry{
+    "registry",
+    {{"hpt_nocuts", "all tracks;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+     {"hpt_cuts", "selected tracks;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}}}};
+
+  void process(aod::Collision const& collision,
+               soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TrackSelection> const& tracks)
+  {
+
+    for (auto& track : tracks) {
+
+      int trackQualityStatus = 0;
+      if (b_doPlots) {
+        registry.get<TH1>(HIST("hpt_nocuts"))->Fill(track.pt());
+      }
+      UChar_t clustermap = track.itsClusterMap();
+      if (track.isGlobalTrack() && track.tpcNClsFound() >= d_tpcnclsfound &&
+          track.flags() & o2::aod::track::ITSrefit &&
+          (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1))) {
+        trackQualityStatus = 1;
+        if (b_doPlots) {
+          registry.get<TH1>(HIST("hpt_cuts"))->Fill(track.pt());
+        }
+      }
+
+      // fill table row
+      trackQualityTable(trackQualityStatus);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HFTrackQualitySelector>("hf-track-quality-selector")};
+}

--- a/Analysis/Tasks/PWGHF/taskD0.cxx
+++ b/Analysis/Tasks/PWGHF/taskD0.cxx
@@ -54,13 +54,13 @@ struct TaskD0 {
      {"hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}},
      {"hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}}}};
 
-  Configurable<int> d_selectionFlagD0{"d_selectionFlagD0", 1, "Selection Flag for D0"};
-  Configurable<int> d_selectionFlagD0bar{"d_selectionFlagD0bar", 1, "Selection Flag for D0bar"};
+  Configurable<int> d_selectionFlagD0ToPiK{"d_selectionFlagD0ToPiK", 1, "Selection Flag for D0ToPiK"};
+  Configurable<int> d_selectionFlagD0ToPiKbar{"d_selectionFlagD0ToPiKbar", 1, "Selection Flag for D0ToPiKbar"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_d0::isSelD0 >= d_selectionFlagD0 || aod::hf_selcandidate_d0::isSelD0bar >= d_selectionFlagD0bar);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_d0::isSelD0ToPiK >= d_selectionFlagD0ToPiK || aod::hf_selcandidate_d0::isSelD0ToPiKbar >= d_selectionFlagD0ToPiKbar);
 
-  void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate>> const& candidates)
+  void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0ToPiKCandidate>> const& candidates)
   {
     //Printf("Candidates: %d", candidates.size());
     for (auto& candidate : candidates) {
@@ -71,10 +71,10 @@ struct TaskD0 {
         //Printf("Candidate: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (candidate.isSelD0() >= d_selectionFlagD0) {
+      if (candidate.isSelD0ToPiK() >= d_selectionFlagD0ToPiK) {
         registry.fill(HIST("hmass"), InvMassD0(candidate));
       }
-      if (candidate.isSelD0bar() >= d_selectionFlagD0bar) {
+      if (candidate.isSelD0ToPiKbar() >= d_selectionFlagD0ToPiKbar) {
         registry.fill(HIST("hmass"), InvMassD0bar(candidate));
       }
       registry.fill(HIST("hptcand"), candidate.pt());
@@ -89,7 +89,7 @@ struct TaskD0 {
       registry.fill(HIST("hCt"), CtD0(candidate));
       registry.fill(HIST("hCPA"), candidate.cpa());
       registry.fill(HIST("hEta"), candidate.eta());
-      registry.fill(HIST("hselectionstatus"), candidate.isSelD0() + (candidate.isSelD0bar() * 2));
+      registry.fill(HIST("hselectionstatus"), candidate.isSelD0ToPiK() + (candidate.isSelD0ToPiKbar() * 2));
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0());
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1());
       registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength());
@@ -112,13 +112,13 @@ struct TaskD0MC {
      {"hEtaRecBg", "2-prong candidates (unmatched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}},
      {"hEtaGen", "MC particles (matched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}}}};
 
-  Configurable<int> d_selectionFlagD0{"d_selectionFlagD0", 1, "Selection Flag for D0"};
-  Configurable<int> d_selectionFlagD0bar{"d_selectionFlagD0bar", 1, "Selection Flag for D0bar"};
+  Configurable<int> d_selectionFlagD0ToPiK{"d_selectionFlagD0ToPiK", 1, "Selection Flag for D0ToPiK"};
+  Configurable<int> d_selectionFlagD0ToPiKbar{"d_selectionFlagD0ToPiKbar", 1, "Selection Flag for D0ToPiKbar"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_d0::isSelD0 >= d_selectionFlagD0 || aod::hf_selcandidate_d0::isSelD0bar >= d_selectionFlagD0bar);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_d0::isSelD0ToPiK >= d_selectionFlagD0ToPiK || aod::hf_selcandidate_d0::isSelD0ToPiKbar >= d_selectionFlagD0ToPiKbar);
 
-  void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate, aod::HfCandProng2MCRec>> const& candidates,
+  void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0ToPiKCandidate, aod::HfCandProng2MCRec>> const& candidates,
                soa::Join<aod::McParticles, aod::HfCandProng2MCGen> const& particlesMC, aod::BigTracksMC const& tracks)
   {
     // MC rec.

--- a/Analysis/Tasks/PWGHF/taskJpsi.cxx
+++ b/Analysis/Tasks/PWGHF/taskJpsi.cxx
@@ -51,10 +51,10 @@ struct TaskJpsi {
      {"hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}},
      {"hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}}}};
 
-  Configurable<int> d_selectionFlagJpsi{"d_selectionFlagJpsi", 1, "Selection Flag for Jpsi"};
+  Configurable<int> d_selectionFlagJpsiToEE{"d_selectionFlagJpsiToEE", 1, "Selection Flag for JpsiToEE"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_jpsi::isSelJpsiToEE >= d_selectionFlagJpsi);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_jpsi::isSelJpsiToEE >= d_selectionFlagJpsiToEE);
 
   void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelJpsiToEECandidate>> const& candidates)
   //  void process(aod::HfCandProng2 const& candidates)
@@ -101,9 +101,9 @@ struct TaskJpsiMC {
      {"hEtaRecBg", "2-prong candidates (rec. unmatched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}},
      {"hEtaGen", "2-prong candidates (gen. matched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}}}};
 
-  Configurable<int> d_selectionFlagJpsi{"d_selectionFlagJpsi", 1, "Selection Flag for Jpsi"};
+  Configurable<int> d_selectionFlagJpsiToEE{"d_selectionFlagJpsiToEE", 1, "Selection Flag for JpsiToEE"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
-  Filter filterSelectCandidates = (aod::hf_selcandidate_jpsi::isSelJpsiToEE >= d_selectionFlagJpsi);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_jpsi::isSelJpsiToEE >= d_selectionFlagJpsiToEE);
 
   void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelJpsiToEECandidate, aod::HfCandProng2MCRec>> const& candidates,
                soa::Join<aod::McParticles, aod::HfCandProng2MCGen> const& particlesMC)

--- a/Analysis/Tasks/PWGHF/taskLc.cxx
+++ b/Analysis/Tasks/PWGHF/taskLc.cxx
@@ -54,13 +54,13 @@ struct TaskLc {
      {"hDecLenErr", "3-prong candidates;decay length error (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}},
      {"hdca2", "3-prong candidates;prong DCA to sec. vertex (cm);entries", {HistType::kTH1F, {{100, 0., 1.}}}}}};
 
-  Configurable<int> d_selectionFlagLc{"d_selectionFlagLc", 1, "Selection Flag for Lc"};
+  Configurable<int> d_selectionFlagLcToPKPi{"d_selectionFlagLcToPKPi", 1, "Selection Flag for LcToPKPi"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_lc::isSelLcpKpi >= d_selectionFlagLc || aod::hf_selcandidate_lc::isSelLcpiKp >= d_selectionFlagLc);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_lc::isSelLcToPKPi >= d_selectionFlagLcToPKPi || aod::hf_selcandidate_lc::isSelLcToPiKP >= d_selectionFlagLcToPKPi);
 
   //void process(aod::HfCandProng3 const& candidates)
-  void process(soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelLcCandidate>> const& candidates)
+  void process(soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelLcToPKPiCandidate>> const& candidates)
   {
     for (auto& candidate : candidates) {
       if (!(candidate.hfflag() & 1 << LcToPKPi)) {
@@ -70,10 +70,10 @@ struct TaskLc {
         //Printf("Candidate: eta rejection: %g", candidate.eta());
         continue;
       }
-      if (candidate.isSelLcpKpi() >= d_selectionFlagLc) {
+      if (candidate.isSelLcToPKPi() >= d_selectionFlagLcToPKPi) {
         registry.fill(HIST("hmass"), InvMassLcpKpi(candidate));
       }
-      if (candidate.isSelLcpiKp() >= d_selectionFlagLc) {
+      if (candidate.isSelLcToPiKP() >= d_selectionFlagLcToPKPi) {
         registry.fill(HIST("hmass"), InvMassLcpiKp(candidate));
       }
       registry.fill(HIST("hptcand"), candidate.pt());
@@ -87,8 +87,8 @@ struct TaskLc {
       registry.fill(HIST("hCt"), CtLc(candidate));
       registry.fill(HIST("hCPA"), candidate.cpa());
       registry.fill(HIST("hEta"), candidate.eta());
-      registry.fill(HIST("hselectionstatus"), candidate.isSelLcpKpi());
-      registry.fill(HIST("hselectionstatus"), candidate.isSelLcpiKp());
+      registry.fill(HIST("hselectionstatus"), candidate.isSelLcToPKPi());
+      registry.fill(HIST("hselectionstatus"), candidate.isSelLcToPiKP());
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0());
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1());
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter2());
@@ -111,13 +111,13 @@ struct TaskLcMC {
      {"hEtaRecBg", "3-prong candidates (rec. unmatched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}},
      {"hEtaGen", "3-prong candidates (gen. matched);#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}}}}};
 
-  Configurable<int> d_selectionFlagLc{"d_selectionFlagLc", 1, "Selection Flag for Lc"};
-  Configurable<int> d_selectionFlagLcbar{"d_selectionFlagLcbar", 1, "Selection Flag for Lcbar"};
+  Configurable<int> d_selectionFlagLcToPKPi{"d_selectionFlagLcToPKPi", 1, "Selection Flag for LcToPKPi"};
+  Configurable<int> d_selectionFlagLcToPKPibar{"d_selectionFlagLcToPKPibar", 1, "Selection Flag for LcToPKPibar"};
   Configurable<double> cutEtaCandMax{"cutEtaCandMax", -1., "max. cand. pseudorapidity"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_lc::isSelLcpKpi >= d_selectionFlagLc || aod::hf_selcandidate_lc::isSelLcpiKp >= d_selectionFlagLc);
+  Filter filterSelectCandidates = (aod::hf_selcandidate_lc::isSelLcToPKPi >= d_selectionFlagLcToPKPi || aod::hf_selcandidate_lc::isSelLcToPiKP >= d_selectionFlagLcToPKPi);
 
-  void process(soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelLcCandidate, aod::HfCandProng3MCRec>> const& candidates,
+  void process(soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelLcToPKPiCandidate, aod::HfCandProng3MCRec>> const& candidates,
                soa::Join<aod::McParticles, aod::HfCandProng3MCGen> const& particlesMC)
   {
     // MC rec.

--- a/Analysis/Tasks/PWGJE/jetfinderhf.cxx
+++ b/Analysis/Tasks/PWGJE/jetfinderhf.cxx
@@ -48,18 +48,18 @@ struct JetFinderHFTask {
                              60, 0., 60.));
   }
 
-  Configurable<int> d_selectionFlagD0{"d_selectionFlagD0", 1, "Selection Flag for D0"};
-  Configurable<int> d_selectionFlagD0bar{"d_selectionFlagD0bar", 1, "Selection Flag for D0bar"};
+  Configurable<int> d_selectionFlagD0ToPiK{"d_selectionFlagD0ToPiK", 1, "Selection Flag for D0ToPiK"};
+  Configurable<int> d_selectionFlagD0ToPiKbar{"d_selectionFlagD0ToPiKbar", 1, "Selection Flag for D0ToPiKbar"};
 
   //need enum as configurable
   enum pdgCode { pdgD0 = 421 };
 
   Filter trackCuts = (aod::track::pt > 0.15f && aod::track::eta > -0.9f && aod::track::eta < 0.9f);
-  Filter seltrack = (aod::hf_selcandidate_d0::isSelD0 >= d_selectionFlagD0 || aod::hf_selcandidate_d0::isSelD0bar >= d_selectionFlagD0bar);
+  Filter seltrack = (aod::hf_selcandidate_d0::isSelD0ToPiK >= d_selectionFlagD0ToPiK || aod::hf_selcandidate_d0::isSelD0ToPiKbar >= d_selectionFlagD0ToPiKbar);
 
   void process(aod::Collision const& collision,
                soa::Filtered<aod::Tracks> const& tracks,
-               soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate>> const& candidates)
+               soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0ToPiKCandidate>> const& candidates)
   {
     std::cout << "Per Event" << std::endl;
     // TODO: retrieve pion mass from somewhere
@@ -85,7 +85,7 @@ struct JetFinderHFTask {
       for (const auto& jet : jets) {
         isHFJet = false;
         for (const auto& constituent : jet.constituents()) {
-          if (constituent.user_index() == 1 && (candidate.isSelD0() == 1 || candidate.isSelD0bar() == 1)) {
+          if (constituent.user_index() == 1 && (candidate.isSelD0ToPiK() == 1 || candidate.isSelD0ToPiKbar() == 1)) {
             isHFJet = true;
             break;
           }


### PR DESCRIPTION
PR includes:

Fixing last remaining naming inconsistencies
Adding switch for selector PID (Also TPC and TOF only PID)
Adding assymetric PID
Adding HF track quality task (useful for run 5)
Removing detector specific calls without protection
Adding debug option for selectors