### PR TITLE
Don't request quitting in TRDTrapSimulatorSpec

### DIFF
--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -334,8 +334,6 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   }
 
   LOG(debug) << "TRD Trap Simulator Device exiting";
-  pc.services().get<ControlService>().endOfStream();
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(bool useMC)


### PR DESCRIPTION
@bazinski I don't think it is needed, right?
I remember at some point without those two lines the processing never finished and one had to hit ctrl-c to manually end it (although this was another DPL device I think). But I just tested the trap simulation workflow and it works fine also without those lines.