### PR TITLE
[WIP] Create template for TRD vDrift calibration

### DIFF
--- a/Detectors/TRD/CMakeLists.txt
+++ b/Detectors/TRD/CMakeLists.txt
@@ -9,6 +9,7 @@
 # submit itself to any jurisdiction.
 
 add_subdirectory(base)
+add_subdirectory(calibration)
 add_subdirectory(simulation)
 add_subdirectory(reconstruction)
 add_subdirectory(macros)

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright CERN and copyright holders of ALICE O2.This software is distributed
+#under the terms of the GNU General Public License v3(GPL Version 3), copied
+#verbatim in the file "COPYING".
+#
+#See http: //alice-o2.web.cern.ch/license for full licensing information.
+#
+#In applying this license CERN does not waive the privileges and immunities
+#granted to it by virtue of its status as an Intergovernmental Organization or
+#submit itself to any jurisdiction.
+
+o2_add_library(TRDCalibration
+               SOURCES src/CalibVDrift.cxx
+               PUBLIC_LINK_LIBRARIES O2::TRDBase
+                                     O2::DataFormatsTRD
+                                     O2::GPUTracking)
+
+ o2_target_root_dictionary(TRDCalibration
+                           HEADERS include/TRDCalibration/CalibVDrift.h)

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibVDrift.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibVDrift.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_CALIBVDRIFT_H_
+#define ALICEO2_TRD_CALIBVDRIFT_H_
+
+/// \file   CalibVDrift.h
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+#include "GPUO2Interface.h"
+#include "GPUTRDSpacePointInternal.h" // FIXME: replace with actual data type
+
+namespace o2
+{
+namespace trd
+{
+
+/// \brief VDrift calibration class
+///
+/// This class is used to determine chamber-wise vDrift values
+///
+/// origin: TRD
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+class CalibVDrift
+{
+ public:
+  /// default constructor
+  CalibVDrift() = default;
+
+  /// default destructor
+  ~CalibVDrift() = default;
+
+  /// set input angular deviations
+  void setAngDevInp(const std::vector<o2::gpu::GPUTRDSpacePointInternal> input) { mAngulerDeviationProf = input; }
+
+  /// main processing function
+  void process();
+
+ private:
+  //FIXME: replace GPUTRDSpacePointInternal with the type Sven creates for collecting the angular deviations
+  std::vector<o2::gpu::GPUTRDSpacePointInternal> mAngulerDeviationProf; ///< input TRD track to tracklet angular deviations
+};
+
+} // namespace trd
+
+} // namespace o2
+#endif

--- a/Detectors/TRD/calibration/src/CalibVDrift.cxx
+++ b/Detectors/TRD/calibration/src/CalibVDrift.cxx
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CalibVDrift.cxx
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+#include "TFile.h"
+#include "TH2F.h"
+
+#include <fairlogger/Logger.h>
+
+#include "TRDCalibration/CalibVDrift.h"
+
+using namespace o2::trd;
+
+void CalibVDrift::process()
+{
+  LOG(info) << "Started processing for vDrift calibration";
+
+  // as an example I loop over the input, create a histogram and write it to a file
+  auto fOut = TFile::Open("trdcalibdummy.root", "recreate");
+  auto hXY = std::make_unique<TH2F>("histDummy", "foo", 100, -60, 60, 100, 250, 400); // xy distribution of TRD space points
+  for (int i = 0; i < mAngulerDeviationProf.size(); ++i) {
+    hXY->Fill(mAngulerDeviationProf[i].mX[0], mAngulerDeviationProf[i].mR);
+  }
+  fOut->cd();
+  hXY->Write();
+  hXY.reset(); // delete the histogram before closing the output file
+  fOut->Close();
+}

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::CalibVDrift + ;
+
+#endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -25,8 +25,8 @@ o2_add_library(TRDWorkflow
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackingWorkflow.cxx
                        src/EntropyDecoderSpec.cxx
-                       src/EntropyEncoderSpec.cxx                       
-                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::GPUTracking O2::GlobalTrackingWorkflow)
+                       src/EntropyEncoderSpec.cxx
+                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflow)
 
                    #o2_target_root_dictionary(TRDWorkflow
                    # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -17,6 +17,7 @@
 #include "Framework/Task.h"
 #include "TStopwatch.h"
 #include "TRDBase/GeometryFlat.h"
