### PR TITLE
[ITS vertexer] Fix compilation with ITS debug

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/RangeReference.h
+++ b/DataFormats/common/include/CommonDataFormat/RangeReference.h
@@ -75,18 +75,18 @@ class RangeRefComp
   GPUd() RangeRefComp(int ent, int n) { set(ent, n); }
   GPUdDefault() RangeRefComp() = default;
   GPUdDefault() RangeRefComp(const RangeRefComp& src) = default;
-  GPUd() void set(int ent, int n)
+  GPUhd() void set(int ent, int n)
   {
     mData = (Base(ent) << NBitsN) + (Base(n) & MaskN);
   }
   GPUd() static constexpr Base getMaxFirstEntry() { return MaskR >> NBitsN; }
   GPUd() static constexpr Base getMaxEntries() { return MaskN; }
-  GPUd() int getFirstEntry() const { return mData >> NBitsN; }
-  GPUd() int getEntries() const { return mData & ((0x1 << NBitsN) - 1); }
-  GPUd() void setFirstEntry(int ent) { mData = (Base(ent) << NBitsN) | (mData & MaskN); }
-  GPUd() void setEntries(int n) { mData = (mData & MaskR) | (Base(n) & MaskN); }
-  GPUd() void changeEntriesBy(int inc) { setEntries(getEntries() + inc); }
-  GPUd() bool operator==(const RangeRefComp& other) const
+  GPUhd() int getFirstEntry() const { return mData >> NBitsN; }
+  GPUhd() int getEntries() const { return mData & ((0x1 << NBitsN) - 1); }
+  GPUhd() void setFirstEntry(int ent) { mData = (Base(ent) << NBitsN) | (mData & MaskN); }
+  GPUhd() void setEntries(int n) { mData = (mData & MaskR) | (Base(n) & MaskN); }
+  GPUhd() void changeEntriesBy(int inc) { setEntries(getEntries() + inc); }
+  GPUhd() bool operator==(const RangeRefComp& other) const
   {
     return mData == other.mData;
   }

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreVertexerGPU.h
@@ -226,7 +226,7 @@ inline std::array<std::vector<int>, 2> DeviceStoreVertexerGPU::getHistogramXYFro
 {
   std::array<std::vector<int>, 2> histoXY;
   for (int iHisto{0}; iHisto < 2; ++iHisto) {
-    histoXY[iHisto].resize(mGPUConf.nBinsXYZ[iHisto] - 1);
+    histoXY[iHisto].resize(mGPUConf.histConf.nBinsXYZ[iHisto] - 1);
     mHistogramXYZ[iHisto].copyIntoSizedVector(histoXY[iHisto]);
   }
 
@@ -236,7 +236,7 @@ inline std::array<std::vector<int>, 2> DeviceStoreVertexerGPU::getHistogramXYFro
 inline std::vector<int> DeviceStoreVertexerGPU::getHistogramZFromGPU()
 {
   std::vector<int> histoZ;
-  histoZ.resize(mGPUConf.nBinsXYZ[2] - 1);
+  histoZ.resize(mGPUConf.histConf.nBinsXYZ[2] - 1);
   mHistogramXYZ[2].copyIntoSizedVector(histoZ);
 
   return histoZ;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -91,9 +91,9 @@ VertexerTraitsGPU::VertexerTraitsGPU()
   setIsGPU(true);
 }
 
+VertexerTraitsGPU::~VertexerTraitsGPU() = default;
 #endif
 
-VertexerTraitsGPU::~VertexerTraitsGPU() = default;
 
 void VertexerTraitsGPU::initialise(ROframe* event)
 {

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
@@ -223,7 +223,7 @@ inline std::array<std::vector<int>, 2> DeviceStoreVertexerHIP::getHistogramXYFro
 {
   std::array<std::vector<int>, 2> histoXY;
   for (int iHisto{0}; iHisto < 2; ++iHisto) {
-    histoXY[iHisto].resize(mGPUConf.nBinsXYZ[iHisto] - 1);
+    histoXY[iHisto].resize(mGPUConf.histConf.nBinsXYZ[iHisto] - 1);
     mHistogramXYZ[iHisto].copyIntoSizedVector(histoXY[iHisto]);
   }
 
@@ -233,7 +233,7 @@ inline std::array<std::vector<int>, 2> DeviceStoreVertexerHIP::getHistogramXYFro
 inline std::vector<int> DeviceStoreVertexerHIP::getHistogramZFromGPU()
 {
   std::vector<int> histoZ;
-  histoZ.resize(mGPUConf.nBinsXYZ[2] - 1);
+  histoZ.resize(mGPUConf.histConf.nBinsXYZ[2] - 1);
   std::cout << "Size of dest vector to be refined" << std::endl;
   mHistogramXYZ[2].copyIntoSizedVector(histoZ);
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
@@ -87,11 +87,11 @@ VertexerTraitsHIP::~VertexerTraitsHIP()
   delete mDebugger;
 }
 #else
+
 VertexerTraitsHIP::VertexerTraitsHIP()
 {
   setIsGPU(true);
 }
-
 #endif
 
 void VertexerTraitsHIP::initialise(ROframe* event)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -35,7 +35,7 @@ struct Line final {
   GPUhd() Line(const Tracklet&, const Cluster*, const Cluster*);
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-  Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters, const int evId);
+  GPUhd() Line(const Tracklet& tracklet, const Cluster* innerClusters, const Cluster* outerClusters, const int evId);
 #endif
 
   inline static float getDistanceFromPoint(const Line& line, const std::array<float, 3>& point);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Definitions.h
@@ -21,7 +21,7 @@
 #include <array>
 #endif
 
-//#define CA_DEBUG
+// #define CA_DEBUG
 
 #ifdef CA_DEBUG
 #define CA_DEBUGGER(x) x

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
@@ -19,9 +19,12 @@
 #include <iterator>
 
 // Tracker
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
+#include "ITStracking/ROframe.h"
+#endif
+
 #include "DataFormatsITS/TrackITS.h"
 #include "ITStracking/PrimaryVertexContext.h"
-#include "ITStracking/ROframe.h"
 
 namespace o2
 {
@@ -40,6 +43,7 @@ class ClusterLines;
 
 using constants::its::UnusedIndex;
 
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 template <int numClusters = TrackITSExt::MaxClusters>
 struct FakeTrackInfo {
  public:
@@ -123,6 +127,7 @@ struct FakeTrackInfo {
   int nFakeClusters = 0;
   ClassDefNV(FakeTrackInfo, 1);
 }; // namespace its
+#endif
 
 class StandaloneDebugger
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -31,7 +31,7 @@ struct Tracklet final {
 #ifdef _ALLOW_DEBUG_TREES_ITS_
   unsigned char isEmpty() const;
   void dump();
-  unsigned char operator<(const Tracklet&);
+  unsigned char operator<(const Tracklet&) const;
 #endif
 
   int firstClusterIndex;
@@ -63,7 +63,7 @@ inline unsigned char Tracklet::isEmpty() const
   return !firstClusterIndex && !secondClusterIndex && !tanLambda && !phiCoordinate;
 }
 
-inline unsigned char Tracklet::operator<(const Tracklet& t)
+inline unsigned char Tracklet::operator<(const Tracklet& t) const
 {
   if (isEmpty() && t.isEmpty()) {
     return false;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -24,9 +24,6 @@
 #include "ITStracking/ClusterLines.h"
 #include "ITStracking/Definitions.h"
 #include "ITStracking/IndexTableUtils.h"
-#ifdef _ALLOW_DEBUG_TREES_ITS_
-#include "ITStracking/StandaloneDebugger.h"
-#endif
 #include "ITStracking/Tracklet.h"
 
 #include "GPUCommonMath.h"
@@ -43,7 +40,7 @@ class TreeStreamRedirector;
 
 namespace its
 {
-
+class StandaloneDebugger;
 class ROframe;
 
 using constants::its::LayersNumberVertexer;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -22,12 +22,10 @@
 #include "ITStracking/ClusterLines.h"
 #include "ITStracking/Tracklet.h"
 
-// debug
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-#include "CommonUtils/TreeStreamRedirector.h"
+#include "ITStracking/StandaloneDebugger.h"
 #include <unordered_map>
 #endif
-// \debug
 
 #define LAYER0_TO_LAYER1 0
 #define LAYER1_TO_LAYER2 1
@@ -137,9 +135,9 @@ void trackletSelectionKernelSerial(
 VertexerTraits::VertexerTraits() : mAverageClustersRadii{std::array<float, 3>{0.f, 0.f, 0.f}},
                                    mMaxDirectorCosine3{0.f}
 {
-  mVrtParams.phiSpan = static_cast<int>(std::ceil(constants::index_table::PhiBins * mVrtParams.phiCut /
+  mVrtParams.phiSpan = static_cast<int>(std::ceil(constants::its2::PhiBins * mVrtParams.phiCut /
                                                   constants::math::TwoPi));
-  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * constants::index_table::InverseZBinSize()[0]));
+  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * constants::its2::InverseZBinSize()[0]));
   setIsGPU(false);
 
   std::cout << "[DEBUG] Creating file: dbg_ITSVertexerCPU.root" << std::endl;


### PR DESCRIPTION
It should not change anything as the flag is disabled by default.
I additionaly need the {nv, h}cc compiler to know about some dataformat methods also when compiling host code.