### PR TITLE
TRD: Add missing hit dictionary

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
@@ -109,7 +109,7 @@ class SimTraits
 // forward declares the HitTypes
 namespace trd
 {
-class HitType;
+class Hit;
 }
 namespace itsmft
 {
@@ -173,7 +173,7 @@ struct DetIDToHitTypes {
 // specialize for detectors
 template <>
 struct DetIDToHitTypes<o2::detectors::DetID::TRD> {
-  using HitType = o2::trd::HitType;
+  using HitType = o2::trd::Hit;
 };
 template <>
 struct DetIDToHitTypes<o2::detectors::DetID::ITS> {

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
@@ -38,6 +38,8 @@ class Hit : public o2::BasicXYZQHit<float>
   float locC{-99}; // col direction in amplification or drift volume
   float locR{-99}; // row direction in amplification or drift volume
   float locT{-99}; // time direction in amplification or drift volume
+
+  ClassDefNV(Hit, 1);
 };
 } // namespace o2::trd
 

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -27,5 +27,6 @@
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TriggerRecord > +;
 #pragma link C++ class std::vector < o2::trd::LinkRecord > +;
+#pragma link C++ class std::vector < o2::trd::Hit > +;
 
 #endif

--- a/macro/duplicateHits.C
+++ b/macro/duplicateHits.C
@@ -185,7 +185,7 @@ void duplicateHits(const char* filebase = "o2sim", const char* newfilebase = "o2
   duplicateV<o2::itsmft::Hit>(grp, filebase, DetID::MFT, newfilebase, factor);
   duplicateV<o2::tof::HitType>(grp, filebase, DetID::TOF, newfilebase, factor);
   duplicateV<o2::emcal::Hit>(grp, filebase, DetID::EMC, newfilebase, factor);
-  duplicateV<o2::trd::HitType>(grp, filebase, DetID::TRD, newfilebase, factor);
+  duplicateV<o2::trd::Hit>(grp, filebase, DetID::TRD, newfilebase, factor);
   duplicateV<o2::phos::Hit>(grp, filebase, DetID::PHS, newfilebase, factor);
   duplicateV<o2::cpv::Hit>(grp, filebase, DetID::CPV, newfilebase, factor);
   duplicateV<o2::zdc::Hit>(grp, filebase, DetID::ZDC, newfilebase, factor);


### PR DESCRIPTION
Add missing dictionary definition to the TRD Hit, and fix macros producing hits for running the pileup and embedding check production test.