### PR TITLE
[Tracking] Templetize Propagator and TrackLTIntegral to allow double precision

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -19,6 +19,7 @@
 #include "MathUtils/detail/StatAccumulator.h"
 #include "MathUtils/detail/trigonometric.h"
 #include "MathUtils/detail/TypeTruncation.h"
+#include "MathUtils/detail/basicMath.h"
 
 namespace o2
 {
@@ -217,6 +218,168 @@ GPUhdi() double fastATan2d(double y, double x)
 {
   return detail::fastATan2<double>(y, x);
 }
+
+template <class T>
+GPUhdi() T min(const T x, const T y)
+{
+  return detail::min<T>(x, y);
+};
+
+GPUhdi() double mind(const double x, const double y)
+{
+  return detail::min<double>(x, y);
+};
+
+template <class T>
+GPUhdi() T max(const T x, const T y)
+{
+  return detail::max<T>(x, y);
+};
+
+GPUhdi() double maxd(const double x, const double y)
+{
+  return detail::max<double>(x, y);
+};
+
+GPUhdi() float sqrt(float x)
+{
+  return detail::sqrt<float>(x);
+};
+
+GPUhdi() double sqrtd(double x)
+{
+  return detail::sqrt<double>(x);
+};
+
+GPUhdi() float abs(float x)
+{
+  return detail::abs<float>(x);
+};
+
+GPUhdi() double absd(double x)
+{
+  return detail::abs<double>(x);
+};
+
+GPUdi() float asin(float x)
+{
+  return detail::asin<float>(x);
+};
+
+GPUdi() double asind(double x)
+{
+  return detail::asin<double>(x);
+};
+
+GPUdi() float atan(float x)
+{
+  return detail::atan<float>(x);
+};
+
+GPUdi() double atand(double x)
+{
+  return detail::atan<double>(x);
+};
+
+GPUdi() float atan2(float y, float x)
+{
+  return detail::atan2<float>(y, x);
+};
+
+GPUdi() double atan2d(double y, double x)
+{
+  return detail::atan2<double>(y, x);
+};
+
+GPUdi() float sin(float x)
+{
+  return detail::sin<float>(x);
+};
+
+GPUdi() double sind(double x)
+{
+  return detail::sin<double>(x);
+};
+
+GPUdi() float cos(float x)
+{
+  return detail::cos<float>(x);
+};
+
+GPUdi() double cosd(double x)
+{
+  return detail::cos<double>(x);
+};
+
+GPUdi() float tan(float x)
+{
+  return detail::tan<float>(x);
+};
+
+GPUdi() double tand(double x)
+{
+  return detail::tan<double>(x);
+};
+
+GPUdi() float twoPi()
+{
+  return detail::twoPi<float>();
+};
+
+GPUdi() double twoPid()
+{
+  return detail::twoPi<double>();
+};
+
+GPUdi() float pi()
+{
+  return detail::pi<float>();
+}
+
+GPUdi() double pid()
+{
+  return detail::pi<double>();
+}
+
+GPUdi() int nint(float x)
+{
+  return detail::nint<float>(x);
+};
+
+GPUdi() int nintd(double x)
+{
+  return detail::nint<double>(x);
+};
+
+GPUdi() bool finite(float x)
+{
+  return detail::finite<float>(x);
+}
+
+GPUdi() bool finited(double x)
+{
+  return detail::finite<double>(x);
+}
+
+GPUdi() unsigned int clz(unsigned int val)
+{
+  return detail::clz(val);
+};
+
+GPUdi() unsigned int popcount(unsigned int val)
+{
+  return detail::popcount(val);
+};
+
+GPUdi() float log(float x)
+{
+  return detail::log<float>(x);
+};
+
+GPUdi() double logd(double x)
+{
+  return detail::log<double>(x);
+};
 
 using detail::StatAccumulator;
 

--- a/Common/MathUtils/include/MathUtils/detail/basicMath.h
+++ b/Common/MathUtils/include/MathUtils/detail/basicMath.h
@@ -37,12 +37,6 @@ GPUhdi() T copysign(T x, T y)
   return o2::gpu::GPUCommonMath::Copysign(x, y);
 }
 
-template <>
-GPUhdi() double copysign(double x, double y)
-{
-  return std::copysign(x, y);
-}
-
 template <class T>
 GPUhdi() T min(const T x, const T y)
 {
@@ -61,21 +55,10 @@ GPUhdi() T sqrt(T x)
   return o2::gpu::GPUCommonMath::Sqrt(x);
 };
 
-template <>
-GPUhdi() double sqrt(double x)
-{
-  return std::sqrt(x);
-};
-
 template <class T>
 GPUhdi() T abs(T x)
 {
   return o2::gpu::GPUCommonMath::Abs(x);
-};
-
-GPUhdi() double abs(double x)
-{
-  return std::abs(x);
 };
 
 template <class T>
@@ -84,22 +67,10 @@ GPUdi() int nint(T x)
   return o2::gpu::GPUCommonMath::Nint(x);
 };
 
-template <>
-GPUdi() int nint(double x)
-{
-  return std::nearbyint(x);
-};
-
 template <class T>
 GPUdi() bool finite(T x)
 {
   return o2::gpu::GPUCommonMath::Finite(x);
-}
-
-template <>
-GPUdi() bool finite(double x)
-{
-  return std::isfinite(x);
 }
 
 GPUdi() unsigned int clz(unsigned int val)
@@ -118,11 +89,37 @@ GPUdi() T log(T x)
   return o2::gpu::GPUCommonMath::Log(x);
 };
 
+#ifndef GPUCA_GPUCODE_DEVICE // Double overloads using std namespace not visible on GPU
+template <>
+GPUhdi() double copysign(double x, double y)
+{
+  return std::copysign(x, y);
+}
+template <>
+GPUhdi() double sqrt(double x)
+{
+  return std::sqrt(x);
+};
+GPUhdi() double abs(double x)
+{
+  return std::abs(x);
+};
+template <>
+GPUdi() int nint(double x)
+{
+  return std::nearbyint(x);
+};
+template <>
+GPUdi() bool finite(double x)
+{
+  return std::isfinite(x);
+}
 template <>
 GPUdi() double log(double x)
 {
   return std::log(x);
 };
+#endif
 
 } // namespace detail
 } // namespace math_utils

