### PR TITLE
HMPID CTF

### DIFF
--- a/DataFormats/Detectors/HMPID/CMakeLists.txt
+++ b/DataFormats/Detectors/HMPID/CMakeLists.txt
@@ -9,7 +9,9 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(DataFormatsHMP
-               SOURCES src/Digit.cxx src/Cluster.cxx src/Trigger.cxx
+               SOURCES src/Digit.cxx 
+                       src/Cluster.cxx 
+                       src/Trigger.cxx
                PUBLIC_LINK_LIBRARIES O2::ReconstructionDataFormats
                                      O2::HMPIDBase
                                      O2::CommonDataFormat 

--- a/DataFormats/Detectors/HMPID/CMakeLists.txt
+++ b/DataFormats/Detectors/HMPID/CMakeLists.txt
@@ -12,6 +12,7 @@ o2_add_library(DataFormatsHMP
                SOURCES src/Digit.cxx 
                        src/Cluster.cxx 
                        src/Trigger.cxx
+                       src/CTF.cxx
                PUBLIC_LINK_LIBRARIES O2::ReconstructionDataFormats
                                      O2::HMPIDBase
                                      O2::CommonDataFormat 
@@ -22,4 +23,5 @@ o2_target_root_dictionary(DataFormatsHMP
                                   include/DataFormatsHMP/Digit.h
                                   include/DataFormatsHMP/Trigger.h
                                   include/DataFormatsHMP/Cluster.h
-                                  include/DataFormatsHMP/Hit.h)
+                                  include/DataFormatsHMP/Hit.h
+                                  include/DataFormatsHMP/CTF.h)

--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/CTF.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/CTF.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for HMPID CTF data
+
+#ifndef O2_HMP_CTF_H
+#define O2_HMP_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+
+namespace o2
+{
+namespace hmpid
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nTriggers = 0;  /// number of triggers
+  uint32_t nDigits = 0;    /// number of digits
+  uint32_t firstOrbit = 0; /// orbit of 1st trigger
+  uint16_t firstBC = 0;    /// bc of 1st trigger
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded triggers and cells of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 8, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncTrig,
+               BLC_orbitIncTrig,
+               BLC_entriesDig,
+               BLC_ChID, // digits sorted in ChamberID -> 1st entry of trigger keeps abs ChID, then increments
+               BLC_Q,
+               BLC_Ph,
+               BLC_X,
+               BLC_Y
+  };
+  ClassDefNV(CTF, 1);
+};
+
+} // namespace hmpid
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Digit.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Digit.h
@@ -78,11 +78,8 @@ class Digit
 
   // Getter & Setters
   uint16_t getCharge() const { return mQ; }
-  void setCharge(uint16_t Q)
-  {
-    mQ = Q;
-    return;
-  };
+  void setCharge(uint16_t Q) { mQ = Q; };
+
   int getPadID() const { return mCh << 24 | mPh << 16 | mX << 8 | mY; }
   void setPadID(uint32_t pad)
   {
@@ -90,7 +87,6 @@ class Digit
     mPh = (pad & 0x00FF0000) >> 16;
     mX = (pad & 0x0000FF00) >> 8;
     mY = (pad & 0x000000FF);
-    return;
   };
 
   bool isValid() { return (mCh == 0xFF ? true : false); };
@@ -117,6 +113,12 @@ class Digit
     }
   }
   void subCharge(float q) { mQ -= q; }
+
+  uint16_t getQ() const { return mQ; }
+  uint8_t getCh() const { return mCh; }
+  uint8_t getPh() const { return mPh; }
+  uint8_t getX() const { return mX; }
+  uint8_t getY() const { return mY; }
 
  public:
   // Members

