### PR TITLE
[DPL Analysis] Simple workflow suffix solution

### DIFF
--- a/Analysis/Tasks/ALICE3/alice3-trackselection.cxx
+++ b/Analysis/Tasks/ALICE3/alice3-trackselection.cxx
@@ -51,6 +51,6 @@ struct TrackSelectionTask {
 //****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TrackSelectionTask>("track-selection")};
+  WorkflowSpec workflow{adaptAnalysisTask<TrackSelectionTask>(cfgc, "track-selection")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -313,8 +313,8 @@ struct CorrelationTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<CorrelationTask>("correlation-task")};
+    adaptAnalysisTask<CorrelationTask>(cfgc, "correlation-task")};
 }

--- a/Analysis/Tasks/PWGCF/correlationsFiltered.cxx
+++ b/Analysis/Tasks/PWGCF/correlationsFiltered.cxx
@@ -438,8 +438,8 @@ struct CorrelationTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<CorrelationTask>("correlation-task")};
+    adaptAnalysisTask<CorrelationTask>(cfgc, "correlation-task")};
 }

--- a/Analysis/Tasks/PWGCF/correlationsMixed.cxx
+++ b/Analysis/Tasks/PWGCF/correlationsMixed.cxx
@@ -500,9 +500,9 @@ struct CorrelationTask {
   //   float getInvMassSquared(float pt1, float eta1, float phi1, float pt2, float eta2, float phi2, float m0_1, float m0_2)
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HashTask>("produce-hashes"),
-    adaptAnalysisTask<CorrelationTask>("correlation-task")};
+    adaptAnalysisTask<HashTask>(cfgc, "produce-hashes"),
+    adaptAnalysisTask<CorrelationTask>(cfgc, "correlation-task")};
 }

--- a/Analysis/Tasks/PWGCF/dptdptcorrelations.cxx
+++ b/Analysis/Tasks/PWGCF/dptdptcorrelations.cxx
@@ -841,8 +841,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   int nranges = tokens->GetEntries();
 
   WorkflowSpec workflow{
-    adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>("DptDptCorrelationsFilterAnalysisTask"),
-    adaptAnalysisTask<TracksAndEventClassificationQA>("TracksAndEventClassificationQA")};
+    adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, "DptDptCorrelationsFilterAnalysisTask"),
+    adaptAnalysisTask<TracksAndEventClassificationQA>(cfgc, "TracksAndEventClassificationQA")};
   for (int i = 0; i < nranges; ++i) {
     float cmmin = 0.0f;
     float cmmax = 0.0f;

--- a/Analysis/Tasks/PWGCF/dptdptcorrelations.cxx
+++ b/Analysis/Tasks/PWGCF/dptdptcorrelations.cxx
@@ -847,7 +847,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     float cmmin = 0.0f;
     float cmmax = 0.0f;
     sscanf(tokens->At(i)->GetName(), "%f-%f", &cmmin, &cmmax);
-    workflow.push_back(adaptAnalysisTask<DptDptCorrelationsTask>(Form("DptDptCorrelationsTask-%s", tokens->At(i)->GetName()), cmmin, cmmax));
+    workflow.push_back(adaptAnalysisTask<DptDptCorrelationsTask>(cfgc, Form("DptDptCorrelationsTask-%s", tokens->At(i)->GetName()), cmmin, cmmax));
   }
   delete tokens;
   return workflow;

--- a/Analysis/Tasks/PWGCF/filterCF.cxx
+++ b/Analysis/Tasks/PWGCF/filterCF.cxx
@@ -75,8 +75,8 @@ struct FilterCF {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<FilterCF>("filter-cf")};
+    adaptAnalysisTask<FilterCF>(cfgc, "filter-cf")};
 }

--- a/Analysis/Tasks/PWGDQ/dileptonEE.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonEE.cxx
@@ -328,12 +328,12 @@ struct DileptonEE {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>("my-event-selection"),
-    adaptAnalysisTask<BarrelTrackSelection>("barrel-track-selection"),
-    adaptAnalysisTask<DileptonEE>("dilepton-ee"),
+    adaptAnalysisTask<EventSelection>(cfgc, "my-event-selection"),
+    adaptAnalysisTask<BarrelTrackSelection>(cfgc, "barrel-track-selection"),
+    adaptAnalysisTask<DileptonEE>(cfgc, "dilepton-ee"),
 
   };
 }

--- a/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
@@ -370,10 +370,10 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
   } // end loop over histogram classes
 }
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>("my-event-selection"),
-    adaptAnalysisTask<MuonTrackSelection>("muon-track-selection"),
-    adaptAnalysisTask<DileptonMuMu>("dilepton-mumu")};
+    adaptAnalysisTask<EventSelection>(cfgc, "my-event-selection"),
+    adaptAnalysisTask<MuonTrackSelection>(cfgc, "muon-track-selection"),
+    adaptAnalysisTask<DileptonMuMu>(cfgc, "dilepton-mumu")};
 }

--- a/Analysis/Tasks/PWGDQ/filterPP.cxx
+++ b/Analysis/Tasks/PWGDQ/filterPP.cxx
@@ -318,12 +318,12 @@ struct FilterPPTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelectionTask>("dq-event-selection"),
-    adaptAnalysisTask<BarrelTrackSelectionTask>("dq-barrel-track-selection"),
-    adaptAnalysisTask<FilterPPTask>("dq-ppFilter")};
+    adaptAnalysisTask<EventSelectionTask>(cfgc, "dq-event-selection"),
+    adaptAnalysisTask<BarrelTrackSelectionTask>(cfgc, "dq-barrel-track-selection"),
+    adaptAnalysisTask<FilterPPTask>(cfgc, "dq-ppFilter")};
 }
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses)

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -241,9 +241,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec workflow;
   const bool isPbPb = cfgc.options().get<bool>("isPbPb");
   if (isPbPb) {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>("table-maker"));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>(cfgc, "table-maker"));
   } else {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>("table-maker"));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>(cfgc, "table-maker"));
   }
 
   return workflow;

--- a/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
@@ -165,8 +165,8 @@ struct TableMakerMuon_pp {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<TableMakerMuon_pp>("table-maker-muon-pp")};
+    adaptAnalysisTask<TableMakerMuon_pp>(cfgc, "table-maker-muon-pp")};
 }

--- a/Analysis/Tasks/PWGDQ/tableReader.cxx
+++ b/Analysis/Tasks/PWGDQ/tableReader.cxx
@@ -616,15 +616,15 @@ struct DileptonHadronAnalysis {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>("my-event-selection"),
-    adaptAnalysisTask<BarrelTrackSelection>("barrel-track-selection"),
-    adaptAnalysisTask<EventMixing>("event-mixing"),
-    adaptAnalysisTask<MuonTrackSelection>("muon-track-selection"),
-    adaptAnalysisTask<TableReader>("table-reader"),
-    adaptAnalysisTask<DileptonHadronAnalysis>("dilepton-hadron")
+    adaptAnalysisTask<EventSelection>(cfgc, "my-event-selection"),
+    adaptAnalysisTask<BarrelTrackSelection>(cfgc, "barrel-track-selection"),
+    adaptAnalysisTask<EventMixing>(cfgc, "event-mixing"),
+    adaptAnalysisTask<MuonTrackSelection>(cfgc, "muon-track-selection"),
+    adaptAnalysisTask<TableReader>(cfgc, "table-reader"),
+    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc, "dilepton-hadron")
 
   };
 }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -199,11 +199,11 @@ struct HFCandidateCreator2ProngMC {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<HFCandidateCreator2Prong>("hf-cand-creator-2prong"),
-    adaptAnalysisTask<HFCandidateCreator2ProngExpressions>("hf-cand-creator-2prong-expressions")};
+    adaptAnalysisTask<HFCandidateCreator2Prong>(cfgc, "hf-cand-creator-2prong"),
+    adaptAnalysisTask<HFCandidateCreator2ProngExpressions>(cfgc, "hf-cand-creator-2prong-expressions")};
   const bool doMC = cfgc.options().get<bool>("doMC");
   if (doMC) {
-    workflow.push_back(adaptAnalysisTask<HFCandidateCreator2ProngMC>("hf-cand-creator-2prong-mc"));
+    workflow.push_back(adaptAnalysisTask<HFCandidateCreator2ProngMC>(cfgc, "hf-cand-creator-2prong-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -247,11 +247,11 @@ struct HFCandidateCreator3ProngMC {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<HFCandidateCreator3Prong>("hf-cand-creator-3prong"),
-    adaptAnalysisTask<HFCandidateCreator3ProngExpressions>("hf-cand-creator-3prong-expressions")};
+    adaptAnalysisTask<HFCandidateCreator3Prong>(cfgc, "hf-cand-creator-3prong"),
+    adaptAnalysisTask<HFCandidateCreator3ProngExpressions>(cfgc, "hf-cand-creator-3prong-expressions")};
   const bool doMC = cfgc.options().get<bool>("doMC");
   if (doMC) {
-    workflow.push_back(adaptAnalysisTask<HFCandidateCreator3ProngMC>("hf-cand-creator-3prong-mc"));
+    workflow.push_back(adaptAnalysisTask<HFCandidateCreator3ProngMC>(cfgc, "hf-cand-creator-3prong-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/HFD0CandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFD0CandidateSelector.cxx
@@ -404,8 +404,8 @@ struct HFD0CandidateSelector {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HFD0CandidateSelector>("hf-d0-candidate-selector")};
+    adaptAnalysisTask<HFD0CandidateSelector>(cfgc, "hf-d0-candidate-selector")};
 }

--- a/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
@@ -199,8 +199,8 @@ struct HFJpsiToEECandidateSelector {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HFJpsiToEECandidateSelector>("hf-jpsi-toee-candidate-selector")};
+    adaptAnalysisTask<HFJpsiToEECandidateSelector>(cfgc, "hf-jpsi-toee-candidate-selector")};
 }

--- a/Analysis/Tasks/PWGHF/HFLcCandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFLcCandidateSelector.cxx
@@ -366,8 +366,8 @@ struct HFLcCandidateSelector {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HFLcCandidateSelector>("hf-lc-candidate-selector")};
+    adaptAnalysisTask<HFLcCandidateSelector>(cfgc, "hf-lc-candidate-selector")};
 }

