### PR TITLE
Improve treatment of run/TF/digitization_sampling_start in digitization and digit->raw conversion

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
@@ -52,6 +52,10 @@ class GRPObject
   timePoint getTimeEnd() const { return mTimeEnd; }
   void setTimeStart(timePoint t) { mTimeStart = t; }
   void setTimeEnd(timePoint t) { mTimeEnd = t; }
+
+  void setFirstOrbit(uint32_t o) { mFirstOrbit = o; }
+  uint32_t getFirstOrbit() const { return mFirstOrbit; }
+
   /// getters/setters for beams crossing angle (deviation from 0)
   o2::units::AngleRad_t getCrossingAngle() const { return mCrossingAngle; }
   void setCrossingAngle(o2::units::AngleRad_t v) { mCrossingAngle = v; }
@@ -137,6 +141,8 @@ class GRPObject
   timePoint mTimeStart = 0; ///< DAQ_time_start entry from DAQ logbook
   timePoint mTimeEnd = 0;   ///< DAQ_time_end entry from DAQ logbook
 
+  uint32_t mFirstOrbit = 0; /// 1st orbit of the 1st TF, in the MC set at digitization // RS Not sure it will stay in GRP, may go to some CTP object
+
   DetID::mask_t mDetsReadout;      ///< mask of detectors which are read out
   DetID::mask_t mDetsContinuousRO; ///< mask of detectors read out in continuos mode
   DetID::mask_t mDetsTrigger;      ///< mask of detectors which provide trigger
@@ -154,7 +160,7 @@ class GRPObject
   std::string mDataPeriod = ""; ///< name of the period
   std::string mLHCState = "";   ///< machine state
 
-  ClassDefNV(GRPObject, 2);
+  ClassDefNV(GRPObject, 3);
 };
 
 //______________________________________________

--- a/DataFormats/Parameters/src/GRPObject.cxx
+++ b/DataFormats/Parameters/src/GRPObject.cxx
@@ -50,6 +50,7 @@ void GRPObject::print() const
   printf("Start: %s", std::ctime(&t));
   t = mTimeEnd; // system_clock::to_time_t(mTimeEnd);
   printf("End  : %s", std::ctime(&t));
+  printf("1st orbit: %u\n", mFirstOrbit);
   printf("Beam0: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamClockWise), getBeamA(BeamClockWise),
          getBeamEnergyPerNucleon(BeamClockWise));
   printf("Beam1: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamAntiClockWise), getBeamA(BeamAntiClockWise),

--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -48,6 +48,9 @@ class DigitizationContext
  public:
   DigitizationContext() : mNofEntries{0}, mMaxPartNumber{0}, mEventRecords(), mEventParts() {}
 
+  uint32_t getFirstOrbitForSampling() const { return mFirstOrbitForSampling; }
+  void setFirstOrbitForSampling(uint32_t o) { mFirstOrbitForSampling = o; }
+
   int getNCollisions() const { return mNofEntries; }
   void setNCollisions(int n) { mNofEntries = n; }
 
@@ -111,6 +114,8 @@ class DigitizationContext
  private:
   int mNofEntries = 0;
   int mMaxPartNumber = 0; // max number of parts in any given collision
+  uint32_t mFirstOrbitForSampling = 0; // 1st orbit to start sampling
+
   float mMuBC;            // probability of hadronic interaction per bunch
 
   std::vector<o2::InteractionTimeRecord> mEventRecords;
@@ -127,7 +132,7 @@ class DigitizationContext
   std::string mQEDSimPrefix;                         // prefix for QED production/contribution
   mutable o2::parameters::GRPObject* mGRP = nullptr; //!
 
-  ClassDefNV(DigitizationContext, 3);
+  ClassDefNV(DigitizationContext, 4);
 };
 
 /// function reading the hits from a chain (previously initialized with initSimChains

--- a/Detectors/CPV/simulation/src/RawCreator.cxx
+++ b/Detectors/CPV/simulation/src/RawCreator.cxx
@@ -26,6 +26,7 @@
 #include "DataFormatsCPV/TriggerRecord.h"
 #include "CPVBase/Geometry.h"
 #include "CPVSimulation/RawWriter.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace bpo = boost::program_options;
 
