### PR TITLE
Added macro to read event info from a Pythia8 heavy-ion simulation header

### DIFF
--- a/run/SimExamples/Custom_EventInfo/read_event_info_pythia8hi.macro
+++ b/run/SimExamples/Custom_EventInfo/read_event_info_pythia8hi.macro
@@ -1,0 +1,27 @@
+void
+read_event_info(const char *fname)
+{
+
+  auto fin = TFile::Open(fname);
+  auto tin = (TTree*)fin->Get("o2sim");
+  auto head = new o2::dataformats::MCEventHeader;
+  tin->SetBranchAddress("MCEventHeader.", &head);
+
+  bool isvalid;
+  
+  for (int iev = 0; iev < tin->GetEntries(); ++iev) {
+
+    tin->GetEntry(iev);
+
+    std::cout << " ---------------" << std::endl;
+    auto name = head->getInfo<std::string>("generator", isvalid);
+    if (isvalid) std::cout << "generator = " << name << std::endl;
+    auto Bimpact = head->getInfo<double>("Bimpact", isvalid);
+    if (isvalid) std::cout << "  Bimpact = " << Bimpact << std::endl;
+    auto Ncoll = head->getInfo<int>("Ncoll", isvalid);
+    if (isvalid) std::cout << "    Ncoll = " << Ncoll << std::endl;
+    auto Npart = head->getInfo<int>("Npart", isvalid);
+    if (isvalid) std::cout << "    Npart = " << Npart << std::endl;
+  }
+  
+}


### PR DESCRIPTION
this PR just adds one macro among the examples.
It is to read the event information from a Pythia8 heavy-ion simulation.