### PR TITLE
DPL: fix for sending configuration with spaces

### DIFF
--- a/Analysis/Tutorials/src/configurableObjects.cxx
+++ b/Analysis/Tutorials/src/configurableObjects.cxx
@@ -52,7 +52,7 @@ auto printMatrix(Array2D<T> const& m)
 }
 
 static constexpr float defaultm[3][4] = {{1.1, 1.2, 1.3, 1.4}, {2.1, 2.2, 2.3, 2.4}, {3.1, 3.2, 3.3, 3.4}};
-static LabeledArray<float> la{&defaultm[0][0], 3, 4, {"r1", "r2", "r3"}, {"c1", "c2", "c3", "c4"}};
+static LabeledArray<float> la{&defaultm[0][0], 3, 4, {"r 1", "r 2", "r 3"}, {"c 1", "c 2", "c 3", "c 4"}};
 
 struct ConfigurableObjectDemo {
   Configurable<configurableCut> cut{"cut", {0.5, 1, true}, "generic cut"};
@@ -61,7 +61,7 @@ struct ConfigurableObjectDemo {
   // note that size is fixed by this declaration - externally supplied vector needs to be the same size!
   Configurable<std::vector<int>> array{"array", {0, 0, 0, 0, 0, 0, 0}, "generic array"};
   Configurable<Array2D<float>> vmatrix{"matrix", {&defaultm[0][0], 3, 4}, "generic matrix"};
-  Configurable<LabeledArray<float>> vla{"vla", {defaultm[0], 3, 4, {"r1", "r2", "r3"}, {"c1", "c2", "c3", "c4"}}, "labeled array"};
+  Configurable<LabeledArray<float>> vla{"vla", {defaultm[0], 3, 4, {"r 1", "r 2", "r 3"}, {"c 1", "c 2", "c 3", "c 4"}}, "labeled array"};
 
   void init(InitContext const&){};
   void process(aod::Collision const&, aod::Tracks const& tracks)

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -238,7 +238,7 @@ void DataProcessingDevice::Init()
     } else {
       str = entry.second.get_value<std::string>();
     }
-    std::string configString = fmt::format("[CONFIG] {}={} 1 {}", entry.first, str, configStore->provenance(entry.first.c_str())).c_str();
+    std::string configString = fmt::format("[CONFIG];{}={};1;{}", entry.first, str, configStore->provenance(entry.first.c_str())).c_str();
     mServiceRegistry.get<DriverClient>().tell(configString.c_str());
   }
 

--- a/Framework/Core/src/DeviceConfigInfo.cxx
+++ b/Framework/Core/src/DeviceConfigInfo.cxx
@@ -24,7 +24,7 @@ bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& matc
 {
   const char* begin = s.begin();
   const char* end = s.end();
-  if (s.size() > 17 && (strncmp("[CONFIG] ", begin + 17, 9) != 0)) {
+  if (s.size() > 17 && (strncmp("[CONFIG];", begin + 17, 9) != 0)) {
     return false;
   }
   if (s.size() < 17 + 9) {
@@ -36,14 +36,14 @@ bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& matc
     return false;
   }
   match.beginValue = match.endKey + 1;
-  match.endValue = (char const*)memchr(match.beginValue, ' ', end - match.beginValue);
+  match.endValue = (char const*)memchr(match.beginValue, ';', end - match.beginValue);
   if (match.endValue == nullptr) {
     return false;
   }
   char* next = nullptr;
   match.timestamp = strtoll(match.endValue, &next, 10);
 
-  if (!next || *next != ' ') {
+  if (!next || *next != ';') {
     return false;
   }
 

--- a/Framework/Core/src/DeviceConfigInfo.cxx
+++ b/Framework/Core/src/DeviceConfigInfo.cxx
@@ -40,8 +40,9 @@ bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& matc
   if (match.endValue == nullptr) {
     return false;
   }
+
   char* next = nullptr;
-  match.timestamp = strtoll(match.endValue, &next, 10);
+  match.timestamp = strtoll(match.endValue + 1, &next, 10);
 
   if (!next || *next != ';') {
     return false;

--- a/Framework/Core/test/test_DeviceConfigInfo.cxx
+++ b/Framework/Core/test/test_DeviceConfigInfo.cxx
@@ -83,9 +83,9 @@ BOOST_AUTO_TEST_CASE(TestDeviceConfigInfo)
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Parse a simple configuration bit
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG];foo=bar;1789372894;prov\n";
   std::string_view config{configString.data() + 3, configString.size() - 4};
-  BOOST_REQUIRE_EQUAL(config, std::string("[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov"));
+  BOOST_REQUIRE_EQUAL(config, std::string("[XX:XX:XX][INFO] [CONFIG];foo=bar;1789372894;prov"));
   result = DeviceConfigHelper::parseConfig(config, match);
   BOOST_REQUIRE_EQUAL(result, true);
   BOOST_CHECK(strncmp(match.beginKey, "foo", 3) == 0);
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(TestDeviceConfigInfo)
   BOOST_CHECK_EQUAL(info.currentProvenance.get<std::string>("foo"), "prov");
 
   // Parse an array
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] array={\"\":\"1\",\"\":\"2\",\"\":\"3\",\"\":\"4\",\"\":\"5\"} 1789372894 prov\n";
+  configString = "foo[XX:XX:XX][INFO] [CONFIG];array={\"\":\"1\",\"\":\"2\",\"\":\"3\",\"\":\"4\",\"\":\"5\"};1789372894;prov\n";
   std::string_view configa{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(configa, match);
   auto valueString = std::string(match.beginValue, match.endValue - match.beginValue);


### PR DESCRIPTION
Use a semicolon as a field separator for config parsing, this allows to send values with whitespaces (e.g. array labels). 