### PR TITLE
TPC CDBInterface: enable fetching CalPad from any path in CCDB

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CDBInterface.h
+++ b/Detectors/TPC/base/include/TPCBase/CDBInterface.h
@@ -119,6 +119,12 @@ class CDBInterface
   /// \return gain map object
   const CalPad& getGainMap();
 
+  /// Return any CalPad object
+  ///
+  /// The function returns the CalPad object stored at the given path in the CCDB
+  /// \return CalPad object
+  const CalPad& getCalPad(const std::string_view path);
+
   /// Return the Detector parameters
   ///
   /// The function checks if the object is already loaded and returns it

--- a/Detectors/TPC/base/src/CDBInterface.cxx
+++ b/Detectors/TPC/base/src/CDBInterface.cxx
@@ -116,6 +116,12 @@ const CalPad& CDBInterface::getGainMap()
 }
 
 //______________________________________________________________________________
+const CalPad& CDBInterface::getCalPad(const std::string_view path)
+{
+  return getObjectFromCDB<CalPad>(path.data());
+}
+
+//______________________________________________________________________________
 const ParameterDetector& CDBInterface::getParameterDetector()
 {
   if (mUseDefaults) {


### PR DESCRIPTION
This adds `getAnyObject` to CDBInterface to get a `CalPad` object from any path in the CCDB.