### PR TITLE
PWGHF: Revert "Add flag to switch off TPC cluster selection"

### DIFF
--- a/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFJpsiToEECandidateSelector.cxx
@@ -49,7 +49,6 @@ struct HFJpsiToEECandidateSelector {
   Configurable<double> d_pidTPCMaxpT{"d_pidTPCMaxpT", 10., "Upper bound of track pT for TPC PID"};
 
   Configurable<double> d_TPCNClsFindablePIDCut{"d_TPCNClsFindablePIDCut", 70., "Lower bound of TPC findable clusters for good PID"};
-  Configurable<bool> b_requireTPC{"b_requireTPC", true, "Flag to require a positive Number of found clusters in TPC"};
   Configurable<double> d_nSigmaTPC{"d_nSigmaTPC", 3., "Nsigma cut on TPC only"};
 
   /// Gets corresponding pT bin from cut file array
@@ -80,7 +79,7 @@ struct HFJpsiToEECandidateSelector {
     if (track.charge() == 0) {
       return false;
     }
-    if (b_requireTPC.value && track.tpcNClsFound() == 0) {
+    if (track.tpcNClsFound() == 0) {
       return false; //is it clusters findable or found - need to check
     }
     return true;

--- a/Analysis/Tasks/PWGHF/HFLcCandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFLcCandidateSelector.cxx
@@ -52,7 +52,6 @@ struct HFLcCandidateSelector {
   Configurable<double> d_pidTOFMaxpT{"d_pidTOFMaxpT", 4., "Upper bound of track pT for TOF PID"};
 
   Configurable<double> d_TPCNClsFindablePIDCut{"d_TPCNClsFindablePIDCut", 70., "Lower bound of TPC findable clusters for good PID"};
-  Configurable<bool> b_requireTPC{"b_requireTPC", true, "Flag to require a positive Number of found clusters in TPC"};
   Configurable<double> d_nSigmaTPC{"d_nSigmaTPC", 3., "Nsigma cut on TPC only"};
   Configurable<double> d_nSigmaTPCCombined{"d_nSigmaTPCCombined", 5., "Nsigma cut on TPC combined with TOF"};
   Configurable<double> d_nSigmaTOF{"d_nSigmaTOF", 3., "Nsigma cut on TOF only"};
@@ -86,7 +85,7 @@ struct HFLcCandidateSelector {
     if (track.charge() == 0) {
       return false;
     }
-    if (b_requireTPC.value && track.tpcNClsFound() == 0) {
+    if (track.tpcNClsFound() == 0) {
       return false; //is it clusters findable or found - need to check
     }
     return true;


### PR DESCRIPTION
This reverts commit 29705b6c4f6e372c53ea323763cee759787bd445.
- the selection on the number of TPC clusters is already included in a previous step of the reconstruction