### PR TITLE
TRD calibration subdirectory added

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -56,6 +56,7 @@ constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; // granula
 
 // OS: Should this not be flexible for example in case of Kr calib?
 constexpr int TIMEBINS = 30; // the number of time bins
+constexpr int NBINSANGLEDIFF = 26; // the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking (last bin is for under-/overflow entries)
 
 // Trigger parameters
 constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.

--- a/Detectors/TRD/CMakeLists.txt
+++ b/Detectors/TRD/CMakeLists.txt
@@ -9,6 +9,7 @@
 # submit itself to any jurisdiction.
 
 add_subdirectory(base)
+add_subdirectory(calibration)
 add_subdirectory(simulation)
 add_subdirectory(reconstruction)
 add_subdirectory(macros)

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -1,0 +1,17 @@
+#Copyright CERN and copyright holders of ALICE O2.This software is distributed
+#under the terms of the GNU General Public License v3(GPL Version 3), copied
+#verbatim in the file "COPYING".
+#
+#See http: //alice-o2.web.cern.ch/license for full licensing information.
+#
+#In applying this license CERN does not waive the privileges and immunities
+#granted to it by virtue of its status as an Intergovernmental Organization or
+#submit itself to any jurisdiction.
+
+o2_add_library(TRDCalibration
+               SOURCES src/CalibVDrift.cxx
+               PUBLIC_LINK_LIBRARIES O2::TRDBase
+                                     O2::DataFormatsTRD)
+
+ o2_target_root_dictionary(TRDCalibration
+                           HEADERS include/TRDCalibration/CalibVDrift.h)

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibVDrift.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibVDrift.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_CALIBVDRIFT_H_
+#define ALICEO2_TRD_CALIBVDRIFT_H_
+
+/// \file   CalibVDrift.h
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+#include "DataFormatsTRD/Constants.h"
+#include <array>
+
+namespace o2
+{
+namespace trd
+{
+
+/// \brief VDrift calibration class
+///
+/// This class is used to determine chamber-wise vDrift values
+///
+/// origin: TRD
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+class CalibVDrift
+{
+ public:
+  /// default constructor
+  CalibVDrift() = default;
+
+  /// default destructor
+  ~CalibVDrift() = default;
+
+  /// set input angular difference sums
+  void setAngleDiffSums(float* input)
+  {
+    for (int i = 0; i < constants::MAXCHAMBER * constants::NBINSANGLEDIFF; ++i) {
+      mAngleDiffSums[i] = input[i];
+    }
+  }
+
+  /// set input angular difference bin counters
+  void setAngleDiffCounters(short* input)
+  {
+    for (int i = 0; i < constants::MAXCHAMBER * constants::NBINSANGLEDIFF; ++i) {
+      mAngleDiffCounters[i] = input[i];
+    }
+  }
+
+  /// main processing function
+  void process();
+
+ private:
+  std::array<float, constants::MAXCHAMBER * constants::NBINSANGLEDIFF> mAngleDiffSums{};     ///< input TRD track to tracklet angular difference sums per bin
+  std::array<short, constants::MAXCHAMBER * constants::NBINSANGLEDIFF> mAngleDiffCounters{}; ///< input bin counters
+};
+
+} // namespace trd
+
+} // namespace o2
+#endif

--- a/Detectors/TRD/calibration/src/CalibVDrift.cxx
+++ b/Detectors/TRD/calibration/src/CalibVDrift.cxx
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CalibVDrift.cxx
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+#include "TFile.h"
+#include "TH2F.h"
+
+#include <fairlogger/Logger.h>
+
+#include "TRDCalibration/CalibVDrift.h"
+
+using namespace o2::trd;
+using namespace o2::trd::constants;
+
+void CalibVDrift::process()
+{
+  LOG(info) << "Started processing for vDrift calibration";
+
+  for (int iDet = 0; iDet < constants::MAXCHAMBER; ++iDet) {
+    for (int iBin = 0; iBin < constants::NBINSANGLEDIFF; ++iBin) { // note: iBin = constants::NBINSANGLEDIFF - 1 is under-/overflow bin
+      short nEntries = mAngleDiffCounters[iDet * constants::NBINSANGLEDIFF + iBin];
+      float angleDiffSum = mAngleDiffSums[iDet * constants::NBINSANGLEDIFF + iBin];
+      if (nEntries > 0) {
+        LOGF(INFO, "Found %i entrie(s) in chamber %i, bin %i. Average angular deviation: %f", nEntries, iDet, iBin, angleDiffSum / nEntries);
+      }
+    }
+  }
+
+  /*
+  // as an example I loop over the input, create a histogram and write it to a file
+  auto fOut = TFile::Open("trdcalibdummy.root", "recreate");
+  auto hXY = std::make_unique<TH2F>("histDummy", "foo", 100, -60, 60, 100, 250, 400); // xy distribution of TRD space points
+  for (int i = 0; i < mAngulerDeviationProf.size(); ++i) {
+    hXY->Fill(mAngulerDeviationProf[i].mX[0], mAngulerDeviationProf[i].mR);
+  }
+  fOut->cd();
+  hXY->Write();
+  hXY.reset(); // delete the histogram before closing the output file
+  fOut->Close();
+  */
+}

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::CalibVDrift + ;
+
+#endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -25,8 +25,8 @@ o2_add_library(TRDWorkflow
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackingWorkflow.cxx
                        src/EntropyDecoderSpec.cxx
-                       src/EntropyEncoderSpec.cxx                       
-                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::GPUTracking O2::GlobalTrackingWorkflow)
+                       src/EntropyEncoderSpec.cxx
+                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflow)
 
                    #o2_target_root_dictionary(TRDWorkflow
                    # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -17,6 +17,7 @@
 #include "Framework/Task.h"
 #include "TStopwatch.h"
 #include "TRDBase/GeometryFlat.h"
