### PR TITLE
Additional documentation and cleanup for TRAPsim

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -81,8 +81,8 @@ class Tracklet64
   // ----- Getters for tracklet information -----
   int getMCM() const { return 4 * (getPadRow() % 4) + getColumn(); }                                 // returns MCM position on ROB [0..15]
   int getROB() const { return (getHCID() % 2) ? (getPadRow() / 4) * 2 + 1 : (getPadRow() / 4) * 2; } // returns ROB number [0..5] for C0 chamber and [0..7] for C1 chamber
-  float getY() const;                                                                                // translate local position into global y (in cm)
-  float getDy(float nTbDrift = 19.4f) const;                                                         // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
+  float getUncalibratedY() const;                                                                    // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
+  float getUncalibratedDy(float nTbDrift = 19.4f) const;                                             // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
 
   // ----- Getters for offline corresponding values -----
   int getDetector() const { return getHCID() / 2; }

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -22,7 +22,7 @@ namespace trd
 
 using namespace constants;
 
-float Tracklet64::getY() const
+float Tracklet64::getUncalibratedY() const
 {
   int padLocalBin = getPosition();
   int padLocal = 0;
@@ -37,7 +37,7 @@ float Tracklet64::getY() const
   return (offset + padLocal * GRANULARITYTRKLPOS) * padWidth;
 }
 
-float Tracklet64::getDy(float nTbDrift) const
+float Tracklet64::getUncalibratedDy(float nTbDrift) const
 {
   float dy;
   int dyLocalBin = getSlope();

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -342,7 +342,7 @@ class TrapSimulator
   std::vector<unsigned int> mMCMT;      // tracklet word for one mcm/trap-chip
   std::vector<Tracklet64> mTrackletArray64; // Array of 64 bit tracklets
   std::vector<unsigned short> mTrackletDigitCount; // Keep track of the number of digits contributing to the tracklet (for MC labels)
-  std::vector<unsigned int> mTrackletDigitIndices; // For each tracklet the up to two indices of the digits which contributed
+  std::vector<unsigned int> mTrackletDigitIndices; // For each tracklet the up to two global indices of the digits which contributed (global digit indices are managed in the TRDDPLTrapSimulatorTask class)
   std::vector<TrackletDetail> mTrackletDetails; // store additional tracklet information for eventual debug output.
   std::vector<int> mZSMap;              // Zero suppression map (1 dimensional projection)
 

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -19,6 +19,9 @@
 #include "Framework/Task.h"
 #include "TRDSimulation/TrapSimulator.h"
 #include "TRDSimulation/TrapConfig.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
 
 class Calibrations;
 
@@ -48,12 +51,13 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
-
+  std::chrono::duration<double> mTrapSimTime{0}; // timer for the actual processing in the TRAP chips
 
   TrapConfig* getTrapConfig();
   void loadTrapConfig();
   void loadDefaultTrapConfig();
   void setOnlineGainTables();
+  void processTRAPchips(int currDetector, int& nTrackletsInTrigRec, std::vector<Tracklet64>& trapTrackletsAccum, o2::dataformats::MCTruthContainer<o2::MCCompLabel>& trackletMCLabels, const o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>& digitMCLabels);
 };
 
 o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec();


### PR DESCRIPTION
- rename getters for offset and slope of Tracklet64 to make clear they are uncalibrated values
- move TRAP processing into an extra method to avoid duplicating a code block
- explain a bit more the MC label assignment to tracklets based on digit indices

This does not change the processing itself, I only tried to improve the readability.