+#include "TRDCalibration/CalibVDrift.h"
 #include "GPUO2Interface.h"
 #include "GPUTRDTracker.h"
 
@@ -41,6 +42,7 @@ class TRDGlobalTracking : public o2::framework::Task
   std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
   bool mUseTrackletTransform{false};                  ///< if true, output from TrackletTransformer is used instead of uncalibrated Tracklet64 directly
+  CalibVDrift mCalibVDrift{};                         ///< steers the vDrift calibration
   TStopwatch mTimer;
 };
 

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -68,6 +68,7 @@ void TRDGlobalTracking::init(InitContext& ic)
   mTracker->SetProcessPerTimeFrame();
   mTracker->SetNMaxCollisions(mRec->GetProcessingSettings().trdNMaxCollisions);
   mTracker->SetTrkltTransformNeeded(!mUseTrackletTransform);
+  mTracker->SetDoImpactAngleHistograms(true);
 
   mRec->RegisterGPUProcessor(mTracker, false);
   mChainTracking->SetTRDGeometry(std::move(mFlatGeo));
@@ -171,6 +172,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   mTracker->SetTriggerRecordIndices(&(trdTriggerIndices[0]));
   mTracker->SetNCollisions(nCollisions);
   //mTracker->DumpTracks();
+  mTracker->ResetImpactAngleHistograms();
   mTracker->DoTracking(mChainTracking);
   //mTracker->DumpTracks();
 

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -176,6 +176,13 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
 
   std::vector<GPUTRDTrack> tracksOut(mTracker->NTracks());
   std::copy(mTracker->Tracks(), mTracker->Tracks() + mTracker->NTracks(), tracksOut.begin());
