### PR TITLE
[MCH] Introduce DCS processor

### DIFF
--- a/Detectors/DCS/src/DetectorsDCSLinkDef.h
+++ b/Detectors/DCS/src/DetectorsDCSLinkDef.h
@@ -19,8 +19,9 @@
 #pragma link C++ struct o2::dcs::DataPointValue + ;
 #pragma link C++ class o2::dcs::DCSProcessor + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue> + ;
+#pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, std::vector < o2::dcs::DataPointValue>> + ;
 #pragma link C++ function o2::dcs::expandAlias(const std::string&);
-#pragma link C++ function o2::dcs::expandAliases(const std::vector<std::string>&);
+#pragma link C++ function o2::dcs::expandAliases(const std::vector <std::string>&);
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, std::string> + ;
 
 #endif

--- a/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
+++ b/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
@@ -47,7 +47,7 @@ std::vector<int> generateIntegers(size_t size, int min, int max)
   }
   std::shuffle(begin(data), end(data), generator);
   for (auto i = 0; i < data.size(); ++i) {
-    LOG(INFO) << "Generating randomly DP at index " << data[i];
+    LOG(DEBUG) << "Generating randomly DP at index " << data[i];
   }
   return data;
 }
@@ -147,7 +147,7 @@ void DCSRandomDataGenerator::run(o2::framework::ProcessingContext& pc)
   TDatime d;
   auto dpcoms = generate(mDataPointHints, fraction, tfid);
 
-  LOG(INFO) << "***************** TF " << tfid << " has generated " << dpcoms.size() << " DPs for TOF";
+  LOG(INFO) << "***************** TF " << tfid << " has generated " << dpcoms.size() << " DPs";
   pc.outputs().snapshot(Output{"DCS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);
   mTFs++;
 }

--- a/Detectors/MUON/MCH/Conditions/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Conditions/CMakeLists.txt
@@ -22,3 +22,19 @@ if(BUILD_TESTING)
     PUBLIC_LINK_LIBRARIES O2::MCHConditions)
 endif()
 
+o2_add_executable(dcs-check-ccdb
+                  COMPONENT_NAME mch
+                  SOURCES src/dcs-check-ccdb.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsDCS O2::MCHConditions O2::CCDB)
+
+o2_add_executable(mch-dcs-processor-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES workflow/dcs-processor-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsDCS O2::MCHConditions)
+
+
+o2_add_executable(mch-dcs-sim-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES workflow/dcs-sim-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DCStestWorkflow O2::MCHConditions)
+

--- a/Detectors/MUON/MCH/Conditions/README.md
+++ b/Detectors/MUON/MCH/Conditions/README.md
@@ -4,13 +4,13 @@
 
 # MCH Conditions
 
-## From DCS
+## DCS to CCDB
 
 To test the DCS to CCDB route you can use the following 3 parts worfklow pipeline : 
 
 ```shell
-o2-calibration-mch-dcs-sim-workflow --max-timeframes 10000 --max-cycles-no-full-map 100 -b | \
-o2-calibration-mch-dcs-processor-workflow -b | \
+o2-calibration-mch-dcs-sim-workflow --max-timeframes 600 --max-cycles-no-full-map 10 -b | \
+o2-calibration-mch-dcs-processor-workflow --hv-max-size 0 --hv-max-duration 300 -b | \
 o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:6464" -b
 ```
 
@@ -18,7 +18,9 @@ o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:6464" -b
 - `o2-calibration-mch-dcs-processor-workflow` gathers the received data points into a container object 
 - `o2-calibration-ccdb-populator-workflow` uploads the container object to the CCDB (in this example a local dev ccdb).
 
- The container object that groups the datapoints is considered ready to be shipped either when the data points span a long enough duration (see the `--calib-object-max-duration` option of the `o2-calibration-mch-dcs-processor-workflow`) or is big enough (see the `--calib-object-max-size` option).
+ The container object that groups the datapoints is considered ready to be shipped either when the data points span a long enough duration (see the `--hv-max-duration` and `--hv-max-duration` options of the `o2-calibration-mch-dcs-processor-workflow`) or is big enough (see the `--lv-max-size` and `--hv-max-size` options).
+
+## DCS Data Points
 
 ### HV
 
@@ -35,4 +37,12 @@ The MCH low voltage (LV) system is composed of 328 channels :
   electronics (dualsampas)
 - 112 channels to power up the readout crates hosting the solar (readout) cards
 
