### PR TITLE
MCH CTF encoding/decoding added

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -10,9 +10,12 @@
 
 o2_add_library(DataFormatsMCH
                SOURCES src/TrackMCH.cxx
-	           PUBLIC_LINK_LIBRARIES O2::CommonDataFormat)
+	                     src/CTF.cxx
+	           PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
+                                   O2::DetectorsCommonDataFormats)
 
 o2_target_root_dictionary(DataFormatsMCH
                           HEADERS include/DataFormatsMCH/ROFRecord.h
                                   include/DataFormatsMCH/TrackMCH.h
-                                  include/DataFormatsMCH/DsChannelGroup.h)
+                                  include/DataFormatsMCH/DsChannelGroup.h
+				                          include/DataFormatsMCH/CTF.h)

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for MCH CTF data
+
+#ifndef O2_MCH_CTF_H
+#define O2_MCH_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+
+namespace o2
+{
+namespace mch
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nROFs = 0;      /// number of ROFrames in TF
+  uint32_t nDigits = 0;    /// number of digits in TF
+  uint32_t firstOrbit = 0; /// 1st orbit of TF
+  uint16_t firstBC = 0;    /// 1st BC of TF
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded clusters of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 8, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncROF,
+               BLC_orbitIncROF,
+               BLC_nDigitsROF,
+               BLC_tfTime,
+               BLC_nSamples, // TODO saturation bit
+               BLC_detID,
+               BLC_padID,
+               BLC_ADC };
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/MUON/MCH/src/CTF.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/CTF.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsMCH/CTF.h"
+
+using namespace o2::mch;

--- a/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
+++ b/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
@@ -18,4 +18,9 @@
 #pragma link C++ class o2::mch::TrackMCH + ;
 #pragma link C++ class o2::mch::DsChannelId + ;
 #pragma link C++ class o2::mch::DsChannelGroup + ;
+
+#pragma link C++ struct o2::mch::CTFHeader + ;
+#pragma link C++ struct o2::mch::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::mch::CTFHeader, 8, uint32_t> + ;
+
 #endif

