### PR TITLE
DPL: add helpers to avoid adaptStateful and adaptStateless

### DIFF
--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -152,9 +152,9 @@ void AODJAlienReaderHelpers::dumpFileMetrics(Monitoring& monitoring, TFile* curr
 
 AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback()
 {
-  auto callback = AlgorithmSpec{adaptStateful([](ConfigParamRegistry const& options,
-                                                 DeviceSpec const& spec,
-                                                 Monitoring& monitoring) {
+  auto callback = AlgorithmSpec{[](ConfigParamRegistry const& options,
+                                   DeviceSpec const& spec,
+                                   Monitoring& monitoring) {
     monitoring.send(Metric{(uint64_t)0, "arrow-bytes-created"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
     monitoring.send(Metric{(uint64_t)0, "arrow-messages-created"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
     monitoring.send(Metric{(uint64_t)0, "arrow-bytes-destroyed"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
@@ -321,7 +321,7 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback()
       *numTF = ntf;
       currentFileIOTime += (uv_hrtime() - ioStart);
     });
-  })};
+  }};
 
   return callback;
 }

--- a/Framework/Core/include/Framework/AlgorithmSpec.h
+++ b/Framework/Core/include/Framework/AlgorithmSpec.h
@@ -81,6 +81,16 @@ struct AlgorithmSpec {
   {
   }
 
+  template <typename LAMBDA>
+  AlgorithmSpec(LAMBDA l, decltype(adaptStatelessF(FFL(std::declval<LAMBDA>())))* = nullptr) : AlgorithmSpec(adaptStatelessF(FFL(l)))
+  {
+  }
+
+  template <typename LAMBDA>
+  AlgorithmSpec(LAMBDA l, decltype(adaptStatefulF(FFL(std::declval<LAMBDA>())))* = nullptr) : AlgorithmSpec(adaptStatefulF(FFL(l)))
+  {
+  }
+
   InitCallback onInit = nullptr;
   ProcessCallback onProcess = nullptr;
   ErrorCallback onError = nullptr;

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -411,7 +411,7 @@ DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
   spec.name = name;
   spec.inputs = inputSpecs;
   spec.outputs = {};
-  spec.algorithm = adaptStateful([inputSpecs](CallbackService& callbacks, RawDeviceService& rds) {
+  spec.algorithm = [inputSpecs](CallbackService& callbacks, RawDeviceService& rds) {
     auto device = rds.device();
     // check that the input spec bindings have corresponding output channels
     // FairMQDevice calls the custom init before the channels have been configured
@@ -460,7 +460,7 @@ DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
       }
       sendOnChannel(device, outputs, "downstream");
     });
-  });
+  };
   const char* d = strdup(((std::string(defaultChannelConfig).find("name=") == std::string::npos ? (std::string("name=") + name + ",") : "") + std::string(defaultChannelConfig)).c_str());
   spec.options = {
     ConfigParamSpec{"channel-config", VariantType::String, d, {"Out-of-band channel config"}},
@@ -477,7 +477,7 @@ DataProcessorSpec specifyFairMQDeviceMultiOutputProxy(char const* name,
   spec.name = name;
   spec.inputs = inputSpecs;
   spec.outputs = {};
-  spec.algorithm = adaptStateful([inputSpecs](CallbackService& callbacks, RawDeviceService& rds) {
+  spec.algorithm = [inputSpecs](CallbackService& callbacks, RawDeviceService& rds) {
     auto device = rds.device();
     // check that the input spec bindings have corresponding output channels
     // FairMQDevice calls the custom init before the channels have been configured
@@ -534,7 +534,7 @@ DataProcessorSpec specifyFairMQDeviceMultiOutputProxy(char const* name,
         sendOnChannel(device, channelParts, channelName);
       }
     });
-  });
+  };
   const char* d = strdup(((std::string(defaultChannelConfig).find("name=") == std::string::npos ? (std::string("name=") + name + ",") : "") + std::string(defaultChannelConfig)).c_str());
   spec.options = {
     ConfigParamSpec{"channel-config", VariantType::String, d, {"Out-of-band channel config"}},

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -179,7 +179,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
                   }
                 }),
     Outputs(),
-    AlgorithmSpec{adaptStateful([checkMap, bindings = std::move(bindings)](CallbackService& callbacks) {
+    AlgorithmSpec{[checkMap, bindings = std::move(bindings)](CallbackService& callbacks) {
       callbacks.set(CallbackService::Id::EndOfStream, [checkMap](EndOfStreamContext& ctx) {
         for (auto const& [subspec, pipeline] : *checkMap) {
           // we require all checks to be invalidated
@@ -218,7 +218,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         // we require each input cycle to have data on datain channel
         ASSERT_ERROR(haveDataIn);
       });
-    })}});
+    }}});
 
   return workflowSpecs;
 }

