### PR TITLE
Fixes for TOF CTF creation

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
@@ -67,13 +67,13 @@ struct CompressedInfos {
   std::vector<uint16_t> stripID;      /// increment of stripID wrt that of prev. strip
   std::vector<uint8_t> chanInStrip;   /// channel in strip 0-95 (ordered in time)
   std::vector<uint16_t> tot;          /// Time-Over-Threshold in TOF channel (about 48.8 ps)
-  std::vector<uint32_t> pattMap;      /// explict patterns container
+  std::vector<uint8_t> pattMap;       /// explict patterns container
 
   CompressedInfos() = default;
 
   void clear();
 
-  ClassDefNV(CompressedInfos, 2);
+  ClassDefNV(CompressedInfos, 3);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF

--- a/Detectors/CTF/test/test_ctf_io_tof.cxx
+++ b/Detectors/CTF/test/test_ctf_io_tof.cxx
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
 
   std::vector<Digit> digits;
   std::vector<ReadoutWindowData> rows;
-  std::vector<uint32_t> pattVec;
+  std::vector<uint8_t> pattVec;
 
   TStopwatch sw;
   sw.Start();
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
 
   std::vector<Digit> digitsD;
   std::vector<ReadoutWindowData> rowsD;
-  std::vector<uint32_t> pattVecD;
+  std::vector<uint8_t> pattVecD;
   sw.Start();
   const auto ctfImage = CTF::getImage(vec.data());
   {

--- a/Detectors/TOF/base/CMakeLists.txt
+++ b/Detectors/TOF/base/CMakeLists.txt
@@ -16,7 +16,8 @@ o2_add_library(TOFBase
                        src/Strip.cxx
                        src/WindowFiller.cxx
                PUBLIC_LINK_LIBRARIES Boost::serialization FairRoot::Base ms_gsl::ms_gsl
-                                     O2::DetectorsBase O2::CommonDataFormat O2::DetectorsRaw)
+                                     O2::DetectorsBase O2::CommonDataFormat O2::DetectorsRaw
+                                     O2::DataFormatsTOF)
 
 o2_target_root_dictionary(TOFBase
                           HEADERS include/TOFBase/Geo.h include/TOFBase/Digit.h

--- a/Detectors/TOF/base/include/TOFBase/WindowFiller.h
+++ b/Detectors/TOF/base/include/TOFBase/WindowFiller.h
@@ -75,7 +75,7 @@ class WindowFiller
     memset(mChannelCounts, 0, o2::tof::Geo::NCHANNELS * sizeof(mChannelCounts[0]));
   }
 
-  std::vector<uint32_t>& getPatterns() { return mPatterns; }
+  std::vector<uint8_t>& getPatterns() { return mPatterns; }
   void addPattern(const uint32_t val, int icrate, int orbit, int bc) { mCratePatterns.emplace_back(val, icrate, orbit * 3 + (bc + 100) / Geo::BC_IN_WINDOW); }
   void addCrateHeaderData(unsigned long orbit, int crate, int32_t bc, uint32_t eventCounter);
 
@@ -111,7 +111,7 @@ class WindowFiller
   // arrays with digit and MCLabels out of the current readout windows (stored to fill future readout window)
   std::vector<Digit> mFutureDigits;
 
-  std::vector<uint32_t> mPatterns;
+  std::vector<uint8_t> mPatterns;
   std::vector<uint64_t> mErrors;
 
   std::vector<PatternData> mCratePatterns;

--- a/Detectors/TOF/calibration/src/TOFFEElightConfig.cxx
+++ b/Detectors/TOF/calibration/src/TOFFEElightConfig.cxx
@@ -17,9 +17,5 @@ TOFFEEchannelConfig* TOFFEElightConfig::getChannelConfig(int icrate, int itrm, i
 
   // return the channel config for the given crate, trm, chain, tdc, tdcchannel
 
-  return icrate >= Geo::kNCrate ? nullptr : itrm >= Geo::kNTRM     ? nullptr
-                                          : ichain >= Geo::kNChain ? nullptr
-                                          : itdc >= Geo::kNTdc     ? nullptr
-                                          : ichtdc >= Geo::kNCh    ? nullptr
-                                                                   : &mChannelConfig[icrate][itrm][ichain][itdc][ichtdc];
+  return icrate >= Geo::kNCrate ? nullptr : itrm >= Geo::kNTRM ? nullptr : ichain >= Geo::kNChain ? nullptr : itdc >= Geo::kNTdc ? nullptr : ichtdc >= Geo::kNCh ? nullptr : &mChannelConfig[icrate][itrm][ichain][itdc][ichtdc];
 }

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -39,7 +39,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec);
+  void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec);
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VDIG, typename VPAT>
@@ -49,14 +49,14 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
  private:
   /// compres compact clusters to CompressedInfos
