### PR TITLE
fix for TOF cosmic calib

### DIFF
--- a/Detectors/TOF/reconstruction/src/CosmicProcessor.cxx
+++ b/Detectors/TOF/reconstruction/src/CosmicProcessor.cxx
@@ -22,13 +22,17 @@ using namespace o2::tof;
 void CosmicProcessor::clear()
 {
   mCosmicInfo.clear();
-  for (int i = 0; i < Geo::NCHANNELS; i++) {
-    mCounters[i] = 0;
-  }
+  mCosmicInfo.reserve(5200);
+
+  memset(mCounters, 0, sizeof(int) * Geo::NCHANNELS);
 }
 //__________________________________________________
 void CosmicProcessor::process(DigitDataReader& reader, bool fill)
 {
+  if (mCosmicInfo.size() > 5000) {
+    return;
+  }
+
   TStopwatch timerProcess;
   timerProcess.Start();
 
@@ -39,6 +43,8 @@ void CosmicProcessor::process(DigitDataReader& reader, bool fill)
   int ndig = array->size();
   int ndig2 = ndig * fill;
 
+  int npair = 0;
+
   int bcdist = 200;
   float thr = 5000000; // in ps
 
@@ -46,6 +52,9 @@ void CosmicProcessor::process(DigitDataReader& reader, bool fill)
   float pos1[3], pos2[3];
 
   for (int i = 0; i < ndig; i++) {
+    if (npair >= 150) {
+      break;
+    }
     auto& dig1 = (*array)[i];
     int ch1 = dig1.getChannel();
     mCounters[ch1]++;
@@ -100,6 +109,7 @@ void CosmicProcessor::process(DigitDataReader& reader, bool fill)
         continue;
       }
 
+      npair++;
       mCosmicInfo.emplace_back(ch1, ch2, dtime, tot1, tot2, l, tm1, tm2);
     }
   }

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -76,7 +76,7 @@ class TOFDPLClustererTask
     // get digit data
     auto digits = pc.inputs().get<gsl::span<o2::tof::Digit>>("tofdigits");
     auto row = pc.inputs().get<gsl::span<o2::tof::ReadoutWindowData>>("readoutwin");
-    
+
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
     mClusterer.setFirstOrbit(dh->firstTForbit);
 

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -75,9 +75,8 @@ class TOFDPLClustererTask
     mTimer.Start(false);
     // get digit data
     auto digits = pc.inputs().get<gsl::span<o2::tof::Digit>>("tofdigits");
-    auto rowp = pc.inputs().get<gsl::span<o2::tof::ReadoutWindowData>>("readoutwin");
-    auto row = &rowp;
-
+    auto row = pc.inputs().get<gsl::span<o2::tof::ReadoutWindowData>>("readoutwin");
+    
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
     mClusterer.setFirstOrbit(dh->firstTForbit);
 
@@ -129,9 +128,9 @@ class TOFDPLClustererTask
       mCosmicProcessor.clear();
     }
 
-    for (int i = 0; i < row->size(); i++) {
-      //printf("# TOF readout window for clusterization = %d/%lu (N digits = %d)\n", i, row->size(), row->at(i).size());
-      auto digitsRO = row->at(i).getBunchChannelData(digits);
+    for (int i = 0; i < row.size(); i++) {
+      //printf("# TOF readout window for clusterization = %d/%lu (N digits = %d)\n", i, row.size(), row[i].size());
+      auto digitsRO = row[i].getBunchChannelData(digits);
       mReader.setDigitArray(&digitsRO);
 
       if (mIsCosmic) {

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -75,7 +75,8 @@ class TOFDPLClustererTask
     mTimer.Start(false);
     // get digit data
     auto digits = pc.inputs().get<gsl::span<o2::tof::Digit>>("tofdigits");
-    auto row = pc.inputs().get<std::vector<o2::tof::ReadoutWindowData>*>("readoutwin");
+    auto rowp = pc.inputs().get<gsl::span<o2::tof::ReadoutWindowData>>("readoutwin");
+    auto row = &rowp;
 
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
     mClusterer.setFirstOrbit(dh->firstTForbit);


### PR DESCRIPTION
Reserve memory to avoid allocation when emplacing_back elements (causing problem for high message rates)