### PR TITLE
Enable uniform magnetic field on SimConfig and GRPObject

### DIFF
--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -69,7 +69,7 @@ class MagneticField : public FairField
   ~MagneticField() override = default;
 
   /// create field from rounded value, i.e. +-5 or +-2 kGauss
-  static MagneticField* createNominalField(int fld);
+  static MagneticField* createNominalField(int fld, bool uniform = false);
 
   /// real field creation is here
   void CreateField();

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -148,13 +148,13 @@ MagneticField::MagneticField(const MagFieldParam& param)
   CreateField();
 }
 
-MagneticField* MagneticField::createNominalField(int fld)
+MagneticField* MagneticField::createNominalField(int fld, bool uniform)
 {
   float fldCoeff;
   o2::field::MagFieldParam::BMap_t fldType;
   switch (std::abs(fld)) {
     case 5:
-      fldType = o2::field::MagFieldParam::k5kG;
+      fldType = uniform ? o2::field::MagFieldParam::k5kGUniform : o2::field::MagFieldParam::k5kG;
       fldCoeff = fld > 0 ? 1. : -1;
       break;
     case 0:

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -48,8 +48,9 @@ struct SimConfigData {
   std::string mCCDBUrl;                      // the URL where to find CCDB
   long mTimestamp;                           // timestamp to anchor transport simulation to
   int mField;                                // L3 field setting in kGauss: +-2,+-5 and 0
+  bool mUniformField = false;                // uniform magnetic field
 
-  ClassDefNV(SimConfigData, 3);
+  ClassDefNV(SimConfigData, 4);
 };
 
 // A singleton class which can be used

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -43,8 +43,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "chunkSize", bpo::value<unsigned int>()->default_value(500), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
-    "field", bpo::value<int>()->default_value(-5), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0")(
-    "uniformField", bpo::value<bool>()->default_value(false), "set uniform magnetic field")(
+    "field", bpo::value<std::string>()->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-5U for uniform field ")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
@@ -109,8 +108,8 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   if (vm.count("noemptyevents")) {
     mConfigData.mFilterNoHitEvents = true;
   }
-  mConfigData.mField = vm["field"].as<int>();
-  mConfigData.mUniformField = vm["uniformField"].as<bool>();
+  mConfigData.mField = std::stoi((vm["field"].as<std::string>()).substr(0, (vm["field"].as<std::string>()).rfind("U")));
+  mConfigData.mUniformField = (vm["field"].as<std::string>()).find("U") != std::string::npos;
   return true;
 }
 

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -44,6 +44,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
     "field", bpo::value<int>()->default_value(-5), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0")(
+    "uniformField", bpo::value<bool>()->default_value(false), "set uniform magnetic field")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
@@ -109,6 +110,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
     mConfigData.mFilterNoHitEvents = true;
   }
   mConfigData.mField = vm["field"].as<int>();
+  mConfigData.mUniformField = vm["uniformField"].as<bool>();
   return true;
 }
 

--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
@@ -70,8 +70,10 @@ class GRPObject
   /// getters/setters for magnets currents
   o2::units::Current_t getL3Current() const { return mL3Current; }
   o2::units::Current_t getDipoleCurrent() const { return mDipoleCurrent; }
+  bool getFieldUniformity() const { return mUniformField; }
   void setL3Current(o2::units::Current_t v) { mL3Current = v; }
   void setDipoleCurrent(o2::units::Current_t v) { mDipoleCurrent = v; }
+  void setFieldUniformity(bool v) { mUniformField = v; }
   /// getter/setter for data taking period name
   const std::string& getDataPeriod() const { return mDataPeriod; }
   void setDataPeriod(const std::string v) { mDataPeriod = v; }
@@ -142,6 +144,7 @@ class GRPObject
   o2::units::AngleRad_t mCrossingAngle = 0.f; ///< crossing angle in radians (as deviation from pi)
   o2::units::Current_t mL3Current = 0.f;      ///< signed current in L3
   o2::units::Current_t mDipoleCurrent = 0.f;  ///< signed current in Dipole
