### PR TITLE
DPL: improve handling of unbalanced queues

### DIFF
--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -11,6 +11,7 @@
 #define O2_FRAMEWORK_CHANNELINFO_H
 
 #include <string>
+#include <FairMQParts.h>
 
 class FairMQChannel;
 
@@ -35,6 +36,7 @@ struct InputChannelInfo {
   InputChannelState state = InputChannelState::Running;
   uint32_t hasPendingEvents = 0;
   FairMQChannel* channel = nullptr;
+  FairMQParts parts;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -118,7 +118,7 @@ class DataProcessingDevice : public FairMQDevice
   // Processing functions are now renetrant
   static void doRun(DataProcessorContext& context);
   static void doPrepare(DataProcessorContext& context);
-  static void handleData(DataProcessorContext& context, FairMQParts&, InputChannelInfo&);
+  static void handleData(DataProcessorContext& context, InputChannelInfo&);
   static bool tryDispatchComputation(DataProcessorContext& context, std::vector<DataRelayer::RecordAction>& completed);
   std::vector<DataProcessorContext> mDataProcessorContexes;
 

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -92,15 +92,15 @@ class DataRelayer
   /// @a restSize is how many messages are there in restOfParts
   /// is the header which is common across all subsequent elements.
   /// Notice that we expect that the header is an O2 Header Stack
-  RelayChoice relay(std::unique_ptr<FairMQMessage>&& firstHeader,
+  RelayChoice relay(std::unique_ptr<FairMQMessage>& firstHeader,
                     std::unique_ptr<FairMQMessage>* restOfParts,
                     size_t restSize);
 
   /// This is used to ask for relaying a given (header,payload) pair.
   /// Notice that we expect that the header is an O2 Header Stack
   /// with a DataProcessingHeader inside so that we can assess time.
-  RelayChoice relay(std::unique_ptr<FairMQMessage>&& header,
-                    std::unique_ptr<FairMQMessage>&& payload);
+  RelayChoice relay(std::unique_ptr<FairMQMessage>& header,
+                    std::unique_ptr<FairMQMessage>& payload);
 
   /// @returns the actions ready to be performed.
   void getReadyToProcess(std::vector<RecordAction>& completed);

--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -122,7 +122,7 @@ class TimesliceIndex
   std::vector<bool> mDirty;
 
   /// What to do in case of backpressure
-  BackpressureOp mBackpressurePolicy = BackpressureOp::DropAncient;
+  BackpressureOp mBackpressurePolicy = BackpressureOp::Wait;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -597,8 +597,9 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
   // to be completed. In the case of data source devices, as they do not have
   // real data input channels, they have to signal EndOfStream themselves.
   context.allDone = std::any_of(context.deviceContext->state->inputChannelInfos.begin(), context.deviceContext->state->inputChannelInfos.end(), [](const auto& info) {
-    return info.state != InputChannelState::Pull;
+    return info.parts.fParts.empty() == true && info.state != InputChannelState::Pull;
   });
+
   // Whether or not all the channels are completed
   for (size_t ci = 0; ci < context.deviceContext->spec->inputChannels.size(); ++ci) {
     auto& channel = context.deviceContext->spec->inputChannels[ci];
@@ -608,6 +609,11 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
       context.allDone = false;
     }
     if (info.state != InputChannelState::Running) {
+      // Remember to flush data if we are not running
+      // and there is some message pending.
+      if (info.parts.Size()) {
+        DataProcessingDevice::handleData(context, info);
+      }
       continue;
     }
     int64_t result = -2;
@@ -622,7 +628,7 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
     if (info.hasPendingEvents == 0) {
       socket.Events(&info.hasPendingEvents);
       // If we do not read, we can continue.
-      if ((info.hasPendingEvents & 1) == 0) {
+      if ((info.hasPendingEvents & 1) == 0 && (info.parts.Size() == 0)) {
         continue;
       }
     }
@@ -634,11 +640,15 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
     // we get a message. In order not to overflow the DPL queue we process
     // one message at the time and we keep track of wether there were more
     // to process.
+    bool newMessages = false;
     while (true) {
-      FairMQParts parts;
-      result = info.channel->Receive(parts, 0);
+      int result = info.parts.Size();
+      if (result == 0) {
+        result = info.channel->Receive(info.parts, 0);
+        newMessages = true;
+      }
       if (result >= 0) {
-        DataProcessingDevice::handleData(context, parts, info);
+        DataProcessingDevice::handleData(context, info);
         // Receiving data counts as activity now, so that
         // We can make sure we process all the pending
         // messages without hanging on the uv_run.
@@ -651,7 +661,7 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
     // if more events are pending due to zeromq level triggered approach.
     socket.Events(&info.hasPendingEvents);
     if (info.hasPendingEvents) {
-      *context.wasActive |= true;
+      *context.wasActive |= newMessages;
     }
   }
 }
@@ -726,15 +736,23 @@ void DataProcessingDevice::ResetTask()
   mRelayer->clear();
 }
 
+struct WaitBackpressurePolicy {
+  void backpressure(InputChannelInfo const& info)
+  {
+    // FIXME: fill metrics rather than log.
+    LOGP(WARN, "Backpressure on channel {}. Waiting.", info.channel->GetName());
+  }
+};
+
 /// This is the inner loop of our framework. The actual implementation
 /// is divided in two parts. In the first one we define a set of lambdas
 /// which describe what is actually going to happen, hiding all the state
 /// boilerplate which the user does not need to care about at top level.
-void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts& parts, InputChannelInfo& info)
+void DataProcessingDevice::handleData(DataProcessorContext& context, InputChannelInfo& info)
 {
   ZoneScopedN("DataProcessingDevice::handleData");
   assert(context.deviceContext->spec->inputChannels.empty() == false);
-  assert(parts.Size() > 0);
+  assert(info.parts.Size() > 0);
 
   // Initial part. Let's hide all the unnecessary and have
   // simple lambdas for each of the steps I am planning to have.
@@ -751,7 +769,8 @@ void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts
   // than an input, because we do not want the outer loop actually be exposed
   // to the implementation details of the messaging layer.
   auto getInputTypes = [&stats = context.registry->get<DataProcessingStats>(),
-                        &parts, &info, &context]() -> std::optional<std::vector<InputType>> {
+                        &info, &context]() -> std::optional<std::vector<InputType>> {
+    auto& parts = info.parts;
     stats.inputParts = parts.Size();
 
     TracyPlot("messages received", (int64_t)parts.Size());
@@ -810,7 +829,9 @@ void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts
     registry.get<DataProcessingStats>().errorCount++;
   };
 
-  auto handleValidMessages = [&parts, &context = context, &relayer = *context.relayer, &reportError](std::vector<InputType> const& types) {
+  auto handleValidMessages = [&info, &context = context, &relayer = *context.relayer, &reportError](std::vector<InputType> const& types) {
+    static WaitBackpressurePolicy policy;
+    auto& parts = info.parts;
     // We relay execution to make sure we have a complete set of parts
     // available.
     for (size_t pi = 0; pi < (parts.Size() / 2); ++pi) {
@@ -820,28 +841,45 @@ void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts
           auto payloadIndex = 2 * pi + 1;
           assert(payloadIndex < parts.Size());
           auto dh = o2::header::get<DataHeader*>(parts.At(headerIndex)->GetData());
-          // If splitPayloadParts = 0, we assume that means there is only one (header, payload)
-          // pair.
-          auto relayed = relayer.relay(std::move(parts.At(headerIndex)),
+          auto relayed = relayer.relay(parts.At(headerIndex),
                                        &parts.At(payloadIndex), dh->splitPayloadParts > 0 ? dh->splitPayloadParts * 2 - 1 : 0);
           pi += dh->splitPayloadParts > 0 ? dh->splitPayloadParts - 1 : 0;
           switch (relayed) {
+            case DataRelayer::Backpressured:
+              policy.backpressure(info);
+              break;
+            case DataRelayer::Dropped:
+            case DataRelayer::Invalid:
             case DataRelayer::WillRelay:
               break;
-            case DataRelayer::Invalid:
-            case DataRelayer::Dropped:
-            case DataRelayer::Backpressured:
-              reportError("Unable to relay part");
           }
         } break;
         case InputType::SourceInfo: {
           *context.wasActive = true;
+          auto headerIndex = 2 * pi;
+          auto payloadIndex = 2 * pi + 1;
+          assert(payloadIndex < parts.Size());
+          auto dh = o2::header::get<DataHeader*>(parts.At(headerIndex)->GetData());
+          // FIXME: the message with the end of stream cannot contain
+          //        split parts.
+          parts.At(headerIndex).reset(nullptr);
+          parts.At(payloadIndex).reset(nullptr);
+          //for (size_t i = 0; i < dh->splitPayloadParts > 0 ? dh->splitPayloadParts * 2 - 1 : 1; ++i) {
+          //  parts.At(headerIndex + 1 + i).reset(nullptr);
+          //}
+          //pi += dh->splitPayloadParts > 0 ? dh->splitPayloadParts - 1 : 0;
 
         } break;
         case InputType::Invalid: {
           reportError("Invalid part found.");
         } break;
       }
+    }
+    auto it = std::remove_if(parts.fParts.begin(), parts.fParts.end(), [](auto& msg) -> bool { return msg.get() == nullptr; });
+    auto r = std::distance(it, parts.fParts.end());
+    parts.fParts.erase(it, parts.end());
+    if (parts.fParts.size()) {
+      LOG(DEBUG) << parts.fParts.size() << " messages backpressured";
     }
   };
 

--- a/Framework/Core/test/benchmark_DataRelayer.cxx
+++ b/Framework/Core/test/benchmark_DataRelayer.cxx
@@ -102,7 +102,7 @@ static void BM_RelaySingleSlot(benchmark::State& state)
     memcpy(header->GetData(), stack.data(), stack.size());
     //state.ResumeTiming();
 
-    relayer.relay(std::move(header), std::move(payload));
+    relayer.relay(header, payload);
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -155,7 +155,7 @@ static void BM_RelayMultipleSlots(benchmark::State& state)
     memcpy(header->GetData(), stack.data(), stack.size());
     //state.ResumeTiming();
 
-    relayer.relay(std::move(header), std::move(payload));
+    relayer.relay(header, payload);
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -223,13 +223,13 @@ static void BM_RelayMultipleRoutes(benchmark::State& state)
     memcpy(header2->GetData(), stack2.data(), stack2.size());
     //state.ResumeTiming();
 
-    relayer.relay(std::move(header1), std::move(payload1));
+    relayer.relay(header1, payload1);
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
     assert(ready[0].op == CompletionPolicy::CompletionOp::Consume);
 
-    relayer.relay(std::move(header2), std::move(payload2));
+    relayer.relay(header2, payload2);
     ready.clear();
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -291,7 +291,7 @@ static void BM_RelaySplitParts(benchmark::State& state)
     }
     state.ResumeTiming();
 
-    relayer.relay(std::move(splitParts[0]), &splitParts[1], splitParts.size() - 1);
+    relayer.relay(splitParts[0], &splitParts[1], splitParts.size() - 1);
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);

