### PR TITLE
TRD renamed HitType to Hit, own file and moved to DataFormats

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -21,4 +21,5 @@ o2_add_library(DataFormatsTRD
                        include/DataFormatsTRD/Tracklet64.h
                        include/DataFormatsTRD/RawData.h
                        include/DataFormatsTRD/Constants.h
-                       include/DataFormatsTRD/CalibratedTracklet.h)
+                       include/DataFormatsTRD/CalibratedTracklet.h
+                       include/DataFormatsTRD/Hit.h)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_HIT_H_
+#define ALICEO2_TRD_HIT_H_
+
+#include <vector>
+#include "DetectorsBase/Detector.h"
+#include "SimulationDataFormat/BaseHits.h"
+#include "CommonUtils/ShmAllocator.h"
+
+namespace o2::trd
+{
+
+class Hit : public o2::BasicXYZQHit<float>
+{
+ public:
+  using BasicXYZQHit<float>::BasicXYZQHit;
+  Hit(float x, float y, float z, float lCol, float lRow, float lTime, float tof, int charge, int trackId, int detId, bool drift)
+    : mInDrift(drift), locC(lCol), locR(lRow), locT(lTime), BasicXYZQHit(x, y, z, tof, charge, trackId, detId){};
+  bool isFromDriftRegion() const { return mInDrift; }
+  void setLocalC(float lCol) { locC = lCol; }
+  void setLocalR(float lRow) { locR = lRow; }
+  void setLocalT(float lTime) { locT = lTime; }
+  float getLocalC() const { return locC; }
+  float getLocalR() const { return locR; }
+  float getLocalT() const { return locT; }
+
+ private:
+  bool mInDrift{false};
+  float locC{-99}; // col direction in amplification or drift volume
+  float locR{-99}; // row direction in amplification or drift volume
+  float locT{-99}; // time direction in amplification or drift volume
+};
+} // namespace o2::trd
+
+#ifdef USESHM
+namespace std
+{
+template <>
+class allocator<o2::trd::Hit> : public o2::utils::ShmAllocator<o2::trd::Hit>
+{
+};
+} // namespace std
+#endif
+
+#endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -22,6 +22,7 @@
 #pragma link C++ struct o2::trd::TrackletMCMData + ;
 #pragma link C++ class o2::trd::Tracklet64 + ;
 #pragma link C++ class o2::trd::CalibratedTracklet + ;
+#pragma link C++ class o2::trd::Hit + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TriggerRecord > +;

--- a/Detectors/TRD/macros/CheckHits.C
+++ b/Detectors/TRD/macros/CheckHits.C
@@ -19,9 +19,10 @@
 #include <TCanvas.h>
 
 #include "FairLogger.h"
-#include "TRDSimulation/Detector.h"
+#include "DataFormatsTRD/Hit.h"
 #include "TRDBase/Geometry.h"
 #include "TRDBase/Calibrations.h"
