### PR TITLE
MCH: digit time from TF start

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -39,19 +39,9 @@ class Digit
   void setTime(int32_t t) { mTFtime = t; }
   int32_t getTime() const { return mTFtime; }
 
-  /// flag indicating wether the time stamp is valid or not
-  bool isTimeValid() const;
-  void setTimeValid(bool valid);
-
-  /// set the index of the TimeFrame this digit belongs to. Possible values:
-  /// idx = 0 -> the digit belongs to the TF before the currently processed one
-  /// idx = 1 -> the digit belongs to the currently processed TF
-  /// idx = 2 -> the digit belongs to the TF after the currently processed one
-  uint8_t getTFindex() const;
-  void setTFindex(uint8_t idx);
-
-  uint16_t nofSamples() const { return mNofSamples; }
   void setNofSamples(uint16_t n) { mNofSamples = n; }
+  uint16_t nofSamples() const { return (mNofSamples & 0x7FFF); }
+  bool isSaturated() const { return ((mNofSamples & 0x8000) > 0); }
 
   int getDetID() const { return mDetID; }
 
@@ -63,7 +53,6 @@ class Digit
 
  private:
   int32_t mTFtime;      /// time since the beginning of the time frame, in bunch crossing units
-  uint8_t mTimeFlags;   /// flags indicating wether the time stamp is valid and to which TimeFrame the digit belongs to
   uint16_t mNofSamples; /// number of samples in the signal
   int mDetID;           /// DetectorIndex to which the digit corresponds to
   int mPadID;           /// PadIndex to which the digit corresponds to

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -28,31 +28,27 @@ namespace mch
 class Digit
 {
  public:
-  struct Time {
-    union {
-      // default value
-      uint64_t time = 0x0000000000000000;
-      struct {                       ///
-        uint32_t sampaTime : 10;     /// bit 0 to 9: sampa time
-        uint32_t bunchCrossing : 20; /// bit 10 to 29: bunch crossing counter
-        uint32_t reserved : 2;       /// bit 30 to 31: reserved
-        uint32_t orbit;              /// bit 32 to 63: orbit
-      };                             ///
-    };
-    uint64_t getBXTime()
-    {
-      return (bunchCrossing + (sampaTime * 4));
-    }
-  };
-
   Digit() = default;
 
-  Digit(int detid, int pad, unsigned long adc, Time time, uint16_t nSamples = 1);
+  Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples = 1);
   ~Digit() = default;
 
   bool operator==(const Digit&) const;
 
-  Time getTime() const { return mTime; }
+  // time in bunch crossing units, relative to the beginning of the TimeFrame
+  void setTime(int32_t t) { mTFtime = t; }
+  int32_t getTime() const { return mTFtime; }
+
+  /// flag indicating wether the time stamp is valid or not
+  bool isTimeValid() const;
+  void setTimeValid(bool valid);
+
+  /// set the index of the TimeFrame this digit belongs to. Possible values:
+  /// idx = 0 -> the digit belongs to the TF before the currently processed one
+  /// idx = 1 -> the digit belongs to the currently processed TF
+  /// idx = 2 -> the digit belongs to the TF after the currently processed one
+  uint8_t getTFindex() const;
+  void setTFindex(uint8_t idx);
 
   uint16_t nofSamples() const { return mNofSamples; }
   void setNofSamples(uint16_t n) { mNofSamples = n; }
@@ -66,11 +62,12 @@ class Digit
   void setADC(unsigned long adc) { mADC = adc; }
 
  private:
-  Time mTime;
+  int32_t mTFtime;      /// time since the beginning of the time frame, in bunch crossing units
+  uint8_t mTimeFlags;   /// flags indicating wether the time stamp is valid and to which TimeFrame the digit belongs to
   uint16_t mNofSamples; /// number of samples in the signal
-  int mDetID;
-  int mPadID;         /// PadIndex to which the digit corresponds to
-  unsigned long mADC; /// Amplitude of signal
+  int mDetID;           /// DetectorIndex to which the digit corresponds to
+  int mPadID;           /// PadIndex to which the digit corresponds to
+  unsigned long mADC;   /// Amplitude of signal
 
   ClassDefNV(Digit, 2);
 }; //class Digit

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -39,8 +39,10 @@ class Digit
   void setTime(int32_t t) { mTFtime = t; }
   int32_t getTime() const { return mTFtime; }
 
-  void setNofSamples(uint16_t n) { mNofSamples = n; }
+  void setNofSamples(uint16_t n);
   uint16_t nofSamples() const { return (mNofSamples & 0x7FFF); }
+
+  void setSaturated(bool sat);
   bool isSaturated() const { return ((mNofSamples & 0x8000) > 0); }
 
   int getDetID() const { return mDetID; }
@@ -54,7 +56,7 @@ class Digit
  private:
   int32_t mTFtime;      /// time since the beginning of the time frame, in bunch crossing units
   uint16_t mNofSamples; /// number of samples in the signal
-  int mDetID;           /// DetectorIndex to which the digit corresponds to
+  int mDetID;           /// ID of the Detection Element to which the digit corresponds to
   int mPadID;           /// PadIndex to which the digit corresponds to
   unsigned long mADC;   /// Amplitude of signal
 

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -20,8 +20,24 @@ bool closeEnough(double x, double y, double eps = 1E-6)
 }
 
 Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples)
-  : mTFtime(time), mDetID(detid), mPadID(pad), mADC(adc), mNofSamples(nSamples)
+  : mTFtime(time), mNofSamples(nSamples), mDetID(detid), mPadID(pad), mADC(adc)
 {
+  setSaturated(false);
+}
+
+void Digit::setNofSamples(uint16_t n)
+{
+  uint16_t sat = mNofSamples & 0x8000;
+  mNofSamples = (n & 0x7FFF) + sat;
+}
+
+void Digit::setSaturated(bool sat)
+{
+  if (sat) {
+    mNofSamples |= 0x8000;
+  } else {
+    mNofSamples &= 0x7FFF;
+  }
 }
 
 bool Digit::operator==(const Digit& other) const

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -11,6 +11,8 @@
 #include "MCHBase/Digit.h"
 #include <cmath>
 
+#define MCH_TF_TIME_VALID_BIT 2
+
 namespace o2::mch
 {
 
@@ -19,9 +21,36 @@ bool closeEnough(double x, double y, double eps = 1E-6)
   return std::fabs(x - y) <= eps * std::max(1.0, std::max(std::fabs(x), std::fabs(y)));
 }
 
-Digit::Digit(int detid, int pad, unsigned long adc, Time time, uint16_t nSamples)
-  : mDetID(detid), mPadID(pad), mADC(adc), mTime(time), mNofSamples(nSamples)
+Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples)
+  : mTFtime(time), mTimeFlags(0), mDetID(detid), mPadID(pad), mADC(adc), mNofSamples(nSamples)
 {
+}
+
+void Digit::setTimeValid(bool valid)
+{
+  if (valid) {
+    mTimeFlags |= (1 << MCH_TF_TIME_VALID_BIT);
+  } else {
+    mTimeFlags &= ~(1 << MCH_TF_TIME_VALID_BIT);
+  }
+}
+
+bool Digit::isTimeValid() const
+{
+  return ((mTimeFlags & (1 << MCH_TF_TIME_VALID_BIT)) != 0);
+}
+
+void Digit::setTFindex(uint8_t idx)
+{
+  // reset the two least significant bits first
+  mTimeFlags &= 0xFC;
+  // then set them to the new value
+  mTimeFlags |= (idx & 0x3);
+}
+
+uint8_t Digit::getTFindex() const
+{
+  return (mTimeFlags & 0x3);
 }
 
 bool Digit::operator==(const Digit& other) const
@@ -29,7 +58,7 @@ bool Digit::operator==(const Digit& other) const
   return mDetID == other.mDetID &&
          mPadID == other.mPadID &&
          mADC == other.mADC &&
-         mTime.time == other.mTime.time &&
+         mTFtime == other.mTFtime &&
          mNofSamples == other.mNofSamples;
 }
 

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -11,8 +11,6 @@
 #include "MCHBase/Digit.h"
 #include <cmath>
 
-#define MCH_TF_TIME_VALID_BIT 2
-
 namespace o2::mch
 {
 
@@ -22,35 +20,8 @@ bool closeEnough(double x, double y, double eps = 1E-6)
 }
 
 Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples)
