### PR TITLE
TRD Fix mc 2 raw data generation

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -27,6 +27,12 @@ constexpr int NLAYER = 6;          // the number of layers
 constexpr int NCHAMBERPERSEC = 30; // the number of chambers per sector
 constexpr int MAXCHAMBER = 540;    // the maximum number of installed chambers
 constexpr int NCHAMBER = 521;      // the number of chambers actually installed
+constexpr int NHALFCRU = 72;       // the number of half cru (link bundles)
+constexpr int NLINKSPERHALFCRU = 15; // the number of links per half cru or cru end point.
+constexpr int NRU = 36;              // the number of CRU we have
+constexpr int NFLP = 12;             // the number of FLP we have.
+constexpr int NCRUPERFLP = 3;        // the number of CRU per FLP
+constexpr int TRDLINKID = 15;        // hard coded link id, specific to TRD
 
 constexpr int NCOLUMN = 144; // the number of pad columns for each chamber
 constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (installed stack 0,1,3 and 4)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -122,7 +122,7 @@ Word 7  |              reserved 5                       |             link 14 da
 struct TrackletHCHeader {
   union {
     //             10987654321098765432109876543210
-    // uint32_t:   00000000000000000000000000000000
+    // uint32_t:   33222222222211111111110000000000
     //                 cccccccccccccccX LLL   SSSSS
     //             ffff|              |y|  sss|
     //             |   |              |||  |  |-----  0-4  supermodule
@@ -130,7 +130,7 @@ struct TrackletHCHeader {
     //             |   |              ||------------  8-10 layer
     //             |   |              |------------- 11    always 0x1
     //             |   |              |------------- 12 side of chamber
-    //             |   ----------------------------- 13-72 MCM Clock counter
+    //             |   ----------------------------- 13-27 MCM Clock counter
     //             --------------------------------- 28-31 tracklet data format number
     uint32_t word;
     struct {
@@ -139,7 +139,7 @@ struct TrackletHCHeader {
       uint32_t layer : 3;
       uint32_t one : 1;   //always 1
       uint32_t side : 1;  // side of chamber
-      uint32_t MCLK : 15; // MCM clock counter 120MHz ... for simulation -- incrementing, and same number in all for each event.
+      uint32_t MCLK : 15; // MCM clock counter 120MHz ... for simulation -- incrementing, and uniform across an event
       uint32_t format : 4;
       //  0 baseline PID 3 time slices, 7 bit each
       //  1 DO NOT USE ! reserved for tracklet end marker disambiguation
@@ -155,7 +155,7 @@ struct TrackletHCHeader {
 struct TrackletMCMHeader {
   //first word          *
   //             10987654321098765432109876543210
-  // uint32_t:   00000000000000000000000000000000
+  // uint32_t:   33222222222211111111110000000000
   //             1zzzz  pppppppp        pppppppp1
   //             ||   yy|       pppppppp |      |--- 0 1 check bits
   //             ||   | |       |        ----------- 1-8   pid for tracklet 3 second part
@@ -218,6 +218,183 @@ struct TRDFeeID {
   };
 };
 
+/// \structure DigitHCHeader
+/// \brief Digit version of the TrackletHCHeader above, although contents are rather different.
+//  TODO come back and comment the fields or make the name more expressive, and fill in the jjjjjjj
+struct DigitHCHeader {
+  //
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  //
+  union { // section 15.6.1 in tdp
+    uint32_t word0;
+    struct {
+      uint32_t res0 : 2;
+      uint32_t side : 1;
+      uint32_t stack : 3;
+      uint32_t layer : 3;
+      uint32_t supermodule : 5;
+      uint32_t numberHCW : 3;
+      uint32_t minor : 7;
+      uint32_t major : 7;
+      uint32_t version : 1;
+    } __attribute__((__packed__));
+  };
+
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  //
+  union { //section 15.6.2 in tdp
+    uint32_t word1;
+    struct {
+      uint32_t res1 : 2;
+      uint32_t ptrigcount : 4;
+      uint32_t ptrigphase : 4;
+      uint32_t bunchcrossing : 16;
+      uint32_t numtimebins : 6;
+    } __attribute__((__packed__));
+  };
+#ifdef DIGITALHCOPTIONALHEADER
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  union { //section 15.6.3 in tdp
+    uint32_t word2;
+    struct {
+      uint32_t res2 : 6;
+      uint32_t dfilter : 6;
+      uint32_t rfilter : 1;
+      uint32_t nlfilter : 1;
+      uint32_t xtfilter : 1;
+      uint32_t tfilter : 1;
+      uint32_t gfilter : 1;
+      uint32_t pfilter : 6;
+    } __attribute__((__packed__));
+  };
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  union { //section 15.6.4 in tdp
+    uint32_t word3;
+    struct {
+      uint32_t res3 : 6;
+      uint32_t svnrver : 13; //readout program svn revision
+      uint32_t svnver : 13;  //assember programm svn revision
+    } __attribute__((__packed__));
+  };
+#endif
+};
+
+struct DigitMCMHeader {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  union {
+    uint32_t word; //MCM header
+    struct {
+      uint32_t res : 4; // reserve 1100
+      uint32_t eventcount : 20;
+      uint32_t mcm : 4;
+      uint32_t rob : 3;
+      uint32_t yearflag : 1; //< oct2007 0,  else 1
+    } __attribute__((__packed__));
+  };
+};
+
+//the odd numbering of 1 2 3 and 6 are taken from the TDP page 111 section 15.7.2, 15.7.3 15.7.4 15.7.5
+struct trdTestPattern1 {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  //  11h41 for 2flp in data stream. before that on 14th dec was1 flp in timeframe.
+  union {
+    uint32_t word;
+    struct {
+      uint32_t eventcount : 6; // lower 6 bits of e counter.
+      uint32_t stack : 5;
+      uint32_t layer : 3;
+      uint32_t roc : 3;
+      uint32_t rob : 3;
+      uint32_t mcmTp2 : 4;
+      uint32_t cpu : 2;
+      uint32_t counter : 6;
+    } __attribute__((__packed__));
+  };
+};
+
+struct trdTestPattern2 {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  union {
+    uint32_t word;
+    struct {
+      uint32_t eventcount : 6; // lower 6 bits of e counter.
+      uint32_t stack : 5;
+      uint32_t layer : 3;
+      uint32_t roc : 3;
+      uint32_t rob : 3;
+      uint32_t mcmTp2 : 4;
+      uint32_t cpu : 2;
+      uint32_t wordcounter : 6;
+    } __attribute__((__packed__));
+  };
+};
+struct trdTestPattern3 {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  union {
+    uint32_t word;
+    struct {
+      uint32_t eventcount : 12; //lower 12 bits of ecounter
+      uint32_t stack : 5;
+      uint32_t layer : 3;
+      uint32_t roc : 3;
+      uint32_t rob : 3;
+      uint32_t mcm : 4;
+      uint32_t cpu : 2;
+    } __attribute__((__packed__));
+  };
+};
+struct trdTestPattern6 {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  //             1zzzz  pppppppp        pppppppp1
+  union {
+    uint32_t word; //HC header0
+    struct {
+      uint32_t eventcount; // lower 4 bits of e counter.
+      uint32_t stack : 5;  // starting at 1
+      uint32_t layer : 3;
+      uint32_t roc : 3;
+      uint32_t rob : 3;
+      uint32_t mcm : 4;
+      uint32_t cpu : 2;
+      uint32_t wordcounter : 6;
+      uint32_t oddadc : 2;
+    } __attribute__((__packed__));
+  };
+};
+
+struct DigitMCMData {
+  //             10987654321098765432109876543210
+  // uint32_t:   00000000000000000000000000000000
+  /*  union {
+    uint32_t word0;
+    struct {
+      uint32_t a : 2;
+      uint32_t b : 5;
+      uint32_t adc : 21; //adc bit patternpad plane
+    } __attribute__((__packed__));
+  };*/
+  union {
+    //             10987654321098765432109876543210
+    // uint32_t:   00000000000000000000000000000000
+    uint32_t word;
+    struct {
+      uint32_t c : 2; // c is wrong I cant remember name, but not a concern at the moment.
+      uint32_t z : 10;
+      uint32_t y : 10;
+      uint32_t x : 10;
+    } __attribute__((__packed__));
+  };
+};
+
 void buildTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format);
 void buildTrackletHCHeaderd(TrackletHCHeader& header, int detector, int rob, int chipclock, int format);
 uint16_t buildTRDFeeID(int supermodule, int side, int endpoint);
@@ -229,16 +406,23 @@ uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkerrorflags(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linkerrorflags);
 uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linksizes);
-std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchamberheader);
+uint32_t getHCIDFromTrackletHCHeader(const TrackletHCHeader& header);
+uint32_t getHCIDFromTrackletHCHeader(const uint32_t& headerword);
+std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader& halfchamberheader);
+std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead);
 std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet);
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet);
 void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead);