+  bool mUniformField = false;                 ///< uniformity of magnetic field
   float mBeamEnergyPerZ = 0.f;                ///< beam energy per charge (i.e. sqrt(s)/2 for pp)
 
   int mBeamAZ[beamDirection::NBeamDirections] = {0, 0}; ///< A<<16+Z for each beam
@@ -151,7 +154,7 @@ class GRPObject
   std::string mDataPeriod = ""; ///< name of the period
   std::string mLHCState = "";   ///< machine state
 
-  ClassDefNV(GRPObject, 1);
+  ClassDefNV(GRPObject, 2);
 };
 
 //______________________________________________

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -91,7 +91,7 @@ int Propagator::initFieldFromGRP(const o2::parameters::GRPObject* grp, bool verb
       delete TGeoGlobalMagField::Instance();
     }
   }
-  auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent());
+  auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
   TGeoGlobalMagField::Instance()->SetField(fld);
   TGeoGlobalMagField::Instance()->Lock();
   if (verbose) {

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -90,7 +90,7 @@ void build_geometry(FairRunSim* run = nullptr)
   run->SetMaterials("media.geo"); // Materials
 
   // we need a field to properly init the media
-  auto field = o2::field::MagneticField::createNominalField(confref.getConfigData().mField);
+  auto field = o2::field::MagneticField::createNominalField(confref.getConfigData().mField, confref.getConfigData().mUniformField);
   run->SetField(field);
 
   // Create geometry

--- a/macro/initSimGeomAndField.C
+++ b/macro/initSimGeomAndField.C
@@ -66,8 +66,8 @@ int initFieldFromGRP(const o2::parameters::GRPObject* grp)
       delete TGeoGlobalMagField::Instance();
     }
   }
-  auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent());
-  TGeoGlobalMagField::Instance()->SetField(fld);
+  auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
+  TGeoGlobalMagField::Instance()->SetField(fld, grp->getFieldUniformity());
   TGeoGlobalMagField::Instance()->Lock();
   std::cout << "Running with the B field constructed out of GRP" << std::endl;
   std::cout << "Access field via TGeoGlobalMagField::Instance()->Field(xyz,bxyz) or via" << std::endl;

--- a/macro/initSimGeomAndField.C
+++ b/macro/initSimGeomAndField.C
@@ -67,7 +67,7 @@ int initFieldFromGRP(const o2::parameters::GRPObject* grp)
     }
   }
   auto fld = o2::field::MagneticField::createFieldMap(grp->getL3Current(), grp->getDipoleCurrent(), o2::field::MagneticField::kConvLHC, grp->getFieldUniformity());
-  TGeoGlobalMagField::Instance()->SetField(fld, grp->getFieldUniformity());
+  TGeoGlobalMagField::Instance()->SetField(fld);
   TGeoGlobalMagField::Instance()->Lock();
   std::cout << "Running with the B field constructed out of GRP" << std::endl;
   std::cout << "Access field via TGeoGlobalMagField::Instance()->Field(xyz,bxyz) or via" << std::endl;

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -158,6 +158,7 @@ FairRunSim* o2sim_init(bool asservice)
       o2::units::Current_t currL3 = field->getCurrentSolenoid();
       grp.setL3Current(currL3);
       grp.setDipoleCurrent(currDip);
+      grp.setFieldUniformity(field->IsUniform());
     }
     // save
     std::string grpfilename = o2::base::NameConf::getGRPFileName(confref.getOutPrefix());

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -61,7 +61,7 @@ class O2PrimaryServerDevice final : public FairMQDevice
     auto& conf = o2::conf::SimConfig::Instance();
 
     // init magnetic field as it might be needed by the generator
-    auto field = o2::field::MagneticField::createNominalField(conf.getConfigData().mField);
+    auto field = o2::field::MagneticField::createNominalField(conf.getConfigData().mField, conf.getConfigData().mUniformField);
     TGeoGlobalMagField::Instance()->SetField(field);
     TGeoGlobalMagField::Instance()->Lock();
 


### PR DESCRIPTION
This PR activates field type `o2::field::MagFieldParam::k5kGUniform` on SimConfig and GRPObject when  `--field` argument is `-5U` or `+5U`.