### PR TITLE
RecoDecay & PWGHF: Improve MC matching.

### DIFF
--- a/Analysis/Core/include/AnalysisCore/RecoDecay.h
+++ b/Analysis/Core/include/AnalysisCore/RecoDecay.h
@@ -538,7 +538,11 @@ class RecoDecay
   /// \param sign  antiparticle indicator of the found mother w.r.t. PDGMother; 1 if particle, -1 if antiparticle, 0 if mother not found
   /// \return index of the mother particle if found, -1 otherwise
   template <typename T>
-  static int getMother(const T& particlesMC, const typename T::iterator& particle, int PDGMother, bool acceptAntiParticles = false, int8_t* sign = nullptr)
+  static int getMother(const T& particlesMC,
+                       const typename T::iterator& particle,
+                       int PDGMother,
+                       bool acceptAntiParticles = false,
+                       int8_t* sign = nullptr)
   {
     int8_t sgn = 0;                 // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
     int indexMother = -1;           // index of the final matched mother, if found
@@ -666,7 +670,13 @@ class RecoDecay
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \return index of the mother particle if the mother and daughters are correct, -1 otherwise
   template <std::size_t N, typename T, typename U>
-  static int getMatchedMCRec(const T& particlesMC, const array<U, N>& arrDaughters, int PDGMother, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
+  static int getMatchedMCRec(const T& particlesMC,
+                             const array<U, N>& arrDaughters,
+                             int PDGMother,
+                             array<int, N> arrPDGDaughters,
+                             bool acceptAntiParticles = false,
+                             int8_t* sign = nullptr,
+                             int depthMax = 1)
   {
     //Printf("MC Rec: Expected mother PDG: %d", PDGMother);
     int8_t sgn = 0;                        // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
@@ -762,7 +772,11 @@ class RecoDecay
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
   /// \return true if PDG code of the particle is correct, false otherwise
   template <typename T, typename U>
-  static int isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, bool acceptAntiParticles = false, int8_t* sign = nullptr)
+  static int isMatchedMCGen(const T& particlesMC,
+                            const U& candidate,
+                            int PDGParticle,
+                            bool acceptAntiParticles = false,
+                            int8_t* sign = nullptr)
   {
     array<int, 0> arrPDGDaughters;
     return isMatchedMCGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles, sign);
@@ -779,7 +793,14 @@ class RecoDecay
   /// \param listIndexDaughters  vector of indices of found daughter
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1, std::vector<int>* listIndexDaughters = nullptr)
+  static bool isMatchedMCGen(const T& particlesMC,
+                             const U& candidate,
+                             int PDGParticle,
+                             array<int, N> arrPDGDaughters,
+                             bool acceptAntiParticles = false,
+                             int8_t* sign = nullptr,
+                             int depthMax = 1,
+                             std::vector<int>* listIndexDaughters = nullptr)
   {
     //Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
     int8_t sgn = 0; // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)

--- a/Analysis/Core/include/AnalysisCore/RecoDecay.h
+++ b/Analysis/Core/include/AnalysisCore/RecoDecay.h
@@ -782,9 +782,10 @@ class RecoDecay
   /// \param acceptAntiParticles  switch to accept the antiparticle
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
+  /// \param listIndexDaughters  vector of indices of found daughter
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <std::size_t N, typename T, typename U>
-  static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1)
+  static bool isMatchedMCGen(const T& particlesMC, const U& candidate, int PDGParticle, array<int, N> arrPDGDaughters, bool acceptAntiParticles = false, int8_t* sign = nullptr, int depthMax = 1, std::vector<int>* listIndexDaughters = nullptr)
   {
     //Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
     int8_t sgn = 0; // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
@@ -847,6 +848,9 @@ class RecoDecay
           //Printf("MC Gen: Rejected: bad daughter PDG: %d", PDGCandidateDaughterI);
           return false;
         }
+      }
+      if (listIndexDaughters) {
+        *listIndexDaughters = arrAllDaughtersIndex;
       }
     }
     //Printf("MC Gen: Accepted: m: %d", candidate.globalIndex());