-std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead);
 void printHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
 void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
 void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
 void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
 std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
+bool trackletMCMHeaderSanityCheck(o2::trd::TrackletMCMHeader& header);
+bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header);
+bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header);
+void printDigitMCMHeader(o2::trd::DigitMCMHeader& header);
+void printDigitHCHeader(o2::trd::DigitHCHeader& header);
 }
 }
 #endif

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -60,7 +60,7 @@ class FeeParam
   static int getMCMfromSharedPad(int irow, int icol);
   static int getROBfromPad(int irow, int icol);
   static int getROBfromSharedPad(int irow, int icol);
-  static int getRobSide(int irob);
+  static int getROBSide(int irob);
   static int getColSide(int icol);
 
   // SCSN-related

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -223,7 +223,7 @@ int FeeParam::getPadColFromADC(int irob, int imcm, int iadc)
   if (iadc < 0 || iadc > NADCMCM) {
     return -100;
   }
-  int mcmcol = imcm % NMCMROBINCOL + getRobSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
+  int mcmcol = imcm % NMCMROBINCOL + getROBSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
   int padcol = mcmcol * NCOLMCM + NCOLMCM + 1 - iadc;
   if (padcol < 0 || padcol >= NCOLUMN) {
     return -1; // this is commented because of reason above OK
@@ -243,7 +243,7 @@ int FeeParam::getExtendedPadColFromADC(int irob, int imcm, int iadc)
   if (iadc < 0 || iadc > NADCMCM) {
     return -100;
   }
-  int mcmcol = imcm % NMCMROBINCOL + getRobSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
+  int mcmcol = imcm % NMCMROBINCOL + getROBSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
   int padcol = mcmcol * NADCMCM + NCOLMCM + 2 - iadc;
 
   return padcol;
@@ -318,7 +318,7 @@ int FeeParam::getROBfromSharedPad(int irow, int icol)
 }
 
 //_____________________________________________________________________________