--- a/Common/MathUtils/include/MathUtils/detail/basicMath.h
+++ b/Common/MathUtils/include/MathUtils/detail/basicMath.h
@@ -1,0 +1,131 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file basicMath.h
+/// \brief
+/// \author ruben.shahoyan@cern.ch, michael.lettrich@cern.ch
+
+#ifndef MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BASICMATH_H_
+#define MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BASICMATH_H_
+
+#ifndef GPUCA_GPUCODE_DEVICE
+#include <cmath>
+#include <tuple>
+#endif
+#include "GPUCommonArray.h"
+#include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
+#include "CommonConstants/MathConstants.h"
+
+namespace o2
+{
+namespace math_utils
+{
+namespace detail
+{
+
+template <typename T>
+GPUhdi() T copysign(T x, T y)
+{
+  return o2::gpu::GPUCommonMath::Copysign(x, y);
+}
+
+template <>
+GPUhdi() double copysign(double x, double y)
+{
+  return std::copysign(x, y);
+}
+
+template <class T>
+GPUhdi() T min(const T x, const T y)
+{
+  return o2::gpu::GPUCommonMath::Min(x, y);
+};
+
+template <class T>
+GPUhdi() T max(const T x, const T y)
+{
+  return o2::gpu::GPUCommonMath::Max(x, y);
+};
+
+template <class T>
+GPUhdi() T sqrt(T x)
+{
+  return o2::gpu::GPUCommonMath::Sqrt(x);
+};
+
+template <>
+GPUhdi() double sqrt(double x)
+{
+  return std::sqrt(x);
+};
+
+template <class T>
+GPUhdi() T abs(T x)
+{
+  return o2::gpu::GPUCommonMath::Abs(x);
+};
+
+GPUhdi() double abs(double x)
+{
+  return std::abs(x);
+};
+
+template <class T>
+GPUdi() int nint(T x)
+{
+  return o2::gpu::GPUCommonMath::Nint(x);
+};
+
+template <>
+GPUdi() int nint(double x)
+{
+  return std::nearbyint(x);
+};
+
+template <class T>
+GPUdi() bool finite(T x)
+{
+  return o2::gpu::GPUCommonMath::Finite(x);
+}
+
+template <>
+GPUdi() bool finite(double x)
+{
+  return std::isfinite(x);
+}
+
+GPUdi() unsigned int clz(unsigned int val)
+{
+  return o2::gpu::GPUCommonMath::Clz(val);
+};
+
+GPUdi() unsigned int popcount(unsigned int val)
+{
+  return o2::gpu::GPUCommonMath::Popcount(val);
+};
+
+template <class T>
+GPUdi() T log(T x)
+{
+  return o2::gpu::GPUCommonMath::Log(x);
+};
+
+template <>
+GPUdi() double log(double x)
+{
+  return std::log(x);
+};
+
+} // namespace detail
+} // namespace math_utils
+} // namespace o2
+
+#endif /* MATHUTILS_INCLUDE_MATHUTILS_DETAIL_BASICMATH_H_ */

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -109,8 +109,8 @@ inline void bringToPMPiGen(T& phi)
 }
 
 #ifdef __OPENCL__ // TODO: get rid of that stupid workaround for OpenCL template address spaces
-template <typename T>
-GPUhdi() void sincos(T ang, T& s, T& c)
+template <typename T, typename S, typename U>
+GPUhdi() void sincos(T ang, S& s, U& c)
 {
   return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
@@ -256,22 +256,10 @@ GPUdi() T asin(T x)
   return o2::gpu::GPUCommonMath::ASin(x);
 };
 
-template <>
-GPUdi() double asin(double x)
-{
-  return std::asin(x);
-};
-
 template <class T>
 GPUdi() T atan(T x)
 {
   return o2::gpu::GPUCommonMath::ATan(x);
-};
-
-template <>
-GPUdi() double atan(double x)
-{
-  return std::atan(x);
 };
 
 template <class T>
@@ -280,22 +268,10 @@ GPUdi() T atan2(T y, T x)
   return o2::gpu::GPUCommonMath::ATan2(y, x);
 };
 
-template <>
-GPUdi() double atan2(double y, double x)
-{
-  return std::atan2(y, x);
-};
-
 template <class T>
 GPUdi() T sin(T x)
 {
   return o2::gpu::GPUCommonMath::Sin(x);
-};
-
-template <>
-GPUdi() double sin(double x)
-{
-  return std::sin(x);
 };
 
 template <class T>
@@ -304,22 +280,10 @@ GPUdi() T cos(T x)
   return o2::gpu::GPUCommonMath::Cos(x);
 };
 
-template <>
-GPUdi() double cos(double x)
-{
-  return std::cos(x);
-};
-
 template <class T>
 GPUdi() T tan(T x)
 {
   return o2::gpu::GPUCommonMath::Tan(x);
-};
-
-template <>
-GPUdi() double tan(double x)
-{
-  return std::tan(x);
 };
 
 template <class T>
@@ -345,6 +309,39 @@ GPUdi() double pi()
 {
   return o2::constants::math::PI;
 }
+
+#ifndef GPUCA_GPUCODE_DEVICE
+template <>
+GPUdi() double tan(double x)
+{
+  return std::tan(x);
+};
+template <>
+GPUdi() double sin(double x)
+{
+  return std::sin(x);
+};
+template <>
+GPUdi() double atan2(double y, double x)
+{
+  return std::atan2(y, x);
+};
+template <>
+GPUdi() double atan(double x)
+{
+  return std::atan(x);
+};
+template <>
+GPUdi() double asin(double x)
+{
+  return std::asin(x);
+};
+template <>
+GPUdi() double cos(double x)
+{
+  return std::cos(x);
+};
+#endif
 
 } // namespace detail
 } // namespace math_utils

--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -23,6 +23,7 @@
 #include "GPUCommonDef.h"
 #include "GPUCommonMath.h"
 #include "CommonConstants/MathConstants.h"
+#include "MathUtils/detail/basicMath.h"
 
 namespace o2
 {
@@ -109,7 +110,7 @@ inline void bringToPMPiGen(T& phi)
 
 #ifdef __OPENCL__ // TODO: get rid of that stupid workaround for OpenCL template address spaces
 template <typename T>
-GPUhdi() void sincos(T ang, float& s, float& c)
+GPUhdi() void sincos(T ang, T& s, T& c)
 {
   return o2::gpu::GPUCommonMath::SinCos(ang, s, c);
 }
@@ -208,18 +209,6 @@ GPUhdi() T angle2Alpha(T phi)
 }
 
 template <typename T>
