### PR TITLE
DPL: make sure the WSDriverClient flushes only on main thread

### DIFF
--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -78,9 +78,10 @@ class DataRelayer
   /// This invokes the appropriate `InputRoute::danglingChecker` on every
   /// entry in the cache and if it returns true, it creates a new
   /// cache entry by invoking the associated `InputRoute::expirationHandler`.
+  /// @a createNew true if the dangling inputs are allowed to create new slots.
   /// @return true if there were expirations, false if not.
   ActivityStats processDanglingInputs(std::vector<ExpirationHandler> const&,
-                                      ServiceRegistry& context);
+                                      ServiceRegistry& context, bool createNew);
 
   /// This is used to ask for relaying a given (header,payload) pair.
   /// Notice that we expect that the header is an O2 Header Stack

--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -37,6 +37,23 @@ enum struct StreamingState {
 
 /// Running state information of a given device
 struct DeviceState {
+  /// Motivation for the loop being triggered.
+  enum LoopReason : int {
+    NO_REASON = 0,          // No tracked reason to wake up
+    METRICS_MUST_FLUSH = 1, // Metrics available to flush
+    SIGNAL_ARRIVED = 2,     // Signal has arrived
+    DATA_SOCKET_POLLED = 4, // Data has arrived
+    DATA_INCOMING = 8,      // Data was read
+    DATA_OUTGOING = 16,     // Data was written
+    WS_COMMUNICATION = 32,  // Communication over WS
+    TIMER_EXPIRED = 64,     // Timer expired
+    WS_CONNECTED = 128,     // Connection to driver established
+    WS_CLOSING = 256,       // Events related to WS shutting down
+    WS_READING = 512,       // Events related to WS shutting down
+    WS_WRITING = 1024,      // Events related to WS shutting down
+    ASYNC_NOTIFICATION = 2048
+  };
+
   std::vector<InputChannelInfo> inputChannelInfos;
   StreamingState streaming = StreamingState::Streaming;
   bool quitRequested = false;
@@ -50,6 +67,7 @@ struct DeviceState {
   std::vector<uv_poll_t*> activeOutputPollers;
   /// The list of active signal handlers
   std::vector<uv_signal_t*> activeSignals;
+  int loopReason = 0;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -160,8 +160,6 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        size_t lastTimestamp = 0;
                        size_t firstTimestamp = -1;
                        size_t lastDecision = 0;
-                       static uint64_t now = 0;
-                       now = uv_hrtime();
                        static std::vector<MetricIndices> allIndices = createDefaultIndices(allDeviceMetrics);
                        for (size_t mi = 0; mi < allDeviceMetrics.size(); ++mi) {
                          auto& deviceMetrics = allDeviceMetrics[mi];
@@ -217,7 +215,9 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        static int stateTransitions = 0;
                        static int signalsCount = 0;
                        static int skippedCount = 0;
+                       static uint64_t now = 0;
                        static uint64_t lastSignal = 0;
+                       now = uv_hrtime();
                        while (!done) {
                          stateMetric(driverMetrics, (uint64_t)(currentState), stateTransitions++);
                          switch (currentState) {

--- a/Framework/Core/src/DPLWebSocket.cxx
+++ b/Framework/Core/src/DPLWebSocket.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceController.h"
 #include "DriverServerContext.h"
+#include "DriverClientContext.h"
 #include "HTTPParser.h"
 #include <algorithm>
 #include <atomic>
@@ -241,8 +242,9 @@ void close_client_websocket(uv_handle_t* stream)
 
 void websocket_client_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 {
-  WSDPLClient* client = (WSDPLClient*)stream->data;
-  assert(client);
+  DriverClientContext* context = (DriverClientContext*)stream->data;
+  context->state->loopReason |= DeviceState::WS_COMMUNICATION;
+  assert(context->client);
   if (nread == 0) {
     return;
   }
@@ -262,7 +264,7 @@ void websocket_client_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_
   }
   try {
     LOG(debug) << "Data received from server";
-    parse_http_request(buf->base, nread, client);
+    parse_http_request(buf->base, nread, context->client);
   } catch (RuntimeErrorRef& ref) {
     auto& err = o2::framework::error_from_ref(ref);
     LOG(ERROR) << "Error while parsing request: " << err.what;
@@ -270,14 +272,15 @@ void websocket_client_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_
 }
 
 // FIXME: mNonce should be random
-WSDPLClient::WSDPLClient(uv_stream_t* s, DeviceSpec const& spec, std::function<void()> handshake, std::unique_ptr<WebSocketHandler> handler)
+WSDPLClient::WSDPLClient(uv_stream_t* s, std::unique_ptr<DriverClientContext> context, std::function<void()> handshake, std::unique_ptr<WebSocketHandler> handler)
   : mStream{s},
     mNonce{"dGhlIHNhbXBsZSBub25jZQ=="},
-    mSpec{spec},
+    mContext{std::move(context)},
     mHandshake{handshake},
     mHandler{std::move(handler)}
 {
-  s->data = this;
+  mContext->client = this;
+  s->data = mContext.get();
   uv_read_start((uv_stream_t*)s, (uv_alloc_cb)my_alloc_cb, websocket_client_callback);
 }
 
@@ -285,8 +288,8 @@ void WSDPLClient::sendHandshake()
 {
   std::vector<std::pair<std::string, std::string>> headers = {
     {{"x-dpl-pid"}, std::to_string(getpid())},
-    {{"x-dpl-id"}, mSpec.id},
-    {{"x-dpl-name"}, mSpec.name}};
+    {{"x-dpl-id"}, mContext->spec.id},
+    {{"x-dpl-name"}, mContext->spec.name}};
   std::string handShakeString = encode_websocket_handshake_request("/", "dpl", 13, mNonce.c_str(), headers);
   this->write(handShakeString.c_str(), handShakeString.size());
 }
@@ -341,33 +344,47 @@ void WSDPLClient::endHeaders()
   mHandshake();
 }
 
+struct WriteRequestContext {
+  uv_buf_t buf;
+  DeviceState* state;
+};
+
+struct BulkWriteRequestContext {
+  std::vector<uv_buf_t> buffers;
+  DeviceState* state;
+};
+
 void ws_client_write_callback(uv_write_t* h, int status)
 {
+  WriteRequestContext* context = (WriteRequestContext*)h->data;
   if (status) {
     LOG(ERROR) << "uv_write error: " << uv_err_name(status);
     free(h);
     return;
   }
-  if (h->data) {
-    free(h->data);
+  context->state->loopReason |= DeviceState::WS_COMMUNICATION;
+  if (context->buf.base) {
+    free(context->buf.base);
   }
+  delete context;
   free(h);
 }
 
 void ws_client_bulk_write_callback(uv_write_t* h, int status)
 {
-  if (status) {
+  BulkWriteRequestContext* context = (BulkWriteRequestContext*)h->data;
+  context->state->loopReason |= DeviceState::WS_COMMUNICATION;
+  if (status < 0) {
     LOG(ERROR) << "uv_write error: " << uv_err_name(status);
     free(h);
     return;
   }
-  std::vector<uv_buf_t>* buffers = (std::vector<uv_buf_t>*)h->data;
-  if (buffers) {
-    for (auto& b : *buffers) {
+  if (context->buffers.size()) {
+    for (auto& b : context->buffers) {
       free(b.base);
     }
   }
-  delete buffers;
+  delete context;
   free(h);
 }
 
@@ -380,10 +397,12 @@ void WSDPLClient::body(char* data, size_t s)
 /// Helper to return an error
 void WSDPLClient::write(char const* message, size_t s)
 {
-  uv_buf_t bfr = uv_buf_init(strdup(message), s);
+  WriteRequestContext* context = new WriteRequestContext;
+  context->buf = uv_buf_init(strdup(message), s);
+  context->state = mContext->state;
   uv_write_t* write_req = (uv_write_t*)malloc(sizeof(uv_write_t));
-  write_req->data = bfr.base;
-  uv_write(write_req, (uv_stream_t*)mStream, &bfr, 1, ws_client_write_callback);
+  write_req->data = context;
+  uv_write(write_req, (uv_stream_t*)mStream, &context->buf, 1, ws_client_write_callback);
 }
 
 void WSDPLClient::write(std::vector<uv_buf_t>& outputs)
@@ -392,10 +411,12 @@ void WSDPLClient::write(std::vector<uv_buf_t>& outputs)
     return;
   }
   uv_write_t* write_req = (uv_write_t*)malloc(sizeof(uv_write_t));
-  std::vector<uv_buf_t>* buffers = new std::vector<uv_buf_t>;
-  buffers->swap(outputs);
-  write_req->data = buffers;
-  uv_write(write_req, (uv_stream_t*)mStream, &buffers->at(0), buffers->size(), ws_client_bulk_write_callback);
+  BulkWriteRequestContext* context = new BulkWriteRequestContext;
+  context->buffers.swap(outputs);
+  context->state = mContext->state;
+  write_req->data = context;
+  uv_write(write_req, (uv_stream_t*)mStream, &context->buffers.at(0),
+           context->buffers.size(), ws_client_bulk_write_callback);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/DPLWebSocket.h
+++ b/Framework/Core/src/DPLWebSocket.h
@@ -25,6 +25,7 @@ namespace o2::framework
 
 struct DeviceSpec;
 struct DriverServerContext;
+struct DriverClientContext;
 
 struct WSError {
   int code;
@@ -66,7 +67,11 @@ struct WSDPLClient : public HTTPParser {
   /// to the driver.
   /// @a spec the DeviceSpec associated with this client
   /// @a handshake a callback to invoke whenever we have a successful handshake
-  WSDPLClient(uv_stream_t* stream, DeviceSpec const& spec, std::function<void()> handshake, std::unique_ptr<WebSocketHandler> handler);
+  WSDPLClient(uv_stream_t* stream,
+              std::unique_ptr<DriverClientContext> context,
+              std::function<void()> handshake,
+              std::unique_ptr<WebSocketHandler> handler);
+
   void replyVersion(std::string_view const& s) override;
   void replyCode(std::string_view const& s) override;
   void header(std::string_view const& k, std::string_view const& v) override;
@@ -85,9 +90,9 @@ struct WSDPLClient : public HTTPParser {
   bool isHandshaken() { return mHandshaken; }
 
   std::string mNonce;
-  DeviceSpec const& mSpec;
   std::atomic<bool> mHandshaken = false;
   std::function<void()> mHandshake;
+  std::unique_ptr<DriverClientContext> mContext;
   std::unique_ptr<WebSocketHandler> mHandler;
   uv_stream_t* mStream = nullptr;
   std::map<std::string, std::string> mHeaders;

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -73,9 +73,11 @@ struct ServiceKindExtractor<ConfigurationInterface> {
 
 /// We schedule a timer to reduce CPU usage.
 /// Watching stdin for commands probably a better approach.
-void idle_timer(uv_timer_t* handle)
+void on_idle_timer(uv_timer_t* handle)
 {
   ZoneScopedN("Idle timer");
+  DeviceState* state = (DeviceState*)handle->data;
+  state->loopReason |= DeviceState::TIMER_EXPIRED;
 }
 
 DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry& registry, DeviceState& state)
@@ -140,23 +142,27 @@ void run_completion(uv_work_t* handle, int status)
 
 // Context for polling
 struct PollerContext {
-  char const* name;
-  uv_loop_t* loop;
-  DataProcessingDevice* device;
+  char const* name = nullptr;
+  uv_loop_t* loop = nullptr;
+  DataProcessingDevice* device = nullptr;
+  DeviceState* state = nullptr;
   int fd;
 };
 
 void on_socket_polled(uv_poll_t* poller, int status, int events)
 {
   PollerContext* context = (PollerContext*)poller->data;
+  context->state->loopReason |= DeviceState::DATA_SOCKET_POLLED;
   switch (events) {
     case UV_READABLE: {
       ZoneScopedN("socket readable event");
       LOG(debug) << "socket polled UV_READABLE: " << context->name;
+      context->state->loopReason |= DeviceState::DATA_INCOMING;
     } break;
     case UV_WRITABLE: {
       ZoneScopedN("socket writeable");
       LOG(debug) << "socket polled UV_WRITEABLE";
+      context->state->loopReason |= DeviceState::DATA_OUTGOING;
     } break;
     case UV_DISCONNECT: {
       ZoneScopedN("socket disconnect");
@@ -168,6 +174,12 @@ void on_socket_polled(uv_poll_t* poller, int status, int events)
     } break;
   }
   // We do nothing, all the logic for now stays in DataProcessingDevice::doRun()
+}
+
+void on_communication_requested(uv_async_t* s)
+{
+  DeviceState* state = (DeviceState*)s->data;
+  state->loopReason |= DeviceState::METRICS_MUST_FLUSH;
 }
 
 /// This  takes care  of initialising  the device  from its  specification. In
@@ -264,7 +276,8 @@ void DataProcessingDevice::Init()
   }
   uv_async_t* wakeHandle = (uv_async_t*)malloc(sizeof(uv_async_t));
   assert(mState.loop);
-  int res = uv_async_init(mState.loop, wakeHandle, nullptr);
+  int res = uv_async_init(mState.loop, wakeHandle, on_communication_requested);
+  wakeHandle->data = &mState;
   if (res < 0) {
     LOG(ERROR) << "Unable to initialise subscription";
   }
@@ -283,6 +296,8 @@ void on_signal_callback(uv_signal_t* handle, int signum)
 {
   ZoneScopedN("Signal callaback");
   LOG(debug) << "Signal " << signum << " received.";
+  DeviceState* state = (DeviceState*)handle->data;
+  state->loopReason |= DeviceState::SIGNAL_ARRIVED;
 }
 
 void DataProcessingDevice::InitTask()
@@ -305,12 +320,8 @@ void DataProcessingDevice::InitTask()
   // is no data pending to be processed.
   uv_signal_t* sigusr1Handle = (uv_signal_t*)malloc(sizeof(uv_signal_t));
   uv_signal_init(mState.loop, sigusr1Handle);
+  sigusr1Handle->data = &mState;
   uv_signal_start(sigusr1Handle, on_signal_callback, SIGUSR1);
-  // Handle SIGWINCH by simply forcing the event loop to continue.
-  // This will hopefully hide it from FairMQ on linux.
-  uv_signal_t* sigwinchHandle = (uv_signal_t*)malloc(sizeof(uv_signal_t));
-  uv_signal_init(mState.loop, sigwinchHandle);
-  uv_signal_start(sigwinchHandle, on_signal_callback, SIGWINCH);
 
   // We add a timer only in case a channel poller is not there.
   if ((mStatefulProcess != nullptr) || (mStatelessProcess != nullptr)) {
@@ -340,6 +351,7 @@ void DataProcessingDevice::InitTask()
       pCtx->name = strdup(x.first.c_str());
       pCtx->loop = mState.loop;
       pCtx->device = this;
+      pCtx->state = &mState;
       pCtx->fd = zmq_fd;
       poller->data = pCtx;
       uv_poll_init(mState.loop, poller, zmq_fd);
@@ -372,6 +384,7 @@ void DataProcessingDevice::InitTask()
         pCtx->name = strdup(x.first.c_str());
         pCtx->loop = mState.loop;
         pCtx->device = this;
+        pCtx->state = &mState;
         pCtx->fd = zmq_fd;
         poller->data = pCtx;
         uv_poll_init(mState.loop, poller, zmq_fd);
@@ -385,7 +398,8 @@ void DataProcessingDevice::InitTask()
     // A two second timer to stop internal devices which do not want to
     uv_timer_t* timer = (uv_timer_t*)malloc(sizeof(uv_timer_t));
     uv_timer_init(mState.loop, timer);
-    uv_timer_start(timer, idle_timer, 2000, 2000);
+    timer->data = &mState;
+    uv_timer_start(timer, on_idle_timer, 2000, 2000);
     mState.activeTimers.push_back(timer);
   }
 
@@ -453,6 +467,37 @@ bool DataProcessingDevice::ConditionalRun()
       shouldNotWait = true;
     }
     uv_run(mState.loop, shouldNotWait ? UV_RUN_NOWAIT : UV_RUN_ONCE);
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::METRICS_MUST_FLUSH) {
+      LOG(debug) << "New metric to be sent";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::SIGNAL_ARRIVED) {
+      LOG(debug) << "Signal arrived";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_SOCKET_POLLED) {
+      LOG(debug) << "Socket polled";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_INCOMING) {
+      LOG(debug) << "Data read";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_OUTGOING) {
+      LOG(debug) << "Data written";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::WS_COMMUNICATION) {
+      LOG(debug) << "Communication with WS";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::TIMER_EXPIRED) {
+      LOG(debug) << "Timer expired";
+    }
+    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::WS_CONNECTED) {
+      LOG(debug) << "WS Connected";
+    }
+    if (shouldNotWait) {
+      LOG(debug) << "Should not wait";
+    }
+    if ((mDataProcessorContexes.at(0).state->loopReason == DeviceState::NO_REASON) && (shouldNotWait == false)) {
+      LOG(debug) << "Unknown reason to trigger the loop";
+    }
+    mDataProcessorContexes.at(0).state->loopReason = DeviceState::NO_REASON;
 
     // A new state was requested, we exit.
     if (NewStatePending()) {

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -614,6 +614,10 @@ void DataProcessingDevice::doRun(DataProcessorContext& context)
     registry->get<ControlService>().notifyStreamingState(state->streaming);
   };
 
+  if (context.state->streaming == StreamingState::Idle) {
+    return;
+  }
+
   context.completed->clear();
   context.completed->reserve(16);
   *context.wasActive |= DataProcessingDevice::tryDispatchComputation(context, *context.completed);
@@ -623,7 +627,7 @@ void DataProcessingDevice::doRun(DataProcessorContext& context)
   if (*context.wasActive == false) {
     context.registry->get<CallbackService>()(CallbackService::Id::Idle);
   }
-  auto activity = context.relayer->processDanglingInputs(*context.expirationHandlers, *context.registry);
+  auto activity = context.relayer->processDanglingInputs(*context.expirationHandlers, *context.registry, true);
   *context.wasActive |= activity.expiredSlots > 0;
 
   context.completed->clear();
@@ -645,7 +649,7 @@ void DataProcessingDevice::doRun(DataProcessorContext& context)
     // FIXME: not sure this is the correct way to drain the queues, but
     // I guess we will see.
     while (DataProcessingDevice::tryDispatchComputation(context, *context.completed)) {
-      context.relayer->processDanglingInputs(*context.expirationHandlers, *context.registry);
+      context.relayer->processDanglingInputs(*context.expirationHandlers, *context.registry, false);
     }
     EndOfStreamContext eosContext{*context.registry, *context.allocator};
 

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -82,7 +82,7 @@ TimesliceId DataRelayer::getTimesliceForSlot(TimesliceSlot slot)
 }
 
 DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& expirationHandlers,
-                                                              ServiceRegistry& services)
+                                                              ServiceRegistry& services, bool createNew)
 {
   std::scoped_lock<LockableBase(std::recursive_mutex)> lock(mMutex);
 
@@ -93,8 +93,10 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
   }
   // Create any slot for the time based fields
   std::vector<TimesliceSlot> slotsCreatedByHandlers;
-  for (auto& handler : expirationHandlers) {
-    slotsCreatedByHandlers.push_back(handler.creator(mTimesliceIndex));
+  if (createNew) {
+    for (auto& handler : expirationHandlers) {
+      slotsCreatedByHandlers.push_back(handler.creator(mTimesliceIndex));
+    }
   }
   if (slotsCreatedByHandlers.empty() == false) {
     activity.newSlots++;

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -51,14 +51,20 @@ namespace o2::framework
 
 namespace detail
 {
-void timer_callback(uv_timer_t*)
+void timer_callback(uv_timer_t* handle)
 {
   // We simply wake up the event loop. Nothing to be done here.
+  DeviceState* state = (DeviceState*)handle->data;
+  state->loopReason |= DeviceState::TIMER_EXPIRED;
+  state->loopReason |= DeviceState::DATA_INCOMING;
 }
 
-void signal_callback(uv_signal_t*, int)
+void signal_callback(uv_signal_t* handle, int)
 {
   // We simply wake up the event loop. Nothing to be done here.
+  DeviceState* state = (DeviceState*)handle->data;
+  state->loopReason |= DeviceState::SIGNAL_ARRIVED;
+  state->loopReason |= DeviceState::DATA_INCOMING;
 }
 } // namespace detail
 
@@ -77,6 +83,7 @@ struct ExpirationHandlerHelpers {
       // timeslot creation and record expiration still happens
       // in a synchronous way.
       uv_timer_t* timer = (uv_timer_t*)(malloc(sizeof(uv_timer_t)));
+      timer->data = &state;
       uv_timer_init(state.loop, timer);
       uv_timer_start(timer, detail::timer_callback, period / 1000, period / 1000);
       state.activeTimers.push_back(timer);
@@ -99,6 +106,7 @@ struct ExpirationHandlerHelpers {
       // in a synchronous way.
       uv_signal_t* sh = (uv_signal_t*)(malloc(sizeof(uv_signal_t)));
       uv_signal_init(state.loop, sh);
+      sh->data = &state;
       uv_signal_start(sh, detail::signal_callback, SIGUSR1);
       state.activeSignals.push_back(sh);
 

--- a/Framework/Core/src/DriverClientContext.h
+++ b/Framework/Core/src/DriverClientContext.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+/// Helper struct which holds all the lists the Driver needs to know about.
+#ifndef O2_FRAMEWORK_DRIVERCLIENTCONTEXT_H_
+#define O2_FRAMEWORK_DRIVERCLIENTCONTEXT_H_
+
+namespace o2::framework
+{
+struct DeviceSpec;
+struct DeviceState;
+struct WSDPLClient;
+
+/// Context for the client callbacks
+struct DriverClientContext {
+  DeviceSpec const& spec;
+  DeviceState* state = nullptr;
+  WSDPLClient* client = nullptr;
+};
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DRIVERCLIENTCONTEXT_H_

--- a/Framework/Core/src/WSDriverClient.cxx
+++ b/Framework/Core/src/WSDriverClient.cxx
@@ -9,9 +9,11 @@
 // or submit itself to any jurisdiction.
 #include "WSDriverClient.h"
 #include "Framework/DeviceState.h"
+#include "Framework/DeviceSpec.h"
 #include "Framework/Logger.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/DeviceSpec.h"
+#include "DriverClientContext.h"
 #include "DPLWebSocket.h"
 #include <uv.h>
 
@@ -58,34 +60,51 @@ struct ClientWebSocketHandler : public WebSocketHandler {
   WSDriverClient& mClient;
 };
 
+struct ConnectionContext {
+  WSDriverClient* client;
+  DeviceState* state;
+};
+
 void on_connect(uv_connect_t* connection, int status)
 {
   if (status < 0) {
     LOG(ERROR) << "Unable to connect to driver.";
     return;
   }
-  WSDriverClient* client = (WSDriverClient*)connection->data;
+  ConnectionContext* context = (ConnectionContext*)connection->data;
+  WSDriverClient* client = context->client;
+  context->state->loopReason |= DeviceState::WS_CONNECTED;
   auto onHandshake = [client]() {
     client->flushPending();
   };
   std::lock_guard<std::mutex> lock(client->mutex());
   auto handler = std::make_unique<ClientWebSocketHandler>(*client);
-  client->setDPLClient(std::make_unique<WSDPLClient>(connection->handle, client->spec(), onHandshake, std::move(handler)));
+  auto clientContext = std::make_unique<o2::framework::DriverClientContext>(DriverClientContext{client->spec(), context->state});
+  client->setDPLClient(std::make_unique<WSDPLClient>(connection->handle, std::move(clientContext), onHandshake, std::move(handler)));
   client->sendHandshake();
 }
 
 /// Helper to connect to a
-void connectToDriver(WSDriverClient* driver, uv_loop_t* loop, char const* address, short port)
+void connectToDriver(WSDriverClient* driver, DeviceState* state, char const* address, short port)
 {
   uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
-  uv_tcp_init(loop, socket);
+  uv_tcp_init(state->loop, socket);
   uv_connect_t* connection = (uv_connect_t*)malloc(sizeof(uv_connect_t));
-  connection->data = driver;
+  ConnectionContext* context = new ConnectionContext;
+  context->client = driver;
+  context->state = state;
+  connection->data = context;
 
   struct sockaddr_in dest;
   uv_ip4_addr(strdup(address), port, &dest);
 
   uv_tcp_connect(connection, socket, (const struct sockaddr*)&dest, on_connect);
+}
+
+void on_awake_main_thread(uv_async_t* handle)
+{
+  DeviceState* state = (DeviceState*)handle->data;
+  state->loopReason |= DeviceState::ASYNC_NOTIFICATION;
 }
 
 WSDriverClient::WSDriverClient(ServiceRegistry& registry, DeviceState& state, char const* ip, unsigned short port)
@@ -94,9 +113,10 @@ WSDriverClient::WSDriverClient(ServiceRegistry& registry, DeviceState& state, ch
   // Must connect the device to the server and send a websocket request.
   // On successful connection we can then start to send commands to the driver.
   // We keep a backlog to make sure we do not lose messages.
-  connectToDriver(this, state.loop, ip, port);
+  connectToDriver(this, &state, ip, port);
   this->mAwakeMainThread = (uv_async_t*)malloc(sizeof(uv_async_t));
-  uv_async_init(state.loop, this->mAwakeMainThread, nullptr);
+  this->mAwakeMainThread->data = &state;
+  uv_async_init(state.loop, this->mAwakeMainThread, on_awake_main_thread);
 }
 
 WSDriverClient::~WSDriverClient()

--- a/Framework/Core/src/WSDriverClient.h
+++ b/Framework/Core/src/WSDriverClient.h
@@ -20,6 +20,7 @@
 #include <atomic>
 
 typedef struct uv_connect_s uv_connect_t;
+typedef struct uv_async_s uv_async_t;
 
 namespace o2::framework
 {
@@ -36,6 +37,7 @@ class WSDriverClient : public DriverClient
 {
  public:
   WSDriverClient(ServiceRegistry& registry, DeviceState& state, char const* ip, unsigned short port);
+  ~WSDriverClient();
   void tell(const char* msg, size_t s, bool flush = true) final;
   void observe(const char* command, std::function<void(char const*)>) final;
   void flushPending() final;
@@ -47,11 +49,14 @@ class WSDriverClient : public DriverClient
   std::mutex& mutex() { return mClientMutex; }
 
  private:
+  /// Use this to awake the main thread.
+  void awake();
   // Whether or not we managed to connect.
   std::atomic<bool> mConnected = false;
   std::mutex mClientMutex;
   DeviceSpec const& mSpec;
   std::vector<uv_buf_t> mBacklog;
+  uv_async_t* mAwakeMainThread = nullptr;
   uv_connect_t* mConnection = nullptr;
   std::unique_ptr<WSDPLClient> mClient;
 };


### PR DESCRIPTION
This will avoid thread safety issues within libuv. Notice this
will most likely kill any rate limiting as currently implemented
as I will need a protection against event loop being waken up by
metrics rather than sigusr1.