### PR TITLE
fill calib infos during clusterization if requested

### DIFF
--- a/DataFormats/Detectors/TOF/CMakeLists.txt
+++ b/DataFormats/Detectors/TOF/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DataFormatsTOF
                        src/CalibLHCphaseTOF.cxx
                        src/CalibTimeSlewingParamTOF.cxx
                        src/CTF.cxx
+                       src/CalibInfoCluster.cxx
                PUBLIC_LINK_LIBRARIES O2::ReconstructionDataFormats
                                      Boost::serialization)
 
@@ -27,4 +28,5 @@ o2_target_root_dictionary(DataFormatsTOF
                                   include/DataFormatsTOF/RawDataFormat.h
                                   include/DataFormatsTOF/CompressedDataFormat.h
                                   include/DataFormatsTOF/CTF.h
+                                  include/DataFormatsTOF/CalibInfoCluster.h
 				  )

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoCluster.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoCluster.h
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Cluster.h
+/// \brief Definition of the TOF cluster
+
+#ifndef ALICEO2_TOF_CLUSTERCALINFOCLASS_H
+#define ALICEO2_TOF_CLUSTERCALINFOCLASS_H
+
+#include <vector>
+#include "Rtypes.h"
+
+namespace o2
+{
+namespace tof
+{
+/// \class CalibInfoCluster
+/// \brief CalibInfoCluster for TOF
+///
+class CalibInfoCluster
+{
+  int ch = 0;
+  int8_t deltach = 0;
+  float deltat = 0;
+  short tot1 = 0;
+  short tot2 = 0;
+
+ public:
+  CalibInfoCluster() = default;
+  CalibInfoCluster(int ich, int8_t ideltach, float dt, short t1, short t2) : ch(ich), deltach(ideltach), deltat(dt), tot1(t1), tot2(t2) {}
+  ClassDefNV(CalibInfoCluster, 1);
+};
+} // namespace tof
+
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TOF/src/CalibInfoCluster.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibInfoCluster.cxx
@@ -8,19 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZER_H_
-#define STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZER_H_
+/// \file CalibInfoCluster.cxx
+/// \brief Implementation of the TOF cluster calib info
 
-#include "Framework/DataProcessorSpec.h"
+#include "DataFormatsTOF/CalibInfoCluster.h"
 
-namespace o2
-{
-namespace tof
-{
-
-o2::framework::DataProcessorSpec getTOFClusterizerSpec(bool useMC, bool useCCDB = 0, bool doCalib = 0);
-
-} // end namespace tof
-} // end namespace o2
-
-#endif /* STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZERSPEC_H_ */
+ClassImp(o2::tof::CalibInfoCluster);

--- a/DataFormats/Detectors/TOF/src/DataFormatsTOFLinkDef.h
+++ b/DataFormats/Detectors/TOF/src/DataFormatsTOFLinkDef.h
@@ -14,7 +14,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ class o2::tof::Cluster + ;
+#pragma link C++ class o2::tof::CalibInfoCluster + ;
 #pragma link C++ class std::vector < o2::tof::Cluster> + ;
+#pragma link C++ class std::vector < o2::tof::CalibInfoCluster> + ;
 
 #pragma link C++ class o2::dataformats::CalibInfoTOFshort + ;
 #pragma link C++ class o2::dataformats::CalibInfoTOF + ;

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -59,6 +59,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
   workflowOptions.push_back(ConfigParamSpec{"disable-row-writing", o2::framework::VariantType::Bool, false, {"disable ROW in Digit writing"}});
   workflowOptions.push_back(ConfigParamSpec{"write-decoding-errors", o2::framework::VariantType::Bool, false, {"trace errors in digits output when decoding"}});
+  workflowOptions.push_back(ConfigParamSpec{"calib-cluster", VariantType::Bool, false, {"to enable calib info production from clusters"}});
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -137,6 +138,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool disableRootOutput = cfgc.options().get<bool>("disable-root-output");
   bool conetmode = cfgc.options().get<bool>("conet-mode");
   bool disableROWwriting = cfgc.options().get<bool>("disable-row-writing");
+  auto isCalibFromCluster = cfgc.options().get<bool>("calib-cluster");
 
   LOG(INFO) << "TOF RECO WORKFLOW configuration";
   LOG(INFO) << "TOF input = " << cfgc.options().get<std::string>("input-type");
@@ -180,7 +182,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   if (!clusterinput && writecluster) {
     LOG(INFO) << "Insert TOF Clusterizer";
-    specs.emplace_back(o2::tof::getTOFClusterizerSpec(useMC, useCCDB));
+    specs.emplace_back(o2::tof::getTOFClusterizerSpec(useMC, useCCDB, isCalibFromCluster));
     if (writecluster && !disableRootOutput) {
       LOG(INFO) << "Insert TOF Cluster Writer";
       specs.emplace_back(o2::tof::getTOFClusterWriterSpec(useMC));

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Clusterer.h
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 #include "DataFormatsTOF/Cluster.h"
+#include "DataFormatsTOF/CalibInfoCluster.h"
 #include "TOFBase/Geo.h"
 #include "TOFReconstruction/DataReader.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -51,8 +52,17 @@ class Clusterer
     mCalibApi = calibApi;
   }
 
+  void addCalibFromCluster(int ch1, int8_t dch, float dtime, short tot1, short tot2);
+
   void setFirstOrbit(uint64_t orb);
   uint64_t getFirstOrbit() const { return mFirstOrbit; }
+
+  void setCalibFromCluster(bool val = 1) { mCalibFromCluster = val; }
+  bool isCalibFromCluster() const { return mCalibFromCluster; }
+
+  void setDeltaTforClustering(float val) { mDeltaTforClustering = val; }
+  float getDeltaTforClustering() const { return mDeltaTforClustering; }
+  std::vector<o2::tof::CalibInfoCluster>* getInfoFromCluster() { return &mCalibInfosFromCluster; }
 
  private:
   void calibrateStrip();
@@ -70,6 +80,11 @@ class Clusterer
   CalibApi* mCalibApi = nullptr; //! calib api to handle the TOF calibration
   uint64_t mFirstOrbit = 0;      //! 1st orbit of the TF
   uint64_t mBCOffset = 0;        //! 1st orbit of the TF converted to BCs
+
+  float mDeltaTforClustering = 5000; //! delta time (in ps) accepted for clustering
+  bool mCalibFromCluster = false;    //! if producing calib from clusters
+
+  std::vector<o2::tof::CalibInfoCluster> mCalibInfosFromCluster;
 };
 
 } // namespace tof

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -100,7 +100,7 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
       // check if the TOF time are close enough to be merged; if not, it means that nothing else will contribute to the cluster (since digits are ordered in time)
       double timeDigNext = digNext->getCalibratedTime(); // in ps
       LOG(DEBUG) << "Time difference = " << timeDigNext - timeDig;
