### PR TITLE
MCH: added configurable input spec for calibrator

### DIFF
--- a/Detectors/MUON/MCH/Calibration/src/MCHChannelCalibratorSpec.h
+++ b/Detectors/MUON/MCH/Calibration/src/MCHChannelCalibratorSpec.h
@@ -153,7 +153,7 @@ class MCHChannelCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getMCHChannelCalibDeviceSpec()
+DataProcessorSpec getMCHChannelCalibDeviceSpec(const std::string inputSpec)
 {
   constexpr int64_t INFINITE_TF = 0xffffffffffffffff;
   using device = o2::mch::calibration::MCHChannelCalibDevice;
@@ -164,12 +164,9 @@ DataProcessorSpec getMCHChannelCalibDeviceSpec()
   outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
   outputs.emplace_back(OutputSpec{"MCH", "PEDESTALS", 0, Lifetime::Timeframe});
 
-  std::vector<InputSpec> inputs;
-  inputs.emplace_back("input", "MCH", "PDIGITS");
-
   return DataProcessorSpec{
     "calib-mchchannel-calibration",
-    inputs,
+    select(inputSpec.data()),
     outputs,
     AlgorithmSpec{adaptFromTask<device>()},
     Options{

--- a/Detectors/MUON/MCH/Calibration/src/channel-calib-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/channel-calib-workflow.cxx
@@ -17,7 +17,7 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  //workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-spec", VariantType::String, "input:MCH/PDIGITS", {"selection string input specs"}});
 }
 
 // ------------------------------------------------------------------
@@ -26,8 +26,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
+  const std::string inputSpec = configcontext.options().get<std::string>("input-spec");
   WorkflowSpec specs;
-  //auto useCCDB = configcontext.options().get<bool>("use-ccdb");
-  specs.emplace_back(getMCHChannelCalibDeviceSpec());
+  specs.emplace_back(getMCHChannelCalibDeviceSpec(inputSpec));
   return specs;
 }

--- a/Detectors/MUON/MCH/Calibration/src/pedestals-decoding-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/pedestals-decoding-workflow.cxx
@@ -376,7 +376,7 @@ using namespace o2::framework;
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"dataspec", VariantType::String, "TF:MCH/RAWDATA", {"selection string for the input data"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-spec", VariantType::String, "TF:MCH/RAWDATA", {"selection string for the input data"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -404,7 +404,7 @@ o2::framework::DataProcessorSpec getPedestalsSpec(std::string inputSpec)
 
 WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
-  auto inputSpec = config.options().get<std::string>("dataspec");
+  auto inputSpec = config.options().get<std::string>("input-spec");
 
   WorkflowSpec specs;
 


### PR DESCRIPTION
This PR introduces an `--input-spec` command line option in the pedestal calibrator, to make the input data spec configurable from the command line. It also changes the input spec command line option of the pedestal decoder from`--dataspec` to `--input-spec` for the sake of consistency.