### PR TITLE
Fix: further cleanup of redundant labels

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
@@ -91,11 +91,6 @@ class NameConf
   // public standard CTF dictionary
   static constexpr std::string_view CTFDICT = "ctf_dictionary"; // hardcoded
 
-  // Block for ITS/TPC matching
-  static constexpr std::string_view TPCITS_TracksBranchName = "TPCITS";              ///< name of branch containing output matched tracks
-  static constexpr std::string_view TPCITS_TPCMCTruthBranchName = "MatchTPCMCTruth"; ///< name of branch for output matched tracks TPC MC
-  static constexpr std::string_view TPCITS_ITSMCTruthBranchName = "MatchITSMCTruth"; ///< name of branch for output matched tracks ITS MC
-
   // CTF tree name
   static constexpr std::string_view CTFTREENAME = "ctf"; // hardcoded
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -297,8 +297,6 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
   auto tracksTPCMCTruth = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCMCTruth");
   auto tracksITSMCTruth = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSMCTruth");
-  auto tracksITSTPC_ITSMC = pc.inputs().get<gsl::span<o2::MCCompLabel>>("tracksITSTPC_ITSMC");
-  auto tracksITSTPC_TPCMC = pc.inputs().get<gsl::span<o2::MCCompLabel>>("tracksITSTPC_TPCMC");
 
   LOG(DEBUG) << "FOUND " << tracksTPC.size() << " TPC tracks";
   LOG(DEBUG) << "FOUND " << tracksITS.size() << " ITS tracks";
