### PR TITLE
[MCH] fix broken workflows

### DIFF
--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -79,7 +79,7 @@ Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/
 
 ## Local to global cluster transformation
 
-The `o2-mch-clusters-transformer-workflow` takes as as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
+The `o2-mch-clusters-transformer-workflow` takes as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
 
 It sends the list of the same clusters, but converted in global reference frame, with the data description "GLOBALCLUSTERS".
 
@@ -175,7 +175,7 @@ Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records
 ### Cluster sampler
 
 ```shell
-o2-mch-clusters-sampler-workflow --infile "clusters.in"
+o2-mch-clusters-sampler-workflow --infile "clusters.in" [--global]
 ```
 
 where `clusters.in` is a binary file containing for each event:
@@ -185,7 +185,7 @@ where `clusters.in` is a binary file containing for each event:
 * list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
 * list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))
 
-Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
 
 Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
 
@@ -248,7 +248,7 @@ o2-mch-clusters-sink-workflow --outfile "clusters.out" [--txt] [--no-digits] [--
 Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the current time frame, and, optionnally, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), "CLUSTERDIGITS" (unless `--no-digits` option is used) and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
 
 * number of clusters (int)
-* number of associated digits (int) (unless option `--no-digits` is used)
+* number of associated digits (int) (= 0 if `--no-digits` is used)
 * list of clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h))
 * list of associated digits ([Digit](../Base/include/MCHBase/Digit.h))(unless option `--no-digits` is used)
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -149,7 +149,7 @@ o2::framework::DataProcessorSpec getTrackFinderOriginalSpec()
   return DataProcessorSpec{
     "TrackFinderOriginal",
     Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
-           InputSpec{"clusters", "MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
+           InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
             OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe},
             OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -147,7 +147,7 @@ o2::framework::DataProcessorSpec getTrackFinderSpec()
   return DataProcessorSpec{
     "TrackFinder",
     Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
-           InputSpec{"clusters", "MCH", "CLUSTERS", 0, Lifetime::Timeframe}},
+           InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
             OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe},
             OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/clusters-sampler-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-sampler-workflow.cxx
@@ -28,24 +28,24 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
 
 #include "DataFormatsMCH/ROFRecord.h"
 #include "MCHBase/ClusterBlock.h"
 #include "MCHBase/Digit.h"
 
-// add workflow options, note that customization needs to be declared before
-// including Framework/runDataProcessing
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+using namespace o2::framework;
+
+//_________________________________________________________________________________________________
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  std::vector<o2::framework::ConfigParamSpec> options{
-    {"global", o2::framework::VariantType::Bool, false, {"assume the read clusters are in global reference frame"}},
-  };
-  std::swap(workflowOptions, options);
+  /// add workflow options. Note that customization needs to be declared before including Framework/runDataProcessing
+  workflowOptions.emplace_back("global", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"assume the read clusters are in global reference frame"});
 }
 
 #include "Framework/runDataProcessing.h"
 
-using namespace o2::framework;
 using namespace o2::mch;
 
 class ClusterSamplerTask
@@ -159,7 +159,7 @@ class ClusterSamplerTask
 o2::framework::DataProcessorSpec getClusterSamplerSpec(bool globalReferenceSystem)
 {
 
-  std::string spec = fmt::format("clusters:MCH/{}CLUSTERS", globalReferenceSystem ? "GLOBAL" : "");
+  std::string spec = fmt::format("clusters:MCH/{}CLUSTERS/0", globalReferenceSystem ? "GLOBAL" : "");
   InputSpec itmp = o2::framework::select(spec.c_str())[0];
 
   return DataProcessorSpec{
@@ -168,11 +168,11 @@ o2::framework::DataProcessorSpec getClusterSamplerSpec(bool globalReferenceSyste
     Outputs{OutputSpec{{"rofs"}, "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
             DataSpecUtils::asOutputSpec(itmp)},
     AlgorithmSpec{adaptFromTask<ClusterSamplerTask>()},
-    Options{
-      {"infile", VariantType::String, "", {"input filename"}},
-      {"nEventsPerTF", VariantType::Int, 1, {"number of events per time frame"}}}}; // namespace mch
+    Options{{"infile", VariantType::String, "", {"input filename"}},
+            {"nEventsPerTF", VariantType::Int, 1, {"number of events per time frame"}}}};
 }
 
+//_________________________________________________________________________________________________
 WorkflowSpec defineDataProcessing(const ConfigContext& cc)
 {
   return WorkflowSpec{getClusterSamplerSpec(cc.options().get<bool>("global"))};


### PR DESCRIPTION
This fixes a bug in clusters-sink-workflow when disabling the writing of the digits (the clusters were also not written in the binary file)

It also adds the SubSpec of the messages in the clusters-sink/sampler-workflows (needed to connect with other workflows) and use GLOBALCLUSTERS (i.e. clusters in the global coordinate system) in the tracking workflows
