### PR TITLE
Generate a o2-build-database.json file

### DIFF
--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -56,3 +56,14 @@ add_library(O2::VersionShared ALIAS O2Version_shared)
 install(FILES O2Version.h DESTINATION include)
 install(TARGETS O2Version_shared DESTINATION lib)
 
+
+# We also create a simple queryable json file containing the full
+# alibuild/alidist information. Can be augmented with further information.
+
+if(DEFINED ENV{ALIBUILD_VERSION})
+  execute_process(COMMAND ${CMAKE_SOURCE_DIR}/version/RecordBuildDetails.py
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  OUTPUT_FILE o2-build-database.json)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/o2-build-database.json DESTINATION share/version/)
+endif()

--- a/version/RecordBuildDetails.py
+++ b/version/RecordBuildDetails.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# A simple python script producing a JSON
+# containing details of O2 software dependencies
+# in the alibuild/alidist stack during build.
+# The json can be used as a single and fast place
+# to query for instance which Geant4, etc., this O2 
+# was compiled against.
+
+# Alibuild provides environment variables _REVISION _VERSION
+# which tell us the software packages going into the build.
+
+import os
+import re
+
+# check if we found a possible Alibuild Entry
+# the package name is returned in variable package
+def isAlibuildEntry(key):
+    m = re.match('(.*)_(VERSION)',key)
+    if m!=None:
+       package=m.group(1)
+       entry="VERSION"
+       return (package, entry)
+    m = re.match('(.*)_HASH',key)
+    if m!=None:
+       package=m.group(1)
+       entry="HASH"
+       return (package, entry)
+
+    return None
+
+# we record information in this dictionary
+build_dict={}
+
+for e in os.environ:
+    check = isAlibuildEntry(e)
+    if check!=None:
+       package=check[0]
+       entry=check[1]
+       packageentry=build_dict.get(package)
+       if packageentry != None:
+           packageentry[entry]=os.environ[e]
+       else:
+           build_dict[package]={ entry:os.environ[e] }
+
+# only keep entries that have all wanted features
+final_build_dict = { e:v for e,v in build_dict.items() if len(v) == 2 }
+
+import json
+with open('o2-build-database.json', 'w') as outfile:
+    json.dump(final_build_dict, outfile, indent=2)
+


### PR DESCRIPTION
Generate a json database file that contains
full information about software packages and their
versions, that went into the O2 build.

This is an incremental step to more versioning
information. As a json, this can be easily queried
by external tools. The file could be used to detect
the exact dependency differences between any two O2
installations.

The file is inspired by compilations_database.json
produced by CMake with a similar intention (but different
scope).