### PR TITLE
DPL: allow custom orbit when using timer / enumeration

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -83,6 +83,7 @@ class ConfigParamRegistry
     } catch (...) {
       throw std::invalid_argument(std::string("error parsing option: ") + key);
     }
+    throw std::invalid_argument(std::string("bad type for option: ") + key);
   }
 
  private:

--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -36,6 +36,10 @@ struct ConfigParamsHelper {
                                options_description& options,
                                boost::program_options::options_description vetos = options_description());
 
+  /// Add the ConfigParamSpec @a spec to @a specs if there is no parameter with
+  /// the same name already.
+  static void addOptionIfMissing(std::vector<ConfigParamSpec>& specs, ConfigParamSpec spec);
+
   /// populate boost program options for a complete workflow
   template <typename ContainerType>
   static boost::program_options::options_description

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -41,6 +41,13 @@ struct ContextRef {
   inline bool operator==(ContextRef const& other) const;
 };
 
+/// Special positions for variables in context.
+enum ContextPos {
+  STARTTIME_POS = 0,    /// The DataProcessingHeader::startTime associated to the timeslice
+  TFCOUNTER_POS = 14,   /// The DataHeader::tfCounter associated to the timeslice
+  FIRSTTFORBIT_POS = 15 /// The DataHeader::firstTFOrbit associated to the timeslice
+};
+
 /// An element of the matching context. Context itself is really a vector of
 /// those. It's up to the matcher builder to build the vector in a suitable way.
 /// We do not have any float in the value, because AFAICT there is no need for

--- a/Framework/Core/include/Framework/ExpirationHandler.h
+++ b/Framework/Core/include/Framework/ExpirationHandler.h
@@ -8,17 +8,16 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef FRAMEWORK_EXPIRATIONHANDLER_H
-#define FRAMEWORK_EXPIRATIONHANDLER_H
+#ifndef O2_FRAMEWORK_EXPIRATIONHANDLER_H_
+#define O2_FRAMEWORK_EXPIRATIONHANDLER_H_
 
 #include "Framework/Lifetime.h"
 #include "Framework/RoutingIndices.h"
+#include "Framework/DataDescriptorMatcher.h"
 #include <cstdint>
 #include <functional>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 struct PartRef;
