### PR TITLE
Remove hacks to extract TF 1st orbit

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -457,14 +457,12 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   findMinMaxBc(ft0RecPoints, primVertices, mcRecords);
 
-  // TODO: determine the beginning of a TF in case when there are no reconstructed vertices
+  const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
+  o2::InteractionRecord startIR = {0, dh->firstTForbit};
+
   uint64_t firstVtxGlBC = minGlBC;
-  uint64_t startBCofTF = 0;
-  if (primVertices.empty()) {
-    auto startIRofTF = o2::raw::HBFUtils::Instance().getFirstIRofTF(primVertices[0].getIRMin());
-    startBCofTF = startIRofTF.orbit * o2::constants::lhc::LHCMaxBunches + startIRofTF.bc;
-    firstVtxGlBC = std::round(startBCofTF + primVertices[0].getTimeStamp().getTimeStamp() / o2::constants::lhc::LHCBunchSpacingMS);
-  }
+  uint64_t startBCofTF = startIR.toLong();
+  firstVtxGlBC = std::round(startBCofTF + primVertices[0].getTimeStamp().getTimeStamp() / o2::constants::lhc::LHCBunchSpacingMS);
 
   uint64_t tfNumber;
   int runNumber = 244918; // TODO: get real run number

--- a/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -172,7 +172,6 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
 {
   auto& reqMap = requests.requestMap;
 
-  /// RS FIXME: this will not work until the framework does not propagate the dh->firstTForbit
   const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
   startIR = {0, dh->firstTForbit};
 
@@ -230,11 +229,6 @@ void RecoContainer::addITSTracks(ProcessingContext& pc, bool mc)
   tracksROFsPool.registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("trackITSROF"), GTrackID::ITS);
   if (mc) {
     tracksMCPool.registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSMCTR"), GTrackID::ITS);
-  }
-  //RSTODO: below is a hack, to remove once the framework will start propagating the header.firstTForbit
-  const auto tracksITSROF = getITSTracksROFRecords<o2::itsmft::ROFRecord>();
-  if (tracksITSROF.size()) {
-    startIR = o2::raw::HBFUtils::Instance().getFirstIRofTF(tracksITSROF[0].getBCData());
   }
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -160,13 +160,8 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     mMatching.setFITInfoInp(fitInfo);
   }
 
-  const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("trackITSROF").header);
+  const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
   mMatching.setStartIR({0, dh->firstTForbit});
-
-  //RSTODO: below is a hack, to remove once the framework will start propagating the header.firstTForbit
-  if (tracksITSROF.size()) {
-    mMatching.setStartIR(o2::raw::HBFUtils::Instance().getFirstIRofTF(tracksITSROF[0].getBCData()));
-  }
 
   mMatching.run();
 

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -77,19 +77,8 @@ class TOFDPLClustererTask
     auto digits = pc.inputs().get<gsl::span<o2::tof::Digit>>("tofdigits");
     auto row = pc.inputs().get<std::vector<o2::tof::ReadoutWindowData>*>("readoutwin");
 
-    //auto header = o2::header::get<o2::header::DataHeader*>(pc.inputs().get("tofdigits").header);
-
-    if (row->size() > 0) {
-      mClusterer.setFirstOrbit(row->at(0).mFirstIR.orbit);
-    }
-
-    //RSTODO: below is a hack, to remove once the framework will start propagating the header.firstTForbit
-    //Here I extract the orbit/BC from the abs.BC, since the triggerer orbit/bunch are not set. Then why they are needed?
-    //    if (digits.size()) {
-    //      auto bcabs = digits[0].getBC();
-    //      auto ir0 = o2::raw::HBFUtils::Instance().getFirstIRofTF({uint16_t(bcabs % Geo::BC_IN_ORBIT), uint32_t(bcabs / Geo::BC_IN_ORBIT)});
-    //      mClusterer.setFirstOrbit(ir0.orbit);
-    //    }
+    const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
+    mClusterer.setFirstOrbit(dh->firstTForbit);
 
     auto labelvector = std::make_shared<std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>>();
     if (mUseMC) {


### PR DESCRIPTION
Since the framework now propagates the 1st orbit of the TF in the DataHeader, the hacks to extract the 1st orbit by other means can be dropped. @noferini @preghenella: I see that in TOF you had a special treatment of ``conet`` mode, could you please check if my fixes for TOF (added in a separate commit) will pose a problem?