### PR TITLE
Define DetID::mask_t as bitset<32> regardless on nDetectors

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFHeader.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFHeader.h
@@ -32,7 +32,7 @@ struct CTFHeader {
   std::string describe() const;
   void print() const;
 
-  ClassDefNV(CTFHeader, 1)
+  ClassDefNV(CTFHeader, 2)
 };
 
 std::ostream& operator<<(std::ostream& stream, const CTFHeader& c);

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
@@ -84,7 +84,7 @@ class DetID
   static constexpr std::string_view NONE{"none"}; ///< keywork for no-detector
   static constexpr std::string_view ALL{"all"};   ///< keywork for all detectors
 
-  typedef std::bitset<nDetectors> mask_t;
+  typedef std::bitset<32> mask_t;
 
   DetID(ID id) : mID(id) {}
   DetID(const char* name);
@@ -164,7 +164,7 @@ class DetID
 #endif
   };
 
-  ClassDefNV(DetID, 1);
+  ClassDefNV(DetID, 2);
 };
 
 } // namespace detectors

--- a/DataFormats/Detectors/Common/src/DetID.cxx
+++ b/DataFormats/Detectors/Common/src/DetID.cxx
@@ -45,7 +45,7 @@ DetID::mask_t DetID::getMask(const std::string_view detList)
     return mask;
   }
   if (ss.find(ALL) != std::string::npos) {
-    mask.set();
+    mask = (0x1u << nDetectors) - 1;
     return mask;
   }
   std::replace(ss.begin(), ss.end(), ' ', ',');

--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
@@ -164,7 +164,7 @@ class GRPObject
   std::string mDataPeriod = ""; ///< name of the period
   std::string mLHCState = "";   ///< machine state
 
-  ClassDefNV(GRPObject, 3);
+  ClassDefNV(GRPObject, 4);
 };
 
 //______________________________________________


### PR DESCRIPTION
Depending on o2 version and `ENABLE_UPGRADES` status `DetID::mask_t = bitset<nDetectors>` had different lenght, leading to exception when reading the GRP (or CTF) created with different version, see https://alice.its.cern.ch/jira/browse/O2-2179
This PR sets the `DetID::mask_t` to fixed `bitset<32>` regardless on `nDetectors`.