--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Trigger.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Trigger.h
@@ -19,6 +19,7 @@
 
 #include <iosfwd>
 #include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
 
 namespace o2
 {
@@ -26,24 +27,25 @@ namespace hmpid
 {
 /// \class Trigger
 /// \brief HMPID Trigger declaration
-class Event
+class Trigger
 {
+  using DataRange = o2::dataformats::RangeReference<int>;
+
  public:
   static inline uint64_t getTriggerID(uint32_t Orbit, uint16_t BC) { return ((Orbit << 12) | (0x0FFF & BC)); };
 
  public:
-  Event() = default;
-  Event(InteractionRecord ir, int32_t first, int32_t last)
-  {
-    mIr.bc = ir.bc;
-    mIr.orbit = ir.orbit;
-    mFirstDigit = first;
-    mLastDigit = last;
-  };
+  Trigger() = default;
+  Trigger(InteractionRecord ir, int32_t first, int32_t n) : mIr(ir), mDataRange(first, n) {}
+
   const InteractionRecord& getIr() const { return mIr; };
   uint32_t getOrbit() const { return mIr.orbit; };
   uint16_t getBc() const { return mIr.bc; };
   uint64_t getTriggerID() const { return ((mIr.orbit << 12) | (0x0FFF & mIr.bc)); };
+  void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
+  int getNumberOfObjects() const { return mDataRange.getEntries(); }
+  int getFirstEntry() const { return mDataRange.getFirstEntry(); }
+  int getLastEntry() const { return mDataRange.getFirstEntry() + mDataRange.getEntries() - 1; }
   void setOrbit(uint32_t orbit)
   {
     mIr.orbit = orbit;
@@ -60,33 +62,24 @@ class Event
     mIr.bc = (trigger & 0x0FFF);
     return;
   }
-  void setDigitsPointer(int32_t first, int32_t last)
-  {
-    mFirstDigit = first;
-    mLastDigit = last;
-    return;
-  }
 
   // Operators definition !
-  friend inline bool operator<(const Event& l, const Event& r) { return l.getTriggerID() < r.getTriggerID(); };
-  friend inline bool operator==(const Event& l, const Event& r) { return l.getTriggerID() == r.getTriggerID(); };
-  friend inline bool operator>(const Event& l, const Event& r) { return r < l; };
-  friend inline bool operator<=(const Event& l, const Event& r) { return !(l > r); };
-  friend inline bool operator>=(const Event& l, const Event& r) { return !(l < r); };
-  friend inline bool operator!=(const Event& l, const Event& r) { return !(l == r); };
+  friend inline bool operator<(const Trigger& l, const Trigger& r) { return l.getTriggerID() < r.getTriggerID(); };
+  friend inline bool operator==(const Trigger& l, const Trigger& r) { return l.getTriggerID() == r.getTriggerID(); };
+  friend inline bool operator>(const Trigger& l, const Trigger& r) { return r < l; };
+  friend inline bool operator<=(const Trigger& l, const Trigger& r) { return !(l > r); };
+  friend inline bool operator>=(const Trigger& l, const Trigger& r) { return !(l < r); };
+  friend inline bool operator!=(const Trigger& l, const Trigger& r) { return !(l == r); };
 
   // Digit ASCII format (Orbit,BunchCrossing)[LHC Time nSec]
-  friend std::ostream& operator<<(std::ostream& os, const Event& d);
-
- public:
-  int32_t mFirstDigit = 0;
-  int32_t mLastDigit = -1;
+  friend std::ostream& operator<<(std::ostream& os, const Trigger& d);
 
  private:
   // Members
   InteractionRecord mIr;
+  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
 
-  ClassDefNV(Event, 2);
+  ClassDefNV(Trigger, 2);
 };
 
 } // namespace hmpid

--- a/DataFormats/Detectors/HMPID/src/CTF.cxx
+++ b/DataFormats/Detectors/HMPID/src/CTF.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsHMP/CTF.h"
+
+using namespace o2::hmpid;

--- a/DataFormats/Detectors/HMPID/src/DataFormatsHMPLinkDef.h
+++ b/DataFormats/Detectors/HMPID/src/DataFormatsHMPLinkDef.h
@@ -23,4 +23,8 @@
 #pragma link C++ class o2::hmpid::Trigger + ;
 #pragma link C++ class vector < o2::hmpid::Trigger> + ;
 
+#pragma link C++ struct o2::hmpid::CTFHeader + ;
+#pragma link C++ struct o2::hmpid::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::hmpid::CTFHeader, 8, uint32_t> + ;
+
 #endif

--- a/DataFormats/Detectors/HMPID/src/DataFormatsHMPLinkDef.h
+++ b/DataFormats/Detectors/HMPID/src/DataFormatsHMPLinkDef.h
@@ -20,7 +20,7 @@
 #pragma link C++ class vector < o2::hmpid::HitType> + ;
 #pragma link C++ class o2::hmpid::Cluster + ;
 #pragma link C++ class vector < o2::hmpid::Cluster> + ;
-#pragma link C++ class o2::hmpid::Event + ;
-#pragma link C++ class vector < o2::hmpid::Event> + ;
+#pragma link C++ class o2::hmpid::Trigger + ;
+#pragma link C++ class vector < o2::hmpid::Trigger> + ;
 
 #endif

--- a/DataFormats/Detectors/HMPID/src/Trigger.cxx
+++ b/DataFormats/Detectors/HMPID/src/Trigger.cxx
@@ -22,7 +22,7 @@
 #include <iostream>
 #include "DataFormatsHMP/Trigger.h"
 
-ClassImp(o2::hmpid::Event);
+ClassImp(o2::hmpid::Trigger);
 
 namespace o2
 {
@@ -30,9 +30,9 @@ namespace hmpid
 {
 
 // Digit ASCCI format Dump := (Orbit,BC @ LHCtime ns) [first_digit_idx .. last_digit_idx]
-std::ostream& operator<<(std::ostream& os, const o2::hmpid::Event& d)
+std::ostream& operator<<(std::ostream& os, const o2::hmpid::Trigger& d)
 {
-  os << "(" << d.mIr.orbit << "," << d.mIr.bc << " @ " << d.mIr.bc2ns() << " ns) [" << d.mFirstDigit << " .. " << d.mLastDigit << "]";
+  os << "(" << d.mIr.orbit << "," << d.mIr.bc << " @ " << d.mIr.bc2ns() << " ns) [" << d.mDataRange.getFirstEntry() << "," << d.mDataRange.getEntries() << "]";
   return os;
 };
 

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -95,3 +95,11 @@ o2_add_test(trd
             SOURCES test/test_ctf_io_trd.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
+    
+o2_add_test(hmpid
+            PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                                  O2::DataFormatsHMP
+                                  O2::HMPIDReconstruction
+            SOURCES test/test_ctf_io_hmpid.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf)

--- a/Detectors/CTF/test/test_ctf_io_hmpid.cxx
+++ b/Detectors/CTF/test/test_ctf_io_hmpid.cxx
@@ -1,0 +1,103 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test HMPIDCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "HMPIDReconstruction/CTFCoder.h"
+#include "DataFormatsHMP/CTF.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::hmpid;
+
+BOOST_AUTO_TEST_CASE(CTFTest)
+{
+  std::vector<Trigger> triggers;
+  std::vector<Digit> digits;
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir(0, 0);
+  Digit clu;
+  for (int irof = 0; irof < 1000; irof++) {
+    ir += 1 + gRandom->Integer(200);
+
+    auto start = digits.size();
+    uint8_t chID = 0;
+    int n = 0;
+    while ((chID += gRandom->Integer(10)) < 0xff) {
+      uint16_t q = gRandom->Integer(0xffff);
+      uint8_t ph = gRandom->Integer(0xff);
+      uint8_t x = gRandom->Integer(0xff);
+      uint8_t y = gRandom->Integer(0xff);
+      digits.emplace_back(chID, ph, x, y, q);
+    }
+    triggers.emplace_back(ir, start, digits.size() - start);
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, triggers, digits); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::hmpid::CTF::get(vec.data());
+    TFile flOut("test_ctf_hmpid.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "HMP");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  LOG(INFO) << "Start reading from tree ";
+  {
+    sw.Start();
+    TFile flIn("test_ctf_hmpid.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::hmpid::CTF::readFromTree(vec, *(tree.get()), "HMP");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<Trigger> triggersD;
+  std::vector<Digit> digitsD;
+
+  sw.Start();
+  const auto ctfImage = o2::hmpid::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, triggersD, digitsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  BOOST_CHECK(triggersD.size() == triggers.size());
+  BOOST_CHECK(digitsD.size() == digits.size());
+
+  BOOST_TEST(triggersD == triggers, boost::test_tools::per_element());
+  BOOST_TEST(digitsD == digits, boost::test_tools::per_element());
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -23,7 +23,8 @@ o2_add_library(CTFWorkflow
                                      O2::DataFormatsMID
                                      O2::DataFormatsPHOS
                                      O2::DataFormatsCPV
-                                     O2::DataFormatsZDC             
+                                     O2::DataFormatsZDC
+                                     O2::DataFormatsHMP				     
                                      O2::DataFormatsParameters
                                      O2::ITSMFTWorkflow
                                      O2::TPCWorkflow
@@ -37,6 +38,7 @@ o2_add_library(CTFWorkflow
                                      O2::PHOSWorkflow
                                      O2::CPVWorkflow
                                      O2::ZDCWorkflow
+				     O2::HMPIDWorkflow
                                      O2::Algorithm
                                      O2::CommonUtils)
 

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -35,6 +35,7 @@
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
 #include "DataFormatsZDC/CTF.h"
+#include "DataFormatsHMP/CTF.h"
 #include "Algorithm/RangeTokenizer.h"
 #include <TStopwatch.h>
 
@@ -221,6 +222,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::zdc::CTF));
     o2::zdc::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::HMP;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::hmpid::CTF));
+    o2::hmpid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -24,6 +24,7 @@
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
 #include "DataFormatsTRD/CTF.h"
+#include "DataFormatsHMP/CTF.h"
 #include "DataFormatsFT0/CTF.h"
 #include "DataFormatsFV0/CTF.h"
 #include "DataFormatsFDD/CTF.h"
@@ -225,6 +226,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::phos::CTF>(pc, DetID::PHS, header, treeOut.get());
   processDet<o2::cpv::CTF>(pc, DetID::CPV, header, treeOut.get());
   processDet<o2::zdc::CTF>(pc, DetID::ZDC, header, treeOut.get());
+  processDet<o2::hmpid::CTF>(pc, DetID::HMP, header, treeOut.get());
 
   mTimer.Stop();
 
@@ -299,6 +301,8 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::phos::CTF>(DetID::PHS, header);
   storeDictionary<o2::cpv::CTF>(DetID::CPV, header);
   storeDictionary<o2::zdc::CTF>(DetID::ZDC, header);
+  storeDictionary<o2::hmpid::CTF>(DetID::HMP, header);
+
   // close remnants
   if (mDictTreeOut) {
     closeDictionaryTreeAndFile(header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -23,6 +23,7 @@
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "TPCWorkflow/EntropyDecoderSpec.h"
 #include "TRDWorkflow/EntropyDecoderSpec.h"
+#include "HMPIDWorkflow/EntropyDecoderSpec.h"
 #include "FT0Workflow/EntropyDecoderSpec.h"
 #include "FV0Workflow/EntropyDecoderSpec.h"
 #include "FDDWorkflow/EntropyDecoderSpec.h"
@@ -111,6 +112,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (dets[DetID::ZDC]) {
     specs.push_back(o2::zdc::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::HMP]) {
+    specs.push_back(o2::hmpid::getEntropyDecoderSpec());
   }
 
   return std::move(specs);

--- a/Detectors/HMPID/reconstruction/CMakeLists.txt
+++ b/Detectors/HMPID/reconstruction/CMakeLists.txt
@@ -12,6 +12,8 @@ o2_add_library(HMPIDReconstruction
                SOURCES src/Clusterer.cxx 
                        src/HmpidDecoder2.cxx 
                        src/HmpidEquipment.cxx
+                       src/CTFHelper.cxx
+                       src/CTFCoder.cxx
                PUBLIC_LINK_LIBRARIES O2::HMPIDBase
                                      O2::DataFormatsHMP
                                      O2::HMPIDSimulation)

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
@@ -1,0 +1,158 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of HMPID data
+
+#ifndef O2_HMPID_CTFCODER_H
+#define O2_HMPID_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsHMP/CTF.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "rANS/rans.h"
+#include "HMPIDReconstruction/CTFHelper.h"
+
+class TTree;
+
+namespace o2
+{
+namespace hmpid
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::HMP) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VTRG, typename VDIG>
+  void decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<Trigger>& trigVec, std::vector<Digit>& digVec);
+};
+
+/// entropy-encode digits and to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncTrig
+    MD::EENCODE, // BLC_orbitIncTrig
+    MD::EENCODE, // BLC_entriesDig
+    MD::EENCODE, // BLC_ChID
+    MD::EENCODE, // BLC_Q
+    MD::EENCODE, // BLC_Ph
+    MD::EENCODE, // BLC_X
+    MD::EENCODE  // BLC_Y
+  };
+
+  CTFHelper helper(trigData, digData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODEHMP(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODEHMP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  ENCODEHMP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  ENCODEHMP(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
+  
+  ENCODEHMP(helper.begin_ChID(),         helper.end_ChID(),          CTF::BLC_ChID,         0);
+  ENCODEHMP(helper.begin_Q(),            helper.end_Q(),             CTF::BLC_Q,            0);
+  ENCODEHMP(helper.begin_Ph(),           helper.end_Ph(),            CTF::BLC_Ph,           0);
+  ENCODEHMP(helper.begin_X(),            helper.end_X(),             CTF::BLC_X,            0);
+  ENCODEHMP(helper.begin_Y(),            helper.end_Y(),             CTF::BLC_Y,            0);
+
+  // clang-format on
+  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded data to digits
+template <typename VTRG, typename VDIG>
+void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+  std::vector<uint16_t> bcInc, q;
+  std::vector<uint32_t> orbitInc, entriesDig;
+  std::vector<uint8_t> chID, ph, x, y;
+
+#define DECODEHMP(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODEHMP(bcInc,       CTF::BLC_bcIncTrig);
+  DECODEHMP(orbitInc,    CTF::BLC_orbitIncTrig);
+  DECODEHMP(entriesDig,  CTF::BLC_entriesDig);
+
+  DECODEHMP(chID,        CTF::BLC_ChID);
+  DECODEHMP(q,           CTF::BLC_Q);
+  DECODEHMP(ph,          CTF::BLC_Ph);
+  DECODEHMP(x,           CTF::BLC_X);
+  DECODEHMP(y,           CTF::BLC_Y);
+  // clang-format on
+  //
+  trigVec.clear();
+  digVec.clear();
+  trigVec.reserve(header.nTriggers);
+  digVec.reserve(header.nDigits);
+
+  uint32_t digCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  for (uint32_t itrig = 0; itrig < header.nTriggers; itrig++) {
+    // restore TrigRecord
+    if (orbitInc[itrig]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[itrig]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[itrig];
+    } else {
+      ir.bc += bcInc[itrig];
+    }
+
+    uint32_t firstEntryDig = digVec.size();
+    int8_t chid = 0;
+    for (uint32_t id = 0; id < entriesDig[itrig]; id++) {
+      chid += chID[digCount]; // 1st digit of trigger was encoded with abs ChID, then increments
+      auto& dig = digVec.emplace_back(chid, ph[digCount], x[digCount], y[digCount], q[digCount]);
+      digCount++;
+    }
+
+    trigVec.emplace_back(ir, firstEntryDig, entriesDig[itrig]);
+  }
+  assert(digCount == header.nDigits);
+}
+
+} // namespace hmpid
+} // namespace o2
+
+#endif // O2_HMP_CTFCODER_H

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
@@ -1,0 +1,225 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for HMPID CTF creation
+
+#ifndef O2_HMPID_CTF_HELPER_H
+#define O2_HMPID_CTF_HELPER_H
+
+#include "DataFormatsHMP/CTF.h"
+#include "DataFormatsHMP/Trigger.h"
+#include "DataFormatsHMP/Digit.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace hmpid
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const Trigger>& trgRec,
+            const gsl::span<const Digit>& digData)
+    : mTrigRec(trgRec), mDigData(digData), mDigStart(digData.size())
+  {
+    // flag start of new trigger for digits
+    for (const auto& trg : mTrigRec) {
+      if (trg.getNumberOfObjects()) {
+        mDigStart[trg.getFirstEntry()] = true;
+      }
+    }
+  }
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mTrigRec.size()), uint32_t(mDigData.size()), 0, 0};
+    if (mTrigRec.size()) {
+      h.firstOrbit = mTrigRec[0].getOrbit();
+      h.firstBC = mTrigRec[0].getBc();
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mTrigRec.size() * sizeof(Trigger) + mDigData.size() * sizeof(Digit); }
+
+  //>>> =========================== ITERATORS ========================================
+  template <typename I, typename D, typename T, int M = 1>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncTrig : public _Iter<Iter_bcIncTrig, Trigger, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncTrig, Trigger, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].getOrbit() == mData[mIndex - 1].getOrbit()) {
+          return mData[mIndex].getBc() - mData[mIndex - 1].getBc();
+        } else {
+          return mData[mIndex].getBc();
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncTrig : public _Iter<Iter_orbitIncTrig, Trigger, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncTrig, Trigger, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].getOrbit() - mData[mIndex - 1].getOrbit() : 0; }
+  };
+
+  //_______________________________________________
+  // Number of digits for trigger
+  class Iter_entriesDig : public _Iter<Iter_entriesDig, Trigger, uint32_t>
+  {
+   public:
+    using _Iter<Iter_entriesDig, Trigger, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNumberOfObjects(); }
+  };
+
+  //_______________________________________________
+  class Iter_ChID : public _Iter<Iter_ChID, Digit, uint8_t>
+  {
+   private:
+    const std::vector<bool>* mTrigStart{nullptr};
+
+   public:
+    using _Iter<Iter_ChID, Digit, uint8_t>::_Iter;
+    Iter_ChID(const std::vector<bool>* ts, const gsl::span<const Digit>& data, bool end) : mTrigStart(ts), _Iter(data, end) {}
+    Iter_ChID() = default;
+
+    // assume sorting in ChID: for the 1st digit of the trigger return the abs ChID, for the following ones: difference to previous ChID
+    value_type operator*() const
+    {
+      return (*mTrigStart)[mIndex] ? mData[mIndex].getCh() : mData[mIndex].getCh() - mData[mIndex - 1].getCh();
+    }
+  };
+
+  //_______________________________________________
+  class Iter_Q : public _Iter<Iter_Q, Digit, uint16_t>
+  {
+   public:
+    using _Iter<Iter_Q, Digit, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getQ(); }
+  };
+
+  //_______________________________________________
+  class Iter_Ph : public _Iter<Iter_Ph, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_Ph, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPh(); }
+  };
+
+  //_______________________________________________
+  class Iter_X : public _Iter<Iter_X, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_X, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getX(); }
+  };
+
+  //_______________________________________________
+  class Iter_Y : public _Iter<Iter_Y, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_Y, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getY(); }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncTrig begin_bcIncTrig() const { return Iter_bcIncTrig(mTrigRec, false); }
+  Iter_bcIncTrig end_bcIncTrig() const { return Iter_bcIncTrig(mTrigRec, true); }
+
+  Iter_orbitIncTrig begin_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigRec, false); }
+  Iter_orbitIncTrig end_orbitIncTrig() const { return Iter_orbitIncTrig(mTrigRec, true); }
+
+  Iter_entriesDig begin_entriesDig() const { return Iter_entriesDig(mTrigRec, false); }
+  Iter_entriesDig end_entriesDig() const { return Iter_entriesDig(mTrigRec, true); }
+
+  Iter_ChID begin_ChID() const { return Iter_ChID(&mDigStart, mDigData, false); }
+  Iter_ChID end_ChID() const { return Iter_ChID(&mDigStart, mDigData, true); }
+
+  Iter_Q begin_Q() const { return Iter_Q(mDigData, false); }
+  Iter_Q end_Q() const { return Iter_Q(mDigData, true); }
+
+  Iter_Ph begin_Ph() const { return Iter_Ph(mDigData, false); }
+  Iter_Ph end_Ph() const { return Iter_Ph(mDigData, true); }
+
+  Iter_X begin_X() const { return Iter_X(mDigData, false); }
+  Iter_X end_X() const { return Iter_X(mDigData, true); }
+
+  Iter_Y begin_Y() const { return Iter_Y(mDigData, false); }
+  Iter_Y end_Y() const { return Iter_Y(mDigData, true); }
+
+ private:
+  const gsl::span<const o2::hmpid::Trigger> mTrigRec;
+  const gsl::span<const o2::hmpid::Digit> mDigData;
+  std::vector<bool> mDigStart;
+};
+
+} // namespace hmpid
+} // namespace o2
+
+#endif