-  : mTFtime(time), mTimeFlags(0), mDetID(detid), mPadID(pad), mADC(adc), mNofSamples(nSamples)
+  : mTFtime(time), mDetID(detid), mPadID(pad), mADC(adc), mNofSamples(nSamples)
 {
-}
-
-void Digit::setTimeValid(bool valid)
-{
-  if (valid) {
-    mTimeFlags |= (1 << MCH_TF_TIME_VALID_BIT);
-  } else {
-    mTimeFlags &= ~(1 << MCH_TF_TIME_VALID_BIT);
-  }
-}
-
-bool Digit::isTimeValid() const
-{
-  return ((mTimeFlags & (1 << MCH_TF_TIME_VALID_BIT)) != 0);
-}
-
-void Digit::setTFindex(uint8_t idx)
-{
-  // reset the two least significant bits first
-  mTimeFlags &= 0xFC;
-  // then set them to the new value
-  mTimeFlags |= (idx & 0x3);
-}
-
-uint8_t Digit::getTFindex() const
-{
-  return (mTimeFlags & 0x3);
 }
 
 bool Digit::operator==(const Digit& other) const

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -174,7 +174,7 @@ void ClusterFinderOriginal::resetPreCluster(gsl::span<const Digit>& digits)
     double dx = mSegmentation->padSizeX(padID) / 2.;
     double dy = mSegmentation->padSizeY(padID) / 2.;
     double charge = static_cast<double>(digit.getADC()) / static_cast<double>(std::numeric_limits<unsigned long>::max()) * 1024;
-    bool isSaturated = digit.getTime().time > 0;
+    bool isSaturated = false;
     int plane = mSegmentation->isBendingPad(padID) ? 0 : 1;
 
     if (charge <= 0.) {

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -174,7 +174,7 @@ void ClusterFinderOriginal::resetPreCluster(gsl::span<const Digit>& digits)
     double dx = mSegmentation->padSizeX(padID) / 2.;
     double dy = mSegmentation->padSizeY(padID) / 2.;
     double charge = static_cast<double>(digit.getADC()) / static_cast<double>(std::numeric_limits<unsigned long>::max()) * 1024;
-    bool isSaturated = false;
+    bool isSaturated = digit.isSaturated();
     int plane = mSegmentation->isBendingPad(padID) ? 0 : 1;
 
     if (charge <= 0.) {

--- a/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
@@ -35,4 +35,10 @@ if(BUILD_TESTING)
                 LABELS "muon;mch;raw"
                 PUBLIC_LINK_LIBRARIES O2::MCHRawDecoder Boost::boost)
 
+        o2_add_test(digits-time-computation
+                SOURCES src/testDigitsTimeComputation.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawDecoder Boost::boost)
+
 endif()

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -42,7 +42,6 @@ struct OrbitInfoHash {
 
 void dumpOrbits(const std::unordered_set<OrbitInfo, OrbitInfoHash>& mOrbits);
 
-
 //_________________________________________________________________
 //
 // Data decoder
@@ -117,7 +116,7 @@ class DataDecoder
   std::vector<SampaInfo> mSampaInfos;        ///< vector of auxiliary SampaInfo objects
 
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
-  SampaTimeFrameStarts mSampaTimeFrameStarts;                       ///< time stamps of the TimeFrames in the processed buffer
+  SampaTimeFrameStarts mSampaTimeFrameStarts;           ///< time stamps of the TimeFrames in the processed buffer
 
   SampaChannelHandler mChannelHandler;                  ///< optional user function to be called for each decoded SAMPA hit
   std::function<void(o2::header::RDHAny*)> mRdhHandler; ///< optional user function to be called for each RDH

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -47,10 +47,51 @@ struct OrbitInfoHash {
 class DataDecoder
 {
  public:
+  struct SampaInfo {
+    union {
+      uint32_t id = 0;
+      struct {
+        uint32_t chip : 1;
+        uint32_t ds : 6;
+        uint32_t solar : 16;
+        uint32_t unused : 9;
+      };
+    };
+
+    union {
+      // default value
+      uint64_t time = 0x0000000000000000;
+      struct {                       ///
+        uint32_t sampaTime : 10;     /// bit 0 to 9: sampa time
+        uint32_t bunchCrossing : 20; /// bit 10 to 29: bunch crossing counter
+        uint32_t reserved : 2;       /// bit 30 to 31: reserved
+        uint32_t orbit;              /// bit 32 to 63: orbit
+      };                             ///
+    };
+    uint32_t getBXTime()
+    {
+      return (bunchCrossing + (sampaTime * 4));
+    }
+  };
+
+  struct TimeFrameInfo {
+    TimeFrameInfo(uint32_t orbit, uint32_t bunchCrossing) : mOrbit(orbit), mBunchCrossing(bunchCrossing) {}
+
+    uint32_t mOrbit{0};
+    int32_t mBunchCrossing{0};
+  };
+
+  using TimeFrameInfos = std::unordered_map<uint32_t, std::vector<TimeFrameInfo>>;
+
   DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler, std::string mapCRUfile, std::string mapFECfile, bool ds2manu, bool verbose);
 
   void reset();
-  void decodeBuffer(gsl::span<const std::byte> page);
+  void decodeBuffer(gsl::span<const std::byte> buf);
+  static void computeDigitsTime_(std::vector<o2::mch::Digit>& digits, std::vector<SampaInfo>& sampaInfo, TimeFrameInfos& timeFrameInfos, bool debug);
+  void computeDigitsTime()
+  {
+    computeDigitsTime_(mOutputDigits, mSampaInfos, mTimeFrameInfos, mDebug);
+  }
 
   const std::vector<o2::mch::Digit>& getOutputDigits() const { return mOutputDigits; }
   const std::unordered_set<OrbitInfo, OrbitInfoHash>& getOrbits() const { return mOrbits; }
@@ -59,22 +100,27 @@ class DataDecoder
   void initElec2DetMapper(std::string filename);
   void initFee2SolarMapper(std::string filename);
   void init();
+  void decodePage(gsl::span<const std::byte> page);
 
-  Elec2DetMapper mElec2Det{nullptr};
-  FeeLink2SolarMapper mFee2Solar{nullptr};
-  o2::mch::raw::PageDecoder mDecoder;
-  size_t mNrdhs{0};
-  std::vector<o2::mch::Digit> mOutputDigits;
+  Elec2DetMapper mElec2Det{nullptr};       ///< front-end electronics mapping
+  FeeLink2SolarMapper mFee2Solar{nullptr}; ///< CRU electronics mapping
+  std::string mMapFECfile;                 ///< optional text file with custom front-end electronics mapping
+  std::string mMapCRUfile;                 ///< optional text file with custom CRU mapping
+
+  o2::mch::raw::PageDecoder mDecoder; ///< CRU page decoder
+
+  std::vector<o2::mch::Digit> mOutputDigits; ///< vector of decoded digits
+  std::vector<SampaInfo> mSampaInfos;        ///< vector of auxiliary SampaInfo objects
+
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
+  TimeFrameInfos mTimeFrameInfos;                       ///< time stamps of the TimeFrames in the processed buffer
 
-  SampaChannelHandler mChannelHandler;
-  std::function<void(o2::header::RDHAny*)> mRdhHandler;
-
-  std::string mMapCRUfile;
-  std::string mMapFECfile;
+  SampaChannelHandler mChannelHandler;                  ///< optional user function to be called for each decoded SAMPA hit
+  std::function<void(o2::header::RDHAny*)> mRdhHandler; ///< optional user function to be called for each RDH
 
   bool mDebug{false};
   bool mDs2manu{false};
+  uint32_t mOrbit{0};
 };
 
 } // namespace raw

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -17,6 +17,7 @@
 
 #include <gsl/span>
 #include <unordered_set>
+#include <unordered_map>
 
 #include "Headers/RDHAny.h"
 #include "MCHBase/Digit.h"
@@ -89,6 +90,8 @@ class DataDecoder
 
   void reset();
   void decodeBuffer(gsl::span<const std::byte> buf);
+
+  static int32_t digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2);
   static void computeDigitsTime_(std::vector<o2::mch::Digit>& digits, std::vector<SampaInfo>& sampaInfo, SampaTimeFrameStarts& sampaTimeFrameStarts, bool debug);
   void computeDigitsTime()
   {

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
@@ -30,12 +30,19 @@ using SampaChannelHandler = std::function<void(DsElecId dsId,
 
 /// A SampaChannSampaHeartBeatHandler is a function that takes a chip index and
 /// a bunch crossing counter value found in a HeartBeat packet
+using SampaHeartBeatHandler = std::function<void(DsElecId dsId,
+                                                 uint8_t chip,
+                                                 uint20_t bunchCrossing)>;
+
+/// A SampaChannSampaHeartBeatHandler is a function that takes a chip index and
+/// a bunch crossing counter value found in a HeartBeat packet
 using SampaErrorHandler = std::function<void(DsElecId dsId,
                                              int8_t chip,
                                              uint32_t error)>;
 
 struct DecodedDataHandlers {
   SampaChannelHandler sampaChannelHandler;
+  SampaHeartBeatHandler sampaHeartBeatHandler;
   SampaErrorHandler sampaErrorHandler;
 };
 

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
@@ -28,14 +28,14 @@ using SampaChannelHandler = std::function<void(DsElecId dsId,
                                                uint8_t channel,
                                                SampaCluster)>;
 
-/// A SampaChannSampaHeartBeatHandler is a function that takes a chip index and
+/// A SampaHeartBeatHandler is a function that takes a chip index and
 /// a bunch crossing counter value found in a HeartBeat packet
 using SampaHeartBeatHandler = std::function<void(DsElecId dsId,
                                                  uint8_t chip,
                                                  uint20_t bunchCrossing)>;
 
-/// A SampaChannSampaHeartBeatHandler is a function that takes a chip index and
-/// a bunch crossing counter value found in a HeartBeat packet
+/// A SampaErrorHandler is a function that takes a chip index and
+/// a numerical code describing the error encountered during the decoding
 using SampaErrorHandler = std::function<void(DsElecId dsId,
                                              int8_t chip,
                                              uint32_t error)>;

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -285,7 +285,7 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
   }
 };
 
