### PR TITLE
[MRRTF-33] Update the MID CRU User Logic data format

### DIFF
--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -32,7 +32,9 @@ o2_add_library(
     O2::DPLUtils
     O2::CommonConstants
     O2::DetectorsRaw
-    O2::MIDBase)
+    O2::MIDBase
+  TARGETVARNAME midrawtarget)
+# target_compile_definitions(${midrawtarget} PRIVATE "MID_RAW_VECTORS")
 
 add_subdirectory(exe)
 

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -16,12 +16,14 @@ o2_add_library(
           src/DecodedDataAggregator.cxx
           src/Decoder.cxx
           src/ElectronicsDelay.cxx
+          src/ELinkDataShaper.cxx
           src/ELinkDecoder.cxx
+          src/ELinkManager.cxx
           src/Encoder.cxx
           src/FEEIdConfig.cxx
-          src/GBTDecoder.cxx
           src/GBTOutputHandler.cxx
           src/GBTUserLogicEncoder.cxx
+          src/LinkDecoder.cxx
           src/RawFileReader.cxx
   PUBLIC_LINK_LIBRARIES
     ms_gsl::ms_gsl

--- a/Detectors/MUON/MID/Raw/exe/rawdump.cxx
+++ b/Detectors/MUON/MID/Raw/exe/rawdump.cxx
@@ -19,31 +19,9 @@
 #include "DPLUtils/RawParser.h"
 #include "MIDRaw/Decoder.h"
 #include "MIDRaw/RawFileReader.h"
+#include "MIDRaw/Utils.h"
 
 namespace po = boost::program_options;
-
-std::string getOutFilename(const char* inFilename, const char* outDir)
-{
-  std::string basename(inFilename);
-  std::string fdir = "./";
-  auto pos = basename.find_last_of("/");
-  if (pos != std::string::npos) {
-    basename.erase(0, pos + 1);
-    fdir = inFilename;
-    fdir.erase(pos);
-  }
-  basename.insert(0, "dump_");
-  basename += ".txt";
-  std::string outputDir(outDir);
-  if (outputDir.empty()) {
-    outputDir = fdir;
-  }
-  if (outputDir.back() != '/') {
-    outputDir += "/";
-  }
-  std::string outFilename = outputDir + basename;
-  return outFilename;
-}
 
 template <class RDH>
 void decode(o2::mid::Decoder& decoder, gsl::span<const uint8_t> payload, const RDH& rdh, std::ostream& out)
@@ -103,7 +81,7 @@ int main(int argc, char* argv[])
 
   std::vector<std::string> inputfiles{vm["input"].as<std::vector<std::string>>()};
 
-  bool runDecoder = (vm.count("decode") > 0);
+  bool runDecoder = (vm.count("decode") > 0 && vm["decode"].as<bool>() == true);
   std::unique_ptr<o2::mid::Decoder> decoder{nullptr};
 
   std::ofstream outFile;
@@ -135,7 +113,7 @@ int main(int argc, char* argv[])
             }
             decode(*decoder, payload, *rdhPtr, out);
           } else if (!isRdhOnly) {
-            bool isBare = (o2::raw::RDHUtils::getLinkID(rdhPtr) != o2::mid::raw::sUserLogicLinkID);
+            bool isBare = o2::mid::raw::isBare(*rdhPtr);
             size_t wordLength = isBare ? 16 : 32;
             for (size_t iword = 0; iword < payload.size(); iword += wordLength) {
               auto word = payload.subspan(iword, wordLength);

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
@@ -16,7 +16,9 @@
 #define O2_MID_DECODER_H
 
 #include <cstdint>
+#if !defined(MID_RAW_VECTORS)
 #include <unordered_map>
+#endif
 #include <vector>
 #include <gsl/gsl>
 #include "DataFormatsMID/ROFRecord.h"
@@ -45,8 +47,11 @@ class Decoder
   {
     /// Processes the page
     auto feeId = o2::raw::RDHUtils::getFEEID(rdh);
-    // mLinkDecoders[feeId]->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
+#if defined(MID_RAW_VECTORS)
+    mLinkDecoders[feeId]->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
+#else
     mLinkDecoders.find(feeId)->second->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
+#endif
   }
   /// Gets the vector of data
   const std::vector<ROBoard>& getData() const { return mData; }
@@ -57,8 +62,11 @@ class Decoder
   void clear();
 
  protected:
-  // std::vector<std::unique_ptr<LinkDecoder>> mLinkDecoders{}; /// GBT decoders
+#if defined(MID_RAW_VECTORS)
+  std::vector<std::unique_ptr<LinkDecoder>> mLinkDecoders{}; /// GBT decoders
+#else
   std::unordered_map<uint16_t, std::unique_ptr<LinkDecoder>> mLinkDecoders{}; /// GBT decoders
+#endif
 
  private:
   std::vector<ROBoard> mData{};         /// Vector of output data

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ELinkDataShaper.h
+/// \brief  MID e-link data shaper
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 March 2021
+#ifndef O2_MID_ELINKDATASHAPER_H
+#define O2_MID_ELINKDATASHAPER_H
+
+#include <cstdint>
+#include <vector>
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsMID/ROBoard.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/ElectronicsDelay.h"
+#include "MIDRaw/ELinkDecoder.h"
+
+namespace o2
+{
+namespace mid
+{
+class ELinkDataShaper
+{
+ public:
+  ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId);
+  /// Main function to be executed when decoding is done
+  inline void onDone(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { std::invoke(mOnDone, this, decoder, data, rofs); }
+
+  void set(uint32_t orbit);
+
+  /// Sets the delay in the electronics
+  void setElectronicsDelay(const ElectronicsDelay& electronicsDelay) { mElectronicsDelay = electronicsDelay; }
+
+ private:
+  uint8_t mUniqueId{0};                 /// UniqueId
+  uint32_t mRDHOrbit{0};                /// RDH orbit
+  bool mReceivedCalibration{false};     /// Flag to indicate if the  calibration trigger was received
+  ElectronicsDelay mElectronicsDelay{}; /// Delays in the electronics
+
+  InteractionRecord mIR{};      /// Interaction record
+  uint16_t mExpectedFETClock{}; /// Expected FET clock
+  uint16_t mLastClock{};        /// Last clock
+
+  typedef void (ELinkDataShaper::*OnDoneFunction)(const ELinkDecoder&, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  OnDoneFunction mOnDone{&ELinkDataShaper::onDoneLoc}; ///! Processes the board
+
+  void onDoneLoc(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  void onDoneLocDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  void onDoneReg(const ELinkDecoder&, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs){}; /// Dummy function
+  void onDoneRegDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+
+  void addLoc(const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  bool checkLoc(const ELinkDecoder& decoder);
+  EventType processCalibrationTrigger(uint16_t localClock);
+  void processOrbitTrigger(uint16_t localClock, uint8_t triggerWord);
+  EventType processSelfTriggered(uint16_t localClock, uint16_t& correctedClock);
+  bool processTrigger(const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock);
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ELINKDATASHAPER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file   MIDRaw/ELinkDataShaper.h
-/// \brief  MID e-link data shaper
+/// \brief  Properly formats and sets the absolute timestamp of the raw data
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   18 March 2021
 #ifndef O2_MID_ELINKDATASHAPER_H

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
@@ -28,6 +28,7 @@ namespace mid
 class ELinkDecoder
 {
  public:
+  void setBareDecoder(bool isBare);
   /// Adds a byte
   inline void add(const uint8_t byte) { mBytes.emplace_back(byte); }
   void addAndComputeSize(const uint8_t byte);
@@ -35,7 +36,7 @@ class ELinkDecoder
   bool addCore(ITERATOR& it, const ITERATOR& end)
   {
     /// Adds the first 5 bytes
-    auto remaining = sMinimumSize - mBytes.size();
+    auto remaining = mMinimumSize - mBytes.size();
     return add(it, end, remaining);
   }
   template <class ITERATOR>
@@ -44,7 +45,7 @@ class ELinkDecoder
     /// Adds the board bytes
     auto remaining = mTotalSize - mBytes.size();
     if (add(it, end, remaining)) {
-      if (mTotalSize == sMinimumSize) {
+      if (mTotalSize == mMinimumSize) {
         computeSize();
         remaining = mTotalSize - mBytes.size();
         if (remaining) {
@@ -57,7 +58,7 @@ class ELinkDecoder
   }
 
   /// Adds the first 5 bytes
-  inline bool addCore(size_t& idx, gsl::span<const uint8_t> payload, size_t step) { return add(idx, payload, sMinimumSize - mBytes.size(), step); }
+  inline bool addCore(size_t& idx, gsl::span<const uint8_t> payload, size_t step) { return add(idx, payload, mMinimumSize - mBytes.size(), step); }
 
   bool add(size_t& idx, gsl::span<const uint8_t> payload, size_t step);
 
@@ -76,6 +77,8 @@ class ELinkDecoder
   inline uint8_t getId() const { return (mBytes[4] >> 4) & 0xF; }
   /// Gets the inputs
   inline uint8_t getInputs() const { return (mBytes[4] & 0xF); }
+  /// Gets the crate ID when available
+  inline uint8_t getCrateId() const { return (mBytes[5] >> 4) & 0xF; }
   uint16_t getPattern(int cathode, int chamber) const;
   /// Gets the number of bytes read
   inline size_t getNBytes() const { return mBytes.size(); }
@@ -99,10 +102,10 @@ class ELinkDecoder
 
   void computeSize();
 
-  static constexpr size_t sMinimumSize{5};  /// Minimum size of the buffer
-  static constexpr size_t sMaximumSize{21}; /// Maximum size of the buffer
-  std::vector<uint8_t> mBytes{};            /// Vector with encoded information
-  size_t mTotalSize{sMinimumSize};          /// Expected size of the read-out buffer
+  size_t mMinimumSize{5};          /// Minimum size of the buffer
+  size_t mMaximumSize{21};         /// Maximum size of the buffer
+  std::vector<uint8_t> mBytes{};   /// Vector with encoded information
+  size_t mTotalSize{mMinimumSize}; /// Expected size of the read-out buffer
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkManager.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkManager.h
@@ -1,0 +1,80 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ELinkManager.h
+/// \brief  MID e-link data shaper manager
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 March 2021
+#ifndef O2_MID_ELINKMANAGER_H
+#define O2_MID_ELINKMANAGER_H
+
+#include <cstdint>
+#include <vector>
+// #include <unordered_map>
+#include "MIDRaw/ELinkDataShaper.h"
+#include "MIDRaw/ELinkDecoder.h"
+#include "MIDRaw/ElectronicsDelay.h"
+#include "MIDRaw/FEEIdConfig.h"
+
+namespace o2
+{
+namespace mid
+{
+class ELinkManager
+{
+ public:
+  void init(uint16_t feeId, bool isDebugMode, bool isBare = false, const ElectronicsDelay& electronicsDelay = ElectronicsDelay(), const FEEIdConfig& feeIdConfig = FEEIdConfig());
+
+  void set(uint32_t orbit);
+
+  /// Main function to be executed when decoding is done
+  inline void onDone(const ELinkDecoder& decoder, uint8_t boardUniqueId, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { return onDone(decoder, raw::getCrateId(boardUniqueId), raw::getLocId(boardUniqueId), data, rofs); }
+
+  /// Main function to be executed when decoding is done
+  inline void onDone(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { return onDone(decoder, decoder.getCrateId(), decoder.getId(), data, rofs); }
+
+  // Use vectors
+
+  // /// Returns the decoder
+  // inline ELinkDecoder& getDecoder(uint8_t boardUniqueId, bool isLoc) { return mDecoders[mIndex(raw::getCrateId(boardUniqueId), raw::getLocId(boardUniqueId), isLoc)]; }
+
+  // /// Main function to be executed when decoding is done
+  // inline void onDone(const ELinkDecoder& decoder, uint8_t crateId, uint8_t locId, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  // {
+  //   return mDataShapers[mIndex(crateId, locId, raw::isLoc(decoder.getStatusWord()))].onDone(decoder, data, rofs);
+  // }
+
+  // Use unordered maps
+
+  /// Returns the decoder
+  inline ELinkDecoder& getDecoder(uint8_t boardUniqueId, bool isLoc) { return mDecoders.find(makeUniqueId(isLoc, boardUniqueId))->second; }
+
+  /// Main function to be executed when decoding is done
+  inline void onDone(const ELinkDecoder& decoder, uint8_t crateId, uint8_t locId, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  {
+    return mDataShapers.find(makeUniqueId(raw::isLoc(decoder.getStatusWord()), raw::makeUniqueLocID(crateId, locId)))->second.onDone(decoder, data, rofs);
+  }
+
+ private:
+  // Use unordered maps
+  /// Makes a ID which is unique for local and regional board
+  inline uint16_t makeUniqueId(bool isLoc, uint8_t uniqueId) { return (isLoc ? 0 : (1 << 8)) | uniqueId; }
+  std::unordered_map<uint16_t, ELinkDataShaper> mDataShapers; /// Vector with data shapers
+  std::unordered_map<uint16_t, ELinkDecoder> mDecoders;       /// Vector with decoders
+
+  // Use vectors
+  // std::function<size_t(uint8_t, uint8_t, bool)> mIndex{};     ///! Function that returns the index in the vector
+  // std::vector<ELinkDataShaper> mDataShapers; /// Vector with data shapers
+  // std::vector<ELinkDecoder> mDecoders;       /// Vector with decoders
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ELINKMANAGER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -51,9 +51,9 @@ class Encoder
 
  private:
   void completeWord(std::vector<char>& buffer);
-  void writePayload(uint16_t feeId, const InteractionRecord& ir);
+  void writePayload(uint16_t linkId, const InteractionRecord& ir);
   void onOrbitChange(uint32_t orbit);
-  // Returns the interaction record expected for the orbit trigger
+  /// Returns the interaction record expected for the orbit trigger
   inline InteractionRecord getOrbitIR(uint32_t orbit) const { return {o2::constants::lhc::LHCMaxBunches - 1, orbit}; }
 
   o2::raw::RawFileWriter mRawWriter{o2::header::gDataOriginMID}; /// Raw file writer
@@ -63,10 +63,10 @@ class Encoder
   FEEIdConfig mFEEIdConfig{};            /// Crate FEEId mapper
   InteractionRecord mLastIR{};           /// Last interaction record
 
-  std::array<GBTUserLogicEncoder, crateparams::sNGBTs> mGBTEncoders{};     /// Array of encoders per link
-  std::array<std::vector<char>, crateparams::sNGBTs> mOrbitResponse{};     /// Response to orbit trigger
-  std::array<std::vector<char>, crateparams::sNGBTs> mOrbitResponseWord{}; /// CRU word for response to orbit trigger
-  std::array<uint32_t, crateparams::sNGBTs> mGBTIds{};                     /// Array of GBT Ids
+  std::array<uint32_t, crateparams::sNGBTs> mGBTIds{};                 /// Array of GBT Ids
+  std::array<GBTUserLogicEncoder, crateparams::sNGBTs> mGBTEncoders{}; /// Array of encoders per link
+  std::array<std::vector<char>, 4> mOrbitResponse{};                   /// Response to orbit trigger
+  std::array<std::vector<char>, 4> mOrbitResponseWord{};               /// CRU word for response to orbit trigger
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
@@ -34,7 +34,7 @@ class FEEIdConfig
 
   inline const std::vector<uint16_t>& getGBTUniqueIdsInLink(uint16_t feeId) const { return mGBTUniqueIdsInLink.find(feeId)->second; }
 
-  /// Gets the FEE ID from the physical ID of the link
+  /// Gets the GBT unique ID from the physical ID of the link
   uint16_t getGBTUniqueId(uint8_t linkId, uint8_t endPointId, uint16_t cruId) const { return getGBTUniqueId(getLinkUniqueId(linkId, endPointId, cruId)); }
 
   /// Gets a uniqueID from the combination of linkId, endPointId and cruId;

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
@@ -30,36 +30,36 @@ class FEEIdConfig
   FEEIdConfig(const char* filename);
   ~FEEIdConfig() = default;
 
-  uint16_t getFeeId(uint32_t uniqueId) const;
+  uint16_t getGBTUniqueId(uint32_t linkUniqueId) const;
+
+  inline const std::vector<uint16_t>& getGBTUniqueIdsInLink(uint16_t feeId) const { return mGBTUniqueIdsInLink.find(feeId)->second; }
 
   /// Gets the FEE ID from the physical ID of the link
-  uint16_t getFeeId(uint8_t linkId, uint8_t endPointId, uint16_t cruId) const { return getFeeId(getGBTId(linkId, endPointId, cruId)); }
+  uint16_t getGBTUniqueId(uint8_t linkId, uint8_t endPointId, uint16_t cruId) const { return getGBTUniqueId(getLinkUniqueId(linkId, endPointId, cruId)); }
 
   /// Gets a uniqueID from the combination of linkId, endPointId and cruId;
-  inline uint32_t getGBTId(uint8_t linkId, uint8_t endPointId, uint16_t cruId) const { return (linkId + 1) << ((endPointId == 1) ? 8U : 0U) | (cruId << 16U); }
+  inline uint32_t getLinkUniqueId(uint8_t linkId, uint8_t endPointId, uint16_t cruId) const { return (linkId + 1) << ((endPointId == 1) ? 8U : 0U) | (cruId << 16U); }
 
   /// Gets the CRU ID
-  inline uint16_t getCRUId(uint32_t gbtId) const { return gbtId >> 16; }
+  inline uint16_t getCRUId(uint32_t linkUniqueId) const { return linkUniqueId >> 16; }
   /// Gets the end point id
-  inline uint8_t getEndPointId(uint32_t gbtId) const { return (gbtId & 0xFF00) ? 1 : 0; }
+  inline uint8_t getEndPointId(uint32_t linkUniqueId) const { return (linkUniqueId & 0xFF00) ? 1 : 0; }
   /// Gets the Link ID
-  inline uint8_t getLinkId(uint32_t gbtId) const { return ((gbtId >> (8U * getEndPointId(gbtId))) & 0xFF) - 1; }
+  inline uint8_t getLinkId(uint32_t linkUniqueId) const { return ((linkUniqueId >> (8U * getEndPointId(linkUniqueId))) & 0xFF) - 1; }
 
-  std::vector<uint16_t> getConfiguredFeeIds() const;
-  std::vector<uint32_t> getConfiguredGBTIds() const;
+  std::vector<uint16_t> getConfiguredGBTUniqueIDs() const;
+  std::vector<uint32_t> getConfiguredLinkUniqueIDs() const;
+  std::vector<uint16_t> getConfiguredFEEIDs() const;
 
   void write(const char* filename) const;
 
  private:
   bool load(const char* filename);
 
-  std::unordered_map<uint32_t, uint16_t> mGBTIdToFeeId; /// Correspondence between GBT Id and FeeId
+  std::unordered_map<uint32_t, uint16_t> mLinkUniqueIdToGBTUniqueId{};       /// Correspondence between link unique ID and GBT unique Id
+  std::unordered_map<uint16_t, uint16_t> mGBTUniqueIdToFeeId{};              /// Correspondence between GBT unique ID and FEE ID
+  std::unordered_map<uint16_t, std::vector<uint16_t>> mGBTUniqueIdsInLink{}; /// Input GBT links in output link
 };
-namespace raw
-{
-static constexpr uint8_t sUserLogicLinkID = 15;
-}
-
 } // namespace mid
 } // namespace o2
 

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTOutputHandler.h
@@ -33,7 +33,7 @@ class GBTOutputHandler
 {
  public:
   /// Sets the FEE Id
-  void setFeeId(uint16_t feeId) { mFeeId = feeId; }
+  void setGBTUniqueId(uint16_t feeId) { mFeeId = feeId; }
 
   void set(uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
@@ -41,8 +41,7 @@ class GBTUserLogicEncoder
   /// Sets the mask
   void setMask(uint8_t mask) { mMask = mask; }
 
-  /// Sets the feeID
-  void setFeeId(uint16_t feeId) { mFeeId = feeId; }
+  void setGBTUniqueId(uint16_t gbtUniqueId);
 
   /// Sets the delay in the electronics
   void setElectronicsDelay(const ElectronicsDelay& electronicsDelay) { mElectronicsDelay = electronicsDelay; }
@@ -52,7 +51,8 @@ class GBTUserLogicEncoder
   void addShort(std::vector<char>& buffer, uint16_t shortWord) const;
 
   std::map<InteractionRecord, std::vector<ROBoard>> mBoards{}; /// Vector with boards
-  uint16_t mFeeId{0};                                          /// FEE ID
+  uint8_t mCrateId{0};                                         /// Crate ID
+  uint8_t mOffset{0};                                          /// GBT ID offset
   uint8_t mMask{0xFF};                                         /// GBT mask
   ElectronicsDelay mElectronicsDelay;                          /// Delays in the electronics
 };

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/LinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/LinkDecoder.h
@@ -8,31 +8,32 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDRaw/GBTDecoder.h
-/// \brief  Class interface for the MID GBT decoder
+/// \file   MIDRaw/LinkDecoder.h
+/// \brief  Class interface for the MID link decoder
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   07 November 2020
-#ifndef O2_MID_GBTDECODER_H
-#define O2_MID_GBTDECODER_H
+#ifndef O2_MID_LINKDECODER_H
+#define O2_MID_LINKDECODER_H
 
 #include <cstdint>
 #include <vector>
 #include <gsl/gsl>
 #include "DetectorsRaw/RDHUtils.h"
 #include "Headers/RAWDataHeader.h"
+#include "DataFormatsMID/ROBoard.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/ElectronicsDelay.h"
-#include "DataFormatsMID/ROBoard.h"
+#include "MIDRaw/FEEIdConfig.h"
 
 namespace o2
 {
 namespace mid
 {
 
-class GBTDecoder
+class LinkDecoder
 {
  public:
-  GBTDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
+  LinkDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
   void process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 
   template <class RDH>
@@ -45,10 +46,12 @@ class GBTDecoder
   std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> mDecode{nullptr};
 };
 
-std::unique_ptr<GBTDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay);
-std::unique_ptr<GBTDecoder> createGBTDecoder(uint16_t feeId, bool isBare = false, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay());
+std::unique_ptr<LinkDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay);
+
+std::unique_ptr<LinkDecoder> createLinkDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay, const FEEIdConfig& feeIdConfig);
+std::unique_ptr<LinkDecoder> createLinkDecoder(uint16_t feeId, bool isBare = false, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay(), const FEEIdConfig& feeIdConfig = FEEIdConfig());
 
 } // namespace mid
 } // namespace o2
 
-#endif /* O2_MID_GBTDECODER_H */
+#endif /* O2_MID_LINKDECODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Utils.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Utils.h
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/Utils.h
+/// \brief  Raw data utilities for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 November 2019
+#ifndef O2_MID_UTILS_H
+#define O2_MID_UTILS_H
+
+#include "Headers/RDHAny.h"
+#include "DetectorsRaw/RDHUtils.h"
+
+namespace o2
+{
+namespace mid
+{
+namespace raw
+{
+static constexpr uint8_t sUserLogicLinkID = 15; // Link ID for the user logic
+
+/// Test if the data comes from the common logic
+inline bool isBare(const o2::header::RDHAny& rdh) { return (o2::raw::RDHUtils::getLinkID(rdh) != sUserLogicLinkID); }
+
+} // namespace raw
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_UTILS_H */

--- a/Detectors/MUON/MID/Raw/src/Decoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Decoder.cxx
@@ -23,27 +23,14 @@ namespace o2
 namespace mid
 {
 
-// namespace impl
-// {
-class FEEIDGetterImpl
-{
- public:
-  FEEIDGetterImpl(const FEEIdConfig& feeIdConfig) : mFeeIdConfig(feeIdConfig) {}
-  uint16_t operator()(const o2::header::RDHAny& rdh) { return mFeeIdConfig.getFeeId(o2::raw::RDHUtils::getLinkID(rdh), o2::raw::RDHUtils::getEndPointID(rdh), o2::raw::RDHUtils::getCRUID(rdh)); }
-
- private:
-  FEEIdConfig mFeeIdConfig{};
-};
-// } // namespace impl
-
-Decoder::Decoder(bool isDebugMode, bool isBare, const ElectronicsDelay& electronicsDelay, const CrateMasks& crateMasks, const FEEIdConfig& feeIdConfig) : mData(), mROFRecords(), mGBTDecoders()
+Decoder::Decoder(bool isDebugMode, bool isBare, const ElectronicsDelay& electronicsDelay, const CrateMasks& crateMasks, const FEEIdConfig& feeIdConfig) : mData(), mROFRecords(), mLinkDecoders()
 {
   /// Constructor
-  for (uint16_t igbt = 0; igbt < crateparams::sNGBTs; ++igbt) {
-    mGBTDecoders[igbt] = createGBTDecoder(igbt, isBare, isDebugMode, crateMasks.getMask(igbt), electronicsDelay);
-  }
-  if (isBare) {
-    mGetFEEID = FEEIDGetterImpl(feeIdConfig);
+  auto feeIds = isBare ? feeIdConfig.getConfiguredGBTUniqueIDs() : feeIdConfig.getConfiguredFEEIDs();
+
+  for (auto& feeId : feeIds) {
+    // mLinkDecoders.emplace_back(createLinkDecoder(feeId, isBare, isDebugMode, crateMasks.getMask(feeId), electronicsDelay, feeIdConfig));
+    mLinkDecoders.emplace(feeId, createLinkDecoder(feeId, isBare, isDebugMode, crateMasks.getMask(feeId), electronicsDelay, feeIdConfig));
   }
 }
 
@@ -69,10 +56,10 @@ void Decoder::process(gsl::span<const uint8_t> bytes)
   }
 }
 
-std::unique_ptr<Decoder> createDecoder(const o2::header::RDHAny& rdh, bool isDebugMode, ElectronicsDelay& electronicsDelay, const CrateMasks& crateMasks, const FEEIdConfig& feeIdConfig)
+std::unique_ptr<Decoder> createDecoder(const o2::header::RDHAny& rdh, bool isDebugMode, const ElectronicsDelay& electronicsDelay, const CrateMasks& crateMasks, const FEEIdConfig& feeIdConfig)
 {
   /// Creates the decoder from the RDH info
-  bool isBare = (o2::raw::RDHUtils::getLinkID(rdh) != raw::sUserLogicLinkID);
+  bool isBare = raw::isBare(rdh);
   return std::make_unique<Decoder>(isDebugMode, isBare, electronicsDelay, crateMasks, feeIdConfig);
 }
 std::unique_ptr<Decoder> createDecoder(const o2::header::RDHAny& rdh, bool isDebugMode, const char* electronicsDelayFile, const char* crateMasksFile, const char* feeIdConfigFile)

--- a/Detectors/MUON/MID/Raw/src/Decoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Decoder.cxx
@@ -29,8 +29,11 @@ Decoder::Decoder(bool isDebugMode, bool isBare, const ElectronicsDelay& electron
   auto feeIds = isBare ? feeIdConfig.getConfiguredGBTUniqueIDs() : feeIdConfig.getConfiguredFEEIDs();
 
   for (auto& feeId : feeIds) {
-    // mLinkDecoders.emplace_back(createLinkDecoder(feeId, isBare, isDebugMode, crateMasks.getMask(feeId), electronicsDelay, feeIdConfig));
+#if defined(MID_RAW_VECTORS)
+    mLinkDecoders.emplace_back(createLinkDecoder(feeId, isBare, isDebugMode, crateMasks.getMask(feeId), electronicsDelay, feeIdConfig));
+#else
     mLinkDecoders.emplace(feeId, createLinkDecoder(feeId, isBare, isDebugMode, crateMasks.getMask(feeId), electronicsDelay, feeIdConfig));
+#endif
   }
 }
 

--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -1,0 +1,210 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ELinkDataShaper.cxx
+/// \brief  MID e-link data shaper
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 March 2021
+
+#include "MIDRaw/ELinkDataShaper.h"
+
+#include "CommonConstants/LHCConstants.h"
+
+namespace o2
+{
+namespace mid
+{
+
+ELinkDataShaper::ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId) : mUniqueId(uniqueId)
+{
+  /// Ctr
+  if (isDebugMode) {
+    if (isLoc) {
+      mOnDone = &ELinkDataShaper::onDoneLocDebug;
+    } else {
+      mOnDone = &ELinkDataShaper::onDoneRegDebug;
+    }
+  } else {
+    if (isLoc) {
+      mOnDone = &ELinkDataShaper::onDoneLoc;
+    } else {
+      mOnDone = &ELinkDataShaper::onDoneReg;
+    }
+  }
+}
+
+void ELinkDataShaper::set(uint32_t orbit)
+{
+  /// Sets the orbit and the output data vectors
+  mRDHOrbit = orbit;
+
+  if (mIR.isDummy()) {
+    mIR.bc = 0;
+    // The reset changes depending on the way we synch with the orbit
+    // (see processOrbitTrigger for details)
+    // FIXME: pick one of the two
+    // mIR.orbit = orbit - 1; // with orbit increase
+    mIR.orbit = orbit; // with reset to RDH
+    mLastClock = constants::lhc::LHCMaxBunches;
+  }
+}
+
+bool ELinkDataShaper::checkLoc(const ELinkDecoder& decoder)
+{
+  /// Performs checks on the local board
+  return (decoder.getId() == (mUniqueId & 0xF));
+}
+
+EventType ELinkDataShaper::processSelfTriggered(uint16_t localClock, uint16_t& correctedClock)
+{
+  /// Processes the self-triggered event
+  correctedClock = localClock - mElectronicsDelay.BCToLocal;
+  if (mReceivedCalibration && (localClock == mExpectedFETClock)) {
+    // Reset the calibration flag for this e-link
+    mReceivedCalibration = false;
+    return EventType::Dead;
+  }
+  return EventType::Standard;
+}
+
+EventType ELinkDataShaper::processCalibrationTrigger(uint16_t localClock)
+{
+  /// Processes the calibration event
+  mExpectedFETClock = localClock + mElectronicsDelay.calibToFET;
+  mReceivedCalibration = true;
+  return EventType::Noise;
+}
+
+void ELinkDataShaper::processOrbitTrigger(uint16_t localClock, uint8_t triggerWord)
+{
+  /// Processes the orbit trigger event
+
+  // The local clock is reset: we are now in synch with the new HB
+  // We have to way to account for the orbit change:
+  // - increase the orbit counter by 1 for this e-link
+  //   (CAVEAT: synch is lost if we lose some orbit)
+  // - set the orbit to the one found in RDH
+  //   (CAVEAT: synch is lost if we have lot of data, spanning over two orbits)
+  // FIXME: pick one of the two
+  // ++mIR.orbit; // orbit increase
+  mIR.orbit = mRDHOrbit; // reset to RDH
+  if ((triggerWord & raw::sSOX) == 0) {
+    mLastClock = localClock;
+  }
+  // The orbit trigger resets the clock.
+  // If we received a calibration trigger, we need to change the value of the expected clock accordingly
+  if (mReceivedCalibration) {
+    mExpectedFETClock -= (localClock + 1);
+  }
+}
+
+bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock)
+{
+  /// Processes the trigger information
+  /// Returns true if the event should be further processed,
+  /// returns false otherwise.
+  auto localClock = decoder.getCounter();
+
+  if (decoder.getTriggerWord() == 0) {
+    // This is a self-triggered event
+    eventType = processSelfTriggered(localClock, correctedClock);
+    return true;
+  }
+
+  // From here we treat triggered events
+  bool goOn = false;
+  correctedClock = localClock;
+  if (decoder.getTriggerWord() & raw::sCALIBRATE) {
+    // This is an answer to a calibration trigger
+    eventType = processCalibrationTrigger(localClock);
+    goOn = true;
+  }
+
+  if (decoder.getTriggerWord() & raw::sORB) {
+    // This is the answer to an orbit trigger
+    processOrbitTrigger(localClock, decoder.getTriggerWord());
+    eventType = EventType::Standard;
+  }
+
+  return goOn;
+}
+
+void ELinkDataShaper::addLoc(const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+{
+  /// Adds the local board to the output data vector
+  auto firstEntry = data.size();
+  data.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), mUniqueId, decoder.getInputs()});
+  InteractionRecord intRec(mIR.bc + correctedClock, mIR.orbit);
+  rofs.emplace_back(intRec, eventType, firstEntry, 1);
+  for (int ich = 0; ich < 4; ++ich) {
+    if ((data.back().firedChambers & (1 << ich))) {
+      data.back().patternsBP[ich] = decoder.getPattern(0, ich);
+      data.back().patternsNBP[ich] = decoder.getPattern(1, ich);
+    }
+  }
+}
+
+void ELinkDataShaper::onDoneLoc(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+{
+  /// Performs action on decoded local board
+  EventType eventType;
+  uint16_t correctedClock;
+  if (processTrigger(decoder, eventType, correctedClock) && checkLoc(decoder)) {
+    addLoc(decoder, eventType, correctedClock, data, rofs);
+  }
+}
+
+void ELinkDataShaper::onDoneLocDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+{
+  /// This always adds the local board to the output, without performing tests
+  EventType eventType;
+  uint16_t correctedClock;
+  processTrigger(decoder, eventType, correctedClock);
+  addLoc(decoder, eventType, correctedClock, data, rofs);
+  if (decoder.getTriggerWord() & raw::sORB) {
+    // The local clock is increased when receiving an orbit trigger,
+    // but the local counter returned in answering the trigger
+    // belongs to the previous orbit
+    --rofs.back().interactionRecord.orbit;
+  }
+}
+
+void ELinkDataShaper::onDoneRegDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+{
+  /// Performs action on decoded regional board in debug mode.
+  EventType eventType;
+  uint16_t correctedClock;
+  processTrigger(decoder, eventType, correctedClock);
+  // If we want to distinguish the two regional e-links, we can use the link ID instead
+  auto firstEntry = data.size();
+  data.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), mUniqueId, decoder.getInputs()});
+
+  auto orbit = (decoder.getTriggerWord() & raw::sORB) ? mIR.orbit - 1 : mIR.orbit;
+
+  InteractionRecord intRec(mIR.bc + correctedClock, orbit);
+  if (decoder.getTriggerWord() == 0) {
+    if (intRec.bc < mElectronicsDelay.regToLocal) {
+      // In the tests, the HB does not really correspond to a change of orbit
+      // So we need to keep track of the last clock at which the HB was received
+      // and come back to that value
+      // FIXME: Remove this part as well as mLastClock when tests are no more needed
+      intRec -= (constants::lhc::LHCMaxBunches - mLastClock - 1);
+    }
+    // This is a self-triggered event.
+    // In this case the regional card needs to wait to receive the tracklet decision of each local
+    // which result in a delay that needs to be subtracted if we want to be able to synchronize
+    // local and regional cards for the checks
+    intRec -= mElectronicsDelay.regToLocal;
+  }
+  rofs.emplace_back(intRec, eventType, firstEntry, 1);
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file   MID/Raw/src/ELinkDataShaper.cxx
-/// \brief  MID e-link data shaper
+/// \brief  Properly formats and sets the absolute timestamp of the raw data
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   18 March 2021
 
@@ -87,7 +87,7 @@ void ELinkDataShaper::processOrbitTrigger(uint16_t localClock, uint8_t triggerWo
   /// Processes the orbit trigger event
 
   // The local clock is reset: we are now in synch with the new HB
-  // We have to way to account for the orbit change:
+  // We have two ways to account for the orbit change:
   // - increase the orbit counter by 1 for this e-link
   //   (CAVEAT: synch is lost if we lose some orbit)
   // - set the orbit to the one found in RDH

--- a/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
@@ -20,6 +20,14 @@ namespace o2
 namespace mid
 {
 
+void ELinkDecoder::setBareDecoder(bool isBare)
+{
+  /// Sets the decoder type
+  mMinimumSize = isBare ? 5 : 6;
+  mMaximumSize = isBare ? 21 : 22;
+  mTotalSize = mMinimumSize;
+}
+
 bool ELinkDecoder::add(size_t& idx, gsl::span<const uint8_t> payload, size_t nBytes, size_t step)
 {
   /// Fills inner bytes vector
@@ -41,7 +49,7 @@ bool ELinkDecoder::add(size_t& idx, gsl::span<const uint8_t> payload, size_t ste
   /// Adds the bytes of the board
   auto remaining = mTotalSize - mBytes.size();
   if (add(idx, payload, remaining, step)) {
-    if (mTotalSize == sMinimumSize) {
+    if (mTotalSize == mMinimumSize) {
       computeSize();
       remaining = mTotalSize - mBytes.size();
       if (remaining) {
@@ -57,7 +65,7 @@ void ELinkDecoder::addAndComputeSize(uint8_t byte)
 {
   /// Adds next byte and computes the expected data size
   mBytes.emplace_back(byte);
-  if (mBytes.size() == sMinimumSize) {
+  if (mBytes.size() == mMinimumSize) {
     computeSize();
   }
 }
@@ -81,7 +89,7 @@ void ELinkDecoder::reset()
 {
   /// Reset inner objects
   mBytes.clear();
-  mTotalSize = sMinimumSize;
+  mTotalSize = mMinimumSize;
 }
 
 uint16_t ELinkDecoder::getPattern(int cathode, int chamber) const

--- a/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
@@ -33,31 +33,43 @@ void ELinkManager::init(uint16_t feeId, bool isDebugMode, bool isBare, const Ele
       auto uniqueId = raw::makeUniqueLocID(crateId, ilink % 8 + offset);
       ELinkDataShaper shaper(isDebugMode, isLoc, uniqueId);
       shaper.setElectronicsDelay(electronicsDelay);
-      // mDataShapers.emplace_back(shaper);
+#if defined(MID_RAW_VECTORS)
+      mDataShapers.emplace_back(shaper);
+#else
       auto uniqueRegLocId = makeUniqueId(isLoc, uniqueId);
       mDataShapers.emplace(uniqueRegLocId, shaper);
+#endif
 
       if (isBare) {
         ELinkDecoder decoder;
         decoder.setBareDecoder(true);
-        // mDecoders.emplace_back(decoder);
+#if defined(MID_RAW_VECTORS)
+        mDecoders.emplace_back(decoder);
+#else
         mDecoders.emplace(uniqueRegLocId, decoder);
+#endif
       }
     }
   }
 
-  // if (isBare) {
-  //   mIndex = [](uint8_t, uint8_t locId, bool isLoc) { return 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
-  // } else {
-  //   mIndex = [](uint8_t crateId, uint8_t locId, bool isLoc) { return 10 * (2 * (crateId % 4) + (locId / 8)) + 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
+#if defined(MID_RAW_VECTORS)
+  if (isBare) {
+    mIndex = [](uint8_t, uint8_t locId, bool isLoc) { return 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
+  } else {
+    mIndex = [](uint8_t crateId, uint8_t locId, bool isLoc) { return 10 * (2 * (crateId % 4) + (locId / 8)) + 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
+  }
+#endif
 }
 
 void ELinkManager::set(uint32_t orbit)
 {
   /// Setup the orbit
   for (auto& shaper : mDataShapers) {
-    // shaper.set(orbit);
+#if defined(MID_RAW_VECTORS)
+    shaper.set(orbit);
+#else
     shaper.second.set(orbit);
+#endif
   }
 }
 

--- a/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ELinkManager.cxx
+/// \brief  MID e-link data shaper manager
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 March 2021
+
+#include "MIDRaw/ELinkManager.h"
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+void ELinkManager::init(uint16_t feeId, bool isDebugMode, bool isBare, const ElectronicsDelay& electronicsDelay, const FEEIdConfig& feeIdConfig)
+{
+  /// Initializer
+  auto gbtUniqueIds = isBare ? std::vector<uint16_t>{feeId} : feeIdConfig.getGBTUniqueIdsInLink(feeId);
+
+  for (auto& gbtUniqueId : gbtUniqueIds) {
+    auto crateId = crateparams::getCrateIdFromGBTUniqueId(gbtUniqueId);
+    uint8_t offset = crateparams::getGBTIdInCrate(gbtUniqueId) * 8;
+    for (int ilink = 0; ilink < 10; ++ilink) {
+      bool isLoc = ilink < 8;
+      auto uniqueId = raw::makeUniqueLocID(crateId, ilink % 8 + offset);
+      ELinkDataShaper shaper(isDebugMode, isLoc, uniqueId);
+      shaper.setElectronicsDelay(electronicsDelay);
+      // mDataShapers.emplace_back(shaper);
+      auto uniqueRegLocId = makeUniqueId(isLoc, uniqueId);
+      mDataShapers.emplace(uniqueRegLocId, shaper);
+
+      if (isBare) {
+        ELinkDecoder decoder;
+        decoder.setBareDecoder(true);
+        // mDecoders.emplace_back(decoder);
+        mDecoders.emplace(uniqueRegLocId, decoder);
+      }
+    }
+  }
+
+  // if (isBare) {
+  //   mIndex = [](uint8_t, uint8_t locId, bool isLoc) { return 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
+  // } else {
+  //   mIndex = [](uint8_t crateId, uint8_t locId, bool isLoc) { return 10 * (2 * (crateId % 4) + (locId / 8)) + 8 * (1 - static_cast<size_t>(isLoc)) + (locId % 8); };
+}
+
+void ELinkManager::set(uint32_t orbit)
+{
+  /// Setup the orbit
+  for (auto& shaper : mDataShapers) {
+    // shaper.set(orbit);
+    shaper.second.set(orbit);
+  }
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/LinkDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/LinkDecoder.cxx
@@ -8,16 +8,18 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MID/Raw/src/GBTDecoder.cxx
+/// \file   MID/Raw/src/LinkDecoder.cxx
 /// \brief  Class interface for the MID GBT decoder
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   07 November 2020
 
-#include "MIDRaw/GBTDecoder.h"
+#include "MIDRaw/LinkDecoder.h"
 
+#include "DataFormatsMID/ROBoard.h"
+#include "MIDRaw/ELinkManager.h"
 #include "MIDRaw/FEEIdConfig.h"
 #include "MIDRaw/GBTOutputHandler.h"
-#include "DataFormatsMID/ROBoard.h"
+#include "MIDRaw/Utils.h"
 
 namespace o2
 {
@@ -25,12 +27,96 @@ namespace mid
 {
 namespace impl
 {
+
+class GBTUserLogicDecoderImplV2
+{
+ public:
+  GBTUserLogicDecoderImplV2(uint16_t ulFeeId, bool isDebugMode = false, const ElectronicsDelay& electronicsDelay = ElectronicsDelay(), const FEEIdConfig& feeIdConfig = FEEIdConfig())
+  {
+    mElinkManager.init(ulFeeId, isDebugMode, false, electronicsDelay, feeIdConfig);
+    mELinkDecoder.setBareDecoder(false);
+  }
+
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  {
+    /// Decodes the buffer
+    mElinkManager.set(orbit);
+    // for (auto& byte : payload) {
+    auto it = payload.begin();
+    auto end = payload.end();
+    while (it != end) {
+      if (mELinkDecoder.isZero(*it)) {
+        // The e-link decoder is empty, meaning that we expect a new board.
+        // The first byte of the board should have the STARTBIT on.
+        // If this is not the case, we move to the next byte.
+        // Notice that the payload has zeros until the end of the 256 bits word:
+        // a) when moving from the regional high to regional low
+        // b) at the end of the HBF
+        ++it;
+        continue;
+      }
+
+      if (mELinkDecoder.add(it, end)) {
+        mElinkManager.onDone(mELinkDecoder, data, rofs);
+        mELinkDecoder.reset();
+      }
+    }
+  }
+
+ private:
+  ELinkDecoder mELinkDecoder{}; /// E-link decoder
+  ELinkManager mElinkManager{}; /// ELinkManager
+};
+
+class GBTUserLogicDecoderImplV1
+{
+ public:
+  GBTUserLogicDecoderImplV1(uint16_t feeId, bool isDebugMode = false, const ElectronicsDelay& electronicsDelay = ElectronicsDelay())
+  {
+    mCrateId = crateparams::getCrateIdFromGBTUniqueId(feeId);
+    mOffset = 8 * crateparams::getGBTIdInCrate(feeId);
+    mElinkManager.init(feeId, isDebugMode, true, electronicsDelay);
+  }
+
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  {
+    /// Decodes the buffer
+    mElinkManager.set(orbit);
+    // for (auto& byte : payload) {
+    auto it = payload.begin();
+    auto end = payload.end();
+    while (it != end) {
+      if (mELinkDecoder.isZero(*it)) {
+        // The e-link decoder is empty, meaning that we expect a new board.
+        // The first byte of the board should have the STARTBIT on.
+        // If this is not the case, we move to the next byte.
+        // Notice that the payload has zeros until the end of the 256 bits word:
+        // a) when moving from the regional high to regional low
+        // b) at the end of the HBF
+        ++it;
+        continue;
+      }
+
+      if (mELinkDecoder.add(it, end)) {
+        mElinkManager.onDone(mELinkDecoder, mCrateId, mOffset + mELinkDecoder.getId() % 8, data, rofs);
+        mELinkDecoder.reset();
+      }
+    }
+  }
+
+ private:
+  uint8_t mCrateId{0};          /// Crate ID
+  uint8_t mOffset{0};           /// Loc ID offset
+  ELinkDecoder mELinkDecoder{}; /// E-link decoder
+  ELinkManager mElinkManager{}; /// ELinkManager
+};
+
 class GBTUserLogicDecoderImpl
 {
  public:
-  GBTUserLogicDecoderImpl(uint16_t feeId, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay())
+  GBTUserLogicDecoderImpl(uint16_t feeId, bool isDebugMode = false, const ElectronicsDelay& electronicsDelay = ElectronicsDelay())
   {
-    mOutputHandler.setFeeId(feeId);
+    mOutputHandler.setGBTUniqueId(feeId);
     mOutputHandler.setElectronicsDelay(electronicsDelay);
     if (isDebugMode) {
       mOnDoneLoc = &GBTOutputHandler::onDoneLocDebug;
@@ -80,13 +166,108 @@ class GBTUserLogicDecoderImpl
   OnDoneFunction mOnDoneReg{&GBTOutputHandler::onDoneReg}; ///! Processes the regional board
 };
 
+class GBTBareDecoderImplV1
+{
+ public:
+  GBTBareDecoderImplV1(uint16_t feeId, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay()) : mIsDebugMode(isDebugMode), mMask(mask)
+  {
+    /// Constructors
+    mElinkManager.init(feeId, isDebugMode, true, electronicsDelay);
+    auto crateId = crateparams::getCrateIdFromGBTUniqueId(feeId);
+    auto offset = 8 * crateparams::getGBTIdInCrate(feeId);
+    for (int ilink = 0; ilink < 10; ++ilink) {
+      mBoardUniqueIds.emplace_back(raw::makeUniqueLocID(crateId, offset + ilink % 8));
+    }
+  }
+
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  {
+    /// Decodes the buffer
+    mElinkManager.set(orbit);
+    mData = &data;
+    mROFs = &rofs;
+
+    uint8_t byte = 0;
+    size_t ilink = 0, linkMask = 0, byteOffset = 0;
+
+    for (int ireg = 0; ireg < 2; ++ireg) {
+      byteOffset = 5 * ireg;
+      if (mIsDebugMode) {
+        ilink = 8 + ireg;
+        linkMask = (1 << ilink);
+        for (size_t idx = byteOffset + 4; idx < payload.size(); idx += 16) {
+          byte = payload[idx];
+          if ((mIsFeeding & linkMask) || byte) {
+            processRegDebug(ilink, byte);
+          }
+        }
+      }
+      for (int ib = 0; ib < 4; ++ib) {
+        ilink = ib + 4 * ireg;
+        linkMask = (1 << ilink);
+        if (mMask & linkMask) {
+          for (size_t idx = byteOffset + ib; idx < payload.size(); idx += 16) {
+            byte = payload[idx];
+            if ((mIsFeeding & linkMask) || byte) {
+              processLoc(ilink, byte);
+            }
+          }
+        }
+      }
+    }
+  }
+
+ private:
+  void processLoc(size_t ilink, uint8_t byte)
+  {
+    /// Processes the local board information
+    auto& decoder = mElinkManager.getDecoder(mBoardUniqueIds[ilink], true);
+    if (decoder.getNBytes() > 0) {
+      decoder.addAndComputeSize(byte);
+      if (decoder.isComplete()) {
+        mElinkManager.onDone(decoder, mBoardUniqueIds[ilink], *mData, *mROFs);
+        decoder.reset();
+        mIsFeeding &= (~(1 << ilink));
+      }
+    } else if ((byte & (raw::sSTARTBIT | raw::sCARDTYPE)) == (raw::sSTARTBIT | raw::sCARDTYPE)) {
+      decoder.add(byte);
+      mIsFeeding |= (1 << ilink);
+    }
+  }
+
+  void processRegDebug(size_t ilink, uint8_t byte)
+  {
+    /// Processes the regional board information in debug mode
+    auto& decoder = mElinkManager.getDecoder(mBoardUniqueIds[ilink], false);
+    if (decoder.getNBytes() > 0) {
+      decoder.add(byte);
+      if (decoder.isComplete()) {
+        mElinkManager.onDone(decoder, mBoardUniqueIds[ilink], *mData, *mROFs);
+        decoder.reset();
+        mIsFeeding &= (~(1 << ilink));
+      }
+    } else if (byte & raw::sSTARTBIT) {
+      decoder.add(byte);
+      mIsFeeding |= (1 << ilink);
+    }
+  }
+
+  bool mIsDebugMode{false};               /// Debug mode
+  uint8_t mMask{0xFF};                    /// GBT mask
+  uint16_t mIsFeeding{0};                 /// Flag to check if the e-link is feeding
+  ELinkManager mElinkManager{};           /// ELinkManager
+  std::vector<uint8_t> mBoardUniqueIds{}; /// Unique board IDs
+  std::vector<ROBoard>* mData{nullptr};   ///! Data not owner
+  std::vector<ROFRecord>* mROFs{nullptr}; ///! ROFRecords not owner
+};
+
 class GBTBareDecoderImpl
 {
  public:
   GBTBareDecoderImpl(uint16_t feeId, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay()) : mIsDebugMode(isDebugMode), mMask(mask)
   {
     /// Constructor
-    mOutputHandler.setFeeId(feeId);
+    mOutputHandler.setGBTUniqueId(feeId);
     mOutputHandler.setElectronicsDelay(electronicsDelay);
     if (isDebugMode) {
       mOnDoneLoc = &GBTOutputHandler::onDoneLocDebug;
@@ -183,7 +364,7 @@ class GBTBareDecoderLinkImpl
   GBTBareDecoderLinkImpl(uint16_t feeId, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay()) : mIsDebugMode(isDebugMode), mMask(mask)
   {
     /// Constructor
-    mOutputHandler.setFeeId(feeId);
+    mOutputHandler.setGBTUniqueId(feeId);
     mOutputHandler.setElectronicsDelay(electronicsDelay);
     mIsDebugMode = isDebugMode;
     if (isDebugMode) {
@@ -269,7 +450,7 @@ class GBTBareDecoderInsertImpl
   GBTBareDecoderInsertImpl(uint16_t feeId, bool isDebugMode = false, uint8_t mask = 0xFF, const ElectronicsDelay& electronicsDelay = ElectronicsDelay()) : mIsDebugMode(isDebugMode), mMask(mask)
   {
     /// Constructor
-    mOutputHandler.setFeeId(feeId);
+    mOutputHandler.setGBTUniqueId(feeId);
     mOutputHandler.setElectronicsDelay(electronicsDelay);
     if (isDebugMode) {
       mOnDoneLoc = &GBTOutputHandler::onDoneLocDebug;
@@ -334,28 +515,38 @@ class GBTBareDecoderInsertImpl
 
 } // namespace impl
 
-void GBTDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+void LinkDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Decodes the data
   mDecode(payload, orbit, data, rofs);
 }
 
-std::unique_ptr<GBTDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay)
+std::unique_ptr<LinkDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay)
 {
   /// Creates the correct implementation of the GBT decoder
-  if (o2::raw::RDHUtils::getLinkID(rdh) == raw::sUserLogicLinkID) {
-    return std::make_unique<GBTDecoder>(impl::GBTUserLogicDecoderImpl(feeId, isDebugMode, mask, electronicsDelay));
+  if (raw::isBare(rdh)) {
+    return std::make_unique<LinkDecoder>(impl::GBTBareDecoderImplV1(feeId, isDebugMode, mask, electronicsDelay));
   }
-  return std::make_unique<GBTDecoder>(impl::GBTBareDecoderImpl(feeId, isDebugMode, mask, electronicsDelay));
+  std::cout << "Error: GBT decoder not defined for UL. Please use Link decoder instead" << std::endl;
+  return nullptr;
 }
 
-std::unique_ptr<GBTDecoder> createGBTDecoder(uint16_t feeId, bool isBare, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay)
+std::unique_ptr<LinkDecoder> createLinkDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay, const FEEIdConfig& feeIdConfig)
+{
+  /// Creates the correct implementation of the GBT decoder
+  if (raw::isBare(rdh)) {
+    return std::make_unique<LinkDecoder>(impl::GBTBareDecoderImplV1(feeId, isDebugMode, mask, electronicsDelay));
+  }
+  return std::make_unique<LinkDecoder>(impl::GBTUserLogicDecoderImplV2(feeId, isDebugMode, electronicsDelay, feeIdConfig));
+}
+
+std::unique_ptr<LinkDecoder> createLinkDecoder(uint16_t feeId, bool isBare, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay, const FEEIdConfig& feeIdConfig)
 {
   /// Creates the correct implementation of the GBT decoder
   if (isBare) {
-    return std::make_unique<GBTDecoder>(impl::GBTBareDecoderImpl(feeId, isDebugMode, mask, electronicsDelay));
+    return std::make_unique<LinkDecoder>(impl::GBTBareDecoderImplV1(feeId, isDebugMode, mask, electronicsDelay));
   }
-  return std::make_unique<GBTDecoder>(impl::GBTUserLogicDecoderImpl(feeId, isDebugMode, mask, electronicsDelay));
+  return std::make_unique<LinkDecoder>(impl::GBTUserLogicDecoderImplV2(feeId, isDebugMode, electronicsDelay, feeIdConfig));
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
+++ b/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
@@ -23,7 +23,7 @@
 #include "MIDBase/DetectorParameters.h"
 #include "MIDRaw/Decoder.h"
 #include "MIDRaw/Encoder.h"
-#include "MIDRaw/GBTDecoder.h"
+#include "MIDRaw/LinkDecoder.h"
 
 o2::mid::ColumnData getColData(uint8_t deId, uint8_t columnId, uint16_t nbp = 0, uint16_t bp1 = 0, uint16_t bp2 = 0, uint16_t bp3 = 0, uint16_t bp4 = 0)
 {
@@ -122,9 +122,9 @@ static void BM_Decoder(benchmark::State& state)
   state.counters["num"] = benchmark::Counter(num, benchmark::Counter::kIsRate);
 }
 
-static void BM_GBTDecoder(benchmark::State& state)
+static void BM_LinkDecoder(benchmark::State& state)
 {
-  auto decoder = o2::mid::createGBTDecoder(0);
+  auto decoder = o2::mid::createLinkDecoder(0);
 
   int nTF = state.range(0);
   int nEventPerTF = state.range(1);
@@ -164,7 +164,7 @@ static void CustomArguments(benchmark::internal::Benchmark* bench)
   bench->Args({1, 100, 4});
 }
 
-BENCHMARK(BM_GBTDecoder)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_LinkDecoder)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_Decoder)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
 
 BENCHMARK_MAIN();

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -32,9 +32,9 @@
 #include "MIDRaw/CrateParameters.h"
 #include "MIDRaw/DecodedDataAggregator.h"
 #include "MIDRaw/Decoder.h"
-#include "MIDRaw/GBTDecoder.h"
-#include "MIDRaw/GBTUserLogicEncoder.h"
 #include "MIDRaw/Encoder.h"
+#include "MIDRaw/GBTUserLogicEncoder.h"
+#include "MIDRaw/LinkDecoder.h"
 
 BOOST_AUTO_TEST_SUITE(o2_mid_raw)
 
@@ -193,9 +193,9 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
 
   uint8_t crateId = 5;
   uint8_t linkInCrate = 0;
-  uint16_t feeId = o2::mid::crateparams::makeGBTUniqueId(crateId, linkInCrate);
+  uint16_t gbtUniqueId = o2::mid::crateparams::makeGBTUniqueId(crateId, linkInCrate);
   o2::mid::GBTUserLogicEncoder encoder;
-  encoder.setFeeId(feeId);
+  encoder.setGBTUniqueId(gbtUniqueId);
   for (auto& item : inData) {
     encoder.process(item.second, o2::InteractionRecord(item.first, 0));
   }
@@ -204,9 +204,10 @@ BOOST_AUTO_TEST_CASE(GBTUserLogicDecoder)
   o2::header::RAWDataHeader rdh;
   auto memSize = buf.size() + 64;
   rdh.word1 |= (memSize | (memSize << 16));
-  // Sets the feeId
-  rdh.word0 |= ((5 * 2) << 16);
-  auto decoder = o2::mid::createGBTDecoder(feeId);
+  // Sets the linkId
+  uint16_t feeId = gbtUniqueId / 8;
+  rdh.word0 |= (feeId << 16);
+  auto decoder = o2::mid::createLinkDecoder(feeId);
   std::vector<o2::mid::ROBoard> data;
   std::vector<o2::mid::ROFRecord> rofs;
   std::vector<uint8_t> convertedBuffer(buf.size());

--- a/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
@@ -28,9 +28,9 @@
 #include "Framework/Task.h"
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
-#include "DataFormatsMID/ROFRecord.h"
-#include "MIDRaw/GBTDecoder.h"
 #include "DataFormatsMID/ROBoard.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/LinkDecoder.h"
 
 namespace o2
 {
@@ -89,7 +89,7 @@ class RawGBTDecoderDeviceDPL
   }
 
  private:
-  std::unique_ptr<GBTDecoder> mDecoder{nullptr};
+  std::unique_ptr<LinkDecoder> mDecoder{nullptr};
   bool mIsDebugMode{false};
   std::vector<uint16_t> mFeeIds{};
   CrateMasks mCrateMasks{};


### PR DESCRIPTION
The UL format was slightly changed in order to have 1 output per EP, with linkID 15.
This results in one RDH followed by the payload of the 8 GBT links read out by the UL.
Before the change, we had 1 RDH per input GBT link.
The new format optimizes the memory usage of the readout, but requires to encode in the payload the crate that produced the data themselves.
In this PR I profited of the change to further uniformize the the e-links decoding between Common and User Logic.