--- a/Detectors/HMPID/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/HMPID/reconstruction/src/CTFCoder.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of HMP data
+
+#include "HMPIDReconstruction/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::hmpid;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<Trigger>& trigVec, std::vector<Digit>& digVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, trigVec, digVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc, HCIDTrk, q;
+  uint32_t orbitInc, entriesDig;
+  uint8_t chID, ph, x, y;
+
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+  // clang-format off
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
+  MAKECODER(entriesDig, CTF::BLC_entriesDig);
+
+  MAKECODER(chID,       CTF::BLC_ChID);
+  MAKECODER(q,          CTF::BLC_Q);
+  MAKECODER(ph,         CTF::BLC_Ph);
+  MAKECODER(x,          CTF::BLC_X);
+  MAKECODER(y,          CTF::BLC_Y);
+  // clang-format on
+}

--- a/Detectors/HMPID/reconstruction/src/CTFHelper.cxx
+++ b/Detectors/HMPID/reconstruction/src/CTFHelper.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for HMPID CTF creation
+
+#include "HMPIDReconstruction/CTFHelper.h"

--- a/Detectors/HMPID/workflow/CMakeLists.txt
+++ b/Detectors/HMPID/workflow/CMakeLists.txt
@@ -16,6 +16,9 @@ o2_add_library(HMPIDWorkflow
                        src/RawToDigitsSpec.cxx
                        src/ReadRawFileSpec.cxx
                        src/WriteRawFileSpec.cxx
+                       src/EntropyEncoderSpec.cxx
+                       src/EntropyDecoderSpec.cxx
+
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::CCDB
                                      O2::DPLUtils
@@ -29,6 +32,10 @@ o2_add_library(HMPIDWorkflow
 #              COMPONENT_NAME hmpid
 #              SOURCES src/HMPIDRecoWorkflow.cxx 
 #              PUBLIC_LINK_LIBRARIES O2::HMPIDWorkflow)
+o2_add_executable(entropy-encoder-workflow
+                  COMPONENT_NAME hhmpid
+                  SOURCES src/entropy-encoder-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::HMPIDWorkflow)
 
 o2_add_executable(read-raw-file-stream-workflow
               COMPONENT_NAME hmpid
@@ -64,4 +71,8 @@ o2_add_executable(digits-to-raw-stream-workflow
               COMPONENT_NAME hmpid
               SOURCES src/digits-to-raw-stream-workflow.cxx
               PUBLIC_LINK_LIBRARIES O2::HMPIDWorkflow)
-              
+
+o2_add_executable(entropy-encoder-workflow
+                  COMPONENT_NAME hmpid
+                  SOURCES src/entropy-encoder-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::HMPIDWorkflow)

--- a/Detectors/HMPID/workflow/include/HMPIDWorkflow/DataDecoderSpec.h
+++ b/Detectors/HMPID/workflow/include/HMPIDWorkflow/DataDecoderSpec.h
@@ -45,7 +45,7 @@ class DataDecoderTask : public framework::Task
   ExecutionTimer mExTimer;
 };
 
-o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec = "TF:HMP/RAWDATA");
+o2::framework::DataProcessorSpec getDecodingSpec(bool askSTFDist);
 } // end namespace hmpid
 } // end namespace o2
 

