### PR TITLE
Correct treatment of HBFUtils.orbitFirst in TPC raw converter and use DataHeader::firstTForbit

### DIFF
--- a/Detectors/TPC/qc/src/Tracking.cxx
+++ b/Detectors/TPC/qc/src/Tracking.cxx
@@ -48,8 +48,8 @@ void Tracking::initialize(outputModes outputMode, bool postprocessOnly)
   mQAConfig = std::make_unique<GPUO2InterfaceConfiguration>();
   const auto grp = o2::parameters::GRPObject::loadFrom(o2::base::NameConf::getGRPFileName());
   if (grp) {
-    mQAConfig->configEvent.solenoidBz = 5.00668f * grp->getL3Current() / 30000.;
-    mQAConfig->configEvent.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0;
+    mQAConfig->configGRP.solenoidBz = 5.00668f * grp->getL3Current() / 30000.;
+    mQAConfig->configGRP.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0;
   } else {
     throw std::runtime_error("Failed to initialize run parameters from GRP");
   }

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -64,6 +64,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
   GPUTPCDigitsMCInput gpuDigitsMapMC;
   GPUTrackingInOutPointers ptrs;
 
+  ptrs.settingsTF = data->settingsTF;
   ptrs.tpcCompressedClusters = data->compressedClusters;
   ptrs.tpcZS = data->tpcZS;
   if (data->o2Digits) {

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -68,7 +68,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
   ptrs.tpcZS = data->tpcZS;
   if (data->o2Digits) {
     const float zsThreshold = mTrackingCAO2Interface->getConfig().configReconstruction.tpcZSthreshold;
-    const int maxContTimeBin = mTrackingCAO2Interface->getConfig().configEvent.continuousMaxTimeBin;
+    const int maxContTimeBin = mTrackingCAO2Interface->getConfig().configGRP.continuousMaxTimeBin;
     for (int i = 0; i < Sector::MAXSECTOR; i++) {
       const auto& d = (*(data->o2Digits))[i];
       if (zsThreshold > 0 && data->tpcZS == nullptr) {

--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
   config.configProcessing.eventDisplay = nullptr; //Ptr to event display backend, for running standalone OpenGL event display
   //config.configProcessing.eventDisplay = new GPUDisplayBackendGlfw;
 
-  config.configEvent.solenoidBz = solenoidBz;
-  config.configEvent.continuousMaxTimeBin = continuous ? GPUSettings::TPC_MAX_TF_TIME_BIN : 0; //Number of timebins in timeframe if continuous, 0 otherwise
+  config.configGRP.solenoidBz = solenoidBz;
+  config.configGRP.continuousMaxTimeBin = continuous ? GPUSettings::TPC_MAX_TF_TIME_BIN : 0; //Number of timebins in timeframe if continuous, 0 otherwise
 
   config.configReconstruction.NWays = 3;               //Should always be 3!
   config.configReconstruction.NWaysOuter = true;       //Will create outer param for TRD

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -59,7 +59,6 @@ struct ProcessAttributes {
   std::unique_ptr<unsigned long long int[]> zsoutput;
   std::vector<unsigned int> sizes;
   MCLabelContainer mctruthArray;
-  std::unique_ptr<o2::gpu::GPUReconstructionConvert> zsEncoder;
   std::vector<int> inputIds;
   bool zs12bit = true;
   float zsThreshold = 2.f;
@@ -194,7 +193,6 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
 
 void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::raw::RawFileWriter& writer)
 {
-  auto& zsEncoder = processAttributes->zsEncoder;
   const auto zsThreshold = processAttributes->zsThreshold;
   const auto zs12bit = processAttributes->zs12bit;
   GPUParam _GPUParam;
@@ -202,7 +200,8 @@ void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::
   const GPUParam mGPUParam = _GPUParam;
 
   o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
-  zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, zsThreshold, processAttributes->padding);
+  ir.bc = 0; // By convention the TF starts at BC = 0
+  o2::gpu::GPUReconstructionConvert::RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, zsThreshold, processAttributes->padding);
 }
 
 int main(int argc, char** argv)

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -201,8 +201,7 @@ void convert(DigitArray& inputDigits, ProcessAttributes* processAttributes, o2::
   _GPUParam.SetDefaults(5.00668);
   const GPUParam mGPUParam = _GPUParam;
 
-  //o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
-  o2::InteractionRecord ir(0, 0); // we start with the time registered in ditigs, w/o extra offset
+  o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
   zsEncoder->RunZSEncoder<o2::tpc::Digit>(inputDigits, nullptr, nullptr, &writer, &ir, mGPUParam, zs12bit, false, zsThreshold, processAttributes->padding);
 }
 

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -328,6 +328,7 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
       const unsigned int* tpcZSmetaSizes2[GPUTrackingInOutZS::NSLICES][GPUTrackingInOutZS::NENDPOINTS];
       std::array<unsigned int, NEndpoints * NSectors> tpcZSonTheFlySizes;
       gsl::span<const ZeroSuppressedContainer8kb> inputZS;
+      o2::gpu::GPUSettingsTF tfSettings;
 
       bool getWorkflowTPCInput_clusters = false, getWorkflowTPCInput_mc = false, getWorkflowTPCInput_digits = false;
 
@@ -576,6 +577,11 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
       if (specconfig.processMC && specconfig.caClusterer) {
         outputRegions.clusterLabels.allocator = [&clustersMCBuffer](size_t size) -> void* { return &clustersMCBuffer; };
       }
+
+      const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
+      tfSettings.tfStartOrbit = dh->firstTForbit;
+      tfSettings.hasTfStartOrbit = 1;
+      ptrs.settingsTF = &tfSettings;
 
       int retVal = tracker->runTracking(&ptrs, &outputRegions);
       if (processAttributes->suppressOutput) {

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -134,9 +134,9 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
       o2::base::GeometryManager::loadGeometry();
       o2::base::Propagator::initFieldFromGRP(o2::base::NameConf::getGRPFileName());
       if (grp) {
-        config.configEvent.solenoidBz = 5.00668f * grp->getL3Current() / 30000.;
-        config.configEvent.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0; // Number of timebins in timeframe if continuous, 0 otherwise
-        LOG(INFO) << "Initializing run paramerers from GRP bz=" << config.configEvent.solenoidBz << " cont=" << grp->isDetContinuousReadOut(o2::detectors::DetID::TPC);
+        config.configGRP.solenoidBz = 5.00668f * grp->getL3Current() / 30000.;
+        config.configGRP.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0; // Number of timebins in timeframe if continuous, 0 otherwise
+        LOG(INFO) << "Initializing run paramerers from GRP bz=" << config.configGRP.solenoidBz << " cont=" << grp->isDetContinuousReadOut(o2::detectors::DetID::TPC);
       } else {
         throw std::runtime_error("Failed to initialize run parameters from GRP");
       }
@@ -156,8 +156,8 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
 #endif
       }
 
-      if (config.configEvent.continuousMaxTimeBin == -1) {
-        config.configEvent.continuousMaxTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * constants::LHCBCPERTIMEBIN - 2) / constants::LHCBCPERTIMEBIN;
+      if (config.configGRP.continuousMaxTimeBin == -1) {
+        config.configGRP.continuousMaxTimeBin = (o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * constants::LHCBCPERTIMEBIN - 2) / constants::LHCBCPERTIMEBIN;
       }
       if (config.configProcessing.deviceNum == -2) {
         int myId = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -95,9 +95,9 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
 
       GPUParam _GPUParam;
       GPUO2InterfaceConfiguration config;
-      config.configEvent.solenoidBz = 5.00668;
+      config.configGRP.solenoidBz = 5.00668;
       config.ReadConfigurableParam();
-      _GPUParam.SetDefaults(&config.configEvent, &config.configReconstruction, &config.configProcessing, nullptr);
+      _GPUParam.SetDefaults(&config.configGRP, &config.configReconstruction, &config.configProcessing, nullptr);
 
       const auto& inputs = getWorkflowTPCInput(pc, 0, false, false, 0xFFFFFFFFF, true);
       sizes.resize(NSectors * NEndpoints);

--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -119,13 +119,13 @@ void GPUParam::SetDefaults(float solenoidBz)
   GPUTPCGMPolynomialFieldManager::GetPolynomialField(par.BzkG, polynomialField);
 }
 
-void GPUParam::UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsProcessing* p)
+void GPUParam::UpdateGRPSettings(const GPUSettingsGRP* g, const GPUSettingsProcessing* p)
 {
-  if (e) {
-    par.AssumeConstantBz = e->constBz;
-    par.ToyMCEventsFlag = e->homemadeEvents;
-    par.ContinuousTracking = e->continuousMaxTimeBin != 0;
-    par.continuousMaxTimeBin = e->continuousMaxTimeBin == -1 ? GPUSettings::TPC_MAX_TF_TIME_BIN : e->continuousMaxTimeBin;
+  if (g) {
+    par.AssumeConstantBz = g->constBz;
+    par.ToyMCEventsFlag = g->homemadeEvents;
+    par.ContinuousTracking = g->continuousMaxTimeBin != 0;
+    par.continuousMaxTimeBin = g->continuousMaxTimeBin == -1 ? GPUSettings::TPC_MAX_TF_TIME_BIN : g->continuousMaxTimeBin;
     polynomialField.Reset();
     if (par.AssumeConstantBz) {
       GPUTPCGMPolynomialFieldManager::GetPolynomialField(GPUTPCGMPolynomialFieldManager::kUniform, par.BzkG, polynomialField);
@@ -140,9 +140,9 @@ void GPUParam::UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsP
   par.earlyTpcTransform = rec.ForceEarlyTPCTransform == -1 ? (!par.ContinuousTracking) : rec.ForceEarlyTPCTransform;
 }
 
-void GPUParam::SetDefaults(const GPUSettingsEvent* e, const GPUSettingsRec* r, const GPUSettingsProcessing* p, const GPURecoStepConfiguration* w)
+void GPUParam::SetDefaults(const GPUSettingsGRP* g, const GPUSettingsRec* r, const GPUSettingsProcessing* p, const GPURecoStepConfiguration* w)
 {
-  SetDefaults(e->solenoidBz);
+  SetDefaults(g->solenoidBz);
   if (w) {
     par.dodEdx = w->steps.isSet(GPUDataTypes::RecoStep::TPCdEdx);
   }
@@ -152,7 +152,7 @@ void GPUParam::SetDefaults(const GPUSettingsEvent* e, const GPUSettingsRec* r, c
       rec.fitPropagateBzOnly = rec.NWays - 1;
     }
   }
-  UpdateEventSettings(e, p);
+  UpdateGRPSettings(g, p);
 }
 
 #ifndef GPUCA_ALIROOT_LIB

--- a/GPU/GPUTracking/Base/GPUParam.h
+++ b/GPU/GPUTracking/Base/GPUParam.h
@@ -35,7 +35,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 struct GPUSettingsRec;
-struct GPUSettingsEvent;
+struct GPUSettingsGTP;
 struct GPURecoStepConfiguration;
 
 struct GPUParamSlice {
@@ -69,8 +69,8 @@ struct GPUParam : public internal::GPUParam_t<GPUSettingsRec, GPUSettingsParam> 
 
 #ifndef GPUCA_GPUCODE
   void SetDefaults(float solenoidBz);
-  void SetDefaults(const GPUSettingsEvent* e, const GPUSettingsRec* r = nullptr, const GPUSettingsProcessing* p = nullptr, const GPURecoStepConfiguration* w = nullptr);
-  void UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsProcessing* p = nullptr);
+  void SetDefaults(const GPUSettingsGRP* g, const GPUSettingsRec* r = nullptr, const GPUSettingsProcessing* p = nullptr, const GPURecoStepConfiguration* w = nullptr);
+  void UpdateGRPSettings(const GPUSettingsGRP* g, const GPUSettingsProcessing* p = nullptr);
   void LoadClusterErrors(bool Print = 0);
   o2::base::Propagator* GetDefaultO2Propagator(bool useGPUField = false) const;
 #endif

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -224,15 +224,15 @@ class GPUReconstruction
   bool IsGPU() const { return GetDeviceType() != DeviceType::INVALID_DEVICE && GetDeviceType() != DeviceType::CPU; }
   const GPUParam& GetParam() const { return mHostConstantMem->param; }
   const GPUConstantMem& GetConstantMem() const { return *mHostConstantMem; }
-  const GPUSettingsEvent& GetEventSettings() const { return mEventSettings; }
+  const GPUSettingsGRP& GetGRPSettings() const { return mGRPSettings; }
   const GPUSettingsDeviceBackend& GetDeviceBackendSettings() { return mDeviceBackendSettings; }
   const GPUSettingsProcessing& GetProcessingSettings() const { return mProcessingSettings; }
   bool IsInitialized() const { return mInitialized; }
   void SetSettings(float solenoidBz, const GPURecoStepConfiguration* workflow = nullptr);
-  void SetSettings(const GPUSettingsEvent* settings, const GPUSettingsRec* rec = nullptr, const GPUSettingsProcessing* proc = nullptr, const GPURecoStepConfiguration* workflow = nullptr);
+  void SetSettings(const GPUSettingsGRP* grp, const GPUSettingsRec* rec = nullptr, const GPUSettingsProcessing* proc = nullptr, const GPURecoStepConfiguration* workflow = nullptr);
   void SetResetTimers(bool reset) { mProcessingSettings.resetTimers = reset; } // May update also after Init()
   void SetDebugLevelTmp(int level) { mProcessingSettings.debugLevel = level; } // Temporarily, before calling SetSettings()
-  void UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsProcessing* p = nullptr);
+  void UpdateGRPSettings(const GPUSettingsGRP* g, const GPUSettingsProcessing* p = nullptr);
   void SetOutputControl(const GPUOutputControl& v) { mOutputControl = v; }
   void SetOutputControl(void* ptr, size_t size);
   void SetInputControl(void* ptr, size_t size);
@@ -323,7 +323,7 @@ class GPUReconstruction
   GPUConstantMem* mDeviceConstantMem = nullptr;
 
   // Settings
-  GPUSettingsEvent mEventSettings;                      // Event Parameters
+  GPUSettingsGRP mGRPSettings;                          // Global Run Parameters
   GPUSettingsDeviceBackend mDeviceBackendSettings;      // Processing Parameters (at constructor level)
   GPUSettingsProcessing mProcessingSettings;            // Processing Parameters (at init level)
   GPUOutputControl mOutputControl;                      // Controls the output of the individual components

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -12,7 +12,6 @@
 /// \author David Rohr
 
 #ifdef GPUCA_O2_LIB
-#include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RawFileWriter.h"
 #include "TPCBase/Sector.h"
 #include "DataFormatsTPC/Digit.h"
@@ -195,10 +194,10 @@ void GPUReconstructionConvert::ZSstreamOut(unsigned short* bufIn, unsigned int& 
 }
 
 #ifdef HAVE_O2HEADERS
-void GPUReconstructionConvert::ZSfillEmpty(void* ptr, int shift, unsigned int feeId)
+void GPUReconstructionConvert::ZSfillEmpty(void* ptr, int shift, unsigned int feeId, int orbit)
 {
   RAWDataHeaderGPU* rdh = (RAWDataHeaderGPU*)ptr;
-  o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, 0);
+  o2::raw::RDHUtils::setHeartBeatOrbit(*rdh, orbit);
   o2::raw::RDHUtils::setHeartBeatBC(*rdh, shift);
   o2::raw::RDHUtils::setMemorySize(*rdh, sizeof(RAWDataHeaderGPU));
   o2::raw::RDHUtils::setVersion(*rdh, o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>());
@@ -242,9 +241,11 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
 #ifdef GPUCA_O2_LIB
     int rawlnk = rdh_utils::UserLogicLinkID;
     int bcShiftInFirstHBF = ir ? ir->bc : 0;
+    int orbitShift = ir ? ir->orbit : 0;
 #else
     int rawlnk = 15;
     int bcShiftInFirstHBF = 0;
+    int orbitShift = 0;
 #endif
     int rawcru = 0;
     int rawendpoint = 0;
@@ -310,6 +311,9 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         }
         if (ZSEncoderGetTime(tmpBuffer[k]) != lastTime) {
           nexthbf = ((long)ZSEncoderGetTime(tmpBuffer[k]) * LHCBCPERTIMEBIN + bcShiftInFirstHBF) / o2::constants::lhc::LHCMaxBunches;
+          if (nexthbf < 0) {
+            throw std::runtime_error("Received digit before the defined first orbit");
+          }
           if (hbf != nexthbf) {
             lastEndpoint = -2;
           }
@@ -351,7 +355,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           if (raw) {
             size_t size = (padding || lastEndpoint == -1) ? TPCZSHDR::TPC_ZS_PAGE_SIZE : (pagePtr - (unsigned char*)page);
             size = CAMath::nextMultipleOf<o2::raw::RDHUtils::GBTWord>(size);
-            raw->addData(rawfeeid, rawcru, rawlnk, rawendpoint, *ir + hbf * o2::constants::lhc::LHCMaxBunches, gsl::span<char>((char*)page + sizeof(RAWDataHeaderGPU), (char*)page + size), true);
+            raw->addData(rawfeeid, rawcru, rawlnk, rawendpoint, *ir + (hbf - orbitShift) * o2::constants::lhc::LHCMaxBunches, gsl::span<char>((char*)page + sizeof(RAWDataHeaderGPU), (char*)page + size), true);
           } else
 #endif
           {
@@ -371,10 +375,10 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         if (raw) {
           page = &singleBuffer;
         } else {
-          if (buffer[i][endpoint].size() == 0 && nexthbf != 0) {
+          if (buffer[i][endpoint].size() == 0 && nexthbf > orbitShift) {
             // Emplace empty page with RDH containing beginning of TFgpuDigitsMap
             buffer[i][endpoint].emplace_back();
-            ZSfillEmpty(&buffer[i][endpoint].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + endpoint / 2, endpoint & 1, rawlnk));
+            ZSfillEmpty(&buffer[i][endpoint].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + endpoint / 2, endpoint & 1, rawlnk), orbitShift);
             totalPages++;
           }
           buffer[i][endpoint].emplace_back();
@@ -390,7 +394,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
         hdr->cruID = i * 10 + region;
         rawcru = i * 10 + region;
         rawendpoint = endpoint & 1;
-        hdr->timeOffset = ZSEncoderGetTime(tmpBuffer[k]) * LHCBCPERTIMEBIN - (hbf - 0) * o2::constants::lhc::LHCMaxBunches;
+        hdr->timeOffset = (long)ZSEncoderGetTime(tmpBuffer[k]) * LHCBCPERTIMEBIN - (long)hbf * o2::constants::lhc::LHCMaxBunches;
         lastTime = -1;
         tbHdr = nullptr;
         lastEndpoint = endpoint;
@@ -435,7 +439,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
       for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
         if (buffer[i][j].size() == 0) {
           buffer[i][j].emplace_back();
-          ZSfillEmpty(&buffer[i][j].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + j / 2, j & 1, rawlnk));
+          ZSfillEmpty(&buffer[i][j].back(), bcShiftInFirstHBF, rdh_utils::getFEEID(i * 10 + j / 2, j & 1, rawlnk), orbitShift);
           totalPages++;
         }
       }
@@ -475,7 +479,7 @@ void GPUReconstructionConvert::RunZSEncoder(const S& in, std::unique_ptr<unsigne
           }
           int nRowsRegion = param.tpcGeometry.GetRegionRows(region);
 
-          int timeBin = (hdr->timeOffset + (o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstOrbit) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
+          int timeBin = (hdr->timeOffset + (unsigned long)(o2::raw::RDHUtils::getHeartBeatOrbit(*rdh) - firstOrbit) * o2::constants::lhc::LHCMaxBunches) / LHCBCPERTIMEBIN;
           for (int l = 0; l < hdr->nTimeBins; l++) {
             if ((pagePtr - reinterpret_cast<unsigned char*>(page)) & 1) {
               pagePtr++;

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -60,7 +60,7 @@ class GPUReconstructionConvert
 
  private:
   static void ZSstreamOut(unsigned short* bufIn, unsigned int& lenIn, unsigned char* bufOut, unsigned int& lenOut, unsigned int nBits);
-  static void ZSfillEmpty(void* ptr, int shift, unsigned int feeId);
+  static void ZSfillEmpty(void* ptr, int shift, unsigned int feeId, int orbit);
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Benchmark/standalone.cxx
+++ b/GPU/GPUTracking/Benchmark/standalone.cxx
@@ -279,7 +279,7 @@ int SetupReconstruction()
       printf("Error reading event config file\n");
       return 1;
     }
-    printf("Read event settings from dir %s (solenoidBz: %f, home-made events %d, constBz %d, maxTimeBin %d)\n", filename, rec->GetEventSettings().solenoidBz, (int)rec->GetEventSettings().homemadeEvents, (int)rec->GetEventSettings().constBz, rec->GetEventSettings().continuousMaxTimeBin);
+    printf("Read event settings from dir %s (solenoidBz: %f, home-made events %d, constBz %d, maxTimeBin %d)\n", filename, rec->GetGRPSettings().solenoidBz, (int)rec->GetGRPSettings().homemadeEvents, (int)rec->GetGRPSettings().constBz, rec->GetGRPSettings().continuousMaxTimeBin);
     if (configStandalone.testSyncAsync) {
       recAsync->ReadSettings(filename);
     }
@@ -291,7 +291,7 @@ int SetupReconstruction()
   chainTracking->mConfigQA = &configStandalone.QA;
   chainTracking->mConfigDisplay = &configStandalone.GL;
 
-  GPUSettingsEvent ev = rec->GetEventSettings();
+  GPUSettingsGRP grp = rec->GetGRPSettings();
   GPUSettingsRec recSet;
   GPUSettingsProcessing devProc;
   memcpy((void*)&recSet, (void*)&configStandalone.rec, sizeof(GPUSettingsRec));
@@ -299,16 +299,16 @@ int SetupReconstruction()
   GPURecoStepConfiguration steps;
 
   if (configStandalone.eventGenerator) {
-    ev.homemadeEvents = true;
+    grp.homemadeEvents = true;
   }
   if (configStandalone.solenoidBz != -1e6f) {
-    ev.solenoidBz = configStandalone.solenoidBz;
+    grp.solenoidBz = configStandalone.solenoidBz;
   }
   if (configStandalone.constBz) {
-    ev.constBz = true;
+    grp.constBz = true;
   }
   if (configStandalone.TF.nMerge || configStandalone.TF.bunchSim) {
-    if (ev.continuousMaxTimeBin) {
+    if (grp.continuousMaxTimeBin) {
       printf("ERROR: requested to overlay continuous data - not supported\n");
       return 1;
     }
@@ -317,11 +317,11 @@ int SetupReconstruction()
       configStandalone.cont = true;
     }
     if (chainTracking->GetTPCTransform()) {
-      ev.continuousMaxTimeBin = configStandalone.TF.timeFrameLen * ((double)GPUReconstructionTimeframe::TPCZ / (double)GPUReconstructionTimeframe::DRIFT_TIME) / chainTracking->GetTPCTransform()->getVDrift();
+      grp.continuousMaxTimeBin = configStandalone.TF.timeFrameLen * ((double)GPUReconstructionTimeframe::TPCZ / (double)GPUReconstructionTimeframe::DRIFT_TIME) / chainTracking->GetTPCTransform()->getVDrift();
     }
   }
-  if (configStandalone.cont && ev.continuousMaxTimeBin == 0) {
-    ev.continuousMaxTimeBin = -1;
+  if (configStandalone.cont && grp.continuousMaxTimeBin == 0) {
+    grp.continuousMaxTimeBin = -1;
   }
   if (rec->GetDeviceType() == GPUReconstruction::DeviceType::CPU) {
     printf("Standalone Test Framework for CA Tracker - Using CPU\n");
@@ -389,7 +389,7 @@ int SetupReconstruction()
     steps.steps.setBits(GPUDataTypes::RecoStep::TRDTracking, false);
   }
   steps.inputs.set(GPUDataTypes::InOutType::TPCClusters, GPUDataTypes::InOutType::TRDTracklets);
-  if (ev.needsClusterer) {
+  if (grp.needsClusterer) {
     steps.inputs.setBits(GPUDataTypes::InOutType::TPCRaw, true);
     steps.inputs.setBits(GPUDataTypes::InOutType::TPCClusters, false);
   } else {
@@ -421,9 +421,9 @@ int SetupReconstruction()
     }
   }
 
-  rec->SetSettings(&ev, &recSet, &devProc, &steps);
+  rec->SetSettings(&grp, &recSet, &devProc, &steps);
   if (configStandalone.proc.doublePipeline) {
-    recPipeline->SetSettings(&ev, &recSet, &devProc, &steps);
+    recPipeline->SetSettings(&grp, &recSet, &devProc, &steps);
   }
   if (configStandalone.testSyncAsync) {
     // Set settings for asynchronous
@@ -443,7 +443,7 @@ int SetupReconstruction()
     recSet.loopInterpolationInExtraPass = 0;
     recSet.MaxTrackQPt = CAMath::Min(recSet.MaxTrackQPt, recSet.tpcRejectQPt);
     recSet.useMatLUT = true;
-    recAsync->SetSettings(&ev, &recSet, &devProc, &steps);
+    recAsync->SetSettings(&grp, &recSet, &devProc, &steps);
   }
 
   if (configStandalone.outputcontrolmem) {
@@ -845,18 +845,18 @@ int main(int argc, char** argv)
         }
 
         if (configStandalone.overrideMaxTimebin && (chainTracking->mIOPtrs.clustersNative || chainTracking->mIOPtrs.tpcPackedDigits || chainTracking->mIOPtrs.tpcZS)) {
-          GPUSettingsEvent ev = rec->GetEventSettings();
-          if (ev.continuousMaxTimeBin == 0) {
+          GPUSettingsGRP grp = rec->GetGRPSettings();
+          if (grp.continuousMaxTimeBin == 0) {
             printf("Cannot override max time bin for non-continuous data!\n");
           } else {
-            ev.continuousMaxTimeBin = chainTracking->mIOPtrs.tpcZS ? GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.tpcZS) : chainTracking->mIOPtrs.tpcPackedDigits ? GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.tpcPackedDigits) : GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.clustersNative);
-            printf("Max time bin set to %d\n", (int)ev.continuousMaxTimeBin);
-            rec->UpdateEventSettings(&ev);
+            grp.continuousMaxTimeBin = chainTracking->mIOPtrs.tpcZS ? GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.tpcZS) : chainTracking->mIOPtrs.tpcPackedDigits ? GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.tpcPackedDigits) : GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.clustersNative);
+            printf("Max time bin set to %d\n", (int)grp.continuousMaxTimeBin);
+            rec->UpdateGRPSettings(&grp);
             if (recAsync) {
-              recAsync->UpdateEventSettings(&ev);
+              recAsync->UpdateGRPSettings(&grp);
             }
             if (recPipeline) {
-              recPipeline->UpdateEventSettings(&ev);
+              recPipeline->UpdateGRPSettings(&grp);
             }
           }
         }

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -104,6 +104,7 @@ struct GPUTPCMCInfo;
 struct GPUTPCClusterData;
 struct GPUTRDTrackletLabels;
 struct GPUTPCDigitsMCInput;
