### PR TITLE
￼ Several changes (add support for MUON Run3 data model, removed TaskName, etc.)

### DIFF
--- a/Analysis/DataModel/include/AnalysisDataModel/ReducedInfoTables.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/ReducedInfoTables.h
@@ -46,7 +46,7 @@ DECLARE_SOA_TABLE(ReducedEvents, "AOD", "REDUCEDEVENT", o2::soa::Index<>,
                   collision::PosX, collision::PosY, collision::PosZ, collision::NumContrib);
 
 DECLARE_SOA_TABLE(ReducedEventsExtended, "AOD", "REEXTENDED",
-                  bc::GlobalBC, bc::TriggerMask, reducedevent::TriggerAlias, cent::CentV0M);
+                  bc::GlobalBC, bc::TriggerMask, timestamp::Timestamp, reducedevent::TriggerAlias, cent::CentV0M);
 
 DECLARE_SOA_TABLE(ReducedEventsVtxCov, "AOD", "REVTXCOV",
                   collision::CovXX, collision::CovXY, collision::CovXZ,
@@ -63,7 +63,6 @@ DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent);
 DECLARE_SOA_COLUMN(Idx, idx, uint16_t);
 // ----  flags reserved for storing various information during filtering
 DECLARE_SOA_COLUMN(FilteringFlags, filteringFlags, uint64_t);
-// BIT 0: track is from MUON arm      (if not toggled then this is a barrel track)
 // -----------------------------------------------------
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(Eta, eta, float);
@@ -93,11 +92,11 @@ DECLARE_SOA_TABLE(ReducedTracksBarrel, "AOD", "RTBARREL",
                   track::ITSClusterMap, track::ITSChi2NCl,
                   track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                   track::TPCNClsShared, track::TPCChi2NCl,
-                  track::TRDChi2, track::TOFChi2, track::Length, reducedtrack::DcaXY, reducedtrack::DcaZ,
+                  track::TRDChi2, track::TRDPattern, track::TOFChi2, track::Length, reducedtrack::DcaXY, reducedtrack::DcaZ,
                   track::TPCNClsFound<track::TPCNClsFindable, track::TPCNClsFindableMinusFound>,
                   track::TPCNClsCrossedRows<track::TPCNClsFindable, track::TPCNClsFindableMinusCrossedRows>);
 
-// barrel covariance matrix
+// barrel covariance matrix  TODO: add all the elements required for secondary vertexing
 DECLARE_SOA_TABLE(ReducedTracksBarrelCov, "AOD", "RTBARRELCOV",
                   track::CYY, track::CZZ, track::CSnpSnp,
                   track::CTglTgl, track::C1Pt21Pt2);
@@ -107,18 +106,16 @@ DECLARE_SOA_TABLE(ReducedTracksBarrelPID, "AOD", "RTBARRELPID",
                   track::TPCSignal,
                   pidtpc::TPCNSigmaEl, pidtpc::TPCNSigmaMu,
                   pidtpc::TPCNSigmaPi, pidtpc::TPCNSigmaKa, pidtpc::TPCNSigmaPr,
-                  pidtpc::TPCNSigmaDe, pidtpc::TPCNSigmaTr, pidtpc::TPCNSigmaHe, pidtpc::TPCNSigmaAl,
-                  track::TOFSignal, pidtofbeta::Beta,
+                  pidtofbeta::Beta,
                   pidtof::TOFNSigmaEl, pidtof::TOFNSigmaMu,
                   pidtof::TOFNSigmaPi, pidtof::TOFNSigmaKa, pidtof::TOFNSigmaPr,
-                  pidtof::TOFNSigmaDe, pidtof::TOFNSigmaTr, pidtof::TOFNSigmaHe, pidtof::TOFNSigmaAl,
                   track::TRDSignal);
 
 // muon quantities
 namespace reducedmuon
 {
 DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent);
-DECLARE_SOA_COLUMN(FilteringFlags, filteringFlags, uint64_t);
+DECLARE_SOA_COLUMN(FilteringFlags, filteringFlags, uint8_t);
 // the (pt,eta,phi,sign) will be computed in the skimming task
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(Eta, eta, float);
@@ -130,6 +127,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, [](float pt, float eta) -> float { return pt 
 DECLARE_SOA_DYNAMIC_COLUMN(Pmom, pmom, [](float pt, float eta) -> float { return pt * std::cosh(eta); });
 } // namespace reducedmuon
 
+// Muon track kinematics
 DECLARE_SOA_TABLE(ReducedMuons, "AOD", "RTMUON",
                   o2::soa::Index<>, reducedmuon::ReducedEventId, reducedmuon::FilteringFlags,
                   reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign,
@@ -138,13 +136,21 @@ DECLARE_SOA_TABLE(ReducedMuons, "AOD", "RTMUON",
                   reducedmuon::Pz<reducedmuon::Pt, reducedmuon::Eta>,
                   reducedmuon::Pmom<reducedmuon::Pt, reducedmuon::Eta>);
 
-DECLARE_SOA_TABLE(ReducedMuonsExtended, "AOD", "RTMUONEXTENDED",
-                  muon::InverseBendingMomentum,
-                  muon::ThetaX, muon::ThetaY, muon::ZMu,
-                  muon::BendingCoor, muon::NonBendingCoor,
-                  muon::Chi2, muon::Chi2MatchTrigger,
-                  muon::RAtAbsorberEnd<muon::BendingCoor, muon::NonBendingCoor, muon::ThetaX, muon::ThetaY, muon::ZMu>,
-                  muon::PDca<muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY, muon::BendingCoor, muon::NonBendingCoor, muon::ZMu>);
+// Muon track quality details
+DECLARE_SOA_TABLE(ReducedMuonsExtra, "AOD", "RTMUONEXTRA",
+                  muon::InverseBendingMomentum, muon::ThetaX, muon::ThetaY, muon::ZMu, muon::BendingCoor, muon::NonBendingCoor,
+                  muon::Chi2, muon::Chi2MatchTrigger);
+
+// TODO: tables to be used once new AO2Ds are created
+/*DECLARE_SOA_TABLE(ReducedMuonsExtra, "AOD", "RTMUONEXTRA",
+                  fwdtrack::NClusters, fwdtrack::PDca, fwdtrack::RAtAbsorberEnd,
+                  fwdtrack::Chi2, fwdtrack::Chi2MatchMCHMID, fwdtrack::Chi2MatchMCHMFT,
+                  fwdtrack::MatchScoreMCHMFT, fwdtrack::MatchMFTTrackID, fwdtrack::MatchMCHTrackID);
+// Muon covariance, TODO: the rest of the matrix should be added when needed
+DECLARE_SOA_TABLE(ReducedMuonsCov, "AOD", "RTMUONCOV",
+                  aod::fwdtrack::CXX, aod::fwdtrack::CYY, aod::fwdtrack::CPhiPhi,
+                  aod::fwdtrack::CTglTgl, aod::fwdtrack::C1Pt21Pt2);
+*/
 
 // pair information
 namespace reducedpair
@@ -177,7 +183,8 @@ using ReducedTrackBarrel = ReducedTracksBarrel::iterator;
 using ReducedTrackBarrelCov = ReducedTracksBarrelCov::iterator;
 using ReducedTrackBarrelPID = ReducedTracksBarrelPID::iterator;
 using ReducedMuon = ReducedMuons::iterator;
-using ReducedMuonExtended = ReducedMuonsExtended::iterator;
+using ReducedMuonExtra = ReducedMuonsExtra::iterator;
+//using ReducedMuonCov = ReducedMuonsCov::iterator;
 using Dilepton = Dileptons::iterator;
 } // namespace o2::aod
 

--- a/Analysis/PWGDQ/include/PWGDQCore/CutsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/CutsLibrary.h
@@ -29,7 +29,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   // define composie cuts, typically combinations of all the ingredients needed for a full cut
   //
   // TODO: Agree on some conventions for the naming
-  //       Possibly think of possible customization of the predefined cuts
+  //       Think of possible customization of the predefined cuts via names
 
   AnalysisCompositeCut* cut = new AnalysisCompositeCut(cutName, cutName);
   std::string nameStr = cutName;
@@ -42,13 +42,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   }
 
   if (!nameStr.compare("jpsiPID1")) {
-    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));  // standard kine cuts usually are applied via Filter in the task
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
     cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
     cut->AddCut(GetAnalysisCut("electronPID1"));
     return cut;
   }
-
+  
   if (!nameStr.compare("jpsiPID2")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -56,7 +56,76 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPID2"));
     return cut;
   }
-
+  
+  if (!nameStr.compare("jpsiPIDnsigma")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPIDnsigma"));
+    return cut;
+  }
+  
+  //---------------------------------------------------------------------------------------
+  // NOTE: Below there are several TPC pid cuts used for studies of the dE/dx degradation
+  //    and its impact on the high lumi pp quarkonia triggers
+  //  To be removed when not needed anymore
+  if (!nameStr.compare("jpsiPID1Randomized")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));  // standard kine cuts usually are applied via Filter in the task
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPID1randomized"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPID2Randomized")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPID2randomized"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPIDnsigmaRandomized")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPIDnsigmaRandomized"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPIDworseRes")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPIDworseRes"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPIDshift")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPIDshift"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPID1shiftUp")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPID1shiftUp"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("jpsiPID1shiftDown")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQuality"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("electronPID1shiftDown"));
+    return cut;
+  }
+  // -------------------------------------------------------------------------------------------------
+  
   if (!nameStr.compare("lmeePID_TPChadrejTOFrec")) {
     cut->AddCut(GetAnalysisCut("lmeeStandardKine"));
     cut->AddCut(GetAnalysisCut("TightGlobalTrack"));
@@ -173,6 +242,11 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("eventStandardNoINT7")) {
+    cut->AddCut(VarManager::kVtxZ, -10.0, 10.0);
+    return cut;
+  }
+  
   if (!nameStr.compare("int7vtxZ5")) {
     cut->AddCut(VarManager::kVtxZ, -5.0, 5.0);
     cut->AddCut(VarManager::kIsINT7, 0.5, 1.5);
@@ -217,7 +291,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCncls, 100.0, 161.);
     return cut;
   }
