### PR TITLE
[EMCAL-650] Add setters for ALTRO config and error counters

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -167,19 +167,19 @@ class RCUTrailer
   /// \brief Access to the sampling time
   /// \return Sampling time in seconds.
   /// \throw Error if the RCU trailer was not properly initializied
-  double getTimeSample() const;
-
-  /// \brief set time sample
-  /// \param timesample Time sample (in ns)
-  void setTimeSample(double timesample);
+  double getTimeSampleNS() const;
 
   /// \brief Access to the L1 phase
   /// \return L1 phase w.r.t to the LHC clock
-  double getL1Phase() const;
+  double getL1PhaseNS() const;
 
-  /// \brief Set the L1 phase
-  /// \param l1phase L1 phase (in ns)
-  void setL1Phase(double l1phase);
+  /// \brief Set the time sample length and L1 phase based on the trigger time
+  /// \param time Trigger time (in ns)
+  /// \param timesample Time sample (in ns)
+  ///
+  /// L1 phase: Collision time with respect to the sample length. Number
+  /// of phases: Sample length / bunch spacing (25 ns)
+  void setTimeSamplePhaseNS(uint64_t triggertime, uint64_t timesample);
 
   //
   // Error counters

--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <cstdint>
 #include <gsl/span>
-#include "Rtypes.h"
+#include <Rtypes.h>
 
 namespace o2
 {
@@ -30,11 +30,51 @@ namespace emcal
 /// The RCU trailer can be found at the end of
 /// the payload and contains general information
 /// sent by the SRU.
+///
+/// Definition of the trailer words:
+/// - mFirmwareVersion: Firmware version
+/// - mTrailerSize: Size of the trailer in DDL words (32-bit)
+/// - mPayloadSize: Size of the payload in DDL words (32-bit)
+/// - mFECERRA
+/// - mFECERRB
+/// - mERRREG2
+/// - mERRREG3
+///   |    Bits   |                  Error type                   |
+///   |-----------|-----------------------------------------------|
+///   | 0 - 11    | Number of channels with address mismatch      |
+///   | 12 - 24   | Number of channels with length mismatch       |
+///   | 25 - 31   | Zeroed (used for trailer word markers)        |
+/// - mActiveFECsA
+/// - mActiveFECsB
+/// - mAltroCFG1 (32 bit)
+///   |    Bits   |                   Setting                     |
+///   |-----------|-----------------------------------------------|
+///   |  0-3      | Baseline correction                           |
+///   |  4        | Polarity                                      |
+///   |  5-6      | Number of presamples                          |
+///   |  7-10     | Number of postsamples                         |
+///   |  11       | Second baseline correction                    |
+///   |  12-13    | Glitch filter                                 |
+///   |  14-16    | Number of postsamples before zero suppression |
+///   |  17-18    | Number of presamples before zero suppression  |
+///   |  19       | Zero suppression on / off                     |
+///   |  20 - 31  | Zeroed (used for trailer word markers)        |
+/// - mAltroCFG2 (32 bit)
+///   |    Bits   |                   Setting                     |
+///   |-----------|-----------------------------------------------|
+///   | 0 - 4     | L1 phase                                      |
+///   | 5 - 9     | Length of the time sample                     |
+///   | 9         | Sparse readout on / off                       |
+///   | 10 - 19   | Number of samples per channel                 |
+///   | 20 - 23   | Number of pretrigger samples                  |
+///   | 24        | ALTRO buffers (0 - 4 buffers, 1 - 8 buffers)  |
+///   | 25 - 31   | Zeroed (used for trailer word markers)        |
+///
 class RCUTrailer
 {
  public:
   /// \class Error
-  /// \brief Error handling of the
+  /// \brief Error handling of the RCU trailer
   class Error : public std::exception
   {
    public:
@@ -71,6 +111,13 @@ class RCUTrailer
     std::string mErrorMessage; ///< Error Message
   };
 
+  /// \enum BufferMode_t
+  /// \brief Handler for encoding of the number of ALTRO buffers in the configuration
+  enum BufferMode_t {
+    NBUFFERS4 = 0, ///< 4 ALTRO buffers
+    NBUFFERS8 = 1  ///< 8 ALTRO buffers
+  };
+
   /// \brief Constructor
   RCUTrailer() = default;
 
@@ -93,34 +140,29 @@ class RCUTrailer
   /// specified in CDH.
   void constructFromRawPayload(const gsl::span<const uint32_t> payloadwords);
 
-  unsigned int getFECErrorsA() const { return mFECERRA; }
-  unsigned int getFECErrorsB() const { return mFECERRB; }
-  unsigned short getErrorsG2() const { return mERRREG2; }
-  unsigned int getErrorsG3() const { return mERRREG3; }
-  unsigned short getActiveFECsA() const { return mActiveFECsA; }
-  unsigned short getActiveFECsB() const { return mActiveFECsB; }
-  unsigned int getAltroCFGReg1() const { return mAltroCFG1; }
-  unsigned int getAltroCFGReg2() const { return mAltroCFG2; }
+  /// \brief Get index of the RCU the trailer belongs to
+  /// \return RCU index
   int getRCUID() const { return mRCUId; }
-  unsigned int getTrailerSize() const { return mTrailerSize; }
-  unsigned int getPayloadSize() const { return mPayloadSize; }
-  unsigned char getFirmwareVersion() const { return mFirmwareVersion; }
 
-  unsigned short getNumberOfChannelAddressMismatch() const { return (mERRREG3 & 0xFFF); }
-  unsigned short getNumberOfChannelLengthMismatch() const { return ((mERRREG3 >> 12) & 0x1FFF); }
-  unsigned char getBaselineCorrection() const { return mAltroCFG1 & 0xF; }
-  bool getPolarity() const { return (mAltroCFG1 >> 4) & 0x1; }
-  unsigned char getNumberOfPresamples() const { return (mAltroCFG1 >> 5) & 0x3; }
-  unsigned char getNumberOfPostsamples() const { return (mAltroCFG1 >> 7) & 0xF; }
-  bool hasSecondBaselineCorr() const { return (mAltroCFG1 >> 11) & 0x1; }
-  unsigned char getGlitchFilter() const { return (mAltroCFG1 >> 12) & 0x3; }
-  unsigned char getNumberOfNonZeroSuppressedPostsamples() const { return (mAltroCFG1 >> 14) & 0x7; }
-  unsigned char getNumberOfNonZeroSuppressedPresamples() const { return (mAltroCFG1 >> 17) & 0x3; }
-  bool hasZeroSuppression() const { return (mAltroCFG1 >> 19) & 0x1; }
-  bool getNumberOfAltroBuffers() const { return (mAltroCFG2 >> 24) & 0x1; }
-  unsigned char getNumberOfPretriggerSamples() const { return (mAltroCFG2 >> 20) & 0xF; }
-  unsigned short getNumberOfSamplesPerChannel() const { return (mAltroCFG2 >> 10) & 0x3FF; }
-  bool isSparseReadout() const { return (mAltroCFG2 >> 9) & 0x1; }
+  /// \brief Get the trailer size in number of DDL (32 bit) words
+  /// \return Size of the RCU trailer
+  uint32_t getTrailerSize() const { return mTrailerSize; }
+
+  /// \brief Get size of the payload as number of DDL (32-bit) words
+  /// \return Size of the payload as number of 32 bit workds
+  uint32_t getPayloadSize() const { return mPayloadSize; }
+
+  /// \brief Get the firmware version
+  /// \return Firmware version
+  uint8_t getFirmwareVersion() const { return mFirmwareVersion; }
+
+  /// \brief Set the firmware version
+  /// \param version Firmware version
+  void setFirmwareVersion(uint8_t version) { mFirmwareVersion = version; }
+
+  /// \brief set the payload size in number of DDL (32-bit) words
+  /// \param size Payload size
+  void setPayloadSize(uint32_t size) { mPayloadSize = size; }
 
   /// \brief Access to the sampling time
   /// \return Sampling time in seconds.
@@ -139,39 +181,265 @@ class RCUTrailer
   /// \param l1phase L1 phase (in ns)
   void setL1Phase(double l1phase);
 
-  void setFECErrorsA(unsigned int value) { mFECERRA = value; }
-  void setFECErrorsB(unsigned int value) { mFECERRB = value; }
-  void setErrorsG2(unsigned short value) { mERRREG2 = value; }
-  void setErrorsG3(unsigned int value) { mERRREG3 = value; }
-  void setActiveFECsA(unsigned short value) { mActiveFECsA = value; }
-  void setActiveFECsB(unsigned short value) { mActiveFECsB = value; }
-  void setAltroCFGReg1(unsigned int value) { mAltroCFG1 = value; }
-  void setAltroCFGReg2(unsigned int value) { mAltroCFG2 = value; }
-  void setFirmwareVersion(unsigned char version) { mFirmwareVersion = version; }
-  void setPayloadSize(unsigned int size) { mPayloadSize = size; }
+  //
+  // Error counters
+  //
+
+  /// \brief Get the number of channels with address mismatch
+  /// \return Number of channels
+  uint16_t getNumberOfChannelAddressMismatch() const { return mErrorCounter.mNumChannelAddressMismatch; }
+
+  /// \brief Get the number of channels with length mismatch
+  /// \return Number of channels
+  uint16_t getNumberOfChannelLengthMismatch() const { return mErrorCounter.mNumChannelLengthMismatch; }
+
+  /// \brief Set the number of channels with address mismatch
+  /// \param nchannel Number of channels
+  void setNumberOfChannelAddressMismatch(uint16_t nchannel) { mErrorCounter.mNumChannelAddressMismatch = nchannel; }
+
+  /// \brief Set the number of channels with length mismatch
+  /// \param nchannel Number of channels
+  void setNumberOfChannelLengthMismatch(uint8_t nchannel) { mErrorCounter.mNumChannelLengthMismatch = nchannel; }
+
+  uint32_t getFECErrorsA() const { return mFECERRA; }
+  uint32_t getFECErrorsB() const { return mFECERRB; }
+  uint16_t getActiveFECsA() const { return mActiveFECsA; }
+  uint16_t getActiveFECsB() const { return mActiveFECsB; }
+  void setFECErrorsA(uint32_t value) { mFECERRA = value; }
+  void setFECErrorsB(uint32_t value) { mFECERRB = value; }
+  void setActiveFECsA(uint16_t value) { mActiveFECsA = value; }
+  void setActiveFECsB(uint16_t value) { mActiveFECsB = value; }
+
+  //
+  // ALTRO configuration
+  //
+
+  /// \brief Get baseline correction method
+  /// \return baseline correction method
+  uint16_t getBaselineCorrection() const { return mAltroConfig.mBaselineCorrection; }
+
+  /// \brief Check polarity setting
+  /// \return Polarity setting
+  bool getPolarity() const { return mAltroConfig.mPolarity; }
+
+  /// \brief Get the number of presamples (after zero suppression)
+  /// \return Number of presamples
+  uint16_t getNumberOfPresamples() const { return mAltroConfig.mNumPresamples; }
+
+  /// \brief Get the number of postsamples (after zero suppression)
+  /// \return Number of postsamples
+  uint16_t getNumberOfPostsamples() const { return mAltroConfig.mNumPostsamples; }
+
+  /// \brief Check if second baseline correction is applied
+  /// \return True if second baseline correction has been applied, false otherwise
+  bool hasSecondBaselineCorr() const { return mAltroConfig.mSecondBaselineCorrection; }
+
+  /// \brief Get the glitch filter
+  /// \return Glitch filter setting
+  uint16_t getGlitchFilter() const { return mAltroConfig.mGlitchFilter; }
+
+  /// \brief Get the number of postsamples before zero suppression
+  /// \return Number of postsamples
+  uint16_t getNumberOfNonZeroSuppressedPostsamples() const { return mAltroConfig.mNumPostsamplesNoZS; }
+
+  /// \brief Get the number of presamples before zero suppression
+  /// \return Number of presamples
+  uint16_t getNumberOfNonZeroSuppressedPresamples() const { return mAltroConfig.mNumPresamplesNoZS; }
+
+  /// \brief Check whether zero suppression has been applied
+  /// \return True if zero suppression has been applied, false otherwise
+  bool hasZeroSuppression() const { return mAltroConfig.mZeroSuppression; }
+
+  /// \brief Get the number of pretrigger samples
+  /// \return Number of samples
+  uint16_t getNumberOfPretriggerSamples() const { return mAltroConfig.mNumSamplesPretrigger; }
+
+  /// \brief Get the number of samples per channel
+  /// \return Number of samples per channel
+  uint16_t getNumberOfSamplesPerChannel() const { return mAltroConfig.mNumSamplesChannel; }
+
+  /// \brief Get the number of ALTRO buffers
+  /// \return Number of Altro Buffers
+  uint16_t getNumberOfAltroBuffers() const { return BufferMode_t(mAltroConfig.mAltroBuffers) == BufferMode_t::NBUFFERS4 ? 4 : 8; }
+
+  /// \brief Check whether readout is in sparse mode
+  /// \return True if the readout is in sparse mode, false otherwise
+  bool isSparseReadout() const { return mAltroConfig.mSparseReadout; }
+
+  /// \brief Set baseline correction method
+  /// \param baselineCorrection Baseline correction method
+  void setBaselineCorrection(uint16_t baselineCorrection) { mAltroConfig.mBaselineCorrection = baselineCorrection; }
+
+  /// \brief Set the polarity
+  /// \param doSet If true polarity is set
+  void setPolarity(bool doSet) { mAltroConfig.mPolarity = doSet; }
+
+  /// \brief Set the number of presamples (after zero suppression)
+  /// \param npresamples Number of presamples
+  void setNumberOfPresamples(uint16_t npresamples) { mAltroConfig.mNumPresamples = npresamples; }
+
+  /// \brief Set the number of postsamples (after zero suppression)
+  /// \param
+  void setNumberOfPostsamples(uint16_t npostsamples) { mAltroConfig.mNumPostsamples = npostsamples; }
+
+  /// \brief Specify whether second basedline correction has been applied
+  /// \param doHave If true a second baseline correction has bben applied
+  void setSecondBaselineCorrection(bool doHave) { mAltroConfig.mSecondBaselineCorrection = doHave; }
+
+  /// \brief Set the glitch filter
+  /// \param glitchfilter Glitch filter
+  void setGlitchFilter(uint16_t glitchfilter) { mAltroConfig.mGlitchFilter = glitchfilter; }
+
+  /// \brief Set the number of postsamples before zero suppression
+  /// \param npostsamples Number of postsamples
+  void setNumberOfNonZeroSuppressedPostsamples(uint16_t npostsamples) { mAltroConfig.mNumPostsamplesNoZS = npostsamples; }
+
+  /// \brief Set the number of presamples after zero suppression
+  /// \param npresamples Number of presamples
+  void setNumberOfNonZeroSuppressedPresamples(uint16_t npresamples) { mAltroConfig.mNumPresamplesNoZS = npresamples; }
+
+  /// \brief Set the number of pretrigger samples
+  /// \param nsamples Number of samples
+  void setNumberOfPretriggerSamples(uint16_t nsamples) { mAltroConfig.mNumSamplesPretrigger = nsamples; }
+
+  /// \brief Set the number of samples per channel
+  /// \param nsamples Number of samples
+  void setNumberOfSamplesPerChannel(uint16_t nsamples) { mAltroConfig.mNumSamplesChannel = nsamples; }
+
+  /// \brief Specify whether zero suppression has been applied
+  /// \param doHave If true zero suppression has been applied
+  void setZeroSuppression(bool doHave) { mAltroConfig.mZeroSuppression = doHave; }
+
+  /// \brief Set sparse readout mode
+  /// \param isSparse True if readout is in sparse mode, false otherwise
+  void setSparseReadout(bool isSparse) { mAltroConfig.mSparseReadout = isSparse; }
+
+  /// \brief Set the number of ALTRO buffers
+  /// \param bufmode Number of ALTRO buffers (4 or 8 buffers)
+  void setNumberOfAltroBuffers(BufferMode_t bufmode) { mAltroConfig.mAltroBuffers = uint8_t(bufmode); }
+
+  ///
+  /// Direct access to RCU trailer registers (not recommended)
+  ///
+
+  /// \brief Get value stored in error counter register 2
+  /// \return Value of the register
+  uint16_t getErrorsG2() const { return mErrorCounter.mErrorRegister2; }
+
+  /// \brief Get value stored in error counter register 3
+  /// \return Value of the register
+  /// \deprecated Use dedicated getters for error counters
+  uint32_t getErrorsG3() const { return mErrorCounter.mErrorRegister3; }
+
+  /// \brief Get value stored in ALTRO config register 1
+  /// \return Value of the register
+  /// \deprecated Use dedicated getters for ALTRO configuration
+  uint32_t getAltroCFGReg1() const { return mAltroConfig.mWord1; }
+
+  /// \brief Get value stored in ALTRO config register 1
+  /// \return Value of the register
+  /// \deprecated Use dedicated getters for ALTRO configuration
+  uint32_t getAltroCFGReg2() const { return mAltroConfig.mWord2; }
+
+  /// \brief Set error counter register 2
+  /// \param value Value for register
+  void setErrorsG2(uint16_t value) { mErrorCounter.mErrorRegister2 = value; }
+
+  /// \brief Set error counter register 3
+  /// \param value Value for register
+  /// \deprecated Use dedicated setters for error counters
+  void setErrorsG3(uint32_t value) { mErrorCounter.mErrorRegister3 = value; }
+
+  /// \brief Set ALTRO config register 1
+  /// \param value Value for register
+  /// \deprecated Use dedicated setters for configuration
+  void setAltroCFGReg1(uint32_t value) { mAltroConfig.mWord1 = value; }
+
+  /// \brief Set ALTRO config register 2
+  /// \param value Value for register
+  /// \deprecated Use dedicated setters for configuration
+  void setAltroCFGReg2(uint32_t value) { mAltroConfig.mWord2 = value; }
 
   /// \brief checlks whether the RCU trailer is initialzied
   /// \return True if the trailer is initialized, false otherwise
   bool isInitialized() const { return mIsInitialized; }
 
+  /// \brief Encode RCU trailer as array of DDL (32-bit) words
+  /// \return array of trailer words after encoding
+  ///
+  /// Encoded trailer words always contain the trailer pattern
+  /// (bit 30 and bit 31 set)
   std::vector<uint32_t> encode() const;
 
+  /// \brief Decode RCU trailer from payload
+  /// \return RCU trailer found at the end of the given payload
+  ///
+  /// The trailer is expected at the end of the paylaod. Trailer words
+  /// are identified via their trailer marker (bits 30 and 31), and
+  /// are assigned based on the trailer word marker.
   static RCUTrailer constructFromPayloadWords(const gsl::span<const uint32_t> payloadwords);
 
  private:
-  int mRCUId = -1;                    ///< current RCU identifier
-  unsigned char mFirmwareVersion = 0; ///< RCU firmware version
-  unsigned int mTrailerSize = 0;      ///< Size of the trailer (in number of 32 bit words)
-  unsigned int mPayloadSize = 0;      ///< Size of the payload (in nunber of 32 bit words)
-  unsigned int mFECERRA = 0;          ///< contains errors related to ALTROBUS transactions
-  unsigned int mFECERRB = 0;          ///< contains errors related to ALTROBUS transactions
-  unsigned short mERRREG2 = 0;        ///< contains errors related to ALTROBUS transactions or trailer of ALTRO channel block
-  unsigned int mERRREG3 = 0;          ///< contains number of altro channels skipped due to an address mismatch
-  unsigned short mActiveFECsA = 0;    ///< bit pattern of active FECs in branch A
-  unsigned short mActiveFECsB = 0;    ///< bit pattern of active FECs in branch B
-  unsigned int mAltroCFG1 = 0;        ///< ALTROCFG1 register
-  unsigned int mAltroCFG2 = 0;        ///< ALTROCFG2 and ALTROIF register
-  bool mIsInitialized = false;        ///< Flag whether RCU trailer is initialized for the given raw event
+  /// \struct AltroConfig
+  /// \brief Bit field configuration of the ALTRO config registers
+  struct AltroConfig {
+    union {
+      uint32_t mWord1 = 0; ///< ALTROCFG1 register
+      struct {
+        uint32_t mBaselineCorrection : 4;       ///< Baseline correction setting
+        uint32_t mPolarity : 1;                 ///< Polarity
+        uint32_t mNumPresamples : 2;            ///< Number of presamples
+        uint32_t mNumPostsamples : 4;           ///< Number of postsamples
+        uint32_t mSecondBaselineCorrection : 1; ///< Second baseline correction
+        uint32_t mGlitchFilter : 2;             ///< Glitch filter
+        uint32_t mNumPostsamplesNoZS : 3;       ///< Number of postsamples without zero suppression
+        uint32_t mNumPresamplesNoZS : 2;        ///< Number of presamples without zero suppression
+        uint32_t mZeroSuppression : 1;          ///< Zero suppression
+        uint32_t mZero1_1 : 12;                 ///< Zeroed bits
+      };
+    };
+
+    union {
+      uint32_t mWord2 = 0; ///< ALTROCFG2 and ALTROIF register (see class description for bit configuration)
+      struct {
+        uint32_t mL1Phase : 5;              ///< L1 phase
+        uint32_t mSampleTime : 4;           ///< Length of the time sample
+        uint32_t mSparseReadout : 1;        ///< Sparse readout
+        uint32_t mNumSamplesChannel : 10;   ///< Number of samples per channel
+        uint32_t mNumSamplesPretrigger : 4; ///< Number of samples per pretrigger
+        uint32_t mAltroBuffers : 1;         ///< Number of ALTRO buffers
+        uint32_t mZero2_2 : 7;              ///< Zeroed bits
+      };
+    };
+  };
+
+  /// \struct ErrorCounters
+  /// \brief Bit definition for error counter registers
+  struct ErrorCounters {
+    union {
+      uint32_t mErrorRegister2 = 0; ///< contains errors related to ALTROBUS transactions or trailer of ALTRO channel block
+    };
+    union {
+      uint32_t mErrorRegister3 = 0; ///< contains number of altro channels skipped due to an address mismatch
+      struct {
+        uint32_t mNumChannelAddressMismatch : 12; ///< Number of channels with address mismatch
+        uint32_t mNumChannelLengthMismatch : 13;  ///< Number of channels with link mismatch
+        uint32_t mZero3_1 : 7;                    ///< Zeroed bits
+      };
+    };
+  };
+
+  int mRCUId = -1;                      ///< current RCU identifier
+  uint8_t mFirmwareVersion = 0;         ///< RCU firmware version
+  uint32_t mTrailerSize = 0;            ///< Size of the trailer (in number of 32 bit words)
+  uint32_t mPayloadSize = 0;            ///< Size of the payload (in nunber of 32 bit words)
+  uint32_t mFECERRA = 0;                ///< contains errors related to ALTROBUS transactions
+  uint32_t mFECERRB = 0;                ///< contains errors related to ALTROBUS transactions
+  ErrorCounters mErrorCounter = {0, 0}; ///< Error counter registers
+  uint16_t mActiveFECsA = 0;            ///< bit pattern of active FECs in branch A
+  uint16_t mActiveFECsB = 0;            ///< bit pattern of active FECs in branch B
+  AltroConfig mAltroConfig = {0, 0};    ///< ALTRO configuration registers
+  bool mIsInitialized = false;          ///< Flag whether RCU trailer is initialized for the given raw event
 
   ClassDefNV(RCUTrailer, 1);
 };

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -24,12 +24,12 @@ void RCUTrailer::reset()
   mPayloadSize = 0;
   mFECERRA = 0;
   mFECERRB = 0;
-  mERRREG2 = 0;
-  mERRREG3 = 0;
+  mErrorCounter.mErrorRegister2 = 0;
+  mErrorCounter.mErrorRegister3 = 0;
   mActiveFECsA = 0;
   mActiveFECsB = 0;
-  mAltroCFG1 = 0;
-  mAltroCFG2 = 0;
+  mAltroConfig.mWord1 = 0;
+  mAltroConfig.mWord2 = 0;
   mIsInitialized = false;
 }
 
