### PR TITLE
[MRRTF-99] Add support for MCH UserLogic Raw Data Format V1

### DIFF
--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/DataFormats.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/DataFormats.h
@@ -34,6 +34,54 @@ using uint10_t = uint16_t;
 using uint20_t = uint32_t;
 using uint50_t = uint64_t;
 
+// Format of 64 bits-words of the UserLogicFormat
+template <int VERSION>
+struct ULHeaderWord;
+
+// initial UL format (2020)
+template <>
+struct ULHeaderWord<0> {
+  union {
+    uint64_t word;
+    struct {
+      uint64_t data : 50;
+      uint64_t error : 2;
+      uint64_t incomplete : 1;
+      uint64_t dsID : 6;
+      uint64_t linkID : 5;
+    };
+  };
+};
+
+// version 1 of UL format (2021)
+// = as initial version with 1 bit less for linkID and 1 bit more for error
+template <>
+struct ULHeaderWord<1> {
+  union {
+    uint64_t word;
+    struct {
+      uint64_t data : 50;
+      uint64_t error : 3;
+      uint64_t incomplete : 1;
+      uint64_t dsID : 6;
+      uint64_t linkID : 4;
+    };
+  };
+};
+
+// structure of the FEEID field (16 bits) in the MCH Raw Data RDH
+struct FEEID {
+  union {
+    uint16_t word;
+    struct {
+      uint16_t id : 8;
+      uint16_t chargeSum : 1;
+      uint16_t reserved : 3;
+      uint16_t ulFormatVersion : 4;
+    };
+  };
+};
+
 }; // namespace o2::mch::raw
 
 #endif

--- a/Detectors/MUON/MCH/Raw/Decoder/README.md
+++ b/Detectors/MUON/MCH/Raw/Decoder/README.md
@@ -16,15 +16,16 @@ called a (CRU) page. How the loop on the raw pages is done is *not* the decoder 
 
 ## createPageDecoder
 
-On the reading/consumer/decoding end, the choice of the internal decoder to use is made
-using the data itself. You must give (at least) a part of a raw data buffer that contains
- a (valid) RawDataHeader. That RDH is used to deduce which implementation is picked.
+On the reading/consumer/decoding end, the choice of the internal decoder to use
+is made using the data itself. You must give (at least) a part of a raw data
+buffer that contains a (valid) RawDataHeader. That RDH is used to deduce which
+implementation is picked.
 
     gsl::span<const std::byte> rawbuffer = ... ;
     auto pageDecoder = o2::mch::raw::createPageDecoder(rawbuffer,channelHandler);
 
 The `pageDecoder` that is returned is a function that you have to call on each
-data page that you want to decode : 
+data page that you want to decode :
 
     while(some_data_is_available) {
     // get some memory buffer from somewhere ...
@@ -34,20 +35,22 @@ data page that you want to decode :
     pageDecode(buffer);
     }
 
-Internally the implementation is using templatized implementation, `PageDecoderImpl<FORMAT,CHARGESUM>`.
-Currently the following template parameters combinations have been tested : 
+Internally the implementation is using templatized implementation, `PageDecoderImpl<FORMAT,CHARGESUM,VERSION>`.
+Currently the following template parameters combinations have been tested :
 
-|      FORMAT     |   CHARGESUM   |
-| :-------------: | :-----------: |
-|    BareFormat   | ChargeSumMode |
-|    BareFormat   |   SampleMode  |
-| UserLogicFormat | ChargeSumMode |
-| UserLogicFormat |   SampleMode  |
+|      FORMAT     |   CHARGESUM   | VERSION |
+| :-------------: | :-----------: | :-----: |
+|    BareFormat   | ChargeSumMode |    0    |
+|    BareFormat   |   SampleMode  |    0    |
+| UserLogicFormat | ChargeSumMode |    0    |
+| UserLogicFormat |   SampleMode  |    0    |
+| UserLogicFormat | ChargeSumMode |    1    |
+| UserLogicFormat |   SampleMode  |    1    |
 
