### PR TITLE
DPL: introduce preExit callbacks for services (O2-2067)

### DIFF
--- a/Framework/Core/include/Framework/ServiceRegistry.h
+++ b/Framework/Core/include/Framework/ServiceRegistry.h
@@ -94,6 +94,8 @@ struct ServiceRegistry {
   std::vector<ServiceEOSHandle> mPostEOSHandles;
   /// Callbacks for services to be executed after every dispatching
   std::vector<ServiceDispatchingHandle> mPostDispatchingHandles;
+  /// Callbacks for services to be executed on exit
+  std::vector<ServiceExitHandle> mPreExitHandles;
 
  public:
   using hash_type = decltype(TypeIdHelpers::uniqueId<void>());
@@ -135,6 +137,8 @@ struct ServiceRegistry {
   /// Invoke callbacks to monitor inputs after dispatching, regardless of them
   /// being discarded, consumed or processed.
   void postDispatchingCallbacks(ProcessingContext&);
+  /// Invoke callbacks on exit.
+  void preExitCallbacks();
 
   /// Declare a service by its ServiceSpec. If of type Global
   /// / Serial it will be immediately registered for tid 0,

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -37,6 +37,7 @@ class DanglingContext;
 
 /// A callback to create a given Service.
 using ServiceInit = std::function<ServiceHandle(ServiceRegistry&, DeviceState&, fair::mq::ProgOptions&)>;
+using ServiceExitCallback = std::function<void(ServiceRegistry&, void*)>;
 
 /// A callback to configure a given Service. Notice that the
 /// service itself is type erased and it's responsibility of
@@ -129,6 +130,9 @@ struct ServiceSpec {
   /// dispatched.
   ServicePostDispatching postDispatching = nullptr;
 
+  /// Callback invoked on exit
+  ServiceExitCallback exit = nullptr;
+
   /// Kind of service being specified.
   ServiceKind kind;
 };
@@ -155,6 +159,11 @@ struct ServiceEOSHandle {
 
 struct ServiceDispatchingHandle {
   ServicePostDispatching callback;
+  void* service;
+};
+
+struct ServiceExitHandle {
+  ServiceExitCallback callback;
   void* service;
 };
 

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -127,6 +127,7 @@ o2::framework::ServiceSpec CommonMessageBackends::rateLimitingSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -359,6 +360,7 @@ o2::framework::ServiceSpec CommonMessageBackends::arrowBackendSpec()
                        monitoring.send(Metric{(uint64_t)arrow->messagesDestroyed(), "arrow-messages-destroyed"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
                        monitoring.flushBuffer();
                      },
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -400,6 +402,7 @@ o2::framework::ServiceSpec CommonMessageBackends::fairMQBackendSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -421,6 +424,7 @@ o2::framework::ServiceSpec CommonMessageBackends::stringBackendSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -435,6 +439,7 @@ o2::framework::ServiceSpec CommonMessageBackends::rawBufferBackendSpec()
                      nullptr,
                      CommonMessageBackendsHelpers<RawBufferContext>::clearContextEOS(),
                      CommonMessageBackendsHelpers<RawBufferContext>::sendCallbackEOS(),
+                     nullptr,
                      nullptr,
                      nullptr,
                      nullptr,

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -96,6 +96,10 @@ o2::framework::ServiceSpec CommonServices::monitoringSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     [](ServiceRegistry& registry, void* service) {
+                       Monitoring* monitoring = reinterpret_cast<Monitoring*>(service);
+                       delete monitoring;
+                     },
                      ServiceKind::Serial};
 }
 
@@ -104,6 +108,7 @@ o2::framework::ServiceSpec CommonServices::infologgerContextSpec()
   return ServiceSpec{"infologger-contex",
                      simpleServiceInit<InfoLoggerContext, InfoLoggerContext>(),
                      noConfiguration(),
+                     nullptr,
                      nullptr,
                      nullptr,
                      nullptr,
@@ -206,6 +211,7 @@ o2::framework::ServiceSpec CommonServices::infologgerSpec()
                      nullptr,
                      nullptr,
                      nullptr,
+                     nullptr,
                      ServiceKind::Serial};
 }
 
@@ -222,6 +228,7 @@ o2::framework::ServiceSpec CommonServices::configurationSpec()
                            ConfigurationFactory::getConfiguration(backend).release()};
     },
     noConfiguration(),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -266,6 +273,7 @@ o2::framework::ServiceSpec CommonServices::driverClientSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     ServiceKind::Global};
 }
 