@@ -68,11 +68,11 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
         break;
       case 2:
         // ERR_REG2
-        mERRREG2 = parData & 0x1FF;
+        mErrorCounter.mErrorRegister2 = parData & 0x1FF;
         break;
       case 3:
         // ERR_REG3
-        mERRREG3 = parData & 0x1FFFFFF;
+        mErrorCounter.mErrorRegister3 = parData & 0x1FFFFFF;
         break;
       case 4:
         // FEC_RO_A
@@ -84,11 +84,11 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
         break;
       case 6:
         // RDO_CFG1
-        mAltroCFG1 = parData & 0xFFFFF;
+        mAltroConfig.mWord1 = parData & 0xFFFFF;
         break;
       case 7:
         // RDO_CFG2
-        mAltroCFG2 = parData & 0x1FFFFFF;
+        mAltroConfig.mWord2 = parData & 0x1FFFFFF;
         break;
       default:
         std::cerr << "Undefined parameter code " << parCode << ", ignore it !\n";
@@ -101,7 +101,7 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
 
 double RCUTrailer::getTimeSample() const
 {
-  unsigned char fq = (mAltroCFG2 >> 5) & 0xF;
+  uint8_t fq = mAltroConfig.mSampleTime;
   double tSample;
   switch (fq) {
     case 0:
@@ -135,13 +135,13 @@ void RCUTrailer::setTimeSample(double timesample)
   } else {
     throw Error(Error::ErrorType_t::SAMPLINGFREQ_INVALID, fmt::format("invalid time sample: %f", timesample).data());
   }
-  mAltroCFG2 = (mAltroCFG2 & 0x1F) | fq << 5;
+  mAltroConfig.mSampleTime = fq;
 }
 
 double RCUTrailer::getL1Phase() const
 {
   double tSample = getTimeSample(),
-         phase = ((double)(mAltroCFG2 & 0x1F)) * o2::constants::lhc::LHCBunchSpacingNS * 1.e-9;
+         phase = static_cast<double>(mAltroConfig.mL1Phase) * o2::constants::lhc::LHCBunchSpacingNS * 1.e-9;
   if (phase >= tSample) {
     throw Error(Error::ErrorType_t::L1PHASE_INVALID, fmt::format("Invalid L1 trigger phase (%e s (phase) >= %e s (sampling time)) !", phase, tSample).data());
   }
@@ -151,19 +151,19 @@ double RCUTrailer::getL1Phase() const
 void RCUTrailer::setL1Phase(double l1phase)
 {
   int phase = l1phase / 25.;
-  mAltroCFG2 = (mAltroCFG2 & 0x1E0) | phase;
+  mAltroConfig.mL1Phase = phase;
 }
 
 std::vector<uint32_t> RCUTrailer::encode() const
 {
   std::vector<uint32_t> encoded;
   encoded.emplace_back(mPayloadSize | 2 << 30);
-  encoded.emplace_back(mAltroCFG2 | 7 << 26 | 2 << 30);
-  encoded.emplace_back(mAltroCFG1 | 6 << 26 | 2 << 30);
+  encoded.emplace_back(mAltroConfig.mWord2 | 7 << 26 | 2 << 30);
+  encoded.emplace_back(mAltroConfig.mWord1 | 6 << 26 | 2 << 30);
   encoded.emplace_back(mActiveFECsB | 5 << 26 | 2 << 30);
   encoded.emplace_back(mActiveFECsA | 4 << 26 | 2 << 30);
-  encoded.emplace_back(mERRREG3 | 3 << 26 | 2 << 30);
-  encoded.emplace_back(mERRREG2 | 2 << 26 | 2 << 30);
+  encoded.emplace_back(mErrorCounter.mErrorRegister3 | 3 << 26 | 2 << 30);
+  encoded.emplace_back(mErrorCounter.mErrorRegister2 | 2 << 26 | 2 << 30);
   encoded.emplace_back(mFECERRB >> 7 | (mFECERRA >> 7) << 13 | 1 << 26 | 2 << 30);
 
   uint32_t lasttrailerword = 3 << 30 | mFirmwareVersion << 16 | mRCUId << 7 | (encoded.size() + 1);
@@ -195,24 +195,24 @@ void RCUTrailer::printStream(std::ostream& stream) const
          << "Payload size:                              " << mPayloadSize << "\n"
          << "FECERRA:                                   0x" << std::hex << mFECERRA << "\n"
          << "FECERRB:                                   0x" << std::hex << mFECERRB << "\n"
-         << "ERRREG2:                                   0x" << std::hex << mERRREG2 << "\n"
+         << "ERRREG2:                                   0x" << std::hex << mErrorCounter.mErrorRegister2 << "\n"
          << "#channels skipped due to address mismatch: " << std::dec << getNumberOfChannelAddressMismatch() << "\n"
          << "#channels skipped due to bad block length: " << std::dec << getNumberOfChannelLengthMismatch() << "\n"
          << "Active FECs (branch A):                    0x" << std::hex << mActiveFECsA << "\n"
          << "Active FECs (branch B):                    0x" << std::hex << mActiveFECsB << "\n"
-         << "Baseline corr:                             0x" << std::hex << int(getBaselineCorrection()) << "\n"
-         << "Number of presamples:                      " << std::dec << int(getNumberOfPresamples()) << "\n"
-         << "Number of postsamples:                     " << std::dec << int(getNumberOfPostsamples()) << "\n"
+         << "Baseline corr:                             " << std::hex << getBaselineCorrection() << "\n"
+         << "Number of presamples:                      " << std::dec << getNumberOfPresamples() << "\n"
+         << "Number of postsamples:                     " << std::dec << getNumberOfPostsamples() << "\n"
          << "Second baseline corr:                      " << (hasSecondBaselineCorr() ? "yes" : "no") << "\n"
-         << "GlitchFilter:                              " << std::dec << int(getGlitchFilter()) << "\n"
-         << "Number of non-ZS postsamples:              " << std::dec << int(getNumberOfNonZeroSuppressedPostsamples()) << "\n"
-         << "Number of non-ZS presamples:               " << std::dec << int(getNumberOfNonZeroSuppressedPresamples()) << "\n"
+         << "Glitch filter:                             " << std::dec << getGlitchFilter() << "\n"
+         << "Number of non-ZS postsamples:              " << std::dec << getNumberOfNonZeroSuppressedPostsamples() << "\n"
+         << "Number of non-ZS presamples:               " << std::dec << getNumberOfNonZeroSuppressedPresamples() << "\n"
          << "Number of ALTRO buffers:                   " << std::dec << getNumberOfAltroBuffers() << "\n"
-         << "Number of pretrigger samples:              " << std::dec << int(getNumberOfPretriggerSamples()) << "\n"
+         << "Number of pretrigger samples:              " << std::dec << getNumberOfPretriggerSamples() << "\n"
          << "Number of samples per channel:             " << std::dec << getNumberOfSamplesPerChannel() << "\n"
          << "Sparse readout:                            " << (isSparseReadout() ? "yes" : "no") << "\n"
-         << "AltroCFG1:                                 0x" << std::hex << mAltroCFG1 << "\n"
-         << "AltroCFG2:                                 0x" << std::hex << mAltroCFG2 << "\n"
+         << "AltroCFG1:                                 0x" << std::hex << mAltroConfig.mWord1 << "\n"
+         << "AltroCFG2:                                 0x" << std::hex << mAltroConfig.mWord2 << "\n"
          << "Sampling time:                             " << std::scientific << timesample << " s\n"
          << "L1 Phase:                                  " << std::scientific << l1phase << " s\n"
          << std::dec << std::fixed;

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -60,6 +60,7 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
     }
     int parCode = (word >> 26) & 0xF;
     int parData = word & 0x3FFFFFF;
+    // std::cout << "Found trailer word 0x" << std::hex << word << "(Par code: " << std::dec << parCode << ", Par data: 0x" << std::hex << parData << std::dec << ")";
     switch (parCode) {
       case 1:
         // ERR_REG1
@@ -99,7 +100,7 @@ void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payload
   mIsInitialized = true;
 }
 
-double RCUTrailer::getTimeSample() const
+double RCUTrailer::getTimeSampleNS() const
 {
   uint8_t fq = mAltroConfig.mSampleTime;
   double tSample;
@@ -120,38 +121,38 @@ double RCUTrailer::getTimeSample() const
       throw Error(Error::ErrorType_t::SAMPLINGFREQ_INVALID, fmt::format("Invalid sampling frequency value %d !", int(fq)).data());
   }
 
-  return tSample * o2::constants::lhc::LHCBunchSpacingNS * 1.e-9;
+  return tSample * o2::constants::lhc::LHCBunchSpacingNS;
 }
 