--- a/Analysis/Tasks/PWGHF/HFMCValidation.cxx
+++ b/Analysis/Tasks/PWGHF/HFMCValidation.cxx
@@ -196,7 +196,7 @@ struct ValidationRecLevel {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<ValidationGenLevel>("hf-mc-validation-gen"),
-    adaptAnalysisTask<ValidationRecLevel>("hf-mc-validation-rec")};
+    adaptAnalysisTask<ValidationGenLevel>(cfgc, "hf-mc-validation-gen"),
+    adaptAnalysisTask<ValidationRecLevel>(cfgc, "hf-mc-validation-rec")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -851,9 +851,9 @@ struct HFTrackIndexSkimsCreator {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<SelectTracks>("hf-produce-sel-track"),
-    adaptAnalysisTask<HFTrackIndexSkimsCreator>("hf-track-index-skims-creator")};
+    adaptAnalysisTask<SelectTracks>(cfgc, "hf-produce-sel-track"),
+    adaptAnalysisTask<HFTrackIndexSkimsCreator>(cfgc, "hf-track-index-skims-creator")};
 }

--- a/Analysis/Tasks/PWGHF/HFTreeCreatorD0ToKPi.cxx
+++ b/Analysis/Tasks/PWGHF/HFTreeCreatorD0ToKPi.cxx
@@ -265,6 +265,6 @@ struct CandidateTreeWriter {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow;
-  workflow.push_back(adaptAnalysisTask<CandidateTreeWriter>("hf-tree-creator-d0-tokpi"));
+  workflow.push_back(adaptAnalysisTask<CandidateTreeWriter>(cfgc, "hf-tree-creator-d0-tokpi"));
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/HFTreeCreatorLcToPKPi.cxx
+++ b/Analysis/Tasks/PWGHF/HFTreeCreatorLcToPKPi.cxx
@@ -306,6 +306,6 @@ struct CandidateTreeWriter {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow;
-  workflow.push_back(adaptAnalysisTask<CandidateTreeWriter>("hf-tree-creator-lc-topkpi"));
+  workflow.push_back(adaptAnalysisTask<CandidateTreeWriter>(cfgc, "hf-tree-creator-lc-topkpi"));
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/qaTask.cxx
+++ b/Analysis/Tasks/PWGHF/qaTask.cxx
@@ -535,14 +535,14 @@ struct QATrackingEfficiency {
   }
 };
 
-o2fw::WorkflowSpec defineDataProcessing(o2fw::ConfigContext const&)
+o2fw::WorkflowSpec defineDataProcessing(o2fw::ConfigContext const& cfgc)
 {
-  return o2fw::WorkflowSpec{o2fw::adaptAnalysisTask<QAGlobalObservables>("qa-global-observables"),
-                            o2fw::adaptAnalysisTask<QATrackingKine>("qa-tracking-kine"),
-                            o2fw::adaptAnalysisTask<QATrackingResolution>("qa-tracking-resolution"),
-                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kPiPlus>>("qa-tracking-efficiency-pion"),
-                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kProton>>("qa-tracking-efficiency-proton"),
-                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kElectron>>("qa-tracking-efficiency-electron"),
-                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kMuonMinus>>("qa-tracking-efficiency-muon"),
-                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kKPlus>>("qa-tracking-efficiency-kaon")};
+  return o2fw::WorkflowSpec{o2fw::adaptAnalysisTask<QAGlobalObservables>(cfgc, "qa-global-observables"),
+                            o2fw::adaptAnalysisTask<QATrackingKine>(cfgc, "qa-tracking-kine"),
+                            o2fw::adaptAnalysisTask<QATrackingResolution>(cfgc, "qa-tracking-resolution"),
+                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kPiPlus>>(cfgc, "qa-tracking-efficiency-pion"),
+                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kProton>>(cfgc, "qa-tracking-efficiency-proton"),
+                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kElectron>>(cfgc, "qa-tracking-efficiency-electron"),
+                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kMuonMinus>>(cfgc, "qa-tracking-efficiency-muon"),
+                            o2fw::adaptAnalysisTask<QATrackingEfficiency<PDG_t::kKPlus>>(cfgc, "qa-tracking-efficiency-kaon")};
 };

--- a/Analysis/Tasks/PWGHF/qaTaskEfficiency.cxx
+++ b/Analysis/Tasks/PWGHF/qaTaskEfficiency.cxx
@@ -204,19 +204,19 @@ o2fw::WorkflowSpec defineDataProcessing(o2fw::ConfigContext const& cfgc)
 {
   o2fw::WorkflowSpec w;
   if (cfgc.options().get<int>("eff-el")) {
-    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Electron>>("qa-tracking-efficiency-electron"));
+    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Electron>>(cfgc, "qa-tracking-efficiency-electron"));
   }
   if (cfgc.options().get<int>("eff-mu")) {
-    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Muon>>("qa-tracking-efficiency-muon"));
+    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Muon>>(cfgc, "qa-tracking-efficiency-muon"));
   }
   if (cfgc.options().get<int>("eff-pi")) {
-    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Pion>>("qa-tracking-efficiency-pion"));
+    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Pion>>(cfgc, "qa-tracking-efficiency-pion"));
   }
   if (cfgc.options().get<int>("eff-ka")) {
-    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Kaon>>("qa-tracking-efficiency-kaon"));
+    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Kaon>>(cfgc, "qa-tracking-efficiency-kaon"));
   }
   if (cfgc.options().get<int>("eff-pr")) {
-    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Proton>>("qa-tracking-efficiency-proton"));
+    w.push_back(o2fw::adaptAnalysisTask<QATrackingEfficiencyPt<o2::track::PID::Proton>>(cfgc, "qa-tracking-efficiency-proton"));
   }
   return w;
 }

--- a/Analysis/Tasks/PWGHF/qaTaskSimple.cxx
+++ b/Analysis/Tasks/PWGHF/qaTaskSimple.cxx
@@ -336,11 +336,11 @@ struct QATrackingResolution {
   }
 };
 
-o2fw::WorkflowSpec defineDataProcessing(o2fw::ConfigContext const&)
+o2fw::WorkflowSpec defineDataProcessing(o2fw::ConfigContext const& cfgc)
 {
   o2fw::WorkflowSpec w;
-  w.push_back(o2fw::adaptAnalysisTask<QAGlobalObservables>("qa-global-observables"));
-  w.push_back(o2fw::adaptAnalysisTask<QATrackingKine>("qa-tracking-kine"));
-  w.push_back(o2fw::adaptAnalysisTask<QATrackingResolution>("qa-tracking-resolution"));
+  w.push_back(o2fw::adaptAnalysisTask<QAGlobalObservables>(cfgc, "qa-global-observables"));
+  w.push_back(o2fw::adaptAnalysisTask<QATrackingKine>(cfgc, "qa-tracking-kine"));
+  w.push_back(o2fw::adaptAnalysisTask<QATrackingResolution>(cfgc, "qa-tracking-resolution"));
   return w;
 }

--- a/Analysis/Tasks/PWGHF/taskBPlus.cxx
+++ b/Analysis/Tasks/PWGHF/taskBPlus.cxx
@@ -89,10 +89,10 @@ struct TaskBplus {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<AddCollisionId>("hf-task-add-collisionId"),
-    adaptAnalysisTask<TaskBplus>("hf-task-bplus")};
+    adaptAnalysisTask<AddCollisionId>(cfgc, "hf-task-add-collisionId"),
+    adaptAnalysisTask<TaskBplus>(cfgc, "hf-task-bplus")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/taskD0.cxx
+++ b/Analysis/Tasks/PWGHF/taskD0.cxx
@@ -163,10 +163,10 @@ struct TaskD0MC {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<TaskD0>("hf-task-d0")};
+    adaptAnalysisTask<TaskD0>(cfgc, "hf-task-d0")};
   const bool doMC = cfgc.options().get<bool>("doMC");
   if (doMC) {
-    workflow.push_back(adaptAnalysisTask<TaskD0MC>("hf-task-d0-mc"));
+    workflow.push_back(adaptAnalysisTask<TaskD0MC>(cfgc, "hf-task-d0-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/taskDPlus.cxx
+++ b/Analysis/Tasks/PWGHF/taskDPlus.cxx
@@ -95,8 +95,8 @@ struct TaskDPlus {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<TaskDPlus>("hf-task-dplus")};
+    adaptAnalysisTask<TaskDPlus>(cfgc, "hf-task-dplus")};
 }

--- a/Analysis/Tasks/PWGHF/taskJpsi.cxx
+++ b/Analysis/Tasks/PWGHF/taskJpsi.cxx
@@ -150,10 +150,10 @@ struct TaskJpsiMC {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<TaskJpsi>("hf-task-jpsi")};
+    adaptAnalysisTask<TaskJpsi>(cfgc, "hf-task-jpsi")};
   const bool doMC = cfgc.options().get<bool>("doMC");
   if (doMC) {
-    workflow.push_back(adaptAnalysisTask<TaskJpsiMC>("hf-task-jpsi-mc"));
+    workflow.push_back(adaptAnalysisTask<TaskJpsiMC>(cfgc, "hf-task-jpsi-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGHF/taskLc.cxx
+++ b/Analysis/Tasks/PWGHF/taskLc.cxx
@@ -165,10 +165,10 @@ struct TaskLcMC {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<TaskLc>("hf-task-lc")};
+    adaptAnalysisTask<TaskLc>(cfgc, "hf-task-lc")};
   const bool doMC = cfgc.options().get<bool>("doMC");
   if (doMC) {
-    workflow.push_back(adaptAnalysisTask<TaskLcMC>("hf-task-lc-mc"));
+    workflow.push_back(adaptAnalysisTask<TaskLcMC>(cfgc, "hf-task-lc-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGJE/jetfinder.cxx
+++ b/Analysis/Tasks/PWGJE/jetfinder.cxx
@@ -114,8 +114,8 @@ struct JetFinderTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetFinderTask>("jet-finder")};
+    adaptAnalysisTask<JetFinderTask>(cfgc, "jet-finder")};
 }

--- a/Analysis/Tasks/PWGJE/jetfinderhadronrecoil.cxx
+++ b/Analysis/Tasks/PWGJE/jetfinderhadronrecoil.cxx
@@ -120,8 +120,8 @@ struct JetFinderHadronRecoilTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetFinderHadronRecoilTask>("jet-finder-hadron-recoil")};
+    adaptAnalysisTask<JetFinderHadronRecoilTask>(cfgc, "jet-finder-hadron-recoil")};
 }

--- a/Analysis/Tasks/PWGJE/jetfinderhf.cxx
+++ b/Analysis/Tasks/PWGJE/jetfinderhf.cxx
@@ -106,8 +106,8 @@ struct JetFinderHFTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetFinderHFTask>("jet-finder-hf")};
+    adaptAnalysisTask<JetFinderHFTask>(cfgc, "jet-finder-hf")};
 }