--- a/Framework/Core/test/test_SimpleWildcard.cxx
+++ b/Framework/Core/test/test_SimpleWildcard.cxx
@@ -47,12 +47,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           {"B",
            Inputs{InputSpec{"in", {"TST", "OUT"}}},
            Outputs{},
-           AlgorithmSpec{adaptStateful([](CallbackService& callbacks) {
+           AlgorithmSpec{[](CallbackService& callbacks) {
              callbacks.set(CallbackService::Id::EndOfStream, [](EndOfStreamContext& context) {
                context.services().get<ControlService>().readyToQuit(QuitRequest::All);
              });
              return adaptStateless([](InputRecord& inputs) {
                auto s = inputs.get<TObjString*>("in");
                LOG(INFO) << "String is " << s->GetString().Data();
-             }); })}}};
+             }); }}}};
 }

--- a/Framework/Core/test/test_SimpleWildcard02.cxx
+++ b/Framework/Core/test/test_SimpleWildcard02.cxx
@@ -45,7 +45,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           {"B",
            Inputs{InputSpec{"in", ConcreteDataTypeMatcher{"TST", "OUT"}}},
            Outputs{},
-           AlgorithmSpec{adaptStateful([](CallbackService& callbacks) {
+           AlgorithmSpec{[](CallbackService& callbacks) {
              callbacks.set(CallbackService::Id::EndOfStream, [](EndOfStreamContext& context) {
                context.services().get<ControlService>().readyToQuit(QuitRequest::All);
              });
@@ -61,5 +61,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
                  auto dh = o2::header::get<o2::header::DataHeader*>(ref.header);
                  LOG(INFO) << "String is " << s->GetString().Data() << " " << dh->subSpecification;
                }
-             }); })}}};
+             }); }}}};
 }

--- a/Framework/Core/test/test_SlowConsumer.cxx
+++ b/Framework/Core/test/test_SlowConsumer.cxx
@@ -29,29 +29,29 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
     {"A",
      Inputs{},
      {OutputSpec{{"a"}, "TST", "A"}},
-     AlgorithmSpec{adaptStateful([]() { return adaptStateless(
-                                          [](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
-                                            static int count = 0;
-                                            auto& aData = outputs.make<int>(OutputRef{"a"});
-                                            LOG(info) << count;
-                                            aData = count++;
-                                            if (count > 3000) {
-                                              control.endOfStream();
-                                              control.readyToQuit(QuitRequest::Me);
-                                            }
-                                          }); })}},
+     AlgorithmSpec{[]() { return adaptStateless(
+                            [](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
+                              static int count = 0;
+                              auto& aData = outputs.make<int>(OutputRef{"a"});
+                              LOG(info) << count;
+                              aData = count++;
+                              if (count > 3000) {
+                                control.endOfStream();
+                                control.readyToQuit(QuitRequest::Me);
+                              }
+                            }); }}},
     {"B",
      {InputSpec{"x", "TST", "A", Lifetime::Timeframe}},
      {},
-     AlgorithmSpec{adaptStateful([]() { return adaptStateless(
-                                          [](InputRecord& inputs, RawDeviceService& device, ControlService& control) {
-                                            static int expected = 0;
-                                            device.device()->WaitFor(std::chrono::milliseconds(3));
-                                            auto& count = inputs.get<int>("x");
-                                            if (expected != count) {
-                                              LOGP(ERROR, "Missing message. Expected: {}, Found {}.", expected, count);
-                                              control.readyToQuit(QuitRequest::All);
-                                            }
-                                            expected++;
-                                          }); })}}};
+     AlgorithmSpec{[]() { return adaptStateless(
+                            [](InputRecord& inputs, RawDeviceService& device, ControlService& control) {
+                              static int expected = 0;
+                              device.device()->WaitFor(std::chrono::milliseconds(3));
+                              auto& count = inputs.get<int>("x");
+                              if (expected != count) {
+                                LOGP(ERROR, "Missing message. Expected: {}, Found {}.", expected, count);
+                                control.readyToQuit(QuitRequest::All);
+                              }
+                              expected++;
+                            }); }}}};
 }

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -118,7 +118,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     DataSpecUtils::updateMatchingSubspec(input, subspecs[index]);
   };
 