-void RCUTrailer::setTimeSample(double timesample)
+void RCUTrailer::setTimeSamplePhaseNS(uint64_t triggertime, uint64_t timesample)
 {
-  int fq = 0;
-  if (std::abs(timesample - 50) < DBL_EPSILON) {
-    fq = 0;
-  } else if (std::abs(timesample - 100) < DBL_EPSILON) {
-    fq = 1;
-  } else if (std::abs(timesample - 200) < DBL_EPSILON) {
-    fq = 2;
-  } else {
-    throw Error(Error::ErrorType_t::SAMPLINGFREQ_INVALID, fmt::format("invalid time sample: %f", timesample).data());
-  }
-  mAltroConfig.mSampleTime = fq;
+  int sample = 0;
+  switch (timesample) {
+    case 50:
+      sample = 0;
+      break;
+    case 100:
+      sample = 1;
+      break;
+    case 200:
+      sample = 2;
+      break;
+    default:
+      throw Error(Error::ErrorType_t::SAMPLINGFREQ_INVALID, fmt::format("invalid time sample: %f", timesample).data());
+  };
+  mAltroConfig.mSampleTime = sample;
+  // calculate L1 phase
+  mAltroConfig.mL1Phase = (triggertime % timesample) / 25;
 }
 
-double RCUTrailer::getL1Phase() const
+double RCUTrailer::getL1PhaseNS() const
 {
-  double tSample = getTimeSample(),
-         phase = static_cast<double>(mAltroConfig.mL1Phase) * o2::constants::lhc::LHCBunchSpacingNS * 1.e-9;
+  double tSample = getTimeSampleNS(),
+         phase = static_cast<double>(mAltroConfig.mL1Phase) * o2::constants::lhc::LHCBunchSpacingNS;
   if (phase >= tSample) {
-    throw Error(Error::ErrorType_t::L1PHASE_INVALID, fmt::format("Invalid L1 trigger phase (%e s (phase) >= %e s (sampling time)) !", phase, tSample).data());
+    throw Error(Error::ErrorType_t::L1PHASE_INVALID, fmt::format("Invalid L1 trigger phase (%e ns (phase) >= %e ns (sampling time)) !", phase, tSample).data());
   }
   return phase;
-}
-
-void RCUTrailer::setL1Phase(double l1phase)
-{
-  int phase = l1phase / 25.;
-  mAltroConfig.mL1Phase = phase;
 }
 
 std::vector<uint32_t> RCUTrailer::encode() const
