### PR TITLE
Do not quit after processing one TF in event loop

### DIFF
--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -51,8 +51,6 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
     ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
   }
   LOG(INFO) << "Finished, wrote  " << mOutputClusters.size() << " clusters, " << mOutputClusterTrigRecs.size() << "TR and " << mOutputTruthCont.getIndexedSize() << " Labels";
-  ctx.services().get<o2::framework::ControlService>().endOfStream();
-  ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
 }
 o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getClusterizerSpec(bool propagateMC)
 {

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -54,7 +54,6 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   //  eeb->print();
   mTimer.Stop();
   LOG(INFO) << "Created encoded data of size " << eeb->size() << " for TOF in " << mTimer.CpuTime() - cput << " s";
-  //  pc.services().get<ControlService>().endOfStream();
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)


### PR DESCRIPTION
@shahor02 @peressounko : The CPV Clusterizer was exiting after processing one dataset, but the exiting should be signaled from the reader upstream. This is causing part of the memory leak in the full system test, since the devices downstream wait for the CPV messages indefinitely when merging inputs, and the inputs from other devices pile up.

I assume this was copy&pasted incorrectly from one of the reader specs.

@peressounko : I see the same in `Detectors/CPV/calib/CPVCalibWorkflow/src/CPVBadMapCalibDevice.cxx`. Could you check whether it is intended there?

@martenole @bazinski : I see the same in `Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx`: could you check if that is intended there?