--- a/Framework/Core/test/test_TimesliceIndex.cxx
+++ b/Framework/Core/test/test_TimesliceIndex.cxx
@@ -79,21 +79,21 @@ BOOST_AUTO_TEST_CASE(TestLRUReplacement)
     context.put({0, uint64_t{40}});
     context.commit();
     auto [action, slot] = index.replaceLRUWith(context);
-    BOOST_CHECK_EQUAL(slot.index, 0);
-    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceObsolete);
+    BOOST_CHECK_EQUAL(slot.index, TimesliceSlot::INVALID);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::Wait);
   }
   {
     context.put({0, uint64_t{50}});
     context.commit();
     auto [action, slot] = index.replaceLRUWith(context);
-    BOOST_CHECK_EQUAL(slot.index, 1);
-    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceObsolete);
+    BOOST_CHECK_EQUAL(slot.index, TimesliceSlot::INVALID);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::Wait);
   }
   {
     context.put({0, uint64_t{10}});
     context.commit();
     auto [action, slot] = index.replaceLRUWith(context);
     BOOST_CHECK_EQUAL(slot.index, TimesliceSlot::INVALID);
-    BOOST_CHECK(action == TimesliceIndex::ActionTaken::DropObsolete);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::Wait);
   }
 }


### PR DESCRIPTION
In case a device is receiving data from multiple sources
we make sure we wait for the slow producers, rather than
dropping messages.