-int32_t digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2)
+int32_t DataDecoder::digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2)
 {
   // bunch crossings are stored with 20 bits
   static const int32_t BCROLLOVER = (1 << 20);
@@ -347,7 +347,7 @@ void DataDecoder::computeDigitsTime_(std::vector<o2::mch::Digit>& digits, std::v
     int32_t tfTime = 0;
     uint32_t bc = tfStart->mBunchCrossing;
     uint32_t orbit = tfStart->mOrbit;
-    tfTime = digitsTimeDiff(orbit, bc, info.orbit, info.getBXTime());
+    tfTime = DataDecoder::digitsTimeDiff(orbit, bc, info.orbit, info.getBXTime());
     if (debug) {
       std::cout << "[computeDigitsTime_] hit " << info.orbit << "," << info.getBXTime()
                 << "    tfTime(1) " << orbit << "," << bc << "    diff " << tfTime << std::endl;

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -67,9 +67,9 @@ static int ds2manu(int i)
 
 static void patchPage(gsl::span<const std::byte> rdhBuffer, bool verbose)
 {
-  static int mNrdhs = 0;
+  static int sNrdhs = 0;
   auto& rdhAny = *reinterpret_cast<RDH*>(const_cast<std::byte*>(&(rdhBuffer[0])));
-  mNrdhs++;
+  sNrdhs++;
 
   auto cruId = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF;
   auto flags = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF00;
@@ -83,7 +83,7 @@ static void patchPage(gsl::span<const std::byte> rdhBuffer, bool verbose)
   }
 
   if (verbose) {
-    std::cout << mNrdhs << "--\n";
+    std::cout << "RDH number " << sNrdhs << "--\n";
     o2::raw::RDHUtils::printRDH(rdhAny);
   }
 };
@@ -108,11 +108,48 @@ static bool isValidDeID(int deId)
   return false;
 }
 
-void DataDecoder::decodeBuffer(gsl::span<const std::byte> page)
+void DataDecoder::decodeBuffer(gsl::span<const std::byte> buf)
 {
+  if (mDebug) {
+    std::cout << "\n\n============================\nStart of new buffer\n";
+  }
+  size_t bufSize = buf.size();
+  size_t pageStart = 0;
+  while (bufSize > pageStart) {
+    RDH* rdh = reinterpret_cast<RDH*>(const_cast<std::byte*>(&(buf[pageStart])));
+    auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
+    auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
+    if (rdhHeaderSize != 64) {
+      break;
+    }
+    auto pageSize = o2::raw::RDHUtils::getOffsetToNext(rdh);
+
+    gsl::span<const std::byte> page(reinterpret_cast<const std::byte*>(rdh), pageSize);
+    decodePage(page);
+
+    pageStart += pageSize;
+  }
+}
+
+void DataDecoder::decodePage(gsl::span<const std::byte> page)
+{
+  if (mDebug) {
+    std::cout << "\n----------------------------\nStart of new page\n\n";
+  }
   size_t ndigits{0};
 
-  uint32_t orbit;
+  auto heartBeatHandler = [&](DsElecId dsElecId, uint8_t chip, uint32_t bunchCrossing) {
+    SampaInfo sampaId;
+    sampaId.chip = chip;
+    sampaId.ds = dsElecId.elinkId();
+    sampaId.solar = dsElecId.solarId();
+
+    mTimeFrameInfos[sampaId.id].emplace_back(mOrbit, bunchCrossing);
+    if (mDebug) {
+      std::cout << "HeartBeat: solar " << sampaId.solar << "  ds " << sampaId.ds << "  chip " << sampaId.chip
+                << "  mOrbit " << mOrbit << "  bunchCrossing " << bunchCrossing << std::endl;
+    }
+  };
 
   auto channelHandler = [&](DsElecId dsElecId, uint8_t channel, o2::mch::raw::SampaCluster sc) {
     if (mChannelHandler) {
@@ -152,7 +189,7 @@ void DataDecoder::decodeBuffer(gsl::span<const std::byte> page)
       auto ch = fmt::format("{}-CH{:02d}", s, channel);
       std::cout << ch << "  "
                 << fmt::format("PAD ({:04d} {:04d} {:04d})\tADC {:06d}  TIME ({} {} {:02d})  SIZE {}  END {}",
-                               deId, dsIddet, padId, digitadc, orbit, sc.bunchCrossing, sc.sampaTime, sc.nofSamples(), (sc.sampaTime + sc.nofSamples() - 1))
+                               deId, dsIddet, padId, digitadc, mOrbit, sc.bunchCrossing, sc.sampaTime, sc.nofSamples(), (sc.sampaTime + sc.nofSamples() - 1))
                 << (((sc.sampaTime + sc.nofSamples() - 1) >= 98) ? " *" : "") << std::endl;
     }
 
@@ -161,21 +198,31 @@ void DataDecoder::decodeBuffer(gsl::span<const std::byte> page)
       return;
     }
 
-    Digit::Time time;
-    time.sampaTime = sc.sampaTime;
-    time.bunchCrossing = sc.bunchCrossing;
-    time.orbit = orbit;
+    SampaInfo sampaInfo;
+    sampaInfo.chip = channel / 32;
+    sampaInfo.ds = dsElecId.elinkId();
+    sampaInfo.solar = dsElecId.solarId();
+    sampaInfo.sampaTime = sc.sampaTime;
+    sampaInfo.bunchCrossing = sc.bunchCrossing;
+    sampaInfo.orbit = mOrbit;
 
-    mOutputDigits.emplace_back(o2::mch::Digit(deId, padId, digitadc, time, sc.nofSamples()));
+    mOutputDigits.emplace_back(o2::mch::Digit(deId, padId, digitadc, 0, sc.nofSamples()));
+    mSampaInfos.emplace_back(sampaInfo);
 
     if (mDebug) {
-      std::cout << "DIGIT STORED:\nADC " << mOutputDigits.back().getADC() << " DE# " << mOutputDigits.back().getDetID() << " PadId " << mOutputDigits.back().getPadID() << " time " << mOutputDigits.back().getTime().sampaTime << std::endl;
+      std::cout << "DIGIT STORED:\nADC " << mOutputDigits.back().getADC() << " DE# " << mOutputDigits.back().getDetID() << " PadId " << mOutputDigits.back().getPadID() << " time " << mSampaInfos.back().sampaTime << std::endl;
     }
     ++ndigits;
   };
 
   const auto dumpDigits = [&](bool bending) {
-    for (auto d : mOutputDigits) {
+    if (mOutputDigits.size() != mSampaInfos.size()) {
+      return;
+    }
+
+    for (size_t di = 0; di < mOutputDigits.size(); di++) {
+      Digit& d = mOutputDigits[di];
+      SampaInfo& t = mSampaInfos[di];
       if (d.getPadID() < 0) {
         continue;
       }
@@ -186,17 +233,30 @@ void DataDecoder::decodeBuffer(gsl::span<const std::byte> page)
       }
       float X = segment.padPositionX(d.getPadID());
       float Y = segment.padPositionY(d.getPadID());
+      uint32_t orbit = t.orbit;
+      uint32_t bunchCrossing = t.bunchCrossing;
+      uint32_t sampaTime = t.sampaTime;
       std::cout << fmt::format("  DE {:4d}  PAD {:5d}  ADC {:6d}  TIME ({} {} {:4d})",
-                               d.getDetID(), d.getPadID(), d.getADC(), d.getTime().orbit, d.getTime().bunchCrossing, d.getTime().sampaTime);
+                               d.getDetID(), d.getPadID(), d.getADC(), orbit, bunchCrossing, sampaTime);
       std::cout << fmt::format("\tC {}  PAD_XY {:+2.2f} , {:+2.2f}", (bending ? (int)0 : (int)1), X, Y);
       std::cout << std::endl;
+    }
+  };
+
+  const auto dumpOrbits = [&]() {
+    std::set<OrbitInfo> ordered_orbits(mOrbits.begin(), mOrbits.end());
+    for (auto o : ordered_orbits) {
+      std::cout << " FEEID " << o.getFeeID() << "  LINK " << (int)o.getLinkID() << "  ORBIT " << o.getOrbit() << std::endl;
     }
   };
 
   patchPage(page, mDebug);
 
   auto& rdhAny = *reinterpret_cast<RDH*>(const_cast<std::byte*>(&(page[0])));
