### PR TITLE
Possibility to limit max orbit processed by RawFileWriter

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -41,6 +41,8 @@ HBFUtil::fillHBIRvector(std::vector<IR>& dst, const IR& fromIR, const IR& payLoa
 will fill the provided `dst` vector with the IR's (between `fromIR` and `payLoadIR`) for which the HBFs should be
 generated and flushed to raw data **before** filling the payload of `payLoadIR`.
 
+Extra data member `HBFUtil.maxNOrbits` (= highest possible orbit by default) is used only in the RawFileWriter as a maximum orbit number (with respect to 1st orbit) for which detector payload is considered.
+
 See `Detectors/Raw/test/testHBFUtils.cxx` for details of usage of this class (also check the jira ticket about the [MC->Raw conversion](https://alice.its.cern.ch/jira/browse/O2-972)).
 
 ## RawFileWriter
@@ -88,6 +90,8 @@ writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ), <optional
 where <optional arguments> are currently: `bool preformatted = false, uint32_t trigger = 0, uint32_t detField = 0` (see below for the meaning).
 
 By default the data will be written using o2::header::RAWDataHeader. User can request particular RDH version via `writer.useRDHVersion(v)`.
+
+Note that the `addData` will have no effect if its `{bc, orbit}` exceeds the `HBFUtils.getFirstIR()` by more than `HBFUtils.maxNOrbits`.
 
 The `RawFileWriter` will take care of writing created CRU data to file in `super-pages` whose size can be set using
 `writer.setSuperPageSize(size_in_bytes)` (default in 1 MB).

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -126,6 +126,7 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   int nHBFPerTF = 1 + 0xff; // number of orbits per BC
   uint16_t bcFirst = 0;     ///< BC of 1st TF
   uint32_t orbitFirst = 0;  ///< orbit of 1st TF
+  uint32_t maxNOrbits = 0xffffffff; // max number of orbits to accept, used in digit->raw conversion
 
   O2ParamDef(HBFUtils, "HBFUtils");
 };

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -86,7 +86,7 @@ class RawFileWriter
     uint8_t packetCounter = 0;                            // running counter
     uint16_t pageCnt = 0;                                 // running counter
     LinkSubSpec_t subspec = 0;                            // subspec according to DataDistribution
-    int counter = 0;                                      //RSREM
+    bool discardData = false;                             // discard data if true (e.g. desired max IR reached)
     //
     size_t nTFWritten = 0;    // number of TFs written
     size_t nRDHWritten = 0;   // number of RDHs written

--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -169,6 +169,13 @@ void RawFileWriter::addData(uint16_t feeid, uint16_t cru, uint8_t lnk, uint8_t e
     LOG(WARNING) << "provided " << ir << " precedes first TF " << mHBFUtils.getFirstIR() << " | discarding data for " << link.describe();
     return;
   }
+  if (link.discardData || ir.orbit - mHBFUtils.orbitFirst >= mHBFUtils.maxNOrbits) {
+    if (!link.discardData) {
+      link.discardData = true;
+      LOG(INFO) << "max. allowed orbit " << mHBFUtils.orbitFirst + mHBFUtils.maxNOrbits - 1 << " exceeded, " << link.describe() << " will discard further data";
+    }
+    return;
+  }
   if (ir < mFirstIRAdded) {
     mFirstIRAdded = ir;
   }


### PR DESCRIPTION
With option `-configKeyValues "HBFUtils.maxNOrbits=<N>"` the RawFileWriter will ignore all addData calls for orbits equal or exceeding HBFUtils.orbitFirst + N.
As usual, for CRU detectors the TF will be completed by empty HBFs till its end, unless it is explicitly forbidden