--- a/Detectors/HMPID/workflow/include/HMPIDWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/HMPID/workflow/include/HMPIDWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to HMP digit/tracklets stream
+
+#ifndef O2_HMP_ENTROPYDECODER_SPEC
+#define O2_HMP_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace hmpid
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace hmpid
+} // namespace o2
+
+#endif

--- a/Detectors/HMPID/workflow/include/HMPIDWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/HMPID/workflow/include/HMPIDWorkflow/EntropyEncoderSpec.h
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.h
+/// @brief  Convert HMP data to CTF (EncodedBlocks)
+
+#ifndef O2_HMP_ENTROPYENCODER_SPEC
+#define O2_HMP_ENTROPYENCODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace hmpid
+{
+
+/// create a processor spec
+framework::DataProcessorSpec getEntropyEncoderSpec();
+
+} // namespace hmpid
+} // namespace o2
+
+#endif

--- a/Detectors/HMPID/workflow/include/HMPIDWorkflow/RawToDigitsSpec.h
+++ b/Detectors/HMPID/workflow/include/HMPIDWorkflow/RawToDigitsSpec.h
@@ -51,7 +51,7 @@ class RawToDigitsTask : public framework::Task
   o2::raw::RawFileReader mReader;
   o2::hmpid::HmpidDecoder2* mDecod;
   std::vector<o2::hmpid::Digit> mAccumulateDigits;
