### PR TITLE
Fix number of foam wedges at 90deg, add carbon fleece with glue

### DIFF
--- a/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/V3Services.h
+++ b/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/V3Services.h
@@ -96,6 +96,14 @@ class V3Services : public V11Geometry
   void createOBConeSideC(TGeoVolume* mother, const TGeoManager* mgr = gGeoManager);
 
  private:
+  /// Creates a single Foam Wedge (with carbon fleece and glue attached)
+  /// \param rIn  the inner radius
+  /// \param rOut  the outer radius
+  /// \param zlen  the half length along Z
+  /// \param phi  the angular aperture
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoVolume* createFoamWedge(const Double_t rIn, const Double_t rOut, const Double_t zLen, const Double_t phi, const TGeoManager* mgr = gGeoManager);
+
   /// Creates a single Inner Barrel End Wheel on Side A
   /// \param iLay  the layer number
   /// \param endWheel  the End Wheel volume assembly

--- a/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
@@ -556,6 +556,9 @@ void Detector::createMaterials()
   Float_t wRohac[4] = {9., 13., 1., 2.};
   Float_t dRohac = 0.05;
 
+  // Araldite 2011
+  Float_t dAraldite = 1.05;
+
   o2::base::Detector::Mixture(1, "AIR$", aAir, zAir, dAir, 4, wAir);
   o2::base::Detector::Medium(1, "AIR$", 1, 0, ifield, fieldm, tmaxfdAir, stemaxAir, deemaxAir, epsilAir, stminAir);
 
@@ -627,6 +630,11 @@ void Detector::createMaterials()
   // ERG Duocel
   o2::base::Detector::Material(33, "ERGDUOCEL$", 12.0107, 6, 0.06, 999, 999);
   o2::base::Detector::Medium(33, "ERGDUOCEL$", 33, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+
+  // Impregnated carbon fleece
+  // (as educated guess we assume 50% carbon fleece 50% Araldite glue)
+  o2::base::Detector::Material(34, "IMPREG_FLEECE$", 12.0107, 6, 0.5 * (dAraldite + 0.4), 999, 999);
+  o2::base::Detector::Medium(34, "IMPREG_FLEECE$", 34, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
 
   // PEEK CF30
   o2::base::Detector::Mixture(19, "PEEKCF30$", aPEEK, zPEEK, dPEEK, -3, wPEEK);

--- a/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/V3Services.cxx
@@ -75,6 +75,7 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
   //         a TGeoVolume(Assembly) with the half cylinder and wedges
   //
   // Created:      11 Feb 2021  Mario Sitta
+  // Updated:      22 Feb 2021  Mario Sitta  Impregnated carbon fleece added
   //
 
   // For the time being we put all relevant parameters here
@@ -94,7 +95,6 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
   TGeoVolume* layerVol;
   TGeoVolume* foamVol[3];
   TGeoTube* layerSh;
-  TGeoTubeSeg* foamSh[3];
 
   Double_t rmin, rmax, zlen, alpha, phi;
   Double_t xpos, ypos, zpos;
@@ -133,22 +133,16 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
       rmax = layerSh->GetRmin();
     }
 
-    foamSh[j] = new TGeoTubeSeg(rmin, rmax, zlen, 0, phi);
+    foamVol[j] = createFoamWedge(rmin, rmax, zlen, phi);
+    foamVol[j]->SetName(Form("IBSupportWedge%d", j));
   }
 
   // We have all shapes: now create the real volumes
   TGeoMedium* medCarbon = mgr->GetMedium("IT3_F6151B05M$");
-  TGeoMedium* medFoam = mgr->GetMedium("ERGDUOCEL$");
 
   TGeoVolume* suppCylVol = new TGeoVolume("IBSupportCylinder", suppCylSh, medCarbon);
   suppCylVol->SetFillColor(kBlue);
   suppCylVol->SetLineColor(kBlue);
-
-  for (Int_t j = 0; j < 3; j++) {
-    foamVol[j] = new TGeoVolume(Form("IBSupportFoam%d", j), foamSh[j], medFoam);
-    foamVol[j]->SetFillColor(kGreen);
-    foamVol[j]->SetLineColor(kGreen);
-  }
 
   // Finally put everything in the container volume
   TGeoVolumeAssembly* ibSupport = new TGeoVolumeAssembly("IBCylinderSupport");
@@ -163,16 +157,92 @@ TGeoVolume* V3Services::createInnerBarrelSupports(const TGeoManager* mgr)
   Double_t emptySpace = 2 * layerSh->GetDz() - sNFoamWedges * sFoamZLen - 2 * sFoamEdgeZDist;
   emptySpace /= (sNFoamWedges - 1);
 
