### PR TITLE
[EMCAL-650] Fix encoding RCU ID and trailer word order

### DIFF
--- a/Detectors/EMCAL/base/CMakeLists.txt
+++ b/Detectors/EMCAL/base/CMakeLists.txt
@@ -36,6 +36,13 @@ o2_add_test(Mapper
             COMPONENT_NAME emcal
             LABELS emcal
             ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+
+o2_add_test(RCUTrailer
+            SOURCES test/testRCUTrailer.cxx
+            PUBLIC_LINK_LIBRARIES O2::EMCALBase
+            COMPONENT_NAME emcal
+            LABELS emcal
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
             
 o2_add_test_root_macro(test/testGeometryRowColIndexing.C
             PUBLIC_LINK_LIBRARIES O2::EMCALBase

--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -160,6 +160,10 @@ class RCUTrailer
   /// \param version Firmware version
   void setFirmwareVersion(uint8_t version) { mFirmwareVersion = version; }
 
+  /// \brief Set the ID of the RCU
+  /// \param rcuid ID of the RCU
+  void setRCUID(int rcuid) { mRCUId = rcuid; }
+
   /// \brief set the payload size in number of DDL (32-bit) words
   /// \param size Payload size
   void setPayloadSize(uint32_t size) { mPayloadSize = size; }

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -159,13 +159,13 @@ std::vector<uint32_t> RCUTrailer::encode() const
 {
   std::vector<uint32_t> encoded;
   encoded.emplace_back(mPayloadSize | 2 << 30);
-  encoded.emplace_back(mAltroConfig.mWord2 | 7 << 26 | 2 << 30);
-  encoded.emplace_back(mAltroConfig.mWord1 | 6 << 26 | 2 << 30);
-  encoded.emplace_back(mActiveFECsB | 5 << 26 | 2 << 30);
-  encoded.emplace_back(mActiveFECsA | 4 << 26 | 2 << 30);
-  encoded.emplace_back(mErrorCounter.mErrorRegister3 | 3 << 26 | 2 << 30);
-  encoded.emplace_back(mErrorCounter.mErrorRegister2 | 2 << 26 | 2 << 30);
   encoded.emplace_back(mFECERRB >> 7 | (mFECERRA >> 7) << 13 | 1 << 26 | 2 << 30);
+  encoded.emplace_back(mErrorCounter.mErrorRegister2 | 2 << 26 | 2 << 30);
+  encoded.emplace_back(mErrorCounter.mErrorRegister3 | 3 << 26 | 2 << 30);
+  encoded.emplace_back(mActiveFECsA | 4 << 26 | 2 << 30);
+  encoded.emplace_back(mActiveFECsB | 5 << 26 | 2 << 30);
+  encoded.emplace_back(mAltroConfig.mWord1 | 6 << 26 | 2 << 30);
+  encoded.emplace_back(mAltroConfig.mWord2 | 7 << 26 | 2 << 30);
 
   uint32_t lasttrailerword = 3 << 30 | mFirmwareVersion << 16 | mRCUId << 7 | (encoded.size() + 1);
   encoded.emplace_back(lasttrailerword);
@@ -197,6 +197,7 @@ void RCUTrailer::printStream(std::ostream& stream) const
          << "FECERRA:                                   0x" << std::hex << mFECERRA << "\n"
          << "FECERRB:                                   0x" << std::hex << mFECERRB << "\n"
          << "ERRREG2:                                   0x" << std::hex << mErrorCounter.mErrorRegister2 << "\n"
+         << "ERRREG3:                                   0x" << std::hex << mErrorCounter.mErrorRegister3 << "\n"
          << "#channels skipped due to address mismatch: " << std::dec << getNumberOfChannelAddressMismatch() << "\n"
          << "#channels skipped due to bad block length: " << std::dec << getNumberOfChannelLengthMismatch() << "\n"
          << "Active FECs (branch A):                    0x" << std::hex << mActiveFECsA << "\n"

--- a/Detectors/EMCAL/base/test/testMapper.cxx
+++ b/Detectors/EMCAL/base/test/testMapper.cxx
@@ -7,7 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#define BOOST_TEST_MODULE Test EMCAL Reconstruction
+#define BOOST_TEST_MODULE Test EMCAL Base
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>

--- a/Detectors/EMCAL/base/test/testRCUTrailer.cxx
+++ b/Detectors/EMCAL/base/test/testRCUTrailer.cxx
@@ -1,0 +1,129 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test EMCAL Base
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include "EMCALBase/RCUTrailer.h"
+
+/// \macro Test implementation of the EMCAL RCU trailer
+///
+/// Test coverage:
+/// - ALTRO config
+/// - RCU ID
+/// - ALTRO buffers
+/// - error counters
+BOOST_AUTO_TEST_CASE(RCUTrailer_test)
+{
+  // common settings
+  int firmware = 2,
+      activeFECA = 0,
+      activeFECB = 1,
+      baselineCorr = 0,
+      presamples = 0,
+      postsamples = 0,
+      glitchfilter = 0,
+      presamplesNoZS = 1,
+      postsamplesNoZS = 1,
+      samplesChannel = 15,
+      samplesPretrigger = 0,
+      timesample = 100;
+  bool havePolarity = false,
+       haveSecBaselineCorr = false,
+       haveZS = true,
+       haveSpareReadout = true;
+  o2::emcal::RCUTrailer::BufferMode_t bufmode = o2::emcal::RCUTrailer::BufferMode_t::NBUFFERS4;
+
+  o2::emcal::RCUTrailer trailer;
+  trailer.setRCUID(0);
+  trailer.setFirmwareVersion(firmware);
+  trailer.setActiveFECsA(activeFECA);
+  trailer.setActiveFECsB(activeFECB);
+  trailer.setPayloadSize(20);
+  trailer.setTimeSamplePhaseNS(425, timesample);
+  trailer.setBaselineCorrection(baselineCorr);
+  trailer.setPolarity(havePolarity);
+  trailer.setNumberOfPresamples(presamples);
+  trailer.setNumberOfPostsamples(postsamples);
+  trailer.setSecondBaselineCorrection(false);
+  trailer.setGlitchFilter(glitchfilter);
+  trailer.setNumberOfNonZeroSuppressedPostsamples(postsamplesNoZS);
+  trailer.setNumberOfNonZeroSuppressedPresamples(presamplesNoZS);
+  trailer.setNumberOfPretriggerSamples(samplesPretrigger);
+  trailer.setNumberOfSamplesPerChannel(samplesChannel);
+  trailer.setZeroSuppression(haveZS);
+  trailer.setSparseReadout(haveSpareReadout);
+  trailer.setNumberOfAltroBuffers(bufmode);
+
+  //
+  // check ALTRO config
+  //
+  auto encoded_config = trailer.encode();
+  auto trailer_decoded_config = o2::emcal::RCUTrailer::constructFromPayloadWords(encoded_config);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getFirmwareVersion(), firmware);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfPresamples(), presamples);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfPostsamples(), postsamples);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfNonZeroSuppressedPresamples(), presamplesNoZS);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfNonZeroSuppressedPostsamples(), postsamplesNoZS);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getGlitchFilter(), glitchfilter);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfPretriggerSamples(), samplesPretrigger);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getNumberOfSamplesPerChannel(), samplesChannel);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getPolarity(), havePolarity);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.hasSecondBaselineCorr(), haveSecBaselineCorr);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.hasZeroSuppression(), haveZS);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.isSparseReadout(), haveSpareReadout);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getActiveFECsA(), activeFECA);
+  BOOST_CHECK_EQUAL(trailer_decoded_config.getActiveFECsB(), activeFECB);
+  BOOST_CHECK_CLOSE(trailer_decoded_config.getTimeSampleNS(), timesample, 1);
+  BOOST_CHECK_CLOSE(trailer_decoded_config.getL1PhaseNS(), 25, 1);
+
+  //
+  // Check RCU ID
+  //
+  for (int ircu = 0; ircu < 46; ircu++) {
+    trailer.setRCUID(ircu);
+    auto encoded_rcu = trailer.encode();
+    auto trailer_decoded_rcu = o2::emcal::RCUTrailer::constructFromPayloadWords(encoded_rcu);
+    BOOST_CHECK_EQUAL(trailer_decoded_rcu.getRCUID(), ircu);
+  }
+  trailer.setRCUID(0);
+
+  //
+  // Check buffer modes
+  //
+  std::map<o2::emcal::RCUTrailer::BufferMode_t, int> buffertests = {{o2::emcal::RCUTrailer::BufferMode_t::NBUFFERS4, 4}, {o2::emcal::RCUTrailer::BufferMode_t::NBUFFERS8, 8}};
+  for (auto [bufmode, nbuffers] : buffertests) {
+    trailer.setNumberOfAltroBuffers(bufmode);
+    auto encoded_buffer = trailer.encode();
+    auto trailer_decoded_buffer = o2::emcal::RCUTrailer::constructFromPayloadWords(encoded_buffer);
+    BOOST_CHECK_EQUAL(trailer_decoded_buffer.getNumberOfAltroBuffers(), nbuffers);
+  }
+  trailer.setNumberOfAltroBuffers(bufmode);
+
+  //
+  // Check error counters
+  //
+  std::array<int, 10> nerrors = {0, 1, 6, 10, 112, 232, 255, 52, 22, 76};
+  for (auto error : nerrors) {
+    trailer.setNumberOfChannelLengthMismatch(error);
+    auto encoded_error = trailer.encode();
+    auto trailer_decoded_error = o2::emcal::RCUTrailer::constructFromPayloadWords(encoded_error);
+    BOOST_CHECK_EQUAL(trailer_decoded_error.getNumberOfChannelLengthMismatch(), error);
+  }
+  trailer.setNumberOfChannelAddressMismatch(0);
+  for (auto error : nerrors) {
+    trailer.setNumberOfChannelAddressMismatch(error);
+    auto encoded_error = trailer.encode();
+    auto trailer_decoded_error = o2::emcal::RCUTrailer::constructFromPayloadWords(encoded_error);
+    BOOST_CHECK_EQUAL(trailer_decoded_error.getNumberOfChannelAddressMismatch(), error);
+  }
+  trailer.setNumberOfChannelAddressMismatch(0);
+}


### PR DESCRIPTION
- Added setter for the RCU ID
- Fix order of the trailer words as their order was swapped