### PR TITLE
AliECS dump: connect to the correct pipelined devices

### DIFF
--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -216,12 +216,12 @@ std::string findBinder(const std::vector<DeviceSpec>& specs, const std::string& 
   for (const auto& spec : specs) {
     for (const auto& inputChannel : spec.inputChannels) {
       if (inputChannel.method == ChannelMethod::Bind && inputChannel.name == channel) {
-        return spec.name;
+        return spec.id;
       }
     }
     for (const auto& outputChannel : spec.outputChannels) {
       if (outputChannel.method == ChannelMethod::Bind && outputChannel.name == channel) {
-        return spec.name;
+        return spec.id;
       }
     }
   }


### PR DESCRIPTION
Devices which are replicated have `_t<number>` added at the end of the name, which we didn't respect in the generated workflow. Thus we should use `id` instead of `name`.