### PR TITLE
DPL Analysis: Fix and an example for combinations with partitions

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -530,6 +530,8 @@ struct Partition {
   expressions::Filter filter;
   std::unique_ptr<o2::soa::Filtered<T>> mFiltered = nullptr;
 
+  using iterator = typename o2::soa::Filtered<T>::iterator;
+  using const_iterator = typename o2::soa::Filtered<T>::const_iterator;
   using filtered_iterator = typename o2::soa::Filtered<T>::iterator;
   using filtered_const_iterator = typename o2::soa::Filtered<T>::const_iterator;
   inline filtered_iterator begin()


### PR DESCRIPTION
Paritions on mixed-events tracks are temporarily defined in a bit cumbersome way - this should get simplified when we'll have a better event mixing interface.

@a-mathis could you check if this solves your problem?