### PR TITLE
Adapt TRAP simulator spec for new digit format 

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -54,74 +54,75 @@ class Tracklet64
   Tracklet64(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position,
              uint64_t slope, uint64_t Q0, uint64_t Q1, uint64_t Q2)
   {
-    buildTrackletWord(format, hcid, padrow, col, position, slope, Q0, Q1, Q2);
+    mtrackletWord = ((format << formatbs) & formatmask) |
+                    ((hcid << hcidbs) & hcidmask) |
+                    ((padrow << padrowbs) & padrowmask) |
+                    ((col << colbs) & colmask) |
+                    ((position << posbs) & posmask) |
+                    ((slope << slopebs) & slopemask) |
+                    ((Q2 << Q2bs) & Q2mask) |
+                    ((Q1 << Q1bs) & Q1mask) |
+                    ((Q0 << Q0bs) & Q0mask);
   }
 
   ~Tracklet64() = default;
   Tracklet64& operator=(const Tracklet64& rhs) = default;
 
-  //TODO convert to the actual number  regarding compliments.
   // ----- Getters for contents of tracklet word -----
   uint64_t getHCID() const { return ((mtrackletWord & hcidmask) >> hcidbs); };       // no units 0..1077
-  uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // in units of
-  uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // in units of
-  uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs); };     // in units of 0.02 pads [10bits] .. -10.22 to 10.22
-  uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };    // in units of -127 .. 127
-  uint64_t getPID() const { return ((mtrackletWord & PIDmask)); };                   // in units of counts all 3 together
-  uint64_t getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };             // in units of counts all 3 together
-  uint64_t getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };             // in units of counts all 3 together
-  uint64_t getQ2() const { return ((mtrackletWord & Q2mask) >> Q2bs); };             // in units of counts all 3 together
+  uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // pad row number [0..15]
+  uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // column refers to MCM position in column direction on readout board [0..3]
+  uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs); };     // in units of 1/80 pads, 11 bit granularity [-12.8..12.8] relative to MCM center
+  uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };    // in units of 1/1000 pads/timebin, 8 bit granularity [-0.128 to 0.128]
+  uint64_t getPID() const { return ((mtrackletWord & PIDmask)); };                   // no unit, all 3 charge windows combined
+  uint64_t getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };             // no unit
+  uint64_t getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };             // no unit
+  uint64_t getQ2() const { return ((mtrackletWord & Q2mask) >> Q2bs); };             // no unit
 
-  uint64_t buildTrackletWord(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position, uint64_t slope, uint64_t Q2, uint64_t Q1, uint64_t Q0)
-  {
-    LOG(debug) << "Build tracklet with format:" << format << " hcid:" << hcid << " padrow: " << padrow << " col:" << col << " position:" << position << " slope:" << slope << " Q0:1:2:: " << Q0 << ":" << Q1 << ":" << Q2;
-    mtrackletWord = ((format << formatbs) & formatmask) + ((hcid << hcidbs) & hcidmask) + ((padrow << padrowbs) & padrowmask) + ((col << colbs) & colmask) + ((position << posbs) & posmask) + ((slope << slopebs) & slopemask) + ((Q2 << Q2bs) & Q2mask) + ((Q1 << Q1bs) & Q1mask) + ((Q0 << Q0bs) & Q0mask);
-    return 0;
-  }
-  uint64_t setTrackletWord(uint64_t trackletword)
-  {
-    mtrackletWord = trackletword;
-    return 0;
-  }
+  void setTrackletWord(uint64_t trackletword) { mtrackletWord = trackletword; }
 
   // ----- Getters for tracklet information -----
-  int getMCM() const
-  {
-    return (getColumn() % (72)) / 18 + 4 * (getPadRow() % 4);
-  }
-  int getROB() const
-  {
-    int side = getColumn() / 72;
-    return (int)((int)getPadRow() / 8 + side);
-  }
+  int getMCM() const { return 4 * (getPadRow() % 4) + getColumn(); }                                 // returns MCM position on ROB [0..15]
+  int getROB() const { return (getHCID() % 2) ? (getPadRow() / 4) * 2 + 1 : (getPadRow() / 4) * 2; } // returns ROB number [0..5] for C0 chamber and [0..7] for C1 chamber
 
   // ----- Getters for offline corresponding values -----
   int getDetector() const { return getHCID() / 2; }
 