@@ -177,12 +178,12 @@ void RCUTrailer::printStream(std::ostream& stream) const
   std::vector<std::string> errors;
   double timesample = -1., l1phase = -1.;
   try {
-    timesample = getTimeSample();
+    timesample = getTimeSampleNS();
   } catch (Error& e) {
     errors.push_back(e.what());
   }
   try {
-    l1phase = getL1Phase();
+    l1phase = getL1PhaseNS();
   } catch (Error& e) {
     errors.push_back(e.what());
   }
@@ -201,20 +202,22 @@ void RCUTrailer::printStream(std::ostream& stream) const
          << "Active FECs (branch A):                    0x" << std::hex << mActiveFECsA << "\n"
          << "Active FECs (branch B):                    0x" << std::hex << mActiveFECsB << "\n"
          << "Baseline corr:                             " << std::hex << getBaselineCorrection() << "\n"
+         << "Polarity:                                  " << (getPolarity() ? "yes" : "no") << "\n"
          << "Number of presamples:                      " << std::dec << getNumberOfPresamples() << "\n"
          << "Number of postsamples:                     " << std::dec << getNumberOfPostsamples() << "\n"
          << "Second baseline corr:                      " << (hasSecondBaselineCorr() ? "yes" : "no") << "\n"
          << "Glitch filter:                             " << std::dec << getGlitchFilter() << "\n"
          << "Number of non-ZS postsamples:              " << std::dec << getNumberOfNonZeroSuppressedPostsamples() << "\n"
          << "Number of non-ZS presamples:               " << std::dec << getNumberOfNonZeroSuppressedPresamples() << "\n"