--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -15,7 +15,7 @@ o2_add_library(DataFormatsMID
 	       PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils
 	                             O2::CommonDataFormat
 	                             O2::DetectorsCommonDataFormats
-                                     O2::ReconstructionDataFormats)
+                               O2::ReconstructionDataFormats)
 
 o2_target_root_dictionary(DataFormatsMID
                           HEADERS include/DataFormatsMID/Cluster2D.h

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(workflow)
 o2_add_test(itsmft
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::ITSMFTReconstruction
-	                          O2::DataFormatsITSMFT
+                                  O2::DataFormatsITSMFT
             SOURCES test/test_ctf_io_itsmft.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
@@ -21,7 +21,7 @@ o2_add_test(itsmft
 o2_add_test(tpc
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::TPCReconstruction
-	                          O2::DataFormatsTPC
+                                  O2::DataFormatsTPC
             SOURCES test/test_ctf_io_tpc.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
@@ -29,7 +29,7 @@ o2_add_test(tpc
 o2_add_test(ft0
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::FT0Reconstruction
-	                          O2::DataFormatsFT0
+                                  O2::DataFormatsFT0
             SOURCES test/test_ctf_io_ft0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
@@ -37,15 +37,15 @@ o2_add_test(ft0
 o2_add_test(fv0
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::FV0Reconstruction
-	                          O2::DataFormatsFV0
+                                  O2::DataFormatsFV0
             SOURCES test/test_ctf_io_fv0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	    
+      
 o2_add_test(fdd
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::FDDReconstruction
-	                          O2::DataFormatsFDD
+                                  O2::DataFormatsFDD
             SOURCES test/test_ctf_io_fdd.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
@@ -61,12 +61,18 @@ o2_add_test(tof
 
 o2_add_test(mid
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsMID
                                   O2::MIDCTF
             SOURCES test/test_ctf_io_mid.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-          
+
+o2_add_test(mch
+            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                                  O2::MIDCTF
+            SOURCES test/test_ctf_io_mch.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf)
+
 o2_add_test(emcal
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::DataFormatsEMCAL
@@ -74,7 +80,7 @@ o2_add_test(emcal
             SOURCES test/test_ctf_io_emcal.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	  
+    
 o2_add_test(phos
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::DataFormatsPHOS
@@ -90,7 +96,7 @@ o2_add_test(cpv
             SOURCES test/test_ctf_io_cpv.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	    
+      
 o2_add_test(zdc
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::DataFormatsZDC

--- a/Detectors/CTF/test/test_ctf_io_mch.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mch.cxx
@@ -122,6 +122,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     BOOST_CHECK(cor.getPadID() == cdc.getPadID());
     BOOST_CHECK(cor.getTime() == cdc.getTime());
     BOOST_CHECK(cor.nofSamples() == cdc.nofSamples());
+    BOOST_CHECK(cor.isSaturated() == cdc.isSaturated());
     BOOST_CHECK(cor.getADC() == cdc.getADC());
   }
 }

--- a/Detectors/CTF/test/test_ctf_io_mch.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mch.cxx
@@ -1,0 +1,127 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "MCHCTF/CTFCoder.h"
+#include "DataFormatsMCH/CTF.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "MCHBase/Digit.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::mch;
+
+BOOST_AUTO_TEST_CASE(CTFTest)
+{
+  std::vector<ROFRecord> rofs;
+  std::vector<Digit> digs;
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir0(3, 5), ir(ir0);
+
+  for (int irof = 0; irof < 1000; irof++) {
+    ir += 1 + gRandom->Integer(200);
+    int nch = 0;
+    while (nch == 0) {
+      nch = gRandom->Poisson(20);
+    }
+    int start = digs.size();
+    for (int ich = 0; ich < nch; ich++) {
+      int16_t detID = 100 + gRandom->Integer(1025 - 100);
+      int16_t padID = gRandom->Integer(28672);
+      int32_t tfTime = ir.differenceInBC(ir0);
+      uint32_t adc = gRandom->Integer(1024 * 1024);
+      uint16_t nsamp = gRandom->Integer(1025);
+      auto& d = digs.emplace_back(detID, padID, adc, tfTime, nsamp);
+      d.setSaturated(gRandom->Rndm() > 0.9);
+    }
+    rofs.emplace_back(ir, start, nch);
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, rofs, digs); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::mch::CTF::get(vec.data());
+    TFile flOut("test_ctf_mch.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "MCH");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  {
+    sw.Start();
+    TFile flIn("test_ctf_mch.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::mch::CTF::readFromTree(vec, *(tree.get()), "MCH");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<ROFRecord> rofsD;
+  std::vector<Digit> digsD;
+
+  sw.Start();
+  const auto ctfImage = o2::mch::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, rofsD, digsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  BOOST_CHECK(rofsD.size() == rofs.size());
+  BOOST_CHECK(digsD.size() == digs.size());
+  LOG(INFO) << " BOOST_CHECK rofsD.size() " << rofsD.size() << " rofs.size() " << rofs.size()
+            << " BOOST_CHECK(digsD.size() " << digsD.size() << " digs.size()) " << digs.size();
+
+  for (size_t i = 0; i < rofs.size(); i++) {
+    const auto& dor = rofs[i];
+    const auto& ddc = rofsD[i];
+    LOG(DEBUG) << " Orig.ROFRecord " << i << " " << dor.getBCData() << " " << dor.getFirstIdx() << " " << dor.getNEntries();
+    LOG(DEBUG) << " Deco.ROFRecord " << i << " " << ddc.getBCData() << " " << ddc.getFirstIdx() << " " << ddc.getNEntries();
+
+    BOOST_CHECK(dor.getBCData() == ddc.getBCData());
+    BOOST_CHECK(dor.getFirstIdx() == ddc.getFirstIdx());
+    BOOST_CHECK(dor.getNEntries() == ddc.getNEntries());
+  }
+
+  for (size_t i = 0; i < digs.size(); i++) {
+    const auto& cor = digs[i];
+    const auto& cdc = digsD[i];
+    BOOST_CHECK(cor.getDetID() == cdc.getDetID());
+    BOOST_CHECK(cor.getPadID() == cdc.getPadID());
+    BOOST_CHECK(cor.getTime() == cdc.getTime());
+    BOOST_CHECK(cor.nofSamples() == cdc.nofSamples());
+    BOOST_CHECK(cor.getADC() == cdc.getADC());
+  }
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -11,32 +11,33 @@
 o2_add_library(CTFWorkflow
                SOURCES src/CTFWriterSpec.cxx
                        src/CTFReaderSpec.cxx
-	       PUBLIC_LINK_LIBRARIES O2::Framework
-                                     O2::DetectorsCommonDataFormats
-                                     O2::DataFormatsITSMFT
-                                     O2::DataFormatsTPC
-                                     O2::DataFormatsTOF
-                                     O2::DataFormatsFT0
-                                     O2::DataFormatsFV0
-				     O2::DataFormatsFDD
-				     O2::DataFormatsMID
-				     O2::DataFormatsPHOS
-				     O2::DataFormatsCPV
-				     O2::DataFormatsZDC				     
-                                     O2::DataFormatsParameters
-                                     O2::ITSMFTWorkflow
-                                     O2::TPCWorkflow
-                                     O2::FT0Workflow
-                                     O2::FV0Workflow
-				     O2::FDDWorkflow
-                                     O2::TOFWorkflow
-                                     O2::MIDWorkflow
-                                     O2::EMCALWorkflow
-				     O2::PHOSWorkflow
-				     O2::CPVWorkflow
-				     O2::ZDCWorkflow
-                                     O2::Algorithm
-                                     O2::CommonUtils)
+         PUBLIC_LINK_LIBRARIES O2::Framework
+                               O2::DetectorsCommonDataFormats
+                               O2::DataFormatsITSMFT
+                               O2::DataFormatsTPC
+                               O2::DataFormatsTOF
+                               O2::DataFormatsFT0
+                               O2::DataFormatsFV0
+                               O2::DataFormatsFDD
+                               O2::DataFormatsMID
+                               O2::DataFormatsPHOS
+                               O2::DataFormatsCPV
+                               O2::DataFormatsZDC             
+                               O2::DataFormatsParameters
+                               O2::ITSMFTWorkflow
+                               O2::TPCWorkflow
+                               O2::FT0Workflow
+                               O2::FV0Workflow
+                               O2::FDDWorkflow
+                               O2::TOFWorkflow
+                               O2::MIDWorkflow
+                               O2::MCHWorkflow
+                               O2::EMCALWorkflow
+                               O2::PHOSWorkflow
+                               O2::CPVWorkflow
+                               O2::ZDCWorkflow
+                               O2::Algorithm
+                               O2::CommonUtils)
 
 o2_add_executable(writer-workflow
                   SOURCES src/ctf-writer-workflow.cxx

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -30,6 +30,7 @@
 #include "DataFormatsFDD/CTF.h"
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
+#include "DataFormatsMCH/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
@@ -166,6 +167,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mid::CTF));
     o2::mid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::MCH;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mch::CTF));
+    o2::mch::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -27,6 +27,7 @@
 #include "DataFormatsFDD/CTF.h"
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
+#include "DataFormatsMCH/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
@@ -104,8 +105,8 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::tof::CTF>(pc, DetID::TOF, header, treeOut.get());
   processDet<o2::ft0::CTF>(pc, DetID::FT0, header, treeOut.get());
   processDet<o2::fv0::CTF>(pc, DetID::FV0, header, treeOut.get());
-  processDet<o2::fdd::CTF>(pc, DetID::FDD, header, treeOut.get());
   processDet<o2::mid::CTF>(pc, DetID::MID, header, treeOut.get());
+  processDet<o2::mch::CTF>(pc, DetID::MCH, header, treeOut.get());
   processDet<o2::emcal::CTF>(pc, DetID::EMC, header, treeOut.get());
   processDet<o2::phos::CTF>(pc, DetID::PHS, header, treeOut.get());
   processDet<o2::cpv::CTF>(pc, DetID::CPV, header, treeOut.get());
@@ -179,6 +180,7 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::fv0::CTF>(DetID::FV0, header);
   storeDictionary<o2::fdd::CTF>(DetID::FDD, header);
   storeDictionary<o2::mid::CTF>(DetID::MID, header);
+  storeDictionary<o2::mch::CTF>(DetID::MCH, header);
   storeDictionary<o2::emcal::CTF>(DetID::EMC, header);
   storeDictionary<o2::phos::CTF>(DetID::PHS, header);
   storeDictionary<o2::cpv::CTF>(DetID::CPV, header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -27,6 +27,7 @@
 #include "FDDWorkflow/EntropyDecoderSpec.h"
 #include "TOFWorkflowUtils/EntropyDecoderSpec.h"
 #include "MIDWorkflow/EntropyDecoderSpec.h"
+#include "MCHWorkflow/EntropyDecoderSpec.h"
 #include "EMCALWorkflow/EntropyDecoderSpec.h"
 #include "PHOSWorkflow/EntropyDecoderSpec.h"
 #include "CPVWorkflow/EntropyDecoderSpec.h"
@@ -95,6 +96,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (dets[DetID::MID]) {
     specs.push_back(o2::mid::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::MCH]) {
+    specs.push_back(o2::mch::getEntropyDecoderSpec());
   }
   if (dets[DetID::EMC]) {
     specs.push_back(o2::emcal::getEntropyDecoderSpec());

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Digit.h
@@ -30,7 +30,7 @@ class Digit
  public:
   Digit() = default;
 
-  Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples = 1);
+  Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples = 1, bool saturated = false);
   ~Digit() = default;
 
   bool operator==(const Digit&) const;

--- a/Detectors/MUON/MCH/Base/src/Digit.cxx
+++ b/Detectors/MUON/MCH/Base/src/Digit.cxx
@@ -19,10 +19,12 @@ bool closeEnough(double x, double y, double eps = 1E-6)
   return std::fabs(x - y) <= eps * std::max(1.0, std::max(std::fabs(x), std::fabs(y)));
 }
 
-Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples)
+Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples, bool saturated)
   : mTFtime(time), mNofSamples(nSamples), mDetID(detid), mPadID(pad), mADC(adc)
 {
-  setSaturated(false);
+  if (saturated) {
+    setSaturated(true);
+  }
 }
 
 void Digit::setNofSamples(uint16_t n)

--- a/Detectors/MUON/MCH/CTF/CMakeLists.txt
+++ b/Detectors/MUON/MCH/CTF/CMakeLists.txt
@@ -8,16 +8,13 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Contour)
-add_subdirectory(Mapping)
-add_subdirectory(PreClustering)
-add_subdirectory(Geometry)
-add_subdirectory(Clustering)
-add_subdirectory(Simulation)
-add_subdirectory(Tracking)
-add_subdirectory(Raw)
-add_subdirectory(CTF)
-add_subdirectory(Workflow)
-add_subdirectory(Conditions)
-add_subdirectory(Calibration)
+o2_add_library(MCHCTF
+               SOURCES src/CTFCoder.cxx src/CTFHelper.cxx
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH
+                                     O2::MCHBase
+                                     O2::DetectorsBase
+                                     O2::CommonDataFormat
+				     O2::DetectorsCommonDataFormats
+                                     O2::rANS
+                                     ms_gsl::ms_gsl)
+

--- a/Detectors/MUON/MCH/CTF/README.md
+++ b/Detectors/MUON/MCH/CTF/README.md
@@ -1,0 +1,7 @@
+<!-- doxy
+\page refMUONMIDCTF MID CTF encoding library
+/doxy -->
+
+# MID CTF
+This directory contains the classes to handle entropy encoding of MID
+ROFRecord and ColumnData data.

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -130,7 +130,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
 
   uint32_t firstEntry = 0, rofCount = 0, digCount = 0;
   o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
-
+  constexpr uint16_t SMask = 0x1 << 12, NSMask = SMask - 1;
   for (uint32_t irof = 0; irof < header.nROFs; irof++) {
     // restore ROFRecord
     if (orbitInc[irof]) {  // non-0 increment => new orbit
@@ -142,7 +142,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
 
     firstEntry = digVec.size();
     for (uint8_t ic = 0; ic < nDigits[irof]; ic++) {
-      digVec.emplace_back(Digit{detID[digCount], padID[digCount], ADC[digCount], tfTime[digCount], nSamples[digCount]});
+      digVec.emplace_back(Digit{detID[digCount], padID[digCount], ADC[digCount], tfTime[digCount], uint16_t(nSamples[digCount] & NSMask), bool(nSamples[digCount] & SMask)});
       digCount++;
     }
     rofVec.emplace_back(ROFRecord{ir, int(firstEntry), nDigits[irof]});

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -1,0 +1,156 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MCH digit data
+
+#ifndef O2_MCH_CTFCODER_H
+#define O2_MCH_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsMCH/CTF.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "MCHBase/Digit.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "MCHCTF/CTFHelper.h"
+#include "rANS/rans.h"
+
+class TTree;
+
+namespace o2
+{
+namespace mch
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MCH) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VROF, typename VCOL>
+  void decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<Digit>& digVec);
+};
+
+/// entropy-encode clusters to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncROF
+    MD::EENCODE, // BLC_orbitIncROF
+    MD::EENCODE, // BLC_nDigitsROF
+    MD::EENCODE, // BLC_tfTime
+    MD::EENCODE, // BLC_nSamples
+    MD::EENCODE, // BLC_detID
+    MD::EENCODE, // BLC_padID
+    MD::EENCODE  // BLC_ADC
+  };
+  CTFHelper helper(rofData, digData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODEMCH(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODEMCH(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,    0);
+  ENCODEMCH(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF, 0);
+  ENCODEMCH(helper.begin_nDigitsROF(),  helper.end_nDigitsROF(),   CTF::BLC_nDigitsROF,  0);
+
+  ENCODEMCH(helper.begin_tfTime(),      helper.end_tfTime(),       CTF::BLC_tfTime,      0);
+  ENCODEMCH(helper.begin_nSamples(),    helper.end_nSamples(),     CTF::BLC_nSamples,    0);
+  ENCODEMCH(helper.begin_detID(),       helper.end_detID(),        CTF::BLC_detID,       0);
+  ENCODEMCH(helper.begin_padID(),       helper.end_padID(),        CTF::BLC_padID,       0);
+  ENCODEMCH(helper.begin_ADC()  ,       helper.end_ADC(),          CTF::BLC_ADC,         0);
+  // clang-format on
+  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded clusters to standard compact clusters
+template <typename VROF, typename VCOL>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+  std::vector<uint16_t> bcInc, nDigits, nSamples;
+  std::vector<uint32_t> orbitInc, ADC;
+  std::vector<int32_t> tfTime;
+  std::vector<int16_t> detID, padID;
+
+#define DECODEMCH(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODEMCH(bcInc,       CTF::BLC_bcIncROF);
+  DECODEMCH(orbitInc,    CTF::BLC_orbitIncROF);
+  DECODEMCH(nDigits,     CTF::BLC_nDigitsROF);
+
+  DECODEMCH(tfTime,      CTF::BLC_tfTime);
+  DECODEMCH(nSamples,    CTF::BLC_nSamples);
+  DECODEMCH(detID,       CTF::BLC_detID);
+  DECODEMCH(padID,       CTF::BLC_padID);
+  DECODEMCH(ADC,         CTF::BLC_ADC);
+  // clang-format on
+  //
+  rofVec.clear();
+  digVec.clear();
+  rofVec.reserve(header.nROFs);
+  digVec.reserve(header.nDigits);
+
+  uint32_t firstEntry = 0, rofCount = 0, digCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  for (uint32_t irof = 0; irof < header.nROFs; irof++) {
+    // restore ROFRecord
+    if (orbitInc[irof]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[irof]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[irof];
+    } else {
+      ir.bc += bcInc[irof];
+    }
+
+    firstEntry = digVec.size();
+    for (uint8_t ic = 0; ic < nDigits[irof]; ic++) {
+      digVec.emplace_back(Digit{detID[digCount], padID[digCount], ADC[digCount], tfTime[digCount], nSamples[digCount]});
+      digCount++;
+    }
+    rofVec.emplace_back(ROFRecord{ir, int(firstEntry), nDigits[irof]});
+  }
+  assert(digCount == header.nDigits);
+}
+
+} // namespace mch
+} // namespace o2
+
+#endif // O2_MCH_CTFCODER_H

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -142,7 +142,11 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_nSamples, Digit, uint16_t>::_Iter;
-    value_type operator*() const { return mData[mIndex].nofSamples(); }
+    value_type operator*() const
+    {
+      auto ns = mData[mIndex].nofSamples();
+      return mData[mIndex].isSaturated() ? (ns | 0x1 << 12) : ns;
+    }
   };
 
   //_______________________________________________

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -1,0 +1,206 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MCH CTF creation
+
+#ifndef O2_MCH_CTF_HELPER_H
+#define O2_MCH_CTF_HELPER_H
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include "MCHBase/Digit.h"
+#include "DataFormatsMCH/CTF.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace mch
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const o2::mch::ROFRecord>& rofData, const gsl::span<const o2::mch::Digit>& digData)
+    : mROFData(rofData), mDigData(digData) {}
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mDigData.size()), 0, 0};
+    if (mROFData.size()) {
+      h.firstOrbit = mROFData[0].getBCData().orbit;
+      h.firstBC = mROFData[0].getBCData().bc;
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mROFData.size() * sizeof(o2::mch::ROFRecord) + mDigData.size() * sizeof(o2::mch::Digit); }
+
+  //>>> =========================== ITERATORS ========================================
+
+  template <typename I, typename D, typename T, int M = 1>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncROF : public _Iter<Iter_bcIncROF, ROFRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncROF, ROFRecord, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].getBCData().orbit == mData[mIndex - 1].getBCData().orbit) {
+          return mData[mIndex].getBCData().bc - mData[mIndex - 1].getBCData().bc;
+        } else {
+          return mData[mIndex].getBCData().bc;
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncROF : public _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].getBCData().orbit - mData[mIndex - 1].getBCData().orbit : 0; }
+  };
+
+  //_______________________________________________
+  // Number of entries in the ROF
+  class Iter_nDigitsROF : public _Iter<Iter_nDigitsROF, ROFRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_nDigitsROF, ROFRecord, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNEntries(); }
+  };
+
+  //_______________________________________________
+  class Iter_tfTime : public _Iter<Iter_tfTime, Digit, int32_t>
+  {
+   public:
+    using _Iter<Iter_tfTime, Digit, int32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getTime(); }
+  };
+
+  //_______________________________________________
+  class Iter_nSamples : public _Iter<Iter_nSamples, Digit, uint16_t>
+  {
+   public:
+    using _Iter<Iter_nSamples, Digit, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].nofSamples(); }
+  };
+
+  //_______________________________________________
+  class Iter_detID : public _Iter<Iter_detID, Digit, int16_t>
+  {
+   public:
+    using _Iter<Iter_detID, Digit, int16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getDetID(); }
+  };
+
+  //_______________________________________________
+  class Iter_padID : public _Iter<Iter_padID, Digit, int16_t>
+  {
+   public:
+    using _Iter<Iter_padID, Digit, int16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPadID(); }
+  };
+
+  //_______________________________________________
+  class Iter_ADC : public _Iter<Iter_ADC, Digit, uint32_t>
+  {
+   public:
+    using _Iter<Iter_ADC, Digit, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getADC(); }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncROF begin_bcIncROF() const { return Iter_bcIncROF(mROFData, false); }
+  Iter_bcIncROF end_bcIncROF() const { return Iter_bcIncROF(mROFData, true); }
+
+  Iter_orbitIncROF begin_orbitIncROF() const { return Iter_orbitIncROF(mROFData, false); }
+  Iter_orbitIncROF end_orbitIncROF() const { return Iter_orbitIncROF(mROFData, true); }
+
+  Iter_nDigitsROF begin_nDigitsROF() const { return Iter_nDigitsROF(mROFData, false); }
+  Iter_nDigitsROF end_nDigitsROF() const { return Iter_nDigitsROF(mROFData, true); }
+
+  Iter_tfTime begin_tfTime() const { return Iter_tfTime(mDigData, false); }
+  Iter_tfTime end_tfTime() const { return Iter_tfTime(mDigData, true); }
+
+  Iter_nSamples begin_nSamples() const { return Iter_nSamples(mDigData, false); }
+  Iter_nSamples end_nSamples() const { return Iter_nSamples(mDigData, true); }
+
+  Iter_detID begin_detID() const { return Iter_detID(mDigData, false); }
+  Iter_detID end_detID() const { return Iter_detID(mDigData, true); }
+
+  Iter_padID begin_padID() const { return Iter_padID(mDigData, false); }
+  Iter_padID end_padID() const { return Iter_padID(mDigData, true); }
+
+  Iter_ADC begin_ADC() const { return Iter_ADC(mDigData, false); }
+  Iter_ADC end_ADC() const { return Iter_ADC(mDigData, true); }
+
+ private:
+  const gsl::span<const o2::mch::ROFRecord> mROFData;
+  const gsl::span<const o2::mch::Digit> mDigData;
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MCH  data
+
+#include "MCHCTF/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::mch;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<Digit>& digVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, rofVec, digVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc, nDigits, nSamples;
+  uint32_t orbitInc, ADC;
+  int32_t tfTime;
+  int16_t detID, padID;
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+
+  // clang-format off
+  MAKECODER(bcInc,    CTF::BLC_bcIncROF); 
+  MAKECODER(orbitInc, CTF::BLC_orbitIncROF);
+  MAKECODER(nDigits,  CTF::BLC_nDigitsROF);
+  MAKECODER(tfTime,   CTF::BLC_tfTime);
+  MAKECODER(nSamples, CTF::BLC_nSamples);
+  MAKECODER(detID,    CTF::BLC_detID);
+  MAKECODER(padID,    CTF::BLC_padID);
+  MAKECODER(ADC,      CTF::BLC_ADC);
+  // clang-format on
+}

