### PR TITLE
[EMCAL-685] Implementation of a ring buffer for EMCAL digits

### DIFF
--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -10,14 +10,15 @@
 
 o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/DigitizerTask.cxx
-                       src/SpaceFrame.cxx src/SimParam.cxx src/LabeledDigit.cxx
-                       src/RawWriter.cxx
+                       src/DigitsWriteoutBuffer.cxx src/SpaceFrame.cxx src/SimParam.cxx
+                       src/LabeledDigit.cxx src/RawWriter.cxx
                PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h
                                   include/EMCALSimulation/Digitizer.h
                                   include/EMCALSimulation/DigitizerTask.h
+                                  include/EMCALSimulation/DigitsWriteoutBuffer.h
                                   include/EMCALSimulation/RawWriter.h
                                   include/EMCALSimulation/SpaceFrame.h
                                   include/EMCALSimulation/SimParam.h

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -1,0 +1,84 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_DIGITSWRITEOUTBUFFER_H_
+#define ALICEO2_EMCAL_DIGITSWRITEOUTBUFFER_H_
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <deque>
+#include "DataFormatsEMCAL/Digit.h"
+#include "EMCALSimulation/LabeledDigit.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+/// \class DigitsWriteoutBuffer
+/// \brief Container class for time sampled digits
+/// \ingroup EMCALsimulation
+/// \author Hadi Hassan, ORNL
+/// \author Markus Fasel, ORNL
+/// \date 08/03/2021
+
+class DigitsWriteoutBuffer
+{
+ public:
+  /// Default constructor
+  DigitsWriteoutBuffer(unsigned int nTimeBins = 30, unsigned int binWidth = 100);
+
+  /// Destructor
+  ~DigitsWriteoutBuffer() = default;
+
+  /// Reset the container
+  void reset();
+
+  /// Add digit to the container
+  /// \param towerID Cell ID
+  /// \param dig Labaled digit to add
+  /// \param eventTime The time of the event (w.r.t Tigger time)
+  void addDigit(unsigned int towerID, LabeledDigit dig, double eventTime);
+
+  /// Getter for the last N entries (time samples) in the ring buffer
+  /// \param nsample number of entries to be written
+  /// \return Vector of map of cell IDs and labeled digits in that cell
+  gsl::span<std::unordered_map<int, LabeledDigit>> getLastNSamples(int nsample = 15);
+
+  /// Forwards the marker to the next time sample every mTimeBinWidth
+  void forwardMarker(double eventTime);
+
+  void setNumberReadoutSamples(unsigned int nsamples) { mNumberReadoutSamples = nsamples; }
+
+  /// Getter for current position in the ring buffer
+  /// \return current position
+  std::tuple<double, int> getCurrentTimeAndPosition() const { return std::make_tuple(mMarker.mReferenceTime, mMarker.mPositionInBuffer - mTimedDigits.begin()); }
+
+ private:
+  struct Marker {
+    double mReferenceTime;
+    std::deque<std::unordered_map<int, LabeledDigit>>::iterator mPositionInBuffer;
+  };
+
+  unsigned int mBufferSize = 30;                                  ///< The size of the buffer, it has to be at least 2 times the size of the readout cycle
+  unsigned int mTimeBinWidth = 100;                               ///< The size of the time bin (ns)
+  unsigned int mNumberReadoutSamples = 15;                        ///< The number of smaples in a readout window
+  Marker mMarker;                                                 ///< Marker for the current time sample
+  std::deque<std::unordered_map<int, LabeledDigit>> mTimedDigits; ///< Container for time sampled digits per tower ID
+
+  ClassDefNV(DigitsWriteoutBuffer, 1);
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif /* ALICEO2_EMCAL_DIGITSWRITEOUTBUFFER_H_ */

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -1,0 +1,61 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <unordered_map>
+#include <vector>
+#include <deque>
+#include <gsl/span>
+#include "EMCALSimulation/LabeledDigit.h"
+#include "EMCALSimulation/DigitsWriteoutBuffer.h"
+
+using namespace o2::emcal;
+
+DigitsWriteoutBuffer::DigitsWriteoutBuffer(unsigned int nTimeBins, unsigned int binWidth) : mBufferSize(nTimeBins),
+                                                                                            mTimeBinWidth(binWidth)
+{
+  mTimedDigits.resize(nTimeBins);
+  mMarker.mReferenceTime = 0.;
+  mMarker.mPositionInBuffer = mTimedDigits.begin();
+}
+
+void DigitsWriteoutBuffer::reset()
+{
+  mTimedDigits.clear();
+  mMarker.mReferenceTime = 0.;
+  mMarker.mPositionInBuffer = mTimedDigits.begin();
+}
+
+void DigitsWriteoutBuffer::addDigit(unsigned int towerID, LabeledDigit dig, double eventTime)
+{
+
+  int nsamples = int((eventTime - mMarker.mReferenceTime) / mTimeBinWidth);
+  auto timeEntry = mMarker.mPositionInBuffer + nsamples;
+  timeEntry->insert(std::make_pair(towerID, dig));
+}
+
+void DigitsWriteoutBuffer::forwardMarker(double eventTime)
+{
+  mMarker.mReferenceTime = eventTime;
+  mMarker.mPositionInBuffer++;
+
+  // Allocate new memory at the end
+  mTimedDigits.push_back(std::unordered_map<int, LabeledDigit>());
+
+  // Drop entry at the front, because it is outside the current readout window
+  // only done if we have at least 15 entries
+  if (mMarker.mPositionInBuffer - mTimedDigits.begin() > mNumberReadoutSamples) {
+    mTimedDigits.pop_front();
+  }
+}
+
+gsl::span<std::unordered_map<int, LabeledDigit>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
+{
+  return gsl::span<std::unordered_map<int, LabeledDigit>>(&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], nsamples);
+}

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::base::DetImpl < o2::emcal::Detector> + ;
 #pragma link C++ class o2::emcal::Digitizer + ;
 #pragma link C++ class o2::emcal::DigitizerTask + ;
+#pragma link C++ class o2::emcal::DigitsWriteoutBuffer + ;
 #pragma link C++ class o2::emcal::SimParam + ;
 #pragma link C++ class o2::emcal::LabeledDigit + ;
 #pragma link C++ class o2::emcal::RawWriter + ;


### PR DESCRIPTION
A ring buffer is a continuous buffer which has at least 2 times the size of the amount of readout cycles. Once the time response is simulated it is filled in the future direction, but when the readout window is closed, it provides access to the N last digits.