### PR TITLE
[EMCAL-614] Fixing the pileup simulation

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -57,11 +57,8 @@ class Digitizer : public TObject
   void setEventTime(double t);
   double getTriggerTime() const { return mTriggerTime; }
   double getEventTime() const { return mEventTime; }
-  bool isLive(double t) const { return (t < mLiveTime); }
+  bool isLive(double t) const { return (t - mTriggerTime < mLiveTime); }
   bool isLive() const { return (mEventTime < mLiveTime); }
-
-  void setContinuous(bool v) { mContinuous = v; }
-  bool isContinuous() const { return mContinuous; }
 
   bool isEmpty() const { return mEmpty; }
 
@@ -97,7 +94,6 @@ class Digitizer : public TObject
   short mEventTimeOffset = 0;              ///< event time difference from trigger time (in number of bins)
   short mPhase = 0;                        ///< event phase
   double mCoeffToNanoSecond = 1.0;         ///< coefficient to convert event time (Fair) to ns
-  bool mContinuous = false;                ///< flag for continuous simulation
   UInt_t mROFrameMin = 0;                  ///< lowest RO frame of current digits
   UInt_t mROFrameMax = 0;                  ///< highest RO frame of current digits
   int mCurrSrcID = 0;                      ///< current MC source from the manager
@@ -109,12 +105,12 @@ class Digitizer : public TObject
   const SimParam* mSimParam = nullptr;     ///< SimParam object
   bool mEmpty = true;                      ///< Digitizer contains no digits/labels
 
-  std::vector<Digit> mTempDigitVector;                          ///< temporary digit storage
-  std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits;   ///< used to sort digits and labels by tower
+  std::vector<Digit> mTempDigitVector;                        ///< temporary digit storage
+  std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
 
-  TRandom3* mRandomGenerator = nullptr;                       // random number generator
-  std::vector<int> mTimeBinOffset;                            // offset of first time bin
-  std::vector<std::vector<double>> mAmplitudeInTimeBins;      // amplitude of signal for each time bin
+  TRandom3* mRandomGenerator = nullptr;                  // random number generator
+  std::vector<int> mTimeBinOffset;                       // offset of first time bin
+  std::vector<std::vector<double>> mAmplitudeInTimeBins; // amplitude of signal for each time bin
 
   float mLiveTime = 1500;  // EMCal live time (ns)
   float mBusyTime = 35000; // EMCal busy time (ns)

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -174,7 +174,7 @@ void Digitizer::setEventTime(double t)
   // convert to ns
   t *= mCoeffToNanoSecond;
 
-  if (t < mEventTime && mContinuous) {
+  if (t < mEventTime) {
     LOG(FATAL) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")";
   }
 

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -79,7 +79,10 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
-    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive(timesview[collID].getTimeNS()))) {
+
+    mDigitizer.setEventTime(timesview[collID].getTimeNS());
+
+    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive())) {
       // copy digits into accumulator
       mDigits.clear();
       mLabels.clear();
@@ -92,8 +95,6 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
       mDigits.clear();
       mLabels.clear();
     }
-
-    mDigitizer.setEventTime(timesview[collID].getTimeNS());
 
     if (!mDigitizer.isLive()) {
       continue;


### PR DESCRIPTION
The problem with the pileup simulation has been fixed. Now the digitizer can process several digits from different collisions in one interaction record.

![BCvsOrbit1024_1](https://user-images.githubusercontent.com/35664663/107410551-bf1c9380-6b0d-11eb-8e78-49a53da360be.jpg)