+## CCDB quick check
 
+Besides the web browsing of the CCDB, another quick check can be performed with 
+ the `o2-mch-dcs-check-ccdb` program to dump the DCS datapoints (hv, lv, or both)
+  valid at a given timestamp.
+
+```
+$ o2-mch-dcs-check-ccdb --help
+```

--- a/Detectors/MUON/MCH/Conditions/README.md
+++ b/Detectors/MUON/MCH/Conditions/README.md
@@ -6,6 +6,20 @@
 
 ## From DCS
 
+To test the DCS to CCDB route you can use the following 3 parts worfklow pipeline : 
+
+```shell
+o2-calibration-mch-dcs-sim-workflow --max-timeframes 10000 --max-cycles-no-full-map 100 -b | \
+o2-calibration-mch-dcs-processor-workflow -b | \
+o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:6464" -b
+```
+
+- `o2-calibration-mch-dcs-sim-worfklow` is just generating fake random MCH DCS data points, 
+- `o2-calibration-mch-dcs-processor-workflow` gathers the received data points into a container object 
+- `o2-calibration-ccdb-populator-workflow` uploads the container object to the CCDB (in this example a local dev ccdb).
+
+ The container object that groups the datapoints is considered ready to be shipped either when the data points span a long enough duration (see the `--calib-object-max-duration` option of the `o2-calibration-mch-dcs-processor-workflow`) or is big enough (see the `--calib-object-max-size` option).
+
 ### HV
 
 The MCH high voltage (HV) system is composed of 188 channels :

--- a/Detectors/MUON/MCH/Conditions/src/dcs-check-ccdb.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/dcs-check-ccdb.cxx
@@ -1,0 +1,122 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CCDB/CcdbApi.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include <boost/program_options.hpp>
+#include <ctime>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace po = boost::program_options;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPMAP = std::unordered_map<DPID, std::vector<DPVAL>>;
+
+int main(int argc, char** argv)
+{
+  po::variables_map vm;
+  po::options_description usage("Usage");
+
+  std::string ccdbUrl;
+  uint64_t timestamp;
+  bool lv;
+  bool hv;
+  bool verbose;
+
+  std::time_t now = std::time(nullptr);
+
+  // clang-format off
+  usage.add_options()
+      ("help,h", "produce help message")
+      ("ccdb",po::value<std::string>(&ccdbUrl)->default_value("http://localhost:6464"),"ccdb url")
+      ("timestamp,t",po::value<uint64_t>(&timestamp)->default_value(now),"timestamp to query")
+      ("hv",po::bool_switch(&hv),"query HV")
+      ("lv",po::bool_switch(&lv),"query LV")
+      ("verbose,v",po::bool_switch(&verbose),"verbose output")
+      ;
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(usage);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).run(), vm);
+
+  if (vm.count("help")) {
+    std::cout << "This program printout summary information from MCH DCS entries.\n";
+    std::cout << usage << "\n";
+    return 2;
+  }
+
+  try {
+    po::notify(vm);
+  } catch (boost::program_options::error& e) {
+    std::cout << "Error: " << e.what() << "\n";
+    exit(1);
+  }
+
+  if (!hv && !lv) {
+    std::cout << "Must specify at least one of --hv or --lv\n";
+    std::cout << usage << "\n";
+    return 3;
+  }
+
+  std::vector<std::string> what;
+  if (hv) {
+    what.emplace_back("MCH/HV");
+  }
+  if (lv) {
+    what.emplace_back("MCH/LV");
+  }
+
+  // union Converter {
+  //   uint64_t raw_data;
+  //   T t_value;
+  // };
+  // if (dpcom.id.get_type() != dt) {
+  //   throw std::runtime_error("DPCOM is of unexpected type " + o2::dcs::show(dt));
+  // }
+  // Converter converter;
+  // converter.raw_data = dpcom.data.payload_pt1;
+
+  auto sum =
+    [](float s, o2::dcs::DataPointValue v) {
+      union Converter {
+        uint64_t raw_data;
+        double value;
+      } converter;
+      converter.raw_data = v.payload_pt1;
+      return s + converter.value;
+    };
+
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbUrl);
+  for (auto w : what) {
+    std::map<std::string, std::string> metadata;
+    auto* m = api.retrieveFromTFileAny<DPMAP>(w, metadata, timestamp);
+    std::cout << "size of " << w << " map = " << m->size() << std::endl;
+    if (verbose) {
+      for (auto& i : *m) {
+        auto v = i.second;
+        auto mean = std::accumulate(v.begin(), v.end(), 0.0, sum);
+        if (v.size()) {
+          mean /= v.size();
+        }
+        std::cout << fmt::format("{:64s} {:4d} values of mean {:7.2f}\n", i.first.get_alias(), v.size(),
+                                 mean);
+      }
+    }
+  }
+  return 0;
+}

