### PR TITLE
Fixes for the --tpc-sectors option in the TPC workflow

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/WorkflowHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/WorkflowHelper.h
@@ -90,7 +90,7 @@ static auto getWorkflowTPCInput(o2::framework::ProcessingContext& pc, int verbos
       if (recvMask & sectorHeader->sectorBits) {
         throw std::runtime_error("can only have one MC data set per sector");
       }
-      recvMask |= sectorHeader->sectorBits;
+      recvMask |= (sectorHeader->sectorBits & tpcSectorMask);
       retVal->internal.inputrefs[sector].labels = ref;
       if (do_digits) {
         retVal->internal.inputDigitsMCIndex[sector] = retVal->internal.inputDigitsMC.size();
@@ -132,7 +132,7 @@ static auto getWorkflowTPCInput(o2::framework::ProcessingContext& pc, int verbos
       if (recvMask & sectorHeader->sectorBits) {
         throw std::runtime_error("can only have one cluster data set per sector");
       }
-      recvMask |= sectorHeader->sectorBits;
+      recvMask |= (sectorHeader->sectorBits & tpcSectorMask);
       retVal->internal.inputrefs[sector].data = ref;
       if (do_digits) {
         if (tpcSectorMask & (1ul << sector)) {

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CATrackerSpec.h
@@ -63,7 +63,7 @@ struct Config {
 ///
 /// @param specconfig configuration options for the processor spec
 /// @param tpcsectors list of sector numbers
-framework::DataProcessorSpec getCATrackerSpec(o2::tpc::reco_workflow::CompletionPolicyData* policyData, ca::Config const& specconfig, std::vector<int> const& tpcsectors);
+framework::DataProcessorSpec getCATrackerSpec(o2::tpc::reco_workflow::CompletionPolicyData* policyData, ca::Config const& specconfig, std::vector<int> const& tpcsectors, unsigned long tpcSectorMask);
 
 o2::framework::CompletionPolicy getCATrackerCompletionPolicy();
 } // end namespace tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -69,6 +69,7 @@ using CompletionPolicyData = std::vector<framework::InputSpec>;
 /// create the workflow for TPC reconstruction
 framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
                                     std::vector<int> const& tpcSectors,           //
+                                    unsigned long tpcSectorMask,                  //
                                     std::vector<int> const& laneConfiguration,    //
                                     bool propagateMC = true, unsigned nLanes = 1, //
                                     std::string const& cfgInput = "digitizer",    //
@@ -81,6 +82,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,           
 
 static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
                                                   std::vector<int> const& tpcSectors,           //
+                                                  unsigned long tpcSectorMask,                  //
                                                   bool propagateMC = true, unsigned nLanes = 1, //
                                                   std::string const& cfgInput = "digitizer",    //
                                                   std::string const& cfgOutput = "tracks",      //
@@ -93,7 +95,7 @@ static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyDa
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(policyData, tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
+  return getWorkflow(policyData, tpcSectors, tpcSectorMask, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
 }
 
 static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
@@ -109,7 +111,7 @@ static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyDa
   // create a default lane configuration with ids [0, nLanes-1]
   std::vector<int> laneConfiguration(nLanes);
   std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(policyData, {}, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
+  return getWorkflow(policyData, {}, 0xFFFFFFFFF, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
 }
 
 } // end namespace reco_workflow

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -80,40 +80,6 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,           
                                     float zsThreshold = 2.0f,
                                     bool askDISTSTF = true);
 
-static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
-                                                  std::vector<int> const& tpcSectors,           //
-                                                  unsigned long tpcSectorMask,                  //
-                                                  bool propagateMC = true, unsigned nLanes = 1, //
-                                                  std::string const& cfgInput = "digitizer",    //
-                                                  std::string const& cfgOutput = "tracks",      //
-                                                  int caClusterer = 0,                          //
-                                                  int zsOnTheFly = 0,
-                                                  int zs10bit = 0,
-                                                  float zsThreshold = 2.0f,
-                                                  bool askDISTSTF = true)
-{
-  // create a default lane configuration with ids [0, nLanes-1]
-  std::vector<int> laneConfiguration(nLanes);
-  std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(policyData, tpcSectors, tpcSectorMask, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
-}
-
-static inline framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,             //
-                                                  bool propagateMC = true, unsigned nLanes = 1, //
-                                                  std::string const& cfgInput = "digitizer",    //
-                                                  std::string const& cfgOutput = "tracks",      //
-                                                  int caClusterer = 0,                          //
-                                                  int zsOnTheFly = 0,
-                                                  int zs10bit = 0,
-                                                  float zsThreshold = 2.0f,
-                                                  bool askDISTSTF = true)
-{
-  // create a default lane configuration with ids [0, nLanes-1]
-  std::vector<int> laneConfiguration(nLanes);
-  std::iota(laneConfiguration.begin(), laneConfiguration.end(), 0);
-  return getWorkflow(policyData, {}, 0xFFFFFFFFF, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer, zsOnTheFly, zs10bit, zsThreshold, askDISTSTF);
-}
-
 } // end namespace reco_workflow
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ZSSpec.h
@@ -16,7 +16,7 @@ namespace tpc
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs12bit, float threshold, bool outRaw);
+framework::DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs12bit, float threshold, bool outRaw, unsigned long tpcSectorMask);
 
 framework::DataProcessorSpec getZStoDigitsSpec(std::vector<int> const& tpcSectors);
 

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -86,7 +86,7 @@ namespace o2
 namespace tpc
 {
 
-DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config const& specconfig, std::vector<int> const& tpcsectors)
+DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config const& specconfig, std::vector<int> const& tpcsectors, unsigned long tpcSectorMask)
 {
   if (specconfig.outputCAClusters && !specconfig.caClusterer && !specconfig.decompressTPC) {
     throw std::runtime_error("inconsistent configuration: cluster output is only possible if CA clusterer is activated");
@@ -117,9 +117,8 @@ DataProcessorSpec getCATrackerSpec(CompletionPolicyData* policyData, ca::Config 
   };
 
   auto processAttributes = std::make_shared<ProcessAttributes>();
-  for (auto s : tpcsectors) {
-    processAttributes->tpcSectorMask |= (1ul << s);
-  }
+  processAttributes->tpcSectorMask = tpcSectorMask;
+
   auto initFunction = [processAttributes, specconfig](InitContext& ic) {
     processAttributes->config.reset(new GPUO2InterfaceConfiguration);
     GPUO2InterfaceConfiguration& config = *processAttributes->config.get();

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -86,7 +86,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"qa", OutputType::QA},
   {"no-shared-cluster-map", OutputType::NoSharedClusterMap}};
 
-framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, std::vector<int> const& laneConfiguration,
+framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, unsigned long tpcSectorMask, std::vector<int> const& laneConfiguration,
                                     bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput,
                                     int caClusterer, int zsOnTheFly, int zs10bit, float zsThreshold, bool askDISTSTF)
 {
@@ -408,7 +408,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
   }
 
   if (zsOnTheFly) {
-    specs.emplace_back(o2::tpc::getZSEncoderSpec(tpcSectors, zs10bit, zsThreshold, outRaw));
+    specs.emplace_back(o2::tpc::getZSEncoderSpec(tpcSectors, zs10bit, zsThreshold, outRaw, tpcSectorMask));
   }
 
   if (zsToDigit) {
@@ -436,7 +436,7 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     cfg.processMC = propagateMC;
     cfg.sendClustersPerSector = isEnabled(OutputType::SendClustersPerSector);
     cfg.askDISTSTF = askDISTSTF;
-    specs.emplace_back(o2::tpc::getCATrackerSpec(policyData, cfg, tpcSectors));
+    specs.emplace_back(o2::tpc::getCATrackerSpec(policyData, cfg, tpcSectors, tpcSectorMask));
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -56,7 +56,7 @@ namespace o2
 namespace tpc
 {
 
-DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs10bit, float threshold = 2.f, bool outRaw = false)
+DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs10bit, float threshold = 2.f, bool outRaw = false, unsigned long tpcSectorMask = 0xFFFFFFFFF)
 {
   std::string processorName = "tpc-zsEncoder";
   constexpr static size_t NSectors = o2::tpc::Sector::MAXSECTOR;
@@ -72,17 +72,13 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool zs10
     bool finished = false;
   };
 