--- a/Analysis/Tasks/PWGJE/jetskimming.cxx
+++ b/Analysis/Tasks/PWGJE/jetskimming.cxx
@@ -62,8 +62,8 @@ struct JetSkimmingTask1 {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetSkimmingTask1>("jet-skimmer")};
+    adaptAnalysisTask<JetSkimmingTask1>(cfgc, "jet-skimmer")};
 }

--- a/Analysis/Tasks/PWGJE/jetsubstructure.cxx
+++ b/Analysis/Tasks/PWGJE/jetsubstructure.cxx
@@ -118,8 +118,8 @@ struct JetSubstructure {
     jetSubstructure(zg, rg, nsd);
   }
 };
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetSubstructure>("jet-substructure")};
+    adaptAnalysisTask<JetSubstructure>(cfgc, "jet-substructure")};
 }

--- a/Analysis/Tasks/PWGLF/NucleiSpectraTask.cxx
+++ b/Analysis/Tasks/PWGLF/NucleiSpectraTask.cxx
@@ -105,8 +105,8 @@ struct NucleiSpecraTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<NucleiSpecraTask>("nuclei-spectra")};
+    adaptAnalysisTask<NucleiSpecraTask>(cfgc, "nuclei-spectra")};
 }

--- a/Analysis/Tasks/PWGLF/cascadeanalysis.cxx
+++ b/Analysis/Tasks/PWGLF/cascadeanalysis.cxx
@@ -155,9 +155,9 @@ struct cascadeanalysis {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<cascadeanalysis>("lf-cascadeanalysis"),
-    adaptAnalysisTask<cascadeQA>("lf-cascadeQA")};
+    adaptAnalysisTask<cascadeanalysis>(cfgc, "lf-cascadeanalysis"),
+    adaptAnalysisTask<cascadeQA>(cfgc, "lf-cascadeQA")};
 }

--- a/Analysis/Tasks/PWGLF/cascadebuilder.cxx
+++ b/Analysis/Tasks/PWGLF/cascadebuilder.cxx
@@ -274,10 +274,10 @@ struct cascadeinitializer {
   void init(InitContext const&) {}
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<cascadeprefilterpairs>("lf-cascadeprefilterpairs"),
-    adaptAnalysisTask<cascadebuilder>("lf-cascadebuilder"),
-    adaptAnalysisTask<cascadeinitializer>("lf-cascadeinitializer")};
+    adaptAnalysisTask<cascadeprefilterpairs>(cfgc, "lf-cascadeprefilterpairs"),
+    adaptAnalysisTask<cascadebuilder>(cfgc, "lf-cascadebuilder"),
+    adaptAnalysisTask<cascadeinitializer>(cfgc, "lf-cascadeinitializer")};
 }

--- a/Analysis/Tasks/PWGLF/cascadefinder.cxx
+++ b/Analysis/Tasks/PWGLF/cascadefinder.cxx
@@ -428,11 +428,11 @@ struct cascadeinitializer {
   void init(InitContext const&) {}
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<cascadeprefilter>("lf-cascadeprefilter"),
-    adaptAnalysisTask<cascadefinder>("lf-cascadefinder"),
-    adaptAnalysisTask<cascadefinderQA>("lf-cascadefinderQA"),
-    adaptAnalysisTask<cascadeinitializer>("lf-cascadeinitializer")};
+    adaptAnalysisTask<cascadeprefilter>(cfgc, "lf-cascadeprefilter"),
+    adaptAnalysisTask<cascadefinder>(cfgc, "lf-cascadefinder"),
+    adaptAnalysisTask<cascadefinderQA>(cfgc, "lf-cascadefinderQA"),
+    adaptAnalysisTask<cascadeinitializer>(cfgc, "lf-cascadeinitializer")};
 }

--- a/Analysis/Tasks/PWGLF/lambdakzeroanalysis.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzeroanalysis.cxx
@@ -140,9 +140,9 @@ struct lambdakzeroanalysis {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<lambdakzeroanalysis>("lf-lambdakzeroanalysis"),
-    adaptAnalysisTask<lambdakzeroQA>("lf-lambdakzeroQA")};
+    adaptAnalysisTask<lambdakzeroanalysis>(cfgc, "lf-lambdakzeroanalysis"),
+    adaptAnalysisTask<lambdakzeroQA>(cfgc, "lf-lambdakzeroQA")};
 }

--- a/Analysis/Tasks/PWGLF/lambdakzerobuilder.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzerobuilder.cxx
@@ -230,10 +230,10 @@ struct lambdakzeroinitializer {
   void init(InitContext const&) {}
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<lambdakzeroprefilterpairs>("lf-lambdakzeroprefilterpairs"),
-    adaptAnalysisTask<lambdakzerobuilder>("lf-lambdakzerobuilder"),
-    adaptAnalysisTask<lambdakzeroinitializer>("lf-lambdakzeroinitializer")};
+    adaptAnalysisTask<lambdakzeroprefilterpairs>(cfgc, "lf-lambdakzeroprefilterpairs"),
+    adaptAnalysisTask<lambdakzerobuilder>(cfgc, "lf-lambdakzerobuilder"),
+    adaptAnalysisTask<lambdakzeroinitializer>(cfgc, "lf-lambdakzeroinitializer")};
 }

--- a/Analysis/Tasks/PWGLF/lambdakzerofinder.cxx
+++ b/Analysis/Tasks/PWGLF/lambdakzerofinder.cxx
@@ -279,11 +279,11 @@ struct lambdakzeroinitializer {
   void init(InitContext const&) {}
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<lambdakzeroprefilter>("lf-lambdakzeroprefilter"),
-    adaptAnalysisTask<lambdakzerofinder>("lf-lambdakzerofinder"),
-    adaptAnalysisTask<lambdakzerofinderQA>("lf-lambdakzerofinderQA"),
-    adaptAnalysisTask<lambdakzeroinitializer>("lf-lambdakzeroinitializer")};
+    adaptAnalysisTask<lambdakzeroprefilter>(cfgc, "lf-lambdakzeroprefilter"),
+    adaptAnalysisTask<lambdakzerofinder>(cfgc, "lf-lambdakzerofinder"),
+    adaptAnalysisTask<lambdakzerofinderQA>(cfgc, "lf-lambdakzerofinderQA"),
+    adaptAnalysisTask<lambdakzeroinitializer>(cfgc, "lf-lambdakzeroinitializer")};
 }

