### PR TITLE
raw-file-reader can optionally drop some TFs

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -331,6 +331,7 @@ o2-raw-file-reader-workflow
   --cache-data                          cache data at 1st reading, may require excessive memory!!!
   --detect-tf0                          autodetect HBFUtils start Orbit/BC from 1st TF seen (at SOX)
   --calculate-tf-start                  calculate TF start from orbit instead of using TType
+  --drop-tf arg (=none)                Drop each TFid%(1)==(2) of detector, e.g. ITS,2,4;TPC,4[,0];...
   --configKeyValues arg                 semicolon separated key=value strings
 
   # to suppress various error checks / reporting
@@ -372,6 +373,8 @@ To inject such a data to DPL one should use a parallel process starting with `o2
 ```bash
 [Terminal 2]> o2-raw-file-reader-workflow  --session default --loop 1000 --delay 3 --input-conf raw/rawAll.cfg --raw-channel-config "name=raw-reader,type=push,method=bind,address=ipc://@rr-to-dpl,transport=shmem,rateLogging=1" --shm-segment-size 16000000000
 ```
+
+For testing reason one can request dropping of some fraction of the TFs for particular detector. With option `--drop-tf "ITS,3,2;TPC,10"` the reader will not send the output for ITS in TFs with `(TFid%3)==2` and for TPC in TFs with `(TFid%10)==0`. Note that in order to acknowledge the TF, the message `{FLP/DISTSUBTIMEFRAME/0}` will still be sent even if all detector's data was dropped for a given TF.
 
 ## Raw data file checker (standalone executable)
 

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -37,6 +37,7 @@ using IR = o2::InteractionRecord;
 struct ReaderInp {
   std::string inifile{};
   std::string rawChannelConfig{};
+  std::string dropTF{};
   size_t spSize = 1024L * 1024L;
   size_t bufferSize = 1024L * 1024L;
   int loop = 1;

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -22,7 +22,7 @@
 #include "DetectorsRaw/RawFileReader.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "DetectorsRaw/HBFUtils.h"
-
+#include "DetectorsCommonDataFormats/DetID.h"
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
 
@@ -36,6 +36,7 @@
 #include <cctype>
 #include <string>
 #include <climits>
+#include <regex>
 
 using namespace o2::raw;
 
@@ -51,196 +52,9 @@ class RawReaderSpecs : public o2f::Task
     uint32_t mFirstOrbit = uint32_t(-1);
     std::uint32_t mRunNumber = 0;
   };
-
-  explicit RawReaderSpecs(const ReaderInp& rinp)
-    : mLoop(rinp.loop < 0 ? INT_MAX : (rinp.loop < 1 ? 1 : rinp.loop)), mDelayUSec(rinp.delay_us), mMinTFID(rinp.minTF), mMaxTFID(rinp.maxTF), mPartPerSP(rinp.partPerSP), mReader(std::make_unique<o2::raw::RawFileReader>(rinp.inifile, 0, rinp.bufferSize)), mRawChannelName(rinp.rawChannelConfig)
-  {
-    mReader->setCheckErrors(rinp.errMap);
-    mReader->setMaxTFToRead(rinp.maxTF);
-    mReader->setNominalSPageSize(rinp.spSize);
-    mReader->setCacheData(rinp.cache);
-    mReader->setTFAutodetect(rinp.autodetectTF0 ? RawFileReader::FirstTFDetection::Pending : RawFileReader::FirstTFDetection::Disabled);
-    mReader->setPreferCalculatedTFStart(rinp.preferCalcTF);
-    LOG(INFO) << "Will preprocess files with buffer size of " << rinp.bufferSize << " bytes";
-    LOG(INFO) << "Number of loops over whole data requested: " << mLoop;
-    for (int i = NTimers; i--;) {
-      mTimer[i].Stop();
-      mTimer[i].Reset();
-    }
-  }
-
-  void init(o2f::InitContext& ic) final
-  {
-    assert(mReader);
-    mTimer[TimerInit].Start();
-    mReader->init();
-    mTimer[TimerInit].Stop();
-    if (mMaxTFID >= mReader->getNTimeFrames()) {
-      mMaxTFID = mReader->getNTimeFrames() ? mReader->getNTimeFrames() - 1 : 0;
-    }
-  }
-
-  void run(o2f::ProcessingContext& ctx) final
-  {
-    assert(mReader);
-    if (mDone) {
-      return;
-    }
-    auto tTotStart = mTimer[TimerTotal].CpuTime(), tIOStart = mTimer[TimerIO].CpuTime();
-    mTimer[TimerTotal].Start(false);
-    auto device = ctx.services().get<o2f::RawDeviceService>().device();
-    assert(device);
-
-    auto findOutputChannel = [&ctx, this](o2h::DataHeader& h) {
-      if (!this->mRawChannelName.empty()) {
-        return std::string{this->mRawChannelName};
-      } else {
-        auto outputRoutes = ctx.services().get<o2f::RawDeviceService>().spec().outputs;
-        for (auto& oroute : outputRoutes) {
-          LOG(DEBUG) << "comparing with matcher to route " << oroute.matcher << " TSlice:" << oroute.timeslice;
-          if (o2f::DataSpecUtils::match(oroute.matcher, h.dataOrigin, h.dataDescription, h.subSpecification) && ((h.tfCounter % oroute.maxTimeslices) == oroute.timeslice)) {
-            LOG(DEBUG) << "picking the route:" << o2f::DataSpecUtils::describe(oroute.matcher) << " channel " << oroute.channel;
-            return std::string{oroute.channel};
-          }
-        }
-      }
-      LOGP(ERROR, "Failed to find output channel for {}/{}/{} @ timeslice {}", h.dataOrigin.str, h.dataDescription.str, h.subSpecification, h.tfCounter);
-      return std::string{};
-    };
-
-    size_t tfNParts = 0, tfSize = 0;
-    std::unordered_map<std::string, std::unique_ptr<FairMQParts>> messagesPerRoute;
-
-    auto addPart = [&messagesPerRoute, &tfNParts, &tfSize](FairMQMessagePtr hd, FairMQMessagePtr pl, const std::string& fairMQChannel) {
-      FairMQParts* parts = nullptr;
-      parts = messagesPerRoute[fairMQChannel].get(); // FairMQParts*
-      if (!parts) {
-        messagesPerRoute[fairMQChannel] = std::make_unique<FairMQParts>();
-        parts = messagesPerRoute[fairMQChannel].get();
-      }
-      tfSize += pl->GetSize();
-      tfNParts++;
-      parts->AddPart(std::move(hd));
-      parts->AddPart(std::move(pl));
-    };
-
-    // clean-up before reading next TF
-    auto tfID = mReader->getNextTFToRead();
-    int nlinks = mReader->getNLinks();
-
-    if (tfID > mMaxTFID) {
-      if (!mReader->isEmpty() && --mLoop) {
-        mLoopsDone++;
-        tfID = 0;
-        LOG(INFO) << "Starting new loop " << mLoopsDone << " from the beginning of data";
-      } else {
-        mTimer[TimerTotal].Stop();
-        LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", mSentSize, mSentMessages, mTFCounter);
-        for (int i = 0; i < NTimers; i++) {
-          LOGF(INFO, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
-        }
-        ctx.services().get<o2f::ControlService>().endOfStream();
-        ctx.services().get<o2f::ControlService>().readyToQuit(o2f::QuitRequest::Me);
-        mDone = true;
-        return;
-      }
-    }
-
-    if (tfID < mMinTFID) {
-      tfID = mMinTFID;
-    }
-    mReader->setNextTFToRead(tfID);
-    std::vector<RawFileReader::PartStat> partsSP;
-    const auto& hbfU = HBFUtils::Instance();
-
-    // read next time frame
-    LOG(INFO) << "Reading TF#" << mTFCounter << " (" << tfID << " at iteration " << mLoopsDone << ')';
-    o2::header::Stack dummyStack{o2h::DataHeader{}, o2::framework::DataProcessingHeader{0}}; // dummy stack to just to get stack size
-    auto hstackSize = dummyStack.size();
-
-    uint32_t firstOrbit = 0;
-    for (int il = 0; il < nlinks; il++) {
-      auto& link = mReader->getLink(il);
-      if (!link.rewindToTF(tfID)) {
-        continue; // this link has no data for wanted TF
-      }
-
-      o2h::DataHeader hdrTmpl(link.description, link.origin, link.subspec); // template with 0 size
-      int nParts = mPartPerSP ? link.getNextTFSuperPagesStat(partsSP) : link.getNHBFinTF();
-      hdrTmpl.payloadSerializationMethod = o2h::gSerializationMethodNone;
-      hdrTmpl.splitPayloadParts = nParts;
-      hdrTmpl.tfCounter = mTFCounter;
-
-      const auto fmqChannel = findOutputChannel(hdrTmpl);
-      if (fmqChannel.empty()) { // no output channel
-        continue;
-      }
-
-      auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
-      while (hdrTmpl.splitPayloadIndex < hdrTmpl.splitPayloadParts) {
-        hdrTmpl.payloadSize = mPartPerSP ? partsSP[hdrTmpl.splitPayloadIndex].size : link.getNextHBFSize();
-        auto hdMessage = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
-        auto plMessage = fmqFactory->CreateMessage(hdrTmpl.payloadSize, fair::mq::Alignment{64});
-        mTimer[TimerIO].Start(false);
-        auto bread = mPartPerSP ? link.readNextSuperPage(reinterpret_cast<char*>(plMessage->GetData()), &partsSP[hdrTmpl.splitPayloadIndex]) : link.readNextHBF(reinterpret_cast<char*>(plMessage->GetData()));
-        if (bread != hdrTmpl.payloadSize) {
-          LOG(ERROR) << "Link " << il << " read " << bread << " bytes instead of " << hdrTmpl.payloadSize
-                     << " expected in TF=" << mTFCounter << " part=" << hdrTmpl.splitPayloadIndex;
-        }
-        mTimer[TimerIO].Stop();
-        // check if the RDH to send corresponds to expected orbit
-        if (hdrTmpl.splitPayloadIndex == 0) {
-          auto ir = o2::raw::RDHUtils::getHeartBeatIR(plMessage->GetData());
-          auto tfid = hbfU.getTF(ir);
-          firstOrbit = hdrTmpl.firstTForbit = hbfU.getIRTF(tfid).orbit; // will be picked for the following parts
-        }
-        o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter}};
-        memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
-        hdrTmpl.splitPayloadIndex++; // prepare for next
-
-        addPart(std::move(hdMessage), std::move(plMessage), fmqChannel);
-      }
-      LOGF(DEBUG, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFCounter, tfID,
-           mLoopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
-    }
-
-    // send sTF acknowledge message
-    {
-      STFHeader stfHeader{mTFCounter, firstOrbit, 0};
-      o2::header::DataHeader stfDistDataHeader(gDataDescSubTimeFrame, o2::header::gDataOriginFLP, 0, sizeof(STFHeader), 0, 1);
-      stfDistDataHeader.payloadSerializationMethod = o2h::gSerializationMethodNone;
-      stfDistDataHeader.firstTForbit = stfHeader.mFirstOrbit;
-      stfDistDataHeader.tfCounter = mTFCounter;
-      const auto fmqChannel = findOutputChannel(stfDistDataHeader);
-      if (!fmqChannel.empty()) { // no output channel
-        auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
-        o2::header::Stack headerStackSTF{stfDistDataHeader, o2::framework::DataProcessingHeader{mTFCounter}};
-        auto hdMessageSTF = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
-        auto plMessageSTF = fmqFactory->CreateMessage(stfDistDataHeader.payloadSize, fair::mq::Alignment{64});
-        memcpy(hdMessageSTF->GetData(), headerStackSTF.data(), headerStackSTF.size());
-        memcpy(plMessageSTF->GetData(), &stfHeader, sizeof(STFHeader));
-        addPart(std::move(hdMessageSTF), std::move(plMessageSTF), fmqChannel);
-      }
-    }
-
-    if (mTFCounter) { // delay sending
-      usleep(mDelayUSec);
-    }
-    for (auto& msgIt : messagesPerRoute) {
-      LOG(INFO) << "Sending " << msgIt.second->Size() / 2 << " parts to channel " << msgIt.first;
-      device->Send(*msgIt.second.get(), msgIt.first);
-    }
-    mTimer[TimerTotal].Stop();
-
-    LOGF(INFO, "Sent payload of %zu bytes in %zu parts in %zu messages for TF %d | Timing (total/IO): %.3e / %.3e", tfSize, tfNParts,
-         messagesPerRoute.size(), mTFCounter, mTimer[TimerTotal].CpuTime() - tTotStart, mTimer[TimerIO].CpuTime() - tIOStart);
-
-    mSentSize += tfSize;
-    mSentMessages += tfNParts;
-
-    mReader->setNextTFToRead(++tfID);
-    ++mTFCounter;
-  }
+  explicit RawReaderSpecs(const ReaderInp& rinp);
+  void init(o2f::InitContext& ic) final;
+  void run(o2f::ProcessingContext& ctx) final;
 
   uint32_t getMinTFID() const { return mMinTFID; }
   uint32_t getMaxTFID() const { return mMaxTFID; }
@@ -251,19 +65,21 @@ class RawReaderSpecs : public o2f::Task
   }
 
  private:
-  int mLoop = 0;                                   // once last TF reached, loop while mLoop>=0
-  uint32_t mTFCounter = 0;                         // TFId accumulator (accounts for looping)
-  uint32_t mDelayUSec = 0;                         // Delay in microseconds between TFs
-  uint32_t mMinTFID = 0;                           // 1st TF to extract
-  uint32_t mMaxTFID = 0xffffffff;                  // last TF to extrct
+  void processDropTF(const std::string& drops);
+
+  int mLoop = 0;                  // once last TF reached, loop while mLoop>=0
+  uint32_t mTFCounter = 0;        // TFId accumulator (accounts for looping)
+  uint32_t mDelayUSec = 0;        // Delay in microseconds between TFs
+  uint32_t mMinTFID = 0;          // 1st TF to extract
+  uint32_t mMaxTFID = 0xffffffff; // last TF to extrct
   size_t mLoopsDone = 0;
   size_t mSentSize = 0;
   size_t mSentMessages = 0;
-  bool mPartPerSP = true;                          // fill part per superpage
-  bool mDone = false;                              // processing is over or not
-  std::string mRawChannelName = "";                // name of optional non-DPL channel
-  std::unique_ptr<o2::raw::RawFileReader> mReader; // matching engine
-
+  bool mPartPerSP = true;                                          // fill part per superpage
+  bool mDone = false;                                              // processing is over or not
+  std::string mRawChannelName = "";                                // name of optional non-DPL channel
+  std::unique_ptr<o2::raw::RawFileReader> mReader;                 // matching engine
+  std::unordered_map<std::string, std::pair<int, int>> mDropTFMap; // allows to drop certain fraction of TFs
   enum TimerIDs { TimerInit,
                   TimerTotal,
                   TimerIO,
@@ -272,6 +88,240 @@ class RawReaderSpecs : public o2f::Task
   TStopwatch mTimer[NTimers];
 };
 
+//___________________________________________________________
+RawReaderSpecs::RawReaderSpecs(const ReaderInp& rinp)
+  : mLoop(rinp.loop < 0 ? INT_MAX : (rinp.loop < 1 ? 1 : rinp.loop)), mDelayUSec(rinp.delay_us), mMinTFID(rinp.minTF), mMaxTFID(rinp.maxTF), mPartPerSP(rinp.partPerSP), mReader(std::make_unique<o2::raw::RawFileReader>(rinp.inifile, 0, rinp.bufferSize)), mRawChannelName(rinp.rawChannelConfig)
+{
+  mReader->setCheckErrors(rinp.errMap);
+  mReader->setMaxTFToRead(rinp.maxTF);
+  mReader->setNominalSPageSize(rinp.spSize);
+  mReader->setCacheData(rinp.cache);
+  mReader->setTFAutodetect(rinp.autodetectTF0 ? RawFileReader::FirstTFDetection::Pending : RawFileReader::FirstTFDetection::Disabled);
+  mReader->setPreferCalculatedTFStart(rinp.preferCalcTF);
+  LOG(INFO) << "Will preprocess files with buffer size of " << rinp.bufferSize << " bytes";
+  LOG(INFO) << "Number of loops over whole data requested: " << mLoop;
+  for (int i = NTimers; i--;) {
+    mTimer[i].Stop();
+    mTimer[i].Reset();
+  }
+  processDropTF(rinp.dropTF);
+}
+
+//___________________________________________________________
+void RawReaderSpecs::processDropTF(const std::string& dropTF)
+{
+  static const std::regex delimDet(";");
+  if (dropTF.empty() || dropTF == "none") {
+    return;
+  }
+  std::sregex_token_iterator iter(dropTF.begin(), dropTF.end(), delimDet, -1), end;
+  for (; iter != end; ++iter) {
+    std::string sdet = iter->str();
+    if (sdet.length() < 5 || sdet[3] != ',') {
+      throw std::runtime_error(fmt::format("Wrong dropTF argument {} in {}", sdet, dropTF));
+    }
+    std::string detName = sdet.substr(0, 3);
+    o2::detectors::DetID det(detName.c_str()); // make sure this is a valid detector
+    std::string sdetArg = sdet.substr(4, sdet.length());
+    int modV = 0, rej = 0, posrej = sdetArg.find(',');
+    if (posrej != std::string::npos) {
+      modV = std::stoi(sdetArg.substr(0, posrej));
+      rej = std::stoi(sdetArg.substr(++posrej, sdetArg.length()));
+    } else {
+      modV = std::stoi(sdetArg);
+    }
+    if (modV < 1 || rej < 0 || rej >= modV) {
+      throw std::runtime_error(fmt::format("Wrong dropTF argument {}, 1st number must be > than 2nd", sdet));
+    }
+    mDropTFMap[detName] = {modV, rej};
+    LOG(INFO) << " Will drop TF for detector " << detName << " if (TF_ID%" << modV << ")==" << rej;
+  }
+}
+
+//___________________________________________________________
+void RawReaderSpecs::init(o2f::InitContext& ic)
+{
+  assert(mReader);
+  mTimer[TimerInit].Start();
+  mReader->init();
+  mTimer[TimerInit].Stop();
+  if (mMaxTFID >= mReader->getNTimeFrames()) {
+    mMaxTFID = mReader->getNTimeFrames() ? mReader->getNTimeFrames() - 1 : 0;
+  }
+}
+
+//___________________________________________________________
+void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
+{
+  assert(mReader);
+  if (mDone) {
+    return;
+  }
+  auto tTotStart = mTimer[TimerTotal].CpuTime(), tIOStart = mTimer[TimerIO].CpuTime();
+  mTimer[TimerTotal].Start(false);
+  auto device = ctx.services().get<o2f::RawDeviceService>().device();
+  assert(device);
+
+  auto findOutputChannel = [&ctx, this](o2h::DataHeader& h) {
+    if (!this->mRawChannelName.empty()) {
+      return std::string{this->mRawChannelName};
+    } else {
+      auto outputRoutes = ctx.services().get<o2f::RawDeviceService>().spec().outputs;
+      for (auto& oroute : outputRoutes) {
+        LOG(DEBUG) << "comparing with matcher to route " << oroute.matcher << " TSlice:" << oroute.timeslice;
+        if (o2f::DataSpecUtils::match(oroute.matcher, h.dataOrigin, h.dataDescription, h.subSpecification) && ((h.tfCounter % oroute.maxTimeslices) == oroute.timeslice)) {
+          LOG(DEBUG) << "picking the route:" << o2f::DataSpecUtils::describe(oroute.matcher) << " channel " << oroute.channel;
+          return std::string{oroute.channel};
+        }
+      }
+    }
+    LOGP(ERROR, "Failed to find output channel for {}/{}/{} @ timeslice {}", h.dataOrigin.str, h.dataDescription.str, h.subSpecification, h.tfCounter);
+    return std::string{};
+  };
+
+  size_t tfNParts = 0, tfSize = 0;
+  std::unordered_map<std::string, std::unique_ptr<FairMQParts>> messagesPerRoute;
+
+  auto addPart = [&messagesPerRoute, &tfNParts, &tfSize](FairMQMessagePtr hd, FairMQMessagePtr pl, const std::string& fairMQChannel) {
+    FairMQParts* parts = nullptr;
+    parts = messagesPerRoute[fairMQChannel].get(); // FairMQParts*
+    if (!parts) {
+      messagesPerRoute[fairMQChannel] = std::make_unique<FairMQParts>();
+      parts = messagesPerRoute[fairMQChannel].get();
+    }
+    tfSize += pl->GetSize();
+    tfNParts++;
+    parts->AddPart(std::move(hd));
+    parts->AddPart(std::move(pl));
+  };
+
+  // clean-up before reading next TF
+  auto tfID = mReader->getNextTFToRead();
+  int nlinks = mReader->getNLinks();
+
+  if (tfID > mMaxTFID) {
+    if (!mReader->isEmpty() && --mLoop) {
+      mLoopsDone++;
+      tfID = 0;
+      LOG(INFO) << "Starting new loop " << mLoopsDone << " from the beginning of data";
+    } else {
+      mTimer[TimerTotal].Stop();
+      LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", mSentSize, mSentMessages, mTFCounter);
+      for (int i = 0; i < NTimers; i++) {
+        LOGF(INFO, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
+      }
+      ctx.services().get<o2f::ControlService>().endOfStream();
+      ctx.services().get<o2f::ControlService>().readyToQuit(o2f::QuitRequest::Me);
+      mDone = true;
+      return;
+    }
+  }
+
+  if (tfID < mMinTFID) {
+    tfID = mMinTFID;
+  }
+  mReader->setNextTFToRead(tfID);
+  std::vector<RawFileReader::PartStat> partsSP;
+  const auto& hbfU = HBFUtils::Instance();
+
+  // read next time frame
+  LOG(INFO) << "Reading TF#" << mTFCounter << " (" << tfID << " at iteration " << mLoopsDone << ')';
+  o2::header::Stack dummyStack{o2h::DataHeader{}, o2::framework::DataProcessingHeader{0}}; // dummy stack to just to get stack size
+  auto hstackSize = dummyStack.size();
+
+  uint32_t firstOrbit = 0;
+  for (int il = 0; il < nlinks; il++) {
+    auto& link = mReader->getLink(il);
+
+    if (!mDropTFMap.empty()) { // some TFs should be dropped
+      auto res = mDropTFMap.find(link.origin.str);
+      if (res != mDropTFMap.end() && (mTFCounter % res->second.first) == res->second.second) {
+        LOG(INFO) << "Droppint " << mTFCounter << " for " << link.origin.str << "/" << link.description.str << "/" << link.subspec;
+        continue; // drop the data
+      }
+    }
+    if (!link.rewindToTF(tfID)) {
+      continue; // this link has no data for wanted TF
+    }
+
+    o2h::DataHeader hdrTmpl(link.description, link.origin, link.subspec); // template with 0 size
+    int nParts = mPartPerSP ? link.getNextTFSuperPagesStat(partsSP) : link.getNHBFinTF();
+    hdrTmpl.payloadSerializationMethod = o2h::gSerializationMethodNone;
+    hdrTmpl.splitPayloadParts = nParts;
+    hdrTmpl.tfCounter = mTFCounter;
+
+    const auto fmqChannel = findOutputChannel(hdrTmpl);
+    if (fmqChannel.empty()) { // no output channel
+      continue;
+    }
+
+    auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
+    while (hdrTmpl.splitPayloadIndex < hdrTmpl.splitPayloadParts) {
+      hdrTmpl.payloadSize = mPartPerSP ? partsSP[hdrTmpl.splitPayloadIndex].size : link.getNextHBFSize();
+      auto hdMessage = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
+      auto plMessage = fmqFactory->CreateMessage(hdrTmpl.payloadSize, fair::mq::Alignment{64});
+      mTimer[TimerIO].Start(false);
+      auto bread = mPartPerSP ? link.readNextSuperPage(reinterpret_cast<char*>(plMessage->GetData()), &partsSP[hdrTmpl.splitPayloadIndex]) : link.readNextHBF(reinterpret_cast<char*>(plMessage->GetData()));
+      if (bread != hdrTmpl.payloadSize) {
+        LOG(ERROR) << "Link " << il << " read " << bread << " bytes instead of " << hdrTmpl.payloadSize
+                   << " expected in TF=" << mTFCounter << " part=" << hdrTmpl.splitPayloadIndex;
+      }
+      mTimer[TimerIO].Stop();
+      // check if the RDH to send corresponds to expected orbit
+      if (hdrTmpl.splitPayloadIndex == 0) {
+        auto ir = o2::raw::RDHUtils::getHeartBeatIR(plMessage->GetData());
+        auto tfid = hbfU.getTF(ir);
+        firstOrbit = hdrTmpl.firstTForbit = hbfU.getIRTF(tfid).orbit; // will be picked for the following parts
+      }
+      o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter}};
+      memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
+      hdrTmpl.splitPayloadIndex++; // prepare for next
+
+      addPart(std::move(hdMessage), std::move(plMessage), fmqChannel);
+    }
+    LOGF(DEBUG, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFCounter, tfID,
+         mLoopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
+  }
+
+  // send sTF acknowledge message
+  {
+    STFHeader stfHeader{mTFCounter, firstOrbit, 0};
+    o2::header::DataHeader stfDistDataHeader(gDataDescSubTimeFrame, o2::header::gDataOriginFLP, 0, sizeof(STFHeader), 0, 1);
+    stfDistDataHeader.payloadSerializationMethod = o2h::gSerializationMethodNone;
+    stfDistDataHeader.firstTForbit = stfHeader.mFirstOrbit;
+    stfDistDataHeader.tfCounter = mTFCounter;
+    const auto fmqChannel = findOutputChannel(stfDistDataHeader);
+    if (!fmqChannel.empty()) { // no output channel
+      auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
+      o2::header::Stack headerStackSTF{stfDistDataHeader, o2::framework::DataProcessingHeader{mTFCounter}};
+      auto hdMessageSTF = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
+      auto plMessageSTF = fmqFactory->CreateMessage(stfDistDataHeader.payloadSize, fair::mq::Alignment{64});
+      memcpy(hdMessageSTF->GetData(), headerStackSTF.data(), headerStackSTF.size());
+      memcpy(plMessageSTF->GetData(), &stfHeader, sizeof(STFHeader));
+      addPart(std::move(hdMessageSTF), std::move(plMessageSTF), fmqChannel);
+    }
+  }
+
+  if (mTFCounter) { // delay sending
+    usleep(mDelayUSec);
+  }
+  for (auto& msgIt : messagesPerRoute) {
+    LOG(INFO) << "Sending " << msgIt.second->Size() / 2 << " parts to channel " << msgIt.first;
+    device->Send(*msgIt.second.get(), msgIt.first);
+  }
+  mTimer[TimerTotal].Stop();
+
+  LOGF(INFO, "Sent payload of %zu bytes in %zu parts in %zu messages for TF %d | Timing (total/IO): %.3e / %.3e", tfSize, tfNParts,
+       messagesPerRoute.size(), mTFCounter, mTimer[TimerTotal].CpuTime() - tTotStart, mTimer[TimerIO].CpuTime() - tIOStart);
+
+  mSentSize += tfSize;
+  mSentMessages += tfNParts;
+
+  mReader->setNextTFToRead(++tfID);
+  ++mTFCounter;
+}
+
+//_________________________________________________________
 o2f::DataProcessorSpec getReaderSpec(const ReaderInp& rinp)
 {
   // check which inputs are present in files to read

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -35,6 +35,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"cache-data", VariantType::Bool, false, {"cache data at 1st reading, may require excessive memory!!!"}});
   options.push_back(ConfigParamSpec{"detect-tf0", VariantType::Bool, false, {"autodetect HBFUtils start Orbit/BC from 1st TF seen"}});
   options.push_back(ConfigParamSpec{"calculate-tf-start", VariantType::Bool, false, {"calculate TF start instead of using TType"}});
+  options.push_back(ConfigParamSpec{"drop-tf", VariantType::String, "none", {"Drop each TFid%(1)==(2) of detector, e.g. ITS,2,4;TPC,4[,0];..."}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -64,6 +65,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   rinp.preferCalcTF = configcontext.options().get<bool>("calculate-tf-start");
   rinp.rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
   rinp.delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
+  rinp.dropTF = configcontext.options().get<std::string>("drop-tf");
   rinp.errMap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     auto ei = RawFileReader::ErrTypes(i);


### PR DESCRIPTION
For testing reason one can request dropping of some fraction of the TFs for particular detector.
With option `--drop-tf "ITS,3,2;TPC,10"` the reader will not send the output for ITS in TFs with
`(TFid%3)==2` and for TPC in TFs with `(TFid%10)==0`.
Note that in order to acknowledge the TF , the message `{FLP/DISTSUBTIMEFRAME/0}` will still be sent even
if all detector's data were dropped for a given TF.