-      if (timeDigNext - timeDig > 5000 /*in ps*/) { // to be change to 500 ps
+      if (timeDigNext - timeDig > mDeltaTforClustering /*in ps*/) { // to be change to 500 ps
         break;
       }
       digNext->getPhiAndEtaIndex(iphi2, ieta2);
@@ -181,6 +181,10 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
 
   c.setDigitInfo(0, mContributingDigit[0]->getChannel(), mContributingDigit[0]->getCalibratedTime(), mContributingDigit[0]->getTOT() * Geo::TOTBIN_NS);
 
+  int ch1 = mContributingDigit[0]->getChannel();
+  short tot1 = mContributingDigit[0]->getTOT();
+  double dtime = c.getTimeRaw();
+
   int chan1, chan2;
   int phi1, phi2;
   int eta1, eta2;
@@ -228,6 +232,13 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
     if (isOk) {
       c.setDigitInfo(c.getNumOfContributingChannels(), mContributingDigit[idig]->getChannel(), mContributingDigit[idig]->getCalibratedTime(), mContributingDigit[idig]->getTOT() * Geo::TOTBIN_NS);
       c.addBitInContributingChannels(mask);
+
+      if (mCalibFromCluster && c.getNumOfContributingChannels() == 2) { // fill info for calibration
+        int8_t dch = int8_t(mContributingDigit[idig]->getChannel() - ch1);
+        short tot2 = mContributingDigit[idig]->getTOT();
+        dtime -= mContributingDigit[idig]->getTDC() * Geo::TDCBIN + mContributingDigit[idig]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3;
+        addCalibFromCluster(ch1, dch, float(dtime), tot1, tot2);
+      }
     }
   }
 
