### PR TITLE
PWGHF: fix wrong casting of track index

### DIFF
--- a/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator2Prong.cxx
@@ -69,9 +69,11 @@ struct HFCandidateCreator2Prong {
 
     // loop over pairs of track indices
     for (const auto& rowTrackIndexProng2 : rowsTrackIndexProng2) {
-      auto trackParVarPos1 = getTrackParCov(rowTrackIndexProng2.index0_as<aod::BigTracks>());
-      auto trackParVarNeg1 = getTrackParCov(rowTrackIndexProng2.index1_as<aod::BigTracks>());
-      auto collision = rowTrackIndexProng2.index0().collision();
+      auto track0 = rowTrackIndexProng2.index0_as<aod::BigTracks>();
+      auto track1 = rowTrackIndexProng2.index1_as<aod::BigTracks>();
+      auto trackParVarPos1 = getTrackParCov(track0);
+      auto trackParVarNeg1 = getTrackParCov(track1);
+      auto collision = track0.collision();
 
       // reconstruct the 2-prong secondary vertex
       if (df.process(trackParVarPos1, trackParVarNeg1) == 0) {

--- a/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Analysis/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -68,10 +68,13 @@ struct HFCandidateCreator3Prong {
 
     // loop over triplets of track indices
     for (const auto& rowTrackIndexProng3 : rowsTrackIndexProng3) {
-      auto trackParVar0 = getTrackParCov(rowTrackIndexProng3.index0_as<aod::BigTracks>());
-      auto trackParVar1 = getTrackParCov(rowTrackIndexProng3.index1_as<aod::BigTracks>());
-      auto trackParVar2 = getTrackParCov(rowTrackIndexProng3.index2_as<aod::BigTracks>());
-      auto collision = rowTrackIndexProng3.index0().collision();
+      auto track0 = rowTrackIndexProng3.index0_as<aod::BigTracks>();
+      auto track1 = rowTrackIndexProng3.index1_as<aod::BigTracks>();
+      auto track2 = rowTrackIndexProng3.index2_as<aod::BigTracks>();
+      auto trackParVar0 = getTrackParCov(track0);
+      auto trackParVar1 = getTrackParCov(track1);
+      auto trackParVar2 = getTrackParCov(track2);
+      auto collision = track0.collision();
 
       // reconstruct the 3-prong secondary vertex
       if (df.process(trackParVar0, trackParVar1, trackParVar2) == 0) {


### PR DESCRIPTION
Call to default `.index0()` resulted in malformed track iterator and caused a crash. 
Additionally, index getters should be called once, especially in a loop, as each call creates a copy of an iterator object. 