### PR TITLE
TRD tracking with ITS-TPC tracks and TRD tracklets in Run 3 format

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -26,7 +26,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "Rtypes.h" // for ClassDef
+#include "GPUCommonDef.h"
+#include "GPUCommonRtypes.h"
 
 namespace o2
 {
@@ -45,11 +46,11 @@ class Tracklet64
 {
 
  public:
-  Tracklet64() = default;
-  Tracklet64(uint64_t trackletword) { mtrackletWord = trackletword; }
-  Tracklet64(const Tracklet64&) = default;
-  Tracklet64(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position,
-             uint64_t slope, uint64_t Q0, uint64_t Q1, uint64_t Q2)
+  GPUdDefault() Tracklet64() = default;
+  GPUd() Tracklet64(uint64_t trackletword) { mtrackletWord = trackletword; }
+  GPUdDefault() Tracklet64(const Tracklet64&) = default;
+  GPUd() Tracklet64(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position,
+                    uint64_t slope, uint64_t Q0, uint64_t Q1, uint64_t Q2)
   {
     mtrackletWord = ((format << formatbs) & formatmask) |
                     ((hcid << hcidbs) & hcidmask) |
@@ -62,66 +63,68 @@ class Tracklet64
                     ((Q0 << Q0bs) & Q0mask);
   }
 
-  ~Tracklet64() = default;
-  Tracklet64& operator=(const Tracklet64& rhs) = default;
+  GPUdDefault() ~Tracklet64() = default;
+  GPUdDefault() Tracklet64& operator=(const Tracklet64& rhs) = default;
 
   // ----- Getters for contents of tracklet word -----
-  uint64_t getHCID() const { return ((mtrackletWord & hcidmask) >> hcidbs); };       // no units 0..1077
-  uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // pad row number [0..15]
-  uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // column refers to MCM position in column direction on readout board [0..3]
-  uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs); };     // in units of 1/80 pads, 11 bit granularity [-12.8..12.8] relative to MCM center
-  uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };    // in units of 1/1000 pads/timebin, 8 bit granularity [-0.128 to 0.128]
-  uint64_t getPID() const { return ((mtrackletWord & PIDmask)); };                   // no unit, all 3 charge windows combined
-  uint64_t getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };             // no unit
-  uint64_t getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };             // no unit
-  uint64_t getQ2() const { return ((mtrackletWord & Q2mask) >> Q2bs); };             // no unit
+  GPUd() uint64_t getHCID() const { return ((mtrackletWord & hcidmask) >> hcidbs); };       // no units 0..1077
+  GPUd() uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // pad row number [0..15]
+  GPUd() uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // column refers to MCM position in column direction on readout board [0..3]
+  GPUd() uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs); };     // in units of 1/80 pads, 11 bit granularity [-12.8..12.8] relative to MCM center
+  GPUd() uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };    // in units of 1/1000 pads/timebin, 8 bit granularity [-0.128 to 0.128]
+  GPUd() uint64_t getPID() const { return ((mtrackletWord & PIDmask)); };                   // no unit, all 3 charge windows combined
+  GPUd() uint64_t getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };             // no unit
+  GPUd() uint64_t getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };             // no unit
+  GPUd() uint64_t getQ2() const { return ((mtrackletWord & Q2mask) >> Q2bs); };             // no unit
 
-  void setTrackletWord(uint64_t trackletword) { mtrackletWord = trackletword; }
+  GPUd() void setTrackletWord(uint64_t trackletword) { mtrackletWord = trackletword; }
 
   // ----- Getters for tracklet information -----
