### PR TITLE
GPU: Fix race condition in TPC ClusterFinder

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFCheckPadBaseline.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFCheckPadBaseline.cxx
@@ -63,6 +63,7 @@ GPUd() void GPUTPCCFCheckPadBaseline::Thread<0>(int nBlocks, int nThreads, int i
         maxConsecCharges = CAMath::Max(consecCharges, maxConsecCharges);
       }
     }
+    GPUbarrier();
   }
 
   GPUbarrier();


### PR DESCRIPTION
@fweig : FYI: I found this race condition in the TPC Clusterizer.
That is kind of a common mistake in GPU programming, when you protect read after write dependencies in a loop, you have to protect after both the read and the write, since the write of the next loop iteration can overwrite the value otherwise.