### PR TITLE
ConfigurableParam to set I/O paths for ConfigurableParam 

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -11,8 +11,9 @@
 o2_add_library(CommonUtils
                SOURCES src/TreeStream.cxx src/TreeStreamRedirector.cxx
                        src/RootChain.cxx src/CompStream.cxx src/ShmManager.cxx
-	               src/ValueMonitor.cxx
+                       src/ValueMonitor.cxx
                        src/ConfigurableParamHelper.cxx src/ConfigurableParam.cxx src/RootSerializableKeyValueStore.cxx
+                       src/KeyValParam.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
@@ -26,11 +27,12 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/RngHelper.h
                                   include/CommonUtils/StringUtils.h
                                   include/CommonUtils/ValueMonitor.h
-				  include/CommonUtils/MemFileHelper.h
+                                  include/CommonUtils/MemFileHelper.h
                                   include/CommonUtils/ConfigurableParam.h
                                   include/CommonUtils/ConfigurableParamHelper.h
                                   include/CommonUtils/ConfigurationMacroHelper.h
-				  include/CommonUtils/RootSerializableKeyValueStore.h)
+                                  include/CommonUtils/RootSerializableKeyValueStore.h
+                                  include/CommonUtils/KeyValParam.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils
@@ -70,5 +72,5 @@ o2_add_test(MemFileHelper
 
 o2_add_executable(treemergertool
             COMPONENT_NAME CommonUtils
-    	    SOURCES src/TreeMergerTool.cxx
+          SOURCES src/TreeMergerTool.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonUtils Boost::program_options ROOT::Core)

--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -169,6 +169,12 @@ class ConfigurableParam
   static void printAllRegisteredParamNames();
   static void printAllKeyValuePairs();
 
+  static const std::string& getInputDir() { return sInputDir; }
+  static const std::string& getOutputDir() { return sOutputDir; }
+
+  static void setInputDir(const std::string& d) { sInputDir = d; }
+  static void setOutputDir(const std::string& d) { sOutputDir = d; }
+
   static boost::property_tree::ptree readINI(std::string const& filepath);
   static boost::property_tree::ptree readJSON(std::string const& filepath);
   static boost::property_tree::ptree readConfigFile(std::string const& filepath);
@@ -285,6 +291,9 @@ class ConfigurableParam
   // A registry of enum names and their allowed values
   // (stored as a vector of pairs <enumValueLabel, enumValueInt>)
   static EnumRegistry* sEnumRegistry;
+
+  static std::string sInputDir;
+  static std::string sOutputDir;
 
   void setRegisterMode(bool b) { sRegisterMode = b; }
   bool isInitialized() const { return sIsFullyInitialized; }

--- a/Common/Utils/include/CommonUtils/KeyValParam.h
+++ b/Common/Utils/include/CommonUtils/KeyValParam.h
@@ -1,0 +1,33 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief params for ConfigurableParam
+
+#ifndef COMMON_CONFIGURABLE_KEYVAL_PARAM_H_
+#define COMMON_CONFIGURABLE_KEYVAL_PARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace conf
+{
+struct KeyValParam : public o2::conf::ConfigurableParamHelper<KeyValParam> {
+  std::string input_dir = "none";
+  std::string output_dir = "none";
+
+  O2ParamDef(KeyValParam, "keyval");
+};
+} // namespace conf
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -24,4 +24,7 @@
 #pragma link C++ class map < string, o2::utils::RootSerializableKeyValueStore::SerializedInfo> + ;
 #pragma link C++ class o2::utils::RootSerializableKeyValueStore + ;
 
+#pragma link C++ class o2::conf::KeyValParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::KeyValParam> + ;
+
 #endif

--- a/Common/Utils/src/KeyValParam.cxx
+++ b/Common/Utils/src/KeyValParam.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief params for ConfigurableParam
+
+#include "CommonUtils/KeyValParam.h"
+O2ParamImpl(o2::conf::KeyValParam);


### PR DESCRIPTION
The configurabe KeyValParam allows to alter the input and output directories for `ConfigurableParam` INI files
e.g. `--configKeyValues "keyval.input_dir=XXX;keyval.output_dir=YYY"` provided to the workflow will make the `ConfigurableParam::updateFromFile` and `ConfigurableParam::writeINI` methods to use directory XXX instead of the defauld (cwd) directory.

This PR uses one commit present in https://github.com/AliceO2Group/AliceO2/pull/5937, should be merged after it.