### PR TITLE
MC->Raw converters uses HBFUtils settings from digitization stage

### DIFF
--- a/Detectors/CPV/simulation/src/RawCreator.cxx
+++ b/Detectors/CPV/simulation/src/RawCreator.cxx
@@ -49,8 +49,7 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -71,9 +70,9 @@ int main(int argc, const char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
@@ -112,4 +111,8 @@ int main(int argc, const char** argv)
     rawwriter.digitsToRaw(*digitbranch, *triggerbranch);
   }
   rawwriter.getWriter().writeConfFile("CPV", "RAWDATA", o2::utils::concat_string(outputdir, "/CPVraw.cfg"));
+
+  o2::raw::HBFUtils::Instance().print();
+
+  return 0;
 }

--- a/Detectors/EMCAL/simulation/src/RawCreator.cxx
+++ b/Detectors/EMCAL/simulation/src/RawCreator.cxx
@@ -50,8 +50,7 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,subdet,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -77,9 +76,9 @@ int main(int argc, const char** argv)
     FairLogger::GetLogger()->SetLogScreenLevel("DEBUG");
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
@@ -123,4 +122,8 @@ int main(int argc, const char** argv)
     rawwriter.digitsToRaw(*digitbranch, *triggerbranch);
   }
   rawwriter.getWriter().writeConfFile("EMC", "RAWDATA", o2::utils::concat_string(outputdir, "/EMCraw.cfg"));
+
+  o2::raw::HBFUtils::Instance().print();
+
+  return 0;
 }

--- a/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
@@ -52,8 +52,7 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -75,9 +74,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
@@ -85,6 +84,8 @@ int main(int argc, char** argv)
            vm["file-per-link"].as<bool>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }

--- a/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
+++ b/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
@@ -52,8 +52,7 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -75,9 +74,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
@@ -86,6 +85,8 @@ int main(int argc, char** argv)
            vm["file-per-link"].as<bool>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }

--- a/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
@@ -52,8 +52,7 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -75,9 +74,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
@@ -85,6 +84,8 @@ int main(int argc, char** argv)
            vm["file-per-link"].as<bool>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -60,8 +60,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"disable-row-writing", o2::framework::VariantType::Bool, false, {"disable ROW in Digit writing"}});
   workflowOptions.push_back(ConfigParamSpec{"write-decoding-errors", o2::framework::VariantType::Bool, false, {"trace errors in digits output when decoding"}});
   workflowOptions.push_back(ConfigParamSpec{"calib-cluster", VariantType::Bool, false, {"to enable calib info production from clusters"}});
-  //workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, {std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), "configKeyValues file from digitization, used for raw output only!!!"}});
-  workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, "none", {"configKeyValues file from digitization, used for raw output only!!!"}});
+  workflowOptions.push_back(ConfigParamSpec{"hbfutils-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"config file for HBFUtils (or none), used for raw output only!!!"}});
   workflowOptions.push_back(ConfigParamSpec{"cosmics", VariantType::Bool, false, {"to enable cosmics utils"}});
 }
 
@@ -114,9 +113,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
   if (outputType.rfind("raw") < outputType.size()) {
     writeraw = 1;
-    std::string confDig = cfgc.options().get<std::string>("digitization-config");
+    std::string confDig = cfgc.options().get<std::string>("hbfutils-config");
     if (!confDig.empty() && confDig != "none") {
-      o2::conf::ConfigurableParam::updateFromFile(confDig);
+      o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
     }
   }
   if (outputType.rfind("ctf") < outputType.size()) {

--- a/Detectors/HMPID/workflow/src/digits-to-raw-workflow.cxx
+++ b/Detectors/HMPID/workflow/src/digits-to-raw-workflow.cxx
@@ -39,8 +39,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
-  //workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), "configKeyValues file from digitization, used for raw output only!!!");
-  workflowOptions.push_back(o2::framework::ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, "none", {"configKeyValues file from digitization, used for raw output only!!!"}});
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"hbfutils-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"config file for HBFUtils (or none), used for raw output only!!!"}});
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {keyvaluehelp}});
 }
 