-GPUhdi() T copysign(T x, T y)
-{
-  return o2::gpu::GPUCommonMath::Copysign(x, y);
-}
-
-template <>
-GPUhdi() double copysign(double x, double y)
-{
-  return o2::gpu::GPUCommonMath::Copysignd(x, y);
-}
-
-template <typename T>
 GPUhdi() T fastATan2(T y, T x)
 {
   // Fast atan2(y,x) for any angle [-Pi,Pi]
@@ -259,6 +248,102 @@ GPUhdi() T fastATan2(T y, T x)
 
   // fast atan2(y,x) for any angle [-Pi,Pi]
   return copysign<T>(atan2P(o2::gpu::GPUCommonMath::Abs(y), x), y);
+}
+
+template <class T>
+GPUdi() T asin(T x)
+{
+  return o2::gpu::GPUCommonMath::ASin(x);
+};
+
+template <>
+GPUdi() double asin(double x)
+{
+  return std::asin(x);
+};
+
+template <class T>
+GPUdi() T atan(T x)
+{
+  return o2::gpu::GPUCommonMath::ATan(x);
+};
+
+template <>
+GPUdi() double atan(double x)
+{
+  return std::atan(x);
+};
+
+template <class T>
+GPUdi() T atan2(T y, T x)
+{
+  return o2::gpu::GPUCommonMath::ATan2(y, x);
+};
+
+template <>
+GPUdi() double atan2(double y, double x)
+{
+  return std::atan2(y, x);
+};
+
+template <class T>
+GPUdi() T sin(T x)
+{
+  return o2::gpu::GPUCommonMath::Sin(x);
+};
+
+template <>
+GPUdi() double sin(double x)
+{
+  return std::sin(x);
+};
+
+template <class T>
+GPUdi() T cos(T x)
+{
+  return o2::gpu::GPUCommonMath::Cos(x);
+};
+
+template <>
+GPUdi() double cos(double x)
+{
+  return std::cos(x);
+};
+
+template <class T>
+GPUdi() T tan(T x)
+{
+  return o2::gpu::GPUCommonMath::Tan(x);
+};
+
+template <>
+GPUdi() double tan(double x)
+{
+  return std::tan(x);
+};
+
+template <class T>
+GPUdi() T twoPi()
+{
+  return o2::gpu::GPUCommonMath::TwoPi();
+};
+
+template <>
+GPUdi() double twoPi()
+{
+  return o2::constants::math::TwoPI;
+};
+
+template <class T>
+GPUdi() T pi()
+{
+  return o2::gpu::GPUCommonMath::Pi();
+}
+
+template <>
+GPUdi() double pi()
+{
+  return o2::constants::math::PI;
 }
 
 } // namespace detail

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
@@ -23,8 +23,13 @@ namespace o2
 namespace track
 {
 
-using TrackPar = TrackParametrization<float>;
-using TrackParCov = TrackParametrizationWithError<float>;
+using TrackParF = TrackParametrization<float>;
+using TrackParD = TrackParametrization<double>;
+using TrackPar = TrackParF;
+
+using TrackParCovF = TrackParametrizationWithError<float>;
+using TrackParCovD = TrackParametrizationWithError<double>;
+using TrackParCov = TrackParCovF;
 
 } // namespace track
 } // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackLTIntegral.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackLTIntegral.h
@@ -18,7 +18,6 @@
 #include "GPUCommonRtypes.h"
 #include "GPUCommonDef.h"
 #include "ReconstructionDataFormats/PID.h"
-#include "ReconstructionDataFormats/Track.h"
 
 namespace o2
 {
@@ -47,7 +46,7 @@ class TrackLTIntegral
     }
   }
 
-  GPUd() void addStep(float dL, const TrackPar& track);
+  GPUd() void addStep(float dL, float p2Inv);
   GPUd() void addX2X0(float d) { mX2X0 += d; }
 
   GPUd() void setL(float l) { mL = l; }

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -14,9 +14,13 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::track::TrackParF + ;
+#pragma link C++ class o2::track::TrackParD + ;
 #pragma link C++ class o2::track::TrackPar + ;
 #pragma link C++ class o2::track::TrackParametrization < float> + ;
 #pragma link C++ class o2::track::TrackParametrization < double> + ;
+#pragma link C++ class o2::track::TrackParCovF + ;
+#pragma link C++ class o2::track::TrackParCovD + ;
 #pragma link C++ class o2::track::TrackParCov + ;
 #pragma link C++ class o2::track::TrackParametrizationWithError < float> + ;
 #pragma link C++ class o2::track::TrackParametrizationWithError < double> + ;

--- a/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
+++ b/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
@@ -10,10 +10,12 @@
 
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
 #include "CommonConstants/PhysicsConstants.h"
-#include "GPUCommonMath.h"
+#include "MathUtils/Utils.h"
 
-using namespace o2::track;
-using namespace o2::gpu;
+namespace o2
+{
+namespace track
+{
 
 //_____________________________________________________
 GPUd() void TrackLTIntegral::print() const
@@ -28,15 +30,17 @@ GPUd() void TrackLTIntegral::print() const
 }
 
 //_____________________________________________________
-GPUd() void TrackLTIntegral::addStep(float dL, const TrackPar& track)
+GPUd() void TrackLTIntegral::addStep(float dL, float p2Inv)
 {
   ///< add step in cm to integrals
   mL += dL;
-  float p2 = track.getP2Inv();
-  float dTns = dL * 1000.f / o2::constants::physics::LightSpeedCm2NS; // time change in ps for beta = 1 particle
+  const float dTns = dL * 1000.f / o2::constants::physics::LightSpeedCm2NS; // time change in ps for beta = 1 particle
   for (int id = 0; id < getNTOFs(); id++) {
-    float m2z = o2::track::PID::getMass2Z(id);
-    float betaInv = CAMath::Sqrt(1.f + m2z * m2z * p2);
+    const float m2z = track::PID::getMass2Z(id);
+    const float betaInv = math_utils::sqrt(1.f + m2z * m2z * p2Inv);
     mT[id] += dTns * betaInv;
   }
 }
+
+} // namespace track
+} // namespace o2

