### PR TITLE
Add option to create uninitialized std::vector as output message via DataAllocator::UninitializedVector

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -271,6 +271,35 @@ class OwningMessageSpectatorAllocator
   }
 };
 
+// The NoConstructAllocator behaves like the normal pmr vector but does not call constructors / destructors
+template <typename T>
+class NoConstructAllocator : public boost::container::pmr::polymorphic_allocator<T>
+{
+ public:
+  using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
+  using propagate_on_container_move_assignment = std::true_type;
+
+  template <typename... Args>
+  NoConstructAllocator(Args&&... args) : boost::container::pmr::polymorphic_allocator<T>(std::forward<Args>(args)...)
+  {
+  }
+
+  // skip default construction of empty elements
+  // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and
+  // quickly construct large vectors while skipping the element initialization.
+  template <class U>
+  void construct(U*)
+  {
+  }
+
+  // dont try to call destructors, makes no sense since resource is managed externally AND allowed
+  // types cannot have side effects
+  template <typename U>
+  void destroy(U*)
+  {
+  }
+};
+
 //__________________________________________________________________________________________________
 //__________________________________________________________________________________________________
 //__________________________________________________________________________________________________

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -217,7 +217,7 @@ class MessageContext
     using value_type = typename T::value_type;
     using return_type = T;
     using buffer_type = return_type;
-    static_assert(std::is_same<typename T::allocator_type, o2::pmr::polymorphic_allocator<value_type>>::value, "container must have polymorphic allocator");
+    static_assert(std::is_base_of<o2::pmr::polymorphic_allocator<value_type>, typename T::allocator_type>::value, "container must have polymorphic allocator");
     /// default contructor forbidden, object always has to control message instances
     ContainerRefObject() = delete;
     /// constructor taking header message by move and creating the paypload message


### PR DESCRIPTION
This PR adds an optional alternative vector type that can be used for the output message which does not construct / destruct objects, but it will just provide uninitialized memory to the user (also won't initialize at resize).
To avoid abuse, it is currently only supported for primitive types, e.g. `char`, but of course it can be case to any type if desired if the user ensures the data is filled correctly.

To avoid confusion, I have added a class `DataAllocator::UninitializedVector` that must be passed explicitly to the `make<...>(...)` call, such that a user can only explicitly request uninitialized memory.

In the `MemoryResources.h` header I have added a new type `NoConstructAllocator` which behaves like the boost pmr allocator with the only difference that it doesn't call constructors and destructors. It is thus very similar to the `SpectatorAllocator`, which however has some other overloads, which I am not sure if they are safe in any case. I wanted to keep this as simple and safe as possible.

The new output type is used in the tpc reco workflow. Only required change to use it is using
```
pc.outputs().make<DataAllocator::UninitializedVector<type>>(..., size)
```
instead of
```
pc.outputs().make<std::vector<type>>(..., size)
```
