### PR TITLE
BC selection task and alias accounting added

### DIFF
--- a/Analysis/Core/include/AnalysisCore/TriggerAliases.h
+++ b/Analysis/Core/include/AnalysisCore/TriggerAliases.h
@@ -32,18 +32,17 @@ enum triggerAliases {
 };
 
 static const std::string aliasLabels[kNaliases] = {
-    "kINT7",
-    "kEMC7",
-    "kINT7inMUON",
-    "kMuonSingleLowPt7",
-    "kMuonSingleHighPt7",
-    "kMuonUnlikeLowPt7",
-    "kMuonLikeLowPt7",
-    "kCUP8",
-    "kCUP9",
-    "kMUP10",
-    "kMUP11"
-};
+  "kINT7",
+  "kEMC7",
+  "kINT7inMUON",
+  "kMuonSingleLowPt7",
+  "kMuonSingleHighPt7",
+  "kMuonUnlikeLowPt7",
+  "kMuonLikeLowPt7",
+  "kCUP8",
+  "kCUP9",
+  "kMUP10",
+  "kMUP11"};
 
 class TriggerAliases
 {

--- a/Analysis/Core/include/AnalysisCore/TriggerAliases.h
+++ b/Analysis/Core/include/AnalysisCore/TriggerAliases.h
@@ -31,6 +31,20 @@ enum triggerAliases {
   kNaliases
 };
 
+static const std::string aliasLabels[kNaliases] = {
+    "kINT7",
+    "kEMC7",
+    "kINT7inMUON",
+    "kMuonSingleLowPt7",
+    "kMuonSingleHighPt7",
+    "kMuonUnlikeLowPt7",
+    "kMuonLikeLowPt7",
+    "kCUP8",
+    "kCUP9",
+    "kMUP10",
+    "kMUP11"
+};
+
 class TriggerAliases
 {
  public:

--- a/Analysis/Core/src/TriggerAliases.cxx
+++ b/Analysis/Core/src/TriggerAliases.cxx
@@ -18,6 +18,6 @@ void TriggerAliases::AddClassIdToAlias(uint32_t aliasId, int classId)
   } else if (classId < 50) {
     mAliasToTriggerMask[aliasId] |= 1ull << classId;
   } else {
-    mAliasToTriggerMaskNext50[aliasId] |= 1ull << classId;
+    mAliasToTriggerMaskNext50[aliasId] |= 1ull << (classId-50);
   }
 }

--- a/Analysis/Core/src/TriggerAliases.cxx
+++ b/Analysis/Core/src/TriggerAliases.cxx
@@ -18,6 +18,6 @@ void TriggerAliases::AddClassIdToAlias(uint32_t aliasId, int classId)
   } else if (classId < 50) {
     mAliasToTriggerMask[aliasId] |= 1ull << classId;
   } else {
-    mAliasToTriggerMaskNext50[aliasId] |= 1ull << (classId-50);
+    mAliasToTriggerMaskNext50[aliasId] |= 1ull << (classId - 50);
   }
 }