--- a/Analysis/Tasks/PWGLF/mcspectraefficiency.cxx
+++ b/Analysis/Tasks/PWGLF/mcspectraefficiency.cxx
@@ -151,13 +151,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   const bool reco = cfgc.options().get<int>("add-reco");
   WorkflowSpec workflow{};
   if (vertex) {
-    workflow.push_back(adaptAnalysisTask<VertexTask>("vertex-histogram"));
+    workflow.push_back(adaptAnalysisTask<VertexTask>(cfgc, "vertex-histogram"));
   }
   if (gen) {
-    workflow.push_back(adaptAnalysisTask<GeneratedTask>("generator-histogram"));
+    workflow.push_back(adaptAnalysisTask<GeneratedTask>(cfgc, "generator-histogram"));
   }
   if (reco) {
-    workflow.push_back(adaptAnalysisTask<ReconstructedTask>("reconstructed-histogram"));
+    workflow.push_back(adaptAnalysisTask<ReconstructedTask>(cfgc, "reconstructed-histogram"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/raacharged.cxx
+++ b/Analysis/Tasks/PWGLF/raacharged.cxx
@@ -218,8 +218,8 @@ struct raacharged {
 //--------------------------------------------------------------------
 // Workflow definition
 //--------------------------------------------------------------------
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<raacharged>("raa-charged")};
+    adaptAnalysisTask<raacharged>(cfgc, "raa-charged")};
 }

--- a/Analysis/Tasks/PWGLF/spectraTOF.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF.cxx
@@ -88,8 +88,8 @@ struct TOFSpectraTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTask>("tofspectra-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTask>(cfgc, "tofspectra-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTOF_split.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF_split.cxx
@@ -76,8 +76,8 @@ struct TOFSpectraTaskSplit {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskSplit>("tofspectra-split-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskSplit>(cfgc, "tofspectra-split-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTOF_tiny.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF_tiny.cxx
@@ -77,8 +77,8 @@ struct TOFSpectraTaskTiny {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskTiny>("tofspectra-tiny-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TOFSpectraTaskTiny>(cfgc, "tofspectra-tiny-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPC.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPC.cxx
@@ -156,9 +156,9 @@ struct TPCPIDQASignalwTOFTask {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   int TPCwTOF = cfgc.options().get<int>("add-tof-histos");
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTask>("tpcspectra-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTask>(cfgc, "tpcspectra-task")};
   if (TPCwTOF) {
-    workflow.push_back(adaptAnalysisTask<TPCPIDQASignalwTOFTask>("TPCpidqa-signalwTOF-task"));
+    workflow.push_back(adaptAnalysisTask<TPCPIDQASignalwTOFTask>(cfgc, "TPCpidqa-signalwTOF-task"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPC_split.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPC_split.cxx
@@ -77,8 +77,8 @@ struct TPCSpectraTaskSplit {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskSplit>("tpcspectra-split-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskSplit>(cfgc, "tpcspectra-split-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPC_tiny.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPC_tiny.cxx
@@ -77,8 +77,8 @@ struct TPCSpectraTaskTiny {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskTiny>("tpcspectra-tiny-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskTiny>(cfgc, "tpcspectra-tiny-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPCsplitPiKaPr.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPCsplitPiKaPr.cxx
@@ -69,8 +69,8 @@ struct TPCSpectraTaskSplitPiKaPr {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskSplitPiKaPr>("tpcspectra-split-pikapr-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskSplitPiKaPr>(cfgc, "tpcspectra-split-pikapr-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/spectraTPCtinyPiKaPr.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPCtinyPiKaPr.cxx
@@ -69,8 +69,8 @@ struct TPCSpectraTaskTinyPiKaPr {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskTinyPiKaPr>("tpcspectra-tiny-pikapr-task")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraTaskTinyPiKaPr>(cfgc, "tpcspectra-tiny-pikapr-task")};
   return workflow;
 }

--- a/Analysis/Tasks/PWGLF/trackchecks.cxx
+++ b/Analysis/Tasks/PWGLF/trackchecks.cxx
@@ -329,9 +329,9 @@ struct TrackCheckTaskEvSelTrackSel {
   }
 }; // struct TrackCheckTask1
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<TrackCheckTaskEvSel>("track-histos-evsel"),
-    adaptAnalysisTask<TrackCheckTaskEvSelTrackSel>("track-histos-evsel-trksel")};
+    adaptAnalysisTask<TrackCheckTaskEvSel>(cfgc, "track-histos-evsel"),
+    adaptAnalysisTask<TrackCheckTaskEvSelTrackSel>(cfgc, "track-histos-evsel-trksel")};
 }

--- a/Analysis/Tasks/PWGMM/dNdetaRun2Tracklets.cxx
+++ b/Analysis/Tasks/PWGMM/dNdetaRun2Tracklets.cxx
@@ -57,8 +57,8 @@ struct PseudorapidityDensity {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<PseudorapidityDensity>("dNdetaRun2Tracklets-analysis")};
+    adaptAnalysisTask<PseudorapidityDensity>(cfgc, "dNdetaRun2Tracklets-analysis")};
 }

--- a/Analysis/Tasks/PWGUD/upcAnalysis.cxx
+++ b/Analysis/Tasks/PWGUD/upcAnalysis.cxx
@@ -73,8 +73,8 @@ struct UPCAnalysis {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<UPCAnalysis>("upc")};
+    adaptAnalysisTask<UPCAnalysis>(cfgc, "upc")};
 }

--- a/Analysis/Tasks/PWGUD/upcForward.cxx
+++ b/Analysis/Tasks/PWGUD/upcForward.cxx
@@ -107,9 +107,8 @@ struct UPCForward {
 
   } //end of process
 };
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<UPCForward>(
-      "upc-forward")};
+    adaptAnalysisTask<UPCForward>(cfgc, "upc-forward")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/jetProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/jetProvider.cxx
@@ -58,8 +58,8 @@ struct JetProviderTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<JetProviderTask>("jet-task-skim-provider")};
+  WorkflowSpec workflow{adaptAnalysisTask<JetProviderTask>(cfgc, "jet-task-skim-provider")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/jetSpectraAnalyser.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/jetSpectraAnalyser.cxx
@@ -50,8 +50,8 @@ struct JetSpectraAnalyser {
     }
   }
 };
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetSpectraAnalyser>("jetspectra-task-skim-analyser")};
+    adaptAnalysisTask<JetSpectraAnalyser>(cfgc, "jetspectra-task-skim-analyser")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/jetSpectraReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/jetSpectraReference.cxx
@@ -62,8 +62,8 @@ struct JetSpectraReference {
     }
   }
 };
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetSpectraReference>("jetspectra-task-skim-reference")};
+    adaptAnalysisTask<JetSpectraReference>(cfgc, "jetspectra-task-skim-reference")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraNucleiAnalyser.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraNucleiAnalyser.cxx
@@ -64,8 +64,8 @@ struct NucleiSpectraAnalyserTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<NucleiSpectraAnalyserTask>("nucleispectra-task-skim-analyser")};
+    adaptAnalysisTask<NucleiSpectraAnalyserTask>(cfgc, "nucleispectra-task-skim-analyser")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraNucleiProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraNucleiProvider.cxx
@@ -93,8 +93,8 @@ struct NucleiSpectraProviderTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<NucleiSpectraProviderTask>("nucleispectra-task-skim-provider")};
+  WorkflowSpec workflow{adaptAnalysisTask<NucleiSpectraProviderTask>(cfgc, "nucleispectra-task-skim-provider")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraNucleiReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraNucleiReference.cxx
@@ -106,8 +106,8 @@ struct NucleiSpectraReferenceTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<NucleiSpectraReferenceTask>("nucleispectra-task-skim-reference")};
+    adaptAnalysisTask<NucleiSpectraReferenceTask>(cfgc, "nucleispectra-task-skim-reference")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraTPCAnalyser.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraTPCAnalyser.cxx
@@ -107,6 +107,6 @@ struct TPCSpectraAnalyserTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraAnalyserTask>("tpcspectra-task-skim-analyser")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraAnalyserTask>(cfgc, "tpcspectra-task-skim-analyser")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraTPCProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraTPCProvider.cxx
@@ -152,8 +152,8 @@ struct TPCSpectraProviderTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraProviderTask>("tpcspectra-task-skim-provider")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraProviderTask>(cfgc, "tpcspectra-task-skim-provider")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraTPCReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraTPCReference.cxx
@@ -110,6 +110,6 @@ struct TPCSpectraReferenceTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraReferenceTask>("tpcspectra-task-skim-reference")};
+  WorkflowSpec workflow{adaptAnalysisTask<TPCSpectraReferenceTask>(cfgc, "tpcspectra-task-skim-reference")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraUPCAnalyser.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraUPCAnalyser.cxx
@@ -53,6 +53,6 @@ struct UPCSpectraAnalyserTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<UPCSpectraAnalyserTask>("upcspectra-task-skim-analyser")};
+  WorkflowSpec workflow{adaptAnalysisTask<UPCSpectraAnalyserTask>(cfgc, "upcspectra-task-skim-analyser")};
   return workflow;
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraUPCProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraUPCProvider.cxx
@@ -69,8 +69,8 @@ struct UPCSpectraProviderTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<UPCSpectraProviderTask>("upcspectra-task-skim-provider")};
+    adaptAnalysisTask<UPCSpectraProviderTask>(cfgc, "upcspectra-task-skim-provider")};
 }

--- a/Analysis/Tasks/SkimmingTutorials/spectraUPCReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraUPCReference.cxx
@@ -78,8 +78,8 @@ struct UPCSpectraReferenceTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<UPCSpectraReferenceTask>("upcspectra-task-skim-reference")};
+    adaptAnalysisTask<UPCSpectraReferenceTask>(cfgc, "upcspectra-task-skim-reference")};
 }

--- a/Analysis/Tasks/centralityQa.cxx
+++ b/Analysis/Tasks/centralityQa.cxx
@@ -34,8 +34,8 @@ struct CentralityQaTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<CentralityQaTask>("centrality-qa")};
+    adaptAnalysisTask<CentralityQaTask>(cfgc, "centrality-qa")};
 }

--- a/Analysis/Tasks/centralityTable.cxx
+++ b/Analysis/Tasks/centralityTable.cxx
@@ -45,8 +45,8 @@ struct CentralityTableTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<CentralityTableTask>("centrality-table")};
+    adaptAnalysisTask<CentralityTableTask>(cfgc, "centrality-table")};
 }

--- a/Analysis/Tasks/emcalCorrectionTask.cxx
+++ b/Analysis/Tasks/emcalCorrectionTask.cxx
@@ -191,8 +191,8 @@ struct EmcalCorrectionTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EmcalCorrectionTask>("emcal-correction-task")};
+    adaptAnalysisTask<EmcalCorrectionTask>(cfgc, "emcal-correction-task")};
 }

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -208,9 +208,9 @@ struct EventSelectionTaskRun3 {
 WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
   if (ctx.options().get<int>("selection-run") == 2) {
-    return WorkflowSpec{adaptAnalysisTask<EventSelectionTask>("event-selection")};
+    return WorkflowSpec{adaptAnalysisTask<EventSelectionTask>(cfgc, "event-selection")};
   } else {
     return WorkflowSpec{
-      adaptAnalysisTask<EventSelectionTaskRun3>("event-selection")};
+      adaptAnalysisTask<EventSelectionTaskRun3>(cfgc, "event-selection")};
   }
 }

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -205,9 +205,9 @@ struct EventSelectionTaskRun3 {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  if (ctx.options().get<int>("selection-run") == 2) {
+  if (cfgc.options().get<int>("selection-run") == 2) {
     return WorkflowSpec{adaptAnalysisTask<EventSelectionTask>(cfgc, "event-selection")};
   } else {
     return WorkflowSpec{

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -137,8 +137,8 @@ struct EventSelectionTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelectionTask>("event-selection-qa")};
+    adaptAnalysisTask<EventSelectionTask>(cfgc, "event-selection-qa")};
 }

--- a/Analysis/Tasks/multiplicityQa.cxx
+++ b/Analysis/Tasks/multiplicityQa.cxx
@@ -80,8 +80,8 @@ struct MultiplicityQaTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<MultiplicityQaTask>("multiplicity-qa")};
+    adaptAnalysisTask<MultiplicityQaTask>(cfgc, "multiplicity-qa")};
 }

--- a/Analysis/Tasks/multiplicityTable.cxx
+++ b/Analysis/Tasks/multiplicityTable.cxx
@@ -109,9 +109,9 @@ struct MultiplicityTableTaskRun3 {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  if (ctx.options().get<int>("selection-run") == 2) {
+  if (cfgc.options().get<int>("selection-run") == 2) {
     return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskIndexed>(cfgc, "multiplicity-table")};
   } else {
     return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskRun3>(cfgc, "multiplicity-table")};

--- a/Analysis/Tasks/multiplicityTable.cxx
+++ b/Analysis/Tasks/multiplicityTable.cxx
@@ -112,8 +112,8 @@ struct MultiplicityTableTaskRun3 {
 WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
   if (ctx.options().get<int>("selection-run") == 2) {
-    return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskIndexed>("multiplicity-table")};
+    return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskIndexed>(cfgc, "multiplicity-table")};
   } else {
-    return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskRun3>("multiplicity-table")};
+    return WorkflowSpec{adaptAnalysisTask<MultiplicityTableTaskRun3>(cfgc, "multiplicity-table")};
   }
 }

--- a/Analysis/Tasks/pidTOF.cxx
+++ b/Analysis/Tasks/pidTOF.cxx
@@ -244,14 +244,14 @@ struct pidTOFTaskQA {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTOFTask>("pidTOF-task")};
+  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTOFTask>(cfgc, "pidTOF-task")};
   const int add_beta = cfgc.options().get<int>("add-beta");
   const int add_qa = cfgc.options().get<int>("add-qa");
   if (add_beta || add_qa) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskBeta>("pidTOFBeta-task"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskBeta>(cfgc, "pidTOFBeta-task"));
   }
   if (add_qa) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA>("pidTOFQA-task"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA>(cfgc, "pidTOFQA-task"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/pidTOF_split.cxx
+++ b/Analysis/Tasks/pidTOF_split.cxx
@@ -122,5 +122,5 @@ struct pidTOFTaskSplit {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskSplit>("pidTOF-split-task")};
+  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskSplit>(cfgc, "pidTOF-split-task")};
 }

--- a/Analysis/Tasks/pidTOF_tiny.cxx
+++ b/Analysis/Tasks/pidTOF_tiny.cxx
@@ -130,5 +130,5 @@ struct pidTOFTaskTiny {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskTiny>("pidTOF-tiny-task")};
+  return WorkflowSpec{adaptAnalysisTask<pidTOFTaskTiny>(cfgc, "pidTOF-tiny-task")};
 }

