### PR TITLE
DPL Analysis: Add an extra metadata field to ConfigParamSpec to use with Configurable

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamSpec.h
+++ b/Framework/Core/include/Framework/ConfigParamSpec.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_CONFIGPARAMSPEC_H
 
 #include "Framework/Variant.h"
+#include "Framework/ConfigurableKinds.h"
 
 #include <string>
 
@@ -18,7 +19,6 @@ namespace o2
 {
 namespace framework
 {
-
 /// @class ConfigParamSpec Definition of options for a processor
 /// An option definition consists of a name, a type, a help message, and
 /// an optional default value. The type of the argument has to be specified
@@ -38,27 +38,28 @@ struct ConfigParamSpec {
   };
   template <typename T>
   ConfigParamSpec(std::string, ParamType, Variant, T)
-    : type(VariantType::Unknown)
+    : type(VariantType::Unknown), kind{ConfigParamKind::kGeneric}
   {
     static_assert(std::is_same<T, HelpString>::value,
                   R"(help string must be brace-enclosed, e.g. '{"help"}')");
   }
 
   ConfigParamSpec(std::string _name, ParamType _type,
-                  Variant _defaultValue, HelpString _help)
-    : name(_name), type(_type), defaultValue(_defaultValue), help(_help)
+                  Variant _defaultValue, HelpString _help, ConfigParamKind kind_ = ConfigParamKind::kGeneric)
+    : name(_name), type(_type), defaultValue(_defaultValue), help(_help), kind{kind_}
   {
   }
 
   /// config spec without default value, explicitely marked as 'empty'
   /// and will be ignored at other places
   ConfigParamSpec(std::string _name, ParamType _type, HelpString _help)
-    : name(_name), type(_type), defaultValue(VariantType::Empty), help(_help) {}
+    : name(_name), type(_type), defaultValue(VariantType::Empty), help(_help), kind{ConfigParamKind::kGeneric} {}
 
   std::string name;
   ParamType type;
   Variant defaultValue;
   HelpString help;
+  ConfigParamKind kind;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -9,10 +9,11 @@
 // or submit itself to any jurisdiction.
 #ifndef O2_FRAMEWORK_CONFIGURABLE_H_
 #define O2_FRAMEWORK_CONFIGURABLE_H_
+#include "Framework/ConfigurableKinds.h"
 #include <string>
 namespace o2::framework
 {
-template <typename T>
+template <typename T, ConfigParamKind K>
 struct ConfigurableBase {
   ConfigurableBase(std::string const& name, T&& defaultValue, std::string const& help)
     : name(name), value{std::forward<T>(defaultValue)}, help(help)
@@ -22,12 +23,13 @@ struct ConfigurableBase {
   std::string name;
   T value;
   std::string help;
+  static constexpr ConfigParamKind kind = K;
 };
 
-template <typename T>
-struct ConfigurablePolicyConst : ConfigurableBase<T> {
+template <typename T, ConfigParamKind K>
+struct ConfigurablePolicyConst : ConfigurableBase<T, K> {
   ConfigurablePolicyConst(std::string const& name, T&& defaultValue, std::string const& help)
-    : ConfigurableBase<T>{name, std::forward<T>(defaultValue), help}
+    : ConfigurableBase<T, K>{name, std::forward<T>(defaultValue), help}
   {
   }
   operator T()
@@ -40,10 +42,10 @@ struct ConfigurablePolicyConst : ConfigurableBase<T> {
   }
 };
 
-template <typename T>
-struct ConfigurablePolicyMutable : ConfigurableBase<T> {
+template <typename T, ConfigParamKind K>
+struct ConfigurablePolicyMutable : ConfigurableBase<T, K> {
   ConfigurablePolicyMutable(std::string const& name, T&& defaultValue, std::string const& help)
-    : ConfigurableBase<T>{name, std::forward<T>(defaultValue), help}
+    : ConfigurableBase<T, K>{name, std::forward<T>(defaultValue), help}
   {
   }
   operator T()
@@ -58,7 +60,7 @@ struct ConfigurablePolicyMutable : ConfigurableBase<T> {
 
 /// This helper allows you to create a configurable option associated to a task.
 /// Internally it will be bound to a ConfigParamSpec.
-template <typename T, typename IP = ConfigurablePolicyConst<T>>
+template <typename T, ConfigParamKind K = ConfigParamKind::kGeneric, typename IP = ConfigurablePolicyConst<T, K>>
 struct Configurable : IP {
   Configurable(std::string const& name, T&& defaultValue, std::string const& help)
     : IP{name, std::forward<T>(defaultValue), help}
@@ -66,11 +68,14 @@ struct Configurable : IP {
   }
 };
 
-template <typename T>
-using MutableConfigurable = Configurable<T, ConfigurablePolicyMutable<T>>;
+template <typename T, ConfigParamKind K = ConfigParamKind::kGeneric>
+using MutableConfigurable = Configurable<T, K, ConfigurablePolicyMutable<T, K>>;
 
-template <typename T, typename IP>
-std::ostream& operator<<(std::ostream& os, Configurable<T, IP> const& c)
+template <typename T>
+using ConfigurableAxis = Configurable<std::vector<T>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<T>, ConfigParamKind::kAxisSpec>>;
+
+template <typename T, ConfigParamKind K, typename IP>
+std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)
 {
   os << c.value;
   return os;

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -11,6 +11,7 @@
 #define O2_FRAMEWORK_CONFIGURABLE_H_
 #include "Framework/ConfigurableKinds.h"
 #include <string>
+#include <vector>
 namespace o2::framework
 {
 template <typename T, ConfigParamKind K>

--- a/Framework/Core/include/Framework/ConfigurableKinds.h
+++ b/Framework/Core/include/Framework/ConfigurableKinds.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_CONFIGURABLEKINDS_H_
+#define O2_FRAMEWORK_CONFIGURABLEKINDS_H_
+namespace o2::framework
+{
+enum ConfigParamKind : int {
+  kGeneric = 0,
+  kAxisSpec = 1
+};
+}
+#endif // O2_FRAMEWORK_CONFIGURABLEKINDS_H_

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -355,12 +355,12 @@ struct OptionManager {
   }
 };
 
-template <typename T, typename IP>
-struct OptionManager<Configurable<T, IP>> {
-  static bool appendOption(std::vector<ConfigParamSpec>& options, Configurable<T, IP>& what)
+template <typename T, ConfigParamKind K, typename IP>
+struct OptionManager<Configurable<T, K, IP>> {
+  static bool appendOption(std::vector<ConfigParamSpec>& options, Configurable<T, K, IP>& what)
   {
     if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
-      options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<T>>, what.value, {what.help}});
+      options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<T>>, what.value, {what.help}, what.kind});
     } else {
       auto specs = RootConfigParamHelpers::asConfigParamSpecs<T>(what.name, what.value);
       options.insert(options.end(), specs.begin(), specs.end());
@@ -368,7 +368,7 @@ struct OptionManager<Configurable<T, IP>> {
     return true;
   }
 
-  static bool prepare(InitContext& context, Configurable<T, IP>& what)
+  static bool prepare(InitContext& context, Configurable<T, K, IP>& what)
   {
     if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
       what.value = context.options().get<T>(what.name.c_str());

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -637,7 +637,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
   w.Key("workflow");
   w.StartArray();
 
-  for (auto const& processor : workflow) {
+  for (auto& processor : workflow) {
     if (processor.name.rfind("internal-dpl", 0) == 0) {
       continue;
     }
@@ -647,7 +647,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("inputs");
     w.StartArray();
-    for (auto const& input : processor.inputs) {
+    for (auto& input : processor.inputs) {
       /// FIXME: this only works for a selected set of InputSpecs...
       ///        a proper way to fully serialize an InputSpec with
       ///        a DataDescriptorMatcher is needed.
@@ -672,7 +672,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       if (input.metadata.empty() == false) {
         w.Key("metadata");
         w.StartArray();
-        for (auto const& metadata : input.metadata) {
+        for (auto& metadata : input.metadata) {
           w.StartObject();
           w.Key("name");
           w.String(metadata.name.c_str());
@@ -695,7 +695,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("outputs");
     w.StartArray();
-    for (auto const& output : processor.outputs) {
+    for (auto& output : processor.outputs) {
       w.StartObject();
       w.Key("binding");
       if (output.binding.value.empty()) {
@@ -724,7 +724,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("options");
     w.StartArray();
-    for (auto const& option : processor.options) {
+    for (auto& option : processor.options) {
       if (option.name == "start-value-enumeration" || option.name == "end-value-enumeration" || option.name == "step-value-enumeration") {
         continue;
       }
@@ -777,7 +777,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
   w.Key("metadata");
   w.StartArray();
-  for (auto const& info : metadata) {
+  for (auto& info : metadata) {
     w.StartObject();
     w.Key("name");
     w.String(info.name.c_str());
@@ -785,13 +785,13 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.String(info.executable.c_str());
     w.Key("cmdLineArgs");
     w.StartArray();
-    for (auto const& arg : info.cmdLineArgs) {
+    for (auto& arg : info.cmdLineArgs) {
       w.String(arg.c_str());
     }
     w.EndArray();
     w.Key("workflowOptions");
     w.StartArray();
-    for (auto const& option : info.workflowOptions) {
+    for (auto& option : info.workflowOptions) {
       w.StartObject();
       w.Key("name");
       w.String(option.name.c_str());
@@ -809,7 +809,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.EndArray();
     w.Key("channels");
     w.StartArray();
-    for (auto const& channel : info.channels) {
+    for (auto& channel : info.channels) {
       w.String(channel.c_str());
     }
     w.EndArray();

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -22,9 +22,7 @@
 #include <algorithm>
 #include <memory>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 using namespace rapidjson;
@@ -64,6 +62,7 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     IN_OPTION_TYPE,
     IN_OPTION_DEFAULT,
     IN_OPTION_HELP,
+    IN_OPTION_KIND,
     IN_METADATUM,
     IN_METADATUM_NAME,
     IN_METADATUM_EXECUTABLE,
@@ -173,6 +172,9 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       case State::IN_OPTION_HELP:
         s << "IN_OPTION_HELP";
         break;
+      case State::IN_OPTION_KIND:
+        s << "IN_OPTION_KIND";
+        break;
       case State::IN_ERROR:
         s << "IN_ERROR";
         break;
@@ -270,58 +272,58 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       is.str(optionDefault);
       switch (optionType) {
         case VariantType::String:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault.c_str(), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault.c_str(), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Int:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stoi(optionDefault, nullptr), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stoi(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Int64:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stol(optionDefault, nullptr), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stol(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Float:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stof(optionDefault, nullptr), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stof(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Double:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stod(optionDefault, nullptr), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stod(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Bool:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, (bool)std::stoi(optionDefault, nullptr), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, (bool)std::stoi(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::ArrayInt:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayInt>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayInt>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::ArrayFloat:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayFloat>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayFloat>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::ArrayDouble:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayDouble>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayDouble>(is), HelpString{optionHelp}, optionKind);
           break;
           //        case VariantType::ArrayBool:
-          //          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayBool>(is), HelpString{optionHelp});
+          //          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayBool>(is), HelpString{optionHelp}, optionKind);
           //          break;
         case VariantType::ArrayString:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayString>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::ArrayString>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Array2DInt:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DInt>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DInt>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Array2DFloat:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DFloat>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DFloat>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::Array2DDouble:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DDouble>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::Array2DDouble>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::LabeledArrayInt:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayInt>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayInt>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::LabeledArrayFloat:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayFloat>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayFloat>(is), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::LabeledArrayDouble:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayDouble>(is), HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayDouble>(is), HelpString{optionHelp}, optionKind);
           break;
         default:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault, HelpString{optionHelp});
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault, HelpString{optionHelp}, optionKind);
       }
       // Depending on the previous state, push options to the right place.
       if (previousIs(State::IN_OPTIONS)) {
@@ -433,6 +435,8 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       push(State::IN_OPTION_DEFAULT);
     } else if (in(State::IN_OPTION) && strncmp(str, "help", length) == 0) {
       push(State::IN_OPTION_HELP);
+    } else if (in(State::IN_OPTION) && strncmp(str, "kind", length) == 0) {
+      push(State::IN_OPTION_KIND);
     } else if (in(State::IN_METADATUM) && strncmp(str, "name", length) == 0) {
       push(State::IN_METADATUM_NAME);
     } else if (in(State::IN_METADATUM) && strncmp(str, "executable", length) == 0) {
@@ -477,6 +481,8 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       optionName = s;
     } else if (in(State::IN_OPTION_TYPE)) {
       optionType = (VariantType)std::stoi(s, nullptr);
+    } else if (in(State::IN_OPTION_KIND)) {
+      optionKind = (ConfigParamKind)std::stoi(s, nullptr);
     } else if (in(State::IN_OPTION_DEFAULT)) {
       optionDefault = s;
     } else if (in(State::IN_OPTION_HELP)) {
@@ -587,6 +593,7 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   VariantType optionType;
   std::string optionDefault;
   std::string optionHelp;
+  ConfigParamKind optionKind;
   bool outputHasSubSpec;
   bool inputHasSubSpec;
 };
@@ -630,7 +637,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
   w.Key("workflow");
   w.StartArray();
 
-  for (auto& processor : workflow) {
+  for (auto const& processor : workflow) {
     if (processor.name.rfind("internal-dpl", 0) == 0) {
       continue;
     }
@@ -640,7 +647,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("inputs");
     w.StartArray();
-    for (auto& input : processor.inputs) {
+    for (auto const& input : processor.inputs) {
       /// FIXME: this only works for a selected set of InputSpecs...
       ///        a proper way to fully serialize an InputSpec with
       ///        a DataDescriptorMatcher is needed.
@@ -665,7 +672,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       if (input.metadata.empty() == false) {
         w.Key("metadata");
         w.StartArray();
-        for (auto& metadata : input.metadata) {
+        for (auto const& metadata : input.metadata) {
           w.StartObject();
           w.Key("name");
           w.String(metadata.name.c_str());
@@ -688,7 +695,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("outputs");
     w.StartArray();
-    for (auto& output : processor.outputs) {
+    for (auto const& output : processor.outputs) {
       w.StartObject();
       w.Key("binding");
       if (output.binding.value.empty()) {
@@ -717,7 +724,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
     w.Key("options");
     w.StartArray();
-    for (auto& option : processor.options) {
+    for (auto const& option : processor.options) {
       if (option.name == "start-value-enumeration" || option.name == "end-value-enumeration" || option.name == "step-value-enumeration") {
         continue;
       }
@@ -750,6 +757,8 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       w.String(oss.str().c_str());
       w.Key("help");
       w.String(option.help.c_str());
+      w.Key("kind");
+      w.String(std::to_string((int)option.kind).c_str());
       w.EndObject();
     }
     w.EndArray();
@@ -768,7 +777,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
 
   w.Key("metadata");
   w.StartArray();
-  for (auto& info : metadata) {
+  for (auto const& info : metadata) {
     w.StartObject();
     w.Key("name");
     w.String(info.name.c_str());
@@ -776,13 +785,13 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.String(info.executable.c_str());
     w.Key("cmdLineArgs");
     w.StartArray();
-    for (auto& arg : info.cmdLineArgs) {
+    for (auto const& arg : info.cmdLineArgs) {
       w.String(arg.c_str());
     }
     w.EndArray();
     w.Key("workflowOptions");
     w.StartArray();
-    for (auto& option : info.workflowOptions) {
+    for (auto const& option : info.workflowOptions) {
       w.StartObject();
       w.Key("name");
       w.String(option.name.c_str());
@@ -800,7 +809,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.EndArray();
     w.Key("channels");
     w.StartArray();
-    for (auto& channel : info.channels) {
+    for (auto const& channel : info.channels) {
       w.String(channel.c_str());
     }
     w.EndArray();
@@ -810,5 +819,4 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
   w.EndObject();
 }
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework


### PR DESCRIPTION
@jgrosseo this will make workflow options in serialized workflow look like the following:
```json
{
  "name": "array",
  "type": "6",
  "defaultValue": "{\"values\":[0,0,0,0,0,0,0]}",
  "help": "generic array",
  "kind": "0"
},
```

@saganatt this is intended to explicitly mark configurable axis spec 