### PR TITLE
Use o2_add_executable for Data Sampling benchmark workflow

### DIFF
--- a/Utilities/DataSampling/CMakeLists.txt
+++ b/Utilities/DataSampling/CMakeLists.txt
@@ -81,7 +81,7 @@ o2_add_executable(datasampling-time-pipeline
   COMPONENT_NAME DataSampling
   PUBLIC_LINK_LIBRARIES O2::Framework O2::DataSampling)
 
-o2_add_dpl_workflow(datasampling-benchmark
+o2_add_executable(datasampling-benchmark
   SOURCES test/dataSamplingBenchmark.cxx
   COMPONENT_NAME DataSampling
-  PUBLIC_LINK_LIBRARIES O2::DataSampling)
+  PUBLIC_LINK_LIBRARIES O2::Framework O2::DataSampling)


### PR DESCRIPTION
This should fix the errors i've noticed [in CI](https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/AliceO2/5554/2894d60e2a8dd059705019fdce8404d6686dc1bf/build_O2_fullCI/pretty.html):
```
[ 46%] Building CXX object Utilities/Mergers/CMakeFiles/O2exe-mergers-benchmark-topology.dir/test/mergersBenchmarkTopology.cxx.o
[ 46%] Linking CXX executable ../../stage/bin/o2-datasampling-datasampling-benchmark
[ERROR] error while setting up workflow: boost::filesystem::status: Operation not permitted: "/tmp/dataSamplingBenchmark-1.000000.json"
gmake[2]: *** [Utilities/DataSampling/CMakeFiles/O2exe-datasampling-datasampling-benchmark.dir/build.make:155: stage/bin/o2-datasampling-datasampling-benchmark] Error 1
gmake[2]: *** Deleting file 'stage/bin/o2-datasampling-datasampling-benchmark'
gmake[1]: *** [CMakeFiles/Makefile2:16767: Utilities/DataSampling/CMakeFiles/O2exe-datasampling-datasampling-benchmark.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 46%] Linking CXX executable ../../stage/bin/o2-mergers-benchmark-full-vs-diff
```