### PR TITLE
Reduce memory footprint of TPC digitization in GRID mode

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -34,6 +34,11 @@ o2_add_library(TPCWorkflow
                                      O2::TPCCalibration O2::TPCSimulation
                                      O2::DetectorsCalibration)
 
+o2_add_executable(chunkeddigit-merger
+        COMPONENT_NAME tpc
+        SOURCES src/ChunkedDigitPublisher.cxx
+        PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
 o2_add_executable(reco-workflow
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-reco-workflow.cxx

--- a/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
+++ b/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
@@ -1,0 +1,245 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @author Sandro Wenzel
+/// @since  2021-03-10
+/// @brief  Takes TPC digit chunks (such drift times) --> accumulates to digit timeframe format --> publishes
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/ControlService.h"
+#include "DataFormatsTPC/Digit.h"
+#include "TPCSimulation/CommonMode.h"
+#include "DetectorsBase/Detector.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TBranch.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <utility>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+
+using namespace o2::framework;
+using namespace o2::header;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // for the TPC it is useful to take at most half of the available (logical) cores due to memory requirements
+  int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
+  std::string laneshelp("Number of tpc processing lanes. A lane is a pipeline of algorithms.");
+  workflowOptions.push_back(
+    ConfigParamSpec{"tpc-lanes", VariantType::Int, defaultlanes, {laneshelp}});
+
+  // option to disable MC truth
+  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable  mc-truth"}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+
+using MCTruthContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+
+namespace o2
+{
+namespace tpc
+{
+
+template <typename T, typename R>
+void copyHelper(T const& origin, R& target)
+{
+  std::copy(origin.begin(), origin.end(), std::back_inserter(target));
+}
+template <>
+void copyHelper<MCTruthContainer>(MCTruthContainer const& origin, MCTruthContainer& target)
+{
+  target.mergeAtBack(origin);
+}
+
+template <typename T>
+auto makePublishBuffer(framework::ProcessingContext& pc, int sector)
+{
+  LOG(INFO) << "PUBLISHING SECTOR " << sector;
+  uint64_t activeSectors = 0;
+  for (int i = 0; i < 36; ++i) {
+    activeSectors |= (uint64_t)0x1 << i;
+  }
+
+  o2::tpc::TPCSectorHeader header{sector};
+  header.activeSectors = activeSectors;
+  return &pc.outputs().make<T>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe,
+                                      header});
+}
+
+template <>
+auto makePublishBuffer<MCTruthContainer>(framework::ProcessingContext& pc, int sector)
+{
+  return new MCTruthContainer();
+}
+
+template <typename T>
+void publishBuffer(framework::ProcessingContext& pc, int sector, T* accum)
+{
+  // nothing by default
+}
+
+template <>
+void publishBuffer<MCTruthContainer>(framework::ProcessingContext& pc, int sector, MCTruthContainer* accum)
+{
+  uint64_t activeSectors = 0;
+  for (int i = 0; i < 36; ++i) {
+    activeSectors |= (uint64_t)0x1 << i;
+  }
+
+  LOG(INFO) << "PUBLISHING MC LABELS " << accum->getNElements();
+  o2::tpc::TPCSectorHeader header{sector};
+  header.activeSectors = activeSectors;
+  auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(
+    Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(sector), Lifetime::Timeframe, header});
+  accum->flatten_to(sharedlabels);
+  delete accum;
+}
+
+void publishMergedTimeframes(std::vector<int> const& lanes, bool domctruth, framework::ProcessingContext& pc)
+{
+  for (auto l : lanes) {
+    // TODO: we could put each these blocks into a separate thread !
+
+    LOG(DEBUG) << "MERGING CHUNKED DIGITS FOR LANE " << l;
+    // merging the data
+    std::stringstream tmp;
+    tmp << "tpc_driftime_digits_lane" << l << ".root";
+    auto originfile = new TFile(tmp.str().c_str(), "OPEN");
+    assert(originfile);
+
+    auto merge = [originfile, &pc](auto data, auto brprefix) {
+      auto keyslist = originfile->GetListOfKeys();
+      for (int i = 0; i < keyslist->GetEntries(); ++i) {
+        auto key = keyslist->At(i);
+        auto oldtree = (TTree*)originfile->Get(key->GetName());
+        assert(oldtree);
+        std::stringstream digitbrname;
+        digitbrname << brprefix << key->GetName();
+        auto br = oldtree->GetBranch(digitbrname.str().c_str());
+        if (!br) {
+          continue;
+        }
+        decltype(data)* chunk = nullptr;
+        br->SetAddress(&chunk);
+
+        int sector = atoi(key->GetName());
+        auto accum = makePublishBuffer<decltype(data)>(pc, sector);
+
+        for (auto e = 0; e < br->GetEntries(); ++e) {
+          br->GetEntry(e);
+          copyHelper(*chunk, *accum);
+          delete chunk;
+          chunk = nullptr;
+        }
+        br->ResetAddress();
+        br->DropBaskets("all");
+        delete oldtree;
+
+        // some data (labels are published slightly differently)
+        publishBuffer(pc, sector, accum);
+      }
+    };
+
+    //data definitions
+    using DigitsType = std::vector<o2::tpc::Digit>;
+    using LabelType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+    merge(DigitsType(), "TPCDigit_");
+    if (domctruth) {
+      merge(LabelType(), "TPCDigitMCTruth_");
+    }
+    originfile->Close();
+    delete originfile;
+  }
+}
+
+class Task
+{
+ public:
+  Task(std::vector<int> laneConfig, bool mctruth) : mLanes(laneConfig), mDoMCTruth(mctruth)
+  {
+  }
+
+  void run(framework::ProcessingContext& pc)
+  {
+    LOG(INFO) << "Preparing digits (from digit chunks) for reconstruction";
+
+    publishMergedTimeframes(mLanes, mDoMCTruth, pc);
+
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+    return;
+  }
+
+  void init(framework::InitContext& ctx)
+  {
+  }
+
+ private:
+  bool mDoMCTruth = true;
+  std::vector<int> mLanes;
+};
+
+/// create the processor spec
+/// describing a processor aggregating digits for various TPC sectors and writing them to file
+/// MC truth information is also aggregated and written out
+DataProcessorSpec getSpec(std::vector<int> const& laneConfiguration, bool mctruth, bool publish = true)
+{
+  //data definitions
+  using DigitsOutputType = std::vector<o2::tpc::Digit>;
+  using CommonModeOutputType = std::vector<o2::tpc::CommonMode>;
+
+  std::vector<OutputSpec> outputs; // define channel by triple of (origin, type id of data to be sent on this channel, subspecification)
+  if (publish) {
+    // effectively the input expects one sector per subspecification
+    for (int s = 0; s < 36; ++s) {
+      OutputLabel binding{std::to_string(s)};
+      outputs.emplace_back(/*binding,*/ "TPC", "DIGITS", static_cast<SubSpecificationType>(s), Lifetime::Timeframe);
+      if (mctruth) {
+        outputs.emplace_back(/*binding,*/ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(s), Lifetime::Timeframe);
+      }
+    }
+  }
+
+  return DataProcessorSpec{
+    "TPCDigitMerger", {}, outputs, AlgorithmSpec{o2::framework::adaptFromTask<Task>(laneConfiguration, mctruth)}, Options{}};
+}
+
+} // end namespace tpc
+} // end namespace o2
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  auto numlanes = configcontext.options().get<int>("tpc-lanes");
+  bool mctruth = !configcontext.options().get<bool>("disable-mc");
+
+  std::vector<int> lanes(numlanes);
+  std::iota(lanes.begin(), lanes.end(), 0);
+  specs.emplace_back(o2::tpc::getSpec(lanes, mctruth));
+  return specs;
+}

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -8,7 +8,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-
 o2_add_executable(digitizer-workflow
                   COMPONENT_NAME sim
                   SOURCES src/EMCALDigitWriterSpec.cxx

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -8,6 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
 #include "Framework/RootSerializationSupport.h"
 #include "TPCDigitizerSpec.h"
 #include "Framework/ControlService.h"
@@ -16,6 +20,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
+#include "Framework/DeviceSpec.h"
 #include "Headers/DataHeader.h"
 #include "TStopwatch.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
@@ -23,6 +28,7 @@
 #include "TSystem.h"
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
+#include <SimulationDataFormat/IOMCTruthContainerView.h>
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
@@ -31,6 +37,7 @@
 #include "TPCSimulation/Digitizer.h"
 #include "TPCSimulation/Detector.h"
 #include "DetectorsBase/BaseDPLDigitizer.h"
+#include "DetectorsBase/Detector.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "TPCSimulation/SAMPAProcessing.h"
 #include "SimConfig/DigiParams.h"
@@ -44,6 +51,40 @@ namespace o2
 {
 namespace tpc
 {
+
+template <typename T>
+void copyHelper(T const& origin, T& target)
+{
+  std::copy(origin.begin(), origin.end(), std::back_inserter(target));
+}
+template <>
+void copyHelper<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>(o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& origin, o2::dataformats::MCTruthContainer<o2::MCCompLabel>& target)
+{
+  target.mergeAtBack(origin);
+}
+
+template <typename T>
+void writeToBranchHelper(TTree& tree, const char* name, T* accum)
+{
+  auto targetbr = o2::base::getOrMakeBranch(tree, name, accum);
+  targetbr->Fill();
+  targetbr->ResetAddress();
+  targetbr->DropBaskets("all");
+}
+template <>
+void writeToBranchHelper<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>(TTree& tree,
+                                                                             const char* name, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* accum)
+{
+  // we convert first of all to IOMCTruthContainer
+  std::vector<char> buffer;
+  accum->flatten_to(buffer);
+  accum->clear_andfreememory();
+  o2::dataformats::IOMCTruthContainerView view(buffer);
+  auto targetbr = o2::base::getOrMakeBranch(tree, name, &view);
+  targetbr->Fill();
+  targetbr->ResetAddress();
+  targetbr->DropBaskets("all");
+}
 
 std::string getBranchNameLeft(int sector)
 {
@@ -63,13 +104,15 @@ using namespace o2::base;
 class TPCDPLDigitizerTask : public BaseDPLDigitizer
 {
  public:
-  TPCDPLDigitizerTask() : BaseDPLDigitizer(InitServices::FIELD | InitServices::GEOM)
+  TPCDPLDigitizerTask(bool internalwriter) : mInternalWriter(internalwriter), BaseDPLDigitizer(InitServices::FIELD | InitServices::GEOM)
   {
   }
 
   void initDigitizerTask(framework::InitContext& ic) override
   {
     LOG(INFO) << "Initializing TPC digitization";
+
+    mLaneId = ic.services().get<const o2::framework::DeviceSpec>().rank;
 
     mWithMCTruth = o2::conf::DigiParams::Instance().mctruth;
     auto useDistortions = ic.options().get<int>("distortionType");
@@ -131,6 +174,41 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     mWriteGRP = true;
   }
 
+  void writeToROOTFile()
+  {
+    if (!mInternalROOTFlushFile) {
+      std::stringstream tmp;
+      tmp << "tpc_driftime_digits_lane" << mLaneId << ".root";
+      mInternalROOTFlushFile = new TFile(tmp.str().c_str(), "UPDATE");
+      std::stringstream trname;
+      trname << mSector;
+      mInternalROOTFlushTTree = new TTree(trname.str().c_str(), "o2sim");
+    }
+    {
+      std::stringstream brname;
+      brname << "TPCDigit_" << mSector;
+      auto br = o2::base::getOrMakeBranch(*mInternalROOTFlushTTree, brname.str().c_str(), &mDigits);
+      br->Fill();
+      br->ResetAddress();
+    }
+    if (mWithMCTruth) {
+      // labels
+      std::stringstream brname;
+      brname << "TPCDigitMCTruth_" << mSector;
+      auto br = o2::base::getOrMakeBranch(*mInternalROOTFlushTTree, brname.str().c_str(), &mLabels);
+      br->Fill();
+      br->ResetAddress();
+    }
+    {
+      // common
+      std::stringstream brname;
+      brname << "TPCCommonMode_" << mSector;
+      auto br = o2::base::getOrMakeBranch(*mInternalROOTFlushTTree, brname.str().c_str(), &mCommonMode);
+      br->Fill();
+      br->ResetAddress();
+    }
+  }
+
   void run(framework::ProcessingContext& pc)
   {
     LOG(INFO) << "Processing TPC digitization";
@@ -146,6 +224,17 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     for (auto it = pc.inputs().begin(), end = pc.inputs().end(); it != end; ++it) {
       for (auto const& inputref : it) {
         process(pc, inputref);
+        if (mInternalWriter) {
+          mInternalROOTFlushTTree->SetEntries(mFlushCounter);
+          mInternalROOTFlushFile->Write("", TObject::kOverwrite);
+          mInternalROOTFlushFile->Close();
+          // delete mInternalROOTFlushTTree; --> automatically done by ->Close()
+          delete mInternalROOTFlushFile;
+          mInternalROOTFlushFile = nullptr;
+        }
+        //TODO: make generic reset method?
+        mFlushCounter = 0;
+        mDigitCounter = 0;
       }
     }
   }
@@ -180,6 +269,8 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       return;
     }
     auto sector = sectorHeader->sector();
+    mSector = sector;
+    mListOfSectors.push_back(sector);
     LOG(INFO) << "TPC: Processing sector " << sector;
     // the active sectors need to be propagated
     uint64_t activeSectors = 0;
@@ -189,35 +280,46 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     auto makeDigitBuffer = [this, sector, &pc, activeSectors, &dh]() {
       o2::tpc::TPCSectorHeader header{sector};
       header.activeSectors = activeSectors;
-      return &pc.outputs().make<std::vector<o2::tpc::Digit>>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
-                                                                    header});
+      if (mInternalWriter) {
+        using ContainerType = std::decay_t<decltype(pc.outputs().make<std::vector<o2::tpc::Digit>>(Output{"", "", 0}))>*;
+        return ContainerType(nullptr);
+      } else {
+        // default case
+        return &pc.outputs().make<std::vector<o2::tpc::Digit>>(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
+      }
     };
     // lambda that snapshots the common mode vector to be sent out; prepares and attaches header with sector information
     auto snapshotCommonMode = [this, sector, &pc, activeSectors, &dh](std::vector<o2::tpc::CommonMode> const& commonMode) {
       o2::tpc::TPCSectorHeader header{sector};
       header.activeSectors = activeSectors;
-      // note that snapshoting only works with non-const references (to be fixed?)
-      pc.outputs().snapshot(Output{"TPC", "COMMONMODE", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
-                                   header},
-                            const_cast<std::vector<o2::tpc::CommonMode>&>(commonMode));
+      if (!mInternalWriter) {
+        // note that snapshoting only works with non-const references (to be fixed?)
+        pc.outputs().snapshot(Output{"TPC", "COMMONMODE", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
+                                     header},
+                              const_cast<std::vector<o2::tpc::CommonMode>&>(commonMode));
+      }
     };
     // lambda that snapshots labels to be sent out; prepares and attaches header with sector information
     auto snapshotLabels = [this, &sector, &pc, activeSectors, &dh](o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& labels) {
       o2::tpc::TPCSectorHeader header{sector};
       header.activeSectors = activeSectors;
       if (mWithMCTruth) {
-        auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
-        labels.flatten_to(sharedlabels);
+        if (!mInternalWriter) {
+          auto& sharedlabels = pc.outputs().make<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(Output{"TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe, header});
+          labels.flatten_to(sharedlabels);
+        }
       }
     };
     // lambda that snapshots digits grouping (triggers) to be sent out; prepares and attaches header with sector information
     auto snapshotEvents = [this, sector, &pc, activeSectors, &dh](const std::vector<DigiGroupRef>& events) {
       o2::tpc::TPCSectorHeader header{sector};
       header.activeSectors = activeSectors;
-      LOG(INFO) << "TPC: Send TRIGGERS for sector " << sector << " channel " << dh->subSpecification << " | size " << events.size();
-      pc.outputs().snapshot(Output{"TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
-                                   header},
-                            const_cast<std::vector<DigiGroupRef>&>(events));
+      if (!mInternalWriter) {
+        LOG(INFO) << "TPC: Send TRIGGERS for sector " << sector << " channel " << dh->subSpecification << " | size " << events.size();
+        pc.outputs().snapshot(Output{"TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(dh->subSpecification), Lifetime::Timeframe,
+                                     header},
+                              const_cast<std::vector<DigiGroupRef>&>(events));
+      }
     };
 
     auto digitsAccum = makeDigitBuffer();                          // accumulator for digits
@@ -244,17 +346,26 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     auto& eventParts = context->getEventParts();
 
     auto flushDigitsAndLabels = [this, digitsAccum, &labelAccum, &commonModeAccum](bool finalFlush = false) {
+      mFlushCounter++;
       // flush previous buffer
       mDigits.clear();
       mLabels.clear();
       mCommonMode.clear();
       mDigitizer.flush(mDigits, mLabels, mCommonMode, finalFlush);
       LOG(INFO) << "TPC: Flushed " << mDigits.size() << " digits, " << mLabels.getNElements() << " labels and " << mCommonMode.size() << " common mode entries";
-      std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(*digitsAccum));
-      if (mWithMCTruth) {
-        labelAccum.mergeAtBack(mLabels);
+
+      if (mInternalWriter) {
+        // the natural place to write out this independent datachunk immediately ...
+        writeToROOTFile();
+      } else {
+        // ... or to accumulate and later forward to next DPL proc
+        std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(*digitsAccum));
+        if (mWithMCTruth) {
+          labelAccum.mergeAtBack(mLabels);
+        }
+        std::copy(mCommonMode.begin(), mCommonMode.end(), std::back_inserter(commonModeAccum));
       }
-      std::copy(mCommonMode.begin(), mCommonMode.end(), std::back_inserter(commonModeAccum));
+      mDigitCounter += mDigits.size();
     };
 
     static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
@@ -272,7 +383,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       if (!isContinuous) {
         mDigitizer.setStartTime(sampaProcessing.getTimeBinFromTime(eventTime));
       }
-      int startSize = digitsAccum->size();
+      size_t startSize = mDigitCounter; // digitsAccum->size();
 
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)
@@ -293,7 +404,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
         flushDigitsAndLabels();
 
         if (!isContinuous) {
-          eventAccum.emplace_back(startSize, digitsAccum->size() - startSize);
+          eventAccum.emplace_back(startSize, mDigits.size());
         }
       }
     }
@@ -302,14 +413,16 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     if (isContinuous) {
       LOG(INFO) << "TPC: Final flush";
       flushDigitsAndLabels(true);
-      eventAccum.emplace_back(0, digitsAccum->size()); // all digits are grouped to 1 super-event pseudo-triggered mode
+      eventAccum.emplace_back(0, mDigitCounter); // all digits are grouped to 1 super-event pseudo-triggered mode
     }
 
-    // send out to next stage
-    snapshotEvents(eventAccum);
-    // snapshotDigits(digitsAccum); --> done automatically
-    snapshotCommonMode(commonModeAccum);
-    snapshotLabels(labelAccum);
+    if (!mInternalWriter) {
+      // send out to next stage
+      snapshotEvents(eventAccum);
+      // snapshotDigits(digitsAccum); --> done automatically
+      snapshotCommonMode(commonModeAccum);
+      snapshotLabels(labelAccum);
+    }
 
     timer.Stop();
     LOG(INFO) << "TPC: Digitization took " << timer.CpuTime() << "s";
@@ -321,11 +434,19 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
   std::vector<o2::tpc::Digit> mDigits;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels;
   std::vector<o2::tpc::CommonMode> mCommonMode;
+  std::vector<int> mListOfSectors; //  a list of sectors treated by this task
+  TFile* mInternalROOTFlushFile = nullptr;
+  TTree* mInternalROOTFlushTTree = nullptr;
+  size_t mDigitCounter = 0;
+  size_t mFlushCounter = 0;
+  int mLaneId = 0; // the id of the current process within the parallel pipeline
+  int mSector = 0;
   bool mWriteGRP = false;
   bool mWithMCTruth = true;
+  bool mInternalWriter = false;
 };
 