@@ -53,9 +52,9 @@ using namespace o2::framework;
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   WorkflowSpec specs;
-  std::string confDig = configcontext.options().get<std::string>("digitization-config");
+  std::string confDig = configcontext.options().get<std::string>("hbfutils-config");
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   DataProcessorSpec consumer = o2::hmpid::getDigitsToRawSpec();

--- a/Detectors/ITSMFT/ITS/simulation/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/simulation/CMakeLists.txt
@@ -25,6 +25,7 @@ o2_data_file(COPY data  DESTINATION Detectors/ITS/simulation)
 
 o2_add_executable(digi2raw
                   COMPONENT_NAME its
+		  TARGETVARNAME itsdigi2raw_exe
                   SOURCES src/digi2raw.cxx
                   PUBLIC_LINK_LIBRARIES O2::ITSMFTReconstruction
                                         O2::DataFormatsITSMFT
@@ -34,3 +35,9 @@ o2_add_executable(digi2raw
                                         O2::DetectorsCommonDataFormats
                                         O2::CommonUtils
                                         Boost::program_options)
+
+if(NOT APPLE)
+
+ set_property(TARGET ${itsdigi2raw_exe} PROPERTY LINK_WHAT_YOU_USE ON)
+
+endif()

--- a/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
@@ -62,8 +62,7 @@ int main(int argc, char** argv)
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(DefRDHVersion), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -85,9 +84,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
@@ -97,7 +96,9 @@ int main(int argc, char** argv)
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
   LOG(INFO) << "HBFUtils settings used for conversion:";
+
   o2::raw::HBFUtils::Instance().print();
+
   return 0;
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -60,8 +60,7 @@ int main(int argc, char** argv)
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -83,9 +82,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   digi2raw(vm["input-file"].as<std::string>(),
@@ -95,7 +94,9 @@ int main(int argc, char** argv)
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
   LOG(INFO) << "HBFUtils settings used for conversion:";
+
   o2::raw::HBFUtils::Instance().print();
+
   return 0;
 }
 

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digit2raw.cxx
@@ -94,8 +94,7 @@ int main(int argc, char* argv[])
       ("input-file,i",po::value<std::string>(&input)->default_value("mchdigits.root"),"input file name")
       ("configKeyValues", po::value<std::string>()->default_value(""), "comma-separated configKeyValues")
       ("no-empty-hbf,e", po::value<bool>()->default_value(true), "do not create empty HBF pages (except for HBF starting TF)")
-      //("digitization-config", po::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization")
-      ("digitization-config", po::value<std::string>()->default_value("none"), "configKeyValues file from digitization")
+      ("hbfutils-config", po::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)")
       ("verbosity,v",po::value<std::string>()->default_value("verylow"), "(fair)logger verbosity");
   // clang-format on
 
@@ -118,9 +117,9 @@ int main(int argc, char* argv[])
 
   po::notify(vm);
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
@@ -164,6 +163,8 @@ int main(int argc, char* argv[])
   PayloadPaginator paginator(fw, output, solar2feelink, userLogic, chargeSumMode);
 
   digit2raw(input, encoder, paginator);
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }

--- a/Detectors/MUON/MID/Workflow/src/digits-to-raw-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/digits-to-raw-workflow.cxx
@@ -29,8 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
-  //workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), "configKeyValues file from digitization, used for raw output only!!!");
-  workflowOptions.push_back(ConfigParamSpec{"digitization-config", o2::framework::VariantType::String, "none", {"configKeyValues file from digitization, used for raw output only!!!"}});
+  workflowOptions.push_back(ConfigParamSpec{"hbfutils-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"config file for HBFUtils (or none), used for raw output only!!!"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -39,9 +38,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
 
-  std::string confDig = configcontext.options().get<std::string>("digitization-config");
+  std::string confDig = configcontext.options().get<std::string>("hbfutils-config");
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   specs.emplace_back(o2::mid::getDigitReaderSpec(false));

--- a/Detectors/PHOS/simulation/src/RawCreator.cxx
+++ b/Detectors/PHOS/simulation/src/RawCreator.cxx
@@ -49,8 +49,7 @@ int main(int argc, const char** argv)
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -71,9 +70,9 @@ int main(int argc, const char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
@@ -112,4 +111,8 @@ int main(int argc, const char** argv)
     rawwriter.digitsToRaw(*digitbranch, *triggerbranch);
   }
   rawwriter.getWriter().writeConfFile("PHS", "RAWDATA", o2::utils::concat_string(outputdir, "/PHSraw.cfg"));
+
+  o2::raw::HBFUtils::Instance().print();
+
+  return 0;
 }

--- a/Detectors/TOF/simulation/src/digi2raw.cxx
+++ b/Detectors/TOF/simulation/src/digi2raw.cxx
@@ -33,8 +33,8 @@ int main(int argc, char** argv)
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("file-for,f", bpo::value<std::string>()->default_value("cru"), "single file per: all,cru,link");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    //add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value("none"), "config file for HBFUtils (or none)");
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
 
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 
   auto cmd = o2::utils::concat_string("o2-tof-reco-workflow -b --output-type raw --tof-raw-outdir ", vm["output-dir"].as<std::string>(),
                                       " --tof-raw-file-for ", vm["file-for"].as<std::string>(),
-                                      " --digitization-config ", vm["digitization-config"].as<std::string>(),
+                                      " --hbfutils-config ", vm["hbfutils-config"].as<std::string>(),
                                       R"( --configKeyValues ")", vm["configKeyValues"].as<std::string>(), '"');
   return system(cmd.c_str());
 }

--- a/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/simulation/run/convertDigitsToRawZS.cxx
@@ -227,8 +227,7 @@ int main(int argc, char** argv)
     add_option("stop-page,p", bpo::value<bool>()->default_value(false)->implicit_value(true), "HBF stop on separate CRU page");
     add_option("no-padding", bpo::value<bool>()->default_value(false)->implicit_value(true), "Don't pad pages to 8kb");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::gpu::RAWDataHeaderGPU>();
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
@@ -251,9 +250,9 @@ int main(int argc, char** argv)
     exit(2);
   }
 
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   convertDigitsToZSfinal(
@@ -265,6 +264,8 @@ int main(int argc, char** argv)
     vm["stop-page"].as<bool>(),
     vm["no-padding"].as<bool>(),
     !vm.count("no-parent-directories"));
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }

--- a/Detectors/ZDC/simulation/src/digi2raw.cxx
+++ b/Detectors/ZDC/simulation/src/digi2raw.cxx
@@ -60,8 +60,7 @@ int main(int argc, char** argv)
     add_option("ccdb-url,c", bpo::value<std::string>()->default_value(""), "url of the ccdb repository");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
-    //add_option("digitization-config,d", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "configKeyValues file from digitization");
-    add_option("digitization-config,d", bpo::value<std::string>()->default_value("none"), "configKeyValues file from digitization");
+    add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
 
     opt_all.add(opt_general).add(opt_hidden);
@@ -82,9 +81,9 @@ int main(int argc, char** argv)
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
   }
-  std::string confDig = vm["digitization-config"].as<std::string>();
+  std::string confDig = vm["hbfutils-config"].as<std::string>();
   if (!confDig.empty() && confDig != "none") {
-    o2::conf::ConfigurableParam::updateFromFile(confDig);
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
@@ -102,6 +101,8 @@ int main(int argc, char** argv)
            vm["file-per-link"].as<bool>(),
            vm["rdh-version"].as<uint32_t>(),
            ccdbHost);
+
+  o2::raw::HBFUtils::Instance().print();
 
   return 0;
 }


### PR DESCRIPTION
@davidrohr with this the converters will inherit the HBFUtils settings of digitization.
So, I've suppressed in the `full_system_test.sh` passing HBFUtils to converters via configKeyValues (but if needed, the digitization-time settings can be overridden in this way). I left at the moment untouched passing the `HBFUtils.nHBFPerTF` to reco workflows since you use it for the TPC buffers initilization, but I think we should get rid of this since in general, the ccdb info data should not be used before the TF time-stamp is available. Can't you do the initialization right before the 1st TF reconstruction? The it is legit to read nHBFPerTF from the CCDB. Alternatively, it can be passed as an independent TPC option.