### PR TITLE
DataHeader::firstTForbit injection configuration for root-file driven reco workflows

### DIFF
--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "EMCALWorkflow/RecoWorkflow.h"
 #include "Algorithm/RangeTokenizer.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 #include <string>
 #include <stdexcept>
@@ -32,8 +33,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"do not initialize root files readers"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not initialize root file writers"}},
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
   };
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
   std::swap(workflowOptions, options);
 }
 
@@ -54,10 +59,15 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
   //bla
-  return o2::emcal::reco_workflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),        //
-                                               cfgc.options().get<bool>("enable-digits-printer"), //
-                                               cfgc.options().get<std::string>("input-type"),     //
-                                               cfgc.options().get<std::string>("output-type"),    //
-                                               cfgc.options().get<bool>("disable-root-input"),
-                                               cfgc.options().get<bool>("disable-root-output"));
+  auto wf = o2::emcal::reco_workflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),        //
+                                                  cfgc.options().get<bool>("enable-digits-printer"), //
+                                                  cfgc.options().get<std::string>("input-type"),     //
+                                                  cfgc.options().get<std::string>("output-type"),    //
+                                                  cfgc.options().get<bool>("disable-root-input"),
+                                                  cfgc.options().get<bool>("disable-root-output"));
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
+
+  return std::move(wf);
 }

--- a/Detectors/FIT/FDD/workflow/src/fdd-reco-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/fdd-reco-workflow.cxx
@@ -11,6 +11,7 @@
 #include "FDDWorkflow/RecoWorkflow.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 using namespace o2::framework;
 
@@ -20,14 +21,15 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  std::string keyvaluehelp("Semicolon separated key=value strings ...");
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 // ------------------------------------------------------------------
@@ -45,5 +47,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
 
-  return std::move(o2::fdd::getRecoWorkflow(useMC, disableRootInp, disableRootOut));
+  auto wf = o2::fdd::getRecoWorkflow(useMC, disableRootInp, disableRootOut);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);
+
+  return std::move(wf);
 }

--- a/Detectors/FIT/FT0/workflow/src/ft0-reco-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-reco-workflow.cxx
@@ -10,6 +10,7 @@
 
 #include "FT0Workflow/RecoWorkflow.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 using namespace o2::framework;
 
@@ -19,14 +20,15 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  std::string keyvaluehelp("Semicolon separated key=value strings ...");
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 // ------------------------------------------------------------------
@@ -46,5 +48,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
 
   LOG(INFO) << "WorkflowSpec getRecoWorkflow useMC " << useMC;
-  return std::move(o2::fit::getRecoWorkflow(useMC, disableRootInp, disableRootOut));
+  auto wf = o2::fit::getRecoWorkflow(useMC, disableRootInp, disableRootOut);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);
+
+  return std::move(wf);
 }

--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -25,6 +25,7 @@
 #include "GlobalTrackingWorkflow/CosmicsMatchingSpec.h"
 #include "GlobalTrackingWorkflow/TrackCosmicsWriterSpec.h"
 #include "Algorithm/RangeTokenizer.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 using namespace o2::framework;
 using DetID = o2::detectors::DetID;
@@ -41,6 +42,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
 
   std::swap(workflowOptions, options);
 }
@@ -129,5 +132,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::globaltracking::getTrackCosmicsWriterSpec(useMC));
   }
 
-  return specs;
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
 }

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -18,6 +18,7 @@
 #include "TOFWorkflowUtils/ClusterReaderSpec.h"
 #include "FT0Workflow/RecPointReaderSpec.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
@@ -40,6 +41,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"validate-with-ft0", o2::framework::VariantType::Bool, false, {"use FT0 time for vertex validation"}},
     {"vetex-track-matching-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertex-track associations or \"none\" to disable matching"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
 
   std::swap(workflowOptions, options);
 }
@@ -107,5 +110,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!disableRootOut) {
     specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(srcVT.none(), useMC));
   }
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
   return std::move(specs);
 }

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -19,6 +19,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 
@@ -37,6 +38,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
     {"disable-cascade-finder", o2::framework::VariantType::Bool, false, {"do not run cascade finder"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
 
   std::swap(workflowOptions, options);
 }
@@ -85,5 +88,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!disableRootOut) {
     specs.emplace_back(o2::vertexing::getSecondaryVertexWriterSpec());
   }
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
   return std::move(specs);
 }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-global.cxx
@@ -25,6 +25,7 @@
 #include "FairLogger.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 // FIT
 #include "FT0Workflow/RecPointReaderSpec.h"