-  orbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdhAny);
+  mOrbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdhAny);
+  if (mDebug) {
+    std::cout << "[decodeBuffer] mOrbit set to " << mOrbit << std::endl;
+  }
 
   if (mRdhHandler) {
     mRdhHandler(&rdhAny);
@@ -208,17 +268,112 @@ void DataDecoder::decodeBuffer(gsl::span<const std::byte> page)
   if (!mDecoder) {
     DecodedDataHandlers handlers;
     handlers.sampaChannelHandler = channelHandler;
+    handlers.sampaHeartBeatHandler = heartBeatHandler;
     mDecoder = mFee2Solar ? o2::mch::raw::createPageDecoder(page, handlers, mFee2Solar)
                           : o2::mch::raw::createPageDecoder(page, handlers);
   }
   mDecoder(page);
 
   if (mDebug) {
+    std::cout << "[decodeBuffer] mOrbits size: " << mOrbits.size() << std::endl;
+    //dumpOrbits();
     std::cout << "[decodeBuffer] mOutputDigits size: " << mOutputDigits.size() << std::endl;
     dumpDigits(true);
     dumpDigits(false);
   }
 };
+
+int32_t digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2)
+{
+  // bunch crossings are stored with 20 bits
+  static const int32_t BCROLLOVER = (1 << 20);
+  // bunch crossings half range
+  //static const int32_t BCHALFRANGE = (1 << 19);
+  // number of bunch crossings in one orbit
+  static const int32_t BCINORBIT = 3564;
+
+  // We use the difference of orbits values to estimate the minimum and maximum allowed
+  // difference in bunch crossings
+  int64_t dOrbit = static_cast<int64_t>(orbit2) - static_cast<int64_t>(orbit1);
+
+  // Digits might be sent out later than the orbit in which they were recorded.
+  // We account for this by allowing an extra +/- 2 orbits when converting the
+  // difference from orbit numbers to bunch crossings.
+  int64_t dBcMin = (dOrbit - 2) * BCINORBIT;
+  int64_t dBcMax = (dOrbit + 2) * BCINORBIT;
+
+  // Difference in bunch crossing values
+  int64_t dBc = static_cast<int64_t>(bc2) - static_cast<int64_t>(bc1);
+
+  if (dBc < dBcMin) {
+    // the difference is too small, so we assume that it needs to be
+    // incremented by one rollover factor
+    dBc += BCROLLOVER;
+  } else if (dBc > dBcMax) {
+    // the difference is too big, so we assume that it needs to be
+    // decremented by one rollover factor
+    dBc -= BCROLLOVER;
+  }
+
+  return static_cast<int32_t>(dBc);
+}
+
+void DataDecoder::computeDigitsTime_(std::vector<o2::mch::Digit>& digits, std::vector<SampaInfo>& sampaInfo, TimeFrameInfos& timeFrameInfos, bool debug)
+{
+  if (digits.size() != sampaInfo.size()) {
+    return;
+  }
+
+  auto setDigitTime = [&](Digit& d, int32_t tfTime1, int32_t tfTime2) {
+    d.setTime(tfTime1);
+    d.setTimeValid(true);
+    if (tfTime2 < 0) {
+      d.setTime(tfTime1);
+      if (tfTime1 >= 0) {
+        d.setTFindex(1);
+      } else {
+        d.setTFindex(0);
+      }
+    } else {
+      d.setTFindex(2);
+    }
+    if (debug) {
+      std::cout << "[computeDigitsTime_] hit time set to " << d.getTime() << ", TF index is " << (int)d.getTFindex() << std::endl;
+    }
+  };
+
+  for (size_t di = 0; di < digits.size(); di++) {
+    Digit& d = digits[di];
+    SampaInfo& info = sampaInfo[di];
+    std::vector<TimeFrameInfo>& tfInfo = timeFrameInfos[info.id];
+
+    int32_t tfTime1 = 0, tfTime2 = -1;
+
+    if (tfInfo.empty()) {
+      d.setTimeValid(false);
+      continue;
+    }
+    uint32_t bc = tfInfo[0].mBunchCrossing;
+    uint32_t orbit = tfInfo[0].mOrbit;
+    tfTime1 = digitsTimeDiff(orbit, bc, info.orbit, info.getBXTime());
+    if (debug) {
+      std::cout << "[computeDigitsTime_] hit " << info.orbit << "," << info.getBXTime()
+                << "    tfTime(1) " << orbit << "," << bc << "    diff " << tfTime1 << std::endl;
+    }
+
+    if (tfInfo.size() > 1) {
+      bc = tfInfo[1].mBunchCrossing;
+      orbit = tfInfo[1].mOrbit;
+      tfTime2 = digitsTimeDiff(orbit, bc, info.orbit, info.getBXTime());
+      if (debug) {
+        std::cout << "[computeDigitsTime_] hit " << info.orbit << "," << info.getBXTime()
+                  << "    tfTime(1) " << orbit << "," << bc << "    diff " << tfTime2 << std::endl;
+      }
+    }
+
+    setDigitTime(d, tfTime1, tfTime2);
+  }
+}
 
 static std::string readFileContent(std::string& filename)
 {
@@ -259,8 +414,6 @@ void DataDecoder::initFee2SolarMapper(std::string filename)
 //_________________________________________________________________________________________________
 void DataDecoder::init()
 {
-  mNrdhs = 0;
-
   for (int i = 0; i < 64; i++) {
     for (int j = 0; j < 64; j++) {
       if (refManu2ds_st345[j] != i) {
@@ -279,6 +432,7 @@ void DataDecoder::init()
 void DataDecoder::reset()
 {
   mOutputDigits.clear();
+  mSampaInfos.clear();
   mOrbits.clear();
 }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
@@ -72,6 +72,7 @@ class UserLogicElinkDecoder
   void oneLess10BitWord();
   void prepareAndSendCluster();
   void sendCluster(const SampaCluster& sc) const;
+  void sendHBPacket();
   void sendError(int8_t chip, uint32_t error) const;
   void setClusterSize(uint10_t value);
   void setClusterTime(uint10_t value);
@@ -185,6 +186,7 @@ bool UserLogicElinkDecoder<CHARGESUM>::append10(uint10_t data10)
         if (isSync(mSampaHeader.uint64())) {
           reset();
         } else if (mSampaHeader.packetType() == SampaPacketType::HeartBeat) {
+          sendHBPacket();
           transition(State::WaitingHeader);
           result = true;
         } else {
@@ -411,6 +413,15 @@ void UserLogicElinkDecoder<CHARGESUM>::setSample(uint10_t sample)
 
   if (mSamplesToRead == 0) {
     prepareAndSendCluster();
+  }
+}
+
+template <typename CHARGESUM>
+void UserLogicElinkDecoder<CHARGESUM>::sendHBPacket()
+{
+  SampaHeartBeatHandler handler = mDecodedDataHandlers.sampaHeartBeatHandler;
+  if (handler) {
+    handler(mDsId, mSampaHeader.chipAddress() % 2, mSampaHeader.bunchCrossingCounter());
   }
 }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTime)
   DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
-      static_cast<int32_t>(tfBunchCrossing);
+                      static_cast<int32_t>(tfBunchCrossing);
 
   BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
 }
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover)
   DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
-      static_cast<int32_t>(tfBunchCrossing) + BCROLLOVER;
+                      static_cast<int32_t>(tfBunchCrossing) + BCROLLOVER;
 
   BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
 }
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover2)
   DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
-      static_cast<int32_t>(tfBunchCrossing) - BCROLLOVER;
+                      static_cast<int32_t>(tfBunchCrossing) - BCROLLOVER;
 
   BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
 }
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeNoTFStart)
   DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