-  uint64_t getTrackletWord() const { return mtrackletWord; };
+  uint64_t getTrackletWord() const { return mtrackletWord; }
   uint32_t getTrackletWord32() const;
 
-  //  void setDetector(int id) { uint64_t hcid= 2* id; uint64_t side=1;mtrackletWord = hcid << hcidbs + ; }
-  //  void setHCId(int id) { mHCId = id; }
-  // TODO row and mcm to col and padrow mapping.
-  uint64_t setQ0(int charge)
+  void setQ0(int charge)
   {
+    mtrackletWord &= ~Q0mask;
     mtrackletWord |= ((charge << Q0bs) & Q0mask);
-    return mtrackletWord;
   }
-  uint64_t setQ1(int charge)
+  void setQ1(int charge)
   {
+    mtrackletWord &= ~Q1mask;
     mtrackletWord |= ((charge << Q1bs) & Q1mask);
-    return mtrackletWord;
   }
-  uint64_t setQ2(int charge)
+  void setQ2(int charge)
   {
+    mtrackletWord &= ~Q2mask;
     mtrackletWord |= ((charge << Q2bs) & Q2mask);
-    return mtrackletWord;
   }
-  void setPID(uint64_t pid) { mtrackletWord |= ((((uint64_t)pid) << PIDbs) & PIDmask); } // set the entire pid area of the trackletword, all the 3 Q's
-  void setPosition(uint64_t position) { mtrackletWord |= ((((uint64_t)position) << posbs) & posmask); }
-  void setSlope(uint64_t slope) { mtrackletWord |= ((((uint64_t)slope) << slopebs) & slopemask); }
+  void setPID(uint64_t pid)
+  {
+    // set the entire pid area of the trackletword, all the 3 Q's
+    mtrackletWord &= ~PIDmask;
+    mtrackletWord |= ((pid << PIDbs) & PIDmask);
+  }
+  void setPosition(uint64_t position)
+  {
+    mtrackletWord &= ~posmask;
+    mtrackletWord |= ((position << posbs) & posmask);
+  }
+  void setSlope(uint64_t slope)
+  {
+    mtrackletWord &= ~slopemask;
+    mtrackletWord |= ((slope << slopebs) & slopemask);
+  }
+
   void printStream(std::ostream& stream) const;
 
   // bit masks for the above raw data;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -25,11 +25,8 @@
 //  Sean Murray (murrays@cern.ch)                                         //
 //
 ////////////////////////////////////////////////////////////////////////////
-#include <vector>
-#include <array>
-#include <memory>   // for std::unique_ptr
+
 #include "Rtypes.h" // for ClassDef
