### PR TITLE
TRD TRAP simulation uses OpenMP

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -39,6 +39,7 @@ constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (
 constexpr int NROWC1 = 16;   // the number of pad rows for chambers of type C1 (installed in stack 2)
 
 constexpr int NMCMROB = 16;     // the number of MCMs per ROB
+constexpr int NMCMHCMAX = 64;   // the maximum number of MCMs for one half chamber (C1 type)
 constexpr int NMCMROBINROW = 4; // the number of MCMs per ROB in row direction
 constexpr int NMCMROBINCOL = 4; // the number of MCMs per ROB in column direction
 constexpr int NROBC0 = 6;       // the number of ROBs per C0 chamber

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -63,6 +63,7 @@ class Digit
   void setADC(const gsl::span<ADC_t>& adc) { std::copy(adc.begin(), adc.end(), mADC.begin()); }
   // Get methods
   int getDetector() const { return mDetector; }
+  int getHCId() const { return mDetector * 2 + (mROB % 2); }
   int getRow() const { return FeeParam::getPadRowFromMCM(mROB, mMCM); }
   int getPad() const { return FeeParam::getPadColFromADC(mROB, mMCM, mChannel); }
   int getROB() const { return mROB; }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -207,9 +207,8 @@ void Digitizer::process(std::vector<Hit> const& hits)
   getHitContainerPerDetector(hits, hitsPerDetector);
 
 #ifdef WITH_OPENMP
-  omp_set_num_threads(mNumThreads);
 // Loop over all TRD detectors (in a parallel fashion)
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic) num_threads(mNumThreads)
 #endif
   for (int det = 0; det < MAXCHAMBER; ++det) {
 #ifdef WITH_OPENMP

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -107,6 +107,7 @@ void TrapSimulator::reset()
   //clear the adc data
   std::fill(mADCR.begin(), mADCR.end(), 0);
   std::fill(mADCF.begin(), mADCF.end(), 0);
+  std::fill(mADCDigitIndices.begin(), mADCDigitIndices.end(), -1);
 
   for (auto filterreg : mInternalFilterRegisters) {
     filterreg.ClearReg();
@@ -2069,7 +2070,8 @@ void TrapSimulator::fitTracklet()
         }
         bool printoutadcs = false;
         for (int i = 0; i < 21; i++) {
-          if (adchitbp & (1U << i)) {
+          // FIXME it can happen that there is a hit found in a channel where there is no digit provided as input. Is this expected?
+          if ((adchitbp & (1U << i)) && (mADCDigitIndices[i] >= 0)) {
             mTrackletDigitCount.back() += 1;
             mTrackletDigitIndices.push_back(mADCDigitIndices[i]);
           }

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -47,6 +47,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels
   bool mEnableTrapConfigDump{false};
+  int mNumThreads{-1};              // number of threads used for parallel processing
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -20,6 +20,7 @@
 #include "TRDSimulation/TrapSimulator.h"
 #include "TRDSimulation/TrapConfig.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Constants.h"
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 
@@ -41,23 +42,20 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
 
 
  private:
-  std::array<TrapSimulator, 128> mTrapSimulator; //the up to 128 trap simulators for a single chamber
   TrapConfig* mTrapConfig = nullptr;
   unsigned long mRunNumber = 297595; //run number to anchor simulation to.
-  int mShowTrackletStats = 1;        // show some statistics for each run
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels
   bool mEnableTrapConfigDump{false};
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
-  std::chrono::duration<double> mTrapSimTime{0}; // timer for the actual processing in the TRAP chips
 
   TrapConfig* getTrapConfig();
   void loadTrapConfig();
   void loadDefaultTrapConfig();
   void setOnlineGainTables();
-  void processTRAPchips(int currDetector, int& nTrackletsInTrigRec, std::vector<Tracklet64>& trapTrackletsAccum, o2::dataformats::MCTruthContainer<o2::MCCompLabel>& lblTracklets, const o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>* lblDigits);
+  void processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, constants::NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices);
 };
 
 o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(bool useMC);

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -13,7 +13,10 @@
 #include <chrono>
 #include <optional>
 #include <gsl/span>
+
+#ifdef WITH_OPENMP
 #include <omp.h>
+#endif
 
 #include "TFile.h"
 
@@ -233,7 +236,9 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
 
   auto timeParallelStart = std::chrono::high_resolution_clock::now();
 
+#ifdef WITH_OPENMP
 #pragma omp parallel for
+#endif
   for (int iTrig = 0; iTrig < triggerRecords.size(); ++iTrig) {
     int currHCId = -1;
     std::array<TrapSimulator, NMCMHCMAX> trapSimulators{}; //the up to 64 trap simulators for a single half chamber

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <optional>
 #include <gsl/span>
+#include <omp.h>
 
 #include "TFile.h"
 
@@ -26,7 +27,6 @@
 #include "TRDBase/Digit.h"
 #include "TRDBase/Calibrations.h"
 #include "DataFormatsTRD/TriggerRecord.h"
-#include "DataFormatsTRD/Constants.h"
 
 using namespace o2::framework;
 
@@ -143,65 +143,30 @@ void TRDDPLTrapSimulatorTask::setOnlineGainTables()
   }
 }
 