-  int getMCM() const { return 4 * (getPadRow() % 4) + getColumn(); }                                 // returns MCM position on ROB [0..15]
-  int getROB() const { return (getHCID() % 2) ? (getPadRow() / 4) * 2 + 1 : (getPadRow() / 4) * 2; } // returns ROB number [0..5] for C0 chamber and [0..7] for C1 chamber
-  float getUncalibratedY() const;                                                                    // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
-  float getUncalibratedDy(float nTbDrift = 19.4f) const;                                             // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
+  GPUd() int getMCM() const { return 4 * (getPadRow() % 4) + getColumn(); }                                 // returns MCM position on ROB [0..15]
+  GPUd() int getROB() const { return (getHCID() % 2) ? (getPadRow() / 4) * 2 + 1 : (getPadRow() / 4) * 2; } // returns ROB number [0..5] for C0 chamber and [0..7] for C1 chamber
+  GPUd() float getUncalibratedY() const;                                                                    // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
+  GPUd() float getUncalibratedDy(float nTbDrift = 19.4f) const;                                             // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
 
   // ----- Getters for offline corresponding values -----
-  int getDetector() const { return getHCID() / 2; }
+  GPUd() int getDetector() const { return getHCID() / 2; }
 
-  uint64_t getTrackletWord() const { return mtrackletWord; }
+  GPUd() uint64_t getTrackletWord() const { return mtrackletWord; }
 
-  void setQ0(int charge)
+  GPUd() void setQ0(int charge)
   {
     mtrackletWord &= ~Q0mask;
     mtrackletWord |= ((charge << Q0bs) & Q0mask);
   }
-  void setQ1(int charge)
+  GPUd() void setQ1(int charge)
   {
     mtrackletWord &= ~Q1mask;
     mtrackletWord |= ((charge << Q1bs) & Q1mask);
   }
-  void setQ2(int charge)
+  GPUd() void setQ2(int charge)
   {
     mtrackletWord &= ~Q2mask;
     mtrackletWord |= ((charge << Q2bs) & Q2mask);
   }
-  void setPID(uint64_t pid)
+  GPUd() void setPID(uint64_t pid)
   {
     // set the entire pid area of the trackletword, all the 3 Q's
     mtrackletWord &= ~PIDmask;
     mtrackletWord |= ((pid << PIDbs) & PIDmask);
   }
-  void setPosition(uint64_t position)
+  GPUd() void setPosition(uint64_t position)
   {
     mtrackletWord &= ~posmask;
     mtrackletWord |= ((position << posbs) & posmask);
   }
-  void setSlope(uint64_t slope)
+  GPUd() void setSlope(uint64_t slope)
   {
     mtrackletWord &= ~slopemask;
     mtrackletWord |= ((slope << slopebs) & slopemask);
   }
 
+#ifndef GPUCA_GPUCODE_DEVICE
   void printStream(std::ostream& stream) const;
+#endif // GPUCA_GPUCODE_DEVICE
 
   // bit masks for the above raw data;
   static constexpr uint64_t formatmask = 0xf000000000000000;
@@ -152,7 +155,9 @@ class Tracklet64
   ClassDefNV(Tracklet64, 1);
 };
 
+#ifndef GPUCA_GPUCODE_DEVICE
 std::ostream& operator<<(std::ostream& stream, const Tracklet64& trg);
+#endif // GPUCA_GPUCODE_DEVICE
 
 } //namespace trd
 } //namespace o2

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -22,7 +22,7 @@ namespace trd
 
 using namespace constants;
 
-float Tracklet64::getUncalibratedY() const
+GPUd() float Tracklet64::getUncalibratedY() const
 {
   int padLocalBin = getPosition();
   int padLocal = 0;
@@ -37,7 +37,7 @@ float Tracklet64::getUncalibratedY() const
   return (offset + padLocal * GRANULARITYTRKLPOS) * padWidth;
 }
 
-float Tracklet64::getUncalibratedDy(float nTbDrift) const
+GPUd() float Tracklet64::getUncalibratedDy(float nTbDrift) const
 {
   float dy;
   int dyLocalBin = getSlope();
@@ -51,6 +51,7 @@ float Tracklet64::getUncalibratedDy(float nTbDrift) const
   return dy * GRANULARITYTRKLSLOPE * padWidth * nTbDrift;
 }
 
