### PR TITLE
Library to keep track of (build) versions/revisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ if (ENABLE_UPGRADES)
   add_definitions(-DENABLE_UPGRADES)
 endif()
 
+add_subdirectory(version)
+
 include(O2DefineOutputPaths)
 o2_define_output_paths()
 

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -55,7 +55,7 @@ o2_add_executable(serial
 
 o2_add_executable(sim
                   SOURCES o2sim_parallel.cxx
-                  PUBLIC_LINK_LIBRARIES internal::allsim)
+                  PUBLIC_LINK_LIBRARIES internal::allsim O2::Version)
 
 o2_add_executable(primary-server-device-runner
                   COMPONENT_NAME sim

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -37,6 +37,8 @@
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/filewritestream.h"
 
+#include "O2Version.h"
+
 std::string getServerLogName()
 {
   auto& conf = o2::conf::SimConfig::Instance();
@@ -170,6 +172,9 @@ void launchThreadMonitoringEvents(
 // for parallel simulation
 int main(int argc, char* argv[])
 {
+  LOG(INFO) << "This is o2-sim version " << o2::fullVersion() << " (" << o2::gitRevision() << ")";
+  LOG(INFO) << o2::getBuildInfo();
+
   signal(SIGINT, sighandler);
   signal(SIGTERM, sighandler);
   // we enable the forked version of the code by default

--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Generate a O2Version header and library that contain a couple of useful
+# fields such as the git commit with which we build.
+# We can also use this to define VERSION MACROS etc.
+
+include(O2NameTarget)
+
+execute_process(COMMAND git log --oneline -1 --pretty=format:%h
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} 
+                OUTPUT_VARIABLE O2_GIT_REVISION
+                RESULT_VARIABLE O2_GITCHECK_RETURN_STATUS)
+
+# check if above command was ok
+if (NOT O2_GITCHECK_RETURN_STATUS STREQUAL "0")
+  set(O2_GIT_REVISION "--unknown--")
+endif()
+
+# check if we there are uncommited changes to the git
+execute_process(COMMAND git diff-index HEAD --
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE O2_LOCAL_CHANGES
+                RESULT_VARIABLE O2_LOCAL_CHANGES_RETURN_STATUS)
+
+if (O2_LOCAL_CHANGES_RETURN_STATUS STREQUAL "0" 
+    AND DEFINED O2_LOCAL_CHANGES
+    AND NOT O2_LOCAL_CHANGES STREQUAL "")
+  set(O2_GIT_REVISION "${O2_GIT_REVISION} (+local changes)")
+endif()
+
+if(DEFINED ENV{ALIBUILD_VERSION})
+  # The build was done with alibuild
+  # We record the alibuild version and alidist revision.
+  # -- PLEASE KEEP comma separated format with key:value so that parsing is possible --
+  set(BUILD_INFO_TEXT "ALIBUILD:$ENV{ALIBUILD_VERSION}, ALIDIST-REV:$ENV{ALIBUILD_ALIDIST_HASH}")
+else()
+  # The build was done by other means
+  set(BUILD_INFO_TEXT "--unavailable--")
+endif()
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/O2Version.cxx.in
+               ${CMAKE_CURRENT_BINARY_DIR}/O2Version.cxx @ONLY)
+
+# provide a static lib for internal linking
+add_library(version STATIC)
+target_sources(version PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/O2Version.cxx)
+target_include_directories(version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(O2::Version ALIAS version)
+
+# provide also a shared lib + header so that we can query from outside (ROOT macros)
+add_library(O2Version_shared)
+target_sources(O2Version_shared PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/O2Version.cxx)
+target_include_directories(O2Version_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(O2::VersionShared ALIAS O2Version_shared)
+
+install(FILES O2Version.h DESTINATION include)
+install(TARGETS O2Version_shared DESTINATION lib)
+

--- a/version/O2Version.cxx.in
+++ b/version/O2Version.cxx.in
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "O2Version.h"
+
+namespace o2
+{
+
+std::string fullVersion()
+{
+  return "@O2_VERSION@";
+}
+
+std::string gitRevision()
+{
+  return "@O2_GIT_REVISION@";
+}
+
+/// get information about build environment (for example OS and alibuild/alidist release when used)
+std::string getBuildInfo()
+{
+  return "Built by @BUILD_INFO_TEXT@ on OS:@CMAKE_SYSTEM@";
+}
+
+} // namespace o2

--- a/version/O2Version.h
+++ b/version/O2Version.h
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma once
+
+#include <string>
+
+namespace o2
+{
+/// get full version information (official O2 release and git commit)
+std::string fullVersion();
+
+/// get O2 git commit used to build this
+std::string gitRevision();
+
+/// get information about build platform (for example OS and alidist release when used)
+std::string getBuildInfo();
+} // namespace o2

--- a/version/O2Version.h.in
+++ b/version/O2Version.h.in
@@ -1,0 +1,18 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// This file provides information about how O2 was built
+// and potentially other version information.
+
+#pragma once
+
+#define O2_GIT_REVISION "@O2_GIT_REVISION@"
+#define ALIDIST_GIT_REVISION "@ALIDIST_GIT_REVISION@"
+


### PR DESCRIPTION
Introducing an autogenerated lib that
for now contains the O2 + ALIDIST revision used
for building. This can be helpful to check compatibility
of reco/sim products and O2 versions.