### PR TITLE
PID: Merge split tasks into one configurable

### DIFF
--- a/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTPC.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTPC.h
@@ -39,24 +39,24 @@ class ELoss
   ~ELoss() = default;
 
   /// Gets the expected signal of the measurement
-  float GetExpectedSignal(DetectorResponse& response, const Coll& col, const Trck& trk) const;
+  float GetExpectedSignal(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
 
   /// Gets the expected resolution of the measurement
-  float GetExpectedSigma(DetectorResponse& response, const Coll& col, const Trck& trk) const;
+  float GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
 
   /// Gets the number of sigmas with respect the expected value
-  float GetSeparation(DetectorResponse& response, const Coll& col, const Trck& trk) const { return (trk.tpcSignal() - GetExpectedSignal(response, col, trk)) / GetExpectedSigma(response, col, trk); }
+  float GetSeparation(const DetectorResponse& response, const Coll& col, const Trck& trk) const { return (trk.tpcSignal() - GetExpectedSignal(response, col, trk)) / GetExpectedSigma(response, col, trk); }
 };
 
 template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ELoss<Coll, Trck, id>::GetExpectedSignal(DetectorResponse& response, const Coll& col, const Trck& trk) const
+float ELoss<Coll, Trck, id>::GetExpectedSignal(const DetectorResponse& response, const Coll& col, const Trck& trk) const
 {
   const float x[2] = {trk.tpcInnerParam() / o2::track::PID::getMass(id), (float)o2::track::PID::getCharge(id)};
   return response(DetectorResponse::kSignal, x);
 }
 
 template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ELoss<Coll, Trck, id>::GetExpectedSigma(DetectorResponse& response, const Coll& col, const Trck& trk) const
