### PR TITLE
[O2-2180] AliECS dump improvements

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -166,6 +166,7 @@ foreach(t
         FairMQOptionsRetriever
         FairMQResizableBuffer
         FrameworkDataFlowToDDS
+        FrameworkDataFlowToO2Control
         Graphviz
         GroupSlicer
         HistogramRegistry

--- a/Framework/Core/src/O2ControlHelpers.h
+++ b/Framework/Core/src/O2ControlHelpers.h
@@ -29,16 +29,9 @@ namespace framework
 /// - Enter the environment and go to ControlWorkflows local repository.
 /// - Run the DPL workflow(s) with the argument `--o2-control <workflow-name>`.
 ///   The WFT will be created in the "workflows" directory and, analogously, TTs will be put in "tasks".
-/// - Copy the WFT contents into existing "mother" workflow, e.g. readout-dataflow.yaml.
-///   Later, AliECS will allow to include subworkflows in WFTs.
-/// - Create the standard DPL dump (`--dump > <workflow-name>`).
-///   Make sure it is copied into the path specified with dpl_config var in WTF.
+///   It can be included by a mother workflow at the deployment time.
+/// - Replace arguments with templates if needed.
 /// - Commit, push, test, merge to master.
-/// With the future developments we aim to minimise the amount of effort to create WFTs and TTs,
-/// then finally reach JIT workflow translation.
-/// To avoid creating and using the standard DPL dump, one can paste the DPL command
-/// in the place of "cat {{ dpl_config }}"
-
 void dumpDeviceSpec2O2Control(std::string workflowName,
                               std::vector<DeviceSpec> const& specs,
                               std::vector<DeviceExecution> const& executions,

--- a/Framework/Core/src/O2ControlHelpers.h
+++ b/Framework/Core/src/O2ControlHelpers.h
@@ -37,6 +37,21 @@ void dumpDeviceSpec2O2Control(std::string workflowName,
                               std::vector<DeviceExecution> const& executions,
                               CommandInfo const& commandInfo);
 
+/// \brief Dumps only the workflow file
+void dumpWorkflow(std::ostream& dumpOut,
+                  const std::vector<DeviceSpec>& specs,
+                  const std::vector<DeviceExecution>& executions,
+                  const CommandInfo& commandInfo,
+                  std::string workflowName,
+                  std::string indLevel);
+
+/// \brief Dumps only one task
+void dumpTask(std::ostream& dumpOut,
+              const DeviceSpec& spec,
+              const DeviceExecution& execution,
+              std::string taskName,
+              std::string indLevel);
+
 } // namespace framework
 } // namespace o2
 #endif // FRAMEWORK_O2CONTROLHELPERS_H

