### PR TITLE
Fix PR target for clang-format action

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -84,7 +84,7 @@ jobs:
       uses: alisw/pull-request@master
       with:
         source_branch: 'alibuild:alibot-cleanup-${{ github.event.pull_request.number }}'
-        destination_branch: '${{ github.event.pull_request.user.login }}:${{ github.event.pull_request.head.ref }}'
+        destination_branch: '${{ github.event.pull_request.head.label }}'
         github_token: ${{ secrets.ALIBUILD_GITHUB_TOKEN }}
         pr_title: "Please consider the following formatting changes to #${{ github.event.pull_request.number }}"
         pr_body: | 


### PR DESCRIPTION
The person sending the PR might not be the same as the owner of the fork from which the PR was sent.