-  auto sinkFct = adaptStateful([](CallbackService& callbacks) {
+  auto sinkFct = [](CallbackService& callbacks) {
     callbacks.set(CallbackService::Id::EndOfStream, [](EndOfStreamContext& context) {
       context.services().get<ControlService>().readyToQuit(QuitRequest::All);
     });
@@ -127,7 +127,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         auto& data = inputs.get<MyDataType>(input.spec->binding.c_str());
         LOG(INFO) << "received channel " << data;
       } });
-  });
+  };
 
   std::vector<DataProcessorSpec> workflow = parallelPipeline(
     std::vector<DataProcessorSpec>{DataProcessorSpec{

--- a/Framework/GUISupport/test/test_CustomGUIGL.cxx
+++ b/Framework/GUISupport/test/test_CustomGUIGL.cxx
@@ -42,7 +42,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      Inputs{
        {"test", "TST", "A"}},
      Outputs{},
-     AlgorithmSpec{adaptStateful(
+     AlgorithmSpec{
        [](CallbackService& callbacks) {
          void* window = initGUI("A test window");
          auto count = std::make_shared<int>(0);
@@ -62,5 +62,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
              control.readyToQuit(QuitRequest::All);
            }
          });
-       })}}};
+       }}}};
 }

--- a/Framework/GUISupport/test/test_CustomGUISokol.cxx
+++ b/Framework/GUISupport/test/test_CustomGUISokol.cxx
@@ -36,15 +36,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
        OutputSpec{{"test"}, "TST", "A"},
      },
      AlgorithmSpec{
-       adaptStateless([](DataAllocator& outputs) {
+       [](DataAllocator& outputs) {
          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
          auto& out = outputs.make<int>(OutputRef{"test", 0});
-       })}},
+       }}},
     {"dest",
      Inputs{
        {"test", "TST", "A"}},
      Outputs{},
-     AlgorithmSpec{adaptStateful(
+     AlgorithmSpec{
        [](CallbackService& callbacks) {
          void* window = initGUI("A test window");
          auto count = std::make_shared<int>(0);
@@ -64,5 +64,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
              control.readyToQuit(QuitRequest::All);
            }
          });
-       })}}};
+       }}}};
 }

--- a/Framework/GUISupport/test/test_SimpleTracksED.cxx
+++ b/Framework/GUISupport/test/test_SimpleTracksED.cxx
@@ -35,7 +35,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      Inputs{
        {"Collisions", "AOD", "COLLISION"}},
      Outputs{},
-     AlgorithmSpec{adaptStateful(
+     AlgorithmSpec{
        [](CallbackService& callbacks) {
          void* window = initGUI("A test window");
          auto count = std::make_shared<int>(0);
@@ -63,5 +63,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
              control.readyToQuit(QuitRequest::All);
            }
          });
-       })}}};
+       }}}};
 }

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -42,13 +42,13 @@ void customize(std::vector<CompletionPolicy>& policies)
 
 AlgorithmSpec simplePipe(std::string const& what, int minDelay)
 {
-  return AlgorithmSpec{adaptStateful([what, minDelay]() {
+  return [what, minDelay]() {
     srand(getpid());
     return adaptStateless([what, minDelay](DataAllocator& outputs, RawDeviceService& device) {
       device.device()->WaitFor(std::chrono::seconds(rand() % 2));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });
-  })};
+  };
 }
 
 // This is how you can define your processing in a declarative way
@@ -59,13 +59,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      Inputs{},
      {OutputSpec{{"a1"}, "TST", "A1"},
       OutputSpec{{"a2"}, "TST", "A2"}},
