### PR TITLE
MCReader: release early

### DIFF
--- a/Steer/include/Steer/MCKinematicsReader.h
+++ b/Steer/include/Steer/MCKinematicsReader.h
@@ -75,6 +75,9 @@ class MCKinematicsReader
   /// variant returning all tracks for source and event at once
   std::vector<MCTrack> const& getTracks(int source, int event) const;
 
+  /// API to ask releasing tracks (freeing memory) for source + event
+  void releaseTracksForSourceAndEvent(int source, int event);
+
   /// variant returning all tracks for source and event at once
   std::vector<MCTrack> const& getTracks(int event) const;
 
@@ -106,7 +109,8 @@ class MCKinematicsReader
   }
 
  private:
-  void loadTracksForSource(int source) const;
+  void initTracksForSource(int source) const;
+  void loadTracksForSourceAndEvent(int source, int eventID) const;
   void loadHeadersForSource(int source) const;
   void loadTrackRefsForSource(int source) const;
   void initIndexedTrackRefs(std::vector<o2::TrackReference>& refs, o2::dataformats::MCTruthContainer<o2::TrackReference>& indexedrefs) const;
@@ -117,7 +121,7 @@ class MCKinematicsReader
   std::vector<TChain*> mInputChains;
 
   // a vector of tracks foreach source and each collision
-  mutable std::vector<std::vector<std::vector<o2::MCTrack>>> mTracks;                                        // the in-memory track container
+  mutable std::vector<std::vector<std::vector<o2::MCTrack>*>> mTracks;                                       // the in-memory track container
   mutable std::vector<std::vector<o2::dataformats::MCEventHeader>> mHeaders;                                 // the in-memory header container
   mutable std::vector<std::vector<o2::dataformats::MCTruthContainer<o2::TrackReference>>> mIndexedTrackRefs; // the in-memory track ref container
 
@@ -134,10 +138,7 @@ inline MCTrack const* MCKinematicsReader::getTrack(o2::MCCompLabel const& label)
 
 inline MCTrack const* MCKinematicsReader::getTrack(int source, int event, int track) const
 {
-  if (mTracks[source].size() == 0) {
-    loadTracksForSource(source);
-  }
-  return &mTracks[source][event][track];
+  return &getTracks(source, event)[track];
 }
 
 inline MCTrack const* MCKinematicsReader::getTrack(int event, int track) const
@@ -148,9 +149,12 @@ inline MCTrack const* MCKinematicsReader::getTrack(int event, int track) const
 inline std::vector<MCTrack> const& MCKinematicsReader::getTracks(int source, int event) const
 {
   if (mTracks[source].size() == 0) {
-    loadTracksForSource(source);
+    initTracksForSource(source);
   }
-  return mTracks[source][event];
+  if (mTracks[source][event] == nullptr) {
+    loadTracksForSourceAndEvent(source, event);
+  }
+  return *mTracks[source][event];
 }
 
 inline std::vector<MCTrack> const& MCKinematicsReader::getTracks(int event) const
@@ -195,7 +199,7 @@ inline size_t MCKinematicsReader::getNSources() const
 inline size_t MCKinematicsReader::getNEvents(int source) const
 {
   if (mTracks[source].size() == 0) {
-    loadTracksForSource(source);
+    initTracksForSource(source);
   }
   return mTracks[source].size();
 }


### PR DESCRIPTION
Provide some control on MCKinematicsReader to release track memory for some source,event IDs.