### PR TITLE
[Tracking] Updates and fixes  - preparations for alignment code 

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackLTIntegral.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackLTIntegral.h
@@ -27,6 +27,8 @@ namespace track
 class TrackLTIntegral
 {
  public:
+  static constexpr float NeglectTime = -1.; // if 1st mT slot contains this, don't fill time
+
   GPUdDefault() TrackLTIntegral() = default;
   GPUdDefault() TrackLTIntegral(const TrackLTIntegral& stc) = default;
   GPUdDefault() ~TrackLTIntegral() = default;
@@ -35,12 +37,14 @@ class TrackLTIntegral
 
   GPUd() float getL() const { return mL; }
   GPUd() float getX2X0() const { return mX2X0; }
+  GPUd() float getXRho() const { return mXRho; }
   GPUd() float getTOF(int id) const { return mT[id]; }
 
   GPUd() void clear()
   {
     mL = 0.f;
     mX2X0 = 0.f;
+    mXRho = 0.f;
     for (int i = getNTOFs(); i--;) {
       mT[i] = 0.f;
     }
@@ -48,19 +52,25 @@ class TrackLTIntegral
 
   GPUd() void addStep(float dL, float p2Inv);
   GPUd() void addX2X0(float d) { mX2X0 += d; }
+  GPUd() void addXRho(float d) { mXRho += d; }
 
   GPUd() void setL(float l) { mL = l; }
   GPUd() void setX2X0(float x) { mX2X0 = x; }
+  GPUd() void setXRho(float x) { mXRho = x; }
   GPUd() void setTOF(float t, int id) { mT[id] = t; }
+
+  GPUd() void setTimeNotNeeded() { mT[0] = NeglectTime; }
+  GPUd() bool isTimeNotNeeded() const { return mT[0] == NeglectTime; }
 
   GPUd() void print() const;
 
  private:
   float mL = 0.;                         // length in cm
   float mX2X0 = 0.;                      // integrated X/X0
+  float mXRho = 0.;                      // average X*rho
   float mT[o2::track::PID::NIDs] = {0.}; // TOF in ps
 
-  ClassDefNV(TrackLTIntegral, 1);
+  ClassDefNV(TrackLTIntegral, 2);
 };
 }; // namespace track
 }; // namespace o2

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -37,6 +37,7 @@
 #include <cmath>
 #include <cstring>
 #include <iosfwd>
+#include <type_traits>
 #endif
 
 #ifndef GPUCA_ALIGPUCODE //Used only by functions that are hidden on the GPU
