### PR TITLE
GPU: Reactivate option to process only individual TPC sectors

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -216,24 +216,24 @@ class ClusterNativeHelper
     // @param mcBuffer
     // @param inputs         data arrays, fixed array, one per sector
     // @param mcinputs       vectors mc truth container, fixed array, one per sector
-    // @param checkFct       check whether a sector index is valid
-    template <typename DataArrayType, typename MCArrayType, typename CheckFct = std::function<bool(size_t&)>>
+    // @param sectorMask     Bitmask with tpc sectors to process
+    template <typename DataArrayType, typename MCArrayType>
     static int fillIndex(
       ClusterNativeAccess& clusterIndex, std::unique_ptr<ClusterNative[]>& clusterBuffer,
       ConstMCLabelContainerViewWithBuffer& mcBuffer, DataArrayType& inputs, MCArrayType const& mcinputs,
-      CheckFct checkFct = [](auto const&) { return true; });
+      unsigned long sectorMask = 0xFFFFFFFFF);
 
-    template <typename DataArrayType, typename CheckFct = std::function<bool(size_t&)>>
+    template <typename DataArrayType>
     static int fillIndex(
       ClusterNativeAccess& clusterIndex, std::unique_ptr<ClusterNative[]>& clusterBuffer,
-      DataArrayType& inputs, CheckFct checkFct = [](auto const&) { return true; })
+      DataArrayType& inputs, unsigned long sectorMask = 0xFFFFFFFFF)
     {
       // just use a dummy parameter with empty vectors
       // TODO: maybe do in one function with conditional template parameter
       std::vector<std::unique_ptr<MCLabelContainer>> dummy;
       // another default, nothing will be added to the container
       ConstMCLabelContainerViewWithBuffer mcBuffer;
-      return fillIndex(clusterIndex, clusterBuffer, mcBuffer, inputs, dummy, checkFct);
+      return fillIndex(clusterIndex, clusterBuffer, mcBuffer, inputs, dummy, sectorMask);
     }
 
     // Process data for one sector.
@@ -348,10 +348,10 @@ class ClusterNativeHelper
   static void copySectorData(ClusterNativeAccess const& index, int sector, BufferType& target, MCArrayType& mcTarget);
 };
 
-template <typename DataArrayType, typename MCArrayType, typename CheckFct>
+template <typename DataArrayType, typename MCArrayType>
 int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
                                            std::unique_ptr<ClusterNative[]>& clusterBuffer, ConstMCLabelContainerViewWithBuffer& mcBuffer,
