### PR TITLE
WIP: Reduce memory footprint of TPC digitization in GRID mode

### DIFF
--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -8,6 +8,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+o2_add_executable(tpc-digit-merger-writer
+                  COMPONENT_NAME sim
+                  SOURCES src/TPCDigitMergerWriterSpec.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::TPCSimulation
+                 )
 
 o2_add_executable(digitizer-workflow
                   COMPONENT_NAME sim

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -148,6 +148,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(
     ConfigParamSpec{"tpc-reco-type", VariantType::String, "", {tpcrthelp}});
 
+  // Option to write TPC digits internaly, without forwarding to a special writer instance.
+  // This is useful in GRID productions with small available memory.
+  workflowOptions.push_back(ConfigParamSpec{"tpc-internal-writer", o2::framework::VariantType::Bool, false, {"Write TPC digits where produced / disable TPC digit writer device."}});
+
   std::string simhelp("Comma separated list of simulation prefixes (for background, signal productions)");
   workflowOptions.push_back(
     ConfigParamSpec{"sims", VariantType::String, "o2sim", {simhelp}});
@@ -439,14 +443,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     auto lanes = helpasked ? 1 : getNumTPCLanes(tpcsectors, configcontext);
     detList.emplace_back(o2::detectors::DetID::TPC);
 
-    WorkflowSpec tpcPipelines = o2::tpc::getTPCDigitizerSpec(lanes, tpcsectors, mctruth);
+    auto internalwrite = configcontext.options().get<bool>("tpc-internal-writer");
+    WorkflowSpec tpcPipelines = o2::tpc::getTPCDigitizerSpec(lanes, tpcsectors, mctruth, internalwrite);
     specs.insert(specs.end(), tpcPipelines.begin(), tpcPipelines.end());
 
     if (configcontext.options().get<std::string>("tpc-reco-type").empty() == false) {
       throw std::runtime_error("option 'tpc-reco-type' is deprecated, please connect workflows on the command line by pipe");
     }
-    // for writing digits to disc
-    specs.emplace_back(o2::tpc::getTPCDigitRootWriterSpec(tpcsectors, mctruth));
+    if (!internalwrite) {
+      // for writing digits to disc
+      specs.emplace_back(o2::tpc::getTPCDigitRootWriterSpec(tpcsectors, mctruth));
+    }
   }
 
   // first 36 channels are reserved for the TPC