--- a/Analysis/Tasks/pidTOFqa.cxx
+++ b/Analysis/Tasks/pidTOFqa.cxx
@@ -187,21 +187,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   auto workflow = WorkflowSpec{};
   if (cfgc.options().get<int>("pid-el")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Electron>>("pidTOF-qa-El"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Electron>>(cfgc, "pidTOF-qa-El"));
   }
   if (cfgc.options().get<int>("pid-mu")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Muon>>("pidTOF-qa-Mu"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Muon>>(cfgc, "pidTOF-qa-Mu"));
   }
   if (cfgc.options().get<int>("pid-pikapr")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Pion>>("pidTOF-qa-Pi"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Kaon>>("pidTOF-qa-Ka"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Proton>>("pidTOF-qa-Pr"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Pion>>(cfgc, "pidTOF-qa-Pi"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Kaon>>(cfgc, "pidTOF-qa-Ka"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Proton>>(cfgc, "pidTOF-qa-Pr"));
   }
   if (cfgc.options().get<int>("pid-nuclei")) {
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Deuteron>>("pidTOF-qa-De"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Triton>>("pidTOF-qa-Tr"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Helium3>>("pidTOF-qa-He"));
-    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Alpha>>("pidTOF-qa-Al"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Deuteron>>(cfgc, "pidTOF-qa-De"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Triton>>(cfgc, "pidTOF-qa-Tr"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Helium3>>(cfgc, "pidTOF-qa-He"));
+    workflow.push_back(adaptAnalysisTask<pidTOFTaskQA<PID::Alpha>>(cfgc, "pidTOF-qa-Al"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/pidTPC.cxx
+++ b/Analysis/Tasks/pidTPC.cxx
@@ -206,9 +206,9 @@ struct pidTPCTaskQA {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTPCTask>("pidTPC-task")};
+  auto workflow = WorkflowSpec{adaptAnalysisTask<pidTPCTask>(cfgc, "pidTPC-task")};
   if (cfgc.options().get<int>("add-qa")) {
-    workflow.push_back(adaptAnalysisTask<pidTPCTaskQA>("pidTPCQA-task"));
+    workflow.push_back(adaptAnalysisTask<pidTPCTaskQA>(cfgc, "pidTPCQA-task"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/pidTPC_split.cxx
+++ b/Analysis/Tasks/pidTPC_split.cxx
@@ -123,5 +123,5 @@ struct pidTPCTaskSplit {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTPCTaskSplit>("pidTPC-split-task")};
+  return WorkflowSpec{adaptAnalysisTask<pidTPCTaskSplit>(cfgc, "pidTPC-split-task")};
 }

--- a/Analysis/Tasks/pidTPC_tiny.cxx
+++ b/Analysis/Tasks/pidTPC_tiny.cxx
@@ -131,5 +131,5 @@ struct pidTPCTaskTiny {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<pidTPCTaskTiny>("pidTPC-tiny-task")};
+  return WorkflowSpec{adaptAnalysisTask<pidTPCTaskTiny>(cfgc, "pidTPC-tiny-task")};
 }

--- a/Analysis/Tasks/timestamp.cxx
+++ b/Analysis/Tasks/timestamp.cxx
@@ -103,7 +103,7 @@ struct TimestampTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<TimestampTask>("TimestampTask")};
+  return WorkflowSpec{adaptAnalysisTask<TimestampTask>(cfgc, "TimestampTask")};
 }

--- a/Analysis/Tasks/trackextension.cxx
+++ b/Analysis/Tasks/trackextension.cxx
@@ -60,6 +60,6 @@ struct TrackExtensionTask {
 //****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TrackExtensionTask>("track-extension")};
+  WorkflowSpec workflow{adaptAnalysisTask<TrackExtensionTask>(cfgc, "track-extension")};
   return workflow;
 }

--- a/Analysis/Tasks/trackqa.cxx
+++ b/Analysis/Tasks/trackqa.cxx
@@ -181,12 +181,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   const int add_cut_qa = cfgc.options().get<int>("add-cut-qa");
 
   WorkflowSpec workflow;
-  workflow.push_back(adaptAnalysisTask<TrackQATask>("track-qa-histograms"));
+  workflow.push_back(adaptAnalysisTask<TrackQATask>(cfgc, "track-qa-histograms"));
   if (add_cut_qa) {
-    workflow.push_back(adaptAnalysisTask<TrackCutQATask>("track-cut-qa-histograms"));
+    workflow.push_back(adaptAnalysisTask<TrackCutQATask>(cfgc, "track-cut-qa-histograms"));
   }
   if (isMC) {
-    workflow.push_back(adaptAnalysisTask<TrackQATaskMC>("track-qa-histograms-mc"));
+    workflow.push_back(adaptAnalysisTask<TrackQATaskMC>(cfgc, "track-qa-histograms-mc"));
   }
   return workflow;
 }

--- a/Analysis/Tasks/trackselection.cxx
+++ b/Analysis/Tasks/trackselection.cxx
@@ -57,6 +57,6 @@ struct TrackSelectionTask {
 //****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TrackSelectionTask>("track-selection")};
+  WorkflowSpec workflow{adaptAnalysisTask<TrackSelectionTask>(cfgc, "track-selection")};
   return workflow;
 }

--- a/Analysis/Tasks/validation.cxx
+++ b/Analysis/Tasks/validation.cxx
@@ -68,8 +68,8 @@ struct ValidationTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ValidationTask>("validation-qa")};
+    adaptAnalysisTask<ValidationTask>(cfgc, "validation-qa")};
 }

--- a/Analysis/Tasks/weakDecayIndices.cxx
+++ b/Analysis/Tasks/weakDecayIndices.cxx
@@ -45,10 +45,10 @@ struct IndexCascades {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<IndexV0s>("weak-decay-indices-v0"),
-    adaptAnalysisTask<IndexCascades>("weak-decay-indices-cascades"),
+    adaptAnalysisTask<IndexV0s>(cfgc, "weak-decay-indices-v0"),
+    adaptAnalysisTask<IndexCascades>(cfgc, "weak-decay-indices-cascades"),
   };
 }

--- a/Analysis/Tutorials/src/ZDCVZeroIteration.cxx
+++ b/Analysis/Tutorials/src/ZDCVZeroIteration.cxx
@@ -86,12 +86,12 @@ struct IterateV0ZDC {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<IterateV0>("iterate-v0"),
-    adaptAnalysisTask<IterateV0Exclusive>("iterate-v0-exclusive"),
-    adaptAnalysisTask<IterateV0Tracks>("iterate-v0-tracks"),
-    adaptAnalysisTask<IterateV0ZDC>("iterate-v0-zdc"),
+    adaptAnalysisTask<IterateV0>(cfgc, "iterate-v0"),
+    adaptAnalysisTask<IterateV0Exclusive>(cfgc, "iterate-v0-exclusive"),
+    adaptAnalysisTask<IterateV0Tracks>(cfgc, "iterate-v0-tracks"),
+    adaptAnalysisTask<IterateV0ZDC>(cfgc, "iterate-v0-zdc"),
   };
 }

--- a/Analysis/Tutorials/src/aodreader.cxx
+++ b/Analysis/Tutorials/src/aodreader.cxx
@@ -149,8 +149,8 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("process-unoduetre")};
+    adaptAnalysisTask<ATask>(cfgc, "process-unoduetre")};
 }

--- a/Analysis/Tutorials/src/aodwriter.cxx
+++ b/Analysis/Tutorials/src/aodwriter.cxx
@@ -149,8 +149,8 @@ struct ATask {
   size_t cnt = 0;
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-unoduetre")};
+    adaptAnalysisTask<ATask>(cfgc, "produce-unoduetre")};
 }

--- a/Analysis/Tutorials/src/associatedExample.cxx
+++ b/Analysis/Tutorials/src/associatedExample.cxx
@@ -118,12 +118,12 @@ struct ZTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-etaphi"),
-    adaptAnalysisTask<BTask>("consume-etaphi"),
-    adaptAnalysisTask<MTask>("produce-mult"),
-    adaptAnalysisTask<TTask>("consume-mult"),
-    adaptAnalysisTask<ZTask>("partition-mult")};
+    adaptAnalysisTask<ATask>(cfgc, "produce-etaphi"),
+    adaptAnalysisTask<BTask>(cfgc, "consume-etaphi"),
+    adaptAnalysisTask<MTask>(cfgc, "produce-mult"),
+    adaptAnalysisTask<TTask>(cfgc, "consume-mult"),
+    adaptAnalysisTask<ZTask>(cfgc, "partition-mult")};
 }

--- a/Analysis/Tutorials/src/ccdbaccess.cxx
+++ b/Analysis/Tutorials/src/ccdbaccess.cxx
@@ -59,7 +59,7 @@ struct TimestampUserTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<TimestampUserTask>("TimestampUserTask")};
+  return WorkflowSpec{adaptAnalysisTask<TimestampUserTask>(cfgc, "TimestampUserTask")};
 }

--- a/Analysis/Tutorials/src/collisionTracksIteration.cxx
+++ b/Analysis/Tutorials/src/collisionTracksIteration.cxx
@@ -30,8 +30,8 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("collision-tracks-iteration-tutorial")};
+    adaptAnalysisTask<ATask>(cfgc, "collision-tracks-iteration-tutorial")};
 }

--- a/Analysis/Tutorials/src/compatibleBCs.cxx
+++ b/Analysis/Tutorials/src/compatibleBCs.cxx
@@ -93,10 +93,10 @@ struct CompatibleT0V0A {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<CompatibleBCs>("compatible-bcs"),
-    adaptAnalysisTask<CompatibleT0V0A>("compatible-t0-v0a"),
+    adaptAnalysisTask<CompatibleBCs>(cfgc, "compatible-bcs"),
+    adaptAnalysisTask<CompatibleT0V0A>(cfgc, "compatible-t0-v0a"),
   };
 }

--- a/Analysis/Tutorials/src/configurableObjects.cxx
+++ b/Analysis/Tutorials/src/configurableObjects.cxx
@@ -97,8 +97,8 @@ struct ConfigurableObjectDemo {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ConfigurableObjectDemo>("configurable-demo")};
+    adaptAnalysisTask<ConfigurableObjectDemo>(cfgc, "configurable-demo")};
 }

--- a/Analysis/Tutorials/src/dynamicColumns.cxx
+++ b/Analysis/Tutorials/src/dynamicColumns.cxx
@@ -36,9 +36,9 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   // create and use table
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("attach-showcase")};
+    adaptAnalysisTask<ATask>(cfgc, "attach-showcase")};
 }

