### PR TITLE
Add cascade finder to SVertexer

### DIFF
--- a/Common/Constants/include/CommonConstants/PhysicsConstants.h
+++ b/Common/Constants/include/CommonConstants/PhysicsConstants.h
@@ -36,6 +36,8 @@ constexpr float MassTriton = 2.8089211;
 constexpr float MassHelium3 = 2.8083916;
 constexpr float MassAlpha = 3.7273794;
 constexpr float MassHyperTriton = 2.992;
+constexpr float MassXiMinus = 1.32171;
+constexpr float MassOmegaMinus = 1.67245;
 
 constexpr float LightSpeedCm2S = 299792458.e2;           // C in cm/s
 constexpr float LightSpeedCm2NS = LightSpeedCm2S * 1e-9; // C in cm/ns

--- a/Common/MathUtils/include/MathUtils/detail/Bracket.h
+++ b/Common/MathUtils/include/MathUtils/detail/Bracket.h
@@ -73,6 +73,7 @@ class Bracket
   void update(T v);
   Relation isOutside(const Bracket<T>& t) const;
   Relation isOutside(T t, T tErr) const;
+  Relation isOutside(T t) const;
 
 #ifndef GPUCA_ALIGPUCODE
   std::string asString() const;
@@ -236,6 +237,13 @@ inline typename Bracket<T>::Relation Bracket<T>::isOutside(T t, T tErr) const
 {
   ///< check if the provided value t with error tErr is outside of the bracket
   return t + tErr < mMin ? Below : (t - tErr > mMax ? Above : Inside);
+}
+
+template <typename T>
+inline typename Bracket<T>::Relation Bracket<T>::isOutside(T t) const
+{
+  ///< check if provided point is outside of this bracket
+  return t < mMin ? Below : (t > mMax ? Above : Inside);
 }
 
 #ifndef GPUCA_ALIGPUCODE

