### PR TITLE
Add missing class to ROOT Dictionary

### DIFF
--- a/Detectors/MUON/MCH/Base/src/MCHBaseLinkDef.h
+++ b/Detectors/MUON/MCH/Base/src/MCHBaseLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ namespace o2::mch;
 
 #pragma link C++ class o2::mch::Digit + ;
+#pragma link C++ class o2::mch::Digit::Time + ;
 #pragma link C++ class std::vector < o2::mch::Digit > +;
 
 #endif


### PR DESCRIPTION
For me ROOT complains about a missing dictionary for `o2::mch::Digit::Time` and cannot read the MCH digits.
No idea why it works in the CI.
I am also not 100% sure if this is the correct thing to do for nested classes, and whether we would need to add a `ClassDefNV`.