--- a/Analysis/Tutorials/src/efficiencyGlobal.cxx
+++ b/Analysis/Tutorials/src/efficiencyGlobal.cxx
@@ -61,7 +61,7 @@ struct EfficiencyGlobal {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<EfficiencyGlobal>("EfficiencyGlobal")};
+  return WorkflowSpec{adaptAnalysisTask<EfficiencyGlobal>(cfgc, "EfficiencyGlobal")};
 }

--- a/Analysis/Tutorials/src/efficiencyPerRun.cxx
+++ b/Analysis/Tutorials/src/efficiencyPerRun.cxx
@@ -64,7 +64,7 @@ struct EfficiencyPerRun {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<EfficiencyPerRun>("EfficiencyPerRun")};
+  return WorkflowSpec{adaptAnalysisTask<EfficiencyPerRun>(cfgc, "EfficiencyPerRun")};
 }

--- a/Analysis/Tutorials/src/eventMixing.cxx
+++ b/Analysis/Tutorials/src/eventMixing.cxx
@@ -131,9 +131,9 @@ struct MixedEventsTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HashTask>("collisions-hashed"),
-    adaptAnalysisTask<CollisionsCombinationsTask>("mixed-event-tracks")};
+    adaptAnalysisTask<HashTask>(cfgc, "collisions-hashed"),
+    adaptAnalysisTask<CollisionsCombinationsTask>(cfgc, "mixed-event-tracks")};
 }

--- a/Analysis/Tutorials/src/extendedColumns.cxx
+++ b/Analysis/Tutorials/src/extendedColumns.cxx
@@ -36,9 +36,9 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   // create and use table
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("extend-showcase")};
+    adaptAnalysisTask<ATask>(cfgc, "extend-showcase")};
 }

--- a/Analysis/Tutorials/src/filters.cxx
+++ b/Analysis/Tutorials/src/filters.cxx
@@ -97,11 +97,11 @@ struct DTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-normalizedphi"),
-    adaptAnalysisTask<BTask>("consume-normalizedphi"),
-    adaptAnalysisTask<CTask>("consume-spawned-ephi"),
-    adaptAnalysisTask<DTask>("consume-spawned-mtracks")};
+    adaptAnalysisTask<ATask>(cfgc, "produce-normalizedphi"),
+    adaptAnalysisTask<BTask>(cfgc, "consume-normalizedphi"),
+    adaptAnalysisTask<CTask>(cfgc, "consume-spawned-ephi"),
+    adaptAnalysisTask<DTask>(cfgc, "consume-spawned-mtracks")};
 }

--- a/Analysis/Tutorials/src/fullTrackIteration.cxx
+++ b/Analysis/Tutorials/src/fullTrackIteration.cxx
@@ -36,8 +36,8 @@ struct ATask {
   size_t count = 2016927;
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("track-iteration-tutorial")};
+    adaptAnalysisTask<ATask>(cfgc, "track-iteration-tutorial")};
 }

--- a/Analysis/Tutorials/src/histHelpersTest.cxx
+++ b/Analysis/Tutorials/src/histHelpersTest.cxx
@@ -203,8 +203,8 @@ struct HistHelpersTest {
  * Workflow definition.
  */
 //****************************************************************************************
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HistHelpersTest>("hist-helpers-test")};
+    adaptAnalysisTask<HistHelpersTest>(cfgc, "hist-helpers-test")};
 }

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -294,14 +294,14 @@ struct GTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ETask>("output-obj-test"),
-    adaptAnalysisTask<ATask>("eta-and-phi-histograms"),
-    adaptAnalysisTask<BTask>("filtered-histograms"),
-    adaptAnalysisTask<CTask>("dimension-test"),
-    adaptAnalysisTask<DTask>("realistic-example"),
-    adaptAnalysisTask<FTask>("tlist-test"),
-    adaptAnalysisTask<GTask>("configurables-test")};
+    adaptAnalysisTask<ETask>(cfgc, "output-obj-test"),
+    adaptAnalysisTask<ATask>(cfgc, "eta-and-phi-histograms"),
+    adaptAnalysisTask<BTask>(cfgc, "filtered-histograms"),
+    adaptAnalysisTask<CTask>(cfgc, "dimension-test"),
+    adaptAnalysisTask<DTask>(cfgc, "realistic-example"),
+    adaptAnalysisTask<FTask>(cfgc, "tlist-test"),
+    adaptAnalysisTask<GTask>(cfgc, "configurables-test")};
 }

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -294,14 +294,15 @@ struct GTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
+  auto suffix = ctx.options().get<std::string>("workflow-suffix");
   return WorkflowSpec{
-    adaptAnalysisTask<ETask>("output-obj-test"),
-    adaptAnalysisTask<ATask>("eta-and-phi-histograms"),
-    adaptAnalysisTask<BTask>("filtered-histograms"),
-    adaptAnalysisTask<CTask>("dimension-test"),
-    adaptAnalysisTask<DTask>("realistic-example"),
-    adaptAnalysisTask<FTask>("tlist-test"),
-    adaptAnalysisTask<GTask>("configurables-test")};
+    adaptAnalysisTask<ETask>(("output-obj-test" + suffix).c_str()),
+    adaptAnalysisTask<ATask>(("eta-and-phi-histograms" + suffix).c_str()),
+    adaptAnalysisTask<BTask>(("filtered-histograms" + suffix).c_str()),
+    adaptAnalysisTask<CTask>(("dimension-test" + suffix).c_str()),
+    adaptAnalysisTask<DTask>(("realistic-example" + suffix).c_str()),
+    adaptAnalysisTask<FTask>(("tlist-test" + suffix).c_str()),
+    adaptAnalysisTask<GTask>(("configurables-test" + suffix).c_str())};
 }

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -296,13 +296,12 @@ struct GTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
-  auto suffix = ctx.options().get<std::string>("workflow-suffix");
-  return WorkflowSpec{
-    adaptAnalysisTask<ETask>(("output-obj-test" + suffix).c_str()),
-    adaptAnalysisTask<ATask>(("eta-and-phi-histograms" + suffix).c_str()),
-    adaptAnalysisTask<BTask>(("filtered-histograms" + suffix).c_str()),
-    adaptAnalysisTask<CTask>(("dimension-test" + suffix).c_str()),
-    adaptAnalysisTask<DTask>(("realistic-example" + suffix).c_str()),
-    adaptAnalysisTask<FTask>(("tlist-test" + suffix).c_str()),
-    adaptAnalysisTask<GTask>(("configurables-test" + suffix).c_str())};
+  return adaptAnalysisWorkflow(ctx,
+                               TaskSpec<ETask>("output-obj-test"),
+                               TaskSpec<ATask>("eta-and-phi-histograms"),
+                               TaskSpec<BTask>("filtered-histograms"),
+                               TaskSpec<CTask>("dimension-test"),
+                               TaskSpec<DTask>("realistic-example"),
+                               TaskSpec<FTask>("tlist-test"),
+                               TaskSpec<GTask>("configurables-test"));
 }

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -294,14 +294,14 @@ struct GTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  return adaptAnalysisWorkflow(ctx,
-                               TaskSpec<ETask>("output-obj-test"),
-                               TaskSpec<ATask>("eta-and-phi-histograms"),
-                               TaskSpec<BTask>("filtered-histograms"),
-                               TaskSpec<CTask>("dimension-test"),
-                               TaskSpec<DTask>("realistic-example"),
-                               TaskSpec<FTask>("tlist-test"),
-                               TaskSpec<GTask>("configurables-test"));
+  return WorkflowSpec{
+    adaptAnalysisTask<ETask>("output-obj-test"),
+    adaptAnalysisTask<ATask>("eta-and-phi-histograms"),
+    adaptAnalysisTask<BTask>("filtered-histograms"),
+    adaptAnalysisTask<CTask>("dimension-test"),
+    adaptAnalysisTask<DTask>("realistic-example"),
+    adaptAnalysisTask<FTask>("tlist-test"),
+    adaptAnalysisTask<GTask>("configurables-test")};
 }

--- a/Analysis/Tutorials/src/histogramTrackSelection.cxx
+++ b/Analysis/Tutorials/src/histogramTrackSelection.cxx
@@ -52,8 +52,8 @@ struct HistogramTrackSelection {
 //--------------------------------------------------------------------
 // Workflow definition
 //--------------------------------------------------------------------
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HistogramTrackSelection>("histogram-track-selection")};
+    adaptAnalysisTask<HistogramTrackSelection>(cfgc, "histogram-track-selection")};
 }

--- a/Analysis/Tutorials/src/histograms.cxx
+++ b/Analysis/Tutorials/src/histograms.cxx
@@ -101,11 +101,9 @@ struct DTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
-  auto suffix = ctx.options().get<std::string>("workflow-suffix");
-  return WorkflowSpec{
-    adaptAnalysisTask<ATask>(("eta-and-phi-histograms" + suffix).c_str()),
-    adaptAnalysisTask<BTask>(("etaphi-histogram" + suffix).c_str()),
-    adaptAnalysisTask<CTask>(("pt-histogram" + suffix).c_str()),
-    adaptAnalysisTask<DTask>(("output-wrapper" + suffix).c_str()),
-  };
+  return adaptAnalysisWorkflow(ctx,
+                               TaskSpec<ATask>("eta-and-phi-histograms"),
+                               TaskSpec<BTask>("etaphi-histogram"),
+                               TaskSpec<CTask>("pt-histogram"),
+                               TaskSpec<DTask>("output-wrapper"));
 }

--- a/Analysis/Tutorials/src/histograms.cxx
+++ b/Analysis/Tutorials/src/histograms.cxx
@@ -99,12 +99,12 @@ struct DTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("eta-and-phi-histograms", ctx),
-    adaptAnalysisTask<BTask>("etaphi-histogram", ctx),
-    adaptAnalysisTask<CTask>("pt-histogram", ctx),
-    adaptAnalysisTask<DTask>("output-wrapper", ctx),
+    adaptAnalysisTask<ATask>(cfgc, "eta-and-phi-histograms"),
+    adaptAnalysisTask<BTask>(cfgc, "etaphi-histogram"),
+    adaptAnalysisTask<CTask>(cfgc, "pt-histogram"),
+    adaptAnalysisTask<DTask>(cfgc, "output-wrapper"),
   };
 }