+#ifndef GPUCA_GPUCODE_DEVICE
 void Tracklet64::printStream(std::ostream& stream) const
 {
   stream << "Tracklet64 : 0x" << std::hex << getTrackletWord();
@@ -65,6 +66,7 @@ std::ostream& operator<<(std::ostream& stream, const Tracklet64& trg)
   trg.printStream(stream);
   return stream;
 }
+#endif // GPUCA_GPUCODE_DEVICE
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -140,11 +140,8 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
 
   for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
     auto trklt = trackletsTRD[iTrklt];
-    unsigned int trkltWord = 0; // DUMMY
-    GPUTRDTrackletWord trkltLoad;
+    GPUTRDTrackletWord trkltLoad(trklt.getTrackletWord());
     trkltLoad.SetId(iTrklt);
-    trkltLoad.SetHCId(trklt.getHCID());
-    trkltLoad.SetTrackletWord(trkltWord);
     if (mTracker->LoadTracklet(trkltLoad) > 0) {
       LOG(WARNING) << "Could not load tracklet " << iTrklt;
     }

--- a/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cl
+++ b/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCL.cl
@@ -56,6 +56,7 @@
   #define nullptr NULL
   #define NULL (0x0)
 #endif
+#define uint64_t unsigned long
 #define uint32_t unsigned int
 #define uint16_t unsigned short
 #define uint8_t unsigned char

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -169,7 +169,7 @@ class GPUTRDTracker_t : public GPUProcessor
  protected:
   float* mR;                               // radial position of each TRD chamber, alignment taken into account, radial spread within chambers < 7mm
   bool mIsInitialized;                     // flag is set upon initialization
-  bool mProcessPerTimeFrame;               // if true, tracking is done per time frame instead of on a single events basis //FIXME is this needed??
+  bool mProcessPerTimeFrame;               // if true, tracking is done per time frame instead of on a single events basis
   short mMemoryPermanent;                  // size of permanent memory for the tracker
   short mMemoryTracklets;                  // size of memory for TRD tracklets
   short mMemoryTracks;                     // size of memory for tracks (used for i/o)
@@ -181,12 +181,15 @@ class GPUTRDTracker_t : public GPUProcessor
   int mNCollisions;                        // number of collisions with TRD tracklet data
   int mNTracks;                            // number of TPC tracks to be matched
   int mNEvents;                            // number of processed events
-  int* mTriggerRecordIndices;              // index of first tracklet for each collision
+  int* mTriggerRecordIndices;              // index of first tracklet for each collision within mTracklets array
   float* mTriggerRecordTimes;              // time in us for each collision
-  GPUTRDTrackletWord* mTracklets;          // array of all tracklets, later sorted by HCId
+  GPUTRDTrackletWord* mTracklets;          // array of all tracklets (later sorted by HCId for each collision individually)
   int mMaxThreads;                         // maximum number of supported threads
   int mNTracklets;                         // total number of tracklets in event
-  int* mTrackletIndexArray;                // index of first tracklet for each chamber, last entry is the total amount of tracklets
+  // index of first tracklet for each chamber within mTracklets array, last entry is total number of tracklets for given collision
+  // the array has (kNChambers + 1) * mNCollisions entries
+  // note, that for collision iColl one has to add an offset of mTriggerRecordIndices[iColl] to the index stored in mTrackletIndexArray
+  int* mTrackletIndexArray;
   Hypothesis* mHypothesis;                 // array with multiple track hypothesis
   TRDTRK* mCandidates;                     // array of tracks for multiple hypothesis tracking
   GPUTRDSpacePointInternal* mSpacePoints;  // array with tracklet coordinates in global tracking frame

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
@@ -13,6 +13,12 @@
 
 #include "GPUTRDTrackletWord.h"
 using namespace GPUCA_NAMESPACE::gpu;
+
+#ifndef GPUCA_TPC_GEOMETRY_O2
+
+#include "AliTRDtrackletWord.h"
+#include "AliTRDtrackletMCM.h"
+
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <new>
 #endif
