### PR TITLE
[CTF] tests: no need to link to CTFWorkflow lib

### DIFF
--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -11,48 +11,42 @@
 add_subdirectory(workflow)
 
 o2_add_test(itsmft
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::ITSMFTReconstruction
-	                          O2::DataFormatsITSMFT
+            PUBLIC_LINK_LIBRARIES O2::ITSMFTReconstruction
+                                  O2::DataFormatsITSMFT
             SOURCES test/test_ctf_io_itsmft.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 
 o2_add_test(tpc
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::TPCReconstruction
-	                          O2::DataFormatsTPC
+            PUBLIC_LINK_LIBRARIES O2::TPCReconstruction
+                                  O2::DataFormatsTPC
             SOURCES test/test_ctf_io_tpc.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
           
 o2_add_test(ft0
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::FT0Reconstruction
-	                          O2::DataFormatsFT0
+            PUBLIC_LINK_LIBRARIES O2::FT0Reconstruction
+                                  O2::DataFormatsFT0
             SOURCES test/test_ctf_io_ft0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
           
 o2_add_test(fv0
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::FV0Reconstruction
-	                          O2::DataFormatsFV0
+            PUBLIC_LINK_LIBRARIES O2::FV0Reconstruction
+                                  O2::DataFormatsFV0
             SOURCES test/test_ctf_io_fv0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 	    
 o2_add_test(fdd
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::FDDReconstruction
-	                          O2::DataFormatsFDD
+            PUBLIC_LINK_LIBRARIES O2::FDDReconstruction
+                                  O2::DataFormatsFDD
             SOURCES test/test_ctf_io_fdd.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 
 o2_add_test(tof
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::TOFBase
+            PUBLIC_LINK_LIBRARIES O2::TOFBase
                                   O2::TOFReconstruction
                                   O2::DataFormatsTOF
             SOURCES test/test_ctf_io_tof.cxx
@@ -60,40 +54,35 @@ o2_add_test(tof
             LABELS ctf)
 
 o2_add_test(mid
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsMID
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsMID
                                   O2::MIDCTF
             SOURCES test/test_ctf_io_mid.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
           
 o2_add_test(emcal
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsEMCAL
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsEMCAL
                                   O2::EMCALReconstruction
             SOURCES test/test_ctf_io_emcal.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 	  
 o2_add_test(phos
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsPHOS
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsPHOS
                                   O2::PHOSReconstruction
             SOURCES test/test_ctf_io_phos.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 
 o2_add_test(cpv
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsCPV
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsCPV
                                   O2::CPVReconstruction
             SOURCES test/test_ctf_io_cpv.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
 	    
 o2_add_test(zdc
-            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
-                                  O2::DataFormatsZDC
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsZDC
                                   O2::ZDCReconstruction
             SOURCES test/test_ctf_io_zdc.cxx
             COMPONENT_NAME ctf


### PR DESCRIPTION
For the CTF tests there's no need to link to CTFWorkflow lib.

Actually, with the linking the tests cannot work without a proper env (e.g. O2_ROOT env variable must be set) and each test executable is linked with quite a bunch of O2 libs : 

```
[ (python) brew ]~/alice/brew/sw/BUILD/O2-latest/O2$ stage/tests/o2-test-ctf-mid
[INFO] Mapping of global channel and (PM, PM channel) pair
could not open file /share/Detectors/TPC/files/TABLE-IROC.txt

[ (python) brew ]~/alice/brew/sw/BUILD/O2-latest/O2$ otool -L stage/tests/o2-test-ctf-mid | grep O2 | wc -l
     106
```

with this PR : 

```
[ (python) brew ]~/alice/brew/sw/BUILD/O2-latest/O2$ stage/tests/o2-test-ctf-mid
Running 1 test case...
...snip...
*** No errors detected

[ (python) brew ]~/alice/brew/sw/BUILD/O2-latest/O2$ otool -L stage/tests/o2-test-ctf-mid | grep O2 | wc -l
      19

```