-
+  
   if (!nameStr.compare("standardPrimaryTrack")) {
     cut->AddCut(VarManager::kTrackDCAxy, -1.0, 1.0);
     cut->AddCut(VarManager::kTrackDCAz, -3.0, 3.0);
@@ -225,16 +299,73 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   }
 
   TF1* cutLow1 = new TF1("cutLow1", "pol1", 0., 10.);
-  cutLow1->SetParameters(130., -40.0);
   if (!nameStr.compare("electronPID1")) {
+    cutLow1->SetParameters(130., -40.0);  
     cut->AddCut(VarManager::kTPCsignal, 70., 100.);
     cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
+  
+  if (!nameStr.compare("electronPID1shiftUp")) {
+    cut->AddCut(VarManager::kTPCsignal, 70.-0.85, 100.-0.85);
+    cutLow1->SetParameters(130.-0.85, -40.0);
+    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0-0.85, false, VarManager::kPin, 0.5, 3.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPID1shiftDown")) {
+    cut->AddCut(VarManager::kTPCsignal, 70.0+0.85, 100.0+0.85);
+    cutLow1->SetParameters(130.+0.85, -40.0);
+    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0+0.85, false, VarManager::kPin, 0.5, 3.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPID1randomized")) {
+    cutLow1->SetParameters(130., -40.0);
+    cut->AddCut(VarManager::kTPCsignalRandomized, 70., 100.);
+    cut->AddCut(VarManager::kTPCsignalRandomized, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
+    return cut;
+  }
 
   if (!nameStr.compare("electronPID2")) {
+    cutLow1->SetParameters(130., -40.0);  
     cut->AddCut(VarManager::kTPCsignal, 73., 100.);
     cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPID2randomized")) {
+    cutLow1->SetParameters(130., -40.0);  
+    cut->AddCut(VarManager::kTPCsignalRandomized, 73., 100.);
+    cut->AddCut(VarManager::kTPCsignalRandomized, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPIDnsigma")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
+    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0, 3000.0);
+    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0, 3000.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPIDnsigmaRandomized")) {
+    cut->AddCut(VarManager::kTPCnSigmaElRandomized, -3.0, 3.0);
+    cut->AddCut(VarManager::kTPCnSigmaPrRandomized, 3.0, 3000.0);
+    cut->AddCut(VarManager::kTPCnSigmaPiRandomized, 3.0, 3000.0);
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPIDworseRes")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
+    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0*0.8, 3000.0);  // emulates a 20% degradation in PID resolution
+    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0*0.8, 3000.0);  //    proton and pion rejections are effectively relaxed by 20%   
+    return cut;
+  }
+  
+  if (!nameStr.compare("electronPIDshift")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
+    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0-0.2, 3000.0);
+    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0-0.2, 3000.0);
     return cut;
   }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/CutsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/CutsLibrary.h
@@ -42,13 +42,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   }
 
   if (!nameStr.compare("jpsiPID1")) {
-    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));  // standard kine cuts usually are applied via Filter in the task
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine")); // standard kine cuts usually are applied via Filter in the task
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
     cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
     cut->AddCut(GetAnalysisCut("electronPID1"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPID2")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -56,7 +56,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPID2"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPIDnsigma")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -64,19 +64,19 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPIDnsigma"));
     return cut;
   }
-  
+
   //---------------------------------------------------------------------------------------
   // NOTE: Below there are several TPC pid cuts used for studies of the dE/dx degradation
   //    and its impact on the high lumi pp quarkonia triggers
   //  To be removed when not needed anymore
   if (!nameStr.compare("jpsiPID1Randomized")) {
-    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));  // standard kine cuts usually are applied via Filter in the task
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine")); // standard kine cuts usually are applied via Filter in the task
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
     cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
     cut->AddCut(GetAnalysisCut("electronPID1randomized"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPID2Randomized")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -84,7 +84,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPID2randomized"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPIDnsigmaRandomized")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -92,7 +92,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPIDnsigmaRandomized"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPIDworseRes")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -100,7 +100,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPIDworseRes"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPIDshift")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -108,7 +108,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPIDshift"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPID1shiftUp")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -116,7 +116,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("electronPID1shiftUp"));
     return cut;
   }
-  
+
   if (!nameStr.compare("jpsiPID1shiftDown")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQuality"));
@@ -125,7 +125,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
   // -------------------------------------------------------------------------------------------------
-  
+
   if (!nameStr.compare("lmeePID_TPChadrejTOFrec")) {
     cut->AddCut(GetAnalysisCut("lmeeStandardKine"));
     cut->AddCut(GetAnalysisCut("TightGlobalTrack"));
@@ -246,7 +246,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kVtxZ, -10.0, 10.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("int7vtxZ5")) {
     cut->AddCut(VarManager::kVtxZ, -5.0, 5.0);
     cut->AddCut(VarManager::kIsINT7, 0.5, 1.5);
@@ -291,7 +291,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCncls, 100.0, 161.);
     return cut;
   }
-  
+
   if (!nameStr.compare("standardPrimaryTrack")) {
     cut->AddCut(VarManager::kTrackDCAxy, -1.0, 1.0);
     cut->AddCut(VarManager::kTrackDCAz, -3.0, 3.0);
@@ -300,26 +300,26 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
 
   TF1* cutLow1 = new TF1("cutLow1", "pol1", 0., 10.);
   if (!nameStr.compare("electronPID1")) {
-    cutLow1->SetParameters(130., -40.0);  
+    cutLow1->SetParameters(130., -40.0);
     cut->AddCut(VarManager::kTPCsignal, 70., 100.);
     cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPID1shiftUp")) {
-    cut->AddCut(VarManager::kTPCsignal, 70.-0.85, 100.-0.85);
-    cutLow1->SetParameters(130.-0.85, -40.0);
-    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0-0.85, false, VarManager::kPin, 0.5, 3.0);
+    cut->AddCut(VarManager::kTPCsignal, 70. - 0.85, 100. - 0.85);
+    cutLow1->SetParameters(130. - 0.85, -40.0);
+    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0 - 0.85, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPID1shiftDown")) {
-    cut->AddCut(VarManager::kTPCsignal, 70.0+0.85, 100.0+0.85);
-    cutLow1->SetParameters(130.+0.85, -40.0);
-    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0+0.85, false, VarManager::kPin, 0.5, 3.0);
+    cut->AddCut(VarManager::kTPCsignal, 70.0 + 0.85, 100.0 + 0.85);
+    cutLow1->SetParameters(130. + 0.85, -40.0);
+    cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0 + 0.85, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPID1randomized")) {
     cutLow1->SetParameters(130., -40.0);
     cut->AddCut(VarManager::kTPCsignalRandomized, 70., 100.);
@@ -328,44 +328,44 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   }
 
   if (!nameStr.compare("electronPID2")) {
-    cutLow1->SetParameters(130., -40.0);  
+    cutLow1->SetParameters(130., -40.0);
     cut->AddCut(VarManager::kTPCsignal, 73., 100.);
     cut->AddCut(VarManager::kTPCsignal, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPID2randomized")) {
-    cutLow1->SetParameters(130., -40.0);  
+    cutLow1->SetParameters(130., -40.0);
     cut->AddCut(VarManager::kTPCsignalRandomized, 73., 100.);
     cut->AddCut(VarManager::kTPCsignalRandomized, cutLow1, 100.0, false, VarManager::kPin, 0.5, 3.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPIDnsigma")) {
     cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPr, 3.0, 3000.0);
     cut->AddCut(VarManager::kTPCnSigmaPi, 3.0, 3000.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPIDnsigmaRandomized")) {
     cut->AddCut(VarManager::kTPCnSigmaElRandomized, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPrRandomized, 3.0, 3000.0);
     cut->AddCut(VarManager::kTPCnSigmaPiRandomized, 3.0, 3000.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPIDworseRes")) {
     cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
-    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0*0.8, 3000.0);  // emulates a 20% degradation in PID resolution
-    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0*0.8, 3000.0);  //    proton and pion rejections are effectively relaxed by 20%   
+    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0 * 0.8, 3000.0); // emulates a 20% degradation in PID resolution
+    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0 * 0.8, 3000.0); //    proton and pion rejections are effectively relaxed by 20%
     return cut;
   }
-  
+
   if (!nameStr.compare("electronPIDshift")) {
     cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
-    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0-0.2, 3000.0);
-    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0-0.2, 3000.0);
+    cut->AddCut(VarManager::kTPCnSigmaPr, 3.0 - 0.2, 3000.0);
+    cut->AddCut(VarManager::kTPCnSigmaPi, 3.0 - 0.2, 3000.0);
     return cut;
   }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
@@ -135,7 +135,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "Chi2MatchTrigger", "", false, 100, 0.0, 20.0, VarManager::kMuonChi2MatchTrigger);
       hm->AddHistogram(histClass, "RAtAbsorberEnd", "", false, 100, 10, 2000, VarManager::kMuonRAtAbsorberEnd);
       hm->AddHistogram(histClass, "pdca", "", false, 100, 0.0, 1000, VarManager::kMuonPDca);
