### PR TITLE
Fix for index shift in detector list

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
@@ -86,7 +86,8 @@ class SimTraits
       /*FT0*/ VS{ "FT0Hit" },
       /*FV0*/ VS{ "FV0Hit" },
       /*FDD*/ VS{ "FDDHit" },
-      /*ACO*/ VS{ "ACOHit" }
+      /*ACO*/ VS{ "ACOHit" },
+      /*CTP*/ VS{ "CTPHit" }
 #ifdef ENABLE_UPGRADES
       ,
       /*IT3*/ VS{ "IT3Hit" },


### PR DESCRIPTION
Hi @sawenzel @shahor02,
I am not sure if this is reasonable, as I don't know whether `CTP` has hits. 
We observed a shift in accessing the `DETECTORBRANCHNAMES` detector list by this line in writing trees by migrateSimFiles macro:
https://github.com/AliceO2Group/AliceO2/blob/b80c66b08e5aca3eafcf8e09158b0f588a3bf388/macro/migrateSimFiles.C#L89

I know this would not affect others but upgrade simulations, unless we are going to add further pseudo detector for run 3.
Any other option is welcome, I would just like to restore the expected behaviour. 

Thanks and cheers