### PR TITLE
Option to detect TF from orbit and SOX info instead of TType

### DIFF
--- a/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
@@ -24,6 +24,7 @@
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "FDDSimulation/Digits2Raw.h"
+#include "DataFormatsParameters/GRPObject.h"
 
 /// MC->raw conversion for FDD
 
@@ -88,6 +89,9 @@ void digi2raw(const std::string& inpName, const std::string& outDir, bool filePe
   o2::fdd::Digits2Raw m2r;
   m2r.setFilePerLink(filePerLink);
   auto& wr = m2r.getWriter();
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+  wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::FDD)); // must be set explicitly
   wr.setSuperPageSize(superPageSizeInB);
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);

--- a/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
@@ -24,6 +24,7 @@
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "FV0Simulation/Digits2Raw.h"
+#include "DataFormatsParameters/GRPObject.h"
 
 /// MC->raw conversion for FV0
 
@@ -88,6 +89,9 @@ void digi2raw(const std::string& inpName, const std::string& outDir, bool filePe
   o2::fv0::Digits2Raw m2r;
   m2r.setFilePerLink(filePerLink);
   auto& wr = m2r.getWriter();
+  std::string inputGRP = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+  wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::FV0)); // must be set explicitly
   wr.setSuperPageSize(superPageSizeInB);
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -318,7 +318,8 @@ o2-raw-file-reader-workflow
   --part-per-hbf                        FMQ parts per superpage (default) of HBF
   --raw-channel-config arg              optional raw FMQ channel for non-DPL output
   --cache-data                          cache data at 1st reading, may require excessive memory!!!
-  --detect-tf0                          autodetect HBFUtils start Orbit/BC from 1st TF seen
+  --detect-tf0                          autodetect HBFUtils start Orbit/BC from 1st TF seen (at SOX)
+  --calculate-tf-start                  calculate TF start from orbit instead of using TType
   --configKeyValues arg                 semicolon separated key=value strings
 
   # to suppress various error checks / reporting
@@ -331,6 +332,9 @@ o2-raw-file-reader-workflow
   --nocheck-tf-per-link                 ignore /Number of TFs is less than expected/
   --nocheck-hbf-jump                    ignore /Wrong HBF orbit increment/
   --nocheck-no-spage-for-tf             ignore /TF does not start by new superpage/
+  --nocheck-no-sox                      ignore /No SOX found on 1st page/
+  --nocheck-tf-start-mismatch           ignore /Mismatch between TType-flagged and calculated new TF start/
+
 ```
 
 The workflow takes an input from the configuration file (as described in `RawFileReader` section), reads the data and sends them as DPL messages
@@ -369,6 +373,7 @@ Options:
   -v [ --verbosity ] arg (=0)    1: long report, 2 or 3: print or dump all RDH
   -s [ --spsize ]    arg (=1048576) nominal super-page size in bytes
   --detect-tf0                      autodetect HBFUtils start Orbit/BC from 1st TF seen
+  --calculate-tf-start              calculate TF start from orbit instead of using TType
   --rorc                            impose RORC as default detector mode
   --configKeyValues arg             semicolon separated key=value strings
   --nocheck-packet-increment        ignore /Wrong RDH.packetCounter increment/
@@ -380,6 +385,8 @@ Options:
   --nocheck-tf-per-link             ignore /Number of TFs is less than expected/
   --nocheck-hbf-jump                ignore /Wrong HBF orbit increment/
   --nocheck-no-spage-for-tf         ignore /TF does not start by new superpage/
+  --nocheck-no-sox                  ignore /No SOX found on 1st page/
+  --nocheck-tf-start-mismatch       ignore /Mismatch between TType-flagged and calculated new TF start/
   (input files are optional if config file was provided)
 ```
 

--- a/Detectors/Raw/src/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.h
@@ -20,11 +20,9 @@ namespace o2
 {
 namespace raw
 {
+struct ReaderInp;
 
-framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, int loop = 1, uint32_t delay_us = 0, uint32_t errMap = 0xffffffff,
-                                                 uint32_t minTF = 0, uint32_t maxTF = 0xffffffff, bool partPerSP = true, bool cache = false, bool autodetectTF0 = false,
-                                                 size_t spSize = 1024L * 1024L, size_t bufferSize = 1024L * 1024L,
-                                                 const std::string& rawChannelConfig = "");
+framework::WorkflowSpec getRawFileReaderWorkflow(const ReaderInp& rinp);
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -34,6 +34,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"raw-channel-config", VariantType::String, "", {"optional raw FMQ channel for non-DPL output"}});
   options.push_back(ConfigParamSpec{"cache-data", VariantType::Bool, false, {"cache data at 1st reading, may require excessive memory!!!"}});
   options.push_back(ConfigParamSpec{"detect-tf0", VariantType::Bool, false, {"autodetect HBFUtils start Orbit/BC from 1st TF seen"}});