+struct GPUSettingsTF;
 
 class GPUDataTypes
 {
@@ -248,6 +249,7 @@ struct GPUTrackingInOutPointers {
   unsigned int nTRDTrackletsMC = 0;
   const GPUTRDTrackGPU* trdTracks = nullptr;
   unsigned int nTRDTracks = 0;
+  const GPUSettingsTF* settingsTF = nullptr;
 };
 #else
 struct GPUTrackingInOutPointers {

--- a/GPU/GPUTracking/DataTypes/GPUSettings.h
+++ b/GPU/GPUTracking/DataTypes/GPUSettings.h
@@ -50,8 +50,8 @@ class GPUSettings
 };
 
 #ifdef GPUCA_NOCOMPAT
-// Settings describing the events / time frames
-struct GPUSettingsEvent {
+// Settings describing the global run parameters
+struct GPUSettingsGRP {
   // All new members must be sizeof(int) resp. sizeof(float) for alignment reasons!
   float solenoidBz = -5.00668;  // solenoid field strength
   int constBz = 0;              // for test-MC events with constant Bz

--- a/GPU/GPUTracking/DataTypes/GPUSettings.h
+++ b/GPU/GPUTracking/DataTypes/GPUSettings.h
@@ -60,6 +60,16 @@ struct GPUSettingsGRP {
   int needsClusterer = 0;       // Set to true if the data requires the clusterizer
 };
 
+// Parameters of the current time frame
+struct GPUSettingsTF {
+  int hasTfStartOrbit = 0;
+  int tfStartOrbit = 0;
+  int hasRunStartOrbit = 0;
+  int runStartOrbit = 0;
+  int hasSimStartOrbit = 0;
+  int simStartOrbit = 0;
+};
+
 // Settings defining the setup of the GPUReconstruction processing (basically selecting the device / class instance)
 struct GPUSettingsDeviceBackend {
   unsigned int deviceType = GPUDataTypes::DeviceType::CPU; // Device type, shall use GPUDataTypes::DEVICE_TYPE constants, e.g. CPU / CUDA

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -218,7 +218,7 @@ EndConfig()
 
 #ifdef BeginConfig
 // Settings concerning the standlone timeframe from run 2 events assembly tool
-BeginSubConfig(GPUSettingsTF, TF, configStandalone, "TF", 't', "Timeframe settings")
+BeginSubConfig(GPUSettingsTFSim, TF, configStandalone, "TF", 't', "Timeframe settings")
 AddOption(nMerge, int, 0, "", 0, "Merge n events in a timeframe", min(0))
 AddOption(averageDistance, float, 50., "", 0, "Average distance in cm of events merged into timeframe", min(0.f))
 AddOption(randomizeDistance, bool, true, "", 0, "Randomize distance around average distance of merged events")
@@ -309,7 +309,7 @@ AddHelp("help", 'h')
 AddHelpAll("helpall", 'H')
 AddSubConfig(GPUSettingsRec, rec)
 AddSubConfig(GPUSettingsProcessing, proc)
-AddSubConfig(GPUSettingsTF, TF)
+AddSubConfig(GPUSettingsTFSim, TF)
 AddSubConfig(GPUSettingsQA, QA)
 AddSubConfig(GPUSettingsDisplay, GL)
 AddSubConfig(GPUSettingsDisplayLight, GLlight)

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -56,7 +56,7 @@ class GPUChain
   virtual void ReadSettings(const char* dir = "") {}
 
   const GPUParam& GetParam() const { return mRec->mHostConstantMem->param; }
-  const GPUSettingsEvent& GetEventSettings() const { return mRec->mEventSettings; }
+  const GPUSettingsGRP& GetGRPSettings() const { return mRec->mGRPSettings; }
   const GPUSettingsDeviceBackend& GetDeviceBackendSettings() const { return mRec->mDeviceBackendSettings; }
   const GPUSettingsProcessing& GetProcessingSettings() const { return mRec->mProcessingSettings; }
   GPUReconstruction* rec() { return mRec; }

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -54,10 +54,10 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
   unsigned int digits = 0;
   unsigned int pages = 0;
   for (unsigned short j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
-    unsigned short posInEndpoint = 0;
-    unsigned short pagesEndpoint = 0;
     clusterer.mMinMaxCN[j] = mCFContext->fragmentData[fragment.index].minMaxCN[iSlice][j];
     if (doGPU) {
+      unsigned short posInEndpoint = 0;
+      unsigned short pagesEndpoint = 0;
       for (unsigned int k = clusterer.mMinMaxCN[j].minC; k < clusterer.mMinMaxCN[j].maxC; k++) {
         const unsigned int minL = (k == clusterer.mMinMaxCN[j].minC) ? clusterer.mMinMaxCN[j].minN : 0;
         const unsigned int maxL = (k + 1 == clusterer.mMinMaxCN[j].maxC) ? clusterer.mMinMaxCN[j].maxN : mIOPtrs.tpcZS->slice[iSlice].nZSPtr[j][k];
@@ -69,6 +69,9 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
           }
           pagesEndpoint++;
         }
+      }
+      if (pagesEndpoint != mCFContext->fragmentData[fragment.index].pageDigits[iSlice][j].size()) {
+        GPUFatal("TPC raw page count mismatch in TPCClusterizerDecodeZSCountUpdate: expected %d / buffered %lu", pagesEndpoint, mCFContext->fragmentData[fragment.index].pageDigits[iSlice][j].size());
       }
     } else {
       clusterer.mPzsOffsets[j] = GPUTPCClusterFinder::ZSOffset{digits, j, 0};

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -414,7 +414,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
   auto* digitsMC = propagateMCLabels ? processors()->ioPtrs.tpcPackedDigits->tpcDigitsMC : nullptr;
 
   if (param().par.continuousMaxTimeBin > 0 && mCFContext->tpcMaxTimeBin >= (unsigned int)std::max(param().par.continuousMaxTimeBin + 1, TPC_MAX_FRAGMENT_LEN)) {
-    GPUError("Input data has invalid time bin\n");
+    GPUError("Input data has invalid time bin %u > %d\n", mCFContext->tpcMaxTimeBin, std::max(param().par.continuousMaxTimeBin + 1, TPC_MAX_FRAGMENT_LEN));
     return 1;
   }
   bool buildNativeGPU = (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCConversion) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCSliceTracking) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCMerging) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCCompression);

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -91,7 +91,7 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
   unsigned int nDigits = 0;
   unsigned int nPages = 0;
   bool doGPU = mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding;
-  int firstHBF = o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0]);
+  int firstHBF = (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasTfStartOrbit) ? mIOPtrs.settingsTF->tfStartOrbit : o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0]);
 
   for (unsigned short j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
 #ifndef GPUCA_NO_VC
@@ -506,7 +506,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
         }
 
         if (mIOPtrs.tpcZS) {
-          int firstHBF = o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0]);
+          int firstHBF = (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasTfStartOrbit) ? mIOPtrs.settingsTF->tfStartOrbit : o2::raw::RDHUtils::getHeartBeatOrbit(*(const RAWDataHeaderGPU*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0]);
           runKernel<GPUTPCCFDecodeZS, GPUTPCCFDecodeZS::decodeZS>(GetGridBlk(doGPU ? clusterer.mPmemory->counters.nPagesSubslice : GPUTrackingInOutZS::NENDPOINTS, lane), {iSlice}, {}, firstHBF);
           TransferMemoryResourceLinkToHost(RecoStep::TPCClusterFinding, clusterer.mMemoryId, lane);
         }

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -52,7 +52,7 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
   GPUTPCClusterFinder& clusterer = processors()->tpcClusterer[iSlice];
   GPUTPCClusterFinder::ZSOffset* o = processors()->tpcClusterer[iSlice].mPzsOffsets;
   unsigned int digits = 0;
