### PR TITLE
[EMCAL-684] Add mapping for FEC index

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -339,6 +339,12 @@ class MappingHandler
   /// \throw DDLInvalid if DDL is invalid for EMCAL
   Mapper& getMappingForDDL(int ddl);
 
+  /// \brief Get FEC index for channel based on DDL and information in the channel header
+  /// \param ddl Absolute DDL index
+  /// \param channelFEC FEC index in channel header
+  /// \param branch Branch index (0 or 1) in DDL
+  int getFEEForChannelInDDL(int dll, int channelFEC, int branch);
+
  private:
   std::array<Mapper, 4> mMappings; ///< Mapping container
 

--- a/Detectors/EMCAL/base/src/Mapper.cxx
+++ b/Detectors/EMCAL/base/src/Mapper.cxx
@@ -119,6 +119,16 @@ Mapper& MappingHandler::getMappingForDDL(int ddl)
   return mMappings[sideID * NDDLSM + ddlInSM];
 }
 
+int MappingHandler::getFEEForChannelInDDL(int ddl, int channelFEC, int branch)
+{
+  int ddlInSupermodule = ddl % 2;
+  int fecID = ddlInSupermodule ? 20 : 0;
+  if (branch)
+    fecID += 10;
+  fecID += channelFEC;
+  return fecID;
+}
+
 std::ostream& o2::emcal::operator<<(std::ostream& stream, const Mapper::ChannelID& channel)
 {
   stream << "Row " << static_cast<int>(channel.mRow) << ", Column " << static_cast<int>(channel.mColumn) << ", type " << o2::emcal::channelTypeToString(channel.mChannelType);

--- a/Detectors/EMCAL/base/src/Mapper.cxx
+++ b/Detectors/EMCAL/base/src/Mapper.cxx
@@ -123,8 +123,9 @@ int MappingHandler::getFEEForChannelInDDL(int ddl, int channelFEC, int branch)
 {
   int ddlInSupermodule = ddl % 2;
   int fecID = ddlInSupermodule ? 20 : 0;
-  if (branch)
+  if (branch) {
     fecID += 10;
+  }
   fecID += channelFEC;
   return fecID;
 }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
@@ -105,7 +105,7 @@ class Channel
   /// \throw HadrwareAddressError in case the hardware address is not initialized
   int getBranchIndex() const;
 
-  /// \brief Provide the front-end card index for the current hardware address
+  /// \brief Provide the front-end card index (0-9) in branch for the current hardware address
   /// \return Front-end card index for the current hardware address
   /// \throw HadrwareAddressError in case the hardware address is not initialized
   int getFECIndex() const;


### PR DESCRIPTION
FEC index in supermodule is encoded based
on the DDL (FEC) in the RDH, the FEC index
in the ALTRO channel and the branch index.
A mapping function in the MappingHandler
calculates the absolute FEC index based on
the parameters specified above.