+float ELoss<Coll, Trck, id>::GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const
 {
   const float x[2] = {trk.tpcSignal(), (float)trk.tpcNClsFound()};
   return response(DetectorResponse::kSigma, x);

--- a/Analysis/Tasks/pidTOF_split.cxx
+++ b/Analysis/Tasks/pidTOF_split.cxx
@@ -8,11 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+///
+/// \file   pidTOF_split.cxx
+/// \author Nicolo' Jacazio
+/// \brief  Task to produce PID tables for TOF split for each particle.
+///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
+///
+
 // O2 includes
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/Track.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "AnalysisDataModel/PID/PIDResponse.h"
@@ -24,29 +32,36 @@ using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
 
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  std::vector<ConfigParamSpec> options{
-    {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
-    {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
-    {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
-    {"pid-nuclei", VariantType::Int, 1, {"Produce PID information for the Deuteron, Triton, Alpha mass hypothesis"}}};
-  std::swap(workflowOptions, options);
-}
-
-#include "Framework/runDataProcessing.h"
-
-template <o2::track::PID::ID pid_type, typename table>
-struct pidTOFTaskPerParticle {
+struct pidTOFTaskSplit {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
-  Produces<table> tofpid;
-  DetectorResponse resp;
+  // Tables to produce
+  Produces<o2::aod::pidRespTOFEl> tablePIDEl;
+  Produces<o2::aod::pidRespTOFMu> tablePIDMu;
+  Produces<o2::aod::pidRespTOFPi> tablePIDPi;
+  Produces<o2::aod::pidRespTOFKa> tablePIDKa;
+  Produces<o2::aod::pidRespTOFPr> tablePIDPr;
+  Produces<o2::aod::pidRespTOFDe> tablePIDDe;
+  Produces<o2::aod::pidRespTOFTr> tablePIDTr;
+  Produces<o2::aod::pidRespTOFHe> tablePIDHe;
+  Produces<o2::aod::pidRespTOFAl> tablePIDAl;
+  // Detector response and input parameters
+  DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
   Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
+  // Configuration flags to include and exclude particle hypotheses
+  Configurable<int> pidEl{"pid-el", 0, {"Produce PID information for the Electron mass hypothesis"}};
+  Configurable<int> pidMu{"pid-mu", 0, {"Produce PID information for the Muon mass hypothesis"}};
+  Configurable<int> pidPi{"pid-pi", 0, {"Produce PID information for the Pion mass hypothesis"}};
+  Configurable<int> pidKa{"pid-ka", 0, {"Produce PID information for the Kaon mass hypothesis"}};
+  Configurable<int> pidPr{"pid-pr", 0, {"Produce PID information for the Proton mass hypothesis"}};
+  Configurable<int> pidDe{"pid-de", 0, {"Produce PID information for the Deuterons mass hypothesis"}};
+  Configurable<int> pidTr{"pid-tr", 0, {"Produce PID information for the Triton mass hypothesis"}};
+  Configurable<int> pidHe{"pid-he", 0, {"Produce PID information for the Helium3 mass hypothesis"}};
+  Configurable<int> pidAl{"pid-al", 0, {"Produce PID information for the Alpha mass hypothesis"}};
 
   void init(o2::framework::InitContext&)
   {
@@ -58,47 +73,54 @@ struct pidTOFTaskPerParticle {
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
     //
     const std::vector<float> p = {0.008, 0.008, 0.002, 40.0};
-    resp.SetParameters(DetectorResponse::kSigma, p);
+    response.SetParameters(DetectorResponse::kSigma, p);
     const std::string fname = paramfile.value;
     if (!fname.empty()) { // Loading the parametrization from file
-      resp.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
+      response.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
     } else { // Loading it from CCDB
       const std::string path = "Analysis/PID/TOF";
-      resp.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
+      response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
     }
   }
 
+  template <o2::track::PID::ID pid>
+  using ResponseImplementation = tof::ExpTimes<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
-    constexpr tof::ExpTimes<Coll::iterator, Trks::iterator, pid_type> resp_PID = tof::ExpTimes<Coll::iterator, Trks::iterator, pid_type>();
+    constexpr auto responseEl = ResponseImplementation<PID::Electron>();
+    constexpr auto responseMu = ResponseImplementation<PID::Muon>();
+    constexpr auto responsePi = ResponseImplementation<PID::Pion>();
+    constexpr auto responseKa = ResponseImplementation<PID::Kaon>();
+    constexpr auto responsePr = ResponseImplementation<PID::Proton>();
+    constexpr auto responseDe = ResponseImplementation<PID::Deuteron>();
+    constexpr auto responseTr = ResponseImplementation<PID::Triton>();
+    constexpr auto responseHe = ResponseImplementation<PID::Helium3>();
+    constexpr auto responseAl = ResponseImplementation<PID::Alpha>();
 
-    tofpid.reserve(tracks.size());
-    for (auto const& trk : tracks) {
-      tofpid(resp_PID.GetExpectedSigma(resp, trk.collision(), trk),
-             resp_PID.GetSeparation(resp, trk.collision(), trk));
-    }
+    // Check and fill enabled tables
+    auto makeTable = [&tracks](const Configurable<int>& flag, auto& table, const DetectorResponse& response, const auto& responsePID) {
+      if (flag.value) {
+        // Prepare memory for enabled tables
+        table.reserve(tracks.size());
+        for (auto const& trk : tracks) { // Loop on Tracks
+          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
+                responsePID.GetSeparation(response, trk.collision(), trk));
+        }
+      }
+    };
+    makeTable(pidEl, tablePIDEl, response, responseEl);
+    makeTable(pidMu, tablePIDMu, response, responseMu);
+    makeTable(pidPi, tablePIDPi, response, responsePi);
+    makeTable(pidKa, tablePIDKa, response, responseKa);
+    makeTable(pidPr, tablePIDPr, response, responsePr);
+    makeTable(pidDe, tablePIDDe, response, responseDe);
+    makeTable(pidTr, tablePIDTr, response, responseTr);
+    makeTable(pidHe, tablePIDHe, response, responseHe);
+    makeTable(pidAl, tablePIDAl, response, responseAl);
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow;
-  if (cfgc.options().get<int>("pid-el")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Electron, o2::aod::pidRespTOFEl>>("pidTOFEl-task"));
-  }
-  if (cfgc.options().get<int>("pid-mu")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Muon, o2::aod::pidRespTOFMu>>("pidTOFMu-task"));
-  }
-  if (cfgc.options().get<int>("pid-pikapr")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Pion, o2::aod::pidRespTOFPi>>("pidTOFPi-task"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Kaon, o2::aod::pidRespTOFKa>>("pidTOFKa-task"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Proton, o2::aod::pidRespTOFPr>>("pidTOFPr-task"));
-  }
-  if (cfgc.options().get<int>("pid-nuclei")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Deuteron, o2::aod::pidRespTOFDe>>("pidTOFDe-task"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Triton, o2::aod::pidRespTOFTr>>("pidTOFTr-task"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Helium3, o2::aod::pidRespTOFHe>>("pidTOFHe-task"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskPerParticle<PID::Alpha, o2::aod::pidRespTOFAl>>("pidTOFAl-task"));
-  }
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskSplit>("pidTOF-split-task")};
 }

--- a/Analysis/Tasks/pidTOF_tiny.cxx
+++ b/Analysis/Tasks/pidTOF_tiny.cxx
@@ -8,11 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+///
+/// \file   pidTOF_tiny.cxx
+/// \author Nicolo' Jacazio
+/// \brief  Task to produce PID tables for TOF split for each particle with only the Nsigma information.
+///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
+///
+
 // O2 includes
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/Track.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "AnalysisDataModel/PID/PIDResponse.h"
@@ -24,29 +32,36 @@ using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
 
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  std::vector<ConfigParamSpec> options{
-    {"pid-el", VariantType::Int, 1, {"Produce PID information for the electron mass hypothesis"}},
-    {"pid-mu", VariantType::Int, 1, {"Produce PID information for the muon mass hypothesis"}},
-    {"pid-pikapr", VariantType::Int, 1, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
-    {"pid-nuclei", VariantType::Int, 1, {"Produce PID information for the Deuteron, Triton, Alpha mass hypothesis"}}};
-  std::swap(workflowOptions, options);
-}
-
-#include "Framework/runDataProcessing.h"
-
-template <o2::track::PID::ID pid_type, typename table>
 struct pidTOFTaskTiny {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
-  Produces<table> tofpid;
-  DetectorResponse resp;
+  // Tables to produce
+  Produces<o2::aod::pidRespTPCTEl> tablePIDEl;
+  Produces<o2::aod::pidRespTPCTMu> tablePIDMu;
+  Produces<o2::aod::pidRespTPCTPi> tablePIDPi;
+  Produces<o2::aod::pidRespTPCTKa> tablePIDKa;
+  Produces<o2::aod::pidRespTPCTPr> tablePIDPr;
+  Produces<o2::aod::pidRespTPCTDe> tablePIDDe;
+  Produces<o2::aod::pidRespTPCTTr> tablePIDTr;
+  Produces<o2::aod::pidRespTPCTHe> tablePIDHe;
+  Produces<o2::aod::pidRespTPCTAl> tablePIDAl;
+  // Detector response and input parameters
+  DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
   Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
+  // Configuration flags to include and exclude particle hypotheses
+  Configurable<int> pidEl{"pid-el", 0, {"Produce PID information for the Electron mass hypothesis"}};
+  Configurable<int> pidMu{"pid-mu", 0, {"Produce PID information for the Muon mass hypothesis"}};
+  Configurable<int> pidPi{"pid-pi", 0, {"Produce PID information for the Pion mass hypothesis"}};
+  Configurable<int> pidKa{"pid-ka", 0, {"Produce PID information for the Kaon mass hypothesis"}};
+  Configurable<int> pidPr{"pid-pr", 0, {"Produce PID information for the Proton mass hypothesis"}};
+  Configurable<int> pidDe{"pid-de", 0, {"Produce PID information for the Deuterons mass hypothesis"}};
+  Configurable<int> pidTr{"pid-tr", 0, {"Produce PID information for the Triton mass hypothesis"}};
+  Configurable<int> pidHe{"pid-he", 0, {"Produce PID information for the Helium3 mass hypothesis"}};
+  Configurable<int> pidAl{"pid-al", 0, {"Produce PID information for the Alpha mass hypothesis"}};
 
   void init(o2::framework::InitContext&)
   {
@@ -58,56 +73,62 @@ struct pidTOFTaskTiny {
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
     //
     const std::vector<float> p = {0.008, 0.008, 0.002, 40.0};
-    resp.SetParameters(DetectorResponse::kSigma, p);
+    response.SetParameters(DetectorResponse::kSigma, p);
     const std::string fname = paramfile.value;
     if (!fname.empty()) { // Loading the parametrization from file
-      resp.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
+      response.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
     } else { // Loading it from CCDB
       const std::string path = "Analysis/PID/TOF";
-      resp.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
+      response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
     }
   }
 
+  template <o2::track::PID::ID pid>
+  using ResponseImplementation = tof::ExpTimes<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
-    constexpr tof::ExpTimes<Coll::iterator, Trks::iterator, pid_type> resp_PID = tof::ExpTimes<Coll::iterator, Trks::iterator, pid_type>();
+    constexpr auto responseEl = ResponseImplementation<PID::Electron>();
+    constexpr auto responseMu = ResponseImplementation<PID::Muon>();
+    constexpr auto responsePi = ResponseImplementation<PID::Pion>();
+    constexpr auto responseKa = ResponseImplementation<PID::Kaon>();
+    constexpr auto responsePr = ResponseImplementation<PID::Proton>();
+    constexpr auto responseDe = ResponseImplementation<PID::Deuteron>();
+    constexpr auto responseTr = ResponseImplementation<PID::Triton>();
+    constexpr auto responseHe = ResponseImplementation<PID::Helium3>();
+    constexpr auto responseAl = ResponseImplementation<PID::Alpha>();
 
-    tofpid.reserve(tracks.size());
-    for (auto const& trk : tracks) {
-      const float exp_sigma = resp_PID.GetExpectedSigma(resp, trk.collision(), trk);
-      const float separation = resp_PID.GetSeparation(resp, trk.collision(), trk);
-      if (separation <= o2::aod::pidtof_tiny::binned_min) {
-        tofpid(o2::aod::pidtof_tiny::lower_bin);
-      } else if (separation >= o2::aod::pidtof_tiny::binned_max) {
-        tofpid(o2::aod::pidtof_tiny::upper_bin);
-      } else if (separation >= 0) {
-        tofpid(separation / o2::aod::pidtof_tiny::bin_width + 0.5f);
-      } else {
-        tofpid(separation / o2::aod::pidtof_tiny::bin_width - 0.5f);
+    // Check and fill enabled tables
+    auto makeTable = [&tracks](const Configurable<int>& flag, auto& table, const DetectorResponse& response, const auto& responsePID) {
+      if (flag.value) {
+        // Prepare memory for enabled tables
+        table.reserve(tracks.size());
+        for (auto const& trk : tracks) { // Loop on Tracks
+          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          if (separation <= o2::aod::pidtof_tiny::binned_min) {
+            table(o2::aod::pidtof_tiny::lower_bin);
+          } else if (separation >= o2::aod::pidtof_tiny::binned_max) {
+            table(o2::aod::pidtof_tiny::upper_bin);
+          } else if (separation >= 0) {
+            table(separation / o2::aod::pidtof_tiny::bin_width + 0.5f);
+          } else {
+            table(separation / o2::aod::pidtof_tiny::bin_width - 0.5f);
+          }
+        }
       }
-    }
+    };
+    makeTable(pidEl, tablePIDEl, response, responseEl);
+    makeTable(pidMu, tablePIDMu, response, responseMu);
+    makeTable(pidPi, tablePIDPi, response, responsePi);
+    makeTable(pidKa, tablePIDKa, response, responseKa);
+    makeTable(pidPr, tablePIDPr, response, responsePr);
+    makeTable(pidDe, tablePIDDe, response, responseDe);
+    makeTable(pidTr, tablePIDTr, response, responseTr);
+    makeTable(pidHe, tablePIDHe, response, responseHe);
+    makeTable(pidAl, tablePIDAl, response, responseAl);
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow;
-  if (cfgc.options().get<int>("pid-el")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Electron, o2::aod::pidRespTOFTEl>>("pidTOFEl-task-tiny"));
-  }
-  if (cfgc.options().get<int>("pid-mu")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Muon, o2::aod::pidRespTOFTMu>>("pidTOFMu-task-tiny"));
-  }
-  if (cfgc.options().get<int>("pid-pikapr")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Pion, o2::aod::pidRespTOFTPi>>("pidTOFPi-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Kaon, o2::aod::pidRespTOFTKa>>("pidTOFKa-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Proton, o2::aod::pidRespTOFTPr>>("pidTOFPr-task-tiny"));
-  }
-  if (cfgc.options().get<int>("pid-nuclei")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Deuteron, o2::aod::pidRespTOFTDe>>("pidTOFDe-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Triton, o2::aod::pidRespTOFTTr>>("pidTOFTr-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Helium3, o2::aod::pidRespTOFTHe>>("pidTOFHe-task-tiny"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskTiny<PID::Alpha, o2::aod::pidRespTOFTAl>>("pidTOFAl-task-tiny"));
-  }
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskTiny>("pidTOF-tiny-task")};
 }

--- a/Analysis/Tasks/pidTPC_tiny.cxx
+++ b/Analysis/Tasks/pidTPC_tiny.cxx
@@ -8,11 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+///
+/// \file   pidTPC_split.cxx
+/// \author Nicolo' Jacazio
+/// \brief  Task to produce PID tables for TPC split for each particle with only the Nsigma information.
+///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
+///
+
 // O2 includes
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/Track.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "AnalysisDataModel/PID/PIDResponse.h"
@@ -24,31 +32,37 @@ using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
 
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  std::vector<ConfigParamSpec> options{
-    {"pid-all", VariantType::Int, 1, {"Produce PID information for all mass hypotheses"}},
-    {"pid-el", VariantType::Int, 0, {"Produce PID information for the electron mass hypothesis"}},
-    {"pid-mu", VariantType::Int, 0, {"Produce PID information for the muon mass hypothesis"}},
-    {"pid-pikapr", VariantType::Int, 0, {"Produce PID information for the Pion, Kaon, Proton mass hypothesis"}},
-    {"pid-nuclei", VariantType::Int, 0, {"Produce PID information for the Deuteron, Triton, Alpha mass hypothesis"}}};
-  std::swap(workflowOptions, options);
-}
-
-#include "Framework/runDataProcessing.h"
-
-template <o2::track::PID::ID pid_type, typename table>
 struct pidTPCTaskTiny {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
-  Produces<table> tpcpid;
-  DetectorResponse resp;
+  // Tables to produce
+  Produces<o2::aod::pidRespTPCTEl> tablePIDEl;
+  Produces<o2::aod::pidRespTPCTMu> tablePIDMu;
+  Produces<o2::aod::pidRespTPCTPi> tablePIDPi;
+  Produces<o2::aod::pidRespTPCTKa> tablePIDKa;
+  Produces<o2::aod::pidRespTPCTPr> tablePIDPr;
+  Produces<o2::aod::pidRespTPCTDe> tablePIDDe;
+  Produces<o2::aod::pidRespTPCTTr> tablePIDTr;
+  Produces<o2::aod::pidRespTPCTHe> tablePIDHe;
+  Produces<o2::aod::pidRespTPCTAl> tablePIDAl;
+  // Detector response and input parameters
+  DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> signalname{"param-signal", "BetheBloch", "Name of the parametrization for the expected signal, used in both file and CCDB mode"};
   Configurable<std::string> sigmaname{"param-sigma", "TPCReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
   Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
+  // Configuration flags to include and exclude particle hypotheses
+  Configurable<int> pidEl{"pid-el", 0, {"Produce PID information for the Electron mass hypothesis"}};
+  Configurable<int> pidMu{"pid-mu", 0, {"Produce PID information for the Muon mass hypothesis"}};
+  Configurable<int> pidPi{"pid-pi", 0, {"Produce PID information for the Pion mass hypothesis"}};
+  Configurable<int> pidKa{"pid-ka", 0, {"Produce PID information for the Kaon mass hypothesis"}};
+  Configurable<int> pidPr{"pid-pr", 0, {"Produce PID information for the Proton mass hypothesis"}};
+  Configurable<int> pidDe{"pid-de", 0, {"Produce PID information for the Deuterons mass hypothesis"}};
+  Configurable<int> pidTr{"pid-tr", 0, {"Produce PID information for the Triton mass hypothesis"}};
+  Configurable<int> pidHe{"pid-he", 0, {"Produce PID information for the Helium3 mass hypothesis"}};
+  Configurable<int> pidAl{"pid-al", 0, {"Produce PID information for the Alpha mass hypothesis"}};
 
   void init(o2::framework::InitContext&)
   {
@@ -61,153 +75,61 @@ struct pidTPCTaskTiny {
     //
     const std::string fname = paramfile.value;
     if (!fname.empty()) { // Loading the parametrization from file
-      resp.LoadParamFromFile(fname.data(), signalname.value, DetectorResponse::kSignal);
-      resp.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
+      response.LoadParamFromFile(fname.data(), signalname.value, DetectorResponse::kSignal);
+      response.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
     } else { // Loading it from CCDB
       const std::string path = "Analysis/PID/TPC";
-      resp.LoadParam(DetectorResponse::kSignal, ccdb->getForTimeStamp<Parametrization>(path + "/" + signalname.value, timestamp.value));
-      resp.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
+      response.LoadParam(DetectorResponse::kSignal, ccdb->getForTimeStamp<Parametrization>(path + "/" + signalname.value, timestamp.value));
+      response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
     }
   }
 
+  template <o2::track::PID::ID pid>
+  using ResponseImplementation = tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, pid_type> resp_PID = tpc::ELoss<Coll::iterator, Trks::iterator, pid_type>();
+    constexpr auto responseEl = ResponseImplementation<PID::Electron>();
+    constexpr auto responseMu = ResponseImplementation<PID::Muon>();
+    constexpr auto responsePi = ResponseImplementation<PID::Pion>();
+    constexpr auto responseKa = ResponseImplementation<PID::Kaon>();
+    constexpr auto responsePr = ResponseImplementation<PID::Proton>();
+    constexpr auto responseDe = ResponseImplementation<PID::Deuteron>();
+    constexpr auto responseTr = ResponseImplementation<PID::Triton>();
+    constexpr auto responseHe = ResponseImplementation<PID::Helium3>();
+    constexpr auto responseAl = ResponseImplementation<PID::Alpha>();
 
-    tpcpid.reserve(tracks.size());
-    for (auto const& trk : tracks) {
-      const float exp_sigma = resp_PID.GetExpectedSigma(resp, trk.collision(), trk);
-      const float separation = resp_PID.GetSeparation(resp, trk.collision(), trk);
-      if (separation <= o2::aod::pidtpc_tiny::binned_min) {
-        tpcpid(o2::aod::pidtpc_tiny::lower_bin);
-      } else if (separation >= o2::aod::pidtpc_tiny::binned_max) {
-        tpcpid(o2::aod::pidtpc_tiny::upper_bin);
-      } else if (separation >= 0) {
-        tpcpid(separation / o2::aod::pidtpc_tiny::bin_width + 0.5f);
-      } else {
-        tpcpid(separation / o2::aod::pidtpc_tiny::bin_width - 0.5f);
+    // Check and fill enabled tables
+    auto makeTable = [&tracks](const Configurable<int>& flag, auto& table, const DetectorResponse& response, const auto& responsePID) {
+      if (flag.value) {
+        // Prepare memory for enabled tables
+        table.reserve(tracks.size());
+        for (auto const& trk : tracks) { // Loop on Tracks
+          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          if (separation <= o2::aod::pidtpc_tiny::binned_min) {
+            table(o2::aod::pidtpc_tiny::lower_bin);
+          } else if (separation >= o2::aod::pidtpc_tiny::binned_max) {
+            table(o2::aod::pidtpc_tiny::upper_bin);
+          } else if (separation >= 0) {
+            table(separation / o2::aod::pidtpc_tiny::bin_width + 0.5f);
+          } else {
+            table(separation / o2::aod::pidtpc_tiny::bin_width - 0.5f);
+          }
+        }
       }
-    }
-  }
-};
-
-struct pidTPCTaskTinyFull {
-  using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
-  using Coll = aod::Collisions;
-
-  Produces<o2::aod::pidRespTPCTEl> tpcpidEl;
-  Produces<o2::aod::pidRespTPCTMu> tpcpidMu;
-  Produces<o2::aod::pidRespTPCTPi> tpcpidPi;
-  Produces<o2::aod::pidRespTPCTKa> tpcpidKa;
-  Produces<o2::aod::pidRespTPCTPr> tpcpidPr;
-  Produces<o2::aod::pidRespTPCTDe> tpcpidDe;
-  Produces<o2::aod::pidRespTPCTTr> tpcpidTr;
-  Produces<o2::aod::pidRespTPCTHe> tpcpidHe;
-  Produces<o2::aod::pidRespTPCTAl> tpcpidAl;
-
-  DetectorResponse resp;
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
-  Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
-  Configurable<std::string> signalname{"param-signal", "BetheBloch", "Name of the parametrization for the expected signal, used in both file and CCDB mode"};
-  Configurable<std::string> sigmaname{"param-sigma", "TPCReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
-  Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
-
-  void init(o2::framework::InitContext&)
-  {
-    ccdb->setURL(url.value);
-    ccdb->setTimestamp(timestamp.value);
-    ccdb->setCaching(true);
-    ccdb->setLocalObjectValidityChecking();
-    // Not later than now objects
-    ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-    //
-    const std::string fname = paramfile.value;
-    if (!fname.empty()) { // Loading the parametrization from file
-      resp.LoadParamFromFile(fname.data(), signalname.value, DetectorResponse::kSignal);
-      resp.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
-    } else { // Loading it from CCDB
-      const std::string path = "Analysis/PID/TPC";
-      resp.LoadParam(DetectorResponse::kSignal, ccdb->getForTimeStamp<Parametrization>(path + "/" + signalname.value, timestamp.value));
-      resp.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path + "/" + sigmaname.value, timestamp.value));
-    }
-  }
-
-  void process(Coll const& collisions, Trks const& tracks)
-  {
-
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Electron> resp_El = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Electron>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Muon> resp_Mu = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Muon>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Pion> resp_Pi = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Pion>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Kaon> resp_Ka = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Kaon>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Proton> resp_Pr = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Proton>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Deuteron> resp_De = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Deuteron>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Triton> resp_Tr = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Triton>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Helium3> resp_He = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Helium3>();
-    constexpr tpc::ELoss<Coll::iterator, Trks::iterator, PID::Alpha> resp_Al = tpc::ELoss<Coll::iterator, Trks::iterator, PID::Alpha>();
-
-    tpcpidEl.reserve(tracks.size());
-    tpcpidMu.reserve(tracks.size());
-    tpcpidPi.reserve(tracks.size());
-    tpcpidKa.reserve(tracks.size());
-    tpcpidPr.reserve(tracks.size());
-    tpcpidDe.reserve(tracks.size());
-    tpcpidTr.reserve(tracks.size());
-    tpcpidHe.reserve(tracks.size());
-    tpcpidAl.reserve(tracks.size());
-    for (auto const& trk : tracks) {
-#define FILL_PID_TABLE(PID_TABLE, PID_RESPONSE)                                        \
-  {                                                                                    \
-    const float exp_sigma = PID_RESPONSE.GetExpectedSigma(resp, trk.collision(), trk); \
-    const float separation = PID_RESPONSE.GetSeparation(resp, trk.collision(), trk);   \
-    if (separation <= o2::aod::pidtpc_tiny::binned_min) {                              \
-      PID_TABLE(o2::aod::pidtpc_tiny::lower_bin);                                      \
-    } else if (separation >= o2::aod::pidtpc_tiny::binned_max) {                       \
-      PID_TABLE(o2::aod::pidtpc_tiny::upper_bin);                                      \
-    } else if (separation >= 0) {                                                      \
-      PID_TABLE(separation / o2::aod::pidtpc_tiny::bin_width + 0.5f);                  \
-    } else {                                                                           \
-      PID_TABLE(separation / o2::aod::pidtpc_tiny::bin_width - 0.5f);                  \
-    }                                                                                  \
-  }
-
-      FILL_PID_TABLE(tpcpidEl, resp_El);
-      FILL_PID_TABLE(tpcpidMu, resp_Mu);
-      FILL_PID_TABLE(tpcpidPi, resp_Pi);
-      FILL_PID_TABLE(tpcpidKa, resp_Ka);
-      FILL_PID_TABLE(tpcpidPr, resp_Pr);
-      FILL_PID_TABLE(tpcpidDe, resp_De);
-      FILL_PID_TABLE(tpcpidTr, resp_Tr);
-      FILL_PID_TABLE(tpcpidHe, resp_He);
-      FILL_PID_TABLE(tpcpidAl, resp_Al);
-#undef FILL_PID_TABLE
-    }
+    };
+    makeTable(pidEl, tablePIDEl, response, responseEl);
+    makeTable(pidMu, tablePIDMu, response, responseMu);
+    makeTable(pidPi, tablePIDPi, response, responsePi);
+    makeTable(pidKa, tablePIDKa, response, responseKa);
+    makeTable(pidPr, tablePIDPr, response, responsePr);
+    makeTable(pidDe, tablePIDDe, response, responseDe);
+    makeTable(pidTr, tablePIDTr, response, responseTr);
+    makeTable(pidHe, tablePIDHe, response, responseHe);
+    makeTable(pidAl, tablePIDAl, response, responseAl);
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow;
-  if (cfgc.options().get<int>("pid-all")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskTinyFull>("pidTPCFull-task"));
-  } else {
-    if (cfgc.options().get<int>("pid-el")) {
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Electron, o2::aod::pidRespTPCTEl>>("pidTPCEl-task"));
-    }
-    if (cfgc.options().get<int>("pid-mu")) {
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Muon, o2::aod::pidRespTPCTMu>>("pidTPCMu-task"));
-    }
-    if (cfgc.options().get<int>("pid-pikapr")) {
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Pion, o2::aod::pidRespTPCTPi>>("pidTPCPi-task"));
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Kaon, o2::aod::pidRespTPCTKa>>("pidTPCKa-task"));
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Proton, o2::aod::pidRespTPCTPr>>("pidTPCPr-task"));
-    }
-    if (cfgc.options().get<int>("pid-nuclei")) {
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Deuteron, o2::aod::pidRespTPCTDe>>("pidTPCDe-task"));
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Triton, o2::aod::pidRespTPCTTr>>("pidTPCTr-task"));
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Helium3, o2::aod::pidRespTPCTHe>>("pidTPCHe-task"));
-      workflow.push_back(adaptAnalysisTask<pidTPCTaskTiny<PID::Alpha, o2::aod::pidRespTPCTAl>>("pidTPCAl-task"));
-    }
-  }
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<pidTPCTaskTiny>("pidTPC-tiny-task")};
 }


### PR DESCRIPTION
This PR creates split tables for only required particle hypothesis, in a single task.
In addition: 
    - This commit create all split tables for TPC and TOF PID response in the split tasks
    - The filling of the split PID tables is done based on the configuration recieved by the task
    - Empty tables are sent for mass hypotheses that are not requested
    - The creation of several tasks is now avoided because of the large memory consumption overhead that was shown in the past
    - Uniformized PID tasks