-  for (Int_t j = 0; j < sNFoamWedges; j++) {
-    zpos = -layerSh->GetDz() + sFoamEdgeZDist + j * (sFoamZLen + emptySpace) + 0.5 * sFoamZLen;
-    for (Int_t i = 0; i < 3; i++) {
+  for (Int_t i = 0; i < 3; i++) {
+    for (Int_t j = 0; j < sNFoamWedges; j++) {
+      zpos = -layerSh->GetDz() + sFoamEdgeZDist + j * (sFoamZLen + emptySpace) + 0.5 * sFoamZLen;
       ibSupport->AddNode(foamVol[i], j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", alpha, 0, 0)));
       ibSupport->AddNode(foamVol[i], sNFoamWedges + j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", 180. - alpha - phi, 0, 0)));
-      ibSupport->AddNode(foamVol[i], 2 * sNFoamWedges + j + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", 90. - phi / 2, 0, 0)));
     }
+    // There are only two wedges at 90deg located at the far ends
+    zpos = -layerSh->GetDz() + sFoamEdgeZDist + 0.5 * sFoamZLen;
+    ibSupport->AddNode(foamVol[i], 2 * sNFoamWedges + 1, new TGeoCombiTrans(0, 0, zpos, new TGeoRotation("", 90. - phi / 2, 0, 0)));
+    ibSupport->AddNode(foamVol[i], 2 * sNFoamWedges + 2, new TGeoCombiTrans(0, 0, -zpos, new TGeoRotation("", 90. - phi / 2, 0, 0)));
   }
+
   //
   return ibSupport;
+}
+
+TGeoVolume* V3Services::createFoamWedge(const Double_t rIn, const Double_t rOut, const Double_t zLen, const Double_t phi, const TGeoManager* mgr)
+{
+  //
+  // Creates a single foam wedge with glue-impregnated carbon fleece attached
+  //
+  // Input:
+  //         rIn  : the inner radius
+  //         rOut : the outer radius
+  //         zLen : the half length along Z
+  //         phi  : the angular aperture
+  //         mgr  : the GeoManager (used only to get the proper material)
+  //
+  // Output:
+  //
+  // Return:
+  //         a TGeoVolume with all elements, ready to be displaced
+  //
+  // Created:      22 Feb 2021  Mario Sitta
+  //
+
+  // For the time being we put all relevant parameters here
+  // May be changed into static const's when definitively set
+  const Double_t sIBSuppWedgeCFThick = 20.0 * sMicron;
+
+  // Local variables
+  Double_t rmin, rmax;
+
+  // The foam wedge container: a TubeSeg
+  TGeoTubeSeg* wedgeSh = new TGeoTubeSeg(rIn, rOut, zLen, 0, phi);
+
+  // The foam wedge: a TubeSeg
+  rmin = rIn + sIBSuppWedgeCFThick;
+  rmax = rOut - sIBSuppWedgeCFThick;
+  TGeoTubeSeg* foamSh = new TGeoTubeSeg(rmin, rmax, zLen, 0, phi);
+
+  // The two carbon fleece layers: two TubeSeg's
+  rmax = rIn + sIBSuppWedgeCFThick;
+  TGeoTubeSeg* fleeceInSh = new TGeoTubeSeg(rIn, rmax, zLen, 0, phi);
+
+  rmin = rOut - sIBSuppWedgeCFThick;
+  TGeoTubeSeg* fleeceOutSh = new TGeoTubeSeg(rmin, rOut, zLen, 0, phi);
+
+  // We have all shapes: now create the real volumes
+  TGeoMedium* medAir = mgr->GetMedium("IT3_AIR$");
+  TGeoMedium* medFoam = mgr->GetMedium("IT3_ERGDUOCEL$");
+  TGeoMedium* medFleece = mgr->GetMedium("IT3_IMPREG_FLEECE$");
+
+  TGeoVolume* wedgeVol = new TGeoVolume("IBSupportWedge", wedgeSh, medAir);
+  wedgeVol->SetFillColor(kGreen);
+  wedgeVol->SetLineColor(kGreen);
+
+  TGeoVolume* foamVol = new TGeoVolume("IBSupportFoam", foamSh, medFoam);
+  foamVol->SetFillColor(kGreen);
+  foamVol->SetLineColor(kGreen);
+
+  TGeoVolume* fleeceInVol = new TGeoVolume("IBSupportFleeceI", fleeceInSh, medFleece);
+  fleeceInVol->SetFillColor(kViolet);
+  fleeceInVol->SetLineColor(kViolet);
+
+  TGeoVolume* fleeceOutVol = new TGeoVolume("IBSupportFleeceO", fleeceOutSh, medFleece);
+  fleeceOutVol->SetFillColor(kViolet);
+  fleeceOutVol->SetLineColor(kViolet);
+
+  // Finally put everything in the container volume
+  wedgeVol->AddNode(foamVol, 1, nullptr);
+  wedgeVol->AddNode(fleeceInVol, 1, nullptr);
+  wedgeVol->AddNode(fleeceOutVol, 1, nullptr);
+
+  // Done
+  return wedgeVol;
 }
 
 TGeoVolume* V3Services::createIBEndWheelsSideA(const TGeoManager* mgr)


### PR DESCRIPTION
The number of foam wedges in vertical position was erroneously set equal to the horizontal side, while there are only two: this was fixed.
The glue-impregnated carbon fleece sheets between the foam wedges and the Silicon layers were added.
![IBIT3corr_all](https://user-images.githubusercontent.com/23243716/109311397-188efd00-7846-11eb-80c7-a98181836758.gif)