--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -137,6 +137,10 @@ DECLARE_SOA_DYNAMIC_COLUMN(CPA, cpa, [](float xVtxP, float yVtxP, float zVtxP, f
 DECLARE_SOA_DYNAMIC_COLUMN(CPAXY, cpaXY, [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float px, float py) { return RecoDecay::CPAXY(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, array{px, py}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Ct, ct, [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) { return RecoDecay::Ct(array{px, py, pz}, RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}), m); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterXY, impactParameterXY, [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) { return RecoDecay::ImpParXY(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
+
+// mapping of origin type
+enum OriginType { Prompt = 1,
+                  NonPrompt };
 } // namespace hf_cand
 
 // specific 2-prong decay properties
@@ -152,9 +156,10 @@ DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, [](float px0, float py0, 
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, [](float impParProng0, float impParProng1) { return RecoDecay::sumOfSquares(impParProng0, impParProng1); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1}, array{errIp0, errIp1}, array{array{px0, py0}, array{px1, py1}}); });
 // MC matching result:
-// - ±D0ToPiK: D0(bar) → π± K∓
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t); // generator level
+DECLARE_SOA_COLUMN(OriginMCRec, originMCRec, int8_t);       // particle origin, reconstruction level
+DECLARE_SOA_COLUMN(OriginMCGen, originMCGen, int8_t);       // particle origin, generator level
 
 // mapping of decay types
 enum DecayType { D0ToPiK = 0,
@@ -295,11 +300,13 @@ using HfCandProng2 = HfCandProng2Ext;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandProng2MCRec, "AOD", "HFCANDP2MCREC",
-                  hf_cand_prong2::FlagMCMatchRec);
+                  hf_cand_prong2::FlagMCMatchRec,
+                  hf_cand_prong2::OriginMCRec);
 
 // table with results of generator level MC matching
 DECLARE_SOA_TABLE(HfCandProng2MCGen, "AOD", "HFCANDP2MCGEN",
-                  hf_cand_prong2::FlagMCMatchGen);
+                  hf_cand_prong2::FlagMCMatchGen,
+                  hf_cand_prong2::OriginMCGen);
 
 // specific 3-prong decay properties
 namespace hf_cand_prong3
@@ -312,13 +319,12 @@ DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, [](float px0, float py0, float pz0, float px1
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, [](float impParProng0, float impParProng1, float impParProng2) { return RecoDecay::sumOfSquares(impParProng0, impParProng1, impParProng2); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float ip2, float errIp2, float px0, float py0, float px1, float py1, float px2, float py2) { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1, ip2}, array{errIp0, errIp1, errIp2}, array{array{px0, py0}, array{px1, py1}, array{px2, py2}}); });
 // MC matching result:
