### PR TITLE
[QC-547] Make retrieveFromTFile public

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -370,7 +370,6 @@ class CcdbApi //: public DatabaseInterface
                           const std::string& createdNotAfter = "", const std::string& createdNotBefore = "") const;
 
  private:
-
   /**
    * A helper function to extract object from a local ROOT file
    * @param filename name of ROOT file

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -362,13 +362,14 @@ class CcdbApi //: public DatabaseInterface
   void storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
                          long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
 
- private:
   /**
    * A generic helper implementation to query obj whose type is given by a std::type_info
    */
   void* retrieveFromTFile(std::type_info const&, std::string const& path, std::map<std::string, std::string> const& metadata,
                           long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",
                           const std::string& createdNotAfter = "", const std::string& createdNotBefore = "") const;
+
+ private:
 
   /**
    * A helper function to extract object from a local ROOT file


### PR DESCRIPTION
Because I want to use it directly in QC. `storeAsTFile_impl` is already public.