-     AlgorithmSpec{adaptStateless(
-       [](DataAllocator& outputs, InfoLogger& logger, RawDeviceService& device) {
-         device.device()->WaitFor(std::chrono::seconds(rand() % 2));
-         auto& aData = outputs.make<int>(OutputRef{"a1"}, 1);
-         auto& bData = outputs.make<int>(OutputRef{"a2"}, 1);
-         logger.log("This goes to infologger");
-       })},
+     [](DataAllocator& outputs, InfoLogger& logger, RawDeviceService& device) {
+       device.device()->WaitFor(std::chrono::seconds(rand() % 2));
+       auto& aData = outputs.make<int>(OutputRef{"a1"}, 1);
+       auto& bData = outputs.make<int>(OutputRef{"a2"}, 1);
+       logger.log("This goes to infologger");
+     },
      {ConfigParamSpec{"some-device-param", VariantType::Int, 1, {"Some device parameter"}}}},
     {"B",
      {InputSpec{"x", "TST", "A1", Lifetime::Timeframe, {ConfigParamSpec{"somestring", VariantType::String, "", {"Some input param"}}}}},
@@ -81,5 +80,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
        InputSpec{"c", "TST", "C1"},
      },
      Outputs{},
-     AlgorithmSpec{adaptStateless([]() {})}}};
+     adaptStateless([]() {})}};
 }

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -44,7 +44,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
 {
   return [what, minDelay]() {
     srand(getpid());
-    return adaptStateless([what, minDelay](DataAllocator& outputs, RawDeviceService& device) {
+    return adaptStateless([what, minDelay](DataAllocator& outputs, RawDeviceService& device) -> void {
       device.device()->WaitFor(std::chrono::seconds(rand() % 2));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });

--- a/Framework/TestWorkflows/src/o2OutputWildcardWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2OutputWildcardWorkflow.cxx
@@ -33,13 +33,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
     {"A",
      Inputs{},
      {OutputSpec{{"a1"}, {"TST", "A1"}}},
-     AlgorithmSpec{adaptStateless(
+     AlgorithmSpec{
        [](DataAllocator& outputs) {
          auto rn = rand() % 5;
          std::this_thread::sleep_for(std::chrono::seconds(rn));
          auto& aData = outputs.make<int>(OutputRef{"a1", static_cast<DataAllocator::SubSpecificationType>(rn)});
          LOGP(info, "A random subspec:{}", rn);
-       })}},
+       }}},
     {"B",
      {InputSpec{"x", {"TST", "A1"}}},
      {},

--- a/Framework/TestWorkflows/src/o2SimpleSink.cxx
+++ b/Framework/TestWorkflows/src/o2SimpleSink.cxx
@@ -20,13 +20,13 @@ using namespace o2::framework;
 
 AlgorithmSpec simplePipe(std::string const& what, int minDelay)
 {
-  return AlgorithmSpec{adaptStateful([what, minDelay]() {
+  return AlgorithmSpec{[what, minDelay]() {
     srand(getpid());
     return adaptStateless([what, minDelay](DataAllocator& outputs) {
       std::this_thread::sleep_for(std::chrono::seconds((rand() % 5) + minDelay));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });
-  })};
+  }};
 }
 
 // This is how you can define your processing in a declarative way

--- a/Framework/TestWorkflows/src/o2SimpleSource.cxx
+++ b/Framework/TestWorkflows/src/o2SimpleSource.cxx
@@ -21,13 +21,13 @@ using namespace o2::framework;
 
 AlgorithmSpec simplePipe(std::string const& what, int minDelay)
 {
-  return AlgorithmSpec{adaptStateful([what, minDelay]() {
+  return AlgorithmSpec{[what, minDelay]() {
     srand(getpid());
     return adaptStateless([what, minDelay](DataAllocator& outputs) {
       std::this_thread::sleep_for(std::chrono::seconds((rand() % 5) + minDelay));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });
-  })};
+  }};
 }
 
 // This is how you can define your processing in a declarative way


### PR DESCRIPTION
With this the AlgorithmSpec constructor is able to take a
lambda directly, selecting the correct version of the adapters
based on the lambda type. This means that what was:

    AlgorithmSpec{adaptStateless([](InputRecord& inputs) {
      //...
    })}

now becomes:

    [](InputRecord& inputs) {
      //...
    }

Waiting eagerly on C++20 to be able to use designated initialisers.