@@ -650,8 +648,9 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   if (mFillTracksITSTPC) {
     fillTracksTable(tracksITSTPC, vCollRefsTPCITS, tracksCursor, o2::vertexing::GIndex::Source::ITSTPC); // fTrackType = 0
     for (int i = 0; i < tracksITSTPC.size(); i++) {
-      auto& mcTruthITS = tracksITSTPC_ITSMC[i];
-      auto& mcTruthTPC = tracksITSTPC_TPCMC[i];
+      const auto& trc = tracksITSTPC[i];
+      auto mcTruthITS = tracksITSMCTruth[trc.getRefITS()];
+      auto mcTruthTPC = tracksTPCMCTruth[trc.getRefTPC()];
       labelID = std::numeric_limits<uint32_t>::max();
       labelITS = std::numeric_limits<uint32_t>::max();
       labelTPC = std::numeric_limits<uint32_t>::max();
@@ -710,8 +709,6 @@ DataProcessorSpec getAODProducerWorkflowSpec()
   inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCMCTruth", "TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackITSMCTruth", "ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
-  inputs.emplace_back("tracksITSTPC_ITSMC", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
-  inputs.emplace_back("tracksITSTPC_TPCMC", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
 
   outputs.emplace_back(OutputLabel{"O2bc"}, "AOD", "BC", 0, Lifetime::Timeframe);
   outputs.emplace_back(OutputLabel{"O2collision"}, "AOD", "COLLISION", 0, Lifetime::Timeframe);

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1475,7 +1475,6 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
   if (mMCTruthON) { // store MC info: we assign TPC track label and declare the match fake if the ITS and TPC labels are different (their fake flag is ignored)
     auto& lbl = mOutLabels.emplace_back(mTPCLblWork[iTPC]);
     lbl.setFakeFlag(mITSLblWork[iITS] != mTPCLblWork[iTPC]);
-    LOG(INFO) << "ITS: " << mITSLblWork[iITS] << " TPC: " << mTPCLblWork[iTPC] << " -> " << lbl;
   }
 
   // if requested, fill the difference of ITS and TPC tracks tgl for vdrift calibation

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -62,10 +62,9 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
   double timeCPU0 = mTimer.CpuTime(), timeReal0 = mTimer.RealTime();
   mTimer.Start(false);
   const auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("match");
-  gsl::span<const o2::MCCompLabel> lblITS, lblTPC;
+  gsl::span<const o2::MCCompLabel> lblTPCITS;
   if (mUseMC) {
-    lblITS = pc.inputs().get<gsl::span<o2::MCCompLabel>>("lblITS");
-    lblTPC = pc.inputs().get<gsl::span<o2::MCCompLabel>>("lblTPC");
+    lblTPCITS = pc.inputs().get<gsl::span<o2::MCCompLabel>>("lblTPCITS");
   }
   std::vector<PVertex> vertices;
   std::vector<GIndex> vertexTrackIDs;
@@ -94,7 +93,7 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
     }
   }
 
-  mVertexer.process(tracksITSTPC, idxVec, ft0Data, vertices, vertexTrackIDs, v2tRefs, lblITS, lblTPC, lblVtx);
+  mVertexer.process(tracksITSTPC, idxVec, ft0Data, vertices, vertexTrackIDs, v2tRefs, lblTPCITS, lblVtx);
   pc.outputs().snapshot(Output{"GLO", "PVTX", 0, Lifetime::Timeframe}, vertices);
   pc.outputs().snapshot(Output{"GLO", "PVTX_CONTIDREFS", 0, Lifetime::Timeframe}, v2tRefs);
   pc.outputs().snapshot(Output{"GLO", "PVTX_CONTID", 0, Lifetime::Timeframe}, vertexTrackIDs);
@@ -129,8 +128,7 @@ DataProcessorSpec getPrimaryVertexingSpec(bool validateWithFT0, bool useMC)
   outputs.emplace_back("GLO", "PVTX_CONTIDREFS", 0, Lifetime::Timeframe);
 
   if (useMC) {
-    inputs.emplace_back("lblITS", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("lblTPC", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("lblTPCITS", "GLO", "TPCITS_MC", 0, Lifetime::Timeframe);
     outputs.emplace_back("GLO", "PVTX_MCTR", 0, Lifetime::Timeframe);
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowWithTPCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowWithTPCSpec.cxx
@@ -167,8 +167,6 @@ o2::framework::DataProcessorSpec getTOFRecoWorkflowWithTPCSpec(bool useMC, bool 
 
   if (useMC) {
     outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTOF_TPC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTPC_TPC", 0, Lifetime::Timeframe);
-    outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHITS_TPC", 0, Lifetime::Timeframe);
   }
   outputs.emplace_back(o2::header::gDataOriginTOF, "CALIBDATA_TPC", 0, Lifetime::Timeframe);
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -96,12 +96,6 @@ DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tp
 
   if (useMC) {
     LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";
-    // are the MC inputs from ITS-TPC matching and TOF matching duplicates? if trackITSMCTR == matchTOFMCITS one of them should be removed
-    inputs.emplace_back("trackITSMCTR", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("trackTPCMCTR", "GLO", "TPCITSMC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMC", o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMCTPC", o2::header::gDataOriginTOF, "MCMATCHTPC", 0, Lifetime::Timeframe);
-    inputs.emplace_back("matchTOFMCITS", o2::header::gDataOriginTOF, "MCMATCHITS", 0, Lifetime::Timeframe);
   }
 
   outputs.emplace_back("GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -175,8 +175,6 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC)
 
   if (useMC) {
     LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";
-    //inputs.emplace_back("itstracklabel", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
-    //inputs.emplace_back("tpctracklabel", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
   }
 
   outputs.emplace_back(o2::header::gDataOriginTRD, "MATCHTRD", 0, Lifetime::Timeframe);

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -54,11 +54,11 @@ class PVertexer
   template <typename TR, typename BC>
   int process(const TR& tracks, const gsl::span<o2d::GlobalTrackID> gids, const BC& bcData,
               std::vector<PVertex>& vertices, std::vector<o2d::VtxTrackIndex>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs,
-              gsl::span<const o2::MCCompLabel> lblITS, gsl::span<const o2::MCCompLabel> lblTPC, std::vector<o2::MCEventLabel>& lblVtx)
+              gsl::span<const o2::MCCompLabel> lblTracks, std::vector<o2::MCEventLabel>& lblVtx)
   {
     auto nv = process(tracks, gids, bcData, vertices, vertexTrackIDs, v2tRefs);
-    if (lblITS.size() && lblTPC.size()) {
-      createMCLabels(lblITS, lblTPC, vertices, vertexTrackIDs, v2tRefs, lblVtx);
+    if (lblTracks.size()) {
+      createMCLabels(lblTracks, vertices, vertexTrackIDs, v2tRefs, lblVtx);
     }
     return nv;
   }
@@ -67,7 +67,7 @@ class PVertexer
   int process(const TR& tracks, const gsl::span<o2d::GlobalTrackID> gids, const BC& bcData,
               std::vector<PVertex>& vertices, std::vector<o2d::VtxTrackIndex>& vertexTrackIDs, std::vector<V2TRef>& v2tRefs);
 
-  static void createMCLabels(gsl::span<const o2::MCCompLabel> lblITS, gsl::span<const o2::MCCompLabel> lblTPC,
+  static void createMCLabels(gsl::span<const o2::MCCompLabel> lblTracks,
                              const std::vector<PVertex> vertices, const std::vector<o2d::VtxTrackIndex> vertexTrackIDs, const std::vector<V2TRef> v2tRefs,
                              std::vector<o2::MCEventLabel>& lblVtx);
   bool findVertex(const VertexingInput& input, PVertex& vtx);


### PR DESCRIPTION
This is to amend https://github.com/AliceO2Group/AliceO2/pull/5366
Suppression of standalone track lables in the output of barrel matched tracks
was not propagated everywhere