-// - ±DPlusToPiKPi: D± → π± K∓ π±
-// - ±LcToPKPi: Λc± → p± K∓ π±
-// - ±XicToPKPi: Ξc± → p± K∓ π±
 DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t);         // reconstruction level
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t);         // generator level
-DECLARE_SOA_COLUMN(FlagMCDecayChanRec, flagMCDecayChanRec, int8_t); // Resonant decay channel flag, reconstruction level
-DECLARE_SOA_COLUMN(FlagMCDecayChanGen, flagMCDecayChanGen, int8_t); // Resonant decay channel flag, generator level
+DECLARE_SOA_COLUMN(OriginMCRec, originMCRec, int8_t);               // particle origin, reconstruction level
+DECLARE_SOA_COLUMN(OriginMCGen, originMCGen, int8_t);               // particle origin, generator level
+DECLARE_SOA_COLUMN(FlagMCDecayChanRec, flagMCDecayChanRec, int8_t); // resonant decay channel flag, reconstruction level
+DECLARE_SOA_COLUMN(FlagMCDecayChanGen, flagMCDecayChanGen, int8_t); // resonant decay channel flag, generator level
 
 // mapping of decay types
 enum DecayType { DPlusToPiKPi = 0,
@@ -467,11 +473,13 @@ using HfCandProng3 = HfCandProng3Ext;
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandProng3MCRec, "AOD", "HFCANDP3MCREC",
                   hf_cand_prong3::FlagMCMatchRec,
+                  hf_cand_prong3::OriginMCRec,
                   hf_cand_prong3::FlagMCDecayChanRec);
 
 // table with results of generator level MC matching
 DECLARE_SOA_TABLE(HfCandProng3MCGen, "AOD", "HFCANDP3MCGEN",
                   hf_cand_prong3::FlagMCMatchGen,
+                  hf_cand_prong3::OriginMCGen,
                   hf_cand_prong3::FlagMCDecayChanGen);
 
 } // namespace o2::aod

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -22,6 +22,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong2;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
@@ -148,36 +149,48 @@ struct HFCandidateCreator2ProngMC {
                aod::BigTracksMC const& tracks,
                aod::McParticles const& particlesMC)
   {
+    int indexRec = -1;
     int8_t sign = 0;
     int8_t flag = 0;
+    int8_t origin = 0;
 
     // Match reconstructed candidates.
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
       flag = 0;
+      origin = 0;
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>()};
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
-      if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 421, array{+kPiPlus, -kKPlus}, true, &sign) > -1) {
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 421, array{+kPiPlus, -kKPlus}, true, &sign);
+      if (indexRec > -1) {
         flag = sign * (1 << D0ToPiK);
       }
 
       // J/ψ → e+ e-
       if (flag == 0) {
         //Printf("Checking J/ψ → e+ e-");
-        if (RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 443, array{+kElectron, -kElectron}, true) > -1) {
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::move(arrayDaughters), 443, array{+kElectron, -kElectron}, true);
+        if (indexRec > -1) {
           flag = 1 << JpsiToEE;
         }
       }
 
-      rowMCMatchRec(flag);
+      // Check whether the particle is non-prompt (from a b quark).
+      if (flag != 0) {
+        auto particle = particlesMC.iteratorAt(indexRec);
+        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+      }
+
+      rowMCMatchRec(flag, origin);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
       flag = 0;
+      origin = 0;
 
       // D0(bar) → π± K∓
       //Printf("Checking D0(bar) → π± K∓");
@@ -193,7 +206,12 @@ struct HFCandidateCreator2ProngMC {
         }
       }
 
