### PR TITLE
[EMCAL-686] Implement error handling in Raw fitter

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -64,6 +64,10 @@ class AltroDecoderError : public std::exception
   /// \return the error type
   static ErrorType_t intToErrorType(int errornumber);
 
+  /// \brief Get the number of error types handled by the AltroDecoderError
+  /// \return Number of error types
+  static constexpr int getNumberOfErrorTypes() noexcept { return 8; }
+
   /// \brief Access to the error type connected to the erro
   /// \return Error type
   const ErrorType_t getErrorType() const noexcept { return mErrorType; }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
@@ -39,13 +39,38 @@ class CaloRawFitter
 {
 
  public:
+  /**
+   * \enum RawFitterError_t
+   * \brief Error codes for failures in raw fitter procedure
+   */
+  enum class RawFitterError_t {
+    SAMPLE_UNINITIALIZED, ///< Samples not initialized or length is 0
+    FIT_ERROR,            ///< Fit procedure failed
+    CHI2_ERROR,           ///< Chi2 cannot be determined (usually due to insufficient amount of samples)
+    BUNCH_NOT_OK          ///< Bunch selection failed
+  };
+
+  /// \brief Create error message for a given error type
+  /// \param fiterror Fit error type
+  /// \return Error message connected to the error type
+  static std::string createErrorMessage(RawFitterError_t fiterror);
+
+  /// \brief Convert error type to numeric representation
+  /// \param fiterror Fit error type
+  /// \return Numeric representation of the raw fitter error
+  static int getErrorNumber(RawFitterError_t fiterror);
+
+  /// \brief Get the number of raw fit error types supported
+  /// \return Number of error types (4)
+  static constexpr int getNumberOfErrorTypes() noexcept { return 4; }
+
   /// \brief Constructor
   CaloRawFitter(const char* name, const char* nameshort);
 
   /// \brief Destructor
   virtual ~CaloRawFitter() = default;
 
-  virtual CaloFitResults evaluate(const std::vector<Bunch>& bunchvector,
+  virtual CaloFitResults evaluate(const gsl::span<const Bunch> bunchvector,
                                   std::optional<unsigned int> altrocfg1,
                                   std::optional<unsigned int> altrocfg2) = 0;
 
@@ -58,7 +83,7 @@ class CaloRawFitter
   /// \return pedestal,
   /// \return first time bin,
   /// \return last time bin,
-  std::tuple<int, int, float, short, short, float, int, int> preFitEvaluateSamples(const std::vector<Bunch>& bunchvector,
+  std::tuple<int, int, float, short, short, float, int, int> preFitEvaluateSamples(const gsl::span<const Bunch> bunchvector,
                                                                                    std::optional<unsigned int> altrocfg1, std::optional<unsigned int> altrocfg2, int acut);
 
   /// \brief The require time range if the maximum ADC value is between min and max (timebin)
@@ -103,7 +128,7 @@ class CaloRawFitter
   /// \return The index of the array with the maximum aplitude
   /// \return The bin where we have a maximum amp
   /// \return The maximum ADC signal
-  std::tuple<short, short, short> selectBunch(const std::vector<Bunch>& bunchvector);
+  std::tuple<short, short, short> selectBunch(const gsl::span<const Bunch>& bunchvector);
 
   /// \brief Selection of subset of data from one bunch that will be used for fitting or Peak finding.
   /// Go to the left and right of index of the maximum time bin
@@ -113,7 +138,7 @@ class CaloRawFitter
   std::tuple<int, int> selectSubarray(const gsl::span<double> data, short maxindex, int cut) const;
 
   /// \brief Pedestal evaluation if not zero suppressed
-  float evaluatePedestal(const std::vector<uint16_t>& data, std::optional<int> length) const;
+  float evaluatePedestal(const gsl::span<const uint16_t> data, std::optional<int> length) const;
 
   /// \brief Calculates the chi2 of the fit
   ///

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterGamma2.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterGamma2.h
@@ -52,8 +52,10 @@ class CaloRawFitterGamma2 final : public CaloRawFitter
   int getNiterationsMax() { return mNiterationsMax; }
 
   /// \brief Evaluation Amplitude and TOF
-  /// return Container with the fit results (amp, time, chi2, ...)
-  CaloFitResults evaluate(const std::vector<Bunch>& bunchvector,
+  /// \param
+  /// \throw RawFitterError_t::FIT_ERROR in case the peak fit failed
+  /// \return Container with the fit results (amp, time, chi2, ...)
+  CaloFitResults evaluate(const gsl::span<const Bunch> bunchvector,
                           std::optional<unsigned int> altrocfg1,
                           std::optional<unsigned int> altrocfg2) final;
 
@@ -62,12 +64,22 @@ class CaloRawFitterGamma2 final : public CaloRawFitter
   int mNiterationsMax = 15; ///< max number of iteraions
 
   /// \brief Fits the raw signal time distribution
-  /// \return chi2, fit status.
-  std::tuple<float, bool> doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time);
+  /// \param firstTimeBin First timebin in the ALTRO bunch
+  /// \param nSamples Number of time samples of the ALTRO bunch
+  /// \param[in] ampl Initial guess of the amplitude for the fit
+  /// \param[out] ampl Amplitude result of the peak fit
+  /// \param[in] time Initial guess of the time for the fit
+  /// \param[out] time Time result of the peak fit
+  /// \return chi2 of the fit
+  /// \throw RawFitterError_t::FIT_ERROR in case of fit errors (insufficient number of time samples, matrix diagonalization error, ...)
+  float doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time);
 
   /// \brief Fits the raw signal time distribution
+  /// \param maxTimeBin Time bin of the max. amplitude
   /// \return the fit parameters: amplitude, time.
-  std::tuple<float, float> doParabolaFit(int x) const;
+  ///
+  /// Fit performed as parabola fit to the signal
+  std::tuple<float, float> doParabolaFit(int maxTimeBin) const;
 
   ClassDefNV(CaloRawFitterGamma2, 1);
 }; // End of CaloRawFitterGamma2

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
@@ -50,20 +50,27 @@ class CaloRawFitterStandard final : public CaloRawFitter
   ~CaloRawFitterStandard() final = default;
 
   /// \brief Approximate response function of the EMCal electronics.
-  /// \param x: bin
-  /// \param par: function parameters
+  /// \param x bin
+  /// \param par function parameters
   /// \return double with signal for a given time bin
   static double rawResponseFunction(double* x, double* par);
 
   /// \brief Evaluation Amplitude and TOF
-  /// return Container with the fit results (amp, time, chi2, ...)
-  CaloFitResults evaluate(const std::vector<Bunch>& bunchvector,
+  /// \param bunchvector Calo bunches for the tower and event
+  /// \param altrocfg1 ALTRO config register 1 from RCU trailer
+  /// \param altrocfg2 ALTRO config register 2 from RCU trailer
+  /// \return Container with the fit results (amp, time, chi2, ...)
+  /// \throw RawFitterError_t in case the fit failed (including all possible errors from upstream)
+  CaloFitResults evaluate(const gsl::span<const Bunch> bunchvector,
                           std::optional<unsigned int> altrocfg1,
                           std::optional<unsigned int> altrocfg2) final;
 
-  /// \brief Fits the raw signal time distribution
-  /// \return the fit parameters: amplitude, time, chi2, fit status.
-  std::tuple<float, float, float, bool> fitRaw(int firstTimeBin, int lastTimeBin) const;
+  /// \brief Fits the raw signal time distribution using TMinuit
+  /// \param firstTimeBin First timebin of the ALTRO bunch
+  /// \param lastTimeBin Last timebin of the ALTRO bunch
+  /// \return the fit parameters: amplitude, time, chi2
+  /// \throw RawFitter_t::FIT_ERROR in case the fit failed (insufficient number of samples or fit error from MINUIT)
+  std::tuple<float, float, float> fitRaw(int firstTimeBin, int lastTimeBin) const;
 
  private:
   ClassDefNV(CaloRawFitterStandard, 1);

--- a/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
+++ b/Detectors/EMCAL/reconstruction/macros/RawFitterTESTs.C
@@ -97,10 +97,14 @@ void RawFitterTESTs(const char* filename = "")
           std::cout << "processing next channel idx " << chan.getChannelIndex() << ", " << chan.getHardwareAddress() << std::endl;
           // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
           continue;
-          o2::emcal::CaloFitResults fitResults = RawFitter.evaluate(chan.getBunches(), 0, 0);
+          try {
+            o2::emcal::CaloFitResults fitResults = RawFitter.evaluate(chan.getBunches(), 0, 0);
 
-          // print the fit output
-          std::cout << "The Time is : " << fitResults.getTime() << " And the Amplitude is : " << fitResults.getAmp() << std::endl;
+            // print the fit output
+            std::cout << "The Time is : " << fitResults.getTime() << " And the Amplitude is : " << fitResults.getAmp() << std::endl;
+          } catch (o2::emcal::CaloRawFitter::RawFitterError_t& fiterror) {
+            std::cerr << "Error processing raw fit: " << o2::emcal::CaloRawFitter::createErrorMessage(fiterror) << std::endl;
+          }
         }
       }
     }

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
@@ -12,6 +12,7 @@
 /// \author Martin Poghosyan (Martin.Poghosyan@cern.ch)
 
 #include "FairLogger.h"
