### PR TITLE
TRD digitizer: add shared pads + fix pileup logic

### DIFF
--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -51,3 +51,33 @@ default would then be the following :
 ```
 o2-trd-trap2raw -d trddigits.root -t trdtracklets.root -l halfcru -o ./ -x -r 6 -e
 ```
+
+# Some technical details:
+## Pileup implementation
+There are two general cases:
+**Case 1:** The first signal triggers the readout at `t=A`. The signal is read out for 30 time bins (3 microseconds). A second signal can arrive at `t=C`. The second signal will contribute to the tail of the first signal with `(B-C)*samplingRate` bins from its head.
+```
+A        B
+**********
+      **********
+      C        D
+```
+**Case 2:** A trigger happened in the past at `t<A`, but `A` is within the deadtime of the TRD so the detector can't trigger again and the signal isn't readout. Still, the signal can contribute to a future signal. When a new signal arrives at `t=C` that can trigger, the signal will be readout for 30 time bins and will have `(B-C)*samplingRate` bins from the tail of the previous signal onto it's head.
+```
+A        B
+**********
+      **********
+      C        D
+```
+We keep a deque of signals that is flushed when the detector gets a new trigger. All signals are stored in the deque and are pop from the front only when they are too old. A signal can contribute to two events, one in the past and one in the future. See for example **Case 3**:
+```
+A        B
+**********
+        **********
+        C        D
+               **********
+               E        F
+```
+In this example, we consider a trigger at `t=A`. The second signal contributes with `(B-C)*samplingRate` bins from its head onto the tail of the first signal. A third signal arrives at `t=E`, with `E>A+BUSY_TIME`, which can trigger the detector and be readout. The third signal will have `(D-E)*samplingRate` from the tail of the second signal onto its head. So, the requirement for a signal to be too old, and be dropped, is:
+- new trigger arrives, and
+- the time difference between the first time bin of the previous signal and the new trigger is greater than `READOUT_TIME`.

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -48,7 +48,6 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels
   bool mEnableTrapConfigDump{false};
-  bool mShareDigitsManually{true};  // duplicate digits connected to shared pads if digitizer did not do so
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -91,6 +91,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     for (int collID = 0; collID < irecords.size(); ++collID) {
       currentTime = irecords[collID];
       // Trigger logic implemented here
+      bool isNewTrigger = true; // flag newly accepted readout trigger
       if (firstEvent) {
         triggerTime = currentTime;
         firstEvent = false;
@@ -98,6 +99,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         double dT = currentTime.getTimeNS() - triggerTime.getTimeNS();
         if (dT < o2::trd::Digitizer::BUSY_TIME) {
           // BUSY_TIME = READOUT_TIME + DEAD_TIME, if less than that, pile up the signals and update the last time
+          isNewTrigger = false;
           mDigitizer.pileup();
         } else {
           // A new signal can be received, and the detector read it out:
@@ -117,7 +119,10 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         }
       }
 
-      mDigitizer.setEventTime(triggerTime.getTimeNS()); // do we need this?
+      mDigitizer.setEventTime(triggerTime.getTimeNS());
+      if (isNewTrigger) {
+        mDigitizer.setTriggerTime(triggerTime.getTimeNS());
+      }
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)
@@ -127,7 +132,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         // get the hits for this event and this source and process them
         std::vector<o2::trd::Hit> hits;
         context->retrieveHits(mSimChains, "TRDHit", part.sourceID, part.entryID, &hits);
-        mDigitizer.process(hits, digits, labels);
+        mDigitizer.process(hits);
       }
     }
 


### PR DESCRIPTION
This adds the creation of digits for shared pads into the digitizer. Afterwards it can be removed from the TRAP simulator spec. The digitization is the natural place to put it, as this way the digits from shared pads also enter into the raw data stream (in MC->raw conversion).

I took a look at the current implementation of pileup and unfortunately the way it was done before it cannot have worked. The current trigger time of the digitizer was set to -1 and never changed. Also the logic for adding pileup signal was not correct.

I tried to fix that with as minor changes as possible, but I need to do further tests to see if now it really does what it is supposed to do. @jolopezl could you have a look please and let me know what you think?

Reasoning for changes in `addSignalsFromPileup`: whenever we are adding pileup signal from a previous trigger the next readout trigger will only be accepted after at least one additional busy time. After that time the signal is obsolete and can therefore be removed.