### PR TITLE
[EMCAL-650] Split payload per SRU link

### DIFF
--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -112,8 +112,9 @@ bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
 
   // Create and fill DMA pages for each channel
   std::cout << "encode data" << std::endl;
-  std::vector<char> payload;
   for (auto srucont : mSRUdata) {
+
+    std::vector<char> payload; // this must be initialized per SRU, becuase pages are per SRU, therefore the payload was not reset.
 
     for (const auto& [tower, channel] : srucont.mChannels) {
       // Find out hardware address of the channel


### PR DESCRIPTION
Previous implementation was not resetting the payload after the SRU link has been processed.
As a result the payload from previous SRUs were duplicated on pages for SRUs with a higher link ID, with the last SRU containing the payload from all SRUs.

Also a new carryOverMethod has been implemented. This new method checks whether the RCUtrailer fully fits on the current page in case it is the last page, and if not split page so the the RCUtrailer is fully on the 
next page.
