### PR TITLE
Show one ERROR per device and do not return exitCode=1

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -278,10 +278,12 @@ int calculateExitCode(DeviceSpecs& deviceSpecs, DeviceInfos& infos)
   for (size_t di = 0; di < deviceSpecs.size(); ++di) {
     auto& info = infos[di];
     auto& spec = deviceSpecs[di];
-    if (exitCode == 0 && info.maxLogLevel >= LogParsingHelpers::LogLevel::Error) {
+    if (info.maxLogLevel >= LogParsingHelpers::LogLevel::Error) {
       LOG(ERROR) << "SEVERE: Device " << spec.name << " (" << info.pid << ") had at least one "
                  << "message above severity ERROR: " << std::regex_replace(info.firstSevereError, regexp, "");
-      exitCode = 1;
+      if (info.maxLogLevel >= LogParsingHelpers::LogLevel::Fatal) {
+        exitCode = 1;
+      }
     }
   }
   return exitCode;


### PR DESCRIPTION
@ktf : This leaves the exit code at 0 in case there were ERROR messages, still 1 for FATALs.
The rationale is: Error message hint at corrupt raw data, numerical errors during processing in several places, so they appear kind of randomly during processing. Currently, they break the full system test CI, since in that case the return value of the DPL workflow becomes one, which is treated as an error.
The alternative would be to either ignore the error code here, which I don't want because it can be non-zero for other real problems.
Or we could avoid using `LOG(ERROR) << ` everwhere in the code where we don't want such a behavior. But I think that would be quite complicated, and also make the ERROR log level quite useless. In fact, we have the FATAL log level to indicate a fatal error that should stop the processing.
Also this PR changes the logic to print one above ERROR message per device, which can help debugging.
(Ping @sawenzel since we have discussed this some time ago.)