+#include "TRDCalibration/CalibVDrift.h"
 #include "GPUO2Interface.h"
 #include "GPUTRDTracker.h"
 
@@ -41,6 +42,7 @@ class TRDGlobalTracking : public o2::framework::Task
   std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
   bool mUseTrackletTransform{false};                  ///< if true, output from TrackletTransformer is used instead of uncalibrated Tracklet64 directly
+  CalibVDrift mCalibVDrift{};                         ///< steers the vDrift calibration
   TStopwatch mTimer;
 };
 

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -101,7 +101,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   int nTrackletsCal = 0;
 
   if (mUseTrackletTransform) {
-    cTrklts.emplace(pc.inputs().get<gsl::span<CalibratedTracklet>>("trdctracklets")); // MC labels associated to the input digits
+    cTrklts.emplace(pc.inputs().get<gsl::span<CalibratedTracklet>>("trdctracklets"));
     cTrkltsPtr = &cTrklts.value();
     nTrackletsCal = cTrkltsPtr->size();
     LOGF(INFO, "Got %i calibrated tracklets as input", nTrackletsCal);

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -301,7 +301,7 @@ class trackInterface<GPUTPCGMTrackParam> : public GPUTPCGMTrackParam
   GPUd() const float* getPar() const { return GetPar(); }
   GPUd() const float* getCov() const { return GetCov(); }
   GPUd() float getTime() const { return -1.f; }
-
+  GPUd() void resetCovariance(float s) { ResetCovariance(); }
   GPUd() void setAlpha(float alpha) { mAlpha = alpha; }
   GPUd() void set(float x, float alpha, const float param[5], const float cov[15])
   {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -122,6 +122,9 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);
   GPUd() bool CalculateSpacePoints(int iCollision = 0);
   GPUd() bool FollowProlongation(PROP* prop, TRDTRK* t, int threadId, int collisionId);
+  GPUd() int FillImpactAngleHistograms(PROP* prop, TRDTRK* t);
+  GPUd() void ResetImpactAngleHistograms();
+  GPUd() int PropagateToLayerAndUpdate(PROP* prop, TRDTRK* trkWork, int iLayer, bool doUpdate = true);
   GPUd() int GetDetectorNumber(const float zPos, const float alpha, const int layer) const;
   GPUd() bool AdjustSector(PROP* prop, TRDTRK* t) const;
   GPUd() int GetSector(float alpha) const;
@@ -146,6 +149,7 @@ class GPUTRDTracker_t : public GPUProcessor
   // settings
   GPUd() void SetTrkltTransformNeeded(bool flag) { mTrkltTransfNeeded = flag; }
   GPUd() void SetProcessPerTimeFrame() { mProcessPerTimeFrame = true; }
+  GPUd() void SetDoImpactAngleHistograms(bool flag) { mDoImpactAngleHistograms = flag; }
   GPUd() void SetMCEvent(AliMCEvent* mc) { mMCEvent = mc; }
   GPUd() void EnableDebugOutput() { mDebugOutput = true; }
   GPUd() void SetMaxEta(float maxEta) { mMaxEta = maxEta; }
@@ -164,6 +168,8 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() TRDTRK* Tracks() const { return mTracks; }
   GPUd() int NTracklets() const { return mNTracklets; }
   GPUd() GPUTRDSpacePointInternal* SpacePoints() const { return mSpacePoints; }
+  GPUd() float* AngleDiffSums() const { return mAngleDiffSums; }
+  GPUd() short* AngleDiffCounters() const { return mAngleDiffCounters; }
   GPUd() GPUTRDTrackletWord* Tracklets() const { return mTracklets; }
   GPUd() void DumpTracks();
 
@@ -172,6 +178,9 @@ class GPUTRDTracker_t : public GPUProcessor
   bool mIsInitialized;                     // flag is set upon initialization
   bool mTrkltTransfNeeded;                 // if the output of the TRDTrackletTransformer is used we don't need to do the coordinate transformation for the tracklets
   bool mProcessPerTimeFrame;               // if true, tracking is done per time frame instead of on a single events basis
+  bool mDoImpactAngleHistograms;           // if true, impact angle vs angle difference histograms are filled
+  short mNAngleHistogramBins;              // number of bins per chamber for the angular difference histograms
+  float mAngleHistogramRange;              // range of impact angles covered by each histogram
   short mMemoryPermanent;                  // size of permanent memory for the tracker
   short mMemoryTracklets;                  // size of memory for TRD tracklets
   short mMemoryTracks;                     // size of memory for tracks (used for i/o)
@@ -196,6 +205,8 @@ class GPUTRDTracker_t : public GPUProcessor
   Hypothesis* mHypothesis;                 // array with multiple track hypothesis
   TRDTRK* mCandidates;                     // array of tracks for multiple hypothesis tracking
   GPUTRDSpacePointInternal* mSpacePoints;  // array with tracklet coordinates in global tracking frame
+  float* mAngleDiffSums;                   // array with sum of angular differences for a given bin
+  short* mAngleDiffCounters;               // array with number of entries for a given bin
   int* mTrackletLabels;                    // array with MC tracklet labels
   TRD_GEOMETRY_CONST GPUTRDGeometry* mGeo; // TRD geometry
   /// ---- error parametrization depending on magnetic field ----


### PR DESCRIPTION
- template for vDrift calibration
- after global tracking angular differences between TRD-only tracks and tracklets are collected
- small correction to always update to the correct pad plane during track following, since the pad row size depends also on the stack, not only on the layer