### PR TITLE
TPC IDCs: adding device for integration of digits and averaging/merging of IDCs

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Mapper.h
+++ b/Detectors/TPC/base/include/TPCBase/Mapper.h
@@ -57,6 +57,19 @@ class Mapper
     return mMapPadOffsetPerRow[globalPadPosition.getRow()] + globalPadPosition.getPad();
   }
 
+  /// \return returns the global pad number for given local pad row and pad
+  /// \param lrow ungrouped local row in a region
+  /// \param pad ungrouped pad in row
+  GlobalPadNumber static getGlobalPadNumber(const unsigned int lrow, const unsigned int pad, const unsigned int region) { return GLOBALPADOFFSET[region] + OFFSETCRULOCAL[region][lrow] + pad; }
+
+  /// \param row global pad row
+  /// \param pad pad in row
+  /// \return returns local pad number in region
+  static unsigned int getLocalPadNumber(const unsigned int row, const unsigned int pad) { return OFFSETCRUGLOBAL[row] + pad; }
+
+  /// \param row global pad row
+  static unsigned int getLocalRowFromGlobalRow(const unsigned int row) { return row - ROWOFFSET[REGION[row]]; }
+
   /// return the cru number from sector and global pad number
   /// \param sec sector
   /// \param globalPad global pad number in sector
@@ -485,6 +498,70 @@ class Mapper
     return LocalPosition2D(float(double(pos.X()) * cs - double(pos.Y()) * sn),
                            float(double(pos.X()) * sn + double(pos.Y() * cs)));
   }
