### PR TITLE
DPL Analysis: Make filter/table matching rely on a type hash rather than a string name

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -897,7 +897,7 @@ class Table
 
   static constexpr auto hashes()
   {
-    return std::vector{typeid(C).hash_code()...};
+    return std::set{typeid(C).hash_code()...};
   }
 
   template <typename IP, typename Parent, typename... T>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -27,6 +27,7 @@
 #include <gandiva/selection_vector.h>
 #include <cassert>
 #include <fmt/format.h>
+#include <typeinfo>
 
 namespace o2::soa
 {
@@ -894,6 +895,11 @@ class Table
   using persistent_columns_t = framework::selected_pack<is_persistent_t, C...>;
   using external_index_columns_t = framework::selected_pack<is_external_index_t, C...>;
 
+  static constexpr auto hashes()
+  {
+    return std::vector{typeid(C).hash_code()...};
+  }
+
   template <typename IP, typename Parent, typename... T>
   struct RowViewBase : public RowViewCore<IP, C...> {
 
@@ -1266,7 +1272,7 @@ constexpr auto is_binding_compatible_v()
       return *mColumnIterator;                                                                                                                                                    \
     }                                                                                                                                                                             \
   };                                                                                                                                                                              \
-  static const o2::framework::expressions::BindingNode _Getter_ { _Label_,                                                                                                        \
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_, typeid(_Name_).hash_code(),                                                                            \
                                                                   o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_) \
@@ -1274,32 +1280,32 @@ constexpr auto is_binding_compatible_v()
 
 /// An 'expression' column. i.e. a column that can be calculated from other
 /// columns with gandiva based on supplied C++ expression.