--- a/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
@@ -39,7 +39,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(SEL8, sel8, [](bool bbT0A, bool bbT0C, bool bbZNA, bo
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL",
                   evsel::Alias,
                   evsel::BBT0A, evsel::BBT0C,
-                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C, 
+                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBZNA, evsel::BBZNC,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::SEL7<evsel::BBV0A, evsel::BBV0C, evsel::BBZNA, evsel::BBZNC>,

--- a/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
@@ -39,37 +39,20 @@ DECLARE_SOA_DYNAMIC_COLUMN(SEL8, sel8, [](bool bbT0A, bool bbT0C, bool bbZNA, bo
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL",
                   evsel::Alias,
                   evsel::BBT0A, evsel::BBT0C,
-                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C, evsel::BBZNA, evsel::BBZNC,
+                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C, 
+                  evsel::BBZNA, evsel::BBZNC,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::SEL7<evsel::BBV0A, evsel::BBV0C, evsel::BBZNA, evsel::BBZNC>,
                   evsel::SEL8<evsel::BBT0A, evsel::BBT0C, evsel::BBZNA, evsel::BBZNC>,
                   evsel::FoundFT0);
 using EvSel = EvSels::iterator;
 
-// bc-joinable event selection decisions
-namespace bcsel
-{
-// TODO bool arrays are not supported? Storing in int32 for the moment
-DECLARE_SOA_COLUMN(Alias, alias, int32_t[kNaliases]);
-DECLARE_SOA_COLUMN(BBT0A, bbT0A, bool); // beam-beam time in T0A
-DECLARE_SOA_COLUMN(BBT0C, bbT0C, bool); // beam-beam time in T0C
-DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool); // beam-beam time in V0A
-DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool); // beam-beam time in V0C
-DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool); // beam-gas time in V0A
-DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool); // beam-gas time in V0C
-DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool); // beam-beam time in ZNA
-DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool); // beam-beam time in ZNC
-DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool); // beam-beam time in FDA
-DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool); // beam-beam time in FDC
-DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool); // beam-gas time in FDA
-DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool); // beam-gas time in FDC
-} // namespace bcsel
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL",
-                  bcsel::Alias,
-                  bcsel::BBT0A, bcsel::BBT0C,
-                  bcsel::BBV0A, bcsel::BBV0C, bcsel::BGV0A, bcsel::BGV0C,
-                  bcsel::BBZNA, bcsel::BBZNC,
-                  bcsel::BBFDA, bcsel::BBFDC, bcsel::BGFDA, bcsel::BGFDC);
+                  evsel::Alias,
+                  evsel::BBT0A, evsel::BBT0C,
+                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
+                  evsel::BBZNA, evsel::BBZNC,
+                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC);
 using BcSel = BcSels::iterator;
 } // namespace o2::aod
 

--- a/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
@@ -15,6 +15,7 @@
 
 namespace o2::aod
 {
+// collision-joinable event selection decisions
 namespace evsel
 {
 // TODO bool arrays are not supported? Storing in int32 for the moment
@@ -44,6 +45,32 @@ DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL",
                   evsel::SEL8<evsel::BBT0A, evsel::BBT0C, evsel::BBZNA, evsel::BBZNC>,
                   evsel::FoundFT0);
 using EvSel = EvSels::iterator;
+
+// bc-joinable event selection decisions
+namespace bcsel
+{
+// TODO bool arrays are not supported? Storing in int32 for the moment
+DECLARE_SOA_COLUMN(Alias, alias, int32_t[kNaliases]);
+DECLARE_SOA_COLUMN(BBT0A, bbT0A, bool); // beam-beam time in T0A
+DECLARE_SOA_COLUMN(BBT0C, bbT0C, bool); // beam-beam time in T0C
+DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool); // beam-beam time in V0A
+DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool); // beam-beam time in V0C
+DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool); // beam-gas time in V0A
+DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool); // beam-gas time in V0C
+DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool); // beam-beam time in ZNA
+DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool); // beam-beam time in ZNC
+DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool); // beam-beam time in FDA
+DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool); // beam-beam time in FDC
+DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool); // beam-gas time in FDA
+DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool); // beam-gas time in FDC
+} // namespace bcsel
+DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL",
+                  bcsel::Alias,
+                  bcsel::BBT0A, bcsel::BBT0C,
+                  bcsel::BBV0A, bcsel::BBV0C, bcsel::BGV0A, bcsel::BGV0C,
+                  bcsel::BBZNA, bcsel::BBZNC,
+                  bcsel::BBFDA, bcsel::BBFDC, bcsel::BGFDA, bcsel::BGFDC);
+using BcSel = BcSels::iterator;
 } // namespace o2::aod
 
 #endif // O2_ANALYSIS_EVENTSELECTION_H_

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -67,7 +67,6 @@ struct EvSelParameters {
   float fT0CBBupper = 2.0;  // ns
 };
 
-
 struct BcSelectionTask {
   Produces<aod::BcSels> bcsel;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -137,14 +136,13 @@ struct BcSelectionTask {
   }
 };
 