-                                           DataArrayType& inputs, MCArrayType const& mcinputs, CheckFct checkFct)
+                                           DataArrayType& inputs, MCArrayType const& mcinputs, unsigned long sectorMask)
 {
   if (mcinputs.size() > 0 && mcinputs.size() != inputs.size()) {
     std::runtime_error("inconsistent size of MC label array " + std::to_string(mcinputs.size()) + ", expected " + std::to_string(inputs.size()));
@@ -371,6 +371,13 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
     if (sizeof(ClusterCountIndex) + clusterIndex.nClustersTotal * sizeof(ClusterNative) > inputs[0].size()) {
       throw std::runtime_error("inconsistent input buffer, expecting size " + std::to_string(sizeof(ClusterCountIndex) + clusterIndex.nClustersTotal * sizeof(ClusterNative)) + " got " + std::to_string(inputs[0].size()));
     }
+    if (sectorMask != 0xFFFFFFFFF) {
+      for (unsigned int sector = 0; sector < NSectors; sector++) {
+        if (!(sectorMask & (1ul << sector)) && clusterIndex.nClustersSector[sector]) {
+          throw std::runtime_error("TPC sector mask provided, but received more sectors than set. (A filter could be implemented here if needed.)");
+        }
+      }
+    }
     return clusterIndex.nClustersTotal;
   }
 
@@ -378,9 +385,6 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex,
   const ConstMCLabelContainerView* clustersMCTruth[NSectors] = {nullptr};
   int result = 0;
   for (size_t index = 0, end = inputs.size(); index < end; index++) {
-    if (!checkFct(index)) {
-      continue;
-    }
     o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> const* labelsptr = nullptr;
 #ifdef MS_GSL_V3
     std::size_t extent = 0;

--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -189,7 +189,7 @@ int ClusterNativeHelper::Reader::fillIndex(ClusterNativeAccess& clusterIndex, st
     }
   }
 
-  int result = fillIndex(clusterIndex, clusterBuffer, mcBuffer, clustersTPC, constMCLabelContainerViews, [](auto&) { return true; });
+  int result = fillIndex(clusterIndex, clusterBuffer, mcBuffer, clustersTPC, constMCLabelContainerViews);
   return result;
 }
 

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -71,7 +71,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data, GPUInterfaceOutputs* 
     const float zsThreshold = mTrackingCAO2Interface->getConfig().configReconstruction.tpcZSthreshold;
     const int maxContTimeBin = mTrackingCAO2Interface->getConfig().configGRP.continuousMaxTimeBin;
     for (int i = 0; i < Sector::MAXSECTOR; i++) {
-      const auto& d = (*(data->o2Digits))[i];
+      const auto& d = (*data->o2Digits)[i];
       if (zsThreshold > 0 && data->tpcZS == nullptr) {
         gpuDigits[i].reserve(d.size());
       }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
@@ -16,9 +16,9 @@ namespace tpc
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs12bit, float threshold, bool outRaw);
+framework::DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs12bit, float threshold, bool outRaw);
 
