### PR TITLE
DPL: do not protect against invalid JSONs

### DIFF
--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -14,6 +14,7 @@
 #include "Framework/DataSpecUtils.h"
 #include "Framework/VariantJSONHelpers.h"
 #include "Framework/DataDescriptorMatcher.h"
+#include "Framework/Logger.h"
 
 #include <rapidjson/reader.h>
 #include <rapidjson/prettywriter.h>
@@ -625,21 +626,6 @@ void WorkflowSerializationHelpers::import(std::istream& s,
                                           std::vector<DataProcessorSpec>& workflow,
                                           std::vector<DataProcessorInfo>& metadata)
 {
-  // Skip any line which does not start with '{'
-  // If we do not find a starting {, we simply assume that no workflow
-  // was actually passed on the PIPE.
-  // FIXME: not particularly resilient, but works for now.
-  // FIXME: this will fail if { is found at char 1024.
-  char buf[1024];
-  while (s.peek() != '{') {
-    if (s.eof()) {
-      return;
-    }
-    if (s.fail() || s.bad()) {
-      throw std::runtime_error("Malformatted input workflow");
-    }
-    s.getline(buf, 1024, '\n');
-  }
   rapidjson::Reader reader;
   rapidjson::IStreamWrapper isw(s);
   WorkflowImporter importer{workflow, metadata};


### PR DESCRIPTION
There is no point anymore to protect against invalid jsons,
because we generate them without any spurious preamble, unlike in
the past. This will at least change where the 8 core queues will
hang.