### PR TITLE
PWGHF: Fix Dplus selector device name

### DIFF
--- a/Analysis/Tasks/PWGHF/HFDplusToPiKPiCandidateSelector.cxx
+++ b/Analysis/Tasks/PWGHF/HFDplusToPiKPiCandidateSelector.cxx
@@ -288,5 +288,5 @@ struct HFDplusToPiKPiCandidateSelector {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HFDplusToPiKPiCandidateSelector>(cfgc, "hf-dplus-topikpi-candidate-selector")};
+    adaptAnalysisTask<HFDplusToPiKPiCandidateSelector>(cfgc, TaskName{"hf-dplus-topikpi-candidate-selector"})};
 }


### PR DESCRIPTION
@vkucera From my understanding of the mattermost discussion, this is the new approach to follow.

P.S. What is currently in the O2 dev for `HFDplusToPiKPiCandidateSelector` has to be updated in any case