+
+  static constexpr unsigned int NSECTORS{36};                                                                                                                      ///< total number of sectors in the TPC
+  static constexpr unsigned int NREGIONS{10};                                                                                                                      ///< total number of regions in one sector
+  static constexpr unsigned int PADROWS{152};                                                                                                                      ///< total number of pad rows
+  static constexpr unsigned int PADSPERREGION[NREGIONS]{1200, 1200, 1440, 1440, 1440, 1440, 1600, 1600, 1600, 1600};                                               ///< number of pads per CRU
+  static constexpr unsigned int GLOBALPADOFFSET[NREGIONS]{0, 1200, 2400, 3840, 5280, 6720, 8160, 9760, 11360, 12960};                                              ///< offset of number of pads for region
+  static constexpr unsigned int ROWSPERREGION[NREGIONS]{17, 15, 16, 15, 18, 16, 16, 14, 13, 12};                                                                   ///< number of pad rows for region
+  static constexpr unsigned int ROWOFFSET[NREGIONS]{0, 17, 32, 48, 63, 81, 97, 113, 127, 140};                                                                     ///< offset to calculate local row from global row
+  static constexpr float REGIONAREA[NREGIONS]{374.4f, 378.f, 453.6f, 470.88f, 864.f, 864.f, 1167.36f, 1128.96f, 1449.6f, 1456.8f};                                 ///< volume of each region in cm^2
+  static constexpr float PADAREA[NREGIONS]{1 / 0.312f, 1 / 0.315f, 1 / 0.315f, 1 / 0.327f, 1 / 0.6f, 1 / 0.6f, 1 / 0.7296f, 1 / 0.7056f, 1 / 0.906f, 1 / 0.9105f}; ///< inverse size of the pad area padwidth*padLength
+  static constexpr unsigned REGION[PADROWS] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9}; ///< region for global pad row
+  const inline static std::vector<unsigned int> ADDITIONALPADSPERROW[NREGIONS]{
+    {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5},    // region 0
+    {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4},          // region 1
+    {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4},       // region 2
+    {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4},          // region 3
+    {0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4}, // region 4
+    {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4},       // region 5
+    {0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5, 5, 6},       // region 6
+    {0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4},             // region 7
+    {0, 0, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5},                // region 8
+    {0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5}                    // region 9
+  };                                                        ///< additional pads per row compared to first row
+  const inline static std::vector<unsigned int> OFFSETCRULOCAL[NREGIONS]{
+    {0, 66, 132, 198, 266, 334, 402, 472, 542, 612, 684, 756, 828, 902, 976, 1050, 1124},         // region 0
+    {0, 76, 152, 228, 306, 384, 462, 542, 622, 702, 784, 866, 948, 1032, 1116},                   // region 1
+    {0, 86, 172, 258, 346, 434, 522, 612, 702, 792, 882, 974, 1066, 1158, 1252, 1346},            // region 2
+    {0, 92, 184, 276, 370, 464, 558, 654, 750, 846, 944, 1042, 1140, 1240, 1340},                 // region 3
+    {0, 76, 152, 228, 304, 382, 460, 538, 618, 698, 778, 858, 940, 1022, 1104, 1188, 1272, 1356}, // region 4
+    {0, 86, 172, 258, 346, 434, 522, 612, 702, 792, 882, 974, 1066, 1158, 1252, 1346},            // region 5
+    {0, 94, 190, 286, 382, 480, 578, 676, 776, 876, 978, 1080, 1182, 1286, 1390, 1494},           // region 6
+    {0, 110, 220, 332, 444, 556, 670, 784, 898, 1014, 1130, 1246, 1364, 1482},                    // region 7
+    {0, 118, 236, 356, 476, 598, 720, 844, 968, 1092, 1218, 1344, 1472},                          // region 8
+    {0, 128, 258, 388, 520, 652, 784, 918, 1052, 1188, 1324, 1462}                                // region 9
+  };                                                                                              ///< row offset in cru for given local pad row
+  const inline static std::vector<unsigned int> PADSPERROW[NREGIONS]{
+    {66, 66, 66, 68, 68, 68, 70, 70, 70, 72, 72, 72, 74, 74, 74, 74, 76},      // region 0
+    {76, 76, 76, 78, 78, 78, 80, 80, 80, 82, 82, 82, 84, 84, 84},              // region 1
+    {86, 86, 86, 88, 88, 88, 90, 90, 90, 90, 92, 92, 92, 94, 94, 94},          // region 2
+    {92, 92, 92, 94, 94, 94, 96, 96, 96, 98, 98, 98, 100, 100, 100},           // region 3
+    {76, 76, 76, 76, 78, 78, 78, 80, 80, 80, 80, 82, 82, 82, 84, 84, 84, 84},  // region 4
+    {86, 86, 86, 88, 88, 88, 90, 90, 90, 90, 92, 92, 92, 94, 94, 94},          // region 5
+    {94, 96, 96, 96, 98, 98, 98, 100, 100, 102, 102, 102, 104, 104, 104, 106}, // region 6
+    {110, 110, 112, 112, 112, 114, 114, 114, 116, 116, 116, 118, 118, 118},    // region 7
+    {118, 118, 120, 120, 122, 122, 124, 124, 124, 126, 126, 128, 128},         // region 8
+    {128, 130, 130, 132, 132, 132, 134, 134, 136, 136, 138, 138}               // region 9
+  };                                                                           ///< number of pads per row in region
+  static constexpr unsigned int OFFSETCRUGLOBAL[PADROWS]{
+    0, 66, 132, 198, 266, 334, 402, 472, 542, 612, 684, 756, 828, 902, 976, 1050, 1124,         // region 0
+    0, 76, 152, 228, 306, 384, 462, 542, 622, 702, 784, 866, 948, 1032, 1116,                   // region 1
+    0, 86, 172, 258, 346, 434, 522, 612, 702, 792, 882, 974, 1066, 1158, 1252, 1346,            // region 2
+    0, 92, 184, 276, 370, 464, 558, 654, 750, 846, 944, 1042, 1140, 1240, 1340,                 // region 3
+    0, 76, 152, 228, 304, 382, 460, 538, 618, 698, 778, 858, 940, 1022, 1104, 1188, 1272, 1356, // region 4
+    0, 86, 172, 258, 346, 434, 522, 612, 702, 792, 882, 974, 1066, 1158, 1252, 1346,            // region 5
+    0, 94, 190, 286, 382, 480, 578, 676, 776, 876, 978, 1080, 1182, 1286, 1390, 1494,           // region 6
+    0, 110, 220, 332, 444, 556, 670, 784, 898, 1014, 1130, 1246, 1364, 1482,                    // region 7
+    0, 118, 236, 356, 476, 598, 720, 844, 968, 1092, 1218, 1344, 1472,                          // region 8
+    0, 128, 258, 388, 520, 652, 784, 918, 1052, 1188, 1324, 1462                                // region 9
+  };                                                                                            ///< row offset in cru for given global pad row
 
  private:
   Mapper(const std::string& mappingDir);

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -11,6 +11,7 @@
 add_subdirectory(SpacePoints)
 
 o2_add_library(TPCCalibration
+               TARGETVARNAME targetName
                SOURCES src/CalibRawBase.cxx
                        src/CalibPedestal.cxx
                        src/CalibPulser.cxx
@@ -20,6 +21,14 @@ o2_add_library(TPCCalibration
                        src/DigitDump.cxx
                        src/DigitDumpParam.cxx
                        src/CalibPadGainTracks.cxx
+                       src/IDCAverageGroup.cxx
+                       src/IDCGroup.cxx
+                       src/IDCGroupHelperRegion.cxx
+                       src/IDCGroupingParameter.cxx
+                       src/IDCFactorization.cxx
+                       src/IDCFourierTransform.cxx
+                       src/RobustAverage.cxx
+                       src/IDCCCDBHelper.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL)
@@ -34,7 +43,17 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/DigitDump.h
                                   include/TPCCalibration/DigitDumpParam.h
                                   include/TPCCalibration/CalibPadGainTracks.h
-                                  include/TPCCalibration/FastHisto.h)
+                                  include/TPCCalibration/FastHisto.h
+                                  include/TPCCalibration/IDCAverageGroup.h
+                                  include/TPCCalibration/IDCGroup.h
+                                  include/TPCCalibration/IDCGroupHelperRegion.h
+                                  include/TPCCalibration/IDCGroupHelperSector.h
+                                  include/TPCCalibration/IDCFactorization.h
+                                  include/TPCCalibration/IDCGroupingParameter.h
+                                  include/TPCCalibration/IDCContainer.h
+                                  include/TPCCalibration/RobustAverage.h
+                                  include/TPCCalibration/IDCFourierTransform.h
+                                  include/TPCCalibration/IDCCCDBHelper.h)
 
 o2_add_test_root_macro(macro/comparePedestalsAndNoise.C
                        PUBLIC_LINK_LIBRARIES O2::TPCBase
@@ -67,3 +86,16 @@ o2_add_test_root_macro(macro/extractGainMap.C
 o2_add_test_root_macro(macro/preparePedestalFiles.C
                        PUBLIC_LINK_LIBRARIES O2::TPCCalibration
                        LABELS tpc)
+
+o2_add_test(IDCFourierTransform
+            COMPONENT_NAME calibration
+            PUBLIC_LINK_LIBRARIES O2::TPCCalibration
+            SOURCES test/testO2TPCIDCFourierTransform.cxx
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+            LABELS tpc
+            CONFIGURATIONS RelWithDebInfo Release MinRelSize)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
@@ -1,0 +1,167 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCAverageGroup.h
+/// \brief class for averaging and grouping of IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_IDCAVERAGEGROUP_H_
+#define ALICEO2_IDCAVERAGEGROUP_H_
+
+#include <vector>
+#include "TPCCalibration/IDCGroup.h"
+#include "TPCBase/Mapper.h"
+#include "Rtypes.h"
+
+namespace o2::utils
+{
+class TreeStreamRedirector;
+}
+
+namespace o2::tpc
+{
+
+/// class for averaging and grouping IDCs
+/// usage:
+/// 1. Define grouping parameters
+/// const int region = 3;
+/// IDCAverageGroup idcaverage(6, 4, 3, 2, region);
+/// 2. set the ungrouped IDCs for one CRU
+/// const int nIntegrationIntervals = 3;
+/// std::vector<float> idcsungrouped(nIntegrationIntervals*Mapper::PADSPERREGION[region], 11.11); // vector containing IDCs for one region
+/// idcaverage.setIDCs(idcsungrouped)
+/// 3. perform the averaging and grouping
+/// idcaverage.processIDCs();
+/// 4. draw IDCs
+/// idcaverage.drawUngroupedIDCs(0)
+/// idcaverage.drawGroupedIDCs(0)
+
+class IDCAverageGroup
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param region region of the TPC
+  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0, const Sector sector = Sector{0})
+    : mIDCsGrouped{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mSector{sector} {}
+
+  /// set the IDCs which will be averaged and grouped
+  /// \param idcs vector containing the IDCs
+  void setIDCs(const std::vector<float>& idcs);
+
+  /// set the IDCs which will be averaged and grouped using move operator
+  /// \param IDCs vector containing the IDCs
+  void setIDCs(std::vector<float>&& idcs);
+
+  /// \return returns number of integration intervalls stored in this object
+  unsigned int getNIntegrationIntervals() const { return mIDCsUngrouped.size() / Mapper::PADSPERREGION[mIDCsGrouped.getRegion()]; }
+
+  /// grouping and averaging of IDCs
+  void processIDCs();
+
+  /// \return returns grouped IDC object
+  const auto& getIDCGroup() const { return mIDCsGrouped; }
+
+  /// dump object to disc
+  /// \param outFileName name of the output file
+  /// \param outName name of the object in the output file
+  void dumpToFile(const char* outFileName = "IDCAverageGroup.root", const char* outName = "IDCAverageGroup") const;
+
+  /// draw ungrouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawUngroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsUngrouped.pdf") const;
+
+  /// draw grouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawGroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsGrouped.pdf") const { mIDCsGrouped.draw(integrationInterval, filename); }
+
+  /// \return returns the stored ungrouped IDC value for local ungrouped pad row and ungrouped pad
+  /// \param ulrow ungrouped local row in region
+  /// \param upad ungrouped pad in pad direction
+  /// \param integrationInterval integration interval for which the IDCs will be returned
+  float getUngroupedIDCValLocal(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const { return mIDCsUngrouped[getUngroupedIndex(ulrow, upad, integrationInterval)]; }
+
+  /// \return returns the stored ungrouped IDC value for global ungrouped pad row and ungrouped pad
+  /// \param ugrow ungrouped global row
+  /// \param upad ungrouped pad in pad direction
+  /// \param integrationInterval integration interval for which the IDCs will be returned
+  float getUngroupedIDCValGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const { return mIDCsUngrouped[getUngroupedIndexGlobal(ugrow, upad, integrationInterval)]; }
+
+  /// \return returns the stored ungrouped IDC value for local pad number
+  /// \param localPadNumber local pad number for region
+  /// \param integrationInterval integration interval for which the IDCs will be returned
+  float getUngroupedIDCVal(const unsigned int localPadNumber, const unsigned int integrationInterval) const { return mIDCsUngrouped[localPadNumber + integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()]]; }
+
+  /// \return returns the stored grouped IDC value for local ungrouped pad row and ungrouped pad
+  /// \param ulrow local row in region of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getGroupedIDCValLocal(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped.getValUngrouped(ulrow, upad, integrationInterval); }
+
+  /// \return returns the stored grouped IDC value for local ungrouped pad row and ungrouped pad
+  /// \param ugrow global ungrouped row
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getGroupedIDCValGlobal(unsigned int ugrow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped.getValUngroupedGlobal(ugrow, upad, integrationInterval); }
+
+  /// get the number of threads used for some of the calculations
+  static int getNThreads() { return sNThreads; }
+
+  /// \return returns sector of which the IDCs are averaged and grouped
+  Sector getSector() const { return mSector; }
+
+  /// \return returns ungrouped IDCs
+  const auto& getIDCsUngrouped() const { return mIDCsGrouped; }
+
+  /// \return returns region
+  unsigned int getRegion() const { return mIDCsGrouped.getRegion(); }
+
+  /// set the number of threads used for some of the calculations
+  static void setNThreads(const int nThreads) { sNThreads = nThreads; }
+
+  /// for debugging: creating debug tree
+  /// \param nameTree name of the output file
+  void createDebugTree(const char* nameTree) const;
+
+  /// for debugging: creating debug tree for integrated IDCs for all objects which are in the same file
+  /// \param nameTree name of the output file
+  /// \param filename name of the input file containing all objects
+  static void createDebugTreeForAllCRUs(const char* nameTree, const char* filename);
+
+ private:
+  inline static int sNThreads{1};      ///< number of threads which are used during the calculations
+  std::vector<float> mIDCsUngrouped{}; ///< integrated ungrouped IDC values per pad
+  IDCGroup mIDCsGrouped{};             ///< grouped and averaged IDC values
+  const Sector mSector{};              ///< sector of averaged and grouped IDCs (used for debugging)
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param ulrow ungrouped local row in region
+  /// \param upad ungrouped pad in pad direction
+  unsigned int getUngroupedIndex(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const { return integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()] + Mapper::OFFSETCRULOCAL[mIDCsGrouped.getRegion()][ulrow] + upad; }
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param ugrow ungrouped global row
+  /// \param upad ungrouped pad in pad direction
+  unsigned int getUngroupedIndexGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const { return integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()] + Mapper::OFFSETCRUGLOBAL[ugrow] + upad; }
+
+  /// called from createDebugTreeForAllCRUs()
+  static void createDebugTree(const IDCAverageGroup& idcavg, o2::utils::TreeStreamRedirector& pcstream);
+
+  ClassDefNV(IDCAverageGroup, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
@@ -1,0 +1,124 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCCCDBHelper.h
+/// \brief helper class for accessing IDC0 and IDCDelta from CCDB
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_IDCCCDBHELPER_H_
+#define ALICEO2_TPC_IDCCCDBHELPER_H_
+
+#include "TPCCalibration/IDCContainer.h"
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Rtypes.h"
+
+namespace o2::tpc
+{
+
+/// Usage
+/// o2::tpc::IDCCCDBHelper<short> helper;
+/// helper.setTimeStamp(0);
+/// helper.loadAll();
+/// helper.drawIDCZeroSide(o2::tpc::Side::A);
+/// const unsigned int sector 10;
+/// const unsigned int integrationInterval =3;
+/// helper.drawIDCDeltaSector(sector, 3);
+/// TODO add drawing of 1D-distributions
+
+/// \tparam DataT the data type for the IDCDelta which are stored in the CCDB (short, char, float)
+template <typename DataT = short>
+class IDCCCDBHelper
+{
+ public:
+  /// constructor
+  /// \param uri path to CCDB
+  IDCCCDBHelper(const char* uri = "http://ccdb-test.cern.ch:8080") { mCCDBManager.setURL(uri); }
+
+  /// update timestamp (time frame)
+  void setTimeStamp(const long long timestamp) { mCCDBManager.setTimestamp(timestamp); }
+
+  /// load IDC-Delta, 0D-IDCs, grouping parameter needed for access
+  void loadAll();
+
+  /// load/update IDCDelta
+  void loadIDCDelta() { mIDCDelta = mCCDBManager.get<o2::tpc::IDCDelta<DataT>>("TPC/Calib/IDC/IDCDELTA"); }
+
+  /// load/update 0D-IDCs
+  void loadIDCZero() { mIDCZero = mCCDBManager.get<o2::tpc::IDCZero>("TPC/Calib/IDC/IDC0"); }
+
+  /// load/update grouping parameter
+  void loadGroupingParameter() { mHelperSector = std::make_unique<IDCGroupHelperSector>(IDCGroupHelperSector{*mCCDBManager.get<o2::tpc::ParameterIDCGroupCCDB>("TPC/Calib/IDC/GROUPINGPAR")}); }
+
+  /// \return returns the stored IDC0 value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  float getIDCZeroVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad) const { return mIDCZero->getValueIDCZero(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, 0)); }
+
+  /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param chunk chunk of the Delta IDC (can be obtained with getLocalIntegrationInterval())
+  /// \param localintegrationInterval local integration interval for chunk (can be obtained with getLocalIntegrationInterval())
+  float getIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const { return mIDCDelta->getValue(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, localintegrationInterval)); }
+
+  /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param side side which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCZeroSide(const o2::tpc::Side side, const std::string filename = "IDCZeroSide.pdf") const { drawSide(IDCType::IDCZero, side, 0, filename); }
+
+  /// draw IDCDelta for one side for one integration interval
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSide.pdf") const { drawSide(IDCType::IDCDelta, side, integrationInterval, filename); }
+
+  /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param sector sector which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCZeroSector(const unsigned int sector, const std::string filename = "IDCZeroSector.pdf") const { drawSector(IDCType::IDCZero, sector, 0, filename); }
+
+  /// draw IDCDelta for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSector.pdf") const { drawSector(IDCType::IDCDelta, sector, integrationInterval, filename); }
+
+ private:
+  IDCZero* mIDCZero = nullptr;                                                      ///< 0D-IDCs: ///< I_0(r,\phi) = <I(r,\phi,t)>_t
+  IDCDelta<DataT>* mIDCDelta = nullptr;                                             ///< compressed or uncompressed Delta IDC: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  std::unique_ptr<IDCGroupHelperSector> mHelperSector{};                            ///< helper for accessing IDC0 and IDC-Delta
+  o2::ccdb::BasicCCDBManager mCCDBManager = o2::ccdb::BasicCCDBManager::instance(); ///< CCDB manager for loading objects
+
+  /// draw IDCs for one side for one integration interval
+  /// \param Side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawSide(const IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename) const;
+
+  /// draw IDCs for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename) const;
+
+  /// return returns title for z axis for given IDCType
+  std::string getZAxisTitle(const o2::tpc::IDCType type) const;
+
+  ClassDefNV(IDCCCDBHelper, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
@@ -1,0 +1,320 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCContainer.h
+/// \brief This file provides the structs for storing the factorized IDC values and fourier coefficients to be stored in the CCDB
+///
+/// \author  Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 30, 2021
+
+#ifndef ALICEO2_TPC_IDCCONTAINER_H_
+#define ALICEO2_TPC_IDCCONTAINER_H_
+
+#include <array>
+#include <vector>
+#include <limits>
+#include "DataFormatsTPC/Defs.h"
+#include "TPCCalibration/IDCGroupingParameter.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+/// IDC types
+enum class IDCType { IDC = 0,     ///< integrated and grouped IDCs
+                     IDCZero = 1, ///< IDC0: I_0(r,\phi) = <I(r,\phi,t)>_t
+                     IDCOne = 2,  ///< IDC1: I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+                     IDCDelta = 3 ///< IDCDelta: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+};
+
+/// struct containing the IDC delta values
+template <typename DataT>
+struct IDCDeltaContainer {
+  std::array<std::vector<DataT>, o2::tpc::SIDES> mIDCDelta{}; ///< \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+};
+
+/// storage for the factor used to compress IDCDelta.
+/// This factor is separated from the IDCDelta struct to able to store those values independently in the CCDB
+struct IDCDeltaCompressionFactors {
+  std::array<float, o2::tpc::SIDES> mFactors{1.f, 1.f}; ///< compression factors for each TPC side
+};
+
+/// struct to access and set Delta IDCs
+template <typename DataT>
+struct IDCDelta {
+
+  /// set idcDelta for given index
+  /// \param idcDelta Delta IDC value which will be set
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  void setValue(const float idcDelta, const o2::tpc::Side side, const unsigned int index) { mIDCDelta.mIDCDelta[side][index] = compressValue(idcDelta, side); }
+
+  /// set idcDelta ath the end of storage
+  /// \param idcDelta Delta IDC value which will be set
+  /// \param side side of the TPC
+  void emplace_back(const float idcDelta, const o2::tpc::Side side) { mIDCDelta.mIDCDelta[side].emplace_back(compressValue(idcDelta, side)); }
+
+  /// \return returns converted IDC value from float to new data type specified by template parameter of the object
+  /// \param idcDelta Delta IDC value which will be set
+  /// \param side side of the TPC
+  DataT compressValue(const float idcDelta, const o2::tpc::Side side) const
+  {
+    const static auto& paramIDCGroup = ParameterIDCCompression::Instance();
+    return (std::abs(idcDelta) >= paramIDCGroup.MaxIDCDeltaValue) ? static_cast<DataT>(std::copysign(paramIDCGroup.MaxIDCDeltaValue * mCompressionFactor.mFactors[side] + 0.5f, idcDelta)) : static_cast<DataT>(idcDelta * mCompressionFactor.mFactors[side] + std::copysign(0.5f, idcDelta));
+  }
+
+  /// \return returns stored Delta IDC value
+  /// \param side side of the TPC
+  /// \param index index in the storage (see: getIndexUngrouped int IDCGroupHelperSector)
+  float getValue(const o2::tpc::Side side, const unsigned int index) const { return (static_cast<float>(mIDCDelta.mIDCDelta[side][index]) / mCompressionFactor.mFactors[side]); }
+
+  /// set compression factor
+  /// \param side side of the TPC
+  /// \param factor factor which will be used for the compression
+  void setCompressionFactor(const o2::tpc::Side side, const float factor) { mCompressionFactor.mFactors[side] = factor; }
+
+  /// \return returns vector of Delta IDCs for given side
+  /// \param side side of the TPC
+  const auto& getIDCDelta(const o2::tpc::Side side) const { return mIDCDelta.mIDCDelta[side]; }
+
+  /// \return returns vector of Delta IDCs for given side
+  /// \param side side of the TPC
+  auto& getIDCDelta(const o2::tpc::Side side) { return mIDCDelta.mIDCDelta[side]; }
+
+  /// \return returns compression factors to uncompress Delta IDC
+  const auto& getCompressionFactors() const { return mCompressionFactor; }
+
+  /// \return returns compression factors to uncompress Delta IDC
+  /// \param side side of the TPC
+  auto getCompressionFactor(const o2::tpc::Side side) const { return mCompressionFactor.mFactors[side]; }
+
+  IDCDeltaContainer<DataT> mIDCDelta{};            ///< storage for Delta IDCs
+  IDCDeltaCompressionFactors mCompressionFactor{}; ///< compression factor for Delta IDCs
+};
+
+// template specialization for float as no compression factor is needed in this case
+template <>
+struct IDCDelta<float> {
+  /// set idcDelta for given index
+  /// \param idcDelta Delta IDC value which will be set
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  void setValue(const float idcDelta, const o2::tpc::Side side, const unsigned int index) { mIDCDelta.mIDCDelta[side][index] = idcDelta; }
+
+  /// \return returns stored Delta IDC value
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  float getValue(const o2::tpc::Side side, const unsigned int index) const { return mIDCDelta.mIDCDelta[side][index]; }
+
+  /// \return returns vector of Delta IDCs for given side
+  /// \param side side of the TPC
+  const auto& getIDCDelta(const o2::tpc::Side side) const { return mIDCDelta.mIDCDelta[side]; }
+
+  /// \return returns vector of Delta IDCs for given side
+  /// \param side side of the TPC
+  auto& getIDCDelta(const o2::tpc::Side side) { return mIDCDelta.mIDCDelta[side]; }
+
+  IDCDeltaContainer<float> mIDCDelta{}; ///< storage for uncompressed Delta IDCs
+};
+
+/// helper class to compress Delta IDC values
+/// \tparam template parameter specifying the output format of the compressed IDCDelta
+template <typename DataT>
+class IDCDeltaCompressionHelper
+{
+ public:
+  IDCDeltaCompressionHelper() = default;
+
+  /// static method to get the compressed Delta IDCs from uncompressed Delta IDCs
+  /// \return returns compressed Delta IDC values
+  /// \param idcDeltaUncompressed uncompressed Delta IDC values
+  static IDCDelta<DataT> getCompressedIDCs(const IDCDelta<float>& idcDeltaUncompressed)
+  {
+    IDCDelta<DataT> idcCompressed{};
+    compress(idcDeltaUncompressed, idcCompressed, o2::tpc::Side::A);
+    compress(idcDeltaUncompressed, idcCompressed, o2::tpc::Side::C);
+    return std::move(idcCompressed);
+  }
+
+ private:
+  static void compress(const IDCDelta<float>& idcDeltaUncompressed, IDCDelta<DataT>& idcCompressed, const o2::tpc::Side side)
+  {
+    idcCompressed.getIDCDelta(side).reserve(idcDeltaUncompressed.getIDCDelta(side).size());
+    const float factor = getCompressionFactor(idcDeltaUncompressed, side);
+    idcCompressed.setCompressionFactor(side, factor);
+    for (auto& idc : idcDeltaUncompressed.getIDCDelta(side)) {
+      idcCompressed.emplace_back(idc, side);
+    }
+  }
+
+  /// \return returns the factor which is used during the compression
+  static float getCompressionFactor(const IDCDelta<float>& idcDeltaUncompressed, const o2::tpc::Side side)
+  {
+    const float maxAbsIDC = getMaxValue(idcDeltaUncompressed.getIDCDelta(side));
+    const auto& paramIDCGroup = ParameterIDCCompression::Instance();
+    const float maxIDC = paramIDCGroup.MaxIDCDeltaValue;
+    return (maxAbsIDC > maxIDC || maxAbsIDC == 0) ? (std::numeric_limits<DataT>::max() / maxIDC) : (std::numeric_limits<DataT>::max() / maxAbsIDC);
+  }
+
+  /// \returns returns maximum abs value in vector
+  static float getMaxValue(const std::vector<float>& idcs)
+  {
+    return std::abs(*std::max_element(idcs.begin(), idcs.end(), [](const int a, const int b) -> bool { return (std::abs(a) < std::abs(b)); }));
+  };
+};
+
+///<struct containing the IDC1 values
+struct IDCZero {
+
+  /// set IDC zero for given index
+  /// \param idcZero Delta IDC value which will be set
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  void setValueIDCZero(const float idcZero, const o2::tpc::Side side, const unsigned int index) { mIDCZero[side][index] = idcZero; }
+
+  /// increase IDC zero for given index
+  /// \param idcZero Delta IDC value which will be set
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  void fillValueIDCZero(const float idcZero, const o2::tpc::Side side, const unsigned int index) { mIDCZero[side][index] += idcZero; }
+
+  /// \return returns stored IDC zero value
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  float getValueIDCZero(const o2::tpc::Side side, const unsigned int index) const { return mIDCZero[side][index]; }
+
+  std::array<std::vector<float>, o2::tpc::SIDES> mIDCZero{}; ///< I_0(r,\phi) = <I(r,\phi,t)>_t
+};
+
+///<struct containing the IDC0
+struct IDCOne {
+  /// set IDC one for given index
+  /// \param idcOne Delta IDC value which will be set
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  void setValueIDCOne(const float idcOne, const o2::tpc::Side side, const unsigned int index) { mIDCOne[side][index] = idcOne; }
+
+  /// \return returns stored IDC one value
+  /// \param side side of the TPC
+  /// \param index index in the storage
+  float getValueIDCOne(const o2::tpc::Side side, const unsigned int index) const { return mIDCOne[side][index]; }
+
+  std::array<std::vector<float>, o2::tpc::SIDES> mIDCOne{}; ///< I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+};
+
+/// struct containing 1D-IDCs
+struct OneDIDC {
+
+  /// default constructor
+  OneDIDC() = default;
+
+  /// constructor for initializing member with default value (this is used in the IDCFourierTransform class to perform calculation of the fourier coefficients for the first aggregation interval)
+  /// \param nIDC number of IDCs which will be initialized
+  OneDIDC(const unsigned int nIDC) : mOneDIDC{std::vector<float>(nIDC), std::vector<float>(nIDC)} {};
+
+  /// \return returns total number of 1D-IDCs for given side
+  /// \param side side of the TPC
+  unsigned int getNIDCs(const o2::tpc::Side side) const { return mOneDIDC[side].size(); }
+
+  std::array<std::vector<float>, o2::tpc::SIDES> mOneDIDC{}; ///< 1D-IDCs = <I(r,\phi,t)>_{r,\phi}
+};
+
+/// Helper class for aggregation of 1D-IDCs from different CRUs
+class OneDIDCAggregator
+{
+ public:
+  /// constructor
+  /// nTimeFrames number of time frames which will be aggregated
+  OneDIDCAggregator(const unsigned int nTimeFrames = 1) : mOneDIDCAgg(nTimeFrames), mWeight(nTimeFrames){};
+
+  /// aggregate 1D-IDCs
+  /// \param side side of the tpcCRUHeader
+  /// \param idc vector containing the 1D-IDCs
+  /// \param timeframe of the input 1D-IDC
+  /// \param region region of the TPC
+  void aggregate1DIDCs(const o2::tpc::Side side, const std::vector<float>& idc, const unsigned int timeframe, const unsigned int region)
+  {
+    if (mOneDIDCAgg[timeframe].mOneDIDC[side].empty()) {
+      mOneDIDCAgg[timeframe].mOneDIDC[side] = idc;
+      mWeight[timeframe][side] = Mapper::REGIONAREA[region];
+    } else {
+      std::transform(mOneDIDCAgg[timeframe].mOneDIDC[side].begin(), mOneDIDCAgg[timeframe].mOneDIDC[side].end(), idc.begin(), mOneDIDCAgg[timeframe].mOneDIDC[side].begin(), std::plus<>());
+      mWeight[timeframe][side] += Mapper::REGIONAREA[region];
+    }
+  }
+
+  /// \return returns struct containing aggregated 1D IDCs normalized to number of channels weighted with the relative length of each region
+  OneDIDC getAggregated1DIDCs()
+  {
+    OneDIDC oneDIDCTmp;
+    for (int iside = 0; iside < o2::tpc::SIDES; ++iside) {
+      const o2::tpc::Side side = iside == 0 ? o2::tpc::Side::A : o2::tpc::Side::C;
+      for (unsigned int i = 0; i < mOneDIDCAgg.size(); ++i) {
+        std::transform(mOneDIDCAgg[i].mOneDIDC[side].begin(), mOneDIDCAgg[i].mOneDIDC[side].end(), mOneDIDCAgg[i].mOneDIDC[side].begin(), [norm = mWeight[i][side]](auto& val) { return val / norm; });
+        oneDIDCTmp.mOneDIDC[side].insert(oneDIDCTmp.mOneDIDC[side].end(), mOneDIDCAgg[i].mOneDIDC[side].begin(), mOneDIDCAgg[i].mOneDIDC[side].end());
+        mOneDIDCAgg[i].mOneDIDC[side].clear();
+      }
+    }
+    return oneDIDCTmp;
+  }
+
+  auto get() { return mOneDIDCAgg; }
+
+ private:
+  std::vector<OneDIDC> mOneDIDCAgg{};                       ///< 1D-IDCs = <I(r,\phi,t)>_{r,\phi}
+  std::vector<std::array<float, o2::tpc::SIDES>> mWeight{}; ///< integrated pad area of received data used for normalization
+};
+
+/// struct containing the fourier coefficients calculated from IDC0 for n timeframes
+struct FourierCoeff {
+  /// constructor
+  /// \param nTimeFrames number of time frames
+  /// \param nCoeff number of real/imag fourier coefficients which will be stored
+  FourierCoeff(const unsigned int nTimeFrames, const unsigned int nCoeff)
+    : mFourierCoefficients{{std::vector<float>(nTimeFrames * nCoeff), std::vector<float>(nTimeFrames * nCoeff)}}, mCoeffPerTF{nCoeff} {};
+
+  /// default constructor for ROOT I/O
+  FourierCoeff() = default;
+
+  /// \return returns total number of stored coefficients for given side and real/complex type
+  /// \param side side
+  unsigned long getNCoefficients(const o2::tpc::Side side) const { return mFourierCoefficients[side].size(); }
+
+  /// \return returns number of stored coefficients for TF
+  unsigned int getNCoefficientsPerTF() const { return mCoeffPerTF; }
+
+  /// \return returns all stored coefficients for given side and real/complex type
+  /// \param side side
+  const auto& getFourierCoefficients(const o2::tpc::Side side) const { return mFourierCoefficients[side]; }
+
+  /// \return returns index to fourier coefficient
+  /// \param interval index of interval
+  /// \param coefficient index of coefficient
+  unsigned int getIndex(const unsigned int interval, const unsigned int coefficient) const { return interval * mCoeffPerTF + coefficient; }
+
+  /// \return returns the stored value
+  /// \param side side of the TPC
+  /// \param index index of the data
+  float operator()(const o2::tpc::Side side, unsigned int index) const { return mFourierCoefficients[side][index]; }
+
+  /// \return returns the stored value
+  /// \param side side of the TPC
+  /// \param index index of the data
+  float& operator()(const o2::tpc::Side side, unsigned int index) { return mFourierCoefficients[side][index]; }
+
+  std::array<std::vector<float>, o2::tpc::SIDES> mFourierCoefficients{}; ///< fourier coefficients. side -> coefficient real and complex parameters are stored alternating
+  const unsigned int mCoeffPerTF{};                                      ///< number of real+imag coefficients per TF
+};
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -1,0 +1,265 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCFactorization.h
+/// \brief class for aggregating IDCs for the full TPC (all sectors) and factorization of aggregated IDCs
+///
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 30, 2021
+
+#ifndef ALICEO2_IDCFACTORIZATION_H_
+#define ALICEO2_IDCFACTORIZATION_H_
+
+#include <vector>
+#include "Rtypes.h"
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/IDCContainer.h"
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "DataFormatsTPC/Defs.h"
+
+#if (defined(WITH_OPENMP) || defined(_OPENMP)) && !defined(__CLING__)
+#include <omp.h>
+#endif
+
+namespace o2::tpc
+{
+
+/// IDC Delta IDC Compression types
+enum class IDCDeltaCompression { NO = 0,     ///< no compression using floats
+                                 MEDIUM = 1, ///< medium compression using short (data compression ratio 2 when stored in CCDB)
+                                 HIGH = 2    ///< high compression using char (data compression ratio ~5.5 when stored in CCDB)
+};
+
+class IDCFactorization : public IDCGroupHelperSector
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped for all regions
+  /// \param groupRows number of pads in row direction which will be grouped for all regions
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction for all regions
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction for all regions
+  /// \param timeFrames number of time frames which will be stored
+  /// \param timeframesDeltaIDC number of time frames stored for each DeltaIDC object
+  IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC);
+
+  /// default constructor for ROOT I/O
+  IDCFactorization() = default;
+
+  /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// calculate I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+  /// calculate \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  void factorizeIDCs();
+
+  /// \return returns the stored grouped and integrated IDC
+  /// \param sector sector
+  /// \param region region
+  /// \param grow row in the region of the grouped IDCs
+  /// \param gpad pad number of the grouped IDCs
+  /// \param integrationInterval integration interval
+  float getIDCValGrouped(const unsigned int sector, const unsigned int region, const unsigned int grow, unsigned int gpad, unsigned int integrationInterval) const { return mIDCs[sector * Mapper::NREGIONS + region][integrationInterval][mOffsRow[region][grow] + gpad]; }
+
+  /// \return returns the stored value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getIDCValUngrouped(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const;
+
+  /// \return returns the stored IDC0 value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  float getIDCZeroVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad) const { return mIDCZero.getValueIDCZero(Sector(sector).side(), getIndexUngrouped(sector, region, urow, upad, 0)); }
+
+  /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param chunk chunk of the Delta IDC (can be obtained with getLocalIntegrationInterval())
+  /// \param localintegrationInterval local integration interval for chunk (can be obtained with getLocalIntegrationInterval())
+  float getIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int chunk, unsigned int localintegrationInterval) const { return mIDCDelta[chunk].getValue(Sector(sector).side(), getIndexUngrouped(sector, region, urow, upad, localintegrationInterval)); }
+
+  /// \return returns index of integration interval in the chunk from global integration interval
+  /// \param region TPC region
+  /// \param integrationInterval integration interval
+  /// \param chunk which will be set in the function
+  /// \param localintegrationInterval local integration interval for chunk which will be set in the function
+  void getLocalIntegrationInterval(const unsigned int region, const unsigned int integrationInterval, unsigned int& chunk, unsigned int& localintegrationInterval) const;
+
+  /// \return returns number of timeframes for which the IDCs are stored
+  unsigned int getNTimeframes() const { return mTimeFrames; }
+
+  /// \return returns the number of stored integration intervals for given Delta IDC chunk
+  /// \param chunk chunk of Delta IDC
+  unsigned long getNIntegrationIntervals(const unsigned int chunk) const;
+
+  /// \return returns the total number of stored integration intervals
+  unsigned long getNIntegrationIntervals() const;
+
+  /// \return returns stored IDC0 I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param side TPC side
+  const std::vector<float>& getIDCZero(const o2::tpc::Side side) const { return mIDCZero.mIDCZero[side]; }
+
+  /// \return returns stored IDC1 I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+  /// \param side TPC side
+  const std::vector<float>& getIDCOne(const o2::tpc::Side side) const { return mIDCOne.mIDCOne[side]; }
+
+  /// \return returns stored IDCDelta \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  /// \param side TPC side
+  /// \param chunk chunk of Delta IDC
+  const std::vector<float>& getIDCDeltaUncompressed(const o2::tpc::Side side, const unsigned int chunk) const { return mIDCDelta[chunk].getIDCDelta(side); }
+
+  /// \return returns stored IDCDelta \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  /// \param chunk chunk of Delta IDC
+  const auto& getIDCDeltaUncompressed(const unsigned int chunk) const { return mIDCDelta[chunk]; }
+
+  /// \return creates and returns medium compressed IDCDelta \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  /// \param chunk chunk of Delta IDC
+  auto getIDCDeltaMediumCompressed(const unsigned int chunk) const { return IDCDeltaCompressionHelper<short>::getCompressedIDCs(mIDCDelta[chunk]); }
+
+  /// \return creates and returns high compressed IDCDelta \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  /// \param chunk chunk of Delta IDC
+  auto getIDCDeltaHighCompressed(const unsigned int chunk) const { return IDCDeltaCompressionHelper<char>::getCompressedIDCs(mIDCDelta[chunk]); }
+
+  /// \return returns number of chunks for Delta IDCs
+  unsigned int getNChunks() const { return mIDCDelta.size(); }
+
+  /// \return returns struct containing IDC0
+  const auto& getIDCZero() const { return mIDCZero; }
+
+  /// \return returns struct containing IDC1
+  const auto& getIDCOne() const& { return mIDCOne; }
+
+  /// \return returns struct containing IDC1 using move semantics
+  auto getIDCOne() && { return std::move(mIDCOne); }
+
+  /// \return returns grouped IDCs
+  const auto& getIDCs() const { return mIDCs; }
+
+  // get number of TFs in which the DeltaIDCs are split/stored
+  unsigned int getTimeFramesDeltaIDC() const { return mTimeFramesDeltaIDC; }
+
+  /// \return returns the number of threads used for some of the calculations
+  static int getNThreads() { return sNThreads; }
+
+  /// set the IDC data
+  /// \param idcs vector containing the IDCs
+  /// \param cru CRU
+  /// \param timeframe time frame of the IDCs
+  void setIDCs(std::vector<float>&& idcs, const unsigned int cru, const unsigned int timeframe) { mIDCs[cru][timeframe] = std::move(idcs); }
+
+  /// set the number of threads used for some of the calculations
+  /// \param nThreads number of threads
+  static void setNThreads(const int nThreads) { sNThreads = nThreads; }
+
+  /// \param maxIDCDeltaValue maximum IDC delta value for compressed IDC delta
+  static void setMaxCompressedIDCDelta(const float maxIDCDeltaValue) { o2::conf::ConfigurableParam::setValue<float>("TPCIDCCompressionParam", "MaxIDCDeltaValue", maxIDCDeltaValue); }
+
+  /// draw IDCs for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCsSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCsSector.pdf") const { drawSector(IDCType::IDC, sector, integrationInterval, filename); }
+
+  /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param sector sector which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCZeroSector(const unsigned int sector, const std::string filename = "IDCZeroSector.pdf") const { drawSector(IDCType::IDCZero, sector, 0, filename); }
+
+  /// draw IDCDelta for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param compression compression of Delta IDCs. (setMaxCompressedIDCDelta() should be called first in case of non standard compression parameter)
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename = "IDCDeltaSector.pdf") const { drawSector(IDCType::IDCDelta, sector, integrationInterval, filename, compression); }
+
+  /// draw IDCs for one side for one integration interval
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCsSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCsSide.pdf") const { drawSide(IDCType::IDC, side, integrationInterval, filename); }
+
+  /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param side side which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCZeroSide(const o2::tpc::Side side, const std::string filename = "IDCZeroSide.pdf") const { drawSide(IDCType::IDCZero, side, 0, filename); }
+
+  /// draw IDCDelta for one side for one integration interval
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param compression compression of Delta IDCs. (setMaxCompressedIDCDelta() should be called first in case of non standard compression parameter)
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename = "IDCDeltaSide.pdf") const { drawSide(IDCType::IDCDelta, side, integrationInterval, filename, compression); }
+
+  /// dump object to disc
+  /// \param outFileName name of the output file
+  /// \param outName name of the object in the output file
+  void dumpToFile(const char* outFileName = "IDCFactorized.root", const char* outName = "IDCFactorized") const;
+
+  /// \param integrationIntervals number of integration intervals which will be dumped to the tree (-1: all integration intervalls)
+  void dumpToTree(int integrationIntervals = -1) const;
+
+  /// \returns vector containing the number of integration intervals for each stored TF
+  std::vector<unsigned int> getIntegrationIntervalsPerTF(const unsigned int region = 0) const;
+
+  /// resetting aggregated IDCs
+  void reset();
+
+ private:
+  const unsigned int mTimeFrames{};                                 ///< number of timeframes which are stored
+  const unsigned int mTimeFramesDeltaIDC{};                         ///< number of timeframes of which Delta IDCs are stored
+  std::array<std::vector<std::vector<float>>, CRU::MaxCRU> mIDCs{}; ///< grouped and integrated IDCs for the whole TPC. CRU -> time frame -> IDCs
+  IDCZero mIDCZero{};                                               ///< I_0(r,\phi) = <I(r,\phi,t)>_t
+  IDCOne mIDCOne{};                                                 ///< I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+  std::vector<IDCDelta<float>> mIDCDelta{};                         ///< uncompressed: chunk -> Delta IDC: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  inline static int sNThreads{1};                                   ///< number of threads which are used during the calculations
+
+  /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
+  void calcIDCZero();
+
+  /// calculate I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
+  void calcIDCOne();
+
+  /// calculate \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  void calcIDCDelta();
+
+  /// draw IDCs for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression = IDCDeltaCompression::NO) const;
+
+  /// draw IDCs for one side for one integration interval
+  /// \param Side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawSide(const IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression = IDCDeltaCompression::NO) const;
+
+  /// get z axis title for given IDC type and compression type
+  std::string getZAxisTitle(const IDCType type, const IDCDeltaCompression compression) const;
+
+  /// get time frame and index of integrationInterval in the TF
+  void getTF(const unsigned int region, unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const;
+
+  /// \returns chunk from timeframe
+  unsigned int getChunk(const unsigned int timeframe) const;
+
+  /// \return returns number of TFs for given chunk
+  unsigned int getNTFsPerChunk(const unsigned int chunk) const;
+
+  ClassDefNV(IDCFactorization, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFourierTransform.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFourierTransform.h
@@ -1,0 +1,159 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCFourierTransform.h
+/// \brief class for calculating the fourier coefficients from 1D-IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date May 11, 2021
+
+#ifndef ALICEO2_IDCFOURIERTRANSFORM_H_
+#define ALICEO2_IDCFOURIERTRANSFORM_H_
+
+#include <vector>
+#include "Rtypes.h"
+#include "DataFormatsTPC/Defs.h"
+#include "TPCCalibration/IDCContainer.h"
+
+namespace o2::tpc
+{
+
+/// class for fourier transform of 1D-IDCs
+/// For example usage see testO2TPCIDCFourierTransform.cxx
+
+class IDCFourierTransform
+{
+ public:
+  /// contructor
+  /// \param rangeIDC number of IDCs for each interval which will be used to calculate the fourier coefficients
+  /// \param timeFrames number of time frames which will be stored
+  /// \param nFourierCoefficientsStore number of courier coefficients (real+imag) which will be stored (the maximum can be 'rangeIDC + 2', should be an even number when using naive FT). If less than maximum is setn the inverse fourier transform will not work.
+  IDCFourierTransform(const unsigned int rangeIDC = 200, const unsigned int timeFrames = 2000, const unsigned int nFourierCoefficientsStore = 200 + 2) : mRangeIDC{rangeIDC}, mTimeFrames{timeFrames}, mFourierCoefficients{mTimeFrames, nFourierCoefficientsStore} {};
+
+  /// set input 1D-IDCs which are used to calculate fourier coefficients
+  /// \param oneDIDCs 1D-IDCs
+  /// \param integrationIntervalsPerTF vector containg for each TF the number of IDCs
+  void setIDCs(OneDIDC&& oneDIDCs, std::vector<unsigned int>&& integrationIntervalsPerTF);
+
+  /// set input 1D-IDCs which are used to calculate fourier coefficients
+  /// \param oneDIDCs 1D-IDCs
+  /// \param integrationIntervalsPerTF vector containg for each TF the number of IDCs
+  void setIDCs(const OneDIDC& oneDIDCs, const std::vector<unsigned int>& integrationIntervalsPerTF);
+
+  /// set fast fourier transform using FFTW3
+  /// \param fft use FFTW3 or not (naive approach)
+  static void setFFT(const bool fft) { sFftw = fft; }
+
+  /// \param nThreads set the number of threads used for calculation of the fourier coefficients
+  static void setNThreads(const int nThreads) { sNThreads = nThreads; }
+
+  /// calculate fourier coefficients
+  void calcFourierCoefficients() { sFftw ? calcFourierCoefficientsFFTW3() : calcFourierCoefficientsNaive(); }
+
+  /// get IDC0 values from the inverse fourier transform. Can be used for debugging. std::vector<std::vector<float>>: first vector interval second vector IDC0 values
+  /// \param side TPC side
+  std::vector<std::vector<float>> inverseFourierTransform(const o2::tpc::Side side) const { return sFftw ? inverseFourierTransformFFTW3(side) : inverseFourierTransformNaive(side); }
+
+  /// \return returns number of IDCs for each interval which will be used to calculate the fourier coefficients
+  unsigned int getrangeIDC() const { return mRangeIDC; }
+
+  /// \return returns number of 1D-IDCs
+  /// \param side TPC side
+  unsigned long getNIDCs(const o2::tpc::Side side) const { return mOneDIDC[!mBufferIndex].mOneDIDC[side].size(); }
+
+  /// \return returns number of time frames for which the coefficients are obtained
+  unsigned int getNIntervals() const { return mTimeFrames; }
+
+  /// \return returns struct holding all fourier coefficients
+  const auto& getFourierCoefficients() const { return mFourierCoefficients; }
+
+  /// \return returns struct of stored 1D-IDC
+  const OneDIDC& getOneDIDC() const { return mOneDIDC[!mBufferIndex]; }
+
+  /// \return returns indices used for accessing correct IDCs for given TF
+  std::vector<unsigned int> getLastIntervals() const;
+
+  /// copy over IDCs from buffer to current IDCOne vector for easier access
+  /// \return returns expanded 1D-IDC vector
+  /// \param side TPC side
+  std::vector<float> getExpandedIDCOne(const o2::tpc::Side side) const;
+
+  /// get type of used fourier transform
+  static bool getFFT() { return sFftw; }
+
+  /// get the number of threads used for calculation of the fourier coefficients
+  static int getNThreads() { return sNThreads; }
+
+  /// dump object to disc
+  /// \param outFileName name of the output file
+  /// \param outName name of the object in the output file
+  void dumpToFile(const char* outFileName = "Fourier.root", const char* outName = "FourierCoefficients") const;
+
+  /// create debug tree
+  /// \param outFileName name of the output tree
+  void dumpToTree(const char* outFileName = "FourierTree.root") const;
+
+ private:
+  const unsigned int mRangeIDC{};                                          ///< number of IDCs used for the calculation of fourier coefficients
+  const unsigned int mTimeFrames{};                                        ///< number of timeframes which for which teh fourier coefficients are stored
+  FourierCoeff mFourierCoefficients;                                       ///< fourier coefficients. side -> interval -> coefficient
+  std::array<OneDIDC, 2> mOneDIDC{OneDIDC(mRangeIDC), OneDIDC(mRangeIDC)}; ///< all 1D-IDCs which are used to calculate the fourier coefficients. A buffer for the last aggregation interval is used to calculate the fourier coefficients for the first TFs
+  std::array<std::vector<unsigned int>, 2> mIntegrationIntervalsPerTF{};   ///< number of integration intervals per TF used to set the correct range of IDCs. A buffer is needed for the last aggregation interval.
+  bool mBufferIndex{true};                                                 ///< index for the buffer
+  inline static int sFftw{1};                                              ///< using fftw or naive approach for calculation of fourier coefficients
+  inline static int sNThreads{1};                                          ///< number of threads which are used during the calculation of the fourier coefficients
+
+  /// calculate fourier coefficients
+  void calcFourierCoefficientsNaive();
+
+  /// calculate fourier coefficients
+  /// \param side TPC side
+  /// \param offsetIndex for accessing index obtained from getLastIntervals()
+  void calcFourierCoefficientsNaive(const o2::tpc::Side side, const std::vector<unsigned int>& offsetIndex);
+
+  /// calculate fourier coefficients
+  void calcFourierCoefficientsFFTW3();
+
+  /// calculate fourier coefficients using FFTW3 package
+  /// get IDC0 values from the inverse fourier transform. Can be used for debugging. std::vector<std::vector<float>>: first vector interval second vector IDC0 values
+  /// \param side TPC side
+  /// \param offsetIndex for accessing index obtained from getLastIntervals()
+  void calcFourierCoefficientsFFTW3(const o2::tpc::Side side, const std::vector<unsigned int>& offsetIndex);
+
+  /// get IDC0 values from the inverse fourier transform. Can be used for debugging. std::vector<std::vector<float>>: first vector interval second vector IDC0 values
+  /// \param side TPC side
+  std::vector<std::vector<float>> inverseFourierTransformNaive(const o2::tpc::Side side) const;
+
+  /// get IDC0 values from the inverse fourier transform using FFTW3. Can be used for debugging. std::vector<std::vector<float>>: first vector interval second vector IDC0 values
+  /// \param side TPC side
+  std::vector<std::vector<float>> inverseFourierTransformFFTW3(const o2::tpc::Side side) const;
+
+  /// copy over IDCs from buffer to current IDCOne vector for easier access using fftwf_alloc_real for possibly/forcing SIMD (?) http://www.fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html
+  /// \param side TPC side
+  /// \param val1DIDCs 1D-IDCs which are allocated using fftwf_alloc_real
+  float* getExpandedIDCOneFFTW(const o2::tpc::Side side) const;
+
+  /// divide coefficients by number of IDCs used
+  void normalizeCoefficients(const o2::tpc::Side side)
+  {
+    std::transform(mFourierCoefficients.mFourierCoefficients[side].begin(), mFourierCoefficients.mFourierCoefficients[side].end(), mFourierCoefficients.mFourierCoefficients[side].begin(), [norm = mRangeIDC](auto& val) { return val / norm; });
+  };
+
+  /// returns whether the buffer has to be used
+  bool useLastBuffer() const { return (mRangeIDC > mIntegrationIntervalsPerTF[!mBufferIndex][0]); }
+
+  /// \return returns maximum numbers of stored real/imag fourier coeffiecients
+  unsigned int getNMaxCoefficients() const { return mRangeIDC / 2 + 1; }
+
+  ClassDefNV(IDCFourierTransform, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
@@ -1,0 +1,105 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCGroup.h
+/// \brief class for storing grouped IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_IDCGROUP_H_
+#define ALICEO2_TPC_IDCGROUP_H_
+
+#include <vector>
+#include "Rtypes.h"
+#include "TPCCalibration/IDCGroupHelperRegion.h"
+
+namespace o2::tpc
+{
+
+/// Class to hold grouped IDC values for one CRU for one TF
+
+class IDCGroup : public IDCGroupHelperRegion
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param region region of the TPC
+  IDCGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0)
+    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mIDCsGrouped(getNIDCsPerIntegrationInterval()){};
+
+  /// extend the size of the grouped and averaged IDC values corresponding to the number of integration intervals. This has to be called befor filling values!
+  /// without using this function the object can hold only one integration interval
+  /// \param nIntegrationIntervals number of ontegration intervals for which teh IDCs are stored
+  void resize(const unsigned int nIntegrationIntervals) { mIDCsGrouped.resize(getNIDCsPerIntegrationInterval() * nIntegrationIntervals); }
+
+  /// \return returns the stored value
+  /// \param glrow local row of the grouped IDCs
+  /// \param pad pad number of the grouped IDCs
+  /// \param integrationInterval integration interval
+  float operator()(unsigned int glrow, unsigned int pad, unsigned int integrationInterval) const { return mIDCsGrouped[getIndex(glrow, pad, integrationInterval)]; }
+
+  /// \return returns the stored value
+  /// \param glrow local row of the grouped IDCs
+  /// \param pad pad number of the grouped IDCs
+  /// \param integrationInterval integration interval
+  float& operator()(unsigned int glrow, unsigned int pad, unsigned int integrationInterval) { return mIDCsGrouped[getIndex(glrow, pad, integrationInterval)]; }
+
+  /// \return returns the stored value for local ungrouped pad row and ungrouped pad
+  /// \param ulrow local row in region of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float& setValUngrouped(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) { return mIDCsGrouped[getIndexUngrouped(ulrow, upad, integrationInterval)]; }
+
+  /// \return returns the stored value for local ungrouped pad row and ungrouped pad
+  /// \param ulrow local row in region of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getValUngrouped(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped[getIndexUngrouped(ulrow, upad, integrationInterval)]; }
+
+  /// \return returns the stored value for local ungrouped pad row and ungrouped pad
+  /// \param ugrow global row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getValUngroupedGlobal(unsigned int ugrow, unsigned int upad, unsigned int integrationInterval) const;
+
+  /// \return returns grouped and averaged IDC values
+  const auto& getData() const { return mIDCsGrouped; }
+
+  /// \return returns number of stored integration intervals
+  unsigned int getNIntegrationIntervals() const { return mIDCsGrouped.size() / getNIDCsPerIntegrationInterval(); }
+
+  /// dump the IDCs to a tree
+  /// \param outname name of the output file
+  void dumpToTree(const char* outname = "IDCGroup.root") const;
+
+  /// dump object to disc
+  /// \param outFileName name of the output file
+  /// \param outName name of the object in the output file
+  void dumpToFile(const char* outFileName = "IDCGroup.root", const char* outName = "IDCGroup") const;
+
+  /// draw grouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void draw(const unsigned int integrationInterval = 0, const std::string filename = "IDCsGrouped.pdf") const;
+
+  /// calculate and return 1D-IDCs for this CRU
+  std::vector<float> get1DIDCs() const;
+
+ private:
+  std::vector<float> mIDCsGrouped{}; ///< grouped and averaged IDC values for n integration intervals for one CRU
+
+  ClassDefNV(IDCGroup, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperRegion.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperRegion.h
@@ -1,0 +1,148 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCGroupHelperRegion.h
+/// \brief helper class for grouping of pads and rows for one region
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_IDCGROUPHELPERREGION_H_
+#define ALICEO2_TPC_IDCGROUPHELPERREGION_H_
+
+#include <vector>
+#include "Rtypes.h"
+
+namespace o2::tpc
+{
+
+/// Helper class for accessing grouped pads for one region
+
+class IDCGroupHelperRegion
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param region region of the TPC
+  IDCGroupHelperRegion(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0)
+    : mGroupPads{groupPads}, mGroupRows{groupRows}, mGroupLastRowsThreshold{groupLastRowsThreshold}, mGroupLastPadsThreshold{groupLastPadsThreshold}, mRegion{region}
+  {
+    initIDCGroupHelperRegion();
+  }
+
+  /// \return returns number of grouped rows
+  unsigned int getNRows() const { return mRows; }
+
+  /// \return returns number of grouped pads
+  /// \param row grouped local row
+  unsigned int getPadsPerRow(const unsigned int glrow) const { return mPadsPerRow[glrow]; }
+
+  /// \return returns number of grouped pads for all rows
+  const std::vector<unsigned int>& getPadsPerRow() const { return mPadsPerRow; }
+
+  /// \return returns offsets for rows to calculate data index
+  const std::vector<unsigned int>& getRowOffset() const { return mOffsRow; }
+
+  /// \return returns the number of pads in pad direction which are grouped
+  unsigned int getGroupPads() const { return mGroupPads; }
+
+  /// \return returns the number of pads in row direction which are grouped
+  unsigned int getGroupRows() const { return mGroupRows; }
+
+  /// \return returns threshold for grouping the last group in row direction
+  unsigned int getGroupLastRowsThreshold() const { return mGroupLastRowsThreshold; }
+
+  /// \return returns threshold for grouping the last group in pad direction
+  unsigned int getGroupLastPadsThreshold() const { return mGroupLastPadsThreshold; }
+
+  /// \return returns the region for which the IDCs are stored
+  unsigned int getRegion() const { return mRegion; }
+
+  /// \returns returns number of IDCS per integration interval
+  unsigned int getNIDCsPerIntegrationInterval() const { return mNIDCsPerCRU; }
+
+  /// \return returns the row of the group from the local ungrouped row in a region
+  /// \param ulrow local ungrouped row in a region
+  /// \param groupRows grouping parameter for number of pads in row direction which are grouped
+  /// \param groupedrows number of grouped rows
+  static unsigned int getGroupedRow(const unsigned int ulrow, const unsigned int groupRows, const unsigned int groupedrows);
+
+  /// \return returns the row of the group from the local ungrouped row in a region
+  /// \param ulrow local ungrouped row in a region
+  unsigned int getGroupedRow(const unsigned int ulrow) const { return getGroupedRow(ulrow, mGroupRows, mRows); }
+
+  /// \return returns the grouped pad index from ungrouped pad and row
+  /// \param upad ungrouped pad
+  /// \param ulrow local ungrouped row in a region
+  /// \param region region
+  /// \param groupPads grouping parameter for number of pads in pad direction which are grouped
+  /// \param groupRows grouping parameter for number of pads in row direction which are grouped
+  /// \param groupedrows number of grouped rows
+  /// \param padsPerRow vector containing the number of pads per row
+  static unsigned int getGroupedPad(const unsigned int upad, const unsigned int ulrow, const unsigned int region, const unsigned int groupPads, const unsigned int groupRows, const unsigned int groupedrows, const std::vector<unsigned int>& padsPerRow);
+
+  /// \return returns the grouped pad index from ungrouped pad and row
+  /// \param pad ungrouped pad
+  /// \param lrow local ungrouped row in a region
+  unsigned int getGroupedPad(const unsigned int pad, const unsigned int ulrow) const { return getGroupedPad(pad, ulrow, mRegion, mGroupPads, mGroupRows, mRows, mPadsPerRow); };
+
+  /// \return returns index to the data
+  /// \param row local row of the grouped IDCs
+  /// \param pad pad of the grouped IDCs
+  /// \param integrationInterval integration interval
+  unsigned int getIndex(const unsigned int glrow, const unsigned int pad, unsigned int integrationInterval) const { return mNIDCsPerCRU * integrationInterval + mOffsRow[glrow] + pad; }
+
+  /// \return returns index to the data
+  /// \param urow local ungrouped row
+  /// \param upad ungrouped pad
+  /// \param integrationInterval integration interval
+  unsigned int getIndexUngrouped(const unsigned int ulrow, const unsigned int upad, unsigned int integrationInterval) const { return getIndex(getGroupedRow(ulrow), getGroupedPad(upad, ulrow), integrationInterval); }
+
+  /// \return returns the global pad number for given local pad row and pad
+  /// \param ulrow local ungrouped row in a region
+  /// \param pad ungrouped pad in row
+  unsigned int getGlobalPadNumber(const unsigned int ulrow, const unsigned int pad) const;
+
+  /// \return returns last ungrouped row
+  unsigned int getLastRow() const;
+
+  /// \return returns last ungrouped pad for given global row
+  /// \param row local ungrouped row
+  unsigned int getLastPad(const unsigned int ulrow) const;
+
+  /// dump object to disc
+  /// \param outFileName name of the output file
+  /// \param outName name of the object in the output file
+  void dumpToFile(const char* outFileName = "IDCGroupHelperRegion.root", const char* outName = "IDCGroupHelperRegion") const;
+
+ protected:
+  const unsigned char mGroupPads{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  const unsigned char mGroupRows{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  const unsigned char mGroupLastRowsThreshold{}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
+  const unsigned char mGroupLastPadsThreshold{}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+  const unsigned int mRegion{};                  ///< region of input IDCs
+  unsigned int mNIDCsPerCRU{};                   ///< total number of IDCs per CRU per integration interval
+  unsigned int mRows{};                          ///< number of grouped rows
+  std::vector<unsigned int> mPadsPerRow{};       ///< number of grouped pads per grouped row
+  std::vector<unsigned int> mOffsRow{};          ///< offset to calculate the index in the data from grouped row and grouped pad
+
+  /// set number of grouped rows
+  void setRows(const unsigned int nRows);
+
+  /// initialize members
+  void initIDCGroupHelperRegion();
+
+  ClassDefNV(IDCGroupHelperRegion, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCGroupHelperSector.h
+/// \brief helper class for grouping of pads and rows for one sector
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_IDCGROUPHELPERSECTOR_H_
+#define ALICEO2_TPC_IDCGROUPHELPERSECTOR_H_
+
+#include <vector>
+#include <numeric>
+#include "Rtypes.h"
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/IDCGroupHelperRegion.h"
+#include "TPCCalibration/IDCGroupingParameter.h"
+
+namespace o2::tpc
+{
+
+/// Helper class for accessing grouped pads for one sector
+
+class IDCGroupHelperSector
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  IDCGroupHelperSector(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold)
+    : mGroupingPar{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold} { initIDCGroupHelperSector(); };
+
+  /// constructor
+  /// \param groupingParameter struct holding the grouping parameter
+  IDCGroupHelperSector(const ParameterIDCGroupCCDB& groupingParameter) : mGroupingPar{groupingParameter} { initIDCGroupHelperSector(); };
+
+  /// default constructor for ROOT I/O
+  IDCGroupHelperSector() = default;
+
+  /// \return returns index to the data
+  /// \param glrow grouped local row
+  /// \param pad pad of the grouped IDCs
+  unsigned int getIndexGrouped(const unsigned int sector, const unsigned int region, const unsigned int glrow, const unsigned int pad, unsigned int integrationInterval) const { return mNIDCsPerSector * (integrationInterval * SECTORSPERSIDE + sector) + mRegionOffs[region] + mOffsRow[region][glrow] + pad; }
+
+  /// \return returns the index to the grouped data with ungrouped inputs
+  /// \param sector sector
+  /// \param region TPC region
+  /// \param ulrow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  unsigned int getIndexUngrouped(const unsigned int sector, const unsigned int region, unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexGrouped(sector % o2::tpc::SECTORSPERSIDE, region, getGroupedRow(region, ulrow), getGroupedPad(region, ulrow, upad), integrationInterval); }
+
+  /// \return returns grouped pad for ungrouped row and pad
+  /// \param region region
+  /// \param ulrow local ungrouped row in a region
+  /// \param upad ungrouped pad
+  unsigned int getGroupedPad(const unsigned int region, unsigned int ulrow, unsigned int upad) const { return IDCGroupHelperRegion::getGroupedPad(upad, ulrow, region, mGroupingPar.GroupPads[region], mGroupingPar.GroupRows[region], mRows[region], mPadsPerRow[region]); }
+
+  /// \return returns the row of the group from the local ungrouped row in a region
+  /// \param region region
+  /// \param ulrow local ungrouped row in a region
+  unsigned int getGroupedRow(const unsigned int region, unsigned int ulrow) const { return IDCGroupHelperRegion::getGroupedRow(ulrow, mGroupingPar.GroupRows[region], mRows[region]); }
+
+  /// \returns grouping parameter
+  const auto& getGroupingParameter() const { return mGroupingPar; }
+
+  /// \return returns number if IDCs for given region
+  unsigned int getNIDCs(const unsigned int region) { return mNIDCsPerCRU[region]; }
+
+ protected:
+  ParameterIDCGroupCCDB mGroupingPar{};                                  ///< struct containg the grouping parameter
+  std::array<unsigned int, Mapper::NREGIONS> mNIDCsPerCRU{};             ///< total number of IDCs per region per integration interval
+  unsigned int mNIDCsPerSector{};                                        ///< number of grouped IDCs per sector
+  std::array<unsigned int, Mapper::NREGIONS> mRows{};                    ///< number of grouped rows per region
+  std::array<unsigned int, Mapper::NREGIONS> mRegionOffs{};              ///< offset for the region per region
+  std::array<std::vector<unsigned int>, Mapper::NREGIONS> mPadsPerRow{}; ///< number of pads per row per region
+  std::array<std::vector<unsigned int>, Mapper::NREGIONS> mOffsRow{};    ///< offset to calculate the index in the data from row and pad per region
+
+  void initIDCGroupHelperSector()
+  {
+    for (unsigned int reg = 0; reg < Mapper::NREGIONS; ++reg) {
+      const IDCGroupHelperRegion groupTmp(mGroupingPar.GroupPads[reg], mGroupingPar.GroupRows[reg], mGroupingPar.GroupLastRowsThreshold[reg], mGroupingPar.GroupLastPadsThreshold[reg], reg);
+      mNIDCsPerCRU[reg] = groupTmp.getNIDCsPerIntegrationInterval();
+      mRows[reg] = groupTmp.getNRows();
+      mPadsPerRow[reg] = groupTmp.getPadsPerRow();
+      mOffsRow[reg] = groupTmp.getRowOffset();
+      if (reg > 0) {
+        const unsigned int lastInd = reg - 1;
+        mRegionOffs[reg] = mRegionOffs[lastInd] + mNIDCsPerCRU[lastInd];
+      }
+    }
+    mNIDCsPerSector = static_cast<unsigned int>(std::accumulate(mNIDCsPerCRU.begin(), mNIDCsPerCRU.end(), decltype(mNIDCsPerCRU)::value_type(0)));
+  }
+
+  ClassDefNV(IDCGroupHelperSector, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCGroupingParameter.h
+/// \brief Definition of the parameter for the grouping of the IDCs
+/// \author Matthias Kleiner, mkleiner@ikf.uni-frankfurt.de
+
+#ifndef ALICEO2_TPC_IDCGROUPINGPARAMETER_H_
+#define ALICEO2_TPC_IDCGROUPINGPARAMETER_H_
+
+#include <array>
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include "TPCBase/Mapper.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+/// struct for setting the parameters for the grouping of IDCs
+struct ParameterIDCGroup : public o2::conf::ConfigurableParamHelper<ParameterIDCGroup> {
+  unsigned char GroupPads[Mapper::NREGIONS]{7, 7, 7, 7, 6, 6, 6, 6, 5, 5};              ///< grouping parameter in pad direction (how many pads are grouped)
+  unsigned char GroupRows[Mapper::NREGIONS]{5, 5, 5, 5, 4, 4, 4, 4, 3, 3};              ///< group parameter in row direction (how many rows are grouped)
+  unsigned char GroupLastRowsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 2, 2}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
+  unsigned char GroupLastPadsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 1, 1}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+  O2ParamDef(ParameterIDCGroup, "TPCIDCGroupParam");
+};
+
+/// struct for storing the parameters for the grouping of IDCs to CCDB
+struct ParameterIDCGroupCCDB {
+
+  /// contructor
+  /// \param groupPads number of pads in pad direction which are grouped
+  /// \param groupRows number of pads in row direction which are grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  ParameterIDCGroupCCDB(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold)
+    : GroupPads{groupPads}, GroupRows{groupRows}, GroupLastRowsThreshold{groupLastRowsThreshold}, GroupLastPadsThreshold{groupLastPadsThreshold} {};
+
+  ParameterIDCGroupCCDB() = default;
+
+  /// \return returns number of pads in pad direction which are grouped
+  /// \parameter region TPC region
+  unsigned char getGroupPads(const unsigned int region) const { return GroupPads[region]; }
+
+  /// \return returns number of pads in row direction which are grouped
+  /// \parameter region TPC region
+  unsigned char getGroupRows(const unsigned int region) const { return GroupRows[region]; }
+
+  /// \return returns minimum number of pads in row direction for the last group in row direction
+  /// \parameter region TPC region
+  unsigned char getGroupLastRowsThreshold(const unsigned int region) const { return GroupLastRowsThreshold[region]; }
+
+  /// \return returns minimum number of pads in pad direction for the last group in pad direction
+  /// \parameter region TPC region
+  unsigned char getGroupLastPadsThreshold(const unsigned int region) const { return GroupLastPadsThreshold[region]; }
+
+  /// \return returns number of pads in pad direction which are grouped for all regions
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupPads() const { return GroupPads; }
+
+  /// \return returns number of pads in row direction which are grouped for all regions
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupRows() const { return GroupRows; }
+
+  /// \return returns minimum number of pads in row direction for the last group in row direction for all regions
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastRowsThreshold() const { return GroupLastRowsThreshold; }
+
+  /// \return returns minimum number of pads in pad direction for the last group in pad direction for all regions
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastPadsThreshold() const { return GroupLastPadsThreshold; }
+
+  std::array<unsigned char, Mapper::NREGIONS> GroupPads{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  std::array<unsigned char, Mapper::NREGIONS> GroupRows{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  std::array<unsigned char, Mapper::NREGIONS> GroupLastRowsThreshold{}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
+  std::array<unsigned char, Mapper::NREGIONS> GroupLastPadsThreshold{}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+};
+
+struct ParameterIDCCompression : public o2::conf::ConfigurableParamHelper<ParameterIDCCompression> {
+  float MaxIDCDeltaValue = 0.3f; ///< maximum Delta IDC
+  O2ParamDef(ParameterIDCCompression, "TPCIDCCompressionParam");
+};
+
+} // namespace tpc
+} // namespace o2
+
+#endif // ALICEO2_TPC_ParameterGEM_H_

--- a/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RobustAverage.h
+/// \brief class for performing robust averaging and outlier filtering
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_ROBUSTAVERAGE_H_
+#define ALICEO2_ROBUSTAVERAGE_H_
+
+#include <vector>
+#include <numeric>
+
+namespace o2::tpc
+{
+
+/// class to perform filtering of outliers and robust averaging of a set of values.
+/// This class is more or less a dummy for now... TODO add more sophisticated methods
+///
+/// Usage using existing data:
+/// 1. std::vector<float> values{1., 2., 2.3};
+/// 2. o2::tpc::RobustAverage rob(std::move(values));
+/// 3. float average = rob.getFilteredAverage(3);
+///
+/// Usage using copy of data:
+/// 1. o2::tpc::RobustAverage rob(3);
+/// 2. rob.addValue(1.);
+///    rob.addValue(2.);
+///    rob.addValue(2.3);
+/// 3. float average = rob.getFilteredAverage(3);
+///
+
+class RobustAverage
+{
+ public:
+  /// constructor
+  /// \param maxValues maximum number of values which will be averaged. Copy of values will be done.
+  RobustAverage(const unsigned int maxValues) { mValues.reserve(maxValues); }
+
+  /// constructor
+  /// \param values values which will be averaged and filtered. Move operator is used here!
+  RobustAverage(std::vector<float>&& values) : mValues{std::move(values)} {};
+
+  /// clear the stored values
+  void clear() { mValues.clear(); }
+
+  /// \param value value which will be added to the list of stored values for averaging
+  void addValue(const float value) { mValues.emplace_back(value); }
+
+  /// returns the filtered average value
+  /// \param sigma maximum accepted standard deviation: sigma*stdev
+  float getFilteredAverage(const float sigma = 3);
+
+  /// values which will be averaged and filtered
+  void print() const;
+
+ private:
+  std::vector<float> mValues{}; ///< values which will be averaged and filtered
+
+  /// \return returns mean of stored values
+  float getMean() const { return std::accumulate(mValues.begin(), mValues.end(), decltype(mValues)::value_type(0)) / mValues.size(); }
+
+  /// performing outlier filtering of the stored values
+  float getStdDev(const float mean) const;
+
+  /// performing outlier filtering of the stored values by defining range of included values in terms of standard deviation
+  /// \param mean mean of the stored values
+  /// \param stdev standard deviation of the values
+  /// \param sigma maximum accepted standard deviation: sigma*stdev
+  void filterOutliers(const float mean, const float stdev, const float sigma);
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
@@ -1,0 +1,215 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCAverageGroup.h"
+#include "TPCCalibration/IDCGroup.h"
+#include "TPCCalibration/RobustAverage.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+
+#include "TFile.h"
+#include "TPCBase/Painter.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include "Framework/Logger.h"
+
+#if (defined(WITH_OPENMP) || defined(_OPENMP)) && !defined(__CLING__)
+#include <omp.h>
+#endif
+
+void o2::tpc::IDCAverageGroup::processIDCs()
+{
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int integrationInterval = 0; integrationInterval < getNIntegrationIntervals(); ++integrationInterval) {
+    const unsigned int lastRow = mIDCsGrouped.getLastRow();
+    unsigned int rowGrouped = 0;
+    for (unsigned int iRow = 0; iRow <= lastRow; iRow += mIDCsGrouped.getGroupRows()) {
+      // the sectors is divide in to two parts around ylocal=0 to get the same simmetric grouping around ylocal=0
+      for (int iYLocalSide = 0; iYLocalSide < 2; ++iYLocalSide) {
+        const unsigned int region = mIDCsGrouped.getRegion();
+        const unsigned int nPads = Mapper::PADSPERROW[region][iRow] / 2;
+        const unsigned int endPads = mIDCsGrouped.getLastPad(iRow) + nPads;
+
+        const unsigned int halfPadsInRow = mIDCsGrouped.getPadsPerRow(rowGrouped) / 2;
+        unsigned int padGrouped = iYLocalSide ? halfPadsInRow : halfPadsInRow - 1;
+        for (unsigned int ipad = nPads; ipad <= endPads; ipad += mIDCsGrouped.getGroupPads()) {
+          const unsigned int endRows = (iRow == lastRow) ? (Mapper::ROWSPERREGION[region] - iRow) : mIDCsGrouped.getGroupRows();
+
+          // TODO Mapper::ADDITIONALPADSPERROW[region].back() factor is to large, but doesnt really matter
+          const unsigned int maxGoup = (mIDCsGrouped.getGroupRows() + mIDCsGrouped.getGroupLastRowsThreshold()) * (mIDCsGrouped.getGroupPads() + mIDCsGrouped.getGroupLastPadsThreshold() + Mapper::ADDITIONALPADSPERROW[region].back());
+          RobustAverage robustAverage(maxGoup);
+
+          for (unsigned int iRowMerge = 0; iRowMerge < endRows; ++iRowMerge) {
+            const unsigned int iRowTmp = iRow + iRowMerge;
+            const auto offs = Mapper::ADDITIONALPADSPERROW[region][iRowTmp] - Mapper::ADDITIONALPADSPERROW[region][iRow];
+            const auto padStart = (ipad == 0) ? 0 : offs;
+            const unsigned int endPadsTmp = (ipad == endPads) ? (Mapper::PADSPERROW[region][iRowTmp] - ipad) : mIDCsGrouped.getGroupPads() + offs;
+            for (unsigned int ipadMerge = padStart; ipadMerge < endPadsTmp; ++ipadMerge) {
+              const unsigned int iPadTmp = ipad + ipadMerge;
+              const unsigned int iPadSide = iYLocalSide ? iPadTmp : Mapper::PADSPERROW[region][iRowTmp] - iPadTmp - 1;
+              const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][iRowTmp] + iPadSide;
+              robustAverage.addValue(mIDCsUngrouped[indexIDC] * Mapper::PADAREA[region]);
+            }
+          }
+          mIDCsGrouped(rowGrouped, padGrouped, integrationInterval) = robustAverage.getFilteredAverage();
+          iYLocalSide ? ++padGrouped : --padGrouped;
+        }
+      }
+      ++rowGrouped;
+    }
+  }
+}
+
+void o2::tpc::IDCAverageGroup::dumpToFile(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "RECREATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}
+
+void o2::tpc::IDCAverageGroup::drawUngroupedIDCs(const unsigned int integrationInterval, const std::string filename) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+
+  TLatex lat;
+  lat.SetTextFont(63);
+  lat.SetTextSize(2);
+
+  poly->Draw("colz");
+  const unsigned int region = mIDCsGrouped.getRegion();
+  for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+    for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+      const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+      const auto coordinate = coords[padNum];
+      const float yPos = -0.5 * (coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
+      const float xPos = 0.5 * (coordinate.xVals[0] + coordinate.xVals[2]);
+      const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][irow] + ipad;
+      const float idc = mIDCsUngrouped[indexIDC] * Mapper::PADAREA[region];
+      poly->Fill(xPos, yPos, idc);
+      lat.SetTextAlign(12);
+      lat.DrawLatex(xPos, yPos, Form("%i", ipad));
+    }
+  }
+
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+/// for debugging: creating debug tree for integrated IDCs
+/// \param nameTree name of the output file
+void o2::tpc::IDCAverageGroup::createDebugTree(const char* nameTree) const
+{
+  o2::utils::TreeStreamRedirector pcstream(nameTree, "RECREATE");
+  pcstream.GetFile()->cd();
+  createDebugTree(*this, pcstream);
+  pcstream.Close();
+}
+
+void o2::tpc::IDCAverageGroup::createDebugTreeForAllCRUs(const char* nameTree, const char* filename)
+{
+  o2::utils::TreeStreamRedirector pcstream(nameTree, "RECREATE");
+  pcstream.GetFile()->cd();
+  TFile fInp(filename, "READ");
+
+  for (TObject* keyAsObj : *fInp.GetListOfKeys()) {
+    const auto key = dynamic_cast<TKey*>(keyAsObj);
+    LOGP(info, "Key name: {} Type: {}", key->GetName(), key->GetClassName());
+
+    if (std::strcmp(o2::tpc::IDCAverageGroup::Class()->GetName(), key->GetClassName()) != 0) {
+      LOGP(info, "skipping object. wrong class.");
+      continue;
+    }
+
+    IDCAverageGroup* idcavg = (IDCAverageGroup*)fInp.Get(key->GetName());
+    createDebugTree(*idcavg, pcstream);
+    delete idcavg;
+  }
+  pcstream.Close();
+}
+
+void o2::tpc::IDCAverageGroup::createDebugTree(const IDCAverageGroup& idcavg, o2::utils::TreeStreamRedirector& pcstream)
+{
+  const Mapper& mapper = Mapper::instance();
+  unsigned int sector = idcavg.getSector();
+  unsigned int cru = sector * Mapper::NREGIONS + idcavg.getRegion();
+  const o2::tpc::CRU cruTmp(cru);
+  unsigned int region = cruTmp.region();
+
+  for (unsigned int integrationInterval = 0; integrationInterval < idcavg.getNIntegrationIntervals(); ++integrationInterval) {
+    const unsigned long padsPerCRU = Mapper::PADSPERREGION[region];
+    std::vector<unsigned int> vRow(padsPerCRU);
+    std::vector<unsigned int> vPad(padsPerCRU);
+    std::vector<float> vXPos(padsPerCRU);
+    std::vector<float> vYPos(padsPerCRU);
+    std::vector<float> vGlobalXPos(padsPerCRU);
+    std::vector<float> vGlobalYPos(padsPerCRU);
+    std::vector<float> idcsPerIntegrationInterval(padsPerCRU);        // idcs for one time bin
+    std::vector<float> groupedidcsPerIntegrationInterval(padsPerCRU); // idcs for one time bin
+    std::vector<float> invPadArea(padsPerCRU);
+
+    for (unsigned int iPad = 0; iPad < padsPerCRU; ++iPad) {
+      const GlobalPadNumber globalNum = Mapper::GLOBALPADOFFSET[region] + iPad;
+      const auto& padPosLocal = mapper.padPos(globalNum);
+      vRow[iPad] = padPosLocal.getRow();
+      vPad[iPad] = padPosLocal.getPad();
+      vXPos[iPad] = mapper.getPadCentre(padPosLocal).X();
+      vYPos[iPad] = mapper.getPadCentre(padPosLocal).Y();
+      invPadArea[iPad] = Mapper::PADAREA[region];
+      const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[iPad], vYPos[iPad]), cruTmp.sector());
+      vGlobalXPos[iPad] = globalPos.X();
+      vGlobalYPos[iPad] = globalPos.Y();
+      idcsPerIntegrationInterval[iPad] = idcavg.getUngroupedIDCVal(iPad, integrationInterval);
+      groupedidcsPerIntegrationInterval[iPad] = idcavg.getGroupedIDCValGlobal(vRow[iPad], vPad[iPad], integrationInterval);
+    }
+
+    pcstream << "tree"
+             << "cru=" << cru
+             << "sector=" << sector
+             << "region=" << region
+             << "integrationInterval=" << integrationInterval
+             << "IDCUngrouped.=" << idcsPerIntegrationInterval
+             << "IDCGrouped.=" << groupedidcsPerIntegrationInterval
+             << "invPadArea.=" << invPadArea
+             << "pad.=" << vPad
+             << "row.=" << vRow
+             << "lx.=" << vXPos
+             << "ly.=" << vYPos
+             << "gx.=" << vGlobalXPos
+             << "gy.=" << vGlobalYPos
+             << "\n";
+  }
+}
+
+void o2::tpc::IDCAverageGroup::setIDCs(const std::vector<float>& idcs)
+{
+  mIDCsUngrouped = idcs;
+  mIDCsGrouped.resize(getNIntegrationIntervals());
+}
+
+void o2::tpc::IDCAverageGroup::setIDCs(std::vector<float>&& idcs)
+{
+  mIDCsUngrouped = std::move(idcs);
+  mIDCsGrouped.resize(getNIntegrationIntervals());
+}

--- a/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
@@ -1,0 +1,160 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCCCDBHelper.h"
+#include "TPCBase/Mapper.h"
+#include "TPCBase/Painter.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+
+template <typename DataT>
+std::string o2::tpc::IDCCCDBHelper<DataT>::getZAxisTitle(const o2::tpc::IDCType type) const
+{
+  switch (type) {
+    case IDCType::IDCZero:
+    default:
+      return "#it{IDC_{0}}";
+      break;
+    case IDCType::IDCDelta:
+      return "#Delta#it{IDC}";
+      break;
+    case IDCType::IDCOne:
+    case IDCType::IDC:
+      return "Wrong Type";
+      break;
+  }
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::drawSide(const o2::tpc::IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSideHist(side);
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetXaxis()->SetTitleOffset(1.2f);
+  poly->GetYaxis()->SetTitleOffset(1.3f);
+  poly->GetZaxis()->SetTitleOffset(1.2f);
+  poly->GetZaxis()->SetTitle(getZAxisTitle(type).data());
+  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 650, 600);
+  can->SetTopMargin(0.04f);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.1f);
+  poly->Draw("colz");
+
+  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
+  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
+    for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+      for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+        for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+          const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+          const float angDeg = 10.f + sector * 20;
+          auto coordinate = coords[padNum];
+          coordinate.rotate(angDeg);
+          const float yPos = 0.25f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]);
+          const float xPos = 0.25f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]);
+          const auto padTmp = (side == Side::A) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
+          switch (type) {
+            case IDCType::IDCZero:
+            default:
+              poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, padTmp));
+              break;
+            case IDCType::IDCDelta:
+              poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, padTmp, integrationInterval));
+              break;
+            case IDCType::IDC:
+              break;
+            case IDCType::IDCOne:
+              break;
+          }
+        }
+      }
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+  poly->GetZaxis()->SetTitle(getZAxisTitle(type).data());
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+
+  TLatex lat;
+  lat.SetTextFont(63);
+  lat.SetTextSize(2);
+  poly->Draw("colz");
+
+  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+        const auto coordinate = coords[padNum];
+        const float yPos = -0.5f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
+        const float xPos = 0.5f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]);
+        switch (type) {
+          case IDCType::IDCZero:
+          default:
+            poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, ipad));
+            break;
+          case IDCType::IDCDelta:
+            poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, ipad, integrationInterval));
+            break;
+          case IDCType::IDC:
+            break;
+          case IDCType::IDCOne:
+            break;
+        }
+        // draw global pad number
+        lat.SetTextAlign(12);
+        lat.DrawLatex(xPos, yPos, Form("%i", ipad));
+      }
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+/// load IDC-Delta, 0D-IDCs, grouping parameter
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::loadAll()
+{
+  loadIDCDelta();
+  loadIDCZero();
+  loadGroupingParameter();
+}
+
+template class o2::tpc::IDCCCDBHelper<float>;
+template class o2::tpc::IDCCCDBHelper<short>;
+template class o2::tpc::IDCCCDBHelper<char>;

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -1,0 +1,495 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCFactorization.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "Framework/Logger.h"
+#include "TPCBase/Painter.h"
+#include "TH2Poly.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include <functional>
+
+o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC)
+  : IDCGroupHelperSector{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold}, mTimeFrames{timeFrames}, mTimeFramesDeltaIDC{timeframesDeltaIDC}, mIDCDelta{timeFrames / timeframesDeltaIDC + (timeFrames % timeframesDeltaIDC != 0)}
+{
+  for (auto& idc : mIDCs) {
+    idc.resize(mTimeFrames);
+  }
+}
+
+void o2::tpc::IDCFactorization::drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+  poly->GetZaxis()->SetTitle(getZAxisTitle(type, compression).data());
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+
+  TLatex lat;
+  lat.SetTextFont(63);
+  lat.SetTextSize(2);
+  poly->Draw("colz");
+
+  unsigned int chunk = 0;
+  unsigned int localintegrationInterval = 0;
+  getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
+  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+        const auto coordinate = coords[padNum];
+        const float yPos = -0.5f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
+        const float xPos = 0.5f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]);
+
+        switch (type) {
+          case IDCType::IDC:
+          default:
+            poly->Fill(xPos, yPos, getIDCValUngrouped(sector, region, irow, ipad, integrationInterval));
+            break;
+          case IDCType::IDCZero:
+            poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, ipad));
+            break;
+          case IDCType::IDCDelta:
+            switch (compression) {
+              case IDCDeltaCompression::NO:
+              default: {
+                poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, ipad, chunk, localintegrationInterval));
+                break;
+              }
+              case IDCDeltaCompression::MEDIUM: {
+                const static auto idcDeltaMedium = getIDCDeltaMediumCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
+                const float val = idcDeltaMedium.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, ipad, localintegrationInterval));
+                poly->Fill(xPos, yPos, val);
+                break;
+              }
+              case IDCDeltaCompression::HIGH: {
+                const static auto idcDeltaHigh = getIDCDeltaHighCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
+                const float val = idcDeltaHigh.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, ipad, localintegrationInterval));
+                poly->Fill(xPos, yPos, val);
+                break;
+              }
+            }
+          case IDCType::IDCOne:
+            break;
+        }
+        // draw global pad number
+        lat.SetTextAlign(12);
+        lat.DrawLatex(xPos, yPos, Form("%i", ipad));
+      }
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+void o2::tpc::IDCFactorization::drawSide(const IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSideHist(side);
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetXaxis()->SetTitleOffset(1.2f);
+  poly->GetYaxis()->SetTitleOffset(1.3f);
+  poly->GetZaxis()->SetTitleOffset(1.2f);
+  poly->GetZaxis()->SetTitle(getZAxisTitle(type, compression).data());
+  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 650, 600);
+  can->SetTopMargin(0.04f);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.1f);
+  poly->Draw("colz");
+
+  unsigned int chunk = 0;
+  unsigned int localintegrationInterval = 0;
+  getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
+  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
+  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
+    for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+      for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+        for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+          const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+          const float angDeg = 10.f + sector * 20;
+          auto coordinate = coords[padNum];
+          coordinate.rotate(angDeg);
+          const float yPos = 0.25f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]);
+          const float xPos = 0.25f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]);
+          const auto padTmp = (side == Side::A) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
+          switch (type) {
+            case IDCType::IDC:
+            default:
+              poly->Fill(xPos, yPos, getIDCValUngrouped(sector, region, irow, padTmp, integrationInterval));
+              break;
+            case IDCType::IDCZero:
+              poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, padTmp));
+              break;
+            case IDCType::IDCDelta:
+              switch (compression) {
+                case IDCDeltaCompression::NO:
+                default: {
+                  poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, padTmp, chunk, localintegrationInterval));
+                  break;
+                }
+                case IDCDeltaCompression::MEDIUM: {
+                  const static auto idcDeltaMedium = getIDCDeltaMediumCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
+                  const float val = idcDeltaMedium.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
+                  poly->Fill(xPos, yPos, val);
+                  break;
+                }
+                case IDCDeltaCompression::HIGH: {
+                  const static auto idcDeltaHigh = getIDCDeltaHighCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
+                  const float val = idcDeltaHigh.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
+                  poly->Fill(xPos, yPos, val);
+                  break;
+                }
+              }
+            case IDCType::IDCOne:
+              break;
+          }
+        }
+      }
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+std::string o2::tpc::IDCFactorization::getZAxisTitle(const IDCType type, const IDCDeltaCompression compression) const
+{
+  switch (type) {
+    case IDCType::IDC:
+    default:
+      return "#it{IDC}";
+      break;
+    case IDCType::IDCZero:
+      return "#it{IDC_{0}}";
+      break;
+    case IDCType::IDCDelta:
+      switch (compression) {
+        case IDCDeltaCompression::NO:
+        default:
+          return "#Delta#it{IDC}";
+          break;
+        case IDCDeltaCompression::MEDIUM:
+          return "#Delta#it{IDC}_{medium compressed}";
+          break;
+        case IDCDeltaCompression::HIGH:
+          return "#Delta#it{IDC}_{high compressed}";
+          break;
+      }
+    case IDCType::IDCOne:
+      return "#Delta#it{IDC}_{1}";
+      break;
+  }
+}
+
+void o2::tpc::IDCFactorization::dumpToFile(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "RECREATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}
+
+void o2::tpc::IDCFactorization::dumpToTree(int integrationIntervals) const
+{
+  const Mapper& mapper = Mapper::instance();
+  o2::utils::TreeStreamRedirector pcstream("IDCTree.root", "RECREATE");
+  pcstream.GetFile()->cd();
+
+  if (integrationIntervals <= 0) {
+    integrationIntervals = static_cast<int>(getNIntegrationIntervals());
+  }
+
+  std::vector<float> idcOneA = mIDCOne.mIDCOne[0];
+  std::vector<float> idcOneC = mIDCOne.mIDCOne[1];
+  for (unsigned int integrationInterval = 0; integrationInterval < integrationIntervals; ++integrationInterval) {
+    const unsigned int nIDCsSector = Mapper::getPadsInSector() * Mapper::NSECTORS;
+    std::vector<int> vRow(nIDCsSector);
+    std::vector<int> vPad(nIDCsSector);
+    std::vector<float> vXPos(nIDCsSector);
+    std::vector<float> vYPos(nIDCsSector);
+    std::vector<float> vGlobalXPos(nIDCsSector);
+    std::vector<float> vGlobalYPos(nIDCsSector);
+    std::vector<float> idcs(nIDCsSector);
+    std::vector<float> idcsZero(nIDCsSector);
+    std::vector<float> idcsDelta(nIDCsSector);
+    std::vector<float> idcsDeltaMedium(nIDCsSector);
+    std::vector<float> idcsDeltaHigh(nIDCsSector);
+    std::vector<unsigned int> sectorv(nIDCsSector);
+
+    unsigned int chunk = 0;
+    unsigned int localintegrationInterval = 0;
+    getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
+    const auto idcDeltaMedium = getIDCDeltaMediumCompressed(chunk);
+    const auto idcDeltaHigh = getIDCDeltaHighCompressed(chunk);
+
+    unsigned int index = 0;
+    for (unsigned int sector = 0; sector < Mapper::NSECTORS; ++sector) {
+      for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+        for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+          for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+            const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+            const auto padTmp = (sector < SECTORSPERSIDE) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
+            const auto& padPosLocal = mapper.padPos(padNum);
+            vRow[index] = padPosLocal.getRow();
+            vPad[index] = padPosLocal.getPad();
+            vXPos[index] = mapper.getPadCentre(padPosLocal).X();
+            vYPos[index] = mapper.getPadCentre(padPosLocal).Y();
+            const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[index], vYPos[index]), Sector(sector));
+            vGlobalXPos[index] = globalPos.X();
+            vGlobalYPos[index] = globalPos.Y();
+            idcs[index] = getIDCValUngrouped(sector, region, irow, padTmp, integrationInterval);
+            idcsZero[index] = getIDCZeroVal(sector, region, irow, padTmp);
+            idcsDelta[index] = getIDCDeltaVal(sector, region, irow, padTmp, chunk, localintegrationInterval);
+            idcsDeltaMedium[index] = idcDeltaMedium.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
+            idcsDeltaHigh[index] = idcDeltaHigh.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
+            sectorv[index++] = sector;
+          }
+        }
+      }
+    }
+    float idcOneATmp = idcOneA[integrationInterval];
+    float idcOneCTmp = idcOneC[integrationInterval];
+    unsigned int timeFrame = 0;
+    unsigned int interval = 0;
+    getTF(0, integrationInterval, timeFrame, interval);
+
+    pcstream << "tree"
+             << "integrationInterval=" << integrationInterval
+             << "localintervalinTF=" << interval
+             << "indexinchunk=" << localintegrationInterval
+             << "chunk=" << chunk
+             << "timeframe=" << timeFrame
+             << "IDC.=" << idcs
+             << "IDC0.=" << idcsZero
+             << "IDC1A=" << idcOneATmp
+             << "IDC1C=" << idcOneCTmp
+             << "IDCDeltaNoComp.=" << idcsDelta
+             << "IDCDeltaMediumComp.=" << idcsDeltaMedium
+             << "IDCDeltaHighComp.=" << idcsDeltaHigh
+             << "pad.=" << vPad
+             << "row.=" << vRow
+             << "lx.=" << vXPos
+             << "ly.=" << vYPos
+             << "gx.=" << vGlobalXPos
+             << "gy.=" << vGlobalYPos
+             << "sector.=" << sectorv
+             << "\n";
+  }
+  pcstream.Close();
+}
+
+void o2::tpc::IDCFactorization::calcIDCZero()
+{
+  const unsigned int nIDCsSide = mNIDCsPerSector * o2::tpc::SECTORSPERSIDE;
+  mIDCZero.mIDCZero[Side::A].resize(nIDCsSide);
+  mIDCZero.mIDCZero[Side::C].resize(nIDCsSide);
+
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const unsigned int region = cruTmp.region();
+    for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
+      for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
+        const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+        mIDCZero.fillValueIDCZero(mIDCs[cru][timeframe][idcs], cruTmp.side(), indexGlob % nIDCsSide);
+      }
+    }
+  }
+  std::transform(mIDCZero.mIDCZero[Side::A].begin(), mIDCZero.mIDCZero[Side::A].end(), mIDCZero.mIDCZero[Side::A].begin(), [norm = getNIntegrationIntervals()](auto& val) { return val / norm; });
+  std::transform(mIDCZero.mIDCZero[Side::C].begin(), mIDCZero.mIDCZero[Side::C].end(), mIDCZero.mIDCZero[Side::C].begin(), [norm = getNIntegrationIntervals()](auto& val) { return val / norm; });
+}
+
+void o2::tpc::IDCFactorization::calcIDCOne()
+{
+  const unsigned int nIDCsSide = mNIDCsPerSector * SECTORSPERSIDE;
+  const unsigned int integrationIntervals = getNIntegrationIntervals();
+  mIDCOne.mIDCOne[Side::A].resize(integrationIntervals);
+  mIDCOne.mIDCOne[Side::C].resize(integrationIntervals);
+  const unsigned int crusPerSide = Mapper::NREGIONS * SECTORSPERSIDE;
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const unsigned int region = cruTmp.region();
+    unsigned int integrationIntervallast = 0;
+    for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
+      for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
+        const unsigned int integrationInterval = idcs / mNIDCsPerCRU[region] + integrationIntervallast;
+        const auto side = cruTmp.side();
+        const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+        mIDCOne.mIDCOne[side][integrationInterval] += mIDCs[cru][timeframe][idcs] / (crusPerSide * mNIDCsPerCRU[region] * mIDCZero.mIDCZero[side][indexGlob % nIDCsSide]);
+      }
+      integrationIntervallast += mIDCs[cru][timeframe].size() / mNIDCsPerCRU[region];
+    }
+  }
+}
+
+void o2::tpc::IDCFactorization::calcIDCDelta()
+{
+  const unsigned int nIDCsSide = mNIDCsPerSector * SECTORSPERSIDE;
+  for (unsigned int i = 0; i < getNChunks(); ++i) {
+    const auto idcsSide = nIDCsSide * getNIntegrationIntervals(i);
+    mIDCDelta[i].getIDCDelta(Side::A).resize(idcsSide);
+    mIDCDelta[i].getIDCDelta(Side::C).resize(idcsSide);
+  }
+
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const unsigned int region = cruTmp.region();
+    unsigned int integrationIntervallast = 0;
+    unsigned int integrationIntervallastLocal = 0;
+    unsigned int lastChunk = 0;
+
+    for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
+      const unsigned int chunk = getChunk(timeframe);
+      if (lastChunk != chunk) {
+        integrationIntervallastLocal = 0;
+      }
+
+      for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
+        const unsigned int intervallocal = idcs / mNIDCsPerCRU[region];
+        const unsigned int integrationIntervalGlobal = intervallocal + integrationIntervallast;
+        const unsigned int integrationIntervalLocal = intervallocal + integrationIntervallastLocal;
+        const auto side = cruTmp.side();
+        const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+        const unsigned int indexGlobMod = indexGlob % nIDCsSide;
+        const auto idcZero = mIDCZero.mIDCZero[side][indexGlobMod];
+        const auto idcOne = mIDCOne.mIDCOne[side][integrationIntervalGlobal];
+        const auto mult = idcZero * idcOne;
+        const auto val = (mult > 0) ? mIDCs[cru][timeframe][idcs] / mult : 0;
+        mIDCDelta[chunk].getIDCDelta(side)[indexGlobMod + integrationIntervalLocal * nIDCsSide] = val - 1;
+      }
+
+      const unsigned int intervals = mIDCs[cru][timeframe].size() / mNIDCsPerCRU[region];
+      integrationIntervallast += intervals;
+      integrationIntervallastLocal += intervals;
+      lastChunk = chunk;
+    }
+  }
+}
+
+float o2::tpc::IDCFactorization::getIDCValUngrouped(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const
+{
+  unsigned int timeFrame = 0;
+  unsigned int interval = 0;
+  getTF(region, integrationInterval, timeFrame, interval);
+  return mIDCs[sector * Mapper::NREGIONS + region][timeFrame][interval * mNIDCsPerCRU[region] + mOffsRow[region][getGroupedRow(region, urow)] + getGroupedPad(region, urow, upad)];
+}
+
+void o2::tpc::IDCFactorization::getTF(const unsigned int region, unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const
+{
+  unsigned int nintervals = 0;
+  unsigned int intervalTmp = 0;
+  for (unsigned int tf = 0; tf < mTimeFrames; ++tf) {
+    nintervals += mIDCs[region][tf].size() / mNIDCsPerCRU[region];
+    if (integrationInterval < nintervals) {
+      timeFrame = tf;
+      interval = integrationInterval - intervalTmp;
+      return;
+    }
+    intervalTmp = nintervals;
+  }
+}
+
+void o2::tpc::IDCFactorization::factorizeIDCs()
+{
+  LOGP(info, "Using {} threads for factorization of IDCs", sNThreads);
+  calcIDCZero();
+  calcIDCOne();
+  calcIDCDelta();
+}
+
+unsigned long o2::tpc::IDCFactorization::getNIntegrationIntervals(const unsigned int chunk) const
+{
+  std::size_t sum = 0;
+  const auto firstTF = chunk * getNTFsPerChunk(0);
+  for (unsigned int i = firstTF; i < firstTF + getNTFsPerChunk(chunk); ++i) {
+    sum += mIDCs[0][i].size();
+  }
+  return sum / mNIDCsPerCRU[0];
+}
+
+unsigned long o2::tpc::IDCFactorization::getNIntegrationIntervals() const
+{
+  std::size_t sum = 0;
+  for (auto&& idcsTF : mIDCs[0]) {
+    sum += idcsTF.size();
+  }
+  return sum / mNIDCsPerCRU[0];
+}
+
+void o2::tpc::IDCFactorization::getLocalIntegrationInterval(const unsigned int region, const unsigned int integrationInterval, unsigned int& chunk, unsigned int& localintegrationInterval) const
+{
+  unsigned int nintervals = 0;
+  unsigned int nitervalsChunk = 0;
+  unsigned int globalTF = 0;
+  for (unsigned int ichunk = 0; ichunk < getNChunks(); ++ichunk) {
+    const auto nTFsPerChunk = getNTFsPerChunk(ichunk);
+    for (unsigned int tf = 0; tf < nTFsPerChunk; ++tf) {
+      nintervals += mIDCs[region][globalTF].size() / mNIDCsPerCRU[region];
+      if (integrationInterval < nintervals) {
+        chunk = getChunk(globalTF);
+        localintegrationInterval = integrationInterval - nitervalsChunk;
+        return;
+      }
+      ++globalTF;
+    }
+    nitervalsChunk = nintervals;
+  }
+}
+
+unsigned int o2::tpc::IDCFactorization::getChunk(const unsigned int timeframe) const
+{
+  return timeframe / mTimeFramesDeltaIDC;
+}
+
+unsigned int o2::tpc::IDCFactorization::getNTFsPerChunk(const unsigned int chunk) const
+{
+  const unsigned int remain = mTimeFrames % mTimeFramesDeltaIDC;
+  return ((chunk == getNChunks() - 1) && remain) ? remain : mTimeFramesDeltaIDC;
+}
+
+std::vector<unsigned int> o2::tpc::IDCFactorization::getIntegrationIntervalsPerTF(const unsigned int region) const
+{
+  std::vector<unsigned int> integrationIntervalsPerTF(mTimeFrames);
+  for (unsigned int tf = 0; tf < mTimeFrames; ++tf) {
+    integrationIntervalsPerTF[tf] = mIDCs[region][tf].size() / mNIDCsPerCRU[region];
+  }
+  return integrationIntervalsPerTF;
+}
+
+void o2::tpc::IDCFactorization::reset()
+{
+  for (auto& tf : mIDCs) {
+    for (auto& idcs : tf) {
+      idcs.clear();
+    }
+  }
+}

--- a/Detectors/TPC/calibration/src/IDCFourierTransform.cxx
+++ b/Detectors/TPC/calibration/src/IDCFourierTransform.cxx
@@ -1,0 +1,234 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCFourierTransform.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "CommonConstants/MathConstants.h"
+#include "Framework/Logger.h"
+#include "TFile.h"
+#include <cmath>
+// #include <fftw3.h>
+
+#if (defined(WITH_OPENMP) || defined(_OPENMP)) && !defined(__CLING__)
+#include <omp.h>
+#endif
+
+void o2::tpc::IDCFourierTransform::setIDCs(OneDIDC&& oneDIDCs, std::vector<unsigned int>&& integrationIntervalsPerTF)
+{
+  mOneDIDC[mBufferIndex] = std::move(oneDIDCs);
+  mIntegrationIntervalsPerTF[mBufferIndex] = std::move(integrationIntervalsPerTF);
+  mBufferIndex = !mBufferIndex;
+}
+
+void o2::tpc::IDCFourierTransform::setIDCs(const OneDIDC& oneDIDCs, const std::vector<unsigned int>& integrationIntervalsPerTF)
+{
+  mOneDIDC[mBufferIndex] = oneDIDCs;
+  mIntegrationIntervalsPerTF[mBufferIndex] = integrationIntervalsPerTF;
+  mBufferIndex = !mBufferIndex;
+}
+
+void o2::tpc::IDCFourierTransform::calcFourierCoefficientsNaive()
+{
+  if (mFourierCoefficients.getNCoefficientsPerTF() % 2) {
+    LOGP(warning, "number of specified fourier coefficients is {}, but should be an even number! you can use FFTW3 method instead!", mFourierCoefficients.getNCoefficientsPerTF());
+  }
+  const std::vector<unsigned int> offsetIndex = getLastIntervals();
+  calcFourierCoefficientsNaive(o2::tpc::Side::A, offsetIndex);
+  calcFourierCoefficientsNaive(o2::tpc::Side::C, offsetIndex);
+}
+
+void o2::tpc::IDCFourierTransform::calcFourierCoefficientsFFTW3()
+{
+  LOGP(warning, "FFTW3 method not available yet. Using naive approach...");
+  calcFourierCoefficientsNaive();
+  // const std::vector<unsigned int> offsetIndex = getLastIntervals();
+  // calcFourierCoefficientsFFTW3(o2::tpc::Side::A, offsetIndex);
+  // calcFourierCoefficientsFFTW3(o2::tpc::Side::C, offsetIndex);
+}
+
+void o2::tpc::IDCFourierTransform::calcFourierCoefficientsNaive(const o2::tpc::Side side, const std::vector<unsigned int>& offsetIndex)
+{
+  // see: https://en.wikipedia.org/wiki/Discrete_Fourier_transform#Definitiona
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int interval = 0; interval < getNIntervals(); ++interval) {
+    const auto idcOneExpanded = getExpandedIDCOne(side);
+    for (unsigned int coeff = 0; coeff < mFourierCoefficients.getNCoefficientsPerTF() / 2; ++coeff) {
+      const unsigned int indexDataReal = mFourierCoefficients.getIndex(interval, 2 * coeff); // index for storing real fourier coefficient
+      const unsigned int indexDataImag = indexDataReal + 1;                                  // index for storing complex fourier coefficient
+      const float term0 = o2::constants::math::TwoPI * coeff / mRangeIDC;
+      for (unsigned int index = 0; index < mRangeIDC; ++index) {
+        const float term = term0 * index;
+        const float idc0 = idcOneExpanded[index + offsetIndex[interval]];
+        mFourierCoefficients(side, indexDataReal) += idc0 * std::cos(term);
+        mFourierCoefficients(side, indexDataImag) -= idc0 * std::sin(term);
+      }
+    }
+  }
+  // normalize coefficient to number of used points
+  normalizeCoefficients(side);
+}
+
+void o2::tpc::IDCFourierTransform::calcFourierCoefficientsFFTW3(const o2::tpc::Side side, const std::vector<unsigned int>& offsetIndex)
+{
+  //   // for FFTW and OMP see: https://stackoverflow.com/questions/15012054/fftw-plan-creation-using-openmp
+  // #pragma omp parallel num_threads(sNThreads)
+  //   {
+  //     fftwf_plan fftwPlan = nullptr;
+  //     float* val1DIDCs = getExpandedIDCOneFFTW(side);
+  //     fftwf_complex* coefficients = fftwf_alloc_complex(getNMaxCoefficients());
+  //
+  // #pragma omp critical(make_plan)
+  //     fftwPlan = fftwf_plan_dft_r2c_1d(mRangeIDC, val1DIDCs, coefficients, FFTW_ESTIMATE);
+  //
+  // #pragma omp for
+  //     for (unsigned int interval = 0; interval < getNIntervals(); ++interval) {
+  //       fftwf_execute_dft_r2c(fftwPlan, &(val1DIDCs[offsetIndex[interval]]), coefficients);
+  //       std::memcpy(&(*(mFourierCoefficients.mFourierCoefficients[side].begin() + mFourierCoefficients.getIndex(interval, 0))), coefficients, mFourierCoefficients.getNCoefficientsPerTF() * sizeof(float));
+  //     }
+  //     // free memory
+  //     fftwf_free(coefficients);
+  //     fftwf_free(val1DIDCs);
+  //     fftwf_destroy_plan(fftwPlan);
+  //   }
+  //   normalizeCoefficients(side);
+}
+
+std::vector<std::vector<float>> o2::tpc::IDCFourierTransform::inverseFourierTransformNaive(const o2::tpc::Side side) const
+{
+  // vector containing for each intervall the inverse fourier IDCs
+  std::vector<std::vector<float>> inverse(getNIntervals());
+  const float factor = o2::constants::math::TwoPI / mRangeIDC;
+
+  // loop over all the intervals. For each interval the coefficients are calculated
+  for (unsigned int interval = 0; interval < getNIntervals(); ++interval) {
+    inverse[interval].resize(mRangeIDC);
+    for (unsigned int index = 0; index < mRangeIDC; ++index) {
+      const float term0 = factor * index;
+      unsigned int coeffTmp = 0;
+      int fac = 1; // if input data is real (and it is) the coefficients are mirrored https://dsp.stackexchange.com/questions/4825/why-is-the-fft-mirrored
+      for (unsigned int coeff = 0; coeff < mRangeIDC; ++coeff) {
+        const unsigned int indexDataReal = mFourierCoefficients.getIndex(interval, 2 * coeffTmp); // index for storing real fourier coefficient
+        const unsigned int indexDataImag = indexDataReal + 1;                                     // index for storing complex fourier coefficient
+        const float term = term0 * coeff;
+        inverse[interval][index] += mFourierCoefficients(side, indexDataReal) * std::cos(term) - fac * mFourierCoefficients(side, indexDataImag) * std::sin(term);
+        if (coeff < getNMaxCoefficients() - 1) {
+          ++coeffTmp;
+        } else {
+          --coeffTmp;
+          fac = -1;
+        };
+      }
+    }
+  }
+  return inverse;
+}
+
+std::vector<std::vector<float>> o2::tpc::IDCFourierTransform::inverseFourierTransformFFTW3(const o2::tpc::Side side) const
+{
+  LOGP(warning, "FFTW3 method not available yet. Using naive approach...");
+  return inverseFourierTransformNaive(side);
+  // // vector containing for each intervall the inverse fourier IDCs
+  // std::vector<std::vector<float>> inverse(getNIntervals());
+  //
+  // // loop over all the intervals. For each interval the coefficients are calculated
+  // // this loop and execution of FFTW is not optimized as it is used only for debugging
+  // for (unsigned int interval = 0; interval < getNIntervals(); ++interval) {
+  //   inverse[interval].resize(mRangeIDC);
+  //   std::vector<std::array<float, 2>> val1DIDCs;
+  //   val1DIDCs.reserve(mRangeIDC);
+  //   for (unsigned int index = 0; index < getNMaxCoefficients(); ++index) {
+  //     const unsigned int indexDataReal = mFourierCoefficients.getIndex(interval, 2 * index); // index for storing real fourier coefficient
+  //     const unsigned int indexDataImag = indexDataReal + 1;                                  // index for storing complex fourier coefficient
+  //     val1DIDCs.emplace_back(std::array<float, 2>{mFourierCoefficients(side, indexDataReal), mFourierCoefficients(side, indexDataImag)});
+  //   }
+  //   const fftwf_plan fftwPlan = fftwf_plan_dft_c2r_1d(mRangeIDC, reinterpret_cast<fftwf_complex*>(val1DIDCs.data()), inverse[interval].data(), FFTW_ESTIMATE);
+  //   fftwf_execute(fftwPlan);
+  //   fftwf_destroy_plan(fftwPlan);
+  // }
+  // return inverse;
+}
+
+void o2::tpc::IDCFourierTransform::dumpToFile(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "RECREATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}
+
+void o2::tpc::IDCFourierTransform::dumpToTree(const char* outFileName) const
+{
+  o2::utils::TreeStreamRedirector pcstream(outFileName, "RECREATE");
+  pcstream.GetFile()->cd();
+  const std::vector<unsigned int> offsetIndex = getLastIntervals();
+  for (unsigned int iSide = 0; iSide < o2::tpc::SIDES; ++iSide) {
+    const o2::tpc::Side side = iSide == 0 ? Side::A : Side::C;
+    const auto idcOneExpanded = getExpandedIDCOne(side);
+    const auto inverseFourier = inverseFourierTransformNaive(side);
+    const auto inverseFourierFFTW3 = inverseFourierTransformFFTW3(side);
+
+    for (unsigned int interval = 0; interval < getNIntervals(); ++interval) {
+      std::vector<float> oneDIDCInverse = inverseFourier[interval];
+      std::vector<float> oneDIDCInverseFFTW3 = inverseFourierFFTW3[interval];
+
+      // get 1D-IDC values used for calculation of the fourier coefficients
+      std::vector<float> oneDIDC;
+      oneDIDC.reserve(mRangeIDC);
+      for (unsigned int index = 0; index < mRangeIDC; ++index) {
+        oneDIDC.emplace_back(idcOneExpanded[index + offsetIndex[interval]]);
+      }
+
+      for (unsigned int coeff = 0; coeff < mFourierCoefficients.getNCoefficientsPerTF(); ++coeff) {
+        float coefficient = mFourierCoefficients(side, mFourierCoefficients.getIndex(interval, coeff));
+
+        pcstream << "tree"
+                 << "side=" << iSide
+                 << "interval=" << interval
+                 << "icoefficient=" << coeff      // index of ith coefficient
+                 << "coefficient=" << coefficient // value for ith coefficient
+                 << "1DIDC.=" << oneDIDC
+                 << "1DIDCiDFT.=" << oneDIDCInverse
+                 << "1DIDiDFTFFTW3.=" << oneDIDCInverseFFTW3
+                 << "\n";
+      }
+    }
+  }
+}
+
+std::vector<unsigned int> o2::tpc::IDCFourierTransform::getLastIntervals() const
+{
+  std::vector<unsigned int> endIndex;
+  endIndex.reserve(mTimeFrames);
+  endIndex.emplace_back(0);
+  for (unsigned int interval = 1; interval < mTimeFrames; ++interval) {
+    endIndex.emplace_back(endIndex[interval - 1] + mIntegrationIntervalsPerTF[!mBufferIndex][interval]);
+  }
+  return endIndex;
+}
+
+std::vector<float> o2::tpc::IDCFourierTransform::getExpandedIDCOne(const o2::tpc::Side side) const
+{
+  std::vector<float> val1DIDCs = mOneDIDC[!mBufferIndex].mOneDIDC[side]; // just copy the elements
+  if (useLastBuffer()) {
+    val1DIDCs.insert(val1DIDCs.begin(), mOneDIDC[mBufferIndex].mOneDIDC[side].end() - mRangeIDC + mIntegrationIntervalsPerTF[!mBufferIndex][0], mOneDIDC[mBufferIndex].mOneDIDC[side].end());
+  }
+  return val1DIDCs;
+}
+
+// float* o2::tpc::IDCFourierTransform::getExpandedIDCOneFFTW(const o2::tpc::Side side) const
+// {
+// const unsigned int nElementsLastBuffer = useLastBuffer() ? mRangeIDC - mIntegrationIntervalsPerTF[!mBufferIndex][0] : 0;
+// const unsigned int nElementsAll = mOneDIDC[!mBufferIndex].getNIDCs(side) + nElementsLastBuffer;
+// float* val1DIDCs = fftwf_alloc_real(nElementsAll);
+// if (useLastBuffer()) {
+// std::memcpy(val1DIDCs, &(*(mOneDIDC[mBufferIndex].mOneDIDC[side].end() - nElementsLastBuffer)), nElementsLastBuffer * sizeof(float)); // copy IDCs from old buffer
+// }
+// std::memcpy(&val1DIDCs[nElementsLastBuffer], mOneDIDC[!mBufferIndex].mOneDIDC[side].data(), mOneDIDC[!mBufferIndex].getNIDCs(side) * sizeof(float)); // copy all IDCs from current buffer
+// return val1DIDCs;
+// }

--- a/Detectors/TPC/calibration/src/IDCGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroup.cxx
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCGroup.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "TPCBase/Painter.h"
+#include "TPCBase/Mapper.h"
+#include "TH2Poly.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include <numeric>
+
+void o2::tpc::IDCGroup::dumpToTree(const char* outname) const
+{
+  o2::utils::TreeStreamRedirector pcstream(outname, "RECREATE");
+  pcstream.GetFile()->cd();
+  for (unsigned int integrationInterval = 0; integrationInterval < getNIntegrationIntervals(); ++integrationInterval) {
+    for (unsigned int irow = 0; irow < mRows; ++irow) {
+      for (unsigned int ipad = 0; ipad < mPadsPerRow[irow]; ++ipad) {
+        float idc = (*this)(irow, ipad, integrationInterval);
+        pcstream << "idcs"
+                 << "row=" << irow
+                 << "pad=" << ipad
+                 << "IDC=" << idc
+                 << "\n";
+      }
+    }
+  }
+  pcstream.Close();
+}
+
+void o2::tpc::IDCGroup::draw(const unsigned int integrationInterval, const std::string filename) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+
+  TLatex lat;
+  lat.SetTextFont(63);
+  lat.SetTextSize(2);
+
+  poly->Draw("colz");
+  for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[mRegion]; ++irow) {
+    for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[mRegion][irow]; ++ipad) {
+      const auto padNum = getGlobalPadNumber(irow, ipad);
+      const auto coordinate = coords[padNum];
+      const float yPos = -0.5f * (coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
+      const float xPos = 0.5f * (coordinate.xVals[0] + coordinate.xVals[2]);
+      poly->Fill(xPos, yPos, (*this)(getGroupedRow(irow), getGroupedPad(ipad, irow), integrationInterval));
+      lat.SetTextAlign(12);
+      lat.DrawLatex(xPos, yPos, Form("%i", ipad));
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+void o2::tpc::IDCGroup::dumpToFile(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "UPDATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}
+
+float o2::tpc::IDCGroup::getValUngroupedGlobal(unsigned int ugrow, unsigned int upad, unsigned int integrationInterval) const
+{
+  return mIDCsGrouped[getIndexUngrouped(Mapper::getLocalRowFromGlobalRow(ugrow), upad, integrationInterval)];
+}
+
+std::vector<float> o2::tpc::IDCGroup::get1DIDCs() const
+{
+  // integrate IDCs for each interval
+  std::vector<float> idc;
+  const unsigned int nIntervals = getNIntegrationIntervals();
+  idc.reserve(nIntervals);
+  for (unsigned int i = 0; i < nIntervals; ++i) {
+    // set integration range for one integration interval
+    const auto start = mIDCsGrouped.begin() + i * getNIDCsPerIntegrationInterval();
+    const auto end = start + getNIDCsPerIntegrationInterval();
+    idc.emplace_back(std::accumulate(start, end, decltype(mIDCsGrouped)::value_type(0)));
+  }
+  // normalize 1D-IDCs to absolute space charge
+  const float norm = Mapper::REGIONAREA[mRegion] / getNIDCsPerIntegrationInterval();
+  std::transform(idc.begin(), idc.end(), idc.begin(), [norm](auto& val) { return val * norm; });
+
+  return idc;
+}

--- a/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCGroupHelperRegion.h"
+#include "TPCBase/Mapper.h"
+#include "TFile.h"
+#include <numeric>
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getGlobalPadNumber(const unsigned int ulrow, const unsigned int pad) const
+{
+  return Mapper::getGlobalPadNumber(ulrow, pad, mRegion);
+}
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedRow(const unsigned int ulrow, const unsigned int groupRows, const unsigned int groupedrows)
+{
+  const unsigned int row = ulrow / groupRows;
+  return (row >= groupedrows) ? (groupedrows - 1) : row;
+}
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedPad(const unsigned int upad, const unsigned int ulrow, const unsigned int region, const unsigned int groupPads, const unsigned int groupRows, const unsigned int groupedrows, const std::vector<unsigned int>& padsPerRow)
+{
+  const int relPadHalf = static_cast<int>(std::floor((upad - 0.5f * Mapper::PADSPERROW[region][ulrow]) / groupPads));
+  const unsigned int nGroupedPads = padsPerRow[getGroupedRow(ulrow, groupRows, groupedrows)];
+  const unsigned int nGroupedPadsHalf = (nGroupedPads / 2);
+  if (std::abs(relPadHalf) >= nGroupedPadsHalf) {
+    return std::signbit(relPadHalf) ? 0 : nGroupedPads - 1;
+  }
+  return static_cast<unsigned int>(static_cast<int>(nGroupedPadsHalf) + relPadHalf);
+}
+
+void o2::tpc::IDCGroupHelperRegion::setRows(const unsigned int nRows)
+{
+  mRows = nRows;
+  mPadsPerRow.resize(mRows);
+  mOffsRow.resize(mRows);
+}
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getLastRow() const
+{
+  const unsigned int nTotRows = Mapper::ROWSPERREGION[mRegion];
+  const unsigned int rowsRemainder = nTotRows % mGroupRows;
+  unsigned int lastRow = nTotRows - rowsRemainder;
+  if (rowsRemainder <= mGroupLastRowsThreshold) {
+    lastRow -= mGroupRows;
+  }
+  return lastRow;
+}
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getLastPad(const unsigned int ulrow) const
+{
+  const unsigned int nPads = Mapper::PADSPERROW[mRegion][ulrow] / 2;
+  const unsigned int padsRemainder = nPads % mGroupPads;
+  int unsigned lastPad = (padsRemainder == 0) ? nPads - mGroupPads : nPads - padsRemainder;
+  if (padsRemainder && padsRemainder <= mGroupLastPadsThreshold) {
+    lastPad -= mGroupPads;
+  }
+  return lastPad;
+}
+
+void o2::tpc::IDCGroupHelperRegion::initIDCGroupHelperRegion()
+{
+  const unsigned int nRows = getLastRow() / mGroupRows + 1;
+  setRows(nRows);
+  for (unsigned int irow = 0; irow < nRows; ++irow) {
+    const unsigned int row = irow * mGroupRows;
+    mPadsPerRow[irow] = 2 * (getLastPad(row) / mGroupPads + 1);
+  }
+
+  mNIDCsPerCRU = std::accumulate(mPadsPerRow.begin(), mPadsPerRow.end(), decltype(mPadsPerRow)::value_type(0));
+  for (unsigned int i = 1; i < mRows; ++i) {
+    const unsigned int lastInd = i - 1;
+    mOffsRow[i] = mOffsRow[lastInd] + mPadsPerRow[lastInd];
+  }
+}
+
+void o2::tpc::IDCGroupHelperRegion::dumpToFile(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "UPDATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}

--- a/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCGroupingParameter.h"
+
+using namespace o2::tpc;
+O2ParamImpl(o2::tpc::ParameterIDCGroup);
+O2ParamImpl(o2::tpc::ParameterIDCCompression);

--- a/Detectors/TPC/calibration/src/RobustAverage.cxx
+++ b/Detectors/TPC/calibration/src/RobustAverage.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/RobustAverage.h"
+#include "Framework/Logger.h"
+
+float o2::tpc::RobustAverage::getFilteredAverage(const float sigma)
+{
+  if (mValues.empty()) {
+    return 0;
+  }
+
+  const float mean = getMean();
+  const float stdev = getStdDev(mean);
+  filterOutliers(mean, stdev, sigma);
+
+  if (mValues.empty()) {
+    return 0;
+  }
+
+  return getMean();
+}
+
+float o2::tpc::RobustAverage::getStdDev(const float mean) const
+{
+  std::vector<float> diff(mValues.size());
+  std::transform(mValues.begin(), mValues.end(), diff.begin(), [mean](const float val) { return val - mean; });
+  const float sqsum = std::inner_product(diff.begin(), diff.end(), diff.begin(), decltype(diff)::value_type(0));
+  const float stdev = std::sqrt(sqsum / diff.size());
+  return stdev;
+}
+
+void o2::tpc::RobustAverage::filterOutliers(const float mean, const float stdev, const float sigma)
+{
+  std::sort(mValues.begin(), mValues.end());
+  const float sigmastddev = sigma * stdev;
+  const float minVal = mean - sigmastddev;
+  const float maxVal = mean + sigmastddev;
+  const auto upper = std::upper_bound(mValues.begin(), mValues.end(), maxVal);
+  mValues.erase(upper, mValues.end());
+  const auto lower = std::lower_bound(mValues.begin(), mValues.end(), minVal);
+  mValues.erase(mValues.begin(), lower);
+}
+
+void o2::tpc::RobustAverage::print() const
+{
+  LOGP(info, "PRINTING STORED VALUES");
+  for (auto val : mValues) {
+    LOGP(info, "{}", val);
+  }
+}

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -28,5 +28,32 @@
 #pragma link C++ class o2::tpc::CalibPadGainTracks;
 #pragma link C++ class o2::tpc::FastHisto<float> +;
 #pragma link C++ class o2::tpc::FastHisto<unsigned int> +;
+#pragma link C++ class o2::tpc::IDCGroup +;
+#pragma link C++ class o2::tpc::IDCGroupHelperRegion +;
+#pragma link C++ class o2::tpc::IDCGroupHelperSector +;
+#pragma link C++ struct o2::tpc::ParameterIDCGroup;
+#pragma link C++ struct o2::tpc::ParameterIDCCompression;
+#pragma link C++ class o2::tpc::IDCAverageGroup +;
+#pragma link C++ class o2::tpc::IDCFactorization +;
+#pragma link C++ struct o2::tpc::IDCDelta<float> +;
+#pragma link C++ struct o2::tpc::IDCDelta<short> +;
+#pragma link C++ struct o2::tpc::IDCDelta<char> +;
+#pragma link C++ struct o2::tpc::IDCDeltaCompressionFactors +;
+#pragma link C++ struct o2::tpc::IDCDeltaContainer<float> +;
+#pragma link C++ struct o2::tpc::IDCDeltaContainer<short> +;
+#pragma link C++ struct o2::tpc::IDCDeltaContainer<char> +;
+#pragma link C++ class o2::tpc::IDCDeltaCompressionHelper<short> +;
+#pragma link C++ class o2::tpc::IDCDeltaCompressionHelper<char> +;
+#pragma link C++ struct o2::tpc::IDCZero +;
+#pragma link C++ struct o2::tpc::IDCOne +;
+#pragma link C++ struct o2::tpc::OneDIDC +;
+#pragma link C++ class o2::tpc::OneDIDCAggregator +;
+#pragma link C++ struct o2::tpc::FourierCoeff +;
+#pragma link C++ struct o2::tpc::ParameterIDCGroupCCDB +;
+#pragma link C++ class o2::tpc::RobustAverage +;
+#pragma link C++ class o2::tpc::IDCFourierTransform +;
+#pragma link C++ class o2::tpc::IDCCCDBHelper<float> +;
+#pragma link C++ class o2::tpc::IDCCCDBHelper<short> +;
+#pragma link C++ class o2::tpc::IDCCCDBHelper<char> +;
 
 #endif

--- a/Detectors/TPC/calibration/test/testO2TPCIDCFourierTransform.cxx
+++ b/Detectors/TPC/calibration/test/testO2TPCIDCFourierTransform.cxx
@@ -1,0 +1,92 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  testO2TPCIDCFourierTransform.cxx
+/// \brief this task tests the calculation of fourier coefficients by comparing input values with FT->IFT values
+///
+/// \author  Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#define BOOST_TEST_MODULE Test TPC O2TPCIDCFourierTransform class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "TPCCalibration/IDCFourierTransform.h"
+#include "TRandom.h"
+#include <numeric>
+
+namespace o2::tpc
+{
+
+static constexpr float ABSTOLERANCE = 0.01f; // absolute tolerance is taken at small values near 0
+static constexpr float TOLERANCE = 0.4f;     // difference between original 1D-IDC and 1D-IDC from fourier transform -> inverse fourier transform
+
+o2::tpc::OneDIDC get1DIDCs(const std::vector<unsigned int>& integrationIntervals)
+{
+  const unsigned int nIDCs = std::accumulate(integrationIntervals.begin(), integrationIntervals.end(), static_cast<unsigned int>(0));
+  o2::tpc::OneDIDC idcsOut;
+  for (unsigned int iside = 0; iside < 2; ++iside) {
+    std::vector<float> idcs(nIDCs);
+    for (auto& val : idcs) {
+      val = gRandom->Gaus(0, 0.2);
+    }
+    idcsOut.mOneDIDC[iside] = std::move(idcs);
+  }
+  return idcsOut;
+}
+
+std::vector<unsigned int> getIntegrationIntervalsPerTF(const unsigned int integrationIntervals, const unsigned int tfs)
+{
+  std::vector<unsigned int> intervals;
+  intervals.reserve(tfs);
+  for (unsigned int i = 0; i < tfs; ++i) {
+    const unsigned int additionalInterval = (i % 3) ? 1 : 0; // in each integration inerval are either 10 or 11 values when having 128 orbits per TF and 12 orbits integration length
+    intervals.emplace_back(integrationIntervals + additionalInterval);
+  }
+  return intervals;
+}
+
+BOOST_AUTO_TEST_CASE(IDCFourierTransform_test)
+{
+  const unsigned int integrationIntervals = 10;    // number of integration intervals for first TF
+  const unsigned int tfs = 200;                    // number of aggregated TFs
+  const unsigned int rangeIDC = 200;               // number of IDCs used to calculate the fourier coefficients
+  const unsigned int nFourierCoeff = rangeIDC + 2; // number of fourier coefficients which will be calculated/stored needs to be the maximum value to be able to perform IFT
+  gRandom->SetSeed(0);
+
+  for (int iType = 0; iType < 2; ++iType) {
+    const bool fft = iType == 0 ? false : true;
+    o2::tpc::IDCFourierTransform::setFFT(fft);
+    o2::tpc::IDCFourierTransform idcFourierTransform{rangeIDC, tfs, nFourierCoeff};
+    const auto intervalsPerTF = getIntegrationIntervalsPerTF(integrationIntervals, tfs);
+    idcFourierTransform.setIDCs(get1DIDCs(intervalsPerTF), intervalsPerTF);
+    idcFourierTransform.setIDCs(get1DIDCs(intervalsPerTF), intervalsPerTF);
+    idcFourierTransform.calcFourierCoefficients();
+
+    const std::vector<unsigned int> offsetIndex = idcFourierTransform.getLastIntervals();
+    for (unsigned int iSide = 0; iSide < o2::tpc::SIDES; ++iSide) {
+      const o2::tpc::Side side = iSide == 0 ? Side::A : Side::C;
+      const auto idcOneExpanded = idcFourierTransform.getExpandedIDCOne(side);
+      const auto inverseFourier = idcFourierTransform.inverseFourierTransform(side);
+      for (unsigned int interval = 0; interval < idcFourierTransform.getNIntervals(); ++interval) {
+        for (unsigned int index = 0; index < rangeIDC; ++index) {
+          const float origIDCOne = idcOneExpanded[index + offsetIndex[interval]];
+          const float iFTIDCOne = inverseFourier[interval][index];
+          if (std::fabs(origIDCOne) < ABSTOLERANCE) {
+            BOOST_CHECK_SMALL(iFTIDCOne - origIDCOne, ABSTOLERANCE);
+          } else {
+            BOOST_CHECK_CLOSE(iFTIDCOne, origIDCOne, TOLERANCE);
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace o2::tpc

--- a/Detectors/TPC/simulation/CMakeLists.txt
+++ b/Detectors/TPC/simulation/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(TPCSimulation
                        src/PadResponse.cxx
                        src/Point.cxx
                        src/SAMPAProcessing.cxx
+                       src/IDCSim.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat
                                      O2::TPCBase O2::TPCSpaceCharge
                                      ROOT::Physics)
@@ -37,7 +38,8 @@ o2_target_root_dictionary(TPCSimulation
                                   include/TPCSimulation/GEMAmplification.h
                                   include/TPCSimulation/PadResponse.h
                                   include/TPCSimulation/Point.h
-                                  include/TPCSimulation/SAMPAProcessing.h)
+                                  include/TPCSimulation/SAMPAProcessing.h
+                                  include/TPCSimulation/IDCSim.h)
 
 o2_data_file(COPY files DESTINATION Detectors/TPC)
 o2_data_file(COPY data  DESTINATION Detectors/TPC/simulation)

--- a/Detectors/TPC/simulation/include/TPCSimulation/IDCSim.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/IDCSim.h
@@ -1,0 +1,177 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCSim.h
+/// \brief class for integration of IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 16, 2021
+
+#ifndef ALICEO2_TPC_IDCSIM_H_
+#define ALICEO2_TPC_IDCSIM_H_
+
+#include <vector>
+#include <array>
+#include "DataFormatsTPC/Constants.h"
+#include "CommonConstants/LHCConstants.h"
+#include "TPCBase/Mapper.h"
+#include <gsl/span>
+#include "Rtypes.h"
+
+namespace o2::utils
+{
+class TreeStreamRedirector;
+}
+
+namespace o2::tpc
+{
+
+class Digit;
+
+/// \class IDCSim
+/// This class is for the integration of IDCs for one sector.
+/// The input has to be provided for one TF.
+/// The IDCs are stored per CRU for all integration intervals.
+
+class IDCSim
+{
+ public:
+  /// constructor
+  /// \param sector sector for which the data is processed
+  /// \param nOrbits length of integration intervals
+  IDCSim(const unsigned int sector = 0, const unsigned int nOrbits = 12) : mSector{sector}, mNOrbits{nOrbits} {}
+
+  // integrate IDCs for one TF
+  /// \param digits digits for one sector for one Time Frame
+  void integrateDigitsForOneTF(const gsl::span<const o2::tpc::Digit>& digits);
+
+  /// set number of orbits per TF which is used to determine the size of the vectors etc.
+  /// \param nOrbitsPerTF number of orbits per TF
+  static void setNOrbitsPerTF(const unsigned int nOrbitsPerTF) { mOrbitsPerTF = nOrbitsPerTF; }
+
+  /// for debugging: dumping IDCs to ROOT file
+  /// \param filename name of the output file
+  void dumpIDCs(const char* outFileName, const char* outName = "IDCSim") const;
+
+  /// for debugging: creating debug tree for integrated IDCs
+  /// \param nameTree name of the output file
+  void createDebugTree(const char* nameTree) const;
+
+  /// for debugging: creating debug tree for integrated IDCs for all objects which are in the same file
+  /// \param nameTree name of the output file
+  /// \param filename name of the input file containing the objects
+  static void createDebugTreeForAllSectors(const char* nameTree, const char* filename);
+
+  /// \return returns the IDCs for all regions
+  const auto& get() const { return mIDCs[!mBufferIndex]; }
+
+  /// \return returns the sector for which the IDCs are integrated
+  unsigned int getSector() const { return mSector; }
+
+  /// \return returns the number of orbits for one TF
+  static unsigned int getNOrbitsPerTF() { return mOrbitsPerTF; }
+
+  /// \return returns number of orbits used for each integration interval
+  unsigned int getNOrbitsPerIntegrationInterval() const { return mNOrbits; }
+
+  /// \return returns number of time stamps per integration interval (should be 5346)
+  unsigned int getNTimeStampsPerIntegrationInterval() const { return mTimeStampsPerIntegrationInterval; }
+
+  /// \return returns the check if an additional interval is used (if the last integration interval can also be empty)
+  bool additionalInterval() const { return mAddInterval; }
+
+  /// \return returns maximum number of integration intervals used for one TF
+  unsigned int getNIntegrationIntervalsPerTF() const { return mIntegrationIntervalsPerTF; }
+
+  /// \return number time stamps which remain in one TF and will be buffered to the next TF
+  unsigned int getNTimeStampsRemainder() const { return mTimeStampsRemainder; }
+
+  /// \return offset from last time bin
+  int getTimeBinsOff() const { return mTimeBinsOff; }
+
+  /// draw ungrouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCs.pdf") const;
+
+  /// \return returns maximum number of IDCs per region for all integration intervals
+  unsigned int getMaxIDCs(const unsigned int region) const { return mMaxIDCs[region]; }
+
+ private:
+  inline static unsigned int mOrbitsPerTF{256};                                                                                               ///< length of one TF in units of orbits
+  const unsigned int mSector{};                                                                                                               ///< sector for which the IDCs are integrated
+  const unsigned int mNOrbits{12};                                                                                                            ///< integration intervals of IDCs in units of orbits
+  const unsigned int mTimeStampsPerIntegrationInterval{(o2::constants::lhc::LHCMaxBunches * mNOrbits) / o2::tpc::constants::LHCBCPERTIMEBIN}; ///< number of time stamps for each integration interval (5346)
+  const bool mAddInterval{(mOrbitsPerTF % mNOrbits) > 0 ? true : false};                                                                      ///< if the division has a remainder 256/12=21.333 then add an additional integration interval
+  const unsigned int mIntegrationIntervalsPerTF{mOrbitsPerTF / mNOrbits + mAddInterval};                                                      ///< number of integration intervals per TF. Add 1: 256/12=21.333
+  const unsigned int mTimeStampsRemainder{mTimeStampsPerIntegrationInterval * (mOrbitsPerTF % mNOrbits) / mNOrbits};                          ///< number time stamps which remain in one TF and will be buffered to the next TF
+  int mTimeBinsOff{};                                                                                                                         ///< offset from last time bin
+  bool mBufferIndex{false};                                                                                                                   ///< index for the buffer
+  const std::array<unsigned int, Mapper::NREGIONS> mMaxIDCs{
+    Mapper::PADSPERREGION[0] * mIntegrationIntervalsPerTF, // region 0
+    Mapper::PADSPERREGION[1] * mIntegrationIntervalsPerTF, // region 1
+    Mapper::PADSPERREGION[2] * mIntegrationIntervalsPerTF, // region 2
+    Mapper::PADSPERREGION[3] * mIntegrationIntervalsPerTF, // region 3
+    Mapper::PADSPERREGION[4] * mIntegrationIntervalsPerTF, // region 4
+    Mapper::PADSPERREGION[5] * mIntegrationIntervalsPerTF, // region 5
+    Mapper::PADSPERREGION[6] * mIntegrationIntervalsPerTF, // region 6
+    Mapper::PADSPERREGION[7] * mIntegrationIntervalsPerTF, // region 7
+    Mapper::PADSPERREGION[8] * mIntegrationIntervalsPerTF, // region 8
+    Mapper::PADSPERREGION[9] * mIntegrationIntervalsPerTF  // region 9
+  };                                                       ///< maximum number of IDCs per region
+  std::array<std::vector<float>, Mapper::NREGIONS> mIDCs[2]{
+    {std::vector<float>(mMaxIDCs[0]),  // region 0
+     std::vector<float>(mMaxIDCs[1]),  // region 1
+     std::vector<float>(mMaxIDCs[2]),  // region 2
+     std::vector<float>(mMaxIDCs[3]),  // region 3
+     std::vector<float>(mMaxIDCs[4]),  // region 4
+     std::vector<float>(mMaxIDCs[5]),  // region 5
+     std::vector<float>(mMaxIDCs[6]),  // region 6
+     std::vector<float>(mMaxIDCs[7]),  // region 7
+     std::vector<float>(mMaxIDCs[8]),  // region 8
+     std::vector<float>(mMaxIDCs[9])}, // region 9
+    {std::vector<float>(mMaxIDCs[0]),  // region 0
+     std::vector<float>(mMaxIDCs[1]),  // region 1
+     std::vector<float>(mMaxIDCs[2]),  // region 2
+     std::vector<float>(mMaxIDCs[3]),  // region 3
+     std::vector<float>(mMaxIDCs[4]),  // region 4
+     std::vector<float>(mMaxIDCs[5]),  // region 5
+     std::vector<float>(mMaxIDCs[6]),  // region 6
+     std::vector<float>(mMaxIDCs[7]),  // region 7
+     std::vector<float>(mMaxIDCs[8]),  // region 8
+     std::vector<float>(mMaxIDCs[9])}  // region 9
+  };                                   ///< IDCs for one sector. The array is needed to buffer the IDCs for the last integration interval
+
+  /// \return returns the last time bin after which the buffer is switched
+  unsigned int getLastTimeBinForSwitch() const;
+
+  // set offset for the next time frame
+  void setNewOffset();
+
+  /// set all IDC values to 0
+  void resetIDCs();
+
+  /// return orbit for given timeStamp
+  unsigned int getOrbit(const unsigned int timeStamp) const { return static_cast<unsigned int>((timeStamp + mTimeBinsOff) / mTimeStampsPerIntegrationInterval); }
+
+  /// \return returns index in the vector of the mIDCs member
+  /// \param timeStamp timeStamp for which the index is calculated
+  /// \param region region in the sector
+  /// \param row global pad row
+  /// \param pad pad in row
+  unsigned int getIndex(const unsigned int timeStamp, const unsigned int region, const unsigned int row, const unsigned int pad) const { return getOrbit(timeStamp) * Mapper::PADSPERREGION[region] + Mapper::getLocalPadNumber(row, pad); }
+
+  static void createDebugTree(const IDCSim& idcsim, o2::utils::TreeStreamRedirector& pcstream);
+
+  ClassDefNV(IDCSim, 1)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/simulation/src/IDCSim.cxx
+++ b/Detectors/TPC/simulation/src/IDCSim.cxx
@@ -1,0 +1,215 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCSimulation/IDCSim.h"
+#include "DataFormatsTPC/Digit.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "TFile.h"
+#include "TPCBase/Mapper.h"
+#include <fmt/format.h>
+#include "Framework/Logger.h"
+#include "TPCBase/Painter.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include "TKey.h"
+
+void o2::tpc::IDCSim::integrateDigitsForOneTF(const gsl::span<const o2::tpc::Digit>& digits)
+{
+  resetIDCs();
+
+  // loop over digits from one sector for ALL Time Frames
+  const unsigned int switchAfterTB = getLastTimeBinForSwitch();
+
+  if (mAddInterval) {
+    // decrease the size of the vector if the last integration intervall is empty
+    if (switchAfterTB == (mIntegrationIntervalsPerTF - 1) * mTimeStampsPerIntegrationInterval) {
+      for (unsigned int ireg = 0; ireg < Mapper::NREGIONS; ++ireg) {
+        mIDCs[mBufferIndex][ireg].resize(mMaxIDCs[ireg] - Mapper::PADSPERREGION[ireg]);
+      }
+    } else {
+      for (auto& idcs : mIDCs[mBufferIndex]) {
+        idcs.resize(idcs.capacity());
+      }
+    }
+  }
+
+  for (const auto& digit : digits) {
+    const o2::tpc::CRU cru(digit.getCRU());
+    const unsigned int region = cru.region();
+    const int timeStamp = digit.getTimeStamp();
+    if (timeStamp < switchAfterTB) {
+      const unsigned int indexPad = getIndex(timeStamp, region, digit.getRow(), digit.getPad());
+      mIDCs[mBufferIndex][region][indexPad] += digit.getChargeFloat();
+    } else {
+      const unsigned int indexPad = getIndex(timeStamp - switchAfterTB, region, digit.getRow(), digit.getPad());
+      mIDCs[!mBufferIndex][region][indexPad] += digit.getChargeFloat();
+    }
+  }
+
+  mBufferIndex = !mBufferIndex; // switch buffer index
+  setNewOffset();               // set offset
+}
+
+unsigned int o2::tpc::IDCSim::getLastTimeBinForSwitch() const
+{
+  const int totaloffs = mTimeBinsOff + static_cast<int>(mTimeStampsRemainder);
+  return (totaloffs >= mTimeStampsPerIntegrationInterval) ? mIntegrationIntervalsPerTF * mTimeStampsPerIntegrationInterval - mTimeBinsOff : (mIntegrationIntervalsPerTF - mAddInterval) * mTimeStampsPerIntegrationInterval - mTimeBinsOff;
+}
+
+void o2::tpc::IDCSim::setNewOffset()
+{
+  const int totaloffs = mTimeBinsOff + static_cast<int>(mTimeStampsRemainder);
+  mTimeBinsOff = (totaloffs >= mTimeStampsPerIntegrationInterval) ? (totaloffs - static_cast<int>(mTimeStampsPerIntegrationInterval)) : totaloffs;
+}
+
+/// set all IDC values to 0
+void o2::tpc::IDCSim::resetIDCs()
+{
+  for (auto& idcs : mIDCs[!mBufferIndex]) {
+    std::fill(idcs.begin(), idcs.end(), 0);
+  }
+}
+
+void o2::tpc::IDCSim::dumpIDCs(const char* outFileName, const char* outName) const
+{
+  TFile fOut(outFileName, "RECREATE");
+  fOut.WriteObject(this, outName);
+  fOut.Close();
+}
+
+void o2::tpc::IDCSim::createDebugTree(const char* nameTree) const
+{
+  o2::utils::TreeStreamRedirector pcstream(nameTree, "RECREATE");
+  pcstream.GetFile()->cd();
+  createDebugTree(*this, pcstream);
+  pcstream.Close();
+}
+
+void o2::tpc::IDCSim::createDebugTreeForAllSectors(const char* nameTree, const char* filename)
+{
+  o2::utils::TreeStreamRedirector pcstream(nameTree, "RECREATE");
+  pcstream.GetFile()->cd();
+
+  TFile fInp(filename, "READ");
+  for (TObject* keyAsObj : *fInp.GetListOfKeys()) {
+    const auto key = dynamic_cast<TKey*>(keyAsObj);
+    LOGP(info, "Key name: {} Type: {}", key->GetName(), key->GetClassName());
+
+    if (std::strcmp(o2::tpc::IDCSim::Class()->GetName(), key->GetClassName()) != 0) {
+      LOGP(info, "skipping object. wrong class.");
+      continue;
+    }
+
+    IDCSim* idcsim = (IDCSim*)fInp.Get(key->GetName());
+    createDebugTree(*idcsim, pcstream);
+    delete idcsim;
+  }
+  pcstream.Close();
+}
+
+void o2::tpc::IDCSim::createDebugTree(const IDCSim& idcsim, o2::utils::TreeStreamRedirector& pcstream)
+{
+  const Mapper& mapper = Mapper::instance();
+  const unsigned int sector = idcsim.getSector();
+  unsigned int cru = sector * Mapper::NREGIONS;
+
+  // loop over data from regions
+  for (const auto& idcs : idcsim.get()) {
+    int sectorTmp = sector;
+    const o2::tpc::CRU cruTmp(cru);
+    unsigned int region = cruTmp.region();
+    const unsigned long padsPerCRU = Mapper::PADSPERREGION[region];
+    std::vector<int> vRow(padsPerCRU);
+    std::vector<int> vPad(padsPerCRU);
+    std::vector<float> vXPos(padsPerCRU);
+    std::vector<float> vYPos(padsPerCRU);
+    std::vector<float> vGlobalXPos(padsPerCRU);
+    std::vector<float> vGlobalYPos(padsPerCRU);
+    std::vector<float> idcsPerTimeBin(padsPerCRU); // idcs for one time bin
+
+    for (unsigned int iPad = 0; iPad < padsPerCRU; ++iPad) {
+      const GlobalPadNumber globalNum = Mapper::GLOBALPADOFFSET[region] + iPad;
+      const auto& padPosLocal = mapper.padPos(globalNum);
+      vRow[iPad] = padPosLocal.getRow();
+      vPad[iPad] = padPosLocal.getPad();
+      vXPos[iPad] = mapper.getPadCentre(padPosLocal).X();
+      vYPos[iPad] = mapper.getPadCentre(padPosLocal).Y();
+      const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[iPad], vYPos[iPad]), cruTmp.sector());
+      vGlobalXPos[iPad] = globalPos.X();
+      vGlobalYPos[iPad] = globalPos.Y();
+    }
+
+    for (unsigned int integrationInterval = 0; integrationInterval < idcsim.getNIntegrationIntervalsPerTF(); ++integrationInterval) {
+      for (unsigned int iPad = 0; iPad < padsPerCRU; ++iPad) {
+        idcsPerTimeBin[iPad] = (idcs)[iPad + integrationInterval * Mapper::PADSPERREGION[region]];
+      }
+
+      pcstream << "tree"
+               << "cru=" << cru
+               << "sector=" << sectorTmp
+               << "region=" << region
+               << "integrationInterval=" << integrationInterval
+               << "IDC.=" << idcsPerTimeBin
+               << "pad.=" << vPad
+               << "row.=" << vRow
+               << "lx.=" << vXPos
+               << "ly.=" << vYPos
+               << "gx.=" << vGlobalXPos
+               << "gy.=" << vGlobalYPos
+               << "\n";
+    }
+    ++cru;
+  }
+}
+
+void o2::tpc::IDCSim::drawIDCs(const unsigned int integrationInterval, const std::string filename) const
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+
+  TLatex lat;
+  lat.SetTextFont(63);
+  lat.SetTextSize(2);
+
+  poly->Draw("colz");
+  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+        const auto coordinate = coords[padNum];
+        const float yPos = -0.5 * (coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
+        const float xPos = 0.5 * (coordinate.xVals[0] + coordinate.xVals[2]);
+        const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][irow] + ipad;
+        const float idc = mIDCs[!mBufferIndex][region][indexIDC];
+        poly->Fill(xPos, yPos, idc);
+        lat.SetTextAlign(12);
+        lat.DrawLatex(xPos, yPos, Form("%i", ipad));
+      }
+    }
+  }
+
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -32,6 +32,7 @@
 #pragma link C++ class std::vector < o2::tpc::ElementalHit> + ;
 #pragma link C++ class o2::tpc::HitGroup + ;
 #pragma link C++ class o2::tpc::SAMPAProcessing + ;
+#pragma link C++ class o2::tpc::IDCSim + ;
 
 #pragma link C++ class std::vector < o2::tpc::HitGroup> + ;
 

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -7,7 +7,7 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
-                     
+
 o2_add_library(TPCWorkflow
                SOURCES src/RecoWorkflow.cxx
                        src/ClustererSpec.cxx
@@ -59,6 +59,21 @@ o2_add_executable(raw-to-digits-workflow
 o2_add_executable(calib-pedestal
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-calib-pedestal.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(integrate-idc
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-integrate-idc.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(averagegroup-idc
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-averagegroup-idc.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(aggregate-idc
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-aggregate-grouped-idc.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_executable(track-reader

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCAggregateGroupedIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCAggregateGroupedIDCSpec.h
@@ -1,0 +1,208 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TPCAggregateGroupedIDCSpec.h
+/// \brief TPC aggregation of grouped IDCs and factorization + fourier transform
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 22, 2021
+
+#ifndef O2_TPCAGGREGATEGROUPIDCSPEC_H
+#define O2_TPCAGGREGATEGROUPIDCSPEC_H
+
+#include <vector>
+#include <fmt/format.h>
+#include <limits>
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Headers/DataHeader.h"
+#include "TPCCalibration/IDCFactorization.h"
+#include "CCDB/CcdbApi.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TPCCalibration/IDCGroupingParameter.h"
+#include "TPCCalibration/IDCFourierTransform.h"
+#include "TPCWorkflow/TPCAverageGroupIDCSpec.h"
+#include "TPCBase/CRU.h"
+
+using namespace o2::framework;
+using o2::header::gDataOriginTPC;
+using namespace o2::tpc;
+
+namespace o2::tpc
+{
+
+class TPCAggregateGroupedIDCSpec : public o2::framework::Task
+{
+ public:
+  TPCAggregateGroupedIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int nFourierCoefficientsStore, const unsigned int timeframesDeltaIDC, std::array<unsigned char, Mapper::NREGIONS> groupPads,
+                             std::array<unsigned char, Mapper::NREGIONS> groupRows, std::array<unsigned char, Mapper::NREGIONS> groupLastRowsThreshold,
+                             std::array<unsigned char, Mapper::NREGIONS> groupLastPadsThreshold, const unsigned int rangeIDC, const IDCDeltaCompression compression, const bool debug = false)
+    : mCRUs{crus}, mIDCFactorization{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, timeframes, timeframesDeltaIDC}, mIDCFourierTransform{rangeIDC, timeframes, nFourierCoefficientsStore}, mOneDIDCAggregator{timeframes}, mCompressionDeltaIDC{compression}, mDebug{debug} {};
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    mDBapi.init(ic.options().get<std::string>("ccdb-uri")); // or http://localhost:8080 for a local installation
+    mWriteToDB = mDBapi.isHostReachable() ? true : false;
+    mUpdateGroupingPar = !(ic.options().get<bool>("update-not-grouping-parameter"));
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    // set the min range of TFs for first TF
+    if (mProcessedTFs == 0) {
+      mTFRange[0] = getCurrentTF(pc);
+    }
+
+    // write struct containing grouping parameters to access grouped IDCs to CCDB
+    if (mWriteToDB && mUpdateGroupingPar) {
+      // validity for grouping parameters is from first TF to some really large TF (until it is updated)
+      mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCFactorization.getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, getFirstTF(), std::numeric_limits<uint32_t>::max());
+      mUpdateGroupingPar = false; // write grouping parameters only once
+    }
+
+    for (int i = 0; i < 2 * mCRUs.size(); ++i) {
+      const DataRef ref = pc.inputs().getByPos(i);
+      auto const* tpcCRUHeader = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      const int cru = tpcCRUHeader->subSpecification >> 7;
+      const auto descr = tpcCRUHeader->dataDescription;
+      if (TPCAverageGroupIDCDevice::getDataDescription1DIDC() == descr) {
+        // 1D-IDCs as input which will be used for FT
+        const o2::tpc::CRU cruTmp(cru);
+        mOneDIDCAggregator.aggregate1DIDCs(cruTmp.side(), pc.inputs().get<std::vector<float>>(ref), mProcessedTFs, cruTmp.region());
+      } else if (TPCAverageGroupIDCDevice::getDataDescriptionIDCGroup() == descr) {
+        // 3D-IDCs as input which will be factorized
+        mIDCFactorization.setIDCs(pc.inputs().get<std::vector<float>>(ref), cru, mProcessedTFs); // aggregate IDCs
+      } else {
+        // wrong description;
+      }
+    }
+    ++mProcessedTFs;
+
+    if (mProcessedTFs == mIDCFactorization.getNTimeframes()) {
+      mTFRange[1] = getCurrentTF(pc);    // set the TF for last aggregated TF
+      mProcessedTFs = 0;                 // reset processed TFs for next aggregation interval
+      mIDCFactorization.factorizeIDCs(); // calculate DeltaIDC, 0D-IDC, 1D-IDC
+
+      // perform fourier transform of 1D-IDCs
+      mIDCFourierTransform.setIDCs(std::move(mOneDIDCAggregator).getAggregated1DIDCs(), mIDCFactorization.getIntegrationIntervalsPerTF());
+      mIDCFourierTransform.calcFourierCoefficients();
+
+      if (mDebug) {
+        LOGP(info, "dumping aggregated and factorized IDCs and FT to file");
+        mIDCFactorization.dumpToFile(fmt::format("IDCFactorized_{:02}.root", getCurrentTF(pc)).data());
+        mIDCFourierTransform.dumpToFile(fmt::format("Fourier_{:02}.root", getCurrentTF(pc)).data());
+      }
+
+      // storing to CCDB
+      sendOutput(pc.outputs());
+    }
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    ec.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+
+ private:
+  const std::vector<uint32_t> mCRUs{};              ///< CRUs to process in this instance
+  int mProcessedTFs{0};                             ///< number of processed time frames to keep track of when the writing to CCDB will be done
+  IDCFactorization mIDCFactorization{};             ///< object aggregating the IDCs and performing the factorization of the IDCs
+  IDCFourierTransform mIDCFourierTransform{};       ///< object for performing the fourier transform of 1D-IDCs
+  OneDIDCAggregator mOneDIDCAggregator{};           ///< helper class for aggregation of 1D-IDCs
+  const IDCDeltaCompression mCompressionDeltaIDC{}; ///< compression type for IDC Delta
+  const bool mDebug{false};                         ///< dump IDCs to tree for debugging
+  o2::ccdb::CcdbApi mDBapi;                         ///< API for storing the IDCs in the CCDB
+  std::map<std::string, std::string> mMetadata;     ///< meta data of the stored object in CCDB
+  bool mWriteToDB{};                                ///< flag if writing to CCDB will be done
+  std::array<uint32_t, 2> mTFRange{};               ///< storing of first and last TF used when setting the validity of the objects when writing to CCDB
+  bool mUpdateGroupingPar{true};                    ///< flag to set if grouping parameters should be updated or not
+
+  /// \return returns TF of current processed data
+  uint32_t getCurrentTF(o2::framework::ProcessingContext& pc) const { return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getByPos(0))->tfCounter; }
+
+  /// \return returns first TF for validity range when storing to CCDB
+  uint32_t getFirstTF() const { return mTFRange[0]; }
+
+  /// \return returns last TF for validity range when storing to CCDB
+  uint32_t getLastTF() const { return mTFRange[1]; }
+
+  /// \return returns first TF for validity range when storing to IDCDelta CCDB
+  unsigned int getFirstTFDeltaIDC(const unsigned int iChunk) const { return getFirstTF() + iChunk * mIDCFactorization.getTimeFramesDeltaIDC(); }
+
+  /// \return returns last TF for validity range when storing to IDCDelta CCDB
+  unsigned int getLastTFDeltaIDC(const unsigned int iChunk) const { return (iChunk == mIDCFactorization.getNChunks() - 1) ? (mIDCFactorization.getNTimeframes() - 1 + getFirstTF()) : (getFirstTFDeltaIDC(iChunk) + mIDCFactorization.getTimeFramesDeltaIDC() - 1); }
+
+  void sendOutput(DataAllocator& output)
+  {
+    if (mWriteToDB) {
+      const long timeStampStart = getFirstTF();
+      const long timeStampEnd = getLastTF();
+      mDBapi.storeAsTFileAny<o2::tpc::IDCZero>(&mIDCFactorization.getIDCZero(), "TPC/Calib/IDC/IDC0", mMetadata, timeStampStart, timeStampEnd);
+      mDBapi.storeAsTFileAny<o2::tpc::IDCOne>(&mIDCFactorization.getIDCOne(), "TPC/Calib/IDC/IDC1", mMetadata, timeStampStart, timeStampEnd);
+      mDBapi.storeAsTFileAny<o2::tpc::FourierCoeff>(&mIDCFourierTransform.getFourierCoefficients(), "TPC/Calib/IDC/FOURIER", mMetadata, timeStampStart, timeStampEnd);
+
+      for (unsigned int iChunk = 0; iChunk < mIDCFactorization.getNChunks(); ++iChunk) {
+        switch (mCompressionDeltaIDC) {
+          case IDCDeltaCompression::MEDIUM:
+          default: {
+            auto idcDeltaMediumCompressed = mIDCFactorization.getIDCDeltaMediumCompressed(iChunk);
+            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<short>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            break;
+          }
+          case IDCDeltaCompression::HIGH: {
+            auto idcDeltaHighCompressed = mIDCFactorization.getIDCDeltaHighCompressed(iChunk);
+            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<char>>(&idcDeltaHighCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            break;
+          }
+          case IDCDeltaCompression::NO:
+            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCFactorization.getIDCDeltaUncompressed(iChunk), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            break;
+        }
+      }
+    }
+    // reseting aggregated IDCs. This is done for safety, but if all data is received in the next aggregation interval it isnt necessary... remove it?
+    mIDCFactorization.reset();
+  }
+};
+
+DataProcessorSpec getTPCAggregateGroupedIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int timeframesDeltaIDC, const unsigned int rangeIDC, const unsigned int nFourierCoefficientsStore, const IDCDeltaCompression compression, const bool debug = false)
+{
+  std::vector<OutputSpec> outputSpecs;
+  std::vector<InputSpec> inputSpecs;
+  inputSpecs.reserve(crus.size());
+  for (const auto& cru : crus) {
+    const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+    inputSpecs.emplace_back(InputSpec{"idcsgroup", gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescriptionIDCGroup(), subSpec, Lifetime::Timeframe});
+    inputSpecs.emplace_back(InputSpec{"1didc", gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescription1DIDC(), subSpec, Lifetime::Timeframe});
+  }
+
+  const auto& paramIDCGroup = ParameterIDCGroup::Instance();
+  std::array<unsigned char, Mapper::NREGIONS> groupPads{};
+  std::array<unsigned char, Mapper::NREGIONS> groupRows{};
+  std::array<unsigned char, Mapper::NREGIONS> groupLastRowsThreshold{};
+  std::array<unsigned char, Mapper::NREGIONS> groupLastPadsThreshold{};
+  std::copy(std::begin(paramIDCGroup.GroupPads), std::end(paramIDCGroup.GroupPads), std::begin(groupPads));
+  std::copy(std::begin(paramIDCGroup.GroupRows), std::end(paramIDCGroup.GroupRows), std::begin(groupRows));
+  std::copy(std::begin(paramIDCGroup.GroupLastRowsThreshold), std::end(paramIDCGroup.GroupLastRowsThreshold), std::begin(groupLastRowsThreshold));
+  std::copy(std::begin(paramIDCGroup.GroupLastPadsThreshold), std::end(paramIDCGroup.GroupLastPadsThreshold), std::begin(groupLastPadsThreshold));
+
+  return DataProcessorSpec{
+    "tpc-aggregate-idc",
+    inputSpecs,
+    outputSpecs,
+    AlgorithmSpec{adaptFromTask<TPCAggregateGroupedIDCSpec>(crus, timeframes, nFourierCoefficientsStore, timeframesDeltaIDC, groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, rangeIDC, compression, debug)},
+    Options{{"ccdb-uri", VariantType::String, "http://ccdb-test.cern.ch:8080", {"URI for the CCDB access."}},
+            {"update-not-grouping-parameter", VariantType::Bool, false, {"Do NOT Update/Writing grouping parameters to CCDB."}}}}; // end DataProcessorSpec
+}
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCAverageGroupIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCAverageGroupIDCSpec.h
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TPCAverageGroupIDCSpec.h
+/// \brief TPC merging and averaging of IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 16, 2021
+
+#ifndef O2_TPCAVERAGEGROUPIDCSPEC_H
+#define O2_TPCAVERAGEGROUPIDCSPEC_H
+
+#include <vector>
+#include <fmt/format.h>
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Headers/DataHeader.h"
+#include "TPCCalibration/IDCAverageGroup.h"
+#include "TPCWorkflow/TPCIntegrateIDCSpec.h"
+#include "TPCCalibration/IDCGroupingParameter.h"
+
+using namespace o2::framework;
+using o2::header::gDataOriginTPC;
+using namespace o2::tpc;
+
+namespace o2::tpc
+{
+
+class TPCAverageGroupIDCDevice : public o2::framework::Task
+{
+ public:
+  TPCAverageGroupIDCDevice(const int lane, const std::vector<uint32_t>& crus, const bool debug = false)
+    : mLane{lane}, mCRUs{crus}, mDebug{debug}
+  {
+    auto& paramIDCGroup = ParameterIDCGroup::Instance();
+    for (const auto& cru : mCRUs) {
+      const CRU cruTmp(cru);
+      const unsigned int reg = cruTmp.region();
+      mIDCs.emplace(cru, IDCAverageGroup(paramIDCGroup.GroupPads[reg], paramIDCGroup.GroupRows[reg], paramIDCGroup.GroupLastRowsThreshold[reg], paramIDCGroup.GroupLastPadsThreshold[reg], reg, cruTmp.sector()));
+    }
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    LOGP(info, "averaging and grouping IDCs for one TF for CRUs {} to {} using {} threads", mCRUs.front(), mCRUs.back(), mIDCs.begin()->second.getNThreads());
+
+    for (int i = 0; i < mCRUs.size(); ++i) {
+      const DataRef ref = pc.inputs().getByPos(i);
+      auto const* tpcCRUHeader = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      const int cru = tpcCRUHeader->subSpecification >> 7;
+      mIDCs[cru].setIDCs(pc.inputs().get<std::vector<float>>(ref));
+      mIDCs[cru].processIDCs();
+
+      // send the output for one CRU for one TF
+      sendOutput(pc.outputs(), cru);
+    }
+
+    if (mDebug) {
+      TFile fOut(fmt::format("IDCGroup_{}_tf_{}.root", mLane, o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getByPos(0))->tfCounter).data(), "RECREATE");
+      for (int i = 0; i < mCRUs.size(); ++i) {
+        const DataRef ref = pc.inputs().getByPos(i);
+        auto const* tpcCRUHeader = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+        const int cru = tpcCRUHeader->subSpecification >> 7;
+        fOut.WriteObject(&mIDCs[cru], fmt::format("CRU_{}", cru).data());
+      }
+    }
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    ec.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+
+  /// return data description for IDC Group
+  static constexpr header::DataDescription getDataDescriptionIDCGroup() { return header::DataDescription{"IDCGROUP"}; }
+
+  /// return data description for 1D IDCs
+  static constexpr header::DataDescription getDataDescription1DIDC() { return header::DataDescription{"1DIDC"}; }
+
+ private:
+  const int mLane{};                                         ///< lane number of processor
+  const std::vector<uint32_t> mCRUs{};                       ///< CRUs to process in this instance
+  const bool mDebug{};                                       ///< dump IDCs to tree for debugging
+  std::unordered_map<unsigned int, IDCAverageGroup> mIDCs{}; ///< object for averaging and grouping of the IDCs
+
+  void sendOutput(DataAllocator& output, const uint32_t cru)
+  {
+    const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+    output.snapshot(Output{gDataOriginTPC, getDataDescriptionIDCGroup(), subSpec, Lifetime::Timeframe}, mIDCs[cru].getIDCGroup().getData());
+
+    // calculate 1D-IDCs = sum over 2D-IDCs as a function of the integration interval
+    const std::vector<float> vec1DIDCs = mIDCs[cru].getIDCGroup().get1DIDCs();
+    output.snapshot(Output{gDataOriginTPC, getDataDescription1DIDC(), subSpec, Lifetime::Timeframe}, vec1DIDCs);
+  }
+};
+
+DataProcessorSpec getTPCAverageGroupIDCSpec(const int ilane, const std::vector<uint32_t>& crus, const bool debug = false)
+{
+  std::vector<OutputSpec> outputSpecs;
+  std::vector<InputSpec> inputSpecs;
+  outputSpecs.reserve(crus.size());
+  inputSpecs.reserve(crus.size());
+
+  for (const auto& cru : crus) {
+    const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+    inputSpecs.emplace_back(InputSpec{"idcs", gDataOriginTPC, TPCIntegrateIDCDevice::getDataDescription(TPCIntegrateIDCDevice::IDCFormat::Sim), subSpec, Lifetime::Timeframe});
+    outputSpecs.emplace_back(ConcreteDataMatcher{gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescriptionIDCGroup(), subSpec});
+    outputSpecs.emplace_back(ConcreteDataMatcher{gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescription1DIDC(), subSpec});
+  }
+
+  const auto id = fmt::format("tpc-averagegroup-idc-{:02}", ilane);
+  return DataProcessorSpec{
+    id.data(),
+    inputSpecs,
+    outputSpecs,
+    AlgorithmSpec{adaptFromTask<TPCAverageGroupIDCDevice>(ilane, crus, debug)},
+  }; // end DataProcessorSpec
+}
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateIDCSpec.h
@@ -1,0 +1,139 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TPCIntegrateIDCSpec.h
+/// \brief TPC integration of IDCs processor
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+/// \date Apr 16, 2021
+
+#ifndef O2_TPCINTEGRATEIDCSPEC_H
+#define O2_TPCINTEGRATEIDCSPEC_H
+
+#include <vector>
+#include <fmt/format.h>
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Headers/DataHeader.h"
+#include "TPCSimulation/IDCSim.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "DataFormatsTPC/Digit.h"
+#include "TPCBase/Mapper.h"
+
+using namespace o2::framework;
+using o2::header::gDataOriginTPC;
+using namespace o2::tpc;
+
+namespace o2::tpc
+{
+
+class TPCIntegrateIDCDevice : public o2::framework::Task
+{
+ public:
+  // enum for the output format of the integrated IDCs
+  enum class IDCFormat : int {
+    Sim = 0, // output format of simulation for faster processing
+    Real = 1 // output format of real CRUs
+  };
+
+  TPCIntegrateIDCDevice(const std::vector<unsigned int>& sectors, const int nOrbitsPerIDCIntervall, const IDCFormat outputFormat, const bool debug) : mSectors{sectors}, mIDCFormat{outputFormat}, mDebug{debug}
+  {
+    for (const auto& sector : mSectors) {
+      mIDCs.emplace(sector, IDCSim(sector, nOrbitsPerIDCIntervall));
+    }
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    LOGP(info, "integrating digits for sectors {} to {}", mSectors.front(), mSectors.back());
+
+    for (int iSec = 0; iSec < mSectors.size(); ++iSec) {
+      const DataRef ref = pc.inputs().getByPos(iSec);
+      const int sector = o2::framework::DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref)->sector();
+
+      // integrate digits for given sector
+      mIDCs[sector].integrateDigitsForOneTF(pc.inputs().get<gsl::span<o2::tpc::Digit>>(ref));
+
+      if (mDebug) {
+        auto const* tpcHeader = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+        mIDCs[sector].dumpIDCs(fmt::format("idcs_obj_sec{:02}_tf{:02}.root", sector, tpcHeader->tfCounter).data(), fmt::format("IDCSim_sec{:02}", sector).data());
+      }
+
+      // send the output for one sector for one TF
+      sendOutput(pc.outputs(), sector);
+    }
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final { ec.services().get<ControlService>().readyToQuit(QuitRequest::Me); }
+
+  /// return the kind of the output for given type.
+  /// \param idcFormat type of the IDC format
+  static constexpr header::DataDescription getDataDescription(const IDCFormat idcFormat) { return (idcFormat == IDCFormat::Sim) ? header::DataDescription{"IDCVECTOR"} : header::DataDescription{"IDC"}; }
+
+ private:
+  const std::vector<unsigned int> mSectors{};       ///< sectors to process in this instance
+  const IDCFormat mIDCFormat{IDCFormat::Sim};       ///< type of the output format. Sim=simulation, Real=realistic format
+  const bool mDebug{false};                         ///< dump IDCs to tree for debugging
+  std::unordered_map<unsigned int, IDCSim> mIDCs{}; ///< integrated IDCs for one TF for all specified sectors
+
+  // send output for one sector
+  void sendOutput(DataAllocator& output, const int sector)
+  {
+    uint32_t cru = sector * Mapper::NREGIONS;
+    for (const auto& idcs : mIDCs[sector].get()) {
+      const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+      if (mIDCFormat == IDCFormat::Sim) {
+        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec, Lifetime::Timeframe}, idcs);
+      } else {
+        // TODO
+        // convert to format from thorsten here
+        // send.......
+        // DUMMY FOR NOW
+        // const TPCCRUHeader cruheader{cru, mIntegrationIntervalsPerTF};
+        output.snapshot(Output{gDataOriginTPC, getDataDescription(mIDCFormat), subSpec, Lifetime::Timeframe}, idcs);
+      }
+      ++cru;
+    }
+  }
+};
+
+DataProcessorSpec getTPCIntegrateIDCSpec(const int ilane, const std::vector<unsigned int>& sectors, const int nOrbits = 12, const TPCIntegrateIDCDevice::IDCFormat outputFormat = TPCIntegrateIDCDevice::IDCFormat::Sim, const bool debug = false)
+{
+  std::vector<InputSpec> inputSpecs;
+  inputSpecs.reserve(sectors.size());
+
+  std::vector<OutputSpec> outputSpecs;
+  outputSpecs.reserve(sectors.size() * Mapper::NREGIONS);
+
+  // define input and output specs
+  for (const auto& sector : sectors) {
+    inputSpecs.emplace_back(InputSpec{"digits", gDataOriginTPC, "DIGITS", sector, Lifetime::Timeframe});
+
+    // output spec
+    unsigned int cru = sector * Mapper::NREGIONS;
+    for (int iRegion = 0; iRegion < Mapper::NREGIONS; ++iRegion) {
+      const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+      outputSpecs.emplace_back(ConcreteDataMatcher{gDataOriginTPC, TPCIntegrateIDCDevice::getDataDescription(outputFormat), subSpec});
+      ++cru;
+    }
+  }
+
+  const auto id = fmt::format("tpc-integrate-idc-{:02}", ilane);
+  return DataProcessorSpec{
+    id.data(),
+    inputSpecs,
+    outputSpecs,
+    AlgorithmSpec{adaptFromTask<TPCIntegrateIDCDevice>(sectors, nOrbits, outputFormat, debug)}}; // end DataProcessorSpec
+}
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/src/tpc-aggregate-grouped-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-aggregate-grouped-idc.cxx
@@ -1,0 +1,101 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <string>
+#include "Algorithm/RangeTokenizer.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Logger.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TPCWorkflow/TPCAggregateGroupedIDCSpec.h"
+#include "TPCCalibration/IDCFactorization.h"
+#include "TPCCalibration/IDCFourierTransform.h"
+
+using namespace o2::framework;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-idc-aggregate.*", CompletionPolicy::CompletionOp::Consume));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  const std::string cruDefault = "0-" + std::to_string(o2::tpc::CRU::MaxCRU - 1);
+
+  std::vector<ConfigParamSpec> options{
+    {"configFile", VariantType::String, "o2tpcaveragegroupidc_configuration.ini", {"configuration file for configurable parameters"}},
+    {"timeframes", VariantType::Int, 2000, {"Number of TFs which will be aggregated per aggregation interval."}},
+    {"timeframesDeltaIDC", VariantType::Int, 100, {"Number of TFs used for storing the IDCDelta struct in the CCDB."}},
+    {"rangeIDC", VariantType::Int, 200, {"Number of 1D-IDCs which will be used for the calculation of the fourier coefficients."}},
+    {"nFourierCoeff", VariantType::Int, 60, {"Number of fourier coefficients (real+imag) which will be stored in the CCDB. The maximum can be 'rangeIDC + 2'."}},
+    {"nthreads-IDC-factorization", VariantType::Int, 1, {"Number of threads which will be used during the factorization of the IDCs."}},
+    {"nthreads-IDC-fourier-transform", VariantType::Int, 1, {"Number of threads which will be used during the calculation of the fourier coefficients."}},
+    {"debug", VariantType::Bool, false, {"create debug files"}},
+    {"use-naive-fft", VariantType::Bool, false, {"using naive fourier transform (true) or FFTW (false)"}},
+    {"crus", VariantType::String, cruDefault.c_str(), {"List of CRUs, comma separated ranges, e.g. 0-3,7,9-15"}},
+    {"compression", VariantType::Int, 1, {"compression of DeltaIDC: 0 -> No, 1 -> Medium (data compression ratio 2), 2 -> High (data compression ratio ~6)"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g. for pp 50kHz: 'TPCIDCCompressionParam.MaxIDCDeltaValue=15;')"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  using namespace o2::tpc;
+
+  // set up configuration
+  o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
+  o2::conf::ConfigurableParam::writeINI("o2tpcaggregateidc_configuration.ini");
+
+  const auto tpcCRUs = o2::RangeTokenizer::tokenize<int>(config.options().get<std::string>("crus"));
+  const auto nCRUs = tpcCRUs.size();
+  const auto timeframes = static_cast<unsigned int>(config.options().get<int>("timeframes"));
+  const auto timeframesDeltaIDC = static_cast<unsigned int>(config.options().get<int>("timeframesDeltaIDC"));
+  const auto debug = config.options().get<bool>("debug");
+  const bool fft = config.options().get<bool>("use-naive-fft");
+  const auto rangeIDC = static_cast<unsigned int>(config.options().get<int>("rangeIDC"));
+  const auto nFourierCoeff = static_cast<unsigned int>(config.options().get<int>("nFourierCoeff"));
+  const auto nthreadsFactorization = static_cast<unsigned long>(config.options().get<int>("nthreads-IDC-factorization"));
+  const auto nthreadsFourier = static_cast<unsigned long>(config.options().get<int>("nthreads-IDC-fourier-transform"));
+  IDCFactorization::setNThreads(nthreadsFactorization);
+  IDCFourierTransform::setNThreads(nthreadsFourier);
+  IDCFourierTransform::setFFT(!fft);
+
+  const int compressionTmp = config.options().get<int>("compression");
+  IDCDeltaCompression compression;
+  switch (compressionTmp) {
+    case static_cast<int>(IDCDeltaCompression::NO):
+    case static_cast<int>(IDCDeltaCompression::MEDIUM):
+    case static_cast<int>(IDCDeltaCompression::HIGH):
+      compression = static_cast<IDCDeltaCompression>(compressionTmp);
+      break;
+    default:
+      LOGP(error, "wrong compression type set. Setting compression to medium compression");
+      compression = static_cast<IDCDeltaCompression>(IDCDeltaCompression::MEDIUM);
+      break;
+  }
+
+  WorkflowSpec workflow;
+  const auto first = tpcCRUs.begin();
+  const auto last = std::min(tpcCRUs.end(), first + nCRUs);
+  const std::vector<uint32_t> rangeCRUs(first, last);
+  workflow.emplace_back(getTPCAggregateGroupedIDCSpec(rangeCRUs, timeframes, timeframesDeltaIDC, rangeIDC, nFourierCoeff, compression, debug));
+
+  return workflow;
+}

--- a/Detectors/TPC/workflow/src/tpc-averagegroup-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-averagegroup-idc.cxx
@@ -1,0 +1,149 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <fmt/format.h>
+#include <vector>
+#include <string>
+#include "Algorithm/RangeTokenizer.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Logger.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TPCWorkflow/TPCAverageGroupIDCSpec.h"
+#include "TPCBase/CRU.h"
+#include "TPCBase/Mapper.h"
+#include "Framework/Variant.h"
+#include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
+#include "TPCCalibration/IDCAverageGroup.h"
+
+using namespace o2::framework;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-idc-averagegroup.*", CompletionPolicy::CompletionOp::Consume));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  const std::string cruDefault = "0-" + std::to_string(o2::tpc::CRU::MaxCRU - 1);
+  const int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
+
+  std::vector<ConfigParamSpec> options{
+    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"debug", VariantType::Bool, false, {"create debug files"}},
+    {"lanes", VariantType::Int, defaultlanes, {"Number of parallel processing lanes."}},
+    {"nthreads", VariantType::Int, 1, {"Number of threads which will be used during averaging and grouping."}},
+    {"crus", VariantType::String, cruDefault.c_str(), {"List of CRUs, comma separated ranges, e.g. 0-3,7,9-15"}},
+    {"groupPads", VariantType::String, "7,7,7,7,6,6,6,6,5,5", {"number of pads in a row which will be grouped per region"}},
+    {"groupRows", VariantType::String, "5,5,5,5,4,4,4,4,3,3", {"number of pads in row direction which will be grouped per region"}},
+    {"groupLastRowsThreshold", VariantType::String, "3,3,3,3,2,2,2,2,2,2", {"set threshold in row direction for merging the last group to the previous group per region"}},
+    {"groupLastPadsThreshold", VariantType::String, "3,3,3,3,2,2,2,2,1,1", {"set threshold in pad direction for merging the last group to the previous group per region"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  using namespace o2::tpc;
+
+  const auto tpcCRUs = o2::RangeTokenizer::tokenize<int>(config.options().get<std::string>("crus"));
+  const auto nCRUs = tpcCRUs.size();
+  const auto nLanes = std::min(static_cast<unsigned long>(config.options().get<int>("lanes")), nCRUs);
+  const auto crusPerLane = nCRUs / nLanes + ((nCRUs % nLanes) != 0);
+  const auto debug = config.options().get<bool>("debug");
+  const auto nthreads = static_cast<unsigned long>(config.options().get<int>("nthreads"));
+  IDCAverageGroup::setNThreads(nthreads);
+
+  const std::string sgroupPads = config.options().get<std::string>("groupPads");
+  const std::string sgroupRows = config.options().get<std::string>("groupRows");
+  const std::string sgroupLastRowsThreshold = config.options().get<std::string>("groupLastRowsThreshold");
+  const std::string sgroupLastPadsThreshold = config.options().get<std::string>("groupLastPadsThreshold");
+
+  // convert input string to std::vector<unsigned char>
+  const boost::char_separator<char> sep(","); /// char separator for the tokenizer
+  const boost::tokenizer<boost::char_separator<char>> tgroupPads(sgroupPads, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupRows(sgroupRows, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupLastRowsThreshold(sgroupLastRowsThreshold, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupLastPadsThreshold(sgroupLastPadsThreshold, sep);
+
+  std::vector<unsigned char> vgroupPads;
+  std::vector<unsigned char> vgroupRows;
+  std::vector<unsigned char> vgroupLastRowsThreshold;
+  std::vector<unsigned char> vgroupLastPadsThreshold;
+  vgroupPads.reserve(Mapper::NREGIONS);
+  vgroupRows.reserve(Mapper::NREGIONS);
+  vgroupLastRowsThreshold.reserve(Mapper::NREGIONS);
+  vgroupLastPadsThreshold.reserve(Mapper::NREGIONS);
+
+  std::transform(tgroupPads.begin(), tgroupPads.end(), std::back_inserter(vgroupPads), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupRows.begin(), tgroupRows.end(), std::back_inserter(vgroupRows), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupLastRowsThreshold.begin(), tgroupLastRowsThreshold.end(), std::back_inserter(vgroupLastRowsThreshold), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupLastPadsThreshold.begin(), tgroupLastPadsThreshold.end(), std::back_inserter(vgroupLastPadsThreshold), &boost::lexical_cast<int, std::string>);
+
+  if (vgroupPads.size() == 1) {
+    vgroupPads = std::vector<unsigned char>(Mapper::NREGIONS, vgroupPads.front());
+  } else if (vgroupPads.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupPads (n={}). Number should be 1 or {}", vgroupPads.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupRows.size() == 1) {
+    vgroupRows = std::vector<unsigned char>(Mapper::NREGIONS, vgroupRows.front());
+  } else if (vgroupRows.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupRows (n={}). Number should be 1 or {}", vgroupRows.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupLastRowsThreshold.size() == 1) {
+    vgroupLastRowsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastRowsThreshold.front());
+  } else if (vgroupLastRowsThreshold.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupLastRowsThreshold (n={}). Number should be 1 or {}", vgroupLastRowsThreshold.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupLastPadsThreshold.size() == 1) {
+    vgroupLastPadsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastPadsThreshold.front());
+  } else if (vgroupLastPadsThreshold.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupLastPadsThreshold (n={}). Number should be 1 or {}", vgroupLastPadsThreshold.size(), Mapper::NREGIONS);
+  }
+
+  for (int i = 0; i < Mapper::NREGIONS; ++i) {
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupPads[{}]", i).data(), vgroupPads[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupRows[{}]", i).data(), vgroupRows[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupLastRowsThreshold[{}]", i).data(), vgroupLastRowsThreshold[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupLastPadsThreshold[{}]", i).data(), vgroupLastPadsThreshold[i]);
+  }
+
+  // set up configuration
+  o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::writeINI("o2tpcaveragegroupidc_configuration.ini");
+
+  WorkflowSpec workflow;
+  if (nLanes <= 0) {
+    return workflow;
+  }
+
+  for (int ilane = 0; ilane < nLanes; ++ilane) {
+    const auto first = tpcCRUs.begin() + ilane * crusPerLane;
+    if (first >= tpcCRUs.end()) {
+      break;
+    }
+    const auto last = std::min(tpcCRUs.end(), first + crusPerLane);
+    const std::vector<uint32_t> rangeCRUs(first, last);
+    workflow.emplace_back(getTPCAverageGroupIDCSpec(ilane, rangeCRUs, debug));
+  }
+
+  return workflow;
+}

--- a/Detectors/TPC/workflow/src/tpc-integrate-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-integrate-idc.cxx
@@ -1,0 +1,94 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <string>
+#include "Algorithm/RangeTokenizer.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TPCWorkflow/TPCIntegrateIDCSpec.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsRaw/HBFUtils.h"
+#include "TPCSimulation/IDCSim.h"
+#include "TPCBase/Sector.h"
+
+using namespace o2::framework;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-idc-integrateidc.*", CompletionPolicy::CompletionOp::Consume));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  const std::string sectorDefault = "0-" + std::to_string(o2::tpc::Sector::MAXSECTOR - 1);
+  const int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
+
+  std::vector<ConfigParamSpec> options{
+    {"nOrbits", VariantType::Int, 12, {"number of orbits for which the IDCs are integrated"}},
+    {"outputFormat", VariantType::String, "Sim", {"setting the output format type: 'Sim'=IDC simulation format, 'Real'=real output format of CRUs (not implemented yet)"}},
+    {"debug", VariantType::Bool, false, {"create debug tree"}},
+    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"lanes", VariantType::Int, defaultlanes, {"Number of parallel processing lanes."}},
+    {"sectors", VariantType::String, sectorDefault.c_str(), {"List of TPC sectors, comma separated ranges, e.g. 0-3,7,9-15"}},
+    {"hbfutils-config", VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {"config file for HBFUtils (or none) to get number of orbits per TF"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  using namespace o2::tpc;
+
+  // set up configuration
+  o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  std::string confDig = config.options().get<std::string>("hbfutils-config");
+  if (!confDig.empty() && confDig != "none") {
+    o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
+  }
+  o2::conf::ConfigurableParam::writeINI("o2tpcintegrateidc_configuration.ini");
+
+  const auto& hbfu = o2::raw::HBFUtils::Instance();
+  o2::tpc::IDCSim::setNOrbitsPerTF(hbfu.getNOrbitsPerTF());
+
+  const auto nOrbits = config.options().get<int>("nOrbits");
+  const auto outputFormatStr = config.options().get<std::string>("outputFormat");
+  const TPCIntegrateIDCDevice::IDCFormat outputFormat = outputFormatStr.compare("Sim") ? TPCIntegrateIDCDevice::IDCFormat::Real : TPCIntegrateIDCDevice::IDCFormat::Sim;
+  const auto debug = config.options().get<bool>("debug");
+  const auto tpcsectors = o2::RangeTokenizer::tokenize<int>(config.options().get<std::string>("sectors"));
+  const auto nSectors = tpcsectors.size();
+  const auto nLanes = std::min(static_cast<unsigned long>(config.options().get<int>("lanes")), nSectors);
+  const auto sectorsPerLane = nSectors / nLanes + ((nSectors % nLanes) != 0);
+
+  WorkflowSpec workflow;
+  if (nLanes <= 0) {
+    return workflow;
+  }
+
+  for (int ilane = 0; ilane < nLanes; ++ilane) {
+    const auto first = tpcsectors.begin() + ilane * sectorsPerLane;
+    if (first >= tpcsectors.end()) {
+      break;
+    }
+    const auto last = std::min(tpcsectors.end(), first + sectorsPerLane);
+    const std::vector<unsigned int> rangeSectors(first, last);
+    workflow.emplace_back(getTPCIntegrateIDCSpec(ilane, rangeSectors, nOrbits, outputFormat, debug));
+  }
+
+  return workflow;
+}


### PR DESCRIPTION
Adding a device for integration of tpc digits. The time intervals can be set in multiples of orbits.
The averaging and merging of the IDCs are done in a second device (which is just more or less a dummy for now)