### PR TITLE
DPL: Reconstruct the full command and propagate it to workflow dump tools

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(Framework
                        src/ChannelMatching.cxx
                        src/ChannelConfigurationPolicyHelpers.cxx
                        src/ChannelSpecHelpers.cxx
+                       src/CommandInfo.cxx
                        src/CommonDataProcessors.cxx
                        src/CommonServices.cxx
                        src/CommonMessageBackends.cxx

--- a/Framework/Core/include/Framework/CommandInfo.h
+++ b/Framework/Core/include/Framework/CommandInfo.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_COMMANDINFO_H_
+#define O2_FRAMEWORK_COMMANDINFO_H_
+
+#include <string>
+
+namespace o2::framework
+{
+
+struct CommandInfo {
+  CommandInfo() = default;
+  CommandInfo(std::string command) : command(std::move(command)) {}
+  CommandInfo(int argc, char* const* argv);
+
+  void merge(CommandInfo const& other);
+
+  std::string command;
+};
+
+} // namespace o2::framework
+
+#endif //O2_FRAMEWORK_COMMANDINFO_H_

--- a/Framework/Core/include/Framework/DriverControl.h
+++ b/Framework/Core/include/Framework/DriverControl.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <vector>
 
+#include "Framework/CommandInfo.h"
 #include "Framework/DriverInfo.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DeviceSpec.h"
@@ -37,7 +38,8 @@ struct DriverControl {
   using Callback = std::function<void(std::vector<DataProcessorSpec> const& workflow,
                                       std::vector<DeviceSpec> const&,
                                       std::vector<DeviceExecution> const&,
-                                      std::vector<DataProcessorInfo>&)>;
+                                      std::vector<DataProcessorInfo>&,
+                                      CommandInfo const&)>;
   /// States to be added to the stack on next iteration
   /// of the state machine processing.
   std::vector<DriverState> forcedTransitions;

--- a/Framework/Core/src/CommandInfo.cxx
+++ b/Framework/Core/src/CommandInfo.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CommandInfo.h"
+
+#include <sstream>
+#include <cassert>
+#include <cstring>
+
+namespace o2::framework
+{
+
+CommandInfo::CommandInfo(int argc, char* const* argv)
+{
+  assert(argc > 0);
+
+  std::stringstream commandStream;
+  commandStream << argv[0];
+
+  for (size_t ai = 1; ai < argc; ++ai) {
+    const char* arg = argv[ai];
+    if (strpbrk(arg, "\" ;@") != nullptr || arg[0] == 0) {
+      commandStream << " '" << arg << "'";
+    } else if (strpbrk(arg, "'") != nullptr) {
+      commandStream << " \"" << arg << "\"";
+    } else {
+      commandStream << " " << arg;
+    }
+  }
+  command = commandStream.str();
+}
+
+void CommandInfo::merge(CommandInfo const& other)
+{
+  if (!command.empty()) {
+    command += " | ";
+  }
+  command += other.command;
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -292,13 +292,14 @@ void dumpWorkflow(std::ostream& dumpOut, const std::vector<DeviceSpec>& specs, c
     auto& execution = executions[di];
     dumpRole(dumpOut, taskName(workflowName, spec.id), spec, specs, execution, indLevel + indScheme);
   }
-};
+}
 
 } // namespace implementation
 
 void dumpDeviceSpec2O2Control(std::string workflowName,
                               const std::vector<DeviceSpec>& specs,
-                              const std::vector<DeviceExecution>& executions)
+                              const std::vector<DeviceExecution>& executions,
+                              const CommandInfo&)
 {
   const char* tasksDirectory = "tasks";
   const char* workflowsDirectory = "workflows";

--- a/Framework/Core/src/O2ControlHelpers.h
+++ b/Framework/Core/src/O2ControlHelpers.h
@@ -12,6 +12,7 @@
 
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceExecution.h"
+#include "Framework/CommandInfo.h"
 #include <vector>
 #include <iosfwd>
 
@@ -40,7 +41,8 @@ namespace framework
 
 void dumpDeviceSpec2O2Control(std::string workflowName,
                               std::vector<DeviceSpec> const& specs,
-                              std::vector<DeviceExecution> const& executions);
+                              std::vector<DeviceExecution> const& executions,
+                              CommandInfo const& commandInfo);
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/WorkflowSerializationHelpers.h
+++ b/Framework/Core/src/WorkflowSerializationHelpers.h
@@ -12,6 +12,7 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataProcessorInfo.h"
+#include "Framework/CommandInfo.h"
 
 #include <iosfwd>
 #include <vector>
@@ -22,10 +23,12 @@ namespace o2::framework
 struct WorkflowSerializationHelpers {
   static void import(std::istream& s,
                      std::vector<DataProcessorSpec>& workflow,
-                     std::vector<DataProcessorInfo>& metadata);
+                     std::vector<DataProcessorInfo>& metadata,
+                     CommandInfo& command);
   static void dump(std::ostream& o,
                    std::vector<DataProcessorSpec> const& workflow,
-                   std::vector<DataProcessorInfo> const& metadata);
+                   std::vector<DataProcessorInfo> const& metadata,
+                   CommandInfo const& commandInfo);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/test/test_WorkflowSerialization.cxx
+++ b/Framework/Core/test/test_WorkflowSerialization.cxx
@@ -57,19 +57,23 @@ BOOST_AUTO_TEST_CASE(TestVerifyWorkflow)
     {"D", "test_Framework_test_SerializationWorkflow", {}},
   };
 
+  CommandInfo commandInfoOut{"o2-dpl-workflow -b --option 1 --option 2"};
+
   std::vector<DataProcessorInfo> metadataIn{};
+  CommandInfo commandInfoIn;
 
   std::ostringstream firstDump;
-  WorkflowSerializationHelpers::dump(firstDump, w0, metadataOut);
+  WorkflowSerializationHelpers::dump(firstDump, w0, metadataOut, commandInfoOut);
   std::istringstream is;
   is.str(firstDump.str());
   WorkflowSpec w1;
-  WorkflowSerializationHelpers::import(is, w1, metadataIn);
+  WorkflowSerializationHelpers::import(is, w1, metadataIn, commandInfoIn);
 
   std::ostringstream secondDump;
-  WorkflowSerializationHelpers::dump(secondDump, w1, metadataIn);
+  WorkflowSerializationHelpers::dump(secondDump, w1, metadataIn, commandInfoIn);
 
   BOOST_REQUIRE_EQUAL(w0.size(), 4);
   BOOST_REQUIRE_EQUAL(w0.size(), w1.size());
   BOOST_CHECK_EQUAL(firstDump.str(), secondDump.str());
+  BOOST_CHECK_EQUAL(commandInfoIn.command, commandInfoOut.command);
 }


### PR DESCRIPTION
@ktf I took a stab on providing to the AliECS the full command used to run the workflow (including all the workflow merging). This would enable the AliECS to avoid generating intermediate files to run a topology and thus streamline it as much as possible. 