@@ -281,4 +292,9 @@ void Clusterer::setFirstOrbit(uint64_t orb)
 {
   mFirstOrbit = orb;
   mBCOffset = orb * o2::constants::lhc::LHCMaxBunches;
+}
+//_____________________________________________________________________
+void Clusterer::addCalibFromCluster(int ch1, int8_t dch, float dtime, short tot1, short tot2)
+{
+  mCalibInfosFromCluster.emplace_back(ch1, dch, dtime, tot1, tot2);
 }

--- a/Detectors/TOF/workflow/CMakeLists.txt
+++ b/Detectors/TOF/workflow/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TOFWorkflowUtils
                        src/CompressedAnalysisTask.cxx
                        src/EntropyEncoderSpec.cxx
                        src/EntropyDecoderSpec.cxx
+                       src/TOFCalClusInfoWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::TOFBase O2::DataFormatsTOF O2::TOFReconstruction)
 
 o2_add_executable(entropy-encoder-workflow
@@ -36,3 +37,9 @@ o2_add_executable(cluster-writer-workflow
                   SOURCES src/cluster-writer-commissioning.cxx
                   COMPONENT_NAME tof
                   PUBLIC_LINK_LIBRARIES O2::TOFWorkflowUtils)
+
+o2_add_executable(cluster-calib
+                  SOURCES src/cluster-calib.cxx
+                  COMPONENT_NAME tof
+                  PUBLIC_LINK_LIBRARIES O2::TOFWorkflowUtils)
+

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFCalClusInfoWriterSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFCalClusInfoWriterSpec.h
@@ -8,19 +8,25 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZER_H_
-#define STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZER_H_
+/// @file   TOFCalClusInfoWriterSpec.h
+
+#ifndef STEER_DIGITIZERWORKFLOW_TOFCALCLUSINFOWRITER_H_
+#define STEER_DIGITIZERWORKFLOW_TOFCALCLUSINFOWRITER_H_
 
 #include "Framework/DataProcessorSpec.h"
+
+using namespace o2::framework;
 
 namespace o2
 {
 namespace tof
 {
 
-o2::framework::DataProcessorSpec getTOFClusterizerSpec(bool useMC, bool useCCDB = 0, bool doCalib = 0);
+/// create a processor spec
+/// write ITS tracks a root file
+o2::framework::DataProcessorSpec getTOFCalClusInfoWriterSpec();
 
-} // end namespace tof
-} // end namespace o2
+} // namespace tof
+} // namespace o2
 
-#endif /* STEER_DIGITIZERWORKFLOW_TOFCLUSTERIZERSPEC_H_ */
+#endif /* STEER_DIGITIZERWORKFLOW_TOFCALCLUSINFOWRITER_H_ */

--- a/Detectors/TOF/workflow/src/TOFCalClusInfoWriterSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFCalClusInfoWriterSpec.cxx
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TOFCalClusInfoWriterSpec.cxx
+
+#include "TOFWorkflowUtils/TOFCalClusInfoWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "DataFormatsTOF/CalibInfoCluster.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tof
+{
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using OutputType = std::vector<o2::tof::CalibInfoCluster>;
+using namespace o2::header;
+
+DataProcessorSpec getTOFCalClusInfoWriterSpec()
+{
+  // Spectators for logging
+  auto logger = [](OutputType const& indata) {
+    LOG(DEBUG) << "RECEIVED CLUS CAL INFO SIZE " << indata.size();
+  };
+  return MakeRootTreeWriterSpec("TOFCalClusInfoWriter",
+                                "tofclusCalInfo.root",
+                                "o2sim",
+                                BranchDefinition<OutputType>{InputSpec{"clusters", gDataOriginTOF, "INFOCALCLUS", 0},
+                                                             "TOFClusterCalInfo",
+                                                             "tofclusters-branch-name",
+                                                             1,
+                                                             logger})();
+}
+} // namespace tof
+} // namespace o2

--- a/Detectors/TOF/workflow/src/cluster-calib.cxx
+++ b/Detectors/TOF/workflow/src/cluster-calib.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFWorkflowUtils/TOFCalClusInfoWriterSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::tof::getTOFCalClusInfoWriterSpec());
+  return wf;
+}


### PR DESCRIPTION
Multi-hit clusters infos provided (if requested) from tof clusterizer to calibration devices (currently just written to file)
A couple of options added to clusterizer devices