+
+  // FIXME instead of the space points we need to get the profile 'histograms' here
+  std::vector<GPUTRDSpacePointInternal> spacePointsOut(mTracker->NTracklets());
+  std::copy(mTracker->SpacePoints(), mTracker->SpacePoints() + mTracker->NTracklets(), spacePointsOut.begin());
+  mCalibVDrift.setAngDevInp(spacePointsOut);
+  mCalibVDrift.process();
+
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCHTRD", 0, Lifetime::Timeframe}, tracksOut);
 
   mTimer.Stop();

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -110,7 +110,7 @@ set(HDRS_INSTALL
     TRDTracking/GPUTRDTrackPoint.h
     TRDTracking/GPUTRDTrack.h
     TRDTracking/GPUTRDTrackData.h
-    TRDTracking/GPUTRDTrackPoint.h
+    TRDTracking/GPUTRDSpacePointInternal.h
     TRDTracking/GPUTRDTrackletLabels.h
     Base/GPUReconstructionIncludes.h
     SliceTracker/GPUTPCDef.h

--- a/GPU/GPUTracking/TRDTracking/GPUTRDAngularResiduals.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDAngularResiduals.h
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTRDAngularResiduals.h
+/// \brief This data structure stores the angular residuals between the TRD tracks and their tracklets
+
+/// \author Sven Hoppner
+// \E-Mail sven.hoppner@cern.ch
+
+#include "GPUCommonDef.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+struct AngularResiduals {
+  //float mImpactAngle;                 // Impact Angle of track
+  unsigned short mTrackletCounter; //counter of the tracklets
+  float mAngleDiffSum;             //Sum of Angle Difference of tracklet to track for each bin
+  //short mDetectorId;                  // Detector index
+
+  GPUd() AngularResiduals() : mTrackletCounter(0), mAngleDiffSum(0)
+  {
+  }
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -301,7 +301,7 @@ class trackInterface<GPUTPCGMTrackParam> : public GPUTPCGMTrackParam
   GPUd() const float* getPar() const { return GetPar(); }
   GPUd() const float* getCov() const { return GetCov(); }
   GPUd() float getTime() const { return -1.f; }
-
+  GPUd() void resetCovariance(float s) { ResetCovariance(); }
   GPUd() void setAlpha(float alpha) { mAlpha = alpha; }
   GPUd() void set(float x, float alpha, const float param[5], const float cov[15])
   {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDSpacePointInternal.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDSpacePointInternal.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTRDSpacePointInternal.h
+/// \brief This data structure stores the TRD space point used internally by the tracking code
+
+/// \author Ole Schmidt
+
+#ifndef GPUTRDSPACEPOINTINTERNAL_H
+#define GPUTRDSPACEPOINTINTERNAL_H
+
+#include "GPUCommonDef.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+// struct to hold the information on the space points
+struct GPUTRDSpacePointInternal {
+  float mR;                 // x position (3.5 mm above anode wires) - radial offset due to t0 mis-calibration, measured -1 mm for run 245353
+  float mX[2];              // y and z position (sector coordinates)
+  float mDy;                // deflection over drift length
+  unsigned short mVolumeId; // basically derived from TRD chamber number
+  GPUd() GPUTRDSpacePointInternal(float x, float y, float z, float dy) : mR(x), mDy(dy), mVolumeId(0)
+  {
+    mX[0] = y;
+    mX[1] = z;
+  }
+  GPUd() GPUTRDSpacePointInternal() : mR(0), mDy(0), mVolumeId(0)
+  {
+    mX[0] = 0;
+    mX[1] = 0;
+  }
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif // GPUTRDSPACEPOINTINTERNAL_H

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -22,6 +22,7 @@
 #include "GPUDef.h"
 #include "GPUTRDTrack.h"
 #include "GPULogging.h"
+#include "GPUTRDSpacePointInternal.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <vector>
@@ -77,19 +78,6 @@ class GPUTRDTracker_t : public GPUProcessor
                         kNStacks = 5,
                         kNSectors = 18,
                         kNChambers = 540 };
-
-  // struct to hold the information on the space points
-  struct GPUTRDSpacePointInternal {
-    float mR;                 // x position (3.5 mm above anode wires) - radial offset due to t0 mis-calibration, measured -1 mm for run 245353
-    float mX[2];              // y and z position (sector coordinates)
-    float mDy;                // deflection over drift length
-    unsigned short mVolumeId; // basically derived from TRD chamber number
-    GPUd() GPUTRDSpacePointInternal(float x, float y, float z, float dy) : mR(x), mDy(dy), mVolumeId(0)
-    {
-      mX[0] = y;
-      mX[1] = z;
-    }
-  };
 
   struct Hypothesis {
     int mLayers;      // number of layers with TRD space point

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.cxx
@@ -30,6 +30,7 @@
 #include "AliHLTTRDDefinitions.h"
 #include "AliHLTTPCDefinitions.h"
 #include "GPUTRDTrackPoint.h"
+#include "GPUTRDSpacePointInternal.h"
 #include "AliHLTGlobalBarrelTrack.h"
 #include "AliExternalTrackParam.h"
 #include "AliHLTExternalTrackParam.h"
@@ -386,7 +387,7 @@ int GPUTRDTrackerComponent::DoEvent(const AliHLTComponentEventData& evtData, con
 
   GPUTRDTrackGPU* trackArray = fTracker->Tracks();
   int nTracks = fTracker->NTracks();
-  GPUTRDTrackerGPU::GPUTRDSpacePointInternal* spacePoints = fTracker->SpacePoints();
+  GPUTRDSpacePointInternal* spacePoints = fTracker->SpacePoints();
 
   // TODO delete fTrackList since it only works for TObjects (or use compiler flag after tests with GPU track type)
   // for (int iTrack=0; iTrack<nTracks; ++iTrack) {
@@ -458,7 +459,7 @@ int GPUTRDTrackerComponent::DoEvent(const AliHLTComponentEventData& evtData, con
     }
 
     for (int i = 0; i < nTrackletsTotal; ++i) {
-      const GPUTRDTrackerGPU::GPUTRDSpacePointInternal& sp = spacePoints[i];
+      const GPUTRDSpacePointInternal& sp = spacePoints[i];
       GPUTRDTrackPoint* currOutPoint = &outTrackPoints->fPoints[i];
       currOutPoint->fX[0] = sp.mR;    // x in sector coordinates
       currOutPoint->fX[1] = sp.mX[0]; // y in sector coordinates


### PR DESCRIPTION
@aschmah @aberdnikova @SvenHoppner,
this is a template for the vDrift calibration. I did not yet add another DPL device. Instead, the calibration is simply appended to the `o2-trd-global-tracking` workflow. So when you run that workflow also the calibration template is called. At the moment it creates a root file with a dummy histogram.
In principle we just need to replace the `GPUTRDSpacePointInternal` with the data type which Sven creates for the angular deviations. Afterwards you can add everything you needed into the `CalibVDrift::process()` method.

@davidrohr please ignore for the moment. Instead of `GPUTRDSpacePointInternal` I want to use `CalibratedTracklet` when built with O2. Also I have not yet tested whether it is still working with AliRoot