-      
+
       /*hm->AddHistogram(histClass, "MuonNClusters", "", false, 100, 0.0, 10.0, VarManager::kMuonNClusters);
       hm->AddHistogram(histClass, "pdca", "", false, 100, 0.0, 1000., VarManager::kMuonPDca);
       hm->AddHistogram(histClass, "RAtAbsorberEnd", "", false, 100, 10, 2000, VarManager::kMuonRAtAbsorberEnd);

--- a/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
@@ -41,10 +41,22 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
 
     if (subGroupStr.Contains("trigger")) {
       hm->AddHistogram(histClass, "IsINT7", "Is INT7", false, 2, -0.5, 1.5, VarManager::kIsINT7);
-      hm->AddHistogram(histClass, "IsINT7inMUON", "INT7inMUON", false, 2, -0.5, 1.5, VarManager::kIsINT7inMUON);
-      hm->AddHistogram(histClass, "IsMuonSingleLowPt7", "Is MuonSingleLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonSingleLowPt7);
-      hm->AddHistogram(histClass, "IsMuonUnlikeLowPt7", "Is MuonUnlikeLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonUnlikeLowPt7);
-      hm->AddHistogram(histClass, "IsMuonLikeLowPt7", "Is MuonLikeLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonLikeLowPt7);
+      if (subGroupStr.Contains("muon") || subGroupStr.Contains("all")) {
+        hm->AddHistogram(histClass, "IsINT7inMUON", "INT7inMUON", false, 2, -0.5, 1.5, VarManager::kIsINT7inMUON);
+        hm->AddHistogram(histClass, "IsMuonSingleLowPt7", "Is MuonSingleLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonSingleLowPt7);
+        hm->AddHistogram(histClass, "IsMuonSingleHighPt7", "Is MuonSingleHighPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonSingleHighPt7);
+        hm->AddHistogram(histClass, "IsMuonUnlikeLowPt7", "Is MuonUnlikeLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonUnlikeLowPt7);
+        hm->AddHistogram(histClass, "IsMuonLikeLowPt7", "Is MuonLikeLowPt7", false, 2, -0.5, 1.5, VarManager::kIsMuonLikeLowPt7);
+      }
+      if (subGroupStr.Contains("up") || subGroupStr.Contains("all")) {
+        hm->AddHistogram(histClass, "IsCUP8", "CUP8", false, 2, -0.5, 1.5, VarManager::kIsCUP8);
+        hm->AddHistogram(histClass, "IsCUP9", "CUP9", false, 2, -0.5, 1.5, VarManager::kIsCUP9);
+        hm->AddHistogram(histClass, "IsMUP10", "MUP10", false, 2, -0.5, 1.5, VarManager::kIsMUP10);
+        hm->AddHistogram(histClass, "IsMUP11", "MUP11", false, 2, -0.5, 1.5, VarManager::kIsMUP11);
+      }
+      if (subGroupStr.Contains("emc") || subGroupStr.Contains("all")) {
+        hm->AddHistogram(histClass, "IsEMC7", "EMC7", false, 2, -0.5, 1.5, VarManager::kIsEMC7);
+      }
     }
     if (subGroupStr.Contains("vtx")) {
       hm->AddHistogram(histClass, "VtxX", "Vtx X", false, 100, -0.5, 0.5, VarManager::kVtxX);
@@ -88,13 +100,25 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
                        10, -0.5, 159.5, VarManager::kTPCncls, 10, 0., 1., VarManager::kNothing, VarManager::GetRunStr().Data());
       hm->AddHistogram(histClass, "TPCnclsCR", "Number of crossed rows in TPC", false, 160, -0.5, 159.5, VarManager::kTPCnclsCR);
       hm->AddHistogram(histClass, "IsTPCrefit", "", false, 2, -0.5, 1.5, VarManager::kIsTPCrefit);
+      hm->AddHistogram(histClass, "IsGoldenChi2", "", false, 2, -0.5, 1.5, VarManager::kIsGoldenChi2);
       hm->AddHistogram(histClass, "TPCchi2", "TPC chi2", false, 100, 0.0, 10.0, VarManager::kTPCchi2);
     }
     if (subGroupStr.Contains("tpcpid")) {
-      hm->AddHistogram(histClass, "TPCdedx_pIN", "TPC dE/dx vs pIN", false, 200, 0.0, 20.0, VarManager::kPin, 200, 0.0, 200., VarManager::kTPCsignal);
+      hm->AddHistogram(histClass, "TPCdedx_pIN", "TPC dE/dx vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 200, 0.0, 200., VarManager::kTPCsignal);
+      hm->AddHistogram(histClass, "TPCdedxRandomized_pIN", "TPC dE/dx (randomized) vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 200, 0.0, 200., VarManager::kTPCsignalRandomized);
+      hm->AddHistogram(histClass, "TPCdedxRandomizedDelta_pIN", "TPC dE/dx (randomized - delta) vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, 0.0, 10., VarManager::kTPCsignalRandomizedDelta);
+      hm->AddHistogram(histClass, "TPCnSigEle_pIN", "TPC n-#sigma(e) vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaEl);
+      hm->AddHistogram(histClass, "TPCnSigEleRandomized_pIN", "TPC n-#sigma(e) - randomized - vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaElRandomized);
+      hm->AddHistogram(histClass, "TPCnSigEleRandomizedDelta_pIN", "TPC n-#sigma(e) - randomized delta - vs pIN", false, 20, 0.0, 10.0, VarManager::kPin, 200, -0.5, 0.5, VarManager::kTPCnSigmaElRandomizedDelta);
+      hm->AddHistogram(histClass, "TPCnSigEleRandomized_TPCnSigEle", "TPC n-#sigma(e) - randomized - vs TPC n-#sigma(e)", false, 100, -5.0, 5.0, VarManager::kTPCnSigmaEl, 100, -5.0, 5.0, VarManager::kTPCnSigmaElRandomized);
+      hm->AddHistogram(histClass, "TPCnSigPiRandomized_TPCnSigPi", "TPC n-#sigma(#pi) - randomized - vs TPC n-#sigma(#pi)", false, 100, -5.0, 5.0, VarManager::kTPCnSigmaPi, 100, -5.0, 5.0, VarManager::kTPCnSigmaPiRandomized);
+      hm->AddHistogram(histClass, "TPCnSigPrRandomized_TPCnSigPr", "TPC n-#sigma(p) - randomized - vs TPC n-#sigma(p)", false, 100, -5.0, 5.0, VarManager::kTPCnSigmaPr, 100, -5.0, 5.0, VarManager::kTPCnSigmaPrRandomized);
+      hm->AddHistogram(histClass, "TPCnSigPiRandomized_pIN", "TPC n-#sigma(#pi) - randomized - vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaPiRandomized);
+      hm->AddHistogram(histClass, "TPCnSigPrRandomized_pIN", "TPC n-#sigma(p) - randomized - vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaPrRandomized);
     }
     if (subGroupStr.Contains("tofpid")) {
       hm->AddHistogram(histClass, "TOFbeta_pIN", "TOF #beta vs pIN", false, 200, 0.0, 20.0, VarManager::kPin, 120, 0.0, 1.2, VarManager::kTOFbeta);
+      hm->AddHistogram(histClass, "TOFnSigEle_pIN", "TOF n-#sigma(e) vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTOFnSigmaEl);
     }
     if (subGroupStr.Contains("dca")) {
       hm->AddHistogram(histClass, "DCAxy", "DCAxy", false, 100, -3.0, 3.0, VarManager::kTrackDCAxy);
@@ -111,6 +135,20 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "Chi2MatchTrigger", "", false, 100, 0.0, 20.0, VarManager::kMuonChi2MatchTrigger);
       hm->AddHistogram(histClass, "RAtAbsorberEnd", "", false, 100, 10, 2000, VarManager::kMuonRAtAbsorberEnd);
       hm->AddHistogram(histClass, "pdca", "", false, 100, 0.0, 1000, VarManager::kMuonPDca);
+      
+      /*hm->AddHistogram(histClass, "MuonNClusters", "", false, 100, 0.0, 10.0, VarManager::kMuonNClusters);
+      hm->AddHistogram(histClass, "pdca", "", false, 100, 0.0, 1000., VarManager::kMuonPDca);
+      hm->AddHistogram(histClass, "RAtAbsorberEnd", "", false, 100, 10, 2000, VarManager::kMuonRAtAbsorberEnd);
+      hm->AddHistogram(histClass, "Chi2", "", false, 100, 0.0, 200.0, VarManager::kMuonChi2);
+      hm->AddHistogram(histClass, "Chi2MCHMID", "", false, 100, 0.0, 200.0, VarManager::kMuonChi2MatchMCHMID);
+      hm->AddHistogram(histClass, "Chi2MCHMFT", "", false, 100, 0.0, 200.0, VarManager::kMuonChi2MatchMCHMFT);
+      hm->AddHistogram(histClass, "Chi2MatchScoreMCHMFT", "", false, 100, 0.0, 200.0, VarManager::kMuonMatchScoreMCHMFT);
+      hm->AddHistogram(histClass, "MatchMFTTrackID", "", false, 100, 0.0, 200.0, VarManager::kMuonMatchMFTTrackID);
+      hm->AddHistogram(histClass, "MuonCXX", "", false, 100, -1.0, 1.0, VarManager::kMuonCXX);
+      hm->AddHistogram(histClass, "MuonCYY", "", false, 100, -1.0, 1.0, VarManager::kMuonCYY);
+      hm->AddHistogram(histClass, "MuonCPhiPhi", "", false, 100, -1.0, 1.0, VarManager::kMuonCPhiPhi);
+      hm->AddHistogram(histClass, "MuonCTglTgl", "", false, 100, -1.0, 1.0, VarManager::kMuonCTglTgl);
+      hm->AddHistogram(histClass, "MuonC1Pt21Pt2", "", false, 100, -1.0, 1.0, VarManager::kMuonC1Pt21Pt2);*/
     }
   }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -19,7 +19,7 @@
 #include <TObject.h>
 #include <TString.h>
 #include <Math/Vector4D.h>
-#include <TMath.h>
+#include <TRandom.h>
 
 #include <vector>
 #include <map>
