### PR TITLE
TRD tracker can use transformer/calibrated tracklets as input directly

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
@@ -21,7 +21,7 @@ namespace trd
 // The CalibratedTracklet has been calibrated in x and dy according to a calculated Lorentz Angle and Drift Velocity.
 // Tracklet positions in local z direction are reported at the center of the pad-row.
 // Pad-tilting correction is performed after tracking.
-class CalibratedTracklet : public Tracklet64
+class CalibratedTracklet : public Tracklet64 // OS: why do we inherit from Tracklet64? Should this not be an independent, transient data type?
 {
  public:
   CalibratedTracklet() = default;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
@@ -11,8 +11,6 @@
 #ifndef O2_TRD_CALIBRATEDTRACKLET_H
 #define O2_TRD_CALIBRATEDTRACKLET_H
 
-#include "DataFormatsTRD/Tracklet64.h"
-
 namespace o2
 {
 namespace trd
@@ -21,12 +19,12 @@ namespace trd
 // The CalibratedTracklet has been calibrated in x and dy according to a calculated Lorentz Angle and Drift Velocity.
 // Tracklet positions in local z direction are reported at the center of the pad-row.
 // Pad-tilting correction is performed after tracking.
-class CalibratedTracklet : public Tracklet64 // OS: why do we inherit from Tracklet64? Should this not be an independent, transient data type?
+class CalibratedTracklet
 {
  public:
   CalibratedTracklet() = default;
-  CalibratedTracklet(uint64_t trackletWord, float x, float y, float z, float dy)
-    : Tracklet64(trackletWord), mx(x), my(y), mz(z), mdy(dy){};
+  CalibratedTracklet(float x, float y, float z, float dy)
+    : mx(x), my(y), mz(z), mdy(dy){};
   ~CalibratedTracklet() = default;
 
   float getX() const { return mx; }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalibratedTracklet.h
@@ -29,10 +29,10 @@ class CalibratedTracklet : public Tracklet64
     : Tracklet64(trackletWord), mx(x), my(y), mz(z), mdy(dy){};
   ~CalibratedTracklet() = default;
 
-  float getX() { return mx; }
-  float getY() { return my; }
-  float getZ() { return mz; }
-  float getDy() { return mdy; }
+  float getX() const { return mx; }
+  float getY() const { return my; }
+  float getZ() const { return mz; }
+  float getDy() const { return mdy; }
 
   void setX(float x) { mx = x; }
   void setY(float y) { my = y; }

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -141,7 +141,6 @@ std::array<float, 3> TrackletTransformer::transformL2T(int hcid, std::array<doub
 
 CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
 {
-  uint64_t trackletWord = tracklet.getTrackletWord();
   uint64_t hcid = tracklet.getHCID();
   uint64_t padrow = tracklet.getPadRow();
   uint64_t column = tracklet.getColumn();
@@ -164,7 +163,5 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
              << "y: " << sectorSpacePoint[1] << " | "
              << "z: " << sectorSpacePoint[2];
 
-  CalibratedTracklet calibratedTracklet = CalibratedTracklet(trackletWord, sectorSpacePoint[0], sectorSpacePoint[1], sectorSpacePoint[2], dy);
-
-  return calibratedTracklet;
+  return CalibratedTracklet(sectorSpacePoint[0], sectorSpacePoint[1], sectorSpacePoint[2], dy);
 }

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -28,7 +28,7 @@ namespace trd
 class TRDGlobalTracking : public o2::framework::Task
 {
  public:
-  TRDGlobalTracking(bool useMC) : mUseMC(useMC) {}
+  TRDGlobalTracking(bool useMC, bool useTrkltTransf) : mUseMC(useMC), mUseTrackletTransform(useTrkltTransf) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
@@ -40,11 +40,12 @@ class TRDGlobalTracking : public o2::framework::Task
   o2::gpu::GPUChainTracking* mChainTracking{nullptr}; ///< TRD tracker is run in the tracking chain
   std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
+  bool mUseTrackletTransform{false};                  ///< if true, output from TrackletTransformer is used instead of uncalibrated Tracklet64 directly
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC);
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, bool useTrkltTransf);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace trd
 {
 
-framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut);
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrackletTransformer);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletReaderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletReaderSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/CalibratedTracklet.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
@@ -30,18 +31,23 @@ namespace trd
 class TRDTrackletReader : public o2::framework::Task
 {
  public:
-  TRDTrackletReader(bool useMC) : mUseMC(useMC) {}
+  TRDTrackletReader(bool useMC, bool useTrkltTransf) : mUseMC(useMC), mUseTrackletTransform(useTrkltTransf) {}
   ~TRDTrackletReader() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
 
  private:
-  void connectTree(const std::string& filename);
+  void connectTree();
+  void connectTreeCTracklet();
   bool mUseMC{false};
-  std::unique_ptr<TFile> mFile;
-  std::unique_ptr<TTree> mTree;
-  std::string mInFileName{"trdtracklets.root"};
-  std::string mInTreeName{"o2sim"};
+  bool mUseTrackletTransform{false};
+  std::unique_ptr<TFile> mFileTrklt;
+  std::unique_ptr<TTree> mTreeTrklt;
+  std::unique_ptr<TFile> mFileCTrklt;
+  std::unique_ptr<TTree> mTreeCTrklt;
+  std::string mInFileNameTrklt{"trdtracklets.root"};
+  std::string mInTreeNameTrklt{"o2sim"};
+  std::vector<o2::trd::CalibratedTracklet> mTrackletsCal, *mTrackletsCalPtr = &mTrackletsCal;
   std::vector<o2::trd::Tracklet64> mTracklets, *mTrackletsPtr = &mTracklets;
   std::vector<o2::trd::TriggerRecord> mTriggerRecords, *mTriggerRecordsPtr = &mTriggerRecords;
   std::vector<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
@@ -49,7 +55,7 @@ class TRDTrackletReader : public o2::framework::Task
 
 /// create a processor spec
 /// read TRD tracklets from a root file
-framework::DataProcessorSpec getTRDTrackletReaderSpec(bool useMC);
+framework::DataProcessorSpec getTRDTrackletReaderSpec(bool useMC, bool useCalibratedTracklets);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
@@ -23,16 +23,16 @@ namespace o2
 namespace trd
 {
 
-framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut)
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrkltTransf)
 {
   framework::WorkflowSpec specs;
   bool useMC = false;
   if (!disableRootInp) {
     specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
-    specs.emplace_back(o2::trd::getTRDTrackletReaderSpec(useMC));
+    specs.emplace_back(o2::trd::getTRDTrackletReaderSpec(useMC, useTrkltTransf));
   }
 
-  specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC));
+  specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC, useTrkltTransf));
 
   if (!disableRootOut) {
     specs.emplace_back(o2::trd::getTRDTrackWriterSpec(useMC));

--- a/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletReaderSpec.cxx
@@ -28,49 +28,72 @@ void TRDTrackletReader::init(InitContext& ic)
 {
   // get the option from the init context
   LOG(INFO) << "Init TRD tracklet reader!";
-  mInFileName = ic.options().get<std::string>("trd-tracklet-infile");
-  mInTreeName = ic.options().get<std::string>("treename");
-  connectTree(mInFileName);
+  mInFileNameTrklt = ic.options().get<std::string>("trd-tracklet-infile");
+  mInTreeNameTrklt = ic.options().get<std::string>("treename");
+  connectTree();
+  if (mUseTrackletTransform) {
+    connectTreeCTracklet();
+  }
 }
 
-void TRDTrackletReader::connectTree(const std::string& filename)
+void TRDTrackletReader::connectTreeCTracklet()
 {
-  mTree.reset(nullptr); // in case it was already loaded
-  mFile.reset(TFile::Open(filename.c_str()));
-  assert(mFile && !mFile->IsZombie());
-  mTree.reset((TTree*)mFile->Get(mInTreeName.c_str()));
-  assert(mTree);
-  mTree->SetBranchAddress("Tracklet", &mTrackletsPtr);
-  mTree->SetBranchAddress("TrackTrg", &mTriggerRecordsPtr);
+  mTreeCTrklt.reset(nullptr); // in case it was already loaded
+  mFileCTrklt.reset(TFile::Open("trdcalibratedtracklets.root"));
+  assert(mFileCTrklt && !mFileCTrklt->IsZombie());
+  mTreeCTrklt.reset((TTree*)mFileCTrklt->Get("ctracklets"));
+  assert(mTreeCTrklt);
+  mTreeCTrklt->SetBranchAddress("CTracklets", &mTrackletsCalPtr);
+  LOG(INFO) << "Loaded tree from trdcalibratedtracklets.root with " << mTreeCTrklt->GetEntries() << " entries";
+}
+
+void TRDTrackletReader::connectTree()
+{
+  mTreeTrklt.reset(nullptr); // in case it was already loaded
+  mFileTrklt.reset(TFile::Open(mInFileNameTrklt.c_str()));
+  assert(mFileTrklt && !mFileTrklt->IsZombie());
+  mTreeTrklt.reset((TTree*)mFileTrklt->Get(mInTreeNameTrklt.c_str()));
+  assert(mTreeTrklt);
+  mTreeTrklt->SetBranchAddress("Tracklet", &mTrackletsPtr);
+  mTreeTrklt->SetBranchAddress("TrackTrg", &mTriggerRecordsPtr);
   if (mUseMC) {
     LOG(FATAL) << "MC information not yet included for TRD tracklets";
   }
-  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+  LOG(INFO) << "Loaded tree from " << mInFileNameTrklt << " with " << mTreeTrklt->GetEntries() << " entries";
 }
 
 void TRDTrackletReader::run(ProcessingContext& pc)
 {
-  auto currEntry = mTree->GetReadEntry() + 1;
-  assert(currEntry < mTree->GetEntries()); // this should not happen
-  mTree->GetEntry(currEntry);
+  auto currEntry = mTreeTrklt->GetReadEntry() + 1;
+  assert(currEntry < mTreeTrklt->GetEntries()); // this should not happen
+  mTreeTrklt->GetEntry(currEntry);
   LOG(INFO) << "Pushing " << mTriggerRecords.size() << " TRD trigger records at entry " << currEntry;
-  LOG(INFO) << "Pushing " << mTracklets.size() << " TRD tracklets for these trigger records";
-
+  LOG(INFO) << "Pushing " << mTracklets.size() << " uncalibrated TRD tracklets for these trigger records";
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe}, mTracklets);
+  if (mUseTrackletTransform) {
+    assert(mTreeTrklt->GetEntries() == mTreeCTrklt->GetEntries());
+    mTreeCTrklt->GetEntry(currEntry);
+    LOG(INFO) << "Pushing " << mTrackletsCal.size() << " calibrated TRD tracklets for these trigger records";
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "CTRACKLETS", 0, Lifetime::Timeframe}, mTrackletsCal);
+  }
+
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe}, mTriggerRecords);
   if (mUseMC) {
     LOG(FATAL) << "MC information not yet included for TRD tracklets";
   }
 
