### PR TITLE
DPL Analysis: Use new configurable alias for AxisSpec

### DIFF
--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -22,7 +22,7 @@ using namespace o2::framework;
 // This is a very simple example showing how to create an histogram
 // FIXME: this should really inherit from AnalysisTask but
 //        we need GCC 7.4+ for that
-struct ATask {
+struct EtaPhiHistograms {
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry",
@@ -41,7 +41,7 @@ struct ATask {
   }
 };
 
-struct BTask {
+struct FilteredHistograms {
   /// Construct a registry object with direct declaration
   HistogramRegistry registry{
     "registry",
@@ -58,7 +58,7 @@ struct BTask {
   }
 };
 
-struct CTask {
+struct DimensionTest {
 
   HistogramRegistry registry{
     "registry",
@@ -132,7 +132,7 @@ struct CTask {
   }
 };
 
-struct DTask {
+struct RealisticExample {
   HistogramRegistry spectra{"spectra", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry etaStudy{"etaStudy", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
@@ -216,7 +216,7 @@ struct DTask {
   }
 };
 
-struct ETask {
+struct OutputObjTest {
   OutputObj<TH1F> phiH{TH1F("phi", "phi", 100, 0., 2. * M_PI)};
   OutputObj<TH1F> etaH{TH1F("eta", "eta", 102, -2.01, 2.01)};
 
@@ -229,7 +229,7 @@ struct ETask {
   }
 };
 
-struct FTask {
+struct TListTest {
   Configurable<int> cfgTrackType{"trktype", 1, "Type of selected tracks: 0 = no selection, 1 = global tracks FB96"};
   OutputObj<TList> fOutput{"TListForTests", OutputObjHandlingPolicy::AnalysisObject, OutputObjSourceType::OutputObjSource};
   HistogramRegistry registry{
@@ -257,13 +257,13 @@ struct FTask {
   }
 };
 
-struct GTask {
+struct ConfigurablesTest {
   HistogramRegistry histos{"Histos"};
 
   // for testing: assume first element in vector is number of bins; if it is zero variable binning is assumed
   // note that the size of the default vector fixes the size of the vector that can be provided via configurable
-  Configurable<std::vector<double>> ptBinning{"pt-bin-edges", {0., 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
-  Configurable<std::vector<double>> centBinning{"cent-binning", {9., 0., 90}, ""};               // fixed size bins
+  ConfigurableAxis<double> ptBinning{"pt-bin-edges", {0., 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
+  ConfigurableAxis<double> centBinning{"cent-binning", {9, 0., 90}, ""};                // fixed size bins
 
   // best would be to make it work with the actual AxisSpec and its ctors:
   //Configurable<AxisSpec> phiAxis{"phi-axis", {{0., 0.25, 0.5, 0.75, 1., 1.6, 2.}}, ""};
@@ -271,10 +271,8 @@ struct GTask {
 
   void init(InitContext const&)
   {
-    // first bool argument is needed here to distingish the custom ctor (from double vector where first element is nBins)
-    // form the 'ordinary' one which has bin edges as argument
-    AxisSpec ptAxis = {true, ptBinning, "#it{p}_{T} (GeV/c)"};
-    AxisSpec centAxis = {true, centBinning, "#it{p}_{T} (GeV/c)"};
+    AxisSpec ptAxis = {ptBinning, "#it{p}_{T} (GeV/c)"};
+    AxisSpec centAxis = {centBinning, "#it{p}_{T} (GeV/c)"};
 
     // for all axes that do not actually need to be configurable, better dont use the Configurables to avoid code clutter!
     const int nCuts = 5;
@@ -297,11 +295,11 @@ struct GTask {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ETask>(cfgc, TaskName{"output-obj-test"}),
-    adaptAnalysisTask<ATask>(cfgc, TaskName{"eta-and-phi-histograms"}),
-    adaptAnalysisTask<BTask>(cfgc, TaskName{"filtered-histograms"}),
-    adaptAnalysisTask<CTask>(cfgc, TaskName{"dimension-test"}),
-    adaptAnalysisTask<DTask>(cfgc, TaskName{"realistic-example"}),
-    adaptAnalysisTask<FTask>(cfgc, TaskName{"tlist-test"}),
-    adaptAnalysisTask<GTask>(cfgc, TaskName{"configurables-test"})};
+    adaptAnalysisTask<OutputObjTest>(cfgc),
+    adaptAnalysisTask<EtaPhiHistograms>(cfgc),
+    adaptAnalysisTask<FilteredHistograms>(cfgc),
+    adaptAnalysisTask<DimensionTest>(cfgc),
+    adaptAnalysisTask<RealisticExample>(cfgc),
+    adaptAnalysisTask<TListTest>(cfgc),
+    adaptAnalysisTask<ConfigurablesTest>(cfgc)};
 }

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -260,9 +260,8 @@ struct TListTest {
 struct ConfigurablesTest {
   HistogramRegistry histos{"Histos"};
 
-  // for testing: assume first element in vector is number of bins; if it is zero variable binning is assumed
-  // note that the size of the default vector fixes the size of the vector that can be provided via configurable
-  ConfigurableAxis<double> ptBinning{"pt-bin-edges", {0., 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
+  // first element in vector is number of bins (fixed binning) or VARIABLE_WIDTH (variable binning)
+  ConfigurableAxis<double> ptBinning{"pt-bin-edges", {VARIABLE_WIDTH, 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
   ConfigurableAxis<double> centBinning{"cent-binning", {9, 0., 90}, ""};                // fixed size bins
 
   // best would be to make it work with the actual AxisSpec and its ctors:

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -262,7 +262,7 @@ struct ConfigurablesTest {
 
   // first element in vector is number of bins (fixed binning) or VARIABLE_WIDTH (variable binning)
   ConfigurableAxis<double> ptBinning{"pt-bin-edges", {VARIABLE_WIDTH, 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
-  ConfigurableAxis<double> centBinning{"cent-binning", {9, 0., 90}, ""};                // fixed size bins
+  ConfigurableAxis<double> centBinning{"cent-binning", {9, 0., 90}, ""};                            // fixed size bins
 
   // best would be to make it work with the actual AxisSpec and its ctors:
   //Configurable<AxisSpec> phiAxis{"phi-axis", {{0., 0.25, 0.5, 0.75, 1., 1.6, 2.}}, ""};

--- a/Analysis/Tutorials/src/histogramRegistry.cxx
+++ b/Analysis/Tutorials/src/histogramRegistry.cxx
@@ -261,12 +261,8 @@ struct ConfigurablesTest {
   HistogramRegistry histos{"Histos"};
 
   // first element in vector is number of bins (fixed binning) or VARIABLE_WIDTH (variable binning)
-  ConfigurableAxis<double> ptBinning{"pt-bin-edges", {VARIABLE_WIDTH, 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
-  ConfigurableAxis<double> centBinning{"cent-binning", {9, 0., 90}, ""};                            // fixed size bins
-
-  // best would be to make it work with the actual AxisSpec and its ctors:
-  //Configurable<AxisSpec> phiAxis{"phi-axis", {{0., 0.25, 0.5, 0.75, 1., 1.6, 2.}}, ""};
-  //Configurable<AxisSpec> etaAxis{"eta-axis", {{8, -1., 1.}}, ""};
+  ConfigurableAxis ptBinning{"pt-bin-edges", {VARIABLE_WIDTH, 0.15, 1., 5., 10., 50.}, ""}; // variable bin edges
+  ConfigurableAxis centBinning{"cent-binning", {9, 0., 90}, ""};                            // fixed size bins
 
   void init(InitContext const&)
   {
@@ -280,8 +276,6 @@ struct ConfigurablesTest {
     histos.add("myPtHistFromConfig", "", {HistType::kTH1D, {ptAxis}});
     histos.add("myCentHistFromConfig", "", {HistType::kTH1D, {centAxis}});
     histos.add("myCutHistNotFromConfig", "", {HistType::kTH1D, {cutAxis}});
-
-    //histos.add("histFromConfigAxisSpec", "", {HistType::kTH2F, {phiAxis, etaAxis}});
   }
 
   void process(aod::Track const& track)

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -72,8 +72,7 @@ struct Configurable : IP {
 template <typename T, ConfigParamKind K = ConfigParamKind::kGeneric>
 using MutableConfigurable = Configurable<T, K, ConfigurablePolicyMutable<T, K>>;
 
-template <typename T>
-using ConfigurableAxis = Configurable<std::vector<T>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<T>, ConfigParamKind::kAxisSpec>>;
+using ConfigurableAxis = Configurable<std::vector<double>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<double>, ConfigParamKind::kAxisSpec>>;
 
 template <typename T, ConfigParamKind K, typename IP>
 std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -109,7 +109,7 @@ struct AxisSpec {
   }
 
   // first entry is assumed to be the number of bins; in case of variable size binning it must be set to zero
-  AxisSpec(ConfigurableAxis<double> binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)
+  AxisSpec(ConfigurableAxis binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)
     : nBins(std::nullopt),
       binEdges(std::vector<double>(binEdges_)),
       title(title_),

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -105,19 +105,18 @@ struct AxisSpec {
   {
   }
 
-  // temporary ctor to allow building axis from double array that we can currently get via Configurables
-  // (first entry is assumed to be the number of bins; in case of variable size binning it must be set to zero)
-  AxisSpec(bool isFromConfig_, std::vector<double> binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)
+  // first entry is assumed to be the number of bins; in case of variable size binning it must be set to zero
+  AxisSpec(ConfigurableAxis<double> binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)
     : nBins(std::nullopt),
-      binEdges(binEdges_),
+      binEdges(std::vector<double>(binEdges_)),
       title(title_),
       name(name_)
   {
-    if (!isFromConfig_ || binEdges.empty()) {
-      return; // just treat bin edges vector as bin edges...
+    if (binEdges.empty()) {
+      return;
     }
-    if (binEdges_[0] != 0.) {
-      nBins = static_cast<int>(binEdges_[0]);
+    if (binEdges[0] != 0.) {
+      nBins = static_cast<int>(binEdges[0]);
       binEdges.resize(3); // nBins, lowerBound, upperBound, disregard whatever else is stored in vecotr
     }
     binEdges.erase(binEdges.begin()); // remove first entry that we assume to be number of bins
@@ -127,9 +126,6 @@ struct AxisSpec {
   std::vector<double> binEdges{};
   std::optional<std::string> title{};
   std::optional<std::string> name{}; // optional axis name for ndim histograms
-
-  //AxisSpec() = default;
-  //ClassDef(AxisSpec, 1);
 };
 
 //**************************************************************************************************

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -88,6 +88,9 @@ using HistPtr = std::variant<std::shared_ptr<THn>, std::shared_ptr<THnSparse>, s
  * Specification of an Axis.
  */
 //**************************************************************************************************
+// Flag to mark variable bin size in configurable bin edges
+const int VARIABLE_WIDTH = 0;
+
 struct AxisSpec {
   AxisSpec(std::vector<double> binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)
     : nBins(std::nullopt),
@@ -115,7 +118,7 @@ struct AxisSpec {
     if (binEdges.empty()) {
       return;
     }
-    if (binEdges[0] != 0.) {
+    if (binEdges[0] != VARIABLE_WIDTH) {
       nBins = static_cast<int>(binEdges[0]);
       binEdges.resize(3); // nBins, lowerBound, upperBound, disregard whatever else is stored in vecotr
     }

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -89,7 +89,7 @@ using HistPtr = std::variant<std::shared_ptr<THn>, std::shared_ptr<THnSparse>, s
  */
 //**************************************************************************************************
 // Flag to mark variable bin size in configurable bin edges
-const int VARIABLE_WIDTH = 0;
+constexpr int VARIABLE_WIDTH = 0;
 
 struct AxisSpec {
   AxisSpec(std::vector<double> binEdges_, std::optional<std::string> title_ = std::nullopt, std::optional<std::string> name_ = std::nullopt)


### PR DESCRIPTION
Hi @jgrosseo @mario-krueger @aalkin 

This is a modified histogram registry example with the usage of the new metadata provided by Anton.

@mario-krueger - to make use of having variable vector size on Hyperloop, we need to keep the vector as a separate Configurable. I simplified the constructor a bit instead.