--- a/Detectors/MUON/MCH/Conditions/src/dcs-check-ccdb.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/dcs-check-ccdb.cxx
@@ -80,16 +80,6 @@ int main(int argc, char** argv)
     what.emplace_back("MCH/LV");
   }
 
-  // union Converter {
-  //   uint64_t raw_data;
-  //   T t_value;
-  // };
-  // if (dpcom.id.get_type() != dt) {
-  //   throw std::runtime_error("DPCOM is of unexpected type " + o2::dcs::show(dt));
-  // }
-  // Converter converter;
-  // converter.raw_data = dpcom.data.payload_pt1;
-
   auto sum =
     [](float s, o2::dcs::DataPointValue v) {
       union Converter {

--- a/Detectors/MUON/MCH/Conditions/workflow/dcs-processor-workflow.cxx
+++ b/Detectors/MUON/MCH/Conditions/workflow/dcs-processor-workflow.cxx
@@ -1,0 +1,248 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "DetectorsCalibration/Utils.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/EndOfStreamContext.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/runDataProcessing.h"
+#include "MCHConditions/DCSNamer.h"
+#include <gsl/span>
+#include <iostream>
+#include <unordered_map>
+#include <array>
+#include <vector>
+
+namespace
+{
+
+using namespace o2::calibration;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPMAP = std::unordered_map<DPID, std::vector<DPVAL>>;
+
+std::vector<o2::framework::OutputSpec> calibrationOutputs{
+  o2::framework::ConcreteDataTypeMatcher{Utils::gDataOriginCLB, Utils::gDataDescriptionCLBPayload},
+  o2::framework::ConcreteDataTypeMatcher{Utils::gDataOriginCLB, Utils::gDataDescriptionCLBInfo}};
+
+std::array<DPMAP, 2> dataPoints;
+int t0{-1};
+
+o2::ccdb::CcdbObjectInfo createDefaultInfo(const char* path)
+{
+  DPMAP obj;
+  auto clName = o2::utils::MemFileHelper::getClassName(obj);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  o2::ccdb::CcdbObjectInfo info;
+  info.setPath(path);
+  info.setObjectType(clName);
+  info.setFileName(flName);
+  info.setStartValidityTimestamp(0);
+  info.setEndValidityTimestamp(99999999999999);
+  std::map<std::string, std::string> md;
+  info.setMetaData(md);
+  return info;
+}
+
+std::array<o2::ccdb::CcdbObjectInfo, 2> info{createDefaultInfo("MCH/HV"), createDefaultInfo("MCH/LV")};
+
+void sendOutput(const DPMAP& dpmap, o2::framework::DataAllocator& output, o2::ccdb::CcdbObjectInfo info, const std::string& reason)
+{
+  if (dpmap.empty()) {
+    // do not write empty objects
+    return;
+  }
+  auto md = info.getMetaData();
+  md["upload reason"] = reason;
+  info.setMetaData(md);
+  auto image = o2::ccdb::CcdbApi::createObjectImage(&dpmap, &info);
+  LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+            << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+  output.snapshot(o2::framework::Output{Utils::gDataOriginCLB, Utils::gDataDescriptionCLBPayload, 0}, *image.get());
+  output.snapshot(o2::framework::Output{Utils::gDataOriginCLB, Utils::gDataDescriptionCLBInfo, 0}, info);
+}
+
+void endOfStream(o2::framework::EndOfStreamContext& eosc)
+{
+  std::cout << "This is the end. Must write what we have left ?\n";
+  for (auto i = 0; i < 2; i++) {
+    sendOutput(dataPoints[i], eosc.outputs(), info[i], "end of stream");
+  }
+}
+
+size_t computeSize(const DPMAP& dpmap)
+{
+  constexpr int itemSize = 64; // DataPointIdentifier or DataPointValue have the same size = 64 bytes
+  constexpr float byte2KB = 1.0 / 1024;
+
+  size_t nofItems = 0;
+  for (auto did : dpmap) {
+    nofItems++;                    // +1 for the DataPointIdentifier itself
+    nofItems += did.second.size(); // +number of DataPointValues
+  }
+  return static_cast<size_t>(std::floor(nofItems * itemSize * byte2KB));
+}
+
+int computeDuration(const DPMAP& dpmap)
+{
+  uint64_t minTime{std::numeric_limits<uint64_t>::max()};
+  uint64_t maxTime{0};
+
+  for (auto did : dpmap) {
+    for (auto d : did.second) {
+      minTime = std::min(minTime, d.get_epoch_time());
+      maxTime = std::max(maxTime, d.get_epoch_time());
+    }
+  }
+  return static_cast<int>((maxTime - minTime) / 1000);
+}
+
+std::tuple<bool, std::string> needOutput(const DPMAP& dpmap, int maxSize, int maxDuration)
+{
+  std::string reason;
+
+  if (dpmap.empty()) {
+    return {false, reason};
+  }
+
+  bool bigEnough{false};
+  bool longEnough{false};
+  bool complete{true}; // FIXME: should check here that we indeed have all our dataPoints
+
+  if (maxSize && (computeSize(dpmap) > maxSize)) {
+    bigEnough = true;
+    reason += "[big enough]";
+  }
+
+  if (maxDuration) {
+    auto seconds = computeDuration(dpmap);
+    if (seconds > maxDuration) {
+      longEnough = true;
+      reason += fmt::format("[long enough ({} s)]", seconds);
+    }
+  }
+
+  return {complete && (bigEnough || longEnough), reason};
+}
+
+o2::ccdb::CcdbObjectInfo addTFInfo(o2::ccdb::CcdbObjectInfo inf,
+                                   uint64_t t0, uint64_t t1)
+{
+  auto md = inf.getMetaData();
+  md["tf range"] = fmt::format("{}-{}", t0, t1);
+  inf.setMetaData(md);
+  return inf;
+}
+
+void processDataPoints(o2::framework::ProcessingContext& pc,
+                       std::array<std::vector<std::string>, 2> aliases,
+                       std::array<int, 2> maxSize,
+                       std::array<int, 2> maxDuration)
+{
+
+  auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+  if (t0 < 0) {
+    t0 = tfid;
+  }
+  auto dps = pc.inputs().get<gsl::span<o2::dcs::DataPointCompositeObject>>("input");
+  for (auto dp : dps) {
+    //FIXME: check we're not adding twice the same dp (i.e. check timestamp ?)
+    for (auto i = 0; i < 2; i++) {
+      if (std::find(aliases[i].begin(), aliases[i].end(), dp.id.get_alias()) != aliases[i].end()) {
+        dataPoints[i][dp.id].emplace_back(dp.data);
+      }
+    }
+  }
+  for (auto i = 0; i < 2; i++) {
+    auto [shouldOutput, reason] = needOutput(dataPoints[i], maxSize[i], maxDuration[i]);
+    if (shouldOutput) {
+      auto inf = addTFInfo(info[i], t0, tfid);
+      sendOutput(dataPoints[i], pc.outputs(), inf, reason);
+      t0 = tfid;
+      dataPoints[i].clear(); //FIXME: here the clear should be more clever and keep at least one value per dp
+    }
+  }
+}
+
+o2::framework::AlgorithmSpec::ProcessCallback createProcessFunction(o2::framework::InitContext& ic)
+{
+  auto& callbacks = ic.services().get<o2::framework::CallbackService>();
+  callbacks.set(o2::framework::CallbackService::Id::EndOfStream, endOfStream);
+
+  std::array<std::vector<std::string>, 2> aliases = {
+    o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::HV_V,
+                           o2::mch::dcs::MeasurementType::HV_I}),
+    o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::LV_V_FEE_ANALOG,
+                           o2::mch::dcs::MeasurementType::LV_V_FEE_DIGITAL,
+                           o2::mch::dcs::MeasurementType::LV_V_SOLAR})};
+
+  std::array<int, 2> maxSize{
+    ic.options().get<int>("hv-max-size"),
+    ic.options().get<int>("lv-max-size")};
+
+  std::array<int, 2> maxDuration{
+    ic.options().get<int>("hv-max-duration"),
+    ic.options().get<int>("lv-max-duration")};
+
+  for (auto i = 0; i < 2; i++) {
+    dataPoints[i].clear();
+  }
+
+  return [aliases, maxSize, maxDuration](o2::framework::ProcessingContext& pc) {
+    processDataPoints(pc, aliases, maxSize, maxDuration);
+  };
+}
+
+o2::framework::ConfigParamSpec whenToSendOption(const char* name, int value,
+                                                const char* what, const char* unit)
+{
+  std::string uname(name);
+  o2::dcs::to_upper_case(uname);
+
+  std::string description = fmt::format(R"(max {} calibration object {} (in {}).
+When that {} is reached the object is shipped. Use 0 to disable this check.)",
+                                        uname, what, unit, what);
+
+  return {fmt::format("{}-max-{}", name, what),
+          o2::framework::VariantType::Int,
+          value,
+          {description}};
+}
+
+} // namespace
+
+using o2::framework::AlgorithmSpec;
+using o2::framework::ConfigContext;
+using o2::framework::DataProcessorSpec;
+using o2::framework::WorkflowSpec;
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  DataProcessorSpec dcsProcessor;
+
+  AlgorithmSpec algo(createProcessFunction);
+
+  dcsProcessor.name = "mch-dcs-processor";
+  dcsProcessor.inputs = o2::framework::Inputs{{"input", "DCS", "MCHDATAPOINTS"}};
+  dcsProcessor.outputs = calibrationOutputs;
+  dcsProcessor.algorithm = algo;
+  dcsProcessor.options = {
+    whenToSendOption("hv", 128, "size", "KB"),
+    whenToSendOption("lv", 128, "size", "KB"),
+    whenToSendOption("hv", 8 * 3600, "duration", "seconds"),
+    whenToSendOption("lv", 8 * 3600, "duration", "seconds")};
+
+  return {dcsProcessor};
+}