-#include "fairlogger/Logger.h"
 
 namespace o2
 {
@@ -89,7 +86,6 @@ class Tracklet64
   int getDetector() const { return getHCID() / 2; }
 
   uint64_t getTrackletWord() const { return mtrackletWord; }
-  uint32_t getTrackletWord32() const;
 
   void setQ0(int charge)
   {

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -8,8 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <iostream>
 #include "DataFormatsTRD/Tracklet64.h"
+
+#include "fairlogger/Logger.h"
+#include <iostream>
 
 namespace o2
 {

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -66,7 +66,7 @@ class Digit
   int getROB() const { return mROB; }
   int getMCM() const { return mMCM; }
   int getChannel() const { return mChannel; }
-  bool isSharedDigit();
+  bool isSharedDigit() const;
 
   ArrayADC const& getADC() const { return mADC; }
   ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }

--- a/Detectors/TRD/base/src/Digit.cxx
+++ b/Detectors/TRD/base/src/Digit.cxx
@@ -48,7 +48,7 @@ Digit::Digit(const int det, const int rob, const int mcm, const int channel) // 
   setChannel(channel);
 }
 
-bool Digit::isSharedDigit()
+bool Digit::isSharedDigit() const
 {
   if (mChannel == 0 || mChannel == 1 || mChannel == NADCMCM - 1) {
     return 1;

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -59,44 +59,22 @@ using namespace o2::trd::constants;
 
 bool TrapSimulator::mgApplyCut = true;
 int TrapSimulator::mgAddBaseline = 0;
-bool TrapSimulator::mgStoreClusters = true;
+bool TrapSimulator::mgStoreClusters = false;
 const int TrapSimulator::mgkFormatIndex = std::ios_base::xalloc();
 const std::array<unsigned short, 4> TrapSimulator::mgkFPshifts{11, 14, 17, 21};
-
-TrapSimulator::TrapSimulator()
-  : mInitialized(false), mDetector(-1), mRobPos(-1), mMcmPos(-1), mRow(-1), mNTimeBin(-1), mTrklBranchName("mcmtrklbranch"), mFeeParam(nullptr), mTrapConfig(nullptr)
-{
-  //
-  // TrapSimulator default constructor
-  // It is necessary to issue init before use.
-
-  mFitPtr[0] = 0;
-  mFitPtr[1] = 0;
-  mFitPtr[2] = 0;
-  mFitPtr[3] = 0;
-  mNHits = 0;
-  //  mCalib.setCCDBForSimulation(297595);
-}
 
 void TrapSimulator::init(TrapConfig* trapconfig, int det, int robPos, int mcmPos)
 {
   //
   // Initialize the class with new MCM position information
-  // memory is allocated in the first initialization
   //
-  //
-  LOG(debug) << " : trap sim is at : 0x" << hex << trapconfig;
-  if (!mInitialized) {
-    mFeeParam = FeeParam::instance();
-    mTrapConfig = trapconfig;
-  }
-
   mDetector = det;
   mRobPos = robPos;
   mMcmPos = mcmPos;
   mRow = mFeeParam->getPadRowFromMCM(mRobPos, mMcmPos);
 
   if (!mInitialized) {
+    mTrapConfig = trapconfig;
     mNTimeBin = mTrapConfig->getTrapReg(TrapConfig::kC13CPUA, mDetector, mRobPos, mMcmPos);
     mZSMap.resize(NADCMCM);
 
@@ -127,15 +105,16 @@ void TrapSimulator::reset()
   }
 
   //clear the adc data
-  memset(&mADCR[0], 0, sizeof(mADCR[0]) * mADCR.size());
-  memset(&mADCF[0], 0, sizeof(mADCF[0]) * mADCF.size());
+  std::fill(mADCR.begin(), mADCR.end(), 0);
+  std::fill(mADCF.begin(), mADCF.end(), 0);
+
   //clear the labels
-  mADCLabels[0].clear();
-  mADCLabels[1].clear();
-  mADCLabels[2].clear();
+  for (auto& adcLabels : mADCLabels) {
+    adcLabels.clear();
+  }
 
   mTrackletLabels.clear(); // as the name implies clear the stored labels
-  mNHits = 0;
+  // OS: Should the hits be reset? mHits and mNHits? This is anyway done in calcFitReg(), maybe move it here?
 
   for (auto filterreg : mInternalFilterRegisters) {
     filterreg.ClearReg();
@@ -145,16 +124,22 @@ void TrapSimulator::reset()
     trackletdetail.clear();
   }
   // Default unread, low active bit mask
-  // Default unread, low active bit mask
-  memset(&mZSMap[0], 0, sizeof(mZSMap[0]) * NADCMCM);
-  memset(&mMCMT[0], 0, sizeof(mMCMT[0]) * mgkMaxTracklets);
-  //mDict1.clear();
-  //mDict2.clear();
-  //mDict3.clear();
+  std::fill(mZSMap.begin(), mZSMap.end(), 0);
+  std::fill(mMCMT.begin(), mMCMT.end(), 0);
 
   filterPedestalInit();
   filterGainInit();
   filterTailInit();
+
+  for (auto& fitreg : mFitReg) {
+    fitreg.ClearReg();
+  }
+  mADCFilled = 0;
+
+  mTrackletLabels.clear(); // clear the stored labels.
+  mTrackletArray64.clear();
+
+  mDataIsSet = false;
 }
 
 // ----- I/O implementation -----
@@ -788,11 +773,12 @@ void TrapSimulator::setData(int adc, const ArrayADC& data, std::vector<o2::MCCom
   }
 
   if (adc < 0 || adc >= NADCMCM) {
-    //    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << NADCMCM - 1 << ")";
+    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << NADCMCM - 1 << ")";
     return;
   }
 
   //  LOG(debug) <<  "Set Data : Det:Rob:MCM::"<< getDetector() <<":" <<getRobPos()<<":"<<getMcmPos() << " t:"<< mNTimeBin;
+  // OS: in Run 2 zero was suppressed!!!
   for (int it = 0; it < mNTimeBin; it++) {
     mADCR[adc * mNTimeBin + it] = ((int)(data[it]) << mgkAddDigits) + (mgAddBaseline << mgkAddDigits);
     mADCF[adc * mNTimeBin + it] = ((int)(data[it]) << mgkAddDigits) + (mgAddBaseline << mgkAddDigits);
@@ -1603,10 +1589,10 @@ void TrapSimulator::calcFitreg()
     fitreg.ClearReg();
   }
 
-  //  mFitReg.clear();
   for (int i = 0; i < mNHits; i++) {
     mHits[i].ClearHits(); // do it this way as we dont want to zero 150 members if we only used 3 ....
   }
+  mNHits = 0;
 
   for (timebin = timebin1; timebin < timebin2; timebin++) {
     // first find the hit candidates and store the total cluster charge in qTotal array
@@ -1663,7 +1649,6 @@ void TrapSimulator::calcFitreg()
     marked[4] = 19; // invalid channel
     marked[5] = 19; // invalid channel
     qTotal[19] = 0;
-    int loopcount = 0;
     while ((adcch < 16) && (found < 3)) {
       if (qTotal[adcch] > 0) {
         fromLeft = adcch;
@@ -1726,6 +1711,7 @@ void TrapSimulator::calcFitreg()
         qTotal[worse2] = 0;
         // LOG(debug) << "Kill ch " << worse2;
       }
+      // OS: do we need to kill 3 channels instead of 2 if we write out at max 3 tracklets?
     }
 
     for (adcch = 0; adcch < 19; adcch++) {
@@ -1772,11 +1758,9 @@ void TrapSimulator::calcFitreg()
         LOG(debug) << "ypos before lut correction : " << ypos;
         ypos = ypos + mTrapConfig->getTrapReg((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + (ypos & 0x7F)),
                                               mDetector, mRobPos, mMcmPos);
+        LOG(debug) << "ypos after lut correction : " << ypos;
         if (adcLeft > adcRight) {
-          LOG(debug) << "ypos after lut correction : " << ypos;
-          if (adcLeft > adcRight) {
-            ypos = -ypos;
-          }
+          ypos = -ypos;
         }
         /*   TODO this is left in here as a ref for what was done with labels, its stored externally now figure something out.
                 */
@@ -1808,8 +1792,8 @@ void TrapSimulator::trackletSelection()
   // and assign them to the CPUs.
   LOG(debug) << "ENTERING : " << __FILE__ << ":" << __func__ << ":" << __LINE__ << " :: " << getDetector() << ":" << getRobPos() << ":" << getMcmPos();
   unsigned short adcIdx, i, j, ntracks, tmp;
-  std::array<unsigned short, 18> trackletCandch{};   // store the adcch[0] and number of hits[1] for all tracklet candidates
-  std::array<unsigned short, 18> trackletCandhits{}; // store the adcch[0] and number of hits[1] for all tracklet candidates
+  std::array<unsigned short, 18> trackletCandch{};   // store the adcch for all tracklet candidates
+  std::array<unsigned short, 18> trackletCandhits{}; // store the number of hits for all tracklet candidates
 
   ntracks = 0;
   for (adcIdx = 0; adcIdx < 18; adcIdx++) { // ADCs
@@ -1921,8 +1905,9 @@ void TrapSimulator::fitTracklet()
 
   // calculated in fitred.asm
   int padrow = ((mRobPos >> 1) << 2) | (mMcmPos >> 2);
-  int yoffs = (((((mRobPos & 0x1) << 2) + (mMcmPos & 0x3)) * 18) << 8) -
-              ((18 * 4 * 2 - 18 * 2 - 1) << 7);
+  //int yoffs = (((((mRobPos & 0x1) << 2) + (mMcmPos & 0x3)) * 18) << 8) -
+  //            ((18 * 4 * 2 - 18 * 2 - 1) << 7);
+  int yoffs = 0; // we do the shift to the MCM center in the tracklet transformer
   // TODO we dont need the stuff calculated in fitred.asm because we are now all relative to the mcm ?? check this statement
   LOG(debug) << "padrow:" << padrow << " yoffs:" << yoffs << " and rndAdd:" << rndAdd;
 
@@ -1934,8 +1919,10 @@ void TrapSimulator::fitTracklet()
 
   yoffs = yoffs << decPlaces; // holds position of ADC channel 1
   int layer = mDetector % 6;
-  unsigned int scaleY = 1; //(unsigned int)((0.635 + 0.03 * layer) / (256.0 * 160.0e-4) * shift);
-  unsigned int scaleD = 1; //(unsigned int)((0.635 + 0.03 * layer) / (256.0 * 140.0e-4) * shift);
+  // we need to scale the offset since we want to store it in units of 1/75 pad and the calculation is done in 1/256 pad width granularity
+  // TODO correct the scaling factors for desired granularity
+  unsigned int scaleY = (UInt_t)((0.635 + 0.03 * layer) / (256.0 * 160.0e-4) * shift);
+  unsigned int scaleD = (UInt_t)((0.635 + 0.03 * layer) / (256.0 * 140.0e-4) * shift);
   LOG(debug) << "scaleY : " << scaleY << "  scaleD=" << scaleD << " shift:" << std::hex << shift << std::dec;
   int deflCorr = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCorr, mDetector, mRobPos, mMcmPos);
   int ndrift = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos);
@@ -2007,8 +1994,12 @@ void TrapSimulator::fitTracklet()
       slope = -slope;
       temp = mult * position;
       position = temp >> 32; // take the upper 32 bits
+
+      position += yoffs;
+
       LOG(debug) << "slope = " << slope;
       //slope = slope;//this is here as a reference for what was done in run2 //* ndrift) >> ndriftDp) + deflCorr;
+      //slope = ((slope * ndrift) >> ndriftDp) + deflCorr;
       auto oldpos = position;
       LOG(debug) << "position = position - (mFitPtr[cpu] << (8 + decPlaces));";
       position = position - (mFitPtr[cpu] << (8 + decPlaces));
@@ -2064,39 +2055,13 @@ void TrapSimulator::fitTracklet()
       if (rejected && getApplyCut()) {
         mMCMT[cpu] = 0x10001000; //??? FeeParam::getTrackletEndmarker();
       } else {
-        if (slope > 127 || slope < -127) { // wrapping in TRAP!
+        if (slope > 127 || slope < -128) { // wrapping in TRAP!
           LOG(debug) << "Overflow in slope: " << slope << ", tracklet discarded!";
           mMCMT[cpu] = 0x10001000;
           continue;
         }
 
         slope = slope & 0xff; // 8 bit
-
-        yoffs = yoffs << decPlaces; // holds position of ADC channel 1
-        int layer = mDetector % 6;
-        unsigned int scaleY = (unsigned int)((0.635 + 0.03 * layer) / (256.0 * 160.0e-4) * shift);
-        unsigned int scaleD = (unsigned int)((0.635 + 0.03 * layer) / (256.0 * 140.0e-4) * shift);
-        LOG(debug) << "scaleY : " << scaleY << "  scaleD=" << scaleD << " shift:" << std::hex << shift << std::dec;
-        int deflCorr = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCorr, mDetector, mRobPos, mMcmPos);
-        int ndrift = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos);
-
-        // local variables for calculation
-        long mult, temp, denom;
-        unsigned int q0, q1, q2 = 23, pid; // charges in the two windows and total charge
-        float rawpid, rawz, rawy, rawslope, rawposition;
-        float rawslope4trackletword, rawoffset4trackletword;
-        //             unsigned short nHits;         // number of hits
-        int slope, position;          // slope and position of the tracklet
-        int sumX, sumY, sumXY, sumX2; // fit sums from fit registers
-        int sumY2;                    // not used in the current TRAP program, used for error calculation (simulation only)
-        float fitError, fitSlope, fitOffset;
-        FitReg *fit0, *fit1; // pointers to relevant fit registers
-
-        //  const uint32_t OneDivN[32] = {  // 2**31/N : exactly like in the TRAP, the simple division here gives the same result!
-        //      0x00000000, 0x80000000, 0x40000000, 0x2AAAAAA0, 0x20000000, 0x19999990, 0x15555550, 0x12492490,
-        //      0x10000000, 0x0E38E380, 0x0CCCCCC0, 0x0BA2E8B0, 0x0AAAAAA0, 0x09D89D80, 0x09249240, 0x08888880,
-        //      0x08000000, 0x07878780, 0x071C71C0, 0x06BCA1A0, 0x06666660, 0x06186180, 0x05D17450, 0x0590B210,
-        //      0x05555550, 0x051EB850, 0x04EC4EC0, 0x04BDA120, 0x04924920, 0x0469EE50, 0x04444440, 0x04210840};
 
         if (position > 0x7ff || position < -0x7ff) { // 11 bits.
           LOG(warning) << "Overflow in position with position of " << position << " in hex 0x" << std::hex << position;
@@ -2172,7 +2137,7 @@ void TrapSimulator::fitTracklet()
         uint32_t format = 0;
         uint32_t hcid = mDetector * 2 + mRobPos % 2;
         uint32_t padrow = ((mRobPos >> 1) << 2) | (mMcmPos >> 2);
-        uint32_t col = mFeeParam->getPadColFromADC(mRobPos, mMcmPos, 1);
+        uint32_t col = mMcmPos % NMCMROBINCOL;
         //defined above uint32_t position = ;
         //uint32_t s
         mTrackletArray64.emplace_back(format, hcid, padrow, col, position, slope, q0, q1, q2);
@@ -2350,7 +2315,6 @@ void TrapSimulator::tracklet()
     return;
   }
   LOG(debug) << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^";
-  mTrackletArray64.clear();
   calcFitreg();
   if (mNHits == 0) {
     return;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -42,37 +42,26 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
 
- protected:
-  void setTriggerRecord(std::vector<o2::trd::TriggerRecord>& triggerrecord, uint32_t currentrecord, uint64_t recordsize);
-  void setTrapSimulatorData(int adc, std::vector<o2::trd::Digit>& digits, int digitposition);
-  // TODO LABELS, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* labels)
 
  private:
-  std::array<TrapSimulator, 8> mTrapSimulator; //the 8 trap simulators for a given padrow.
-  FeeParam* mFeeParam = nullptr;
+  std::array<TrapSimulator, 128> mTrapSimulator; //the up to 128 trap simulators for a single chamber
   TrapConfig* mTrapConfig = nullptr;
-  std::unique_ptr<Geometry> mGeo;
   //  std::unique_ptr<TrapConfigHandler> mTrapConfigHandler;
   unsigned long mRunNumber = 297595; //run number to anchor simulation to.
   bool mDriveFromConfig{false};     // option to disable using the trapconfig to drive the simulation
   int mPrintTrackletOptions = 0;    // print the trap chips adc vs timebin to the screen, ascii art
   int mDrawTrackletOptions = 0;     //draw the tracklets 1 per file
-  int mShowTrackletStats = 25000;   //how frequencly to show the trapsimulator stats
+  int mShowTrackletStats = 1;       // show some statistics for each run
   bool mPrintOutTrapConfig{false};
   bool mDebugRejectedTracklets{false};
   bool mEnableOnlineGainCorrection{false};
   bool mEnableTrapConfigDump{false};
-  std::vector<Tracklet64> mTracklets; // store of found tracklets
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";
   std::unique_ptr<CalOnlineGainTables> mGainTable; //this will probably not be used in run3.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
-  std::vector<o2::trd::LinkRecord> mLinkRecords;
-  //arrays to keep some stats during processing
-  std::array<unsigned int, 8> mTrapUsedCounter{0};
-  std::array<unsigned int, 8> mTrapUsedFrequency{0};
 
   //various timers so we can see how long things take
   std::chrono::duration<double> mTrapSimAccumulatedTime{0}; ///< full timer
@@ -82,10 +71,6 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   std::chrono::duration<double> mTrackletTime{0};           ///< full timer
   std::chrono::duration<double> mSortingTime{0};            ///< full timer
 
-  uint64_t mTotalRawWordsWritten = 0; // words written for the raw format of 4x32bits, where 4 can be 2 to 4 depending on # of tracklets in the block.
-  int32_t mOldHalfChamberLinkId = 0;
-  bool mNewTrackletHCHeaderHasBeenWritten{false};
-  TrackletHCHeader mTrackletHCHeader; // the current half chamber header, that will be written if a first tracklet is found for this halfchamber.
   TrapConfig* getTrapConfig();
   void loadTrapConfig();
   void loadDefaultTrapConfig();

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -44,6 +44,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   int mShowTrackletStats = 1;        // show some statistics for each run
   bool mEnableOnlineGainCorrection{false};
   bool mEnableTrapConfigDump{false};
+  bool mShareDigitsManually{false}; // duplicate digits connected to shared pads if digitizer did not do so
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -43,7 +43,6 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) override;
 
  protected:
-  void fixTriggerRecords(std::vector<o2::trd::TriggerRecord>& trigRecord); // should be temporary.
   void setTriggerRecord(std::vector<o2::trd::TriggerRecord>& triggerrecord, uint32_t currentrecord, uint64_t recordsize);
   void setTrapSimulatorData(int adc, std::vector<o2::trd::Digit>& digits, int digitposition);
   // TODO LABELS, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* labels)
@@ -54,7 +53,6 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   TrapConfig* mTrapConfig = nullptr;
   std::unique_ptr<Geometry> mGeo;
   //  std::unique_ptr<TrapConfigHandler> mTrapConfigHandler;
-  int mNumThreads = 8;
   unsigned long mRunNumber = 297595; //run number to anchor simulation to.
   bool mDriveFromConfig{false};     // option to disable using the trapconfig to drive the simulation
   int mPrintTrackletOptions = 0;    // print the trap chips adc vs timebin to the screen, ascii art

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -13,18 +13,12 @@
 
 #include <vector>
 #include <array>
-#include <iostream>
+#include <string>
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-#include "TRDBase/FeeParam.h"
 #include "TRDSimulation/TrapSimulator.h"
-#include "DataFormatsTRD/TriggerRecord.h"
-#include "DataFormatsTRD/LinkRecord.h"
-#include "DataFormatsTRD/Tracklet64.h"
-#include "DataFormatsTRD/RawData.h"
 #include "TRDSimulation/TrapConfig.h"
-#include "CCDB/BasicCCDBManager.h"
 
 class Calibrations;
 
@@ -46,30 +40,14 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
  private:
   std::array<TrapSimulator, 128> mTrapSimulator; //the up to 128 trap simulators for a single chamber
   TrapConfig* mTrapConfig = nullptr;
-  //  std::unique_ptr<TrapConfigHandler> mTrapConfigHandler;
   unsigned long mRunNumber = 297595; //run number to anchor simulation to.
-  bool mDriveFromConfig{false};     // option to disable using the trapconfig to drive the simulation
-  int mPrintTrackletOptions = 0;    // print the trap chips adc vs timebin to the screen, ascii art
-  int mDrawTrackletOptions = 0;     //draw the tracklets 1 per file
-  int mShowTrackletStats = 1;       // show some statistics for each run
-  bool mPrintOutTrapConfig{false};
-  bool mDebugRejectedTracklets{false};
+  int mShowTrackletStats = 1;        // show some statistics for each run
   bool mEnableOnlineGainCorrection{false};
   bool mEnableTrapConfigDump{false};
   std::string mTrapConfigName;      // the name of the config to be used.
-  std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";
-  std::unique_ptr<CalOnlineGainTables> mGainTable; //this will probably not be used in run3.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
-
-  //various timers so we can see how long things take
-  std::chrono::duration<double> mTrapSimAccumulatedTime{0}; ///< full timer
-  std::chrono::duration<double> mDigitLoopTime{0};          ///< full timer
-  std::chrono::duration<double> mTrapLoopTime{0};           ///< full timer
-  std::chrono::duration<double> moldelse{0};                ///< full timer
-  std::chrono::duration<double> mTrackletTime{0};           ///< full timer
-  std::chrono::duration<double> mSortingTime{0};            ///< full timer
 
   TrapConfig* getTrapConfig();
   void loadTrapConfig();

--- a/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
@@ -15,6 +15,7 @@
 #include "Headers/DataHeader.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "fairlogger/Logger.h"
 
 using namespace o2::framework;
 

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -241,17 +241,14 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   mSortingTime = std::chrono::high_resolution_clock::now() - sortstart;
   LOG(warn) << "TRD Digit Sorting took " << mSortingTime.count();
 
-  // now to loop over the incoming digits.
   auto timeDigitLoopStart = std::chrono::high_resolution_clock::now();
-  //uint64_t digitcounter = 0;
 
-  // set current detector and row for the first digit
   int currDetector = -1;
 
   for (int iTrig = 0; iTrig < inputTriggerRecords.size(); ++iTrig) {
     int nTrackletsInTrigRec = 0;
-    for (auto digitIdx : digitIndices) {
-      const auto& digit = &inputDigits[digitIdx];
+    for (int iDigit = inputTriggerRecords[iTrig].getFirstEntry(); iDigit < (inputTriggerRecords[iTrig].getFirstEntry() + inputTriggerRecords[iTrig].getNumberOfObjects()); ++iDigit) {
+      const auto& digit = &inputDigits[digitIndices[iDigit]];
       if (currDetector < 0) {
         currDetector = digit->getDetector();
       }
@@ -281,11 +278,10 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
       // TODO check MC label part
       std::vector<o2::MCCompLabel> dummyLabels;
       /*
-      auto digitslabels = digitMCLabels.getLabels(digitcounter);
+      auto digitslabels = digitMCLabels.getLabels(iDigit);
       for (auto& tmplabel : digitslabels) {
         tmplabels.push_back(tmplabel);
       }
-      ++digitcounter;
       */
       // end MC label part
       mTrapSimulator[trapIdx].setData(digit->getChannel(), digit->getADC(), dummyLabels);

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -86,7 +86,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     // connect the TRD digitization
     o2::trd::getTRDTrapSimulatorSpec(),
     // connect the TRD digit writer
-    o2::trd::getTRDTrackletWriterSpec(),
-    // connect the TRD digit writer
-    o2::trd::getTRDTrapRawWriterSpec()};
+    o2::trd::getTRDTrackletWriterSpec()};
 }


### PR DESCRIPTION
- New digits are created for shared pads, so the filling of the TRAP chips doesn't need to take that into account

TODOs:
- add correct scaling factors for dy and y
- check if sorting of the digits is still needed
- MC labels not yet added
- remove MC->raw conversion part?