### PR TITLE
Move DataHeader to use fmt::format

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -42,9 +42,7 @@
 #include "MemoryResources/Types.h"
 #include <cerrno>
 
-namespace o2
-{
-namespace header
+namespace o2::header
 {
 
 //__________________________________________________________________________________________________
@@ -148,10 +146,6 @@ struct TraitsIntType<4> {
   using Type = uint32_t;
 };
 
-struct defaultPrinter {
-  void operator()(const char* str) const {}
-};
-
 /// compile time evaluation of a string length, which is either N - 1 or
 /// shorter if one character in the array has been set to 0.
 template <int N>
@@ -253,7 +247,7 @@ struct DescriptorCompareTraits<2> {
 /// solution is working also for multiples of 64 bit, but then the itg member needs
 /// to be an array for all. This has not been enabled yet, first the implications
 /// have to be studied.
-template <std::size_t N, typename PrinterPolicy = internal::defaultPrinter>
+template <std::size_t N>
 struct Descriptor {
   static_assert(internal::NumberOfActiveBits<N>::value == 1,
                 "Descriptor size is required to be a power of 2");
@@ -351,13 +345,6 @@ struct Descriptor {
     std::string ret(str, len);
     return std::move(ret);
   }
-  // print function needs to be implemented for every derivation
-  void print() const
-  {
-    // eventually terminate string before printing
-    PrinterPolicy printer;
-    printer(str);
-  };
 };
 
 //__________________________________________________________________________________________________
@@ -593,20 +580,8 @@ T stoui(const std::string& str, size_t* pos = nullptr, int base = 10)
   }
 };
 
-//__________________________________________________________________________________________________
-/// this 128 bit type for a header field describing the payload data type
-struct printDataDescription {
-  void operator()(const char* str) const;
-};
-
-using DataDescription = Descriptor<gSizeDataDescriptionString, printDataDescription>;
-
-//__________________________________________________________________________________________________
-// 32bit (4 characters) for data origin, ex. the detector or subsystem name
-struct printDataOrigin {
-  void operator()(const char* str) const;
-};
-using DataOrigin = Descriptor<gSizeDataOriginString, printDataOrigin>;
+using DataOrigin = Descriptor<gSizeDataOriginString>;
+using DataDescription = Descriptor<gSizeDataDescriptionString>;
 
 //__________________________________________________________________________________________________
 /// @defgroup data_description_defines Defines for data description
@@ -789,7 +764,6 @@ struct DataHeader : public BaseHeader {
   bool operator==(const DataOrigin&) const;          //comparison
   bool operator==(const DataDescription&) const;     //comparison
   bool operator==(const SerializationMethod&) const; //comparison
-  void print() const;                                ///pretty print the contents
 
   static const DataHeader* Get(const BaseHeader* baseHeader)
   {
@@ -818,7 +792,6 @@ struct DataIdentifier {
   }
 
   bool operator==(const DataIdentifier&) const;
-  void print() const;
 };
 
 //__________________________________________________________________________________________________
@@ -843,12 +816,10 @@ template <typename T>
 struct is_descriptor : std::false_type {
 };
 
-template <std::size_t S, typename P>
-struct is_descriptor<o2::header::Descriptor<S, P>> : std::true_type {
+template <std::size_t S>
+struct is_descriptor<o2::header::Descriptor<S>> : std::true_type {
 };
 
-} //namespace header
-
-} //namespace o2
+} //namespace o2::header
 
 #endif

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -52,21 +52,6 @@ void o2::header::BaseHeader::throwInconsistentStackError() const
 }
 
 //__________________________________________________________________________________________________
-void o2::header::DataHeader::print() const
-{
-  printf("Data header version %u, flags: %u\n", headerVersion, flags);
-  printf("  origin       : %s\n", dataOrigin.str);
-  printf("  serialization: %s\n", payloadSerializationMethod.str);
-  printf("  description  : %s\n", dataDescription.str);
-  printf("  sub spec.    : %llu\n", (long long unsigned int)subSpecification);
-  printf("  header size  : %d\n", headerSize);
-  printf("  payloadSize  : %llu\n", (long long unsigned int)payloadSize);
-  printf("  firstTFOrbit : %u\n", firstTForbit);
-  printf("  tfCounter    : %u\n", tfCounter);
-  printf("  runNumber    : %u\n", runNumber);
-}
-
-//__________________________________________________________________________________________________
 bool o2::header::DataHeader::operator==(const DataOrigin& that) const
 {
   return (that == gDataOriginAny ||
@@ -99,18 +84,6 @@ bool o2::header::DataHeader::operator==(const DataHeader& that) const
 }
 
 //__________________________________________________________________________________________________
-void o2::header::printDataDescription::operator()(const char* str) const
-{
-  printf("Data description  : %s\n", str);
-}
-
-//__________________________________________________________________________________________________
-void o2::header::printDataOrigin::operator()(const char* str) const
-{
-  printf("Data origin  : %s\n", str);
-}
-
-//__________________________________________________________________________________________________
 o2::header::DataIdentifier::DataIdentifier()
   : dataDescription(), dataOrigin()
 {
@@ -127,13 +100,6 @@ bool o2::header::DataIdentifier::operator==(const DataIdentifier& other) const
     return false;
   }
   return true;
-}
-
-//__________________________________________________________________________________________________
-void o2::header::DataIdentifier::print() const
-{
-  dataOrigin.print();
-  dataDescription.print();
 }
 
 //__________________________________________________________________________________________________


### PR DESCRIPTION
Allows us to remove some code from DataHeader.h, which is
included pretty much everywhere.