### PR TITLE
[MCH] modify (pre)clustering workflows to process several ROF per TF

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/ClusterBlock.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/ClusterBlock.h
@@ -17,6 +17,7 @@
 #define ALICEO2_MCH_CLUSTERBLOCK_H_
 
 #include <iostream>
+#include <stdexcept>
 
 namespace o2
 {
@@ -51,7 +52,10 @@ struct ClusterStruct {
   /// Build the unique ID of the cluster from the chamber ID, detection element ID and cluster index
   static uint32_t buildUniqueId(int chamberId, int deId, int clusterIndex)
   {
-    return (((chamberId & 0xF) << 28) | ((deId & 0x7FF) << 17) | (clusterIndex & 0x1FFFF));
+    if ((clusterIndex & 0x1FFFF) != clusterIndex) {
+      throw std::runtime_error("invalid cluster index. Cannot build unique ID");
+    }
+    return (((chamberId & 0xF) << 28) | ((deId & 0x7FF) << 17) | clusterIndex);
   }
 };
 

--- a/Detectors/MUON/MCH/Base/include/MCHBase/PreCluster.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/PreCluster.h
@@ -29,11 +29,11 @@ namespace mch
 
 /// precluster minimal structure
 struct PreCluster {
-  uint16_t firstDigit; ///< index of first associated digit in the ordered vector of digits
-  uint16_t nDigits;    ///< number of digits attached to this precluster
+  uint32_t firstDigit; ///< index of first associated digit in the ordered vector of digits
+  uint32_t nDigits;    ///< number of digits attached to this precluster
 
   /// return the index of last associated digit in the ordered vector of digits
-  uint16_t lastDigit() const { return firstDigit + nDigits - 1; }
+  uint32_t lastDigit() const { return firstDigit + nDigits - 1; }
 
   void print(std::ostream& stream, gsl::span<const Digit> digits) const;
 };

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
@@ -178,8 +178,8 @@ void PreClusterFinder::getPreClusters(std::vector<o2::mch::PreCluster>& preClust
         }
 
         // add this precluster
-        uint16_t firstDigit = digits.size();
-        uint16_t nDigits = cluster->lastPad - cluster->firstPad + 1;
+        uint32_t firstDigit = digits.size();
+        uint32_t nDigits = cluster->lastPad - cluster->firstPad + 1;
         preClusters.push_back({firstDigit, nDigits});
 
         // add the digits of this precluster

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -14,7 +14,7 @@ o2_add_library(MCHWorkflow
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHRawDecoder Boost::program_options
                                      O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface
                                      O2::MCHPreClustering O2::MCHMappingImpl4 O2::MCHRawElecMap O2::MCHBase
-                                     O2::MCHClustering)
+                                     O2::DataFormatsMCH O2::MCHClustering)
 
 o2_add_executable(
         cru-page-reader-workflow
@@ -56,13 +56,13 @@ o2_add_executable(
         digits-reader-workflow
         SOURCES src/DigitSamplerSpec.cxx src/digits-reader-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3)
 
 o2_add_executable(
         preclusters-sink-workflow
         SOURCES src/PreClusterSinkSpec.cxx src/preclusters-sink-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3)
 
 o2_add_executable(
         preclusters-to-clusters-original-workflow
@@ -74,7 +74,7 @@ o2_add_executable(
         clusters-sink-workflow
         SOURCES src/ClusterSinkSpec.cxx src/clusters-sink-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3)
 
 o2_add_executable(
         clusters-sampler-workflow

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -7,25 +7,30 @@
 <!-- vim-markdown-toc GFM -->
 
 * [Raw to digits](#raw-to-digits)
-* [Digits to preclusters](#digits-to-preclusters)
+* [Preclustering](#preclustering)
+* [Clustering](#clustering)
 * [Tracking](#tracking)
   * [Original track finder](#original-track-finder)
   * [New track finder](#new-track-finder)
 * [Track extrapolation to vertex](#track-extrapolation-to-vertex)
 * [Track fitter](#track-fitter)
 * [Samplers](#samplers)
+  * [Digit sampler](#digit-sampler)
   * [Cluster sampler](#cluster-sampler)
   * [Track sampler](#track-sampler)
   * [Vertex sampler](#vertex-sampler)
 * [Sinks](#sinks)
-  * [Preclusters sink](#preclusters-sink)
+  * [Precluster sink](#precluster-sink)
+  * [Cluster sink](#cluster-sink)
   * [Track sink](#track-sink)
 
 <!-- vim-markdown-toc -->
 
 ## Raw to digits
 
-`o2-mch-raw-to-digits-workflow`
+```shell
+o2-mch-raw-to-digits-workflow
+```
 
 The workflow accepts the following options:
 
@@ -34,10 +39,6 @@ The workflow accepts the following options:
 * `--cru-map`: path to custom CRU mapping file
 * `--fec-map`: path to custom FEC mapping file
 * `--ds2manu`: convert channel numbering from Run3 to Run1-2 order
-
-## Digits to preclusters
-
-`o2-mch-digits-to-preclusters-workflow`
 
 Example of a DPL chain to go from a raw data file to a file of preclusters :
 
@@ -57,13 +58,33 @@ dataDescription = RAWDATA
 filePath = /home/data/data-de819-ped-raw.raw
 ```
 
+## Preclustering
+
+```shell
+o2-mch-digits-to-preclusters-workflow
+```
+
+Take as input the list of all digits ([Digit](../Base/include/MCHBase/Digit.h)) in the current time frame, with the data description "DIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the data description "DIGITROFS". Send the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction in three separate messages with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively.
+
+Option `--check-no-leftover-digits xxx` allows to drop an error message (`xxx = "error"` (default)) or an exception (`xxx = "fatal"`) in case not all the input digits end up in a precluster, or to disable this check (`xxx = "off"`).
+
+## Clustering
+
+```shell
+o2-mch-preclusters-to-clusters-original-workflow
+```
+
+Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
+
 ## Tracking
 
 ### Original track finder
 
-`o2-mch-clusters-to-tracks-original-workflow`
+```shell
+o2-mch-clusters-to-tracks-original-workflow
+```
 
-Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
@@ -73,15 +94,19 @@ Option `--debug x` allows to enable the debug level x (0 = no debug, 1 or 2).
 
 ### New track finder
 
-`o2-mch-clusters-to-tracks-workflow`
+```shell
+o2-mch-clusters-to-tracks-workflow
+```
 
 Same behavior and options as [Original track finder](#original-track-finder)
 
 ## Track extrapolation to vertex
 
-`o2-mch-tracks-to-tracks-at-vertex-workflow`
+```shell
+o2-mch-tracks-to-tracks-at-vertex-workflow
+```
 
-Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of ROF records pointing to the tracks associated to each interaction and their vertex position (`Point3D<double>`), with the data description "TRACKS", "TRACKROFS" and "VERTICES", respectively. Send the list of all tracks at vertex (`TrackAtVtxStruct` as described below) in the time frame with the data description "TRACKSATVERTEX".
+Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction and their vertex position (`Point3D<double>`), with the data description "TRACKS", "TRACKROFS" and "VERTICES", respectively. Send the list of all tracks at vertex (`TrackAtVtxStruct` as described below) in the time frame with the data description "TRACKSATVERTEX".
 
 ```c++
 struct TrackAtVtxStruct {
@@ -96,13 +121,38 @@ Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current
 
 ## Track fitter
 
-`o2-mch-tracks-to-tracks-workflow`
+```shell
+o2-mch-tracks-to-tracks-workflow
+```
 
-Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction, with the data description "TRACKSIN", "TRACKCLUSTERSIN" and "TRACKROFSIN", respectively. Send the list of all refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction, with the data description "TRACKSIN", "TRACKCLUSTERSIN" and "TRACKROFSIN", respectively. Send the list of all refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
 ## Samplers
+
+### Digit sampler
+
+```shell
+o2-mch-digits-reader-workflow --infile "digits.in"
+```
+
+where `digits.in` is a binary file containing for each event:
+
+* number of digits (int)
+* list of digits ([Digit](../Base/include/MCHBase/Digit.h))
+
+Send the list of all digits ([Digit](../Base/include/MCHBase/Digit.h)) in the current time frame, with the data description "DIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the data description "DIGITROFS".
+
+Option `--useRun2DigitUID` allows to specify that the input digits data member mPadID contains the digit UID in run2 format and need to be converted in the corresponding run3 pad ID.
+
+Option `--print` allows to print the digitUID - padID conversion in the terminal.
+
+Option `--nEvents xxx` allows to limit the number of events to process (all by default).
+
+Option `--event xxx` allows to process only this event.
+
+Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
 
 ### Cluster sampler
 
@@ -117,27 +167,31 @@ where `clusters.in` is a binary file containing for each event:
 * list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
 * list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))
 
-Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
 
-Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1)
+Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
 
 ### Track sampler
 
-`o2-mch-tracks-sampler-workflow --infile "tracks.in"`
+```shell
+o2-mch-tracks-sampler-workflow --infile "tracks.in"
+```
 
 where `tracks.in` is a binary file with the same format as the one written by the workflow [o2-mch-tracks-sink-workflow](#track-sink)
 
-Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN", "TRACKCLUSTERSIN" and TRACKROFSIN, respectively, as expected by the workflow [o2-mch-tracks-to-tracks-workflow](#track-fitter).
 
-Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1)
+Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
 
 ### Vertex sampler
 
-`o2-mch-vertex-sampler-workflow`
+```shell
+o2-mch-vertex-sampler-workflow
+```
 
-Take as input the list of ROF records in the current time frame, with the data description "TRACKROFS". Send the list of all vertex positions (`Point3D<double>`) in the time frame, one per interaction, with the data description "VERTICES".
+Take as input the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) in the current time frame, with the data description "TRACKROFS". Send the list of all vertex positions (`Point3D<double>`) in the time frame, one per interaction, with the data description "VERTICES".
 
 Option `--infile "vertices.in"` allows to read the position of the vertex from the binary file `vertices.in` containing for each event:
 
@@ -150,15 +204,47 @@ If no binary file is provided, the vertex is always set to (0,0,0).
 
 ## Sinks
 
-### Preclusters sink
+### Precluster sink
 
-`o2-mch-preclusters-sink-workflow`
+```shell
+o2-mch-preclusters-sink-workflow --outfile "preclusters.out"
+```
+
+Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively, and write them event-by-event in the binary file `preclusters.out` with the following format for each event:
+
+* number of preclusters (int)
+* number of associated digits (int)
+* list of preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h))
+* list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))
+
+Option `--txt` allows to write the preclusters in the output file in text format.
+
+Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit data member mPadID into a digit UID in run2 format.
+
+### Cluster sink
+
+```shell
+o2-mch-clusters-sink-workflow --outfile "clusters.out"
+```
+
+Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
+
+* number of clusters (int)
+* number of associated digits (int)
+* list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
+* list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))
+
+Option `--txt` allows to write the clusters in the output file in text format.
+
+Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit data member mPadID into a digit UID in run2 format.
 
 ### Track sink
 
-`o2-mch-tracks-sink-workflow --outfile "tracks.out"`
+```shell
+o2-mch-tracks-sink-workflow --outfile "tracks.out"
+```
 
-Take as input the list of all tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)) in the current time frame, the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records pointing to the MCH tracks associated to each interaction, with the data description "TRACKSATVERTEX", "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively, and write them event-by-event in the binary file `tracks.out` with the following format for each event:
+Take as input the list of all tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)) in the current time frame, the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), the list of all associated clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the MCH tracks associated to each interaction, with the data description "TRACKSATVERTEX", "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively, and write them event-by-event in the binary file `tracks.out` with the following format for each event:
 
 * number of tracks at vertex (int)
 * number of MCH tracks (int)

--- a/Detectors/MUON/MCH/Workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-reader-workflow.cxx
@@ -14,21 +14,13 @@
 /// \author Philippe Pillot, Subatech
 /// \author Andrea Ferrero, CEA
 
-#include "Framework/CallbackService.h"
-#include "Framework/ControlService.h"
-#include "Framework/Task.h"
 #include "Framework/runDataProcessing.h"
+
 #include "DigitSamplerSpec.h"
 
-using namespace o2;
 using namespace o2::framework;
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
-  WorkflowSpec specs;
-
-  DataProcessorSpec producer = o2::mch::getDigitSamplerSpec();
-  specs.push_back(producer);
-
-  return specs;
+  return WorkflowSpec{o2::mch::getDigitSamplerSpec()};
 }

--- a/Detectors/MUON/MCH/Workflow/src/preclusters-sink-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/preclusters-sink-workflow.cxx
@@ -21,21 +21,13 @@
 /// \endcode
 ///
 
-#include "Framework/CallbackService.h"
-#include "Framework/ControlService.h"
-#include "Framework/Task.h"
 #include "Framework/runDataProcessing.h"
+
 #include "PreClusterSinkSpec.h"
 
-using namespace o2;
 using namespace o2::framework;
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
-  WorkflowSpec specs;
-
-  DataProcessorSpec producer = o2::mch::getPreClusterSinkSpec();
-  specs.push_back(producer);
-
-  return specs;
+  return WorkflowSpec{o2::mch::getPreClusterSinkSpec()};
 }


### PR DESCRIPTION
These modifications allow to send and process several events per time frame. Each individual interaction in the time frame is identified by an MCH ROF record, which contains the interaction record and the location of the associated objects (e.g. clusters) in the overall list.

@aphecetche @aferrero2707 I created a new PR because I messed-up the draft while trying to solve a conflict.

As we discussed, the modification of the preclustering workflow will temporarily break the linkup with the raw-to-digit workflow. My understanding is that we can go ahead with this PR and the linkup will fixed later on with the introduction of the temporal preclustering.