### PR TITLE
DPL: reduce chances of dropping messages

### DIFF
--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -47,8 +47,8 @@ std::vector<ConfigParamSpec> WorkflowCustomizationHelpers::requiredWorkflowOptio
                                        ConfigParamSpec{"aod-writer-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}},
 
                                        ConfigParamSpec{"fairmq-rate-logging", VariantType::Int, 0, {"Rate logging for FairMQ channels"}},
-                                       ConfigParamSpec{"fairmq-recv-buffer-size", VariantType::Int, 1000, {"recvBufferSize option for FairMQ channels"}},
-                                       ConfigParamSpec{"fairmq-send-buffer-size", VariantType::Int, 1000, {"sendBufferSize option for FairMQ channels"}},
+                                       ConfigParamSpec{"fairmq-recv-buffer-size", VariantType::Int, 1, {"recvBufferSize option for FairMQ channels"}},
+                                       ConfigParamSpec{"fairmq-send-buffer-size", VariantType::Int, 1, {"sendBufferSize option for FairMQ channels"}},
                                        /// Find out a place where we can write the sockets
                                        ConfigParamSpec{"fairmq-ipc-prefix", VariantType::String, defaultIPCFolder(), {"Prefix for FairMQ channels location"}},
 

--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -47,8 +47,8 @@ std::vector<ConfigParamSpec> WorkflowCustomizationHelpers::requiredWorkflowOptio
                                        ConfigParamSpec{"aod-writer-keep", VariantType::String, "", {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION:treename:col1/col2/..:filename"}},
 
                                        ConfigParamSpec{"fairmq-rate-logging", VariantType::Int, 0, {"Rate logging for FairMQ channels"}},
-                                       ConfigParamSpec{"fairmq-recv-buffer-size", VariantType::Int, 1, {"recvBufferSize option for FairMQ channels"}},
-                                       ConfigParamSpec{"fairmq-send-buffer-size", VariantType::Int, 1, {"sendBufferSize option for FairMQ channels"}},
+                                       ConfigParamSpec{"fairmq-recv-buffer-size", VariantType::Int, 4, {"recvBufferSize option for FairMQ channels"}},
+                                       ConfigParamSpec{"fairmq-send-buffer-size", VariantType::Int, 4, {"sendBufferSize option for FairMQ channels"}},
                                        /// Find out a place where we can write the sockets
                                        ConfigParamSpec{"fairmq-ipc-prefix", VariantType::String, defaultIPCFolder(), {"Prefix for FairMQ channels location"}},
 


### PR DESCRIPTION
This will prevent the producer to overflow the consumer, at least under certain circumstances. I guess we can ask people to use the command line options in case they want the old behaviour for performance reasons.