--- a/Detectors/MUON/MCH/CTF/src/CTFHelper.cxx
+++ b/Detectors/MUON/MCH/CTF/src/CTFHelper.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MCH CTF creation
+
+#include "MCHCTF/CTFHelper.h"

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
@@ -91,10 +91,12 @@ int main(int argc, char* argv[])
       ("userLogic,u",po::bool_switch(&userLogic),"user logic format")
       ("dummyElecMap,d",po::bool_switch(&dummyElecMap),"use a dummy electronic mapping (for testing only)")
       ("output-dir,o",po::value<std::string>()->default_value("./"),"output directory for file(s)")
+      ("file-per-link,l", po::value<bool>()->default_value(false)->implicit_value(true), "produce single file per link")
       ("input-file,i",po::value<std::string>(&input)->default_value("mchdigits.root"),"input file name")
       ("configKeyValues", po::value<std::string>()->default_value(""), "comma-separated configKeyValues")
       ("no-empty-hbf,e", po::value<bool>()->default_value(true), "do not create empty HBF pages (except for HBF starting TF)")
       ("verbosity,v",po::value<std::string>()->default_value("verylow"), "(fair)logger verbosity");
+
   // clang-format on
 
   po::options_description cmdline;
@@ -152,12 +154,11 @@ int main(int argc, char* argv[])
     }
   }
 