--- a/Steer/DigitizerWorkflow/src/TPCDigitMergerWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitMergerWriterSpec.cxx
@@ -1,0 +1,172 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TPCDigitMergerWriterSpec.cxx
+/// @author Sandro Wenzel
+/// @since  2021-03-10
+/// @brief  Processor spec for post-step; merging exisisting ROOT files
+///         into a single one
+
+#include "TPCDigitMergerWriterSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "DataFormatsTPC/Digit.h"
+#include "TPCSimulation/CommonMode.h"
+#include "DetectorsBase/Detector.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/IOMCTruthContainerView.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TBranch.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <utility>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+using namespace o2::framework;
+using namespace o2::header;
+
+namespace o2
+{
+namespace tpc
+{
+
+template <typename T>
+void copyHelper(T const& origin, T& target)
+{
+  std::copy(origin.begin(), origin.end(), std::back_inserter(target));
+}
+template <>
+void copyHelper<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>(o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& origin, o2::dataformats::MCTruthContainer<o2::MCCompLabel>& target)
+{
+  target.mergeAtBack(origin);
+}
+
+template <typename T>
+void writeToBranchHelper(TTree& tree, const char* name, T* accum)
+{
+  auto targetbr = o2::base::getOrMakeBranch(tree, name, accum);
+  targetbr->Fill();
+  targetbr->ResetAddress();
+  targetbr->DropBaskets("all");
+}
+
+template <>
+void writeToBranchHelper<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>(TTree& tree,
+                                                                             const char* name, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* accum)
+{
+  // we convert first of all to IOMCTruthContainer
+  std::vector<char> buffer;
+  accum->flatten_to(buffer);
+  accum->clear_andfreememory();
+  o2::dataformats::IOMCTruthContainerView view(buffer);
+  auto targetbr = o2::base::getOrMakeBranch(tree, name, &view);
+  targetbr->Fill();
+  targetbr->ResetAddress();
+  targetbr->DropBaskets("all");
+}
+
+// just produce a final chain on existing files
+// void produceChain(std::vector<int> const& lanes) {
+// auto newfile = new TFile("tpcdigits.root", "RECREATE");
+//  assert(newfile);
+//  auto chain = new TChain("o2sim", "o2sim");
+// assert(newtree);
+// for(auto l : lanes) {
+// merging the data
+//  std::stringstream tmp;
+//  tmp << "tpcdigits_lane" << l << ".root";
+//  auto originfile = new TFile(tmp.str().c_str(), "OPEN");
+//  assert(originfile);
+// }
+//}
+
+void produceMergedTimeframeFile(std::vector<int> const& lanes)
+{
+  //
+  auto newfile = new TFile("tpcdigits.root", "RECREATE");
+  assert(newfile);
+  auto newtree = new TTree("o2sim", "o2sim");
+  assert(newtree);
+  for (auto l : lanes) {
+    LOG(INFO) << "MERGING FOR LANE " << l;
+    // merging the data
+    std::stringstream tmp;
+    tmp << "tpc_driftime_digits_lane" << l << ".root";
+    auto originfile = new TFile(tmp.str().c_str(), "OPEN");
+    assert(originfile);
+
+    auto merge = [originfile, newfile, newtree](auto data, auto brprefix) {
+      auto keyslist = originfile->GetListOfKeys();
+      for (int i = 0; i < keyslist->GetEntries(); ++i) {
+        auto key = keyslist->At(i);
+        auto oldtree = (TTree*)originfile->Get(key->GetName());
+        assert(oldtree);
+        std::stringstream digitbrname;
+        digitbrname << brprefix << key->GetName();
+        auto br = oldtree->GetBranch(digitbrname.str().c_str());
+        if (!br) {
+          continue;
+        }
+        decltype(data)* chunk = nullptr;
+        br->SetAddress(&chunk);
+        decltype(data) accum;
+        for (auto e = 0; e < br->GetEntries(); ++e) {
+          br->GetEntry(e);
+          copyHelper(*chunk, accum);
+          delete chunk;
+          chunk = nullptr;
+        }
+        br->ResetAddress();
+        br->DropBaskets("all");
+        writeToBranchHelper(*newtree, br->GetName(), &accum);
+        newfile->Write("", TObject::kOverwrite);
+        delete oldtree;
+      }
+    };
+
+    //data definitions
+    using DigitsType = std::vector<o2::tpc::Digit>;
+    using CommonModeType = std::vector<o2::tpc::CommonMode>;
+    using LabelType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+    merge(DigitsType(), "TPCDigit_");
+    merge(LabelType(), "TPCDigitMCTruth_");
+    merge(CommonModeType(), "TPCCommonMode_");
+    originfile->Close();
+    delete originfile;
+  }
+  newfile->Close();
+  delete newfile;
+}
+
+/// create the processor spec
+/// describing a processor aggregating digits for various TPC sectors and writing them to file
+/// MC truth information is also aggregated and written out
+DataProcessorSpec getTPCDigitMergerWriterSpec(std::vector<int> const& laneConfiguration, bool mctruth)
+{
+  //data definitions
+  using DigitsOutputType = std::vector<o2::tpc::Digit>;
+  using CommonModeOutputType = std::vector<o2::tpc::CommonMode>;
+}
+
+} // end namespace tpc
+} // end namespace o2
+
+int main(int argc, char* argv[])
+{
+  int numlanes = atoi(argv[1]);
+  std::vector<int> lanes(numlanes);
+  std::iota(lanes.begin(), lanes.end(), 0);
+  o2::tpc::produceMergedTimeframeFile(lanes);
+}

--- a/Steer/DigitizerWorkflow/src/TPCDigitMergerWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDigitMergerWriterSpec.h
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma once
+
+#include "Framework/DataProcessorSpec.h"
+#include <vector>
+#include <numeric> // std::iota
+
+namespace o2
+{
+namespace tpc
+{
+/// get the processor spec
+/// the laneConfiguration is a vector of subspecs which the processor subscribes to
+o2::framework::DataProcessorSpec getTPCDigitMergerWriterSpec(std::vector<int> const& laneConfiguration, bool mctruth);
+
+// numberofsourcedevices is the number of devices we receive digits from
+inline o2::framework::DataProcessorSpec getTPCDigitMergerWriterSpec(int numberofsourcedevices = 1)
+{
+  std::vector<int> defaultConfiguration(numberofsourcedevices);
+  std::iota(defaultConfiguration.begin(), defaultConfiguration.end(), 0);
+  return getTPCDigitMergerWriterSpec(defaultConfiguration, true);
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
@@ -19,9 +19,9 @@ namespace o2
 namespace tpc
 {
 
-o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth);
+o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth, bool internalwriter);
 
-o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth);
+o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth, bool internalwriter);
 
 } // end namespace tpc
 } // end namespace o2


### PR DESCRIPTION
TPC digitization may require large RAM which may hit the limit of
16GB on 8-core GRID sites easily for moderate timeframe sizes.
Next to limiting the timeframe size, this poses also large constraints
on possible parallel scheduling with other tasks.

This commit introduces an alternative treatment of writing the data,
which will flush for any independent TPC drift-time chunk.

This IO flushing is done in the digitizer process itself, since it happens
at a smaller granularity than the DPL "run" invocation, and as such is
only useful for (GRID) productions in which we save intermediate
 digit files.

The effect of this is the following:
a) Substantial reduction of memory, limited by the size of a drift-time.
   (We can stay on the order of 2GB even with 8 lanes). Here, TPC digitization
   may approach a 1-core "usability" limit.

b) Mem-reduction by a factor of 2 if we post-generate the full timeframe file
   in an after-burner.

For the purpose of digits on disc, it is maybe not even necessary to ever
store them as a timeframe. It would be thinkable that reconstruction could
read files produced in option a) and construct the timeframe structures on the fly.
In this way, we never do ROOT IO on large vectors.