### PR TITLE
[MID] Global renaming for better clarity

### DIFF
--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -8,19 +8,19 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(DataFormatsMID
-               SOURCES src/ColumnData.cxx
-                       src/Track.cxx
-                       src/CTF.cxx
-	       PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils
-	                             O2::CommonDataFormat
-	                             O2::DetectorsCommonDataFormats
-                                     O2::ReconstructionDataFormats)
+o2_add_library(
+  DataFormatsMID
+  SOURCES src/ColumnData.cxx src/CTF.cxx src/ROBoard.cxx src/Track.cxx
+  PUBLIC_LINK_LIBRARIES
+    Boost::serialization O2::MathUtils O2::CommonDataFormat
+    O2::DetectorsCommonDataFormats O2::ReconstructionDataFormats)
 
-o2_target_root_dictionary(DataFormatsMID
-                          HEADERS include/DataFormatsMID/Cluster2D.h
-                                  include/DataFormatsMID/Cluster3D.h
-                                  include/DataFormatsMID/ColumnData.h
-                                  include/DataFormatsMID/ROFRecord.h
-                                  include/DataFormatsMID/Track.h
-                                  include/DataFormatsMID/CTF.h)
+o2_target_root_dictionary(
+  DataFormatsMID
+  HEADERS include/DataFormatsMID/Cluster2D.h
+          include/DataFormatsMID/Cluster3D.h
+          include/DataFormatsMID/ColumnData.h
+          include/DataFormatsMID/ROBoard.h
+          include/DataFormatsMID/ROFRecord.h
+          include/DataFormatsMID/Track.h
+          include/DataFormatsMID/CTF.h)

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROBoard.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROBoard.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDRaw/LocalBoardRO.h
-/// \brief  Structure to store the FEE local board information
+/// \file   DataFormatsMID/ROBoard.h
+/// \brief  Structure to store the readout board information
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   19 November 2019
-#ifndef O2_MID_LocalBoardRO_H
-#define O2_MID_LocalBoardRO_H
+#ifndef O2_MID_ROBOARD_H
+#define O2_MID_ROBOARD_H
 
 #include <cstdint>
 #include <array>
@@ -23,7 +23,7 @@ namespace o2
 {
 namespace mid
 {
-struct LocalBoardRO {
+struct ROBoard {
   uint8_t statusWord{0};                 /// Status word
   uint8_t triggerWord{0};                /// Trigger word
   uint8_t boardId{0};                    /// Board ID in crate
@@ -32,27 +32,28 @@ struct LocalBoardRO {
   std::array<uint16_t, 4> patternsNBP{}; /// Non-bending plane pattern
 };
 
-std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc);
+std::ostream& operator<<(std::ostream& os, const ROBoard& loc);
 
 namespace raw
 {
-static constexpr uint32_t sSTARTBIT = 1 << 7;
-static constexpr uint32_t sCARDTYPE = 1 << 6;
-static constexpr uint32_t sLOCALBUSY = 1 << 5;
-static constexpr uint32_t sLOCALDECISION = 1 << 4;
-static constexpr uint32_t sACTIVE = 1 << 3;
-static constexpr uint32_t sREJECTING = 1 << 2;
-static constexpr uint32_t sMASKED = 1 << 1;
-static constexpr uint32_t sOVERWRITTEN = 1;
 
-static constexpr uint32_t sSOX = 1 << 7;
-static constexpr uint32_t sEOX = 1 << 6;
-static constexpr uint32_t sPAUSE = 1 << 5;
-static constexpr uint32_t sRESUME = 1 << 4;
-static constexpr uint32_t sCALIBRATE = 1 << 3;
-static constexpr uint32_t sPHY = 1 << 2;
-static constexpr uint32_t sRESET = 1 << 1;
-static constexpr uint32_t sORB = 1;
+static constexpr uint8_t sSTARTBIT = 1 << 7;
+static constexpr uint8_t sCARDTYPE = 1 << 6;
+static constexpr uint8_t sLOCALBUSY = 1 << 5;
+static constexpr uint8_t sLOCALDECISION = 1 << 4;
+static constexpr uint8_t sACTIVE = 1 << 3;
+static constexpr uint8_t sREJECTING = 1 << 2;
+static constexpr uint8_t sMASKED = 1 << 1;
+static constexpr uint8_t sOVERWRITTEN = 1;
+
+static constexpr uint8_t sSOX = 1 << 7;
+static constexpr uint8_t sEOX = 1 << 6;
+static constexpr uint8_t sPAUSE = 1 << 5;
+static constexpr uint8_t sRESUME = 1 << 4;
+static constexpr uint8_t sCALIBRATE = 1 << 3;
+static constexpr uint8_t sPHY = 1 << 2;
+static constexpr uint8_t sRESET = 1 << 1;
+static constexpr uint8_t sORB = 1;
 
 /// Tests the local card bit
 inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
@@ -60,9 +61,15 @@ inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
 inline bool isCalibration(uint8_t triggerWord) { return ((triggerWord & 0xc) == 0x8); }
 /// Tests if this is a Front End Test event
 inline bool isFET(uint8_t triggerWord) { return ((triggerWord & 0xc) == 0xc); }
+/// Gets the crate ID from the absolute local board ID
+inline uint8_t getCrateId(uint8_t uniqueLocId) { return (uniqueLocId >> 4) & 0xF; }
+/// Gets the loc ID in the crate from the unique local board ID
+inline uint8_t getLocId(uint8_t uniqueLocId) { return uniqueLocId & 0xF; }
+/// Builds the unique loc ID from the crate ID and the loc ID in the crate
+inline uint8_t makeUniqueLocID(uint8_t crateId, uint8_t locId) { return locId | (crateId << 4); }
 } // namespace raw
 
 } // namespace mid
 } // namespace o2
 
-#endif /* O2_MID_LocalBoardRO_H */
+#endif /* O2_MID_ROBOARD_H */

--- a/DataFormats/Detectors/MUON/MID/src/ROBoard.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/ROBoard.cxx
@@ -8,25 +8,24 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MID/Raw/src/LocalBoardRO.cxx
-/// \brief  Structure to store the FEE local board information
+/// \file   MID/Raw/src/ROBoard.cxx
+/// \brief  Structure to store the readout board information
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   19 November 2019
 
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 #include <iostream>
 #include "fmt/format.h"
-#include "MIDRaw/CrateParameters.h"
 
 namespace o2
 {
 namespace mid
 {
-std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc)
+std::ostream& operator<<(std::ostream& os, const ROBoard& loc)
 {
-  /// Stream operator for LocalBoardRO
-  os << fmt::format("Crate ID: {:2d}  Loc ID: {:2d}  status: 0x{:2x}  trigger: 0x{:2x}  firedChambers: 0x{:1x}", static_cast<int>(crateparams::getCrateId(loc.boardId)), static_cast<int>(crateparams::getLocId(loc.boardId)), static_cast<int>(loc.statusWord), static_cast<int>(loc.triggerWord), static_cast<int>(loc.firedChambers));
+  /// Stream operator for ROBoard
+  os << fmt::format("Crate ID: {:2d}  {} ID: {:2d}  status: 0x{:2x}  trig: 0x{:2x}  fired: 0x{:1x}", static_cast<int>(raw::getCrateId(loc.boardId)), (raw::isLoc(loc.statusWord) ? "Loc" : "Reg"), static_cast<int>(raw::getLocId(loc.boardId)), static_cast<int>(loc.statusWord), static_cast<int>(loc.triggerWord), static_cast<int>(loc.firedChambers));
   for (int ich = 0; ich < 4; ++ich) {
     os << fmt::format("  X: 0x{:4x} Y: 0x{:4x}", loc.patternsBP[ich], loc.patternsNBP[ich]);
   }

--- a/Detectors/MUON/MID/QC/exe/raw-checker.cxx
+++ b/Detectors/MUON/MID/QC/exe/raw-checker.cxx
@@ -26,7 +26,7 @@
 #include "MIDRaw/Decoder.h"
 #include "MIDRaw/ElectronicsDelay.h"
 #include "MIDRaw/FEEIdConfig.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 #include "MIDRaw/RawFileReader.h"
 
 namespace po = boost::program_options;
@@ -101,7 +101,7 @@ int process(po::variables_map& vm)
     }
     std::cout << "Writing output to: " << outFilename << " ..." << std::endl;
 
-    std::vector<o2::mid::LocalBoardRO> data;
+    std::vector<o2::mid::ROBoard> data;
     std::vector<o2::mid::ROFRecord> rofRecords;
     std::vector<o2::mid::ROFRecord> hbRecords;
 

--- a/Detectors/MUON/MID/QC/include/MIDQC/GBTRawDataChecker.h
+++ b/Detectors/MUON/MID/QC/include/MIDQC/GBTRawDataChecker.h
@@ -23,7 +23,7 @@
 #include <gsl/gsl>
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -33,7 +33,7 @@ class GBTRawDataChecker
 {
  public:
   void init(uint16_t feeId, uint8_t mask);
-  bool process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords);
+  bool process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords);
   /// Gets the number of processed events
   unsigned int getNEventsProcessed() const { return mStatistics[0]; }
   /// Gets the number of faulty events
@@ -57,30 +57,30 @@ class GBTRawDataChecker
   };
 
   struct GBT {
-    std::vector<LocalBoardRO> regs{}; /// Regional boards
-    std::vector<LocalBoardRO> locs{}; /// Local boards
-    std::vector<long int> pages{};    /// Pages information
+    std::vector<ROBoard> regs{};   /// Regional boards
+    std::vector<ROBoard> locs{};   /// Local boards
+    std::vector<long int> pages{}; /// Pages information
   };
 
   struct BoardInfo {
-    LocalBoardRO board{};
+    ROBoard board{};
     o2::InteractionRecord interactionRecord{};
     long int page{-1};
   };
 
   void clearChecked(bool isTriggered, bool clearTrigEvents);
