### PR TITLE
TRD CTF

### DIFF
--- a/DataFormats/Detectors/CPV/CMakeLists.txt
+++ b/DataFormats/Detectors/CPV/CMakeLists.txt
@@ -13,7 +13,7 @@ o2_add_library(DataFormatsCPV
                        src/Digit.cxx 
                        src/Cluster.cxx 
                        src/TriggerRecord.cxx
-		       src/CTF.cxx
+                       src/CTF.cxx
                 PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
                                      O2::Headers 
                                      O2::MathUtils 
@@ -27,4 +27,4 @@ o2_target_root_dictionary(DataFormatsCPV
                                   include/DataFormatsCPV/Digit.h
                                   include/DataFormatsCPV/Cluster.h
                                   include/DataFormatsCPV/TriggerRecord.h
-				  include/DataFormatsCPV/CTF.h)
+                                  include/DataFormatsCPV/CTF.h)

--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -13,13 +13,15 @@ o2_add_library(DataFormatsTRD
                        src/LinkRecord.cxx
                        src/Tracklet64.cxx
                        src/RawData.cxx
-                       PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
+                       src/CTF.cxx
+               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
-           o2_target_root_dictionary(DataFormatsTRD
+o2_target_root_dictionary(DataFormatsTRD
                HEADERS include/DataFormatsTRD/TriggerRecord.h
                        include/DataFormatsTRD/LinkRecord.h
                        include/DataFormatsTRD/Tracklet64.h
                        include/DataFormatsTRD/RawData.h
                        include/DataFormatsTRD/Constants.h
                        include/DataFormatsTRD/CalibratedTracklet.h
-                       include/DataFormatsTRD/Hit.h)
+                       include/DataFormatsTRD/Hit.h
+                       include/DataFormatsTRD/CTF.h)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CTF.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CTF.h
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for TRD CTF data
+
+#ifndef O2_TRD_CTF_H
+#define O2_TRD_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nTriggers = 0;  /// number of triggers
+  uint32_t nTracklets = 0; /// number of tracklets
+  uint32_t nDigits = 0;    /// number of digits
+  uint32_t firstOrbit = 0; /// orbit of 1st trigger
+  uint16_t firstBC = 0;    /// bc of 1st trigger
+  uint16_t format = 0;     /// format word to be added to tracklet
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded triggers and cells of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 15, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncTrig,
+               BLC_orbitIncTrig,
+               BLC_entriesTrk,
+               BLC_entriesDig,
+               BLC_HCIDTrk, // tracklers sorted in HCID -> 1st entry of trigger keeps abs HCID, then increments
+               BLC_padrowTrk,
+               BLC_colTrk,
+               BLC_posTrk,
+               BLC_slopeTrk,
+               BLC_pidTrk,
+               BLC_CIDDig, // digits sorted in CID -> 1st entry of trigger keeps abs CID, then increments
+               BLC_ROBDig,
+               BLC_MCMDig,
+               BLC_chanDig,
+               BLC_ADCDig
+  };
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -64,10 +64,23 @@ class Tracklet64
                     ((Q0 << Q0bs) & Q0mask);
   }
 
+  Tracklet64(uint64_t format, uint64_t hcid, uint64_t padrow, uint64_t col, uint64_t position,
+             uint64_t slope, uint64_t pid)
+  {
+    mtrackletWord = ((format << formatbs) & formatmask) |
+                    ((hcid << hcidbs) & hcidmask) |
+                    ((padrow << padrowbs) & padrowmask) |
+                    ((col << colbs) & colmask) |
+                    ((position << posbs) & posmask) |
+                    ((slope << slopebs) & slopemask) |
+                    (pid & PIDmask);
+  }
+
   GPUdDefault() ~Tracklet64() = default;
   GPUdDefault() Tracklet64& operator=(const Tracklet64& rhs) = default;
 
   // ----- Getters for contents of tracklet word -----
+  GPUd() uint64_t getFormat() const { return ((mtrackletWord & formatmask) >> formatbs); }; // no units 0..1077
   GPUd() uint64_t getHCID() const { return ((mtrackletWord & hcidmask) >> hcidbs); };       // no units 0..1077
   GPUd() uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // pad row number [0..15]
   GPUd() uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // column refers to MCM position in column direction on readout board [0..3]
@@ -122,6 +135,8 @@ class Tracklet64
     mtrackletWord &= ~slopemask;
     mtrackletWord |= ((slope << slopebs) & slopemask);
   }
+
+  GPUd() bool operator==(const Tracklet64& o) const { return mtrackletWord == o.mtrackletWord; }
 
 #ifndef GPUCA_GPUCODE_DEVICE
   void printStream(std::ostream& stream) const;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
@@ -57,6 +57,11 @@ class TriggerRecord
 
   void printStream(std::ostream& stream) const;
 
+  bool operator==(const TriggerRecord& o) const
+  {
+    return mBCData == o.mBCData && mDigitDataRange == o.mDigitDataRange && mTrackletDataRange == o.mTrackletDataRange;
+  }
+
  private:
   BCData mBCData;       /// Bunch crossing data of the trigger
   DataRange mDigitDataRange;    /// Index of the underlying digit data, indexes into the vector/array/span

--- a/DataFormats/Detectors/TRD/src/CTF.cxx
+++ b/DataFormats/Detectors/TRD/src/CTF.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsTRD/CTF.h"
+
+using namespace o2::trd;

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -29,4 +29,8 @@
 #pragma link C++ class std::vector < o2::trd::LinkRecord > +;
 #pragma link C++ class std::vector < o2::trd::Hit > +;
 
