### PR TITLE
[MCH] change digit ADC format from ulong to uint

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
@@ -30,7 +30,7 @@ class Digit
  public:
   Digit() = default;
 
-  Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples = 1);
+  Digit(int detid, int pad, uint32_t adc, int32_t time, uint16_t nSamples = 1);
   ~Digit() = default;
 
   bool operator==(const Digit&) const;
@@ -50,15 +50,15 @@ class Digit
   int getPadID() const { return mPadID; }
   void setPadID(int padID) { mPadID = padID; }
 
-  unsigned long getADC() const { return mADC; }
-  void setADC(unsigned long adc) { mADC = adc; }
+  uint32_t getADC() const { return mADC; }
+  void setADC(uint32_t adc) { mADC = adc; }
 
  private:
   int32_t mTFtime;      /// time since the beginning of the time frame, in bunch crossing units
   uint16_t mNofSamples; /// number of samples in the signal
   int mDetID;           /// ID of the Detection Element to which the digit corresponds to
   int mPadID;           /// PadIndex to which the digit corresponds to
-  unsigned long mADC;   /// Amplitude of signal
+  uint32_t mADC;        /// Amplitude of signal
 
   ClassDefNV(Digit, 2);
 }; //class Digit

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
@@ -60,7 +60,7 @@ class Digit
   int mPadID;           /// PadIndex to which the digit corresponds to
   uint32_t mADC;        /// Amplitude of signal
 
-  ClassDefNV(Digit, 2);
+  ClassDefNV(Digit, 3);
 }; //class Digit
 
 } //namespace mch

--- a/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
@@ -19,7 +19,7 @@ bool closeEnough(double x, double y, double eps = 1E-6)
   return std::fabs(x - y) <= eps * std::max(1.0, std::max(std::fabs(x), std::fabs(y)));
 }
 
-Digit::Digit(int detid, int pad, unsigned long adc, int32_t time, uint16_t nSamples)
+Digit::Digit(int detid, int pad, uint32_t adc, int32_t time, uint16_t nSamples)
   : mTFtime(time), mNofSamples(nSamples), mDetID(detid), mPadID(pad), mADC(adc)
 {
   setSaturated(false);

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -19,6 +19,7 @@
 #include "MCHClustering/ClusterFinderOriginal.h"
 
 #include <algorithm>
+#include <cstring>
 #include <iterator>
 #include <limits>
 #include <numeric>
@@ -174,7 +175,9 @@ void ClusterFinderOriginal::resetPreCluster(gsl::span<const Digit>& digits)
     double y = mSegmentation->padPositionY(padID);
     double dx = mSegmentation->padSizeX(padID) / 2.;
     double dy = mSegmentation->padSizeY(padID) / 2.;
-    double charge = static_cast<double>(digit.getADC()) / static_cast<double>(std::numeric_limits<unsigned long>::max()) * 1024;
+    uint32_t adc = digit.getADC();
+    float charge(0.);
+    std::memcpy(&charge, &adc, sizeof(adc));
     bool isSaturated = digit.isSaturated();
     int plane = mSegmentation->isBendingPad(padID) ? 0 : 1;
 

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
@@ -38,7 +38,7 @@ class Response
   float etocharge(float edepos);
   double chargePadfraction(float xmin, float xmax, float ymin, float ymax);
   double chargefrac1d(float min, float max, double k2, double sqrtk3, double k4);
-  unsigned long response(unsigned long adc);
+  uint32_t response(uint32_t adc);
   float getAnod(float x);
   float chargeCorr();
   bool aboveThreshold(float charge) { return charge > mChargeThreshold; };

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -173,7 +173,7 @@ int Digitizer::processHit(const Hit& hit, int detID, int event_time)
       } else {
         q *= chargenon;
       }
-      auto signal = (unsigned long)q * resp.getInverseChargeThreshold();
+      auto signal = (uint32_t)q * resp.getInverseChargeThreshold();
       if (signal > 0) {
         /// FIXME: which time definition is used when calling this function?
         digits.emplace_back(detID, padid, signal, static_cast<int32_t>(time));
@@ -238,7 +238,7 @@ void Digitizer::mergeDigits()
     while (j < indices.size() && (getGlobalDigit(sortedDigits(i).getDetID(), sortedDigits(i).getPadID())) == (getGlobalDigit(sortedDigits(j).getDetID(), sortedDigits(j).getPadID())) && (std::fabs(sortedDigits(i).getTime() - sortedDigits(j).getTime()) < mDeltat)) {
       j++;
     }
-    unsigned long adc{0};
+    uint32_t adc{0};
     float padc{0};
     Response& resp = response(isStation1(sortedDigits(i).getDetID()));
 

--- a/Detectors/MUON/MCH/Simulation/src/Response.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Response.cxx
@@ -105,7 +105,7 @@ double Response::chargefrac1d(float min, float max, double k2, double sqrtk3, do
   return 2. * k4 * (TMath::ATan(u2) - TMath::ATan(u1));
 }
 //______________________________________________________________________
-unsigned long Response::response(unsigned long adc)
+uint32_t Response::response(uint32_t adc)
 {
   //DecalibrateTrackerDigit functionality from
   //AliMuonDigitizerV3 in aliroot


### PR DESCRIPTION
@aphecetche @aferrero2707 @mwinn2 I went through all pieces of O2 code using the digits and I think these are the only places that requested a modification following this change of format. Do you confirm?

I also changed the way the run2 calibrated charge (float) is encoded in the run3 ADC (uint) in the clustering (for the moment the clustering only handles run2 calibrated charge. The handling of run3 ADC will be come in another PR as it also requires to change some thresholds and the Mathieson function parameterizations).