-  std::vector<o2::hmpid::Event> mEvents;
+  std::vector<o2::hmpid::Trigger> mEvents;
 
   long mDigitsReceived;
   long mFramesReceived;

--- a/Detectors/HMPID/workflow/include/HMPIDWorkflow/WriteRawFileSpec.h
+++ b/Detectors/HMPID/workflow/include/HMPIDWorkflow/WriteRawFileSpec.h
@@ -38,7 +38,7 @@ class WriteRawFileTask : public framework::Task
   //     static bool eventEquipPadsComparision(o2::hmpid::Digit d1, o2::hmpid::Digit d2);
   std::string mBaseFileName = "";
   std::vector<o2::hmpid::Digit> mDigits;
-  std::vector<o2::hmpid::Event> mEvents;
+  std::vector<o2::hmpid::Trigger> mEvents;
   bool mSkipEmpty = false;
   bool mFixedPacketLenght = false;
   bool mOrderTheEvents = true;

--- a/Detectors/HMPID/workflow/src/DigitsToRawSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DigitsToRawSpec.cxx
@@ -12,7 +12,7 @@
 /// \author Antonio Franco - INFN Bari
 /// \version 1.0
 /// \date 01 feb 2021
-/// \brief Implementation of a data processor to produce raw files from a Digits/Event root file
+/// \brief Implementation of a data processor to produce raw files from a Digits/Trigger root file
 ///
 
 #include <random>