--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(ReconstructionDataFormats
                        src/PID.cxx
                        src/DCA.cxx
                        src/V0.cxx
+                       src/Cascade.cxx
                        src/GlobalTrackID.cxx
                        src/VtxTrackIndex.cxx
                        src/VtxTrackRef.cxx
@@ -44,6 +45,7 @@ o2_target_root_dictionary(
           include/ReconstructionDataFormats/PID.h
           include/ReconstructionDataFormats/DCA.h
           include/ReconstructionDataFormats/V0.h
+          include/ReconstructionDataFormats/Cascade.h
           include/ReconstructionDataFormats/GlobalTrackID.h
           include/ReconstructionDataFormats/VtxTrackIndex.h
           include/ReconstructionDataFormats/VtxTrackRef.h

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Cascade.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_CASCADE_H
+#define ALICEO2_CASCADE_H
+
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/PID.h"
+#include "ReconstructionDataFormats/V0.h"
+#include <array>
+#include <Math/SVector.h>
+
+namespace o2
+{
+namespace dataformats
+{
+
+class Cascade : public V0
+{
+ public:
+  Cascade() = default;
+  Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
+          const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
+          int v0ID, GIndex bachelorID, o2::track::PID pid = o2::track::PID::XiMinus);
+
+  GIndex getBachelorID() const { return mProngIDs[1]; }
+  void setBachelorID(GIndex gid) { mProngIDs[1] = gid; }
+
+  int getV0ID() const { return int(mProngIDs[0].getRaw()); }
+  void setV0ID(int vid) { mProngIDs[0].setRaw(GIndex::Base_t(vid)); }
+
+  const Track& getV0Track() const { return mProngs[0]; }
+  Track& getV0Track() { return mProngs[0]; }
+
+  const Track& getBachelorTrack() const { return mProngs[1]; }
+  Track& getBachelorTrack() { return mProngs[1]; }
+
+  void setV0Track(const Track& t) { mProngs[0] = t; }
+  void setBachelorTrack(const Track& t) { mProngs[1] = t; }
+
+ protected:
+  GIndex getProngID(int i) const = delete;
+
+  ClassDefNV(Cascade, 1);
+};
+
+} // namespace dataformats
+} // namespace o2
+#endif

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/DCA.h
@@ -55,6 +55,7 @@ class DCA
 
   GPUd() auto getY() const { return mY; }
   GPUd() auto getZ() const { return mZ; }
+  GPUd() auto getR2() const { return mY * mY + mZ * mZ; }
   GPUd() auto getSigmaY2() const { return mCov[0]; }
   GPUd() auto getSigmaYZ() const { return mCov[1]; }
   GPUd() auto getSigmaZ2() const { return mCov[2]; }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h
@@ -28,17 +28,16 @@ namespace o2cp = o2::constants::physics;
 namespace pid_constants // GPUs currently cannot have static constexpr array members
 {
 typedef uint8_t ID;
-static constexpr ID NIDsTot = 14;
+static constexpr ID NIDsTot = 16;
 GPUconstexpr() const char* sNames[NIDsTot + 1] = ///< defined particle names
   {"Electron", "Muon", "Pion", "Kaon", "Proton", "Deuteron", "Triton", "He3", "Alpha",
-   "Pion0", "Photon", "K0", "Lambda", "HyperTriton",
-   nullptr};
+   "Pion0", "Photon", "K0", "Lambda", "HyperTriton", "XiMinus", "OmegaMinus", nullptr};
 
 GPUconstexpr() const float sMasses[NIDsTot] = ///< defined particle masses
   {o2cp::MassElectron, o2cp::MassMuon, o2cp::MassPionCharged, o2cp::MassKaonCharged,
    o2cp::MassProton, o2cp::MassDeuteron, o2cp::MassTriton, o2cp::MassHelium3,
    o2cp::MassAlpha, o2cp::MassPionNeutral, o2cp::MassPhoton,
-   o2cp::MassKaonNeutral, o2cp::MassLambda, o2cp::MassHyperTriton};
+   o2cp::MassKaonNeutral, o2cp::MassLambda, o2cp::MassHyperTriton, o2cp::MassXiMinus, o2cp::MassOmegaMinus};
 
 GPUconstexpr() const float sMasses2[NIDsTot] = ///< defined particle masses^2
   {o2cp::MassElectron * o2cp::MassElectron,
@@ -54,7 +53,9 @@ GPUconstexpr() const float sMasses2[NIDsTot] = ///< defined particle masses^2
    o2cp::MassPhoton* o2cp::MassPhoton,
    o2cp::MassKaonNeutral* o2cp::MassKaonNeutral,
    o2cp::MassLambda* o2cp::MassLambda,
-   o2cp::MassHyperTriton* o2cp::MassHyperTriton};
+   o2cp::MassHyperTriton* o2cp::MassHyperTriton,
+   o2cp::MassXiMinus* o2cp::MassXiMinus,
+   o2cp::MassOmegaMinus* o2cp::MassOmegaMinus};
 
 GPUconstexpr() const float sMasses2Z[NIDsTot] = ///< defined particle masses / Z
   {o2cp::MassElectron, o2cp::MassMuon,
@@ -62,11 +63,13 @@ GPUconstexpr() const float sMasses2Z[NIDsTot] = ///< defined particle masses / Z
    o2cp::MassProton, o2cp::MassDeuteron,
    o2cp::MassTriton, o2cp::MassHelium3 / 2.,
    o2cp::MassAlpha / 2.,
-   0, 0, 0, 0, o2cp::MassHyperTriton};
+   0, 0, 0, 0, o2cp::MassHyperTriton,
+   o2cp::MassXiMinus, o2cp::MassOmegaMinus};
 
 GPUconstexpr() const int sCharges[NIDsTot] = ///< defined particle charges
   {1, 1, 1, 1, 1, 1, 1, 2, 2,
-   0, 0, 0, 0, 1};
+   0, 0, 0, 0, 1,
+   1, 1};
 } // namespace pid_constants
 
 class PID
@@ -95,8 +98,10 @@ class PID
   static constexpr ID K0 = 11;
   static constexpr ID Lambda = 12;
   static constexpr ID HyperTriton = 13;
+  static constexpr ID XiMinus = 14;
+  static constexpr ID OmegaMinus = 15;
   static constexpr ID FirstExt = PI0;
-  static constexpr ID LastExt = HyperTriton;
+  static constexpr ID LastExt = OmegaMinus;
   static constexpr ID NIDsTot = pid_constants::NIDsTot; ///< total number of defined IDs
   static_assert(NIDsTot == LastExt + 1, "Incorrect NIDsTot, please update!");
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -54,6 +54,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   using TrackParametrization<value_T>::TrackParametrization;
 
   GPUd() void set(value_t x, value_t alpha, const params_t& par, const covMat_t& cov, int charge = 1, const PID pid = PID::Pion);