@@ -38,25 +38,31 @@ class VarManager : public TObject
  public:
   // map the information contained in the objects passed to the Fill functions
   enum ObjTypes {
+    // NOTE: Elements containing "Reduced" in their name refer to skimmed data tables
+    //       and the ones that don't refer to tables from the Framework data model
     BC = BIT(0),
     Collision = BIT(1),
     CollisionCent = BIT(2),
-    ReducedEvent = BIT(3),
-    ReducedEventExtended = BIT(4),
-    ReducedEventVtxCov = BIT(5),
+    CollisionTimestamp = BIT(3),
+    ReducedEvent = BIT(4),
+    ReducedEventExtended = BIT(5),
+    ReducedEventVtxCov = BIT(6),
     Track = BIT(0),
     TrackCov = BIT(1),
     TrackExtra = BIT(2),
     TrackPID = BIT(3),
     TrackDCA = BIT(4),
     TrackSelection = BIT(5),
-    // TODO: Central model MUON variables to be added
     ReducedTrack = BIT(6),
     ReducedTrackBarrel = BIT(7),
     ReducedTrackBarrelCov = BIT(8),
     ReducedTrackBarrelPID = BIT(9),
-    ReducedTrackMuon = BIT(10),
-    Pair = BIT(11)
+    Muon = BIT(10),
+    MuonCov = BIT(11),
+    ReducedMuon = BIT(12),
+    ReducedMuonExtra = BIT(13),
+    ReducedMuonCov = BIT(14),
+    Pair = BIT(15)
   };
 
   enum PairCandidateType {
@@ -74,15 +80,20 @@ class VarManager : public TObject
     kNRunWiseVariables,
 
     // Event wise variables   // Daria: imedjat ai ziua mja
-    kCollisionTime,
+    kTimestamp,
     kBC,
     kIsPhysicsSelection,
     kIsINT7,
     kIsEMC7,
     kIsINT7inMUON,
     kIsMuonSingleLowPt7,
+    kIsMuonSingleHighPt7,
     kIsMuonUnlikeLowPt7,
     kIsMuonLikeLowPt7,
+    kIsCUP8,
+    kIsCUP9,
+    kIsMUP10,
+    kIsMUP11,
     kVtxX,
     kVtxY,
     kVtxZ,
@@ -97,7 +108,7 @@ class VarManager : public TObject
     kCentVZERO,
     kNEventWiseVariables,
 
-    // Basic track(pair) wise variables
+    // Basic track/muon/pair wise variables
     kPt,
     kEta,
     kPhi,
@@ -126,22 +137,31 @@ class VarManager : public TObject
     kTPCnclsCR,
     kTPCchi2,
     kTPCsignal,
+    kTPCsignalRandomized,
+    kTPCsignalRandomizedDelta,
     kTRDsignal,
-    kTOFsignal,
+    kTRDPattern,
     kTOFbeta,
     kTrackLength,
     kTrackDCAxy,
     kTrackDCAz,
+    kIsGoldenChi2,
     kTrackCYY,
     kTrackCZZ,
     kTrackCSnpSnp,
     kTrackCTglTgl,
     kTrackC1Pt21Pt2,
     kTPCnSigmaEl,
+    kTPCnSigmaElRandomized,
+    kTPCnSigmaElRandomizedDelta,
     kTPCnSigmaMu,
     kTPCnSigmaPi,
+    kTPCnSigmaPiRandomized,
+    kTPCnSigmaPiRandomizedDelta,
     kTPCnSigmaKa,
     kTPCnSigmaPr,
+    kTPCnSigmaPrRandomized,
+    kTPCnSigmaPrRandomizedDelta,
     kTOFnSigmaEl,
     kTOFnSigmaMu,
     kTOFnSigmaPi,
@@ -160,6 +180,20 @@ class VarManager : public TObject
     kMuonPDca,
     kMuonChi2,
     kMuonChi2MatchTrigger,
+ /*   kMuonNClusters,
+    kMuonPDca,
+    kMuonRAtAbsorberEnd,
+    kMuonChi2,
+    kMuonChi2MatchMCHMID,
+    kMuonChi2MatchMCHMFT,
+    kMuonMatchScoreMCHMFT,
+    kMuonMatchMFTTrackID,
+    kMuonMatchMCHTrackID,
+    kMuonCXX,
+    kMuonCYY,
+    kMuonCPhiPhi,
+    kMuonCTglTgl,
+    kMuonC1Pt21Pt2,*/
     kNMuonTrackVariables,
 
     // Pair variables
@@ -269,6 +303,10 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kRunNo] = event.bc().runNumber(); // accessed via Collisions table
     values[kBC] = event.bc().globalBC();
   }
+  
+  if constexpr ((fillMap & CollisionTimestamp) > 0) {
+    values[kTimestamp] = event.timestamp();
+  }
 
   if constexpr ((fillMap & Collision) > 0) {
     if (fgUsedVars[kIsINT7]) {
@@ -283,17 +321,31 @@ void VarManager::FillEvent(T const& event, float* values)
     if (fgUsedVars[kIsMuonSingleLowPt7]) {
       values[kIsMuonSingleLowPt7] = (event.alias()[kMuonSingleLowPt7] > 0);
     }
+    if (fgUsedVars[kIsMuonSingleHighPt7]) {
+      values[kIsMuonSingleHighPt7] = (event.alias()[kMuonSingleHighPt7] > 0);
+    }
     if (fgUsedVars[kIsMuonUnlikeLowPt7]) {
       values[kIsMuonUnlikeLowPt7] = (event.alias()[kMuonUnlikeLowPt7] > 0);
     }
     if (fgUsedVars[kIsMuonLikeLowPt7]) {
       values[kIsMuonLikeLowPt7] = (event.alias()[kMuonLikeLowPt7] > 0);
     }
+    if (fgUsedVars[kIsCUP8]) {
+      values[kIsCUP8] = (event.alias()[kCUP8] > 0);
+    }
+    if (fgUsedVars[kIsCUP9]) {
+      values[kIsCUP9] = (event.alias()[kCUP9] > 0);
+    }
+    if (fgUsedVars[kIsMUP10]) {
+      values[kIsMUP10] = (event.alias()[kMUP10] > 0);
+    }
+    if (fgUsedVars[kIsMUP11]) {
+      values[kIsMUP11] = (event.alias()[kMUP11] > 0);
+    }
     values[kVtxX] = event.posX();
     values[kVtxY] = event.posY();
     values[kVtxZ] = event.posZ();
     values[kVtxNcontrib] = event.numContrib();
-    values[kCollisionTime] = event.collisionTime();
     values[kVtxCovXX] = event.covXX();
     values[kVtxCovXY] = event.covXY();
     values[kVtxCovXZ] = event.covXZ();
@@ -319,6 +371,7 @@ void VarManager::FillEvent(T const& event, float* values)
 
   if constexpr ((fillMap & ReducedEventExtended) > 0) {
     values[kBC] = event.globalBC();
+    values[kTimestamp] = event.timestamp();
     values[kCentVZERO] = event.centV0M();
     if (fgUsedVars[kIsINT7]) {
       values[kIsINT7] = (event.triggerAlias() & (uint32_t(1) << kINT7)) > 0;
@@ -332,11 +385,26 @@ void VarManager::FillEvent(T const& event, float* values)
     if (fgUsedVars[kIsMuonSingleLowPt7]) {
       values[kIsMuonSingleLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonSingleLowPt7)) > 0;
     }
+    if (fgUsedVars[kIsMuonSingleHighPt7]) {
+      values[kIsMuonSingleHighPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonSingleHighPt7)) > 0;
+    }
     if (fgUsedVars[kIsMuonUnlikeLowPt7]) {
       values[kIsMuonUnlikeLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonUnlikeLowPt7)) > 0;
     }
     if (fgUsedVars[kIsMuonLikeLowPt7]) {
       values[kIsMuonLikeLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonLikeLowPt7)) > 0;
+    }
+    if (fgUsedVars[kIsCUP8]) {
+      values[kIsCUP8] = (event.triggerAlias() & (uint32_t(1) << kCUP8)) > 0;
+    }
+    if (fgUsedVars[kIsCUP9]) {
+      values[kIsCUP9] = (event.triggerAlias() & (uint32_t(1) << kCUP9)) > 0;
+    }
+    if (fgUsedVars[kIsMUP10]) {
+      values[kIsMUP10] = (event.triggerAlias() & (uint32_t(1) << kMUP10)) > 0;
+    }
+    if (fgUsedVars[kIsMUP11]) {
+      values[kIsMUP11] = (event.triggerAlias() & (uint32_t(1) << kMUP11)) > 0;
     }
   }
 
@@ -360,7 +428,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values = fgValues;
   }
 