-      static_cast<int32_t>(tfBunchCrossing);
+                      static_cast<int32_t>(tfBunchCrossing);
 
   BOOST_CHECK_EQUAL(digits[0].getTime(), 0xFFFFFFFF);
 }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -1,0 +1,172 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHRaw DigitsTimeComputation
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "MCHRawDecoder/DataDecoder.h"
+
+using namespace o2::mch::raw;
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(digitstimecomputation)
+
+static const int32_t BCINORBIT = 3564;
+static const int32_t BCROLLOVER = (1 << 20);
+
+BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitNoRollover)
+{
+  uint32_t orbit1 = 1;
+  uint32_t orbit2 = 1;
+  uint32_t bc1 = 0;
+  uint32_t bc2 = BCINORBIT - 10;
+  auto diff = DataDecoder::digitsTimeDiff(orbit1, bc1, orbit2, bc2);
+  BOOST_CHECK_EQUAL(diff, bc2);
+}
+
+BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitWithRollover)
+{
+  uint32_t orbit1 = 1;
+  uint32_t orbit2 = 1;
+  uint32_t bc1 = BCROLLOVER - 10;
+  uint32_t bc2 = 10;
+  auto diff = DataDecoder::digitsTimeDiff(orbit1, bc1, orbit2, bc2);
+  BOOST_CHECK_EQUAL(diff, 20);
+}
+
+BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitWithRollover2)
+{
+  uint32_t orbit1 = 1;
+  uint32_t orbit2 = 1;
+  uint32_t bc1 = 10;
+  uint32_t bc2 = BCROLLOVER - 10;
+  auto diff = DataDecoder::digitsTimeDiff(orbit1, bc1, orbit2, bc2);
+  BOOST_CHECK_EQUAL(diff, -20);
+}
+
+static std::vector<o2::mch::Digit> makeDigitsVector()
+{
+  std::vector<o2::mch::Digit> digits;
+  digits.emplace_back(100, 10, 1000, 0x7FFFFFFF, 10);
+  return digits;
+}
+
+static std::vector<DataDecoder::SampaInfo> makeInfoVector(uint32_t sampaTime, uint32_t bunchCrossing, uint32_t orbit)
+{
+  DataDecoder::SampaInfo sampaId;
+  std::vector<DataDecoder::SampaInfo> sampaInfos;
+  sampaId.chip = 1;
+  sampaId.ds = 2;
+  sampaId.solar = 80;
+  sampaId.sampaTime = sampaTime;
+  sampaId.bunchCrossing = bunchCrossing;
+  sampaId.orbit = orbit;
+  sampaInfos.push_back(sampaId);
+
+  return sampaInfos;
+}
+
+BOOST_AUTO_TEST_CASE(ComputeDigitsTime)
+{
+  uint32_t sampaTime = 10;
+  uint32_t bunchCrossing = BCINORBIT - 100;
+  uint32_t orbit = 1;
+
+  std::vector<o2::mch::Digit> digits = makeDigitsVector();
+  std::vector<DataDecoder::SampaInfo> sampaInfos = makeInfoVector(sampaTime, bunchCrossing, orbit);
+
+  uint32_t tfOrbit = 1;
+  uint32_t tfBunchCrossing = 0;
+
+  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
+  sampaTimeFrameStarts[sampaInfos[0].id].emplace(tfOrbit, tfBunchCrossing);
+
+  DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
+
+  int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
+      static_cast<int32_t>(tfBunchCrossing);
+
+  BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover)
+{
+  uint32_t sampaTime = 10;
+  uint32_t bunchCrossing = 100;
+  uint32_t orbit = 1;
+
+  std::vector<o2::mch::Digit> digits = makeDigitsVector();
+  std::vector<DataDecoder::SampaInfo> sampaInfos = makeInfoVector(sampaTime, bunchCrossing, orbit);
+
+  uint32_t tfOrbit = 1;
+  uint32_t tfBunchCrossing = BCROLLOVER - 100;
+
+  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
+  sampaTimeFrameStarts[sampaInfos[0].id].emplace(tfOrbit, tfBunchCrossing);
+
+  DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
+
+  int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
+      static_cast<int32_t>(tfBunchCrossing) + BCROLLOVER;
+
+  BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover2)
+{
+  uint32_t sampaTime = 10;
+  uint32_t bunchCrossing = BCROLLOVER - 100;
+  uint32_t orbit = 1;
+
+  std::vector<o2::mch::Digit> digits = makeDigitsVector();
+  std::vector<DataDecoder::SampaInfo> sampaInfos = makeInfoVector(sampaTime, bunchCrossing, orbit);
+
+  uint32_t tfOrbit = 1;
+  uint32_t tfBunchCrossing = 100;
+
+  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
+  sampaTimeFrameStarts[sampaInfos[0].id].emplace(tfOrbit, tfBunchCrossing);
+
+  DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
+
+  int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
+      static_cast<int32_t>(tfBunchCrossing) - BCROLLOVER;
+
+  BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
+}
+
+BOOST_AUTO_TEST_CASE(ComputeDigitsTimeNoTFStart)
+{
+  uint32_t sampaTime = 10;
+  uint32_t bunchCrossing = BCINORBIT - 100;
+  uint32_t orbit = 1;
+
+  std::vector<o2::mch::Digit> digits = makeDigitsVector();
+  std::vector<DataDecoder::SampaInfo> sampaInfos = makeInfoVector(sampaTime, bunchCrossing, orbit);
+
+  uint32_t tfOrbit = 1;
+  uint32_t tfBunchCrossing = 0;
+
+  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
+  sampaTimeFrameStarts[sampaInfos[0].id + 1].emplace(tfOrbit, tfBunchCrossing);
+
+  DataDecoder::computeDigitsTime_(digits, sampaInfos, sampaTimeFrameStarts, false);
+
+  int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
+      static_cast<int32_t>(tfBunchCrossing);
+
+  BOOST_CHECK_EQUAL(digits[0].getTime(), 0xFFFFFFFF);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitEncoder.cxx
@@ -83,7 +83,8 @@ DigitEncoder createDigitEncoder(Det2ElecMapper det2elec)
       auto elecId = optElecId.value().first;
       int dschid = optElecId.value().second;
       // FIXME: add a warning if timestamp is not in range
-      uint16_t ts(static_cast<int>(d.getTime().sampaTime) & 0x3FF);
+      // FIXME: what to do now that the SAMPA time is not stored in the digits?
+      uint16_t ts(0); //(static_cast<int>(d.getTime().sampaTime) & 0x3FF);
       int sampachid = dschid % 32;
       // FIXME: add a warning if ADC is not in range
       auto clusters = createSampaClusters<CHARGESUM>(ts, d.getADC() & 0xFFFFF);

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitReader.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitReader.cxx
@@ -37,7 +37,8 @@ void DigitReader::readNextEntry()
   const o2::raw::HBFUtils& hbfutils = o2::raw::HBFUtils::Instance();
 
   for (auto d : (*mDigits)) {
-    o2::InteractionTimeRecord ir(d.getTime().sampaTime);
+    // FIXME: is it safe to use the new digit time definition in the context?
+    o2::InteractionTimeRecord ir(d.getTime());
     // get the closest (previous) HBF from this IR
     // and assign the digits to that one
     auto hbf = hbfutils.getIRHBF(hbfutils.getHBF(ir));

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
@@ -54,7 +54,7 @@ std::ostream& operator<<(std::ostream& os, const o2::mch::Digit& d)
 {
   os << fmt::format("DE {:4d} PADUID {:8d} ADC {:6d} TS {:g}",
                     d.getDetID(), d.getPadID(), d.getADC(),
-                    d.getTime().sampaTime);
+                    d.getTime());
   return os;
 }
 

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -175,9 +175,8 @@ int Digitizer::processHit(const Hit& hit, int detID, int event_time)
       }
       auto signal = (unsigned long)q * resp.getInverseChargeThreshold();
       if (signal > 0) {
-        Digit::Time dtime;
-        dtime.sampaTime = static_cast<uint16_t>(time) & 0x3FF;
-        digits.emplace_back(detID, padid, signal, dtime);
+        /// FIXME: which time definition is used when calling this function?
+        digits.emplace_back(detID, padid, signal, static_cast<int32_t>(time));
         ++ndigits;
       }
     }