+         << "Zero suppression:                          " << (hasZeroSuppression() ? "yes" : "no") << "\n"
          << "Number of ALTRO buffers:                   " << std::dec << getNumberOfAltroBuffers() << "\n"
          << "Number of pretrigger samples:              " << std::dec << getNumberOfPretriggerSamples() << "\n"
          << "Number of samples per channel:             " << std::dec << getNumberOfSamplesPerChannel() << "\n"
          << "Sparse readout:                            " << (isSparseReadout() ? "yes" : "no") << "\n"
          << "AltroCFG1:                                 0x" << std::hex << mAltroConfig.mWord1 << "\n"
          << "AltroCFG2:                                 0x" << std::hex << mAltroConfig.mWord2 << "\n"
-         << "Sampling time:                             " << std::scientific << timesample << " s\n"
-         << "L1 Phase:                                  " << std::scientific << l1phase << " s\n"
+         << "Sampling time:                             " << timesample << " ns\n"
+         << "L1 Phase:                                  " << l1phase << " ns\n"
          << std::dec << std::fixed;
   if (errors.size()) {
     stream << "Errors: \n"

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -14,6 +14,7 @@
 #include <gsl/span>
 
 #include <array>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -107,7 +108,7 @@ class RawWriter
   std::tuple<int, int> getLinkAssignment(int ddlID);
 
   ChannelHeader createChannelHeader(int hardwareAddress, int payloadSize, bool isBadChannel);
-  std::vector<char> createRCUTrailer(int payloadsize, int feca, int fecb, double timesample, double l1phase);
+  std::vector<char> createRCUTrailer(int payloadsize, int feca, int fecb, double timesample, uint64_t triggertime);
   std::vector<int> encodeBunchData(const std::vector<int>& data);
 
  private:

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -159,7 +159,7 @@ bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
     }
 
     // Create RCU trailer
