### PR TITLE
Fix in CPV clusterer TriggerRecord creation

### DIFF
--- a/Detectors/CPV/reconstruction/src/Clusterer.cxx
+++ b/Detectors/CPV/reconstruction/src/Clusterer.cxx
@@ -68,7 +68,7 @@ void Clusterer::process(gsl::span<const Digit> digits, gsl::span<const TriggerRe
 
     LOG(DEBUG) << "Found clusters from " << indexStart << " to " << clusters->size();
 
-    trigRec->emplace_back(tr.getBCData(), indexStart, clusters->size());
+    trigRec->emplace_back(tr.getBCData(), indexStart, clusters->size() - indexStart);
   }
 }
 //____________________________________________________________________________


### PR DESCRIPTION
The RangeReference used in TriggerRecord needs the number of entries for given trigger and not the container size