### PR TITLE
    [EMCAL-610, EMCAL-630] Handle Zero-Suppresion in the raw fitter

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -312,7 +312,7 @@ class RCUTrailer
 
   /// \brief Specify whether zero suppression has been applied
   /// \param doHave If true zero suppression has been applied
-  void setZeroSuppression(bool doHave) { mAltroConfig.mZeroSuppression = doHave; }
+  void setZeroSuppression(bool doHave) { mAltroConfig.mZeroSuppression = doHave ? 1 : 0; }
 
   /// \brief Set sparse readout mode
   /// \param isSparse True if readout is in sparse mode, false otherwise

--- a/Detectors/EMCAL/reconstruction/macros/RawFitterTESTMulti.C
+++ b/Detectors/EMCAL/reconstruction/macros/RawFitterTESTMulti.C
@@ -72,6 +72,7 @@ void RawFitterTESTMulti(const char* configfile = "")
         o2::emcal::AltroDecoder decoder(parser);
         std::cout << "Decoding" << std::endl;
         decoder.decode();
+        RawFitter.setIsZeroSuppressed(decoder.getRCUTrailer().hasZeroSuppression());
 
         //std::cout << decoder.getRCUTrailer() << std::endl;
         std::cout << "Found number of channels: " << decoder.getChannels().size() << std::endl;

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -319,6 +319,8 @@ std::vector<char> RawWriter::createRCUTrailer(int payloadsize, double timesample
   trailer.setNumberOfNonZeroSuppressedPresamples(1);
   trailer.setNumberOfPretriggerSamples(0);
   trailer.setNumberOfSamplesPerChannel(15);
+  // For MC we don't simulate pedestals. In order to prevent pedestal subtraction
+  // in the raw fitter we set the zero suppression to true in the RCU trailer
   trailer.setZeroSuppression(true);
   trailer.setSparseReadout(true);
   trailer.setNumberOfAltroBuffers(RCUTrailer::BufferMode_t::NBUFFERS4);

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -178,6 +178,8 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       }
 
       LOG(DEBUG) << decoder.getRCUTrailer();
+      // Apply zero suppression only in case it was enabled
+      mRawFitter->setIsZeroSuppressed(decoder.getRCUTrailer().hasZeroSuppression());
 
       const auto& map = mMapper->getMappingForDDL(feeID);
       int iSM = feeID / 2;


### PR DESCRIPTION
    - Setting zero-suppression mode in the raw fitter
      (for pedestal subtraction) is based on the ZS status
      in the RCU trailer
    - Set zero-suppression to true in RawWriter as
      pedestals are not simulated