-int FeeParam::getRobSide(int irob)
+int FeeParam::getROBSide(int irob)
 {
   //
   // Return on which side this rob sits (A side = 0, B side = 1)
@@ -513,9 +513,9 @@ void FeeParam::createORILookUpTable()
 
 int FeeParam::getORI(int detector, int readoutboard)
 {
-  int supermodule = detector / 30;
-  LOG(debug3) << "getORI : " << detector << " :: " << readoutboard << getORIinSM(detector, readoutboard) + 60 * detector;
-  return getORIinSM(detector, readoutboard) + 2 * detector; // 2 ORI per detector
+  int supermodule = detector / NCHAMBERPERSEC;
+  ///  LOG(info) << "getORI : " << detector << " :: " << readoutboard << " -- " << getORIinSM(detector, readoutboard) << "   " << getORIinSM(detector, readoutboard) + NCHAMBERPERSEC * 2 * detector;
+  return getORIinSM(detector, readoutboard) + NCHAMBER * 2 * detector; // 60 ORI per supermodule
 }
 
 int FeeParam::getORIinSM(int detector, int readoutboard)
@@ -524,8 +524,8 @@ int FeeParam::getORIinSM(int detector, int readoutboard)
   int chamberside = 0;
   int trdstack = Geometry::getStack(detector);
   int trdlayer = Geometry::getLayer(detector);
-  int side = getRobSide(readoutboard);
-  //see TDP for explanation of mapping TODO should probably come from CCDB for the instances where the mapping of ori fibers is misconfigured (accidental fibre swaps).
+  int side = getROBSide(readoutboard);
+  //see TDP for explanation of mapping TODO should probably come from CCDB
   if (trdstack < 2 || (trdstack == 2 && side == 0)) // A Side
   {
     ori = trdstack * 12 + (5 - trdlayer + side * 5) + trdlayer / 6 + side; // <- that is correct for A side at least for now, probably not for very long LUT as that will come form CCDB ni anycase.

--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -20,3 +20,30 @@ o2-sim -m PIPE MAG TRD -n 1000 -g boxgen --configKeyValues 'BoxGun.pdg=211;BoxGu
 ```
 --configKeyValues 'TRDSimParams.doTR=false;TRDSimParams.maxMCStepSize=0.1'
 ```
+
+# Generate Raw data from MonteCarlo:
+
+```
+o2-trd-trap2raw
+```
+This will convert the tracklets and digits in the current directory to a series of files containing the raw data as it would appear coming out of the cru.
+There are multiple options :
+- -d [ --input-file-digits ] default of trddigits.root  
+                                        input Trapsim digits file, empty string to have no digits.
+- -t [ --input-file-tracklets ] default of trdtracklets.root
+                                        input Trapsim tracklets file
+-   -l [ --fileper ] how to distrbute the data into raw files. 
+	- all : 1 raw file 
+	- halfcru : 1 file per cru end point, so 2 files per cru. 
+	- cru : one file per cru 
+    - sm: one file per supermodule 
+-  -o [ --output-dir ]  output directory for raw data defaults to local directory
+-  -x [ --trackletHCHeader ] include tracklet half chamber header (for run3, and not in run2) 
+-  -e [ --no-empty-hbf ] do not create empty HBF pages (except for HBF starting TF)
+-  -r [ --rdh-version ] rdh version in use default of 6
+-  --configKeyValues arg                 comma-separated configKeyValues
+
+default would then be the following :
+```
+o2-trd-trap2raw -d trddigits.root -t trdtracklets.root -l halfcru -o ./ -x -r 6 -e
+```

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -27,6 +27,7 @@
 #include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RawFileWriter.h"
 #include "TRDSimulation/Trap2CRU.h"
+#include "TRDSimulation/TrapSimulator.h"
 #include "CommonUtils/StringUtils.h"
 #include "TRDBase/CommonParam.h"
 #include "TFile.h"
@@ -40,6 +41,7 @@
 #include <bitset>
 #include <vector>
 #include <gsl/span>
+#include <typeinfo>
 
 using namespace o2::raw;
 
@@ -48,86 +50,172 @@ namespace o2
 namespace trd
 {
 
-Trap2CRU::Trap2CRU(const std::string& outputDir, const std::string& inputFilename)
+Trap2CRU::Trap2CRU(const std::string& outputDir, const std::string& inputdigitsfilename, const std::string& inputtrackletsfilename)
 {
-  readTrapData(outputDir, inputFilename, 1024 * 1024);
+  mOutputDir = outputDir;
+  mSuperPageSizeInB = 1024 * 1024;
+  mInputDigitsFileName = inputdigitsfilename;
+  mInputTrackletsFileName = inputtrackletsfilename;
+  mCurrentDigit = 0;
+  mCurrentTracklet = 0;
 }
 
-void Trap2CRU::readTrapData(const std::string& outputDir, const std::string& inputFilename, int superPageSizeInB)
+void Trap2CRU::openInputFiles()
+{
+  mDigitsFile = TFile::Open(mInputDigitsFileName.data());
+  if (mDigitsFile != nullptr) {
+    mDigitsTree = (TTree*)mDigitsFile->Get("o2sim");
+    mDigitsTree->SetBranchAddress("TRDDigit", &mDigitsPtr);                   // the branch with the actual digits
+    mDigitsTree->SetBranchAddress("TriggerRecord", &mDigitTriggerRecordsPtr); // branch with trigger records for digits
+                                                                              //    LOG(info) << "Digit tree has " << mDigitsTree->GetEntries() << " entries"; //<<
+  } else {
+    LOG(warn) << " cant open file containing digit tree";
+  }
+  mTrackletsFile = TFile::Open(mInputTrackletsFileName.data());
+  if (mTrackletsFile != nullptr) {
+    mTrackletsTree = (TTree*)mTrackletsFile->Get("o2sim");
+    mTrackletsTree->SetBranchAddress("Tracklet", &mTrackletsPtr);              // the branch with the actual tracklets.
+    mTrackletsTree->SetBranchAddress("TrackTrg", &mTrackletTriggerRecordsPtr); // branch with trigger records for digits
+                                                                               //  LOG(info) << "Tracklet tree has " << mTrackletsTree->GetEntries() << " entries";//<<
+  } else {
+    LOG(fatal) << " cant open file containing tracklet tree";
+  }
+}
+
+void Trap2CRU::sortDataToLinks()
+{
+  //sort the digits array TODO refactor this intoa vector index sort and possibly generalise past merely digits.
+  auto sortstart = std::chrono::high_resolution_clock::now();
+  //build indexes
+  // digits first
+  mDigitsIndex.resize(mDigits.size());
+  std::iota(mDigitsIndex.begin(), mDigitsIndex.end(), 0);
+
+  for (auto& trig : mDigitTriggerRecords) {
+    if (trig.getNumberOfObjects() != 0) {
+      LOG(debug) << " sorting digits from : " << trig.getFirstEntry() << " till " << trig.getFirstEntry() + trig.getNumberOfObjects();
+      std::stable_sort(mDigitsIndex.begin() + trig.getFirstEntry(), mDigitsIndex.begin() + trig.getNumberOfObjects() + trig.getFirstEntry(), //,digitcompare);
+                       [this](const uint32_t i, const uint32_t j) { 
+             uint32_t hcida = mDigits[i].getDetector() * 2 + (mDigits[i].getROB() % 2);
+             uint32_t hcidb = mDigits[j].getDetector() * 2 + (mDigits[j].getROB() % 2);
+             if(hcida!=hcidb){return hcida<hcidb;}
+             if(mDigits[i].getROB() != mDigits[j].getROB()){return (mDigits[i].getROB() < mDigits[j].getROB());}
+             return (mDigits[i].getMCM() < mDigits[j].getMCM()); });
+    }
+  }
+  for (auto& trig : mTrackletTriggerRecords) {
+    if (trig.getNumberOfObjects() > 0) {
+      LOG(debug) << " sorting digits from : " << trig.getFirstEntry() << " till " << trig.getFirstEntry() + trig.getNumberOfObjects();
+      std::stable_sort(std::begin(mTracklets) + trig.getFirstEntry(), std::begin(mTracklets) + trig.getNumberOfObjects() + trig.getFirstEntry(),
+                       [this](auto&& t1, auto&& t2) {
+                         if (t1.getHCID() != t2.getHCID()) {
+                           return t1.getHCID() < t2.getHCID();
+                         }
+                         if (t1.getPadRow() != t2.getPadRow()) {
+                           return t1.getPadRow() < t2.getPadRow();
+                         }
+                         return t1.getMCM() < t2.getMCM();
+                       });
+    }
+  }
+
+  std::chrono::duration<double> duration = std::chrono::high_resolution_clock::now() - sortstart;
+  LOG(debug) << "TRD Digit/Tracklet Sorting took " << duration.count() << " s";
+}
+
+void Trap2CRU::readTrapData()
 {
   //set things up, read the file and then deligate to convertTrapdata to do the conversion.
   //
   mRawData.reserve(1024 * 1024); //TODO take out the hardcoded 1MB its supposed to come in from the options
   LOG(debug) << "Trap2CRU::readTrapData";
-  // data comes in index by event (triggerrecord) and link (linke record) both sequentially.
-  // first 15 links go to cru0a, second 15 links go to cru0b, 3rd 15 links go to cru1a ... first 90 links to flp0 and then repate for 12 flp
+  // data comes in index by event (triggerrecord)
+  // first 15 links go to cru0a, second 15 links go to cru0b, 3rd 15 links go to cru1a ... first 90 links to flp0 and then repeat for 12 flp
   // then do next event
 
   // lets register our links
-  std::string prefix = outputDir;
+  std::string prefix = mOutputDir;
   if (!prefix.empty() && prefix.back() != '/') {
     prefix += '/';
   }
 
-  for (int link = 0; link < NumberOfHalfCRU; link++) {
+  for (int link = 0; link < o2::trd::constants::NHALFCRU; link++) {
     // FeeID *was* 0xFEED, now is indicates the cru Supermodule, side (A/C) and endpoint. See RawData.cxx for details.
     int supermodule = link / 4;
     int endpoint = link / 2;
     int side = link % 2 ? 1 : 0;
     mFeeID = buildTRDFeeID(supermodule, side, endpoint);
     mCruID = link / 2;
-    mEndPointID = link % 2 ? 1 : 0; //TODO figure out a value ... endpoint needs a rebase to PR4106
-    mLinkID = TRDLinkID;
-    std::string trdside = link % 2 ? "c" : "a"; // the side of supermodule readout A or C, odd numbered CRU are A, even numbered CRU are C.
-    // filenmae structure of trd_cru_[CRU#]_[upper/lower].raw
-    std::string outputFilelink = o2::utils::concat_string(prefix, "trd_cru_", std::to_string(mCruID), "_", trdside, ".raw");
-    mWriter.registerLink(mFeeID, mCruID, mLinkID, mEndPointID, outputFilelink);
+    mEndPointID = link % 2 ? 1 : 0;
+    mLinkID = o2::trd::constants::TRDLINKID;
+
+    std::string outFileLink;
+    std::string outPrefix = "trd";
+    std::string outSuffix = ".raw";
+    std::string trdside = mEndPointID ? "_h" : "_l"; // the side of cru lower or higher
+    // filename structure of trd_cru_[CRU#]_[upper/lower].raw
+    std::string whichrun = mUseTrackletHCHeader ? "run3" : "run2";
+    if (mFilePer == "all") { // single file for all links
+      outFileLink = o2::utils::concat_string(mOutputDir, "/", outPrefix, outSuffix);
+    } else if (mFilePer == "sm") {
+      int sm = link / 4;
+      std::stringstream ss;
+      ss << std::setw(2) << std::setfill('0') << sm;
+      std::string supermodule = ss.str();
+      outFileLink = o2::utils::concat_string(mOutputDir, "/", outPrefix, "_sm_", supermodule, outSuffix);
+    } else if (mFilePer == "cru") {
+      outFileLink = o2::utils::concat_string(mOutputDir, "/", outPrefix, "_cru_", std::to_string(mCruID), outSuffix);
+    } else if (mFilePer == "halfcru") {
+      outFileLink = o2::utils::concat_string(mOutputDir, "/", outPrefix, "_cru_", std::to_string(mCruID), trdside, outSuffix);
+    } else {
+      throw std::runtime_error("invalid option provided for file grouping");
+    }
+
+    //std::string outputFilelink = o2::utils::concat_string(prefix, "trd_cru_", std::to_string(mCruID), "_", trdside, "_", whichrun, ".raw");
+    LOG(info) << "registering links";
+    mWriter.registerLink(mFeeID, mCruID, mLinkID, mEndPointID, outFileLink);
   }
-  mTrapRawFile = TFile::Open(inputFilename.data());
-  assert(mTrapRawFile != nullptr);
-  LOG(debug) << "Trap Raw file open " << inputFilename;
-  mTrapRawTree = (TTree*)mTrapRawFile->Get("o2sim");
 
-  mTrapRawTree->SetBranchAddress("TrapLinkRecord", &mLinkRecordsPtr);      // branch with the link records
-  mTrapRawTree->SetBranchAddress("RawTriggerRecord", &mTriggerRecordsPtr); // branch with the trigger records
-  mTrapRawTree->SetBranchAddress("TrapRaw", &mTrapRawDataPtr);             // branch with the actual incoming data.
+  openInputFiles();
 
-  for (int entry = 0; entry < mTrapRawTree->GetEntries(); entry++) {
-    mTrapRawTree->GetEntry(entry);
-    LOG(debug) << "Before Trigger Reord loop Event starts at:" << mTriggerRecords[0].getFirstEntry() << " and has " << mTriggerRecords[0].getNumberOfObjects() << " entries";
+  if (mDigitsTree->GetEntries() != 1) {
+    LOG(fatal) << "more than one entry in digits tree " << mDigitsTree->GetEntries();
+  }
+  if (mTrackletsTree->GetEntries() != 1) {
+    LOG(fatal) << "more than one entry in tracklets tree " << mTrackletsTree->GetEntries();
+  }
+
+  for (int entry = 0; entry < mDigitsTree->GetEntries(); entry++) {
+    mDigitsTree->GetEntry(entry);
     uint32_t linkcount = 0;
-    for (auto trigger : mTriggerRecords) {
+  }
+  for (int entry = 0; entry < mTrackletsTree->GetEntries(); entry++) {
+    mTrackletsTree->GetEntry(entry);
+  }
+  sortDataToLinks();
+  // everything is passed as the first entry in the tree.
+  // and then work with the resulting vectors from the branches.
+  uint32_t linkcount = 0;
+  for (auto tracklettrigger : mTrackletTriggerRecords) {
+    //get the event limits from TriggerRecord;
+    uint32_t eventstart = tracklettrigger.getFirstEntry();
+    uint32_t eventend = tracklettrigger.getFirstEntry() + tracklettrigger.getNumberOfObjects();
+    LOG(debug) << "looping over tracklet trigger : " << eventstart << " -> " << eventend << " with bc of " << tracklettrigger.getBCData().bc << " orbit of : " << tracklettrigger.getBCData().orbit;
+    for (auto digitstrigger : mDigitTriggerRecords) {
       //get the event limits from TriggerRecord;
-      uint32_t eventstart = trigger.getFirstEntry();
-      uint32_t eventend = trigger.getFirstEntry() + trigger.getNumberOfObjects();
-      LOG(debug) << "Event starts at:" << eventstart << " and ends at :" << eventend;
-      convertTrapData(trigger);
+      uint32_t eventstart = digitstrigger.getFirstEntry();
+      uint32_t eventend = digitstrigger.getFirstEntry() + digitstrigger.getNumberOfObjects();
+      if (digitstrigger.getBCData() == tracklettrigger.getBCData()) {
+        LOG(debug) << " we have a match for bc : " << tracklettrigger.getBCData().bc << " orbit of : " << tracklettrigger.getBCData().orbit;
+        convertTrapData(tracklettrigger, digitstrigger);
+      }
     }
   }
 }
 
-int Trap2CRU::sortByORI()
-{
-  // data comes in sorted by padcolum, a row of 8 trap chips.
-  // this is sadly not how the electronics is actually connected.
-  // we therefore need to resort the data according to the ORI link.
-  // TODO consider unpacking an entire event into memory into a per ori vector, then dump it all out.
-  // this is not for production running so the performance hit of sortin is probably ok ?? TODO ask someone to verify that.
-  return 1;
-}
-
-void Trap2CRU::buildCRUPayLoad()
-{
-  // go through the data for the event in question, sort via above method, produce the raw stream for each cru.
-  // i.e. 30 link per cru, 3cru per flp.
-  // 30x [HalfCRUHeader, TrackletHCHeader0, [MCMHeader TrackletMCMData. .....] TrackletHCHeader1 ..... TrackletHCHeader30 ...]
-  //
-  // data must be padded into blocks of 256bit so on average 4 padding 32 bit words.
-}
-
 void Trap2CRU::linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_t& padding)
 {
-  // all data must be 256 bit aligned (8x64bit).
+
   // if zero the whole 256 bit must be padded (empty link)
   // crudatasize is the size to be stored in the cruheader, i.e. units of 256bits.
   // linksize is the incoming link size from the linkrecord,
@@ -151,47 +239,225 @@ void Trap2CRU::linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_
     padding = 8;
     LOG(debug) << "We have data with linkdatasize=" << linksize << " with size number in header of:" << crudatasize << " padded with " << padding << " 32bit words";
   }
-  LOG(debug) << "linkSizePadding : CRUDATASIZE : " << crudatasize;
+  LOG(debug) << __func__ << " leaving linkSizePadding : CRUDATASIZE : " << crudatasize;
 }
 
-uint32_t Trap2CRU::buildCRUHeader(HalfCRUHeader& header, uint32_t bc, uint32_t halfcru, int startlinkrecord)
+uint32_t Trap2CRU::buildHalfCRUHeader(HalfCRUHeader& header, const uint32_t bc, const uint32_t halfcru)
 {
   int bunchcrossing = bc;
   int stopbits = 0x01; // do we care about this and eventtype in simulations?
   int eventtype = 0x01;
   int crurdhversion = 6;
-  int feeid = 0;                      //TODO must be in cruheader down the road, inside the reserved somewhere ...
-  int cruid = 0;                      //TODO """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-  uint32_t crudatasize = 0;           //link size in units of 256 bits.
-  int endpoint = halfcru % 2 ? 1 : 0; //TODO figure out a value ... endpoint needs a rebase to PR4106
+  int feeid = 0;
+  int cruid = 0;
+  uint32_t crudatasize = 0; //link size in units of 256 bits.
+  int endpoint = halfcru % 2 ? 1 : 0;
   uint32_t padding = 0;
-  //setHalfCRUHeader(halfcruheader, rdhversion, bunchcrossing, stopbits, endpoint, eventtype); //TODO come back and pull this from somewhere.
   setHalfCRUHeader(header, crurdhversion, bunchcrossing, stopbits, endpoint, eventtype, feeid, cruid); //TODO come back and pull this from somewhere.
-                                                                                                       //  memset(&tmpLinkInfo[0],0,sizeof(tmpLinkInfo[0])*tmpLinkInfo.size());
 
-  // halfcruheader from the relevant mLinkRecords.
-  int linkrecord = startlinkrecord;
-  int totallinkdatasize = 0; //in units of 256bits
-  for (int link = 0; link < NLinksPerHalfCRU; link++) {
-    int linkid = link + halfcru * NLinksPerHalfCRU; // TODO this might have to change to a lut I dont think the mapping is linear.
-    int errors = 0;
-    int linksize = 0; // linkSizePadding will convert it to 1 for the no data case.
-    if (mLinkRecords[linkrecord].getLinkId() == linkid) {
-      linksize = mLinkRecords[linkrecord].getNumberOfObjects();
-      // this can be done differently by keeping a pointer to halfcruheader and setting it after reading it all in and going back per link to set the size.
-      LOG(debug3) << "setting CRU HEADER for halfcru : " << halfcru << "and link : " << link << " contents" << header << ":" << link << ":" << linksize << ":" << errors;
-      linkrecord++; // increment locally for walking through linkrecords.
-    }
-    linkSizePadding(linksize, crudatasize, padding);
-    setHalfCRUHeaderLinkData(header, link, crudatasize, errors); // write one padding block for empty links.
-    totallinkdatasize += crudatasize;
-  }
-  return totallinkdatasize;
+  return 1;
 }
 
-void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& TrigRecord)
+bool Trap2CRU::isTrackletOnLink(const int linkid, const int currenttrackletpos)
 {
+  //hcid is simply the halfcru*15+linkid
+  int hcid = mTracklets[currenttrackletpos].getHCID();
+  if (linkid == hcid) {
+    // this tracklet is on this link.
+    return true;
+  }
+  return false;
+}
 
+bool Trap2CRU::isDigitOnLink(const int linkid, const int currentdigitpos)
+{
+  Digit* digit = &mDigits[currentdigitpos];
+  if ((digit->getDetector() * 2 + (digit->getROB() % 2)) == linkid) {
+    return true;
+  }
+  return false;
+}
+
+int Trap2CRU::buildDigitRawData(const int digitindex, const std::array<int64_t, o2::trd::constants::NADCMCM>& localParsedDigits, const uint32_t bc)
+{
+  LOG(debug) << __func__ << " digitindex:" << digitindex << " and bc of" << bc;
+  //this is not zero suppressed.
+  int digitswritten = 0;
+  //    Digit
+  DigitMCMHeader header;
+  DigitMCMData data;
+  int startdet = mDigits[digitindex].getDetector();
+  int startrob = mDigits[digitindex].getROB();
+  int startmcm = mDigits[digitindex].getMCM();
+  int digitcounter = 0;
+  header.res = 12; //1100
+  header.mcm = startmcm;
+  header.rob = startrob;
+  header.yearflag = 1; // >2007
+  header.eventcount = bc;
+  header.yearflag = 1;
+  memcpy(mRawDataPtr, (char*)&header, 4); // 32 bits -- 4 bytes.
+  LOG(debug) << "writing data to digit stream of " << std::hex << header.word;
+  mRawDataPtr += 4;
+  for (auto digitindex : localParsedDigits) {
+    LOG(debug) << "digit indexof : " << digitindex; //<<
+    if (digitindex != -1) {
+      Digit* d = &mDigits[digitindex];
+      ArrayADC adcdata = d->getADC();
+      //write these 2 now as we only have it now.
+      header.mcm = d->getMCM();
+      header.rob = d->getROB();
+
+      for (int timebin = 0; timebin < o2::trd::constants::TIMEBINS; timebin += 3) {
+        LOG(debug) << "ADC values  : " << timebin << " = " << adcdata[timebin] << ":" << adcdata[timebin + 1] << ":" << adcdata[timebin + 2];
+        data.x = adcdata[timebin];
+        data.y = adcdata[timebin + 1];
+        data.z = adcdata[timebin + 2];
+        data.c = 0;
+        LOG(debug) << "writing data to digit stream of " << std::hex << data.word;
+        memcpy(mRawDataPtr, (char*)&data, 4); // 32 bits -- 4 bytes.
+        mRawDataPtr += 4;
+      }
+      digitswritten++;
+    } else {
+      //blank digit;//10 words of 0 for the 30 timebins, its done this way incase we want to or need to change c.
+      for (int timebin = 0; timebin < o2::trd::constants::TIMEBINS; timebin += 3) {
+        data.x = 0;
+        data.y = 0;
+        data.z = 0;
+        data.c = 0;
+        LOG(debug) << "writing data to digit stream of " << std::hex << data.word;
+        memcpy(mRawDataPtr, (char*)&data, 4); // 32 bits -- 4 bytes.
+        mRawDataPtr += 4;
+      }
+      digitswritten++;
+    }
+  }
+  LOG(debug) << __func__ << " leaving with digitswritten of: " << digitswritten << " for det:rob:mcm of " << startdet << ":" << startrob << ":" << startmcm;
+  return digitswritten;
+}
+
+int Trap2CRU::buildTrackletRawData(const int trackletindex, const int linkid)
+{
+  TrackletMCMHeader header;
+  bool destroytracklets = false;
+  std::array<TrackletMCMData, 3> trackletdata;
+  header.col = mTracklets[trackletindex].getColumn();
+  header.padrow = mTracklets[trackletindex].getPadRow();
+  header.onea = 1;
+  header.oneb = 1;
+  int trackletcounter = 0;
+  LOG(debug) << header;
+  while (linkid == mTracklets[trackletindex + trackletcounter].getHCID() && header.col == mTracklets[trackletindex + trackletcounter].getColumn() && header.padrow == mTracklets[trackletindex + trackletcounter].getPadRow()) {
+    buildTrackletMCMData(trackletdata[trackletcounter], mTracklets[trackletindex + trackletcounter].getSlope(),
+                         mTracklets[trackletindex + trackletcounter].getPosition(), mTracklets[trackletindex + trackletcounter].getQ0(),
+                         mTracklets[trackletindex + trackletcounter].getQ1(), mTracklets[trackletindex + trackletcounter].getQ2());
+    int headerqpart = ((mTracklets[trackletindex + trackletcounter].getQ2()) << 2) + ((mTracklets[trackletindex + trackletcounter].getQ1()) >> 5);
+    switch (trackletcounter) {
+      case 0:
+        header.pid0 = headerqpart;
+        break;
+      case 1:
+        header.pid1 = headerqpart;
+        break;
+      case 2:
+        header.pid2 = headerqpart;
+        break;
+      default:
+        LOG(warn) << ">3 tracklets when building the Tracklet raw data stream for hcid=" << mTracklets[trackletindex + trackletcounter].getHCID() << " col:" << mTracklets[trackletindex + trackletcounter].getColumn() << " padrow:" << mTracklets[trackletindex + trackletcounter].getPadRow();
+        destroytracklets = true;
+        break;
+    }
+    trackletcounter++;
+  }
+  //now copy the mcmheader and mcmdata.
+  if (!destroytracklets) {
+    memcpy((char*)mRawDataPtr, (char*)&header, sizeof(TrackletMCMHeader));
+    mRawDataPtr += sizeof(TrackletMCMHeader);
+    for (int i = 0; i < trackletcounter; i++) {
+      memcpy((char*)mRawDataPtr, (char*)&trackletdata[i], sizeof(TrackletMCMData));
+      mRawDataPtr += sizeof(TrackletMCMData);
+    }
+  } else {
+    LOG(warn) << "something wrong with these tracklets, there are too many. You might want to take a closer look. Rejecting for now, and moving on.";
+  }
+  return trackletcounter;
+}
+
+int Trap2CRU::writeDigitEndMarker()
+{
+  int wordswritten = 0;
+  uint32_t digitendmarker = 0;
+
+  memcpy(mRawDataPtr, (char*)&digitendmarker, 4);
+  mRawDataPtr += 4;
+  wordswritten++;
+  memcpy(mRawDataPtr, (char*)&digitendmarker, 4);
+  mRawDataPtr += 4;
+  wordswritten++;
+
+  return wordswritten;
+}
+
+int Trap2CRU::writeTrackletEndMarker()
+{
+  int wordswritten = 0;
+  uint32_t trackletendmarker = 0x10001000;
+
+  memcpy(mRawDataPtr, (char*)&trackletendmarker, 4);
+  mRawDataPtr += 4;
+  wordswritten++;
+  memcpy(mRawDataPtr, (char*)&trackletendmarker, 4);
+  mRawDataPtr += 4;
+  wordswritten++;
+  return wordswritten;
+}
+
+int Trap2CRU::writeHCHeader(uint64_t bc, uint32_t linkid)
+{ // we have 2 HCHeaders defined Tracklet and Digit in Rawdata.h
+  //TODO is it a case of run2 and run3 ? for digithcheader and tracklethcheader?
+  //The parsing I am doing of CRU raw data only has a DigitHCHeader in it after the TrackletEndMarker ... confusion?
+  int wordswritten = 0;
+  //from linkid we can get supermodule, stack, layer, side
+  int detector = linkid / 2;
+  TrackletHCHeader trackletheader;
+  trackletheader.supermodule = linkid / 60;
+  trackletheader.stack = linkid;
+  trackletheader.layer = linkid;
+  trackletheader.one = 1;
+  trackletheader.side = (linkid % 2) ? 1 : 0;
+  trackletheader.MCLK = bc; // just has to be a consistant increasing number per event.
+  trackletheader.format = 12;
+
+  DigitHCHeader digitheader;
+  digitheader.res0 = 1;
+  digitheader.side = (linkid % 2) ? 1 : 0;
+  digitheader.stack = (detector % (o2::trd::constants::NLAYER * o2::trd::constants::NSTACK)) / o2::trd::constants::NLAYER;
+  digitheader.layer = (detector % o2::trd::constants::NLAYER);
+  digitheader.supermodule = linkid / 60;
+  digitheader.numberHCW = 1;
+  digitheader.minor = 42;
+  digitheader.major = 42;
+  digitheader.version = 1;
+  digitheader.res1 = 1;
+  digitheader.ptrigcount = 1;
+  digitheader.ptrigphase = 1;
+  digitheader.bunchcrossing = bc;
+  digitheader.numtimebins = 30;
+  if (mUseTrackletHCHeader) { // run 3 we also have a TrackletHalfChamber, that comes after thetracklet endmarker.
+    memcpy(mRawDataPtr, (char*)&trackletheader, sizeof(TrackletHCHeader));
+    mRawDataPtr += 4;
+    wordswritten++;
+  }
+  memcpy(mRawDataPtr, (char*)&digitheader, 8); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
+  mRawDataPtr += 8;
+  wordswritten += 2;
+  return wordswritten;
+}
+
+void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& trackletTriggerRecord, o2::trd::TriggerRecord const& digitTriggerRecord)
+{
+  //  LOG(info) << "starting :" << __func__ ; //<<
   //build a HalfCRUHeader for this event/cru/endpoint
   //loop over cru's
   //  loop over all half chambers, thankfully they data is sorted.
@@ -199,111 +465,149 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& TrigRecord)
   //      if not blank, else fill in data from link records
   //  dump data to rawwriter
   //finished for event. this method is only called per event.
-  int currentlinkrecord = 0;
-  char* traprawdataptr = (char*)&mTrapRawData[0];
-  for (int halfcru = 0; halfcru < NumberOfHalfCRU; halfcru++) {
-    int supermodule = halfcru / 4;
-    int endpoint = halfcru / 2;
+  //    char* traprawdataptr = (char*)&mTrapRawData[0];
+  std::array<int64_t, 21> localParsedDigitsindex; // store the index of the digits of an mcm
+  int rawwords = 0;
+  char* rawdataptratstart;
+  std::vector<char> rawdatavector(1024 * 1024 * 2); // sum of link sizes + padding in units of bytes and some space for the header (512 bytes).
+  LOG(debug) << "BUNCH CROSSING : " << trackletTriggerRecord.getBCData().bc << " with orbit : " << trackletTriggerRecord.getBCData().orbit;
+  LOG(debug) << "BUNCH CROSSING : " << digitTriggerRecord.getBCData().bc << " with orbit : " << digitTriggerRecord.getBCData().orbit;
+  for (int halfcru = 0; halfcru < o2::trd::constants::NHALFCRU; halfcru++) {
+    int halfcruwordswritten = 0;
+    int supermodule = halfcru / 4; // 2 cru per supermodule.
+    int endpoint = halfcru / 2;    // 2 pci end points per cru, 15 links each
     int side = halfcru % 2 ? 1 : 0;
     mFeeID = buildTRDFeeID(supermodule, side, endpoint);
     mCruID = halfcru / 2;
-    mLinkID = TRDLinkID;
+    mLinkID = o2::trd::constants::TRDLINKID;
     mEndPointID = halfcru % 2 ? 1 : 0;
-
+    //15 links per half cru or cru end point.
     memset(&mRawData[0], 0, sizeof(mRawData[0]) * mRawData.size()); //   zero the rawdata storage
     int numberofdetectors = o2::trd::constants::MAXCHAMBER;
     HalfCRUHeader halfcruheader;
     //now write the cruheader at the head of all the data for this halfcru.
-    LOG(debug) << "cru before building cruheader for halfcru index : " << halfcru << " with contents \n"
-               << halfcruheader;
-    uint32_t totalhalfcrudatasize = buildCRUHeader(halfcruheader, TrigRecord.getBCData().bc, halfcru, currentlinkrecord);
-
-    std::vector<char> rawdatavector(totalhalfcrudatasize * 32 + sizeof(halfcruheader)); // sum of link sizes + padding in units of bytes and some space for the header (512 bytes).
-    char* rawdataptr = rawdatavector.data();
-
-    //dumpHalfCRUHeader(halfcruheader);
-    memcpy(rawdataptr, (char*)&halfcruheader, sizeof(halfcruheader));
-    std::array<uint64_t, 8> raw{};
-    memcpy((char*)&raw[0], rawdataptr, sizeof(halfcruheader));
-    for (int i = 0; i < 2; i++) {
-      int index = 4 * i;
-      LOG(debug) << "[1/2rawdaptr " << i << " " << std::hex << raw[index + 3] << " " << raw[index + 2] << " " << raw[index + 1] << " " << raw[index + 0];
-    }
-    rawdataptr += sizeof(halfcruheader);
-
-    int linkdatasize = 0; // in 32 bit words
-    int link = halfcru / 2;
-    for (int halfcrulink = 0; halfcrulink < NLinksPerHalfCRU; halfcrulink++) {
+    buildHalfCRUHeader(halfcruheader, trackletTriggerRecord.getBCData().bc, halfcru);
+    halfcruheader.EndPoint = mEndPointID;
+    mRawDataPtr = rawdatavector.data();
+    memcpy(mRawDataPtr, (char*)&halfcruheader, sizeof(halfcruheader));
+    mRawDataPtr += sizeof(halfcruheader);
+    halfcruwordswritten += sizeof(halfcruheader) / 4;
+    int totallinklengths = 0;
+    rawdataptratstart = mRawDataPtr; // keep track of where we started.
+    for (int halfcrulink = 0; halfcrulink < o2::trd::constants::NLINKSPERHALFCRU; halfcrulink++) {
       //links run from 0 to 14, so linkid offset is halfcru*15;
-      int linkid = halfcrulink + halfcru * NLinksPerHalfCRU;
-      LOG(debug) << "Currently checking for data on linkid : " << linkid << " from halfcru=" << halfcru << " and halfcrulink:" << halfcrulink << " ?? " << linkid << "==" << mLinkRecords[currentlinkrecord].getLinkId();
+      int linkid = halfcrulink + halfcru * o2::trd::constants::NLINKSPERHALFCRU;
+      LOG(debug) << __func__ << " " << __LINE__ << " linkid : " << linkid << " with link " << halfcrulink << "  of halfcru " << halfcru;
+      int linkwordswritten = 0;
       int errors = 0;           // put no errors in for now.
       int size = 0;             // in 32 bit words
-      int datastart = 0;        // in 32 bit words
-      int dataend = 0;          // in 32 bit words
       uint32_t paddingsize = 0; // in 32 bit words
       uint32_t crudatasize = 0; // in 256 bit words.
-      if (mLinkRecords[currentlinkrecord].getLinkId() == linkid) {
-        //this link has data in the stream.
-        LOG(debug) << "+++ We have data on linkid = " << linkid << " halfcrulink : " << halfcrulink;
-        linkdatasize = mLinkRecords[currentlinkrecord].getNumberOfObjects();
-        datastart = mLinkRecords[currentlinkrecord].getFirstEntry();
-        dataend = datastart + size;
-        LOG(debug) << "We have data on linkid = " << linkid << " and linksize : " << linkdatasize << " so :" << linkdatasize / 8 << " 256 bit words";
-        currentlinkrecord++;
-      } else {
-        assert(mLinkRecords[currentlinkrecord].getLinkId() < linkid);
-        LOG(debug) << "---We do not have data on linkid = " << linkid << " halfcrulink : " << halfcrulink;
-        //blank data for this link
-        // put in a 1 256 bit word of data for the link and padd with 0xeeee x 8
-        linkdatasize = 0;
-        paddingsize = 8;
-      }
-      // now copy data to rawdata, padding as and where needed.
-      //
-      linkSizePadding(linkdatasize, crudatasize, paddingsize); //TODO this can come out as we have already called it, but previously we have lost the #padding words, solve to remove.
+      //loop over tracklets for mcm's that match
+      if (isTrackletOnLink(linkid, mCurrentTracklet) || isDigitOnLink(linkid, mCurrentDigit)) {
+        //we have some data on this link
+        int trackletcounter = 0;
+        while (isTrackletOnLink(linkid, mCurrentTracklet)) {
+          // still on an mcm on this link
+          int tracklets = buildTrackletRawData(mCurrentTracklet, linkid); //returns # of 32 bits, header plus trackletdata words that would have come from the mcm.
+          mCurrentTracklet += tracklets;
+          trackletcounter += tracklets;
+          linkwordswritten += tracklets + 1;
+          rawwords += tracklets + 1; //1 to include the header
+        }
+        //write tracklet end marker
+        int trackletendmarker = writeTrackletEndMarker();
+        linkwordswritten += trackletendmarker;
+        rawwords += trackletendmarker;
+        int hcheaderwords = writeHCHeader(trackletTriggerRecord.getBCData().bc, linkid);
+        linkwordswritten += hcheaderwords;
+        rawwords += hcheaderwords;
+        while (isDigitOnLink(linkid, mDigitsIndex[mCurrentDigit])) {
+          //while we are on a single mcm, copy the digits timebins to the array.
+          int digitcounter = 0;
+          int currentROB = mDigits[mDigitsIndex[mCurrentDigit]].getROB();
+          int currentMCM = mDigits[mDigitsIndex[mCurrentDigit]].getMCM();
+          int currentDetector = mDigits[mDigitsIndex[mCurrentDigit]].getDetector();
+          int startmCurrentDigit = mCurrentDigit;
+          localParsedDigitsindex.fill(-1); // clear the digit index array
+          while (mDigits[mDigitsIndex[mCurrentDigit]].getMCM() == currentMCM &&
+                 mDigits[mDigitsIndex[mCurrentDigit]].getROB() == currentROB &&
+                 mDigits[mDigitsIndex[mCurrentDigit]].getDetector() == currentDetector) {
+            localParsedDigitsindex[mDigits[mDigitsIndex[mCurrentDigit]].getChannel()] = mDigitsIndex[mCurrentDigit];
+            mCurrentDigit++;
+            digitcounter++;
+            if (digitcounter > 22) {
+              LOG(error) << " we are on the 22nd digit of an mcm ?? This is not possible";
+            }
+          }
+          // mcm digits are full, now write it out.
+          char* preptr;
+          preptr = mRawDataPtr;
+          int digits = buildDigitRawData(mDigitsIndex[mCurrentDigit], localParsedDigitsindex, digitTriggerRecord.getBCData().bc);
+          //mCurrentDigit += digits;
+          //due to not being zero suppressed, digits returned from buildDigitRawData should *always* be 21.
+          if (digits != 21) {
+            LOG(error) << "We are writing non zero suppressed digits yet we dont have 21 digits"; //<<
+          }
+          rawwords += digits * 10 + 1; //10 for the tiembins and 1 for the header.
+          linkwordswritten += digits * 10 + 1;
+        }
+        int digitendmarkerwritten = writeDigitEndMarker();
+        linkwordswritten += digitendmarkerwritten;
+        rawwords += digitendmarkerwritten;
 
-      LOG(debug) << "WRITING " << crudatasize << " 256 bit data words to output stream";
-      LOG(debug) << "setting CRY HEADER for " << halfcruheader << ":" << halfcrulink << ":" << crudatasize << ":" << errors;
-      // now pad ....
-      LOG(debug) << " now to pump data into the stream with : " << linkdatasize << " crudatasize:" << crudatasize << " paddingsize: " << paddingsize << " and rem:" << linkdatasize % 8;
-      char* olddataptr = rawdataptr; // store the old pointer so we can do some sanity checks for how far we advance.
-      //linkdatasize is the #of 32 bit words coming from the incoming tree.
-      //paddingsize is the number of padding words to add 0xeeee
-      uint32_t bytestocopy = linkdatasize * (sizeof(uint32_t));
-      LOG(debug) << "copying " << bytestocopy << " bytes of link tracklet data at pos:" << std::hex << static_cast<void*>(rawdataptr);
-      memcpy(rawdataptr, traprawdataptr, bytestocopy);
-      //increment pointer
-      rawdataptr += bytestocopy;
-      traprawdataptr += bytestocopy;
-      //now for padding
-      uint16_t padbytes = paddingsize * sizeof(uint32_t);
-      LOG(debug) << "writing " << padbytes << " bytes of padding data  at pos:" << std::hex << static_cast<void*>(rawdataptr);
-      memset(rawdataptr, 0xee, padbytes);
-      //increment pointer.
-      rawdataptr += padbytes;
-      if (padbytes + bytestocopy != crudatasize * 32) {
-        LOG(debug) << "something wrong with data size writing padbytes:" << padbytes << " bytestocopy : " << bytestocopy << " crudatasize:" << crudatasize;
+      } else {
+        LOG(debug) << "no data on link : " << linkid;
       }
-      LOG(debug3) << std::hex << " rawdataptr:" << static_cast<void*>(rawdataptr) << " traprawdataptr " << static_cast<void*>(traprawdataptr);
-      //sanity check for now:
-      if (((char*)rawdataptr - (char*)olddataptr) != crudatasize * 32) { // cru words are 8 uint32 and comparison is in bytes.
-        LOG(debug) << "according to pointer arithmatic we have added " << rawdataptr - olddataptr << "bytes from " << static_cast<void*>(rawdataptr) << "-" << static_cast<void*>(olddataptr) << " when we should have added  " << crudatasize * 8 * 4 << " because crudatasize=" << crudatasize;
-      }
-      if (crudatasize != o2::trd::getlinkdatasize(halfcruheader, halfcrulink)) {
-        // we have written the wrong amount of data ....
-        LOG(debug) << "crudata is ! = get link data size " << crudatasize << "!=" << o2::trd::getlinkdatasize(halfcruheader, halfcrulink);
-      }
-      LOG(debug) << "copied " << crudatasize * 32 << "bytes to halfcrurawdata which now has  size of " << rawdatavector.size() << " for " << link << ":" << endpoint;
+      //write digit end marker.
+      //pad up to a whole 256 bit word size
+      if (linkwordswritten != 0) {
+        crudatasize = linkwordswritten / 8;
+        linkSizePadding(linkwordswritten, crudatasize, paddingsize);
+
+        // now pad the data if needed ....
+        char* olddataptr = mRawDataPtr; // store the old pointer so we can do some sanity checks for how far we advance.
+        //now for padding
+        uint16_t padbytes = paddingsize * sizeof(uint32_t);
+        uint32_t padword = 0xeeeeeeee;
+        for (int i = 0; i < paddingsize; ++i) {
+          memcpy(mRawDataPtr, (char*)&padword, 4);
+          mRawDataPtr += 4;
+          linkwordswritten++;
+          rawwords++;
+        }
+        crudatasize = linkwordswritten / 8; //convert to 256 bit alignment.
+        if ((linkwordswritten % 8) != 0) {
+          LOG(error) << "linkwordswritten is not 256 bit aligned " << linkwordswritten << " %8 = " << linkwordswritten % 8 << " and a padding size of : " << paddingsize << " or padbytes of : " << padbytes;
+        }
+        //fix the halfcruheader for the length of this link.
+        setHalfCRUHeaderLinkData(halfcruheader, halfcrulink, crudatasize, errors);
+        uint32_t bytescopied;
+        totallinklengths += crudatasize;
+        if ((mRawDataPtr - rawdataptratstart) != (totallinklengths * 32)) {
+          bytescopied = mRawDataPtr - rawdataptratstart;
+          LOG(debug) << "something wrong with data size in cruheader writing"
+                     << "linkwordswriten:" << linkwordswritten << " rawwords:" << rawwords << "bytestocopy : " << bytescopied << " crudatasize:" << crudatasize << " sum of links up to now : " << totallinklengths << " mRawDataPtr:0x" << std::hex << (void*)mRawDataPtr << "  start ptr:" << std::hex << (void*)rawdataptratstart;
+          //something wrong with data size writing padbytes:81 bytestocopy : 3488 crudatasize:81 mRawDataPtr:0x0x7f669acdedf0  start ptr:0x7f669acde050
+
+        } else {
+          LOG(debug) << "all fine with data size writing padbytes:" << paddingsize << " linkwordswriten:" << linkwordswritten << " bytestocopy : " << bytescopied << " crudatasize:" << crudatasize << " mRawDataPtr:0x" << std::hex << (void*)mRawDataPtr << "  start ptr:" << std::hex << (void*)rawdataptratstart;
+        }
+        //sanity check for now:
+        if (crudatasize != o2::trd::getlinkdatasize(halfcruheader, halfcrulink)) {
+          // we have written the wrong amount of data ....
+          LOG(debug) << "crudata is ! = get link data size " << crudatasize << "!=" << o2::trd::getlinkdatasize(halfcruheader, halfcrulink);
+        }
+        LOG(debug) << "Link words to be written : " << linkwordswritten * 4;
+      } // if we have data on link
+      halfcruwordswritten += linkwordswritten;
     }
-    LOG(debug) << "writing to " << std::hex << mFeeID << std::dec << " : " << mCruID << " : " << mLinkID << " : " << mEndPointID;
-    mWriter.addData(mFeeID, mCruID, mLinkID, mEndPointID, TrigRecord.getBCData(), rawdatavector);
-    if (DebugDataWriting) {
-      std::ofstream out2("crutestdumprawdatavector");
-      out2.write(rawdatavector.data(), rawdatavector.size());
-      out2.flush();
-      halfcru = NumberOfHalfCRU; // exit loop after 1 half cru for now.
-    }
+    //write halfcru data here.
+    std::vector<char> feeidpayload(halfcruwordswritten * 4);
+    memcpy(feeidpayload.data(), &rawdatavector[0], halfcruwordswritten * 4);
+    assert(halfcruwordswritten % 8 == 0);
+    mWriter.addData(mFeeID, mCruID, mLinkID, mEndPointID, trackletTriggerRecord.getBCData(), feeidpayload);
+    LOG(debug) << "written file for feeid of 0x" << std::hex << mFeeID << " and payload size of : " << halfcruwordswritten;
   }
 }
 


### PR DESCRIPTION
Parts of raw data generation are moved out of the trapsimulator dpl device.
The digits and tracklets files are now used to generate the raw data streams singular or per cru end point (72 files)
Raw data format now complies with what is coming out of CRU.
Digits are now included in addtion to the original of only tracklets.
Rejects any erroneous >3 tracklets.

This also includes an updated rawdata definitions for digits from the compressor branch.
Fix the optional groupings per file. Can now do per supermodule, per cru, per half cru, or all together.
Add instructions to README.md