### PR TITLE
[MCH] fix bug in Segmentation::findPadPairByPosition

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationCImpl3.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationCImpl3.cxx
@@ -89,7 +89,7 @@ void mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(MchDetec
 O2MCHMAPPINGIMPL3_EXPORT
 int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return catPadIndex != segHandle->impl->InvalidCatPadIndex;
+  return segHandle->impl->isValid(catPadIndex);
 }
 
 O2MCHMAPPINGIMPL3_EXPORT

--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.cxx
@@ -160,6 +160,11 @@ std::vector<int> CathodeSegmentation::getNeighbouringCatPadIndexs(int catPadInde
   return pads;
 }
 
+bool CathodeSegmentation::isValid(int catPadIndex) const
+{
+  return catPadIndex >= 0 && catPadIndex < static_cast<int>(mCatPadIndex2PadGroupIndex.size());
+}
+
 double CathodeSegmentation::squaredDistance(int catPadIndex, double x, double y) const
 {
   double px = padPositionX(catPadIndex) - x;

--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.h
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.h
@@ -78,6 +78,8 @@ class CathodeSegmentation
 
   int padDualSampaChannel(int catPadIndex) const;
 
+  bool isValid(int catPadIndex) const;
+
  private:
   int dualSampaIndex(int dualSampaId) const;
 

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationCImpl4.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationCImpl4.cxx
@@ -107,7 +107,7 @@ O2MCHMAPPINGIMPL4_EXPORT void
 O2MCHMAPPINGIMPL4_EXPORT int mchCathodeSegmentationIsPadValid(
   MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return catPadIndex != segHandle->impl->InvalidCatPadIndex;
+  return segHandle->impl->isValid(catPadIndex);
 }
 
 O2MCHMAPPINGIMPL4_EXPORT void mchCathodeSegmentationForEachPadInDualSampa(

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
@@ -172,6 +172,11 @@ std::vector<int> CathodeSegmentation::getNeighbouringCatPadIndexs(
   return pads;
 }
 
+bool CathodeSegmentation::isValid(int catPadIndex) const
+{
+  return catPadIndex >= 0 && catPadIndex < static_cast<int>(mCatPadIndex2PadGroupIndex.size());
+}
+
 double CathodeSegmentation::squaredDistance(int catPadIndex, double x,
                                             double y) const
 {

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
@@ -88,6 +88,8 @@ class CathodeSegmentation
 
   int padDualSampaChannel(int catPadIndex) const;
 
+  bool isValid(int catPadIndex) const;
+
  private:
   int dualSampaIndex(int dualSampaId) const;
 

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
@@ -65,10 +65,7 @@ inline int Segmentation::findPadByFEE(int dualSampaId, int dualSampaChannel) con
 
 inline bool Segmentation::isValid(int dePadIndex) const
 {
-  if (dePadIndex < mPadIndexOffset) {
-    return mBending.isValid(dePadIndex);
-  }
-  return mNonBending.isValid(dePadIndex - mPadIndexOffset);
+  return dePadIndex >= 0 && dePadIndex < nofPads();
 }
 
 inline int Segmentation::padC2DE(int catPadIndex, bool isBending) const
@@ -99,7 +96,9 @@ inline bool Segmentation::findPadPairByPosition(double x, double y, int& b, int&
   b = mBending.findPadByPosition(x, y);
   nb = mNonBending.findPadByPosition(x, y);
   if (!mBending.isValid(b)) {
-    nb = padC2DE(nb, false);
+    if (mNonBending.isValid(nb)) {
+      nb = padC2DE(nb, false);
+    }
     return false;
   }
   if (!mNonBending.isValid(nb)) {

--- a/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentation.cxx
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <iostream>
 #include "TestParameters.h"
+#include <fmt/format.h>
 
 using namespace o2::mch::mapping;
 namespace bdata = boost::unit_test::data;
@@ -297,6 +298,20 @@ BOOST_AUTO_TEST_CASE(ThrowsIfDualSampaChannelIsNotBetween0And63)
 {
   BOOST_CHECK_THROW(seg.findPadByFEE(102, -1), std::out_of_range);
   BOOST_CHECK_THROW(seg.findPadByFEE(102, 64), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(ReturnsFalseIfCatPadIdIsOutOfRange)
+{
+  forOneDetectionElementOfEachSegmentationType([](int detElemId) {
+    for (auto plane : {true, false}) {
+      CathodeSegmentation seg{detElemId, plane};
+      BOOST_TEST_INFO_SCOPE(fmt::format("DeId {} Bending {}", detElemId, plane));
+      BOOST_CHECK_EQUAL(seg.isValid(0), true);
+      BOOST_CHECK_EQUAL(seg.isValid(seg.nofPads() - 1), true);
+      BOOST_CHECK_EQUAL(seg.isValid(-1), false);
+      BOOST_CHECK_EQUAL(seg.isValid(seg.nofPads()), false);
+    }
+  });
 }
 
 BOOST_AUTO_TEST_CASE(ReturnsTrueIfPadIsConnected)


### PR DESCRIPTION
In the case where this method returns false (at least one cathode plane has
no pad at this position), the pass-by-reference b and nb
indices were not (always) meaningful, preventing to deduce which
 side (bending, non bending or both) was actually missing.

Also rationalize the meaning of isValid(padindex) for both Cathode and
Segmentation levels : a padindex is valid if it's in the range
0..npads-1 where npads is the number of pads for either the cathode (for
 Cathode object) or both cathodes (for Segmentation object).