-  fw.writeConfFile("MCH", "RAWDATA", fmt::format("{}/MCHraw.cfg", outDirName));
-
-  std::string output = fmt::format("{}/mch.raw", outDirName);
-  PayloadPaginator paginator(fw, output, solar2feelink, userLogic, chargeSumMode);
+  std::string output = fmt::format("{:s}/mch", outDirName);
+  PayloadPaginator paginator(fw, output, vm["file-per-link"].as<bool>(), solar2feelink, userLogic, chargeSumMode);
 
   digit2raw(input, encoder, paginator);
+  fw.writeConfFile("MCH", "RAWDATA", fmt::format("{:s}/MCHraw.cfg", outDirName));
 
   return 0;
 }

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadPaginator.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadPaginator.h
@@ -33,14 +33,15 @@ class PayloadPaginator
  public:
   /// @param fw a RawFileWriter instance, that should be
   /// properly configured (once) _before_ calling the () operator
-  /// @param outputFileName the name of the single output file
-  /// used to store the produced RAW data
+  /// @param outputFileName directory/basename of file to store the raw data
+  /// @param filePerLink produce 1 file per link
   /// @param solar2feelink a mapper that converts a solarId value into
   /// a FeeLinkId object
   /// @param userLogic whether or not the format to emulate is UL
   /// @param chargeSumMode whether or not the format to emulate is in chargeSumMode
   PayloadPaginator(o2::raw::RawFileWriter& fw,
                    const std::string outputFileName,
+                   bool filePerLink,
                    Solar2FeeLinkMapper solar2feelink,
                    bool userLogic,
                    bool chargeSumMode);
