### PR TITLE
Support ptree entries with dot in the name

### DIFF
--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -183,6 +183,9 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
     std::string key = spec.name.substr(0, spec.name.find(','));
     auto it = in.get_child_optional(key);
     if (!it) {
+      it = in.get_child_optional(boost::property_tree::path(key, '/'));
+    }
+    if (!it) {
       continue;
     }
     try {


### PR DESCRIPTION
Allows configuration JSON to have entries with dot in the name, enabling import of flattened configuration in AliHyperloop.