### PR TITLE
Fix conversion from string to seconds

### DIFF
--- a/Detectors/DCS/src/DataPointGenerator.cxx
+++ b/Detectors/DCS/src/DataPointGenerator.cxx
@@ -34,10 +34,10 @@ std::pair<uint32_t, uint16_t> getDate(const std::string& refDate)
     std::tm t{};
     std::istringstream ss(refDate);
     ss >> std::get_time(&t, "%Y-%b-%d %H:%M:%S");
-    if (ss.fail()) { // let's see if it was passed as a TDatime
+    if (ss.fail()) { // let's see if it was passed as a TDatime, as SQL string
       std::tm tt{};
       std::istringstream sss(refDate);
-      sss >> std::get_time(&tt, "%a %b %d %H:%M:%S %Y");
+      sss >> std::get_time(&tt, "%Y-%m-%d %H:%M:%S");
       if (sss.fail()) {
         LOG(ERROR) << "We cannot parse the date";
       }

--- a/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
+++ b/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
@@ -70,7 +70,7 @@ std::vector<o2::dcs::DataPointCompositeObject> generate(const std::vector<o2::dc
   dsec += tfid;
   d.Set(dsec);
 
-  std::string refDate = d.AsString();
+  std::string refDate = d.AsSQLString();
 
   auto GenerateVisitor = [refDate](const auto& t) {
     return o2::dcs::generateRandomDataPoints({t.aliasPattern}, t.minValue, t.maxValue, refDate);

--- a/Detectors/TOF/calibration/testWorkflow/README.md
+++ b/Detectors/TOF/calibration/testWorkflow/README.md
@@ -14,7 +14,7 @@ aliases. You can specify the path of CCDB also with `--ccdb-path`.
 YOu can also specify to run in verbose mode (`--use-verbose-mode`)
 
 ```shell
-o2-calibration-tof-sim-workflow --max-timeframes 3 --delta-fraction 0.5 -b |
+o2-calibration-tof-dcs-sim-workflow --max-timeframes 3 --delta-fraction 0.5 -b |
 o2-calibration-tof-dcs-workflow --use-ccdb-to-configure -b |
 o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" -b
 ```


### PR DESCRIPTION
For some reason, libstdc seems to have issues parsing the month
("%b" option), so now I use the SQL format.