### PR TITLE
[EMCAL-630] Adding container for decoder errors

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(DataFormatsEMCAL
                        src/Digit.cxx
                        src/EventHandler.cxx
                        src/CTF.cxx
+                       src/ErrorTypeFEE.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
                                      O2::Headers 
                                      O2::MathUtils 
@@ -35,7 +36,8 @@ o2_target_root_dictionary(DataFormatsEMCAL
                                   include/DataFormatsEMCAL/AnalysisCluster.h
                                   include/DataFormatsEMCAL/EventHandler.h
                                   include/DataFormatsEMCAL/MCLabel.h
-                                  include/DataFormatsEMCAL/CTF.h)
+                                  include/DataFormatsEMCAL/CTF.h
+                                  include/DataFormatsEMCAL/ErrorTypeFEE.h)
 
 o2_add_test(Cell
             SOURCES test/testCell.cxx

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_ERRORTYPEFEE_H
+#define ALICEO2_EMCAL_ERRORTYPEFEE_H
+
+#include <iostream>
+#include "Rtypes.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class ErrorTypeFEE
+/// \brief Errors per FEE information
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since March 04, 2021
+/// \ingroup EMCALDataFormat
+///
+/// Class containing decoding and raw fitter errors per FEE
+///
+
+class ErrorTypeFEE
+{
+ public:
+  /// \brief Constructor
+  ErrorTypeFEE() = default;
+
+  ErrorTypeFEE(int FEEID, int decoderError, int rawFitError) : mFEEID(FEEID), mDecodeError(decoderError), mRawFitterError(rawFitError) {}
+
+  /// \brief
+  ~ErrorTypeFEE() = default;
+
+  void setFEEID(int feeid) { mFEEID = feeid; }
+  void setDecodeErrorType(int decodeError) { mDecodeError = decodeError; }
+  void setRawFitErrorType(int rawfitterError) { mRawFitterError = rawfitterError; }
+
+  int getFEEID() const { return mFEEID; }
+  int getDecodeErrorType() const { return mDecodeError; }
+  int getRawFitErrorType() const { return mRawFitterError; }
+
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  int mFEEID = -1;          ///< FEE ID of the SM responsible for the error
+  int mDecodeError = -1;    ///< Decoding error type
+  int mRawFitterError = -1; ///< RawFitter error type
+
+  ClassDefNV(ErrorTypeFEE, 1);
+};
+
+/// \brief Stream operator for FEE and it errors
+/// \param stream Stream where to print the fee and its errors
+/// \param errorType error type to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const ErrorTypeFEE& errorType);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -21,12 +21,14 @@
 #pragma link C++ class o2::emcal::Cluster + ;
 #pragma link C++ class o2::emcal::AnalysisCluster + ;
 #pragma link C++ class o2::emcal::MCLabel + ;
+#pragma link C++ class o2::emcal::ErrorTypeFEE + ;
 
 #pragma link C++ class std::vector < o2::emcal::TriggerRecord> + ;
 #pragma link C++ class std::vector < o2::emcal::Cell> + ;
 #pragma link C++ class std::vector < o2::emcal::Digit> + ;
 #pragma link C++ class std::vector < o2::emcal::Cluster> + ;
-#pragma link C++ class std::vector < o2::emcal::AnalysisCluster > + ;
+#pragma link C++ class std::vector < o2::emcal::AnalysisCluster> + ;
+#pragma link C++ class std::vector < o2::emcal::ErrorTypeFEE> + ;
 
 #include "SimulationDataFormat/MCTruthContainer.h"
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::emcal::MCLabel> + ;

--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsEMCAL/ErrorTypeFEE.h"
+#include <iostream>
+
+using namespace o2::emcal;
+
+void ErrorTypeFEE::PrintStream(std::ostream& stream) const
+{
+  stream << "EMCAL SM: " << getFEEID() << ", Decode error Type: " << getDecodeErrorType() << ", Raw fitter error: " << getRawFitErrorType();
+}
+
+std::ostream& operator<<(std::ostream& stream, const ErrorTypeFEE& error)
+{
+  error.PrintStream(stream);
+  return stream;
+}

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -56,6 +56,14 @@ class AltroDecoderError : public std::exception
   /// \return Error message
   const char* what() const noexcept override { return mErrorMessage.data(); }
 
+  /// \brief convert the error type from symoblic constant into int
+  /// \return the error number
+  static int errorTypeToInt(ErrorType_t errortype);
+
+  /// \brief convert the error from number into a type (symbolic constant)
+  /// \return the error type
+  static ErrorType_t intToErrorType(int errornumber);
+
   /// \brief Access to the error type connected to the erro
   /// \return Error type
   const ErrorType_t getErrorType() const noexcept { return mErrorType; }

--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -107,3 +107,79 @@ const std::vector<Channel>& AltroDecoder::getChannels() const
   }
   return mChannels;
 }