+  GPUd() void set(const dim3_t& xyz, const dim3_t& pxpypz, const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int sign, bool sectorAlpha = true, const PID pid = PID::Pion);
   GPUd() const value_t* getCov() const;
   GPUd() value_t getSigmaY2() const;
   GPUd() value_t getSigmaZY() const;

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
@@ -50,17 +50,11 @@ class V0 : public o2::track::TrackParCov
   int getVertexID() const { return mVertexID; }
   void setVertexID(int id) { mVertexID = id; }
 
-  float getMass2() const
-  {
-    return calcMass2(mProngs[0].getPID(), mProngs[1].getPID());
-  }
-
-  float calcMass2(PID pidPos, PID pidNeg) const
-  {
-    return calcMass2(PID::getMass2(pidPos), PID::getMass2(pidNeg));
-  }
-
+  float calcMass2() const { return calcMass2(mProngs[0].getPID(), mProngs[1].getPID()); }
+  float calcMass2(PID pidPos, PID pidNeg) const { return calcMass2(PID::getMass2(pidPos), PID::getMass2(pidNeg)); }
   float calcMass2(float massPos2, float massNeg2) const;
+
+  float calcR2() const { return getX() * getX() + getY() * getY(); }
 
  protected:
   std::array<GIndex, 2> mProngIDs; // global IDs of prongs

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/V0.h
@@ -30,9 +30,9 @@ class V0 : public o2::track::TrackParCov
   using PID = o2::track::PID;
 
   V0() = default;
-  V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz,
+  V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
      const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg,
-     GIndex trPosID, GIndex trNegID);
+     GIndex trPosID, GIndex trNegID, o2::track::PID pid = o2::track::PID::K0);
 
   GIndex getProngID(int i) const { return mProngIDs[i]; }
   void setProngID(int i, GIndex gid) { mProngIDs[i] = gid; }

--- a/DataFormats/Reconstruction/src/Cascade.cxx
+++ b/DataFormats/Reconstruction/src/Cascade.cxx
@@ -1,0 +1,33 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ReconstructionDataFormats/Cascade.h"
+
+using namespace o2::dataformats;
+
+Cascade::Cascade(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
+                 const o2::track::TrackParCov& v0, const o2::track::TrackParCov& bachelor,
+                 int v0ID, GIndex bachelorID, o2::track::PID pid)
+{
+  std::array<float, 21> covV{}, covB{};
+  v0.getCovXYZPxPyPzGlo(covV);
+  bachelor.getCovXYZPxPyPzGlo(covB);
+  for (int i = 0; i < 21; i++) {
+    covV[i] += covB[i];
+  }
+  for (int i = 0; i < 6; i++) {
+    covV[i] = covxyz[i];
+  }
+  this->set(xyz, pxyz, covV, v0.getCharge() + bachelor.getCharge(), true, pid);
+  setV0ID(v0ID);
+  setBachelorID(bachelorID);
+  setV0Track(v0);
+  setBachelorTrack(bachelor);
+}

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -67,4 +67,7 @@
 #pragma link C++ class o2::dataformats::V0 + ;
 #pragma link C++ class std::vector < o2::dataformats::V0> + ;
 