+#include "TRDSimulation/Detector.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #endif
@@ -39,7 +40,7 @@ void CheckHits(const int detector = 50, // 354, 14, 242, 50
 
   TFile* fin = TFile::Open(hitfile.data());
   TTree* hitTree = (TTree*)fin->Get("o2sim");
-  std::vector<o2::trd::HitType>* hits = nullptr;
+  std::vector<o2::trd::Hit>* hits = nullptr;
   hitTree->SetBranchAddress("TRDHit", &hits);
   int nev = hitTree->GetEntries();
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -16,44 +16,9 @@
 #include "SimulationDataFormat/BaseHits.h"
 #include "CommonUtils/ShmAllocator.h"
 
+#include "DataFormatsTRD/Hit.h"
+
 class FairVolume;
-
-namespace o2
-{
-namespace trd
-{
-class HitType : public o2::BasicXYZQHit<float>
-{
- public:
-  using BasicXYZQHit<float>::BasicXYZQHit;
-  HitType(float x, float y, float z, float lCol, float lRow, float lTime, float tof, int charge, int trackId, int detId, bool drift)
-    : mInDrift(drift), locC(lCol), locR(lRow), locT(lTime), BasicXYZQHit(x, y, z, tof, charge, trackId, detId){};
-  bool isFromDriftRegion() const { return mInDrift; }
-  void setLocalC(float lCol) { locC = lCol; }
-  void setLocalR(float lRow) { locR = lRow; }
-  void setLocalT(float lTime) { locT = lTime; }
-  float getLocalC() const { return locC; }
-  float getLocalR() const { return locR; }
-  float getLocalT() const { return locT; }
-
- private:
-  bool mInDrift{false};
-  float locC{-99}; // col direction in amplification or drift volume
-  float locR{-99}; // row direction in amplification or drift volume
-  float locT{-99}; // time direction in amplification or drift volume
-};
-} // namespace trd
-} // namespace o2
-
-#ifdef USESHM
-namespace std
-{
-template <>
-class allocator<o2::trd::HitType> : public o2::utils::ShmAllocator<o2::trd::HitType>
-{
-};
-} // namespace std
-#endif
 
 namespace o2
 {
@@ -71,7 +36,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void InitializeO2Detector() override;
   bool ProcessHits(FairVolume* v = nullptr) override;
   void Register() override;
-  std::vector<HitType>* getHits(int iColl) const
+  std::vector<Hit>* getHits(int iColl) const
   {
     if (iColl == 0) {
       return mHits;
@@ -102,7 +67,7 @@ class Detector : public o2::base::DetImpl<Detector>
   // Create TR hits
   void createTRhit(int);
 
-  std::vector<HitType>* mHits = nullptr; ///!< Collection of TRD hits
+  std::vector<Hit>* mHits = nullptr; ///!< Collection of TRD hits
 
   float mFoilDensity;
   float mGasNobleFraction;

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -57,7 +57,7 @@ class Digitizer
   ~Digitizer() = default;
   void init(); // setup everything
 
-  void process(std::vector<HitType> const&, DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
+  void process(std::vector<Hit> const&, DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void flush(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void pileup();
   void setEventTime(double timeNS) { mTime = timeNS; }
@@ -115,21 +115,21 @@ class Digitizer
   int mMaxTimeBinsTRAP = 30;                               // Maximum number of time bins for processing adcs; should be read from the CCDB or the TRAP config
 
   // Digitization containers
-  std::vector<HitType> mHitContainer;                                            // the container of hits in a given detector
+  std::vector<Hit> mHitContainer;                                                // the container of hits in a given detector
   std::vector<MCLabel> mMergedLabels;                                            // temporary label container
   std::array<SignalContainer, constants::MAXCHAMBER> mSignalsMapCollection;      // container for caching signals over a timeframe
   std::deque<std::array<SignalContainer, constants::MAXCHAMBER>> mPileupSignals; // container for piled up signals
 
-  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, constants::MAXCHAMBER>&);
+  void getHitContainerPerDetector(const std::vector<Hit>&, std::array<std::vector<Hit>, constants::MAXCHAMBER>&);
   void setSimulationParameters();
 
   // Digitization chain methods
   int triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   SignalContainer addSignalsFromPileup();
   void clearContainers();
-  bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, int thread = 0); // True if hit-to-signal conversion is successful
+  bool convertHits(const int, const std::vector<Hit>&, SignalContainer&, int thread = 0);     // True if hit-to-signal conversion is successful
   bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                // True if signal-to-ADC conversion is successful
-  void addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
+  void addLabel(const o2::trd::Hit& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 
   // Helpers for signal handling

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -15,6 +15,7 @@
 #include "TRDSimulation/TRsim.h"
 #include "TRDSimulation/TRDSimParams.h"
 #include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/Hit.h"
 
 #include "CommonUtils/ShmAllocator.h"
 #include "SimulationDataFormat/Stack.h"
@@ -34,13 +35,13 @@ using namespace o2::trd::constants;
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("TRD", active)
 {
-  mHits = o2::utils::createSimVector<HitType>();
+  mHits = o2::utils::createSimVector<Hit>();
   InitializeParams();
 }
 
 Detector::Detector(const Detector& rhs)
   : o2::base::DetImpl<Detector>(rhs),
-    mHits(o2::utils::createSimVector<HitType>()),
+    mHits(o2::utils::createSimVector<Hit>()),
     mFoilDensity(rhs.mFoilDensity),
     mGasNobleFraction(rhs.mGasNobleFraction),
     mGasDensity(rhs.mGasDensity),
@@ -285,7 +286,7 @@ void Detector::FinishEvent()
 {
   // Sort hit vector by detector number before the End of the Event
   std::sort(mHits->begin(), mHits->end(),
-            [](const HitType& a, const HitType& b) {
+            [](const Hit& a, const Hit& b) {
               return a.GetDetectorID() < b.GetDetectorID();
             });
 }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -14,6 +14,8 @@
 #include "FairLogger.h"
 #include "DetectorsBase/GeometryManager.h"
 
+#include "DataFormatsTRD/Hit.h"
+
 #include "TRDBase/Geometry.h"
 #include "TRDBase/SimParam.h"
 #include "TRDBase/PadPlane.h"
@@ -188,7 +190,7 @@ void Digitizer::clearContainers()
   }
 }
 
-void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits,
+void Digitizer::process(std::vector<Hit> const& hits, DigitContainer& digits,
                         o2::dataformats::MCTruthContainer<MCLabel>& labels)
 {
   if (!mCalib) {
@@ -196,7 +198,7 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits
   }
 
   // Get the a hit container for all the hits in a given detector then call convertHits for a given detector (0 - 539)
-  std::array<std::vector<HitType>, MAXCHAMBER> hitsPerDetector;
+  std::array<std::vector<Hit>, MAXCHAMBER> hitsPerDetector;
   getHitContainerPerDetector(hits, hitsPerDetector);
 
 #ifdef WITH_OPENMP
@@ -232,7 +234,7 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digits
   }
 }
 
-void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, MAXCHAMBER>& hitsPerDetector)
+void Digitizer::getHitContainerPerDetector(const std::vector<Hit>& hits, std::array<std::vector<Hit>, MAXCHAMBER>& hitsPerDetector)
 {
   //
   // Fill an array of size MAXCHAMBER (540)
@@ -244,7 +246,7 @@ void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std
   }
 }
 
-bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, SignalContainer& signalMapCont, int thread)
+bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalContainer& signalMapCont, int thread)
 {
   //
   // Convert the detector-wise sorted hits to detector signals
@@ -439,7 +441,7 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
   return true;
 }
 