--- a/Detectors/MUON/MCH/Conditions/workflow/dcs-sim-workflow.cxx
+++ b/Detectors/MUON/MCH/Conditions/workflow/dcs-sim-workflow.cxx
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DCStestWorkflow/DCSRandomDataGeneratorSpec.h"
+#include "Framework/runDataProcessing.h"
+#include "MCHConditions/DCSNamer.h"
+
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
+{
+  std::vector<o2::dcs::test::HintType> dphints;
+
+  for (auto a : o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::HV_V})) {
+    dphints.emplace_back(o2::dcs::test::DataPointHint<double>{a, 1630, 1670});
+  }
+
+  for (auto a : o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::HV_I})) {
+    dphints.emplace_back(o2::dcs::test::DataPointHint<double>{a, 0.1, 10});
+  }
+
+  for (auto a : o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::LV_V_FEE_DIGITAL})) {
+    dphints.emplace_back(o2::dcs::test::DataPointHint<double>{a, 1.15, 1.25});
+  }
+
+  for (auto a : o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::LV_V_FEE_ANALOG})) {
+    dphints.emplace_back(o2::dcs::test::DataPointHint<double>{a, 1.15, 1.25});
+  }
+
+  for (auto a : o2::mch::dcs::aliases({o2::mch::dcs::MeasurementType::LV_V_SOLAR})) {
+    dphints.emplace_back(o2::dcs::test::DataPointHint<double>{a, 2.4, 2.6});
+  }
+
+  o2::framework::WorkflowSpec specs;
+  specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "MCH"));
+  return specs;
+}

--- a/Detectors/MUON/MCH/Conditions/workflow/dcs-sim-workflow.cxx
+++ b/Detectors/MUON/MCH/Conditions/workflow/dcs-sim-workflow.cxx
@@ -12,6 +12,12 @@
 #include "Framework/runDataProcessing.h"
 #include "MCHConditions/DCSNamer.h"
 
+/**
+* DPL workflow which generates fake random MCH DCS data points.
+*
+* Data points are generated for HV (currents and voltages) as well as 
+* for LV (DualSampa analog and digital voltages, and SOLAR voltages).
+*/
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
 {
   std::vector<o2::dcs::test::HintType> dphints;


### PR DESCRIPTION
Add two workflows and one check program to deal with MCH DCS data points : 

- o2-calibration-mch-dcs-sim-workflow to generate fake random DCS data points
- o2-calibration-mch-dcs-processor-workflow to accumulate those data points, until some condition is satisfied (either on size or duration). Once satisfied, the accumulation is sent to output to be further consumed (typically by the ccdb populator)
- o2-mch-dcs-check-ccdb small program to quickly dump the accumulated MCH DCS data points from the CCDB 