-  bool checkEvent(bool isTriggered, const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs);
+  bool checkEvent(bool isTriggered, const std::vector<ROBoard>& regs, const std::vector<ROBoard>& locs);
   bool checkEvents(bool isTriggered);
-  bool checkConsistency(const LocalBoardRO& board);
-  bool checkConsistency(const std::vector<LocalBoardRO>& boards);
-  bool checkMasks(const std::vector<LocalBoardRO>& locs);
-  bool checkLocalBoardSize(const LocalBoardRO& board);
-  bool checkLocalBoardSize(const std::vector<LocalBoardRO>& boards);
-  bool checkRegLocConsistency(const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs);
-  uint8_t getElinkId(const LocalBoardRO& board) const;
+  bool checkConsistency(const ROBoard& board);
+  bool checkConsistency(const std::vector<ROBoard>& boards);
+  bool checkMasks(const std::vector<ROBoard>& locs);
+  bool checkLocalBoardSize(const ROBoard& board);
+  bool checkLocalBoardSize(const std::vector<ROBoard>& boards);
+  bool checkRegLocConsistency(const std::vector<ROBoard>& regs, const std::vector<ROBoard>& locs);
+  uint8_t getElinkId(const ROBoard& board) const;
   unsigned int getLastCompleteTrigEvent();
   bool isCompleteSelfTrigEvent(const o2::InteractionRecord& ir) const;
-  std::string printBoards(const std::vector<LocalBoardRO>& boards) const;
+  std::string printBoards(const std::vector<ROBoard>& boards) const;
   bool runCheckEvents(unsigned int completeMask);
   void sortEvents(bool isTriggered);
 

--- a/Detectors/MUON/MID/QC/include/MIDQC/RawDataChecker.h
+++ b/Detectors/MUON/MID/QC/include/MIDQC/RawDataChecker.h
@@ -21,7 +21,7 @@
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/CrateMasks.h"
 #include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 #include "MIDQC/GBTRawDataChecker.h"
 
 namespace o2
@@ -32,7 +32,7 @@ class RawDataChecker
 {
  public:
   void init(const CrateMasks& masks);
-  bool process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords);
+  bool process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords);
   /// Gets the number of processed events
   unsigned int getNEventsProcessed() const;
   /// Gets the number of faulty events

--- a/Detectors/MUON/MID/QC/src/GBTRawDataChecker.cxx
+++ b/Detectors/MUON/MID/QC/src/GBTRawDataChecker.cxx
@@ -31,7 +31,7 @@ void GBTRawDataChecker::init(uint16_t feeId, uint8_t mask)
   mCrateMask = mask;
 }
 
-bool GBTRawDataChecker::checkLocalBoardSize(const LocalBoardRO& board)
+bool GBTRawDataChecker::checkLocalBoardSize(const ROBoard& board)
 {
   /// Checks that the board has the expected non-null patterns
 
@@ -52,7 +52,7 @@ bool GBTRawDataChecker::checkLocalBoardSize(const LocalBoardRO& board)
   return true;
 }
 