-  if constexpr ((fillMap & Track) > 0 || (fillMap & ReducedTrack) > 0) {
+  if constexpr ((fillMap & Track) > 0 || (fillMap & Muon) > 0 || (fillMap & ReducedTrack) > 0 || (fillMap & ReducedMuon) > 0) {
     values[kPt] = track.pt();
     if (fgUsedVars[kPx]) {
       values[kPx] = track.px();
@@ -379,10 +447,13 @@ void VarManager::FillTrack(T const& track, float* values)
   if constexpr ((fillMap & TrackExtra) > 0 || (fillMap & ReducedTrackBarrel) > 0) {
     values[kPin] = track.tpcInnerParam();
     if (fgUsedVars[kIsITSrefit]) {
-      values[kIsITSrefit] = (track.flags() & (uint32_t(1) << 0)) > 0;
+      values[kIsITSrefit] = (track.flags() & o2::aod::track::ITSrefit) > 0;
     }
     if (fgUsedVars[kIsTPCrefit]) {
-      values[kIsTPCrefit] = (track.flags() & (uint32_t(1) << 1)) > 0;
+      values[kIsTPCrefit] = (track.flags() & o2::aod::track::TPCrefit) > 0;
+    }
+    if (fgUsedVars[kIsGoldenChi2]) {
+      values[kIsGoldenChi2] = (track.flags() & o2::aod::track::GoldenChi2) > 0;
     }
     if (fgUsedVars[kIsSPDfirst]) {
       values[kIsSPDfirst] = (track.itsClusterMap() & uint8_t(1)) > 0;
@@ -398,7 +469,8 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kTPCchi2] = track.tpcChi2NCl();
     values[kTrackLength] = track.length();
     values[kTPCnclsCR] = track.tpcNClsCrossedRows();
-
+    values[kTRDPattern] = track.trdPattern();
+    
     if constexpr ((fillMap & TrackExtra) > 0) {
       if (fgUsedVars[kITSncls]) {
         values[kITSncls] = track.itsNCls(); // dynamic column
@@ -447,11 +519,25 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kTOFnSigmaPr] = track.tofNSigmaPr();
     values[kTPCsignal] = track.tpcSignal();
     values[kTRDsignal] = track.trdSignal();
-    values[kTOFsignal] = track.tofSignal();
     values[kTOFbeta] = track.beta();
+    if (fgUsedVars[kTPCsignalRandomized] || fgUsedVars[kTPCnSigmaElRandomized] || fgUsedVars[kTPCnSigmaPiRandomized] || fgUsedVars[kTPCnSigmaPrRandomized]) {
+      // NOTE: this is needed temporarilly for the study of the impact of TPC pid degradation on the quarkonium triggers in high lumi pp
+      //     This study involves a degradation from a dE/dx resolution of 5% to one of 6% (20% worsening)
+      //     For this we smear the dE/dx and n-sigmas using a gaus distribution with a width of 3.3%
+      //         which is approx the needed amount to get dE/dx to a resolution of 6%  
+      double randomX = gRandom->Gaus(0.0,0.033);  
+      values[kTPCsignalRandomized] = values[kTPCsignal]*(1.0 + randomX);
+      values[kTPCsignalRandomizedDelta] = values[kTPCsignal]*randomX;
+      values[kTPCnSigmaElRandomized] = values[kTPCnSigmaEl]*(1.0 + randomX);
+      values[kTPCnSigmaElRandomizedDelta] = values[kTPCnSigmaEl]*randomX;
+      values[kTPCnSigmaPiRandomized] = values[kTPCnSigmaPi]*(1.0 + randomX);
+      values[kTPCnSigmaPiRandomizedDelta] = values[kTPCnSigmaPi]*randomX;
+      values[kTPCnSigmaPrRandomized] = values[kTPCnSigmaPr]*(1.0 + randomX);
+      values[kTPCnSigmaPrRandomizedDelta] = values[kTPCnSigmaPr]*randomX;
+    }
   }
 
-  if constexpr ((fillMap & ReducedTrackMuon) > 0) {
+  if constexpr ((fillMap & ReducedMuonExtra) > 0) {
     values[kMuonInvBendingMomentum] = track.inverseBendingMomentum();
     values[kMuonThetaX] = track.thetaX();
     values[kMuonThetaY] = track.thetaY();
@@ -463,6 +549,27 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonChi2] = track.chi2();
     values[kMuonChi2MatchTrigger] = track.chi2MatchTrigger();
   }
+  
+  // TODO: Uncomment when AO2Ds with the new data model are produced
+  /*if constexpr ((fillMap & ReducedMuonExtra) > 0 || (fillMap & Muon) > 0) {
+    values[kMuonNClusters] = track.nClusters();
+    values[kMuonPDca] = track.pDca();
+    values[kMuonRAtAbsorberEnd] = track.rAtAbsorberEnd();
+    values[kMuonChi2] = track.chi2();
+    values[kMuonChi2MatchMCHMID] = track.chi2MatchMCHMID();
+    values[kMuonChi2MatchMCHMFT] = track.chi2MatchMCHMFT();
+    values[kMuonMatchScoreMCHMFT] = track.matchScoreMCHMFT();
+    values[kMuonMatchMFTTrackID] = track.matchMFTTrackID();
+    values[kMuonMatchMCHTrackID] = track.matchMCHTrackID();
+  }*/
+  /*if constexpr ((fillMap & ReducedMuonCov) > 0 || (fillMap & MuonCov) > 0) {
+    values[kMuonCXX] = track.cXX();
+    values[kMuonCYY] = track.cYY();
+    values[kMuonCPhiPhi] = track.cPhiPhi();
+    values[kMuonCTglTgl] = track.cTglTgl();
+    values[kMuonC1Pt21Pt2] = track.c1Pt21Pt2();
+  }*/
+  
 
   if constexpr ((fillMap & Pair) > 0) {
     values[kMass] = track.mass();
@@ -522,7 +629,7 @@ void VarManager::FillDileptonHadron(T1 const& dilepton, T2 const& hadron, float*
     values[kDeltaPhi] = delta;
   }
   if (fgUsedVars[kDeltaPhiSym]) {
-    double delta = TMath::Abs(dilepton.phi() - hadron.phi());
+    double delta = std::abs(dilepton.phi() - hadron.phi());
     if (delta > M_PI) {
       delta = 2 * M_PI - delta;
     }

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -79,7 +79,7 @@ class VarManager : public TObject
     kRunId,
     kNRunWiseVariables,
 
-    // Event wise variables   // Daria: imedjat ai ziua mja
+    // Event wise variables
     kTimestamp,
     kBC,
     kIsPhysicsSelection,

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -180,7 +180,7 @@ class VarManager : public TObject
     kMuonPDca,
     kMuonChi2,
     kMuonChi2MatchTrigger,
- /*   kMuonNClusters,
+    /*   kMuonNClusters,
     kMuonPDca,
     kMuonRAtAbsorberEnd,
     kMuonChi2,
@@ -303,7 +303,7 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kRunNo] = event.bc().runNumber(); // accessed via Collisions table
     values[kBC] = event.bc().globalBC();
   }
-  
+
   if constexpr ((fillMap & CollisionTimestamp) > 0) {
     values[kTimestamp] = event.timestamp();
   }
@@ -470,7 +470,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kTrackLength] = track.length();
     values[kTPCnclsCR] = track.tpcNClsCrossedRows();
     values[kTRDPattern] = track.trdPattern();
-    
+
     if constexpr ((fillMap & TrackExtra) > 0) {
       if (fgUsedVars[kITSncls]) {
         values[kITSncls] = track.itsNCls(); // dynamic column
@@ -524,16 +524,16 @@ void VarManager::FillTrack(T const& track, float* values)
       // NOTE: this is needed temporarilly for the study of the impact of TPC pid degradation on the quarkonium triggers in high lumi pp
       //     This study involves a degradation from a dE/dx resolution of 5% to one of 6% (20% worsening)
       //     For this we smear the dE/dx and n-sigmas using a gaus distribution with a width of 3.3%
-      //         which is approx the needed amount to get dE/dx to a resolution of 6%  
-      double randomX = gRandom->Gaus(0.0,0.033);  
-      values[kTPCsignalRandomized] = values[kTPCsignal]*(1.0 + randomX);
-      values[kTPCsignalRandomizedDelta] = values[kTPCsignal]*randomX;
-      values[kTPCnSigmaElRandomized] = values[kTPCnSigmaEl]*(1.0 + randomX);
-      values[kTPCnSigmaElRandomizedDelta] = values[kTPCnSigmaEl]*randomX;
-      values[kTPCnSigmaPiRandomized] = values[kTPCnSigmaPi]*(1.0 + randomX);
-      values[kTPCnSigmaPiRandomizedDelta] = values[kTPCnSigmaPi]*randomX;
-      values[kTPCnSigmaPrRandomized] = values[kTPCnSigmaPr]*(1.0 + randomX);
-      values[kTPCnSigmaPrRandomizedDelta] = values[kTPCnSigmaPr]*randomX;
+      //         which is approx the needed amount to get dE/dx to a resolution of 6%
+      double randomX = gRandom->Gaus(0.0, 0.033);
+      values[kTPCsignalRandomized] = values[kTPCsignal] * (1.0 + randomX);
+      values[kTPCsignalRandomizedDelta] = values[kTPCsignal] * randomX;
+      values[kTPCnSigmaElRandomized] = values[kTPCnSigmaEl] * (1.0 + randomX);
+      values[kTPCnSigmaElRandomizedDelta] = values[kTPCnSigmaEl] * randomX;
+      values[kTPCnSigmaPiRandomized] = values[kTPCnSigmaPi] * (1.0 + randomX);
+      values[kTPCnSigmaPiRandomizedDelta] = values[kTPCnSigmaPi] * randomX;
+      values[kTPCnSigmaPrRandomized] = values[kTPCnSigmaPr] * (1.0 + randomX);
+      values[kTPCnSigmaPrRandomizedDelta] = values[kTPCnSigmaPr] * randomX;
     }
   }
 
@@ -549,7 +549,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonChi2] = track.chi2();
     values[kMuonChi2MatchTrigger] = track.chi2MatchTrigger();
   }
-  
+
   // TODO: Uncomment when AO2Ds with the new data model are produced
   /*if constexpr ((fillMap & ReducedMuonExtra) > 0 || (fillMap & Muon) > 0) {
     values[kMuonNClusters] = track.nClusters();
@@ -569,7 +569,6 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonCTglTgl] = track.cTglTgl();
     values[kMuonC1Pt21Pt2] = track.c1Pt21Pt2();
   }*/
-  
 
   if constexpr ((fillMap & Pair) > 0) {
     values[kMass] = track.mass();

--- a/Analysis/PWGDQ/src/VarManager.cxx
+++ b/Analysis/PWGDQ/src/VarManager.cxx
@@ -10,7 +10,7 @@
 
 #include "PWGDQCore/VarManager.h"
 
-#include <TMath.h>
+#include <cmath>
 
 ClassImp(VarManager);
 
@@ -101,7 +101,7 @@ void VarManager::FillTrackDerived(float* values)
   // Fill track-wise derived quantities (these are all quantities which can be computed just based on the values already filled in the FillTrack() function)
   //
   if (fgUsedVars[kP]) {
-    values[kP] = values[kPt] * TMath::CosH(values[kEta]);
+    values[kP] = values[kPt] * std::cosh(values[kEta]);
   }
 }
 
@@ -120,8 +120,6 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kRunNo] = "";
   fgVariableNames[kRunId] = "Run number";
   fgVariableUnits[kRunId] = "";
-  fgVariableNames[kCollisionTime] = "collision time";
-  fgVariableUnits[kCollisionTime] = "";
   fgVariableNames[kBC] = "Bunch crossing";
   fgVariableUnits[kBC] = "";
   fgVariableNames[kIsPhysicsSelection] = "Physics selection";
@@ -188,8 +186,6 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kTPCsignal] = "";
   fgVariableNames[kTRDsignal] = "TRD dE/dx";
   fgVariableUnits[kTRDsignal] = "";
-  fgVariableNames[kTOFsignal] = "TOF signal";
-  fgVariableUnits[kTOFsignal] = "";
   fgVariableNames[kTOFbeta] = "TOF #beta";
   fgVariableUnits[kTOFbeta] = "";
   fgVariableNames[kTrackLength] = "track length";

--- a/Analysis/Tasks/PWGDQ/dileptonEE.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonEE.cxx
@@ -76,7 +76,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses);
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
 
-struct EventSelection {
+struct DQEventSelection {
   Produces<aod::EventCuts> eventSel;
   Produces<aod::MixingHashes> hash;
   OutputObj<THashList> fOutputList{"output"};
@@ -146,7 +146,7 @@ struct EventSelection {
   }
 };
 
-struct BarrelTrackSelection {
+struct DQBarrelTrackSelection {
   Produces<aod::BarrelTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -344,7 +344,7 @@ struct DileptonEE {
   }
 };
 
-struct EventMixing {
+struct DQEventMixing {
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
   float* fValues;
@@ -446,10 +446,10 @@ struct EventMixing {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>(cfgc),
-    adaptAnalysisTask<BarrelTrackSelection>(cfgc),
+    adaptAnalysisTask<DQEventSelection>(cfgc),
+    adaptAnalysisTask<DQBarrelTrackSelection>(cfgc),
     adaptAnalysisTask<DileptonEE>(cfgc),
-    adaptAnalysisTask<EventMixing>(cfgc),
+    adaptAnalysisTask<DQEventMixing>(cfgc),
 
   };
 }

--- a/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
@@ -72,7 +72,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses);
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedMuon;
 
-struct EventSelection {
+struct DQEventSelection {
   Produces<aod::EventCuts> eventSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -125,7 +125,7 @@ struct EventSelection {
   }
 };
 
-struct MuonTrackSelection {
+struct DQMuonTrackSelection {
   Produces<aod::MuonTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -372,7 +372,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>(cfgc),
-    adaptAnalysisTask<MuonTrackSelection>(cfgc),
+    adaptAnalysisTask<DQEventSelection>(cfgc),
+    adaptAnalysisTask<DQMuonTrackSelection>(cfgc),
     adaptAnalysisTask<DileptonMuMu>(cfgc)};
 }

--- a/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
+++ b/Analysis/Tasks/PWGDQ/dileptonMuMu.cxx
@@ -20,7 +20,6 @@
 #include "PWGDQCore/AnalysisCut.h"
 #include "PWGDQCore/AnalysisCompositeCut.h"
 #include <TH1F.h>
-#include <TMath.h>
 #include <THashList.h>
 #include <TString.h>
 #include <iostream>
@@ -58,8 +57,8 @@ using MyEvents = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended>;
 using MyEventsSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::EventCuts>;
 using MyEventsVtxCov = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsVtxCov>;
 using MyEventsVtxCovSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsVtxCov, aod::EventCuts>;
-using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtended>;
-using MyMuonTracksSelected = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtended, aod::MuonTrackCuts>;
+using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
+using MyMuonTracksSelected = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::MuonTrackCuts>;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
@@ -71,7 +70,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses);
 //        This is a temporary fix until the arrow/ROOT issues are solved, at which point it will be possible
 //           to automatically detect the object types transmitted to the VarManager
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
-constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackMuon;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedMuon;
 
 struct EventSelection {
   Produces<aod::EventCuts> eventSel;
@@ -346,14 +345,14 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
       histMan->AddHistogram(classStr.Data(), "Pz", "p_{z} distribution", false, 400, -20.0, 20.0, VarManager::kPz);
 
       if (classStr.Contains("Muon")) {
-        histMan->AddHistogram(classStr.Data(), "InvBendingMom", "", false, 100, 0.0, 1.0, VarManager::kMuonInvBendingMomentum);
+        /*histMan->AddHistogram(classStr.Data(), "InvBendingMom", "", false, 100, 0.0, 1.0, VarManager::kMuonInvBendingMomentum);
         histMan->AddHistogram(classStr.Data(), "ThetaX", "", false, 100, -1.0, 1.0, VarManager::kMuonThetaX);
         histMan->AddHistogram(classStr.Data(), "ThetaY", "", false, 100, -2.0, 2.0, VarManager::kMuonThetaY);
         histMan->AddHistogram(classStr.Data(), "ZMu", "", false, 100, -30.0, 30.0, VarManager::kMuonZMu);
         histMan->AddHistogram(classStr.Data(), "BendingCoor", "", false, 100, 0.32, 0.35, VarManager::kMuonBendingCoor);
         histMan->AddHistogram(classStr.Data(), "NonBendingCoor", "", false, 100, 0.065, 0.07, VarManager::kMuonNonBendingCoor);
         histMan->AddHistogram(classStr.Data(), "Chi2", "", false, 100, 0.0, 200.0, VarManager::kMuonChi2);
-        histMan->AddHistogram(classStr.Data(), "Chi2MatchTrigger", "", false, 100, 0.0, 20.0, VarManager::kMuonChi2MatchTrigger);
+        histMan->AddHistogram(classStr.Data(), "Chi2MatchTrigger", "", false, 100, 0.0, 20.0, VarManager::kMuonChi2MatchTrigger);*/
         histMan->AddHistogram(classStr.Data(), "RAtAbsorberEnd", "", false, 140, 10, 150, VarManager::kMuonRAtAbsorberEnd);
         histMan->AddHistogram(classStr.Data(), "p x dca", "", false, 700, 0.0, 700, VarManager::kMuonRAtAbsorberEnd);
       }
@@ -373,7 +372,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>(cfgc, TaskName{"my-event-selection"}),
-    adaptAnalysisTask<MuonTrackSelection>(cfgc, TaskName{"muon-track-selection"}),
-    adaptAnalysisTask<DileptonMuMu>(cfgc, TaskName{"dilepton-mumu"})};
+    adaptAnalysisTask<EventSelection>(cfgc),
+    adaptAnalysisTask<MuonTrackSelection>(cfgc),
+    adaptAnalysisTask<DileptonMuMu>(cfgc)};
 }

--- a/Analysis/Tasks/PWGDQ/filterPP.cxx
+++ b/Analysis/Tasks/PWGDQ/filterPP.cxx
@@ -29,7 +29,6 @@
 #include "AnalysisDataModel/TrackSelectionTables.h"
 #include <TH1F.h>
 #include <TH2I.h>
-#include <TMath.h>
 #include <THashList.h>
 #include <TString.h>
 #include <iostream>
@@ -68,7 +67,7 @@ constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarMana
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
-struct EventSelectionTask {
+struct DQEventSelectionTask {
   Produces<aod::DQEventCuts> eventSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -125,7 +124,7 @@ struct EventSelectionTask {
   }
 };
 
-struct BarrelTrackSelectionTask {
+struct DQBarrelTrackSelectionTask {
   Produces<aod::DQBarrelTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -197,7 +196,7 @@ struct BarrelTrackSelectionTask {
   }
 };
 
-struct FilterPPTask {
+struct DQFilterPPTask {
   Produces<aod::DQEventFilter> eventFilter;
   OutputObj<THashList> fOutputList{"output"};
   OutputObj<TH2I> fStats{"stats"};
@@ -321,9 +320,9 @@ struct FilterPPTask {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelectionTask>(cfgc, TaskName{"dq-event-selection"}),
-    adaptAnalysisTask<BarrelTrackSelectionTask>(cfgc, TaskName{"dq-barrel-track-selection"}),
-    adaptAnalysisTask<FilterPPTask>(cfgc, TaskName{"dq-ppFilter"})};
+    adaptAnalysisTask<DQEventSelectionTask>(cfgc),
+    adaptAnalysisTask<DQBarrelTrackSelectionTask>(cfgc),
+    adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses)

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -80,7 +80,6 @@ struct TableMaker {
   Produces<ReducedMuons> muonBasic;
   Produces<ReducedMuonsExtra> muonExtra;
   //Produces<ReducedMuonsCov> muonCov;   // TODO: use with fwdtracks
-  
 
   float* fValues;
 
@@ -102,13 +101,13 @@ struct TableMaker {
   // TODO: filter on TPC dedx used temporarily until electron PID will be improved
   Filter barrelSelectedTracks = aod::track::trackType == uint8_t(aod::track::Run2Track) && o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
   //Filter barrelSelectedTracks = aod::track::trackType == uint8_t(aod::track::Run2GlobalTrack);
-  
+
   //Filter barrelSelectedTracks = o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f;
   //Filter trackFilter = aod::track::trackType == aod::track::Run2GlobalTrack;
   // TODO: some of the muon variables which could be used in the filter expression are currently DYNAMIC columns (e.g. eta)
   //       Add more basic muon cuts
   // TODO: Use Partition to avoid the cross-talk between filters which use variables with the same name (e.g. pt for both barrel and muon tracks)
-  
+
   //       Replace by Filter when the bug is fixed
   Partition<MyMuons> selectedMuons = o2::aod::muon::pt >= fConfigMuonPtLow;
   //Partition<MyMuons> selectedMuons = o2::aod::fwdtrack::pt >= fConfigMuonPtLow;
@@ -154,7 +153,7 @@ struct TableMaker {
     }
     uint64_t tag = 0;
     //uint64_t tag = collision.run2bcinfo().eventCuts();   // TODO: get the event cuts
-         
+
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables, fValues);
     VarManager::FillEvent<eventFillMap>(collision, fValues); // extract event information and place it in the fgValues array
     fHistMan->FillHistClass("Event_BeforeCuts", fValues);    // automatically fill all the histograms in the class Event
@@ -203,12 +202,12 @@ struct TableMaker {
                      track.beta(),
                      track.tofNSigmaEl(), track.tofNSigmaMu(),
                      track.tofNSigmaPi(), track.tofNSigmaKa(), track.tofNSigmaPr(),
-                     track.trdSignal());    
+                     track.trdSignal());
     }
 
     muonBasic.reserve(selectedMuons.size());
     muonExtra.reserve(selectedMuons.size());
-    for (auto& muon : selectedMuons) {      
+    for (auto& muon : selectedMuons) {
       if (muon.bcId() != collision.bcId()) {
         continue;
       }
@@ -221,7 +220,7 @@ struct TableMaker {
       muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
       muonExtra(muon.inverseBendingMomentum(), muon.thetaX(), muon.thetaY(), muon.zMu(), muon.bendingCoor(), muon.nonBendingCoor(), muon.chi2(), muon.chi2MatchTrigger());
     }
-    
+
     // TODO: to be used with the fwdtrack tables
     /*muonBasic.reserve(tracksMuon.size());
     muonExtra.reserve(tracksMuon.size());

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -48,6 +48,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection, aod::pidRespTPC, aod::pidRespTOF, aod::pidRespTOFbeta>;
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels, aod::Cents>;
 using MyEventsNoCent = soa::Join<aod::Collisions, aod::EvSels>;
+using MyMuons = aod::Muons;
+//using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
+//using MyMuons = aod::FullFwdTracks;
 
 // HACK: In order to be able to deduce which kind of aod object is transmitted to the templated VarManager::Fill functions
 //         a constexpr static bit map must be defined and sent as template argument
@@ -59,7 +62,8 @@ using MyEventsNoCent = soa::Join<aod::Collisions, aod::EvSels>;
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCent;
 constexpr static uint32_t gkEventFillMapNoCent = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
-constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::ReducedTrackMuon;
+//constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 
 template <uint32_t eventFillMap, typename T>
 struct TableMaker {
@@ -74,11 +78,14 @@ struct TableMaker {
   Produces<ReducedTracksBarrelCov> trackBarrelCov;
   Produces<ReducedTracksBarrelPID> trackBarrelPID;
   Produces<ReducedMuons> muonBasic;
-  Produces<ReducedMuonsExtended> muonExtended;
+  Produces<ReducedMuonsExtra> muonExtra;
+  //Produces<ReducedMuonsCov> muonCov;   // TODO: use with fwdtracks
+  
 
   float* fValues;
 
   OutputObj<THashList> fOutputList{"output"};
+  OutputObj<TH1F> etaH{TH1F("eta", "eta", 102, -2.01, 2.01)};
   HistogramManager* fHistMan;
 
   Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};
@@ -93,12 +100,18 @@ struct TableMaker {
   AnalysisCompositeCut* fMuonCut;
 
   // TODO: filter on TPC dedx used temporarily until electron PID will be improved
-  Filter barrelSelectedTracks = o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
+  Filter barrelSelectedTracks = aod::track::trackType == uint8_t(aod::track::Run2Track) && o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f && o2::aod::track::tpcSignal >= 70.0f && o2::aod::track::tpcSignal <= 100.0f && o2::aod::track::tpcChi2NCl < 4.0f && o2::aod::track::itsChi2NCl < 36.0f;
+  //Filter barrelSelectedTracks = aod::track::trackType == uint8_t(aod::track::Run2GlobalTrack);
+  
+  //Filter barrelSelectedTracks = o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f;
+  //Filter trackFilter = aod::track::trackType == aod::track::Run2GlobalTrack;
   // TODO: some of the muon variables which could be used in the filter expression are currently DYNAMIC columns (e.g. eta)
   //       Add more basic muon cuts
   // TODO: Use Partition to avoid the cross-talk between filters which use variables with the same name (e.g. pt for both barrel and muon tracks)
+  
   //       Replace by Filter when the bug is fixed
-  Partition<o2::aod::Muons> selectedMuons = o2::aod::muon::pt >= fConfigMuonPtLow;
+  Partition<MyMuons> selectedMuons = o2::aod::muon::pt >= fConfigMuonPtLow;
+  //Partition<MyMuons> selectedMuons = o2::aod::fwdtrack::pt >= fConfigMuonPtLow;
 
   void init(o2::framework::InitContext&)
   {
@@ -131,16 +144,17 @@ struct TableMaker {
     VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
   }
 
-  void process(MyEvent const& collision, aod::Muons const& tracksMuon, aod::BCs const& bcs, soa::Filtered<MyBarrelTracks> const& tracksBarrel)
+  void process(MyEvent const& collision, MyMuons const& tracksMuon, aod::BCs const& bcs, soa::Filtered<MyBarrelTracks> const& tracksBarrel)
   {
-    uint64_t tag = 0;
     uint32_t triggerAliases = 0;
     for (int i = 0; i < kNaliases; i++) {
       if (collision.alias()[i] > 0) {
         triggerAliases |= (uint32_t(1) << i);
       }
     }
-
+    uint64_t tag = 0;
+    //uint64_t tag = collision.run2bcinfo().eventCuts();   // TODO: get the event cuts
+         
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables, fValues);
     VarManager::FillEvent<eventFillMap>(collision, fValues); // extract event information and place it in the fgValues array
     fHistMan->FillHistClass("Event_BeforeCuts", fValues);    // automatically fill all the histograms in the class Event
@@ -152,7 +166,7 @@ struct TableMaker {
     fHistMan->FillHistClass("Event_AfterCuts", fValues);
 
     event(tag, collision.bc().runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib());
-    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), triggerAliases, fValues[VarManager::kCentVZERO]);
+    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), 0, triggerAliases, fValues[VarManager::kCentVZERO]);
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
     uint64_t trackFilteringTag = 0;
@@ -169,6 +183,7 @@ struct TableMaker {
       }
       fHistMan->FillHistClass("TrackBarrel_AfterCuts", fValues);
 
+      etaH->Fill(track.eta());
       if (track.isGlobalTrack()) {
         trackFilteringTag |= (uint64_t(1) << 0);
       }
@@ -179,39 +194,52 @@ struct TableMaker {
       trackBarrel(track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
                   track.tpcNClsFindable(), track.tpcNClsFindableMinusFound(), track.tpcNClsFindableMinusCrossedRows(),
                   track.tpcNClsShared(), track.tpcChi2NCl(),
-                  track.trdChi2(), track.tofChi2(),
+                  track.trdChi2(), track.trdPattern(), track.tofChi2(),
                   track.length(), track.dcaXY(), track.dcaZ());
       trackBarrelCov(track.cYY(), track.cZZ(), track.cSnpSnp(), track.cTglTgl(), track.c1Pt21Pt2());
       trackBarrelPID(track.tpcSignal(),
                      track.tpcNSigmaEl(), track.tpcNSigmaMu(),
                      track.tpcNSigmaPi(), track.tpcNSigmaKa(), track.tpcNSigmaPr(),
-                     track.tpcNSigmaDe(), track.tpcNSigmaTr(), track.tpcNSigmaHe(), track.tpcNSigmaAl(),
-                     track.tofSignal(), track.beta(),
+                     track.beta(),
                      track.tofNSigmaEl(), track.tofNSigmaMu(),
                      track.tofNSigmaPi(), track.tofNSigmaKa(), track.tofNSigmaPr(),
-                     track.tofNSigmaDe(), track.tofNSigmaTr(), track.tofNSigmaHe(), track.tofNSigmaAl(),
-                     track.trdSignal());
+                     track.trdSignal());    
     }
 
     muonBasic.reserve(selectedMuons.size());
-    muonExtended.reserve(selectedMuons.size());
-    for (auto& muon : selectedMuons) {
-      // TODO: add proper information for muon tracks
+    muonExtra.reserve(selectedMuons.size());
+    for (auto& muon : selectedMuons) {      
       if (muon.bcId() != collision.bcId()) {
         continue;
       }
       VarManager::FillTrack<gkMuonFillMap>(muon, fValues);
       fHistMan->FillHistClass("Muons_BeforeCuts", fValues);
-      // TODO: the trackFilteringTag will not be needed to encode whether the track is a muon since there is a dedicated table for muons
-      trackFilteringTag |= (uint64_t(1) << 0); // this is a MUON arm track  TODO: to be taken out
+      if (!fMuonCut->IsSelected(fValues)) {
+        continue;
+      }
+      fHistMan->FillHistClass("Muons_AfterCuts", fValues);
+      muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
+      muonExtra(muon.inverseBendingMomentum(), muon.thetaX(), muon.thetaY(), muon.zMu(), muon.bendingCoor(), muon.nonBendingCoor(), muon.chi2(), muon.chi2MatchTrigger());
+    }
+    
+    // TODO: to be used with the fwdtrack tables
+    /*muonBasic.reserve(tracksMuon.size());
+    muonExtra.reserve(tracksMuon.size());
+    //muonCov.reserve(tracksMuon.size());
+    for (auto& muon : tracksMuon) {
+      VarManager::FillTrack<gkMuonFillMap>(muon, fValues);
+      fHistMan->FillHistClass("Muons_BeforeCuts", fValues);
       if (!fMuonCut->IsSelected(fValues)) {
         continue;
       }
       fHistMan->FillHistClass("Muons_AfterCuts", fValues);
 
       muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
-      muonExtended(muon.inverseBendingMomentum(), muon.thetaX(), muon.thetaY(), muon.zMu(), muon.bendingCoor(), muon.nonBendingCoor(), muon.chi2(), muon.chi2MatchTrigger());
-    }
+      muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
+                   muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
+                   muon.matchScoreMCHMFT(), muon.matchMFTTrackID(), muon.matchMCHTrackID());
+      //muonCov(muon.cXX(), muon.cYY(), muon.cPhiPhi(), muon.cTglTgl(), muon.c1Pt21Pt2());
+    }*/
   }
 
   void DefineHistograms(TString histClasses)
@@ -223,11 +251,11 @@ struct TableMaker {
 
       // NOTE: The level of detail for histogramming can be controlled via configurables
       if (classStr.Contains("Event")) {
-        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "event", "trigger,cent");
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "event", "triggerall,cent");
       }
 
       if (classStr.Contains("Track")) {
-        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "tpcpid");
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "dca,its,tpcpid");
       }
       if (classStr.Contains("Muons")) {
         dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "muon");
@@ -241,9 +269,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec workflow;
   const bool isPbPb = cfgc.options().get<bool>("isPbPb");
   if (isPbPb) {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>(cfgc, TaskName{"table-maker"}));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>(cfgc, TaskName{"table-maker-pbpb"}));
   } else {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>(cfgc, TaskName{"table-maker"}));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>(cfgc, TaskName{"table-maker-pp"}));
   }
 
   return workflow;

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -268,9 +268,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec workflow;
   const bool isPbPb = cfgc.options().get<bool>("isPbPb");
   if (isPbPb) {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>(cfgc, TaskName{"table-maker-pbpb"}));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMap, MyEvents>>(cfgc, TaskName{"dq-table-maker-pbpb"}));
   } else {
-    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>(cfgc, TaskName{"table-maker-pp"}));
+    workflow.push_back(adaptAnalysisTask<TableMaker<gkEventFillMapNoCent, MyEventsNoCent>>(cfgc, TaskName{"dq-table-maker-pp"}));
   }
 
   return workflow;