-  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+  if (mTreeTrklt->GetReadEntry() + 1 >= mTreeTrklt->GetEntries()) {
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
 }
 
-DataProcessorSpec getTRDTrackletReaderSpec(bool useMC)
+DataProcessorSpec getTRDTrackletReaderSpec(bool useMC, bool useCalibratedTracklets)
 {
   std::vector<OutputSpec> outputs;
+  if (useCalibratedTracklets) {
+    outputs.emplace_back(o2::header::gDataOriginTRD, "CTRACKLETS", 0, Lifetime::Timeframe);
+  }
   outputs.emplace_back(o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back(o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
   if (useMC) {
@@ -81,7 +104,7 @@ DataProcessorSpec getTRDTrackletReaderSpec(bool useMC)
     "TRDTrackletReader",
     Inputs{},
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDTrackletReader>(useMC)},
+    AlgorithmSpec{adaptFromTask<TRDTrackletReader>(useMC, useCalibratedTracklets)},
     Options{
       {"trd-tracklet-infile", VariantType::String, "trdtracklets.root", {"Name of the input file"}},
       {"treename", VariantType::String, "o2sim", {"Name of top-level TTree"}},

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -48,8 +48,7 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
   LOG(info) << tracklets.size() << " tracklets found!";
 
   for (const auto& tracklet : tracklets) {
-    CalibratedTracklet calibratedTracklet = mTransformer.transformTracklet(tracklet);
-    calibratedTracklets.push_back(calibratedTracklet);
+    calibratedTracklets.push_back(mTransformer.transformTracklet(tracklet));
   }
 
   pc.outputs().snapshot(Output{"TRD", "CTRACKLETS", 0, Lifetime::Timeframe}, calibratedTracklets);

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -35,7 +35,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   WorkflowSpec spec;
 
   if (rootIn) {
-    spec.emplace_back(o2::trd::getTRDTrackletReaderSpec(0));
+    spec.emplace_back(o2::trd::getTRDTrackletReaderSpec(false, false));
   }
 
   spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec());

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -20,6 +20,8 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}});
+  workflowOptions.push_back(ConfigParamSpec{"use-tracklet-transformer", VariantType::Bool, false, {"Use calibrated tracklets instead raw Tracklet64"}});
   workflowOptions.push_back(ConfigParamSpec{
     "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
   workflowOptions.push_back(ConfigParamSpec{
@@ -40,5 +42,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::writeINI("o2trdtracking-workflow_configuration.ini");
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
-  return std::move(o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut));
+  auto useTrackletTransformer = configcontext.options().get<bool>("use-tracklet-transformer");
+  return std::move(o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut, useTrackletTransformer));
 }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -86,6 +86,7 @@ void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracklets(void* base)
   // (size might change for different events)
   //--------------------------------------------------------------------
   computePointerWithAlignment(base, mTracklets, mNMaxSpacePoints * mNMaxCollisions);
+  computePointerWithAlignment(base, mTrackletIndices, mNMaxSpacePoints * mNMaxCollisions);
   computePointerWithAlignment(base, mSpacePoints, mNMaxSpacePoints * mNMaxCollisions);
   computePointerWithAlignment(base, mTrackletLabels, 3 * mNMaxSpacePoints * mNMaxCollisions);
   return base;
@@ -102,7 +103,7 @@ void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracks(void* base)
 }
 
 template <class TRDTRK, class PROP>