@@ -37,17 +38,22 @@
 // including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"input-type", o2::framework::VariantType::String, "clusters,tracks", {"clusters, tracks, fit"}});
-  workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "matching-info,calib-info", {"matching-info, calib-info"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
-  workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"input-type", o2::framework::VariantType::String, "clusters,tracks", {"clusters, tracks, fit"}},
+    {"output-type", o2::framework::VariantType::String, "matching-info,calib-info", {"matching-info, calib-info"}},
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}},
+    {"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}},
+    {"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}},
+    {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}},
+    {"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}},
+    {"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -148,6 +154,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     }
   }
   LOG(INFO) << "Number of active devices = " << specs.size();
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
 
   return std::move(specs);
 }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-matcher-tpc.cxx
@@ -27,6 +27,7 @@
 #include "TPCWorkflow/TrackReaderSpec.h"
 #include "TPCWorkflow/PublisherSpec.h"
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 // GRP
 #include "DataFormatsParameters/GRPObject.h"
@@ -42,18 +43,23 @@
 // including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "matching-info", {"matching-info, calib-info"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
-  workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
-  workflowOptions.push_back(ConfigParamSpec{"tpc-refit", o2::framework::VariantType::Bool, false, {"refit matched TPC tracks"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  workflowOptions.push_back(ConfigParamSpec{"cosmics", o2::framework::VariantType::Bool, false, {"reco for cosmics"}});
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"output-type", o2::framework::VariantType::String, "matching-info", {"matching-info, calib-info"}},
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}},
+    {"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}},
+    {"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}},
+    {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}},
+    {"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}},
+    {"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}},
+    {"tpc-refit", o2::framework::VariantType::Bool, false, {"refit matched TPC tracks"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"cosmics", o2::framework::VariantType::Bool, false, {"reco for cosmics"}},
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -162,6 +168,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   LOG(INFO) << "Number of active devices = " << specs.size();
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
 
   return std::move(specs);
 }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -33,6 +33,7 @@
 #include "FairLogger.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 // FIT
 #include "FT0Workflow/RecPointReaderSpec.h"
@@ -45,23 +46,27 @@
 // including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"input-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters"}});
-  workflowOptions.push_back(ConfigParamSpec{"output-type", o2::framework::VariantType::String, "clusters,matching-info,calib-info", {"digits, clusters, matching-info, calib-info, raw, ctf"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}});
-  workflowOptions.push_back(ConfigParamSpec{"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  workflowOptions.push_back(ConfigParamSpec{"conet-mode", o2::framework::VariantType::Bool, false, {"enable conet mode"}});
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
-  workflowOptions.push_back(ConfigParamSpec{"disable-row-writing", o2::framework::VariantType::Bool, false, {"disable ROW in Digit writing"}});
-  workflowOptions.push_back(ConfigParamSpec{"write-decoding-errors", o2::framework::VariantType::Bool, false, {"trace errors in digits output when decoding"}});
-  workflowOptions.push_back(ConfigParamSpec{"calib-cluster", VariantType::Bool, false, {"to enable calib info production from clusters"}});
-  workflowOptions.push_back(ConfigParamSpec{"hbfutils-config", o2::framework::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"config file for HBFUtils (or none), used for raw output only!!!"}});
-  workflowOptions.push_back(ConfigParamSpec{"cosmics", VariantType::Bool, false, {"to enable cosmics utils"}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"input-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters"}},
+    {"output-type", o2::framework::VariantType::String, "clusters,matching-info,calib-info", {"digits, clusters, matching-info, calib-info, raw, ctf"}},
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information, TBI"}},
+    {"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}},
+    {"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}},
+    {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}},
+    {"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}},
+    {"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"conet-mode", o2::framework::VariantType::Bool, false, {"enable conet mode"}},
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}},
+    {"disable-row-writing", o2::framework::VariantType::Bool, false, {"disable ROW in Digit writing"}},
+    {"write-decoding-errors", o2::framework::VariantType::Bool, false, {"trace errors in digits output when decoding"}},
+    {"calib-cluster", VariantType::Bool, false, {"to enable calib info production from clusters"}},
+    {"cosmics", VariantType::Bool, false, {"to enable cosmics utils"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -113,10 +118,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
   if (outputType.rfind("raw") < outputType.size()) {
     writeraw = 1;
-    std::string confDig = cfgc.options().get<std::string>("hbfutils-config");
-    if (!confDig.empty() && confDig != "none") {
-      o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
-    }
   }
   if (outputType.rfind("ctf") < outputType.size()) {
     writectf = 1;
@@ -224,6 +225,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   LOG(INFO) << "Number of active devices = " << specs.size();
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
 
   return std::move(specs);
 }

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -56,7 +56,7 @@ o2_add_executable(
         digits-reader-workflow
         SOURCES src/DigitSamplerSpec.cxx src/digits-reader-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsRaw O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3)
 
 o2_add_executable(
         preclusters-sink-workflow

--- a/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
@@ -23,6 +23,8 @@
 #include "MIDSimulation/MCLabel.h"
 #include "MIDWorkflow/DigitReaderSpec.h"
 #include "MIDWorkflow/ZeroSuppressionSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
 
@@ -31,8 +33,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}},
-    {"disable-zero-suppression", VariantType::Bool, false, {"Do not apply zero suppression"}}};
-  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+    {"disable-zero-suppression", VariantType::Bool, false, {"Do not apply zero suppression"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h"
@@ -42,11 +48,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool disableZS = cfgc.options().get<bool>("disable-zero-suppression");
   bool useMC = !cfgc.options().get<bool>("disable-mc");
 
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
   WorkflowSpec specs;
   specs.emplace_back(o2::mid::getDigitReaderSpec(useMC, disableZS ? "DATA" : "DATAMC"));
   if (!disableZS) {
     specs.emplace_back(o2::mid::getZeroSuppressionSpec(useMC));
   }
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
 
   return specs;
 }

--- a/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
+++ b/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
@@ -18,6 +18,7 @@
 #include "PHOSWorkflow/RecoWorkflow.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 #include <string>
 #include <stdexcept>
@@ -34,6 +35,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
   std::swap(workflowOptions, options);
 }
 
@@ -57,10 +61,14 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  return o2::phos::reco_workflow::getWorkflow(cfgc.options().get<bool>("disable-root-input"),
-                                              cfgc.options().get<bool>("disable-root-output"),
-                                              !cfgc.options().get<bool>("disable-mc"),       //
-                                              cfgc.options().get<std::string>("input-type"), //
-                                              cfgc.options().get<std::string>("output-type") //
-  );
+  auto wf = o2::phos::reco_workflow::getWorkflow(cfgc.options().get<bool>("disable-root-input"),
+                                                 cfgc.options().get<bool>("disable-root-output"),
+                                                 !cfgc.options().get<bool>("disable-mc"),       //
+                                                 cfgc.options().get<std::string>("input-type"), //
+                                                 cfgc.options().get<std::string>("output-type"));
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
+
+  return std::move(wf);
 }

--- a/Detectors/Raw/CMakeLists.txt
+++ b/Detectors/Raw/CMakeLists.txt
@@ -14,7 +14,8 @@ o2_add_library(DetectorsRaw
                        src/SimpleRawReader.cxx
                        src/SimpleSTF.cxx
                        src/HBFUtils.cxx
-                       src/RDHUtils.cxx           
+                       src/RDHUtils.cxx
+                       src/HBFUtilsInitializer.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::Headers
                                      O2::CommonDataFormat

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
@@ -1,0 +1,44 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// @brief Aux.class initialize HBFUtils
+// @author ruben.shahoyan@cern.ch
+
+#ifndef _O2_HBFUTILS_INITIALIZER_
+#define _O2_HBFUTILS_INITIALIZER_
+
+#include <vector>
+
+namespace o2
+{
+
+namespace framework
+{
+class ConfigContext;
+class DataProcessorSpec;
+class ConfigParamSpec;
+using WorkflowSpec = std::vector<DataProcessorSpec>;
+} // namespace framework
+
+namespace raw
+{
+
+struct HBFUtilsInitializer {
+  static constexpr char HBFConfOpt[] = "hbfutils-config";
+
+  HBFUtilsInitializer(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& wf);
+
+  static void addConfigOption(std::vector<o2::framework::ConfigParamSpec>& opts);
+};
+
+} // namespace raw
+} // namespace o2
+
+#endif

--- a/Detectors/Raw/src/HBFUtilsInitializer.cxx
+++ b/Detectors/Raw/src/HBFUtilsInitializer.cxx
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// @brief Aux.class initialize HBFUtils
+// @author ruben.shahoyan@cern.ch
+
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/HBFUtils.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ConfigParamsHelper.h"
+#include "Framework/Logger.h"
+
+using namespace o2::raw;
+namespace o2f = o2::framework;
+
+/// If the workflow has devices w/o inputs, we assume that these are data readers in root-file based workflow.
+/// In this case this class will configure these devices DataHeader.firstTForbit generator to provide orbit according to HBFUtil setings
+/// In case the configcontext has relevant option, the HBFUtils will be beforehand updated from the file indicated by this option.
+/// (only those fields of HBFUtils which were not modified before, e.g. by ConfigurableParam::updateFromString)
+
+HBFUtilsInitializer::HBFUtilsInitializer(const o2f::ConfigContext& configcontext, o2f::WorkflowSpec& wf)
+{
+  auto updateHBFUtils = [&configcontext]() {
+    static bool done = false;
+    if (!done) {
+      bool helpasked = configcontext.helpOnCommandLine(); // if help is asked, don't take for granted that the ini file is there, don't produce an error if it is not!
+      std::string conf = configcontext.options().isSet(HBFConfOpt) ? configcontext.options().get<std::string>(HBFConfOpt) : "";
+      if (!conf.empty() && conf != "none" && !(helpasked && !o2::base::NameConf::pathExists(conf))) {
+        o2::conf::ConfigurableParam::updateFromFile(conf, "HBFUtils", true); // update only those values which were not touched yet (provenance == kCODE)
+      }
+      done = true;
+    }
+  };
+
+  const auto& hbfu = o2::raw::HBFUtils::Instance();
+  for (auto& spec : wf) {
+    if (spec.inputs.empty()) {
+      updateHBFUtils();
+      o2f::ConfigParamsHelper::addOptionIfMissing(spec.options, o2f::ConfigParamSpec{"orbit-offset-enumeration", o2f::VariantType::Int64, int64_t(hbfu.getFirstIRofTF({0, hbfu.orbitFirstSampled}).orbit), {"1st injected orbit"}});
+      o2f::ConfigParamsHelper::addOptionIfMissing(spec.options, o2f::ConfigParamSpec{"orbit-multiplier-enumeration", o2f::VariantType::Int64, int64_t(hbfu.nHBFPerTF), {"orbits/TF"}});
+    }
+  }
+}
+
+void HBFUtilsInitializer::addConfigOption(std::vector<o2f::ConfigParamSpec>& opts)
+{
+  o2f::ConfigParamsHelper::addOptionIfMissing(opts, o2f::ConfigParamSpec{HBFConfOpt, o2f::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"configKeyValues file for HBFUtils (or none)"}});
+}

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -11,6 +11,7 @@
 #include "TRDWorkflow/TRDTrackingWorkflow.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 
 using namespace o2::framework;
 
@@ -20,14 +21,16 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}});
-  workflowOptions.push_back(ConfigParamSpec{"use-tracklet-transformer", VariantType::Bool, false, {"Use calibrated tracklets instead raw Tracklet64"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}});
-  workflowOptions.push_back(ConfigParamSpec{
-    "disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
-  std::string keyvaluehelp("Semicolon separated key=value strings ...");
-  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}},
+    {"use-tracklet-transformer", VariantType::Bool, false, {"Use calibrated tracklets instead raw Tracklet64"}},
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
 }
 
 // ------------------------------------------------------------------
@@ -43,5 +46,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto useTrackletTransformer = configcontext.options().get<bool>("use-tracklet-transformer");
-  return std::move(o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut, useTrackletTransformer));
+
+  auto wf = o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut, useTrackletTransformer);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);
+
+  return std::move(wf);
 }


### PR DESCRIPTION
The aim of this PR is to inject correct `DataHeader::firstTForbit` into the reco. workflows for simulated data reconstruction.

All reco. workflows, when reading data from root files, will try to read the HBFUtils setting from the config file and set up correct `DataHeader::firstTForbit` propagation. 
The initial value of firstTForbit will correspond to 1st orbit of the TF containing the `HBFUtils::orbitFirstSampled` (orbit from which the interaction sampling started in the digitization), in case of mutiple TFs it will be incremented by `HBFUtils::nHBFPerTF` for each TF.

The HBFUtils.. setting provided from the command line will override those loaded from the config file.
By default the o2simdigitizerworkflow_configuration.ini written during digitization will be loaded, can be overridden by `--hbfutils-config <filename>`.

Reading of config file can be disable by providing option `--hbfutils-config none`.

This PR depends contains also the commits https://github.com/AliceO2Group/AliceO2/pull/5907, which should be merged first.

@aphecetche @dstocco I did not modify MUON workflows because did not find any which does the full processing (starting by reading the data). Are always piping the reconstruction to digits reading workflows or planning to add a full workflow for MC? 
In the former case, the same modifications as in this PR should be applied to you "sampler" workflows.