### PR TITLE
TPC: Use OpenMP parallel digit publishing

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -34,10 +34,19 @@ o2_add_library(TPCWorkflow
                                      O2::TPCCalibration O2::TPCSimulation
                                      O2::DetectorsCalibration)
 
+
 o2_add_executable(chunkeddigit-merger
         COMPONENT_NAME tpc
+        TARGETVARNAME mergertargetName
         SOURCES src/ChunkedDigitPublisher.cxx
         PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+if(OpenMP_CXX_FOUND)
+  # Must be private, depending libraries might be compiled by compiler not understanding -fopenmp
+  target_compile_definitions(${mergertargetName} PRIVATE WITH_OPENMP)
+  target_link_libraries(${mergertargetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
 
 o2_add_executable(reco-workflow
                   COMPONENT_NAME tpc


### PR DESCRIPTION
Introducing parallelism into digit publishing,
for the case when digits were written in chunked mode.

Using OpenMP for this. Some critial sections protect
access to DPL ProcessingContext as well as when writing
to the shared mem container. (Maybe this could be avoided
by some mechanism.)

This significantly improves the startup phase of
TPC reconstruction on the GRID.