### PR TITLE
DPL: add constructor for origin only InputSpec

### DIFF
--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -51,6 +51,11 @@ struct InputSpec {
             ConcreteDataTypeMatcher const& dataType,
             enum Lifetime lifetime_ = Lifetime::Timeframe,
             std::vector<ConfigParamSpec> const& metadata_ = {});
+  /// Create an InputSpec which does not check for the description and the subSpec.
+  InputSpec(std::string binding_,
+            header::DataOrigin const& dataType,
+            enum Lifetime lifetime_ = Lifetime::Timeframe,
+            std::vector<ConfigParamSpec> const& metadata_ = {});
   InputSpec(std::string binding,
             data_matcher::DataDescriptorMatcher&& matcher,
             std::vector<ConfigParamSpec> const& metadata_ = {});

--- a/Framework/Core/src/InputSpec.cxx
+++ b/Framework/Core/src/InputSpec.cxx
@@ -56,6 +56,17 @@ InputSpec::InputSpec(std::string binding_,
 }
 
 InputSpec::InputSpec(std::string binding_,
+                     header::DataOrigin const& origin_,
+                     enum Lifetime lifetime_,
+                     std::vector<ConfigParamSpec> const& metadata_)
+  : binding{binding_},
+    matcher{DataSpecUtils::dataDescriptorMatcherFrom(origin_)},
+    lifetime{lifetime_},
+    metadata{metadata_}
+{
+}
+
+InputSpec::InputSpec(std::string binding_,
                      ConcreteDataTypeMatcher const& dataType,
                      enum Lifetime lifetime_,
                      std::vector<ConfigParamSpec> const& metadata_)

--- a/Framework/Core/test/test_InputSpec.cxx
+++ b/Framework/Core/test/test_InputSpec.cxx
@@ -14,6 +14,7 @@
 
 #include "Framework/InputSpec.h"
 #include "Framework/DataSpecUtils.h"
+#include "Headers/DataHeader.h"
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <vector>
@@ -27,6 +28,22 @@ BOOST_AUTO_TEST_CASE(TestSorting)
   std::vector<InputSpec> inputs{
     InputSpec{"foo", {"TST", "B"}},
     InputSpec{"bar", {"TST", "A"}}};
+  std::swap(inputs[0], inputs[1]);
+  auto sorter = [](InputSpec const& a, InputSpec const& b) {
+    return a.binding < b.binding;
+  };
+  std::stable_sort(inputs.begin(), inputs.end(), sorter);
+}
+
+BOOST_AUTO_TEST_CASE(TestCreation)
+{
+  // At some point
+  std::vector<InputSpec> inputs{
+    InputSpec{"everything", "TST", "B", 0},
+    InputSpec{"0-subspec", "TST", "B"},
+    InputSpec{"wildcard-subspec", {"TST", "A"}},
+    InputSpec{"wildcard-desc-and-subspec", o2::header::DataOrigin{"TST"}},
+    InputSpec{"everything-again", {"TST", "B", 0}}};
   std::swap(inputs[0], inputs[1]);
   auto sorter = [](InputSpec const& a, InputSpec const& b) {
     return a.binding < b.binding;


### PR DESCRIPTION
Descriptiona and SubSpec are left as wildcards