--- a/Analysis/Tutorials/src/histograms.cxx
+++ b/Analysis/Tutorials/src/histograms.cxx
@@ -101,9 +101,10 @@ struct DTask {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
-  return adaptAnalysisWorkflow(ctx,
-                               TaskSpec<ATask>("eta-and-phi-histograms"),
-                               TaskSpec<BTask>("etaphi-histogram"),
-                               TaskSpec<CTask>("pt-histogram"),
-                               TaskSpec<DTask>("output-wrapper"));
+  return WorkflowSpec{
+    adaptAnalysisTask<ATask>("eta-and-phi-histograms", ctx),
+    adaptAnalysisTask<BTask>("etaphi-histogram", ctx),
+    adaptAnalysisTask<CTask>("pt-histogram", ctx),
+    adaptAnalysisTask<DTask>("output-wrapper", ctx),
+  };
 }

--- a/Analysis/Tutorials/src/histograms.cxx
+++ b/Analysis/Tutorials/src/histograms.cxx
@@ -99,12 +99,13 @@ struct DTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
 {
+  auto suffix = ctx.options().get<std::string>("workflow-suffix");
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("eta-and-phi-histograms"),
-    adaptAnalysisTask<BTask>("etaphi-histogram"),
-    adaptAnalysisTask<CTask>("pt-histogram"),
-    adaptAnalysisTask<DTask>("output-wrapper"),
+    adaptAnalysisTask<ATask>(("eta-and-phi-histograms" + suffix).c_str()),
+    adaptAnalysisTask<BTask>(("etaphi-histogram" + suffix).c_str()),
+    adaptAnalysisTask<CTask>(("pt-histogram" + suffix).c_str()),
+    adaptAnalysisTask<DTask>(("output-wrapper" + suffix).c_str()),
   };
 }

--- a/Analysis/Tutorials/src/histogramsFullTracks.cxx
+++ b/Analysis/Tutorials/src/histogramsFullTracks.cxx
@@ -29,9 +29,9 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("eta-and-cls-histograms"),
+    adaptAnalysisTask<ATask>(cfgc, "eta-and-cls-histograms"),
   };
 }

--- a/Analysis/Tutorials/src/jetAnalysis.cxx
+++ b/Analysis/Tutorials/src/jetAnalysis.cxx
@@ -49,8 +49,8 @@ struct JetAnalysis {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<JetAnalysis>("jet-analysis")};
+    adaptAnalysisTask<JetAnalysis>(cfgc, "jet-analysis")};
 }

--- a/Analysis/Tutorials/src/mcHistograms.cxx
+++ b/Analysis/Tutorials/src/mcHistograms.cxx
@@ -76,11 +76,11 @@ struct CTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("vertex-histogram"),
-    adaptAnalysisTask<BTask>("etaphi-histogram"),
-    adaptAnalysisTask<CTask>("eta-resolution-histogram"),
+    adaptAnalysisTask<ATask>(cfgc, "vertex-histogram"),
+    adaptAnalysisTask<BTask>(cfgc, "etaphi-histogram"),
+    adaptAnalysisTask<CTask>(cfgc, "eta-resolution-histogram"),
   };
 }

--- a/Analysis/Tutorials/src/multiplicityEventTrackSelection.cxx
+++ b/Analysis/Tutorials/src/multiplicityEventTrackSelection.cxx
@@ -50,8 +50,8 @@ struct MultiplicityEventTrackSelection {
 };
 
 // Workflow definition
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<MultiplicityEventTrackSelection>("multiplicity-event-track-selection")};
+    adaptAnalysisTask<MultiplicityEventTrackSelection>(cfgc, "multiplicity-event-track-selection")};
 }

--- a/Analysis/Tutorials/src/muonIteration.cxx
+++ b/Analysis/Tutorials/src/muonIteration.cxx
@@ -48,10 +48,10 @@ struct IterateMuonsSparse {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<IterateMuons>("iterate-muons"),
-    adaptAnalysisTask<IterateMuonsSparse>("iterate-muons-sparse"),
+    adaptAnalysisTask<IterateMuons>(cfgc, "iterate-muons"),
+    adaptAnalysisTask<IterateMuonsSparse>(cfgc, "iterate-muons-sparse"),
   };
 }

--- a/Analysis/Tutorials/src/newCollections.cxx
+++ b/Analysis/Tutorials/src/newCollections.cxx
@@ -52,9 +52,9 @@ struct BTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-etaphi"),
-    adaptAnalysisTask<BTask>("consume-etaphi")};
+    adaptAnalysisTask<ATask>(cfgc, "produce-etaphi"),
+    adaptAnalysisTask<BTask>(cfgc, "consume-etaphi")};
 }

--- a/Analysis/Tutorials/src/outputs.cxx
+++ b/Analysis/Tutorials/src/outputs.cxx
@@ -64,10 +64,10 @@ struct DummyTask3 {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<DummyTask>("task1"),
-    adaptAnalysisTask<DummyTask2>("task2"),
-    adaptAnalysisTask<DummyTask3>("task3")};
+    adaptAnalysisTask<DummyTask>(cfgc, "task1"),
+    adaptAnalysisTask<DummyTask2>(cfgc, "task2"),
+    adaptAnalysisTask<DummyTask3>(cfgc, "task3")};
 }

--- a/Analysis/Tutorials/src/partitions.cxx
+++ b/Analysis/Tutorials/src/partitions.cxx
@@ -74,9 +74,9 @@ struct BTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("consume-tracks"),
-    adaptAnalysisTask<BTask>("partition-in-process")};
+    adaptAnalysisTask<ATask>(cfgc, "consume-tracks"),
+    adaptAnalysisTask<BTask>(cfgc, "partition-in-process")};
 }

--- a/Analysis/Tutorials/src/schemaEvolution.cxx
+++ b/Analysis/Tutorials/src/schemaEvolution.cxx
@@ -78,12 +78,12 @@ struct CTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-etaphi-v1"),
-    adaptAnalysisTask<BTask>("produce-etaphi-v2"),
-    adaptAnalysisTask<CTask<aod::EtaPhiV1>>("consume-etaphi-v1"), // here CTask is added with EtaPhiV1 input
-    adaptAnalysisTask<CTask<aod::EtaPhiV2>>("consume-etaphi-v2"), // here CTask is added with EtaPhiV2 input
+    adaptAnalysisTask<ATask>(cfgc, "produce-etaphi-v1"),
+    adaptAnalysisTask<BTask>(cfgc, "produce-etaphi-v2"),
+    adaptAnalysisTask<CTask<aod::EtaPhiV1>>(cfgc, "consume-etaphi-v1"), // here CTask is added with EtaPhiV1 input
+    adaptAnalysisTask<CTask<aod::EtaPhiV2>>(cfgc, "consume-etaphi-v2"), // here CTask is added with EtaPhiV2 input
   };
 }

--- a/Analysis/Tutorials/src/trackCollectionIteration.cxx
+++ b/Analysis/Tutorials/src/trackCollectionIteration.cxx
@@ -42,8 +42,8 @@ struct ATask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("track-collection-iteration-tutorial")};
+    adaptAnalysisTask<ATask>(cfgc, "track-collection-iteration-tutorial")};
 }

--- a/Analysis/Tutorials/src/trackIteration.cxx
+++ b/Analysis/Tutorials/src/trackIteration.cxx
@@ -34,8 +34,8 @@ struct ATask {
   size_t count = 2016927;
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("track-iteration-tutorial")};
+    adaptAnalysisTask<ATask>(cfgc, "track-iteration-tutorial")};
 }

--- a/Analysis/Tutorials/src/tracksCombinations.cxx
+++ b/Analysis/Tutorials/src/tracksCombinations.cxx
@@ -90,10 +90,10 @@ struct BTask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("tracks-pairs"),
-    adaptAnalysisTask<HashTask>("tracks-hashed"),
-    adaptAnalysisTask<BTask>("tracks-pairs-categorised")};
+    adaptAnalysisTask<ATask>(cfgc, "tracks-pairs"),
+    adaptAnalysisTask<HashTask>(cfgc, "tracks-hashed"),
+    adaptAnalysisTask<BTask>(cfgc, "tracks-pairs-categorised")};
 }

--- a/Analysis/Tutorials/src/weakDecayIteration.cxx
+++ b/Analysis/Tutorials/src/weakDecayIteration.cxx
@@ -62,12 +62,12 @@ struct ETask {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<BTask>("consume-v0s"),
-    adaptAnalysisTask<CTask>("consume-cascades"),
-    adaptAnalysisTask<DTask>("consume-grouped-v0s"),
-    adaptAnalysisTask<ETask>("consume-grouped-cascades"),
+    adaptAnalysisTask<BTask>(cfgc, "consume-v0s"),
+    adaptAnalysisTask<CTask>(cfgc, "consume-cascades"),
+    adaptAnalysisTask<DTask>(cfgc, "consume-grouped-v0s"),
+    adaptAnalysisTask<ETask>(cfgc, "consume-grouped-cascades"),
   };
 }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -14,8 +14,10 @@
 #include "../../src/AnalysisManagers.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/CallbackService.h"
+#include "Framework/ConfigContext.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/WorkflowSpec.h"
 #include "Framework/Expressions.h"
 #include "../src/ExpressionHelpers.h"
 #include "Framework/EndOfStreamContext.h"
@@ -681,6 +683,21 @@ DataProcessorSpec adaptAnalysisTask(char const* name, Args&&... args)
     algo,
     options};
   return spec;
+}
+
+template <typename T>
+struct TaskSpec {
+  TaskSpec(char const* name_) : name(name_) {}
+  const char* name;
+};
+
+/// Adapter to make a WorkflowSpec from TaskSpecs
+///
+template <typename... Ts>
+WorkflowSpec adaptAnalysisWorkflow(ConfigContext const& ctx, TaskSpec<Ts>&&... specs)
+{
+  auto suffix = ctx.options().get<std::string>("workflow-suffix");
+  return WorkflowSpec{adaptAnalysisTask<Ts>((specs.name + suffix).c_str())...};
 }
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -589,7 +589,7 @@ class has_init
 /// Adaptor to make an AlgorithmSpec from a o2::framework::Task
 ///
 template <typename T, typename... Args>
