### PR TITLE
[MCH] Use aligned geometry if any

### DIFF
--- a/Detectors/MUON/MCH/Geometry/Transformer/src/convert-geometry.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/convert-geometry.cxx
@@ -145,9 +145,13 @@ void convertGeom(const TGeoManager& geom)
     }
     writer.Key("symname");
     writer.String(symname.c_str());
-    auto matrix = ae->GetMatrix();
-    bool aligned{true};
-    if (!matrix) {
+    auto pn = ae->GetPhysicalNode();
+    const TGeoHMatrix* matrix{nullptr};
+    bool aligned{false};
+    if (pn) {
+      matrix = pn->GetMatrix();
+      aligned = pn->IsAligned();
+    } else {
       matrix = ae->GetGlobalOrig();
       aligned = false;
     }


### PR DESCRIPTION
The code was always return the transformations from the ideal geometry even if it was aligned.

My understanding is that the global transformation from ideal geometry+alignment is stored in the fMatrices of the PhysicalNode, while the original global transformation from ideal geometry is stored in the PNEntry (in fGlobalOrigin).

I tested these modifications with ideal and aligned AliRoot geometry.

@aphecetche can you check if it works with o2 geometry as well, or tell me where to find the input .root and reference .json to do it please?