--- a/DataFormats/Reconstruction/test/testLTOFIntegration.cxx
+++ b/DataFormats/Reconstruction/test/testLTOFIntegration.cxx
@@ -32,8 +32,8 @@ BOOST_AUTO_TEST_CASE(TrackLTIntegral)
   const int nStep = 100;
   const float dx2x0 = 0.01f;
   for (int i = 0; i < nStep; i++) {
-    lt.addStep(1., trc);
-    lt1.addStep(1., trc1);
+    lt.addStep(1., trc.getP2Inv());
+    lt1.addStep(1., trc1.getP2Inv());
     lt1.addX2X0(dx2x0);
   }
   trc.printParam();

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -51,9 +51,15 @@ class GPUTPCGMPolynomialField;
 
 namespace base
 {
-class Propagator
+
+template <typename value_T>
+class PropagatorImpl
 {
  public:
+  using value_type = value_T;
+  using TrackPar_t = track::TrackParametrization<value_type>;
+  using TrackParCov_t = track::TrackParametrizationWithError<value_type>;
+
   enum class MatCorrType : int {
     USEMatCorrNONE, // flag to not use material corrections
     USEMatCorrTGeo, // flag to use TGeo for material queries
@@ -63,60 +69,60 @@ class Propagator
   static constexpr float MAX_SIN_PHI = 0.85f;
   static constexpr float MAX_STEP = 2.0f;
 
-  GPUd() bool PropagateToXBxByBz(o2::track::TrackParCov& track, float x,
-                                 float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                                 o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
+  GPUd() bool PropagateToXBxByBz(TrackParCov_t& track, value_type x,
+                                 value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                                 track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  GPUd() bool PropagateToXBxByBz(o2::track::TrackPar& track, float x,
-                                 float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                                 o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
+  GPUd() bool PropagateToXBxByBz(TrackPar_t& track, value_type x,
+                                 value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                                 track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  GPUd() bool propagateToX(o2::track::TrackParCov& track, float x, float bZ,
-                           float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                           o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
+  GPUd() bool propagateToX(TrackParCov_t& track, value_type x, value_type bZ,
+                           value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                           track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  GPUd() bool propagateToX(o2::track::TrackPar& track, float x, float bZ,
-                           float maxSnp = MAX_SIN_PHI, float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                           o2::track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
+  GPUd() bool propagateToX(TrackPar_t& track, value_type x, value_type bZ,
+                           value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                           track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
-  GPUd() bool propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track, float bZ,
-                             float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                             o2::dataformats::DCA* dcaInfo = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
-                             int signCorr = 0, float maxD = 999.f) const;
+  GPUd() bool propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParametrizationWithError<value_type>& track, value_type bZ,
+                             value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                             o2::dataformats::DCA* dcaInfo = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                             int signCorr = 0, value_type maxD = 999.f) const;
 
-  GPUd() bool propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track,
-                                   float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                                   o2::dataformats::DCA* dcaInfo = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
-                                   int signCorr = 0, float maxD = 999.f) const;
+  GPUd() bool propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2::track::TrackParametrizationWithError<value_type>& track,
+                                   value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                                   o2::dataformats::DCA* dcaInfo = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                                   int signCorr = 0, value_type maxD = 999.f) const;
 
-  GPUd() bool propagateToDCA(const o2::math_utils::Point3D<float>& vtx, o2::track::TrackPar& track, float bZ,
-                             float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                             gpu::gpustd::array<float, 2>* dca = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
-                             int signCorr = 0, float maxD = 999.f) const;
+  GPUd() bool propagateToDCA(const o2::math_utils::Point3D<value_type>& vtx, o2::track::TrackParametrization<value_type>& track, value_type bZ,
+                             value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                             gpu::gpustd::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                             int signCorr = 0, value_type maxD = 999.f) const;
 
-  GPUd() bool propagateToDCABxByBz(const o2::math_utils::Point3D<float>& vtx, o2::track::TrackPar& track,
-                                   float maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
-                                   gpu::gpustd::array<float, 2>* dca = nullptr, o2::track::TrackLTIntegral* tofInfo = nullptr,
-                                   int signCorr = 0, float maxD = 999.f) const;
+  GPUd() bool propagateToDCABxByBz(const o2::math_utils::Point3D<value_type>& vtx, o2::track::TrackParametrization<value_type>& track,
+                                   value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
+                                   gpu::gpustd::array<value_type, 2>* dca = nullptr, track::TrackLTIntegral* tofInfo = nullptr,
+                                   int signCorr = 0, value_type maxD = 999.f) const;
 
-  Propagator(Propagator const&) = delete;
-  Propagator(Propagator&&) = delete;
-  Propagator& operator=(Propagator const&) = delete;
-  Propagator& operator=(Propagator&&) = delete;
+  PropagatorImpl(PropagatorImpl const&) = delete;
+  PropagatorImpl(PropagatorImpl&&) = delete;
+  PropagatorImpl& operator=(PropagatorImpl const&) = delete;
+  PropagatorImpl& operator=(PropagatorImpl&&) = delete;
 
   // Bz at the origin
-  GPUd() float getNominalBz() const { return mBz; }
+  GPUd() value_type getNominalBz() const { return mBz; }
 
   GPUd() void setMatLUT(const o2::base::MatLayerCylSet* lut) { mMatLUT = lut; }
   GPUd() const o2::base::MatLayerCylSet* getMatLUT() const { return mMatLUT; }
   GPUd() void setGPUField(const o2::gpu::GPUTPCGMPolynomialField* field) { mGPUField = field; }
   GPUd() const o2::gpu::GPUTPCGMPolynomialField* getGPUField() const { return mGPUField; }
-  GPUd() void setBz(float bz) { mBz = bz; }
+  GPUd() void setBz(value_type bz) { mBz = bz; }
 
 #ifndef GPUCA_GPUCODE
-  static Propagator* Instance(bool uninitialized = false)
+  static PropagatorImpl* Instance(bool uninitialized = false)
   {
-    static Propagator instance(uninitialized);
+    static PropagatorImpl instance(uninitialized);
     return &instance;
   }
 
@@ -124,24 +130,34 @@ class Propagator
   static int initFieldFromGRP(const std::string grpFileName, std::string grpName = "GRP", bool verbose = false);
 #endif
 
-  GPUd() MatBudget getMatBudget(MatCorrType corrType, const o2::math_utils::Point3D<float>& p0, const o2::math_utils::Point3D<float>& p1) const;
+  GPUd() MatBudget getMatBudget(MatCorrType corrType, const o2::math_utils::Point3D<value_type>& p0, const o2::math_utils::Point3D<value_type>& p1) const;
+
   GPUd() void getFieldXYZ(const math_utils::Point3D<float> xyz, float* bxyz) const;
+
   GPUd() void getFieldXYZ(const math_utils::Point3D<double> xyz, double* bxyz) const;
 
  private:
 #ifndef GPUCA_GPUCODE
-  Propagator(bool uninitialized = false);
-  ~Propagator() = default;
+  PropagatorImpl(bool uninitialized = false);
+  ~PropagatorImpl() = default;
 #endif
 
+  template <typename T>
+  GPUd() void getFieldXYZImpl(const math_utils::Point3D<T> xyz, T* bxyz) const;
+
   const o2::field::MagFieldFast* mField = nullptr; ///< External fast field (barrel only for the moment)
-  float mBz = 0;                                   // nominal field
+  value_type mBz = 0;                              // nominal field
 
   const o2::base::MatLayerCylSet* mMatLUT = nullptr;           // externally set LUT
   const o2::gpu::GPUTPCGMPolynomialField* mGPUField = nullptr; // externally set GPU Field
 
-  ClassDef(Propagator, 0);
+  ClassDefNV(PropagatorImpl, 0);
 };
+
+using PropagatorF = PropagatorImpl<float>;
+using PropatatorD = PropagatorImpl<double>;
+using Propagator = PropagatorF;
+
 } // namespace base
 } // namespace o2
 

--- a/Detectors/Base/src/DetectorsBaseLinkDef.h
+++ b/Detectors/Base/src/DetectorsBaseLinkDef.h
@@ -16,6 +16,9 @@
 
 #pragma link C++ class o2::base::Detector + ;
 #pragma link C++ class o2::base::Propagator + ;
+#pragma link C++ class o2::base::PropagatorF + ;
+#pragma link C++ class o2::base::PropagatorImpl < double> + ;
+#pragma link C++ class o2::base::PropagatorImpl < float> + ;
 
 #pragma link C++ class o2::base::GeometryManager + ;
 #pragma link C++ class o2::base::GeometryManager::MatBudgetExt + ;

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -29,7 +29,8 @@ using namespace o2::gpu;
 #include <FairRunAna.h> // eventually will get rid of it
 #include <TGeoGlobalMagField.h>
 
-Propagator::Propagator(bool uninitialized)
+template <typename value_T>
+PropagatorImpl<value_T>::PropagatorImpl(bool uninitialized)
 {
   if (uninitialized) {
     return;
@@ -54,12 +55,13 @@ Propagator::Propagator(bool uninitialized)
     slowField->AllowFastField(true);
   }
   mField = slowField->getFastField();
-  const float xyz[3] = {0.};
+  const value_type xyz[3] = {0.};
   mField->GetBz(xyz, mBz);
 }
 
 //____________________________________________________________
-int Propagator::initFieldFromGRP(const std::string grpFileName, std::string grpName, bool verbose)
+template <typename value_T>
+int PropagatorImpl<value_T>::initFieldFromGRP(const std::string grpFileName, std::string grpName, bool verbose)
 {
   /// load grp and init magnetic field
   if (verbose) {
@@ -77,7 +79,8 @@ int Propagator::initFieldFromGRP(const std::string grpFileName, std::string grpN
 }
 
 //____________________________________________________________
-int Propagator::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verbose)
+template <typename value_T>
+int PropagatorImpl<value_T>::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verbose)
 {
   /// init mag field from GRP data and attach it to TGeoGlobalMagField
 
@@ -102,14 +105,16 @@ int Propagator::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verb
   return 0;
 }
 #elif !defined(GPUCA_GPUCODE)
-Propagator::Propagator(bool uninitialized)
+template <typename value_T>
+PropagatorImpl<value_T>::PropagatorImpl(bool uninitialized)
 {
 } // empty dummy constructor for standalone benchmark
 #endif
 
 //_______________________________________________________________________
-GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float xToGo, float maxSnp, float maxStep,
-                                           Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::PropagateToXBxByBz(TrackParCov_t& track, value_type xToGo, value_type maxSnp, value_type maxStep,
+                                                        PropagatorImpl<value_T>::MatCorrType matCorr, track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
   //
@@ -122,16 +127,16 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float 
   //
   // matCorr  - material correction type, it is up to the user to make sure the pointer is attached (if LUT is requested)
   //----------------------------------------------------------------
-  const float Epsilon = 0.00001;
+  const value_type Epsilon = 0.00001;
   auto dx = xToGo - track.getX();
   int dir = dx > 0.f ? 1 : -1;
   if (!signCorr) {
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  gpu::gpustd::array<float, 3> b;
-  while (CAMath::Abs(dx) > Epsilon) {
-    auto step = CAMath::Min(CAMath::Abs(dx), maxStep);
+  gpu::gpustd::array<value_type, 3> b;
+  while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
+    auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
       step = -step;
     }
@@ -142,7 +147,7 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float 
     if (!track.propagateTo(x, b)) {
       return false;
     }
-    if (maxSnp > 0 && CAMath::Abs(track.getSnp()) >= maxSnp) {
+    if (maxSnp > 0 && math_utils::detail::abs<value_type>(track.getSnp()) >= maxSnp) {
       return false;
     }
     if (matCorr != MatCorrType::USEMatCorrNONE) {
@@ -153,13 +158,13 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float 
       }
 
       if (tofInfo) {
-        tofInfo->addStep(mb.length, track); // fill L,ToF info using already calculated step length
+        tofInfo->addStep(mb.length, track.getP2Inv()); // fill L,ToF info using already calculated step length
         tofInfo->addX2X0(mb.meanX2X0);
       }
     } else if (tofInfo) { // if tofInfo filling was requested w/o material correction, we need to calculate the step lenght
       auto xyz1 = track.getXYZGlo();
-      math_utils::Vector3D<float> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
-      tofInfo->addStep(stepV.R(), track);
+      math_utils::Vector3D<value_type> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
+      tofInfo->addStep(stepV.R(), track.getP2Inv());
     }
     dx = xToGo - track.getX();
   }
@@ -168,8 +173,9 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackParCov& track, float 
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xToGo, float maxSnp, float maxStep,
-                                           Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::PropagateToXBxByBz(TrackPar_t& track, value_type xToGo, value_type maxSnp, value_type maxStep,
+                                                        PropagatorImpl<value_T>::MatCorrType matCorr, track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
   //
@@ -182,16 +188,16 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xTo
   //
   // matCorr  - material correction type, it is up to the user to make sure the pointer is attached (if LUT is requested)
   //----------------------------------------------------------------
-  const float Epsilon = 0.00001;
+  const value_type Epsilon = 0.00001;
   auto dx = xToGo - track.getX();
   int dir = dx > 0.f ? 1 : -1;
   if (!signCorr) {
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  gpu::gpustd::array<float, 3> b;
-  while (CAMath::Abs(dx) > Epsilon) {
-    auto step = CAMath::Min(CAMath::Abs(dx), maxStep);
+  gpu::gpustd::array<value_type, 3> b;
+  while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
+    auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
       step = -step;
     }
@@ -202,7 +208,7 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xTo
     if (!track.propagateParamTo(x, b)) {
       return false;
     }
-    if (maxSnp > 0 && CAMath::Abs(track.getSnp()) >= maxSnp) {
+    if (maxSnp > 0 && math_utils::detail::abs<value_type>(track.getSnp()) >= maxSnp) {
       return false;
     }
     if (matCorr != MatCorrType::USEMatCorrNONE) {
@@ -212,13 +218,13 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xTo
         return false;
       }
       if (tofInfo) {
-        tofInfo->addStep(mb.length, track); // fill L,ToF info using already calculated step length
+        tofInfo->addStep(mb.length, track.getP2Inv()); // fill L,ToF info using already calculated step length
         tofInfo->addX2X0(mb.meanX2X0);
       }
     } else if (tofInfo) { // if tofInfo filling was requested w/o material correction, we need to calculate the step lenght
       auto xyz1 = track.getXYZGlo();
-      math_utils::Vector3D<float> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
-      tofInfo->addStep(stepV.R(), track);
+      math_utils::Vector3D<value_type> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
+      tofInfo->addStep(stepV.R(), track.getP2Inv());
     }
     dx = xToGo - track.getX();
   }
@@ -227,8 +233,9 @@ GPUd() bool Propagator::PropagateToXBxByBz(o2::track::TrackPar& track, float xTo
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo, float bZ, float maxSnp, float maxStep,
-                                     Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToX(TrackParCov_t& track, value_type xToGo, value_type bZ, value_type maxSnp, value_type maxStep,
+                                                  PropagatorImpl<value_T>::MatCorrType matCorr, track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
   //
@@ -241,15 +248,15 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo,
   //
   // matCorr  - material correction type, it is up to the user to make sure the pointer is attached (if LUT is requested)
   //----------------------------------------------------------------
-  const float Epsilon = 0.00001;
+  const value_type Epsilon = 0.00001;
   auto dx = xToGo - track.getX();
   int dir = dx > 0.f ? 1 : -1;
   if (!signCorr) {
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  while (CAMath::Abs(dx) > Epsilon) {
-    auto step = CAMath::Min(CAMath::Abs(dx), maxStep);
+  while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
+    auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
       step = -step;
     }
@@ -259,7 +266,7 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo,
     if (!track.propagateTo(x, bZ)) {
       return false;
     }
-    if (maxSnp > 0 && CAMath::Abs(track.getSnp()) >= maxSnp) {
+    if (maxSnp > 0 && math_utils::detail::abs<value_type>(track.getSnp()) >= maxSnp) {
       return false;
     }
     if (matCorr != MatCorrType::USEMatCorrNONE) {
@@ -271,13 +278,13 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo,
       }
 
       if (tofInfo) {
-        tofInfo->addStep(mb.length, track); // fill L,ToF info using already calculated step length
+        tofInfo->addStep(mb.length, track.getP2Inv()); // fill L,ToF info using already calculated step length
         tofInfo->addX2X0(mb.meanX2X0);
       }
     } else if (tofInfo) { // if tofInfo filling was requested w/o material correction, we need to calculate the step lenght
       auto xyz1 = track.getXYZGlo();
-      math_utils::Vector3D<float> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
-      tofInfo->addStep(stepV.R(), track);
+      math_utils::Vector3D<value_type> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
+      tofInfo->addStep(stepV.R(), track.getP2Inv());
     }
     dx = xToGo - track.getX();
   }
@@ -286,8 +293,9 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackParCov& track, float xToGo,
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, float bZ, float maxSnp, float maxStep,
-                                     Propagator::MatCorrType matCorr, o2::track::TrackLTIntegral* tofInfo, int signCorr) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToX(TrackPar_t& track, value_type xToGo, value_type bZ, value_type maxSnp, value_type maxStep,
+                                                  PropagatorImpl<value_T>::MatCorrType matCorr, track::TrackLTIntegral* tofInfo, int signCorr) const
 {
   //----------------------------------------------------------------
   //
@@ -300,15 +308,15 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, fl
   //
   // matCorr  - material correction type, it is up to the user to make sure the pointer is attached (if LUT is requested)
   //----------------------------------------------------------------
-  const float Epsilon = 0.00001;
+  const value_type Epsilon = 0.00001;
   auto dx = xToGo - track.getX();
   int dir = dx > 0.f ? 1 : -1;
   if (!signCorr) {
     signCorr = -dir; // sign of eloss correction is not imposed
   }
 
-  while (CAMath::Abs(dx) > Epsilon) {
-    auto step = CAMath::Min(CAMath::Abs(dx), maxStep);
+  while (math_utils::detail::abs<value_type>(dx) > Epsilon) {
+    auto step = math_utils::detail::min<value_type>(math_utils::detail::abs<value_type>(dx), maxStep);
     if (dir < 0) {
       step = -step;
     }
@@ -318,7 +326,7 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, fl
     if (!track.propagateParamTo(x, bZ)) {
       return false;
     }
-    if (maxSnp > 0 && CAMath::Abs(track.getSnp()) >= maxSnp) {
+    if (maxSnp > 0 && math_utils::detail::abs<value_type>(track.getSnp()) >= maxSnp) {
       return false;
     }
     if (matCorr != MatCorrType::USEMatCorrNONE) {
@@ -330,13 +338,13 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, fl
       }
 
       if (tofInfo) {
-        tofInfo->addStep(mb.length, track); // fill L,ToF info using already calculated step length
+        tofInfo->addStep(mb.length, track.getP2Inv()); // fill L,ToF info using already calculated step length
         tofInfo->addX2X0(mb.meanX2X0);
       }
     } else if (tofInfo) { // if tofInfo filling was requested w/o material correction, we need to calculate the step lenght
       auto xyz1 = track.getXYZGlo();
-      math_utils::Vector3D<float> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
-      tofInfo->addStep(stepV.R(), track);
+      math_utils::Vector3D<value_type> stepV(xyz1.X() - xyz0.X(), xyz1.Y() - xyz0.Y(), xyz1.Z() - xyz0.Z());
+      tofInfo->addStep(stepV.R(), track.getP2Inv());
     }
     dx = xToGo - track.getX();
   }
@@ -345,35 +353,36 @@ GPUd() bool Propagator::propagateToX(o2::track::TrackPar& track, float xToGo, fl
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track, float bZ,
-                                       float maxStep, Propagator::MatCorrType matCorr,
-                                       o2::dataformats::DCA* dca, o2::track::TrackLTIntegral* tofInfo,
-                                       int signCorr, float maxD) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::VertexBase& vtx, TrackParCov_t& track, value_type bZ,
+                                                    value_type maxStep, PropagatorImpl<value_type>::MatCorrType matCorr,
+                                                    o2::dataformats::DCA* dca, track::TrackLTIntegral* tofInfo,
+                                                    int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex
-  float sn, cs, alp = track.getAlpha();
-  o2::math_utils::sincos(alp, sn, cs);
-  float x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = CAMath::Sqrt((1.f - snp) * (1.f + snp));
-  float xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
+  value_type sn, cs, alp = track.getAlpha();
+  math_utils::detail::sincos<value_type>(alp, sn, cs);
+  value_type x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = math_utils::detail::sqrt<value_type>((1.f - snp) * (1.f + snp));
+  value_type xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  float d = CAMath::Abs(x * snp - y * csp);
+  value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
-  float crv = track.getCurvature(bZ);
-  float tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / CAMath::Sqrt(1.f + tgfv * tgfv);
-  cs = CAMath::Sqrt((1. - sn) * (1. + sn));
-  cs = (CAMath::Abs(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
+  value_type crv = track.getCurvature(bZ);
+  value_type tgfv = -(crv * x - snp) / (crv * y + csp);
+  sn = tgfv / math_utils::detail::sqrt<value_type>(1.f + tgfv * tgfv);
+  cs = math_utils::detail::sqrt<value_type>((1. - sn) * (1. + sn));
+  cs = (math_utils::detail::abs<value_type>(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(track); // operate on the copy to recover after the failure
-  alp += CAMath::ASin(sn);
+  alp += math_utils::detail::asin<value_type>(sn);
   if (!tmpT.rotate(alp) || !propagateToX(tmpT, xv, bZ, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: ";
     tmpT.print();
@@ -381,7 +390,7 @@ GPUd() bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o
   }
   track = tmpT;
   if (dca) {
-    o2::math_utils::sincos(alp, sn, cs);
+    math_utils::detail::sincos<value_type>(alp, sn, cs);
     auto s2ylocvtx = vtx.getSigmaX2() * sn * sn + vtx.getSigmaY2() * cs * cs - 2. * vtx.getSigmaXY() * cs * sn;
     dca->set(track.getY() - yv, track.getZ() - zv,
              track.getSigmaY2() + s2ylocvtx, track.getSigmaZY(), track.getSigmaZ2() + vtx.getSigmaZ2());
@@ -390,35 +399,36 @@ GPUd() bool Propagator::propagateToDCA(const o2::dataformats::VertexBase& vtx, o
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, o2::track::TrackParCov& track,
-                                             float maxStep, Propagator::MatCorrType matCorr,
-                                             o2::dataformats::DCA* dca, o2::track::TrackLTIntegral* tofInfo,
-                                             int signCorr, float maxD) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats::VertexBase& vtx, TrackParCov_t& track,
+                                                          value_type maxStep, PropagatorImpl<value_type>::MatCorrType matCorr,
+                                                          o2::dataformats::DCA* dca, track::TrackLTIntegral* tofInfo,
+                                                          int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex
-  float sn, cs, alp = track.getAlpha();
-  o2::math_utils::sincos(alp, sn, cs);
-  float x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = CAMath::Sqrt((1.f - snp) * (1.f + snp));
-  float xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
+  value_type sn, cs, alp = track.getAlpha();
+  math_utils::detail::sincos<value_type>(alp, sn, cs);
+  value_type x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = math_utils::detail::sqrt<value_type>((1.f - snp) * (1.f + snp));
+  value_type xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  float d = CAMath::Abs(x * snp - y * csp);
+  value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
-  float crv = track.getCurvature(mBz);
-  float tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / CAMath::Sqrt(1.f + tgfv * tgfv);
-  cs = CAMath::Sqrt((1. - sn) * (1. + sn));
-  cs = (CAMath::Abs(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
+  value_type crv = track.getCurvature(mBz);
+  value_type tgfv = -(crv * x - snp) / (crv * y + csp);
+  sn = tgfv / math_utils::detail::sqrt<value_type>(1.f + tgfv * tgfv);
+  cs = math_utils::detail::sqrt<value_type>((1. - sn) * (1. + sn));
+  cs = (math_utils::detail::abs<value_type>(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(track); // operate on the copy to recover after the failure
-  alp += CAMath::ASin(sn);
+  alp += math_utils::detail::asin<value_type>(sn);
   if (!tmpT.rotate(alp) || !PropagateToXBxByBz(tmpT, xv, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << vtx << " | Track is: ";
     tmpT.print();
@@ -426,7 +436,7 @@ GPUd() bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& 
   }
   track = tmpT;
   if (dca) {
-    o2::math_utils::sincos(alp, sn, cs);
+    math_utils::detail::sincos<value_type>(alp, sn, cs);
     auto s2ylocvtx = vtx.getSigmaX2() * sn * sn + vtx.getSigmaY2() * cs * cs - 2. * vtx.getSigmaXY() * cs * sn;
     dca->set(track.getY() - yv, track.getZ() - zv,
              track.getSigmaY2() + s2ylocvtx, track.getSigmaZY(), track.getSigmaZ2() + vtx.getSigmaZ2());
@@ -435,35 +445,36 @@ GPUd() bool Propagator::propagateToDCABxByBz(const o2::dataformats::VertexBase& 
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToDCA(const math_utils::Point3D<float>& vtx, o2::track::TrackPar& track, float bZ,
-                                       float maxStep, Propagator::MatCorrType matCorr,
-                                       gpu::gpustd::array<float, 2>* dca, o2::track::TrackLTIntegral* tofInfo,
-                                       int signCorr, float maxD) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<value_type>& vtx, TrackPar_t& track, value_type bZ,
+                                                    value_type maxStep, PropagatorImpl<value_T>::MatCorrType matCorr,
+                                                    gpu::gpustd::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
+                                                    int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex
-  float sn, cs, alp = track.getAlpha();
-  o2::math_utils::sincos(alp, sn, cs);
-  float x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = CAMath::Sqrt((1.f - snp) * (1.f + snp));
-  float xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
+  value_type sn, cs, alp = track.getAlpha();
+  math_utils::detail::sincos<value_type>(alp, sn, cs);
+  value_type x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = math_utils::detail::sqrt<value_type>((1.f - snp) * (1.f + snp));
+  value_type xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  float d = CAMath::Abs(x * snp - y * csp);
+  value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
-  float crv = track.getCurvature(bZ);
-  float tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / CAMath::Sqrt(1.f + tgfv * tgfv);
-  cs = CAMath::Sqrt((1. - sn) * (1. + sn));
-  cs = (CAMath::Abs(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
+  value_type crv = track.getCurvature(bZ);
+  value_type tgfv = -(crv * x - snp) / (crv * y + csp);
+  sn = tgfv / math_utils::detail::sqrt<value_type>(1.f + tgfv * tgfv);
+  cs = math_utils::detail::sqrt<value_type>((1. - sn) * (1. + sn));
+  cs = (math_utils::detail::abs<value_type>(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(track); // operate on the copy to recover after the failure
-  alp += CAMath::ASin(sn);
+  alp += math_utils::detail::asin<value_type>(sn);
   if (!tmpT.rotateParam(alp) || !propagateToX(tmpT, xv, bZ, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
@@ -479,35 +490,36 @@ GPUd() bool Propagator::propagateToDCA(const math_utils::Point3D<float>& vtx, o2
 }
 
 //_______________________________________________________________________
-GPUd() bool Propagator::propagateToDCABxByBz(const math_utils::Point3D<float>& vtx, o2::track::TrackPar& track,
-                                             float maxStep, Propagator::MatCorrType matCorr,
-                                             gpu::gpustd::array<float, 2>* dca, o2::track::TrackLTIntegral* tofInfo,
-                                             int signCorr, float maxD) const
+template <typename value_T>
+GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Point3D<value_type>& vtx, TrackPar_t& track,
+                                                          value_type maxStep, PropagatorImpl<value_T>::MatCorrType matCorr,
+                                                          gpu::gpustd::array<value_type, 2>* dca, track::TrackLTIntegral* tofInfo,
+                                                          int signCorr, value_type maxD) const
 {
   // propagate track to DCA to the vertex
-  float sn, cs, alp = track.getAlpha();
-  o2::math_utils::sincos(alp, sn, cs);
-  float x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = CAMath::Sqrt((1.f - snp) * (1.f + snp));
-  float xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
+  value_type sn, cs, alp = track.getAlpha();
+  math_utils::detail::sincos<value_type>(alp, sn, cs);
+  value_type x = track.getX(), y = track.getY(), snp = track.getSnp(), csp = math_utils::detail::sqrt<value_type>((1.f - snp) * (1.f + snp));
+  value_type xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  float d = CAMath::Abs(x * snp - y * csp);
+  value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
-  float crv = track.getCurvature(mBz);
-  float tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / CAMath::Sqrt(1.f + tgfv * tgfv);
-  cs = CAMath::Sqrt((1. - sn) * (1. + sn));
-  cs = (CAMath::Abs(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
+  value_type crv = track.getCurvature(mBz);
+  value_type tgfv = -(crv * x - snp) / (crv * y + csp);
+  sn = tgfv / math_utils::detail::sqrt<value_type>(1.f + tgfv * tgfv);
+  cs = math_utils::detail::sqrt<value_type>((1. - sn) * (1. + sn));
+  cs = (math_utils::detail::abs<value_type>(tgfv) > o2::constants::math::Almost0) ? sn / tgfv : o2::constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(track); // operate on the copy to recover after the failure
-  alp += CAMath::ASin(sn);
+  alp += math_utils::detail::asin<value_type>(sn);
   if (!tmpT.rotateParam(alp) || !PropagateToXBxByBz(tmpT, xv, 0.85, maxStep, matCorr, tofInfo, signCorr)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
@@ -523,7 +535,8 @@ GPUd() bool Propagator::propagateToDCABxByBz(const math_utils::Point3D<float>& v
 }
 
 //____________________________________________________________
-GPUd() MatBudget Propagator::getMatBudget(Propagator::MatCorrType corrType, const math_utils::Point3D<float>& p0, const math_utils::Point3D<float>& p1) const
+template <typename value_T>
+GPUd() MatBudget PropagatorImpl<value_T>::getMatBudget(PropagatorImpl<value_type>::MatCorrType corrType, const math_utils::Point3D<value_type>& p0, const math_utils::Point3D<value_type>& p1) const
 {
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
   if (corrType == MatCorrType::USEMatCorrTGeo || !mMatLUT) {
@@ -533,23 +546,9 @@ GPUd() MatBudget Propagator::getMatBudget(Propagator::MatCorrType corrType, cons
   return mMatLUT->getMatBudget(p0.X(), p0.Y(), p0.Z(), p1.X(), p1.Y(), p1.Z());
 }
 
-GPUd() void Propagator::getFieldXYZ(const math_utils::Point3D<float> xyz, float* bxyz) const
-{
-  if (mGPUField) {
-#if defined(GPUCA_GPUCODE_DEVICE) && defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
-    const auto* f = &GPUCA_CONSMEM.param.polynomialField; // Access directly from constant memory on GPU (copied here to avoid complicated header dependencies)
-#else
-    const auto* f = mGPUField;
-#endif
-    f->GetField(xyz.X(), xyz.Y(), xyz.Z(), bxyz);
-  } else {
-#ifndef GPUCA_GPUCODE
-    mField->Field(xyz, bxyz); // Must not call the host-only function in GPU compilation
-#endif
-  }
-}
-
-GPUd() void Propagator::getFieldXYZ(const math_utils::Point3D<double> xyz, double* bxyz) const
+template <typename value_T>
+template <typename T>
+GPUd() void PropagatorImpl<value_T>::getFieldXYZImpl(const math_utils::Point3D<T> xyz, T* bxyz) const
 {
   if (mGPUField) {
 #if defined(GPUCA_GPUCODE_DEVICE) && defined(GPUCA_HAS_GLOBAL_SYMBOL_CONSTANT_MEM)
@@ -559,12 +558,34 @@ GPUd() void Propagator::getFieldXYZ(const math_utils::Point3D<double> xyz, doubl
 #endif
     float bxyzF[3];
     f->GetField(xyz.X(), xyz.Y(), xyz.Z(), bxyzF);
-    bxyz[0] = bxyzF[0];
-    bxyz[1] = bxyzF[1];
-    bxyz[2] = bxyzF[2];
+    //copy and convert
+    for (uint i = 0; i < 3; ++i) {
+      bxyz[i] = static_cast<value_type>(bxyzF[i]);
+    }
+
   } else {
 #ifndef GPUCA_GPUCODE
     mField->Field(xyz, bxyz); // Must not call the host-only function in GPU compilation
 #endif
   }
 }
+
+template <typename value_T>
+GPUd() void PropagatorImpl<value_T>::getFieldXYZ(const math_utils::Point3D<float> xyz, float* bxyz) const
+{
+  getFieldXYZImpl<float>(xyz, bxyz);
+}
+
+template <typename value_T>
+GPUd() void PropagatorImpl<value_T>::getFieldXYZ(const math_utils::Point3D<double> xyz, double* bxyz) const
+{
+  getFieldXYZImpl<double>(xyz, bxyz);
+}
+
+namespace o2::base
+{
+template class PropagatorImpl<float>;
+#ifndef GPUCA_GPUCODE_DEVICE
+template class PropagatorImpl<double>;
+#endif
+} // namespace o2::base

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1457,7 +1457,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
       d2XY = arcXY * arcXY;
     }
     auto lInt = std::sqrt(d2XY + dZ * dZ);
-    tofL.addStep(lInt, tracOut);
+    tofL.addStep(lInt, tracOut.getP2Inv());
     tofL.addX2X0(lInt * mTPCmeanX0Inv);
     propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, MaxSnp, 10., mUseMatCorrFlag, &tofL);
     /*

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -65,7 +65,6 @@ class GPUCommonMath
   GPUhdni() static void SinCosd(double x, double& s, double& c);
   GPUd() static float Tan(float x);
   GPUhdni() static float Copysign(float x, float y);
-  GPUhdni() static double Copysignd(double x, double y);
   GPUd() static float TwoPi() { return 6.28319f; }
   GPUd() static float Pi() { return 3.1415926535897f; }
   GPUd() static int Nint(float x);
@@ -395,20 +394,6 @@ GPUhdi() float GPUCommonMath::Copysign(float x, float y)
   return copysignf(x, y);
 #elif defined(__cplusplus) && __cplusplus >= 201103L
   return std::copysignf(x, y);
-#else
-  x = GPUCommonMath::Abs(x);
-  return (y >= 0) ? x : -x;
-#endif // GPUCA_GPUCODE
-}
-
-GPUhdi() double GPUCommonMath::Copysignd(double x, double y)
-{
-#if defined(__OPENCLCPP__)
-  return copysign(x, y);
-#elif defined(GPUCA_GPUCODE) && !defined(__OPENCL__)
-  return copysignf(x, y);
-#elif defined(__cplusplus) && __cplusplus >= 201103L
-  return std::copysign(x, y);
 #else
   x = GPUCommonMath::Abs(x);
   return (y >= 0) ? x : -x;

--- a/GPU/GPUTracking/Base/GPUParam.h
+++ b/GPU/GPUTracking/Base/GPUParam.h
@@ -21,13 +21,14 @@
 #include "GPUTPCGeometry.h"
 #include "GPUTPCGMPolynomialField.h"
 
-namespace o2
+#ifndef GPUCA_GPUCODE
+namespace o2::base
 {
-namespace base
-{
-class Propagator;
-} // namespace base
-} // namespace o2
+template <typename>
+class PropagatorImpl;
+using Propagator = PropagatorImpl<float>;
+} // namespace o2::base
+#endif
 
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -49,7 +49,8 @@ namespace o2
 class MCCompLabel;
 namespace base
 {
-class Propagator;
+template <typename>
+class PropagatorImpl;
 class MatLayerCylSet;
 } // namespace base
 namespace trd
@@ -178,7 +179,7 @@ struct GPUCalibObjectsTemplate {
   typename S<o2::trd::GeometryFlat>::type* trdGeometry = nullptr;
   typename S<TPCdEdxCalibrationSplines>::type* dEdxSplines = nullptr;
   typename S<TPCPadGainCalib>::type* tpcPadGain = nullptr;
-  typename S<o2::base::Propagator>::type* o2Propagator = nullptr;
+  typename S<o2::base::PropagatorImpl<float>>::type* o2Propagator = nullptr;
 };
 typedef GPUCalibObjectsTemplate<DefaultPtr> GPUCalibObjects; // NOTE: These 2 must have identical layout since they are memcopied
 typedef GPUCalibObjectsTemplate<ConstPtr> GPUCalibObjectsConst;

--- a/GPU/GPUTracking/DataTypes/GPUTRDDef.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDDef.h
@@ -34,7 +34,8 @@ class TrackTPCITS;
 } // namespace dataformats
 namespace base
 {
-class Propagator;
+template <typename>
+class PropagatorImpl;
 } // namespace base
 } // namespace o2
 #endif
@@ -65,7 +66,7 @@ typedef AliTrackerBase TRDBasePropagator;
 class GPUTPCGMPropagator;
 typedef GPUTPCGMPropagator TRDBasePropagatorGPU;
 #else
-typedef o2::base::Propagator TRDBasePropagator;
+typedef o2::base::PropagatorImpl<float> TRDBasePropagator;
 class GPUTPCGMPropagator;
 typedef GPUTPCGMPropagator TRDBasePropagatorGPU;
 #endif

--- a/GPU/GPUTracking/Refit/GPUTrackingRefit.h
+++ b/GPU/GPUTracking/Refit/GPUTrackingRefit.h
@@ -30,7 +30,9 @@ using TrackParCov = TrackParametrizationWithError<float>;
 } // namespace o2::track
 namespace o2::base
 {
-class Propagator;
+template <typename>
+class PropagatorImpl;
+using Propagator = PropagatorImpl<float>;
 class MatLayerCylSet;
 } // namespace o2::base
 namespace o2::tpc


### PR DESCRIPTION
To allow double precision calculations needed for Alignment, `TrackLTIntegral` and `Propagator` have been templetized
Along the way,`base::math_utils` were extended providing single and double precision floating point overloads of functions in  `gpu::CAMath`