@@ -29,7 +28,7 @@ struct TimesliceSlot;
 struct ExpirationHandler {
   using Creator = std::function<TimesliceSlot(TimesliceIndex&)>;
   using Checker = std::function<bool(uint64_t timestamp)>;
-  using Handler = std::function<void(ServiceRegistry&, PartRef& expiredInput, uint64_t timestamp)>;
+  using Handler = std::function<void(ServiceRegistry&, PartRef& expiredInput, uint64_t timestamp, data_matcher::VariableContext& variables)>;
 
   RouteIndex routeIndex;
   Lifetime lifetime;
@@ -38,7 +37,6 @@ struct ExpirationHandler {
   Handler handler;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_EXPIRATIONHANDLER_H
+#endif // O2_FRAMEWORK_EXPIRATIONHANDLER_H_

--- a/Framework/Core/include/Framework/LifetimeHelpers.h
+++ b/Framework/Core/include/Framework/LifetimeHelpers.h
@@ -76,7 +76,8 @@ struct LifetimeHelpers {
   /// dataOrigin, dataDescrition and dataSpecification of the given @a route.
   /// The payload of each message will contain an incremental number for each
   /// message being created.
-  static ExpirationHandler::Handler enumerate(ConcreteDataMatcher const& spec, std::string const& sourceChannel);
+  static ExpirationHandler::Handler enumerate(ConcreteDataMatcher const& spec, std::string const& sourceChannel,
+                                              int64_t orbitOffset, int64_t orbitMultiplier);
 
   /// Create a dummy (empty) message every time a record expires, suing @a spec
   /// as content of the payload.

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -122,7 +122,7 @@ inline uint32_t TimesliceIndex::getFirstTFOrbitForSlot(TimesliceSlot slot) const
 {
   assert(mVariables.size() > slot.index);
   // firstTForbit is always at register 15
-  auto pval = std::get_if<uint32_t>(&mVariables[slot.index].get(15));
+  auto pval = std::get_if<uint32_t>(&mVariables[slot.index].get(data_matcher::FIRSTTFORBIT_POS));
   if (pval == nullptr) {
     return -1;
   }
@@ -132,7 +132,7 @@ inline uint32_t TimesliceIndex::getFirstTFOrbitForSlot(TimesliceSlot slot) const
 inline uint32_t TimesliceIndex::getFirstTFCounterForSlot(TimesliceSlot slot) const
 {
   assert(mVariables.size() > slot.index);
-  // firstTForbit is always at register 15
+  // tfCounter is always at register 14
   auto pval = std::get_if<uint32_t>(&mVariables[slot.index].get(14));
   if (pval == nullptr) {
     return -1;

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -89,6 +89,16 @@ void ConfigParamsHelper::populateBoostProgramOptions(
   }
 }
 
+void ConfigParamsHelper::addOptionIfMissing(std::vector<ConfigParamSpec>& specs, ConfigParamSpec spec)
+{
+  for (auto& old : specs) {
+    if (old.name == spec.name) {
+      return;
+    }
+  }
+  specs.push_back(spec);
+}
+
 /// populate boost program options making all options of type string
 /// this is used for filtering the command line argument
 bool ConfigParamsHelper::dpl2BoostOptions(const std::vector<ConfigParamSpec>& spec,

--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -106,9 +106,9 @@ bool StartTimeValueMatcher::match(header::DataHeader const& dh, DataProcessingHe
     }
     context.put({ref->index, dph.startTime / mScale});
     // We always put in 14 the tfCounter
-    context.put({14, dh.tfCounter});
+    context.put({TFCOUNTER_POS, dh.tfCounter});
     // We always put in 15 the firstTForbit
-    context.put({15, dh.firstTForbit});
+    context.put({FIRSTTFORBIT_POS, dh.firstTForbit});
     return true;
   } else if (auto v = std::get_if<uint64_t>(&mValue)) {
     return (dph.startTime / mScale) == *v;

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -108,6 +108,7 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
     }
     assert(mDistinctRoutesIndex.empty() == false);
     auto timestamp = mTimesliceIndex.getTimesliceForSlot(slot);
+    auto& variables = mTimesliceIndex.getVariablesForSlot(slot);
     // We iterate on all the hanlders checking if they need to be expired.
     for (size_t ei = 0; ei < expirationHandlers.size(); ++ei) {
       auto& expirator = expirationHandlers[ei];
@@ -137,7 +138,7 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
       if (part.size() == 0) {
         part.parts.resize(1);
       }
-      expirator.handler(services, part[0], timestamp.value);
+      expirator.handler(services, part[0], timestamp.value, variables);
       activity.expiredSlots++;
 
       mTimesliceIndex.markAsDirty(slot, true);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -11,6 +11,7 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/ChannelMatching.h"
+#include "Framework/ConfigParamsHelper.h"
 #include "Framework/CommonDataProcessors.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/DeviceSpec.h"
@@ -263,6 +264,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {ConfigParamSpec{"aod-file", VariantType::String, {"Input AOD file"}},
      ConfigParamSpec{"aod-reader-json", VariantType::String, {"json configuration file"}},
      ConfigParamSpec{"time-limit", VariantType::Int64, 0ll, {"Maximum run time limit in seconds"}},
+     ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
+     ConfigParamSpec{"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},
      ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
      ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
      ConfigParamSpec{"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}}},
@@ -289,6 +292,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     std::string prefix = "internal-dpl-";
     if (processor.inputs.empty() && processor.name.compare(0, prefix.size(), prefix) != 0) {
       processor.inputs.push_back(InputSpec{"enumeration", "DPL", "ENUM", static_cast<DataAllocator::SubSpecificationType>(compile_time_hash(processor.name.c_str())), Lifetime::Enumeration});
+      ConfigParamsHelper::addOptionIfMissing(processor.options, ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"1st injected orbit"}});
+      ConfigParamsHelper::addOptionIfMissing(processor.options, ConfigParamSpec{"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"orbits/TForbit"}});
       processor.options.push_back(ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}});
       processor.options.push_back(ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}});
       processor.options.push_back(ConfigParamSpec{"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}});

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -765,7 +765,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.Key("options");
     w.StartArray();
     for (auto& option : processor.options) {
-      if (option.name == "start-value-enumeration" || option.name == "end-value-enumeration" || option.name == "step-value-enumeration") {
+      if (option.name == "start-value-enumeration" || option.name == "end-value-enumeration" || option.name == "step-value-enumeration" || option.name == "orbit-offset-enumeration" || option.name == "orbit-multiplier-enumeration") {
         continue;
       }
       w.StartObject();


### PR DESCRIPTION
The firstTForbit field is now given by the formula:

firstTForbit = orbit-offset-enumeration + orbit-multiplier-enumeration + dh.tfCounter

for the enumeration and timer cases. One can use, e.g.:

--orbit-offset-enumeration and --orbit-multiplier-enumeration

on the command line to affect the two parameters.