--- a/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
@@ -35,7 +35,9 @@ using namespace o2::framework;
 //using namespace o2::framework::expressions;
 using namespace o2::aod;
 
-using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels, aod::Timestamps>;
+//using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
+using MyMuons = aod::Muons;
 
 // HACK: In order to be able to deduce which kind of aod object is transmitted to the templated VarManager::Fill functions
 //         a constexpr static bit map must be defined and sent as template argument
@@ -53,8 +55,9 @@ struct TableMakerMuon_pp {
   Produces<ReducedEventsVtxCov> eventVtxCov;
   Produces<ReducedTracks> trackBasic;
   Produces<ReducedMuons> muonBasic;
-  Produces<ReducedMuonsExtended> muonExtended;
-
+  Produces<ReducedMuonsExtra> muonExtended;
+  //Produces<ReducedMuonsCov> muonCov;   // TODO: use with fwdtracks
+  
   float* fValues;
 
   OutputObj<THashList> fOutputList{"output"};
@@ -67,7 +70,7 @@ struct TableMakerMuon_pp {
 
   // TODO a few of the important muon variables in the central data model are dynamic columns so not usable in expressions (e.g. eta, phi)
   //        Update the data model to have them as expression columns
-  Partition<aod::Muons> muonSelectedTracks = o2::aod::muon::pt >= 0.5f; // For pp collisions a 0.5 GeV/c pp cuts is defined
+  Partition<MyMuons> muonSelectedTracks = o2::aod::muon::pt >= 0.5f; // For pp collisions a 0.5 GeV/c pp cuts is defined
 
   void init(o2::framework::InitContext&)
   {
@@ -94,7 +97,7 @@ struct TableMakerMuon_pp {
     VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
   }
 
-  void process(MyEvents::iterator const& collision, aod::MuonClusters const& clustersMuon, aod::Muons const& tracksMuon, aod::BCs const& bcs)
+  void process(MyEvents::iterator const& collision, MyMuons const& muonTracks, aod::BCs const& bcs)
   {
     uint64_t tag = 0;
     uint32_t triggerAliases = 0;
@@ -115,7 +118,7 @@ struct TableMakerMuon_pp {
     fHistMan->FillHistClass("Event_AfterCuts", fValues);
 
     event(tag, collision.bc().runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib());
-    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), triggerAliases, 0.0f);
+    eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), collision.timestamp(), triggerAliases, 0.0f);
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
     uint64_t trackFilteringTag = 0;
@@ -132,6 +135,17 @@ struct TableMakerMuon_pp {
       muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
       muonExtended(muon.inverseBendingMomentum(), muon.thetaX(), muon.thetaY(), muon.zMu(), muon.bendingCoor(), muon.nonBendingCoor(), muon.chi2(), muon.chi2MatchTrigger());
     }
+    // TODO: to be used with the fwdtrack tables
+    /*muonBasic.reserve(muonSelectedTracks.size());
+    muonExtended.reserve(muonSelectedTracks.size());
+    muonCov.reserve(muonSelectedTracks.size());
+    for (auto& muon : muonSelectedTracks) {
+      muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
+      muonExtended(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
+                   muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
+                   muon.matchScoreMCHMFT(), muon.matchMFTTrackID(), muon.matchMCHTrackID());
+      muonCov(muon.cXX(), muon.cYY(), muon.cPhiPhi(), muon.cTglTgl(), muon.c1Pt21Pt2());
+    }*/
   }
 
   void DefineHistograms(TString histClasses)