@@ -261,70 +262,70 @@ GPUdi() void TrackParametrization<value_T>::set(value_t x, value_t alpha, const 
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() const typename TrackParametrization<value_T>::value_t* TrackParametrization<value_T>::getParams() const
+GPUdi() auto TrackParametrization<value_T>::getParams() const -> const value_t*
 {
   return mP;
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getParam(int i) const
+GPUdi() auto TrackParametrization<value_T>::getParam(int i) const -> value_t
 {
   return mP[i];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getX() const
+GPUdi() auto TrackParametrization<value_T>::getX() const -> value_t
 {
   return mX;
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getAlpha() const
+GPUdi() auto TrackParametrization<value_T>::getAlpha() const -> value_t
 {
   return mAlpha;
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getY() const
+GPUdi() auto TrackParametrization<value_T>::getY() const -> value_t
 {
   return mP[kY];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getZ() const
+GPUdi() auto TrackParametrization<value_T>::getZ() const -> value_t
 {
   return mP[kZ];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getSnp() const
+GPUdi() auto TrackParametrization<value_T>::getSnp() const -> value_t
 {
   return mP[kSnp];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTgl() const
+GPUdi() auto TrackParametrization<value_T>::getTgl() const -> value_t
 {
   return mP[kTgl];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getQ2Pt() const
+GPUdi() auto TrackParametrization<value_T>::getQ2Pt() const -> value_t
 {
   return mP[kQ2Pt];
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCharge2Pt() const
+GPUdi() auto TrackParametrization<value_T>::getCharge2Pt() const -> value_t
 {
   return mAbsCharge ? mP[kQ2Pt] : 0.f;
 }
@@ -353,7 +354,7 @@ GPUdi() void TrackParametrization<value_T>::setPID(const PID pid)
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp2() const
+GPUdi() auto TrackParametrization<value_T>::getCsp2() const -> value_t
 {
   const value_t csp2 = (1.f - mP[kSnp]) * (1.f + mP[kSnp]);
   return csp2 > o2::constants::math::Almost0 ? csp2 : o2::constants::math::Almost0;
@@ -361,7 +362,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCsp() const
+GPUdi() auto TrackParametrization<value_T>::getCsp() const -> value_t
 {
   return gpu::CAMath::Sqrt(getCsp2());
 }
@@ -474,7 +475,7 @@ GPUdi() void TrackParametrization<value_T>::getLineParams(o2::math_utils::Interv
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getCurvature(value_t b) const
+GPUdi() auto TrackParametrization<value_T>::getCurvature(value_t b) const -> value_t
 {
   return mAbsCharge ? mP[kQ2Pt] * b * o2::constants::math::B2C : 0.;
 }
@@ -495,7 +496,7 @@ GPUdi() int TrackParametrization<value_T>::getSign() const
 
 //_______________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhi() const
+GPUdi() auto TrackParametrization<value_T>::getPhi() const -> value_t
 {
   // track pt direction phi (in 0:2pi range)
   value_t phi = gpu::CAMath::ASin(getSnp()) + getAlpha();
@@ -505,7 +506,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //_______________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPhiPos() const
+GPUdi() auto TrackParametrization<value_T>::getPhiPos() const -> value_t
 {
   // angle of track position (in -pi:pi range)
   value_t phi = gpu::CAMath::ATan2(getY(), getX()) + getAlpha();
@@ -515,7 +516,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPtInv() const
+GPUdi() auto TrackParametrization<value_T>::getPtInv() const -> value_t
 {
   // return the inverted track pT
   const value_t ptInv = gpu::CAMath::Abs(mP[kQ2Pt]);
@@ -524,7 +525,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2Inv() const
+GPUdi() auto TrackParametrization<value_T>::getP2Inv() const -> value_t
 {
   // return the inverted track momentum^2
   const value_t p2 = mP[kQ2Pt] * mP[kQ2Pt] / (1.f + getTgl() * getTgl());
@@ -533,7 +534,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP2() const
+GPUdi() auto TrackParametrization<value_T>::getP2() const -> value_t
 {
   // return the track momentum^2
   const value_t p2inv = getP2Inv();
@@ -542,7 +543,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPInv() const
+GPUdi() auto TrackParametrization<value_T>::getPInv() const -> value_t
 {
   // return the inverted track momentum^2
   const value_t pInv = gpu::CAMath::Abs(mP[kQ2Pt]) / gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
@@ -551,7 +552,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getP() const
+GPUdi() auto TrackParametrization<value_T>::getP() const -> value_t
 {
   // return the track momentum
   const value_t pInv = getPInv();
@@ -560,7 +561,7 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getPt() const
+GPUdi() auto TrackParametrization<value_T>::getPt() const -> value_t
 {
   // return the track transverse momentum
   value_t ptI = gpu::CAMath::Abs(mP[kQ2Pt]);
@@ -572,21 +573,21 @@ GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<val
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getTheta() const
+GPUdi() auto TrackParametrization<value_T>::getTheta() const -> value_t
 {
   return constants::math::PIHalf - gpu::CAMath::ATan(mP[3]);
 }
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrization<value_T>::value_t TrackParametrization<value_T>::getEta() const
+GPUdi() auto TrackParametrization<value_T>::getEta() const -> value_t
 {
   return -gpu::CAMath::Log(gpu::CAMath::Tan(0.5f * getTheta()));
 }
 
 //_______________________________________________________
 template <typename value_T>
-GPUdi() math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGlo() const
+GPUdi() auto TrackParametrization<value_T>::getXYZGlo() const -> math_utils::Point3D<value_t>
 {
 #ifndef GPUCA_ALIGPUCODE
   return math_utils::Rotation2D<value_t>(getAlpha())(math_utils::Point3D<value_t>(getX(), getY(), getZ()));
@@ -610,7 +611,7 @@ GPUdi() void TrackParametrization<value_T>::getXYZGlo(dim3_t& xyz) const
 
 //_______________________________________________________
 template <typename value_T>
-GPUdi() math_utils::Point3D<typename TrackParametrization<value_T>::value_t> TrackParametrization<value_T>::getXYZGloAt(value_t xk, value_t b, bool& ok) const
+GPUdi() auto TrackParametrization<value_T>::getXYZGloAt(value_t xk, value_t b, bool& ok) const -> math_utils::Point3D<value_t>
 {
   //----------------------------------------------------------------
   // estimate global X,Y,Z in global frame at given X

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -139,6 +139,7 @@ class TrackParametrization
   GPUdDefault() ~TrackParametrization() = default;
 
   GPUd() void set(value_t x, value_t alpha, const params_t& par, int charge = 1, const PID pid = PID::Pion);
+  GPUd() void set(value_t x, value_t alpha, const value_t* par, int charge = 1, const PID pid = PID::Pion);
   GPUd() const value_t* getParams() const;
   GPUd() value_t getParam(int i) const;
   GPUd() value_t getX() const;
@@ -219,9 +220,9 @@ class TrackParametrization
   std::string asString() const;
 #endif
 
- protected:
   GPUd() void updateParam(value_t delta, int i);
-  GPUd() void updateParams(const value_t delta[kNParams]);
+  GPUd() void updateParams(const params_t& delta);
+  GPUd() void updateParams(const value_t* delta);
 
  private:
   //
@@ -250,6 +251,13 @@ GPUdi() TrackParametrization<value_T>::TrackParametrization(value_t x, value_t a
 //____________________________________________________________
 template <typename value_T>
 GPUdi() void TrackParametrization<value_T>::set(value_t x, value_t alpha, const params_t& par, int charge, const PID pid)
+{
+  set(x, alpha, par.data(), charge, pid);
+}
+
+//____________________________________________________________
+template <typename value_T>
+GPUdi() void TrackParametrization<value_T>::set(value_t x, value_t alpha, const value_t* par, int charge, const PID pid)
 {
   mX = x;
   mAlpha = alpha;
@@ -666,7 +674,14 @@ GPUdi() void TrackParametrization<value_T>::updateParam(value_t delta, int i)
 
 //____________________________________________________________
 template <typename value_T>
-GPUdi() void TrackParametrization<value_T>::updateParams(const value_t delta[kNParams])
+GPUdi() void TrackParametrization<value_T>::updateParams(const params_t& delta)
+{
+  updateParams(delta.data());
+}
+
+//____________________________________________________________
+template <typename value_T>
+GPUdi() void TrackParametrization<value_T>::updateParams(const value_t* delta)
 {
   for (int i = kNParams; i--;) {
     mP[i] += delta[i];

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -26,6 +26,7 @@ namespace track
 template <typename value_T = float>
 class TrackParametrizationWithError : public TrackParametrization<value_T>
 { // track+error parameterization
+ public:
 
   using typename TrackParametrization<value_T>::value_t;
   using typename TrackParametrization<value_T>::dim3_t;
@@ -36,7 +37,6 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
   static_assert(std::is_floating_point_v<value_t>);
 #endif
 
- public:
   using covMat_t = gpu::gpustd::array<value_t, kCovMatSize>;
   using MatrixDSym5 = ROOT::Math::SMatrix<double, kNParams, kNParams, ROOT::Math::MatRepSym<double, kNParams>>;
   using MatrixD5 = ROOT::Math::SMatrix<double, kNParams, kNParams, ROOT::Math::MatRepStd<double, kNParams, kNParams>>;
@@ -149,126 +149,126 @@ GPUdi() void TrackParametrizationWithError<value_T>::set(value_t x, value_t alph
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() const typename TrackParametrizationWithError<value_T>::value_t* TrackParametrizationWithError<value_T>::getCov() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getCov() const -> const value_t*
 {
   return mC;
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaY2() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaY2() const -> value_t
 {
   return mC[kSigY2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZY() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaZY() const -> value_t
 {
   return mC[kSigZY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaZ2() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaZ2() const -> value_t
 {
   return mC[kSigZ2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpY() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaSnpY() const -> value_t
 {
   return mC[kSigSnpY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnpZ() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaSnpZ() const -> value_t
 {
   return mC[kSigSnpZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaSnp2() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaSnp2() const -> value_t
 {
   return mC[kSigSnp2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglY() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaTglY() const -> value_t
 {
   return mC[kSigTglY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglZ() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaTglZ() const -> value_t
 {
   return mC[kSigTglZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTglSnp() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaTglSnp() const -> value_t
 {
   return mC[kSigTglSnp];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigmaTgl2() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigmaTgl2() const -> value_t
 {
   return mC[kSigTgl2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtY() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigma1PtY() const -> value_t
 {
   return mC[kSigQ2PtY];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtZ() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigma1PtZ() const -> value_t
 {
   return mC[kSigQ2PtZ];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtSnp() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigma1PtSnp() const -> value_t
 {
   return mC[kSigQ2PtSnp];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1PtTgl() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigma1PtTgl() const -> value_t
 {
   return mC[kSigQ2PtTgl];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getSigma1Pt2() const
+GPUdi() auto TrackParametrizationWithError<value_T>::getSigma1Pt2() const -> value_t
 {
   return mC[kSigQ2Pt2];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getCovarElem(int i, int j) const
+GPUdi() auto TrackParametrizationWithError<value_T>::getCovarElem(int i, int j) const -> value_t
 {
   return mC[CovarMap[i][j]];
 }
 
 //__________________________________________________________________________
 template <typename value_T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getDiagError2(int i) const
+GPUdi() auto TrackParametrizationWithError<value_T>::getDiagError2(int i) const -> value_t
 {
   return mC[DiagMap[i]];
 }
@@ -276,7 +276,7 @@ GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametriz
 //__________________________________________________________________________
 template <typename value_T>
 template <typename T>
-GPUdi() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const BaseCluster<T>& p) const
+GPUdi() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const BaseCluster<T>& p) const -> value_t
 {
   const dim2_t pyz = {p.getY(), p.getZ()};
   const dim3_t cov = {p.getSigmaY2(), p.getSigmaYZ(), p.getSigmaZ2()};

--- a/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
+++ b/DataFormats/Reconstruction/src/TrackLTIntegral.cxx
@@ -21,9 +21,13 @@ namespace track
 GPUd() void TrackLTIntegral::print() const
 {
 #ifndef GPUCA_GPUCODE_DEVICE
-  printf("L(cm): %6.2f, X2X0: %5.3f TOF(ps): ", getL(), getX2X0());
-  for (int i = 0; i < getNTOFs(); i++) {
-    printf(" %7.1f |", getTOF(i));
+  printf("L(cm): %6.2f, X2X0: %e XRho: %e TOF(ps): ", getL(), getX2X0(), getXRho());
+  if (isTimeNotNeeded()) {
+    printf(" Times not filled");
+  } else {
+    for (int i = 0; i < getNTOFs(); i++) {
+      printf(" %7.1f |", getTOF(i));
+    }
   }
   printf("\n");
 #endif
@@ -34,6 +38,9 @@ GPUd() void TrackLTIntegral::addStep(float dL, float p2Inv)
 {
   ///< add step in cm to integrals
   mL += dL;
+  if (isTimeNotNeeded()) {
+    return;
+  }
   const float dTns = dL * 1000.f / o2::constants::physics::LightSpeedCm2NS; // time change in ps for beta = 1 particle
   for (int id = 0; id < getNTOFs(); id++) {
     const float m2z = track::PID::getMass2Z(id);

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -57,9 +57,9 @@ GPUd() TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, co
   value_t radPos2 = xyz[0] * xyz[0] + xyz[1] * xyz[1];
   value_t alp = 0;
   if (sectorAlpha || radPos2 < 1) {
-    alp = gpu::CAMath::ATan2(pxpypz[1], pxpypz[0]);
+    alp = math_utils::detail::atan2<value_T>(pxpypz[1], pxpypz[0]);
   } else {
-    alp = gpu::CAMath::ATan2(xyz[1], xyz[0]);
+    alp = math_utils::detail::atan2<value_T>(xyz[1], xyz[0]);
   }
   if (sectorAlpha) {
     alp = math_utils::detail::angle2Alpha<value_t>(alp);
@@ -70,7 +70,7 @@ GPUd() TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, co
   // protection against cosp<0
   if (cs * pxpypz[0] + sn * pxpypz[1] < 0) {
     LOG(WARNING) << "alpha from phiPos() will invalidate this track parameters, overriding to alpha from phi()";
-    alp = gpu::CAMath::ATan2(pxpypz[1], pxpypz[0]);
+    alp = math_utils::detail::atan2<value_T>(pxpypz[1], pxpypz[0]);
     if (sectorAlpha) {
       alp = math_utils::detail::angle2Alpha<value_t>(alp);
     }
@@ -78,14 +78,14 @@ GPUd() TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, co
   }
 
   // protection:  avoid alpha being too close to 0 or +-pi/2
-  if (gpu::CAMath::Abs(sn) < 2 * kSafe) {
+  if (math_utils::detail::abs<value_T>(sn) < 2 * kSafe) {
     if (alp > 0) {
       alp += alp < constants::math::PIHalf ? 2 * kSafe : -2 * kSafe;
     } else {
       alp += alp > -constants::math::PIHalf ? -2 * kSafe : 2 * kSafe;
     }
     math_utils::detail::sincos(alp, sn, cs);
-  } else if (gpu::CAMath::Abs(cs) < 2 * kSafe) {
+  } else if (math_utils::detail::abs<value_T>(cs) < 2 * kSafe) {
     if (alp > 0) {
       alp += alp > constants::math::PIHalf ? 2 * kSafe : -2 * kSafe;
     } else {
@@ -108,13 +108,13 @@ GPUd() TrackParametrization<value_T>::TrackParametrization(const dim3_t& xyz, co
   mP[kZ] = ver[2];
   mP[kSnp] = mom[1] * ptI;
   mP[kTgl] = mom[2] * ptI;
-  mAbsCharge = gpu::CAMath::Abs(charge);
+  mAbsCharge = math_utils::detail::abs<value_T>(charge);
   mP[kQ2Pt] = charge ? ptI * charge : ptI;
   mPID = pid;
   //
-  if (gpu::CAMath::Abs(1 - getSnp()) < kSafe) {
+  if (math_utils::detail::abs<value_T>(1 - getSnp()) < kSafe) {
     mP[kSnp] = 1.f - kSafe; // Protection
-  } else if (gpu::CAMath::Abs(-1 - getSnp()) < kSafe) {
+  } else if (math_utils::detail::abs<value_T>(-1 - getSnp()) < kSafe) {
     mP[kSnp] = -1.f + kSafe; // Protection
   }
   //
@@ -125,11 +125,11 @@ template <typename value_T>
 GPUd() bool TrackParametrization<value_T>::getPxPyPzGlo(dim3_t& pxyz) const
 {
   // track momentum
-  if (gpu::CAMath::Abs(getQ2Pt()) < constants::math::Almost0 || gpu::CAMath::Abs(getSnp()) > constants::math::Almost1) {
+  if (math_utils::detail::abs<value_T>(getQ2Pt()) < constants::math::Almost0 || math_utils::detail::abs<value_T>(getSnp()) > constants::math::Almost1) {
     return false;
   }
   value_t cs, sn, pt = getPt();
-  value_t r = gpu::CAMath::Sqrt((1.f - getSnp()) * (1.f + getSnp()));
+  value_t r = math_utils::detail::sqrt<value_T>((1.f - getSnp()) * (1.f + getSnp()));
   math_utils::detail::sincos(getAlpha(), sn, cs);
   pxyz[0] = pt * (r * cs - getSnp() * sn);
   pxyz[1] = pt * (getSnp() * cs + r * sn);
@@ -142,14 +142,14 @@ template <typename value_T>
 GPUd() bool TrackParametrization<value_T>::getPosDirGlo(gpu::gpustd::array<value_t, 9>& posdirp) const
 {
   // fill vector with lab x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha
-  value_t ptI = gpu::CAMath::Abs(getQ2Pt());
+  value_t ptI = math_utils::detail::abs<value_T>(getQ2Pt());
   value_t snp = getSnp();
-  if (ptI < constants::math::Almost0 || gpu::CAMath::Abs(snp) > constants::math::Almost1) {
+  if (ptI < constants::math::Almost0 || math_utils::detail::abs<value_T>(snp) > constants::math::Almost1) {
     return false;
   }
   value_t &sn = posdirp[7], &cs = posdirp[8];
-  value_t csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp));
-  value_t cstht = gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
+  value_t csp = math_utils::detail::sqrt<value_T>((1.f - snp) * (1.f + snp));
+  value_t cstht = math_utils::detail::sqrt<value_T>(1.f + getTgl() * getTgl());
   value_t csthti = 1.f / cstht;
   math_utils::detail::sincos(getAlpha(), sn, cs);
   posdirp[0] = getX() * cs - getY() * sn;
@@ -167,7 +167,7 @@ template <typename value_T>
 GPUd() bool TrackParametrization<value_T>::rotateParam(value_t alpha)
 {
   // rotate to alpha frame
-  if (gpu::CAMath::Abs(getSnp()) > constants::math::Almost1) {
+  if (math_utils::detail::abs<value_T>(getSnp()) > constants::math::Almost1) {
     LOGP(WARNING, "Precondition is not satisfied: |sin(phi)|>1 ! {:f}", getSnp());
     return false;
   }
@@ -176,7 +176,7 @@ GPUd() bool TrackParametrization<value_T>::rotateParam(value_t alpha)
   //
   value_t ca = 0, sa = 0;
   math_utils::detail::sincos(alpha - getAlpha(), sa, ca);
-  value_t snp = getSnp(), csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp)); // Improve precision
+  value_t snp = getSnp(), csp = math_utils::detail::sqrt<value_T>((1.f - snp) * (1.f + snp)); // Improve precision
   // RS: check if rotation does no invalidate track model (cos(local_phi)>=0, i.e. particle
   // direction in local frame is along the X axis
   if ((csp * ca + snp * sa) < 0) {
@@ -185,7 +185,7 @@ GPUd() bool TrackParametrization<value_T>::rotateParam(value_t alpha)
   }
   //
   value_t tmp = snp * ca - csp * sa;
-  if (gpu::CAMath::Abs(tmp) > constants::math::Almost1) {
+  if (math_utils::detail::abs<value_T>(tmp) > constants::math::Almost1) {
     LOGP(WARNING, "Rotation failed: new snp {:.2f}", tmp);
     return false;
   }
@@ -209,11 +209,11 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
   //----------------------------------------------------------------
 
   value_t dx = xk - getX();
-  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
+  if (math_utils::detail::abs<value_T>(dx) < constants::math::Almost0) {
     return true;
   }
   // Do not propagate tracks outside the ALICE detector
-  if (gpu::CAMath::Abs(dx) > 1e5 || gpu::CAMath::Abs(getY()) > 1e5 || gpu::CAMath::Abs(getZ()) > 1e5) {
+  if (math_utils::detail::abs<value_T>(dx) > 1e5 || math_utils::detail::abs<value_T>(getY()) > 1e5 || math_utils::detail::abs<value_T>(getZ()) > 1e5) {
     LOGP(WARNING, "Anomalous track, target X:{:f}", xk);
     //    print();
     return false;
@@ -221,21 +221,21 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
   value_t crv = getCurvature(b[2]);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if (gpu::CAMath::Abs(f1) > constants::math::Almost1 || gpu::CAMath::Abs(f2) > constants::math::Almost1) {
+  if (math_utils::detail::abs<value_T>(f1) > constants::math::Almost1 || math_utils::detail::abs<value_T>(f2) > constants::math::Almost1) {
     return false;
   }
-  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
-  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
+  value_t r1 = math_utils::detail::sqrt<value_T>((1.f - f1) * (1.f + f1));
+  if (math_utils::detail::abs<value_T>(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
-  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
+  value_t r2 = math_utils::detail::sqrt<value_T>((1.f - f2) * (1.f + f2));
+  if (math_utils::detail::abs<value_T>(r2) < constants::math::Almost0) {
     return false;
   }
   value_t dy2dx = (f1 + f2) / (r1 + r2);
-  value_t step = (gpu::CAMath::Abs(x2r) < 0.05f) ? dx * gpu::CAMath::Abs(r2 + f2 * dy2dx)                                              // chord
-                                                 : 2.f * CAMath::ASin(0.5f * dx * gpu::CAMath::Sqrt(1.f + dy2dx * dy2dx) * crv) / crv; // arc
-  step *= gpu::CAMath::Sqrt(1.f + getTgl() * getTgl());
+  value_t step = (math_utils::detail::abs<value_T>(x2r) < 0.05f) ? dx * math_utils::detail::abs<value_T>(r2 + f2 * dy2dx)                                              // chord
+                                                                 : 2.f * CAMath::ASin(0.5f * dx * math_utils::detail::sqrt<value_T>(1.f + dy2dx * dy2dx) * crv) / crv; // arc
+  step *= math_utils::detail::sqrt<value_T>(1.f + getTgl() * getTgl());
   //
   // get the track x,y,z,px/p,py/p,pz/p,p,sinAlpha,cosAlpha in the Global System
   gpu::gpustd::array<value_t, 9> vecLab{0.f};
@@ -245,13 +245,13 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
 
   // rotate to the system where Bx=By=0.
   value_t bxy2 = b[0] * b[0] + b[1] * b[1];
-  value_t bt = gpu::CAMath::Sqrt(bxy2);
+  value_t bt = math_utils::detail::sqrt<value_T>(bxy2);
   value_t cosphi = 1.f, sinphi = 0.f;
   if (bt > constants::math::Almost0) {
     cosphi = b[0] / bt;
     sinphi = b[1] / bt;
   }
-  value_t bb = gpu::CAMath::Sqrt(bxy2 + b[2] * b[2]);
+  value_t bb = math_utils::detail::sqrt<value_T>(bxy2 + b[2] * b[2]);
   value_t costet = 1.f, sintet = 0.f;
   if (bb > constants::math::Almost0) {
     costet = b[2] / bb;
@@ -289,8 +289,8 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
 
   // Do the final correcting step to the target plane (linear approximation)
   value_t x = vecLab[0], y = vecLab[1], z = vecLab[2];
-  if (gpu::CAMath::Abs(dx) > constants::math::Almost0) {
-    if (gpu::CAMath::Abs(vecLab[3]) < constants::math::Almost0) {
+  if (math_utils::detail::abs<value_T>(dx) > constants::math::Almost0) {
+    if (math_utils::detail::abs<value_T>(vecLab[3]) < constants::math::Almost0) {
       return false;
     }
     dx = xk - vecLab[0];
@@ -300,7 +300,7 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
   }
 
   // Calculate the track parameters
-  t = 1.f / gpu::CAMath::Sqrt(vecLab[3] * vecLab[3] + vecLab[4] * vecLab[4]);
+  t = 1.f / math_utils::detail::sqrt<value_T>(vecLab[3] * vecLab[3] + vecLab[4] * vecLab[4]);
   mX = xk;
   mP[kY] = y;
   mP[kZ] = z;
@@ -321,28 +321,28 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, value_t 
   // distances only (<mm, i.e. misalignment)
   //----------------------------------------------------------------
   value_t dx = xk - getX();
-  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
+  if (math_utils::detail::abs<value_T>(dx) < constants::math::Almost0) {
     return true;
   }
-  value_t crv = (gpu::CAMath::Abs(b) < constants::math::Almost0) ? 0.f : getCurvature(b);
+  value_t crv = (math_utils::detail::abs<value_T>(b) < constants::math::Almost0) ? 0.f : getCurvature(b);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if ((gpu::CAMath::Abs(f1) > constants::math::Almost1) || (gpu::CAMath::Abs(f2) > constants::math::Almost1)) {
+  if ((math_utils::detail::abs<value_T>(f1) > constants::math::Almost1) || (math_utils::detail::abs<value_T>(f2) > constants::math::Almost1)) {
     return false;
   }
-  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
-  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
+  value_t r1 = math_utils::detail::sqrt<value_T>((1.f - f1) * (1.f + f1));
+  if (math_utils::detail::abs<value_T>(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
-  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
+  value_t r2 = math_utils::detail::sqrt<value_T>((1.f - f2) * (1.f + f2));
+  if (math_utils::detail::abs<value_T>(r2) < constants::math::Almost0) {
     return false;
   }
   mX = xk;
   double dy2dx = (f1 + f2) / (r1 + r2);
   mP[kY] += dx * dy2dx;
   mP[kSnp] += x2r;
-  if (gpu::CAMath::Abs(x2r) < 0.05f) {
+  if (math_utils::detail::abs<value_T>(x2r) < 0.05f) {
     mP[kZ] += dx * (r2 + f2 * dy2dx) * getTgl();
   } else {
     // for small dx/R the linear apporximation of the arc by the segment is OK,
@@ -373,27 +373,27 @@ GPUd() bool TrackParametrization<value_T>::propagateParamToDCA(const math_utils:
   // propagate track to DCA to the vertex
   value_t sn, cs, alp = getAlpha();
   math_utils::detail::sincos(alp, sn, cs);
-  value_t x = getX(), y = getY(), snp = getSnp(), csp = gpu::CAMath::Sqrt((1.f - snp) * (1.f + snp));
+  value_t x = getX(), y = getY(), snp = getSnp(), csp = math_utils::detail::sqrt<value_T>((1.f - snp) * (1.f + snp));
   value_t xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
   //Estimate the impact parameter neglecting the track curvature
-  value_t d = gpu::CAMath::Abs(x * snp - y * csp);
+  value_t d = math_utils::detail::abs<value_T>(x * snp - y * csp);
   if (d > maxD) {
     return false;
   }
   value_t crv = getCurvature(b);
   value_t tgfv = -(crv * x - snp) / (crv * y + csp);
-  sn = tgfv / gpu::CAMath::Sqrt(1.f + tgfv * tgfv);
-  cs = gpu::CAMath::Sqrt((1.f - sn) * (1.f + sn));
-  cs = (gpu::CAMath::Abs(tgfv) > constants::math::Almost0) ? sn / tgfv : constants::math::Almost1;
+  sn = tgfv / math_utils::detail::sqrt<value_T>(1.f + tgfv * tgfv);
+  cs = math_utils::detail::sqrt<value_T>((1.f - sn) * (1.f + sn));
+  cs = (math_utils::detail::abs<value_T>(tgfv) > constants::math::Almost0) ? sn / tgfv : constants::math::Almost1;
 
   x = xv * cs + yv * sn;
   yv = -xv * sn + yv * cs;
   xv = x;
 
   auto tmpT(*this); // operate on the copy to recover after the failure
-  alp += gpu::CAMath::ASin(sn);
+  alp += math_utils::detail::asin<value_T>(sn);
   if (!tmpT.rotateParam(alp) || !tmpT.propagateParamTo(xv, b)) {
     LOG(WARNING) << "failed to propagate to alpha=" << alp << " X=" << xv << " for vertex "
                  << vtx.X() << ' ' << vtx.Y() << ' ' << vtx.Z() << " | Track is: ";
@@ -418,26 +418,26 @@ GPUd() bool TrackParametrization<value_T>::getYZAt(value_t xk, value_t b, value_
   value_t dx = xk - getX();
   y = mP[kY];
   z = mP[kZ];
-  if (gpu::CAMath::Abs(dx) < constants::math::Almost0) {
+  if (math_utils::detail::abs<value_T>(dx) < constants::math::Almost0) {
     return true;
   }
   value_t crv = getCurvature(b);
   value_t x2r = crv * dx;
   value_t f1 = getSnp(), f2 = f1 + x2r;
-  if ((gpu::CAMath::Abs(f1) > constants::math::Almost1) || (gpu::CAMath::Abs(f2) > constants::math::Almost1)) {
+  if ((math_utils::detail::abs<value_T>(f1) > constants::math::Almost1) || (math_utils::detail::abs<value_T>(f2) > constants::math::Almost1)) {
     return false;
   }
-  value_t r1 = gpu::CAMath::Sqrt((1.f - f1) * (1.f + f1));
-  if (gpu::CAMath::Abs(r1) < constants::math::Almost0) {
+  value_t r1 = math_utils::detail::sqrt<value_T>((1.f - f1) * (1.f + f1));
+  if (math_utils::detail::abs<value_T>(r1) < constants::math::Almost0) {
     return false;
   }
-  value_t r2 = gpu::CAMath::Sqrt((1.f - f2) * (1.f + f2));
-  if (gpu::CAMath::Abs(r2) < constants::math::Almost0) {
+  value_t r2 = math_utils::detail::sqrt<value_T>((1.f - f2) * (1.f + f2));
+  if (math_utils::detail::abs<value_T>(r2) < constants::math::Almost0) {
     return false;
   }
   double dy2dx = (f1 + f2) / (r1 + r2);
   y += dx * dy2dx;
-  if (gpu::CAMath::Abs(x2r) < 0.05f) {
+  if (math_utils::detail::abs<value_T>(x2r) < 0.05f) {
     z += dx * (r2 + f2 * dy2dx) * getTgl();
   } else {
     // for small dx/R the linear apporximation of the arc by the segment is OK,
@@ -531,16 +531,16 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
   const value_t kEps = 1.e-6;
   //
   auto crv = getCurvature(bz);
-  if (gpu::CAMath::Abs(crv) > constants::math::Almost0) { // helix
+  if (math_utils::detail::abs<value_T>(crv) > constants::math::Almost0) { // helix
     // get center of the track circle
     math_utils::CircleXY<value_t> circle;
     getCircleParamsLoc(bz, circle);
-    value_t r0 = gpu::CAMath::Sqrt(circle.getCenterD2());
+    value_t r0 = math_utils::detail::sqrt<value_T>(circle.getCenterD2());
     if (r0 <= constants::math::Almost0) {
       return false; // the track is concentric to circle
     }
     value_t tR2r0 = 1.f, g = 0.f, tmp = 0.f;
-    if (gpu::CAMath::Abs(circle.rC - r0) > kEps) {
+    if (math_utils::detail::abs<value_T>(circle.rC - r0) > kEps) {
       tR2r0 = circle.rC / r0;
       g = 0.5f * (r * r / (r0 * circle.rC) - tR2r0 - 1.f / tR2r0);
       tmp = 1.f + g * tR2r0;
@@ -553,7 +553,7 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
     if (det < 0.f) {
       return false; // does not reach raduis r
     }
-    det = gpu::CAMath::Sqrt(det);
+    det = math_utils::detail::sqrt<value_T>(det);
     //
     // the intersection happens in 2 points: {circle.xC+tR*C,circle.yC+tR*S}
     // with C=f*c0+-|s0|*det and S=f*s0-+c0 sign(s0)*det
@@ -561,8 +561,8 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
     //
     x = circle.xC * tmp;
     value_t y = circle.yC * tmp;
-    if (gpu::CAMath::Abs(circle.yC) > constants::math::Almost0) { // when circle.yC==0 the x,y is unique
-      value_t dfx = tR2r0 * gpu::CAMath::Abs(circle.yC) * det;
+    if (math_utils::detail::abs<value_T>(circle.yC) > constants::math::Almost0) { // when circle.yC==0 the x,y is unique
+      value_t dfx = tR2r0 * math_utils::detail::abs<value_T>(circle.yC) * det;
       value_t dfy = tR2r0 * circle.xC * (circle.yC > 0.f ? det : -det);
       if (dir == DirAuto) {                              // chose the one which corresponds to smallest step
         value_t delta = (x - mX) * dfx - (y - fy) * dfy; // the choice of + in C will lead to smaller step if delta<0
@@ -573,7 +573,7 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
         if (dfeps < -kEps) {
           return true;
         }
-        if (gpu::CAMath::Abs(dfeps) < kEps && gpu::CAMath::Abs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+        if (math_utils::detail::abs<value_T>(dfeps) < kEps && math_utils::detail::abs<value_T>(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
           return mX;
         }
         x += dfx + dfx;
@@ -590,7 +590,7 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
         if (dfeps < -kEps) {
           return true;
         }
-        if (gpu::CAMath::Abs(dfeps) < kEps && gpu::CAMath::Abs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+        if (math_utils::detail::abs<value_T>(dfeps) < kEps && math_utils::detail::abs<value_T>(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
           return mX;
         }
         x -= dfx + dfx;
@@ -608,8 +608,8 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
         return false;
       }
     }
-  } else {                                                  // this is a straight track
-    if (gpu::CAMath::Abs(sn) >= constants::math::Almost1) { // || to Y axis
+  } else {                                                                  // this is a straight track
+    if (math_utils::detail::abs<value_T>(sn) >= constants::math::Almost1) { // || to Y axis
       value_t det = (r - mX) * (r + mX);
       if (det < 0.f) {
         return false; // does not reach raduis r
@@ -618,7 +618,7 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
       if (dir == DirAuto) {
         return true;
       }
-      det = gpu::CAMath::Sqrt(det);
+      det = math_utils::detail::sqrt<value_T>(det);
       if (dir == DirOutward) { // along the track direction
         if (sn > 0.f) {
           if (fy > det) {
@@ -638,12 +638,12 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
           return false; // track is against Y axis
         }
       }
-    } else if (gpu::CAMath::Abs(sn) <= constants::math::Almost0) { // || to X axis
+    } else if (math_utils::detail::abs<value_T>(sn) <= constants::math::Almost0) { // || to X axis
       value_t det = (r - fy) * (r + fy);
       if (det < 0.f) {
         return false; // does not reach raduis r
       }
-      det = gpu::CAMath::Sqrt(det);
+      det = math_utils::detail::sqrt<value_T>(det);
       if (dir == DirAuto) {
         x = mX > 0.f ? det : -det; // choose the solution requiring the smalest step
         return true;
@@ -661,13 +661,13 @@ GPUd() bool TrackParametrization<value_T>::getXatLabR(value_t r, value_t& x, val
         }
       }
     } else { // general case of straight line
-      value_t cs = gpu::CAMath::Sqrt((1.f - sn) * (1.f + sn));
+      value_t cs = math_utils::detail::sqrt<value_T>((1.f - sn) * (1.f + sn));
       value_t xsyc = mX * sn - fy * cs;
       value_t det = (r - xsyc) * (r + xsyc);
       if (det < 0.f) {
         return false; // does not reach raduis r
       }
-      det = gpu::CAMath::Sqrt(det);
+      det = math_utils::detail::sqrt<value_T>(det);
       value_t xcys = mX * cs + fy * sn;
       value_t t = -xcys;
       if (dir == DirAuto) {
@@ -711,7 +711,7 @@ GPUd() bool TrackParametrization<value_T>::correctForELoss(value_t xrho, bool an
   if (anglecorr) {
     value_t csp2 = (1.f - getSnp()) * (1.f + getSnp()); // cos(phi)^2
     value_t cst2I = (1.f + getTgl() * getTgl());        // 1/cos(lambda)^2
-    value_t angle = gpu::CAMath::Sqrt(cst2I / (csp2));
+    value_t angle = math_utils::detail::sqrt<value_T>(cst2I / (csp2));
     xrho *= angle;
   }
   value_t p = getP();
@@ -729,8 +729,8 @@ GPUd() bool TrackParametrization<value_T>::correctForELoss(value_t xrho, bool an
     }
 
     value_t dE = dedx * xrho;
-    value_t e = gpu::CAMath::Sqrt(e2);
-    if (gpu::CAMath::Abs(dE) > kMaxELossFrac * e) {
+    value_t e = math_utils::detail::sqrt<value_T>(e2);
+    if (math_utils::detail::abs<value_T>(dE) > kMaxELossFrac * e) {
       return false; // 30% energy loss is too much!
     }
     value_t eupd = e + dE;
@@ -738,7 +738,7 @@ GPUd() bool TrackParametrization<value_T>::correctForELoss(value_t xrho, bool an
     if (pupd2 < kMinP * kMinP) {
       return false;
     }
-    setQ2Pt(getQ2Pt() * p / gpu::CAMath::Sqrt(pupd2));
+    setQ2Pt(getQ2Pt() * p / math_utils::detail::sqrt<value_T>(pupd2));
   }
 
   return true;

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -99,7 +99,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, valu
     //    mP1 += rot/crv*mP3;
     //
     value_t rot = gpu::CAMath::ASin(r1 * f2 - r2 * f1); // more economic version from Yura.
-    if (f1 * f1 + f2 * f2 > 1.f && f1 * f2 < 0.f) { // special cases of large rotations or large abs angles
+    if (f1 * f1 + f2 * f2 > 1.f && f1 * f2 < 0.f) {     // special cases of large rotations or large abs angles
       if (f2 > 0.f) {
         rot = constants::math::PI - rot; //
       } else {
@@ -691,7 +691,7 @@ GPUd() void TrackParametrizationWithError<value_T>::resetCovariance(value_t s2)
 
 //______________________________________________
 template <typename value_T>
-GPUd() typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const dim2_t& p, const dim3_t& cov) const
+GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const dim2_t& p, const dim3_t& cov) const -> value_t
 {
   // Estimate the chi2 of the space point "p" with the cov. matrix "cov"
   auto sdd = static_cast<double>(getSigmaY2()) + static_cast<double>(cov[0]);
@@ -735,7 +735,7 @@ void TrackParametrizationWithError<value_T>::buildCombinedCovMatrix(const TrackP
 
 //______________________________________________
 template <typename value_T>
-typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const TrackParametrizationWithError<value_T>& rhs) const
+auto TrackParametrizationWithError<value_T>::getPredictedChi2(const TrackParametrizationWithError<value_T>& rhs) const -> value_t
 {
   MatrixDSym5 cov; // perform matrix operations in double!
   return getPredictedChi2(rhs, cov);
@@ -743,7 +743,7 @@ typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWit
 
 //______________________________________________
 template <typename value_T>
-typename TrackParametrizationWithError<value_T>::value_t TrackParametrizationWithError<value_T>::getPredictedChi2(const TrackParametrizationWithError<value_T>& rhs, MatrixDSym5& covToSet) const
+auto TrackParametrizationWithError<value_T>::getPredictedChi2(const TrackParametrizationWithError<value_T>& rhs, MatrixDSym5& covToSet) const -> value_t
 {
   // get chi2 wrt other track, which must be defined at the same parameters X,alpha
   // Supplied non-initialized covToSet matrix is filled by inverse combined matrix for further use

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -84,7 +84,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, valu
   }
   this->setX(xk);
   double dy2dx = (f1 + f2) / (r1 + r2);
-  value_t dP[kNParams] = {0.f};
+  params_t dP{0.f};
   dP[kY] = dx * dy2dx;
   dP[kSnp] = x2r;
   if (gpu::CAMath::Abs(x2r) < 0.05f) {
@@ -691,7 +691,7 @@ GPUd() void TrackParametrizationWithError<value_T>::resetCovariance(value_t s2)
 
 //______________________________________________
 template <typename value_T>
-GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const dim2_t& p, const dim3_t& cov) const -> value_t
+GPUd() auto TrackParametrizationWithError<value_T>::getPredictedChi2(const value_t* p, const value_t* cov) const -> value_t
 {
   // Estimate the chi2 of the space point "p" with the cov. matrix "cov"
   auto sdd = static_cast<double>(getSigmaY2()) + static_cast<double>(cov[0]);
@@ -860,7 +860,7 @@ bool TrackParametrizationWithError<value_T>::update(const TrackParametrizationWi
 
 //______________________________________________
 template <typename value_T>
-GPUd() bool TrackParametrizationWithError<value_T>::update(const dim2_t& p, const dim3_t& cov)
+GPUd() bool TrackParametrizationWithError<value_T>::update(const value_t* p, const value_t* cov)
 {
   // Update the track parameters with the space point "p" having
   // the covariance matrix "cov"
@@ -897,8 +897,8 @@ GPUd() bool TrackParametrizationWithError<value_T>::update(const dim2_t& p, cons
     return false;
   }
 
-  value_t dP[kNParams] = {value_t(k00 * dy + k01 * dz), value_t(k10 * dy + k11 * dz), dsnp, value_t(k30 * dy + k31 * dz),
-                          value_t(k40 * dy + k41 * dz)};
+  const params_t dP{value_t(k00 * dy + k01 * dz), value_t(k10 * dy + k11 * dz), dsnp, value_t(k30 * dy + k31 * dz),
+                    value_t(k40 * dy + k41 * dz)};
   this->updateParams(dP);
 
   double c01 = cm10, c02 = cm20, c03 = cm30, c04 = cm40;

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -85,6 +85,13 @@ class PropagatorImpl
                            value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
                            track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const;
 
+  template <typename track_T>
+  GPUd() bool propagateTo(track_T& track, value_type x, bool bzOnly = false, value_type maxSnp = MAX_SIN_PHI, value_type maxStep = MAX_STEP,
+                          MatCorrType matCorr = MatCorrType::USEMatCorrLUT, track::TrackLTIntegral* tofInfo = nullptr, int signCorr = 0) const
+  {
+    return bzOnly ? propagateToX(track, x, getNominalBz(), maxSnp, maxStep, matCorr, tofInfo, signCorr) : PropagateToXBxByBz(track, x, maxSnp, maxStep, matCorr, tofInfo, signCorr);
+  }
+
   GPUd() bool propagateToDCA(const o2::dataformats::VertexBase& vtx, o2::track::TrackParametrizationWithError<value_type>& track, value_type bZ,
                              value_type maxStep = MAX_STEP, MatCorrType matCorr = MatCorrType::USEMatCorrLUT,
                              o2::dataformats::DCA* dcaInfo = nullptr, track::TrackLTIntegral* tofInfo = nullptr,

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -160,6 +160,7 @@ GPUd() bool PropagatorImpl<value_T>::PropagateToXBxByBz(TrackParCov_t& track, va
       if (tofInfo) {
         tofInfo->addStep(mb.length, track.getP2Inv()); // fill L,ToF info using already calculated step length
         tofInfo->addX2X0(mb.meanX2X0);
+        tofInfo->addXRho(mb.getXRho(signCorr));
       }
     } else if (tofInfo) { // if tofInfo filling was requested w/o material correction, we need to calculate the step lenght
       auto xyz1 = track.getXYZGlo();

--- a/GPU/Common/GPUCommonArray.h
+++ b/GPU/Common/GPUCommonArray.h
@@ -24,8 +24,10 @@ namespace o2::gpu::gpustd
 #ifdef GPUCA_GPUCODE_DEVICE
 template <typename T, size_t N>
 struct array {
-  GPUd() T& operator[](size_t i) { return m_internal_V__[i]; }
-  GPUd() const T& operator[](size_t i) const { return m_internal_V__[i]; }
+  GPUd() T& operator[](size_t i) { return m_internal_V__[i]; };
+  GPUd() const T& operator[](size_t i) const { return m_internal_V__[i]; };
+  GPUd() T* data() { return m_internal_V__; };
+  GPUd() const T* data() const { return m_internal_V__; };
   T m_internal_V__[N];
 };
 template <class T, class... E>


### PR DESCRIPTION
* TrackParametrization: less verbose interfaces by using trailing return semantics 
* TrackParametrizartion: replace C-style arrays by `gpu::gpustd::array`
* Propagator: unify interfaces for different types of propagation
* TrackLTIntegral optionally update only L and mat.budget integral