### PR TITLE
TRD FeeParam singleton is made thread-safe for OMP

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/CommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/CommonParam.h
@@ -55,7 +55,7 @@ class CommonParam
  protected:
   void sampleTimeStruct(float vdrift);
 
-  static CommonParam* fgInstance; //  Instance of this class (singleton implementation)
+  static CommonParam* mgInstance; //  Instance of this class (singleton implementation)
   static constexpr int TIMEBIN = 38;
   static constexpr int ZBIN = 11;
   bool mExBOn{true};          // Switch for the ExB effects

--- a/Detectors/TRD/base/include/TRDBase/CommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/CommonParam.h
@@ -12,6 +12,7 @@
 #define O2_TRD_COMMONPARAM_H
 
 #include "GPUCommonRtypes.h"
+#include <array>
 
 namespace o2
 {
@@ -26,58 +27,58 @@ class CommonParam
   enum { kXenon = 0,
          kArgon = 1 };
 
-  CommonParam(const CommonParam& p);
-  CommonParam& operator=(const CommonParam& p);
-  ~CommonParam();
+  CommonParam(const CommonParam&) = delete;
+  CommonParam& operator=(const CommonParam&) = delete;
+  ~CommonParam() = default;
 
-  static CommonParam* Instance();
-  static void Terminate();
+  static CommonParam* instance();
 
-  void SetExB(int exbOn = 1) { mExBOn = exbOn; }
-  void SetSamplingFrequency(float freq) { mSamplingFrequency = freq; }
-  void SetXenon();
-  void SetArgon();
+  void setExB(bool flag = true) { mExBOn = flag; }
+  void setSamplingFrequency(float freq) { mSamplingFrequency = freq; }
+  void setXenon();
+  void setArgon();
 
-  bool ExBOn() const { return mExBOn; }
-  bool IsXenon() const { return (mGasMixture == kXenon); }
-  bool IsArgon() const { return (mGasMixture == kArgon); }
-  int GetGasMixture() const { return mGasMixture; }
-  float GetSamplingFrequency() const { return mSamplingFrequency; }
-  float GetCachedField() const { return mField; }
+  bool isExBOn() const { return mExBOn; }
+  bool isXenon() const { return (mGasMixture == kXenon); }
+  bool isArgon() const { return (mGasMixture == kArgon); }
+  int getGasMixture() const { return mGasMixture; }
+  float getSamplingFrequency() const { return mSamplingFrequency; }
+  float getCachedField() const { return mField; }
 
   // Cached magnetic field, to be called by the user before using GetDiffCoeff or GetOmegaTau
   bool cacheMagField();
-  float GetOmegaTau(float vdrift);
-  bool GetDiffCoeff(float& dl, float& dt, float vdrift);
+  float getOmegaTau(float vdrift);
+  bool getDiffCoeff(float& dl, float& dt, float vdrift);
 
-  double TimeStruct(float vdrift, double xd, double z);
+  double timeStruct(float vdrift, double xd, double z);
 
  protected:
-  void SampleTimeStruct(float vdrift);
+  void sampleTimeStruct(float vdrift);
 
 #ifndef GPUCA_GPUCODE_DEVICE
   static CommonParam* fgInstance; //  Instance of this class (singleton implementation)
-  static bool fgTerminated;       //  Defines if this class has already been terminated
 #endif
-  int mExBOn;            // Switch for the ExB effects
-  double mField;         // cached magnetic field
-  float mDiffusionT;     // Transverse drift coefficient
-  float mDiffusionL;     // Longitudinal drift coefficient
-  float mDiffLastVdrift; // The structures are valid for fLastVdrift (caching)
+  static constexpr int TIMEBIN = 38;
+  static constexpr int ZBIN = 11;
+  bool mExBOn{true};          // Switch for the ExB effects
+  double mField{-0.5};        // cached magnetic field
+  float mDiffusionT{0.};      // Transverse drift coefficient
+  float mDiffusionL{0.};      // Longitudinal drift coefficient
+  float mDiffLastVdrift{-1.}; // The structures are valid for fLastVdrift (caching)
 
-  float* mTimeStruct1;   //! Time Structure of Drift Cells
-  float* mTimeStruct2;   //! Time Structure of Drift Cells
-  float mVDlo;           //  Lower drift velocity, for interpolation
-  float mVDhi;           //  Higher drift velocity, for interpolation
-  float mTimeLastVdrift; //  The structures are valid for fLastVdrift (caching)
+  std::array<float, TIMEBIN * ZBIN> mTimeStruct1{}; // Time Structure of Drift Cells
+  std::array<float, TIMEBIN * ZBIN> mTimeStruct2{}; // Time Structure of Drift Cells
+  float mVDlo{0.};                                  //  Lower drift velocity, for interpolation
+  float mVDhi{0.};                                  //  Higher drift velocity, for interpolation
+  float mTimeLastVdrift{-1.};                       //  The structures are valid for fLastVdrift (caching)
 
-  float mSamplingFrequency; //  Sampling Frequency in MHz
+  float mSamplingFrequency{10.}; //  Sampling Frequency in MHz
 
-  int mGasMixture; //  Gas mixture: 0-Xe/C02 1-Ar/CO2.
+  int mGasMixture{kXenon}; //  Gas mixture: 0-Xe/C02 1-Ar/CO2.
 
  private:
   // This is a singleton, constructor is private!
-  CommonParam();
+  CommonParam() = default;
 
   ClassDef(CommonParam, 1); // The constant parameters common to simulation and reconstruction
 };

--- a/Detectors/TRD/base/include/TRDBase/CommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/CommonParam.h
@@ -55,27 +55,27 @@ class CommonParam
  protected:
   void sampleTimeStruct(float vdrift);
 
-  static CommonParam* mgInstance; //  Instance of this class (singleton implementation)
-  static constexpr int TIMEBIN = 38;
-  static constexpr int ZBIN = 11;
-  bool mExBOn{true};          // Switch for the ExB effects
-  double mField{-0.5};        // cached magnetic field
-  float mDiffusionT{0.};      // Transverse drift coefficient
-  float mDiffusionL{0.};      // Longitudinal drift coefficient
-  float mDiffLastVdrift{-1.}; // The structures are valid for fLastVdrift (caching)
+  static CommonParam* mgInstance;    ///<  Instance of this class (singleton implementation)
+  static constexpr int TIMEBIN = 38; ///< Number of bins in time direction used for garfield simulation
+  static constexpr int ZBIN = 11;    ///< Number of bins in z direction used for garfield simulation
+  bool mExBOn{true};                 ///< Switch for the ExB effects
+  double mField{-0.5};               ///< Cached magnetic field
+  float mDiffusionT{0.};             ///< Transverse drift coefficient
+  float mDiffusionL{0.};             ///< Longitudinal drift coefficient
+  float mDiffLastVdrift{-1.};        ///< The structures are valid for fLastVdrift (caching)
 
-  std::array<float, TIMEBIN * ZBIN> mTimeStruct1{}; // Time Structure of Drift Cells
-  std::array<float, TIMEBIN * ZBIN> mTimeStruct2{}; // Time Structure of Drift Cells
-  float mVDlo{0.};                                  //  Lower drift velocity, for interpolation
-  float mVDhi{0.};                                  //  Higher drift velocity, for interpolation
-  float mTimeLastVdrift{-1.};                       //  The structures are valid for fLastVdrift (caching)
+  std::array<float, TIMEBIN * ZBIN> mTimeStruct1{}; ///< Time Structure of Drift Cells
+  std::array<float, TIMEBIN * ZBIN> mTimeStruct2{}; ///< Time Structure of Drift Cells
+  float mVDlo{0.};                                  ///< Lower drift velocity, for interpolation
+  float mVDhi{0.};                                  ///< Higher drift velocity, for interpolation
+  float mTimeLastVdrift{-1.};                       ///< The structures are valid for fLastVdrift (caching)
 
-  float mSamplingFrequency{10.}; //  Sampling Frequency in MHz
+  float mSamplingFrequency{10.}; ///< Sampling Frequency in MHz
 
-  int mGasMixture{kXenon}; //  Gas mixture: 0-Xe/C02 1-Ar/CO2.
+  int mGasMixture{kXenon}; ///< Gas mixture: 0-Xe/C02 1-Ar/CO2.
 
  private:
-  // This is a singleton, constructor is private!
+  /// This is a singleton, constructor is private!
   CommonParam() = default;
 
   ClassDef(CommonParam, 1); // The constant parameters common to simulation and reconstruction

--- a/Detectors/TRD/base/include/TRDBase/CommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/CommonParam.h
@@ -11,8 +11,8 @@
 #ifndef O2_TRD_COMMONPARAM_H
 #define O2_TRD_COMMONPARAM_H
 
-#include "GPUCommonRtypes.h"
 #include <array>
