### PR TITLE
Changed log message from WARNING to DEBUG.

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -308,7 +308,7 @@ DataProcessorSpec
       // loop over the DataRefs which are contained in pc.inputs()
       for (const auto& ref : pc.inputs()) {
         if (!ref.spec || !ref.payload) {
-          LOGP(WARNING, "The input \"{}\" is not valid and will be skipped!", ref.spec->binding);
+          LOGP(DEBUG, "The input \"{}\" is not valid and will be skipped!", ref.spec->binding);
           continue;
         }
 


### PR DESCRIPTION
It happens that messages with empty payload arrive at the aod-writer. These messages are skipped. However, so far a WARNING log was created which seems to have caused some confusion for users. The log message is hence changed from WARNING to DEBUG.
The fact that messages with empty payload are passed to the writer might however need further investigation.