-    auto trailerwords = createRCUTrailer(payload.size() / 4, 16, 16, 100., 0.);
+    auto trailerwords = createRCUTrailer(payload.size() / 4, 16, 16, 100., trg.getBCData().toLong());
     for (auto word : trailerwords) {
       payload.emplace_back(word);
     }
@@ -286,14 +286,13 @@ ChannelHeader RawWriter::createChannelHeader(int hardwareAddress, int payloadSiz
   return header;
 }
 
-std::vector<char> RawWriter::createRCUTrailer(int payloadsize, int feca, int fecb, double timesample, double l1phase)
+std::vector<char> RawWriter::createRCUTrailer(int payloadsize, int feca, int fecb, double timesample, uint64_t triggertime)
 {
   RCUTrailer trailer;
   trailer.setActiveFECsA(feca);
   trailer.setActiveFECsB(fecb);
   trailer.setPayloadSize(payloadsize);
-  trailer.setL1Phase(l1phase);
-  trailer.setTimeSample(timesample);
+  trailer.setTimeSamplePhaseNS(triggertime, timesample);
   auto trailerwords = trailer.encode();
   std::vector<char> encoded(trailerwords.size() * sizeof(uint32_t));
   memcpy(encoded.data(), trailerwords.data(), trailerwords.size() * sizeof(uint32_t));


### PR DESCRIPTION
Setters were present only for the registers and not
the dedicated configurations. In order to simplify
the encoding dedicated setters for the parameters
in the ALTRO configuration parameters and error
counters have been added. Registers are converted
to structs of unions of bitfields (similar to RDH). In
addition the bit ranges are added for the different
registers in the documentation, and doxygen
documentation has been added to various functions.