@@ -48,6 +49,8 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -68,6 +71,10 @@ int main(int argc, const char** argv)
     exit(2);
   }
 
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   auto digitfilename = vm["input-file"].as<std::string>(),

--- a/Detectors/EMCAL/simulation/src/RawCreator.cxx
+++ b/Detectors/EMCAL/simulation/src/RawCreator.cxx
@@ -27,6 +27,7 @@
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALSimulation/RawWriter.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace bpo = boost::program_options;
 
@@ -49,6 +50,8 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,subdet,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -74,6 +77,10 @@ int main(int argc, const char** argv)
     FairLogger::GetLogger()->SetLogScreenLevel("DEBUG");
   }
 
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   auto digitfilename = vm["input-file"].as<std::string>(),

--- a/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
@@ -52,6 +52,8 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -71,6 +73,11 @@ int main(int argc, char** argv)
   } catch (std::exception& e) {
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
+  }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),

--- a/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
+++ b/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
@@ -52,6 +52,8 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -71,6 +73,11 @@ int main(int argc, char** argv)
   } catch (std::exception& e) {
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
+  }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),

--- a/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
@@ -52,6 +52,8 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -71,6 +73,11 @@ int main(int argc, char** argv)
   } catch (std::exception& e) {
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
+  }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),

--- a/Detectors/HMPID/workflow/src/digits-to-raw-workflow.cxx
+++ b/Detectors/HMPID/workflow/src/digits-to-raw-workflow.cxx
@@ -23,6 +23,7 @@
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DispatchPolicy.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 // customize the completion policy
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
@@ -36,6 +37,8 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
+  //workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), "configKeyValues file from digitization, used for raw output only!!!");
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, "none", {"configKeyValues file from digitization, used for raw output only!!!"}});
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {keyvaluehelp}});
 }
 
@@ -48,6 +51,10 @@ using namespace o2::framework;
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   WorkflowSpec specs;
+  std::string confDig = configcontext.options().get<std::string>("digitization-config");
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   DataProcessorSpec consumer = o2::hmpid::getDigitsToRawSpec();
   specs.push_back(consumer);

--- a/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
@@ -62,6 +62,8 @@ int main(int argc, char** argv)
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(DefRDHVersion), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -82,6 +84,11 @@ int main(int argc, char** argv)
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
   }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
            vm["output-dir"].as<std::string>(),
@@ -89,7 +96,8 @@ int main(int argc, char** argv)
            vm["verbosity"].as<uint32_t>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
-
+  LOG(INFO) << "HBFUtils settings used for conversion:";
+  o2::raw::HBFUtils::Instance().print();
   return 0;
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -80,6 +82,11 @@ int main(int argc, char** argv)
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
   }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
            vm["output-dir"].as<std::string>(),
@@ -87,7 +94,8 @@ int main(int argc, char** argv)
            vm["verbosity"].as<uint32_t>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
-
+  LOG(INFO) << "HBFUtils settings used for conversion:";
+  o2::raw::HBFUtils::Instance().print();
   return 0;
 }
 

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -17,7 +17,7 @@
 #include <deque>
 #include <memory>
 
-#include "Rtypes.h"  // for Digitizer::Class, Double_t, ClassDef, etc
+#include "Rtypes.h" // for Digitizer::Class
 #include "TObject.h" // for TObject
 
 #include "ITSMFTSimulation/ChipDigitsContainer.h"
@@ -71,7 +71,7 @@ class Digitizer : public TObject
 
   void setContinuous(bool v) { mParams.setContinuous(v); }
   bool isContinuous() const { return mParams.isContinuous(); }
-  void fillOutputContainer(UInt_t maxFrame = 0xffffffff);
+  void fillOutputContainer(uint32_t maxFrame = 0xffffffff);
 
   void setDigiParams(const o2::itsmft::DigiParams& par) { mParams = par; }
   const o2::itsmft::DigiParams& getDigitParams() const { return mParams; }
@@ -79,8 +79,8 @@ class Digitizer : public TObject
   // provide the common itsmft::GeometryTGeo to access matrices and segmentation
   void setGeometry(const o2::itsmft::GeometryTGeo* gm) { mGeometry = gm; }
 