-GPUTRDTracker_t<TRDTRK, PROP>::GPUTRDTracker_t() : mR(nullptr), mIsInitialized(false), mProcessPerTimeFrame(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxCollisions(1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNCollisions(1), mNTracks(0), mNEvents(0), mTriggerRecordIndices(nullptr), mTriggerRecordTimes(nullptr), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mRPhiA2(0), mRPhiB(0), mRPhiC2(0), mDyA2(0), mDyB(0), mDyC2(0), mAngleToDyA(0), mAngleToDyB(0), mAngleToDyC(0), mDebugOutput(false), mTimeWindow(.1f), mRadialOffset(-0.1), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug<TRDTRK>())
+GPUTRDTracker_t<TRDTRK, PROP>::GPUTRDTracker_t() : mR(nullptr), mIsInitialized(false), mTrkltTransfNeeded(true), mProcessPerTimeFrame(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxCollisions(1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNCollisions(1), mNTracks(0), mNEvents(0), mTriggerRecordIndices(nullptr), mTriggerRecordTimes(nullptr), mTracklets(nullptr), mTrackletIndices(nullptr), mMaxThreads(100), mNTracklets(0), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mRPhiA2(0), mRPhiB(0), mRPhiC2(0), mDyA2(0), mDyB(0), mDyC2(0), mAngleToDyA(0), mAngleToDyB(0), mAngleToDyC(0), mDebugOutput(false), mTimeWindow(.1f), mRadialOffset(-0.1), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug<TRDTRK>())
 {
   //--------------------------------------------------------------------
   // Default constructor
@@ -204,24 +205,32 @@ void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking(GPUChainTracking* chainTracking)
   // Steering function for the tracking
   //--------------------------------------------------------------------
 
+  for (int i = 0; i < mNTracklets; ++i) {
+    // fill index array (is there something like std::iota() for GPUs?)
+    mTrackletIndices[i] = i;
+  }
   // sort tracklets and fill index array
   for (int iColl = 0; iColl < mNCollisions; ++iColl) {
     int nTrklts = 0;
+    int idxOffset = 0;
     if (mProcessPerTimeFrame) {
+      idxOffset = mTriggerRecordIndices[iColl];
       nTrklts = (iColl < mNCollisions - 1) ? mTriggerRecordIndices[iColl + 1] - mTriggerRecordIndices[iColl] : mNTracklets - mTriggerRecordIndices[iColl];
     } else {
       nTrklts = mNTracklets;
     }
-    GPUTRDTrackletWord* tracklets = (mProcessPerTimeFrame) ? &(mTracklets[mTriggerRecordIndices[iColl]]) : mTracklets;
-    CAAlgo::sort(tracklets, tracklets + nTrklts); // tracklets are sorted by HCId
+    GPUTRDTrackletWord* tracklets = &(mTracklets[idxOffset]);
+    int* trkltIndices = &(mTrackletIndices[idxOffset]);
+    // TODO after the tracklet output of the TRAP simulator in O2 is sorted by HCId this sorting step is not needed anymore for O2
+    CAAlgo::sort(trkltIndices, trkltIndices + nTrklts, [=, &tracklets](int a, int b) { return tracklets[a - idxOffset].GetHCId() < tracklets[b - idxOffset].GetHCId(); });
     int* trkltIndexArray = &mTrackletIndexArray[iColl * (kNChambers + 1) + 1];
     trkltIndexArray[-1] = 0;
     int currDet = 0;
     int nextDet = 0;
     int trkltCounter = 0;
     for (int iTrklt = 0; iTrklt < nTrklts; ++iTrklt) {
-      if (tracklets[iTrklt].GetDetector() > currDet) {
-        nextDet = tracklets[iTrklt].GetDetector();
+      if (tracklets[trkltIndices[iTrklt] - idxOffset].GetDetector() > currDet) {
+        nextDet = tracklets[trkltIndices[iTrklt] - idxOffset].GetDetector();
         for (int iDet = currDet; iDet < nextDet; ++iDet) {
           trkltIndexArray[iDet] = trkltCounter;
         }
@@ -232,10 +241,11 @@ void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking(GPUChainTracking* chainTracking)
     for (int iDet = currDet; iDet <= kNChambers; ++iDet) {
       trkltIndexArray[iDet] = trkltCounter;
     }
-
-    if (!CalculateSpacePoints(iColl)) {
-      GPUError("Space points for at least one chamber could not be calculated (for interaction %i)", iColl);
-      break;
+    if (mTrkltTransfNeeded) {
+      if (!CalculateSpacePoints(iColl)) {
+        GPUError("Space points for at least one chamber could not be calculated (for interaction %i)", iColl);
+        break;
+      }
     }
   }
 
@@ -323,7 +333,7 @@ void GPUTRDTracker_t<TRDTRK, PROP>::CountMatches(const int trackID, std::vector<
     for (int trkltIdx = mTrackletIndexArray[k]; trkltIdx < mTrackletIndexArray[k + 1]; trkltIdx++) {
       bool trkltStored = false;
       for (int il = 0; il < 3; il++) {
-        int lb = mSpacePoints[trkltIdx].mLabel[il];
+        int lb = mTrackletLabels[3 * trkltIdx + il];
         if (lb < 0) {
           // no more valid labels
           break;
@@ -549,11 +559,13 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CalculateSpacePoints(int iCollision)
   //--------------------------------------------------------------------
 
   bool result = true;
-  int idxOffset = iCollision * (kNChambers + 1);
+  int idxOffset = iCollision * (kNChambers + 1); // offset for accessing mTrackletIndexArray for collision iCollision
 
   for (int iDet = 0; iDet < kNChambers; ++iDet) {
-    int nTracklets = mTrackletIndexArray[idxOffset + iDet + 1] - mTrackletIndexArray[idxOffset + iDet];
-    if (nTracklets == 0) {
+    int iFirstTrackletInDet = mTrackletIndexArray[idxOffset + iDet];
+    int iFirstTrackletInNextDet = mTrackletIndexArray[idxOffset + iDet + 1];
+    int nTrackletsInDet = iFirstTrackletInNextDet - iFirstTrackletInDet;
+    if (nTrackletsInDet == 0) {
       continue;
     }
     if (!mGeo->ChamberInGeometry(iDet)) {
@@ -567,38 +579,28 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CalculateSpacePoints(int iCollision)
       continue;
     }
     const GPUTRDpadPlane* pp = mGeo->GetPadPlane(iDet);
-    float tilt = CAMath::Tan(M_PI / 180.f * pp->GetTiltingAngle());
-    float t2 = tilt * tilt;      // tan^2 (tilt)
-    float c2 = 1.f / (1.f + t2); // cos^2 (tilt)
-    float sy2 = 0.1f * 0.1f;     // sigma_rphi^2, currently assume sigma_rphi = 1 mm
 
-    int trkltIdxOffset = mTriggerRecordIndices[iCollision];
-    for (int trkltIdx = trkltIdxOffset + mTrackletIndexArray[idxOffset + iDet]; trkltIdx < trkltIdxOffset + mTrackletIndexArray[idxOffset + iDet + 1]; ++trkltIdx) {
-      int trkltZbin = mTracklets[trkltIdx].GetZbin();
-      float sz2 = pp->GetRowSize(trkltZbin) * pp->GetRowSize(trkltZbin) / 12.f; // sigma_z = l_pad/sqrt(12) TODO try a larger z error
+    int trkltIdxOffset = (mProcessPerTimeFrame) ? mTriggerRecordIndices[iCollision] : 0; // global index of first tracklet (not yet sorted by HCId) in iCollision
+    int trkltIdxStart = trkltIdxOffset + iFirstTrackletInDet;
+    for (int trkltIdx = trkltIdxStart; trkltIdx < trkltIdxStart + nTrackletsInDet; ++trkltIdx) {
+      int trkltIdxGlb = mTrackletIndices[trkltIdx]; // sorted by HCId
+      int trkltZbin = mTracklets[trkltIdxGlb].GetZbin();
       My_Float xTrkltDet[3] = {0.f};                                            // trklt position in chamber coordinates
       My_Float xTrkltSec[3] = {0.f};                                            // trklt position in sector coordinates
       xTrkltDet[0] = mGeo->AnodePos() + mRadialOffset;
-      xTrkltDet[1] = mTracklets[trkltIdx].GetY();
+      xTrkltDet[1] = mTracklets[trkltIdxGlb].GetY();
       xTrkltDet[2] = pp->GetRowPos(trkltZbin) - pp->GetRowSize(trkltZbin) / 2.f - pp->GetRowPos(pp->GetNrows() / 2);
-      //GPUInfo("Space point local %i: x=%f, y=%f, z=%f", trkltIdx, xTrkltDet[0], xTrkltDet[1], xTrkltDet[2]);
+      //GPUInfo("Space point local %i: x=%f, y=%f, z=%f", trkltIdxGlb, xTrkltDet[0], xTrkltDet[1], xTrkltDet[2]);
       matrix->LocalToMaster(xTrkltDet, xTrkltSec);
-      mSpacePoints[trkltIdx].mR = xTrkltSec[0];
-      mSpacePoints[trkltIdx].mX[0] = xTrkltSec[1];
-      mSpacePoints[trkltIdx].mX[1] = xTrkltSec[2];
-      mSpacePoints[trkltIdx].mId = mTracklets[trkltIdx].GetId();
-      for (int i = 0; i < 3; i++) {
-        mSpacePoints[trkltIdx].mLabel[i] = mTrackletLabels[3 * mTracklets[trkltIdx].GetId() + i];
-      }
-      mSpacePoints[trkltIdx].mCov[0] = c2 * (sy2 + t2 * sz2);
-      mSpacePoints[trkltIdx].mCov[1] = c2 * tilt * (sz2 - sy2);
-      mSpacePoints[trkltIdx].mCov[2] = c2 * (t2 * sy2 + sz2);
-      mSpacePoints[trkltIdx].mDy = 0.014f * mTracklets[trkltIdx].GetdY();
+      mSpacePoints[trkltIdxGlb].mR = xTrkltSec[0];
+      mSpacePoints[trkltIdxGlb].mX[0] = xTrkltSec[1];
+      mSpacePoints[trkltIdxGlb].mX[1] = xTrkltSec[2];
+      mSpacePoints[trkltIdxGlb].mDy = 0.014f * mTracklets[trkltIdxGlb].GetdY();
 
       int modId = mGeo->GetSector(iDet) * GPUTRDGeometry::kNstack + mGeo->GetStack(iDet); // global TRD stack number
       unsigned short volId = mGeo->GetGeomManagerVolUID(iDet, modId);
-      mSpacePoints[trkltIdx].mVolumeId = volId;
-      //GPUInfo("Space point global %i: x=%f, y=%f, z=%f", trkltIdx, mSpacePoints[trkltIdx].mR, mSpacePoints[trkltIdx].mX[0], mSpacePoints[trkltIdx].mX[1]);
+      mSpacePoints[trkltIdxGlb].mVolumeId = volId;
+      //GPUInfo("Space point global %i: x=%f, y=%f, z=%f", trkltIdxGlb, mSpacePoints[trkltIdxGlb].mR, mSpacePoints[trkltIdxGlb].mX[0], mSpacePoints[trkltIdxGlb].mX[1]);
     }
   }
   return result;
@@ -638,8 +640,8 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
 
   int candidateIdxOffset = threadId * 2 * mNCandidates;
   int hypothesisIdxOffset = threadId * mNCandidates;
-  int trkltIdxOffset = collisionId * (kNChambers + 1);
-  int glbTrkltIdxOffset = mTriggerRecordIndices[collisionId];
+  int trkltIdxOffset = collisionId * (kNChambers + 1);                                     // offset for accessing mTrackletIndexArray for given collision
+  int glbTrkltIdxOffset = (mProcessPerTimeFrame) ? mTriggerRecordIndices[collisionId] : 0; // offset of first tracklet in given collision in global tracklet array
 
   auto trkWork = t;
   if (mNCandidates > 1) {
@@ -752,33 +754,34 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         }
         // first propagate track to x of tracklet
         for (int trkltIdx = glbTrkltIdxOffset + mTrackletIndexArray[trkltIdxOffset + currDet]; trkltIdx < glbTrkltIdxOffset + mTrackletIndexArray[trkltIdxOffset + currDet + 1]; ++trkltIdx) {
-          if (CAMath::Abs(trkWork->getY() - mSpacePoints[trkltIdx].mX[0]) > roadY || CAMath::Abs(trkWork->getZ() - mSpacePoints[trkltIdx].mX[1]) > roadZ) {
+          int trkltIdxGlb = mTrackletIndices[trkltIdx];
+          if (CAMath::Abs(trkWork->getY() - mSpacePoints[trkltIdxGlb].mX[0]) > roadY || CAMath::Abs(trkWork->getZ() - mSpacePoints[trkltIdxGlb].mX[1]) > roadZ) {
             // skip tracklets which are too far away
             // although the radii of space points and tracks may differ by ~ few mm the roads are large enough to allow no efficiency loss by this cut
             continue;
           }
           float projY, projZ;
-          prop->getPropagatedYZ(mSpacePoints[trkltIdx].mR, projY, projZ);
+          prop->getPropagatedYZ(mSpacePoints[trkltIdxGlb].mR, projY, projZ);
           // correction for tilted pads (only applied if deltaZ < l_pad && track z err << l_pad)
-          float tiltCorr = tilt * (mSpacePoints[trkltIdx].mX[1] - projZ);
-          float l_pad = pad->GetRowSize(mTracklets[trkltIdx].GetZbin());
-          if (!((CAMath::Abs(mSpacePoints[trkltIdx].mX[1] - projZ) < l_pad) && (trkWork->getSigmaZ2() < (l_pad * l_pad / 12.f)))) {
+          float tiltCorr = tilt * (mSpacePoints[trkltIdxGlb].mX[1] - projZ);
+          float l_pad = pad->GetRowSize(mTracklets[trkltIdxGlb].GetZbin());
+          if (!((CAMath::Abs(mSpacePoints[trkltIdxGlb].mX[1] - projZ) < l_pad) && (trkWork->getSigmaZ2() < (l_pad * l_pad / 12.f)))) {
             tiltCorr = 0.f;
           }
           // correction for mean z position of tracklet (is not the center of the pad if track eta != 0)
-          float zPosCorr = mSpacePoints[trkltIdx].mX[1] + mZCorrCoefNRC * trkWork->getTgl();
-          float yPosCorr = mSpacePoints[trkltIdx].mX[0] - tiltCorr;
+          float zPosCorr = mSpacePoints[trkltIdxGlb].mX[1] + mZCorrCoefNRC * trkWork->getTgl();
+          float yPosCorr = mSpacePoints[trkltIdxGlb].mX[0] - tiltCorr;
           float deltaY = yPosCorr - projY;
           float deltaZ = zPosCorr - projZ;
           My_Float trkltPosTmpYZ[2] = {yPosCorr, zPosCorr};
           My_Float trkltCovTmp[3] = {0.f};
           if ((CAMath::Abs(deltaY) < roadY) && (CAMath::Abs(deltaZ) < roadZ)) { // TODO: check if this is still necessary after the cut before propagation of track
             // tracklet is in windwow: get predicted chi2 for update and store tracklet index if best guess
-            RecalcTrkltCov(tilt, trkWork->getSnp(), pad->GetRowSize(mTracklets[trkltIdx].GetZbin()), trkltCovTmp);
+            RecalcTrkltCov(tilt, trkWork->getSnp(), pad->GetRowSize(mTracklets[trkltIdxGlb].GetZbin()), trkltCovTmp);
             float chi2 = prop->getPredictedChi2(trkltPosTmpYZ, trkltCovTmp);
             // GPUInfo("layer %i: chi2 = %f", iLayer, chi2);
-            if (chi2 < Param().rec.trdMaxChi2 && CAMath::Abs(GetAngularPull(mSpacePoints[trkltIdx].mDy, trkWork->getSnp())) < 4) {
-              Hypothesis hypo(trkWork->GetNlayers(), iCandidate, trkltIdx, trkWork->GetChi2() + chi2);
+            if (chi2 < Param().rec.trdMaxChi2 && CAMath::Abs(GetAngularPull(mSpacePoints[trkltIdxGlb].mDy, trkWork->getSnp())) < 4) {
+              Hypothesis hypo(trkWork->GetNlayers(), iCandidate, trkltIdxGlb, trkWork->GetChi2() + chi2);
               InsertHypothesis(hypo, nCurrHypothesis, hypothesisIdxOffset);
             } // end tracklet chi2 < Param().rec.trdMaxChi2
           }   // end tracklet in window
@@ -912,7 +915,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         mDebug->SetTrackParameter(*trkWork, iLayer);
         mDebug->SetRawTrackletPosition(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX, iLayer);
         mDebug->SetCorrectedTrackletPosition(trkltPosUp, iLayer);
-        mDebug->SetTrackletCovariance(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mCov, iLayer);
+        mDebug->SetTrackletCovariance(trkltCovUp, iLayer);
         mDebug->SetTrackletProperties(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mDy, mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector(), iLayer);
         wasTrackStored = true;
       }
@@ -975,7 +978,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         if (t->GetTracklet(iLy) != -1) {
           int lbTracklet;
           for (int il = 0; il < 3; il++) {
-            if ((lbTracklet = mSpacePoints[t->GetTracklet(iLy)].mLabel[il]) < 0) {
+            if ((lbTracklet = mTrackletLabels[3 * t->GetTracklet(iLy) + il]) < 0) {
               // no more valid labels
               continue;
             }
@@ -993,7 +996,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
               if (isRelated) {
                 break;
               }
-              if ((lbTracklet = mSpacePoints[t->GetTracklet(iLy)].mLabel[il]) < 0) {
+              if ((lbTracklet = mTrackletLabels[3 * t->GetTracklet(iLy) + il]) < 0) {
                 // no more valid labels
                 continue;
               }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -595,7 +595,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CalculateSpacePoints(int iCollision)
       mSpacePoints[trkltIdxGlb].mR = xTrkltSec[0];
       mSpacePoints[trkltIdxGlb].mX[0] = xTrkltSec[1];
       mSpacePoints[trkltIdxGlb].mX[1] = xTrkltSec[2];
-      mSpacePoints[trkltIdxGlb].mDy = 0.014f * mTracklets[trkltIdxGlb].GetdY();
+      mSpacePoints[trkltIdxGlb].mDy = mTracklets[trkltIdxGlb].GetdY();
 
       int modId = mGeo->GetSector(iDet) * GPUTRDGeometry::kNstack + mGeo->GetStack(iDet); // global TRD stack number
       unsigned short volId = mGeo->GetGeomManagerVolUID(iDet, modId);

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
@@ -459,11 +459,7 @@ int GPUTRDTrackerComponent::DoEvent(const AliHLTComponentEventData& evtData, con
 
     for (int i = 0; i < nTrackletsTotal; ++i) {
       const GPUTRDTrackerGPU::GPUTRDSpacePointInternal& sp = spacePoints[i];
-      int id = sp.mId;
-      if (id < 0 || id >= nTrackletsTotal) {
-        HLTError("Internal error: wrong space point index %d", id);
-      }
-      GPUTRDTrackPoint* currOutPoint = &outTrackPoints->fPoints[id];
+      GPUTRDTrackPoint* currOutPoint = &outTrackPoints->fPoints[i];
       currOutPoint->fX[0] = sp.mR;    // x in sector coordinates
       currOutPoint->fX[1] = sp.mX[0]; // y in sector coordinates
       currOutPoint->fX[2] = sp.mX[1]; // z in sector coordinates

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletReaderComponent.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletReaderComponent.cxx
@@ -305,7 +305,6 @@ int GPUTRDTrackletReaderComponent::DoEvent(const AliHLTComponentEventData& hltEv
       HLTInfo("There are %i tracklets in this event\n", nTracklets);
       for (int iTracklet = 0; iTracklet < nTracklets; ++iTracklet) {
         GPUTRDTrackletWord trkl = *((AliTRDtrackletWord*)fTrackletArray->At(iTracklet));
-        trkl.SetId(iTracklet);
         outputTrkls.push_back(trkl);
       }
       LogDebug("pushing data for sectors: 0x%05x", sourceSectors);
@@ -373,7 +372,6 @@ int GPUTRDTrackletReaderComponent::DoEvent(const AliHLTComponentEventData& hltEv
           continue;
         }
         GPUTRDTrackletWord hltTrkl = *trkl;
-        hltTrkl.SetId(iTracklet);
         outputTrkls.push_back(hltTrkl);
         GPUTRDTrackletLabels trklMC;
         trklMC.mLabel[0] = trkl->GetLabel(0);

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
@@ -49,7 +49,7 @@ GPUd() int GPUTRDTrackletWord::GetYbin() const
   }
 }
 
-GPUd() int GPUTRDTrackletWord::GetdY() const
+GPUd() int GPUTRDTrackletWord::GetdYbin() const
 {
   // returns (signed) value of the deflection length
   if (mTrackletWord & (1 << 19)) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.cxx
@@ -16,19 +16,19 @@ using namespace GPUCA_NAMESPACE::gpu;
 
 #ifndef GPUCA_TPC_GEOMETRY_O2
 
-GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord) : mId(-1), mHCId(-1), mTrackletWord(trackletWord)
+GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord) : mHCId(-1), mTrackletWord(trackletWord)
 {
 }
-GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord, int hcid, int id) : mId(id), mHCId(hcid), mTrackletWord(trackletWord) {}
+GPUd() GPUTRDTrackletWord::GPUTRDTrackletWord(unsigned int trackletWord, int hcid) : mHCId(hcid), mTrackletWord(trackletWord) {}
 
 #ifdef GPUCA_ALIROOT_LIB
 #include "AliTRDtrackletWord.h"
 #include "AliTRDtrackletMCM.h"
 
-GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletWord& rhs) : mId(-1), mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord())
+GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletWord& rhs) : mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord())
 {
 }
-GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletMCM& rhs) : mId(-1), mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord()) {}
+GPUTRDTrackletWord::GPUTRDTrackletWord(const AliTRDtrackletMCM& rhs) : mHCId(rhs.GetHCId()), mTrackletWord(rhs.GetTrackletWord()) {}
 
 GPUTRDTrackletWord& GPUTRDTrackletWord::operator=(const AliTRDtrackletMCM& rhs)
 {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
@@ -32,7 +32,7 @@ class GPUTRDTrackletWord
 {
  public:
   GPUd() GPUTRDTrackletWord(unsigned int trackletWord = 0);
-  GPUd() GPUTRDTrackletWord(unsigned int trackletWord, int hcid, int id);
+  GPUd() GPUTRDTrackletWord(unsigned int trackletWord, int hcid);
   GPUdDefault() GPUTRDTrackletWord(const GPUTRDTrackletWord& rhs) CON_DEFAULT;
   GPUdDefault() GPUTRDTrackletWord& operator=(const GPUTRDTrackletWord& rhs) CON_DEFAULT;
   GPUdDefault() ~GPUTRDTrackletWord() CON_DEFAULT;
@@ -53,8 +53,6 @@ class GPUTRDTrackletWord
   GPUd() int GetZbin() const { return ((mTrackletWord >> 20) & 0xf); }
   GPUd() int GetPID() const { return ((mTrackletWord >> 24) & 0xff); }
 
-  GPUd() int GetId() const { return mId; }
-
   // ----- Getters for offline corresponding values -----
   GPUd() double GetPID(int /* is */) const { return (double)GetPID() / 256.f; }
   GPUd() int GetDetector() const { return mHCId / 2; }
@@ -65,11 +63,9 @@ class GPUTRDTrackletWord
 
   GPUd() void SetTrackletWord(unsigned int trackletWord) { mTrackletWord = trackletWord; }
   GPUd() void SetDetector(int id) { mHCId = 2 * id + (GetYbin() < 0 ? 0 : 1); }
-  GPUd() void SetId(int id) { mId = id; }
   GPUd() void SetHCId(int id) { mHCId = id; }
 
  protected:
-  int mId;                    // index in tracklet array
   int mHCId;                  // half-chamber ID
   unsigned int mTrackletWord; // tracklet word: PID | Z | deflection length | Y
                               //          bits:   8   4            7          13
@@ -103,12 +99,7 @@ class GPUTRDTrackletWord : private o2::trd::Tracklet64
   GPUd() float GetY() const { return getUncalibratedY(); }
   GPUd() float GetdY() const { return getUncalibratedDy(); }
   GPUd() int GetDetector() const { return getDetector(); }
-  GPUd() int GetId() const { return mId; }
-
-  GPUd() void SetId(int id) { mId = id; }
-
- protected:
-  int mId; // index in tracklet input block
+  GPUd() int GetHCId() const { return getHCID(); }
 };
 
 } // namespace gpu

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackletWord.h
@@ -49,7 +49,7 @@ class GPUTRDTrackletWord
 
   // ----- Getters for contents of tracklet word -----
   GPUd() int GetYbin() const;
-  GPUd() int GetdY() const;
+  GPUd() int GetdYbin() const;
   GPUd() int GetZbin() const { return ((mTrackletWord >> 20) & 0xf); }
   GPUd() int GetPID() const { return ((mTrackletWord >> 24) & 0xff); }
 
@@ -57,7 +57,8 @@ class GPUTRDTrackletWord
   GPUd() double GetPID(int /* is */) const { return (double)GetPID() / 256.f; }
   GPUd() int GetDetector() const { return mHCId / 2; }
   GPUd() int GetHCId() const { return mHCId; }
-  GPUd() float GetdYdX() const { return (GetdY() * 140e-4f / 3.f); }
+  GPUd() float GetdYdX() const { return (GetdYbin() * 140e-4f / 3.f); }
+  GPUd() float GetDy() const { return GetdYbin() * 140e-4f; }
   GPUd() float GetY() const { return (GetYbin() * 160e-4f); }
   GPUd() unsigned int GetTrackletWord() const { return mTrackletWord; }
 


### PR DESCRIPTION
At the moment I don't see any attached tracklets when using input form the tracklet transformer. @jbarrella how far along did you get with your tracklet visualization? Probably we need to check the default values which are hard coded in the tracklet transformer at the moment. When I use the uncalibrated Tracklet64 I see that tracklets get attached to the tracks.
In order to use the transformed tracklets directly one can run the tracking with `o2-trd-global-tracking -b --use-tracklet-transformer`. Without the flag the uncalibrated tracklets are used.

In addition I did some cleanup. `GPUTRDSpacePointInternal` does not need fields for labels (they are stored in a separate array anyways), covariance matrix (is calculated on-the-fly during track following since it depends on the track inclincation) and ID (tracklets and space points are kept in the same order as they arrive now. For the sorting by HCId I fill an index array, although for O2 this will not be needed anymore once the tracklets arrive in order from the TRAP (respectively from the raw stream).

I simply added the possibility to read calibrated tracklets to the TrackletReaderComponent. Or would it be better to create another DPL device for reading calibrated tracklets?