-  void compress(CompressedInfos& cc, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec);
+  void compress(CompressedInfos& cc, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec);
   size_t estimateCompressedSize(const CompressedInfos& cc);
   /// decompress CompressedInfos to compact clusters
   template <typename VROF, typename VDIG, typename VPAT>
   void decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
 
   void appendToTree(TTree& tree, CTF& ec);
-  void readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint32_t>& pattVec);
+  void readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint8_t>& pattVec);
 
  protected:
   ClassDefNV(CTFCoder, 1);
@@ -65,7 +65,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 ///___________________________________________________________________________________
 /// entropy-encode digits to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint32_t>& pattVec)
+void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -180,7 +180,7 @@ void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdig
 
     int firstDig = digCount;
 
-    int BCrow = prevIR.orbit * Geo::BC_IN_ORBIT + prevIR.bc;
+    int64_t BCrow = prevIR.toLong();
 
     digCopy.resize(cc.ndigROF[irof]);
     for (uint32_t idig = 0; idig < cc.ndigROF[irof]; idig++) {
@@ -192,7 +192,7 @@ void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdig
       } else {
         ctdc += cc.timeTDCInc[digCount];
       }
-      LOGF(DEBUG, "BC=%d, TDC=%d, TOT=%d, CH=%d", uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow, ctdc % 1024, cc.tot[digCount], uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
+      LOGF(DEBUG, "BC=%ld, TDC=%d, TOT=%d, CH=%d", uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow, ctdc % 1024, cc.tot[digCount], uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
 
       digit.setBC(uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow);
       digit.setTDC(ctdc % 1024);

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -27,7 +27,7 @@ void CTFCoder::appendToTree(TTree& tree, CTF& ec)
 
 ///___________________________________________________________________________________
 // extract and decode data from the tree
-void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint32_t>& pattVec)
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint8_t>& pattVec)
 {
   assert(entry >= 0 && entry < tree.GetEntries());
   CTF ec;
@@ -39,7 +39,7 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowDat
 void CTFCoder::compress(CompressedInfos& cc,
                         const gsl::span<const ReadoutWindowData>& rofRecVec,
                         const gsl::span<const Digit>& cdigVec,
-                        const gsl::span<const uint32_t>& pattVec)
+                        const gsl::span<const uint8_t>& pattVec)
 {
   // store in the header the orbit of 1st ROF
   cc.clear();
@@ -49,7 +49,7 @@ void CTFCoder::compress(CompressedInfos& cc,
   const auto& rofRec0 = rofRecVec[0];
   int nrof = rofRecVec.size();
 
-  LOGF(INFO, "TOF compress %d ReadoutWindow with %ld digits", nrof, cdigVec.size());
+  LOGF(DEBUG, "TOF compress %d ReadoutWindow with %ld digits", nrof, cdigVec.size());
 
   cc.header.nROFs = nrof;
   cc.header.firstOrbit = rofRec0.getBCData().orbit;
@@ -68,7 +68,7 @@ void CTFCoder::compress(CompressedInfos& cc,
   cc.stripID.resize(cc.header.nDigits);
   cc.chanInStrip.resize(cc.header.nDigits);
   cc.tot.resize(cc.header.nDigits);
-  cc.pattMap.resize(cc.header.nPatternBytes);
+  cc.pattMap.resize(pattVec.size());
 
   uint16_t prevBC = cc.header.firstBC;
   uint32_t prevOrbit = cc.header.firstOrbit;
@@ -79,7 +79,7 @@ void CTFCoder::compress(CompressedInfos& cc,
     const auto& rofRec = rofRecVec[irof];
 
     const auto& intRec = rofRec.getBCData();
-    int rofInBC = intRec.toLong();
+    int64_t rofInBC = intRec.toLong();
     // define interaction record
     if (intRec.orbit == prevOrbit) {
       cc.orbitIncROF[irof] = 0;
@@ -150,7 +150,6 @@ void CTFCoder::compress(CompressedInfos& cc,
       LOGF(DEBUG, "%d) TF=%d, TDC=%d, STRIP=%d, CH=%d, TOT=%d", idig, cc.timeFrameInc[idig], cc.timeTDCInc[idig], cc.stripID[idig], cc.chanInStrip[idig], cc.tot[idig]);
     }
   }
-  // store explicit patters as they are
   memcpy(cc.pattMap.data(), pattVec.data(), cc.header.nPatternBytes); // RSTODO: do we need this?
 }
 
@@ -219,6 +218,6 @@ size_t CTFCoder::estimateCompressedSize(const CompressedInfos& cc)
   sz += ESTSIZE(cc.pattMap,      CTF::BLCpattMap);
   // clang-format on
   sz *= 2. / 3; // if needed, will be autoexpanded
-  LOG(INFO) << "Estimated output size is " << sz << " bytes";
+  LOG(DEBUG) << "Estimated output size is " << sz << " bytes";
   return sz;
 }

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/CompressedDecodingTask.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/CompressedDecodingTask.h
@@ -66,6 +66,7 @@ class CompressedDecodingTask : public DecoderBase, public Task
   bool mHasToBePosted = false;
   bool mConetMode = false;
   uint32_t mInitOrbit = 0;
+  uint32_t mCurrentOrbit = 0;
   bool mRowFilter = false;
   bool mMaskNoise = false;
   int mNoiseRate = 1000;

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/DigitReaderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/DigitReaderSpec.h
@@ -44,7 +44,7 @@ class DigitReader : public Task
   std::vector<o2::tof::Digit> mDigits, *mPdigits = &mDigits;
   std::vector<o2::tof::ReadoutWindowData> mRow, *mProw = &mRow;
   std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>> mLabels, *mPlabels = &mLabels;
-  std::vector<uint32_t> mPatterns, *mPpatterns = &mPatterns;
+  std::vector<uint8_t> mPatterns, *mPpatterns = &mPatterns;
 };
 
 /// create a processor spec

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFDigitWriterSplitterSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFDigitWriterSplitterSpec.h
@@ -33,7 +33,7 @@ class TOFDigitWriterSplitter : public Task
 {
   using OutputType = std::vector<o2::tof::Digit>;
   using ReadoutWinType = std::vector<o2::tof::ReadoutWindowData>;
-  using PatternType = std::vector<uint32_t>;
+  using PatternType = std::vector<uint8_t>;
   using ErrorType = std::vector<uint64_t>;
   using HeaderType = o2::tof::DigitHeader;
 

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -43,7 +43,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
   auto compDigits = pc.inputs().get<gsl::span<Digit>>("compDigits");
-  auto pspan = pc.inputs().get<gsl::span<uint32_t>>("patterns");
+  auto pspan = pc.inputs().get<gsl::span<uint8_t>>("patterns");
   auto rofs = pc.inputs().get<gsl::span<ReadoutWindowData>>("ROframes");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe});

--- a/Detectors/TOF/workflow/src/TOFDigitWriterSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFDigitWriterSpec.cxx
@@ -26,7 +26,7 @@ template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 using OutputType = std::vector<o2::tof::Digit>;
 using ReadoutWinType = std::vector<o2::tof::ReadoutWindowData>;
-using PatternType = std::vector<uint32_t>;
+using PatternType = std::vector<uint8_t>;
 using ErrorType = std::vector<uint64_t>;
 using LabelsType = std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>;
 using HeaderType = o2::tof::DigitHeader;


### PR DESCRIPTION
Mainly to fix CTF encoding from digits.
Diagnostic patterns moved to 8bit words to deal with 26bit limits