-The `createPageDecoder` function requires two parameters : a raw memory buffer 
-(in the form of a `gsl::span<const std::byte>` (note that the span is on constant bytes, 
-i.e. the input buffer is read-only)
-and a `SampaChannelHandler`.
+The `createPageDecoder` function requires two parameters : a raw memory buffer
+(in the form of a `gsl::span<const std::byte>` (note that the span is on
+constant bytes, i.e. the input buffer is read-only) and a
+`SampaChannelHandler`.
 
 ## SampaChannelHandler
 
@@ -57,7 +60,7 @@ identifier within that dual sampa, a `SampaCluster` and returns nothing, i.e. :
 
 > A word of caution here about the naming. A `SampaCluster` is a group of raw
 > data samples of *one* dual sampa channel, and has nothing to do with a
-> cluster of pads or something alike. 
+> cluster of pads or something alike.
 
 ```.cpp
 using SampaChannelHandler = std::function<void(DsElecId dsId,
@@ -67,7 +70,7 @@ using SampaChannelHandler = std::function<void(DsElecId dsId,
 
 That function is called by the raw data decoder for each `SampaCluster` that it
 finds in the data.
-A very simple example would be a function to dump the SampaClusters : 
+A very simple example would be a function to dump the SampaClusters :
 
 ```.cpp
 SampaChannelHandler handlePacket(DsElecId dsId, uint8_t channel, SampaCluster sc) {
@@ -78,5 +81,5 @@ SampaChannelHandler handlePacket(DsElecId dsId, uint8_t channel, SampaCluster sc
 
 ## Example of decoding raw data
 
-A (not particularly clean) example of how to decode raw data can be found in the source of the `o2-mchraw-dump` 
- executable [rawdump](../Tools/rawdump.cxx)
+A (not particularly clean) example of how to decode raw data can be found in
+the source of the `o2-mchraw-dump` executable [rawdump](../Tools/rawdump.cxx)

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -74,8 +74,13 @@ static void patchPage(gsl::span<const std::byte> rdhBuffer, bool verbose)
   auto cruId = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF;
   auto flags = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF00;
   auto endpoint = o2::raw::RDHUtils::getEndPointID(rdhAny);
-  uint32_t feeId = cruId * 2 + endpoint + flags;
-  o2::raw::RDHUtils::setFEEID(rdhAny, feeId);
+  auto existingFeeId = o2::raw::RDHUtils::getFEEID(rdhAny);
+  if (existingFeeId == 0) {
+    // early versions of raw data did not set the feeId
+    // which we need to select the right decoder
+    uint32_t feeId = cruId * 2 + endpoint + flags;
+    o2::raw::RDHUtils::setFEEID(rdhAny, feeId);
+  }
 
   if (verbose) {
     std::cout << mNrdhs << "--\n";

--- a/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
@@ -20,10 +20,8 @@ namespace o2::mch::raw
 {
 namespace impl
 {
-uint16_t CRUID_MASK = 0xFF;
-uint16_t CHARGESUM_MASK = 0x100;
 
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION = 0>
 struct PayloadDecoderImpl {
 
   using type = struct PayloadDecoderImplReturnType {
@@ -33,18 +31,18 @@ struct PayloadDecoderImpl {
   type operator()(const FeeLinkId& feeLinkId, DecodedDataHandlers decodedDataHandlers, FeeLink2SolarMapper fee2solar);
 };
 
-template <typename CHARGESUM>
-struct PayloadDecoderImpl<UserLogicFormat, CHARGESUM> {
-  using type = UserLogicEndpointDecoder<CHARGESUM>;
+template <typename CHARGESUM, int VERSION>
+struct PayloadDecoderImpl<UserLogicFormat, CHARGESUM, VERSION> {
+  using type = UserLogicEndpointDecoder<CHARGESUM, VERSION>;
 
   type operator()(const FeeLinkId& feeLinkId, DecodedDataHandlers decodedDataHandlers, FeeLink2SolarMapper fee2solar)
   {
-    return std::move(UserLogicEndpointDecoder<CHARGESUM>(feeLinkId.feeId(), fee2solar, decodedDataHandlers));
+    return std::move(UserLogicEndpointDecoder<CHARGESUM, VERSION>(feeLinkId.feeId(), fee2solar, decodedDataHandlers));
   }
 };
 
 template <typename CHARGESUM>
-struct PayloadDecoderImpl<BareFormat, CHARGESUM> {
+struct PayloadDecoderImpl<BareFormat, CHARGESUM, 0> {
   using type = BareGBTDecoder<CHARGESUM>;
 
   type operator()(const FeeLinkId& feeLinkId, DecodedDataHandlers decodedDataHandlers, FeeLink2SolarMapper fee2solar)
@@ -57,7 +55,7 @@ struct PayloadDecoderImpl<BareFormat, CHARGESUM> {
   }
 };
 
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION = 0>
 class PageDecoderImpl
 {
  public:
@@ -75,11 +73,12 @@ class PageDecoderImpl
 
     auto feeId = o2::raw::RDHUtils::getFEEID(rdhP);
     auto linkId = o2::raw::RDHUtils::getLinkID(rdhP);
-    FeeLinkId feeLinkId(feeId & CRUID_MASK, linkId);
+    FEEID f{feeId};
+    FeeLinkId feeLinkId(f.id, linkId);
 
     auto p = mPayloadDecoders.find(feeLinkId);
     if (p == mPayloadDecoders.end()) {
-      mPayloadDecoders.emplace(feeLinkId, PayloadDecoderImpl<FORMAT, CHARGESUM>()(feeLinkId, mDecodedDataHandlers, mFee2SolarMapper));
+      mPayloadDecoders.emplace(feeLinkId, PayloadDecoderImpl<FORMAT, CHARGESUM, VERSION>()(feeLinkId, mDecodedDataHandlers, mFee2SolarMapper));
       p = mPayloadDecoders.find(feeLinkId);
     }
 
@@ -95,7 +94,7 @@ class PageDecoderImpl
  private:
   DecodedDataHandlers mDecodedDataHandlers;
   FeeLink2SolarMapper mFee2SolarMapper;
-  std::map<FeeLinkId, typename PayloadDecoderImpl<FORMAT, CHARGESUM>::type> mPayloadDecoders;
+  std::map<FeeLinkId, typename PayloadDecoderImpl<FORMAT, CHARGESUM, VERSION>::type> mPayloadDecoders;
 };
 
 } // namespace impl
@@ -109,19 +108,32 @@ PageDecoder createPageDecoder(RawBuffer rdhBuffer, DecodedDataHandlers decodedDa
   }
   auto linkId = o2::raw::RDHUtils::getLinkID(rdhP);
   auto feeId = o2::raw::RDHUtils::getFEEID(rdhP);
+  FEEID f{feeId};
   if (linkId == 15) {
-    if (feeId & impl::CHARGESUM_MASK) {
-      return impl::PageDecoderImpl<UserLogicFormat, ChargeSumMode>(decodedDataHandlers, fee2solar);
+    if (f.ulFormatVersion != 0 && f.ulFormatVersion != 1) {
+      throw std::logic_error(fmt::format("ulFormatVersion {} is unknown", static_cast<int>(f.ulFormatVersion)));
+    }
+    if (f.chargeSum) {
+      if (f.ulFormatVersion == 0) {
+        return impl::PageDecoderImpl<UserLogicFormat, ChargeSumMode, 0>(decodedDataHandlers, fee2solar);
+      } else if (f.ulFormatVersion == 1) {
+        return impl::PageDecoderImpl<UserLogicFormat, ChargeSumMode, 1>(decodedDataHandlers, fee2solar);
+      }
     } else {
-      return impl::PageDecoderImpl<UserLogicFormat, SampleMode>(decodedDataHandlers, fee2solar);
+      if (f.ulFormatVersion == 0) {
+        return impl::PageDecoderImpl<UserLogicFormat, SampleMode, 0>(decodedDataHandlers, fee2solar);
+      } else if (f.ulFormatVersion == 1) {
+        return impl::PageDecoderImpl<UserLogicFormat, SampleMode, 1>(decodedDataHandlers, fee2solar);
+      }
     }
   } else {
-    if (feeId & impl::CHARGESUM_MASK) {
+    if (f.chargeSum) {
       return impl::PageDecoderImpl<BareFormat, ChargeSumMode>(decodedDataHandlers, fee2solar);
     } else {
       return impl::PageDecoderImpl<BareFormat, SampleMode>(decodedDataHandlers, fee2solar);
     }
   }
+  return nullptr;
 }
 
 PageDecoder createPageDecoder(RawBuffer rdhBuffer, DecodedDataHandlers decodedDataHandlers)

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
@@ -36,7 +36,7 @@ class UserLogicElinkDecoder
   UserLogicElinkDecoder(DsElecId dsId, DecodedDataHandlers decodedDataHandlers);
 
   /// Append 50 bits-worth of data
-  void append(uint64_t data50, uint8_t error);
+  void append(uint64_t data50, uint8_t error, bool incomplete);
 
   /// Reset our internal state
   /// i.e. assume the sync has to be found again
@@ -99,11 +99,6 @@ constexpr bool isSync(uint64_t data)
   return data == sampaSyncWord;
 };
 
-constexpr bool isIncomplete(uint8_t error)
-{
-  return (error & 0x4) > 0;
-}
-
 template <typename CHARGESUM>
 UserLogicElinkDecoder<CHARGESUM>::UserLogicElinkDecoder(DsElecId dsId,
                                                         DecodedDataHandlers decodedDataHandlers)
@@ -112,10 +107,10 @@ UserLogicElinkDecoder<CHARGESUM>::UserLogicElinkDecoder(DsElecId dsId,
 }
 
 template <typename CHARGESUM>
-void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error)
+void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error, bool incomplete)
 {
 #ifdef ULDEBUG
-  debugHeader() << (*this) << fmt::format(" --> append50 {:013x} error {} incomplete {} data10={:d} {:d} {:d} {:d} {:d}\n", data50, error, (int)isIncomplete(error), static_cast<uint10_t>(data50 & 0x3FF), static_cast<uint10_t>((data50 & 0xFFC00) >> 10), static_cast<uint10_t>((data50 & 0x3FF00000) >> 20), static_cast<uint10_t>((data50 & 0xFFC0000000) >> 30), static_cast<uint10_t>((data50 & 0x3FF0000000000) >> 40));
+  debugHeader() << (*this) << fmt::format(" --> append50 {:013x} error {} incomplete {} data10={:d} {:d} {:d} {:d} {:d}\n", data50, error, incomplete, static_cast<uint10_t>(data50 & 0x3FF), static_cast<uint10_t>((data50 & 0xFFC00) >> 10), static_cast<uint10_t>((data50 & 0x3FF00000) >> 20), static_cast<uint10_t>((data50 & 0xFFC0000000) >> 30), static_cast<uint10_t>((data50 & 0x3FF0000000000) >> 40));
 #endif
 
   if (isSync(data50)) {
@@ -134,8 +129,8 @@ void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error)
     bool packetEnd = append10(static_cast<uint10_t>(data & 0x3FF));
     data >>= 10;
 #ifdef ULDEBUG
-    if (isIncomplete(error)) {
-      debugHeader() << (*this) << fmt::format(" --> incomplete {} packetEnd @i={}\n", (int)isIncomplete(error), packetEnd, i);
+    if (incomplete) {
+      debugHeader() << (*this) << fmt::format(" --> incomplete {} packetEnd @i={}\n", incomplete, packetEnd, i);
     }
 #endif
     if (hasError()) {
@@ -145,7 +140,7 @@ void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error)
       reset();
       break;
     }
-    if (isIncomplete(error) && packetEnd) {
+    if (incomplete && packetEnd) {
 #ifdef ULDEBUG
       debugHeader() << (*this) << " stop due to isIncomplete\n";
 #endif
@@ -153,7 +148,7 @@ void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error)
     }
   }
 
-  if (isIncomplete(error) && (i == 5) && (mState != State::WaitingSync)) {
+  if (incomplete && (i == 5) && (mState != State::WaitingSync)) {
 #ifdef ULDEBUG
     debugHeader() << (*this) << " data packet end not found when isIncomplete --> resetting\n";
 #endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.h
@@ -17,7 +17,7 @@
 
 namespace o2::mch::raw
 {
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION = 0>
 class ElinkEncoder;
 } // namespace o2::mch::raw
 

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoderMerger.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoderMerger.h
@@ -17,13 +17,13 @@
 
 namespace o2::mch::raw
 {
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION>
 struct ElinkEncoder;
 
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION = 0>
 struct ElinkEncoderMerger {
   void operator()(uint16_t gbtId,
-                  gsl::span<ElinkEncoder<FORMAT, CHARGESUM>> elinks,
+                  gsl::span<ElinkEncoder<FORMAT, CHARGESUM, VERSION>> elinks,
                   std::vector<uint64_t>& b64);
 };
 

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/GBTEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/GBTEncoder.h
@@ -38,7 +38,7 @@ namespace o2::mch::raw
 ///
 /// \nosubgrouping
 
-template <typename FORMAT, typename CHARGESUM>
+template <typename FORMAT, typename CHARGESUM, int VERSION = 0>
 class GBTEncoder
 {
  public:
@@ -84,10 +84,10 @@ class GBTEncoder
   size_t size() const { return mGbtWords.size(); }
 
  private:
-  uint16_t mLinkId;                                        //< id of this GBT (0..11)
-  std::array<ElinkEncoder<FORMAT, CHARGESUM>, 40> mElinks; //< the 40 Elinks we manage
-  std::vector<uint64_t> mGbtWords;                         //< the GBT words (each GBT word of 80 bits is represented by 2 64 bits words) we've accumulated so far
-  ElinkEncoderMerger<FORMAT, CHARGESUM> mElinkMerger;
+  uint16_t mLinkId;                                                 //< id of this GBT (0..11)
+  std::array<ElinkEncoder<FORMAT, CHARGESUM, VERSION>, 40> mElinks; //< the 40 Elinks we manage
+  std::vector<uint64_t> mGbtWords;                                  //< the GBT words (each GBT word of 80 bits is represented by 2 64 bits words) we've accumulated so far
+  ElinkEncoderMerger<FORMAT, CHARGESUM, VERSION> mElinkMerger;
 };
 
 inline int phase(int i, bool forceNoPhase)
@@ -107,22 +107,22 @@ inline int phase(int i, bool forceNoPhase)
   return -1;
 }
 
-template <typename FORMAT, typename CHARGESUM>
-bool GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase = false;
+template <typename FORMAT, typename CHARGESUM, int VERSION>
+bool GBTEncoder<FORMAT, CHARGESUM, VERSION>::forceNoPhase = false;
 
-template <typename FORMAT, typename CHARGESUM>
-GBTEncoder<FORMAT, CHARGESUM>::GBTEncoder(uint16_t linkId)
+template <typename FORMAT, typename CHARGESUM, int VERSION>
+GBTEncoder<FORMAT, CHARGESUM, VERSION>::GBTEncoder(uint16_t linkId)
   : mLinkId(linkId),
-    mElinks{impl::makeArray<40>([](size_t i) { return ElinkEncoder<FORMAT, CHARGESUM>(i, phase(i, GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase)); })},
+    mElinks{impl::makeArray<40>([](size_t i) { return ElinkEncoder<FORMAT, CHARGESUM, VERSION>(i, phase(i, GBTEncoder<FORMAT, CHARGESUM, VERSION>::forceNoPhase)); })},
     mGbtWords{},
     mElinkMerger{}
 {
   impl::assertIsInRange("linkId", linkId, 0, 11);
 }
 
-template <typename FORMAT, typename CHARGESUM>
-void GBTEncoder<FORMAT, CHARGESUM>::addChannelData(uint8_t elinkGroupId, uint8_t elinkIndexInGroup, uint8_t chId,
-                                                   const std::vector<SampaCluster>& data)
+template <typename FORMAT, typename CHARGESUM, int VERSION>
+void GBTEncoder<FORMAT, CHARGESUM, VERSION>::addChannelData(uint8_t elinkGroupId, uint8_t elinkIndexInGroup, uint8_t chId,
+                                                            const std::vector<SampaCluster>& data)
 {
 
   impl::assertIsInRange("elinkGroupId", elinkGroupId, 0, 7);
@@ -130,8 +130,8 @@ void GBTEncoder<FORMAT, CHARGESUM>::addChannelData(uint8_t elinkGroupId, uint8_t
   mElinks.at(elinkGroupId * 5 + elinkIndexInGroup).addChannelData(chId, data);
 }
 
-template <typename FORMAT, typename CHARGESUM>
-size_t GBTEncoder<FORMAT, CHARGESUM>::moveToBuffer(std::vector<std::byte>& buffer)
+template <typename FORMAT, typename CHARGESUM, int VERSION>
+size_t GBTEncoder<FORMAT, CHARGESUM, VERSION>::moveToBuffer(std::vector<std::byte>& buffer)
 {
   auto s = gsl::span(mElinks.begin(), mElinks.end());
   mElinkMerger(mLinkId, s, mGbtWords);

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadEncoder.cxx
@@ -22,35 +22,41 @@ namespace impl
 {
 // cannot partially specialize a function, so create a struct (which can
 // be specialized) and use it within the function below.
-template <typename FORMAT, typename CHARGESUM, bool forceNoPhase>
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase, int VERSION>
 struct PayloadEncoderCreator {
   static std::unique_ptr<PayloadEncoder> _(Solar2FeeLinkMapper solar2feelink)
   {
-    GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase = forceNoPhase;
-    return std::make_unique<PayloadEncoderImpl<FORMAT, CHARGESUM>>(solar2feelink);
+    GBTEncoder<FORMAT, CHARGESUM, VERSION>::forceNoPhase = forceNoPhase;
+    return std::make_unique<PayloadEncoderImpl<FORMAT, CHARGESUM, VERSION>>(solar2feelink);
   }
 };
 } // namespace impl
 
-template <typename FORMAT, typename CHARGESUM, bool forceNoPhase>
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase, int VERSION>
 std::unique_ptr<PayloadEncoder> createPayloadEncoder(Solar2FeeLinkMapper solar2feelink)
 {
-  return impl::PayloadEncoderCreator<FORMAT, CHARGESUM, forceNoPhase>::_(solar2feelink);
+  return impl::PayloadEncoderCreator<FORMAT, CHARGESUM, forceNoPhase, VERSION>::_(solar2feelink);
 }
 std::unique_ptr<PayloadEncoder> createPayloadEncoder(Solar2FeeLinkMapper);
 
 // define only the specializations we use
 
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, SampleMode, true>(Solar2FeeLinkMapper);
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, SampleMode, false>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, SampleMode, true, 0>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, SampleMode, false, 0>(Solar2FeeLinkMapper);
 
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, ChargeSumMode, true>(Solar2FeeLinkMapper);
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, ChargeSumMode, false>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, ChargeSumMode, true, 0>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<BareFormat, ChargeSumMode, false, 0>(Solar2FeeLinkMapper);
 
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, true>(Solar2FeeLinkMapper);
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, false>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, true, 0>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, false, 0>(Solar2FeeLinkMapper);
 
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, true>(Solar2FeeLinkMapper);
-template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, false>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, true, 0>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, false, 0>(Solar2FeeLinkMapper);
+
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, true, 1>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, SampleMode, false, 1>(Solar2FeeLinkMapper);
+
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, true, 1>(Solar2FeeLinkMapper);
+template std::unique_ptr<PayloadEncoder> createPayloadEncoder<UserLogicFormat, ChargeSumMode, false, 1>(Solar2FeeLinkMapper);
 
 } // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoder.h
@@ -26,8 +26,8 @@
 namespace o2::mch::raw
 {
 
-template <typename CHARGESUM>
-class ElinkEncoder<UserLogicFormat, CHARGESUM>
+template <typename CHARGESUM, int VERSION>
+class ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>
 {
  public:
   explicit ElinkEncoder(uint8_t elinkId, int phase = 0);
@@ -44,9 +44,9 @@ class ElinkEncoder<UserLogicFormat, CHARGESUM>
   std::vector<uint10_t> mBuffer;
 };
 
-template <typename CHARGESUM>
-ElinkEncoder<UserLogicFormat, CHARGESUM>::ElinkEncoder(uint8_t elinkId,
-                                                       int phase)
+template <typename CHARGESUM, int VERSION>
+ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>::ElinkEncoder(uint8_t elinkId,
+                                                                int phase)
   : mElinkId{elinkId},
     mHasSync{false},
     mBuffer{}
@@ -54,9 +54,9 @@ ElinkEncoder<UserLogicFormat, CHARGESUM>::ElinkEncoder(uint8_t elinkId,
   impl::assertIsInRange("elinkId", elinkId, 0, 39);
 }
 
-template <typename CHARGESUM>
-void ElinkEncoder<UserLogicFormat, CHARGESUM>::addChannelData(uint8_t chId,
-                                                              const std::vector<SampaCluster>& data)
+template <typename CHARGESUM, int VERSION>
+void ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>::addChannelData(uint8_t chId,
+                                                                       const std::vector<SampaCluster>& data)
 {
   if (data.empty()) {
     throw std::invalid_argument("cannot add empty data");
@@ -73,29 +73,30 @@ void ElinkEncoder<UserLogicFormat, CHARGESUM>::addChannelData(uint8_t chId,
   }
 }
 
-template <typename CHARGESUM>
-void ElinkEncoder<UserLogicFormat, CHARGESUM>::clear()
+template <typename CHARGESUM, int VERSION>
+void ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>::clear()
 {
   mBuffer.clear();
   mHasSync = false;
 }
 
-template <typename CHARGESUM>
-size_t ElinkEncoder<UserLogicFormat, CHARGESUM>::moveToBuffer(std::vector<uint64_t>& buffer, uint16_t gbtId)
+template <typename CHARGESUM, int VERSION>
+size_t ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>::moveToBuffer(std::vector<uint64_t>& buffer, uint16_t gbtId)
 {
   if (mBuffer.empty()) {
     return 0;
   }
 
-  int error{0}; // FIXME: what to do with error ?
-  uint16_t b9{0};
+  ULHeaderWord<VERSION> header{0};
+  header.linkID = gbtId;
+  header.dsID = mElinkId;
+  header.incomplete = 0; // FIXME: what to do with incomplete ?
+  header.error = 0;      // FIXME: what to do with error ?
 
-  b9 |= static_cast<uint64_t>(gbtId & 0x1F) << 9;
-  b9 |= static_cast<uint64_t>(mElinkId & 0x3F) << 3;
-  b9 |= static_cast<uint64_t>(error & 0x3);
+  uint16_t b14 = static_cast<uint16_t>((header.word >> 50) & 0xFFFF); // keep only 14 most significant bits of header word
 
   auto n = buffer.size();
-  impl::b10to64(mBuffer, buffer, b9);
+  impl::b10to64(mBuffer, buffer, b14);
   clear();
   return buffer.size() - n;
 }

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoderMerger.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoderMerger.h
@@ -18,11 +18,11 @@
 namespace o2::mch::raw
 {
 
-template <typename CHARGESUM>
-struct ElinkEncoderMerger<UserLogicFormat, CHARGESUM> {
+template <typename CHARGESUM, int VERSION>
+struct ElinkEncoderMerger<UserLogicFormat, CHARGESUM, VERSION> {
 
   void operator()(uint16_t gbtId,
-                  gsl::span<ElinkEncoder<UserLogicFormat, CHARGESUM>> elinks,
+                  gsl::span<ElinkEncoder<UserLogicFormat, CHARGESUM, VERSION>> elinks,
                   std::vector<uint64_t>& b64)
   {
     for (auto& elink : elinks) {

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadEncoder.h
@@ -66,9 +66,11 @@ class PayloadEncoder
 /// \tparam FORMAT defines the data format (either BareFormat or UserLogic)
 /// \tparam CHARGESUM defines the data format mode (either SampleMode or ChargeSumMode)
 /// \tparam forceNoPhase to be deprecated ?
+/// \tparam VERSION defines the version of the FORMAT
+///         (currently 0 or 1 are possible, just for UserLogic)
 /// \param solar2feelink a mapper to convert solarId values into FeeLinkId objects
 ///
-template <typename FORMAT, typename CHARGESUM, bool forceNoPhase = false>
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase = false, int VERSION = 0>
 std::unique_ptr<PayloadEncoder> createPayloadEncoder(Solar2FeeLinkMapper solar2feelink =
                                                        createSolar2FeeLinkMapper<ElectronicMapperGenerated>());
 } // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -44,7 +44,7 @@ The workflow accepts the following options:
 Example of a DPL chain to go from a raw data file to a file of preclusters :
 
 ```shell
-o2-raw-file-reader-workflow --conf file-reader.cfg --loop 0  -b |
+o2-raw-file-reader-workflow --input-conf file-reader.cfg --loop 0  -b |
 o2-mch-raw-to-digits-workflow -b |
 o2-mch-digits-to-preclusters-workflow -b |
 o2-mch-preclusters-sink-workflow -b


### PR DESCRIPTION
This PR introduces the necessary changes to the MCH decoder (and encoder) to deal with the new raw data format coming from the CRU UserLogic code.

The format changes are somewhat much smaller than the number of changes in this PR, but : 
- the idea is that the next format change will be much easier to absorb ;-) 
- the core of the changes boils down to adding a VERSION template parameter where needed; admittedly in quite a number of locations, but none that are part of interfaces (i.e. the version handling stays an implementation detail)