### PR TITLE
Compilation fixes

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -29,7 +29,7 @@ bool NoiseCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClusterEx
   static int nTF = 0;
   LOG(INFO) << "Processing TF# " << nTF++;
 
-  auto pattIt = patterns.cbegin();
+  auto pattIt = patterns.begin();
   for (const auto& rof : rofs) {
     auto clustersInFrame = rof.getROFData(clusters);
     for (const auto& c : clustersInFrame) {

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
@@ -33,7 +33,7 @@ bool NoiseSlotCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClust
   auto& slotTF = getSlotForTF(nTF);
   auto& noiseMap = *(slotTF.getContainer());
 
-  auto pattIt = patterns.cbegin();
+  auto pattIt = patterns.begin();
   for (const auto& rof : rofs) {
     auto clustersInFrame = rof.getROFData(clusters);
     for (const auto& c : clustersInFrame) {

--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.cxx
@@ -13,6 +13,7 @@
 
 #include "CathodeSegmentationImpl3.h"
 #include "boost/format.hpp"
+#include <boost/geometry.hpp>
 #include "GenDetElemId2SegType.h"
 #include "PadGroup.h"
 #include "PadSize.h"

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.cxx
@@ -13,6 +13,7 @@
 
 #include "CathodeSegmentationImpl4.h"
 #include "boost/format.hpp"
+#include <boost/geometry.hpp>
 #include "GenDetElemId2SegType.h"
 #include "PadGroup.h"
 #include "PadSize.h"

--- a/Detectors/MUON/MCH/PreClustering/include/MCHPreClustering/PreClusterFinder.h
+++ b/Detectors/MUON/MCH/PreClustering/include/MCHPreClustering/PreClusterFinder.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 #include <gsl/span>
 


### PR DESCRIPTION
Fixes for boost >= 1.75, ms_gsl >= 3.0 (following up #5424, in the meantime breaking changes were merged again), and for new GCC.