@@ -197,9 +196,8 @@ void Digitizer::generateNoiseDigits()
     int nNoisyPads = TMath::Nint(gRandom->Gaus(nNoisyPadsAv, TMath::Sqrt(nNoisyPadsAv)));
     for (int i = 0; i < nNoisyPads; i++) {
       int padid = gRandom->Integer(nNoisyPads + 1);
-      Digit::Time dtime;
-      dtime.sampaTime = static_cast<uint16_t>(eventTime) & 0x3FF;
-      digits.emplace_back(detID, padid, 0.6, dtime);
+      // FIXME: can we use eventTime as the digit time?
+      digits.emplace_back(detID, padid, 0.6, static_cast<int32_t>(eventTime));
       //just to roun adbove threshold when added
       MCCompLabel label(-1, eventID, srcID, true);
       mcTruthOutputContainer.addElement(digits.size() - 1, label);
@@ -237,7 +235,7 @@ void Digitizer::mergeDigits()
   int i = 0;
   while (i < indices.size()) {
     int j = i + 1;
-    while (j < indices.size() && (getGlobalDigit(sortedDigits(i).getDetID(), sortedDigits(i).getPadID())) == (getGlobalDigit(sortedDigits(j).getDetID(), sortedDigits(j).getPadID())) && (std::fabs(sortedDigits(i).getTime().sampaTime - sortedDigits(j).getTime().sampaTime) < mDeltat)) {
+    while (j < indices.size() && (getGlobalDigit(sortedDigits(i).getDetID(), sortedDigits(i).getPadID())) == (getGlobalDigit(sortedDigits(j).getDetID(), sortedDigits(j).getPadID())) && (std::fabs(sortedDigits(i).getTime() - sortedDigits(j).getTime()) < mDeltat)) {
       j++;
     }
     unsigned long adc{0};

--- a/Detectors/MUON/MCH/Simulation/test/benchDigitMerging.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/benchDigitMerging.cxx
@@ -23,12 +23,11 @@ std::vector<Digit> createDigits(int N)
   std::vector<Digit> digits;
   float dummyadc{42.0};
   std::srand(std::time(nullptr)); // use current time as seed for random generator
-  Digit::Time dummytime;
   int dummydetID = 100; //to be improved, timing depending on that
 
   for (auto i = 0; i < N; i++) {
     int randomPadID = std::rand() * N;
-    digits.emplace_back(dummydetID, randomPadID, dummyadc, dummytime);
+    digits.emplace_back(dummydetID, randomPadID, dummyadc, 0);
   }
 
   return digits;

--- a/Detectors/MUON/MCH/Simulation/test/testDigitMerging.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/testDigitMerging.cxx
@@ -27,10 +27,10 @@ using o2::mch::Digit;
 std::vector<Digit> createNonOverlappingDigits()
 {
   return std::vector<Digit>{
-    {100, 2, 5, Digit::Time{}},
-    {100, 3, 6, Digit::Time{}},
-    {100, 1, 2, Digit::Time{}},
-    {100, 0, 1, Digit::Time{}}};
+    {100, 2, 5, 0},
+    {100, 3, 6, 0},
+    {100, 1, 2, 0},
+    {100, 0, 1, 0}};
 }
 
 std::vector<o2::MCCompLabel> createLabelsNonOverlappingDigits()
@@ -45,14 +45,14 @@ std::vector<o2::MCCompLabel> createLabelsNonOverlappingDigits()
 std::vector<Digit> createOverlappingDigits()
 {
   return std::vector<Digit>{
-    {100, 2, 5, Digit::Time{}},
-    {100, 3, 6, Digit::Time{}},
-    {100, 1, 2, Digit::Time{}},
-    {100, 0, 0, Digit::Time{}},
-    {100, 0, 1, Digit::Time{}},
-    {100, 1, 3, Digit::Time{}},
-    {100, 3, 7, Digit::Time{}},
-    {100, 1, 4, Digit::Time{}}};
+    {100, 2, 5, 0},
+    {100, 3, 6, 0},
+    {100, 1, 2, 0},
+    {100, 0, 0, 0},
+    {100, 0, 1, 0},
+    {100, 1, 3, 0},
+    {100, 3, 7, 0},
+    {100, 1, 4, 0}};
 }
 
 std::vector<o2::MCCompLabel> createLabelsOverlappingDigits()
@@ -72,10 +72,10 @@ std::vector<o2::MCCompLabel> createLabelsOverlappingDigits()
 std::vector<Digit> expected()
 {
   return std::vector<Digit>{
-    {100, 0, 1, Digit::Time{}},
-    {100, 1, 9, Digit::Time{}},
-    {100, 2, 5, Digit::Time{}},
-    {100, 3, 13, Digit::Time{}}};
+    {100, 0, 1, 0},
+    {100, 1, 9, 0},
+    {100, 2, 5, 0},
+    {100, 3, 13, 0}};
 }
 
 std::vector<o2::MCCompLabel> labelexpected()

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -147,19 +147,27 @@ class DataDecoderTask
     };
 
     mDecoder->reset();
-    decodeTF(pc);
     for (auto&& input : pc.inputs()) {
+      //std::cout << "input: " << input.spec->binding << std::endl;
       if (input.spec->binding == "readout") {
         decodeReadout(input);
       }
+      if (input.spec->binding == "TF") {
+        decodeTF(pc);
+      }
     }
+    mDecoder->computeDigitsTime();
 
     auto& digits = mDecoder->getOutputDigits();
     auto& orbits = mDecoder->getOrbits();
+    std::set<OrbitInfo> ordered_orbits(orbits.begin(), orbits.end());
 
     if (mDebug) {
+      for (auto o : ordered_orbits) {
+        std::cout << " FEEID " << o.getFeeID() << "  LINK " << (int)o.getLinkID() << "  ORBIT " << o.getOrbit() << std::endl;
+      }
       for (auto d : digits) {
-        std::cout << " DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC() << " time " << d.getTime().sampaTime << std::endl;
+        std::cout << " DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC() << " time " << d.getTime() << std::endl;
       }
     }
     // send the output buffer via DPL

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -160,12 +160,9 @@ class DataDecoderTask
 
     auto& digits = mDecoder->getOutputDigits();
     auto& orbits = mDecoder->getOrbits();