+#include "Rtypes.h" // for ClassDef
 
 namespace o2
 {
@@ -55,9 +55,7 @@ class CommonParam
  protected:
   void sampleTimeStruct(float vdrift);
 
-#ifndef GPUCA_GPUCODE_DEVICE
   static CommonParam* fgInstance; //  Instance of this class (singleton implementation)
-#endif
   static constexpr int TIMEBIN = 38;
   static constexpr int ZBIN = 11;
   bool mExBOn{true};          // Switch for the ExB effects

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "DataFormatsTRD/Constants.h"
+#include "TRDBase/CommonParam.h"
 
 #include <array>
 #include <vector>
@@ -44,13 +45,11 @@ class FeeParam
 {
 
  public:
-  FeeParam(const FeeParam& p);
-  virtual ~FeeParam();
-  FeeParam& operator=(const FeeParam& p);
-  virtual void Copy(FeeParam& p) const;
+  ~FeeParam() = default;
+  FeeParam(const FeeParam&) = delete;
+  FeeParam& operator=(const FeeParam&) = delete;
 
   static FeeParam* instance(); // Singleton
-  static void terminate();
 
   // Translation from MCM to Pad and vice versa
   static int getPadRowFromMCM(int irob, int imcm);
@@ -72,25 +71,25 @@ class FeeParam
   // wiring
   static int getORI(int detector, int readoutboard);
   static int getORIinSM(int detector, int readoutboard);
-  //  static void createORILookUpTable();
+  //  void createORILookUpTable();
   static int getORIfromHCID(int hcid);
   static int getHCIDfromORI(int ori, int readoutboard); // TODO we need more info than just ori, for now readoutboard is there ... might change
 
   // tracklet simulation
-  bool getTracklet() const { return mgTracklet; }
-  static void setTracklet(bool trackletSim = true) { mgTracklet = trackletSim; }
-  bool getRejectMultipleTracklets() const { return mgRejectMultipleTracklets; }
-  static void setRejectMultipleTracklets(bool rej = true) { mgRejectMultipleTracklets = rej; }
-  bool getUseMisalignCorr() const { return mgUseMisalignCorr; }
-  static void setUseMisalignCorr(bool misalign = true) { mgUseMisalignCorr = misalign; }
-  bool getUseTimeOffset() const { return mgUseTimeOffset; }
-  static void setUseTimeOffset(bool timeOffset = true) { mgUseTimeOffset = timeOffset; }
+  bool getTracklet() const { return mTracklet; }
+  void setTracklet(bool trackletSim = true) { mTracklet = trackletSim; }
+  bool getRejectMultipleTracklets() const { return mRejectMultipleTracklets; }
+  void setRejectMultipleTracklets(bool rej = true) { mRejectMultipleTracklets = rej; }
+  bool getUseMisalignCorr() const { return mUseMisalignCorr; }
+  void setUseMisalignCorr(bool misalign = true) { mUseMisalignCorr = misalign; }
+  bool getUseTimeOffset() const { return mUseTimeOffset; }
+  void setUseTimeOffset(bool timeOffset = true) { mUseTimeOffset = timeOffset; }
 
   // Concerning raw data format
   int getRAWversion() const { return mRAWversion; }
   void setRAWversion(int rawver);
 
-  inline short padMcmLUT(int index) { return mgLUTPadNumbering[index]; }
+  short padMcmLUT(int index) { return mLUTPadNumbering[index]; }
 
   // configuration settings
   // called with special SCSN commands
@@ -138,56 +137,61 @@ class FeeParam
 
  protected:
   static FeeParam* mgInstance; // Singleton instance
-  static bool mgTerminated;    // Defines if this class has already been terminated
 
-  CommonParam* mCP = nullptr; // TRD common parameters class
+  CommonParam* mCP{CommonParam::instance()}; // TRD common parameters class
 
-  static std::vector<short> mgLUTPadNumbering; // Lookup table mapping Pad to MCM
-  static bool mgLUTPadNumberingFilled;         // Lookup table mapping Pad to MCM
+  std::array<short, constants::NCOLUMN> mLUTPadNumbering; // Lookup table mapping Pad to MCM
 
-  void createPad2MCMLookUpTable();
+  void fillPad2MCMLookUpTable();
 
   // Tracklet  processing on/off
-  static bool mgTracklet;                // tracklet processing
-  static bool mgRejectMultipleTracklets; // only accept best tracklet if found more than once
-  static bool mgUseMisalignCorr;         // add correction for mis-alignment in y
-  static bool mgUseTimeOffset;           // add time offset in calculation of fit sums
+  bool mTracklet{true};                 // tracklet processing
+  bool mRejectMultipleTracklets{false}; // only accept best tracklet if found more than once
+  bool mUseMisalignCorr{false};         // add correction for mis-alignment in y
+  bool mUseTimeOffset{false};           // add time offset in calculation of fit sums
 
   // For raw production
   int mRAWversion{3};                    // Raw data production version
-  static const int mgkMaxRAWversion = 3; // Maximum raw version number supported
+  const int mkMaxRAWversion = 3;         // Maximum raw version number supported
 
   // geometry constants
-  static std::array<float, constants::NCHAMBERPERSEC> mgZrow;    // z-position of pad row edge 6x5
-  static std::array<float, constants::NLAYER> mgX;               // x-position for all layers
-  static std::array<float, constants::NLAYER> mgInvX;            // inverse x-position for all layers (to remove divisions)
-  static std::array<float, constants::NLAYER> mgTiltingAngle;    // tilting angle for every layer
-  static std::array<float, constants::NLAYER> mgTiltingAngleTan; // tan of tilting angle for every layer (look up table to avoid tan calculations)
-  static std::array<float, constants::NLAYER> mgWidthPad;        // pad width for all layers
-  static std::array<float, constants::NLAYER> mgInvWidthPad;     // inverse pad width for all layers (to remove divisions)
-  static float mgLengthInnerPadC0;                // inner pad length C0 chamber
-  static float mgLengthOuterPadC0;                // outer pad length C0 chamber
-  static std::array<float, constants::NLAYER> mgLengthInnerPadC1; // inner pad length C1 chambers
-  static std::array<float, constants::NLAYER> mgLengthOuterPadC1; // outer pad length C1 chambers
-  static float mgScalePad;                        // scaling factor for pad width
-  static float mgDriftLength;                     // length of the  parse gaintbl Krypton_2009-01 drift region
-  static float mgBinDy;                           // bin in dy (140 um)
-  static int mgDyMax;                             // max dy for a tracklet (hard limit)
-  static int mgDyMin;                             // min dy for a tracklet (hard limit)
-                                                  //std::array<int,30> mgAsideLUT;                          // A side LUT to map ORI to stack/layer/side
-                                                  //std::array<int,30> mgCsideLUT;                          // C side LUT to map ORI to stack/layer/side
+  std::array<float, constants::NCHAMBERPERSEC> mZrow{// z-position of pad row edge 6x5
+                                                     301, 177, 53, -57, -181,
+                                                     301, 177, 53, -57, -181,
+                                                     315, 184, 53, -57, -188,
+                                                     329, 191, 53, -57, -195,
+                                                     343, 198, 53, -57, -202,
+                                                     347, 200, 53, -57, -204};
+  std::array<float, constants::NLAYER> mX{300.65, 313.25, 325.85, 338.45, 351.05, 363.65};  // x-position for all layers
+  std::array<float, constants::NLAYER> mInvX;                                               // inverse x-position for all layers (to remove divisions)
+  std::array<float, constants::NLAYER> mTiltingAngle{-2., 2., -2., 2., -2., 2.};            // tilting angle for every layer
+  std::array<float, constants::NLAYER> mTiltingAngleTan;                                    // tan of tilting angle for every layer (look up table to avoid tan calculations)
+  std::array<float, constants::NLAYER> mWidthPad{0.635, 0.665, 0.695, 0.725, 0.755, 0.785}; // pad width for all layers
+  std::array<float, constants::NLAYER> mInvWidthPad;                                        // inverse pad width for all layers (to remove divisions)
+  float mLengthInnerPadC0{9.f};                                                             // inner pad length C0 chamber
+  float mLengthOuterPadC0{8.f};                                                             // outer pad length C0 chamber
+  std::array<float, constants::NLAYER> mLengthInnerPadC1{7.5, 7.5, 8.0, 8.5, 9.0, 9.0};     // inner pad length C1 chambers
+  std::array<float, constants::NLAYER> mLengthOuterPadC1{7.5, 7.5, 7.5, 7.5, 7.5, 8.5};     // outer pad length C1 chambers
+  float mScalePad{256. * 32.};                                                              // scaling factor for pad width
+  float mDriftLength{3.};                                                                   // length of the  parse gaintbl Krypton_2009-01 drift region
+  // WARNING: This values for dY are valid for Run 1+2 format only
+  float mBinDy{140e-4}; // bin in dy (140 um)
+  int mDyMax{63};       // max dy for a tracklet (hard limit)
+  int mDyMin{-64};      // min dy for a tracklet (hard limit)
+                        //std::array<int,30> mAsideLUT;                          // A side LUT to map ORI to stack/layer/side
+                        //std::array<int,30> mCsideLUT;                          // C side LUT to map ORI to stack/layer/side
 
   // settings
-  float mMagField;          // magnetic field
-  float mOmegaTau;          // omega tau, i.e. tan(Lorentz angle)
-  float mPtMin;             // min. pt for deflection cut
-  float mInvPtMin;          // min. pt for deflection cut (Inverted to remove division)
-  int mNtimebins;           // drift time in units of timebins << 5n
-  unsigned int mScaleQ0;    // scale factor for accumulated charge Q0
-  unsigned int mScaleQ1;    // scale factor for accumulated charge Q1
-  bool mPidTracklengthCorr; // enable tracklet length correction
-  bool mTiltCorr;           // enable tilt correction
-  bool mPidGainCorr;        // enable MCM gain correction factor for PID
+  float mMagField{0.f};            // magnetic field
+  float mOmegaTau{0.f};            // omega tau, i.e. tan(Lorentz angle)
+  float mPtMin{.1f};               // min. pt for deflection cut
+  float mInvPtMin{1.f / mPtMin};   // min. pt for deflection cut (Inverted to remove division)
+  int mNtimebins{20 << 5};         // drift time in units of timebins << 5n
+  unsigned int mScaleQ0{0};        // scale factor for accumulated charge Q0
+  unsigned int mScaleQ1{0};        // scale factor for accumulated charge Q1
+  bool mPidTracklengthCorr{false}; // enable tracklet length correction
+  bool mTiltCorr{false};           // enable tilt correction
+  bool mPidGainCorr{false};        // enable MCM gain correction factor for PID
 
  private:
   FeeParam();

--- a/Detectors/TRD/base/include/TRDBase/GeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/GeometryBase.h
@@ -12,7 +12,6 @@
 #define O2_TRD_GEOMETRYBASE_H
 
 #include "GPUCommonDef.h"
-#include "TRDBase/CommonParam.h"
 #include "DataFormatsTRD/Constants.h"
 #include "TRDBase/PadPlane.h"
 

--- a/Detectors/TRD/base/include/TRDBase/SimParam.h
+++ b/Detectors/TRD/base/include/TRDBase/SimParam.h
@@ -8,6 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/// \file SimParam.h
+
 #ifndef O2_TRD_SIMPARAM_H
 #define O2_TRD_SIMPARAM_H
 
@@ -18,22 +20,27 @@ namespace o2
 {
 namespace trd
 {
-////////////////////////////////////////////////////////////////////////////
-//                                                                        //
-// Class containing constant simulation parameters                        //
-//                                                                        //
-////////////////////////////////////////////////////////////////////////////
+
+/// \brief Constant parameters for the TRD simulation
+///
 class SimParam
 {
  public:
   enum {
-    kNPadsInPadResponse = 3 // Number of pads included in the pad response
+    kNPadsInPadResponse = 3 ///< Number of pads included in the pad response
   };
 
+  /// For a singleton class copying and assigning is not allowed
   SimParam(const SimParam&) = delete;
   SimParam& operator=(const SimParam&) = delete;
+
+  /// Returns an instance of this class. A SimParam object is created upon the first call of this function
   static SimParam* instance();
 
+  /// After setting a new gas mixture the parameters need to be re-evaluated
+  void reInit();
+
+  // Setters
   void setGasGain(float gasgain) { mGasGain = gasgain; }
   void setNoise(float noise) { mNoise = noise; }
   void setChipGain(float chipgain) { mChipGain = chipgain; }
@@ -50,6 +57,7 @@ class SimParam
   void setTimeStruct(bool flag = true) { mTimeStructOn = flag; }
   void setPadResponse(bool flag = true) { mPRFOn = flag; }
 
+  // Getters
   float getGasGain() const { return mGasGain; }
   float getNoise() const { return mNoise; }
   float getChipGain() const { return mChipGain; }
@@ -70,50 +78,44 @@ class SimParam
   const int getNumberOfPadsInPadResponse() const { return kNPadsInPadResponse; }
   inline double timeResponse(double) const;
   inline double crossTalk(double) const;
-  void reInit();
 
  protected:
-  static SimParam* mgInstance; //  Instance of this class (singleton implementation)
+  static SimParam* mgInstance; ///<  Instance of this class (singleton implementation)
 
-  // Digitization parameter
-  float mGasGain{4000.f}; //  Gas gain
-  float mNoise{1250.f};   //  Electronics noise
-  float mChipGain{12.4f}; //  Electronics gain
+  float mNoise{1250.f};                 ///< Electronics noise
+  float mChipGain{12.4f};               ///< Electronics gain
+  float mADCoutRange{1023.f};           ///< ADC output range (number of channels for the 10 bit ADC)
+  float mADCinRange{2000.f};            ///< ADC input range (2V)
+  int mADCbaseline{10};                 ///< ADC intrinsic baseline in ADC channel
+  bool mDiffusionOn{true};              ///< Switch for the diffusion
+  bool mElAttachOn{false};              ///< Switch for the electron attachment
+  float mElAttachProp{0.f};             ///< Propability for electron attachment (for 1m)
+  bool mTRFOn{true};                    ///< Switch for the time response
+  bool mCTOn{true};                     ///< Switch for cross talk
+  bool mPRFOn{true};                    ///<  Switch for the pad response
+  static constexpr int mNBinsMax = 200; ///< Maximum number of bins for integrated time response and cross talk
 
-  float mADCoutRange{1023.f}; //  ADC output range (number of channels); 10 bit ADC
-  float mADCinRange{2000.f};  //  ADC input range (input charge); 2V input range
-  int mADCbaseline{10};       //  ADC intrinsic baseline in ADC channel
-
-  bool mDiffusionOn{true}; //  Switch for the diffusion
-
-  bool mElAttachOn{false};  //  Switch for the electron attachment
-  float mElAttachProp{0.f}; //  Propability for electron attachment (for 1m)
-
-  static constexpr int mNBinsMax = 200;                              // maximum number of bins for integrated time response and cross talk
-  bool mTRFOn{true};                                                 //  Switch for the time response
-  std::array<float, mNBinsMax> mTRFsmp{};                            // Integrated time response
-  int mTRFbin{200};                                                  //  Number of bins for the TRF
-  float mTRFlo{-.4f};                                                //  Lower boundary of the TRF
-  float mTRFhi{3.58f};                                               //  Higher boundary of the TRF
-  float mInvTRFwid{static_cast<float>(mTRFbin) / (mTRFhi - mTRFlo)}; //  Inverse of the bin width of the integrated TRF
-
-  bool mCTOn{true};                      //  Switch for cross talk
-  std::array<float, mNBinsMax> mCTsmp{}; // Integrated cross talk
-
-  // The pad coupling factor
   // Use 0.46, instead of the theroetical value 0.3, since it reproduces better
   // the test beam data, even tough it is not understood why.
-  float mPadCoupling{.46f};
-  float mTimeCoupling{.4f}; //  Time coupling factor (image charge of moving ions); same number as for the TPC
-  bool mTimeStructOn{true}; //  Switch for cell time structure
+  float mPadCoupling{.46f}; ///< The pad coupling factor
+  float mTimeCoupling{.4f}; ///< Time coupling factor (image charge of moving ions); same number as for the TPC
+  bool mTimeStructOn{true}; ///< Switch for cell time structure
 
-  bool mPRFOn{true}; //  Switch for the pad response
+  /// The parameters below depend on the gas mixture and are re-evaluated upon a change
+  std::array<float, mNBinsMax> mTRFsmp{};                            ///< Integrated time response
+  std::array<float, mNBinsMax> mCTsmp{};                             ///< Integrated cross talk
+  int mTRFbin{200};                                                  ///<  Number of bins for the TRF and x-talk
+  float mTRFlo{-.4f};                                                ///<  Lower boundary of the TRF and x-talk
+  float mTRFhi{3.58f};                                               ///<  Higher boundary of the TRF and x-talk
+  float mInvTRFwid{static_cast<float>(mTRFbin) / (mTRFhi - mTRFlo)}; ///<  Inverse of the bin width of the integrated TRF and x-talk
+  float mGasGain{4000.f};                                            ///< Gas gain
 
  private:
-  // This is a singleton, constructor is private!
+  /// This is a singleton, constructor is private!
   SimParam();
   ~SimParam() = default;
 
+  /// Fill the arrays mTRDsmp and mCTsmp for the given gas mixture
   void sampleTRF();
 
   ClassDefNV(SimParam, 1); // The TRD simulation parameters

--- a/Detectors/TRD/base/include/TRDBase/SimParam.h
+++ b/Detectors/TRD/base/include/TRDBase/SimParam.h
@@ -11,8 +11,8 @@
 #ifndef O2_TRD_SIMPARAM_H
 #define O2_TRD_SIMPARAM_H
 
-//Forwards to standard header with protection for GPU compilation
-#include "GPUCommonRtypes.h" // for ClassDef
+#include <array>
+#include "Rtypes.h" // for ClassDef
 
 namespace o2
 {
@@ -30,108 +30,96 @@ class SimParam
     kNPadsInPadResponse = 3 // Number of pads included in the pad response
   };
 
-  static SimParam* Instance();
-  static void Terminate();
+  SimParam(const SimParam&) = delete;
+  SimParam& operator=(const SimParam&) = delete;
+  static SimParam* instance();
 
-  void SetGasGain(float gasgain) { mGasGain = gasgain; }
-  void SetNoise(float noise) { mNoise = noise; }
-  void SetChipGain(float chipgain) { mChipGain = chipgain; }
-  void SetADCoutRange(float range) { mADCoutRange = range; }
-  void SetADCinRange(float range) { mADCinRange = range; }
-  void SetADCbaseline(int basel) { mADCbaseline = basel; }
-  void SetDiffusion(int diffOn = 1) { mDiffusionOn = diffOn; }
-  void SetElAttach(int elOn = 1) { mElAttachOn = elOn; }
-  void SetElAttachProp(float prop) { mElAttachProp = prop; }
-  void SetTimeResponse(int trfOn = 1)
-  {
-    mTRFOn = trfOn;
-    ReInit();
-  }
-  void SetCrossTalk(int ctOn = 1)
-  {
-    mCTOn = ctOn;
-    ReInit();
-  }
-  void SetPadCoupling(float v) { mPadCoupling = v; }
-  void SetTimeCoupling(float v) { mTimeCoupling = v; }
-  void SetTimeStruct(bool tsOn = 1) { mTimeStructOn = tsOn; }
-  void SetPadResponse(int prfOn = 1) { mPRFOn = prfOn; }
-  void SetNTimeBins(int ntb) { mNTimeBins = ntb; }
-  void SetNTBoverwriteOCDB(bool over = true) { mNTBoverwriteOCDB = over; }
-  float GetGasGain() const { return mGasGain; }
-  float GetNoise() const { return mNoise; }
-  float GetChipGain() const { return mChipGain; }
-  float GetADCoutRange() const { return mADCoutRange; }
-  float GetADCinRange() const { return mADCinRange; }
-  int GetADCbaseline() const { return mADCbaseline; }
-  float GetTRFlo() const { return mTRFlo; }
-  float GetTRFhi() const { return mTRFhi; }
-  float GetPadCoupling() const { return mPadCoupling; }
-  float GetTimeCoupling() const { return mTimeCoupling; }
-  int GetNTimeBins() const { return mNTimeBins; }
-  bool GetNTBoverwriteOCDB() const { return mNTBoverwriteOCDB; }
-  bool DiffusionOn() const { return mDiffusionOn; }
-  bool ElAttachOn() const { return mElAttachOn; }
-  float GetElAttachProp() const { return mElAttachProp; }
-  bool TRFOn() const { return mTRFOn; }
-  bool CTOn() const { return mCTOn; }
-  bool TimeStructOn() const { return mTimeStructOn; }
-  bool PRFOn() const { return mPRFOn; }
+  void setGasGain(float gasgain) { mGasGain = gasgain; }
+  void setNoise(float noise) { mNoise = noise; }
+  void setChipGain(float chipgain) { mChipGain = chipgain; }
+  void setADCoutRange(float range) { mADCoutRange = range; }
+  void setADCinRange(float range) { mADCinRange = range; }
+  void setADCbaseline(int basel) { mADCbaseline = basel; }
+  void setDiffusion(bool flag = true) { mDiffusionOn = flag; }
+  void setElAttach(bool flag = true) { mElAttachOn = flag; }
+  void setElAttachProp(float prop) { mElAttachProp = prop; }
+  void setTimeResponse(bool flag = true) { mTRFOn = flag; }
+  void setCrossTalk(bool flag = true) { mCTOn = flag; }
+  void setPadCoupling(float v) { mPadCoupling = v; }
+  void setTimeCoupling(float v) { mTimeCoupling = v; }
+  void setTimeStruct(bool flag = true) { mTimeStructOn = flag; }
+  void setPadResponse(bool flag = true) { mPRFOn = flag; }
+
+  float getGasGain() const { return mGasGain; }
+  float getNoise() const { return mNoise; }
+  float getChipGain() const { return mChipGain; }
+  float getADCoutRange() const { return mADCoutRange; }
+  float getADCinRange() const { return mADCinRange; }
+  int getADCbaseline() const { return mADCbaseline; }
+  float getTRFlo() const { return mTRFlo; }
+  float getTRFhi() const { return mTRFhi; }
+  float getPadCoupling() const { return mPadCoupling; }
+  float getTimeCoupling() const { return mTimeCoupling; }
+  bool diffusionOn() const { return mDiffusionOn; }
+  bool elAttachOn() const { return mElAttachOn; }
+  float getElAttachProp() const { return mElAttachProp; }
+  bool trfOn() const { return mTRFOn; }
+  bool ctOn() const { return mCTOn; }
+  bool timeStructOn() const { return mTimeStructOn; }
+  bool prfOn() const { return mPRFOn; }
   const int getNumberOfPadsInPadResponse() const { return kNPadsInPadResponse; }
-  inline double TimeResponse(double) const;
-  inline double CrossTalk(double) const;
-  void ReInit();
+  inline double timeResponse(double) const;
+  inline double crossTalk(double) const;
+  void reInit();
 
  protected:
-  static SimParam* fgInstance; //  Instance of this class (singleton implementation)
-  static bool fgTerminated;    //  Defines if this class has already been terminated and
-                               //  therefore does not return instances in GetInstance anymore
+  static SimParam* mgInstance; //  Instance of this class (singleton implementation)
 
   // Digitization parameter
-  float mGasGain;  //  Gas gain
-  float mNoise;    //  Electronics noise
-  float mChipGain; //  Electronics gain
+  float mGasGain{4000.f}; //  Gas gain
+  float mNoise{1250.f};   //  Electronics noise
+  float mChipGain{12.4f}; //  Electronics gain
 
-  float mADCoutRange; //  ADC output range (number of channels)
-  float mADCinRange;  //  ADC input range (input charge)
-  int mADCbaseline;   //  ADC intrinsic baseline in ADC channel
+  float mADCoutRange{1023.f}; //  ADC output range (number of channels); 10 bit ADC
+  float mADCinRange{2000.f};  //  ADC input range (input charge); 2V input range
+  int mADCbaseline{10};       //  ADC intrinsic baseline in ADC channel
 
-  int mDiffusionOn; //  Switch for the diffusion
+  bool mDiffusionOn{true}; //  Switch for the diffusion
 
-  int mElAttachOn;     //  Switch for the electron attachment
-  float mElAttachProp; //  Propability for electron attachment (for 1m)
+  bool mElAttachOn{false};  //  Switch for the electron attachment
+  float mElAttachProp{0.f}; //  Propability for electron attachment (for 1m)
 
-  int mTRFOn;       //  Switch for the time response
-  float* mTRFsmp;   //! Integrated time response
-  int mTRFbin;      //  Number of bins for the TRF
-  float mTRFlo;     //  Lower boundary of the TRF
-  float mTRFhi;     //  Higher boundary of the TRF
-  float mInvTRFwid; //  Inverse of the bin width of the integrated TRF
+  static constexpr int mNBinsMax = 200;                              // maximum number of bins for integrated time response and cross talk
+  bool mTRFOn{true};                                                 //  Switch for the time response
+  std::array<float, mNBinsMax> mTRFsmp{};                            // Integrated time response
+  int mTRFbin{200};                                                  //  Number of bins for the TRF
+  float mTRFlo{-.4f};                                                //  Lower boundary of the TRF
+  float mTRFhi{3.58f};                                               //  Higher boundary of the TRF
+  float mInvTRFwid{static_cast<float>(mTRFbin) / (mTRFhi - mTRFlo)}; //  Inverse of the bin width of the integrated TRF
 
-  int mCTOn;     //  Switch for cross talk
-  float* mCTsmp; //! Integrated cross talk
+  bool mCTOn{true};                      //  Switch for cross talk
+  std::array<float, mNBinsMax> mCTsmp{}; // Integrated cross talk
 
-  float mPadCoupling;  //  Pad coupling factor
-  float mTimeCoupling; //  Time coupling factor (image charge of moving ions)
-  int mTimeStructOn;   //  Switch for cell time structure
+  // The pad coupling factor
+  // Use 0.46, instead of the theroetical value 0.3, since it reproduces better
+  // the test beam data, even tough it is not understood why.
+  float mPadCoupling{.46f};
+  float mTimeCoupling{.4f}; //  Time coupling factor (image charge of moving ions); same number as for the TPC
+  bool mTimeStructOn{true}; //  Switch for cell time structure
 
-  int mPRFOn; //  Switch for the pad response
-
-  int mNTimeBins;         //  Number of time bins (only used it fNTBoverwriteOCDB = true)
-  bool mNTBoverwriteOCDB; //  Switch to overwrite number of time bins from PCDB
+  bool mPRFOn{true}; //  Switch for the pad response
 
  private:
   // This is a singleton, constructor is private!
   SimParam();
-  ~SimParam();
+  ~SimParam() = default;
 
-  void Init();
-  void SampleTRF();
+  void sampleTRF();
 
   ClassDefNV(SimParam, 1); // The TRD simulation parameters
 };
 
-inline double SimParam::TimeResponse(double time) const
+inline double SimParam::timeResponse(double time) const
 {
   //
   // Applies the preamp shaper time response
@@ -148,7 +136,7 @@ inline double SimParam::TimeResponse(double time) const
   }
 }
 
-inline double SimParam::CrossTalk(double time) const
+inline double SimParam::crossTalk(double time) const
 {
   //
   // Applies the pad-pad capacitive cross talk

--- a/Detectors/TRD/base/src/CommonParam.cxx
+++ b/Detectors/TRD/base/src/CommonParam.cxx
@@ -30,7 +30,7 @@
 using namespace o2::trd;
 ClassImp(CommonParam);
 
-CommonParam* CommonParam::fgInstance = nullptr;
+CommonParam* CommonParam::mgInstance = nullptr;
 
 //_ singleton implementation __________________________________________________
 CommonParam* CommonParam::instance()
@@ -40,11 +40,11 @@ CommonParam* CommonParam::instance()
   // Returns an instance of this class, it is created if neccessary
   //
 
-  if (fgInstance == nullptr) {
-    fgInstance = new CommonParam();
+  if (mgInstance == nullptr) {
+    mgInstance = new CommonParam();
   }
 
-  return fgInstance;
+  return mgInstance;
 }
 
 
@@ -665,11 +665,11 @@ void CommonParam::sampleTimeStruct(float vdrift)
 void CommonParam::setXenon()
 {
   mGasMixture = kXenon;
-  SimParam::Instance()->ReInit();
+  SimParam::instance()->reInit();
 }
 
 void CommonParam::setArgon()
 {
   mGasMixture = kArgon;
-  SimParam::Instance()->ReInit();
+  SimParam::instance()->reInit();
 }

--- a/Detectors/TRD/base/src/DiffAndTimeStructEstimator.cxx
+++ b/Detectors/TRD/base/src/DiffAndTimeStructEstimator.cxx
@@ -531,7 +531,7 @@ bool DiffusionAndTimeStructEstimator::GetDiffCoeff(float& dl, float& dt, float v
   }
   mDiffLastVdrift = vdrift;
 
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     //
     // Vd and B-field dependent diffusion and Lorentz angle
     //
@@ -541,7 +541,7 @@ bool DiffusionAndTimeStructEstimator::GetDiffCoeff(float& dl, float& dt, float v
 
     // If looking at compatibility with AliRoot:
     // ibL and ibT are calculated the same way so, just define ib = ibL = ibT
-    int ib = ((int)(10 * (CommonParam::Instance()->GetCachedField() - 0.15)));
+    int ib = ((int)(10 * (CommonParam::instance()->getCachedField() - 0.15)));
     ib = std::max(0, ib);
     ib = std::min(kNb - 1, ib);
 
@@ -564,7 +564,7 @@ bool DiffusionAndTimeStructEstimator::GetDiffCoeff(float& dl, float& dt, float v
     dl = mDiffusionL;
     dt = mDiffusionT;
     return true;
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     //
     // Diffusion constants and Lorentz angle only for B = 0.5T
     //

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -39,8 +39,10 @@
 #include "TRDBase/Geometry.h"
 #include "TRDBase/PadPlane.h"
 #include "TRDBase/FeeParam.h"
-#include "TRDBase/CommonParam.h"
-//#include "DataFormatsTRD/Constants.h"
+
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
 
 using namespace std;
 using namespace o2::trd;
@@ -49,38 +51,6 @@ using namespace o2::trd::constants;
 //_____________________________________________________________________________
 
 FeeParam* FeeParam::mgInstance = nullptr;
-bool FeeParam::mgTerminated = false;
-bool FeeParam::mgTracklet = true;
-bool FeeParam::mgRejectMultipleTracklets = false;
-bool FeeParam::mgUseMisalignCorr = false;
-bool FeeParam::mgUseTimeOffset = false;
-bool FeeParam::mgLUTPadNumberingFilled = false;
-std::vector<short> FeeParam::mgLUTPadNumbering;
-
-// definition of geometry constants
-std::array<float, NCHAMBERPERSEC> FeeParam::mgZrow = {
-  301, 177, 53, -57, -181,
-  301, 177, 53, -57, -181,
-  315, 184, 53, -57, -188,
-  329, 191, 53, -57, -195,
-  343, 198, 53, -57, -202,
-  347, 200, 53, -57, -204};
-std::array<float, NLAYER> FeeParam::mgX = {300.65, 313.25, 325.85, 338.45, 351.05, 363.65};
-std::array<float, NLAYER> FeeParam::mgTiltingAngle = {-2., 2., -2., 2., -2., 2.};
-int FeeParam::mgDyMax = 63;
-int FeeParam::mgDyMin = -64;
-float FeeParam::mgBinDy = 140e-4;
-std::array<float, NLAYER> FeeParam::mgWidthPad = {0.635, 0.665, 0.695, 0.725, 0.755, 0.785};
-std::array<float, NLAYER> FeeParam::mgLengthInnerPadC1 = {7.5, 7.5, 8.0, 8.5, 9.0, 9.0};
-std::array<float, NLAYER> FeeParam::mgLengthOuterPadC1 = {7.5, 7.5, 7.5, 7.5, 7.5, 8.5};
-std::array<float, NLAYER> FeeParam::mgInvX;
-std::array<float, NLAYER> FeeParam::mgTiltingAngleTan;
-std::array<float, NLAYER> FeeParam::mgInvWidthPad;
-
-float FeeParam::mgLengthInnerPadC0 = 9.0;
-float FeeParam::mgLengthOuterPadC0 = 8.0;
-float FeeParam::mgScalePad = 256. * 32.;
-float FeeParam::mgDriftLength = 3.;
 
 //_____________________________________________________________________________
 FeeParam* FeeParam::instance()
@@ -88,111 +58,39 @@ FeeParam* FeeParam::instance()
   //
   // Instance constructor
   //
-  if (mgTerminated != false) {
-    return nullptr;
-  }
+#ifdef WITH_OPENMP
+#pragma omp critical
+#endif
+  { // start omp critical block
+    if (mgInstance == nullptr) {
+      mgInstance = new FeeParam();
+    }
 
-  if (mgInstance == nullptr) {
-    mgInstance = new FeeParam();
-  }
-  // this is moved here to remove recursive calls induced by the line 2 above this one.
-  if (!mgLUTPadNumberingFilled) {
-    mgInstance->createPad2MCMLookUpTable();
-  }
-  return mgInstance;
+    return mgInstance;
+  } // end omp critical block
 }
 
-//_____________________________________________________________________________
-void FeeParam::terminate()
-{
-  //
-  // Terminate the class and release memory
-  //
-
-  mgTerminated = true;
-
-  if (mgInstance != nullptr) {
-    delete mgInstance;
-    mgInstance = nullptr;
-  }
-}
 
 //_____________________________________________________________________________
-FeeParam::FeeParam() : mMagField(0.),
-                       mOmegaTau(0.),
-                       mPtMin(0.1),
-                       mNtimebins(20 << 5),
-                       mScaleQ0(0),
-                       mScaleQ1(0),
-                       mPidTracklengthCorr(false),
-                       mTiltCorr(false),
-                       mPidGainCorr(false)
+FeeParam::FeeParam()
 {
   //
   // Default constructor
   //
-  mCP = CommonParam::Instance();
 
   // These variables are used internally in the class to elliminate divisions.
   // putting them at the top was messy.
   int j = 0;
-  std::for_each(mgInvX.begin(), mgInvX.end(), [&j](float& x) { x = 1. / mgX[j]; });
+  std::for_each(mInvX.begin(), mInvX.end(), [&](float& x) { x = 1. / mX[j]; });
   j = 0;
-  std::for_each(mgInvWidthPad.begin(), mgInvWidthPad.end(), [&j](float& x) { x = 1. / mgWidthPad[j]; });
+  std::for_each(mInvWidthPad.begin(), mInvWidthPad.end(), [&](float& x) { x = 1. / mWidthPad[j]; });
   j = 0;
-  std::for_each(mgTiltingAngleTan.begin(), mgTiltingAngleTan.end(), [&j](float& x) { x = std::tan(mgTiltingAngle[j] * M_PI / 180.0); });
+  std::for_each(mTiltingAngleTan.begin(), mTiltingAngleTan.end(), [&](float& x) { x = std::tan(mTiltingAngle[j] * M_PI / 180.0); });
 
-  mInvPtMin = 1 / mPtMin;
+  fillPad2MCMLookUpTable();
 }
 
-//_____________________________________________________________________________
-//FeeParam::FeeParam(TRootIoCtor*)
-//{
-//
-// IO constructor
-//
-//}
 
-//_____________________________________________________________________________
-FeeParam::FeeParam(const FeeParam& p)
-{
-  //
-  // FeeParam copy constructor
-  //
-  mRAWversion = p.mRAWversion;
-  mCP = p.mCP;
-  if (!mgLUTPadNumberingFilled) {
-    mgInstance->createPad2MCMLookUpTable();
-  }
-}
-
-//_____________________________________________________________________________
-FeeParam::~FeeParam() = default;
-
-//_____________________________________________________________________________
-FeeParam& FeeParam::operator=(const FeeParam& p)
-{
-  //
-  // Assignment operator
-  //
-
-  if (this != &p) {
-    ((FeeParam&)p).Copy(*this);
-  }
-
-  return *this;
-}
-
-//_____________________________________________________________________________
-void FeeParam::Copy(FeeParam& p) const
-{
-  //
-  // Copy function
-  //
-
-  p.mCP = mCP;
-  p.mRAWversion = mRAWversion;
-}
 
 //_____________________________________________________________________________
 int FeeParam::getPadRowFromMCM(int irob, int imcm)
@@ -367,7 +265,7 @@ int FeeParam::extAliToAli(unsigned int dest, unsigned short linkpair, unsigned s
   unsigned int cmA = 0, cmB = 0; // Chipmask for each A and B side
 
   // Default chipmask for 4 linkpairs (each bit correponds each alice-mcm)
-  static const unsigned int gkChipmaskDefLp[4] = {0x1FFFF, 0x1FFFF, 0x3FFFF, 0x1FFFF};
+  const unsigned int gkChipmaskDefLp[4] = {0x1FFFF, 0x1FFFF, 0x3FFFF, 0x1FFFF};
 
   rob = dest >> 7;                 // Extract ROB pattern from dest.
   mcm = dest & 0x07F;              // Extract MCM pattern from dest.
@@ -471,7 +369,7 @@ short FeeParam::getRobAB(unsigned short robsel, unsigned short linkpair)
 
   return 0;
 }
-/* 
+/*
 void FeeParam::createORILookUpTable()
 {
     int ori;
@@ -482,10 +380,10 @@ void FeeParam::createORILookUpTable()
 
             for(int trdlayer=5;trdlayer>=0;trdlayer++)
             {
-                ori=trdstack*12  + (5-trdlayer + side*6) +trdlayer/6 + side; 
-                mgAsideLUT[ori]= (trdstack<<8) + (trdlayer<<4) + side;           // A side LUT to map ORI to stack/layer/side
+                ori=trdstack*12  + (5-trdlayer + side*6) +trdlayer/6 + side;
+                mAsideLUT[ori]= (trdstack<<8) + (trdlayer<<4) + side;           // A side LUT to map ORI to stack/layer/side
                 if(ori==29) break;
-                
+
             }
                 if(ori==29) break;
         }
@@ -501,7 +399,7 @@ void FeeParam::createORILookUpTable()
                 ori = (4-trdstack)*12  + (5-trdlayer + side*5) +trdlayer/6 + side;
                 int newside;
                 if(ori >=24) newside=1; else newside=side; // a hack as I am not typing this all out.
-                mgCsideLUT[ori]= (trdstack<<8) + (trdlayer<<4) + newside;           // A side LUT to map ORI to stack/layer/side
+                mCsideLUT[ori]= (trdstack<<8) + (trdlayer<<4) + newside;           // A side LUT to map ORI to stack/layer/side
                 if(ori==29) break;
             }
                 if(ori==29) break;
@@ -591,10 +489,10 @@ void FeeParam::setRAWversion(int rawver)
 {
   //
   // Set raw data version (major number only)
-  // Maximum available number is preset in mgkMaxRAWversion
+  // Maximum available number is preset in mkMaxRAWversion
   //
 
-  if (rawver >= 0 && rawver <= mgkMaxRAWversion) {
+  if (rawver >= 0 && rawver <= mkMaxRAWversion) {
     mRAWversion = rawver;
   } else {
     LOG(error) << "Raw version is out of range: " << rawver;
@@ -605,24 +503,18 @@ void FeeParam::setRAWversion(int rawver)
  * This was originally moved here from arrayADC, signalADC etc. We now longer use those classes
  * so removing this for now as its crashing.
  */
-void FeeParam::createPad2MCMLookUpTable()
+void FeeParam::fillPad2MCMLookUpTable()
 {
   //
   // Initializes the Look Up Table to relate
   // pad numbering and mcm channel numbering
   //
-  if (!mgLUTPadNumberingFilled) {
-
-    LOG(debug) << " resizing lookup array to : " << NCOLUMN << " elements previously : " << mgLUTPadNumbering.size();
-    mgLUTPadNumbering.resize(NCOLUMN);
-    memset(&mgLUTPadNumbering[0], 0, sizeof(mgLUTPadNumbering[0]) * NCOLUMN);
-    for (int mcm = 0; mcm < 8; mcm++) {
-      int lowerlimit = 0 + mcm * 18;
-      int upperlimit = 18 + mcm * 18;
-      int shiftposition = 1 + 3 * mcm;
-      for (int index = lowerlimit; index < upperlimit; index++) {
-        mgLUTPadNumbering[index] = index + shiftposition;
-      }
+  for (int mcm = 0; mcm < NMCMROBINCOL * 2; mcm++) {
+    int lowerlimit = mcm * NCOLMCM;
+    int upperlimit = NCOLMCM + mcm * NCOLMCM;
+    int shiftposition = 1 + 3 * mcm;
+    for (int index = lowerlimit; index < upperlimit; index++) {
+      mLUTPadNumbering[index] = index + shiftposition;
     }
   }
 }
@@ -634,17 +526,17 @@ int FeeParam::getDyCorrection(int det, int rob, int mcm) const
 
   int layer = det % NLAYER;
 
-  float dyTilt = (mgDriftLength * std::tan(mgTiltingAngle[layer] * M_PI / 180.) *
-                  getLocalZ(det, rob, mcm) * mgInvX[layer]);
+  float dyTilt = (mDriftLength * std::tan(mTiltingAngle[layer] * M_PI / 180.) *
+                  getLocalZ(det, rob, mcm) * mInvX[layer]);
 
   // calculate Lorentz correction
-  float dyCorr = -mOmegaTau * mgDriftLength;
+  float dyCorr = -mOmegaTau * mDriftLength;
 
   if (mTiltCorr) {
     dyCorr += dyTilt; // add tilt correction
   }
 
-  return (int)TMath::Nint(dyCorr * mgScalePad * mgInvWidthPad[layer]);
+  return (int)TMath::Nint(dyCorr * mScalePad * mInvWidthPad[layer]);
 }
 
 void FeeParam::getDyRange(int det, int rob, int mcm, int ch,
@@ -652,8 +544,8 @@ void FeeParam::getDyRange(int det, int rob, int mcm, int ch,
 {
   // calculate the deflection range in which tracklets are accepted
 
-  dyMinInt = mgDyMin;
-  dyMaxInt = mgDyMax;
+  dyMinInt = mDyMin;
+  dyMaxInt = mDyMax;
 
   // deflection cut is considered for |B| > 0.1 T only
   if (std::abs(mMagField) < 0.1) {
@@ -669,26 +561,26 @@ void FeeParam::getDyRange(int det, int rob, int mcm, int ch,
   if (maxDeflTemp < std::cos(phi)) {
     float maxDeflAngle = std::asin(maxDeflTemp);
 
-    float dyMin = (mgDriftLength *
+    float dyMin = (mDriftLength *
                    std::tan(phi - maxDeflAngle));
 
-    dyMinInt = int(dyMin / mgBinDy);
+    dyMinInt = int(dyMin / mBinDy);
     // clipping to allowed range
-    if (dyMinInt < mgDyMin) {
-      dyMinInt = mgDyMin;
-    } else if (dyMinInt > mgDyMax) {
-      dyMinInt = mgDyMax;
+    if (dyMinInt < mDyMin) {
+      dyMinInt = mDyMin;
+    } else if (dyMinInt > mDyMax) {
+      dyMinInt = mDyMax;
     }
 
-    float dyMax = (mgDriftLength *
+    float dyMax = (mDriftLength *
                    std::tan(phi + maxDeflAngle));
 
-    dyMaxInt = int(dyMax / mgBinDy);
+    dyMaxInt = int(dyMax / mBinDy);
     // clipping to allowed range
-    if (dyMaxInt > mgDyMax) {
-      dyMaxInt = mgDyMax;
-    } else if (dyMaxInt < mgDyMin) {
-      dyMaxInt = mgDyMin;
+    if (dyMaxInt > mDyMax) {
+      dyMaxInt = mDyMax;
+    } else if (dyMaxInt < mDyMin) {
+      dyMaxInt = mDyMin;
     }
   } else if (maxDeflTemp < 0.) {
     // this must not happen
@@ -700,8 +592,8 @@ void FeeParam::getDyRange(int det, int rob, int mcm, int ch,
 
   if ((dyMaxInt - dyMinInt) <= 0) {
     LOG(debug) << "strange dy range: [" << dyMinInt << "," << dyMaxInt << "], using max range now";
-    dyMaxInt = mgDyMax;
-    dyMinInt = mgDyMin;
+    dyMaxInt = mDyMax;
+    dyMinInt = mDyMin;
   }
 }
 
@@ -712,7 +604,7 @@ float FeeParam::getElongation(int det, int rob, int mcm, int ch) const
 
   int layer = det % NLAYER;
 
-  float elongation = std::abs(getDist(det, rob, mcm, ch) * mgInvX[layer]);
+  float elongation = std::abs(getDist(det, rob, mcm, ch) * mInvX[layer]);
 
   // sanity check
   if (elongation < 0.001) {
@@ -752,7 +644,7 @@ float FeeParam::getX(int det, int /* rob */, int /* mcm */) const
   // return the distance to the beam axis in x-direction
 
   int layer = det % NLAYER;
-  return mgX[layer];
+  return mX[layer];
 }
 
 float FeeParam::getLocalY(int det, int rob, int mcm, int ch) const
@@ -762,7 +654,7 @@ float FeeParam::getLocalY(int det, int rob, int mcm, int ch) const
   int layer = det % NLAYER;
   // calculate the pad position as in the TRAP
   float ypos = (-4 + 1 + (rob & 0x1) * 4 + (mcm & 0x3)) * 18 - ch - 0.5; // y position in bins of pad widths
-  return ypos * mgWidthPad[layer];
+  return ypos * mWidthPad[layer];
 }
 
 float FeeParam::getLocalZ(int det, int rob, int mcm) const
@@ -775,19 +667,19 @@ float FeeParam::getLocalZ(int det, int rob, int mcm) const
 
   if (stack == 2) {
     if (row == 0) {
-      return (mgZrow[layer * NLAYER + stack] - 0.5 * mgLengthOuterPadC0);
+      return (mZrow[layer * NLAYER + stack] - 0.5 * mLengthOuterPadC0);
     } else if (row == 11) {
-      return (mgZrow[layer * NLAYER + stack] - 1.5 * mgLengthOuterPadC0 - (row - 1) * mgLengthInnerPadC0);
+      return (mZrow[layer * NLAYER + stack] - 1.5 * mLengthOuterPadC0 - (row - 1) * mLengthInnerPadC0);
     } else {
-      return (mgZrow[layer * NLAYER + stack] - mgLengthOuterPadC0 - (row - 0.5) * mgLengthInnerPadC0);
+      return (mZrow[layer * NLAYER + stack] - mLengthOuterPadC0 - (row - 0.5) * mLengthInnerPadC0);
     }
   } else {
     if (row == 0) {
-      return (mgZrow[layer * NLAYER + stack] - 0.5 * mgLengthOuterPadC1[layer]);
+      return (mZrow[layer * NLAYER + stack] - 0.5 * mLengthOuterPadC1[layer]);
     } else if (row == 15) {
-      return (mgZrow[layer * NLAYER + stack] - 1.5 * mgLengthOuterPadC1[layer] - (row - 1) * mgLengthInnerPadC1[layer]);
+      return (mZrow[layer * NLAYER + stack] - 1.5 * mLengthOuterPadC1[layer] - (row - 1) * mLengthInnerPadC1[layer]);
     } else {
-      return (mgZrow[layer * NLAYER + stack] - mgLengthOuterPadC1[layer] - (row - 0.5) * mgLengthInnerPadC1[layer]);
+      return (mZrow[layer * NLAYER + stack] - mLengthOuterPadC1[layer] - (row - 0.5) * mLengthInnerPadC1[layer]);
     }
   }
 }

--- a/Detectors/TRD/base/src/SimParam.cxx
+++ b/Detectors/TRD/base/src/SimParam.cxx
@@ -171,7 +171,7 @@ void SimParam::ReInit()
   // Reinitializes the parameter class after a change
   //
 
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     // The range and the binwidth for the sampled TRF
     mTRFbin = 200;
     // Start 0.2 mus before the signal
@@ -180,7 +180,7 @@ void SimParam::ReInit()
     mTRFhi = 3.58;
     // Standard gas gain
     mGasGain = 4000.0;
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     // The range and the binwidth for the sampled TRF
     mTRFbin = 50;
     // Start 0.2 mus before the signal
@@ -273,21 +273,21 @@ void SimParam::SampleTRF()
   }
   mCTsmp = new float[mTRFbin];
 
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     if (mTRFbin != kNpasa) {
       LOG(ERROR) << "Array mismatch (xenon)\n\n";
     }
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     if (mTRFbin != kNpasaAr) {
       LOG(ERROR) << "Array mismatch (argon)\n\n";
     }
   }
 
   for (int iBin = 0; iBin < mTRFbin; iBin++) {
-    if (CommonParam::Instance()->IsXenon()) {
+    if (CommonParam::instance()->isXenon()) {
       mTRFsmp[iBin] = signal[iBin];
       mCTsmp[iBin] = xtalk[iBin];
-    } else if (CommonParam::Instance()->IsArgon()) {
+    } else if (CommonParam::instance()->isArgon()) {
       mTRFsmp[iBin] = signalAr[iBin];
       mCTsmp[iBin] = xtalkAr[iBin];
     }

--- a/Detectors/TRD/base/test/testTRDDiffusionCoefficient.cxx
+++ b/Detectors/TRD/base/test/testTRDDiffusionCoefficient.cxx
@@ -34,11 +34,11 @@ BOOST_AUTO_TEST_CASE(TRDDiffusionCoefficient_test1)
   TGeoGlobalMagField::Instance()->SetField(fld);
   TGeoGlobalMagField::Instance()->Lock();
 
-  auto commonParam = CommonParam::Instance();
+  auto commonParam = CommonParam::instance();
   float dl = 0;
   float dt = 0;
   float vd = 1.48;
-  commonParam->GetDiffCoeff(dl, dt, vd);
+  commonParam->getDiffCoeff(dl, dt, vd);
   // check whether the values match the expected AliRoot known output
   BOOST_CHECK_CLOSE(dl, 0.0255211, 0.1);
   BOOST_CHECK_CLOSE(dt, 0.0179734, 0.1);
@@ -47,40 +47,40 @@ BOOST_AUTO_TEST_CASE(TRDDiffusionCoefficient_test1)
 /// \brief Test time structure
 BOOST_AUTO_TEST_CASE(TRDTimeStructure_test)
 {
-  auto commonParam = CommonParam::Instance();
+  auto commonParam = CommonParam::instance();
   DiffusionAndTimeStructEstimator estimator;
-  BOOST_CHECK_CLOSE(estimator.TimeStruct(1.48, 1., 0.1), commonParam->TimeStruct(1.48, 1., 0.1), 0.001);
-  BOOST_CHECK_CLOSE(estimator.TimeStruct(1.1, 1., 0.1), commonParam->TimeStruct(1.1, 1., 0.1), 0.001);
-  BOOST_CHECK_CLOSE(estimator.TimeStruct(2, 1., 0.1), commonParam->TimeStruct(2, 1., 0.1), 0.001);
-  BOOST_CHECK_CLOSE(estimator.TimeStruct(4, 1., 0.1), commonParam->TimeStruct(4, 1., 0.1), 0.001);
+  BOOST_CHECK_CLOSE(estimator.TimeStruct(1.48, 1., 0.1), commonParam->timeStruct(1.48, 1., 0.1), 0.001);
+  BOOST_CHECK_CLOSE(estimator.TimeStruct(1.1, 1., 0.1), commonParam->timeStruct(1.1, 1., 0.1), 0.001);
+  BOOST_CHECK_CLOSE(estimator.TimeStruct(2, 1., 0.1), commonParam->timeStruct(2, 1., 0.1), 0.001);
+  BOOST_CHECK_CLOSE(estimator.TimeStruct(4, 1., 0.1), commonParam->timeStruct(4, 1., 0.1), 0.001);
 }
 
 /// \brief compare diffusion coeff
 BOOST_AUTO_TEST_CASE(TRDDiffusion_test)
 {
-  auto commonParam = CommonParam::Instance();
+  auto commonParam = CommonParam::instance();
   DiffusionAndTimeStructEstimator estimator;
   float dl1 = 0.;
   float dl2 = 0.;
   float dt1 = 0.;
   float dt2 = 0.;
   estimator.GetDiffCoeff(dl1, dt1, 1.48);
-  commonParam->GetDiffCoeff(dl2, dt2, 1.48);
+  commonParam->getDiffCoeff(dl2, dt2, 1.48);
   BOOST_CHECK_CLOSE(dl1, dl2, 0.001);
   BOOST_CHECK_CLOSE(dt1, dt2, 0.001);
 
   estimator.GetDiffCoeff(dl1, dt1, 1.1);
-  commonParam->GetDiffCoeff(dl2, dt2, 1.1);
+  commonParam->getDiffCoeff(dl2, dt2, 1.1);
   BOOST_CHECK_CLOSE(dl1, dl2, 0.001);
   BOOST_CHECK_CLOSE(dt1, dt2, 0.001);
 
   estimator.GetDiffCoeff(dl1, dt1, 2);
-  commonParam->GetDiffCoeff(dl2, dt2, 2);
+  commonParam->getDiffCoeff(dl2, dt2, 2);
   BOOST_CHECK_CLOSE(dl1, dl2, 0.001);
   BOOST_CHECK_CLOSE(dt1, dt2, 0.001);
 
   estimator.GetDiffCoeff(dl1, dt1, 4);
-  commonParam->GetDiffCoeff(dl2, dt2, 4);
+  commonParam->getDiffCoeff(dl2, dt2, 4);
   BOOST_CHECK_CLOSE(dl1, dl2, 0.001);
   BOOST_CHECK_CLOSE(dt1, dt2, 0.001);
 }

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -77,7 +77,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
       hPad->Fill(pad);
       for (int tb = 0; tb < o2::trd::constants::TIMEBINS; ++tb) {
         ADC_t adc = adcs[tb];
-        if (adc == (ADC_t)SimParam::Instance()->GetADCoutRange()) {
+        if (adc == (ADC_t)SimParam::instance()->getADCoutRange()) {
           // LOG(INFO) << "Out of range ADC " << adc;
           continue;
         }

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -63,9 +63,9 @@ void Detector::InitializeO2Detector()
 
 void Detector::InitializeParams()
 {
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     mWion = 23.53; // Ionization energy XeCO2 (85/15)
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     mWion = 27.21; // Ionization energy ArCO2 (82/18)
   } else {
     LOG(FATAL) << "Wrong gas mixture";
@@ -232,9 +232,9 @@ void Detector::createTRhit(int det)
     // The absorbtion cross sections in the drift gas
     // Gas-mixture (Xe/CO2)
     double muNo = 0.0;
-    if (CommonParam::Instance()->IsXenon()) {
+    if (CommonParam::instance()->isXenon()) {
       muNo = mTR->getMuXe(energyMeV);
-    } else if (CommonParam::Instance()->IsArgon()) {
+    } else if (CommonParam::instance()->isArgon()) {
       muNo = mTR->getMuAr(energyMeV);
     }
     double muCO = mTR->getMuCO(energyMeV);
@@ -359,9 +359,9 @@ void Detector::createMaterials()
   float fac = 0.82;
   float dar = 0.00166; // at 20C
   float dgmAr = fac * dar + (1.0 - fac) * dco;
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     Mixture(53, "XeCO2", aXeCO2, zXeCO2, dgmXe, -3, wXeCO2);
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     LOG(INFO) << "Gas mixture: Ar C02 (80/20)";
     Mixture(53, "ArCO2", aArCO2, zArCO2, dgmAr, -3, wArCO2);
   } else {
@@ -492,10 +492,10 @@ void Detector::createMaterials()
   // Save the density values for the TRD absorbtion
   float dmy = 1.39;
   mFoilDensity = dmy;
-  if (CommonParam::Instance()->IsXenon()) {
+  if (CommonParam::instance()->isXenon()) {
     mGasDensity = dgmXe;
     mGasNobleFraction = fxc;
-  } else if (CommonParam::Instance()->IsArgon()) {
+  } else if (CommonParam::instance()->isArgon()) {
     mGasDensity = dgmAr;
     mGasNobleFraction = fac;
   }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -41,7 +41,7 @@ void Digitizer::init()
   mGeo->createClusterMatrixArray();          // Requiered for chamberInGeometry()
   mPRF = new PadResponse();                  // Pad response function initialization
   mSimParam = SimParam::Instance();          // Instance for simulation parameters
-  mCommonParam = CommonParam::Instance();    // Instance for common parameters
+  mCommonParam = CommonParam::instance();    // Instance for common parameters
   if (!mSimParam) {
   }
   if (!mCommonParam) {
@@ -80,11 +80,11 @@ void Digitizer::setSimulationParameters()
 {
   mNpad = mSimParam->getNumberOfPadsInPadResponse(); // Number of pads included in the pad response
   if (mSimParam->TRFOn()) {
-    mTimeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->GetSamplingFrequency())) - 1;
+    mTimeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->getSamplingFrequency())) - 1;
   }
   mMaxTimeBins = TIMEBINS;     // for signals, usually set at 30 tb = 3 microseconds
   mMaxTimeBinsTRAP = TIMEBINS; // for adcs; should be read from the CCDB or the TRAP config
-  mSamplingRate = mCommonParam->GetSamplingFrequency();
+  mSamplingRate = mCommonParam->getSamplingFrequency();
   mElAttachProp = mSimParam->GetElAttachProp() / 100;
 }
 
@@ -259,7 +259,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
     }
 
     double absDriftLength = std::fabs(driftLength); // Normalized drift length
-    if (mCommonParam->ExBOn()) {
+    if (mCommonParam->isExBOn()) {
       absDriftLength /= std::sqrt(1 / (1 + calExBDetValue * calExBDetValue));
     }
 
@@ -286,7 +286,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
       }
 
       // Apply E x B effects
-      if (mCommonParam->ExBOn()) {
+      if (mCommonParam->isExBOn()) {
         locCd = locCd + calExBDetValue * driftLength;
       }
       // The electron position after diffusion and ExB in pad coordinates.
@@ -511,7 +511,7 @@ bool Digitizer::diffusion(float vdrift, float absdriftlength, float exbvalue,
     float sigmaT = driftSqrt * diffT;
     float sigmaL = driftSqrt * diffL;
     lRow = drawGaus(mGausRandomRings[thread], lRow0, sigmaT);
-    if (mCommonParam->ExBOn()) {
+    if (mCommonParam->isExBOn()) {
       const float exbfactor = 1.f / (1.f + exbvalue * exbvalue);
       lCol = drawGaus(mGausRandomRings[thread], lCol0, sigmaT * exbfactor);
       lTime = drawGaus(mGausRandomRings[thread], lTime0, sigmaL * exbfactor);

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -40,7 +40,7 @@ void Digitizer::init()
   mGeo = Geometry::instance();
   mGeo->createClusterMatrixArray();          // Requiered for chamberInGeometry()
   mPRF = new PadResponse();                  // Pad response function initialization
-  mSimParam = SimParam::Instance();          // Instance for simulation parameters
+  mSimParam = SimParam::instance();          // Instance for simulation parameters
   mCommonParam = CommonParam::instance();    // Instance for common parameters
   if (!mSimParam) {
   }
@@ -79,13 +79,13 @@ void Digitizer::init()
 void Digitizer::setSimulationParameters()
 {
   mNpad = mSimParam->getNumberOfPadsInPadResponse(); // Number of pads included in the pad response
-  if (mSimParam->TRFOn()) {
-    mTimeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->getSamplingFrequency())) - 1;
+  if (mSimParam->trfOn()) {
+    mTimeBinTRFend = ((int)(mSimParam->getTRFhi() * mCommonParam->getSamplingFrequency())) - 1;
   }
   mMaxTimeBins = TIMEBINS;     // for signals, usually set at 30 tb = 3 microseconds
   mMaxTimeBinsTRAP = TIMEBINS; // for adcs; should be read from the CCDB or the TRAP config
   mSamplingRate = mCommonParam->getSamplingFrequency();
-  mElAttachProp = mSimParam->GetElAttachProp() / 100;
+  mElAttachProp = mSimParam->getElAttachProp() / 100;
 }
 
 void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<MCLabel>& labels)
@@ -270,7 +270,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
     const int nElectrons = std::fabs(qTotal);
     for (int el = 0; el < nElectrons; ++el) {
       // Electron attachment
-      if (mSimParam->ElAttachOn()) {
+      if (mSimParam->elAttachOn()) {
         if (mFlatRandomRings[thread].getNextValue() < absDriftLength * mElAttachProp) {
           continue;
         }
@@ -279,7 +279,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
       double locRd{locR}, locCd{locC}, locTd{locT};
 
       // Apply diffusion smearing
-      if (mSimParam->DiffusionOn()) {
+      if (mSimParam->diffusionOn()) {
         if (!diffusion(driftVelocity, absDriftLength, calExBDetValue, locR, locC, locT, locRd, locCd, locTd, thread)) {
           continue;
         }
@@ -308,7 +308,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
       // time structure of drift cells (non-isochronity, GARFIELD calculation).
       // Also add absolute time of hits to take pile-up events into account properly
       double driftTime;
-      if (mSimParam->TimeStructOn()) {
+      if (mSimParam->timeStructOn()) {
         // Get z-position with respect to anode wire
         double zz = row0 - locRd + padPlane->getAnodeWireOffset();
         zz -= ((int)(2 * zz)) * 0.5;
@@ -323,10 +323,10 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
       }
 
       // Apply the gas gain including fluctuations
-      const double signal = -(mSimParam->GetGasGain()) * mLogRandomRings[thread].getNextValue();
+      const double signal = -(mSimParam->getGasGain()) * mLogRandomRings[thread].getNextValue();
 
       // Apply the pad response
-      if (mSimParam->PRFOn()) {
+      if (mSimParam->prfOn()) {
         // The distance of the electron to the center of the pad in units of pad width
         double dist = (colOffset - 0.5 * padPlane->getColSize(colE)) / padPlane->getColSize(colE);
         // ********************************************************************************
@@ -378,14 +378,14 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
         if (colPos != colE) {
           for (int tb = firstTimeBin; tb < lastTimeBin; ++tb) {
             const double t = (tb - timeBinTruncated) / mSamplingRate + timeOffset;
-            const double timeResponse = mSimParam->TRFOn() ? mSimParam->TimeResponse(t) : 1;
-            const double crossTalk = mSimParam->CTOn() ? mSimParam->CrossTalk(t) : 0;
+            const double timeResponse = mSimParam->trfOn() ? mSimParam->timeResponse(t) : 1;
+            const double crossTalk = mSimParam->ctOn() ? mSimParam->crossTalk(t) : 0;
             currentSignal[tb] += padSignal[pad] * (timeResponse + crossTalk);
           } // end of loop time bins
         } else {
           for (int tb = firstTimeBin; tb < lastTimeBin; ++tb) {
             const double t = (tb - timeBinTruncated) / mSamplingRate + timeOffset;
-            const double timeResponse = mSimParam->TRFOn() ? mSimParam->TimeResponse(t) : 1;
+            const double timeResponse = mSimParam->trfOn() ? mSimParam->timeResponse(t) : 1;
             currentSignal[tb] += padSignal[pad] * timeResponse;
           } // end of loop time bins
         }
@@ -418,10 +418,10 @@ bool Digitizer::convertSignalsToADC(SignalContainer& signalMapCont, DigitContain
   //
 
   constexpr double kEl2fC = 1.602e-19 * 1.0e15;                                 // Converts number of electrons to fC
-  double coupling = mSimParam->GetPadCoupling() * mSimParam->GetTimeCoupling(); // Coupling factor
-  double convert = kEl2fC * mSimParam->GetChipGain();                           // Electronics conversion factor
-  double adcConvert = mSimParam->GetADCoutRange() / mSimParam->GetADCinRange(); // ADC conversion factor
-  double baseline = mSimParam->GetADCbaseline() / adcConvert;                   // The electronics baseline in mV
+  double coupling = mSimParam->getPadCoupling() * mSimParam->getTimeCoupling(); // Coupling factor
+  double convert = kEl2fC * mSimParam->getChipGain();                           // Electronics conversion factor
+  double adcConvert = mSimParam->getADCoutRange() / mSimParam->getADCinRange(); // ADC conversion factor
+  double baseline = mSimParam->getADCbaseline() / adcConvert;                   // The electronics baseline in mV
   double baselineEl = baseline / convert;                                       // The electronics baseline in electrons
 
   for (auto& signalMapIter : signalMapCont) {
@@ -460,14 +460,14 @@ bool Digitizer::convertSignalsToADC(SignalContainer& signalMapCont, DigitContain
       signalAmp *= coupling;                    // Pad and time coupling
       signalAmp *= padgain;                     // Gain factors
       // Add the noise, starting from minus ADC baseline in electrons
-      signalAmp = std::max((double)drawGaus(mGausRandomRings[thread], signalAmp, mSimParam->GetNoise()), -baselineEl);
+      signalAmp = std::max((double)drawGaus(mGausRandomRings[thread], signalAmp, mSimParam->getNoise()), -baselineEl);
       signalAmp *= convert;  // Convert to mV
       signalAmp += baseline; // Add ADC baseline in mV
       // Convert to ADC counts
       // Set the overflow-bit fADCoutRange if the signal is larger than fADCinRange
       ADC_t adc = 0;
-      if (signalAmp >= mSimParam->GetADCinRange()) {
-        adc = ((ADC_t)mSimParam->GetADCoutRange());
+      if (signalAmp >= mSimParam->getADCinRange()) {
+        adc = ((ADC_t)mSimParam->getADCoutRange());
       } else {
         adc = std::lround(signalAmp * adcConvert);
       }

--- a/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
@@ -478,6 +478,7 @@ void TrapConfigHandler::configureDRange(int det)
   // if pt_min < 0.1 GeV/c the maximal allowed range for the tracklet
   // deflection (-64..63) is used
   //
+  // TODO might need to be updated depending in the FEE configuration for Run 3
 
   if (!mTrapConfig) {
     LOG(error) << "No TRAPconfig given";


### PR DESCRIPTION
- as FeeParam is a singleton the members themselves don't need to be static
- CommonParam (which is also a singleton) is simplified
- for both singletons the copy and assignment operators are deleted
- FeeParam still has hard-coded some values which could in principle also be taken from o2::trd::Geometry or o2::trd::PadPlane
- The dy range calculation in FeeParam is still based on the Run 1-2 tracklet data format

This PR fixes [O2-2226](https://alice.its.cern.ch/jira/browse/O2-2226)