+#pragma link C++ struct o2::trd::CTFHeader + ;
+#pragma link C++ struct o2::trd::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::trd::CTFHeader, 15, uint32_t> + ;
+
 #endif

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -87,3 +87,11 @@ o2_add_test(zdc
             SOURCES test/test_ctf_io_zdc.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
+	    
+o2_add_test(trd
+            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                                  O2::DataFormatsTRD
+                                  O2::TRDReconstruction
+            SOURCES test/test_ctf_io_trd.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf)

--- a/Detectors/CTF/test/test_ctf_io_trd.cxx
+++ b/Detectors/CTF/test/test_ctf_io_trd.cxx
@@ -1,0 +1,123 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TRDCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "TRDReconstruction/CTFCoder.h"
+#include "DataFormatsTRD/CTF.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::trd;
+
+BOOST_AUTO_TEST_CASE(CTFTest)
+{
+  std::vector<TriggerRecord> triggers;
+  std::vector<Tracklet64> tracklets;
+  std::vector<Digit> digits;
+
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir(0, 0);
+  constexpr int NCID = 540, NHCID = 2 * NCID;
+  constexpr uint32_t formatTrk = 5;
+  ArrayADC adc;
+
+  for (int irof = 0; irof < 200; irof++) {
+    ir += 1 + gRandom->Integer(600);
+    bool doDigits = gRandom->Rndm() > 0.8;
+
+    auto startTrk = tracklets.size();
+    auto startDig = digits.size();
+    int cid = 0;
+    while ((cid += gRandom->Poisson(5)) < NHCID) {
+      int hcid = cid / 2;
+      int nTrk = gRandom->Poisson(3);
+      int nDig = doDigits ? nTrk * 5 * (1. + gRandom->Rndm()) : 0;
+
+      for (int i = nTrk; i--;) {
+        tracklets.emplace_back(formatTrk, hcid, gRandom->Integer(0x1 << 4), gRandom->Integer(0x1 << 2),
+                               gRandom->Integer(0x1 << 11), gRandom->Integer(0x1 << 8), gRandom->Integer(0x1 << 24));
+      }
+      for (int i = nDig; i--;) {
+        auto& dig = digits.emplace_back(cid, gRandom->Integer(0x1 << 8), gRandom->Integer(0x1 << 8), gRandom->Integer(0x1 << 8));
+        for (int j = constants::TIMEBINS; j--;) {
+          adc[j] = gRandom->Integer(0x1 << 16);
+        }
+        dig.setADC(adc);
+      }
+    }
+
+    triggers.emplace_back(ir, startDig, digits.size() - startDig, startTrk, tracklets.size() - startTrk);
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, triggers, tracklets, digits); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::trd::CTF::get(vec.data());
+    TFile flOut("test_ctf_trd.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "TRD");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  LOG(INFO) << "Start reading from tree ";
+  {
+    sw.Start();
+    TFile flIn("test_ctf_trd.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::trd::CTF::readFromTree(vec, *(tree.get()), "TRD");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<TriggerRecord> triggersD;
+  std::vector<Tracklet64> trackletsD;
+  std::vector<Digit> digitsD;
+
+  sw.Start();
+  const auto ctfImage = o2::trd::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, triggersD, trackletsD, digitsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  BOOST_CHECK(triggersD.size() == triggers.size());
+  BOOST_CHECK(trackletsD.size() == tracklets.size());
+  BOOST_CHECK(digitsD.size() == digitsD.size());
+
+  BOOST_TEST(triggersD == triggers, boost::test_tools::per_element());
+  BOOST_TEST(trackletsD == tracklets, boost::test_tools::per_element());
+  BOOST_TEST(digitsD == digits, boost::test_tools::per_element());
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -11,30 +11,32 @@
 o2_add_library(CTFWorkflow
                SOURCES src/CTFWriterSpec.cxx
                        src/CTFReaderSpec.cxx
-	       PUBLIC_LINK_LIBRARIES O2::Framework
+         PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::DetectorsCommonDataFormats
                                      O2::DataFormatsITSMFT
                                      O2::DataFormatsTPC
+                                     O2::DataFormatsTRD
                                      O2::DataFormatsTOF
                                      O2::DataFormatsFT0
                                      O2::DataFormatsFV0
-				     O2::DataFormatsFDD
-				     O2::DataFormatsMID
-				     O2::DataFormatsPHOS
-				     O2::DataFormatsCPV
-				     O2::DataFormatsZDC				     
+                                     O2::DataFormatsFDD
+                                     O2::DataFormatsMID
+                                     O2::DataFormatsPHOS
+                                     O2::DataFormatsCPV
+                                     O2::DataFormatsZDC             
                                      O2::DataFormatsParameters
                                      O2::ITSMFTWorkflow
                                      O2::TPCWorkflow
+                                     O2::TRDWorkflow
                                      O2::FT0Workflow
                                      O2::FV0Workflow
-				     O2::FDDWorkflow
+                                     O2::FDDWorkflow
                                      O2::TOFWorkflow
                                      O2::MIDWorkflow
                                      O2::EMCALWorkflow
-				     O2::PHOSWorkflow
-				     O2::CPVWorkflow
-				     O2::ZDCWorkflow
+                                     O2::PHOSWorkflow
+                                     O2::CPVWorkflow
+                                     O2::ZDCWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -13,40 +13,18 @@
 #ifndef O2_CTFREADER_SPEC
 #define O2_CTFREADER_SPEC
 
-#include "TFile.h"
-#include "TTree.h"
-#include <TStopwatch.h>
-
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-
 #include "DetectorsCommonDataFormats/DetID.h"
+#include <string>
 
 namespace o2
 {
 namespace ctf
 {
 
-using DetID = o2::detectors::DetID;
-
-class CTFReaderSpec : public o2::framework::Task
-{
- public:
-  CTFReaderSpec(DetID::mask_t dm, const std::string& inp);
-  ~CTFReaderSpec() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-
- private:
-  DetID::mask_t mDets;             // detectors
-  std::vector<std::string> mInput; // input files
-  uint32_t mTFCounter = 0;
-  size_t mNextToProcess = 0;
-  TStopwatch mTimer;
-};
-
 /// create a processor spec
-framework::DataProcessorSpec getCTFReaderSpec(DetID::mask_t dets, const std::string& inp);
+framework::DataProcessorSpec getCTFReaderSpec(o2::detectors::DetID::mask_t dets, const std::string& inp);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
@@ -13,134 +13,17 @@
 #ifndef O2_CTFWRITER_SPEC
 #define O2_CTFWRITER_SPEC
 
-#include "TFile.h"
-#include "TTree.h"
-
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "DetectorsCommonDataFormats/CTFHeader.h"
-#include "DetectorsCommonDataFormats/NameConf.h"
-#include "DetectorsCommonDataFormats/EncodedBlocks.h"
-#include "CommonUtils/StringUtils.h"
-#include "rANS/rans.h"
-#include <vector>
-#include <array>
-#include <TStopwatch.h>
+#include "DetectorsCommonDataFormats/DetID.h"
 
 namespace o2
 {
 namespace ctf
 {
 
-using DetID = o2::detectors::DetID;
-using FTrans = o2::rans::FrequencyTable;
-
-class CTFWriterSpec : public o2::framework::Task
-{
- public:
-  CTFWriterSpec() = delete;
-  CTFWriterSpec(DetID::mask_t dm, uint64_t r = 0, bool doCTF = true, bool doDict = false, bool dictPerDet = false);
-  ~CTFWriterSpec() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
-  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
-  bool isPresent(DetID id) const { return mDets[id]; }
-
- private:
-  template <typename C>
-  void processDet(o2::framework::ProcessingContext& pc, DetID det, CTFHeader& header, TTree* tree);
-  template <typename C>
-  void storeDictionary(DetID det, CTFHeader& header);
-  void storeDictionaries();
-  void prepareDictionaryTreeAndFile(DetID det);
-  void closeDictionaryTreeAndFile(CTFHeader& header);
-  std::string dictionaryFileName(const std::string& detName = "");
-
-  DetID::mask_t mDets; // detectors
-  bool mWriteCTF = false;
-  bool mCreateDict = false;
-  bool mDictPerDetector = false;
-  size_t mNTF = 0;
-  int mSaveDictAfter = -1; // if positive and mWriteCTF==true, save dictionary after each mSaveDictAfter TFs processed
-  uint64_t mRun = 0;
-
-  std::unique_ptr<TFile> mDictFileOut; // file to store dictionary
-  std::unique_ptr<TTree> mDictTreeOut; // tree to store dictionary
-
-  // For the external dictionary creation we accumulate for each detector the frequency tables of its each block
-  // After accumulation over multiple TFs we store the dictionaries data in the standard CTF format of this detector,
-  // i.e. EncodedBlock stored in a tree, BUT with dictionary data only added to each block.
-  // The metadata of the block (min,max) will be used for the consistency check at the decoding
-  std::array<std::vector<FTrans>, DetID::nDetectors> mFreqsAccumulation;
-  std::array<std::vector<o2::ctf::Metadata>, DetID::nDetectors> mFreqsMetaData;
-  std::array<std::shared_ptr<void>, DetID::nDetectors> mHeaders;
-
-  TStopwatch mTimer;
-};
-
-// process data of particular detector
-template <typename C>
-void CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det, CTFHeader& header, TTree* tree)
-{
-  if (!isPresent(det) || !pc.inputs().isValid(det.getName())) {
-    return;
-  }
-  auto ctfBuffer = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(det.getName());
-  const auto ctfImage = C::getImage(ctfBuffer.data());
-  ctfImage.print(o2::utils::concat_string(det.getName(), ": "));
-  if (mWriteCTF) {
-    ctfImage.appendToTree(*tree, det.getName());
-    header.detectors.set(det);
-  }
-  if (mCreateDict) {
-    if (!mFreqsAccumulation[det].size()) {
-      mFreqsAccumulation[det].resize(C::getNBlocks());
-      mFreqsMetaData[det].resize(C::getNBlocks());
-    }
-    if (!mHeaders[det]) { // store 1st header
-      mHeaders[det] = ctfImage.cloneHeader();
-    }
-    for (int ib = 0; ib < C::getNBlocks(); ib++) {
-      const auto& bl = ctfImage.getBlock(ib);
-      if (bl.getNDict()) {
-        auto& freq = mFreqsAccumulation[det][ib];
-        auto& mdSave = mFreqsMetaData[det][ib];
-        const auto& md = ctfImage.getMetadata(ib);
-        freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-        mdSave = o2::ctf::Metadata{0, 0, md.coderType, md.streamSize, md.probabilityBits, md.opt, freq.getMinSymbol(), freq.getMaxSymbol(), (int)freq.size(), 0, 0};
-      }
-    }
-  }
-}
-
-// store dictionary of a particular detector
-template <typename C>
-void CTFWriterSpec::storeDictionary(DetID det, CTFHeader& header)
-{
-  if (!isPresent(det) || !mFreqsAccumulation[det].size()) {
-    return;
-  }
-  prepareDictionaryTreeAndFile(det);
-  // create vector whose data contains dictionary in CTF format (EncodedBlock)
-  auto dictBlocks = C::createDictionaryBlocks(mFreqsAccumulation[det], mFreqsMetaData[det]);
-  auto& h = C::get(dictBlocks.data())->getHeader();
-  h = *reinterpret_cast<typename std::remove_reference<decltype(h)>::type*>(mHeaders[det].get());
-  C::get(dictBlocks.data())->print(o2::utils::concat_string("Storing dictionary for ", det.getName(), ": "));
-  C::get(dictBlocks.data())->appendToTree(*mDictTreeOut.get(), det.getName()); // cast to EncodedBlock
-  //  mFreqsAccumulation[det].clear();
-  //  mFreqsMetaData[det].clear();
-  if (mDictPerDetector) {
-    header.detectors.reset();
-  }
-  header.detectors.set(det);
-  if (mDictPerDetector) {
-    closeDictionaryTreeAndFile(header);
-  }
-}
-
 /// create a processor spec
-framework::DataProcessorSpec getCTFWriterSpec(DetID::mask_t dets, uint64_t run, bool doCTF = true, bool doDict = false, bool dictPerDet = false);
+framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, bool doCTF = true, bool doDict = false, bool dictPerDet = false);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -10,18 +10,20 @@
 
 /// @file   CTFWriterSpec.cxx
 
-#include <vector>
-#include <TFile.h>
-#include <TTree.h>
-#include <TSystem.h>
-
 #include "Framework/Logger.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/InputSpec.h"
 #include "CTFWorkflow/CTFWriterSpec.h"
+
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsCommonDataFormats/CTFHeader.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+#include "CommonUtils/StringUtils.h"
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
+#include "DataFormatsTRD/CTF.h"
 #include "DataFormatsFT0/CTF.h"
 #include "DataFormatsFV0/CTF.h"
 #include "DataFormatsFDD/CTF.h"
@@ -31,6 +33,14 @@
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
 #include "DataFormatsZDC/CTF.h"
+#include "rANS/rans.h"
+#include <vector>
+#include <array>
+#include <TStopwatch.h>
+#include <vector>
+#include <TFile.h>
+#include <TTree.h>
+#include <TSystem.h>
 
 using namespace o2::framework;
 
@@ -51,6 +61,112 @@ void appendToTree(TTree& tree, const std::string brname, T& ptr)
   }
   br->Fill();
   br->ResetAddress();
+}
+
+using DetID = o2::detectors::DetID;
+using FTrans = o2::rans::FrequencyTable;
+
+class CTFWriterSpec : public o2::framework::Task
+{
+ public:
+  CTFWriterSpec() = delete;
+  CTFWriterSpec(DetID::mask_t dm, uint64_t r = 0, bool doCTF = true, bool doDict = false, bool dictPerDet = false);
+  ~CTFWriterSpec() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  bool isPresent(DetID id) const { return mDets[id]; }
+
+ private:
+  template <typename C>
+  void processDet(o2::framework::ProcessingContext& pc, DetID det, CTFHeader& header, TTree* tree);
+  template <typename C>
+  void storeDictionary(DetID det, CTFHeader& header);
+  void storeDictionaries();
+  void prepareDictionaryTreeAndFile(DetID det);
+  void closeDictionaryTreeAndFile(CTFHeader& header);
+  std::string dictionaryFileName(const std::string& detName = "");
+
+  DetID::mask_t mDets; // detectors
+  bool mWriteCTF = false;
+  bool mCreateDict = false;
+  bool mDictPerDetector = false;
+  size_t mNTF = 0;
+  int mSaveDictAfter = -1; // if positive and mWriteCTF==true, save dictionary after each mSaveDictAfter TFs processed
+  uint64_t mRun = 0;
+
+  std::unique_ptr<TFile> mDictFileOut; // file to store dictionary
+  std::unique_ptr<TTree> mDictTreeOut; // tree to store dictionary
+
+  // For the external dictionary creation we accumulate for each detector the frequency tables of its each block
+  // After accumulation over multiple TFs we store the dictionaries data in the standard CTF format of this detector,
+  // i.e. EncodedBlock stored in a tree, BUT with dictionary data only added to each block.
+  // The metadata of the block (min,max) will be used for the consistency check at the decoding
+  std::array<std::vector<FTrans>, DetID::nDetectors> mFreqsAccumulation;
+  std::array<std::vector<o2::ctf::Metadata>, DetID::nDetectors> mFreqsMetaData;
+  std::array<std::shared_ptr<void>, DetID::nDetectors> mHeaders;
+
+  TStopwatch mTimer;
+};
+
+// process data of particular detector
+template <typename C>
+void CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det, CTFHeader& header, TTree* tree)
+{
+  if (!isPresent(det) || !pc.inputs().isValid(det.getName())) {
+    return;
+  }
+  auto ctfBuffer = pc.inputs().get<gsl::span<o2::ctf::BufferType>>(det.getName());
+  const auto ctfImage = C::getImage(ctfBuffer.data());
+  ctfImage.print(o2::utils::concat_string(det.getName(), ": "));
+  if (mWriteCTF) {
+    ctfImage.appendToTree(*tree, det.getName());
+    header.detectors.set(det);
+  }
+  if (mCreateDict) {
+    if (!mFreqsAccumulation[det].size()) {
+      mFreqsAccumulation[det].resize(C::getNBlocks());
+      mFreqsMetaData[det].resize(C::getNBlocks());
+    }
+    if (!mHeaders[det]) { // store 1st header
+      mHeaders[det] = ctfImage.cloneHeader();
+    }
+    for (int ib = 0; ib < C::getNBlocks(); ib++) {
+      const auto& bl = ctfImage.getBlock(ib);
+      if (bl.getNDict()) {
+        auto& freq = mFreqsAccumulation[det][ib];
+        auto& mdSave = mFreqsMetaData[det][ib];
+        const auto& md = ctfImage.getMetadata(ib);
+        freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+        mdSave = o2::ctf::Metadata{0, 0, md.coderType, md.streamSize, md.probabilityBits, md.opt, freq.getMinSymbol(), freq.getMaxSymbol(), (int)freq.size(), 0, 0};
+      }
+    }
+  }
+}
+
+// store dictionary of a particular detector
+template <typename C>
+void CTFWriterSpec::storeDictionary(DetID det, CTFHeader& header)
+{
+  if (!isPresent(det) || !mFreqsAccumulation[det].size()) {
+    return;
+  }
+  prepareDictionaryTreeAndFile(det);
+  // create vector whose data contains dictionary in CTF format (EncodedBlock)
+  auto dictBlocks = C::createDictionaryBlocks(mFreqsAccumulation[det], mFreqsMetaData[det]);
+  auto& h = C::get(dictBlocks.data())->getHeader();
+  h = *reinterpret_cast<typename std::remove_reference<decltype(h)>::type*>(mHeaders[det].get());
+  C::get(dictBlocks.data())->print(o2::utils::concat_string("Storing dictionary for ", det.getName(), ": "));
+  C::get(dictBlocks.data())->appendToTree(*mDictTreeOut.get(), det.getName()); // cast to EncodedBlock
+  //  mFreqsAccumulation[det].clear();
+  //  mFreqsMetaData[det].clear();
+  if (mDictPerDetector) {
+    header.detectors.reset();
+  }
+  header.detectors.set(det);
+  if (mDictPerDetector) {
+    closeDictionaryTreeAndFile(header);
+  }
 }
 
 CTFWriterSpec::CTFWriterSpec(DetID::mask_t dm, uint64_t r, bool doCTF, bool doDict, bool dictPerDet)
@@ -101,6 +217,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::itsmft::CTF>(pc, DetID::ITS, header, treeOut.get());
   processDet<o2::itsmft::CTF>(pc, DetID::MFT, header, treeOut.get());
   processDet<o2::tpc::CTF>(pc, DetID::TPC, header, treeOut.get());
+  processDet<o2::trd::CTF>(pc, DetID::TRD, header, treeOut.get());
   processDet<o2::tof::CTF>(pc, DetID::TOF, header, treeOut.get());
   processDet<o2::ft0::CTF>(pc, DetID::FT0, header, treeOut.get());
   processDet<o2::fv0::CTF>(pc, DetID::FV0, header, treeOut.get());
@@ -174,6 +291,7 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::itsmft::CTF>(DetID::ITS, header);
   storeDictionary<o2::itsmft::CTF>(DetID::MFT, header);
   storeDictionary<o2::tpc::CTF>(DetID::TPC, header);
+  storeDictionary<o2::trd::CTF>(DetID::TRD, header);
   storeDictionary<o2::tof::CTF>(DetID::TOF, header);
   storeDictionary<o2::ft0::CTF>(DetID::FT0, header);
   storeDictionary<o2::fv0::CTF>(DetID::FV0, header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -22,6 +22,7 @@
 // Specific detectors specs
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "TPCWorkflow/EntropyDecoderSpec.h"
+#include "TRDWorkflow/EntropyDecoderSpec.h"
 #include "FT0Workflow/EntropyDecoderSpec.h"
 #include "FV0Workflow/EntropyDecoderSpec.h"
 #include "FDDWorkflow/EntropyDecoderSpec.h"
@@ -80,6 +81,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (dets[DetID::TPC]) {
     specs.push_back(o2::tpc::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::TRD]) {
+    specs.push_back(o2::trd::getEntropyDecoderSpec());
   }
   if (dets[DetID::TOF]) {
     specs.push_back(o2::tof::getEntropyDecoderSpec());

--- a/Detectors/TRD/CMakeLists.txt
+++ b/Detectors/TRD/CMakeLists.txt
@@ -10,5 +10,6 @@
 
 add_subdirectory(base)
 add_subdirectory(simulation)
+add_subdirectory(reconstruction)
 add_subdirectory(macros)
 add_subdirectory(workflow)

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -20,6 +20,7 @@
 
 #include "TRDBase/FeeParam.h"
 #include "DataFormatsTRD/Constants.h"
+#include <gsl/span>
 
 namespace o2
 {
@@ -59,6 +60,7 @@ class Digit
   void setChannel(int channel) { mChannel = channel; }
   void setDetector(int det) { mDetector = det; }
   void setADC(ArrayADC const& adc) { mADC = adc; }
+  void setADC(const gsl::span<ADC_t>& adc) { std::copy(adc.begin(), adc.end(), mADC.begin()); }
   // Get methods
   int getDetector() const { return mDetector; }
   int getRow() const { return FeeParam::getPadRowFromMCM(mROB, mMCM); }
@@ -71,6 +73,11 @@ class Digit
   ArrayADC const& getADC() const { return mADC; }
   ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }
 
+  bool operator==(const Digit& o) const
+  {
+    return mDetector == o.mDetector && mROB == o.mROB && mMCM == o.mMCM && mChannel == o.mChannel && mADC == o.mADC;
+  }
+
  private:
   std::uint16_t mDetector{0}; // detector, the chamber [0-539]
   std::uint8_t mROB{0};       // read out board within chamber [0-7] [0-5] depending on C0 or C1
@@ -80,6 +87,8 @@ class Digit
   ArrayADC mADC{}; // ADC vector (30 time-bins)
   ClassDefNV(Digit, 3);
 };
+
+std::ostream& operator<<(std::ostream& stream, const Digit& d);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/base/src/Digit.cxx
+++ b/Detectors/TRD/base/src/Digit.cxx
@@ -9,6 +9,8 @@
 // or submit itself to any jurisdiction.
 
 #include "TRDBase/Digit.h"
+#include <iostream>
+
 namespace o2::trd
 {
 
@@ -55,6 +57,15 @@ bool Digit::isSharedDigit() const
   } else {
     return 0;
   }
+}
+
+std::ostream& operator<<(std::ostream& stream, const Digit& d)
+{
+  stream << "Digit Det: " << d.getDetector() << " ROB: " << d.getROB() << " MCM: " << d.getMCM() << " Channel: " << d.getChannel() << " ADCs:";
+  for (int i = 0; i < constants::TIMEBINS; i++) {
+    stream << "[" << d.getADC()[i] << "]";
+  }
+  return stream;
 }
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/CMakeLists.txt
+++ b/Detectors/TRD/reconstruction/CMakeLists.txt
@@ -1,0 +1,21 @@
+#Copyright CERN and copyright holders of ALICE O2.This software is distributed
+#under the terms of the GNU General Public License v3(GPL Version 3), copied
+#verbatim in the file "COPYING".
+#
+#See http: //alice-o2.web.cern.ch/license for full licensing information.
+#
+#In applying this license CERN does not waive the privileges and immunities
+#granted to it by virtue of its status as an Intergovernmental Organization or
+#submit itself to any jurisdiction.
+
+o2_add_library(TRDReconstruction
+               SOURCES src/CTFCoder.cxx
+                       src/CTFHelper.cxx
+               PUBLIC_LINK_LIBRARIES O2::TRDBase
+                                     O2::DataFormatsTRD
+                                     O2::DetectorsRaw
+                                     O2::rANS
+                                     ms_gsl::ms_gsl)
+
+# o2_target_root_dictionary(TRDReconstruction
+#                           HEADERS )

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -1,0 +1,193 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of TRD data
+
+#ifndef O2_TRD_CTFCODER_H
+#define O2_TRD_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsTRD/CTF.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "rANS/rans.h"
+#include "TRDReconstruction/CTFHelper.h"
+
+class TTree;
+
+namespace o2
+{
+namespace trd
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TRD) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VTRG, typename VTRK, typename VDIG>
+  void decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Tracklet64>& trkVec, std::vector<Digit>& digVec);
+};
+
+/// entropy-encode digits and tracklets to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncTrig
+    MD::EENCODE, // BLC_orbitIncTrig
+    MD::EENCODE, // BLC_entriesTrk
+    MD::EENCODE, // BLC_entriesDig
+    MD::EENCODE, // BLC_HCIDTrk
+    MD::EENCODE, // BLC_padrowTrk
+    MD::EENCODE, // BLC_colTrk
+    MD::EENCODE, // BLC_posTrk
+    MD::EENCODE, // BLC_slopeTrk
+    MD::EENCODE, // BLC_pidTrk
+    MD::EENCODE, // BLC_CIDDig
+    MD::EENCODE, // BLC_ROBDig
+    MD::EENCODE, // BLC_MCMDig
+    MD::EENCODE, // BLC_chanDig
+    MD::EENCODE, // BLC_ADCDig
+  };
+
+  CTFHelper helper(trigData, trkData, digData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODETRD(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODETRD(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  ENCODETRD(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  ENCODETRD(helper.begin_entriesTrk(),   helper.end_entriesTrk(),    CTF::BLC_entriesTrk,   0);
+  ENCODETRD(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
+  
+  ENCODETRD(helper.begin_HCIDTrk(),      helper.end_HCIDTrk(),       CTF::BLC_HCIDTrk,      0);
+  ENCODETRD(helper.begin_padrowTrk(),    helper.end_padrowTrk(),     CTF::BLC_padrowTrk,    0);
+  ENCODETRD(helper.begin_colTrk(),       helper.end_colTrk(),        CTF::BLC_colTrk,       0);
+  ENCODETRD(helper.begin_posTrk(),       helper.end_posTrk(),        CTF::BLC_posTrk,       0);
+  ENCODETRD(helper.begin_slopeTrk(),     helper.end_slopeTrk(),      CTF::BLC_slopeTrk,     0);
+  ENCODETRD(helper.begin_pidTrk(),       helper.end_pidTrk(),        CTF::BLC_pidTrk,       0);
+
+  ENCODETRD(helper.begin_CIDDig(),       helper.end_CIDDig(),        CTF::BLC_CIDDig,       0);
+  ENCODETRD(helper.begin_ROBDig(),       helper.end_ROBDig(),        CTF::BLC_ROBDig,       0);
+  ENCODETRD(helper.begin_MCMDig(),       helper.end_MCMDig(),        CTF::BLC_MCMDig,       0);
+  ENCODETRD(helper.begin_chanDig(),      helper.end_chanDig(),       CTF::BLC_chanDig,      0);
+  ENCODETRD(helper.begin_ADCDig(),       helper.end_ADCDig(),        CTF::BLC_ADCDig,       0);
+
+  // clang-format on
+  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded data to tracklets and digits
+template <typename VTRG, typename VTRK, typename VDIG>
+void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+  std::vector<uint16_t> bcInc, HCIDTrk, posTrk, CIDDig, ADCDig;
+  std::vector<uint32_t> orbitInc, entriesTrk, entriesDig, pidTrk;
+  std::vector<uint8_t> padrowTrk, colTrk, slopeTrk, ROBDig, MCMDig, chanDig;
+
+#define DECODETRD(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODETRD(bcInc,       CTF::BLC_bcIncTrig);
+  DECODETRD(orbitInc,    CTF::BLC_orbitIncTrig);
+  DECODETRD(entriesTrk,  CTF::BLC_entriesTrk);
+  DECODETRD(entriesDig,  CTF::BLC_entriesDig);
+
+  DECODETRD(HCIDTrk,     CTF::BLC_HCIDTrk);
+  DECODETRD(padrowTrk,   CTF::BLC_padrowTrk);
+  DECODETRD(colTrk,      CTF::BLC_colTrk);
+  DECODETRD(posTrk,      CTF::BLC_posTrk);
+  DECODETRD(slopeTrk,    CTF::BLC_slopeTrk);
+  DECODETRD(pidTrk,      CTF::BLC_pidTrk);
+
+  DECODETRD(CIDDig,      CTF::BLC_CIDDig);
+  DECODETRD(ROBDig,      CTF::BLC_ROBDig);
+  DECODETRD(MCMDig,      CTF::BLC_MCMDig);
+  DECODETRD(chanDig,     CTF::BLC_chanDig);
+  DECODETRD(ADCDig,      CTF::BLC_ADCDig);
+  // clang-format on
+  //
+  trigVec.clear();
+  trkVec.clear();
+  digVec.clear();
+  trigVec.reserve(header.nTriggers);
+  trkVec.reserve(header.nTracklets);
+  digVec.reserve(header.nDigits);
+
+  uint32_t trkCount = 0, digCount = 0, adcCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  for (uint32_t itrig = 0; itrig < header.nTriggers; itrig++) {
+    // restore TrigRecord
+    if (orbitInc[itrig]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[itrig]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[itrig];
+    } else {
+      ir.bc += bcInc[itrig];
+    }
+
+    uint32_t firstEntryTrk = trkVec.size();
+    uint16_t hcid = 0;
+    for (uint32_t it = 0; it < entriesTrk[itrig]; it++) {
+      hcid += HCIDTrk[trkCount]; // 1st tracklet of trigger was encoded with abs HCID, then increments
+      trkVec.emplace_back(header.format, hcid, padrowTrk[trkCount], colTrk[trkCount], posTrk[trkCount], slopeTrk[trkCount], pidTrk[trkCount]);
+      trkCount++;
+    }
+
+    uint32_t firstEntryDig = digVec.size();
+    int16_t cid = 0;
+    for (uint32_t id = 0; id < entriesDig[itrig]; id++) {
+      cid += CIDDig[digCount]; // 1st digit of trigger was encoded with abs CID, then increments
+      auto& dig = digVec.emplace_back(cid, ROBDig[digCount], MCMDig[digCount], chanDig[digCount]);
+      dig.setADC({&ADCDig[adcCount], constants::TIMEBINS});
+      digCount++;
+      adcCount += constants::TIMEBINS;
+    }
+
+    trigVec.emplace_back(ir, firstEntryDig, entriesDig[itrig], firstEntryTrk, entriesTrk[itrig]);
+  }
+  assert(digCount == header.nDigits && trkCount == header.nTracklets && adcCount == (int)ADCDig.size());
+}
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_CTFCODER_H

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -1,0 +1,323 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for TRD CTF creation
+
+#ifndef O2_TRD_CTF_HELPER_H
+#define O2_TRD_CTF_HELPER_H
+
+#include "DataFormatsTRD/CTF.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "TRDBase/Digit.h" // TODO Consider moving to DataFormats
+#include <gsl/span>
+#include <bitset>
+
+namespace o2
+{
+namespace trd
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const TriggerRecord>& trgRec,
+            const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData)
+    : mTrigRec(trgRec), mTrkData(trkData), mDigData(digData), mTrkStart(trkData.size()), mDigStart(digData.size())
+  {
+    // flag start of new trigger for tracklets and digits
+    for (const auto& trg : mTrigRec) {
+      if (trg.getNumberOfTracklets()) {
+        mTrkStart[trg.getFirstTracklet()] = true;
+      }
+      if (trg.getNumberOfDigits()) {
+        mDigStart[trg.getFirstDigit()] = true;
+      }
+    }
+  }
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mTrigRec.size()), uint32_t(mTrkData.size()), uint32_t(mDigData.size()), 0, 0, 0};
+    if (mTrigRec.size()) {
+      h.firstOrbit = mTrigRec[0].getBCData().orbit;
+      h.firstBC = mTrigRec[0].getBCData().bc;
+    }
+    if (mTrkData.size()) {
+      h.format = (uint16_t)mTrkData[0].getFormat();
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mTrigRec.size() * sizeof(TriggerRecord) + mTrkData.size() * sizeof(Tracklet64) + mDigData.size() * sizeof(Digit); }
+
+  //>>> =========================== ITERATORS ========================================
+  template <typename I, typename D, typename T, int M = 1>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncTrig : public _Iter<Iter_bcIncTrig, TriggerRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncTrig, TriggerRecord, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].getBCData().orbit == mData[mIndex - 1].getBCData().orbit) {
+          return mData[mIndex].getBCData().bc - mData[mIndex - 1].getBCData().bc;
+        } else {
+          return mData[mIndex].getBCData().bc;
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncTrig : public _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].getBCData().orbit - mData[mIndex - 1].getBCData().orbit : 0; }
+  };
+
+  //_______________________________________________
+  // Number of tracklets for trigger
+  class Iter_entriesTrk : public _Iter<Iter_entriesTrk, TriggerRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_entriesTrk, TriggerRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNumberOfTracklets(); }
+  };
+
+  //_______________________________________________
+  // Number of digits for trigger
+  class Iter_entriesDig : public _Iter<Iter_entriesDig, TriggerRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_entriesDig, TriggerRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNumberOfDigits(); }
+  };
+
+  //_______________________________________________
+  class Iter_HCIDTrk : public _Iter<Iter_HCIDTrk, Tracklet64, uint16_t>
+  {
+   private:
+    const std::vector<bool>* mTrigStart{nullptr};
+
+   public:
+    using _Iter<Iter_HCIDTrk, Tracklet64, uint16_t>::_Iter;
+    Iter_HCIDTrk(const std::vector<bool>* ts, const gsl::span<const Tracklet64>& data, bool end) : mTrigStart(ts), _Iter(data, end) {}
+    Iter_HCIDTrk() = default;
+
+    // assume sorting in HCID: for the 1st tracklet of the trigger return the abs HCID, for the following ones: difference to previous HCID
+    value_type operator*() const
+    {
+      return (*mTrigStart)[mIndex] ? mData[mIndex].getHCID() : mData[mIndex].getHCID() - mData[mIndex - 1].getHCID();
+    }
+  };
+
+  //_______________________________________________
+  class Iter_padrowTrk : public _Iter<Iter_padrowTrk, Tracklet64, uint8_t>
+  {
+   public:
+    using _Iter<Iter_padrowTrk, Tracklet64, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPadRow(); }
+  };
+
+  //_______________________________________________
+  class Iter_colTrk : public _Iter<Iter_colTrk, Tracklet64, uint8_t>
+  {
+   public:
+    using _Iter<Iter_colTrk, Tracklet64, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getColumn(); }
+  };
+
+  //_______________________________________________
+  class Iter_posTrk : public _Iter<Iter_posTrk, Tracklet64, uint16_t>
+  {
+   public:
+    using _Iter<Iter_posTrk, Tracklet64, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPosition(); }
+  };
+
+  //_______________________________________________
+  class Iter_slopeTrk : public _Iter<Iter_slopeTrk, Tracklet64, uint8_t>
+  {
+   public:
+    using _Iter<Iter_slopeTrk, Tracklet64, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getSlope(); }
+  };
+
+  //_______________________________________________
+  class Iter_pidTrk : public _Iter<Iter_pidTrk, Tracklet64, uint32_t>
+  {
+   public:
+    using _Iter<Iter_pidTrk, Tracklet64, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPID(); }
+  };
+
+  //_______________________________________________
+  class Iter_CIDDig : public _Iter<Iter_CIDDig, Digit, uint16_t>
+  {
+   private:
+    const std::vector<bool>* mTrigStart{nullptr};
+
+   public:
+    using _Iter<Iter_CIDDig, Digit, uint16_t>::_Iter;
+    Iter_CIDDig(const std::vector<bool>* ts, const gsl::span<const Digit>& data, bool end) : mTrigStart(ts), _Iter(data, end) {}
+    Iter_CIDDig() = default;
+
+    // assume sorting in CID: for the 1st digit of the trigger return the abs CID, for the following ones: difference to previous CID
+    value_type operator*() const
+    {
+      return (*mTrigStart)[mIndex] ? mData[mIndex].getDetector() : mData[mIndex].getDetector() - mData[mIndex - 1].getDetector();
+    }
+  };
+
+  //_______________________________________________
+  class Iter_ROBDig : public _Iter<Iter_ROBDig, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_ROBDig, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getROB(); }
+  };
+
+  //_______________________________________________
+  class Iter_MCMDig : public _Iter<Iter_MCMDig, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_MCMDig, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getMCM(); }
+  };
+
+  //_______________________________________________
+  class Iter_chanDig : public _Iter<Iter_chanDig, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_chanDig, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getChannel(); }
+  };
+
+  //_______________________________________________
+  class Iter_ADCDig : public _Iter<Iter_ADCDig, Digit, uint16_t, constants::TIMEBINS>
+  {
+   public:
+    using _Iter<Iter_ADCDig, Digit, uint16_t, constants::TIMEBINS>::_Iter;
+    value_type operator*() const { return mData[mIndex / constants::TIMEBINS].getADC()[mIndex % constants::TIMEBINS]; }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncTrig begin_bcIncTrig() const { return Iter_bcIncTrig(mTrigRec, false); }
+  Iter_bcIncTrig end_bcIncTrig() const { return Iter_bcIncTrig(mTrigRec, true); }
+
+  Iter_orbitIncTrig begin_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigRec, false); }
+  Iter_orbitIncTrig end_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigRec, true); }
+
+  Iter_entriesTrk begin_entriesTrk() const { return Iter_entriesTrk(mTrigRec, false); }
+  Iter_entriesTrk end_entriesTrk() const { return Iter_entriesTrk(mTrigRec, true); }
+
+  Iter_entriesDig begin_entriesDig() const { return Iter_entriesDig(mTrigRec, false); }
+  Iter_entriesDig end_entriesDig() const { return Iter_entriesDig(mTrigRec, true); }
+
+  Iter_HCIDTrk begin_HCIDTrk() const { return Iter_HCIDTrk(&mTrkStart, mTrkData, false); }
+  Iter_HCIDTrk end_HCIDTrk() const { return Iter_HCIDTrk(&mTrkStart, mTrkData, true); }
+
+  Iter_padrowTrk begin_padrowTrk() const { return Iter_padrowTrk(mTrkData, false); }
+  Iter_padrowTrk end_padrowTrk() const { return Iter_padrowTrk(mTrkData, true); }
+
+  Iter_colTrk begin_colTrk() const { return Iter_colTrk(mTrkData, false); }
+  Iter_colTrk end_colTrk() const { return Iter_colTrk(mTrkData, true); }
+
+  Iter_posTrk begin_posTrk() const { return Iter_posTrk(mTrkData, false); }
+  Iter_posTrk end_posTrk() const { return Iter_posTrk(mTrkData, true); }
+
+  Iter_slopeTrk begin_slopeTrk() const { return Iter_slopeTrk(mTrkData, false); }
+  Iter_slopeTrk end_slopeTrk() const { return Iter_slopeTrk(mTrkData, true); }
+
+  Iter_pidTrk begin_pidTrk() const { return Iter_pidTrk(mTrkData, false); }
+  Iter_pidTrk end_pidTrk() const { return Iter_pidTrk(mTrkData, true); }
+
+  Iter_CIDDig begin_CIDDig() const { return Iter_CIDDig(&mDigStart, mDigData, false); }
+  Iter_CIDDig end_CIDDig() const { return Iter_CIDDig(&mDigStart, mDigData, true); }
+
+  Iter_ROBDig begin_ROBDig() const { return Iter_ROBDig(mDigData, false); }
+  Iter_ROBDig end_ROBDig() const { return Iter_ROBDig(mDigData, true); }
+
+  Iter_MCMDig begin_MCMDig() const { return Iter_MCMDig(mDigData, false); }
+  Iter_MCMDig end_MCMDig() const { return Iter_MCMDig(mDigData, true); }
+
+  Iter_chanDig begin_chanDig() const { return Iter_chanDig(mDigData, false); }
+  Iter_chanDig end_chanDig() const { return Iter_chanDig(mDigData, true); }
+
+  Iter_ADCDig begin_ADCDig() const { return Iter_ADCDig(mDigData, false); }
+  Iter_ADCDig end_ADCDig() const { return Iter_ADCDig(mDigData, true); }
+
+ private:
+  const gsl::span<const o2::trd::TriggerRecord> mTrigRec;
+  const gsl::span<const o2::trd::Tracklet64> mTrkData;
+  const gsl::span<const o2::trd::Digit> mDigData;
+  std::vector<bool> mTrkStart;
+  std::vector<bool> mDigStart;
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TRD/reconstruction/src/CTFCoder.cxx
@@ -1,0 +1,87 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of TRD data
+
+#include "TRDReconstruction/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::trd;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Tracklet64>& trkVec, std::vector<Digit>& digVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, trigVec, trkVec, digVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc, HCIDTrk, posTrk, CIDDig, ADCDig;
+  uint32_t orbitInc, entriesTrk, entriesDig, pidTrk;
+  uint8_t padrowTrk, colTrk, slopeTrk, ROBDig, MCMDig, chanDig;
+
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+  // clang-format off
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
+  MAKECODER(entriesTrk, CTF::BLC_entriesTrk);
+  MAKECODER(entriesDig, CTF::BLC_entriesDig);
+
+  MAKECODER(HCIDTrk,    CTF::BLC_HCIDTrk);
+  MAKECODER(padrowTrk,  CTF::BLC_padrowTrk);
+  MAKECODER(colTrk,     CTF::BLC_colTrk);
+  MAKECODER(posTrk,     CTF::BLC_posTrk);
+  MAKECODER(slopeTrk,   CTF::BLC_slopeTrk);
+  MAKECODER(pidTrk,     CTF::BLC_pidTrk);
+
+  MAKECODER(CIDDig,     CTF::BLC_CIDDig);
+  MAKECODER(ROBDig,     CTF::BLC_ROBDig);
+  MAKECODER(MCMDig,     CTF::BLC_MCMDig);
+  MAKECODER(chanDig,    CTF::BLC_chanDig);
+  MAKECODER(ADCDig,     CTF::BLC_ADCDig);
+  // clang-format on
+}