+#pragma link C++ class o2::dataformats::Cascade + ;
+#pragma link C++ class std::vector < o2::dataformats::Cascade> + ;
+
 #endif

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -265,6 +265,15 @@ GPUd() TrackParametrizationWithError<value_T>::TrackParametrizationWithError(con
                                                                              const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
 {
   // construct track param and covariance from kinematics and lab errors
+  set(xyz, pxpypz, cv, charge, sectorAlpha, pid);
+}
+
+//______________________________________________________________
+template <typename value_T>
+GPUd() void TrackParametrizationWithError<value_T>::set(const dim3_t& xyz, const dim3_t& pxpypz,
+                                                        const gpu::gpustd::array<value_t, kLabCovMatSize>& cv, int charge, bool sectorAlpha, const PID pid)
+{
+  // set track param and covariance from kinematics and lab errors
 
   // Alpha of the frame is defined as:
   // sectorAlpha == false : -> angle of pt direction

--- a/DataFormats/Reconstruction/src/V0.cxx
+++ b/DataFormats/Reconstruction/src/V0.cxx
@@ -12,11 +12,21 @@
 
 using namespace o2::dataformats;
 
-V0::V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz,
+V0::V0(const std::array<float, 3>& xyz, const std::array<float, 3>& pxyz, const std::array<float, 6>& covxyz,
        const o2::track::TrackParCov& trPos, const o2::track::TrackParCov& trNeg,
-       GIndex trPosID, GIndex trNegID)
-  : o2::track::TrackParCov{xyz, pxyz, 0, true}, mProngIDs{trPosID, trNegID}, mProngs{trPos, trNeg}
+       GIndex trPosID, GIndex trNegID, o2::track::PID pid)
+  : mProngIDs{trPosID, trNegID}, mProngs{trPos, trNeg}
 {
+  std::array<float, 21> covV{}, covN{};
+  trPos.getCovXYZPxPyPzGlo(covV);
+  trPos.getCovXYZPxPyPzGlo(covN);
+  for (int i = 0; i < 21; i++) {
+    covV[i] += covN[i];
+  }
+  for (int i = 0; i < 6; i++) {
+    covV[i] = covxyz[i];
+  }
+  this->set(xyz, pxyz, covV, trPos.getCharge() + trNeg.getCharge(), true, pid);
 }
 
 float V0::calcMass2(float massPos2, float massNeg2) const

--- a/DataFormats/common/include/CommonDataFormat/AbstractRef.h
+++ b/DataFormats/common/include/CommonDataFormat/AbstractRef.h
@@ -68,6 +68,7 @@ class AbstractRef
   void set(Idx_t idx, Src_t src) { mRef = (mRef & (FlgMask << (NBIdx + NBSrc))) | ((SrcMask & Src_t(src)) << NBIdx) | (IdxMask & Idx_t(idx)); }
 
   Base_t getRaw() const { return mRef; }
+  void setRaw(Base_t v) { mRef = v; }
   Base_t getRawWOFlags() const { return mRef & (IdxMask | (SrcMask << NBIdx)); }
   bool isIndexSet() const { return getIndex() != IdxMask; }
   bool isSourceSet() const { return getSource() != SrcMask; }

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexReaderSpec.h
@@ -20,6 +20,7 @@
 #include "Framework/Task.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "ReconstructionDataFormats/V0.h"
+#include "ReconstructionDataFormats/Cascade.h"
 
 namespace o2
 {
@@ -31,6 +32,7 @@ class SecondaryVertexReader : public o2::framework::Task
 {
   using RRef = o2::dataformats::RangeReference<int, int>;
   using V0 = o2::dataformats::V0;
+  using Cascade = o2::dataformats::Cascade;
 
  public:
   SecondaryVertexReader() = default;
@@ -45,6 +47,8 @@ class SecondaryVertexReader : public o2::framework::Task
 
   std::vector<V0> mV0s, *mV0sPtr = &mV0s;
   std::vector<RRef> mPV2V0Ref, *mPV2V0RefPtr = &mPV2V0Ref;
+  std::vector<Cascade> mCascs, *mCascsPtr = &mCascs;
+  std::vector<RRef> mPV2CascRef, *mPV2CascRefPtr = &mPV2CascRef;
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
@@ -53,6 +57,8 @@ class SecondaryVertexReader : public o2::framework::Task
   std::string mSVertexTreeName = "o2sim";
   std::string mV0BranchName = "V0s";
   std::string mPVertex2V0RefBranchName = "PV2V0Refs";
+  std::string mCascBranchName = "Cascades";
+  std::string mPVertex2CascRefBranchName = "PV2CascRefs";
 };
 
 /// create a processor spec

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/SecondaryVertexingSpec.h
@@ -28,19 +28,20 @@ using namespace o2::framework;
 class SecondaryVertexingSpec : public Task
 {
  public:
-  SecondaryVertexingSpec() = default;
+  SecondaryVertexingSpec(bool enabCasc) : mEnableCascades(enabCasc) {}
   ~SecondaryVertexingSpec() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
 
  private:
+  bool mEnableCascades = false;
   o2::vertexing::SVertexer mVertexer;
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-DataProcessorSpec getSecondaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src);
+DataProcessorSpec getSecondaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool enableCasc);
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexReaderSpec.cxx
@@ -35,10 +35,12 @@ void SecondaryVertexReader::run(ProcessingContext& pc)
   auto ent = mTree->GetReadEntry() + 1;
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
-  LOG(INFO) << "Pushing " << mV0sPtr->size() << " V0s at entry " << ent;
+  LOG(INFO) << "Pushing " << mV0s.size() << " V0s and " << mCascs.size() << " cascades at entry " << ent;
 
-  pc.outputs().snapshot(Output{"GLO", "V0s", 0, Lifetime::Timeframe}, mV0s);
+  pc.outputs().snapshot(Output{"GLO", "V0S", 0, Lifetime::Timeframe}, mV0s);
   pc.outputs().snapshot(Output{"GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe}, mPV2V0Ref);
+  pc.outputs().snapshot(Output{"GLO", "CASCS", 0, Lifetime::Timeframe}, mCascs);
+  pc.outputs().snapshot(Output{"GLO", "PVTX_CASCREFS", 0, Lifetime::Timeframe}, mPV2CascRef);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();
@@ -55,9 +57,13 @@ void SecondaryVertexReader::connectTree()
   assert(mTree);
   assert(mTree->GetBranch(mV0BranchName.c_str()));
   assert(mTree->GetBranch(mPVertex2V0RefBranchName.c_str()));
+  assert(mTree->GetBranch(mCascBranchName.c_str()));
+  assert(mTree->GetBranch(mPVertex2CascRefBranchName.c_str()));
 
   mTree->SetBranchAddress(mV0BranchName.c_str(), &mV0sPtr);
   mTree->SetBranchAddress(mPVertex2V0RefBranchName.c_str(), &mPV2V0RefPtr);
+  mTree->SetBranchAddress(mCascBranchName.c_str(), &mCascsPtr);
+  mTree->SetBranchAddress(mPVertex2CascRefBranchName.c_str(), &mPV2CascRefPtr);
 
   LOG(INFO) << "Loaded " << mSVertexTreeName << " tree from " << mFileName << " with " << mTree->GetEntries() << " entries";
 }
@@ -65,8 +71,10 @@ void SecondaryVertexReader::connectTree()
 DataProcessorSpec getSecondaryVertexReaderSpec()
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("GLO", "V0s", 0, Lifetime::Timeframe);
-  outputs.emplace_back("GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "V0S", 0, Lifetime::Timeframe);           // found V0s
+  outputs.emplace_back("GLO", "PVTX_V0REFS", 0, Lifetime::Timeframe);   // prim.vertex -> V0s refs
+  outputs.emplace_back("GLO", "CASCS", 0, Lifetime::Timeframe);         // found Cascades
+  outputs.emplace_back("GLO", "PVTX_CASCREFS", 0, Lifetime::Timeframe); // prim.vertex -> Cascades refs
 
   return DataProcessorSpec{
     "secondary-vertex-reader",

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexWriterSpec.cxx
@@ -17,6 +17,7 @@
 #include "CommonDataFormat/TimeStamp.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "ReconstructionDataFormats/V0.h"
+#include "ReconstructionDataFormats/Cascade.h"
 
 using namespace o2::framework;
 
@@ -26,6 +27,7 @@ namespace vertexing
 {
 using RRef = o2::dataformats::RangeReference<int, int>;
 using V0 = o2::dataformats::V0;
+using Cascade = o2::dataformats::Cascade;
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
@@ -34,16 +36,26 @@ using namespace o2::header;
 
 DataProcessorSpec getSecondaryVertexWriterSpec()
 {
-  auto logger = [](std::vector<V0> const& v) {
+  auto loggerV = [](std::vector<V0> const& v) {
     LOG(INFO) << "SecondaryVertexWriter pulled " << v.size() << " v0s";
   };
-  auto inpID = InputSpec{"v0s", "GLO", "V0s", 0};
-  auto inpIDRef = InputSpec{"pv2v0ref", "GLO", "PVTX_V0REFS", 0};
+
+  auto loggerC = [](std::vector<Cascade> const& v) {
+    LOG(INFO) << "SecondaryVertexWriter pulled " << v.size() << " cascades";
+  };
+
+  auto inpV0ID = InputSpec{"v0s", "GLO", "V0S", 0};
+  auto inpV0RefID = InputSpec{"pv2v0ref", "GLO", "PVTX_V0REFS", 0};
+  auto inpCascID = InputSpec{"cascs", "GLO", "CASCS", 0};
+  auto inpCascRefID = InputSpec{"pv2cascref", "GLO", "PVTX_CASCREFS", 0};
+
   return MakeRootTreeWriterSpec("secondary-vertex-writer",
                                 "o2_secondary_vertex.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with Secondary Vertices"},
-                                BranchDefinition<std::vector<V0>>{inpID, "V0s", logger},
-                                BranchDefinition<std::vector<RRef>>{inpIDRef, "PV2V0Refs"})();
+                                BranchDefinition<std::vector<V0>>{inpV0ID, "V0s", loggerV},
+                                BranchDefinition<std::vector<RRef>>{inpV0RefID, "PV2V0Refs"},
+                                BranchDefinition<std::vector<Cascade>>{inpCascID, "Cascades", loggerC},
+                                BranchDefinition<std::vector<RRef>>{inpCascRefID, "PV2CascRefs"})();
 }
 
 } // namespace vertexing

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -35,6 +35,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
+    {"enable-cascade-finder", o2::framework::VariantType::Bool, false, {"run cascade finder for each V0"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);
@@ -55,6 +56,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   bool useMC = false;
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
+  auto enableCasc = configcontext.options().get<bool>("enable-cascade-finder");
 
   GID::mask_t srcSV = alowedSourcesSV & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));
   WorkflowSpec specs;
@@ -78,7 +80,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::vertexing::getPrimaryVertexReaderSpec(useMC));
   }
 