@@ -20,18 +26,12 @@ using namespace GPUCA_NAMESPACE::gpu;
 GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord) : mId(-1), mHCId(-1), mTrackletWord(trackletWord)
 {
 }
-
 GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord, int hcid, int id) : mId(id), mHCId(hcid), mTrackletWord(trackletWord) {}
 
 #ifndef GPUCA_GPUCODE_DEVICE
-#ifdef GPUCA_ALIROOT_LIB
-#include "AliTRDtrackletWord.h"
-#include "AliTRDtrackletMCM.h"
-
 GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletWord& rhs) : mId(-1), mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord())
 {
 }
-
 GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletMCM& rhs) : mId(-1), mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord()) {}
 
 GPUTRDTrackletWord& GPUTRDTrackletWord::operator=(const AliTRDtrackletMCM& rhs)
@@ -41,7 +41,6 @@ GPUTRDTrackletWord& GPUTRDTrackletWord::operator=(const AliTRDtrackletMCM& rhs)
   return *this;
 }
 
-#endif // GPUCA_ALIROOT_LIB
 #endif // GPUCA_GPUCODE_DEVICE
 
 GPUd() int GPUTRDTrackletWord::GetYbin() const
@@ -63,3 +62,5 @@ GPUd() int GPUTRDTrackletWord::GetdY() const
     return ((mTrackletWord >> 13) & 0x7f);
   }
 }
+
+#endif // !GPUCA_TPC_GEOMETRY_O2

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
@@ -18,6 +18,8 @@
 
 #include "GPUDef.h"
 
+#ifndef GPUCA_TPC_GEOMETRY_O2 // compatibility to Run 2 data types
+
 class AliTRDtrackletWord;
 class AliTRDtrackletMCM;
 
@@ -74,5 +76,44 @@ class GPUTRDTrackletWord
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
+
+#else // compatibility with Run 3 data types
+
+#include "DataFormatsTRD/Tracklet64.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+class GPUTRDTrackletWord : private o2::trd::Tracklet64
+{
+ public:
+  GPUd() GPUTRDTrackletWord(uint64_t trackletWord = 0) : o2::trd::Tracklet64(trackletWord){};
+  GPUdDefault() GPUTRDTrackletWord(const GPUTRDTrackletWord& rhs) CON_DEFAULT;
+  GPUdDefault() GPUTRDTrackletWord& operator=(const GPUTRDTrackletWord& rhs) CON_DEFAULT;
+  GPUdDefault() ~GPUTRDTrackletWord() CON_DEFAULT;
+
+  // ----- Override operators < and > to enable tracklet sorting by HCId -----
+  GPUd() bool operator<(const GPUTRDTrackletWord& t) const { return (getHCID() < t.getHCID()); }
+  GPUd() bool operator>(const GPUTRDTrackletWord& t) const { return (getHCID() > t.getHCID()); }
+  GPUd() bool operator<=(const GPUTRDTrackletWord& t) const { return (getHCID() < t.getHCID()) || (getHCID() == t.getHCID()); }
+
+  GPUd() int GetZbin() const { return getPadRow(); }
+  GPUd() float GetY() const { return getUncalibratedY(); }
+  GPUd() float GetdY() const { return getUncalibratedDy(); }
+  GPUd() int GetDetector() const { return getDetector(); }
+  GPUd() int GetId() const { return mId; }
+
+  GPUd() void SetId(int id) { mId = id; }
+
+ protected:
+  int mId; // index in tracklet input block
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif // GPUCA_TPC_GEOMETRY_O2
 
 #endif // GPUTRDTRACKLETWORD_H


### PR DESCRIPTION
With these changes one can already run the reconstruction with TRD tracklets in the new Run 3 format via the `o2-trd-global-tracking` workflow.
Still using the uncalibrated values for offset and deflections, but the results nevertheless look quite good in terms of number of attached tracklets per input track.