### PR TITLE
ITS-tracking: Use propagator in ITS tracker

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -75,14 +75,12 @@ class Tracker
 
   std::vector<TrackITSExt>& getTracks();
   auto& getTrackLabels() { return mTrackLabels; }
-  bool isMatLUT();
 
   void clustersToTracks(const ROframe&, std::ostream& = std::cout);
 
   void setROFrame(std::uint32_t f) { mROFrame = f; }
   std::uint32_t getROFrame() const { return mROFrame; }
   void setParameters(const std::vector<MemoryParameters>&, const std::vector<TrackingParameters>&);
-  void initMatBudLUTFromFile();
   void getGlobalConfiguration();
 
  private:
@@ -116,7 +114,6 @@ class Tracker
   std::uint32_t mROFrame = 0;
   std::vector<TrackITSExt> mTracks;
   std::vector<MCCompLabel> mTrackLabels;
-  o2::base::MatLayerCylSet* mMatLayerCylSet = nullptr;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
 
 #ifdef CA_DEBUG
@@ -138,16 +135,6 @@ inline float Tracker::getBz() const
 inline void Tracker::setBz(float bz)
 {
   mBz = bz;
-}
-
-inline void Tracker::initMatBudLUTFromFile()
-{
-  mMatLayerCylSet = o2::base::MatLayerCylSet::loadFromFile();
-}
-
-inline bool Tracker::isMatLUT()
-{
-  return mMatLayerCylSet;
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -79,7 +79,7 @@ class Tracker
   void setCorrType(const o2::base::PropagatorImpl<float>::MatCorrType& type) { mCorrType = type; }
   void setParameters(const std::vector<MemoryParameters>&, const std::vector<TrackingParameters>&);
   void getGlobalConfiguration();
-  bool isMatLUT() const { return mCorrType == o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT; }
+  bool isMatLUT() const { return o2::base::Propagator::Instance()->getMatLUT() && (mCorrType == o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT); }
 
  private:
   track::TrackParCov buildTrackSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster3,
@@ -91,8 +91,7 @@ class Tracker
   void findCellsNeighbours(int& iteration);
   void findRoads(int& iteration);
   void findTracks(const ROframe& ev);
-  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step, o2::base::PropagatorImpl<float>* propPtr,
-                const float chi2cut = o2::constants::math::VeryBig);
+  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step, const float chi2cut = o2::constants::math::VeryBig);
   void traverseCellsTree(const int, const int);
   void computeRoadsMClabels(const ROframe&);
   void computeTracksMClabels(const ROframe&);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -44,6 +44,12 @@
 
 namespace o2
 {
+namespace base
+{
+template <typename>
+class PropagatorImpl;
+}
+
 namespace gpu
 {
 class GPUChainITS;
@@ -89,7 +95,7 @@ class Tracker
   void findCellsNeighbours(int& iteration);
   void findRoads(int& iteration);
   void findTracks(const ROframe& ev);
-  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step,
+  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step, o2::base::PropagatorImpl<float>* propPtr,
                 const float chi2cut = o2::constants::math::VeryBig);
   void traverseCellsTree(const int, const int);
   void computeRoadsMClabels(const ROframe&);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -31,6 +31,7 @@
 #include "ITStracking/ROframe.h"
 #include "ITStracking/MathUtils.h"
 #include "ITStracking/PrimaryVertexContext.h"
+#include "DetectorsBase/Propagator.h"
 #include "ITStracking/Road.h"
 
 #include "DataFormatsITS/TrackITS.h"
@@ -44,11 +45,6 @@
 
 namespace o2
 {
-namespace base
-{
-template <typename>
-class PropagatorImpl;
-}
 
 namespace gpu
 {
@@ -80,8 +76,10 @@ class Tracker
 
   void setROFrame(std::uint32_t f) { mROFrame = f; }
   std::uint32_t getROFrame() const { return mROFrame; }
+  void setCorrType(const o2::base::PropagatorImpl<float>::MatCorrType& type) { mCorrType = type; }
   void setParameters(const std::vector<MemoryParameters>&, const std::vector<TrackingParameters>&);
   void getGlobalConfiguration();
+  bool isMatLUT() const { return mCorrType == o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT; }
 
  private:
   track::TrackParCov buildTrackSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster3,
@@ -110,6 +108,7 @@ class Tracker
   std::vector<TrackingParameters> mTrkParams;
 
   bool mCUDA = false;
+  o2::base::PropagatorImpl<float>::MatCorrType mCorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT;
   float mBz = 5.f;
   std::uint32_t mROFrame = 0;
   std::vector<TrackITSExt> mTracks;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -37,9 +37,6 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
 
 struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerParamConfig> {
 
-  // Use lookup table for mat. budget
-  bool useMatBudLUT = false;
-
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -37,6 +37,9 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
 
 struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerParamConfig> {
 
+  // Use TGeo for mat. budget
+  bool useMatCorrTGeo = false;
+
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -17,7 +17,6 @@
 #include "ITStracking/Cell.h"
 #include "ITStracking/Constants.h"
 #include "ITStracking/IndexTableUtils.h"
-#include "DetectorsBase/Propagator.h"
 #include "ITStracking/Tracklet.h"
 #include "ITStracking/TrackerTraits.h"
 #include "ITStracking/TrackerTraitsCPU.h"
@@ -425,7 +424,7 @@ bool Tracker::fitTrack(const ROframe& event, TrackITSExt& track, int start, int 
       return false;
     }
 
-    if (!propPtr->propagateToX(track, trackingHit.xTrackingFrame, getBz())) {
+    if (!propPtr->propagateToX(track, trackingHit.xTrackingFrame, getBz(), o2::base::PropagatorImpl<float>::MAX_SIN_PHI, o2::base::PropagatorImpl<float>::MAX_STEP, mCorrType)) {
       return false;
     }
 
@@ -649,6 +648,9 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
 void Tracker::getGlobalConfiguration()
 {
   auto& tc = o2::its::TrackerParamConfig::Instance();
+  if (tc.useMatCorrTGeo) {
+    setCorrType(o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrTGeo);
+  }
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -425,11 +425,7 @@ bool Tracker::fitTrack(const ROframe& event, TrackITSExt& track, int start, int 
       return false;
     }
 
-    // if (!track.propagateTo(trackingHit.xTrackingFrame, getBz())) {
-    // return false;
-    // }
-
-    if (!propPtr->PropagateToXBxByBz(track, trackingHit.xTrackingFrame)) {
+    if (!propPtr->propagateToX(track, trackingHit.xTrackingFrame, getBz())) {
       return false;
     }
 
@@ -441,29 +437,6 @@ bool Tracker::fitTrack(const ROframe& event, TrackITSExt& track, int start, int 
     if (!track.o2::track::TrackParCov::update(trackingHit.positionTrackingFrame, trackingHit.covarianceTrackingFrame)) {
       return false;
     }
-
-    // float xx0 = ((iLayer > 2) ? 0.008f : 0.003f); // Rough layer thickness
-    // float radiationLength = 9.36f;                // Radiation length of Si [cm]
-    // float density = 2.33f;                        // Density of Si [g/cm^3]
-    // float distance = xx0;                         // Default thickness
-    //
-    // if (mMatLayerCylSet) {
-    // if ((iLayer + step) != end) {
-    // const auto cl_0 = mPrimaryVertexContext->getClusters()[iLayer][track.getClusterIndex(iLayer)];
-    // const auto cl_1 = mPrimaryVertexContext->getClusters()[iLayer + step][track.getClusterIndex(iLayer + step)];
-    //
-    // auto matbud = mMatLayerCylSet->getMatBudget(cl_0.xCoordinate, cl_0.yCoordinate, cl_0.zCoordinate, cl_1.xCoordinate, cl_1.yCoordinate, cl_1.zCoordinate);
-    // xx0 = matbud.meanX2X0;
-    // density = matbud.meanRho;
-    // distance = matbud.length;
-    // }
-    // }
-    // The correctForMaterial should be called with anglecorr==true if the material budget is the "mean budget in vertical direction" and with false if the the estimated budget already accounts for the track inclination.
-    // Here using !mMatLayerCylSet as its presence triggers update of parameters
-    //
-    // if (!track.correctForMaterial(xx0, ((start < end) ? -1. : 1.) * distance * density, !mMatLayerCylSet)) { // ~0.14 GeV: mass of charged pion is used by default
-    // return false;
-    // }
   }
   return true;
 }
@@ -676,10 +649,6 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
 void Tracker::getGlobalConfiguration()
 {
   auto& tc = o2::its::TrackerParamConfig::Instance();
-
-  if (tc.useMatBudLUT) {
-    initMatBudLUTFromFile();
-  }
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -116,6 +116,7 @@ void TrackerDPL::init(InitContext& ic)
 
     mVertexer->getGlobalConfiguration();
     mTracker->getGlobalConfiguration();
+    LOG(INFO) << Form("Using %s for material budget approximation", (mTracker->isMatLUT() ? "lookup table" : "TGeometry"));
 
     double origD[3] = {0., 0., 0.};
     mTracker->setBz(field->getBz(origD));

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -116,7 +116,6 @@ void TrackerDPL::init(InitContext& ic)
 
     mVertexer->getGlobalConfiguration();
     mTracker->getGlobalConfiguration();
-    LOG(INFO) << Form("%ssing lookup table for material budget approximation", (mTracker->isMatLUT() ? "U" : "Not u"));
 
     double origD[3] = {0., 0., 0.};
     mTracker->setBz(field->getBz(origD));

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -65,6 +65,16 @@ void TrackerDPL::init(InitContext& ic)
     geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot,
                                                    o2::math_utils::TransformType::T2G));
 
+    std::string matLUTPath = ic.options().get<std::string>("material-lut-path");
+    std::string matLUTFile = o2::base::NameConf::getMatLUTFileName(matLUTPath);
+    if (o2::base::NameConf::pathExists(matLUTFile)) {
+      auto* lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
+      o2::base::Propagator::Instance()->setMatLUT(lut);
+      LOG(INFO) << "Loaded material LUT from " << matLUTFile;
+    } else {
+      LOG(INFO) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
+    }
+
     auto* chainITS = mRecChain->AddChain<o2::gpu::GPUChainITS>();
     mRecChain->Init();
     mVertexer = std::make_unique<Vertexer>(chainITS->GetITSVertexerTraits());
@@ -323,7 +333,8 @@ DataProcessorSpec getTrackerSpec(bool useMC, const std::string& trModeS, o2::gpu
     AlgorithmSpec{adaptFromTask<TrackerDPL>(useMC, trModeS, dType)},
     Options{
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}}}};
+      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
+      {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};
 }
 
 } // namespace its

--- a/macro/run_trac_alice3.C
+++ b/macro/run_trac_alice3.C
@@ -69,6 +69,7 @@ void run_trac_alice3(const string hitsFileName = "o2sim_HitsTRK.root")
 
   o2::its::Tracker tracker(new o2::its::TrackerTraitsCPU());
   tracker.setBz(5.f);
+  tracker.setCorrType(o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrTGeo);
 
   std::uint32_t roFrame;
   std::vector<Hit>* hits = nullptr;

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -35,6 +35,7 @@
 #include "ITStracking/Vertexer.h"
 
 #include "MathUtils/Utils.h"
+#include "DetectorsBase/Propagator.h"
 
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -90,6 +91,7 @@ void run_trac_ca_its(bool cosmics = false,
   }
   double origD[3] = {0., 0., 0.};
   tracker.setBz(field->getBz(origD));
+  // tracker.setCorrType(o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrTGeo);
 
   bool isITS = grp->isDetReadOut(o2::detectors::DetID::ITS);
   if (!isITS) {

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -3,6 +3,7 @@
 #include <string>
 #include <chrono>
 #include <iostream>
+#include <fstream>
 
 #include <TChain.h>
 #include <TFile.h>
@@ -179,6 +180,11 @@ void run_trac_ca_its(bool cosmics = false,
   o2::its::VertexerTraits* traits = o2::its::createVertexerTraits();
   o2::its::Vertexer vertexer(traits);
 
+  o2::its::VertexingParameters parameters;
+  parameters.phiCut = 0.005f;
+  parameters.tanLambdaCut = 0.002f;
+  vertexer.setParameters(parameters);
+
   int roFrameCounter{0};
 
   std::vector<double> ncls;
@@ -200,12 +206,53 @@ void run_trac_ca_its(bool cosmics = false,
       memParams[0].CellsMemoryCoefficients[iLayer] = 0.001f;
     }
   } else {
+    // Comment for pp
+    // ----
     trackParams.resize(3);
     memParams.resize(3);
-    trackParams[0].TrackletMaxDeltaPhi = 0.05f;
-    trackParams[1].TrackletMaxDeltaPhi = 0.1f;
+    for (int iParam{0}; iParam < 3; ++iParam) {
+      for (int iLayer = 0; iLayer < o2::its::constants::its2::TrackletsPerRoad; iLayer++) {
+        memParams[iParam].TrackletsMemoryCoefficients[iLayer] = 5.f;
+        memParams[iParam].CellsMemoryCoefficients[iLayer] = 0.1f;
+      }
+    }
+    for (auto i{0}; i < 3; ++i) {
+      trackParams[i].TrackletMaxDeltaPhi = 3.f;
+      trackParams[i].CellMaxDeltaPhi = 3.f;
+      trackParams[i].CellMaxDeltaTanLambda = 1.f;
+      for (auto j{0}; j < 6; ++j) {
+        trackParams[i].TrackletMaxDeltaZ[j] = 10.f;
+      }
+      for (auto j{0}; j < 5; ++j) {
+        trackParams[i].CellMaxDeltaZ[j] = 10.f;
+      }
+    }
     trackParams[2].MinTrackLength = 4;
-    trackParams[2].TrackletMaxDeltaPhi = 0.3;
+    // ---
+    // Uncomment for pp
+    // trackParams.resize(2);
+    // std::array<const float, 5> kmaxDCAxy1 = {1.f * 2.0, 0.4f * 2.0, 0.4f * 2.0, 2.0f * 2.0, 3.f * 2.0};
+    // std::array<const float, 5> kmaxDCAz1 = {1.f * 2.0, 0.4f * 2.0, 0.4f * 2.0, 2.0f * 2.0, 3.f * 2.0};
+    // std::array<const float, 4> kmaxDN1 = {0.005f * 2.0, 0.0035f * 2.0, 0.009f * 2.0, 0.03f * 2.0};
+    // std::array<const float, 4> kmaxDP1 = {0.02f * 2.0, 0.005f * 2.0, 0.006f * 2.0, 0.007f * 2.0};
+    // std::array<const float, 6> kmaxDZ1 = {1.f * 2.0, 1.f * 2.0, 2.0f * 2.0, 2.0f * 2.0, 2.0f * 2.0, 2.0f * 2.0};
+    // const float kDoublTanL1 = 0.05f * 5.;
+    // const float kDoublPhi1 = 0.2f * 5.;
+    // trackParams[1].MinTrackLength = 7;
+    // trackParams[1].TrackletMaxDeltaPhi = 0.3;
+    // trackParams[1].CellMaxDeltaPhi = 0.2 * 2;
+    // trackParams[1].CellMaxDeltaTanLambda = 0.05 * 2;
+    // std::copy(kmaxDZ1.begin(), kmaxDZ1.end(), trackParams[1].TrackletMaxDeltaZ.begin());
+    // std::copy(kmaxDCAxy1.begin(), kmaxDCAxy1.end(), trackParams[1].CellMaxDCA.begin());
+    // std::copy(kmaxDCAz1.begin(), kmaxDCAz1.end(), trackParams[1].CellMaxDeltaZ.begin());
+    // std::copy(kmaxDP1.begin(), kmaxDP1.end(), trackParams[1].NeighbourMaxDeltaCurvature.begin());
+    // std::copy(kmaxDN1.begin(), kmaxDN1.end(), trackParams[1].NeighbourMaxDeltaN.begin());
+    // memParams.resize(2);
+    // for (auto& coef : memParams[1].CellsMemoryCoefficients)
+    //   coef *= 40;
+    // for (auto& coef : memParams[1].TrackletsMemoryCoefficients)
+    //   coef *= 40;
+    // ---
   }
 
   tracker.setParameters(memParams, trackParams);
@@ -236,7 +283,7 @@ void run_trac_ca_its(bool cosmics = false,
 
     if (!vertITS.empty()) {
       // Using only the first vertex in the list
-      std::cout << " - Reconstructed vertexer: x = " << vertITS[0].getX() << " y = " << vertITS[0].getY() << " x = " << vertITS[0].getZ() << std::endl;
+      std::cout << " - Reconstructed vertex: x = " << vertITS[0].getX() << " y = " << vertITS[0].getY() << " x = " << vertITS[0].getZ() << std::endl;
       event.addPrimaryVertex(vertITS[0].getX(), vertITS[0].getY(), vertITS[0].getZ());
     } else {
       std::cout << " - Vertex not reconstructed, tracking skipped" << std::endl;
@@ -252,6 +299,9 @@ void run_trac_ca_its(bool cosmics = false,
     time.push_back(diff_t.count());
 
     tracks.swap(tracker.getTracks());
+    if (tracks.size()) {
+      std::cout << "\t\tFound " << tracks.size() << " tracks" << std::endl;
+    }
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(trackClIdx.size()); // before adding tracks, create final cluster indices
       int ncl = trc.getNumberOfClusters();


### PR DESCRIPTION
Main points:
 - Material budget lookup table is now assumed as default, as using Propagator is more compact: need to create it also for Run3+ layouts
 - Removed configuration in workflow that sets LUT usage as it is not required anymore
 - Macro tuning for _pp_ in `run_trac_ca_its.C` 
 - Healthier chi2 distribution (see attachments for _pp_)

![chi2prof_pp](https://user-images.githubusercontent.com/4990252/113847484-d1c2ea00-9797-11eb-9258-ddc532275765.png)
![chi2pt_pp](https://user-images.githubusercontent.com/4990252/113847534-e0110600-9797-11eb-90a1-4ee4831fc092.png)
![track_eff_pp](https://user-images.githubusercontent.com/4990252/113847544-e2736000-9797-11eb-8f7d-62465aadd4b7.png)

A comment with respect to the chi2 distribution improvement: the only evident difference is that the correction of the track is now done by propagator **before** updating the track. For the rest it looks to me that we were doing the same things.

@shahor02 