-void Digitizer::addLabel(const o2::trd::HitType& hit, std::vector<o2::trd::MCLabel>& labels, std::unordered_map<int, int>& trackIds)
+void Digitizer::addLabel(const o2::trd::Hit& hit, std::vector<o2::trd::MCLabel>& labels, std::unordered_map<int, int>& trackIds)
 {
   if (trackIds[hit.GetTrackID()] == 0) {
     trackIds[hit.GetTrackID()] = 1;

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -16,7 +16,6 @@
 
 #pragma link C++ class o2::trd::Detector + ;
 #pragma link C++ class o2::base::DetImpl < o2::trd::Detector> + ;
-#pragma link C++ class o2::trd::HitType + ;
 #pragma link C++ class o2::trd::TRsim + ;
 #pragma link C++ class o2::trd::Digitizer + ;
 #pragma link C++ class o2::trd::TrapConfigHandler + ;
@@ -27,9 +26,9 @@
 #pragma link C++ class o2::trd::TrapSimulator + ;
 // dictionaries for the internal classes of TrapSimulator are needed for the debug output
 #pragma link C++ class o2::trd::TrapSimulator::TrackletDetail + ;
-#pragma link C++ class o2::trd::TrapSimulator::Hit + ;
 #pragma link C++ class o2::trd::TrapSimulator::FitReg + ;
 #pragma link C++ class o2::trd::TrapSimulator::FilterReg + ;
+#pragma link C++ class o2::trd::TrapSimulator::Hit + ;
 #pragma link C++ class o2::trd::Trap2CRU + ;
 
 #pragma link C++ class o2::trd::TRDSimParams + ;

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -16,18 +16,19 @@
 #include "Framework/Lifetime.h"
 #include "Headers/DataHeader.h"
 #include "TStopwatch.h"
-#include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "TChain.h"
+#include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include "Framework/Task.h"
+#include "DetectorsBase/BaseDPLDigitizer.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/Hit.h"
 #include "TRDBase/Digit.h" // for the Digit type
+#include "TRDBase/Calibrations.h"
 #include "TRDSimulation/Digitizer.h"
 #include "TRDSimulation/Detector.h" // for the Hit type
-#include "DetectorsBase/BaseDPLDigitizer.h"
-#include "TRDBase/Calibrations.h"
-#include "DataFormatsTRD/TriggerRecord.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -124,7 +125,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         mDigitizer.setEventID(part.entryID);
         mDigitizer.setSrcID(part.sourceID);
         // get the hits for this event and this source and process them
-        std::vector<o2::trd::HitType> hits;
+        std::vector<o2::trd::Hit> hits;
         context->retrieveHits(mSimChains, "TRDHit", part.sourceID, part.entryID, &hits);
         mDigitizer.process(hits, digits, labels);
       }

--- a/macro/analyzeHits.C
+++ b/macro/analyzeHits.C
@@ -5,7 +5,7 @@
 #include "ITSMFTSimulation/Hit.h"
 #include "TOFSimulation/Detector.h"
 #include "EMCALBase/Hit.h"
-#include "TRDSimulation/Detector.h" // For TRD Hit
+#include "DataFormatsTRD/Hit.h"
 #include "FT0Simulation/Detector.h" // for Fit Hit
 #include "DataFormatsFV0/Hit.h"
 #include "HMPIDBase/Hit.h"
@@ -113,7 +113,7 @@ struct HitStats : public HitStatsBase {
 
 struct TRDHitStats : public HitStatsBase {
   // adds a hit to the statistics
-  void addHit(o2::trd::HitType const& hit)
+  void addHit(o2::trd::Hit const& hit)
   {
     NHits++;
     auto x = hit.GetX();
@@ -245,7 +245,7 @@ void analyzeTRD(TTree* reftree)
 {
   if (!reftree)
     return;
-  auto refresult = analyse<o2::trd::HitType, TRDHitStats>(reftree, "TRDHit");
+  auto refresult = analyse<o2::trd::Hit, TRDHitStats>(reftree, "TRDHit");
   std::cout << gPrefix << " TRD ";
   refresult.print();
 }


### PR DESCRIPTION
Move class HitType out of Detectors.h into its own header file in DataFormats.
This removes a dependency of base on simulation for the TrackletTransformer
It also neatens up the code.
Renamed class to simply o2::trd::Hit instead of o2::trd::HitType.
