### PR TITLE
DPL: allow driver communicate with devices

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -51,6 +51,7 @@ o2_add_library(Framework
                        src/DeviceConfigInfo.cxx
                        src/DeviceMetricsInfo.cxx
                        src/DeviceSpec.cxx
+                       src/DeviceController.cxx
                        src/DeviceSpecHelpers.cxx
                        src/DPLMonitoringBackend.cxx
                        src/DriverControl.cxx

--- a/Framework/Core/include/Framework/DeviceControl.h
+++ b/Framework/Core/include/Framework/DeviceControl.h
@@ -7,17 +7,18 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_DEVICECONTROL_H
-#define FRAMEWORK_DEVICECONTROL_H
+#ifndef O2_FRAMEWORK_DEVICECONTROL_H_
+#define O2_FRAMEWORK_DEVICECONTROL_H_
+
+#include "Framework/LogParsingHelpers.h"
 
 #include <map>
 #include <string>
-#include "Framework/LogParsingHelpers.h"
 
-namespace o2
+namespace o2::framework
 {
-namespace framework
-{
+
+struct DeviceController;
 
 constexpr int MAX_USER_FILTER_SIZE = 256;
 
@@ -42,9 +43,10 @@ struct DeviceControl {
   char logStopTrigger[MAX_USER_FILTER_SIZE] = {0};
   /// Where the GUI should store the options it wants.
   std::map<std::string, std::string> options;
+  /// Handler used to communicate with the device (if available)
+  DeviceController* controller = nullptr;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_DEVICECONTROL_H
+#endif // O2_FRAMEWORK_DEVICECONTROL_H_

--- a/Framework/Core/include/Framework/DeviceController.h
+++ b/Framework/Core/include/Framework/DeviceController.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_DEVICECONTROLLER_H_
+#define O2_FRAMEWORK_DEVICECONTROLLER_H_
+
+namespace o2::framework
+{
+
+struct WSDPLHandler;
+
+struct DeviceController {
+  DeviceController(WSDPLHandler* handler);
+  void hello();
+
+  WSDPLHandler* mHandler;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DEVICECONTROLLER_H_

--- a/Framework/Core/src/DeviceController.cxx
+++ b/Framework/Core/src/DeviceController.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DeviceController.h"
+#include "DPLWebSocket.h"
+#include "HTTPParser.h"
+#include "Framework/Logger.h"
+#include <uv.h>
+#include <vector>
+
+namespace o2::framework
+{
+
+DeviceController::DeviceController(WSDPLHandler* handler)
+  : mHandler{handler}
+{
+}
+
+void DeviceController::hello()
+{
+  LOG(INFO) << "Saying hello";
+  std::vector<uv_buf_t> outputs;
+  encode_websocket_frames(outputs, "hello", strlen("hello"), WebSocketOpCode::Binary, 0);
+  mHandler->write(outputs);
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DriverServerContext.h
+++ b/Framework/Core/src/DriverServerContext.h
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+/// Helper struct which holds all the lists the Driver needs to know about.
+#ifndef O2_FRAMEWORK_DRIVERSERVERCONTEXT_H_
+#define O2_FRAMEWORK_DRIVERSERVERCONTEXT_H_
+
+#include "Framework/DeviceInfo.h"
+#include "Framework/DeviceControl.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DeviceMetricsInfo.h"
+#include "Framework/ServiceSpec.h"
+
+#include <uv.h>
+#include <vector>
+
+namespace o2::framework
+{
+struct DriverInfo;
+struct ServiceRegistry;
+
+struct DriverServerContext {
+  uv_loop_t* loop;
+  ServiceRegistry* registry = nullptr;
+  std::vector<DeviceControl>* controls = nullptr;
+  std::vector<DeviceInfo>* infos = nullptr;
+  std::vector<DeviceSpec>* specs = nullptr;
+  std::vector<DeviceMetricsInfo>* metrics = nullptr;
+  std::vector<ServiceMetricHandling>* metricProcessingCallbacks;
+  DriverInfo* driver;
+};
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DRIVERSERVERCONTEXT_H_

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -17,6 +17,7 @@
 #include "Framework/DeviceMetricsInfo.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/Logger.h"
+#include "Framework/DeviceController.h"
 
 #include "DebugGUI/imgui.h"
 #include <csignal>
@@ -243,6 +244,11 @@ void displayDeviceInspector(DeviceSpec const& spec,
     (void)retVal;
   }
 #endif
+  if (control.controller) {
+    if (ImGui::Button("Say hello")) {
+      control.controller->hello();
+    }
+  }
 
   deviceInfoTable(info, metrics);
   for (auto& option : info.currentConfig) {


### PR DESCRIPTION
This makes sure that when we are using the WS driver we can
communicate with devices and have them act on our commands.