-  unsigned short pages = 0;
+  unsigned int pages = 0;
   for (unsigned short j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
     unsigned short posInEndpoint = 0;
     unsigned short pagesEndpoint = 0;
@@ -70,14 +70,15 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
           pagesEndpoint++;
         }
       }
-      pages += pagesEndpoint;
     } else {
       clusterer.mPzsOffsets[j] = GPUTPCClusterFinder::ZSOffset{digits, j, 0};
       digits += mCFContext->fragmentData[fragment.index].nDigits[iSlice][j];
       pages += mCFContext->fragmentData[fragment.index].nPages[iSlice][j];
     }
   }
-
+  if (doGPU) {
+    pages = o - processors()->tpcClusterer[iSlice].mPzsOffsets;
+  }
   return {digits, pages};
 }
 

--- a/GPU/GPUTracking/Global/GPUChainTrackingMerger.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingMerger.cxx
@@ -297,7 +297,7 @@ int GPUChainTracking::RunTPCTrackingMerger(bool synchronizeOutput)
     } else {
       RecordMarker(&mEvents->single, 0);
       TransferMemoryResourceLinkToHost(RecoStep::TPCMerging, Merger.MemoryResOutputO2(), outputStream, nullptr, &mEvents->single);
-      TransferMemoryResourceLinkToHost(RecoStep::TPCMerging, Merger.MemoryResOutputO2Clus(), outputStream, nullptr, &mEvents->single);
+      TransferMemoryResourceLinkToHost(RecoStep::TPCMerging, Merger.MemoryResOutputO2Clus(), outputStream);
       ReleaseEvent(&mEvents->single);
     }
     mRec->PopNonPersistentMemory(RecoStep::TPCMerging, qStr2Tag("TPCMERG2"));

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -37,7 +37,7 @@ int GPUO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
     return (1);
   }
   mConfig.reset(new GPUO2InterfaceConfiguration(config));
