### PR TITLE
Always set ConfigurableParam provenance, add provenance getter

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -242,7 +242,7 @@ class ConfigurableParam
   // provide a path to a configuration file with ConfigurableParam key/values
   // If nonempty comma-separated paramsList is provided, only those params will
   // be updated, absence of data for any of requested params will lead to fatal
-  static void updateFromFile(std::string const&, std::string const& paramsList = "");
+  static void updateFromFile(std::string const&, std::string const& paramsList = "", bool unchangedOnly = false);
 
  protected:
   // constructor is doing nothing else but

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -83,6 +83,13 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   }
 
   // ----------------------------------------------------------------
+  // get the provenace of the member with given key
+  EParamProvenance getMemberProvenance(const std::string& key) const final
+  {
+    return getProvenance(getName() + '.' + key);
+  }
+
+  // ----------------------------------------------------------------
 
   // one of the key methods, using introspection to print itself
   void printKeyValues(bool showProv = true) const final


### PR DESCRIPTION
* Always set ConfigurableParam provenance, add provenance getter
  The provenance of the parameter was not changed if the new parameter happened to be equal to previous one.
  We need to set it to indicate that some action was applied to parameter (e.g. option from the CL was provided for it), even if the   
  value was not changed.

* ConfigurableParam::updateFromFile may skip already touched params 
  updateFromFile got extra argument `unchangedOnly` (false by default) which allows update only those parameters which where not touched by any `setValue` operation (i.e. whose provenance is `kCODE`). Needed to allow higher priority to upstream modification of parameters.