-  UInt_t getEventROFrameMin() const { return mEventROFrameMin; }
-  UInt_t getEventROFrameMax() const { return mEventROFrameMax; }
+  uint32_t getEventROFrameMin() const { return mEventROFrameMin; }
+  uint32_t getEventROFrameMax() const { return mEventROFrameMax; }
   void resetEventROFrames()
   {
     mEventROFrameMin = 0xffffffff;
@@ -88,11 +88,11 @@ class Digitizer : public TObject
   }
 
  private:
-  void processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, int srcID);
-  void registerDigits(ChipDigitsContainer& chip, UInt_t roFrame, float tInROF, int nROF,
-                      UShort_t row, UShort_t col, int nEle, o2::MCCompLabel& lbl);
+  void processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID);
+  void registerDigits(ChipDigitsContainer& chip, uint32_t roFrame, float tInROF, int nROF,
+                      uint16_t row, uint16_t col, int nEle, o2::MCCompLabel& lbl);
 
-  ExtraDig* getExtraDigBuffer(UInt_t roFrame)
+  ExtraDig* getExtraDigBuffer(uint32_t roFrame)
   {
     if (mROFrameMin > roFrame) {
       return nullptr; // nothing to do
@@ -108,13 +108,14 @@ class Digitizer : public TObject
 
   o2::itsmft::DigiParams mParams; ///< digitization parameters
   o2::InteractionTimeRecord mEventTime; ///< global event time and interaction record
+  o2::InteractionRecord mIRFirstSampledTF; ///< IR of the 1st sampled IR, noise-only ROFs will be inserted till this IR only
   double mCollisionTimeWrtROF;
-  UInt_t mROFrameMin = 0;         ///< lowest RO frame of current digits
-  UInt_t mROFrameMax = 0;         ///< highest RO frame of current digits
-  UInt_t mNewROFrame = 0;         ///< ROFrame corresponding to provided time
+  uint32_t mROFrameMin = 0; ///< lowest RO frame of current digits
+  uint32_t mROFrameMax = 0; ///< highest RO frame of current digits
+  uint32_t mNewROFrame = 0; ///< ROFrame corresponding to provided time
 
-  UInt_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
-  UInt_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)
+  uint32_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
+  uint32_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)
 
   std::unique_ptr<o2::itsmft::AlpideSimResponse> mAlpSimResp; // simulated response
 

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
@@ -94,6 +94,8 @@ int main(int argc, char* argv[])
       ("input-file,i",po::value<std::string>(&input)->default_value("mchdigits.root"),"input file name")
       ("configKeyValues", po::value<std::string>()->default_value(""), "comma-separated configKeyValues")
       ("no-empty-hbf,e", po::value<bool>()->default_value(true), "do not create empty HBF pages (except for HBF starting TF)")
+      //("digitization-config", po::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization")
+      ("digitization-config", po::value<std::string>()->default_value("none"), "configKeyValues file from digitization")
       ("verbosity,v",po::value<std::string>()->default_value("verylow"), "(fair)logger verbosity");
   // clang-format on
 