--- a/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMakerMuon_pp.cxx
@@ -57,7 +57,7 @@ struct TableMakerMuon_pp {
   Produces<ReducedMuons> muonBasic;
   Produces<ReducedMuonsExtra> muonExtended;
   //Produces<ReducedMuonsCov> muonCov;   // TODO: use with fwdtracks
-  
+
   float* fValues;
 
   OutputObj<THashList> fOutputList{"output"};

--- a/Analysis/Tasks/PWGDQ/tableReader.cxx
+++ b/Analysis/Tasks/PWGDQ/tableReader.cxx
@@ -22,7 +22,6 @@
 #include "PWGDQCore/HistogramsLibrary.h"
 #include "PWGDQCore/CutsLibrary.h"
 #include <TH1F.h>
-#include <TMath.h>
 #include <THashList.h>
 #include <TString.h>
 #include <iostream>
@@ -68,8 +67,8 @@ using MyEventsVtxCovSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsE
 using MyBarrelTracks = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelCov, aod::ReducedTracksBarrelPID>;
 using MyBarrelTracksSelected = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelCov, aod::ReducedTracksBarrelPID, aod::BarrelTrackCuts>;
 
-using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtended>;
-using MyMuonTracksSelected = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtended, aod::MuonTrackCuts>;
+using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
+using MyMuonTracksSelected = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::MuonTrackCuts>;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
@@ -82,7 +81,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses);
 //           to automatically detect the object types transmitted to the VarManager
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
-constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackMuon;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedMuon;
 
 // NOTE: hardcoded number of parallel electron cuts for the barrel analysis
 // TODO: make it configurable
