### PR TITLE
 AutoSave option for RootTreeWriter 

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/TrackCosmicsWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TrackCosmicsWriterSpec.cxx
@@ -37,6 +37,8 @@ DataProcessorSpec getTrackCosmicsWriterSpec(bool useMC)
   return MakeRootTreeWriterSpec("cosmic-track-writer",
                                 "cosmics.root",
                                 "cosmics",
+                                -1,  // do not limit number of events to store
+                                100, // periodically autosave
                                 BranchDefinition<TracksType>{InputSpec{"tracks", "GLO", "COSMICTRC", 0},
                                                              "tracks",
                                                              "tracks-branch-name",

--- a/Framework/Utils/include/DPLUtils/RootTreeWriter.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeWriter.h
@@ -363,6 +363,17 @@ class RootTreeWriter
     mFile.reset(nullptr);
   }
 
+  /// autosave the tree
+  void autoSave()
+  {
+    if (mIsClosed || !mFile) {
+      return;
+    }
+    mTree->SetEntries();
+    LOG(INFO) << "Autosaving " << mTree->GetName() << " at entry " << mTree->GetEntries();
+    mTree->AutoSave("overwrite");
+  }
+
   bool isClosed() const
   {
     return mIsClosed;


### PR DESCRIPTION
* AutoSave option for RootTreeWriter
`--autosave <n>` option allows to save the tree after every n events.
The default is -1 (autosave off), can be changed in the MakeRootTreeWriterSpec
constructor by providing an integer argument coming after (not necessarilly
immidiately) the number or events.

* Cosmics writer: example of AutoSave request in MakeRootTreeWriterSpec