+
+using AltroErrType = o2::emcal::AltroDecoderError::ErrorType_t;
+
+int AltroDecoderError::errorTypeToInt(AltroErrType errortype)
+{
+
+  int errorNumber = -1;
+
+  switch (errortype) {
+    case AltroErrType::RCU_TRAILER_ERROR:
+      errorNumber = 0;
+      break;
+    case AltroErrType::RCU_VERSION_ERROR:
+      errorNumber = 1;
+      break;
+    case AltroErrType::RCU_TRAILER_SIZE_ERROR:
+      errorNumber = 2;
+      break;
+    case AltroErrType::ALTRO_BUNCH_HEADER_ERROR:
+      errorNumber = 3;
+      break;
+    case AltroErrType::ALTRO_BUNCH_LENGTH_ERROR:
+      errorNumber = 4;
+      break;
+    case AltroErrType::ALTRO_PAYLOAD_ERROR:
+      errorNumber = 5;
+      break;
+    case AltroErrType::ALTRO_MAPPING_ERROR:
+      errorNumber = 6;
+      break;
+    case AltroErrType::CHANNEL_ERROR:
+      errorNumber = 7;
+      break;
+    default:
+      break;
+  }
+
+  return errorNumber;
+}
+
+AltroErrType AltroDecoderError::intToErrorType(int errornumber)
+{
+
+  AltroErrType errorType;
+
+  switch (errornumber) {
+    case 0:
+      errorType = AltroErrType::RCU_TRAILER_ERROR;
+      break;
+    case 1:
+      errorType = AltroErrType::RCU_VERSION_ERROR;
+      break;
+    case 2:
+      errorType = AltroErrType::RCU_TRAILER_SIZE_ERROR;
+      break;
+    case 3:
+      errorType = AltroErrType::ALTRO_BUNCH_HEADER_ERROR;
+      break;
+    case 4:
+      errorType = AltroErrType::ALTRO_BUNCH_LENGTH_ERROR;
+      break;
+    case 5:
+      errorType = AltroErrType::ALTRO_PAYLOAD_ERROR;
+      break;
+    case 6:
+      errorType = AltroErrType::ALTRO_MAPPING_ERROR;
+      break;
+    case 7:
+      errorType = AltroErrType::CHANNEL_ERROR;
+      break;
+    default:
+      break;
+  }
+
+  return errorType;
+}

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
@@ -42,7 +42,7 @@ CaloFitResults CaloRawFitterGamma2::evaluate(const std::vector<Bunch>& bunchlist
   auto [nsamples, bunchIndex, ampEstimate,
         maxADC, timeEstimate, pedEstimate, first, last] = preFitEvaluateSamples(bunchlist, altrocfg1, altrocfg2, mAmpCut);
 
-  if (ampEstimate >= mAmpCut) {
+  if (bunchIndex >= 0 && ampEstimate >= mAmpCut) {
     time = timeEstimate;
     int timebinOffset = bunchlist.at(bunchIndex).getStartTime() - (bunchlist.at(bunchIndex).getBunchLength() - 1);
     amp = ampEstimate;

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -65,6 +65,7 @@ class RawToCellConverterSpec : public framework::Task
   std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;         ///!<! Raw fitter
   std::vector<o2::emcal::Cell> mOutputCells;                    ///< Container with output cells
   std::vector<o2::emcal::TriggerRecord> mOutputTriggerRecords;  ///< Container with output cells
+  std::vector<int> mOutputDecoderErrors;                        ///< Container with decoder errors
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -65,7 +65,7 @@ class RawToCellConverterSpec : public framework::Task
   std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;         ///!<! Raw fitter
   std::vector<o2::emcal::Cell> mOutputCells;                    ///< Container with output cells
   std::vector<o2::emcal::TriggerRecord> mOutputTriggerRecords;  ///< Container with output cells
-  std::vector<int> mOutputDecoderErrors;                        ///< Container with decoder errors
+  std::vector<ErrorTypeFEE> mOutputDecoderErrors;               ///< Container with decoder errors
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -18,6 +18,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "DataFormatsEMCAL/ErrorTypeFEE.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/Mapper.h"
@@ -120,47 +121,39 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       try {
         decoder.decode();
       } catch (AltroDecoderError& e) {
-        std::stringstream errormessage;
+        std::string errormessage;
         using AltroErrType = o2::emcal::AltroDecoderError::ErrorType_t;
-        int errornum = -1;
+        /// @TODO still need to add the RawFitter errors
+        ErrorTypeFEE errornum(feeID, o2::emcal::AltroDecoderError::errorTypeToInt(e.getErrorType()), -1);
         switch (e.getErrorType()) {
           case AltroErrType::RCU_TRAILER_ERROR:
-            errornum = 0;
-            errormessage << " RCU Trailer Error ";
+            errormessage = " RCU Trailer Error ";
             break;
           case AltroErrType::RCU_VERSION_ERROR:
-            errornum = 1;
-            errormessage << " RCU Version Error ";
+            errormessage = " RCU Version Error ";
             break;
           case AltroErrType::RCU_TRAILER_SIZE_ERROR:
-            errornum = 2;
-            errormessage << " RCU Trailer Size Error ";
+            errormessage = " RCU Trailer Size Error ";
             break;
           case AltroErrType::ALTRO_BUNCH_HEADER_ERROR:
-            errornum = 3;
-            errormessage << " ALTRO Bunch Header Error ";
+            errormessage = " ALTRO Bunch Header Error ";
             break;
           case AltroErrType::ALTRO_BUNCH_LENGTH_ERROR:
-            errornum = 4;
-            errormessage << " ALTRO Bunch Length Error ";
+            errormessage = " ALTRO Bunch Length Error ";
             break;
           case AltroErrType::ALTRO_PAYLOAD_ERROR:
-            errornum = 5;
-            errormessage << " ALTRO Payload Error ";
+            errormessage = " ALTRO Payload Error ";
             break;
           case AltroErrType::ALTRO_MAPPING_ERROR:
-            errornum = 6;
-            errormessage << " ALTRO Mapping Error ";
+            errormessage = " ALTRO Mapping Error ";
             break;
           case AltroErrType::CHANNEL_ERROR:
-            errornum = 7;
-            errormessage << " Channel Error ";
+            errormessage = " Channel Error ";
             break;
           default:
             break;
         }
-        errormessage << " in Supermodule " << feeID;
-        std::cout << " EMCAL raw task: " << errormessage.str() << std::endl;
+        LOG(ERROR) << " EMCAL raw task: " << errormessage << " in Supermodule " << feeID << std::endl;
         //fill histograms  with error types
         mOutputDecoderErrors.push_back(errornum);
         continue;

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -237,11 +237,12 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   };
 
   auto makeWriterSpec_CellsTR = [checkReady](const char* processName, const char* defaultFileName, const char* defaultTreeName,
-                                             auto&& CellsBranch, auto&& TriggerRecordBranch) {
+                                             auto&& CellsBranch, auto&& TriggerRecordBranch, auto&& DecoderErrorsBranch) {
     return std::move(o2::framework::MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,
                                                            o2::framework::MakeRootTreeWriterSpec::TerminationCondition{checkReady},
                                                            std::move(CellsBranch),
-                                                           std::move(TriggerRecordBranch)));
+                                                           std::move(TriggerRecordBranch),
+                                                           std::move(DecoderErrorsBranch)));
   };
   /*
     // RS getting input digits and outputing them under the same outputspec will create dependency loop when piping the workflows
@@ -279,6 +280,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
     } else {
       using CellsDataType = std::vector<o2::emcal::Cell>;
       using TriggerRecordDataType = std::vector<o2::emcal::TriggerRecord>;
+      using DecoderErrorsDataType = std::vector<int>;
       specs.push_back(makeWriterSpec_CellsTR("emcal-cells-writer",
                                              "emccells.root",
                                              "o2sim",
@@ -287,7 +289,10 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                                                              "cell-branch-name"},
                                              BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
                                                                                      "EMCALCellTRGR",
-                                                                                     "celltrigger-branch-name"})());
+                                                                                     "celltrigger-branch-name"},
+                                             BranchDefinition<DecoderErrorsDataType>{o2::framework::InputSpec{"errors", "EMC", "DECODERERR", 0},
+                                                                                     "EMCALDECODERERR",
+                                                                                     "decodererror-branch-name"})());
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -20,6 +20,7 @@
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/Cluster.h"
+#include "DataFormatsEMCAL/ErrorTypeFEE.h"
 #include "EMCALWorkflow/RecoWorkflow.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
 #include "EMCALWorkflow/ClusterizerSpec.h"
@@ -280,7 +281,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
     } else {
       using CellsDataType = std::vector<o2::emcal::Cell>;
       using TriggerRecordDataType = std::vector<o2::emcal::TriggerRecord>;
-      using DecoderErrorsDataType = std::vector<int>;
+      using DecoderErrorsDataType = std::vector<o2::emcal::ErrorTypeFEE>;
       specs.push_back(makeWriterSpec_CellsTR("emcal-cells-writer",
                                              "emccells.root",
                                              "o2sim",


### PR DESCRIPTION
This container will be used in the QC. The QC will have its own decoder which can access the errors as well, but it will see only 10% of the data. We want all errors so we need it from the RawToCellConverter.