### PR TITLE
DPL: Properly close websockets when peer quits / dies (O2-2062)

### DIFF
--- a/Framework/Core/src/DPLWebSocket.cxx
+++ b/Framework/Core/src/DPLWebSocket.cxx
@@ -168,6 +168,11 @@ void WSDPLHandler::error(int code, char const* message)
   uv_write(error_rep, (uv_stream_t*)mStream, &bfr, 1, ws_error_write_callback);
 }
 
+void close_client_websocket(uv_handle_t* stream)
+{
+  LOG(debug) << "Closing websocket connection to server";
+}
+
 void websocket_client_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 {
   WSDPLClient* client = (WSDPLClient*)stream->data;
@@ -175,10 +180,18 @@ void websocket_client_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_
   if (nread == 0) {
     return;
   }
+  if (nread == UV_EOF) {
+    LOG(debug) << "EOF received from server, closing.";
+    uv_read_stop(stream);
+    uv_close((uv_handle_t*)stream, close_client_websocket);
+    return;
+  }
   if (nread < 0) {
     // FIXME: improve error message
     // FIXME: should I close?
     LOG(ERROR) << "Error while reading from websocket";
+    uv_read_stop(stream);
+    uv_close((uv_handle_t*)stream, close_client_websocket);
     return;
   }
   try {


### PR DESCRIPTION
Also do not consider EOF as an error.