-void TRDDPLTrapSimulatorTask::processTRAPchips(int currDetector, int& nTrackletsInTrigRec, std::vector<Tracklet64>& trapTrackletsAccum, o2::dataformats::MCTruthContainer<o2::MCCompLabel>& lblTracklets, const o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>* lblDigits)
+void TRDDPLTrapSimulatorTask::processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices)
 {
-  // Loop over all TRAP chips of detector number currDetector.
-  // TRAP chips without input data are skipped
-  int currStack = (currDetector % NCHAMBERPERSEC) / NLAYER;
-  int nTrapsMax = (currStack == 2) ? NROBC0 * NMCMROB : NROBC1 * NMCMROB;
-  for (int iTrap = 0; iTrap < nTrapsMax; ++iTrap) {
-    if (!mTrapSimulator[iTrap].isDataSet()) {
+  // TRAP processing for current half chamber
+  for (int iTrap = 0; iTrap < NMCMHCMAX; ++iTrap) {
+    if (!trapSimulators[iTrap].isDataSet()) {
       continue;
     }
-    auto timeTrapProcessingStart = std::chrono::high_resolution_clock::now();
-    mTrapSimulator[iTrap].filter();
-    mTrapSimulator[iTrap].tracklet();
-    mTrapSimTime += std::chrono::high_resolution_clock::now() - timeTrapProcessingStart;
-    auto trackletsOut = mTrapSimulator[iTrap].getTrackletArray64();
-    int nTrackletsOut = trackletsOut.size();
-    nTrackletsInTrigRec += nTrackletsOut;
+    trapSimulators[iTrap].filter();
+    trapSimulators[iTrap].tracklet();
+    auto trackletsOut = trapSimulators[iTrap].getTrackletArray64();
+    nTracklets += trackletsOut.size();
+    trackletsAccum.insert(trackletsAccum.end(), trackletsOut.begin(), trackletsOut.end());
     if (mUseMC) {
-      auto digitCountOut = mTrapSimulator[iTrap].getTrackletDigitCount();     // number of digits contributing to each tracklet
-      auto digitIndicesOut = mTrapSimulator[iTrap].getTrackletDigitIndices(); // global indices of the digits composing the tracklets
-      int currDigitIndex = 0;                                                 // count the total number of digits which are associated to tracklets for this TRAP
-      int trkltIdxStart = trapTrackletsAccum.size();
-      for (int iTrklt = 0; iTrklt < nTrackletsOut; ++iTrklt) {
-        // for each tracklet of this TRAP check the MC labels of the digits which contribute to the tracklet
-        int tmp = currDigitIndex;
-        for (int iDigitIndex = tmp; iDigitIndex < tmp + digitCountOut[iTrklt]; ++iDigitIndex) {
-          if (iDigitIndex == tmp) {
-            // for the first digit composing the tracklet we don't need to check for duplicate labels
-            lblTracklets.addElements(trkltIdxStart + iTrklt, lblDigits->getLabels(digitIndicesOut[iDigitIndex]));
-          } else {
-            // in case more than one digit composes the tracklet we add only the labels
-            // from the additional digit(s) which are not already contained in the previous
-            // digit(s)
-            auto currentLabels = lblTracklets.getLabels(trkltIdxStart + iTrklt);
-            auto newLabels = lblDigits->getLabels(digitIndicesOut[iDigitIndex]);
-            for (const auto& newLabel : newLabels) {
-              bool isAlreadyIn = false;
-              for (const auto& currLabel : currentLabels) {
-                if (currLabel.compare(newLabel)) {
-                  isAlreadyIn = true;
-                }
-              }
-              if (!isAlreadyIn) {
-                lblTracklets.addElement(trkltIdxStart + iTrklt, newLabel);
-              }
-            }
-          }
-          ++currDigitIndex;
-        }
-      }
+      auto digitCountOut = trapSimulators[iTrap].getTrackletDigitCount();
+      digitCounts.insert(digitCounts.end(), digitCountOut.begin(), digitCountOut.end());
+      auto digitIndicesOut = trapSimulators[iTrap].getTrackletDigitIndices();
+      digitIndices.insert(digitIndices.end(), digitIndicesOut.begin(), digitIndicesOut.end());
     }
-    trapTrackletsAccum.insert(trapTrackletsAccum.end(), trackletsOut.begin(), trackletsOut.end());
-    mTrapSimulator[iTrap].reset();
+    trapSimulators[iTrap].reset();
   }
 }
 
 void TRDDPLTrapSimulatorTask::init(o2::framework::InitContext& ic)
 {
-  mShowTrackletStats = ic.options().get<int>("show-trd-trackletstats");
   mTrapConfigName = ic.options().get<std::string>("trd-trapconfig");
   mEnableOnlineGainCorrection = ic.options().get<bool>("trd-onlinegaincorrection");
   mOnlineGainTableName = ic.options().get<std::string>("trd-onlinegaintable");
@@ -222,87 +187,128 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   LOG(info) << "TRD Trap Simulator Device running over incoming message";
 
   // input
-  auto inputDigits = pc.inputs().get<gsl::span<o2::trd::Digit>>("digitinput");                                 // block of TRD digits
-  auto inputTriggerRecords = pc.inputs().get<std::vector<o2::trd::TriggerRecord>>("triggerrecords");           // time and number of digits for each collision
-  // the above is changed to a vector from a span as the span is constant and cant modify elements.
-  if (inputDigits.size() == 0 || inputTriggerRecords.size() == 0) {
-    LOG(warn) << "Did not receive any digits, trigger records, or neither one nor the other. Aborting.";
-    return;
-  }
-  LOG(debug) << "Read in " << inputDigits.size() << " digits";
+  auto digits = pc.inputs().get<gsl::span<o2::trd::Digit>>("digitinput");                       // block of TRD digits
+  auto triggerRecords = pc.inputs().get<std::vector<o2::trd::TriggerRecord>>("triggerrecords"); // time and number of digits for each collision
+  LOG(debug) << "Received " << digits.size() << " digits from " << triggerRecords.size() << " collisions";
 
+  // load MC information if label processing is enabeld
   const o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>* lblDigitsPtr = nullptr;
   using lblType = std::decay_t<decltype(pc.inputs().get<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>(""))>;
   std::optional<lblType> lblDigits;
-
   if (mUseMC) {
     lblDigits.emplace(pc.inputs().get<o2::dataformats::ConstMCTruthContainer<o2::MCCompLabel>>("labelinput")); // MC labels associated to the input digits
     lblDigitsPtr = &lblDigits.value();
     LOG(debug) << "Labels contain " << lblDigitsPtr->getNElements() << " elements with and indexed size of " << lblDigitsPtr->getIndexedSize();
-    if (lblDigitsPtr->getIndexedSize() != inputDigits.size()) {
-      LOG(warn) << "Digits and Labels coming into TrapSimulator are of differing sizes, labels will be jibberish. " << lblDigitsPtr->getIndexedSize() << "!=" << inputDigits.size();
+    if (lblDigitsPtr->getIndexedSize() != digits.size()) {
+      LOG(warn) << "Digits and Labels coming into TrapSimulator are of differing sizes, labels will be jibberish. " << lblDigitsPtr->getIndexedSize() << "!=" << digits.size();
     }
   }
-  LOG(debug) << "Trigger records are available for " << inputTriggerRecords.size() << " collisions";
 
   // output
-  std::vector<Tracklet64> trapTrackletsAccum;                          // calculated tracklets
+  std::vector<Tracklet64> tracklets;                               // calculated tracklets
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblTracklets; // MC labels for the tracklets, taken from the digits which make up the tracklet (duplicates are removed)
 
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> lblTracklets;                                                    // MC labels for the tracklets, taken from the digits which make up the tracklet (duplicates are removed)
+  auto timeProcessingStart = std::chrono::high_resolution_clock::now(); // measure total processing time
 
-  // sort digits by chamber ID for each collision and keep track in index vector
+  // sort digits by half chamber ID for each collision and keep track in index vector
   auto sortStart = std::chrono::high_resolution_clock::now();
-  std::vector<unsigned int> digitIndices(inputDigits.size()); // digit indices sorted by chamber ID for each time frame
-  std::iota(digitIndices.begin(), digitIndices.end(), 0);
-  for (auto& trig : inputTriggerRecords) {
-    std::stable_sort(std::begin(digitIndices) + trig.getFirstDigit(), std::begin(digitIndices) + trig.getNumberOfDigits() + trig.getFirstDigit(),
-                     [&inputDigits](unsigned int i, unsigned int j) { return inputDigits[i].getDetector() < inputDigits[j].getDetector(); });
+  std::vector<unsigned int> digitIdxArray(digits.size()); // digit indices sorted by half chamber ID for each time frame
+  std::iota(digitIdxArray.begin(), digitIdxArray.end(), 0);
+  for (auto& trig : triggerRecords) {
+    std::stable_sort(std::begin(digitIdxArray) + trig.getFirstDigit(), std::begin(digitIdxArray) + trig.getNumberOfDigits() + trig.getFirstDigit(),
+                     [&digits](unsigned int i, unsigned int j) { return digits[i].getHCId() < digits[j].getHCId(); });
   }
-  std::chrono::duration<double> sortTime = std::chrono::high_resolution_clock::now() - sortStart;
+  auto sortTime = std::chrono::high_resolution_clock::now() - sortStart;
 
-  // initialize timers
-  auto timeDigitLoopStart = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> trapSimAccumulatedTime{};
-  mTrapSimTime = std::chrono::duration<double>::zero();
+  // prepare data structures for accumulating results per collision
+  std::vector<int> nTracklets(triggerRecords.size());
+  std::vector<std::vector<Tracklet64>> trackletsAccum;
+  trackletsAccum.resize(triggerRecords.size());
+  std::vector<std::vector<short>> digitCountsAccum; // holds the number of digits included in each tracklet (therefore has the same number of elements as trackletsAccum)
+  // digitIndicesAccum holds the global indices of the digits which comprise the tracklets
+  // with the help of digitCountsAccum one can loop through this vector and find the corresponding digit indices for each tracklet
+  std::vector<std::vector<int>> digitIndicesAccum;
+  digitCountsAccum.resize(triggerRecords.size());
+  digitIndicesAccum.resize(triggerRecords.size());
 
-  for (int iTrig = 0; iTrig < inputTriggerRecords.size(); ++iTrig) {
-    int nTrackletsInTrigRec = 0;
-    int currDetector = -1;
-    for (int iDigit = inputTriggerRecords[iTrig].getFirstDigit(); iDigit < (inputTriggerRecords[iTrig].getFirstDigit() + inputTriggerRecords[iTrig].getNumberOfDigits()); ++iDigit) {
-      const auto& digit = &inputDigits[digitIndices[iDigit]];
-      if (currDetector < 0) {
-        currDetector = digit->getDetector();
+  auto timeParallelStart = std::chrono::high_resolution_clock::now();
+
+#pragma omp parallel for
+  for (int iTrig = 0; iTrig < triggerRecords.size(); ++iTrig) {
+    int currHCId = -1;
+    std::array<TrapSimulator, NMCMHCMAX> trapSimulators{}; //the up to 64 trap simulators for a single half chamber
+    for (int iDigit = triggerRecords[iTrig].getFirstDigit(); iDigit < (triggerRecords[iTrig].getFirstDigit() + triggerRecords[iTrig].getNumberOfDigits()); ++iDigit) {
+      const auto& digit = &digits[digitIdxArray[iDigit]];
+      if (currHCId < 0) {
+        currHCId = digit->getHCId();
       }
-      if (currDetector != digit->getDetector()) {
-        // we switch to a new chamber, process all TRAPs of the previous chamber which contain data
-        processTRAPchips(currDetector, nTrackletsInTrigRec, trapTrackletsAccum, lblTracklets, lblDigitsPtr);
-        currDetector = digit->getDetector();
+      if (currHCId != digit->getHCId()) {
+        // we switch to a new half chamber, process all TRAPs of the previous half chamber which contain data
+        processTRAPchips(nTracklets[iTrig], trackletsAccum[iTrig], trapSimulators, digitCountsAccum[iTrig], digitIndicesAccum[iTrig]);
+        currHCId = digit->getHCId();
       }
       // fill the digit data into the corresponding TRAP chip
-      int trapIdx = digit->getROB() * NMCMROB + digit->getMCM();
-      if (!mTrapSimulator[trapIdx].isDataSet()) {
-        mTrapSimulator[trapIdx].init(mTrapConfig, digit->getDetector(), digit->getROB(), digit->getMCM());
+      int trapIdx = (digit->getROB() / 2) * NMCMROB + digit->getMCM();
+      if (!trapSimulators[trapIdx].isDataSet()) {
+        trapSimulators[trapIdx].init(mTrapConfig, digit->getDetector(), digit->getROB(), digit->getMCM());
       }
-      mTrapSimulator[trapIdx].setData(digit->getChannel(), digit->getADC(), digitIndices[iDigit]);
+      trapSimulators[trapIdx].setData(digit->getChannel(), digit->getADC(), digitIdxArray[iDigit]);
     }
-    // take care of the TRAPs for the last chamber
-    processTRAPchips(currDetector, nTrackletsInTrigRec, trapTrackletsAccum, lblTracklets, lblDigitsPtr);
-    inputTriggerRecords[iTrig].setTrackletRange(trapTrackletsAccum.size() - nTrackletsInTrigRec, nTrackletsInTrigRec);
+    // take care of the TRAPs for the last half chamber
+    processTRAPchips(nTracklets[iTrig], trackletsAccum[iTrig], trapSimulators, digitCountsAccum[iTrig], digitIndicesAccum[iTrig]);
+  } // done with parallel processing
+  auto parallelTime = std::chrono::high_resolution_clock::now() - timeParallelStart;
+
+  // accumulate results and add MC labels
+  for (int iTrig = 0; iTrig < triggerRecords.size(); ++iTrig) {
+    if (mUseMC) {
+      int currDigitIndex = 0; // counter for all digits which are associated to tracklets
+      int trkltIdxStart = tracklets.size();
+      for (int iTrklt = 0; iTrklt < nTracklets[iTrig]; ++iTrklt) {
+        int tmp = currDigitIndex;
+        for (int iDigitIndex = tmp; iDigitIndex < tmp + digitCountsAccum[iTrig][iTrklt]; ++iDigitIndex) {
+          if (iDigitIndex == tmp) {
+            // for the first digit composing the tracklet we don't need to check for duplicate labels
+            lblTracklets.addElements(trkltIdxStart + iTrklt, lblDigitsPtr->getLabels(digitIndicesAccum[iTrig][iDigitIndex]));
+          } else {
+            // in case more than one digit composes the tracklet we add only the labels
+            // from the additional digit(s) which are not already contained in the previous
+            // digit(s)
+            auto currentLabels = lblTracklets.getLabels(trkltIdxStart + iTrklt);
+            auto newLabels = lblDigitsPtr->getLabels(digitIndicesAccum[iTrig][iDigitIndex]);
+            for (const auto& newLabel : newLabels) {
+              bool alreadyIn = false;
+              for (const auto& currLabel : currentLabels) {
+                if (currLabel.compare(newLabel)) {
+                  alreadyIn = true;
+                  break;
+                }
+              }
+              if (!alreadyIn) {
+                lblTracklets.addElement(trkltIdxStart + iTrklt, newLabel);
+              }
+            }
+          }
+          ++currDigitIndex;
+        }
+      }
+    }
+    tracklets.insert(tracklets.end(), trackletsAccum[iTrig].begin(), trackletsAccum[iTrig].end());
+    triggerRecords[iTrig].setTrackletRange(tracklets.size() - nTracklets[iTrig], nTracklets[iTrig]);
   }
 
-  LOG(info) << "Trap simulator found " << trapTrackletsAccum.size() << " tracklets from " << inputDigits.size() << " Digits.";
+  auto processingTime = std::chrono::high_resolution_clock::now() - timeProcessingStart;
+
+  LOG(info) << "Trap simulator found " << tracklets.size() << " tracklets from " << digits.size() << " Digits.";
   if (mUseMC) {
-    LOG(info) << "In total " << lblTracklets.getNElements() << " MC labels are associated to the tracklets";
+    LOG(info) << "In total " << lblTracklets.getNElements() << " MC labels are associated to the " << lblTracklets.getIndexedSize() << " tracklets";
   }
-  if (mShowTrackletStats > 0) {
-    std::chrono::duration<double> digitLoopTime = std::chrono::high_resolution_clock::now() - timeDigitLoopStart;
-    LOG(info) << "Trap Simulator done ";
-    LOG(info) << "Digit Sorting took " << sortTime.count() << "s";
-    LOG(info) << "Digit loop took : " << digitLoopTime.count() << "s";
-    LOG(info) << "TRAP processing TrapSimulator::filter() + TrapSimulator::tracklet() took : " << trapSimAccumulatedTime.count() << "s";
-  }
-  pc.outputs().snapshot(Output{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}, trapTrackletsAccum);
-  pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 0, Lifetime::Timeframe}, inputTriggerRecords);
+  LOG(info) << "Total processing time : " << std::chrono::duration_cast<std::chrono::milliseconds>(processingTime).count() << "ms";
+  LOG(info) << "Digit Sorting took: " << std::chrono::duration_cast<std::chrono::milliseconds>(sortTime).count() << "ms";
+  LOG(info) << "Processing time for parallel region: " << std::chrono::duration_cast<std::chrono::milliseconds>(parallelTime).count() << "ms";
+
+  pc.outputs().snapshot(Output{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}, tracklets);
+  pc.outputs().snapshot(Output{"TRD", "TRKTRGRD", 0, Lifetime::Timeframe}, triggerRecords);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0, Lifetime::Timeframe}, lblTracklets);
   }
@@ -331,7 +337,6 @@ o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(bool useMC)
                            outputs,
                            AlgorithmSpec{adaptFromTask<TRDDPLTrapSimulatorTask>(useMC)},
                            Options{
-                             {"show-trd-trackletstats", VariantType::Int, 1, {"Display the processing time of the tracklet processing in the TRAPs"}},
                              {"trd-trapconfig", VariantType::String, "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549", {"Name of the trap config from the CCDB default:cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549"}},
                              {"trd-onlinegaincorrection", VariantType::Bool, false, {"Apply online gain calibrations, mostly for back checking to run2 by setting FGBY to 0"}},
                              {"trd-onlinegaintable", VariantType::String, "Krypton_2015-02", {"Online gain table to be use, names found in CCDB, obviously trd-onlinegaincorrection must be set as well."}},

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -248,8 +248,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   auto timeParallelStart = std::chrono::high_resolution_clock::now();
 
 #ifdef WITH_OPENMP
-  omp_set_num_threads(mNumThreads);
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic) num_threads(mNumThreads)
 #endif
   for (int iTrig = 0; iTrig < triggerRecords.size(); ++iTrig) {
     int currHCId = -1;

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -67,6 +67,13 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowoptions)
   //  std::string trapsimconfighelp("Specify the Trap config to use from CCDB yes those long names like cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b2p-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5585");
   //  workflowoptions.push_back(ConfigParamSpec{"trapconfigname", VariantType::Int, -1, {trapsimconfighelp}});
 
+  // option allowing to set parameters
+  std::string keyvaluehelp("Semicolon separated key=value strings (e.g.: 'TRDSimParams.digithreads=4;...')");
+  workflowoptions.push_back(
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  workflowoptions.push_back(
+    ConfigParamSpec{"configFile", VariantType::String, "", {"configuration file for configurable parameters"}});
+
   // json output
   // run2 input
   // trap configuration
@@ -83,6 +90,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // at the end. This places the processor at the beginning of the
   // workflow in the upper left corner of the GUI.
   //
+  using namespace o2::conf;
+  ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   WorkflowSpec specs;
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto disableRootInput = configcontext.options().get<bool>("disable-root-input");

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -174,7 +174,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
 
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
-  workflowOptions.push_back(ConfigParamSpec{"enable-trd-trapsim", VariantType::Bool, false, {"enable the trap simulation of the TRD"}});
+  workflowOptions.push_back(ConfigParamSpec{"disable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
 }
 
 void customize(std::vector<o2::framework::DispatchPolicy>& policies)
@@ -544,8 +544,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::trd::getTRDDigitizerSpec(fanoutsize++, mctruth));
     // connect the TRD digit writer
     specs.emplace_back(o2::trd::getTRDDigitWriterSpec(mctruth));
-    auto enableTrapSim = configcontext.options().get<bool>("enable-trd-trapsim");
-    if (enableTrapSim) {
+    auto disableTrapSim = configcontext.options().get<bool>("disable-trd-trapsim");
+    if (!disableTrapSim) {
       // connect the TRD Trap SimulatorA
       specs.emplace_back(o2::trd::getTRDTrapSimulatorSpec(mctruth));
       // connect to the device to write out the tracklets.

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -61,7 +61,7 @@ QED2HAD=$(awk "BEGIN {printf \"%.2f\",`grep xSectionQED qedgenparam.ini | cut -d
 echo "Obtained ratio of QED to hadronic x-sections = $QED2HAD" >> qedsim.log
 cd ..
 
-DIGITRDOPTREAL="--configKeyValues \"TRDSimParams.digithreads=${NJOBS}\" --enable-trd-trapsim"
+DIGITRDOPTREAL="--configKeyValues \"TRDSimParams.digithreads=${NJOBS}\" "
 if [ $SPLITTRDDIGI == "1" ]; then
   DIGITRDOPT="--skipDet TRD"
 else


### PR DESCRIPTION
- output tracklets are sorted by HCId
- parallelisation is done over collisions
- TODO: check hit calculation in TRAP simulation