### PR TITLE
trigger record with digits and tracklets

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
@@ -32,26 +32,37 @@ class TriggerRecord
 
  public:
   TriggerRecord() = default;
-  TriggerRecord(const BCData& bunchcrossing, int firstentry, int nentries) : mBCData(bunchcrossing), mDataRange(firstentry, nentries) {}
+  TriggerRecord(const BCData& bunchcrossing, int digitentry, int ndigitentries, int trackletentry = 0, int ntrackletentries = 0) : mBCData(bunchcrossing), mTrackletDataRange(trackletentry, ntrackletentries), mDigitDataRange(digitentry, ndigitentries) {}
+  // The above default of 0 for tracklet info, makes the digitizer look more decent as one can simply not put in the tracklet info as you dont have it.
   ~TriggerRecord() = default;
 
   void setBCData(const BCData& data) { mBCData = data; }
-  void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
-  void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
-  void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
 
   const BCData& getBCData() const { return mBCData; }
   BCData& getBCData() { return mBCData; }
-  int getNumberOfObjects() const { return mDataRange.getEntries(); }
-  int getFirstEntry() const { return mDataRange.getFirstEntry(); }
+
+  //Digit information
+  void setFirstDigit(int firstentry) { mDigitDataRange.setFirstEntry(firstentry); }
+  int getFirstDigit() const { return mDigitDataRange.getFirstEntry(); }
+  void setNumberOfDigit(int nentries) { mDigitDataRange.setEntries(nentries); }
+  int getNumberOfDigits() const { return mDigitDataRange.getEntries(); }
+  void setDigitRange(int firstentry, int nentries) { mDigitDataRange.set(firstentry, nentries); }
+
+  //tracklet information
+  void setFirstTracklet(int firstentry) { mTrackletDataRange.setFirstEntry(firstentry); }
+  int getFirstTracklet() const { return mTrackletDataRange.getFirstEntry(); }
+  void setNumberOfTracklet(int nentries) { mTrackletDataRange.setEntries(nentries); }
+  int getNumberOfTracklets() const { return mTrackletDataRange.getEntries(); }
+  void setTrackletRange(int firstentry, int nentries) { mTrackletDataRange.set(firstentry, nentries); }
 
   void printStream(std::ostream& stream) const;
 
  private:
   BCData mBCData;       /// Bunch crossing data of the trigger
-  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
+  DataRange mDigitDataRange;    /// Index of the underlying digit data, indexes into the vector/array/span
+  DataRange mTrackletDataRange; /// Index of the underlying tracklet data, indexes into the vector/array/span
 
-  ClassDefNV(TriggerRecord, 1);
+  ClassDefNV(TriggerRecord, 2);
 };
 
 std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg);

--- a/DataFormats/Detectors/TRD/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/TriggerRecord.cxx
@@ -19,7 +19,10 @@ namespace trd
 
 void TriggerRecord::printStream(std::ostream& stream) const
 {
-  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
+  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit
+         << ", starting from digit entry "
+         << getFirstDigit() << " with " << getNumberOfDigits() << " digits and tracklet entry "
+         << getFirstTracklet() << " with " << getNumberOfTracklets();
 }
 
 std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg)

--- a/Detectors/TRD/macros/convertRun2ToRun3Digits.C
+++ b/Detectors/TRD/macros/convertRun2ToRun3Digits.C
@@ -132,7 +132,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
       }
       trkl.Clear();
       recordSize = run3Digits.size() - triggerRecordsStart;
-      triggerRecords.emplace_back(ievent, triggerRecordsStart, recordSize);
+      triggerRecords.emplace_back(ievent, triggerRecordsStart, recordSize, 0, 0);
       triggerRecordsStart = run3Digits.size();
       ievent++;
     }
@@ -248,7 +248,7 @@ void convertRun2ToRun3Digits(TString qaOutPath = "",
         }
       }
       recordSize = run3Digits.size() - triggerRecordsStart;
-      triggerRecords.emplace_back(ievent, triggerRecordsStart, recordSize);
+      triggerRecords.emplace_back(ievent, triggerRecordsStart, recordSize, 0, 0);
       triggerRecordsStart = run3Digits.size();
       ievent++;
     }

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -39,7 +39,7 @@ class Trap2CRU
   Trap2CRU(const std::string& outputDir, const std::string& inputDigitsFilename, const std::string& inputTrackletsFilename);
   //Trap2CRU(const std::string& outputDir, const std::string& inputFilename, const std::string& inputDigitsFilename, const std::string& inputTrackletsFilename);
   void readTrapData();
-  void convertTrapData(o2::trd::TriggerRecord const& trackletTrigRecord, o2::trd::TriggerRecord const& digitTriggerRecord, const int& triggercount);
+  void convertTrapData(o2::trd::TriggerRecord const& trigrecord, const int& triggercount);
   // default for now will be file per half cru as per the files Guido did for us.
   void setFilePer(std::string fileper) { mFilePer = fileper; };
   std::string getFilePer() { return mFilePer; };
@@ -64,6 +64,8 @@ class Trap2CRU
   bool digitindexcompare(const o2::trd::Digit& A, const o2::trd::Digit& B);
   //boohhl digitindexcompare(const unsigned int A, const unsigned int B);
   o2::trd::Digit& getDigitAt(const int i) { return mDigits[mDigitsIndex[i]]; };
+
+  void mergetriggerDigitRanges();
 
  private:
   int mfileGranularity; /// per link or per half cru for each file

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -99,8 +99,8 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
 #else
     const auto& trg = triggerRecords.at(iEv);
 #endif
-    int nTrackletsCurrent = trg.getNumberOfObjects();
-    int iFirstTracklet = trg.getFirstEntry();
+    int nTrackletsCurrent = trg.getNumberOfTracklets();
+    int iFirstTracklet = trg.getFirstTracklet();
     int64_t evTime = trg.getBCData().toLong() * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
     trdTriggerTimes.push_back(evTime / 1000.);
     trdTriggerIndices.push_back(iFirstTracklet);


### PR DESCRIPTION
Tracklet range added to triggerrecord.
Associated methods for digit and tracklet access.
Default parameters of zero for tracklets in constructor to make triggerrecord creation in digitizer more sane (no tracklets at the time).

MC to raw fixed up to only use 1 triggerrecord. If no digits in the tracklet triggers its copied from digits file.
@martenole digits trigger record into trapsim changed from span to vector else its const and cant add tracklet info. Other option is to copy. 

@shahor02 This of course negates the rawtriggerrecord I had in the raw data stuff.