-    std::set<OrbitInfo> ordered_orbits(orbits.begin(), orbits.end());
 
     if (mDebug) {
-      for (auto o : ordered_orbits) {
-        std::cout << " FEEID " << o.getFeeID() << "  LINK " << (int)o.getLinkID() << "  ORBIT " << o.getOrbit() << std::endl;
-      }
+      dumpOrbits(orbits);
       for (auto d : digits) {
         std::cout << " DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC() << " time " << d.getTime() << std::endl;
       }

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -174,7 +174,7 @@ class PreClusterFinderTask
 //_________________________________________________________________________________________________
 o2::framework::DataProcessorSpec getPreClusterFinderSpec()
 {
-  std::string helpstr = "check that all digits are included in pre-clusters";
+  std::string helpstr = "[off/error/fatal] check that all digits are included in pre-clusters";
   return DataProcessorSpec{
     "PreClusterFinder",
     Inputs{InputSpec{"digitrofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -147,7 +147,7 @@ struct TimeFrame {
 
       offset += pageSize;
     }
-    fmt::printf("total size: {}\n",totalSize);
+    fmt::printf("total size: {}\n", totalSize);
     printf("//////////////////////\n");
   }
 };

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -23,6 +23,7 @@
 
 #include <random>
 #include <iostream>
+#include <queue>
 #include <fstream>
 #include <stdexcept>
 #include "Framework/CallbackService.h"
@@ -42,6 +43,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::raw;
 
 namespace o2
 {
@@ -51,6 +53,108 @@ namespace raw
 {
 
 using RDH = o2::header::RDHAny;
+
+static const int NFEEID = 64;
+static const int NLINKS = 16;
+
+struct TimeFrame {
+  char* buf{nullptr};
+  size_t tfSize{0};
+  size_t totalSize{0};
+  size_t payloadSize{0};
+  std::vector<std::pair<size_t, size_t>> hbframes;
+
+  void computePayloadSize()
+  {
+    payloadSize = 0;
+    if (buf == nullptr)
+      return;
+
+    size_t offset = 0;
+    while (offset < totalSize) {
+      char* ptr = buf + offset;
+      RDH* rdh = (RDH*)ptr;
+
+      auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
+      auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
+      auto memorySize = o2::raw::RDHUtils::getMemorySize(rdh);
+      auto pageSize = o2::raw::RDHUtils::getOffsetToNext(rdh);
+
+      payloadSize += memorySize - rdhHeaderSize;
+
+      offset += pageSize;
+    }
+  }
+
+  void print()
+  {
+    if (buf == nullptr)
+      return;
+
+    int nPrinted = 0;
+
+    printf("\n//////////////////////\n");
+    size_t offset = 0;
+    size_t nStop = 0;
+    while (offset < totalSize) {
+      char* ptr = buf + offset;
+      RDH* rdh = (RDH*)ptr;
+
+      auto stopBit = o2::raw::RDHUtils::getStop(rdh);
+      auto pageSize = o2::raw::RDHUtils::getOffsetToNext(rdh);
+      if (stopBit > 0) {
+        nStop += 1;
+      }
+
+      offset += pageSize;
+    }
+
+    offset = 0;
+    bool doPrint = false;
+    size_t iStop = 0;
+    while (offset < totalSize) {
+      char* ptr = buf + offset;
+      RDH* rdh = (RDH*)ptr;
+
+      auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
+      uint16_t cruID = o2::raw::RDHUtils::getCRUID(rdh) & 0x3F;
+      uint8_t endPointID = o2::raw::RDHUtils::getEndPointID(rdh);
+      uint8_t linkID = o2::raw::RDHUtils::getLinkID(rdh);
+      uint16_t feeID = cruID * 2 + endPointID;
+      auto stopBit = o2::raw::RDHUtils::getStop(rdh);
+      auto triggerType = o2::raw::RDHUtils::getTriggerType(rdh);
+      auto pageSize = o2::raw::RDHUtils::getOffsetToNext(rdh);
+
+      if (iStop < 2 || iStop > (nStop - 3)) {
+
+        printf("%6d:  version %X  offset %4d  packet %3d  srcID %d  cruID %2d  dp %d  link %2d  orbit %u  bc %4d  trig 0x%08X  page %d  stop %d",
+               (int)0, (int)rdhVersion, (int)pageSize,
+               (int)RDHUtils::getPacketCounter(rdh), (int)RDHUtils::getSourceID(rdh),
+               (int)cruID, (int)endPointID, (int)linkID,
+               (uint32_t)RDHUtils::getHeartBeatOrbit(rdh), (int)RDHUtils::getTriggerBC(rdh),
+               (int)triggerType, (int)RDHUtils::getPageCounter(rdh), (int)stopBit);
+        if ((triggerType & 0x800) != 0)
+          printf(" <===");
+        printf("\n");
+      }
+      if (stopBit > 0 && iStop == 3) {
+        printf("........................\n");
+      }
+
+      if (stopBit > 0) {
+        iStop += 1;
+      }
+
+      offset += pageSize;
+    }
+    printf("total size: %d\n", totalSize);
+    printf("//////////////////////\n");
+  }
+};
+
+using TFQueue = std::queue<TimeFrame>;
+
+TFQueue tfQueues[NFEEID][NLINKS];
 
 class FileReaderTask
 {
@@ -63,6 +167,9 @@ class FileReaderTask
     mFrameMax = ic.options().get<int>("nframes");
     mPrint = ic.options().get<bool>("print");
     mFullHBF = ic.options().get<bool>("full-hbf");
+    mFullTF = ic.options().get<bool>("full-tf");
+    mSaveTF = ic.options().get<bool>("save-tf");
+    mOverlap = ic.options().get<int>("overlap");
 
     auto inputFileName = ic.options().get<std::string>("infile");
     mInputFile.open(inputFileName, std::ios::binary);
@@ -78,9 +185,250 @@ class FileReaderTask
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
   }
 
+  bool appendHBF(TimeFrame& tf, char* framePtr, size_t frameSize, bool addHBF)
+  {
+    // new size of the TimeFrame buffer after appending the HBFrame
+    size_t newSize = tf.totalSize + frameSize;
+    // increase the size of the memory buffer
+    tf.buf = (char*)realloc(tf.buf, newSize);
+    if (tf.buf == nullptr) {
+      std::cout << "failed to allocate TimeFrame buffer" << std::endl;
+      return false;
+    }
+
+    // copy the HBFrame into the TimeFrame buffer
+    char* bufPtr = tf.buf + tf.totalSize;
+    memcpy(bufPtr, framePtr, frameSize);
+
+    if (addHBF) {
+      // add the offset and size of the HBFrame to the vector
+      tf.hbframes.emplace_back(std::make_pair(tf.totalSize, frameSize));
+      // increase the  TimeFrame sizes
+      tf.tfSize += frameSize;
+    }
+
+    // increase the total buffer sizes
+    tf.totalSize += frameSize;
+
+    return true;
+  }
+
+  //_________________________________________________________________________________________________
+  void sendTF(framework::ProcessingContext& pc)
+  {
+    /// send one RDH block via DPL
+    RDH rdh;
+    char* buf{nullptr};
+    size_t frameSize{0};
+
+    static int TFid = 0;
+
+    //if (nSent >= 2) {
+    //  pc.services().get<ControlService>().endOfStream();
+    //  return; // probably reached eof
+    //}
+
+    while (true) {
+
+      // stop if the required number of frames has been reached
+      if (mFrameMax == 0) {
+        pc.services().get<ControlService>().endOfStream();
+        return;
+      }
+
+      if (mPrint && false) {
+        printf("mFrameMax: %d\n", mFrameMax);
+      }
+      if (mFrameMax > 0) {
+        mFrameMax -= 1;
+      }
+
+      // read the next RDH, stop if no more data is available
+      mInputFile.read((char*)(&rdh), sizeof(RDH));
+      if (mInputFile.fail()) {
+        if (mPrint) {
+          std::cout << "end of file reached" << std::endl;
+        }
+        pc.services().get<ControlService>().endOfStream();
+        return; // probably reached eof
+      }
+
+      // check that the RDH version is ok (only RDH versions from 4 to 6 are supported at the moment)
+      auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
+      auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
+      if (mPrint) {
+        std::cout << "header_version=" << (int)rdhVersion << std::endl;
+      }
+      if (rdhVersion < 4 || rdhVersion > 6 || rdhHeaderSize != 64) {
+        return;
+      }
+
+      uint16_t cruID = o2::raw::RDHUtils::getCRUID(rdh) & 0x3F;
+      uint8_t endPointID = o2::raw::RDHUtils::getEndPointID(rdh);
+      uint8_t linkID = o2::raw::RDHUtils::getLinkID(rdh);
+      uint16_t feeID = cruID * 2 + endPointID;
+      auto stopBit = o2::raw::RDHUtils::getStop(rdh);
+      auto triggerType = o2::raw::RDHUtils::getTriggerType(rdh);
+      auto pageSize = o2::raw::RDHUtils::getOffsetToNext(rdh);
+      auto pageCounter = RDHUtils::getPageCounter(rdh);
+
+      if (mPrint) {
+        printf("%6d:  version %X  offset %4d  packet %3d  srcID %d  cruID %2d  dp %d  link %2d  orbit %u  bc %4d  trig 0x%08X  page %d  stop %d",
+               (int)0, (int)rdhVersion, (int)pageSize,
+               (int)RDHUtils::getPacketCounter(rdh), (int)RDHUtils::getSourceID(rdh),
+               (int)cruID, (int)endPointID, (int)linkID,
+               (uint32_t)RDHUtils::getHeartBeatOrbit(rdh), (int)RDHUtils::getTriggerBC(rdh),
+               (int)triggerType, (int)pageCounter, (int)stopBit);
+        if ((triggerType & 0x800) != 0)
+          printf(" <===");
+        printf("\n");
+      }
+
+      TFQueue& tfQueue = tfQueues[feeID][linkID];
+
+      // get the frame size from the RDH offsetToNext field
+      if (mPrint && false) {
+        std::cout << "pageSize=" << pageSize << std::endl;
+      }
+
+      // stop if the frame size is too small
+      if (pageSize < rdhHeaderSize) {
+        std::cout << mFrameMax << " - pageSize too small: " << pageSize << std::endl;
+        pc.services().get<ControlService>().endOfStream();
+        return;
+      }
+
+      // allocate or extend the output buffer
+      buf = (char*)realloc(buf, frameSize + pageSize);
+      if (buf == nullptr) {
+        std::cout << mFrameMax << " - failed to allocate buffer" << std::endl;
+        pc.services().get<ControlService>().endOfStream();
+        return;
+      }
+
+      // copy the RDH into the output buffer
+      memcpy(buf + frameSize, &rdh, rdhHeaderSize);
+
+      // read the frame payload into the output buffer
+      mInputFile.read(buf + frameSize + rdhHeaderSize, pageSize - rdhHeaderSize);
+
+      // stop if data cannot be read completely
+      if (mInputFile.fail()) {
+        if (mPrint) {
+          std::cout << "end of file reached" << std::endl;
+        }
+        free(buf);
+        pc.services().get<ControlService>().endOfStream();
+        return; // probably reached eof
+      }
+
+      // increment the total buffer size
+      frameSize += pageSize;
+
+      if ((triggerType & 0x800) != 0 && stopBit == 0 && pageCounter == 0) {
+        // This is the start of a new TimeFrame, so we need to take some actions:
+        // - push a new TimeFrame in the queue
+        // - append the last N HBFrames of the previous TimeFrame at the beginning of the current one
+        // - set the initial total size of the TimeFrame buffer
+        char* prevTFptr{nullptr};
+        size_t prevTFsize{0};
+
+        if (mPrint) {
+          std::cout << "tfQueue.size(): " << tfQueue.size() << std::endl;
+        }
+        if (!tfQueue.empty()) {
+          TimeFrame& prevTF = tfQueue.back();
+          size_t nhbf = prevTF.hbframes.size();
+          if ((mOverlap > 0) && (nhbf >= mOverlap)) {
+            size_t hbfID = nhbf - mOverlap;
+            prevTFptr = prevTF.buf + prevTF.hbframes[hbfID].first;
+            for (size_t i = hbfID; i < nhbf; i++) {
+              prevTFsize += prevTF.hbframes[i].second;
+            }
+          }
+        }
+
+        tfQueue.emplace();
+
+        if (prevTFsize > 0) {
+          tfQueue.back().buf = (char*)malloc(prevTFsize);
+          if (tfQueue.back().buf == nullptr) {
+            std::cout << mFrameMax << " - failed to allocate TimeFrame buffer" << std::endl;
+            pc.services().get<ControlService>().endOfStream();
+            return;
+          }
+
+          memcpy(tfQueue.back().buf, prevTFptr, prevTFsize);
+        }
+
+        tfQueue.back().totalSize = prevTFsize;
+      }
+
+      if (stopBit && tfQueue.size() > 0) {
+        // we reached the end of the current HBFrame, we need to append it to the TimeFrame
+
+        if (!appendHBF(tfQueue.back(), buf, frameSize, true)) {
+          std::cout << mFrameMax << " - failed to append HBframe" << std::endl;
+          pc.services().get<ControlService>().endOfStream();
+          return;
+        }
+
+        if (tfQueue.size() == 2) {
+          // we have two TimeFrames in the queue, we also append mOverlap HBFrames to the first one
+          if (tfQueue.back().hbframes.size() <= mOverlap) {
+            if (!appendHBF(tfQueue.front(), buf, frameSize, false)) {
+              std::cout << mFrameMax << " - failed to append HBframe" << std::endl;
+              pc.services().get<ControlService>().endOfStream();
+              return;
+            }
+          }
+        }
+
+        // free the HBFrame buffer
+        free(buf);
+        buf = nullptr;
+        frameSize = 0;
+
+        if (tfQueue.size() == 2 && tfQueue.back().hbframes.size() >= mOverlap) {
+          // we collected enough HBFrames after the last fully recorded TimeFrame, so we can send it
+          tfQueue.front().computePayloadSize();
+          if (mPrint) {
+            tfQueue.front().print();
+            //sleep(10);
+          }
+          if (tfQueue.front().payloadSize > 0) {
+            if (mSaveTF && TFid < 100) {
+              char fname[500];
+              snprintf(fname, 499, "tf-%03d.raw", TFid);
+              FILE* fout = fopen(fname, "wb");
+              if (fout) {
+                fwrite(tfQueue.front().buf, tfQueue.front().totalSize, 1, fout);
+                fclose(fout);
+              }
+            }
+
+            auto freefct = [](void* data, void* /*hint*/) { free(data); };
+            pc.outputs().adoptChunk(Output{"ROUT", "RAWDATA"}, tfQueue.front().buf, tfQueue.front().totalSize, freefct, nullptr);
+            nSent += 1;
+            TFid += 1;
+          }
+          tfQueue.pop();
+          nSent += 1;
+          break;
+        }
+      }
+    }
+  }
+
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
+    if (mFullTF) {
+      sendTF(pc);
+      //pc.services().get<ControlService>().endOfStream();
+      return;
+    }
+
     /// send one RDH block via DPL
     RDH rdh;
     char* buf{nullptr};
@@ -180,7 +528,11 @@ class FileReaderTask
   std::ifstream mInputFile{}; ///< input file
   int mFrameMax;              ///< number of frames to process
   bool mFullHBF;              ///< send full HeartBeat frames
+  bool mFullTF;               ///< send full time frames
+  bool mSaveTF;               ///< save individual time frames to file
+  int mOverlap;               ///< overlap between contiguous TimeFrames
   bool mPrint = false;        ///< print debug messages
+  int nSent = 0;
 };
 
 //_________________________________________________________________________________________________
@@ -195,6 +547,9 @@ o2::framework::DataProcessorSpec getFileReaderSpec()
     Options{{"infile", VariantType::String, "", {"input file name"}},
             {"nframes", VariantType::Int, -1, {"number of frames to process"}},
             {"full-hbf", VariantType::Bool, false, {"send full HeartBeat frames"}},
+            {"full-tf", VariantType::Bool, false, {"send full time frames"}},
+            {"save-tf", VariantType::Bool, false, {"save individual time frames to file"}},
+            {"overlap", VariantType::Int, 1, {"overlap between contiguous TimeFrames"}},
             {"print", VariantType::Bool, false, {"verbose output"}}}};
 }
 // clang-format on

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -147,7 +147,7 @@ struct TimeFrame {
 
       offset += pageSize;
     }
-    printf("total size: %d\n", totalSize);
+    fmt::printf("total size: {}\n",totalSize);
     printf("//////////////////////\n");
   }
 };

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -67,8 +67,9 @@ struct TimeFrame {
   void computePayloadSize()
   {
     payloadSize = 0;
-    if (buf == nullptr)
+    if (buf == nullptr) {
       return;
+    }
 
     size_t offset = 0;
     while (offset < totalSize) {
@@ -88,8 +89,9 @@ struct TimeFrame {
 
   void print()
   {
-    if (buf == nullptr)
+    if (buf == nullptr) {
       return;
+    }
 
     int nPrinted = 0;
 
@@ -133,8 +135,9 @@ struct TimeFrame {
                (int)cruID, (int)endPointID, (int)linkID,
                (uint32_t)RDHUtils::getHeartBeatOrbit(rdh), (int)RDHUtils::getTriggerBC(rdh),
                (int)triggerType, (int)RDHUtils::getPageCounter(rdh), (int)stopBit);
-        if ((triggerType & 0x800) != 0)
+        if ((triggerType & 0x800) != 0) {
           printf(" <===");
+        }
         printf("\n");
       }
       if (stopBit > 0 && iStop == 3) {
@@ -223,11 +226,6 @@ class FileReaderTask
 
     static int TFid = 0;
 
-    //if (nSent >= 2) {
-    //  pc.services().get<ControlService>().endOfStream();
-    //  return; // probably reached eof
-    //}
-
     while (true) {
 
       // stop if the required number of frames has been reached
@@ -279,8 +277,9 @@ class FileReaderTask
                (int)cruID, (int)endPointID, (int)linkID,
                (uint32_t)RDHUtils::getHeartBeatOrbit(rdh), (int)RDHUtils::getTriggerBC(rdh),
                (int)triggerType, (int)pageCounter, (int)stopBit);
-        if ((triggerType & 0x800) != 0)
+        if ((triggerType & 0x800) != 0) {
           printf(" <===");
+        }
         printf("\n");
       }
 
@@ -409,11 +408,9 @@ class FileReaderTask
 
             auto freefct = [](void* data, void* /*hint*/) { free(data); };
             pc.outputs().adoptChunk(Output{"ROUT", "RAWDATA"}, tfQueue.front().buf, tfQueue.front().totalSize, freefct, nullptr);
-            nSent += 1;
             TFid += 1;
           }
           tfQueue.pop();
-          nSent += 1;
           break;
         }
       }
@@ -532,7 +529,6 @@ class FileReaderTask
   bool mSaveTF;               ///< save individual time frames to file
   int mOverlap;               ///< overlap between contiguous TimeFrames
   bool mPrint = false;        ///< print debug messages
-  int nSent = 0;
 };
 
 //_________________________________________________________________________________________________