--- a/Detectors/TRD/reconstruction/src/CTFHelper.cxx
+++ b/Detectors/TRD/reconstruction/src/CTFHelper.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for TRD CTF creation
+
+#include "TRDReconstruction/CTFHelper.h"

--- a/Detectors/TRD/reconstruction/src/TRDReconstructionLinkDef.h
+++ b/Detectors/TRD/reconstruction/src/TRDReconstructionLinkDef.h
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -24,7 +24,9 @@ o2_add_library(TRDWorkflow
                        src/TRDGlobalTrackingSpec.cxx
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackingWorkflow.cxx
-                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::GPUTracking O2::GlobalTrackingWorkflow)
+                       src/EntropyDecoderSpec.cxx
+                       src/EntropyEncoderSpec.cxx                       
+                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::GPUTracking O2::GlobalTrackingWorkflow)
 
                    #o2_target_root_dictionary(TRDWorkflow
                    # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to TRD digit/tracklets stream
+
+#ifndef O2_TRD_ENTROPYDECODER_SPEC
+#define O2_TRD_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/include/TRDWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert TRD data to CTF (EncodedBlocks)
+
+#ifndef O2_TRD_ENTROPYENCODER_SPEC
+#define O2_TRD_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TRDWorkflow/EntropyDecoderSpec.h"
+#include "TRDReconstruction/CTFCoder.h"
+#include <TStopwatch.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::trd::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("trd-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
+  auto& tracklets = pc.outputs().make<std::vector<Tracklet64>>(OutputRef{"tracklets"});
+  auto& digits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::trd::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, triggers, tracklets, digits);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << tracklets.size() << " TRD tracklets and " << digits.size() << " digits in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "TRD Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"triggers"}, "TRD", "TRIGRECORDS", 0, Lifetime::Timeframe},
+    OutputSpec{{"tracklets"}, "TRD", "TRACKLETS", 0, Lifetime::Timeframe},
+    OutputSpec{{"digits"}, "TRD", "DIGITS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "trd-entropy-decoder",
+    Inputs{InputSpec{"ctf", "TRD", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"trd-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TRDWorkflow/EntropyEncoderSpec.h"
+#include "TRDReconstruction/CTFCoder.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include <TStopwatch.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::trd::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("trd-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
+  auto tracklets = pc.inputs().get<gsl::span<Tracklet64>>("tracklets");
+  auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TRD", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, triggers, tracklets, digits);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for TRD in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "TRD Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("triggers", "TRD", "TRIGRECORDS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("tracklets", "TRD", "TRACKLETS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("digits", "TRD", "DIGITS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "trd-entropy-encoder",
+    inputs,
+    Outputs{{"TRD", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"trd-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+}
+
+} // namespace trd
+} // namespace o2


### PR DESCRIPTION
+ some related fixes.

Before it can be fully deployed, the following should be done (@bazinski ):

* tracklets and digits are expected to be sorted in HCID and CID respectively. This is not yet the case for tracklets from TRAPsim
* entropy encoder device subscribes for (end the decoder device produces) messages https://github.com/shahor02/AliceO2/blob/ea3471aa81f2b864744fafa0fe9cf2c54547b32b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx#L84-L86, which should be provided by both digits/tracklets reader and raw data decoder in root-file and raw-data based workflows respectively.