-      rowMCMatchGen(flag);
+      // Check whether the particle is non-prompt (from a b quark).
+      if (flag != 0) {
+        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+      }
+
+      rowMCMatchGen(flag, origin);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -189,7 +189,7 @@ struct HFCandidateCreator3ProngMC {
           flag = sign * (1 << LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
-          RecoDecay::getDaughters(particlesMC, indexRec, &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMC, particlesMC.iteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.iteratorAt(arrDaughIndex[iProng]);
@@ -245,7 +245,7 @@ struct HFCandidateCreator3ProngMC {
           flag = sign * (1 << LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
-          RecoDecay::getDaughters(particlesMC, particle.globalIndex(), &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMC, particle, &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto jProng = 0; jProng < arrDaughIndex.size(); ++jProng) {
               auto daughJ = particlesMC.iteratorAt(arrDaughIndex[jProng]);

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -22,6 +22,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong3;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
@@ -153,9 +154,11 @@ struct HFCandidateCreator3ProngMC {
                aod::BigTracksMC const& tracks,
                aod::McParticles const& particlesMC)
   {
+    int indexRec = -1;
     int8_t sign = 0;
     int8_t flag = 0;
-    int8_t DecayChannel = 0;
+    int8_t origin = 0;
+    int8_t channel = 0;
     std::vector<int> arrDaughIndex;
     std::array<int, 2> arrPDGDaugh;
     std::array<int, 2> arrPDGResonant1 = {2212, 313}; // Λc± → p± K*
@@ -166,36 +169,38 @@ struct HFCandidateCreator3ProngMC {
     for (auto& candidate : candidates) {
       //Printf("New rec. candidate");
       flag = 0;
-      DecayChannel = 0;
+      origin = 0;
+      channel = 0;
       arrDaughIndex.clear();
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
 
       // D± → π± K∓ π±
       //Printf("Checking D± → π± K∓ π±");
-      if (RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign) > -1) {
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 411, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign);
+      if (indexRec > -1) {
         flag = sign * (1 << DPlusToPiKPi);
       }
 
       // Λc± → p± K∓ π±
       if (flag == 0) {
         //Printf("Checking Λc± → p± K∓ π±");
-        auto indexRecLc = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
-        if (indexRecLc > -1) {
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        if (indexRec > -1) {
           flag = sign * (1 << LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
-          RecoDecay::getDaughters(particlesMC, indexRecLc, &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMC, indexRec, &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.iteratorAt(arrDaughIndex[iProng]);
               arrPDGDaugh[iProng] = std::abs(daughI.pdgCode());
             }
             if (arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) {
-              DecayChannel = 1;
+              channel = 1;
             } else if (arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) {
-              DecayChannel = 2;
+              channel = 2;
             } else if (arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) {
-              DecayChannel = 3;
+              channel = 3;
             }
           }
         }
@@ -209,14 +214,21 @@ struct HFCandidateCreator3ProngMC {
         }
       }
 
-      rowMCMatchRec(flag, DecayChannel);
+      // Check whether the particle is non-prompt (from a b quark).
+      if (flag != 0) {
+        auto particle = particlesMC.iteratorAt(indexRec);
+        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+      }
+
+      rowMCMatchRec(flag, origin, channel);
     }
 
     // Match generated particles.
     for (auto& particle : particlesMC) {
       //Printf("New gen. candidate");
       flag = 0;
-      DecayChannel = 0;
+      origin = 0;
+      channel = 0;
       arrDaughIndex.clear();
 
       // D± → π± K∓ π±
@@ -240,11 +252,11 @@ struct HFCandidateCreator3ProngMC {
               arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
             }
             if (arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) {
-              DecayChannel = 1;
+              channel = 1;
             } else if (arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) {
-              DecayChannel = 2;
+              channel = 2;
             } else if (arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) {
-              DecayChannel = 3;
+              channel = 3;
             }
           }
         }
@@ -258,7 +270,12 @@ struct HFCandidateCreator3ProngMC {
         }
       }
 
-      rowMCMatchGen(flag, DecayChannel);
+      // Check whether the particle is non-prompt (from a b quark).
+      if (flag != 0) {
+        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+      }
+
+      rowMCMatchGen(flag, origin, channel);
     }
   }
 };

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -240,8 +240,7 @@ struct HFCandidateCreator3ProngMC {
       // Λc± → p± K∓ π±
       if (flag == 0) {
         //Printf("Checking Λc± → p± K∓ π±");
-        auto isMatchedGenLc = RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
-        if (isMatchedGenLc) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, 4122, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           flag = sign * (1 << LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");

--- a/Analysis/Tasks/PWGHF/HFMCValidation.cxx
+++ b/Analysis/Tasks/PWGHF/HFMCValidation.cxx
@@ -100,7 +100,7 @@ struct ValidationGenLevel {
       // Checking the decay of the particles and the momentum conservation
       for (int iD = 0; iD < PDGArrayParticle.size(); iD++) {
         if (std::abs(particlePdgCode) == PDGArrayParticle[iD]) {
-          RecoDecay::getDaughters(particlesMC, particle.globalIndex(), &listDaughters, arrPDGFinal[iD], -1);
+          RecoDecay::getDaughters(particlesMC, particle, &listDaughters, arrPDGFinal[iD], -1);
           int arrayPDGsize = arrPDGFinal[iD].size() - std::count(arrPDGFinal[iD].begin(), arrPDGFinal[iD].end(), 0);
           if (listDaughters.size() == arrayPDGsize) {
             counter[iD]++;

--- a/Analysis/Tasks/PWGHF/taskD0.cxx
+++ b/Analysis/Tasks/PWGHF/taskD0.cxx
@@ -21,6 +21,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong2;
 using namespace o2::framework::expressions;
 
@@ -103,8 +104,12 @@ struct TaskD0MC {
   HistogramRegistry registry{
     "registry",
     {{"hPtRecSig", "2-prong candidates (matched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+     {"hPtRecSigPrompt", "2-prong candidates (matched, prompt);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+     {"hPtRecSigNonPrompt", "2-prong candidates (matched, non-prompt);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hPtRecBg", "2-prong candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hPtGen", "MC particles (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+     {"hPtGenPrompt", "MC particles (matched, prompt);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+     {"hPtGenNonPrompt", "MC particles (matched, non-prompt);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hPtGenSig", "2-prong candidates (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hCPARecSig", "2-prong candidates (matched);cosine of pointing angle;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}}},
      {"hCPARecBg", "2-prong candidates (unmatched);cosine of pointing angle;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}}},
@@ -136,7 +141,13 @@ struct TaskD0MC {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCandProng2MCGen>>(), 421, true);
         auto particleMother = particlesMC.iteratorAt(indexMother);
         registry.fill(HIST("hPtGenSig"), particleMother.pt()); // gen. level pT
-        registry.fill(HIST("hPtRecSig"), candidate.pt());      // rec. level pT
+        auto ptRec = candidate.pt();
+        registry.fill(HIST("hPtRecSig"), ptRec); // rec. level pT
+        if (candidate.originMCRec() == Prompt) {
+          registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
+        } else {
+          registry.fill(HIST("hPtRecSigNonPrompt"), ptRec); // rec. level pT, non-prompt
+        }
         registry.fill(HIST("hCPARecSig"), candidate.cpa());
         registry.fill(HIST("hEtaRecSig"), candidate.eta());
       } else {
@@ -153,7 +164,13 @@ struct TaskD0MC {
           //Printf("MC Gen.: Y rejection: %g", RecoDecay::Y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())));
           continue;
         }
-        registry.fill(HIST("hPtGen"), particle.pt());
+        auto ptGen = particle.pt();
+        registry.fill(HIST("hPtGen"), ptGen);
+        if (particle.originMCGen() == Prompt) {
+          registry.fill(HIST("hPtGenPrompt"), ptGen);
+        } else {
+          registry.fill(HIST("hPtGenNonPrompt"), ptGen);
+        }
         registry.fill(HIST("hEtaGen"), particle.eta());
       }
     }


### PR DESCRIPTION
* Allow to get daughters from `isMatchedMCGen`.
  * Useful for matching cascades step by step instead of repeating matching for the same segments of the decay tree with different depths. @chiarazampolli 
* Add non-prompt matching. @ginnocen 
  * Columns `OriginMCRec` and `OriginMCGen` store values `0`, `Prompt = 1`, `NonPrompt = 2`.
  * `0` means not MC matched,
  * `NonPrompt` means MC matched and with an (anti-)b quark among mothers,
  * `Prompt` means MC matched and with no (anti-)b quark among mothers.
* Avoid repetition of `iteratorAt` in `getDaughters`.
  * In most calls of `getDaughters`, the particle row is already available so providing its index and accessing it again inside `getDaughters` is usually redundant.
* Improve formatting of arguments to avoid too long lines.
* Add maximum depth in `getMother` to speed up rejection of fake candidates.