@@ -619,13 +618,12 @@ struct DileptonHadronAnalysis {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>(cfgc, TaskName{"my-event-selection"}),
-    adaptAnalysisTask<BarrelTrackSelection>(cfgc, TaskName{"barrel-track-selection"}),
-    adaptAnalysisTask<EventMixing>(cfgc, TaskName{"event-mixing"}),
-    adaptAnalysisTask<MuonTrackSelection>(cfgc, TaskName{"muon-track-selection"}),
-    adaptAnalysisTask<TableReader>(cfgc, TaskName{"table-reader"}),
-    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc, TaskName{"dilepton-hadron"})
-
+    adaptAnalysisTask<EventSelection>(cfgc),
+    adaptAnalysisTask<BarrelTrackSelection>(cfgc),
+    adaptAnalysisTask<EventMixing>(cfgc),
+    adaptAnalysisTask<MuonTrackSelection>(cfgc),
+    adaptAnalysisTask<TableReader>(cfgc),
+    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc)
   };
 }
 

--- a/Analysis/Tasks/PWGDQ/tableReader.cxx
+++ b/Analysis/Tasks/PWGDQ/tableReader.cxx
@@ -623,8 +623,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<EventMixing>(cfgc),
     adaptAnalysisTask<MuonTrackSelection>(cfgc),
     adaptAnalysisTask<TableReader>(cfgc),
-    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc)
-  };
+    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc)};
 }
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses)

--- a/Analysis/Tasks/PWGDQ/tableReader.cxx
+++ b/Analysis/Tasks/PWGDQ/tableReader.cxx
@@ -87,7 +87,7 @@ constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedTrack | V
 // TODO: make it configurable
 constexpr int gNTrackCuts = 2;
 
-struct EventSelection {
+struct DQEventSelection {
   Produces<aod::EventCuts> eventSel;
   Produces<aod::MixingHashes> hash;
   OutputObj<THashList> fOutputList{"output"};
@@ -152,7 +152,7 @@ struct EventSelection {
   }
 };
 
-struct BarrelTrackSelection {
+struct DQBarrelTrackSelection {
   Produces<aod::BarrelTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -231,7 +231,7 @@ struct BarrelTrackSelection {
   }
 };
 
-struct MuonTrackSelection {
+struct DQMuonTrackSelection {
   Produces<aod::MuonTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -286,7 +286,7 @@ struct MuonTrackSelection {
   }
 };
 
-struct EventMixing {
+struct DQEventMixing {
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
   float* fValues;
@@ -431,7 +431,7 @@ struct EventMixing {
   }       // end process()
 };
 
-struct TableReader {
+struct DQTableReader {
   Produces<aod::Dileptons> dileptonList;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
@@ -535,7 +535,7 @@ struct TableReader {
   }
 };
 
-struct DileptonHadronAnalysis {
+struct DQDileptonHadronAnalysis {
   //
   // This task combines dilepton candidates with a track and could be used for example
   //  in analyses with the dilepton as one of the decay products of a higher mass resonance (e.g. B0 -> Jpsi + K)
@@ -618,12 +618,12 @@ struct DileptonHadronAnalysis {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<EventSelection>(cfgc),
-    adaptAnalysisTask<BarrelTrackSelection>(cfgc),
-    adaptAnalysisTask<EventMixing>(cfgc),
-    adaptAnalysisTask<MuonTrackSelection>(cfgc),
-    adaptAnalysisTask<TableReader>(cfgc),
-    adaptAnalysisTask<DileptonHadronAnalysis>(cfgc)};
+    adaptAnalysisTask<DQEventSelection>(cfgc),
+    adaptAnalysisTask<DQBarrelTrackSelection>(cfgc),
+    adaptAnalysisTask<DQEventMixing>(cfgc),
+    adaptAnalysisTask<DQMuonTrackSelection>(cfgc),
+    adaptAnalysisTask<DQTableReader>(cfgc),
+    adaptAnalysisTask<DQDileptonHadronAnalysis>(cfgc)};
 }
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses)


### PR DESCRIPTION
ReducedInfoTable:
* removed nuclei PID columns
* added few other columns (TRDpattern, event timestamp)
* changed name of ReducedMuonExtended table to ReducedMuonExtra
* prepared new tables to support the new MUON Run3 data model (commented out for now)

CutsLibrary:
* several cuts added for the study of the TPC dE/dx degradation impact on quarkonia triggers in high lumi pp

HistogramsLibrary
* updated trigger histograms
* added more PID histograms
* Run3 MUON histograms (commented out for now)

VarManager
* added more variables (trigger, PID, Run3 MUON)
* replaced some TMath expressions with std

filterPP:
* task names changed to avoid conflicts
* Removed TaskName in the workflow config

tableMaker
* added changes for Run3 muon
* Filter applied now on Run2Track to reject tracklets
* implemented changes from data model

Other tasks:
small changes to remove TaskName where not needed