### PR TITLE
[MCH] set cluster resolution

### DIFF
--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
@@ -70,6 +70,8 @@ class ClusterFinderOriginal
   static constexpr int SNFitClustersMax = 3;                            ///< maximum number of clusters fitted at the same time
   static constexpr int SNFitParamMax = 3 * SNFitClustersMax - 1;        ///< maximum number of fit parameters
   static constexpr double SLowestCoupling = 1.e-2;                      ///< minimum coupling between clusters of pixels and pads
+  static constexpr float SDefaultClusterResolution = 0.2f;              ///< default cluster resolution (cm)
+  static constexpr float SBadClusterResolution = 10.f;                  ///< bad (e.g. mono-cathode) cluster resolution (cm)
 
   void resetPreCluster(gsl::span<const Digit>& digits);
   void simplifyPreCluster(std::vector<int>& removedDigits);
@@ -110,6 +112,8 @@ class ClusterFinderOriginal
   void merge(const std::vector<int>& clustersForFit, const std::vector<int>& coupledClusters, std::vector<std::vector<int>>& clustersOfPixels,
              std::vector<std::vector<double>>& couplingClCl, std::vector<std::vector<double>>& couplingClPad) const;
   void updatePads(const double fitParam[SNFitParamMax + 1], int nParamUsed);
+
+  void setClusterResolution(ClusterStruct& cluster) const;
 
   std::unique_ptr<MathiesonOriginal[]> mMathiesons; ///< Mathieson functions for station 1 and the others
   MathiesonOriginal* mMathieson = nullptr;          ///< pointer to the Mathieson function currently used

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -123,11 +123,12 @@ void ClusterFinderOriginal::findClusters(gsl::span<const Digit> digits)
       }
       int nNewDigits = mUsedDigits.size() - iFirstNewDigit;
 
-      // give the new clusters a unique ID and make them point to these digits
+      // give the new clusters a unique ID, make them point to these digits then set their resolution
       for (; iNewCluster < mClusters.size(); ++iNewCluster) {
         mClusters[iNewCluster].uid = ClusterStruct::buildUniqueId(digits[0].getDetID() / 100 - 1, digits[0].getDetID(), iNewCluster);
         mClusters[iNewCluster].firstDigit = iFirstNewDigit;
         mClusters[iNewCluster].nDigits = nNewDigits;
+        setClusterResolution(mClusters[iNewCluster]);
       }
     }
   }
@@ -2028,6 +2029,42 @@ void ClusterFinderOriginal::updatePads(const double fitParam[SNFitParamMax + 1],
       // reset the pad status to further use it if its charge is high enough
       pad.setStatus((pad.charge() > SLowestPadCharge) ? PadOriginal::kZero : PadOriginal::kOver);
     }
+  }
+}
+
+//_________________________________________________________________________________________________
+void ClusterFinderOriginal::setClusterResolution(ClusterStruct& cluster) const
+{
+  /// set the cluster resolution in both directions depending on whether its position
+  /// lies on top of a fired digit in both planes or not (e.g. mono-cathode)
+
+  if (cluster.getChamberId() < 4) {
+
+    // do not consider mono-cathode clusters in stations 1 and 2
+    cluster.ex = SDefaultClusterResolution;
+    cluster.ey = SDefaultClusterResolution;
+
+  } else {
+
+    // find pads below the cluster
+    int padIDNB(-1), padIDB(-1);
+    bool padsFound = mSegmentation->findPadPairByPosition(cluster.x, cluster.y, padIDB, padIDNB);
+
+    // look for these pads (if any) in the list of digits associated to this cluster
+    auto itPadNB = mUsedDigits.end();
+    if (padsFound || mSegmentation->isValid(padIDNB)) {
+      itPadNB = std::find_if(mUsedDigits.begin() + cluster.firstDigit, mUsedDigits.end(),
+                             [padIDNB](const Digit& digit) { return digit.getPadID() == padIDNB; });
+    }
+    auto itPadB = mUsedDigits.end();
+    if (padsFound || mSegmentation->isValid(padIDB)) {
+      itPadB = std::find_if(mUsedDigits.begin() + cluster.firstDigit, mUsedDigits.end(),
+                            [padIDB](const Digit& digit) { return digit.getPadID() == padIDB; });
+    }
+
+    // set the cluster resolution accordingly
+    cluster.ex = (itPadNB == mUsedDigits.end()) ? SBadClusterResolution : SDefaultClusterResolution;
+    cluster.ey = (itPadB == mUsedDigits.end()) ? SBadClusterResolution : SDefaultClusterResolution;
   }
 }
 


### PR DESCRIPTION
The clustering now sets the cluster resolution, depending whether it is a mono-cathode cluster or not.

This was the last missing piece to connect clustering and tracking.