@@ -108,7 +108,7 @@ void DigitsToRawSpec::readRootFile()
 {
   std::vector<o2::hmpid::Digit> digitsPerEvent;
   std::vector<o2::hmpid::Digit> digits, *hmpBCDataPtr = &digits;
-  std::vector<o2::hmpid::Event> interactions, *interactionsPtr = &interactions;
+  std::vector<o2::hmpid::Trigger> interactions, *interactionsPtr = &interactions;
 
   // Keeps the Interactions !
   mDigTree->SetBranchAddress("InteractionRecords", &interactionsPtr);
@@ -135,9 +135,9 @@ void DigitsToRawSpec::readRootFile()
     if (mDumpDigits) { // we want the dump of digits ?
       std::ofstream dumpfile;
       dumpfile.open("/tmp/hmpDumpDigits.dat");
-      for (o2::hmpid::Event e : interactions) {
-        dumpfile << "Event  Orbit=" << e.getOrbit() << " BC=" << e.getBc() << std::endl;
-        for (int i = e.mFirstDigit; i <= e.mLastDigit; i++) {
+      for (o2::hmpid::Trigger& e : interactions) {
+        dumpfile << "Trigger  Orbit=" << e.getOrbit() << " BC=" << e.getBc() << std::endl;
+        for (int i = e.getFirstEntry(); i <= e.getLastEntry(); i++) {
           dumpfile << digits.at(i) << std::endl;
         }
       }
@@ -145,10 +145,10 @@ void DigitsToRawSpec::readRootFile()
     }
     // ready to operate
     LOG(INFO) << "For the entry = " << ient << " there are " << nbc << " DIGITS stored.";
-    for (o2::hmpid::Event e : interactions) {
+    for (o2::hmpid::Trigger& e : interactions) {
       mEventsReceived++;
       digitsPerEvent.clear();
-      for (int i = e.mFirstDigit; i <= e.mLastDigit; i++) {
+      for (int i = e.getFirstEntry(); i <= e.getLastEntry(); i++) {
         digitsPerEvent.push_back(digits[i]);
       }
       LOG(DEBUG) << "Orbit =" << e.getOrbit() << " BC =" << e.getBc() << "  Digits =" << digitsPerEvent.size();

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "HMPIDWorkflow/EntropyDecoderSpec.h"
+#include "HMPIDReconstruction/CTFCoder.h"
+#include <TStopwatch.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace hmpid
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::hmpid::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("hmpid-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& triggers = pc.outputs().make<std::vector<Trigger>>(OutputRef{"triggers"});
+  auto& digits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::hmpid::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, triggers, digits);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << digits.size() << " HMPID digits in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "HMPID Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"triggers"}, "HMP", "INTRECORDS", 0, Lifetime::Timeframe},
+    OutputSpec{{"digits"}, "HMP", "DIGITS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "hmpid-entropy-decoder",
+    Inputs{InputSpec{"ctf", "HMP", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"hmpid-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace hmpid
+} // namespace o2

--- a/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyEncoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "HMPIDWorkflow/EntropyEncoderSpec.h"
+#include "HMPIDReconstruction/CTFCoder.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include <TStopwatch.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace hmpid
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::hmpid::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("hmpid-ctf-dictionary");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto triggers = pc.inputs().get<gsl::span<Trigger>>("triggers");
+  auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"HMP", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, triggers, digits);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << "Created encoded data of size " << eeb->size() << " for HMPID in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "HMPID Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("triggers", "HMP", "INTRECORDS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("digits", "HMP", "DIGITS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "hmpid-entropy-encoder",
+    inputs,
+    Outputs{{"HMP", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"hmpid-ctf-dictionary", VariantType::String, "ctf_dictionary.root", {"File of CTF encoding dictionary"}}}};
+}
+
+} // namespace hmpid
+} // namespace o2

--- a/Detectors/HMPID/workflow/src/WriteRawFileSpec.cxx
+++ b/Detectors/HMPID/workflow/src/WriteRawFileSpec.cxx
@@ -15,7 +15,7 @@
 /// \brief Implementation of a data processor to produce raw files from a Digits stream
 ///
 
-#include "../include/HMPIDWorkflow/WriteRawFileSpec.h"
+#include "HMPIDWorkflow/WriteRawFileSpec.h"
 
 #include <random>
 #include <iostream>
@@ -97,8 +97,7 @@ void WriteRawFileTask::run(framework::ProcessingContext& pc)
   if (mOrderTheEvents) {
     int first = mDigits.size();
     mDigits.insert(mDigits.end(), digits.begin(), digits.end());
-    int last = mDigits.size() - 1;
-    mEvents.push_back({intReco, first, last});
+    mEvents.push_back({intReco, first, int(mDigits.size() - first)});
   } else {
     mCod->codeEventChunkDigits(digits, intReco);
   }
@@ -120,7 +119,7 @@ void WriteRawFileTask::endOfStream(framework::EndOfStreamContext& ec)
     uint32_t orbit = mEvents[0].getOrbit();
     uint16_t bc = mEvents[0].getBc();
     for (int idx = 0; idx < mEvents.size(); idx++) {
-      if (mSkipEmpty && (mEvents[idx].mLastDigit < mEvents[idx].mFirstDigit || mEvents[idx].getOrbit() == 0)) {
+      if (mSkipEmpty && (mEvents[idx].getNumberOfObjects() == 0 || mEvents[idx].getOrbit() == 0)) {
         continue;
       }
       if (mEvents[idx].getOrbit() != orbit || mEvents[idx].getBc() != bc) {
@@ -130,7 +129,7 @@ void WriteRawFileTask::endOfStream(framework::EndOfStreamContext& ec)
         orbit = mEvents[idx].getOrbit();
         bc = mEvents[idx].getBc();
       }
-      for (int i = mEvents[idx].mFirstDigit; i <= mEvents[idx].mLastDigit; i++) {
+      for (int i = mEvents[idx].getFirstEntry(); i <= mEvents[idx].getLastEntry(); i++) {
         dig.push_back(mDigits[i]);
       }
     }

--- a/Detectors/HMPID/workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/HMPID/workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "HMPIDWorkflow/EntropyEncoderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::hmpid::getEntropyEncoderSpec());
+  return wf;
+}

--- a/Detectors/HMPID/workflow/src/raw-to-digits-stream-workflow.cxx
+++ b/Detectors/HMPID/workflow/src/raw-to-digits-stream-workflow.cxx
@@ -49,6 +49,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(o2::framework::ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {keyvaluehelp}});
+  workflowOptions.push_back(o2::framework::ConfigParamSpec{"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -61,7 +62,8 @@ WorkflowSpec defineDataProcessing(const ConfigContext& cx)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(cx.options().get<std::string>("configKeyValues"));
-  DataProcessorSpec producer = o2::hmpid::getDecodingSpec();
+  auto askSTFDist = !cx.options().get<bool>("ignore-dist-stf");
+  DataProcessorSpec producer = o2::hmpid::getDecodingSpec(askSTFDist);
   specs.push_back(producer);
   return specs;
 }

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
@@ -36,7 +36,7 @@ o2::framework::DataProcessorSpec getHMPIDDigitWriterSpec(bool mctruth = true)
                                 "o2sim",
                                 1,
                                 BranchDefinition<std::vector<o2::hmpid::Digit>>{InputSpec{"digitinput", "HMP", "DIGITS"}, "HMPDigit"},
-                                BranchDefinition<std::vector<o2::hmpid::Event>>{InputSpec{"interactionrecods", "HMP", "INTRECORDS"}, "InteractionRecords"},
+                                BranchDefinition<std::vector<o2::hmpid::Trigger>>{InputSpec{"interactionrecods", "HMP", "INTRECORDS"}, "InteractionRecords"},
                                 BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"labelinput", "HMP", "DIGITLBL"}, "HMPDigitLabels", mctruth ? 1 : 0})();
 }
 

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -80,12 +80,11 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
       LOG(INFO) << "NUMBER OF LABEL OBTAINED " << mLabels.getNElements();
       int32_t first = digitsAccum.size(); // this is the first
       std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(digitsAccum));