@@ -116,6 +118,10 @@ int main(int argc, char* argv[])
 
   po::notify(vm);
 
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   if (vm.count("verbosity")) {

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
@@ -112,7 +112,6 @@ std::vector<std::byte> createBuffer(gsl::span<std::string> data,
 
   const o2::raw::HBFUtils& hbfutils = o2::raw::HBFUtils::Instance();
   o2::conf::ConfigurableParam::setValue<uint32_t>("HBFUtils", "orbitFirst", orbit);
-  o2::conf::ConfigurableParam::setValue<uint16_t>("HBFUtils", "bcFirst", bc);
   std::vector<std::byte> out = o2::mch::raw::paginate(buffer,
                                                       isUserLogicFormat<FORMAT>::value,
                                                       isChargeSumMode<CHARGESUM>::value,

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -102,7 +102,7 @@ void Encoder::finalize(bool closeFile)
 {
   /// Writes remaining data and closes the file
   if (mLastIR.isDummy()) {
-    mLastIR.bc = mRawWriter.getHBFUtils().bcFirst;
+    mLastIR.bc = 0;
     mLastIR.orbit = mRawWriter.getHBFUtils().orbitFirst;
   }
   auto ir = getOrbitIR(mLastIR.orbit);

--- a/Detectors/MUON/MID/Workflow/src/digits-to-raw-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/digits-to-raw-workflow.cxx
@@ -20,6 +20,7 @@
 #include "Framework/Variant.h"
 #include "MIDWorkflow/DigitReaderSpec.h"
 #include "MIDWorkflow/RawWriterSpec.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 using namespace o2::framework;
 
@@ -28,6 +29,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  //workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), "configKeyValues file from digitization, used for raw output only!!!");
+  workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, "none", {"configKeyValues file from digitization, used for raw output only!!!"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -35,6 +38,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
+
+  std::string confDig = configcontext.options().get<std::string>("digitization-config");
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   specs.emplace_back(o2::mid::getDigitReaderSpec(false));
   specs.emplace_back(o2::mid::getRawWriterSpec());

--- a/Detectors/PHOS/simulation/src/RawCreator.cxx
+++ b/Detectors/PHOS/simulation/src/RawCreator.cxx
@@ -26,6 +26,7 @@
 #include "DataFormatsPHOS/TriggerRecord.h"
 #include "PHOSBase/Geometry.h"
 #include "PHOSSimulation/RawWriter.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace bpo = boost::program_options;
 
@@ -48,6 +49,8 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -68,6 +71,10 @@ int main(int argc, const char** argv)
     exit(2);
   }
 
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
+  }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   auto digitfilename = vm["input-file"].as<std::string>(),

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -27,7 +27,7 @@ namespace raw
 {
 /*
     In the MC->Raw conversion we have to make sure that
-    1) The HB and TF starts are in sync for all detectors regardless on time (bc/orbir)
+    1) The HB and TF starts are in sync for all detectors regardless on time (0/orbit)
     distribution of its signal.
     2) All HBF and TF (RAWDataHeaders with corresponding HB and TF trigger flags) are present
     in the emulated raw data, even if some of them had no data in particular detector.
@@ -42,8 +42,7 @@ namespace raw
 struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   using IR = o2::InteractionRecord;
 
-
-  IR getFirstIR() const { return {bcFirst, orbitFirst}; }
+  IR getFirstIR() const { return {0, orbitFirst}; }
 
   int getNOrbitsPerTF() const { return nHBFPerTF; }
 
@@ -68,6 +67,9 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
 
   ///< get 1st IR of the TF corresponding to provided interaction record
   IR getFirstIRofTF(const IR& rec) const { return getIRTF(getTF(rec)); }
+
+  ///< get 1st IR of TF corresponding to the 1st sampled orbit (in MC)
+  IR getFirstSampledTFIR() const { return getFirstIRofTF({0, orbitFirstSampled}); }
 
   ///< get TF and HB (abs) for this IR
   std::pair<int, int> getTFandHB(const IR& rec) const
@@ -123,10 +125,12 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
 
   void print() const { printKeyValues(true); }
 
-  int nHBFPerTF = 1 + 0xff; // number of orbits per BC
-  uint16_t bcFirst = 0;     ///< BC of 1st TF
-  uint32_t orbitFirst = 0;  ///< orbit of 1st TF
-  uint32_t maxNOrbits = 0xffffffff; // max number of orbits to accept, used in digit->raw conversion
+  int nHBFPerTF = 128;     ///< number of orbits per BC
+  uint32_t orbitFirst = 0; ///< orbit of 1st TF of the run
+
+  // used for MC
+  uint32_t orbitFirstSampled = 0;   ///< 1st orbit sampled in the MC
+  uint32_t maxNOrbits = 0xffffffff; ///< max number of orbits to accept, used in digit->raw conversion
 
   O2ParamDef(HBFUtils, "HBFUtils");
 };
@@ -140,10 +144,10 @@ void HBFUtils::updateRDH(H& rdh, const IR& rec, bool setHBTF) const
 
   if (setHBTF) { // need to set the HBF IR and HB / TF trigger flags
     auto tfhb = getTFandHBinTF(rec);
-    RDHUtils::setHeartBeatBC(rdh, bcFirst);
+    RDHUtils::setHeartBeatBC(rdh, 0);
     RDHUtils::setHeartBeatOrbit(rdh, rec.orbit);
 
-    if (rec.bc == bcFirst) { // if we are starting new HB, set the HB trigger flag
+    if (rec.bc == 0) { // if we are starting new HB, set the HB trigger flag
       auto trg = RDHUtils::getTriggerType(rdh) | (o2::trigger::ORBIT | o2::trigger::HB);
       if (tfhb.second == 0) { // if we are starting new TF, set the TF trigger flag
         trg |= o2::trigger::TF;

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -267,7 +267,7 @@ class RawFileReader
   o2::header::DataDescription getDefaultDataSpecification() const { return mDefDataDescription; }
   ReadoutCardType getDefaultReadoutCardType() const { return mDefCardType; }
 
-  void imposeFirstTF(uint32_t orbit, uint16_t bc);
+  void imposeFirstTF(uint32_t orbit);
   void setTFAutodetect(FirstTFDetection v) { mFirstTFAutodetect = v; }
   void setPreferCalculatedTFStart(bool v) { mPreferCalculatedTFStart = v; }
   FirstTFDetection getTFAutodetect() const { return mFirstTFAutodetect; }

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -26,7 +26,7 @@ uint32_t HBFUtils::getHBF(const IR& rec) const
   auto diff = rec.differenceInBC(getFirstIR());
   if (diff < 0) {
     LOG(ERROR) << "IR " << rec.bc << '/' << rec.orbit << " is ahead of the reference IR "
-               << bcFirst << '/' << orbitFirst;
+               << "0/" << orbitFirst;
     throw std::runtime_error("Requested IR is ahead of the reference IR");
   }
   return diff / o2::constants::lhc::LHCMaxBunches;
@@ -39,7 +39,7 @@ int HBFUtils::fillHBIRvector(std::vector<IR>& dst, const IR& fromIR, const IR& t
   // BCs between interaction records "fromIR" and "toIR" (inclusive).
   dst.clear();
   int hb0 = getHBF(fromIR), hb1 = getHBF(toIR);
-  if (fromIR.bc != bcFirst) { // unless we are just starting the HBF of fromIR, it was already counted
+  if (fromIR.bc != 0) { // unless we are just starting the HBF of fromIR, it was already counted
     hb0++;
   }
   for (int ihb = hb0; ihb <= hb1; ihb++) {

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -374,7 +374,7 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDHAny& rdh, bool newSPage
         }
       }
       if (!irOfSOX.isDummy() && reader->getTFAutodetect() == FirstTFDetection::Pending) {
-        reader->imposeFirstTF(irOfSOX.orbit, irOfSOX.bc);
+        reader->imposeFirstTF(irOfSOX.orbit);
       }
     }
     auto newTFCalc = blocks.empty() || HBU.getTF(blocks.back().ir) < HBU.getTF(ir);
@@ -482,7 +482,7 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDHAny& rdh, bool newSPage
     if (newTF) {
       if (reader->getTFAutodetect() == FirstTFDetection::Pending) { // impose first TF
         if (cruDetector) {
-          reader->imposeFirstTF(hbIR.orbit, hbIR.bc);
+          reader->imposeFirstTF(hbIR.orbit);
           bl.tfID = HBU.getTF(hbIR); // update
         } else {
           throw std::runtime_error("HBFUtil first orbit/bc autodetection cannot be done with first link from CRORC detector");
@@ -901,14 +901,13 @@ RawFileReader::InputsMap RawFileReader::parseInput(const std::string& confUri)
   return entries;
 }
 
-void RawFileReader::imposeFirstTF(uint32_t orbit, uint16_t bc)
+void RawFileReader::imposeFirstTF(uint32_t orbit)
 {
   if (mFirstTFAutodetect != FirstTFDetection::Pending) {
     throw std::runtime_error("reader was not expecting imposing first TF");
   }
   auto& hbu = o2::raw::HBFUtils::Instance();
   o2::raw::HBFUtils::setValue("HBFUtils", "orbitFirst", orbit);
-  o2::raw::HBFUtils::setValue("HBFUtils", "bcFirst", bc);
   LOG(INFO) << "Imposed data-driven TF start";
   mFirstTFAutodetect = FirstTFDetection::Done;
   hbu.printKeyValues();

--- a/Detectors/TOF/simulation/src/digi2raw.cxx
+++ b/Detectors/TOF/simulation/src/digi2raw.cxx
@@ -33,6 +33,8 @@ int main(int argc, char** argv)
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("file-for,f", bpo::value<std::string>()->default_value("cru"), "single file per: all,cru,link");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
 
@@ -54,6 +56,7 @@ int main(int argc, char** argv)
 
   auto cmd = o2::utils::concat_string("o2-tof-reco-workflow -b --output-type raw --tof-raw-outdir ", vm["output-dir"].as<std::string>(),
                                       " --tof-raw-file-for ", vm["file-for"].as<std::string>(),
+                                      " --digitization-config ", vm["digitization-config"].as<std::string>(),
                                       R"( --configKeyValues ")", vm["configKeyValues"].as<std::string>(), '"');
   return system(cmd.c_str());
 }

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -229,6 +229,8 @@ int main(int argc, char** argv)
     add_option("stop-page,p", bpo::value<bool>()->default_value(false)->implicit_value(true), "HBF stop on separate CRU page");
     add_option("no-padding", bpo::value<bool>()->default_value(false)->implicit_value(true), "Don't pad pages to 8kb");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>();
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
@@ -249,6 +251,11 @@ int main(int argc, char** argv)
   } catch (std::exception& e) {
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
+  }
+
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   convertDigitsToZSfinal(

--- a/Detectors/ZDC/simulation/src/digi2raw.cxx
+++ b/Detectors/ZDC/simulation/src/digi2raw.cxx
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
     add_option("ccdb-url,c", bpo::value<std::string>()->default_value(""), "url of the ccdb repository");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
+    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
+    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -79,6 +81,10 @@ int main(int argc, char** argv)
   } catch (std::exception& e) {
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
+  }
+  std::string confDig = vm["digitization-config"].as<std::string>();
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig);
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -55,7 +55,8 @@ o2_add_executable(digitizer-workflow
                                         O2::TRDWorkflow
                                         O2::DataFormatsTRD
                                         O2::ZDCSimulation
-					O2::ZDCWorkflow)
+					O2::ZDCWorkflow
+					O2::DetectorsRaw)
 
 
 o2_add_executable(mctruth-testworkflow

--- a/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
@@ -21,6 +21,7 @@
 #include <FairLogger.h>
 #include <memory> // for make_shared, make_unique, unique_ptr
 #include <string>
+#include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
 
@@ -48,9 +49,6 @@ class GRPDPLUpdatedTask
   void run(framework::ProcessingContext& pc)
   {
     const std::string grpName = "GRP";
-    if (mFinished) {
-      return;
-    }
 
     TFile flGRP(mGRPFileName.c_str(), "update");
     if (flGRP.IsZombie()) {
@@ -66,17 +64,15 @@ class GRPDPLUpdatedTask
       }
       grp->setDetROMode(det, roMode);
     }
-    LOG(INFO) << "Updated GRP in " << mGRPFileName << " for detectors RO mode";
+    grp->setFirstOrbit(o2::raw::HBFUtils::Instance().orbitFirst);
+    LOG(INFO) << "Updated GRP in " << mGRPFileName << " for detectors RO mode and 1st orbit of the run";
     grp->print();
     flGRP.WriteObjectAny(grp.get(), grp->Class(), grpName.c_str());
     flGRP.Close();
-    mFinished = true;
-
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
 
  private:
-  bool mFinished = false;
   std::string mGRPFileName = "o2sim_grp.root";
 };
 

--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -41,7 +41,13 @@ class InteractionSampler
     mMuBC = -1.; // invalidate
   }
   float getInteractionRate() const { return mIntRate; }
-  void setFirstIR(const o2::InteractionRecord& ir) { mFirstIR.InteractionRecord::operator=(ir); }
+  void setFirstIR(const o2::InteractionRecord& ir)
+  {
+    mFirstIR.InteractionRecord::operator=(ir);
+    if (mFirstIR.orbit == 0 && mFirstIR.bc < 4) {
+      mFirstIR.bc = 4;
+    }
+  }
   const o2::InteractionRecord& getFirstIR() const { return mFirstIR; }
 
   void setMuPerBC(float mu)
@@ -68,7 +74,7 @@ class InteractionSampler
   o2::math_utils::RandomRing<1000> mCollTimeGenerator; // generator of number of interactions in BC
 
   o2::InteractionTimeRecord mIR{{0, 0}, 0.};
-  o2::InteractionTimeRecord mFirstIR{{0, 0}, 0.};
+  o2::InteractionTimeRecord mFirstIR{{4, 0}, 0.};
   int mIntBCCache = 0;         ///< N interactions left for current BC
 
   float mIntRate = -1.;        ///< total interaction rate in Hz

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -69,14 +69,14 @@ else
 fi
 
 taskwrapper sim.log o2-sim --seed $O2SIMSEED -n $NEvents --skipModules ZDC --configKeyValues "Diamond.width[2]=6." -g pythia8hi -j $NJOBS
-taskwrapper digi.log o2-sim-digitizer-workflow -n $NEvents --simPrefixQED qed/o2sim --qed-x-section-ratio ${QED2HAD} ${NOMCLABELS} --firstOrbit 0 --firstBC 0 --tpc-lanes $((NJOBS < 36 ? NJOBS : 36)) --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} ${DIGITRDOPT}
-[ $SPLITTRDDIGI == "1" ] && taskwrapper digiTRD.log o2-sim-digitizer-workflow -n $NEvents ${NOMCLABELS} --firstOrbit 0 --firstBC 0 --onlyDet TRD --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} --incontext collisioncontext.root ${DIGITRDOPTREAL}
+taskwrapper digi.log o2-sim-digitizer-workflow -n $NEvents --simPrefixQED qed/o2sim --qed-x-section-ratio ${QED2HAD} ${NOMCLABELS} --tpc-lanes $((NJOBS < 36 ? NJOBS : 36)) --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} ${DIGITRDOPT}
+[ $SPLITTRDDIGI == "1" ] && taskwrapper digiTRD.log o2-sim-digitizer-workflow -n $NEvents ${NOMCLABELS} --onlyDet TRD --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} --incontext collisioncontext.root ${DIGITRDOPTREAL}
 touch digiTRD.log_done
 
 mkdir -p zdc
 cd zdc
 taskwrapper zdcsim.log o2-sim --seed $O2SIMSEED -n $NEvents -m PIPE ZDC --configKeyValues '"Diamond.width[2]=6.;SimCutParams.maxRTracking=50;"' -g pythia8hi -j $NJOBS
-taskwrapper digiZDC.log o2-sim-digitizer-workflow -n $NEvents ${NOMCLABELS} --firstOrbit 0 --firstBC 0 --onlyDet ZDC --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} --incontext ../collisioncontext.root
+taskwrapper digiZDC.log o2-sim-digitizer-workflow -n $NEvents ${NOMCLABELS} --onlyDet ZDC --shm-segment-size $SHMSIZE ${GLOBALDPLOPT} --incontext ../collisioncontext.root
 cp zdcdigits.root ../
 cd ..
 


### PR DESCRIPTION
For motivation see [this](https://alice.its.cern.ch/jira/browse/O2-2188) by @davidrohr 

* The `HBFUtils.nHBFPerTF` default is changed from 256 to 128 and `HBFUtils.bcFirst` is eliminated since the TF and HBF are guaranteed to start from 0.
* Extra member `HBFUtils.orbitFirstSampled=0` is added and substitutes the `o2-sim-digitization` options `--firstBC` and `--firstOrbit` which are suppressed.
* `o2-sim-digitization` will store in the GRP the 1st orbit of the run (from `HBFUtils.orbitFirst`) and will store in the `collisioncontext.root` the  `HBFUtils.orbitFirstSampled` as `DigitizationContext::mFirstOrbitForSampling`. 
Note that the settings of the `HBFUtils` will be stored also in the `o2simdigitizerworkflow_configuration.ini` and can be imposed later by `o2::conf::ConfigurableParam::updateFromFile(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE))`
ATTENTION: at the moment there are some problems with loading the INI file, therefore its loading is disabled by the default option `--digitization-config none` added to all converters. Will be reverted to default `std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)` once the ConfigurableParam problems are solved. Until that one should provide the settings of  `HBFUtils` for conversion via `--configKeyValues \"HBFUtils...\"` options (or rely on the HBFUtils defaults.
* All `digit->raw` converters by default will 1st load this INI file and only then apply on top (override if provided) the content of the options passed via `--configKeyValues`. The final settings of the `HBFUtils` are then used by the `RawFileWriter` for pagination of the raw data.

---

* ITS/MFT digitization is changed: in the continuous readout mode the 1st ROF created (filled by the noise only if the `HBFUtils.orbitFirstSampled` is in future wrt `HBFUtils.orbitFirst`)  will correspond not to the 1st orbit of the run but to the 1st HBF of the TF to which `HBFUtils.orbitFirstSampled` belongs.