### PR TITLE
o2-sim: Simple z-dependent R-cut (for ZDC)

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimCutParams.h
+++ b/Common/SimConfig/include/SimConfig/SimCutParams.h
@@ -26,8 +26,11 @@ struct SimCutParams : public o2::conf::ConfigurableParamHelper<SimCutParams> {
 
   double maxRTracking = 1E20;    // max R tracking cut in cm (in the VMC sense) -- applied in addition to cutting in the stepping function
   double maxAbsZTracking = 1E20; // max |Z| tracking cut in cm (in the VMC sense) -- applied in addition to cutting in the stepping function
-  double ZmaxA = 1E20;           // max Z tracking cut on A side in cm -- applied in the stepping function
-  double ZmaxC = 1E20;           // max Z tracking cut on C side in cm -- applied in the stepping function
+  double ZmaxA = 1E20;           // max Z tracking cut on A side in cm -- applied in our custom stepping function
+  double ZmaxC = 1E20;           // max Z tracking cut on C side in cm -- applied in out custom stepping function
+
+  float maxRTrackingZDC = 50; // R-cut applied in the tunnel leading to ZDC when z > beampipeZ (custom stepping function)
+  float tunnelZ = 1900;       // Z-value from where we apply maxRTrackingZDC (default value taken from standard "hall" dimensions)
 
   O2ParamDef(SimCutParams, "SimCutParams");
 };

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -54,14 +54,27 @@ void O2MCApplicationBase::Stepping()
     // we can kill tracks here based on our
     // custom detector specificities
 
+    // Note that this is done in addition to the generic
+    // R + Z-cut mechanism at VMC level.
+
     float x, y, z;
     fMC->TrackPosition(x, y, z);
 
-    if (z > mCutParams.ZmaxA) {
-      fMC->StopTrack();
-      return;
-    }
-    if (-z > mCutParams.ZmaxC) {
+    // this function is implementing a basic z-dependent R cut
+    // can be generalized later on
+    auto outOfR = [x, y, this](float z) {
+      // for the moment for cases when we have ZDC enabled
+      if (std::abs(z) > mCutParams.tunnelZ) {
+        if ((x * x + y * y) > mCutParams.maxRTrackingZDC * mCutParams.maxRTrackingZDC) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (z > mCutParams.ZmaxA ||
+        -z > mCutParams.ZmaxC ||
+        outOfR(z)) {
       fMC->StopTrack();
       return;
     }


### PR DESCRIPTION
Implementation of a simple z-position dependent
R-cut. This is needed since VMC only offers
global R-cuts.

Here we apply a much tigher R-cut in the
tunnel leading to ZDC, to avoid excessive
stepping in the concrete. This is configurable via SimCutParams.