-
 struct EventSelectionTask {
   Produces<aod::EvSels> evsel;
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
 
   using BCsWithBcSels = soa::Join<aod::BCs, aod::BcSels>;
 
-  void process(aod::Collision const& col,  BCsWithBcSels const& bcs)
+  void process(aod::Collision const& col, BCsWithBcSels const& bcs)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
     int32_t alias[kNaliases];
@@ -173,7 +171,6 @@ struct EventSelectionTask {
     evsel(alias, bbT0A, bbT0C, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC, foundFT0);
   }
 };
-
 
 struct EventSelectionTaskRun3 {
   Produces<aod::EvSels> evsel;

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -158,7 +158,7 @@ struct EventSelectionTask {
     bool bbFDA = bc.bbFDA();
     bool bbFDC = bc.bbFDC();
     bool bgFDA = bc.bgFDA();
-    bool bgFDC = bc.bgFDA();
+    bool bgFDC = bc.bgFDC();
     bool bbT0A = bc.bbT0A();
     bool bbT0C = bc.bbT0C();
 

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -16,9 +16,12 @@ using namespace o2;
 using namespace o2::framework;
 
 struct EventSelectionQaPerBc {
+  // TODO fill aliases and class names in axis labels
   OutputObj<TH1F> hFiredClasses{TH1F("hFiredClasses", "", 100, -0.5, 99.5)};
-  void process(soa::Join<aod::BCs, aod::Run2BCInfos>::iterator const& bc)
+  OutputObj<TH1F> hFiredAliases{TH1F("hFiredAliases", "", kNaliases, -0.5, kNaliases)};
+  void process(soa::Join<aod::BCs, aod::Run2BCInfos, aod::BcSels>::iterator const& bc)
   {
+    // Fill fired trigger classes
     uint64_t triggerMask = bc.triggerMask();
     uint64_t triggerMaskNext50 = bc.triggerMaskNext50();
     for (int i = 0; i < 50; i++) {
@@ -27,6 +30,13 @@ struct EventSelectionQaPerBc {
       }
       if (triggerMaskNext50 & 1ull << i) {
         hFiredClasses->Fill(i + 50);
+      }
+    }
+
+    // Fill fired aliases
+    for (int i = 0; i < kNaliases; i++) {
+      if (bc.alias()[i]) {
+        hFiredAliases->Fill(i);
       }
     }
   }

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -20,13 +20,14 @@ using namespace o2::framework;
 struct EventSelectionQaPerBc {
   // TODO fill class names in axis labels
   OutputObj<TH1F> hFiredClasses{TH1F("hFiredClasses", "", 100, -0.5, 99.5)};
-  OutputObj<TH1F> hFiredAliases{TH1F("hFiredAliases", "", kNaliases, -0.5, kNaliases-0.5)};
-  void init(InitContext&){
-    for (int i = 0; i < kNaliases; i++){
-      hFiredAliases->GetXaxis()->SetBinLabel(i+1,aliasLabels[i].data());
+  OutputObj<TH1F> hFiredAliases{TH1F("hFiredAliases", "", kNaliases, -0.5, kNaliases - 0.5)};
+  void init(InitContext&)
+  {
+    for (int i = 0; i < kNaliases; i++) {
+      hFiredAliases->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i].data());
     }
   }
-  
+
   void process(soa::Join<aod::BCs, aod::Run2BCInfos, aod::BcSels>::iterator const& bc)
   {
     // Fill fired trigger classes
@@ -81,7 +82,7 @@ struct EventSelectionQaPerCollision {
     if (!isMC && !col.alias()[kINT7]) {
       return;
     }
-    
+
     float timeZNA = col.has_zdc() ? col.zdc().timeZNA() : -999.f;
     float timeZNC = col.has_zdc() ? col.zdc().timeZNC() : -999.f;
     float timeV0A = col.has_fv0a() ? col.fv0a().time() : -999.f;

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -11,14 +11,22 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "AnalysisDataModel/EventSelection.h"
+#include "AnalysisCore/TriggerAliases.h"
+#include "TH1F.h"
 
 using namespace o2;
 using namespace o2::framework;
 
 struct EventSelectionQaPerBc {
-  // TODO fill aliases and class names in axis labels
+  // TODO fill class names in axis labels
   OutputObj<TH1F> hFiredClasses{TH1F("hFiredClasses", "", 100, -0.5, 99.5)};
-  OutputObj<TH1F> hFiredAliases{TH1F("hFiredAliases", "", kNaliases, -0.5, kNaliases)};
+  OutputObj<TH1F> hFiredAliases{TH1F("hFiredAliases", "", kNaliases, -0.5, kNaliases-0.5)};
+  void init(InitContext&){
+    for (int i = 0; i < kNaliases; i++){
+      hFiredAliases->GetXaxis()->SetBinLabel(i+1,aliasLabels[i].data());
+    }
+  }
+  
   void process(soa::Join<aod::BCs, aod::Run2BCInfos, aod::BcSels>::iterator const& bc)
   {
     // Fill fired trigger classes
@@ -73,7 +81,7 @@ struct EventSelectionQaPerCollision {
     if (!isMC && !col.alias()[kINT7]) {
       return;
     }
-
+    
     float timeZNA = col.has_zdc() ? col.zdc().timeZNA() : -999.f;
     float timeZNC = col.has_zdc() ? col.zdc().timeZNC() : -999.f;
     float timeV0A = col.has_fv0a() ? col.fv0a().time() : -999.f;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -808,6 +808,8 @@ DECLARE_SOA_INDEX_TABLE(MatchedBCCollisionsSparse, BCs, "MA_BCCOL_SP", indices::
 DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run3MatchedToBCExclusive, BCs, "MA_RN3_BC_EX", indices::BCId, indices::ZdcId, indices::FT0Id, indices::FV0AId, indices::FDDId);
 DECLARE_SOA_INDEX_TABLE(Run3MatchedToBCSparse, BCs, "MA_RN3_BC_SP", indices::BCId, indices::ZdcId, indices::FT0Id, indices::FV0AId, indices::FDDId);
 
+DECLARE_SOA_INDEX_TABLE(Run2MatchedToBCSparse, BCs, "MA_RN2_BC_SP", indices::BCId, indices::ZdcId, indices::FT0Id, indices::FV0AId, indices::FV0CId, indices::FDDId);
+
 // Joins with collisions (only for sparse ones)
 // NOTE: index table needs to be always last argument
 using CollisionMatchedRun2Sparse = soa::Join<Collisions, Run2MatchedSparse>::iterator;

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -86,7 +86,6 @@ static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingConte
 AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
-
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();
       // spawn tables
@@ -135,6 +134,8 @@ AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requ
           outputs.adopt(Output{origin, description}, maker(o2::aod::Run3MatchedToBCSparseMetadata{}));
         } else if (description == header::DataDescription{"MA_RN3_BC_EX"}) {
           outputs.adopt(Output{origin, description}, maker(o2::aod::Run3MatchedToBCExclusiveMetadata{}));
+        } else if (description == header::DataDescription{"MA_RN2_BC_SP"}) {
+          outputs.adopt(Output{origin, description}, maker(o2::aod::Run2MatchedToBCSparseMetadata{}));
         } else {
           throw std::runtime_error("Not an index table");
         }
@@ -146,7 +147,6 @@ AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec> requ
 AlgorithmSpec AODReaderHelpers::aodSpawnerCallback(std::vector<InputSpec> requested)
 {
   return AlgorithmSpec::InitCallback{[requested](InitContext& ic) {
-
     return [requested](ProcessingContext& pc) {
       auto outputs = pc.outputs();
       // spawn tables


### PR DESCRIPTION
Switching to bc-based selection:
* All trigger and forward detector timing decisions are filled in a dedicated BcSels table joinable with BCs table. 
* Added Run2MatchedToBCSparse in AODReaderHelpers to link bcs with fit and zdc detectors.
* Keeping EvSels table (joinable with Collisions table) for the moment. Filled directly from BcSels table.
* Added bc-based alias accounting