-      int32_t last = digitsAccum.size() - 1; // this is the last
       labelAccum.mergeAtBack(mLabels);
 
       // save info for the triggers accepted
       LOG(INFO) << "Trigger  Orbit :" << mDigitizer.getOrbit() << "  BC:" << mDigitizer.getBc();
-      mIntRecord.push_back(o2::hmpid::Event(o2::InteractionRecord(mDigitizer.getBc(), mDigitizer.getOrbit()), first, last));
+      mIntRecord.push_back(o2::hmpid::Trigger(o2::InteractionRecord(mDigitizer.getBc(), mDigitizer.getOrbit()), first, digitsAccum.size() - first));
     };
 
     // loop over all composite collisions given from context
@@ -142,7 +141,7 @@ class HMPIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   std::vector<TChain*> mSimChains;
   std::vector<o2::hmpid::Digit> mDigits;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels; // labels which get filled
-  std::vector<o2::hmpid::Event> mIntRecord;
+  std::vector<o2::hmpid::Trigger> mIntRecord;
 
   // RS: at the moment using hardcoded flag for continuous readout
   o2::parameters::GRPObject::ROMode mROMode = o2::parameters::GRPObject::CONTINUOUS; // readout mode


### PR DESCRIPTION
Hi @fapfap69 @gvolpe79 

This PR implements the CTF encoding/decoding for the HMPID, but the corresponding worflow (see below) is not fully functional yet because `o2-hmpid-raw-to-digits-stream-workflow` does not produce what it should: 2 messages with Digits and Triggers vectors. Instead of triggers vector it takes from the HmpidDecoder2 the `o2::InteractionRecord mIntReco`. 
Could you please fix this? Please start from this PR as I had to introduce quite some changes in other places of your code.

Once fixed, you can test it by running the "full system test" then ctf creation workflow:
````
mkdir fst
cd fst
$O2_ROOT/prodtests/full_system_test.sh
o2-raw-file-reader-workflow --input-conf raw/HMP/HMPraw.cfg | o2-hmpid-raw-to-digits-stream-workflow  | o2-hmpid-entropy-encoder-workflow | o2-ctf-writer-workflow --onlyDet HMP
````