+#include <cfloat>
 #include <random>
 
 // ROOT sytem
@@ -30,7 +31,7 @@ CaloRawFitterGamma2::CaloRawFitterGamma2() : CaloRawFitter("Chi Square ( Gamma2 
   mAlgo = FitAlgorithm::Gamma2;
 }
 
-CaloFitResults CaloRawFitterGamma2::evaluate(const std::vector<Bunch>& bunchlist,
+CaloFitResults CaloRawFitterGamma2::evaluate(const gsl::span<const Bunch> bunchlist,
                                              std::optional<unsigned int> altrocfg1, std::optional<unsigned int> altrocfg2)
 {
   float time = 0;
@@ -44,15 +45,18 @@ CaloFitResults CaloRawFitterGamma2::evaluate(const std::vector<Bunch>& bunchlist
 
   if (bunchIndex >= 0 && ampEstimate >= mAmpCut) {
     time = timeEstimate;
-    int timebinOffset = bunchlist.at(bunchIndex).getStartTime() - (bunchlist.at(bunchIndex).getBunchLength() - 1);
+    int timebinOffset = bunchlist[bunchIndex].getStartTime() - (bunchlist[bunchIndex].getBunchLength() - 1);
     amp = ampEstimate;
 
     if (nsamples > 2 && maxADC < constants::OVERFLOWCUT) {
       std::tie(amp, time) = doParabolaFit(timeEstimate - 1);
       mNiter = 0;
-      std::tie(chi2, fitDone) = doFit_1peak(first, nsamples, amp, time);
-
-      if (!fitDone) {
+      try {
+        chi2 = doFit_1peak(first, nsamples, amp, time);
+        fitDone = true;
+      } catch (RawFitterError_t& e) {
+        // Fit has failed, set values to estimates
+        // TODO: Check whether we want to include cases in which the peak fit failed
         amp = ampEstimate;
         time = timeEstimate;
         chi2 = 1.e9;
@@ -85,20 +89,21 @@ CaloFitResults CaloRawFitterGamma2::evaluate(const std::vector<Bunch>& bunchlist
 
     return CaloFitResults(maxADC, pedEstimate, mAlgo, amp, time, (int)time, chi2, ndf);
   }
-  return CaloFitResults(-1, -1);
+  // Fit failed, rethrow error
+  throw RawFitterError_t::FIT_ERROR;
 }
 
-std::tuple<float, bool> CaloRawFitterGamma2::doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time)
+float CaloRawFitterGamma2::doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time)
 {
 
   float chi2(0.);
 
   // fit using gamma-2 function 	(ORDER =2 assumed)
   if (nSamples < 3) {
-    return std::make_tuple(chi2, false);
+    throw RawFitterError_t::FIT_ERROR;
   }
   if (mNiter > mNiterationsMax) {
-    return std::make_tuple(chi2, false);
+    throw RawFitterError_t::FIT_ERROR;
   }
 
   double D, dA, dt;
@@ -136,7 +141,7 @@ std::tuple<float, bool> CaloRawFitterGamma2::doFit_1peak(int firstTimeBin, int n
   D = c11 * c22 - c12 * c21;
 
   if (TMath::Abs(D) < DBL_EPSILON) {
-    return std::make_tuple(chi2, false);
+    throw RawFitterError_t::FIT_ERROR;
   }
 
   dt = (d1 * c22 - d2 * c12) / D * constants::TAU;
@@ -145,13 +150,11 @@ std::tuple<float, bool> CaloRawFitterGamma2::doFit_1peak(int firstTimeBin, int n
   time += dt;
   ampl += dA;
 
-  bool res = true;
-
   if (TMath::Abs(dA) > 1 || TMath::Abs(dt) > 0.01) {
-    std::tie(chi2, res) = doFit_1peak(firstTimeBin, nSamples, ampl, time);
+    chi2 = doFit_1peak(firstTimeBin, nSamples, ampl, time);
   }
 
-  return std::make_tuple(chi2, res);
+  return chi2;
 }
 
 std::tuple<float, float> CaloRawFitterGamma2::doParabolaFit(int maxTimeBin) const
@@ -163,7 +166,7 @@ std::tuple<float, float> CaloRawFitterGamma2::doParabolaFit(int maxTimeBin) cons
 
   double a = (getReversed(maxTimeBin + 2) + getReversed(maxTimeBin) - 2. * getReversed(maxTimeBin + 1)) / 2.;
 
-  if (TMath::Abs(a) < 1.e09) {
+  if (TMath::Abs(a) < DBL_EPSILON) {
     amp = getReversed(maxTimeBin + 1);
     time = maxTimeBin + 1;
     return std::make_tuple(amp, time);

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -37,14 +37,14 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
 {
   LOG(DEBUG) << "[EMCALRawToCellConverter - init] Initialize converter ";
   if (!mGeometry) {
-    mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(223409);
+    mGeometry = Geometry::GetInstanceFromRunNumber(223409);
   }
   if (!mGeometry) {
     LOG(ERROR) << "Failure accessing geometry";
   }
 
   if (!mMapper) {
-    mMapper = std::unique_ptr<o2::emcal::MappingHandler>(new o2::emcal::MappingHandler);
+    mMapper = std::unique_ptr<MappingHandler>(new o2::emcal::MappingHandler);
   }
   if (!mMapper) {
     LOG(ERROR) << "Failed to initialize mapper";
@@ -53,9 +53,9 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
   auto fitmethod = ctx.options().get<std::string>("fitmethod");
   if (fitmethod == "standard") {
     LOG(INFO) << "Using standard raw fitter";
-    mRawFitter = std::unique_ptr<o2::emcal::CaloRawFitter>(new o2::emcal::CaloRawFitterStandard);
+    mRawFitter = std::unique_ptr<CaloRawFitter>(new o2::emcal::CaloRawFitterStandard);
   } else if (fitmethod == "gamma2") {
-    mRawFitter = std::unique_ptr<o2::emcal::CaloRawFitter>(new o2::emcal::CaloRawFitterGamma2);
+    mRawFitter = std::unique_ptr<CaloRawFitter>(new o2::emcal::CaloRawFitterGamma2);
   }
 
   mRawFitter->setAmpCut(mNoiseThreshold);
@@ -68,7 +68,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   const double CONVADCGEV = 0.016; // Conversion from ADC counts to energy: E = 16 MeV / ADC
 
   // Cache cells from for bunch crossings as the component reads timeframes from many links consecutively
-  std::map<o2::InteractionRecord, std::shared_ptr<std::vector<o2::emcal::Cell>>> cellBuffer; // Internal cell buffer
+  std::map<o2::InteractionRecord, std::shared_ptr<std::vector<Cell>>> cellBuffer; // Internal cell buffer
   std::map<o2::InteractionRecord, uint32_t> triggerBuffer;
 
   mOutputDecoderErrors.clear();
@@ -84,7 +84,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 
     //o2::emcal::RawReaderMemory<o2::header::RAWDataHeaderV4> rawreader(gsl::span(rawData.payload, o2::framework::DataRefUtils::getPayloadSize(rawData)));
 
-    o2::emcal::RawReaderMemory rawreader(o2::framework::DataRefUtils::as<const char>(rawData));
+    o2::emcal::RawReaderMemory rawreader(framework::DataRefUtils::as<const char>(rawData));
 
     // loop over all the DMA pages
     while (rawreader.hasNext()) {
@@ -92,16 +92,16 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       rawreader.next();
 
       auto& header = rawreader.getRawHeader();
-      auto triggerBC = o2::raw::RDHUtils::getTriggerBC(header);
-      auto triggerOrbit = o2::raw::RDHUtils::getTriggerOrbit(header);
-      auto feeID = o2::raw::RDHUtils::getFEEID(header);
-      auto triggerbits = o2::raw::RDHUtils::getTriggerType(header);
+      auto triggerBC = raw::RDHUtils::getTriggerBC(header);
+      auto triggerOrbit = raw::RDHUtils::getTriggerOrbit(header);
+      auto feeID = raw::RDHUtils::getFEEID(header);
+      auto triggerbits = raw::RDHUtils::getTriggerType(header);
 
       o2::InteractionRecord currentIR(triggerBC, triggerOrbit);
-      std::shared_ptr<std::vector<o2::emcal::Cell>> currentCellContainer;
+      std::shared_ptr<std::vector<Cell>> currentCellContainer;
       auto found = cellBuffer.find(currentIR);
       if (found == cellBuffer.end()) {
-        currentCellContainer = std::make_shared<std::vector<o2::emcal::Cell>>();
+        currentCellContainer = std::make_shared<std::vector<Cell>>();
         cellBuffer[currentIR] = currentCellContainer;
         // also add trigger bits
         triggerBuffer[currentIR] = triggerbits;
@@ -116,15 +116,15 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       //std::cout<<rawreader.getRawHeader()<<std::endl;
 
       // use the altro decoder to decode the raw data, and extract the RCU trailer
-      o2::emcal::AltroDecoder decoder(rawreader);
+      AltroDecoder decoder(rawreader);
       //check the words of the payload exception in altrodecoder
       try {
         decoder.decode();
       } catch (AltroDecoderError& e) {
         std::string errormessage;
-        using AltroErrType = o2::emcal::AltroDecoderError::ErrorType_t;
+        using AltroErrType = AltroDecoderError::ErrorType_t;
         /// @TODO still need to add the RawFitter errors
-        ErrorTypeFEE errornum(feeID, o2::emcal::AltroDecoderError::errorTypeToInt(e.getErrorType()), -1);
+        ErrorTypeFEE errornum(feeID, AltroDecoderError::errorTypeToInt(e.getErrorType()), -1);
         switch (e.getErrorType()) {
           case AltroErrType::RCU_TRAILER_ERROR:
             errormessage = " RCU Trailer Error ";
@@ -161,7 +161,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 
       LOG(DEBUG) << decoder.getRCUTrailer();
 
-      o2::emcal::Mapper map = mMapper->getMappingForDDL(feeID);
+      const auto& map = mMapper->getMappingForDDL(feeID);
       int iSM = feeID / 2;
 
       // Loop over all the channels
@@ -181,12 +181,19 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         int CellID = mGeometry->GetAbsCellIdFromCellIndexes(iSM, iRow, iCol);
 
         // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
-        o2::emcal::CaloFitResults fitResults = mRawFitter->evaluate(chan.getBunches(), 0, 0);
-        if (fitResults.getAmp() < 0) {
-          fitResults.setAmp(0.);
-        }
-        if (fitResults.getTime() < 0) {
-          fitResults.setTime(0.);
+        CaloFitResults fitResults;
+        try {
+          fitResults = mRawFitter->evaluate(chan.getBunches(), 0, 0);
+          // Prevent negative entries - we should no longer get here as the raw fit usually will end in an error state
+          if (fitResults.getAmp() < 0) {
+            fitResults.setAmp(0.);
+          }
+          if (fitResults.getTime() < 0) {
+            fitResults.setTime(0.);
+          }
+        } catch (CaloRawFitter::RawFitterError_t& fiterror) {
+          LOG(ERROR) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+          mOutputDecoderErrors.emplace_back(feeID, -1, CaloRawFitter::getErrorNumber(fiterror));
         }
         currentCellContainer->emplace_back(CellID, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), chantype);
       }
@@ -200,7 +207,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
     mOutputTriggerRecords.emplace_back(bc, triggerBuffer[bc], mOutputCells.size(), cells->size());
     if (cells->size()) {
       // Sort cells according to cell ID
-      std::sort(cells->begin(), cells->end(), [](o2::emcal::Cell& lhs, o2::emcal::Cell& rhs) { return lhs.getTower() < rhs.getTower(); });
+      std::sort(cells->begin(), cells->end(), [](Cell& lhs, Cell& rhs) { return lhs.getTower() < rhs.getTower(); });
       for (auto cell : *cells) {
         mOutputCells.push_back(cell);
       }
@@ -208,9 +215,9 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   }
 
   LOG(DEBUG) << "[EMCALRawToCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "DECODERERR", 0, o2::framework::Lifetime::Timeframe}, mOutputDecoderErrors);
+  ctx.outputs().snapshot(framework::Output{"EMC", "CELLS", 0, framework::Lifetime::Timeframe}, mOutputCells);
+  ctx.outputs().snapshot(framework::Output{"EMC", "CELLSTRGR", 0, framework::Lifetime::Timeframe}, mOutputTriggerRecords);
+  ctx.outputs().snapshot(framework::Output{"EMC", "DECODERERR", 0, framework::Lifetime::Timeframe}, mOutputDecoderErrors);
 }
 
 o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec()


### PR DESCRIPTION
Error handling is now exception-based, where
the errors thrown are defined as error codes in
enum class, and not inherit from std::exception.
Raw fitter errors are caught in the
RawToCellConverterSpec and pushed to the
error container which is pushed to the QC.

Futhermore a faulty 0 check was found in the
CaloRawFitterGamma2 in the parabola fit
where the numeric check for 0 is replaced by
DBL_EPSILON.