-#define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_) \
-  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                         \
-    static constexpr const char* mLabel = _Label_;                                          \
-    using base = o2::soa::Column<_Type_, _Name_>;                                           \
-    using type = _Type_;                                                                    \
-    using column_t = _Name_;                                                                \
-    using spawnable_t = std::true_type;                                                     \
-    _Name_(arrow::ChunkedArray const* column)                                               \
-      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))              \
-    {                                                                                       \
-    }                                                                                       \
-                                                                                            \
-    _Name_() = default;                                                                     \
-    _Name_(_Name_ const& other) = default;                                                  \
-    _Name_& operator=(_Name_ const& other) = default;                                       \
-                                                                                            \
-    decltype(auto) _Getter_() const                                                         \
-    {                                                                                       \
-      return *mColumnIterator;                                                              \
-    }                                                                                       \
-    static o2::framework::expressions::Projector Projector()                                \
-    {                                                                                       \
-      return _Expression_;                                                                  \
-    }                                                                                       \
-  };                                                                                        \
-  static const o2::framework::expressions::BindingNode _Getter_ { _Label_,                  \
+#define DECLARE_SOA_EXPRESSION_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_, _Expression_)            \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {                                                    \
+    static constexpr const char* mLabel = _Label_;                                                     \
+    using base = o2::soa::Column<_Type_, _Name_>;                                                      \
+    using type = _Type_;                                                                               \
+    using column_t = _Name_;                                                                           \
+    using spawnable_t = std::true_type;                                                                \
+    _Name_(arrow::ChunkedArray const* column)                                                          \
+      : o2::soa::Column<_Type_, _Name_>(o2::soa::ColumnIterator<type>(column))                         \
+    {                                                                                                  \
+    }                                                                                                  \
+                                                                                                       \
+    _Name_() = default;                                                                                \
+    _Name_(_Name_ const& other) = default;                                                             \
+    _Name_& operator=(_Name_ const& other) = default;                                                  \
+                                                                                                       \
+    decltype(auto) _Getter_() const                                                                    \
+    {                                                                                                  \
+      return *mColumnIterator;                                                                         \
+    }                                                                                                  \
+    static o2::framework::expressions::Projector Projector()                                           \
+    {                                                                                                  \
+      return _Expression_;                                                                             \
+    }                                                                                                  \
+  };                                                                                                   \
+  static const o2::framework::expressions::BindingNode _Getter_ { _Label_, typeid(_Name_).hash_code(), \
                                                                   o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_EXPRESSION_COLUMN(_Name_, _Getter_, _Type_, _Expression_) \
@@ -1319,71 +1325,71 @@ constexpr auto is_binding_compatible_v()
 /// needs to go from parent to child, the only way is to either have
 /// a separate "association" with the two indices, or to use the standard
 /// grouping mechanism of AnalysisTask.
-#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_)                \
-  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                       \
-    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                     \
-    static_assert((*_Suffix_ == '\0') || (*_Suffix_ == '_'), "Suffix has to begin with _");       \
-    static constexpr const char* mLabel = "fIndex" #_Table_ _Suffix_;                             \
-    using base = o2::soa::Column<_Type_, _Name_##Id>;                                             \
-    using type = _Type_;                                                                          \
-    using column_t = _Name_##Id;                                                                  \
-    using binding_t = _Table_;                                                                    \
-    _Name_##Id(arrow::ChunkedArray const* column)                                                 \
-      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                \
-    {                                                                                             \
-    }                                                                                             \
-                                                                                                  \
-    _Name_##Id() = default;                                                                       \
-    _Name_##Id(_Name_##Id const& other) = default;                                                \
-    _Name_##Id& operator=(_Name_##Id const& other) = default;                                     \
-    type inline getId() const                                                                     \
-    {                                                                                             \
-      return _Getter_##Id();                                                                      \
-    }                                                                                             \
-                                                                                                  \
-    type _Getter_##Id() const                                                                     \
-    {                                                                                             \
-      return *mColumnIterator;                                                                    \
-    }                                                                                             \
-                                                                                                  \
-    bool has_##_Getter_() const                                                                   \
-    {                                                                                             \
-      return *mColumnIterator >= 0;                                                               \
-    }                                                                                             \
-                                                                                                  \
-    template <typename T>                                                                         \
-    auto _Getter_##_as() const                                                                    \
-    {                                                                                             \
-      assert(mBinding != nullptr);                                                                \
-      return static_cast<T*>(mBinding)->begin() + *mColumnIterator;                               \
-    }                                                                                             \
-                                                                                                  \
-    auto _Getter_() const                                                                         \
-    {                                                                                             \
-      return _Getter_##_as<binding_t>();                                                          \
-    }                                                                                             \
-                                                                                                  \
-    template <typename T>                                                                         \
-    bool setCurrent(T* current)                                                                   \
-    {                                                                                             \
-      if constexpr (o2::soa::is_binding_compatible_v<T, binding_t>()) {                           \
-        assert(current != nullptr);                                                               \
-        this->mBinding = current;                                                                 \
-        return true;                                                                              \
-      }                                                                                           \
-      return false;                                                                               \
-    }                                                                                             \
-                                                                                                  \
-    bool setCurrentRaw(void* current)                                                             \
-    {                                                                                             \
-      this->mBinding = current;                                                                   \
-      return true;                                                                                \
-    }                                                                                             \
-    binding_t* getCurrent() const { return static_cast<binding_t*>(mBinding); }                   \
-    void* getCurrentRaw() const { return mBinding; }                                              \
-    void* mBinding = nullptr;                                                                     \
-  };                                                                                              \
-  static const o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" #_Table_ _Suffix_, \
+#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_)                                                \
+  struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                                       \
+    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                                     \
+    static_assert((*_Suffix_ == '\0') || (*_Suffix_ == '_'), "Suffix has to begin with _");                                       \
+    static constexpr const char* mLabel = "fIndex" #_Table_ _Suffix_;                                                             \
+    using base = o2::soa::Column<_Type_, _Name_##Id>;                                                                             \
+    using type = _Type_;                                                                                                          \
+    using column_t = _Name_##Id;                                                                                                  \
+    using binding_t = _Table_;                                                                                                    \
+    _Name_##Id(arrow::ChunkedArray const* column)                                                                                 \
+      : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                                \
+    {                                                                                                                             \
+    }                                                                                                                             \
+                                                                                                                                  \
+    _Name_##Id() = default;                                                                                                       \
+    _Name_##Id(_Name_##Id const& other) = default;                                                                                \
+    _Name_##Id& operator=(_Name_##Id const& other) = default;                                                                     \
+    type inline getId() const                                                                                                     \
+    {                                                                                                                             \
+      return _Getter_##Id();                                                                                                      \
+    }                                                                                                                             \
+                                                                                                                                  \
+    type _Getter_##Id() const                                                                                                     \
+    {                                                                                                                             \
+      return *mColumnIterator;                                                                                                    \
+    }                                                                                                                             \
+                                                                                                                                  \
+    bool has_##_Getter_() const                                                                                                   \
+    {                                                                                                                             \
+      return *mColumnIterator >= 0;                                                                                               \
+    }                                                                                                                             \
+                                                                                                                                  \
+    template <typename T>                                                                                                         \
+    auto _Getter_##_as() const                                                                                                    \
+    {                                                                                                                             \
+      assert(mBinding != nullptr);                                                                                                \
+      return static_cast<T*>(mBinding)->begin() + *mColumnIterator;                                                               \
+    }                                                                                                                             \
+                                                                                                                                  \
+    auto _Getter_() const                                                                                                         \
+    {                                                                                                                             \
+      return _Getter_##_as<binding_t>();                                                                                          \
+    }                                                                                                                             \
+                                                                                                                                  \
+    template <typename T>                                                                                                         \
+    bool setCurrent(T* current)                                                                                                   \
+    {                                                                                                                             \
+      if constexpr (o2::soa::is_binding_compatible_v<T, binding_t>()) {                                                           \
+        assert(current != nullptr);                                                                                               \
+        this->mBinding = current;                                                                                                 \
+        return true;                                                                                                              \
+      }                                                                                                                           \
+      return false;                                                                                                               \
+    }                                                                                                                             \
+                                                                                                                                  \
+    bool setCurrentRaw(void* current)                                                                                             \
+    {                                                                                                                             \
+      this->mBinding = current;                                                                                                   \
+      return true;                                                                                                                \
+    }                                                                                                                             \
+    binding_t* getCurrent() const { return static_cast<binding_t*>(mBinding); }                                                   \
+    void* getCurrentRaw() const { return mBinding; }                                                                              \
+    void* mBinding = nullptr;                                                                                                     \
+  };                                                                                                                              \
+  static const o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" #_Table_ _Suffix_, typeid(_Name_##Id).hash_code(), \
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "")

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -107,10 +107,10 @@ struct AnalysisDataProcessorBuilder {
   {
     using dT = std::decay_t<T>;
     if constexpr (framework::is_specialization<dT, soa::Filtered>::value) {
-      eInfos.push_back({at, o2::soa::createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
+      eInfos.push_back({at, dT::hashes(), o2::soa::createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
     } else if constexpr (soa::is_soa_iterator_t<dT>::value) {
       if constexpr (std::is_same_v<typename dT::policy_t, soa::FilteredIndexPolicy>) {
-        eInfos.push_back({at, o2::soa::createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
+        eInfos.push_back({at, dT::parent_t::hashes(), o2::soa::createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
       }
     }
     doAppendInputWithMetadata(soa::make_originals_from_type<dT>(), inputs);

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -41,11 +41,12 @@ class Filter;
 #include <string>
 #include <memory>
 #include <typeinfo>
+#include <set>
 
 using atype = arrow::Type;
 struct ExpressionInfo {
   size_t index;
-  std::vector<size_t> hashes;
+  std::set<size_t> hashes;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree;
 };

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -40,10 +40,12 @@ class Filter;
 #include <variant>
 #include <string>
 #include <memory>
+#include <typeinfo>
 
 using atype = arrow::Type;
 struct ExpressionInfo {
   size_t index;
+  std::vector<size_t> hashes;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree;
 };
@@ -104,8 +106,9 @@ struct LiteralNode {
 struct BindingNode {
   BindingNode(BindingNode const&) = default;
   BindingNode(BindingNode&&) = delete;
-  BindingNode(std::string const& name_, atype::type type_) : name{name_}, type{type_} {}
+  BindingNode(std::string const& name_, std::size_t hash_, atype::type type_) : name{name_}, hash{hash_}, type{type_} {}
   std::string name;
+  std::size_t hash;
   atype::type type;
 };
 

--- a/Framework/Core/src/ExpressionHelpers.h
+++ b/Framework/Core/src/ExpressionHelpers.h
@@ -49,10 +49,12 @@ struct DatumSpec {
   /// datum spec either contains an index, a value of a literal or a binding label
   using datum_t = std::variant<std::monostate, size_t, LiteralNode::var_t, std::string>;
   datum_t datum = std::monostate{};
+  size_t hash = 0;
   atype::type type = atype::NA;
+
   explicit DatumSpec(size_t index, atype::type type_) : datum{index}, type{type_} {}
   explicit DatumSpec(LiteralNode::var_t literal, atype::type type_) : datum{literal}, type{type_} {}
-  explicit DatumSpec(std::string binding, atype::type type_) : datum{binding}, type{type_} {}
+  explicit DatumSpec(std::string binding, size_t hash_, atype::type type_) : datum{binding}, hash{hash_}, type{type_} {}
   DatumSpec() = default;
   DatumSpec(DatumSpec const&) = default;
   DatumSpec(DatumSpec&&) = default;

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -527,7 +527,7 @@ gandiva::NodePtr createExpressionTree(Operations const& opSpecs,
   return tree;
 }
 
-bool isTableCompatible(std::vector<size_t> const& hashes, Operations const& specs)
+bool isTableCompatible(std::set<size_t> const& hashes, Operations const& specs)
 {
   std::set<size_t> opHashes;
   for (auto& spec : specs) {
@@ -538,12 +538,8 @@ bool isTableCompatible(std::vector<size_t> const& hashes, Operations const& spec
       opHashes.insert(spec.right.hash);
     }
   }
-  std::set<size_t> tHashes;
-  for (auto& hash : hashes) {
-    tHashes.insert(hash);
-  }
 
-  return std::includes(tHashes.begin(), tHashes.end(),
+  return std::includes(hashes.begin(), hashes.end(),
                        opHashes.begin(), opHashes.end());
 }
 

--- a/Framework/Core/test/test_Expressions.cxx
+++ b/Framework/Core/test/test_Expressions.cxx
@@ -23,13 +23,13 @@ using namespace o2::framework::expressions;
 
 namespace nodes
 {
-static BindingNode pt{"pt", atype::FLOAT};
-static BindingNode phi{"phi", atype::FLOAT};
-static BindingNode eta{"eta", atype::FLOAT};
+static BindingNode pt{"pt", 1, atype::FLOAT};
+static BindingNode phi{"phi", 2, atype::FLOAT};
+static BindingNode eta{"eta", 3, atype::FLOAT};
 
-static BindingNode tgl{"tgl", atype::FLOAT};
-static BindingNode signed1Pt{"signed1Pt", atype::FLOAT};
-static BindingNode testInt{"testInt", atype::INT32};
+static BindingNode tgl{"tgl", 4, atype::FLOAT};
+static BindingNode signed1Pt{"signed1Pt", 5, atype::FLOAT};
+static BindingNode testInt{"testInt", 6, atype::INT32};
 } // namespace nodes
 
 namespace o2::aod::track
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(specs[0].right, (DatumSpec{2u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(specs[0].result, (DatumSpec{0u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(specs[1].left, (DatumSpec{std::string{"eta"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(specs[1].left, (DatumSpec{std::string{"eta"}, 3, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(specs[1].right, (DatumSpec{LiteralNode::var_t{1}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(specs[1].result, (DatumSpec{2u, atype::BOOL}));
 
@@ -53,11 +53,11 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(specs[2].right, (DatumSpec{4u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(specs[2].result, (DatumSpec{1u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(specs[3].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(specs[3].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(specs[3].right, (DatumSpec{LiteralNode::var_t{2}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(specs[3].result, (DatumSpec{4u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(specs[4].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(specs[4].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(specs[4].right, (DatumSpec{LiteralNode::var_t{1}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(specs[4].result, (DatumSpec{3u, atype::BOOL}));
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(gspecs[1].right, (DatumSpec{LiteralNode::var_t{3}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(gspecs[1].result, (DatumSpec{2u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(gspecs[2].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(gspecs[2].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(gspecs[2].right, (DatumSpec{LiteralNode::var_t{M_PI}, atype::DOUBLE}));
   BOOST_REQUIRE_EQUAL(gspecs[2].result, (DatumSpec{3u, atype::DOUBLE}));
 
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(gspecs[3].right, (DatumSpec{LiteralNode::var_t{0.5}, atype::DOUBLE}));
   BOOST_REQUIRE_EQUAL(gspecs[3].result, (DatumSpec{1u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(gspecs[4].left, (DatumSpec{std::string{"eta"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(gspecs[4].left, (DatumSpec{std::string{"eta"}, 3, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(gspecs[4].right, (DatumSpec{LiteralNode::var_t{2.f}, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(gspecs[4].result, (DatumSpec{4u, atype::FLOAT}));
 
@@ -90,11 +90,11 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(hspecs[0].right, (DatumSpec{2u, atype::BOOL}));
   BOOST_REQUIRE_EQUAL(hspecs[0].result, (DatumSpec{0u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(hspecs[1].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(hspecs[1].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(hspecs[1].right, (DatumSpec{LiteralNode::var_t{3}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(hspecs[1].result, (DatumSpec{2u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(hspecs[2].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(hspecs[2].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(hspecs[2].right, (DatumSpec{LiteralNode::var_t{0}, atype::INT32}));
   BOOST_REQUIRE_EQUAL(hspecs[2].result, (DatumSpec{1u, atype::BOOL}));
 
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(uspecs[2].right, (DatumSpec{}));
   BOOST_REQUIRE_EQUAL(uspecs[2].result, (DatumSpec{3u, atype::DOUBLE}));
 
-  BOOST_REQUIRE_EQUAL(uspecs[3].left, (DatumSpec{std::string{"phi"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(uspecs[3].left, (DatumSpec{std::string{"phi"}, 2, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(uspecs[3].right, (DatumSpec{LiteralNode::var_t{2.0 * M_PI}, atype::DOUBLE}));
   BOOST_REQUIRE_EQUAL(uspecs[3].result, (DatumSpec{4u, atype::DOUBLE}));
 
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(uspecs[4].right, (DatumSpec{LiteralNode::var_t{1.0}, atype::DOUBLE}));
   BOOST_REQUIRE_EQUAL(uspecs[4].result, (DatumSpec{1u, atype::BOOL}));
 
-  BOOST_REQUIRE_EQUAL(uspecs[5].left, (DatumSpec{std::string{"eta"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(uspecs[5].left, (DatumSpec{std::string{"eta"}, 3, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(uspecs[5].right, (DatumSpec{}));
   BOOST_REQUIRE_EQUAL(uspecs[5].result, (DatumSpec{5u, atype::FLOAT}));
 
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TestTreeParsing)
   BOOST_REQUIRE_EQUAL(ptfilter.node->left->self.index(), 1);
   BOOST_REQUIRE_EQUAL(ptfilter.node->right->self.index(), 3);
   auto ptfilterspecs = createOperations(ptfilter);
-  BOOST_REQUIRE_EQUAL(ptfilterspecs[0].left, (DatumSpec{std::string{"fPt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptfilterspecs[0].left, (DatumSpec{std::string{"fPt"}, typeid(o2::aod::track::Pt).hash_code(), atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(ptfilterspecs[0].right, (DatumSpec{LiteralNode::var_t{0.5f}, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(ptfilterspecs[0].result, (DatumSpec{0u, atype::BOOL}));
 }
@@ -139,12 +139,12 @@ BOOST_AUTO_TEST_CASE(TestGandivaTreeCreation)
 {
   Projector pze = o2::aod::track::Pze::Projector();
   auto pzspecs = createOperations(std::move(pze));
-  BOOST_REQUIRE_EQUAL(pzspecs[0].left, (DatumSpec{std::string{"fTgl"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[0].left, (DatumSpec{std::string{"fTgl"}, typeid(o2::aod::track::Tgl).hash_code(), atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(pzspecs[0].right, (DatumSpec{1u, atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(pzspecs[0].result, (DatumSpec{0u, atype::FLOAT}));
 
   BOOST_REQUIRE_EQUAL(pzspecs[1].left, (DatumSpec{LiteralNode::var_t{1.f}, atype::FLOAT}));
-  BOOST_REQUIRE_EQUAL(pzspecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(pzspecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, typeid(o2::aod::track::Signed1Pt).hash_code(), atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(pzspecs[1].result, (DatumSpec{1u, atype::FLOAT}));
   auto infield1 = o2::aod::track::Signed1Pt::asArrowField();
   auto infield2 = o2::aod::track::Tgl::asArrowField();
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(TestGandivaTreeCreation)
   BOOST_REQUIRE_EQUAL(ptespecs[0].result, (DatumSpec{0u, atype::FLOAT}));
 
   BOOST_REQUIRE_EQUAL(ptespecs[1].left, (DatumSpec{LiteralNode::var_t{1.f}, atype::FLOAT}));
-  BOOST_REQUIRE_EQUAL(ptespecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, atype::FLOAT}));
+  BOOST_REQUIRE_EQUAL(ptespecs[1].right, (DatumSpec{std::string{"fSigned1Pt"}, typeid(o2::aod::track::Signed1Pt).hash_code(), atype::FLOAT}));
   BOOST_REQUIRE_EQUAL(ptespecs[1].result, (DatumSpec{1u, atype::FLOAT}));
 
   auto infield3 = o2::aod::track::Signed1Pt::asArrowField();


### PR DESCRIPTION
This changes the way filter trees are matched to tables from string comparison, to typeinfo hash comparison. It allows users to apply filters correctly when filtering tables that have identical column names (but not the types). 