### PR TITLE
fix position and slope bit sizes in TrackletMCMData struct

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -187,9 +187,9 @@ struct TrackletMCMData {
     uint32_t word;
     struct {
       uint8_t checkbit : 1; //
-      uint16_t slope : 6;   // Deflection angle of tracklet
-      uint16_t pid : 15;    // Particle Identity
-      uint16_t pos : 10;    // Position of tracklet, signed 10 bits, granularity 0.02 pad widths, -10.22 to +10.22, relative to centre of pad 10
+      uint16_t slope : 8;   // Deflection angle of tracklet
+      uint16_t pid : 12;    // Particle Identity
+      uint16_t pos : 11;    // Position of tracklet, signed 11 bits, granularity 1/80 pad widths, -12.80 to +12.80, relative to centre of pad 10
     } __attribute__((__packed__));
   };
 };

--- a/Detectors/TRD/base/test/testRawData.cxx
+++ b/Detectors/TRD/base/test/testRawData.cxx
@@ -82,8 +82,8 @@ BOOST_AUTO_TEST_CASE(TRDRawDataHeaderInternals)
   mcmrawdataheader.word = 0x01fe;
   BOOST_CHECK_EQUAL(mcmrawdataheader.pid0, 0xff); // 8 bits
   //check tracklet
-  tracklet.word = 0xffc00000;
-  BOOST_CHECK_EQUAL((uint32_t)tracklet.pos, 0x3ff);
+  tracklet.word = 0xffe00000;
+  BOOST_CHECK_EQUAL((uint32_t)tracklet.pos, 0x7ff);
 }
 } // namespace trd
 } // namespace o2


### PR DESCRIPTION
The slope and position bit sizes were inconsistant between  TrackletMCMData and Tracklet64.
Tracklet64 and the tdp documentation are correct. Now fixed in TrackletMCMData.
slope of 8 bits and position of 11 