### PR TITLE
MFT: bug fix in configurable tracker parameters

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -60,7 +60,7 @@ class Tracker : public TrackerConfig
   std::uint32_t getROFrame() const { return mROFrame; }
 
   void initialize();
-  void initConfig(const MFTTrackingParam& trkParam);
+  void initConfig(const MFTTrackingParam& trkParam, bool printConfig = false);
 
  private:
   void findTracks(ROframe&);

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -40,7 +40,7 @@ void Tracker::setBz(Float_t bz)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::initConfig(const MFTTrackingParam& trkParam)
+void Tracker::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
 
@@ -49,7 +49,9 @@ void Tracker::initConfig(const MFTTrackingParam& trkParam)
   mMinTrackStationsLTF = trkParam.MinTrackStationsLTF;
   mMinTrackStationsCA = trkParam.MinTrackStationsCA;
   mLTFclsRCut = trkParam.LTFclsRCut;
+  mLTFclsR2Cut = mLTFclsRCut * mLTFclsRCut;
   mROADclsRCut = trkParam.ROADclsRCut;
+  mROADclsR2Cut = mROADclsRCut * mROADclsRCut;
   mLTFseed2BinWin = trkParam.LTFseed2BinWin;
   mLTFinterBinWin = trkParam.LTFinterBinWin;
 
@@ -65,6 +67,20 @@ void Tracker::initConfig(const MFTTrackingParam& trkParam)
   }
   mRBinSize = (constants::index_table::RMax - constants::index_table::RMin) / mRBins;
   mPhiBinSize = (constants::index_table::PhiMax - constants::index_table::PhiMin) / mPhiBins;
+
+  if (printConfig) {
+    LOG(INFO) << "Configurable tracker parameters:";
+    LOG(INFO) << "MinTrackPointsLTF   = " << mMinTrackPointsLTF;
+    LOG(INFO) << "MinTrackPointsCA    = " << mMinTrackPointsCA;
+    LOG(INFO) << "MinTrackStationsLTF = " << mMinTrackStationsLTF;
+    LOG(INFO) << "MinTrackStationsCA  = " << mMinTrackStationsCA;
+    LOG(INFO) << "LTFclsRCut          = " << mLTFclsRCut;
+    LOG(INFO) << "ROADclsRCut         = " << mROADclsRCut;
+    LOG(INFO) << "RBins               = " << mRBins;
+    LOG(INFO) << "PhiBins             = " << mPhiBins;
+    LOG(INFO) << "LTFseed2BinWin      = " << mLTFseed2BinWin;
+    LOG(INFO) << "LTFinterBinWin      = " << mLTFinterBinWin;
+  }
 }
 
 //_________________________________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -64,7 +64,7 @@ void TrackerDPL::init(InitContext& ic)
     mTracker = std::make_unique<o2::mft::Tracker>(mUseMC);
     double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
     mTracker->setBz(field->getBz(centerMFT));
-    mTracker->initConfig(mftTrackingParam);
+    mTracker->initConfig(mftTrackingParam, true);
     mTracker->initialize();
   } else {
     throw std::runtime_error(o2::utils::concat_string("Cannot retrieve GRP from the ", filename));


### PR DESCRIPTION
Fixing a bug introduced after using configurable parameters for the tracker and optimizing the squared values; active only if the parameter was attempted to be configured in the command line.
Print (optionally) the tracker configurable parameters.