### PR TITLE
FT0 CTF stores gate value + proper usage of DigitizationParams

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/CTF.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/CTF.h
@@ -29,8 +29,8 @@ struct CTFHeader {
   uint32_t nTriggers = 0;  /// number of triggers in TF
   uint32_t firstOrbit = 0; /// 1st orbit of TF
   uint16_t firstBC = 0;    /// 1st BC of TF
-
-  ClassDefNV(CTFHeader, 1);
+  uint16_t triggerGate = 192; // trigger gate used at encoding
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// Intermediate, compressed but not yet entropy-encoded digits

--- a/Detectors/CTF/test/test_ctf_io_ft0.cxx
+++ b/Detectors/CTF/test/test_ctf_io_ft0.cxx
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   o2::InteractionRecord ir(0, 0);
 
-  int mTime_trg_gate = 192; // #channels
+  int trg_gate = DigitizationParameters::Instance().mTime_trg_gate;
   constexpr int MAXChan = 4 * (Geometry::NCellsA + Geometry::NCellsC);
   for (int idig = 0; idig < 1000; idig++) {
     ir += 1 + gRandom->Integer(200);
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
       uint16_t q = gRandom->Integer(4096);
       uint8_t chain = gRandom->Rndm() > 0.5 ? 0 : 1;
       channels.emplace_back(ich, t, q, chain);
-      if (std::abs(t) < DigitizationParameters::mTime_trg_gate) {
+      if (std::abs(t) < trg_gate) {
         if (ich < 4 * uint8_t(Geometry::NCellsA)) {
           trig.nChanA++;
           ampTotA += q;

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
@@ -166,10 +166,7 @@ void CTFCoder::decompress(const CompressedDigits& cd, VDIG& digitVec, VCHAN& cha
       auto icc = channelVec.size();
       const auto& chan = channelVec.emplace_back((chID += cd.idChan[icc]), cd.cfdTime[icc], cd.qtcAmpl[icc], cd.qtcChain[icc]);
       //
-      // rebuild digit
-      int isInTrig = DigitizationParameters::mTime_trg_gate;
-      //      if (std::abs(chan.CFDTime) < DigitizationParameters::mTime_trg_gate) {
-      if (std::abs(chan.CFDTime) < isInTrig) {
+      if (std::abs(chan.CFDTime) < cd.header.triggerGate) {
         if (chan.ChId < 4 * uint8_t(Geometry::NCellsA)) { // A side
           amplA += chan.QTCAmpl;
           timeA += chan.CFDTime;

--- a/Detectors/FIT/FT0/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/CTFCoder.cxx
@@ -13,6 +13,7 @@
 /// \brief class for entropy encoding/decoding of FT0 digits data
 
 #include "FT0Reconstruction/CTFCoder.h"
+#include "FT0Simulation/DigitizationParameters.h"
 #include "CommonUtils/StringUtils.h"
 #include <TTree.h>
 
@@ -48,6 +49,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const Digit>& digi
   cd.header.nTriggers = digitVec.size();
   cd.header.firstOrbit = dig0.getOrbit();
   cd.header.firstBC = dig0.getBC();
+  cd.header.triggerGate = DigitizationParameters::Instance().mTime_trg_gate;
 
   cd.trigger.resize(cd.header.nTriggers);
   cd.bcInc.resize(cd.header.nTriggers);

--- a/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/CollisionTimeRecoTask.cxx
@@ -46,10 +46,11 @@ o2::ft0::RecPoints CollisionTimeRecoTask::process(o2::ft0::Digit const& bcd,
   LOG(DEBUG) << " event time " << timeStamp << " orbit " << bcd.mIntRecord.orbit << " bc " << bcd.mIntRecord.bc;
 
   int nch = inChData.size();
+  const auto parInv = DigitizationParameters::Instance().mMV_2_NchannelsInverse;
   for (int ich = 0; ich < nch; ich++) {
     outChData[ich] = o2::ft0::ChannelDataFloat{inChData[ich].ChId,
                                                inChData[ich].CFDTime * Geometry::ChannelWidth,
-                                               (double)inChData[ich].QTCAmpl * DigitizationParameters::mMV_2_NchannelsInverse,
+                                               (double)inChData[ich].QTCAmpl * parInv,
                                                inChData[ich].ChainQTC};
 
     //  only signals with amplitude participate in collision time

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/DigitizationParameters.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/DigitizationParameters.h
@@ -39,9 +39,10 @@ struct DigitizationParameters
   float mCharge2amp = 0.22;
   float mNoiseVar = 0.1;            //noise level
   float mNoisePeriod = 1 / 0.9;     // GHz low frequency noise period;
+  short mTime_trg_gate = 192;       // #channels
+
   static constexpr float mMV_2_Nchannels = 2.2857143;          //amplitude channel 7 mV ->16channels
   static constexpr float mMV_2_NchannelsInverse = 0.437499997; //inverse amplitude channel 7 mV ->16channels
-  static constexpr int mTime_trg_gate = 192;                   // #channels
 
   O2ParamDef(DigitizationParameters, "DigitizationParameters");
 };

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
@@ -40,7 +40,7 @@ class Digitizer
   typedef math_utils::RandomRing<float_v::size() * DP::NOISE_RANDOM_RING_SIZE> NoiseRandomRingType;
 
  public:
-  Digitizer(const DigitizationParameters& params, Int_t mode = 0) : mMode(mode), mParameters(params), mRndGaus(NoiseRandomRingType::RandomType::Gaus), mNumNoiseSamples(), mNoiseSamples(), mSincTable(), mSignalTable(), mSignalCache() { initParameters(); }
+  Digitizer(Int_t mode = 0) : mMode(mode), mRndGaus(NoiseRandomRingType::RandomType::Gaus), mNumNoiseSamples(), mNoiseSamples(), mSincTable(), mSignalTable(), mSignalCache() { initParameters(); }
   ~Digitizer() = default;
 
   void process(const std::vector<o2::ft0::HitType>* hits, std::vector<o2::ft0::Digit>& digitsBC,
@@ -100,7 +100,7 @@ class Digitizer
     if (x <= 0.0f) {
       return 0.0f;
     }
-    float const y = x / mParameters.mBunchWidth * DP::SIGNAL_TABLE_SIZE;
+    float const y = x / DigitizationParameters::Instance().mBunchWidth * DP::SIGNAL_TABLE_SIZE;
     int const index = std::floor(y);
     if (index + 1 >= DP::SIGNAL_TABLE_SIZE) {
       return mSignalTable.back();
@@ -111,7 +111,7 @@ class Digitizer
 
   inline Vc::float_v signalFormVc(Vc::float_v x) const
   { // table lookup for the signal shape (SIMD version)
-    auto const y = x / mParameters.mBunchWidth * DP::SIGNAL_TABLE_SIZE;
+    auto const y = x / DigitizationParameters::Instance().mBunchWidth * DP::SIGNAL_TABLE_SIZE;
     Vc::float_v::IndexType const index = Vc::floor(y);
     auto const rem = y - index;
     Vc::float_v val(0);
@@ -141,7 +141,6 @@ class Digitizer
   std::deque<BCCache> mCache;
   std::array<GoodInteractionTimeRecord, 208> mDeadTimes;
 
-  DigitizationParameters const& mParameters;
   o2::ft0::Geometry mGeometry;
 
   NoiseRandomRingType mRndGaus;

--- a/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Digitizer.cxx
@@ -56,7 +56,7 @@ Digitizer::CFDOutput Digitizer::get_time(const std::vector<float>& times, float 
     }
     // (2) add noise
     // find the right indices into the sinc table
-    int timeIndex = std::lround(time / mParameters.mNoisePeriod * mSincTable.size());
+    int timeIndex = std::lround(time / DigitizationParameters::Instance().mNoisePeriod * mSincTable.size());
     int timeOffset = timeIndex / mSincTable.size();
     timeIndex %= mSincTable.size();
     if (timeOffset >= mNumNoiseSamples) { // this happens when time >= 25 ns
@@ -90,32 +90,32 @@ Digitizer::CFDOutput Digitizer::get_time(const std::vector<float>& times, float 
   };
   auto const min_time = std::max(deadTime, *std::min_element(std::begin(times),
                                                              std::end(times)));
-  CFDOutput result{std::nullopt, -0.5f * mParameters.mBunchWidth};
+  CFDOutput result{std::nullopt, -0.5f * DigitizationParameters::Instance().mBunchWidth};
   bool is_positive = true;
 
   // reset the chache
   std::fill_n(std::begin(mSignalCache), std::size(mSignalCache), -1.0f);
-
+  const auto& params = DigitizationParameters::Instance();
   // we need double precision for time in order to match previous behaviour
-  for (double time = min_time; time < 0.5 * mParameters.mBunchWidth; time += DP::SIGNAL_CACHE_DT) {
+  for (double time = min_time; time < 0.5 * params.mBunchWidth; time += DP::SIGNAL_CACHE_DT) {
     float const val = value_at(time);
-    int const index = std::lround((time + 0.5 * mParameters.mBunchWidth) / DP::SIGNAL_CACHE_DT);
+    int const index = std::lround((time + 0.5 * params.mBunchWidth) / DP::SIGNAL_CACHE_DT);
     if (index >= 0 && index < mSignalCache.size()) { // save the value for later use
       mSignalCache[index] = val;
     }
     // look up the time-shifted signal value from the past
     float val_prev = 0.0f;
-    int const index_prev = std::lround((time - mParameters.mCFDShiftPos + 0.5f * mParameters.mBunchWidth) / DP::SIGNAL_CACHE_DT);
+    int const index_prev = std::lround((time - params.mCFDShiftPos + 0.5f * params.mBunchWidth) / DP::SIGNAL_CACHE_DT);
     val_prev = ((index_prev < 0 || index_prev >= mSignalCache.size() || mSignalCache[index_prev] < 0.0f)
-                  ? value_at(time - mParameters.mCFDShiftPos) //  was not computed before
-                  : mSignalCache[index_prev]);                //  is available in the cache
+                  ? value_at(time - params.mCFDShiftPos) //  was not computed before
+                  : mSignalCache[index_prev]);           //  is available in the cache
     float const cfd_val = 5.0f * val_prev - val;
-    if (std::abs(val) > mParameters.mCFD_trsh && !is_positive && cfd_val > 0.0f) {
+    if (std::abs(val) > params.mCFD_trsh && !is_positive && cfd_val > 0.0f) {
       if (!result.particle) {
         result.particle = time;
       }
-      result.deadTime = time + mParameters.mCFDdeadTime;
-      time += mParameters.mCFDdeadTime - DP::SIGNAL_CACHE_DT;
+      result.deadTime = time + params.mCFDdeadTime;
+      time += params.mCFDdeadTime - DP::SIGNAL_CACHE_DT;
       is_positive = true;
     } else {
       is_positive = cfd_val > 0.0f;
@@ -126,8 +126,8 @@ Digitizer::CFDOutput Digitizer::get_time(const std::vector<float>& times, float 
 
 double Digitizer::measure_amplitude(const std::vector<float>& times) const
 {
-  float const from = mParameters.mAmpRecordLow;
-  float const to = from + mParameters.mAmpRecordUp;
+  float const from = DigitizationParameters::Instance().mAmpRecordLow;
+  float const to = from + DigitizationParameters::Instance().mAmpRecordUp;
   // SIMD version has a negligible effect on the total wall time
   Vc::float_v acc(0);
   Vc::float_v tv(0);
@@ -165,10 +165,10 @@ void Digitizer::process(const std::vector<o2::ft0::HitType>* hits,
     if (hit.GetEnergyLoss() > 0) {
       continue;
     }
-
+    const auto& params = DigitizationParameters::Instance();
     Int_t hit_ch = hit.GetDetectorID();
     Bool_t is_A_side = (hit_ch < 4 * mGeometry.NCellsA);
-    Float_t time_compensate = is_A_side ? mParameters.mA_side_cable_cmps : mParameters.mC_side_cable_cmps;
+    Float_t time_compensate = is_A_side ? params.mA_side_cable_cmps : params.mC_side_cable_cmps;
     Double_t hit_time = hit.GetTime() - time_compensate;
     if (hit_time > 250) {
       continue; //not collect very slow particles
@@ -199,17 +199,17 @@ void Digitizer::storeBC(BCCache& bc,
   int n_hit_A = 0, n_hit_C = 0, mean_time_A = 0, mean_time_C = 0;
   int summ_ampl_A = 0, summ_ampl_C = 0;
   int vertex_time;
-
+  const auto& params = DigitizationParameters::Instance();
   int first = digitsCh.size(), nStored = 0;
   auto& particles = bc.hits;
   std::sort(std::begin(particles), std::end(particles));
   auto channel_end = particles.begin();
   std::vector<float> channel_times;
-  for (Int_t ipmt = 0; ipmt < mParameters.mMCPs; ++ipmt) {
+  for (Int_t ipmt = 0; ipmt < params.mMCPs; ++ipmt) {
     auto channel_begin = channel_end;
     channel_end = std::find_if(channel_begin, particles.end(),
                                [ipmt](BCCache::particle const& p) { return p.hit_ch != ipmt; });
-    if (channel_end - channel_begin < mParameters.mAmp_trsh) {
+    if (channel_end - channel_begin < params.mAmp_trsh) {
       continue;
     }
     channel_times.resize(channel_end - channel_begin);
@@ -224,10 +224,10 @@ void Digitizer::storeBC(BCCache& bc,
     if (!cfd.particle) {
       continue;
     }
-    int smeared_time = 1000. * (*cfd.particle - mParameters.mCfdShift) * mParameters.mChannelWidthInverse;
-    bool is_time_in_signal_gate = (smeared_time > -mParameters.mTime_trg_gate && smeared_time < mParameters.mTime_trg_gate);
-    float charge = measure_amplitude(channel_times) * mParameters.mCharge2amp;
-    float amp = is_time_in_signal_gate ? mParameters.mMV_2_Nchannels * charge : 0;
+    int smeared_time = 1000. * (*cfd.particle - params.mCfdShift) * params.mChannelWidthInverse;
+    bool is_time_in_signal_gate = (smeared_time > -params.mTime_trg_gate && smeared_time < params.mTime_trg_gate);
+    float charge = measure_amplitude(channel_times) * params.mCharge2amp;
+    float amp = is_time_in_signal_gate ? params.mMV_2_Nchannels * charge : 0;
     if (amp > 4095) {
       amp = 4095;
     }
@@ -255,10 +255,10 @@ void Digitizer::storeBC(BCCache& bc,
   Bool_t is_A, is_C, isVertex, is_Central, is_SemiCentral = 0;
   is_A = n_hit_A > 0;
   is_C = n_hit_C > 0;
-  is_Central = summ_ampl_A + summ_ampl_C >= mParameters.mtrg_central_trh;
-  is_SemiCentral = summ_ampl_A + summ_ampl_C >= mParameters.mtrg_semicentral_trh;
+  is_Central = summ_ampl_A + summ_ampl_C >= params.mtrg_central_trh;
+  is_SemiCentral = summ_ampl_A + summ_ampl_C >= params.mtrg_semicentral_trh;
   vertex_time = (mean_time_A - mean_time_C) * 0.5;
-  isVertex = is_A && is_C && (vertex_time > -mParameters.mTime_trg_gate && vertex_time < mParameters.mTime_trg_gate);
+  isVertex = is_A && is_C && (vertex_time > -params.mTime_trg_gate && vertex_time < params.mTime_trg_gate);
   uint32_t amplA = is_A ? summ_ampl_A * 0.125 : 0;   // sum amplitude A side / 8 (hardware)
   uint32_t amplC = is_C ? summ_ampl_C * 0.125 : 0;   // sum amplitude C side / 8 (hardware)
   uint16_t timeA = is_A ? mean_time_A / n_hit_A : 0; // average time A side
@@ -322,27 +322,28 @@ void Digitizer::initParameters()
   auto const sinc = [](double x) { x *= TMath::Pi(); return (std::abs(x) < 1e-12) ? 1.0 : std::sin(x) / x; };
 
   // number of noise samples in one BC
-  mNumNoiseSamples = std::ceil(mParameters.mBunchWidth / mParameters.mNoisePeriod);
+  const auto& params = DigitizationParameters::Instance();
+  mNumNoiseSamples = std::ceil(params.mBunchWidth / params.mNoisePeriod);
   mNoiseSamples.resize(mNumNoiseSamples);
 
   // set up tables with sinc function values (times noiseVar)
   for (size_t i = 0, n = mSincTable.size(); i < n; ++i) {
-    float const time = i / float(n) * mParameters.mNoisePeriod; // [0 .. 1/mParameters.mNoisePeriod)
+    float const time = i / float(n) * params.mNoisePeriod; // [0 .. 1/params.mNoisePeriod)
     LOG(DEBUG) << "initParameters " << i << "/" << n << " " << time;
     // we make a table of sinc values between -num_noise_samples and 2*num_noise_samples
     mSincTable[i].resize(3 * mNumNoiseSamples);
     for (int j = -mNumNoiseSamples; j < 2 * mNumNoiseSamples; ++j) {
-      mSincTable[i][mNumNoiseSamples + j] = mParameters.mNoiseVar * sinc((time + 0.5f * mParameters.mBunchWidth) / mParameters.mNoisePeriod - j);
+      mSincTable[i][mNumNoiseSamples + j] = params.mNoiseVar * sinc((time + 0.5f * params.mBunchWidth) / params.mNoisePeriod - j);
     }
   }
   // set up the lookup table for the signal form
   for (size_t i = 0; i < DP::SIGNAL_TABLE_SIZE; ++i) {
-    float const x = float(i) / float(DP::SIGNAL_TABLE_SIZE) * mParameters.mBunchWidth;
+    float const x = float(i) / float(DP::SIGNAL_TABLE_SIZE) * params.mBunchWidth;
     mSignalTable[i] = signalForm_i(x);
   }
 
   // cache for signal time series used by the CFD -BC/2 .. +3BC/2
-  mSignalCache.resize(std::lround(mParameters.mBunchWidth / DP::SIGNAL_CACHE_DT));
+  mSignalCache.resize(std::lround(params.mBunchWidth / DP::SIGNAL_CACHE_DT));
 }
 //_______________________________________________________________________
 void Digitizer::init()
@@ -359,13 +360,14 @@ void Digitizer::finish()
 
 void Digitizer::printParameters() const
 {
+  const auto& params = DigitizationParameters::Instance();
   LOG(INFO) << " Run Digitzation with parametrs: \n"
-            << " CFD amplitude threshold \n " << mParameters.mCFD_trsh << " CFD signal gate in ps \n"
-            << mParameters.mTime_trg_gate << "shift to have signal around zero after CFD trancformation  \n"
-            << mParameters.mCfdShift << "CFD distance between 0.3 of max amplitude  to max \n"
-            << mParameters.mCFDShiftPos << "MIP -> mV " << mParameters.mMip_in_V << " Pe in MIP \n"
-            << mParameters.mPe_in_mip << "noise level " << mParameters.mNoiseVar << " noise frequency \n"
-            << mParameters.mNoisePeriod << " mMCPs " << mParameters.mMCPs;
+            << " CFD amplitude threshold \n " << params.mCFD_trsh << " CFD signal gate in ps \n"
+            << params.mTime_trg_gate << "shift to have signal around zero after CFD trancformation  \n"
+            << params.mCfdShift << "CFD distance between 0.3 of max amplitude  to max \n"
+            << params.mCFDShiftPos << "MIP -> mV " << params.mMip_in_V << " Pe in MIP \n"
+            << params.mPe_in_mip << "noise level " << params.mNoiseVar << " noise frequency \n"
+            << params.mNoisePeriod << " mMCPs " << params.mMCPs;
 }
 
 O2ParamImpl(DigitizationParameters);

--- a/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FT0DigitizerSpec.cxx
@@ -17,7 +17,6 @@
 #include "Headers/DataHeader.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "FT0Simulation/Digitizer.h"
-#include "FT0Simulation/DigitizationParameters.h"
 #include "DataFormatsFT0/ChannelData.h"
 #include "DataFormatsFT0/HitType.h"
 #include "DataFormatsFT0/Digit.h"
@@ -44,9 +43,7 @@ class FT0DPLDigitizerTask : public o2::base::BaseDPLDigitizer
   using GRP = o2::parameters::GRPObject;
 
  public:
-  FT0DPLDigitizerTask() : o2::base::BaseDPLDigitizer(), mDigitizer(DigitizationParameters::Instance()) {}
-  explicit FT0DPLDigitizerTask(o2::ft0::DigitizationParameters const& parameters)
-    : o2::base::BaseDPLDigitizer(), mDigitizer(parameters){};
+  FT0DPLDigitizerTask() : o2::base::BaseDPLDigitizer(), mDigitizer() {}
   ~FT0DPLDigitizerTask() override = default;
 
   void initDigitizerTask(framework::InitContext& ic) override


### PR DESCRIPTION
@AllaMaevskaya I've removed the constness of ``DigitizationParameters::mTime_trg_gate`` as you told that this should be a settable parameter and its storage in the CTF. Also, since the DigitizationParameters are supposed to eventually come from the CCDB, I've removed its usage as an argument of the Digitizer constructor and modified the way it is accessed when it is needed (configurable params should be accessed via ::Instance() method, which provides a singleton).