@@ -291,6 +299,7 @@ o2::framework::ServiceSpec CommonServices::controlSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -300,6 +309,7 @@ o2::framework::ServiceSpec CommonServices::rootFileSpec()
     "localrootfile",
     simpleServiceInit<LocalRootFileService, LocalRootFileService>(),
     noConfiguration(),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -339,6 +349,7 @@ o2::framework::ServiceSpec CommonServices::parallelSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -348,6 +359,7 @@ o2::framework::ServiceSpec CommonServices::timesliceIndex()
     "timesliceindex",
     simpleServiceInit<TimesliceIndex, TimesliceIndex>(),
     noConfiguration(),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -383,6 +395,7 @@ o2::framework::ServiceSpec CommonServices::callbacksSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -399,6 +412,7 @@ o2::framework::ServiceSpec CommonServices::dataRelayer()
                                            services.get<TimesliceIndex>())};
     },
     noConfiguration(),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -446,6 +460,7 @@ o2::framework::ServiceSpec CommonServices::tracingSpec()
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     ServiceKind::Serial};
 }
 
@@ -479,6 +494,7 @@ o2::framework::ServiceSpec CommonServices::threadPool(int numWorkers)
       auto numWorkersS = std::to_string(numWorkers);
       setenv("UV_THREADPOOL_SIZE", numWorkersS.c_str(), 0);
     },
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -580,6 +596,7 @@ o2::framework::ServiceSpec CommonServices::dataProcessingStats()
       sendRelayerMetrics(context.services(), *stats);
       flushMetrics(context.services(), *stats);
     },
+    nullptr,
     nullptr,
     nullptr,
     nullptr,

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -412,7 +412,11 @@ void DataProcessingDevice::PreRun()
   mServiceRegistry.get<CallbackService>()(CallbackService::Id::Start);
 }
 
-void DataProcessingDevice::PostRun() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Stop); }
+void DataProcessingDevice::PostRun()
+{
+  mServiceRegistry.get<CallbackService>()(CallbackService::Id::Stop);
+  mServiceRegistry.preExitCallbacks();
+}
 
 void DataProcessingDevice::Reset() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Reset); }
 

--- a/Framework/Core/src/ServiceRegistry.cxx
+++ b/Framework/Core/src/ServiceRegistry.cxx
@@ -96,6 +96,9 @@ void ServiceRegistry::bindService(ServiceSpec const& spec, void* service)
   if (spec.postDispatching) {
     mPostDispatchingHandles.push_back(ServiceDispatchingHandle{spec.postDispatching, service});
   }
+  if (spec.exit) {
+    mPreExitHandles.push_back(ServiceExitHandle{spec.exit, service});
+  }
 }
 
 /// Invoke callbacks to be executed before every process method invokation
@@ -149,6 +152,16 @@ void ServiceRegistry::postDispatchingCallbacks(ProcessingContext& processContext
 {
   for (auto& dispatchingHandle : mPostDispatchingHandles) {
     dispatchingHandle.callback(processContext, dispatchingHandle.service);
+  }
+}
+
+/// Invoke callback to be executed on exit, in reverse order.
+void ServiceRegistry::preExitCallbacks()
+{
+  // FIXME: we need to call the callback only once for the global services
+  /// I guess...
+  for (auto exitHandle = mPreExitHandles.rbegin(); exitHandle != mPreExitHandles.rend(); ++exitHandle) {
+    exitHandle->callback(*this, exitHandle->service);
   }
 }
 


### PR DESCRIPTION
This will make sure that services can be destructed in the correct order.  This
should fix the race condition between the websocket driver and the Monitoring
service being destructed in the wrong order.