### PR TITLE
[WIP] Fix cpv reco workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ xbuild/
 # common editor backups
 *.swp
 *~
+\#*\#
 
 # doxygen stuff
 html-doc/

--- a/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
@@ -16,6 +16,7 @@
 #include "DataFormatsCPV/TriggerRecord.h"
 #include "CPVCalib/CalibParams.h"
 #include "CPVCalib/BadChannelMap.h"
+#include "CPVCalib/Pedestals.h"
 #include "CPVReconstruction/RawDecoder.h"
 
 namespace o2
@@ -62,7 +63,9 @@ class RawToDigitConverterSpec : public framework::Task
 
  private:
   int mDDL = 15;
+  bool mIsPedestalData;
   std::unique_ptr<CalibParams> mCalibParams;        ///< CPV calibration
+  std::unique_ptr<Pedestals> mPedestals;        ///< CPV pedestals
   std::unique_ptr<BadChannelMap> mBadMap;           ///< BadMap
   std::vector<Digit> mOutputDigits;                 ///< Container with output cells
   std::vector<TriggerRecord> mOutputTriggerRecords; ///< Container with output cells

--- a/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
@@ -65,7 +65,7 @@ class RawToDigitConverterSpec : public framework::Task
   int mDDL = 15;
   bool mIsPedestalData;
   std::unique_ptr<CalibParams> mCalibParams;        ///< CPV calibration
-  std::unique_ptr<Pedestals> mPedestals;        ///< CPV pedestals
+  std::unique_ptr<Pedestals> mPedestals;            ///< CPV pedestals
   std::unique_ptr<BadChannelMap> mBadMap;           ///< BadMap
   std::vector<Digit> mOutputDigits;                 ///< Container with output cells
   std::vector<TriggerRecord> mOutputTriggerRecords; ///< Container with output cells

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -35,11 +35,9 @@ void RawToDigitConverterSpec::init(framework::InitContext& ctx)
   std::string optPedestal("");
   if (ctx.options().isSet("pedestal")) {
     optPedestal = ctx.options().get<std::string>("pedestal");
-    
   }
   LOG(INFO) << "Pedestal data: " << optPedestal;
   mIsPedestalData = optPedestal == "on" ? true : false;
-  
 }
 
 void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
@@ -71,7 +69,6 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
     }
   }
 
-  
   if (!mCalibParams) {
     if (o2::cpv::CPVSimParams::Instance().mCCDBPath.compare("localtest") == 0) {
       mCalibParams = std::make_unique<o2::cpv::CalibParams>(1); // test default calibration
@@ -189,20 +186,20 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
       for (uint32_t adch : decoder.getDigits()) {
         AddressCharge ac = {adch};
         unsigned short absId = ac.Address;
-        //if we deal with non-pedestal data? 
-	if(!mIsPedestalData){//not a pedestal data
-	  //test bad map
-	  if (mBadMap->isChannelGood(absId)) {
-	    if (ac.Charge > o2::cpv::CPVSimParams::Instance().mZSthreshold) {
-	      //we need to subtract pedestal from amplidute
-	      //and scale it accordingly to channel gain
-	      float amp = mCalibParams->getGain(absId) * (ac.Charge - mPedestals->getPedestal(absId));
-	      currentDigitContainer->emplace_back(absId, amp, -1);
-	    }
-	  }
-	} else { //pedestal data, no calibration needed.
-	  currentDigitContainer->emplace_back(absId, (float)ac.Charge, -1);
-	}
+        //if we deal with non-pedestal data?
+        if (!mIsPedestalData) { //not a pedestal data
+          //test bad map
+          if (mBadMap->isChannelGood(absId)) {
+            if (ac.Charge > o2::cpv::CPVSimParams::Instance().mZSthreshold) {
+              //we need to subtract pedestal from amplidute
+              //and scale it accordingly to channel gain
+              float amp = mCalibParams->getGain(absId) * (ac.Charge - mPedestals->getPedestal(absId));
+              currentDigitContainer->emplace_back(absId, amp, -1);
+            }
+          }
+        } else { //pedestal data, no calibration needed.
+          currentDigitContainer->emplace_back(absId, (float)ac.Charge, -1);
+        }
       }
       //Check and send list of hwErrors
       for (auto& er : decoder.getErrors()) {

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class o2::eventgen::Generator + ;
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
 #pragma link C++ class o2::eventgen::GeneratorExternalParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorExternalParam> + ;
 #ifdef GENERATORS_WITH_HEPMC3
 #pragma link C++ class o2::eventgen::GeneratorHepMC + ;
 #pragma link C++ class o2::eventgen::GeneratorHepMCParam + ;


### PR DESCRIPTION
CPV reco workflow fix: added pedestal subtraction while converting raw data to digits. 
This should be done for physics data but not for pedestal runs. Subtraction can be switched off by providing '--pedestal=on' option to o2-cpv-reco-workflow.