--- a/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
@@ -1,0 +1,406 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DDSConfigHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Mocking.h"
+#include <boost/test/unit_test.hpp>
+#include "../src/O2ControlHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
+#include "../src/SimpleResourceManager.h"
+#include "../src/ComputingResourceHelpers.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/DeviceControl.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/WorkflowSpec.h"
+
+#include <sstream>
+
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing()
+{
+  return {{"A",                                                       //
+           Inputs{},                                                  //
+           Outputs{OutputSpec{"TST", "A1"}, OutputSpec{"TST", "A2"}}, // A1 will be consumed twice, A2 is dangling
+           AlgorithmSpec{},                                           //
+           {ConfigParamSpec{"channel-config", VariantType::String,    // raw input channel
+                            "name=into_dpl,type=pull,method=connect,address=ipc:///tmp/pipe-into-dpl,transport=shmem,rateLogging=10",
+                            {"Out-of-band channel config"}}}},
+          {"B", // producer, no inputs
+           Inputs{},
+           Outputs{OutputSpec{"TST", "B1"}}},
+          {"C", // first consumer of A1, consumer of B1
+           {InputSpec{"y", "TST", "A1"}, InputSpec{"y", "TST", "B1"}},
+           Outputs{}},
+          {"D", // second consumer of A1
+           Inputs{
+             InputSpec{"x", "TST", "A1"}},
+           Outputs{},
+           AlgorithmSpec{},
+           {ConfigParamSpec{"a-param", VariantType::Int, 1, {"A parameter which should not be escaped"}},
+            ConfigParamSpec{"b-param", VariantType::String, "", {"a parameter which will be escaped"}},
+            ConfigParamSpec{"c-param", VariantType::String, "foo;bar", {"another parameter which will be escaped"}},
+            ConfigParamSpec{"channel-config", VariantType::String, // raw output channel
+                            "name=outta_dpl,type=pull,method=connect,address=ipc:///tmp/pipe-outta-dpl,transport=shmem,rateLogging=10",
+                            {"Out-of-band channel config"}}}}};
+}
+
+char* strdiffchr(const char* s1, const char* s2)
+{
+  while (*s1 && *s1 == *s2) {
+    s1++;
+    s2++;
+  }
+  return (*s1 == *s2) ? nullptr : (char*)s1;
+}
+
+const auto expectedWorkflow = R"EXPECTED(name: testwf
+vars:
+  dpl_command: >-
+    o2-exe --abdf -defg 'asdf fdsa' | o2-exe-2 -b --zxcv "asdf zxcv"
+defaults:
+  monitoring_dpl_url: "no-op://"
+  user: "flp"
+  fmq_rate_logging: 0
+  shm_segment_size: 10000000000
+  shm_throw_bad_alloc: false
+roles:
+  - name: "A"
+    connect:
+    - name: into_dpl
+      type: pull
+      transport: shmem
+      target: "{{ path_to_into_dpl }}"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: testwf-A
+  - name: "B"
+    connect:
+    task:
+      load: testwf-B
+  - name: "C"
+    connect:
+    - name: from_A_to_C
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.A:from_A_to_C"
+      rateLogging: "{{ fmq_rate_logging }}"
+    - name: from_B_to_C
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.B:from_B_to_C"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: testwf-C
+  - name: "D"
+    connect:
+    - name: from_C_to_D
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.C:from_C_to_D"
+      rateLogging: "{{ fmq_rate_logging }}"
+    - name: outta_dpl
+      type: pull
+      transport: shmem
+      target: "{{ path_to_outta_dpl }}"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: testwf-D
+)EXPECTED";
+
+const std::vector expectedTasks{
+  R"EXPECTED(name: A
+defaults:
+  log_task_output: none
+control:
+  mode: "fairmq"
+wants:
+  cpu: 0.15
+  memory: 128
+bind:
+  - name: from_A_to_C
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+command:
+  shell: true
+  log: "{{ log_task_output }}"
+  user: "{{ user }}"
+  value: >-
+    source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 QualityControl Control-OCCPlugin &&
+    {{ dpl_command }} | bcsadc/foo
+  arguments:
+    - "-b"
+    - "--monitoring-backend"
+    - "'{{ monitoring_dpl_url }}'"
+    - "--session"
+    - "'default'"
+    - "--infologger-severity"
+    - "'{{ infologger_severity }}'"
+    - "--infologger-mode"
+    - "'{{ infologger_mode }}'"
+    - "--driver-client-backend"
+    - "'stdout://'"
+    - "--shm-segment-size"
+    - "'{{ shm_segment_size }}'"
+    - "--shm-throw-bad-alloc"
+    - "'{{ shm_throw_bad_alloc }}'"
+    - "--id"
+    - "'A'"
+    - "--shm-monitor"
+    - "'false'"
+    - "--log-color"
+    - "'false'"
+    - "--channel-prefix"
+    - "''"
+    - "--jobs"
+    - "'1'"
+    - "--severity"
+    - "'info'"
+    - "--shm-mlock-segment"
+    - "'false'"
+    - "--shm-segment-id"
+    - "'0'"
+    - "--shm-zero-segment"
+    - "'false'"
+    - "--stacktrace-on-signal"
+    - "'all'"
+)EXPECTED",
+  R"EXPECTED(name: B
+defaults:
+  log_task_output: none
+control:
+  mode: "fairmq"
+wants:
+  cpu: 0.15
+  memory: 128
+bind:
+  - name: from_B_to_C
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+command:
+  shell: true
+  log: "{{ log_task_output }}"
+  user: "{{ user }}"
+  value: >-
+    source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 QualityControl Control-OCCPlugin &&
+    {{ dpl_command }} | foo
+  arguments:
+    - "-b"
+    - "--monitoring-backend"
+    - "'{{ monitoring_dpl_url }}'"
+    - "--session"
+    - "'default'"
+    - "--infologger-severity"
+    - "'{{ infologger_severity }}'"
+    - "--infologger-mode"
+    - "'{{ infologger_mode }}'"
+    - "--driver-client-backend"
+    - "'stdout://'"
+    - "--shm-segment-size"
+    - "'{{ shm_segment_size }}'"
+    - "--shm-throw-bad-alloc"
+    - "'{{ shm_throw_bad_alloc }}'"
+    - "--id"
+    - "'B'"
+    - "--shm-monitor"
+    - "'false'"
+    - "--log-color"
+    - "'false'"
+    - "--channel-prefix"
+    - "''"
+    - "--jobs"
+    - "'1'"
+    - "--severity"
+    - "'info'"
+    - "--shm-mlock-segment"
+    - "'false'"
+    - "--shm-segment-id"
+    - "'0'"
+    - "--shm-zero-segment"
+    - "'false'"
+    - "--stacktrace-on-signal"
+    - "'all'"
+)EXPECTED",
+  R"EXPECTED(name: C
+defaults:
+  log_task_output: none
+control:
+  mode: "fairmq"
+wants:
+  cpu: 0.15
+  memory: 128
+bind:
+  - name: from_C_to_D
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+command:
+  shell: true
+  log: "{{ log_task_output }}"
+  user: "{{ user }}"
+  value: >-
+    source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 QualityControl Control-OCCPlugin &&
+    {{ dpl_command }} | foo
+  arguments:
+    - "-b"
+    - "--monitoring-backend"
+    - "'{{ monitoring_dpl_url }}'"
+    - "--session"
+    - "'default'"
+    - "--infologger-severity"
+    - "'{{ infologger_severity }}'"
+    - "--infologger-mode"
+    - "'{{ infologger_mode }}'"
+    - "--driver-client-backend"
+    - "'stdout://'"
+    - "--shm-segment-size"
+    - "'{{ shm_segment_size }}'"
+    - "--shm-throw-bad-alloc"
+    - "'{{ shm_throw_bad_alloc }}'"
+    - "--id"
+    - "'C'"
+    - "--shm-monitor"
+    - "'false'"
+    - "--log-color"
+    - "'false'"
+    - "--channel-prefix"
+    - "''"
+    - "--jobs"
+    - "'1'"
+    - "--severity"
+    - "'info'"
+    - "--shm-mlock-segment"
+    - "'false'"
+    - "--shm-segment-id"
+    - "'0'"
+    - "--shm-zero-segment"
+    - "'false'"
+    - "--stacktrace-on-signal"
+    - "'all'"
+)EXPECTED",
+  R"EXPECTED(name: D
+defaults:
+  log_task_output: none
+control:
+  mode: "fairmq"
+wants:
+  cpu: 0.15
+  memory: 128
+bind:
+command:
+  shell: true
+  log: "{{ log_task_output }}"
+  user: "{{ user }}"
+  value: >-
+    source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 QualityControl Control-OCCPlugin &&
+    {{ dpl_command }} | foo
+  arguments:
+    - "-b"
+    - "--monitoring-backend"
+    - "'{{ monitoring_dpl_url }}'"
+    - "--session"
+    - "'default'"
+    - "--infologger-severity"
+    - "'{{ infologger_severity }}'"
+    - "--infologger-mode"
+    - "'{{ infologger_mode }}'"
+    - "--driver-client-backend"
+    - "'stdout://'"
+    - "--shm-segment-size"
+    - "'{{ shm_segment_size }}'"
+    - "--shm-throw-bad-alloc"
+    - "'{{ shm_throw_bad_alloc }}'"
+    - "--id"
+    - "'D'"
+    - "--shm-monitor"
+    - "'false'"
+    - "--log-color"
+    - "'false'"
+    - "--channel-prefix"
+    - "''"
+    - "--jobs"
+    - "'1'"
+    - "--severity"
+    - "'info'"
+    - "--shm-mlock-segment"
+    - "'false'"
+    - "--shm-segment-id"
+    - "'0'"
+    - "--shm-zero-segment"
+    - "'false'"
+    - "--stacktrace-on-signal"
+    - "'all'"
+    - "--a-param"
+    - "'1'"
+    - "--b-param"
+    - "''"
+    - "--c-param"
+    - "'foo;bar'"
+)EXPECTED"};
+
+BOOST_AUTO_TEST_CASE(TestO2ControlDump)
+{
+  auto workflow = defineDataProcessing();
+  std::ostringstream ss{""};
+  auto configContext = makeEmptyConfigContext();
+  auto channelPolicies = makeTrivialChannelPolicies(*configContext);
+  std::vector<DeviceSpec> devices;
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
+  SimpleResourceManager rm(resources);
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id", true);
+  std::vector<DeviceControl> controls;
+  std::vector<DeviceExecution> executions;
+  controls.resize(devices.size());
+  executions.resize(devices.size());
+  CommandInfo commandInfo{R"(o2-exe --abdf -defg 'asdf fdsa' | o2-exe-2 -b --zxcv "asdf zxcv")"};
+
+  std::vector<ConfigParamSpec> workflowOptions = {
+    ConfigParamSpec{"jobs", VariantType::Int, 1, {"number of producer jobs"}}};
+
+  std::vector<DataProcessorInfo> dataProcessorInfos = {
+    {
+      {"A", "bcsadc/foo", {}, workflowOptions},
+      {"B", "foo", {}, workflowOptions},
+      {"C", "foo", {}, workflowOptions},
+      {"D", "foo", {}, workflowOptions},
+    }};
+  DeviceSpecHelpers::prepareArguments(false, false, 8080,
+                                      dataProcessorInfos,
+                                      devices, executions, controls,
+                                      "workflow-id");
+
+  dumpWorkflow(ss, devices, executions, commandInfo, "testwf", "");
+
+  BOOST_REQUIRE_EQUAL(strdiffchr(ss.str().data(), expectedWorkflow), strdiffchr(expectedWorkflow, ss.str().data()));
+  BOOST_CHECK_EQUAL(ss.str(), expectedWorkflow);
+
+  BOOST_REQUIRE_EQUAL(devices.size(), executions.size());
+  BOOST_REQUIRE_EQUAL(devices.size(), expectedTasks.size());
+  for (size_t di = 0; di < devices.size(); ++di) {
+    auto& spec = devices[di];
+    auto& execution = executions[di];
+    auto& expected = expectedTasks[di];
+
+    ss.str({});
+    ss.clear();
+    dumpTask(ss, devices[di], executions[di], devices[di].name, "");
+    BOOST_REQUIRE_EQUAL(strdiffchr(ss.str().data(), expected), strdiffchr(expected, ss.str().data()));
+    BOOST_CHECK_EQUAL(ss.str(), expected);
+  }
+}


### PR DESCRIPTION
With this we can generate FLP workflows without any curation needed afterwards (unless some DPL command arguments should be templated, like in QC). Next in line: JIT translation.