-framework::DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds);
+framework::DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& tpcSectors);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -56,7 +56,7 @@ namespace o2
 namespace tpc
 {
 
-DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bit, float threshold = 2.f, bool outRaw = false)
+DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs10bit, float threshold = 2.f, bool outRaw = false)
 {
   std::string processorName = "tpc-zsEncoder";
   constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
@@ -66,21 +66,25 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
   struct ProcessAttributes {
     std::unique_ptr<unsigned long long int[]> zsoutput;
     std::vector<unsigned int> sizes;
-    std::vector<int> inputIds;
+    std::vector<int> tpcSectors;
     bool verify = false;
     int verbosity = 1;
     bool finished = false;
   };
 
-  auto initFunction = [inputIds, zs10bit, threshold, outRaw](InitContext& ic) {
+  auto initFunction = [tpcSectors, zs10bit, threshold, outRaw](InitContext& ic) {
     auto processAttributes = std::make_shared<ProcessAttributes>();
     auto& zsoutput = processAttributes->zsoutput;
-    processAttributes->inputIds = inputIds;
+    processAttributes->tpcSectors = tpcSectors;
     auto& verify = processAttributes->verify;
     auto& sizes = processAttributes->sizes;
     auto& verbosity = processAttributes->verbosity;
+    unsigned long tpcSectorMask = 0;
+    for (auto s : tpcSectors) {
+      tpcSectorMask |= (1ul << s);
+    }
 
-    auto processingFct = [processAttributes, zs10bit, threshold, outRaw](
+    auto processingFct = [processAttributes, zs10bit, threshold, outRaw, tpcSectorMask](
                            ProcessingContext& pc) {
       if (processAttributes->finished) {
         return;
@@ -99,7 +103,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
       config.ReadConfigurableParam();
       _GPUParam.SetDefaults(&config.configGRP, &config.configReconstruction, &config.configProcessing, nullptr);
 
-      const auto& inputs = getWorkflowTPCInput(pc, 0, false, false, 0xFFFFFFFFF, true);
+      const auto& inputs = getWorkflowTPCInput(pc, 0, false, false, tpcSectorMask, true);
       sizes.resize(NSectors * NEndpoints);
       bool zs12bit = !zs10bit;
       o2::InteractionRecord ir = o2::raw::HBFUtils::Instance().getFirstIR();
@@ -164,16 +168,16 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
     return processingFct;
   };
 
-  auto createInputSpecs = [inputIds]() {
+  auto createInputSpecs = [tpcSectors]() {
     Inputs inputs;
     //    inputs.emplace_back(InputSpec{"input", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe});
     inputs.emplace_back(InputSpec{"input", gDataOriginTPC, "DIGITS", 0, Lifetime::Timeframe});
-    return std::move(mergeInputs(inputs, inputIds.size(),
-                                 [inputIds](InputSpec& input, size_t index) {
+    return std::move(mergeInputs(inputs, tpcSectors.size(),
+                                 [tpcSectors](InputSpec& input, size_t index) {
                                    // using unique input names for the moment but want to find
                                    // an input-multiplicity-agnostic way of processing
-                                   input.binding += std::to_string(inputIds[index]);
-                                   DataSpecUtils::updateMatchingSubspec(input, inputIds[index]);
+                                   input.binding += std::to_string(tpcSectors[index]);
+                                   DataSpecUtils::updateMatchingSubspec(input, tpcSectors[index]);
                                  }));
     return inputs;
   };
@@ -195,7 +199,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& inputIds, bool zs10bi
                            AlgorithmSpec(initFunction)};
 } //spec end
 
-DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
+DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& tpcSectors)
 {
   std::string processorName = "tpc-zs-to-Digits";
   constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
@@ -206,7 +210,7 @@ DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
     std::unique_ptr<unsigned long long int[]> zsinput;
     std::vector<unsigned int> sizes;
     std::unique_ptr<o2::tpc::ZeroSuppress> decoder;
-    std::vector<int> inputIds;
+    std::vector<int> tpcSectors;
     bool verify = false;
     int verbosity = 1;
     bool finished = false;
@@ -229,9 +233,9 @@ DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& inputIds)
     }
   };
 
-  auto initFunction = [inputIds](InitContext& ic) {
+  auto initFunction = [tpcSectors](InitContext& ic) {
     auto processAttributes = std::make_shared<ProcessAttributes>();
-    processAttributes->inputIds = inputIds;
+    processAttributes->tpcSectors = tpcSectors;
     auto& outDigits = processAttributes->outDigits;
     auto& decoder = processAttributes->decoder;
     decoder = std::make_unique<o2::tpc::ZeroSuppress>();

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -49,7 +49,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"output-type", VariantType::String, "tracks", {"digits, zsraw, clustershw, clustersnative, tracks, compressed-clusters, encoded-clusters, disable-writer, send-clusters-per-sector, qa, no-shared-cluster-map"}},
     {"no-ca-clusterer", VariantType::Bool, false, {"Use HardwareClusterer instead of clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
-    //{"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},
+    {"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},
     {"tpc-lanes", VariantType::Int, 1, {"number of parallel lanes up to the tracker"}},
     {"dispatching-mode", VariantType::String, "prompt", {"determines when to dispatch: prompt, complete"}},
     {"no-tpc-zs-on-the-fly", VariantType::Bool, false, {"Do not use TPC zero suppression on the fly"}},
@@ -111,9 +111,7 @@ using namespace o2::framework;
 /// This function hooks up the the workflow specifications into the DPL driver.
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  //auto tpcSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tpc-sectors"));
-  std::vector<int> tpcSectors(36);
-  std::iota(tpcSectors.begin(), tpcSectors.end(), 0);
+  std::vector<int> tpcSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tpc-sectors"));
   // the lane configuration defines the subspecification ids to be distributed among the lanes.
   std::vector<int> laneConfiguration = tpcSectors; // Currently just a copy of the tpcSectors, why?
   auto nLanes = cfgc.options().get<int>("tpc-lanes");


### PR DESCRIPTION
This reactivates the --tpc-sectors option for the tpc reco workflow, which was disabled before since it was broken.
Tested in plenty of combinations with ZS / digits / clusters / MC input, but no guarantee for completeness.
