### PR TITLE
Run 2 enums from DataTypes

### DIFF
--- a/Detectors/Upgrades/ALICE3/AOD/include/UpgradesAODUtils/Run2LikeAO2D.h
+++ b/Detectors/Upgrades/ALICE3/AOD/include/UpgradesAODUtils/Run2LikeAO2D.h
@@ -52,18 +52,6 @@ enum TreeIndex {     // Index of the output trees
   kTrees             //N/A
 };
 
-enum TrackTypeEnum : uint8_t {
-  GlobalTrack = 0,
-  ITSStandalone,
-  MFTStandalone,
-  Run2GlobalTrack = 254,
-  Run2Tracklet = 255
-}; // corresponds to O2/Core/Framework/include/Framework/DataTypes.h
-enum TrackFlagsRun2Enum {
-  ITSrefit = 0x1,
-  TPCrefit = 0x2,
-  GoldenChi2 = 0x4
-}; // corresponds to O2/Core/Framework/include/Framework/DataTypes.h
 enum MCParticleFlags : uint8_t {
   ProducedInTransport = 1 // Bit 0: 0 = from generator; 1 = from transport
 };

--- a/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
+++ b/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
@@ -48,6 +48,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/Vertex.h"
+#include "Framework/DataTypes.h"
 #include "UpgradesAODUtils/Run2LikeAO2D.h"
 #endif
 

--- a/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
+++ b/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
@@ -528,12 +528,12 @@ void ALICE3toAO2D()
         hPtSpectraFake->Fill(track.getPt());
 
       tracks.fCollisionsID = lEventNumber;
-      tracks.fTrackType = TrackTypeEnum::Run2GlobalTrack; //Make track selection happy, please
+      tracks.fTrackType = o2::aod::track::TrackTypeEnum::Run2GlobalTrack; //Make track selection happy, please
       tracks.fFlags = 0x0;
       //Assume it all worked, fool regular selections
-      tracks.fFlags |= TrackFlagsRun2Enum::ITSrefit;
-      tracks.fFlags |= TrackFlagsRun2Enum::TPCrefit;
-      tracks.fFlags |= TrackFlagsRun2Enum::GoldenChi2;
+      tracks.fFlags |= o2::aod::track::TrackFlagsRun2Enum::ITSrefit;
+      tracks.fFlags |= o2::aod::track::TrackFlagsRun2Enum::TPCrefit;
+      tracks.fFlags |= o2::aod::track::TrackFlagsRun2Enum::GoldenChi2;
 
       //Main: X, alpha, track params
       tracks.fX = track.getX();

--- a/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
+++ b/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
@@ -528,7 +528,7 @@ void ALICE3toAO2D()
         hPtSpectraFake->Fill(track.getPt());
 
       tracks.fCollisionsID = lEventNumber;
-      tracks.fTrackType = o2::aod::track::TrackTypeEnum::Run2GlobalTrack; //Make track selection happy, please
+      tracks.fTrackType = o2::aod::track::TrackTypeEnum::Run2Track; //Make track selection happy, please
       tracks.fFlags = 0x0;
       //Assume it all worked, fool regular selections
       tracks.fFlags |= o2::aod::track::TrackFlagsRun2Enum::ITSrefit;


### PR DESCRIPTION
@marcovanleeuwen, @mconcas, @qgp: @jgrosseo pointed out that the Run2 utils header for the ALICE3 AO2D conversion tool actually re-declared some enums that already exist in DataTypes.h, so to avoid confusion, I just re-used those and removed the double declarations. 