### PR TITLE
DPL: handle splitted websocket header

### DIFF
--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -89,6 +89,23 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
 
 void decode_websocket(char* start, size_t size, WebSocketHandler& handler)
 {
+  // Handle the case in whiche the header was cut in half in the
+  // last invokation.
+  if (handler.pendingHeaderSize) {
+    assert(handler.pendingHeader);
+    size_t pendingFullSize = handler.pendingHeaderSize + size;
+    char* pendingFull = new char[handler.pendingHeaderSize + size];
+    memcpy(pendingFull, handler.pendingHeader, handler.pendingHeaderSize);
+    memcpy(pendingFull + handler.pendingHeaderSize, start, size);
+    // We do not need the intermediate buffer anymore.
+    handler.pendingHeaderSize = 0;
+    delete[] handler.pendingHeader;
+    handler.pendingHeader = nullptr;
+    decode_websocket(pendingFull, pendingFullSize, handler);
+    delete[] pendingFull;
+    return;
+  }
+
   // Handle the case the previous message was cut in half
   // by the I/O stack.
   char* cur = start + handler.remainingSize;
@@ -103,10 +120,21 @@ void decode_websocket(char* start, size_t size, WebSocketHandler& handler)
     handler.pendingBuffer = nullptr;
   }
   handler.beginChunk();
+  // The + 2 is there because we need at least 2 bytes.
   while (cur - start < size) {
     WebSocketFrameTiny* header = (WebSocketFrameTiny*)cur;
     size_t payloadSize = 0;
     size_t headerSize = 0;
+    if ((cur + 2 - start >= size) ||
+        ((cur + 2 + 2 - start >= size) && header->len >= 126) ||
+        ((cur + 2 + 8 - start >= size) && header->len == 127)) {
+      // We do not have enough bytes for a tiny header. We copy in the pending header
+      handler.pendingHeaderSize = size - (cur - start);
+      handler.pendingHeader = new char[handler.pendingHeaderSize];
+      memcpy(handler.pendingHeader, cur, handler.pendingHeaderSize);
+      break;
+    }
+
     if (header->len < 126) {
       payloadSize = header->len;
       headerSize = 2 + (header->mask ? 4 : 0);
@@ -120,8 +148,6 @@ void decode_websocket(char* start, size_t size, WebSocketHandler& handler)
       headerSize = 2 + 8 + (header->mask ? 4 : 0);
     }
     size_t availableSize = size - (cur - start);
-    /// FIXME: handle the case in which the header itself is cut
-    /// apart.
     if (availableSize < payloadSize + headerSize) {
       handler.remainingSize = payloadSize + headerSize - availableSize;
       handler.pendingSize = availableSize;

--- a/Framework/Core/src/HTTPParser.h
+++ b/Framework/Core/src/HTTPParser.h
@@ -109,6 +109,9 @@ struct WebSocketHandler {
   size_t pendingSize = 0;
   /// A buffer large enough to contain the next frame to be processed.
   char* pendingBuffer = nullptr;
+  /// Bytes from an incomplete header
+  size_t pendingHeaderSize = 0;
+  char* pendingHeader = nullptr;
 };
 
 /// Decoder for websocket data. For now we assume that the frame was not split. However multiple


### PR DESCRIPTION
TCP stack does not know about WebSocket so we need
to protect the case in which the header itself is cut.