-DataProcessorSpec adaptAnalysisTask(char const* name, ConfigContext const& ctx, Args&&... args)
+DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, char const* name, Args&&... args)
 {
   TH1::AddDirectory(false);
 

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
     ConfigContext configContext(workflowOptionsRegistry, argc, argv);
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     overrideCloning(configContext, specs);
-    overrideSuffix(configContext, specs);
+    //overrideSuffix(configContext, specs);
     overridePipeline(configContext, specs);
     for (auto& spec : specs) {
       UserCustomizationsHelper::userDefinedCustomization(spec.requiredServices, 0);

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -109,9 +109,6 @@ void overridePipeline(o2::framework::ConfigContext& ctx, std::vector<o2::framewo
 /// Helper used to customize a workflow via a template data processor
 void overrideCloning(o2::framework::ConfigContext& ctx, std::vector<o2::framework::DataProcessorSpec>& workflow);
 
-/// Helper used to customize the workflow via a global suffix.
-void overrideSuffix(o2::framework::ConfigContext& ctx, std::vector<o2::framework::DataProcessorSpec>& workflow);
-
 // This comes from the framework itself. This way we avoid code duplication.
 int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::ChannelConfigurationPolicy> const& channelPolicies,
@@ -161,7 +158,6 @@ int main(int argc, char** argv)
     ConfigContext configContext(workflowOptionsRegistry, argc, argv);
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     overrideCloning(configContext, specs);
-    //overrideSuffix(configContext, specs);
     overridePipeline(configContext, specs);
     for (auto& spec : specs) {
       UserCustomizationsHelper::userDefinedCustomization(spec.requiredServices, 0);

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1693,17 +1693,6 @@ bool isOutputToPipe()
   return ((s.st_mode & S_IFIFO) != 0);
 }
 
-void overrideSuffix(ConfigContext& ctx, WorkflowSpec& workflow)
-{
-  auto suffix = ctx.options().get<std::string>("workflow-suffix");
-  if (suffix.empty()) {
-    return;
-  }
-  for (auto& processor : workflow) {
-    processor.name = processor.name + suffix;
-  }
-}
-
 void overrideCloning(ConfigContext& ctx, WorkflowSpec& workflow)
 {
   struct CloningSpec {

--- a/Framework/Core/test/Mocking.h
+++ b/Framework/Core/test/Mocking.h
@@ -13,7 +13,6 @@
 #include "Framework/DataSpecUtils.h"
 #include "Framework/SimpleOptionsRetriever.h"
 #include "Framework/WorkflowCustomizationHelpers.h"
-#include "../src/WorkflowHelpers.h"
 
 std::unique_ptr<o2::framework::ConfigContext> makeEmptyConfigContext()
 {

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -11,10 +11,10 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
+#include "Mocking.h"
 #include "TestClasses.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
-#include "Framework/ConfigContext.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -148,14 +148,14 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
   auto cfgc = makeEmptyConfigContext();
 
-  auto task1 = adaptAnalysisTask<ATask>(cfgc, "test1");
+  auto task1 = adaptAnalysisTask<ATask>(*cfgc, "test1");
   BOOST_CHECK_EQUAL(task1.inputs.size(), 2);
   BOOST_CHECK_EQUAL(task1.outputs.size(), 1);
   BOOST_CHECK_EQUAL(task1.inputs[0].binding, std::string("TracksExtension"));
   BOOST_CHECK_EQUAL(task1.inputs[1].binding, std::string("Tracks"));
   BOOST_CHECK_EQUAL(task1.outputs[0].binding.value, std::string("FooBars"));
 
-  auto task2 = adaptAnalysisTask<BTask>(cfgc, "test2");
+  auto task2 = adaptAnalysisTask<BTask>(*cfgc, "test2");
   BOOST_CHECK_EQUAL(task2.inputs.size(), 9);
   BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions");
   BOOST_CHECK_EQUAL(task2.inputs[1].binding, "TracksExtension");
@@ -167,35 +167,35 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   BOOST_CHECK_EQUAL(task2.inputs[7].binding, "Calos");
   BOOST_CHECK_EQUAL(task2.inputs[8].binding, "CaloTriggers");
 
-  auto task3 = adaptAnalysisTask<CTask>(cfgc, "test3");
+  auto task3 = adaptAnalysisTask<CTask>(*cfgc, "test3");
   BOOST_CHECK_EQUAL(task3.inputs.size(), 3);
   BOOST_CHECK_EQUAL(task3.inputs[0].binding, "Collisions");
   BOOST_CHECK_EQUAL(task3.inputs[1].binding, "TracksExtension");
   BOOST_CHECK_EQUAL(task3.inputs[2].binding, "Tracks");
 
-  auto task4 = adaptAnalysisTask<DTask>(cfgc, "test4");
+  auto task4 = adaptAnalysisTask<DTask>(*cfgc, "test4");
   BOOST_CHECK_EQUAL(task4.inputs.size(), 2);
   BOOST_CHECK_EQUAL(task4.inputs[0].binding, "TracksExtension");
   BOOST_CHECK_EQUAL(task4.inputs[1].binding, "Tracks");
 
-  auto task5 = adaptAnalysisTask<ETask>(cfgc, "test5");
+  auto task5 = adaptAnalysisTask<ETask>(*cfgc, "test5");
   BOOST_CHECK_EQUAL(task5.inputs.size(), 1);
   BOOST_CHECK_EQUAL(task5.inputs[0].binding, "FooBars");
 
-  auto task6 = adaptAnalysisTask<FTask>(cfgc, "test6");
+  auto task6 = adaptAnalysisTask<FTask>(*cfgc, "test6");
   BOOST_CHECK_EQUAL(task6.inputs.size(), 1);
   BOOST_CHECK_EQUAL(task6.inputs[0].binding, "FooBars");
 
-  auto task7 = adaptAnalysisTask<GTask>(cfgc, "test7");
+  auto task7 = adaptAnalysisTask<GTask>(*cfgc, "test7");
   BOOST_CHECK_EQUAL(task7.inputs.size(), 3);
 
-  auto task8 = adaptAnalysisTask<HTask>(cfgc, "test8");
+  auto task8 = adaptAnalysisTask<HTask>(*cfgc, "test8");
   BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
 
-  auto task9 = adaptAnalysisTask<ITask>(cfgc, "test9");
+  auto task9 = adaptAnalysisTask<ITask>(*cfgc, "test9");
   BOOST_CHECK_EQUAL(task9.inputs.size(), 4);
 
-  auto task10 = adaptAnalysisTask<JTask>(cfgc, "test10");
+  auto task10 = adaptAnalysisTask<JTask>(*cfgc, "test10");
 }
 
 BOOST_AUTO_TEST_CASE(TestPartitionIteration)

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -14,6 +14,7 @@
 #include "TestClasses.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ConfigContext.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -145,14 +146,16 @@ struct JTask {
 
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
-  auto task1 = adaptAnalysisTask<ATask>("test1");
+  auto cfgc = makeEmptyConfigContext();
+
+  auto task1 = adaptAnalysisTask<ATask>(cfgc, "test1");
   BOOST_CHECK_EQUAL(task1.inputs.size(), 2);
   BOOST_CHECK_EQUAL(task1.outputs.size(), 1);
   BOOST_CHECK_EQUAL(task1.inputs[0].binding, std::string("TracksExtension"));
   BOOST_CHECK_EQUAL(task1.inputs[1].binding, std::string("Tracks"));
   BOOST_CHECK_EQUAL(task1.outputs[0].binding.value, std::string("FooBars"));
 
-  auto task2 = adaptAnalysisTask<BTask>("test2");
+  auto task2 = adaptAnalysisTask<BTask>(cfgc, "test2");
   BOOST_CHECK_EQUAL(task2.inputs.size(), 9);
   BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions");
   BOOST_CHECK_EQUAL(task2.inputs[1].binding, "TracksExtension");
@@ -164,35 +167,35 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   BOOST_CHECK_EQUAL(task2.inputs[7].binding, "Calos");
   BOOST_CHECK_EQUAL(task2.inputs[8].binding, "CaloTriggers");
 
-  auto task3 = adaptAnalysisTask<CTask>("test3");
+  auto task3 = adaptAnalysisTask<CTask>(cfgc, "test3");
   BOOST_CHECK_EQUAL(task3.inputs.size(), 3);
   BOOST_CHECK_EQUAL(task3.inputs[0].binding, "Collisions");
   BOOST_CHECK_EQUAL(task3.inputs[1].binding, "TracksExtension");
   BOOST_CHECK_EQUAL(task3.inputs[2].binding, "Tracks");
 
-  auto task4 = adaptAnalysisTask<DTask>("test4");
+  auto task4 = adaptAnalysisTask<DTask>(cfgc, "test4");
   BOOST_CHECK_EQUAL(task4.inputs.size(), 2);
   BOOST_CHECK_EQUAL(task4.inputs[0].binding, "TracksExtension");
   BOOST_CHECK_EQUAL(task4.inputs[1].binding, "Tracks");
 
-  auto task5 = adaptAnalysisTask<ETask>("test5");
+  auto task5 = adaptAnalysisTask<ETask>(cfgc, "test5");
   BOOST_CHECK_EQUAL(task5.inputs.size(), 1);
   BOOST_CHECK_EQUAL(task5.inputs[0].binding, "FooBars");
 
-  auto task6 = adaptAnalysisTask<FTask>("test6");
+  auto task6 = adaptAnalysisTask<FTask>(cfgc, "test6");
   BOOST_CHECK_EQUAL(task6.inputs.size(), 1);
   BOOST_CHECK_EQUAL(task6.inputs[0].binding, "FooBars");
 
-  auto task7 = adaptAnalysisTask<GTask>("test7");
+  auto task7 = adaptAnalysisTask<GTask>(cfgc, "test7");
   BOOST_CHECK_EQUAL(task7.inputs.size(), 3);
 
-  auto task8 = adaptAnalysisTask<HTask>("test8");
+  auto task8 = adaptAnalysisTask<HTask>(cfgc, "test8");
   BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
 
-  auto task9 = adaptAnalysisTask<ITask>("test9");
+  auto task9 = adaptAnalysisTask<ITask>(cfgc, "test9");
   BOOST_CHECK_EQUAL(task9.inputs.size(), 4);
 
-  auto task10 = adaptAnalysisTask<JTask>("test10");
+  auto task10 = adaptAnalysisTask<JTask>(cfgc, "test10");
 }
 
 BOOST_AUTO_TEST_CASE(TestPartitionIteration)

--- a/Framework/TestWorkflows/src/o2AnalysisTaskExample.cxx
+++ b/Framework/TestWorkflows/src/o2AnalysisTaskExample.cxx
@@ -50,8 +50,8 @@ struct ATask {
   int mSomeState;
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const&)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("mySimpleTrackAnalysis", 0)};
+    adaptAnalysisTask<ATask>(cfgc, "mySimpleTrackAnalysis", 0)};
 }


### PR DESCRIPTION
Hi @jgrosseo @ktf ,

turns out the workflow suffix needs to be appended early enough. The task names and hashes based on them are propagated to objects already inside the `adaptAnalysisTask()`. Any following task name changes prevent proper matching of output objects to tasks in sink.
I tried to do some workaround on the Framework side but we don't have access to the objects after tasks creation and before the sink. We could e.g. record task names in object headers, then in the sink function append the suffix and re-generate the hashes but this actually defies the purpose of having task hashes...