### PR TITLE
Fix mem problems related to RootSerializableKeyValStore

### DIFF
--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -20,8 +20,8 @@
 #pragma link C++ class o2::utils::RngHelper;
 #pragma link C++ class o2::utils::MemFileHelper + ;
 #pragma link C++ class o2::utils::RootSerializableKeyValueStore::SerializedInfo + ;
-#pragma link C++ class pair < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo*> + ;
-#pragma link C++ class map < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo*> + ;
+#pragma link C++ class pair < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo> + ;
+#pragma link C++ class map < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo> + ;
 #pragma link C++ class o2::utils::RootSerializableKeyValueStore + ;
 
 #endif

--- a/Common/Utils/src/RootSerializableKeyValueStore.cxx
+++ b/Common/Utils/src/RootSerializableKeyValueStore.cxx
@@ -18,6 +18,6 @@ void RootSerializableKeyValueStore::print() const
   for (auto& p : mStore) {
     const auto& key = p.first;
     const auto info = p.second;
-    std::cout << "key: " << key << " of-type: " << info->typeinfo_name << "\n";
+    std::cout << "key: " << key << " of-type: " << info.typeinfo_name << "\n";
   }
 }


### PR DESCRIPTION
fixing a problem where the key-value store was copied around
together with MCEventHeaders (a deep copy is better).