### PR TITLE
TRD: Add Configurable TRDSimParams (O2-1807)

### DIFF
--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -1,0 +1,22 @@
+# TRD simulation cheat-sheet
+## Using configurable params to pass additional options to the generator for generating specific events
+- Generate events with an electron particle gun in |eta| < 0.84:
+```
+o2-sim -m PIPE MAG TRD -n 1000 -g boxgen --configKeyValues 'BoxGun.pdg=11;BoxGun.eta[0]=-0.84;BoxGun.eta[1]=0.84'
+```
+- Generate events with an electron particle gun with 0.5 < p < 2.5 GeV and |eta| < 0.84:
+```
+o2-sim -m PIPE MAG TRD -n 1000 -g boxgen --configKeyValues 'BoxGun.pdg=11;BoxGun.eta[0]=-0.84;BoxGun.eta[1]=0.84;BoxGun.prange[0]=0.5;BoxGun.prange[1]=2.5'
+```
+- Generate events with a pion particle gun in |eta| < 0.84:
+```
+o2-sim -m PIPE MAG TRD -n 1000 -g boxgen --configKeyValues 'BoxGun.pdg=11;BoxGun.eta[0]=-0.84;BoxGun.eta[1]=0.84'
+```
+- Generate events with a pion particle gun with p = 2 GeV and |eta| < 0.84:
+```
+o2-sim -m PIPE MAG TRD -n 1000 -g boxgen --configKeyValues 'BoxGun.pdg=211;BoxGun.eta[0]=-0.84;BoxGun.eta[1]=0.84;BoxGun.prange[0]=2;BoxGun.prange[1]=2'
+```
+## Using TRD specific configurable params
+```
+--configKeyValues 'TRDSimParams.doTR=false;TRDSimParams.maxMCStepSize=0.1'
+```

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -90,6 +90,8 @@ class Detector : public o2::base::DetImpl<Detector>
   /// copy constructor (used in MT)
   Detector(const Detector& rhs);
 
+  void InitializeParams();
+
   // defines/sets-up the sensitive volumes
   void defineSensitiveVolumes();
 
@@ -105,6 +107,8 @@ class Detector : public o2::base::DetImpl<Detector>
   float mFoilDensity;
   float mGasNobleFraction;
   float mGasDensity;
+
+  float mMaxMCStepDef;
 
   bool mTRon; // Switch for TR simulation
   TRsim* mTR; // Access to TR simulation

--- a/Detectors/TRD/simulation/include/TRDSimulation/TRDSimParams.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TRDSimParams.h
@@ -22,10 +22,13 @@ namespace trd
 {
 
 // Global parameters for TRD simulation / digitization
+/*
+  See https://github.com/AliceO2Group/AliceO2/blob/dev/Common/SimConfig/doc/ConfigurableParam.md
+*/
 struct TRDSimParams : public o2::conf::ConfigurableParamHelper<TRDSimParams> {
-
-  int digithreads = 4; // number of digitizer threads
-
+  int digithreads = 4;       // number of digitizer threads
+  float maxMCStepSize = 0.1; // maximum size of MC steps
+  bool doTR = true;          // switch for transition radiation
   O2ParamDef(TRDSimParams, "TRDSimParams");
 };
 


### PR DESCRIPTION
Add configurable TRDSimParams for setting transition radiation simulation on/off on the fly. These changes also fix O2-1807.
A few snippets on how to use TRDSimParams are in `Detectors/TRD/simulation/README.md`.