### PR TITLE
[EMCAL-680][O2-1904] Cleaning the buffer by reference

### DIFF
--- a/Detectors/EMCAL/simulation/src/RawCreator.cxx
+++ b/Detectors/EMCAL/simulation/src/RawCreator.cxx
@@ -102,7 +102,7 @@ int main(int argc, const char** argv)
   rawwriter.setFileFor(granularity);
   rawwriter.setGeometry(o2::emcal::Geometry::GetInstanceFromRunNumber(300000));
   rawwriter.setNumberOfADCSamples(15); // @TODO Needs to come from CCDB
-  rawwriter.setPedestal(0);            // @TODO Needs to come from CCDB
+  rawwriter.setPedestal(3);            // @TODO Needs to come from CCDB
   rawwriter.init();
 
   // Loop over all entries in the tree, where each tree entry corresponds to a time frame

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -74,7 +74,7 @@ void RawWriter::digitsToRaw(gsl::span<o2::emcal::Digit> digitsbranch, gsl::span<
 
 bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
 {
-  for (auto srucont : mSRUdata) {
+  for (auto& srucont : mSRUdata) {
     srucont.mChannels.clear();
   }
   std::vector<o2::emcal::Digit*>* bunchDigits;
@@ -183,6 +183,10 @@ std::vector<AltroBunch> RawWriter::findBunches(const std::vector<o2::emcal::Digi
   for (itime = channelDigits.size() - 1; itime >= 0; itime--) {
     auto dig = channelDigits[itime];
     if (!dig) {
+      if (currentBunch) {
+        currentBunch->mStarttime = itime + 1;
+        currentBunch = nullptr;
+      }
       continue;
     }
     int adc = dig->getAmplitudeADC();


### PR DESCRIPTION
The problem with large number of cells has been solved. The problem was that the SRU container was not cleaned, so in every trigger the RawWriter is processing all the digits from the previous triggers.  The reason for that is cleaning of the buffer was done on a copy (by value) and the problem was solved The problem was solved by cleaning the container reference by reference.

We also change the ADC threshold to 3.