### PR TITLE
DPL Analysis: allow to omit LabeledArray labels in JSON

### DIFF
--- a/Analysis/Tutorials/src/configurableObjects.cxx
+++ b/Analysis/Tutorials/src/configurableObjects.cxx
@@ -63,15 +63,20 @@ struct ConfigurableObjectDemo {
   Configurable<Array2D<float>> vmatrix{"matrix", {&defaultm[0][0], 3, 4}, "generic matrix"};
   Configurable<LabeledArray<float>> vla{"vla", {defaultm[0], 3, 4, {"r 1", "r 2", "r 3"}, {"c 1", "c 2", "c 3", "c 4"}}, "labeled array"};
 
-  void init(InitContext const&){};
-  void process(aod::Collision const&, aod::Tracks const& tracks)
+  void init(InitContext const&)
   {
-    LOGF(INFO, "Cut1: %.3f; Cut2: %.3f", cut, mutable_cut);
     LOGF(INFO, "Cut1 bins: %s; Cut2 bins: %s", printArray(cut->getBins()), printArray(mutable_cut->getBins()));
     LOGF(INFO, "Cut1 labels: %s; Cut2 labels: %s", printArray(cut->getLabels()), printArray(mutable_cut->getLabels()));
     auto vec = (std::vector<int>)array;
     LOGF(INFO, "Array: %s", printArray(vec).c_str());
     LOGF(INFO, "Matrix: %s", printMatrix((Array2D<float>)vmatrix));
+    LOGF(INFO, "Labeled:\n %s\n %s\n %s", printArray(vla->getLabelsRows()), printArray(vla->getLabelsCols()), printMatrix(vla->getData()));
+  };
+
+  void process(aod::Collision const&, aod::Tracks const& tracks)
+  {
+    LOGF(INFO, "Cut1: %.3f; Cut2: %.3f", cut, mutable_cut);
+
     for (auto const& track : tracks) {
       if (track.globalIndex() % 500 == 0) {
         std::string decision1;

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -91,6 +91,7 @@ o2_add_library(Framework
                        src/DataInputDirector.cxx
                        src/DataOutputDirector.cxx
                        src/Task.cxx
+                       src/Array2D.cxx
                        src/Variant.cxx
                        src/WorkflowCustomizationHelpers.cxx
                        src/WorkflowHelpers.cxx

--- a/Framework/Core/include/Framework/Array2D.h
+++ b/Framework/Core/include/Framework/Array2D.h
@@ -174,12 +174,12 @@ struct LabelMap {
     return map;
   }
 
-  auto getLabelsRows()
+  auto getLabelsRows() const
   {
     return labels_rows;
   }
 
-  auto getLabelsCols()
+  auto getLabelsCols() const
   {
     return labels_cols;
   }
@@ -257,19 +257,35 @@ class LabeledArray : public LabelMap
     return values[y];
   }
 
-  auto getData()
+  auto getData() const
   {
     return values;
   }
 
-  auto rows()
+  auto rows() const
   {
     return values.rows;
   }
 
-  auto cols()
+  auto cols() const
   {
     return values.cols;
+  }
+
+  void replaceLabelsRows(std::vector<std::string> const& labels)
+  {
+    assert(values.rows == labels.size());
+    labels_rows = labels;
+    rowmap.clear();
+    rowmap = populate(labels.size(), labels);
+  }
+
+  void replaceLabelsCols(std::vector<std::string> const& labels)
+  {
+    assert(values.cols == labels.size());
+    labels_cols = labels;
+    colmap.clear();
+    colmap = populate(labels.size(), labels);
   }
 
  private:

--- a/Framework/Core/include/Framework/Array2D.h
+++ b/Framework/Core/include/Framework/Array2D.h
@@ -10,8 +10,6 @@
 #ifndef FRAMEWORK_ARRAY2D_H
 #define FRAMEWORK_ARRAY2D_H
 
-#include <Framework/RuntimeError.h>
-
 #include <cstdint>
 #include <vector>
 #include <unordered_map>
@@ -160,19 +158,7 @@ struct LabelMap {
   std::vector<std::string> labels_rows;
   std::vector<std::string> labels_cols;
 
-  labelmap_t populate(uint32_t size, std::vector<std::string> labels)
-  {
-    labelmap_t map;
-    if (labels.empty() == false) {
-      if (labels.size() != size) {
-        throw runtime_error("labels array size != array dimension");
-      }
-      for (auto i = 0u; i < size; ++i) {
-        map.emplace(labels[i], (uint32_t)i);
-      }
-    }
-    return map;
-  }
+  static labelmap_t populate(uint32_t size, std::vector<std::string> labels);
 
   auto getLabelsRows() const
   {
@@ -183,6 +169,9 @@ struct LabelMap {
   {
     return labels_cols;
   }
+
+  void replaceLabelsRows(uint32_t size, std::vector<std::string> const& labels);
+  void replaceLabelsCols(uint32_t size, std::vector<std::string> const& labels);
 };
 
 template <typename T>
@@ -274,24 +263,12 @@ class LabeledArray : public LabelMap
 
   void replaceLabelsRows(std::vector<std::string> const& labels)
   {
-    if (values.rows == labels.size()) {
-      labels_rows = labels;
-      rowmap.clear();
-      rowmap = populate(labels.size(), labels);
-    } else {
-      throw runtime_error_f("Row labels array has different size (%d) than number of rows (%d)", labels.size(), values.rows);
-    }
+    LabelMap::replaceLabelsRows(values.rows, labels);
   }
 
   void replaceLabelsCols(std::vector<std::string> const& labels)
   {
-    if (values.cols == labels.size()) {
-      labels_cols = labels;
-      colmap.clear();
-      colmap = populate(labels.size(), labels);
-    } else {
-      throw runtime_error_f("Column labels array has different size (%d) than number of columns (%d)", labels.size(), values.cols);
-    }
+    LabelMap::replaceLabelsCols(values.cols, labels);
   }
 
  private:

--- a/Framework/Core/include/Framework/Array2D.h
+++ b/Framework/Core/include/Framework/Array2D.h
@@ -274,18 +274,24 @@ class LabeledArray : public LabelMap
 
   void replaceLabelsRows(std::vector<std::string> const& labels)
   {
-    assert(values.rows == labels.size());
-    labels_rows = labels;
-    rowmap.clear();
-    rowmap = populate(labels.size(), labels);
+    if (values.rows == labels.size()) {
+      labels_rows = labels;
+      rowmap.clear();
+      rowmap = populate(labels.size(), labels);
+    } else {
+      throw runtime_error_f("Row labels array has different size (%d) than number of rows (%d)", labels.size(), values.rows);
+    }
   }
 
   void replaceLabelsCols(std::vector<std::string> const& labels)
   {
-    assert(values.cols == labels.size());
-    labels_cols = labels;
-    colmap.clear();
-    colmap = populate(labels.size(), labels);
+    if (values.cols == labels.size()) {
+      labels_cols = labels;
+      colmap.clear();
+      colmap = populate(labels.size(), labels);
+    } else {
+      throw runtime_error_f("Column labels array has different size (%d) than number of columns (%d)", labels.size(), values.cols);
+    }
   }
 
  private:

--- a/Framework/Core/include/Framework/VariantPropertyTreeHelpers.h
+++ b/Framework/Core/include/Framework/VariantPropertyTreeHelpers.h
@@ -129,19 +129,12 @@ auto array2DFromBranch(boost::property_tree::ptree const& ptree)
   return basicArray2DFromBranch<T>(ptree.get_child("values"));
 }
 
+std::pair<std::vector<std::string>, std::vector<std::string>> extractLabels(boost::property_tree::ptree const& tree);
+
 template <typename T>
 auto labeledArrayFromBranch(boost::property_tree::ptree const& tree)
 {
-  std::vector<std::string> labels_rows;
-  std::vector<std::string> labels_cols;
-  auto lrc = tree.get_child_optional(labels_rows_str);
-  if (lrc) {
-    labels_rows = basicVectorFromBranch<std::string>(lrc.value());
-  }
-  auto lcc = tree.get_child_optional(labels_cols_str);
-  if (lcc) {
-    labels_cols = basicVectorFromBranch<std::string>(lcc.value());
-  }
+  auto [labels_rows, labels_cols] = extractLabels(tree);
   auto values = basicArray2DFromBranch<T>(tree.get_child("values"));
 
   return LabeledArray<T>{values, labels_rows, labels_cols};

--- a/Framework/Core/include/Framework/VariantPropertyTreeHelpers.h
+++ b/Framework/Core/include/Framework/VariantPropertyTreeHelpers.h
@@ -132,8 +132,16 @@ auto array2DFromBranch(boost::property_tree::ptree const& ptree)
 template <typename T>
 auto labeledArrayFromBranch(boost::property_tree::ptree const& tree)
 {
-  auto labels_rows = basicVectorFromBranch<std::string>(tree.get_child(labels_rows_str));
-  auto labels_cols = basicVectorFromBranch<std::string>(tree.get_child(labels_cols_str));
+  std::vector<std::string> labels_rows;
+  std::vector<std::string> labels_cols;
+  auto lrc = tree.get_child_optional(labels_rows_str);
+  if (lrc) {
+    labels_rows = basicVectorFromBranch<std::string>(lrc.value());
+  }
+  auto lcc = tree.get_child_optional(labels_cols_str);
+  if (lcc) {
+    labels_cols = basicVectorFromBranch<std::string>(lcc.value());
+  }
   auto values = basicArray2DFromBranch<T>(tree.get_child("values"));
 
   return LabeledArray<T>{values, labels_rows, labels_cols};

--- a/Framework/Core/src/Array2D.cxx
+++ b/Framework/Core/src/Array2D.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <Framework/Array2D.h>
+#include <Framework/RuntimeError.h>
+#include <Framework/CompilerBuiltins.h>
+
+namespace o2::framework
+{
+labelmap_t LabelMap::populate(uint32_t size, std::vector<std::string> labels)
+{
+  labelmap_t map;
+  if (labels.empty() == false) {
+    if (labels.size() != size) {
+      throw runtime_error("labels array size != array dimension");
+    }
+    for (auto i = 0u; i < size; ++i) {
+      map.emplace(labels[i], (uint32_t)i);
+    }
+  }
+  return map;
+}
+
+void LabelMap::replaceLabelsRows(uint32_t size, std::vector<std::string> const& labels)
+{
+  if (O2_BUILTIN_UNLIKELY(size != labels.size())) {
+    throw runtime_error_f("Row labels array has different size (%d) than number of rows (%d)", labels.size(), size);
+  };
+  labels_rows = labels;
+  rowmap.clear();
+  rowmap = populate(labels.size(), labels);
+}
+
+void LabelMap::replaceLabelsCols(uint32_t size, std::vector<std::string> const& labels)
+{
+  if (O2_BUILTIN_UNLIKELY(size != labels.size())) {
+    throw runtime_error_f("Column labels array has different size (%d) than number of columns (%d)", labels.size(), size);
+  };
+  labels_cols = labels;
+  colmap.clear();
+  colmap = populate(labels.size(), labels);
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -175,18 +175,16 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
 template <typename T>
 auto replaceLabels(LabeledArray<T>& input, LabeledArray<T>&& spec)
 {
-  bool replace = false;
-  if (input.getLabelsCols().empty() && input.getLabelsRows().empty()) {
-    if (!spec.getLabelsCols().empty()) {
-      input.replaceLabelsCols(spec.getLabelsCols());
-      replace = true;
-    }
-    if (!spec.getLabelsRows().empty()) {
-      input.replaceLabelsRows(spec.getLabelsRows());
-      replace = true;
-    }
+  if (!input.getLabelsCols().empty() || !input.getLabelsRows().empty()) {
+    return false;
   }
-  return replace;
+  if (spec.getLabelsCols().empty() == false) {
+    input.replaceLabelsCols(spec.getLabelsCols());
+  }
+  if (spec.getLabelsRows().empty() == false) {
+    input.replaceLabelsRows(spec.getLabelsRows());
+  }
+  return true;
 }
 
 void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -172,6 +172,23 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
   }
 }
 
+template <typename T>
+auto replaceLabels(LabeledArray<T>& input, LabeledArray<T>&& spec)
+{
+  bool replace = false;
+  if (input.getLabelsCols().empty() && input.getLabelsRows().empty()) {
+    if (!spec.getLabelsCols().empty()) {
+      input.replaceLabelsCols(spec.getLabelsCols());
+      replace = true;
+    }
+    if (!spec.getLabelsRows().empty()) {
+      input.replaceLabelsRows(spec.getLabelsRows());
+      replace = true;
+    }
+  }
+  return replace;
+}
+
 void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
                                    boost::property_tree::ptree& pt,
                                    boost::property_tree::ptree const& in,
@@ -213,11 +230,32 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
         case VariantType::Array2DInt:
         case VariantType::Array2DFloat:
         case VariantType::Array2DDouble:
-        case VariantType::LabeledArrayInt:
-        case VariantType::LabeledArrayFloat:
-        case VariantType::LabeledArrayDouble:
           pt.put_child(key, *it);
           break;
+        case VariantType::LabeledArrayInt: {
+          auto v = labeledArrayFromBranch<int>(it.value());
+          if (!replaceLabels(v, spec.defaultValue.get<LabeledArray<int>>())) {
+            pt.put_child(key, *it);
+          } else {
+            pt.put_child(key, labeledArrayToBranch(std::move(v)));
+          }
+        }; break;
+        case VariantType::LabeledArrayFloat: {
+          auto v = labeledArrayFromBranch<float>(it.value());
+          if (!replaceLabels(v, spec.defaultValue.get<LabeledArray<float>>())) {
+            pt.put_child(key, *it);
+          } else {
+            pt.put_child(key, labeledArrayToBranch(std::move(v)));
+          }
+        }; break;
+        case VariantType::LabeledArrayDouble: {
+          auto v = labeledArrayFromBranch<double>(it.value());
+          if (!replaceLabels(v, spec.defaultValue.get<LabeledArray<double>>())) {
+            pt.put_child(key, *it);
+          } else {
+            pt.put_child(key, labeledArrayToBranch(std::move(v)));
+          }
+        }; break;
         case VariantType::Unknown:
         case VariantType::Empty:
         default:

--- a/Framework/Core/src/Variant.cxx
+++ b/Framework/Core/src/Variant.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/Variant.h"
+#include "Framework/VariantPropertyTreeHelpers.h"
 #include <iostream>
 #include <sstream>
 
@@ -253,6 +254,21 @@ Variant& Variant::operator=(Variant&& other)
       mStore = other.mStore;
       return *this;
   }
+}
+
+std::pair<std::vector<std::string>, std::vector<std::string>> extractLabels(boost::property_tree::ptree const& tree)
+{
+  std::vector<std::string> labels_rows;
+  std::vector<std::string> labels_cols;
+  auto lrc = tree.get_child_optional(labels_rows_str);
+  if (lrc) {
+    labels_rows = basicVectorFromBranch<std::string>(lrc.value());
+  }
+  auto lcc = tree.get_child_optional(labels_cols_str);
+  if (lcc) {
+    labels_cols = basicVectorFromBranch<std::string>(lcc.value());
+  }
+  return std::make_pair(labels_rows, labels_cols);
 }
 
 } // namespace o2::framework


### PR DESCRIPTION
When using external JSON configuration, row and column labels can be omitted for a LabeledArray so that they will be automatically taken from the default. This, however, enforces the default size. 

@jgrosseo 