@@ -57,6 +58,7 @@ class PayloadPaginator
   std::string mOutputFileName;
   std::set<FeeLinkId> mFeeLinkIds{};
   uint16_t mExtraFeeIdMask{0};
+  bool mFilePerLink{false};
 };
 
 /// helper function to wrap usage of PayloadPaginator class to

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -10,11 +10,12 @@
 
 o2_add_library(MCHWorkflow
                SOURCES src/DataDecoderSpec.cxx src/PreClusterFinderSpec.cxx src/ClusterFinderOriginalSpec.cxx
+                       src/EntropyDecoderSpec.cxx src/EntropyEncoderSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHRawDecoder Boost::program_options
                                      O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface
                                      O2::MCHPreClustering O2::MCHMappingImpl4 O2::MCHRawElecMap O2::MCHBase
-                                     O2::DataFormatsMCH O2::MCHClustering)
+                                     O2::DataFormatsMCH O2::MCHClustering O2::MCHCTF)
 
 o2_add_executable(
         cru-page-reader-workflow
@@ -130,3 +131,8 @@ o2_add_executable(
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHGeometryTransformer)
 
+o2_add_executable(
+          entropy-encoder-workflow
+          SOURCES src/entropy-encoder-workflow.cxx
+          COMPONENT_NAME mch
+          PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)          

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -9,6 +9,7 @@
 * [Raw to digits](#raw-to-digits)
 * [Preclustering](#preclustering)
 * [Clustering](#clustering)
+* [CTF encoding/decoding](#ctf)
 * [Local to global cluster transformation](#local-to-global-cluster-transformation)
 * [Tracking](#tracking)
   * [Original track finder](#original-track-finder)
@@ -76,6 +77,17 @@ o2-mch-preclusters-to-clusters-original-workflow
 ```
 
 Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](../Base/include/MCHBase/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
+
+## CTF encoding/decoding
+
+Entropy encoding is done be attaching the `o2-mch-entropy-encoder-workflow`` to the output of `DIGITS` and `DIGITROF` data-descriptions, providing `Digit` and `ROFRecord` respectively, i.e.
+Afterwads the encoded data can be stored by the `o2-ctf-writer-workflow`, e.g.
+
+```shell
+o2-raw-file-reader-workflow --input-conf raw/MCH/MCHraw.cfg | o2-mch-raw-to-digits-workflow  | o2-mch-entropy-encoder-workflow | o2-ctf-writer-workflow --onlyDet MCH
+```
+
+The decoding is sone automatically by the `o2-ctf-reader-workflow`.
 
 ## Local to global cluster transformation
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to MCH ROFRecords/Digits stream
+
+#ifndef O2_MCH_ENTROPYDECODER_SPEC
+#define O2_MCH_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "MCHCTF/CTFCoder.h"
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace mch
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mch::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert MCH data to CTF (EncodedBlocks)
+/// @author ruben.shahoyan@cern.ch
+
+#ifndef O2_MCH_ENTROPYENCODER_SPEC
+#define O2_MCH_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include <TStopwatch.h>
+#include "MCHCTF/CTFCoder.h"
+
+namespace o2
+{
+namespace mch
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mch::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "MCHWorkflow/EntropyDecoderSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mch
+{
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("mch-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& rofs = pc.outputs().make<std::vector<o2::mch::ROFRecord>>(OutputRef{"rofs"});
+  auto& digs = pc.outputs().make<std::vector<o2::mch::Digit>>(OutputRef{"digs"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::mch::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, rofs, digs);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << digs.size() << " MCH digits in " << rofs.size() << " ROFRecords in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MCH Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"rofs"}, "MCH", "DIGITROF", 0, Lifetime::Timeframe},
+    OutputSpec{{"digits"}, "MCH", "DIGITS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "mch-entropy-decoder",
+    Inputs{InputSpec{"ctf", "MCH", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"mch-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,81 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+/// @brief  Convert MCH DATA to CTF (EncodedBlocks)
+/// @author ruben.shahoyan@cern.ch
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "MCHWorkflow/EntropyEncoderSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mch
+{
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("mch-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
+  auto digs = pc.inputs().get<gsl::span<o2::mch::Digit>>("digits");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MCH", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, rofs, digs);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for MCH in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MCH Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("rofs", "MCH", "DIGITROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "mch-entropy-encoder",
+    inputs,
+    Outputs{{"MCH", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"mch-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHWorkflow/EntropyEncoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::mch::getEntropyEncoderSpec());
+  return wf;
+}


### PR DESCRIPTION
@aphecetche The CTF should be working now but:

1) there are serious problems in `digi2raw`: the links must be registered in advance and ``addData`` for some `{bc,orbit}` must be called for all links, even if only part of them have non-0 payload. Otherwise the data will not make sense. I would also suggest no to use `no-empty-hbf` by default, as normally this is an error condition for a detector with continuous readout.
I have added some fixes the  `digi2raw`, see 2nd commit, but did not touch the logic above since this depends on your data structure.

2) As I wrote privately, most of workflows sending `Digit`s don't sent the `ROFRecord`s, while these 2 outputs must always go together. If you can live with `Digit` only, this means it has redundant info, I suspect the `tfTime`. 
At least the encoding does expect both inputs (and the CTF decoding produces them).
Also, I thing it is worth to modify some data members of your `Digit` class (on top of what I wrote you privately: if the 
max value of `mNofSamples` is 1024, you better use to flag the saturation not the highest bit but 12th one: the gaps in the data dynamic range, while do not affect the compression quality but increase the size of the dictionaries).

So, at the moment I was able to validate this PR only by running a unit-test `o2-test-ctf-mch`.