-  specs.emplace_back(o2::vertexing::getSecondaryVertexingSpec(srcSV));
+  specs.emplace_back(o2::vertexing::getSecondaryVertexingSpec(srcSV, enableCasc));
 
   if (!disableRootOut) {
     specs.emplace_back(o2::vertexing::getSecondaryVertexWriterSpec());

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -41,7 +41,7 @@ class SVertexer
   using V0 = o2::dataformats::V0;
   using RRef = o2::dataformats::RangeReference<int, int>;
   using VBracket = o2::math_utils::Bracket<int>;
-
+  static constexpr int POS = 0, NEG = 1;
   struct TrackCand : o2::track::TrackParCov {
     GIndex gid;
     VBracket vBracket;
@@ -65,7 +65,7 @@ class SVertexer
   bool checkV0Pair(TrackCand& seed0, TrackCand& seed1, int ithread);
   void setupThreads();
   void finalizeV0s(std::vector<V0>& v0s, std::vector<RRef>& vtx2V0refs);
-  std::vector<TrackCand> buildT2V(const gsl::span<const GIndex>& trackIndex, const gsl::span<const VRef>& vtxRefs, const o2::globaltracking::RecoContainer& recoTracks);
+  void buildT2V(const gsl::span<const GIndex>& trackIndex, const gsl::span<const VRef>& vtxRefs, const o2::globaltracking::RecoContainer& recoTracks);
 
   uint64_t getPairIdx(GIndex id1, GIndex id2) const
   {
@@ -74,7 +74,8 @@ class SVertexer
 
   gsl::span<const PVertex> mPVertices;
   std::vector<std::vector<V0>> mV0sTmp;
-
+  std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
+  std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;
   std::array<V0Hypothesis, SVertexerParams::NPIDV0> mV0Hyps;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -18,6 +18,7 @@
 #include "GlobalTracking/RecoContainer.h"
 #include "ReconstructionDataFormats/PrimaryVertex.h"
 #include "ReconstructionDataFormats/V0.h"
+#include "ReconstructionDataFormats/Cascade.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
 #include "CommonDataFormat/RangeReference.h"
@@ -39,6 +40,7 @@ class SVertexer
   using VRef = o2::dataformats::VtxTrackRef;
   using PVertex = const o2::dataformats::PrimaryVertex;
   using V0 = o2::dataformats::V0;
+  using Cascade = o2::dataformats::Cascade;
   using RRef = o2::dataformats::RangeReference<int, int>;
   using VBracket = o2::math_utils::Bracket<int>;
   static constexpr int POS = 0, NEG = 1;
@@ -47,25 +49,29 @@ class SVertexer
     VBracket vBracket;
   };
 
+  SVertexer(bool enabCascades = true) : mEnableCascades(enabCascades) {}
+
+  void setEnableCascades(bool v) { mEnableCascades = v; }
   void init();
-  void process(const gsl::span<const PVertex>& vertices,            // primary vertices
-               const gsl::span<const GIndex>& trackIndex,           // Global ID's for associated tracks
-               const gsl::span<const VRef>& vtxRefs,                // references from vertex to these track IDs
-               const o2::globaltracking::RecoContainer& recoTracks, // accessor to various tracks
-               std::vector<V0>& v0s,                                // found V0s
-               std::vector<RRef>& vtx2V0refs                        // references from PVertex to V0
-  );
+  void process(const gsl::span<const PVertex>& vertices,             // primary vertices
+               const gsl::span<const GIndex>& trackIndex,            // Global ID's for associated tracks
+               const gsl::span<const VRef>& vtxRefs,                 // references from vertex to these track IDs
+               const o2::globaltracking::RecoContainer& recoTracks); // accessor to various tracks
 
   auto& getMeanVertex() const { return mMeanVertex; }
   void setMeanVertex(const o2d::VertexBase& v) { mMeanVertex = v; }
   void setNThreads(int n);
   int getNThreads() const { return mNThreads; }
 
+  template <typename V0CONT, typename V0REFCONT, typename CASCCONT, typename CASCREFCONT>
+  void extractSecondaryVertices(V0CONT& v0s, V0REFCONT& vtx2V0Refs, CASCCONT& cascades, CASCREFCONT& vtx2CascRefs);
+
  private:
-  bool checkV0Pair(TrackCand& seed0, TrackCand& seed1, int ithread);
+  bool checkV0(TrackCand& seed0, TrackCand& seed1, int iP, int iN, int ithread);
+  int checkCascades(float r2v0, int avoidTrackID, int posneg, int ithread);
   void setupThreads();
-  void finalizeV0s(std::vector<V0>& v0s, std::vector<RRef>& vtx2V0refs);
   void buildT2V(const gsl::span<const GIndex>& trackIndex, const gsl::span<const VRef>& vtxRefs, const o2::globaltracking::RecoContainer& recoTracks);
+  void updateTimeDependentParams();
 
   uint64_t getPairIdx(GIndex id1, GIndex id2) const
   {
@@ -74,17 +80,106 @@ class SVertexer
 
   gsl::span<const PVertex> mPVertices;
   std::vector<std::vector<V0>> mV0sTmp;
+  std::vector<std::vector<Cascade>> mCascadesTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;
   std::array<V0Hypothesis, SVertexerParams::NPIDV0> mV0Hyps;
-  std::vector<DCAFitterN<2>> mFitter2Prong;
+  std::vector<DCAFitterN<2>> mFitterV0;
+  std::vector<DCAFitterN<2>> mFitterCasc;
   int mNThreads = 1;
   float mMinR2ToMeanVertex = 0;
   float mMaxDCAXY2ToMeanVertex = 0;
-  float mMinCosPointingAngle = 0;
+  float mMaxDCAXY2ToMeanVertexV0Casc = 0;
+  float mMinR2DiffV0Casc = 0;
+  float mMaxR2ToMeanVertexCascV0 = 0;
+
+  bool mEnableCascades = true;
 };
+
+// input containers can be std::vectors or pmr vectors
+template <typename V0CONT, typename V0REFCONT, typename CASCCONT, typename CASCREFCONT>
+void SVertexer::extractSecondaryVertices(V0CONT& v0s, V0REFCONT& vtx2V0Refs, CASCCONT& cascades, CASCREFCONT& vtx2CascRefs)
+{
+  v0s.clear();
+  vtx2V0Refs.clear();
+  vtx2V0Refs.resize(mPVertices.size());
+  cascades.clear();
+  vtx2CascRefs.clear();
+  vtx2CascRefs.resize(mPVertices.size());
+
+  auto& tmpV0s = mV0sTmp[0];
+  auto& tmpCascs = mCascadesTmp[0];
+  int nv0 = tmpV0s.size(), nCasc = tmpCascs.size();
+  std::vector<int> v0SortID(nv0), v0NewInd(nv0), cascSortID(nCasc);
+  std::iota(v0SortID.begin(), v0SortID.end(), 0);
+  std::sort(v0SortID.begin(), v0SortID.end(), [&](int i, int j) { return tmpV0s[i].getVertexID() < tmpV0s[j].getVertexID(); });
+  std::iota(cascSortID.begin(), cascSortID.end(), 0);
+  std::sort(cascSortID.begin(), cascSortID.end(), [&](int i, int j) { return tmpCascs[i].getVertexID() < tmpCascs[j].getVertexID(); });
+
+  // relate V0s to primary vertices
+  int pvID = -1, nForPV = 0;
+  for (int iv = 0; iv < nv0; iv++) {
+    const auto& v0 = tmpV0s[v0SortID[iv]];
+    if (pvID < v0.getVertexID()) {
+      if (pvID > -1) {
+        vtx2V0Refs[pvID].setEntries(nForPV);
+      }
+      pvID = v0.getVertexID();
+      vtx2V0Refs[pvID].setFirstEntry(v0s.size());
+      nForPV = 0;
+    }
+    v0NewInd[v0SortID[iv]] = v0s.size(); // memorise updated v0 id to fix its reference in the cascade
+    v0s.push_back(v0);
+    nForPV++;
+  }
+  if (pvID != -1) { // finalize
+    vtx2V0Refs[pvID].setEntries(nForPV);
+    // fill empty slots
+    int ent = v0s.size();
+    for (int ip = vtx2V0Refs.size(); ip--;) {
+      if (vtx2V0Refs[ip].getEntries()) {
+        ent = vtx2V0Refs[ip].getFirstEntry();
+      } else {
+        vtx2V0Refs[ip].setFirstEntry(ent);
+      }
+    }
+  }
+  // update V0s references in cascades
+  for (auto& casc : tmpCascs) {
+    casc.setV0ID(v0NewInd[casc.getV0ID()]);
+  }
+
+  // relate Cascades to primary vertices
+  pvID = -1;
+  nForPV = 0;
+  for (int iv = 0; iv < nCasc; iv++) {
+    const auto& casc = tmpCascs[cascSortID[iv]];
+    if (pvID < casc.getVertexID()) {
+      if (pvID > -1) {
+        vtx2CascRefs[pvID].setEntries(nForPV);
+      }
+      pvID = casc.getVertexID();
+      vtx2CascRefs[pvID].setFirstEntry(cascades.size());
+      nForPV = 0;
+    }
+    cascades.push_back(casc);
+    nForPV++;
+  }
+  if (pvID != -1) { // finalize
+    vtx2CascRefs[pvID].setEntries(nForPV);
+    // fill empty slots
+    int ent = cascades.size();
+    for (int ip = vtx2CascRefs.size(); ip--;) {
+      if (vtx2CascRefs[ip].getEntries()) {
+        ent = vtx2CascRefs[ip].getFirstEntry();
+      } else {
+        vtx2CascRefs[ip].setFirstEntry(ent);
+      }
+    }
+  }
+}
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -44,12 +44,25 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minRelChi2Change = 0.9; ///< stop when chi2 changes by less than this value
   float maxDZIni = 5.;          ///< don't consider as a seed (circles intersection) if Z distance exceeds this
   float maxRIni = 150;          ///< don't consider as a seed (circles intersection) if its R exceeds this
-
   bool useAbsDCA = true; ///< use abs dca minimization
   //
-  float minRfromMeanVertex = 0.5;     ///< min radial distance of V0 from beam line (mean vertex)
-  float maxDCAXYfromMeanVertex = 0.2; ///< min DCA of V0 from beam line (mean vertex)
-  float minCosPointingAngle = 0.8;
+  float minRToMeanVertex = 0.5;           ///< min radial distance of V0 from beam line (mean vertex)
+  float maxDCAXYToMeanVertex = 0.2;       ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
+  float maxDCAXYToMeanVertexV0Casc = 0.5; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
+
+  float minCosPAXYMeanVertex = 0.85;      ///< min cos of PA to beam line (mean vertex) in tr. plane for prompt V0 candidates
+  float minCosPAXYMeanVertexCascV0 = 0.8; ///< min cos of PA to beam line (mean vertex) in tr. plane for V0 of cascade cand.
+
+  float maxRToMeanVertexCascV0 = 80; // don't consider as a cascade V0 seed if above this R
+  float minCosPACascV0 = 0.8;        // min cos of pointing angle to PV for cascade V0 candidates
+
+  float minCosPA = 0.9; ///< min cos of PA to PV for prompt V0 candidates
+
+  float minRDiffV0Casc = 0.2; ///< cascade should be at least this radial distance below V0
+  float maxRIniCasc = 50.;    // don't consider as a cascade seed (circles/line intersection) if its R exceeds this
+
+  float maxDCAXYCasc = 0.3; // max DCA of cascade to PV in XY // TODO RS: shall we use real chi2 to vertex?
+  float maxDCAZCasc = 0.3;  // max DCA of cascade to PV in Z
 
   // cuts on different PID params
   float pidCutsPhoton[NPIDParams] = {0.001, 20, 0.60, 0.0};   // Photon

--- a/Detectors/Vertexing/test/testDCAFitterN.cxx
+++ b/Detectors/Vertexing/test/testDCAFitterN.cxx
@@ -30,7 +30,7 @@ namespace vertexing
 using Vec3D = ROOT::Math::SVector<double, 3>;
 
 template <class FITTER>
-float checkResults(o2::utils::TreeStreamRedirector& outs, std::string& treeName, const FITTER& fitter,
+float checkResults(o2::utils::TreeStreamRedirector& outs, std::string& treeName, FITTER& fitter,
                    Vec3D& vgen, TLorentzVector& genPar, const std::vector<double>& dtMass)
 {
   int nCand = fitter.getNCandidates();


### PR DESCRIPTION
At the moment disabled by default, since slows down SVertexing, cuts to be tuned.
To enable, run as e.g. `o2-secondary-vertexing-workflow --shm-segment-size 10000000000 --enable-cascade-finder  --threads 6`