### PR TITLE
Templatize PrimaryVertexer inputs

### DIFF
--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/InteractionTag.h
@@ -32,11 +32,6 @@ struct InteractionTag : public o2::conf::ConfigurableParamHelper<InteractionTag>
     return rp.isValidTime(RecPoints::TimeMean) && (rp.getTrigger().amplA + rp.getTrigger().amplC) > minAmplitudeAC;
   }
 
-  float getInteractionTimeNS(const RecPoints& rp, const o2::InteractionRecord& refIR) const
-  {
-    return rp.getInteractionRecord().differenceInBCNS(refIR); // RS FIXME do we want use precise MeanTime?
-  }
-
   O2ParamDef(InteractionTag, "ft0tag");
 };
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1573,7 +1573,7 @@ int MatchTPCITS::prepareInteractionTimes()
       if (!mFT0Params->isSelected(ft)) {
         continue;
       }
-      auto fitTime = time2TPCTimeBin(mFT0Params->getInteractionTimeNS(ft, mStartIR) * 1e-3); // FIT time in TPC timebins
+      auto fitTime = time2TPCTimeBin(ft.getInteractionRecord().differenceInBCNS(mStartIR) * 1e-3); // FIT time in TPC timebins
       // find corresponding ITS ROF, works both in cont. and trigg. modes (ignore T0 MeanTime within the BC)
       for (; rof < nITSROFs; rof++) {
         if (mITSROFTimes[rof] < fitTime) {

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexingSpec.h
@@ -28,7 +28,7 @@ using namespace o2::framework;
 class PrimaryVertexingSpec : public Task
 {
  public:
-  PrimaryVertexingSpec(bool validateWithFT0, bool useMC) : mUseMC(useMC), mValidateWithFT0(validateWithFT0) {}
+  PrimaryVertexingSpec(bool validateWithIR, bool useMC) : mUseMC(useMC), mValidateWithIR(validateWithIR) {}
   ~PrimaryVertexingSpec() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -37,7 +37,7 @@ class PrimaryVertexingSpec : public Task
  private:
   o2::vertexing::PVertexer mVertexer;
   bool mUseMC{false};           ///< MC flag
-  bool mValidateWithFT0{false}; ///< require vertex validation with FT0
+  bool mValidateWithIR{false};  ///< require vertex validation with IR (e.g. from FT0)
   TStopwatch mTimer;
 };
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerParams.h
@@ -47,9 +47,8 @@ struct PVertexerParams : public o2::conf::ConfigurableParamHelper<PVertexerParam
   float upscaleFactor = 9.;          ///< factor for upscaling if not candidate is found
   float slowConvergenceFactor = 0.5; ///< consider convergence as slow if ratio new/old scale2 exceeds it
   //
-  // validation with FT0
-  bool requireFT0ValidTimeMean = false; //true;///< require both FT0A/C
-  int minNContributorsForFT0cut = 4;    ///< do not apply FT0 cut to vertice below FT0 efficiency threshold
+  // validation with externally provided InteractionRecords (e.g. from FT0)
+  int minNContributorsForIRcut = 4;     ///< do not apply IR cut to vertices below IR tagging efficiency threshold
   float maxTError = 0.2;                ///< use min of vertex time error or this for nsigma evaluation
   float minTError = 0.003;              ///< don't use error smaller than that (~BC/2/minNContributorsForFT0cut)
   float nSigmaTimeCut = 4.;             ///< eliminate vertex if there is no FT0 signal within this cut


### PR DESCRIPTION
Hi @njacazio 
you can use this as a starting point to rewrite https://github.com/AliceO2Group/AliceO2/pull/5359.
Note that I still provide containers of labels called lblITS and lblTPC, but these are usual spans of MCCompLabels, in 
particular case of PVertexertSpec corresponding to ITS and TPC parts of the global track. I may find better solution later,
but at the moment you can provide for both arguments the same span of labels of whatever tracks you are providing as 1st argument.