-  mContinuous = mConfig->configEvent.continuousMaxTimeBin != 0;
+  mContinuous = mConfig->configGRP.continuousMaxTimeBin != 0;
   mRec.reset(GPUReconstruction::CreateInstance(mConfig->configDeviceBackend));
   if (mRec == nullptr) {
     GPUError("Error obtaining instance of GPUReconstruction");
@@ -47,9 +47,9 @@ int GPUO2Interface::Initialize(const GPUO2InterfaceConfiguration& config)
   mChain->mConfigDisplay = &mConfig->configDisplay;
   mChain->mConfigQA = &mConfig->configQA;
   if (mConfig->configWorkflow.inputs.isSet(GPUDataTypes::InOutType::TPCRaw)) {
-    mConfig->configEvent.needsClusterer = 1;
+    mConfig->configGRP.needsClusterer = 1;
   }
-  mRec->SetSettings(&mConfig->configEvent, &mConfig->configReconstruction, &mConfig->configProcessing, &mConfig->configWorkflow);
+  mRec->SetSettings(&mConfig->configGRP, &mConfig->configReconstruction, &mConfig->configProcessing, &mConfig->configWorkflow);
   mChain->SetCalibObjects(mConfig->configCalib);
   mOutputRegions.reset(new GPUTrackingOutputs);
   if (mConfig->configInterface.outputToExternalBuffers) {

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfigurableParam.cxx
@@ -98,13 +98,13 @@ GPUSettingsO2 GPUO2InterfaceConfiguration::ReadConfigurableParam_internal()
   configDisplay = GL;
   configQA = QA;
   if (global.continuousMaxTimeBin) {
-    configEvent.continuousMaxTimeBin = global.continuousMaxTimeBin;
+    configGRP.continuousMaxTimeBin = global.continuousMaxTimeBin;
   }
   if (global.solenoidBz > -1e6f) {
-    configEvent.solenoidBz = global.solenoidBz;
+    configGRP.solenoidBz = global.solenoidBz;
   }
   if (global.constBz) {
-    configEvent.constBz = global.constBz;
+    configGRP.constBz = global.constBz;
   }
   if (configReconstruction.TrackReferenceX == 1000.f) {
     configReconstruction.TrackReferenceX = 83.f;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -82,7 +82,7 @@ struct GPUO2InterfaceConfiguration {
 
   GPUSettingsDeviceBackend configDeviceBackend;
   GPUSettingsProcessing configProcessing;
-  GPUSettingsEvent configEvent;
+  GPUSettingsGRP configGRP;
   GPUSettingsRec configReconstruction;
   GPUSettingsDisplay configDisplay;
   GPUSettingsQA configQA;

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -125,6 +125,9 @@ struct GPUO2InterfaceIOPtrs {
 #endif
   // Output for entropy-reduced clusters of TPC compression
   const o2::tpc::CompressedClustersFlat* compressedClusters = nullptr;
+
+  // Ptr to parameters for current TF
+  const GPUSettingsTF* settingsTF = nullptr;
 };
 } // namespace gpu
 } // namespace o2

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceQA.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceQA.cxx
@@ -22,7 +22,7 @@ using namespace o2::tpc;
 GPUO2InterfaceQA::GPUO2InterfaceQA(const GPUO2InterfaceConfiguration* config)
 {
   mParam.reset(new GPUParam);
-  mParam->SetDefaults(&config->configEvent, &config->configReconstruction, &config->configProcessing, nullptr);
+  mParam->SetDefaults(&config->configGRP, &config->configReconstruction, &config->configProcessing, nullptr);
   mQA.reset(new GPUQA(nullptr, &config->configQA, mParam.get()));
 }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMO2Output.cxx
@@ -107,7 +107,7 @@ GPUdii() void GPUTPCGMO2Output::Thread<GPUTPCGMO2Output::output>(int nBlocks, in
   uint2* GPUrestrict() tmpData = merger.ClusRefTmp();
 
   for (int iTmp = get_global_id(0); iTmp < nTracks; iTmp += get_global_size(0)) {
-    auto& oTrack = outputTracks[iTmp];
+    TrackTPC oTrack;
     const int i = trackSort[iTmp].x;
 
     oTrack.set(tracks[i].GetParam().GetX(), tracks[i].GetAlpha(),
@@ -202,6 +202,7 @@ GPUdii() void GPUTPCGMO2Output::Thread<GPUTPCGMO2Output::output>(int nBlocks, in
     } else {
       oTrack.setHasASideClusters();
     }
+    outputTracks[iTmp] = oTrack;
   }
 }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGlobalMergerComponent.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGlobalMergerComponent.cxx
@@ -290,10 +290,10 @@ int GPUTPCGlobalMergerComponent::Configure(const char* cdbEntry, const char* cha
 
   // Initialize the merger
 
-  GPUSettingsEvent ev;
+  GPUSettingsGRP grp;
   GPUSettingsRec rec;
   GPUSettingsProcessing devProc;
-  ev.solenoidBz = fSolenoidBz;
+  grp.solenoidBz = fSolenoidBz;
   if (fClusterErrorCorrectionY > 1.e-4) {
     rec.ClusterError2CorrectionY = fClusterErrorCorrectionY * fClusterErrorCorrectionY;
   }
@@ -313,7 +313,7 @@ int GPUTPCGlobalMergerComponent::Configure(const char* cdbEntry, const char* cha
   steps.inputs.set(GPUDataTypes::InOutType::TPCSectorTracks);
   steps.outputs.set(GPUDataTypes::InOutType::TPCMergedTracks);
 
-  fRec->SetSettings(&ev, &rec, &devProc, &steps);
+  fRec->SetSettings(&grp, &rec, &devProc, &steps);
   fChain->LoadClusterErrors();
   if (fRec->Init()) {
     return -EINVAL;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackerComponent.cxx
@@ -369,11 +369,11 @@ int GPUTPCTrackerComponent::ConfigureSlices()
 {
   // Initialize the tracker slices
   GPUSettingsRec rec;
-  GPUSettingsEvent ev;
+  GPUSettingsGRP grp;
   GPUSettingsProcessing devProc;
 
-  ev.solenoidBz = fSolenoidBz;
-  ev.continuousMaxTimeBin = 0; // triggered events
+  grp.solenoidBz = fSolenoidBz;
+  grp.continuousMaxTimeBin = 0; // triggered events
   if (mNeighboursSearchArea > 0) {
     rec.NeighboursSearchArea = mNeighboursSearchArea;
   }
@@ -399,7 +399,7 @@ int GPUTPCTrackerComponent::ConfigureSlices()
   steps.inputs.set(GPUDataTypes::InOutType::TPCClusters);
   steps.outputs.set(GPUDataTypes::InOutType::TPCSectorTracks);
 
-  fRec->SetSettings(&ev, &rec, &devProc, &steps);
+  fRec->SetSettings(&grp, &rec, &devProc, &steps);
   fChain->LoadClusterErrors();
   return fRec->Init();
 }

--- a/GPU/GPUTracking/Standalone/tools/showLooperMergingStat.txt
+++ b/GPU/GPUTracking/Standalone/tools/showLooperMergingStat.txt
@@ -1,0 +1,27 @@
+new TCanvas("qpttglsign")
+mergeloopers->Draw("tgl2:tgl1>>qpttglsign(100,-0.2,0.2,100,-0.2,0.2)", "labeleq>0.5 && qpt1 * tgl1 * qpt2 * tgl2 < 0 && fabsf(tgl1) < 0.2 && fabsf(tgl2) < 0.2", "colz")
+new TCanvas("okxy")
+mergeloopers->Draw("(x1-x2)*(x1-x2)+(y1-y2)*(y1-y2) >> okxy(100,0,40)", "labeleq > 0.5")
+new TCanvas("okxy2")
+mergeloopers->Draw("x1-x2:y1-y2 >> okxy(100,-10,10,100,-10,10)", "labeleq > 0.5")
+new TCanvas("failxy")
+mergeloopers->Draw("(x1-x2)*(x1-x2)+(y1-y2)*(y1-y2) >> failxy(100,0,40)", "labeleq < 0.5")
+new TCanvas("oktgl")
+mergeloopers->Draw("tgl1-tgl2 >> oktgl(100,0,40)", "labeleq > 0.5")
+new TCanvas("failtgl")
+mergeloopers->Draw("tgl1-tgl2 >> failtgl(100,0,40)", "labeleq < 0.5")
+new TCanvas("okqpt")
+mergeloopers->Draw("qpt1-qpt2 >> okqpt(100,0,40)", "labeleq > 0.5")
+new TCanvas("failqpt")
+mergeloopers->Draw("qpt1-qpt2 >> failqpt(100,0,40)", "labeleq < 0.5")
+
+mergeloopers->Draw("2 * 3.1415 * 0.5*(fabs(tgl1) + fabs(tgl2)) * 1./(0.5*(fabsf(qpt1)+fabsf(qpt2))*0.001501)/(fabsf(refz2)-fabsf(refz1))>>test3(1000,0,5)", "labeleq > 0.5 && sameside==1", "colz")
+
+mergeloopers->Draw("(fabsf(absz2)-fabsf(absz1))/(2 * 3.1415 * 0.5*(fabs(tgl1) + fabs(tgl2)) * 1./(0.5*(fabsf(qpt1)+fabsf(qpt2))*0.001501)):fmodf((asinf(snp1)+a1-asinf(snp2)-a2)/(2*3.1415)+5.5,1.)-0.5>>foo(300,-0.5,0.5,300,0,5)", "labeleq > 0.5 && sameside==1 && qpt1 * qpt2 > 0 &&  snp1 * snp2 > 0", "colz")
+
+positive correction, 1 side, 2d:
+mergeloopers2->Draw("(fabsf(refz2)-fabsf(refz1))/(2 * 3.1415 * 0.5*(fabs(tgl1) + fabs(tgl2)) * 1./(0.5*(fabsf(qpt1)+fabsf(qpt2))*0.001501)):(fmodf((asinf(snp1)+a1-asinf(snp2)-a2)/(2*3.1415)+5.5,1.)-0.5)>>foo(300,-0.5,0.5,300,0,5)", "labeleq > 0.5 && refz1*refz2>0 && refz1 * qpt1 * tgl1 > 0", "colz")
+positive correction, 1 side, 1d:
+mergeloopers2->Draw("(fabsf(refz2)-fabsf(refz1))/(2 * 3.1415 * 0.5*(fabs(tgl1) + fabs(tgl2)) * 1./(0.5*(fabsf(qpt1)+fabsf(qpt2))*0.001501))+(fmodf((asinf(snp1)+a1-asinf(snp2)-a2)/(2*3.1415)+5.5,1.)-0.5)>>hh(300,-1,5)", "labeleq > 0.5 && refz1*refz2>0 && refz1 * qpt1 * tgl1 > 0", "colz")
+negative correction, 1 side, 2d:
+mergeloopers2->Draw("(fabsf(refz2)-fabsf(refz1))/(2 * 3.1415 * 0.5*(fabs(tgl1) + fabs(tgl2)) * 1./(0.5*(fabsf(qpt1)+fabsf(qpt2))*0.001501)):(fmodf((asinf(snp1)+a1-asinf(snp2)-a2)/(2*3.1415)+5.5,1.)-0.5)>>foo(300,-0.5,0.5,300,0,5)", "labeleq > 0.5 && refz1*refz2>0 && refz1 * qpt1 * tgl1 < 0", "colz")

--- a/GPU/GPUTracking/TPCClusterFinder/CfFragment.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfFragment.h
@@ -51,6 +51,11 @@ struct CfFragment {
     return CfFragment{index + 1, hasFuture, tpccf::TPCTime(start + length - (hasFuture ? 2 * OverlapTimebins : 0)), totalSliceLength, maxSubSliceLength};
   }
 
+  GPUdi() unsigned int count() const
+  {
+    return (totalSliceLength + maxSubSliceLength - 4 * OverlapTimebins - 1) / (maxSubSliceLength - 2 * OverlapTimebins);
+  }
+
   GPUdi() tpccf::TPCTime first() const
   {
     return start;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChainContext.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChainContext.h
@@ -63,11 +63,7 @@ struct GPUTPCCFChainContext {
 
     if (tpcZS) {
       tpcMaxTimeBin = 0;
-      CfFragment f = fragmentMax;
-      while (!f.isEnd()) {
-        f = f.next();
-      }
-      nFragments = f.index;
+      nFragments = fragmentMax.count();
       if (fragmentData.size() < nFragments) {
         fragmentData.resize(nFragments);
       }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
@@ -182,8 +182,8 @@ int GPUTRDTrackerComponent::DoInit(int argc, const char** argv)
 
   iResult = ReadConfigurationString(arguments.Data());
 
-  GPUSettingsEvent cfgEvent;
-  cfgEvent.solenoidBz = GetBz();
+  GPUSettingsGRP cfgGRP;
+  cfgGRP.solenoidBz = GetBz();
   GPUSettingsRec cfgRec;
   GPUSettingsProcessing cfgDeviceProcessing;
   GPURecoStepConfiguration cfgRecoStep;
@@ -191,7 +191,7 @@ int GPUTRDTrackerComponent::DoInit(int argc, const char** argv)
   cfgRecoStep.inputs.clear();
   cfgRecoStep.outputs.clear();
   fRec = GPUReconstruction::CreateInstance("CPU", true);
-  fRec->SetSettings(&cfgEvent, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
+  fRec->SetSettings(&cfgGRP, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
   fChain = fRec->AddChain<GPUChainTracking>();
 
   fGeo = new GPUTRDGeometry();

--- a/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
+++ b/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
@@ -56,7 +56,7 @@ void run_trd_tracker(std::string path = "./",
   const o2::trd::GeometryFlat geoFlat(*geo);
 
   //-------- init GPU reconstruction --------//
-  GPUSettingsEvent cfgEvent;                 // defaults should be ok
+  GPUSettingsGRP cfgGRP;                     // defaults should be ok
   GPUSettingsRec cfgRec;                     // don't care for now, NWaysOuter is set in here for instance
   GPUSettingsProcessing cfgDeviceProcessing; // also keep defaults here, or adjust debug level
   cfgDeviceProcessing.debugLevel = 5;
@@ -65,7 +65,7 @@ void run_trd_tracker(std::string path = "./",
   cfgRecoStep.inputs.clear();
   cfgRecoStep.outputs.clear();
   auto rec = GPUReconstruction::CreateInstance("CPU", true);
-  rec->SetSettings(&cfgEvent, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
+  rec->SetSettings(&cfgGRP, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
 
   auto chainTracking = rec->AddChain<GPUChainTracking>();
 

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -44,16 +44,16 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             GPU/TPCFastTransformation/devtools/loadlibs.C # Special macro
             GPU/TPCFastTransformation/alirootMacro/moveTPCFastTransform.C # Relies on initTPCcalibration.C
             GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C # Not yet ready
-	    Detectors/TOF/prototyping/ConvertRun2CalibrationToO2.C
+            Detectors/TOF/prototyping/ConvertRun2CalibrationToO2.C
             Generators/share/external/hijing.C
-	    Generators/share/external/QEDepem.C
-	    Generators/share/external/GenCosmics.C
+            Generators/share/external/QEDepem.C
+            Generators/share/external/GenCosmics.C
             macro/SetIncludePath.C
             macro/loadExtDepLib.C
             macro/load_all_libs.C
             macro/putCondition.C
             macro/rootlogon.C
-	    Detectors/DCS/test/processor_dpcom_o2.C)
+            Detectors/DCS/test/processor_dpcom_o2.C)
 
 if(NOT BUILD_SIMULATION)
   # some complete sub_directories are not added to the build when not building


### PR DESCRIPTION
This provides a proper fix for the shifted TPC time bins instead of the hack used in #3717.
During verification, I came across some bugs when processing sparse data which are fixed as well.
Still to be done:
- Use `o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header)->firstTForbit` for obtaining the orbit of the current time frame (currently read from the RDH of the very first page that is received.
- Provide a means to handle the timebin offset in the digitization as described in https://alice.its.cern.ch/jira/browse/O2-2188
- During the testing I saw that starting from the second processed time frame TPC ITS matching efficiency decreases when TPC GPU tracking is used, still investigating this issue.