-bool GBTRawDataChecker::checkLocalBoardSize(const std::vector<LocalBoardRO>& boards)
+bool GBTRawDataChecker::checkLocalBoardSize(const std::vector<ROBoard>& boards)
 {
   /// Checks that the boards have the expected non-null patterns
   for (auto& board : boards) {
@@ -63,7 +63,7 @@ bool GBTRawDataChecker::checkLocalBoardSize(const std::vector<LocalBoardRO>& boa
   return true;
 }
 
-bool GBTRawDataChecker::checkConsistency(const LocalBoardRO& board)
+bool GBTRawDataChecker::checkConsistency(const ROBoard& board)
 {
   /// Checks that the event information is consistent
 
@@ -91,7 +91,7 @@ bool GBTRawDataChecker::checkConsistency(const LocalBoardRO& board)
   return true;
 }
 
-bool GBTRawDataChecker::checkConsistency(const std::vector<LocalBoardRO>& boards)
+bool GBTRawDataChecker::checkConsistency(const std::vector<ROBoard>& boards)
 {
   /// Checks that the event information is consistent
   for (auto& board : boards) {
@@ -105,7 +105,7 @@ bool GBTRawDataChecker::checkConsistency(const std::vector<LocalBoardRO>& boards
   return true;
 }
 
-bool GBTRawDataChecker::checkMasks(const std::vector<LocalBoardRO>& locs)
+bool GBTRawDataChecker::checkMasks(const std::vector<ROBoard>& locs)
 {
   /// Checks the masks
   for (auto loc : locs) {
@@ -132,12 +132,12 @@ bool GBTRawDataChecker::checkMasks(const std::vector<LocalBoardRO>& locs)
   return true;
 }
 
-bool GBTRawDataChecker::checkRegLocConsistency(const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs)
+bool GBTRawDataChecker::checkRegLocConsistency(const std::vector<ROBoard>& regs, const std::vector<ROBoard>& locs)
 {
   /// Checks consistency between local and regional info
   uint8_t regFired{0};
   for (auto& reg : regs) {
-    uint8_t ireg = crateparams::getLocId(reg.boardId) % 2;
+    uint8_t ireg = raw::getLocId(reg.boardId) % 2;
     auto busyItem = mBusyFlagSelfTrig.find(8 + ireg);
     if (reg.triggerWord == 0) {
       // Self-triggered event: check the decision
@@ -188,7 +188,7 @@ bool GBTRawDataChecker::checkRegLocConsistency(const std::vector<LocalBoardRO>& 
   return true;
 }
 
-std::string GBTRawDataChecker::printBoards(const std::vector<LocalBoardRO>& boards) const
+std::string GBTRawDataChecker::printBoards(const std::vector<ROBoard>& boards) const
 {
   /// Prints the boards
   std::stringstream ss;
@@ -198,7 +198,7 @@ std::string GBTRawDataChecker::printBoards(const std::vector<LocalBoardRO>& boar
   return ss.str();
 }
 
-bool GBTRawDataChecker::checkEvent(bool isTriggered, const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs)
+bool GBTRawDataChecker::checkEvent(bool isTriggered, const std::vector<ROBoard>& regs, const std::vector<ROBoard>& locs)
 {
   /// Checks the cards belonging to the same BC
   mEventDebugMsg.clear();
@@ -223,7 +223,7 @@ bool GBTRawDataChecker::checkEvent(bool isTriggered, const std::vector<LocalBoar
   return true;
 }
 
-uint8_t GBTRawDataChecker::getElinkId(const LocalBoardRO& board) const
+uint8_t GBTRawDataChecker::getElinkId(const ROBoard& board) const
 {
   /// Returns the e-link ID
   if (raw::isLoc(board.statusWord)) {
@@ -434,7 +434,7 @@ bool GBTRawDataChecker::checkEvents(bool isTriggered)
   return isOk;
 }
 
-bool GBTRawDataChecker::process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords)
+bool GBTRawDataChecker::process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords)
 {
   /// Checks the raw data
   mDebugMsg.clear();

--- a/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
+++ b/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
@@ -32,7 +32,7 @@ void RawDataChecker::init(const CrateMasks& crateMasks)
   }
 }
 
-bool RawDataChecker::process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords)
+bool RawDataChecker::process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords, gsl::span<const ROFRecord> pageRecords)
 {
   /// Checks the raw data
 
@@ -41,8 +41,8 @@ bool RawDataChecker::process(gsl::span<const LocalBoardRO> localBoards, gsl::spa
   std::unordered_map<uint16_t, std::vector<ROFRecord>> rofs;
   for (auto& rof : rofRecords) {
     auto& loc = localBoards[rof.firstEntry];
-    auto crateId = crateparams::getCrateId(loc.boardId);
-    auto linkId = crateparams::getGBTIdFromBoardInCrate(crateparams::getLocId(loc.boardId));
+    auto crateId = raw::getCrateId(loc.boardId);
+    auto linkId = crateparams::getGBTIdFromBoardInCrate(raw::getLocId(loc.boardId));
     auto feeId = crateparams::makeROId(crateId, linkId);
     rofs[feeId].emplace_back(rof);
   }

--- a/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
+++ b/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
@@ -43,7 +43,7 @@ bool RawDataChecker::process(gsl::span<const ROBoard> localBoards, gsl::span<con
     auto& loc = localBoards[rof.firstEntry];
     auto crateId = raw::getCrateId(loc.boardId);
     auto linkId = crateparams::getGBTIdFromBoardInCrate(raw::getLocId(loc.boardId));
-    auto feeId = crateparams::makeROId(crateId, linkId);
+    auto feeId = crateparams::makeGBTUniqueId(crateId, linkId);
     rofs[feeId].emplace_back(rof);
   }
 

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(
   SOURCES src/ColumnDataToLocalBoard.cxx
           src/CrateMapper.cxx
           src/CrateMasks.cxx
+          src/DecodedDataAggregator.cxx
           src/Decoder.cxx
           src/ElectronicsDelay.cxx
           src/ELinkDecoder.cxx
@@ -21,8 +22,6 @@ o2_add_library(
           src/GBTDecoder.cxx
           src/GBTOutputHandler.cxx
           src/GBTUserLogicEncoder.cxx
-          src/LocalBoardRO.cxx
-          src/DecodedDataAggregator.cxx
           src/RawFileReader.cxx
   PUBLIC_LINK_LIBRARIES
     ms_gsl::ms_gsl

--- a/Detectors/MUON/MID/Raw/exe/README.md
+++ b/Detectors/MUON/MID/Raw/exe/README.md
@@ -15,7 +15,7 @@ o2-mid-rawdump filename [filename_2 filename_3 ...]
 The output is a file containing a list with:
 -   the interaction record
 
--   the list of decoded [LocalBoardRO](../include/MIDRaw/LocalBoardRO.h)
+-   the list of decoded [ROBoard](../include/DataFormatsMID/ROBoard.h)
 For a list of the other available options:
 ```bash
 o2-mid-rawdump --help

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
@@ -22,7 +22,7 @@
 #include "DataFormatsMID/ColumnData.h"
 #include "MIDBase/Mapping.h"
 #include "MIDRaw/CrateMapper.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -33,17 +33,17 @@ class ColumnDataToLocalBoard
  public:
   void process(gsl::span<const ColumnData> data);
   /// Gets the output data per GBT link
-  const std::unordered_map<uint16_t, std::vector<LocalBoardRO>> getData() { return mGBTMap; }
+  const std::unordered_map<uint16_t, std::vector<ROBoard>> getData() { return mGBTMap; }
   /// Sets debug mode
   void setDebugMode(bool debugMode = true) { mDebugMode = debugMode; }
 
  private:
-  bool keepBoard(const LocalBoardRO& loc) const;
-  std::unordered_map<uint8_t, LocalBoardRO> mLocalBoardsMap{};       /// Map of data per board
-  std::unordered_map<uint16_t, std::vector<LocalBoardRO>> mGBTMap{}; /// Map of data per GBT link
-  CrateMapper mCrateMapper{};                                        /// Crate mapper
-  Mapping mMapping{};                                                /// Segmentation
-  bool mDebugMode{false};                                            /// Debug mode (no zero suppression)
+  bool keepBoard(const ROBoard& loc) const;
+  std::unordered_map<uint8_t, ROBoard> mLocalBoardsMap{};       /// Map of data per board
+  std::unordered_map<uint16_t, std::vector<ROBoard>> mGBTMap{}; /// Map of data per GBT link
+  CrateMapper mCrateMapper{};                                   /// Crate mapper
+  Mapping mMapping{};                                           /// Segmentation
+  bool mDebugMode{false};                                       /// Debug mode (no zero suppression)
 };
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
@@ -45,12 +45,6 @@ inline uint8_t getGBTIdFromBoardInCrate(uint16_t locId) { return locId / sMaxNBo
 inline uint8_t getCrateId(bool isRightSide, uint8_t crateIdOneSide) { return isRightSide ? crateIdOneSide : crateIdOneSide + sNCratesPerSide; }
 /// Tests if the crate is in the right side
 inline bool isRightSide(uint8_t crateId) { return (crateId / sNCratesPerSide) == 0; }
-/// Builds the unique loc ID from the crate ID and the loc ID in the crate
-inline uint8_t makeUniqueLocID(uint8_t crateId, uint8_t locId) { return locId | (crateId << 4); }
-/// Gets the crate ID from the absolute local board ID
-inline uint8_t getCrateId(uint8_t uniqueLocId) { return (uniqueLocId >> 4) & 0xF; }
-/// Gets the loc ID in the crate from the unique local board ID
-inline uint8_t getLocId(uint8_t uniqueLocId) { return uniqueLocId & 0xF; }
 } // namespace crateparams
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
@@ -33,12 +33,12 @@ static constexpr unsigned int sMaxNBoardsInLink = 8;
 static constexpr unsigned int sMaxNBoardsInCrate = sMaxNBoardsInLink * sNGBTsPerCrate;
 static constexpr unsigned int sNELinksPerGBT = 10;
 
-/// Builds the RO ID from the crate ID and the GBT ID in the crate
-inline uint16_t makeROId(uint8_t crateId, uint8_t gbtId) { return sNGBTsPerCrate * crateId + gbtId; }
-/// Gets the crate ID from the RO ID
-inline uint8_t getCrateIdFromROId(uint16_t roId) { return roId / sNGBTsPerCrate; }
+/// Builds the GBT unique ID from the crate ID and the GBT ID in the crate
+inline uint16_t makeGBTUniqueId(uint8_t crateId, uint8_t gbtId) { return sNGBTsPerCrate * crateId + gbtId; }
+/// Gets the crate ID from the GBT unique ID
+inline uint8_t getCrateIdFromGBTUniqueId(uint16_t gbtUniqueId) { return gbtUniqueId / sNGBTsPerCrate; }
 /// Gets the link ID in crate from the RO ID
-inline uint8_t getGBTIdInCrate(uint16_t roId) { return roId % sNGBTsPerCrate; }
+inline uint8_t getGBTIdInCrate(uint16_t gbtUniqueId) { return gbtUniqueId % sNGBTsPerCrate; }
 /// Gets the link ID in crate from the board ID
 inline uint8_t getGBTIdFromBoardInCrate(uint16_t locId) { return locId / sMaxNBoardsInLink; }
 /// Gets the absolute crate ID

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/DecodedDataAggregator.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/DecodedDataAggregator.h
@@ -21,7 +21,7 @@
 #include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/CrateMapper.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -30,7 +30,7 @@ namespace mid
 class DecodedDataAggregator
 {
  public:
-  void process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords);
+  void process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords);
 
   /// Gets the vector of data
   const std::vector<ColumnData>& getData() { return mData; }
@@ -39,7 +39,7 @@ class DecodedDataAggregator
   const std::vector<ROFRecord>& getROFRecords() { return mROFRecords; }
 
  private:
-  void addData(const LocalBoardRO& col, size_t firstEntry);
+  void addData(const ROBoard& col, size_t firstEntry);
   ColumnData& FindColumnData(uint8_t deId, uint8_t columnId, size_t firstEntry);
 
   std::map<uint64_t, std::vector<size_t>> mOrderIndexes; /// Map for time ordering the entries

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
@@ -26,7 +26,7 @@
 #include "MIDRaw/ElectronicsDelay.h"
 #include "MIDRaw/FEEIdConfig.h"
 #include "MIDRaw/GBTDecoder.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -47,7 +47,7 @@ class Decoder
     mGBTDecoders[feeId]->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
   }
   /// Gets the vector of data
-  const std::vector<LocalBoardRO>& getData() const { return mData; }
+  const std::vector<ROBoard>& getData() const { return mData; }
 
   /// Gets the vector of data RO frame records
   const std::vector<ROFRecord>& getROFRecords() const { return mROFRecords; }
@@ -61,7 +61,7 @@ class Decoder
   std::array<std::unique_ptr<GBTDecoder>, crateparams::sNGBTs> mGBTDecoders{nullptr}; /// GBT decoders
 
  private:
-  std::vector<LocalBoardRO> mData{};    /// Vector of output data
+  std::vector<ROBoard> mData{};         /// Vector of output data
   std::vector<ROFRecord> mROFRecords{}; /// List of ROF records
 };
 

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <gsl/gsl>
 
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -27,7 +27,7 @@
 #include "MIDRaw/CrateParameters.h"
 #include "MIDRaw/FEEIdConfig.h"
 #include "MIDRaw/GBTUserLogicEncoder.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 class RDHAny;
 
@@ -58,10 +58,10 @@ class Encoder
 
   o2::raw::RawFileWriter mRawWriter{o2::header::gDataOriginMID}; /// Raw file writer
 
-  std::map<uint16_t, LocalBoardRO> mROData{}; /// Map of data per board
-  ColumnDataToLocalBoard mConverter{};        /// ColumnData to LocalBoardRO converter
-  FEEIdConfig mFEEIdConfig{};                 /// Crate FEEId mapper
-  InteractionRecord mLastIR{};                /// Last interaction record
+  std::map<uint16_t, ROBoard> mROData{}; /// Map of data per board
+  ColumnDataToLocalBoard mConverter{};   /// ColumnData to ROBoard converter
+  FEEIdConfig mFEEIdConfig{};            /// Crate FEEId mapper
+  InteractionRecord mLastIR{};           /// Last interaction record
 
   std::array<GBTUserLogicEncoder, crateparams::sNGBTs> mGBTEncoders{};     /// Array of encoders per link
   std::array<std::vector<char>, crateparams::sNGBTs> mOrbitResponse{};     /// Response to orbit trigger

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTDecoder.h
@@ -22,7 +22,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -32,17 +32,17 @@ namespace mid
 class GBTDecoder
 {
  public:
-  GBTDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
-  void process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs);
+  GBTDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
+  void process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 
   template <class RDH>
-  void process(gsl::span<const uint8_t> payload, const RDH& rdh, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+  void process(gsl::span<const uint8_t> payload, const RDH& rdh, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), data, rofs);
   }
 
  protected:
-  std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)> mDecode{nullptr};
+  std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> mDecode{nullptr};
 };
 
 std::unique_ptr<GBTDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay);

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
@@ -23,7 +23,7 @@
 #include "MIDRaw/CrateParameters.h"
 #include "MIDRaw/ElectronicsDelay.h"
 #include "MIDRaw/ELinkDecoder.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -35,7 +35,7 @@ class GBTOutputHandler
   /// Sets the FEE Id
   void setFeeId(uint16_t feeId) { mFeeId = feeId; }
 
-  void set(uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs);
+  void set(uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 
   void onDoneLoc(size_t ilink, const ELinkDecoder& decoder);
   void onDoneLocDebug(size_t ilink, const ELinkDecoder& decoder);
@@ -46,7 +46,7 @@ class GBTOutputHandler
   void setElectronicsDelay(const ElectronicsDelay& electronicsDelay) { mElectronicsDelay = electronicsDelay; }
 
  private:
-  std::vector<LocalBoardRO>* mData{nullptr};    ///! Vector of output data. Not owner
+  std::vector<ROBoard>* mData{nullptr};         ///! Vector of output data. Not owner
   std::vector<ROFRecord>* mROFRecords{nullptr}; /// List of ROF records. Not owner
   uint16_t mFeeId{0};                           /// FEE ID
   uint32_t mOrbit{};                            /// RDH orbit

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
@@ -21,7 +21,7 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/ElectronicsDelay.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -30,7 +30,7 @@ namespace mid
 class GBTUserLogicEncoder
 {
  public:
-  void process(gsl::span<const LocalBoardRO> data, const InteractionRecord& ir);
+  void process(gsl::span<const ROBoard> data, const InteractionRecord& ir);
   void processTrigger(const InteractionRecord& ir, uint8_t triggerWord);
 
   void flush(std::vector<char>& buffer, const InteractionRecord& ir);
@@ -51,10 +51,10 @@ class GBTUserLogicEncoder
   void addRegionalBoards(uint8_t activeBoards, InteractionRecord ir);
   void addShort(std::vector<char>& buffer, uint16_t shortWord) const;
 
-  std::map<InteractionRecord, std::vector<LocalBoardRO>> mBoards{}; /// Vector with boards
-  uint16_t mFeeId{0};                                               /// FEE ID
-  uint8_t mMask{0xFF};                                              /// GBT mask
-  ElectronicsDelay mElectronicsDelay;                               /// Delays in the electronics
+  std::map<InteractionRecord, std::vector<ROBoard>> mBoards{}; /// Vector with boards
+  uint16_t mFeeId{0};                                          /// FEE ID
+  uint8_t mMask{0xFF};                                         /// GBT mask
+  ElectronicsDelay mElectronicsDelay;                          /// Delays in the electronics
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
+++ b/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
@@ -23,7 +23,7 @@ namespace o2
 namespace mid
 {
 
-bool ColumnDataToLocalBoard::keepBoard(const LocalBoardRO& loc) const
+bool ColumnDataToLocalBoard::keepBoard(const ROBoard& loc) const
 {
   for (int ich = 0; ich < 4; ++ich) {
     if (loc.patternsBP[ich] && loc.patternsNBP[ich]) {
@@ -59,8 +59,8 @@ void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data)
   // Then group the boards belonging to the same GBT link
   for (auto& item : mLocalBoardsMap) {
     if (mDebugMode || keepBoard(item.second)) {
-      auto crateId = crateparams::getCrateId(item.first);
-      auto feeId = crateparams::makeROId(crateId, crateparams::getGBTIdFromBoardInCrate(crateparams::getLocId(item.second.boardId)));
+      auto crateId = raw::getCrateId(item.first);
+      auto feeId = crateparams::makeROId(crateId, crateparams::getGBTIdFromBoardInCrate(raw::getLocId(item.second.boardId)));
       mGBTMap[feeId].emplace_back(item.second);
     }
   }

--- a/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
+++ b/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
@@ -60,7 +60,7 @@ void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data)
   for (auto& item : mLocalBoardsMap) {
     if (mDebugMode || keepBoard(item.second)) {
       auto crateId = raw::getCrateId(item.first);
-      auto feeId = crateparams::makeROId(crateId, crateparams::getGBTIdFromBoardInCrate(raw::getLocId(item.second.boardId)));
+      auto feeId = crateparams::makeGBTUniqueId(crateId, crateparams::getGBTIdFromBoardInCrate(raw::getLocId(item.second.boardId)));
       mGBTMap[feeId].emplace_back(item.second);
     }
   }

--- a/Detectors/MUON/MID/Raw/src/CrateMapper.cxx
+++ b/Detectors/MUON/MID/Raw/src/CrateMapper.cxx
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <exception>
+#include "DataFormatsMID/ROBoard.h"
 #include "MIDBase/DetectorParameters.h"
 #include "MIDRaw/CrateParameters.h"
 
@@ -35,93 +36,93 @@ void CrateMapper::init()
   /// Initalizes the inner mapping
   // Crate 0
   // link 0
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 0), deBoardId(0, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 1), deBoardId(1, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 2), deBoardId(1, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 3), deBoardId(2, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 4), deBoardId(2, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 5), deBoardId(3, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 6), deBoardId(3, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 7), deBoardId(3, 0, 2));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 0), deBoardId(0, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 1), deBoardId(1, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 2), deBoardId(1, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 3), deBoardId(2, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 4), deBoardId(2, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 5), deBoardId(3, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 6), deBoardId(3, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 7), deBoardId(3, 0, 2));
   // link 1
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 8), deBoardId(5, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 9), deBoardId(5, 0, 2));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 10), deBoardId(5, 0, 3));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 11), deBoardId(6, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 12), deBoardId(6, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 13), deBoardId(7, 0, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 14), deBoardId(7, 0, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 15), deBoardId(8, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 8), deBoardId(5, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 9), deBoardId(5, 0, 2));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 10), deBoardId(5, 0, 3));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 11), deBoardId(6, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 12), deBoardId(6, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 13), deBoardId(7, 0, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 14), deBoardId(7, 0, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(0, 15), deBoardId(8, 0, 0));
 
   // Crate 1, 3
   for (int icrate = 0; icrate < 2; ++icrate) {
     uint8_t crateId = (icrate == 0) ? 1 : 3;
     uint8_t columnId = (icrate == 0) ? 1 : 2;
     // link 0
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 7), deBoardId(3, columnId, 2));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 7), deBoardId(3, columnId, 2));
     // link 1
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 8), deBoardId(3, columnId, 3));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 9), deBoardId(4, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 10), deBoardId(4, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 11), deBoardId(4, columnId, 2));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 12), deBoardId(4, columnId, 3));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 13), deBoardId(5, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 14), deBoardId(5, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 8), deBoardId(3, columnId, 3));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 9), deBoardId(4, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 10), deBoardId(4, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 11), deBoardId(4, columnId, 2));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 12), deBoardId(4, columnId, 3));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 13), deBoardId(5, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 14), deBoardId(5, columnId, 1));
   }
 
   // Crate 2
   // link 0
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 0), deBoardId(5, 1, 2));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 1), deBoardId(5, 1, 3));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 2), deBoardId(6, 1, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 3), deBoardId(6, 1, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 4), deBoardId(7, 1, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 5), deBoardId(7, 1, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 6), deBoardId(8, 1, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 0), deBoardId(5, 1, 2));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 1), deBoardId(5, 1, 3));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 2), deBoardId(6, 1, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 3), deBoardId(6, 1, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 4), deBoardId(7, 1, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 5), deBoardId(7, 1, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 6), deBoardId(8, 1, 0));
   // link 1
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 8), deBoardId(5, 2, 2));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 9), deBoardId(5, 2, 3));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 10), deBoardId(6, 2, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 11), deBoardId(6, 2, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 12), deBoardId(7, 2, 0));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 13), deBoardId(7, 2, 1));
-  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 14), deBoardId(8, 2, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 8), deBoardId(5, 2, 2));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 9), deBoardId(5, 2, 3));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 10), deBoardId(6, 2, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 11), deBoardId(6, 2, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 12), deBoardId(7, 2, 0));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 13), deBoardId(7, 2, 1));
+  mROToDEMap.emplace(raw::makeUniqueLocID(2, 14), deBoardId(8, 2, 0));
 
   // Crate 4, 5, 6
   for (int icrate = 0; icrate < 3; ++icrate) {
     uint16_t crateId = icrate + 4;
     uint8_t columnId = icrate + 3;
     // link 0
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 7), deBoardId(4, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 7), deBoardId(4, columnId, 0));
     // link 1
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 8), deBoardId(4, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 9), deBoardId(5, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 10), deBoardId(5, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 11), deBoardId(6, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 12), deBoardId(6, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 13), deBoardId(7, columnId, 0));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 14), deBoardId(7, columnId, 1));
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 15), deBoardId(8, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 8), deBoardId(4, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 9), deBoardId(5, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 10), deBoardId(5, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 11), deBoardId(6, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 12), deBoardId(6, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 13), deBoardId(7, columnId, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 14), deBoardId(7, columnId, 1));
+    mROToDEMap.emplace(raw::makeUniqueLocID(crateId, 15), deBoardId(8, columnId, 0));
   }
 
   // Crate 7
   uint8_t rpcLineId = 0;
   for (uint8_t iboard = 0; iboard < 9; ++iboard) {
-    mROToDEMap.emplace(crateparams::makeUniqueLocID(7, iboard), deBoardId(rpcLineId++, 6, 0));
+    mROToDEMap.emplace(raw::makeUniqueLocID(7, iboard), deBoardId(rpcLineId++, 6, 0));
   }
 
   /// Build the inverse map
@@ -145,7 +146,7 @@ uint8_t CrateMapper::deLocalBoardToRO(uint8_t deId, uint8_t columnId, uint8_t li
 uint16_t CrateMapper::roLocalBoardToDE(uint8_t crateId, uint8_t boardId) const
 {
   /// Converts the local board ID in FEE to the local board ID in MT11 right
-  auto item = mROToDEMap.find(crateparams::makeUniqueLocID(crateId % crateparams::sNCratesPerSide, boardId));
+  auto item = mROToDEMap.find(raw::makeUniqueLocID(crateId % crateparams::sNCratesPerSide, boardId));
   if (item == mROToDEMap.end()) {
     std::stringstream ss;
     ss << "Non-existant crateId: " << static_cast<int>(crateId) << "  boardId: " << static_cast<int>(boardId);

--- a/Detectors/MUON/MID/Raw/src/DecodedDataAggregator.cxx
+++ b/Detectors/MUON/MID/Raw/src/DecodedDataAggregator.cxx
@@ -37,13 +37,13 @@ ColumnData& DecodedDataAggregator::FindColumnData(uint8_t deId, uint8_t columnId
   return mData.back();
 }
 
-void DecodedDataAggregator::addData(const LocalBoardRO& loc, size_t firstEntry)
+void DecodedDataAggregator::addData(const ROBoard& loc, size_t firstEntry)
 {
   /// Converts the local board data to ColumnData
   uint8_t uniqueLocId = loc.boardId;
-  uint8_t crateId = crateparams::getCrateId(uniqueLocId);
+  uint8_t crateId = raw::getCrateId(uniqueLocId);
   bool isRightSide = crateparams::isRightSide(crateId);
-  uint16_t deBoardId = mCrateMapper.roLocalBoardToDE(crateId, crateparams::getLocId(loc.boardId));
+  uint16_t deBoardId = mCrateMapper.roLocalBoardToDE(crateId, raw::getLocId(loc.boardId));
   auto rpcLineId = mCrateMapper.getRPCLine(deBoardId);
   auto columnId = mCrateMapper.getColumnId(deBoardId);
   auto lineId = mCrateMapper.getLineId(deBoardId);
@@ -58,7 +58,7 @@ void DecodedDataAggregator::addData(const LocalBoardRO& loc, size_t firstEntry)
   }
 }
 
-void DecodedDataAggregator::process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords)
+void DecodedDataAggregator::process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords)
 {
   /// Aggregates the decoded raw data
 

--- a/Detectors/MUON/MID/Raw/src/GBTDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTDecoder.cxx
@@ -17,7 +17,7 @@
 
 #include "MIDRaw/FEEIdConfig.h"
 #include "MIDRaw/GBTOutputHandler.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -38,7 +38,7 @@ class GBTUserLogicDecoderImpl
     }
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
     mOutputHandler.set(orbit, data, rofs);
@@ -93,7 +93,7 @@ class GBTBareDecoderImpl
     }
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
     mOutputHandler.set(orbit, data, rofs);
@@ -192,7 +192,7 @@ class GBTBareDecoderLinkImpl
     mLinkPayload.reserve(0x20000);
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
     mOutputHandler.set(orbit, data, rofs);
@@ -276,7 +276,7 @@ class GBTBareDecoderInsertImpl
     }
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
     mOutputHandler.set(orbit, data, rofs);
@@ -334,7 +334,7 @@ class GBTBareDecoderInsertImpl
 
 } // namespace impl
 
-void GBTDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+void GBTDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Decodes the data
   mDecode(payload, orbit, data, rofs);

--- a/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
@@ -20,7 +20,7 @@ namespace o2
 namespace mid
 {
 
-void GBTOutputHandler::set(uint32_t orbit, std::vector<LocalBoardRO>& data, std::vector<ROFRecord>& rofs)
+void GBTOutputHandler::set(uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Sets the orbit and the output data vectors
   mOrbit = orbit;
@@ -126,7 +126,7 @@ void GBTOutputHandler::addLoc(size_t ilink, const ELinkDecoder& decoder, EventTy
 {
   /// Adds the local board to the output data vector
   auto firstEntry = mData->size();
-  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), decoder.getId()), decoder.getInputs()});
+  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), decoder.getId()), decoder.getInputs()});
   InteractionRecord intRec(mIRs[ilink].bc + correctedClock, mIRs[ilink].orbit);
   mROFRecords->emplace_back(intRec, eventType, firstEntry, 1);
   for (int ich = 0; ich < 4; ++ich) {
@@ -170,7 +170,7 @@ void GBTOutputHandler::onDoneRegDebug(size_t ilink, const ELinkDecoder& decoder)
   processTrigger(ilink, decoder, eventType, correctedClock);
   // If we want to distinguish the two regional e-links, we can use the link ID instead
   auto firstEntry = mData->size();
-  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), crateparams::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1)), decoder.getInputs()});
+  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1)), decoder.getInputs()});
 
   auto orbit = (decoder.getTriggerWord() & raw::sORB) ? mIRs[ilink].orbit - 1 : mIRs[ilink].orbit;
 

--- a/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
@@ -126,7 +126,7 @@ void GBTOutputHandler::addLoc(size_t ilink, const ELinkDecoder& decoder, EventTy
 {
   /// Adds the local board to the output data vector
   auto firstEntry = mData->size();
-  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), decoder.getId()), decoder.getInputs()});
+  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromGBTUniqueId(mFeeId), decoder.getId()), decoder.getInputs()});
   InteractionRecord intRec(mIRs[ilink].bc + correctedClock, mIRs[ilink].orbit);
   mROFRecords->emplace_back(intRec, eventType, firstEntry, 1);
   for (int ich = 0; ich < 4; ++ich) {
@@ -170,7 +170,7 @@ void GBTOutputHandler::onDoneRegDebug(size_t ilink, const ELinkDecoder& decoder)
   processTrigger(ilink, decoder, eventType, correctedClock);
   // If we want to distinguish the two regional e-links, we can use the link ID instead
   auto firstEntry = mData->size();
-  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromROId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1)), decoder.getInputs()});
+  mData->push_back({decoder.getStatusWord(), decoder.getTriggerWord(), raw::makeUniqueLocID(crateparams::getCrateIdFromGBTUniqueId(mFeeId), ilink + 8 * (crateparams::getGBTIdInCrate(mFeeId) - 1)), decoder.getInputs()});
 
   auto orbit = (decoder.getTriggerWord() & raw::sORB) ? mIRs[ilink].orbit - 1 : mIRs[ilink].orbit;
 

--- a/Detectors/MUON/MID/Raw/src/GBTUserLogicEncoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTUserLogicEncoder.cxx
@@ -64,7 +64,7 @@ void GBTUserLogicEncoder::addRegionalBoards(uint8_t activeBoards, InteractionRec
   }
 }
 
-void GBTUserLogicEncoder::process(gsl::span<const LocalBoardRO> data, const InteractionRecord& ir)
+void GBTUserLogicEncoder::process(gsl::span<const ROBoard> data, const InteractionRecord& ir)
 {
   /// Encode data
   auto& vec = mBoards[ir];
@@ -72,7 +72,7 @@ void GBTUserLogicEncoder::process(gsl::span<const LocalBoardRO> data, const Inte
   for (auto& loc : data) {
     for (int ich = 0; ich < 4; ++ich) {
       if (loc.patternsBP[ich] && loc.patternsNBP[ich]) {
-        activeBoards |= (1 << (crateparams::getLocId(loc.boardId) % 8));
+        activeBoards |= (1 << (raw::getLocId(loc.boardId) % 8));
       }
     }
     vec.emplace_back(loc);
@@ -83,14 +83,14 @@ void GBTUserLogicEncoder::process(gsl::span<const LocalBoardRO> data, const Inte
 void GBTUserLogicEncoder::flush(std::vector<char>& buffer, const InteractionRecord& ir)
 {
   /// Flush buffer
-  std::map<InteractionRecord, std::vector<LocalBoardRO>> tmpBoards;
+  std::map<InteractionRecord, std::vector<ROBoard>> tmpBoards;
   for (auto& item : mBoards) {
     if (item.first <= ir) {
       for (auto& loc : item.second) {
         buffer.emplace_back(loc.statusWord);
         buffer.emplace_back(loc.triggerWord);
         addShort(buffer, item.first.bc);
-        buffer.emplace_back((crateparams::getLocId(loc.boardId) << 4) | loc.firedChambers);
+        buffer.emplace_back((raw::getLocId(loc.boardId) << 4) | loc.firedChambers);
         if (raw::isLoc(loc.statusWord)) {
           for (int ich = 4; ich >= 0; --ich) {
             if (loc.firedChambers & (1 << ich)) {

--- a/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
+++ b/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
@@ -132,7 +132,7 @@ static void BM_GBTDecoder(benchmark::State& state)
   double num{0};
 
   auto inputData = generateTestData(nTF, nEventPerTF, nFiredPerEvent, 1);
-  std::vector<o2::mid::LocalBoardRO> data;
+  std::vector<o2::mid::ROBoard> data;
   std::vector<o2::mid::ROFRecord> rofs;
 
   for (auto _ : state) {

--- a/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
+++ b/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
@@ -18,6 +18,7 @@
 
 #include <boost/test/data/test_case.hpp>
 #include <iostream>
+#include "DataFormatsMID/ROBoard.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/DetectorParameters.h"
 #include "MIDRaw/CrateMapper.h"
@@ -80,8 +81,8 @@ BOOST_AUTO_TEST_CASE(Consistency)
     for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
       for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
         auto uniqueLocId = crateMapper.deLocalBoardToRO(ide, icol, iline);
-        auto crateId = o2::mid::crateparams::getCrateId(uniqueLocId);
-        auto deBoardId = crateMapper.roLocalBoardToDE(crateId, o2::mid::crateparams::getLocId(uniqueLocId));
+        auto crateId = o2::mid::raw::getCrateId(uniqueLocId);
+        auto deBoardId = crateMapper.roLocalBoardToDE(crateId, o2::mid::raw::getLocId(uniqueLocId));
         BOOST_TEST(static_cast<int>(crateMapper.getColumnId(deBoardId)) == icol);
         BOOST_TEST(static_cast<int>(crateMapper.getLineId(deBoardId)) == iline);
         int rpcLineId = crateMapper.getRPCLine(deBoardId);

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(ColumnDataConverter)
   inData[ir].emplace_back(getColData(14, 1, 0, 0, 0, 0xFF));
 
   std::vector<o2::mid::ROFRecord> rofs;
-  std::vector<o2::mid::LocalBoardRO> outData;
+  std::vector<o2::mid::ROBoard> outData;
   auto inEventType = o2::mid::EventType::Standard;
   o2::mid::ColumnDataToLocalBoard converter;
   converter.setDebugMode(true);
@@ -170,9 +170,9 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
 {
   /// Event with just one link fired
 
-  std::map<uint16_t, std::vector<o2::mid::LocalBoardRO>> inData;
+  std::map<uint16_t, std::vector<o2::mid::ROBoard>> inData;
   uint16_t bc = 100;
-  o2::mid::LocalBoardRO loc;
+  o2::mid::ROBoard loc;
   // Crate 5 link 0
   loc.statusWord = o2::mid::raw::sSTARTBIT | o2::mid::raw::sCARDTYPE;
   loc.triggerWord = 0;
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
   // Sets the feeId
   rdh.word0 |= ((5 * 2) << 16);
   auto decoder = o2::mid::createGBTDecoder(feeId);
-  std::vector<o2::mid::LocalBoardRO> data;
+  std::vector<o2::mid::ROBoard> data;
   std::vector<o2::mid::ROFRecord> rofs;
   std::vector<uint8_t> convertedBuffer(buf.size());
   memcpy(convertedBuffer.data(), buf.data(), buf.size());
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
     for (auto inLoc = inItMap->second.begin(); inLoc != inItMap->second.end(); ++inLoc) {
       BOOST_TEST(inLoc->statusWord == outLoc->statusWord);
       BOOST_TEST(inLoc->triggerWord == outLoc->triggerWord);
-      BOOST_TEST(o2::mid::crateparams::makeUniqueLocID(crateId, inLoc->boardId) == outLoc->boardId);
+      BOOST_TEST(o2::mid::raw::makeUniqueLocID(crateId, inLoc->boardId) == outLoc->boardId);
       BOOST_TEST(inLoc->firedChambers == outLoc->firedChambers);
       for (int ich = 0; ich < 4; ++ich) {
         BOOST_TEST(inLoc->patternsBP[ich] == outLoc->patternsBP[ich]);

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
 
   uint8_t crateId = 5;
   uint8_t linkInCrate = 0;
-  uint16_t feeId = o2::mid::crateparams::makeROId(crateId, linkInCrate);
+  uint16_t feeId = o2::mid::crateparams::makeGBTUniqueId(crateId, linkInCrate);
   o2::mid::GBTUserLogicEncoder encoder;
   encoder.setFeeId(feeId);
   for (auto& item : inData) {

--- a/Detectors/MUON/MID/Workflow/src/RawAggregatorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawAggregatorSpec.cxx
@@ -49,7 +49,7 @@ class RawAggregatorDeviceDPL
     auto tStart = std::chrono::high_resolution_clock::now();
 
     auto msg = pc.inputs().get("mid_decoded");
-    auto data = of::DataRefUtils::as<const LocalBoardRO>(msg);
+    auto data = of::DataRefUtils::as<const ROBoard>(msg);
 
     auto msgROF = pc.inputs().get("mid_decoded_rof");
     auto inROFRecords = of::DataRefUtils::as<const ROFRecord>(msgROF);

--- a/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
@@ -30,7 +30,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/GBTDecoder.h"
-#include "MIDRaw/LocalBoardRO.h"
+#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -69,7 +69,7 @@ class RawGBTDecoderDeviceDPL
       mDecoder = createGBTDecoder(*rdhPtr, mFeeId, mIsDebugMode, mCrateMasks.getMask(mFeeId), mElectronicsDelay);
     }
 
-    std::vector<LocalBoardRO> data;
+    std::vector<ROBoard> data;
     std::vector<ROFRecord> rofRecords;
 
     for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {

--- a/Detectors/MUON/MID/Workflow/src/ZeroSuppressionSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ZeroSuppressionSpec.cxx
@@ -57,7 +57,7 @@ class ZeroSuppressionDeviceDPL
     for (auto& rof : inROFRecords) {
       mConverter.process(patterns.subspan(rof.firstEntry, rof.nEntries));
       if (!mConverter.getData().empty()) {
-        std::vector<LocalBoardRO> decodedData;
+        std::vector<ROBoard> decodedData;
         for (auto& item : mConverter.getData()) {
           decodedData.insert(decodedData.end(), item.second.begin(), item.second.end());
         }


### PR DESCRIPTION
The LocalBoardRO is the basic raw structure for MID.
In principle, the regional information is not used in data, but it is used for the debugging. Since the local and regional board information share the same structure, it is less confusing to have a general ROBoard instead of a specific LocalBoardRO.
Also, it is better to move this basic structure to DataFormatsMID.
With this PR, I also change the name of some functions for better clarity.
The commits are atomic: please do not squash