-o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth)
+o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth, bool internalwriter)
 {
   // create the full data processor spec using
   //  a name identifier
@@ -337,12 +458,14 @@ o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP,
 
   std::vector<OutputSpec> outputs; // define channel by triple of (origin, type id of data to be sent on this channel, subspecification)
 
-  outputs.emplace_back("TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
-  outputs.emplace_back("TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
-  if (mctruth) {
-    outputs.emplace_back("TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
+  if (!internalwriter) {
+    outputs.emplace_back("TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
+    outputs.emplace_back("TPC", "DIGTRIGGERS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
+    if (mctruth) {
+      outputs.emplace_back("TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
+    }
+    outputs.emplace_back("TPC", "COMMONMODE", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   }
-  outputs.emplace_back("TPC", "COMMONMODE", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   if (writeGRP) {
     outputs.emplace_back("TPC", "ROMode", 0, Lifetime::Timeframe);
     LOG(DEBUG) << "TPC: Channel " << channel << " will supply ROMode";
@@ -352,20 +475,20 @@ o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP,
     id.str().c_str(),
     Inputs{InputSpec{"collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCDPLDigitizerTask>()},
+    AlgorithmSpec{adaptFromTask<TPCDPLDigitizerTask>(internalwriter)},
     Options{{"distortionType", VariantType::Int, 0, {"Distortion type to be used. 0 = no distortions (default), 1 = realistic distortions (not implemented yet), 2 = constant distortions"}},
             {"initialSpaceChargeDensity", VariantType::String, "", {"Path to root file containing TH3 with initial space-charge density and name of the TH3 (comma separated)"}},
             {"readSpaceCharge", VariantType::String, "", {"Path to root file containing pre-calculated space-charge object and name of the object (comma separated)"}},
             {"TPCtriggered", VariantType::Bool, false, {"Impose triggered RO mode (default: continuous)"}}}};
 }
 
-o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth)
+o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth, bool internalwriter)
 {
   // channel parameter is deprecated in the TPCDigitizer processor, all descendants
   // are initialized not to publish GRP mode, but the channel will be added to the first
   // processor after the pipelines have been created. The processor will decide upon
   // the index in the ParallelContext whether to publish
-  WorkflowSpec pipelineTemplate{getTPCDigitizerSpec(0, false, mctruth)};
+  WorkflowSpec pipelineTemplate{getTPCDigitizerSpec(0, false, mctruth, internalwriter)};
   // override the predefined name, index will be added by parallelPipeline method
   pipelineTemplate[0].name = "TPCDigitizer";
   WorkflowSpec pipelines = parallelPipeline(

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.h
@@ -19,9 +19,9 @@ namespace o2
 namespace tpc
 {
 
-o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth);
+o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP, bool mctruth, bool internalwriter);
 
-o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth);
+o2::framework::WorkflowSpec getTPCDigitizerSpec(int nLanes, std::vector<int> const& sectors, bool mctruth, bool internalwriter);
 
 } // end namespace tpc
 } // end namespace o2


### PR DESCRIPTION
TPC digitization may require large RAM which may hit the limit of
16GB on 8-core GRID sites easily for moderate timeframe sizes.
Next to limiting the timeframe size, this poses also large constraints
on possible parallel scheduling with other tasks.

This commit introduces an **optional** alternative treatment of writing the data,
which will flush for any independent TPC drift-time chunk.

This IO flushing is done in the digitizer process itself, since it happens
at a smaller granularity than the DPL "run" invocation, and as such is
only useful for (GRID) productions in which we save intermediate
digit files.

The effect of this is the following:
a) Substantial reduction of memory, limited by the size of a drift-time.
   (We can stay on the order of few GB even with 8 lanes). Here, TPC digitization
   may approach a 1-core "usability" limit.

b) Mem-reduction by a factor of 2 if we post-generate the full timeframe file
   in an after-burner.

c) Overall faster digitization/reconstruction because of faster ROOT IO.

To use the new feature one uses

i) `o2-sim-digitizer-workflow --onlyDet TPC --tpc-chunked-writer`
ii) `o2-tpc-chunkeddigit-merger | o2-tpc-reco-workflow --input-type digitizer ...`
(in which way we never do ROOT IO on large vectors)

instead of

i) `o2-sim-digitizer-workflow --onlyDet TPC`
ii) `o2-tpc-reco-workflow --input-type digits ...`