--- a/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
@@ -94,7 +94,7 @@ class DigitsSinkTask
       }
       mOutputFile << "---------------" << std::endl;
       for (auto d : digits) {
-        mOutputFile << " DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC() << " time " << d.getTime().sampaTime << std::endl;
+        mOutputFile << " DE# " << d.getDetID() << "  PadId " << d.getPadID() << "  ADC " << d.getADC() << "  time " << d.getTime() << "  TF index " << (int)d.getTFindex() << std::endl;
       }
     } else {
       int nDigits = digits.size();

--- a/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-sink-workflow.cxx
@@ -94,7 +94,7 @@ class DigitsSinkTask
       }
       mOutputFile << "---------------" << std::endl;
       for (auto d : digits) {
-        mOutputFile << " DE# " << d.getDetID() << "  PadId " << d.getPadID() << "  ADC " << d.getADC() << "  time " << d.getTime() << "  TF index " << (int)d.getTFindex() << std::endl;
+        mOutputFile << " DE# " << d.getDetID() << "  PadId " << d.getPadID() << "  ADC " << d.getADC() << "  time " << d.getTime() << std::endl;
       }
     } else {
       int nDigits = digits.size();

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -91,7 +91,7 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         for (auto& d : digits) {
           LOG(DEBUG) << "ADC " << d.getADC();
           LOG(DEBUG) << "PAD " << d.getPadID();
-          LOG(DEBUG) << "TIME " << d.getTime().sampaTime;
+          LOG(DEBUG) << "TIME " << d.getTime();
           LOG(DEBUG) << "DetID " << d.getDetID();
         }
         std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));


### PR DESCRIPTION
This PR changes the definition of the time in the MCH digit structure. The time of a given digit is now relative to the start of the corresponding TimeFrame, in units of bunch crossings.
The computation of the time difference requires the presence of special SAMPA HeartBeat packets at the beginning of each TimeFrame. Those packets are generated by sending HeartBeat triggers to the front-end electronics, at the beginning of each TimeFrame.

The PR is for the moment marked as a draft because the change in the digit time definition has an impact in different part of the MCH encoder/decoder, which need to be reviewed and eventually fixed.