### PR TITLE
Implementation of cylinder and foam wedges for IB support in ITS3 geometry

### DIFF
--- a/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/V3Services.h
+++ b/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/V3Services.h
@@ -49,6 +49,10 @@ class V3Services : public V11Geometry
   /// Default destructor
   ~V3Services() override;
 
+  /// Creates the supports for IB Layers (cylinder and foam wedges)
+  /// \param mgr The GeoManager (used only to get the proper material)
+  TGeoVolume* createInnerBarrelSupports(const TGeoManager* mgr = gGeoManager);
+
   /// Creates the Inner Barrel End Wheels on Side A
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createIBEndWheelsSideA(const TGeoManager* mgr = gGeoManager);

--- a/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
@@ -624,6 +624,10 @@ void Detector::createMaterials()
   o2::base::Detector::Mixture(32, "ROHACELL$", aRohac, zRohac, dRohac, -4, wRohac);
   o2::base::Detector::Medium(32, "ROHACELL$", 32, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
 
+  // ERG Duocel
+  o2::base::Detector::Material(33, "ERGDUOCEL$", 12.0107, 6, 0.06, 999, 999);
+  o2::base::Detector::Medium(33, "ERGDUOCEL$", 33, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+  
   // PEEK CF30
   o2::base::Detector::Mixture(19, "PEEKCF30$", aPEEK, zPEEK, dPEEK, -3, wPEEK);
   o2::base::Detector::Medium(19, "PEEKCF30$", 19, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
@@ -1044,7 +1048,7 @@ void Detector::constructDetectorGeometry()
   // Finally create the services
   mServicesGeometry = new V3Services();
 
-  //  createInnerBarrelServices(wrapVols[0]);
+  createInnerBarrelServices(wrapVols[0]);
   //  createMiddlBarrelServices(wrapVols[1]);
   //  createOuterBarrelServices(wrapVols[2]);
   //  createOuterBarrelSupports(vITSV);
@@ -1067,26 +1071,15 @@ void Detector::createInnerBarrelServices(TGeoVolume* motherVolume)
   //
   // Return:
   //
-  // Created:      15 May 2019  Mario Sitta
-  //               (partially based on P.Namwongsa implementation in AliRoot)
-  // Updated:      19 Jun 2019  Mario Sitta  IB Side A added
-  // Updated:      21 Oct 2019  Mario Sitta  CYSS added
+  // Created:      11 Feb 2021  Mario Sitta
+  //               (Version rewritten for ITS3 geometry)
   //
 
-  // Create the End Wheels on Side A
-  TGeoVolume* endWheelsA = mServicesGeometry->createIBEndWheelsSideA();
+  // Create and insert the IB Layer supports (cylinder and foam wedges)
+  TGeoVolume* ibSupports = mServicesGeometry->createInnerBarrelSupports();
 
-  motherVolume->AddNode(endWheelsA, 1, nullptr);
-
-  // Create the End Wheels on Side C
-  TGeoVolume* endWheelsC = mServicesGeometry->createIBEndWheelsSideC();
-
-  motherVolume->AddNode(endWheelsC, 1, nullptr);
-
-  // Create the CYSS Assembly (i.e. the supporting half cylinder and cone)
-  TGeoVolume* cyss = mServicesGeometry->createCYSSAssembly();
-
-  motherVolume->AddNode(cyss, 1, nullptr);
+  motherVolume->AddNode(ibSupports, 1, nullptr);
+  motherVolume->AddNode(ibSupports, 2, new TGeoRotation("", 180, 0, 0));
 }
 
 void Detector::createMiddlBarrelServices(TGeoVolume* motherVolume)

--- a/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
@@ -627,7 +627,7 @@ void Detector::createMaterials()
   // ERG Duocel
   o2::base::Detector::Material(33, "ERGDUOCEL$", 12.0107, 6, 0.06, 999, 999);
   o2::base::Detector::Medium(33, "ERGDUOCEL$", 33, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
-  
+
   // PEEK CF30
   o2::base::Detector::Mixture(19, "PEEKCF30$", aPEEK, zPEEK, dPEEK, -3, wPEEK);
   o2::base::Detector::Medium(19, "PEEKCF30$", 19, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);

--- a/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
@@ -104,7 +104,7 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
   zlen = sIBSuppCylZLen / 2;
   rmin = sIBSuppCylRint;
   rmax = rmin + sIBSuppCylThick;
-  
+
   TGeoTubeSeg* suppCylSh = new TGeoTubeSeg(rmin, rmax, zlen, phi, 180. - phi);
 
   // The foam wedges: three TubeSeg's
@@ -122,9 +122,9 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
     layerSh = (TGeoTube*)layerVol->GetShape();
     rmin = layerSh->GetRmax();
 
-    if (j == 2)
+    if (j == 2) {
       rmax = sIBSuppCylRint;
-    else {
+    } else {
       layerVol = mgr->GetVolume(Form("%s%d", o2::its3::GeometryTGeo::getITSLayerPattern(), j + 1));
       if (!layerVol) { // Should really never happen
         LOG(FATAL) << "While building services: ITSU Layer " << j + 1 << " does not exist";

--- a/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
@@ -61,6 +61,120 @@ V3Services::V3Services()
 
 V3Services::~V3Services() = default;
 
+TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
+{
+  //
+  // Creates the ITS3 Inner Barrel support half cylinder and foam wedges
+  //
+  // Input:
+  //         mgr : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         a TGeoVolume(Assembly) with the half cylinder and wedges
+  //
+  // Created:      11 Feb 2021  Mario Sitta
+  //
+
+  // For the time being we put all relevant parameters here
+  // May be changed into static const's when definitively set
+  const Double_t sIBSuppCylRint = 40.0 * sMm;
+  const Double_t sIBSuppCylThick = 2.20 * sMm;
+  const Double_t sIBSuppCylYvoid = 0.50 * sMm;
+  const Double_t sIBSuppCylZLen = 331.20 * sMm;
+
+  const Int_t sNFoamWedges = 12;
+  const Double_t sFoamZLen = 10.0 * sMm;
+  const Double_t sFoamEdgeZDist = 5.20 * sMm;
+  const Double_t sFoamBaseWidth = 4.19 * sMm;
+  const Double_t sFoamYTrans = 1.59 * sMm;
+
+  // Local variables
+  TGeoVolume* layerVol;
+  TGeoVolume* foamVol[3];
+  TGeoTube* layerSh;
+  TGeoTubeSeg* foamSh[3];
+
+  Double_t rmin, rmax, zlen, alpha, phi;
+  Double_t xpos, ypos, zpos;
+
+  // The support half cylinder: a TubeSeg
+  phi = (sIBSuppCylYvoid / sIBSuppCylRint) * TMath::RadToDeg();
+  zlen = sIBSuppCylZLen / 2;
+  rmin = sIBSuppCylRint;
+  rmax = rmin + sIBSuppCylThick;
+  
+  TGeoTubeSeg* suppCylSh = new TGeoTubeSeg(rmin, rmax, zlen, phi, 180. - phi);
+
+  // The foam wedges: three TubeSeg's
+  phi = (sFoamBaseWidth / sIBSuppCylRint) * TMath::RadToDeg();
+  zlen = sFoamZLen / 2;
+
+  // The inner and outer radii of each foam wedge are the outer and inner
+  // radii of the IB Layers where they are located
+  // (except the last one which extends till the support cylinder)
+  for (Int_t j = 0; j < 3; j++) {
+    layerVol = mgr->GetVolume(Form("%s%d", o2::its3::GeometryTGeo::getITSLayerPattern(), j));
+    if (!layerVol) { // Should really never happen
+      LOG(FATAL) << "While building services: ITSU Layer " << j << " does not exist";
+    }
+    layerSh = (TGeoTube*)layerVol->GetShape();
+    rmin = layerSh->GetRmax();
+
+    if (j == 2)
+      rmax = sIBSuppCylRint;
+    else {
+      layerVol = mgr->GetVolume(Form("%s%d", o2::its3::GeometryTGeo::getITSLayerPattern(), j + 1));
+      if (!layerVol) { // Should really never happen
+        LOG(FATAL) << "While building services: ITSU Layer " << j + 1 << " does not exist";
+      }
+      layerSh = (TGeoTube*)layerVol->GetShape();
+      rmax = layerSh->GetRmin();
+    }
+
+    foamSh[j] = new TGeoTubeSeg(rmin, rmax, zlen, 0, phi);
+  }
+
+  // We have all shapes: now create the real volumes
+  TGeoMedium* medCarbon = mgr->GetMedium("IT3_F6151B05M$");
+  TGeoMedium* medFoam = mgr->GetMedium("ERGDUOCEL$");
+
+  TGeoVolume* suppCylVol = new TGeoVolume("IBSupportCylinder", suppCylSh, medCarbon);
+  suppCylVol->SetFillColor(kBlue);
+  suppCylVol->SetLineColor(kBlue);
+
+  for (Int_t j = 0; j < 3; j++) {
+    foamVol[j] = new TGeoVolume(Form("IBSupportFoam%d", j), foamSh[j], medFoam);
+    foamVol[j]->SetFillColor(kGreen);
+    foamVol[j]->SetLineColor(kGreen);
+  }
+
+  // Finally put everything in the container volume
+  TGeoVolumeAssembly* ibSupport = new TGeoVolumeAssembly("IBCylinderSupport");
+
+  // The support cylinder is aligned to the end of the IB Layers
+  // (layerSh points to the last Layer inside the support cylinder)
+  zpos = -layerSh->GetDz() + suppCylSh->GetDz();
+  ibSupport->AddNode(suppCylVol, 1, new TGeoTranslation(0, 0, zpos));
+
+  alpha = ((sIBSuppCylYvoid + sFoamYTrans) / sIBSuppCylRint) * TMath::RadToDeg();
+
+  Double_t emptySpace = 2 * layerSh->GetDz() - sNFoamWedges * sFoamZLen - 2 * sFoamEdgeZDist;
+  emptySpace /= (sNFoamWedges - 1);
+
+  for (Int_t j = 0; j < sNFoamWedges; j++) {
+    zpos = -layerSh->GetDz() + sFoamEdgeZDist + j * (sFoamZLen + emptySpace) + 0.5 * sFoamZLen;
+    for (Int_t i = 0; i < 3; i++) {
+      ibSupport->AddNode(foamVol[i], j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", alpha, 0, 0)));
+      ibSupport->AddNode(foamVol[i], sNFoamWedges + j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", 180. - alpha - phi, 0, 0)));
+      ibSupport->AddNode(foamVol[i], 2 * sNFoamWedges + j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", 90. - phi / 2, 0, 0)));
+    }
+  }
+  //
+  return ibSupport;
+}
+
 TGeoVolume* V3Services::createIBEndWheelsSideA(const TGeoManager* mgr)
 {
   //


### PR DESCRIPTION
The cylinder and the foam wedges supporting the first three IB Layers were implemented in ITS3 geometry following the blueprints and material information given by C.Gargiulo. A new method was introduced in the V3Services class to create the new volumes, while an already existing (and currently unused) method of Detector class was rewritten to insert them in the geometry tree.