+  options.push_back(ConfigParamSpec{"calculate-tf-start", VariantType::Bool, false, {"calculate TF start instead of using TType"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -50,26 +51,28 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
-  auto inifile = configcontext.options().get<std::string>("input-conf");
-  auto loop = configcontext.options().get<int>("loop");
-  uint32_t maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
-  uint32_t minTF = uint32_t(configcontext.options().get<int64_t>("min-tf"));
-  uint64_t buffSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
-  uint64_t spSize = uint64_t(configcontext.options().get<int64_t>("super-page-size"));
-  bool partPerSP = !configcontext.options().get<bool>("part-per-hbf");
-  bool cache = configcontext.options().get<bool>("cache-data");
-  bool autodetectTF0 = configcontext.options().get<bool>("detect-tf0");
-  std::string rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
-  uint32_t errmap = 0;
+  ReaderInp rinp;
+  rinp.inifile = configcontext.options().get<std::string>("input-conf");
+  rinp.loop = configcontext.options().get<int>("loop");
+  rinp.maxTF = uint32_t(configcontext.options().get<int64_t>("max-tf"));
+  rinp.minTF = uint32_t(configcontext.options().get<int64_t>("min-tf"));
+  rinp.bufferSize = uint64_t(configcontext.options().get<int64_t>("buffer-size"));
+  rinp.spSize = uint64_t(configcontext.options().get<int64_t>("super-page-size"));
+  rinp.partPerSP = !configcontext.options().get<bool>("part-per-hbf");
+  rinp.cache = configcontext.options().get<bool>("cache-data");
+  rinp.autodetectTF0 = configcontext.options().get<bool>("detect-tf0");
+  rinp.preferCalcTF = configcontext.options().get<bool>("calculate-tf-start");
+  rinp.rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
+  rinp.errMap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     auto ei = RawFileReader::ErrTypes(i);
     bool defOpt = RawFileReader::ErrCheckDefaults[i];
     if (configcontext.options().get<bool>(RawFileReader::nochk_opt(ei).c_str()) ? !defOpt : defOpt) { // cmdl option inverts default!
-      errmap |= 0x1 << i;
+      rinp.errMap |= 0x1 << i;
     }
   }
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   uint32_t delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
 
-  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, loop, delay_us, errmap, minTF, maxTF, partPerSP, cache, autodetectTF0, spSize, buffSize, rawChannelConfig));
+  return std::move(o2::raw::getRawFileReaderWorkflow(rinp));
 }

--- a/Detectors/Raw/src/rawfileCheck.cxx
+++ b/Detectors/Raw/src/rawfileCheck.cxx
@@ -40,6 +40,7 @@ int main(int argc, char* argv[])
   desc_add_option("spsize,s", bpo::value<int>()->default_value(reader.getNominalSPageSize()), "nominal super-page size in bytes");
   desc_add_option("buffer-size,b", bpo::value<size_t>()->default_value(reader.getNominalSPageSize()), "buffer size for files preprocessing");
   desc_add_option("detect-tf0", "autodetect HBFUtils start Orbit/BC from 1st TF seen");
+  desc_add_option("calculate-tf-start", "calculate TF start instead of using TType");
   desc_add_option("rorc", "impose RORC as default detector mode");
   desc_add_option("configKeyValues", bpo::value(&configKeyValues)->default_value(""), "semicolon separated key=value strings");
   for (int i = 0; i < RawFileReader::NErrorsDefined; i++) {
@@ -91,6 +92,7 @@ int main(int argc, char* argv[])
   reader.setNominalSPageSize(vm["spsize"].as<int>());
   reader.setMaxTFToRead(vm["max-tf"].as<uint32_t>());
   reader.setBufferSize(vm["buffer-size"].as<size_t>());
+  reader.setPreferCalculatedTFStart(vm.count("calculate-tf-start"));
   reader.setDefaultReadoutCardType(rocard);
   reader.setTFAutodetect(vm.count("detect-tf0") ? RawFileReader::FirstTFDetection::Pending : RawFileReader::FirstTFDetection::Disabled);
   uint32_t errmap = 0;

--- a/Detectors/Raw/src/rawfileSplit.cxx
+++ b/Detectors/Raw/src/rawfileSplit.cxx
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
   desc_add_option("spsize,s", bpo::value<int>()->default_value(reader.getNominalSPageSize()), "nominal super-page size in bytes");
   desc_add_option("buffer-size,b", bpo::value<size_t>()->default_value(reader.getNominalSPageSize()), "buffer size for files preprocessing");
   desc_add_option("detect-tf0", "autodetect HBFUtils start Orbit/BC from 1st TF seen");
+  desc_add_option("calculate-tf-start", "calculate TF start instead of using TType");
   desc_add_option("rorc", "impose RORC as default detector mode");
   desc_add_option("tfs-per-chunk,n", bpo::value<uint32_t>()->default_value(0xffffffff), " number of output TFs per chunk");
   desc_add_option("output-dir-prefix,o", bpo::value<std::string>()->default_value("./chunk"), "output directory prefix for raw data chunk (chunk ID will be added)");
@@ -100,6 +101,7 @@ int main(int argc, char* argv[])
   reader.setBufferSize(vm["buffer-size"].as<size_t>());
   reader.setDefaultReadoutCardType(rocard);
   reader.setTFAutodetect(vm.count("detect-tf0") ? RawFileReader::FirstTFDetection::Pending : RawFileReader::FirstTFDetection::Disabled);
+  reader.setPreferCalculatedTFStart(vm.count("calculate-tf-start"));
 
   std::string_view fileFor = vm["file-for"].as<std::string>();
 


### PR DESCRIPTION
@noferini  @preghenella: this PR allows to `o2-raw-file-reader-workflow`  to ignore the TF flags in the ``RDH::TType`` and instead rely on TF detection from the orbit number (if option ``--calculate-tf-start`` is provided).
As before, with `--detect-tf0` option it will detect the 1st orbit of the run from the 1st TF (now will look for SOX in the RDH), overriding `HBFUtils.orbitFirst`. The number of TFs per orbit still should be provided via e.g. `--configKeyValues "HBFUtils.nHBFPerTF=128` (default 256).