### PR TITLE
Use "expired messages" mechanism for ITS/MFT raw data decoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -23,17 +23,17 @@ o2_add_library(ITSMFTReconstruction
                        src/PayLoadCont.cxx
                        src/GBTWord.cxx
                        src/RUInfo.cxx
-		       src/GBTLink.cxx
-		       src/RUDecodeData.cxx
-		       src/RawPixelDecoder.cxx
+                       src/GBTLink.cxx
+                       src/RUDecodeData.cxx
+                       src/RawPixelDecoder.cxx
                        src/CTFCoder.cxx
                        src/DecodingStat.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
                                      O2::CommonDataFormat
-	                             O2::DetectorsRaw
+                                     O2::DetectorsRaw
                                      O2::SimulationDataFormat 
                                      O2::DataFormatsITSMFT
-				     O2::DPLUtils
+                                     O2::DPLUtils
                                      O2::rANS
                                      O2::Headers)
 
@@ -42,7 +42,6 @@ o2_target_root_dictionary(
   HEADERS include/ITSMFTReconstruction/PixelReader.h
           include/ITSMFTReconstruction/GBTLink.h
           include/ITSMFTReconstruction/RUDecodeData.h
-	  include/ITSMFTReconstruction/RawPixelDecoder.h
           include/ITSMFTReconstruction/DigitPixelReader.h
           include/ITSMFTReconstruction/RawPixelReader.h
           include/ITSMFTReconstruction/PixelData.h

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -127,8 +127,6 @@ class RawPixelDecoder final : public PixelReader
   TStopwatch mTimerTFStart;
   TStopwatch mTimerDecode;
   TStopwatch mTimerFetchData;
-
-  ClassDefOverride(RawPixelDecoder, 1);
 };
 
 ///______________________________________________________________

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -14,9 +14,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::itsmft::RawPixelDecoder < o2::itsmft::ChipMappingITS> + ;
-#pragma link C++ class o2::itsmft::RawPixelDecoder < o2::itsmft::ChipMappingMFT> + ;
-
 #pragma link C++ class o2::itsmft::Clusterer + ;
 #pragma link C++ class o2::itsmft::PixelReader + ;
 #pragma link C++ class o2::itsmft::DigitPixelReader + ;

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -14,6 +14,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "ITSMFTReconstruction/RawPixelDecoder.h"
 #include "DPLUtils/DPLRawParser.h"
+#include "Framework/InputRecordWalker.h"
 #include "CommonUtils/StringUtils.h"
 
 #ifdef WITH_OPENMP
@@ -171,6 +172,21 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
   auto origin = (mUserDataOrigin == o2::header::gDataOriginInvalid) ? mMAP.getOrigin() : mUserDataOrigin;
   auto datadesc = (mUserDataDescription == o2::header::gDataDescriptionInvalid) ? o2::header::gDataDescriptionRawData : mUserDataDescription;
   std::vector<InputSpec> filter{InputSpec{"filter", ConcreteDataTypeMatcher{origin, datadesc}, Lifetime::Timeframe}};
+
+  // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
+  // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
+  {
+    std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{origin, datadesc, 0xDEADBEEF}}};
+    for (const auto& ref : InputRecordWalker(inputs, dummy)) {
+      const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      if (dh->payloadSize == 0) {
+        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+        return;
+      }
+    }
+  }
+
   DPLRawParser parser(inputs, filter);
   uint32_t currSSpec = 0xffffffff; // dummy starting subspec
   int linksAdded = 0;

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -62,8 +62,8 @@ using STFDecoderITS = STFDecoder<ChipMappingITS>;
 using STFDecoderMFT = STFDecoder<ChipMappingMFT>;
 
 /// create a processor spec
-o2::framework::DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise);
-o2::framework::DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, const std::string& dict, const std::string& noise);
+o2::framework::DataProcessorSpec getSTFDecoderITSSpec(bool doClusters, bool doPatterns, bool doDigits, bool askDISTSTF, const std::string& dict, const std::string& noise);
+o2::framework::DataProcessorSpec getSTFDecoderMFTSpec(bool doClusters, bool doPatterns, bool doDigits, bool askDISTSTF, const std::string& dict, const std::string& noise);
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -27,6 +27,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"digits", VariantType::Bool, false, {"produce digits (def: skip)"}},
     ConfigParamSpec{"dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}},
     ConfigParamSpec{"noise-file", VariantType::String, "", {"name of the noise map file"}},
+    ConfigParamSpec{"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -44,14 +45,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto doDigits = cfgc.options().get<bool>("digits");
   auto dict = cfgc.options().get<std::string>("dict-file");
   auto noise = cfgc.options().get<std::string>("noise-file");
-
+  auto askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   if (cfgc.options().get<bool>("runmft")) {
-    wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, dict, noise));
+    wf.emplace_back(o2::itsmft::getSTFDecoderMFTSpec(doClusters, doPatterns, doDigits, askSTFDist, dict, noise));
   } else {
-    wf.emplace_back(o2::itsmft::getSTFDecoderITSSpec(doClusters, doPatterns, doDigits, dict, noise));
+    wf.emplace_back(o2::itsmft::getSTFDecoderITSSpec(doClusters, doPatterns, doDigits, askSTFDist, dict, noise));
   }
   return wf;
 }


### PR DESCRIPTION
If detector raw processing device with default completion policy does not receive for some TF the data it has subscribed to (in case of wild-carded subscription - if no message matching to the wildcard was received), it will not produce any output for this TF.
Respectively, the downstream devices expecting this output will also miss the complete set of inputs they need and the whole TF will be eventually lost for all detectors (since the sink, i.e. CTF writer will also not process this TF due to the incomplete input).

In order to avoid this, the if no data were seen for particular InputSpec of the device, the DPL framework may inject a dummy message with requested `<dataOrigin>/<dataDescription>` and `0xdeadbeef` `subSpec` and 0 payload. Detector raw-data processing device must handle such input as regular but empty TF and send corresponding empty output.

In order to activate this mechanism, device should
1) define its InputSpecs for the raw data with `Lifetime::Optional` setting.
2) receive at least 1 guaranteed input (which will allow to acknowledge the TF). This can be a `{FLP/DISTSUBTIMEFRAME/0}` message which is always injected by the DataDistribution and is guaranteed to be available both on FLPs and EPNs.

This PR implements this requirements for the ITS/MFT raw data decoder and can be served as example for other detectors.

-----------------------

* ITS/MFT decoder will watch dummy inputs to trace dropped TFs. 
The `<DET>/RAWDATA/0xdeadbeaf` message with 0 payload means that the "expired messages" mechanism was enacted and dummy message was generated instead of missing TF.

* ITS/MFT decoder subscribes to `FLP/DISTSUBTIMEFRAME/0`:     
In order to acknowledge the TF whose data was dropped and activate the dummy input generation (to avoid workflow blocking), the raw data processors need to subscribe to a message which is  guaranteed to be present in the TF. 
Therefore, the decoder device will subscribe to `FLP/DISTSUBTIMEFRAME/0` by default .
This can be avoided by providing option `--ignore-dist-stf`  to `o2-itsmft-stf-decoder-workflow`
