### PR TITLE
DPL: provide a `--spawners <N>` option

### DIFF
--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -32,6 +32,7 @@ namespace o2::framework
 std::vector<ConfigParamSpec> WorkflowCustomizationHelpers::requiredWorkflowOptions()
 {
   return std::vector<ConfigParamSpec>{{ConfigParamSpec{"readers", VariantType::Int64, 1ll, {"number of parallel readers to use"}},
+                                       ConfigParamSpec{"spawners", VariantType::Int64, 1ll, {"number of parallel spawners to use"}},
                                        ConfigParamSpec{"pipeline", VariantType::String, "", {"override default pipeline size"}},
                                        ConfigParamSpec{"clone", VariantType::String, "", {"clone processors from a template"}},
                                        ConfigParamSpec{"workflow-suffix", VariantType::String, "", {"suffix to add to all dataprocessors"}},

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -409,7 +409,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
 
   if (aodSpawner.outputs.empty() == false) {
-    extraSpecs.push_back(aodSpawner);
+    extraSpecs.push_back(timePipeline(aodSpawner, ctx.options().get<int64_t>("spawners")));
   }
 
   if (indexBuilder.outputs.empty() == false) {


### PR DESCRIPTION
Similar to --readers allows creating <N> spawners which work
in a time-pipelined way.