-  auto initFunction = [tpcSectors, zs10bit, threshold, outRaw](InitContext& ic) {
+  auto initFunction = [tpcSectors, zs10bit, threshold, outRaw, tpcSectorMask](InitContext& ic) {
     auto processAttributes = std::make_shared<ProcessAttributes>();
     auto& zsoutput = processAttributes->zsoutput;
     processAttributes->tpcSectors = tpcSectors;
     auto& verify = processAttributes->verify;
     auto& sizes = processAttributes->sizes;
     auto& verbosity = processAttributes->verbosity;
-    unsigned long tpcSectorMask = 0;
-    for (auto s : tpcSectors) {
-      tpcSectorMask |= (1ul << s);
-    }
 
     auto processingFct = [processAttributes, zs10bit, threshold, outRaw, tpcSectorMask](
                            ProcessingContext& pc) {

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -90,7 +90,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
   // the custom completion policy for the tracker
-  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-tracker.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData)());
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-tracker.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData, &gTpcSectorMask)());
 }
 
 #include "Framework/runDataProcessing.h" // the main driver

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -37,6 +37,7 @@ o2::framework::Output gDispatchTrigger{"", ""};
 
 // Global variable used to transport data to the completion policy
 o2::tpc::reco_workflow::CompletionPolicyData gPolicyData;
+unsigned long gTpcSectorMask = 0xFFFFFFFFF;
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -139,9 +140,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcrecoworkflow_configuration.ini");
 
+  gTpcSectorMask = 0;
+  for (auto s : tpcSectors) {
+    gTpcSectorMask |= (1ul << s);
+  }
+
   bool doMC = not cfgc.options().get<bool>("disable-mc");
   return o2::tpc::reco_workflow::getWorkflow(&gPolicyData,                                      //
                                              tpcSectors,                                        // sector configuration
+                                             gTpcSectorMask,                                    // same as bitmask
                                              laneConfiguration,                                 // lane configuration
                                              doMC,                                              //
                                              nLanes,                                            //


### PR DESCRIPTION
@sawenzel : This filters the tpc sector list in the TPCSectorHeader for the "allowed" sectors provided on the command line, both in parsing the input and in the completion policy. What I am doing here is most certainly correct, but I have tried with the patch to run the digitizer without `--tpc-sector`  option and the tpc reco with `digitizer` input and without the sector option, and it still fails. I am afraid I have no idea where to look else, and since we have a working setup now anyway, I'd leave it be for.
If this should be fixed eventually, I'd suggest we ask @matthiasrichter to have a further look.
In any case I'd merge these changes since they are already supposed to fix some incorrect behavior.