### PR TITLE
[MRRTF-116] [MCH] Make digit binary files 100% reproducibles

### DIFF
--- a/Detectors/MUON/MCH/DevIO/Digits/CMakeLists.txt
+++ b/Detectors/MUON/MCH/DevIO/Digits/CMakeLists.txt
@@ -12,6 +12,8 @@ o2_add_library(MCHDigitIO
             SOURCES DigitWriter.cxx DigitReader.cxx DigitFileFormat.cxx 
                     DigitReaderImpl.cxx DigitWriterImpl.cxx
                     DigitIOV0.cxx DigitIOV1.cxx
+                    DigitIOV2.cxx DigitIOV3.cxx
+                    IO.cxx
             PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl fmt::fmt O2::DataFormatsMCH)
 
 o2_add_test(digits-io

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitD0.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitD0.h
@@ -16,11 +16,11 @@
 namespace o2::mch::io::impl
 {
 struct DigitD0 {
-  int32_t tfTime;      /// time since the beginning of the time frame, in bunch crossing units
-  uint16_t nofSamples; /// number of samples in the signal + saturated bit
-  int detID;           /// ID of the Detection Element to which the digit corresponds to
-  int padID;           /// PadIndex to which the digit corresponds to
-  uint32_t adc;        /// Amplitude of signal
+  int32_t tfTime{0};      /// time since the beginning of the time frame, in bunch crossing units
+  uint16_t nofSamples{0}; /// number of samples in the signal + saturated bit
+  int detID{0};           /// ID of the Detection Element to which the digit corresponds to
+  int padID{0};           /// PadIndex to which the digit corresponds to
+  uint32_t adc{0};        /// Amplitude of signal
 
   void setNofSamples(uint16_t n) { nofSamples = (nofSamples & 0x8000) + (n & 0x7FFF); }
   uint16_t getNofSamples() const { return (nofSamples & 0x7FFF); }

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitFileFormat.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitFileFormat.cxx
@@ -17,9 +17,11 @@
 namespace o2::mch::io
 {
 
-std::array<DigitFileFormat, 2> digitFileFormats = {
+std::array<DigitFileFormat, 4> digitFileFormats = {
   DigitFileFormat{2305844383603244847},
-  DigitFileFormat{1224998065220435759}};
+  DigitFileFormat{1224998065220435759},
+  DigitFileFormat{63069292639436591},
+  DigitFileFormat{1215990797246349103}};
 
 std::ostream& operator<<(std::ostream& os, const DigitFileFormat& dff)
 {

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitFileFormat.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitFileFormat.h
@@ -36,7 +36,7 @@ struct DigitFileFormat {
   };
 };
 
-extern std::array<DigitFileFormat, 2> digitFileFormats;
+extern std::array<DigitFileFormat, 4> digitFileFormats;
 
 std::ostream& operator<<(std::ostream&, const DigitFileFormat&);
 

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV0.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV0.cxx
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include "DigitFileFormat.h"
 #include "CommonDataFormat/InteractionRecord.h"
+#include "IOStruct.h"
 
 //
 // V0 was prior to the introduction of rofs, so the file format is
@@ -50,7 +51,7 @@ bool DigitReaderV0::read(std::istream& in,
   // note the input vectors are not cleared as this is the responsability
   // of the calling class, if need be.
   std::vector<DigitD0> digitsd0;
-  bool ok = readBinary(in, digitsd0, "digits");
+  bool ok = readBinaryStruct(in, digitsd0, "digits");
   if (!ok) {
     return false;
   }
@@ -84,7 +85,7 @@ bool DigitWriterV0::write(std::ostream& out,
       digitsd0.back().setSaturated(d.isSaturated());
     }
     gsl::span<const DigitD0> d0(digitsd0);
-    bool ok = binary(out, d0);
+    bool ok = writeBinaryStruct(out, d0);
     if (!ok) {
       return false;
     }

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
@@ -15,6 +15,7 @@
 #include "DigitFileFormat.h"
 #include "DigitReader.h"
 #include <iostream>
+#include "IOStruct.h"
 
 namespace
 {
@@ -55,13 +56,13 @@ bool DigitReaderV1::read(std::istream& in,
   // note the input vectors are not cleared as this is the responsability
   // of the calling class, if need be.
 
-  bool ok = readBinary(in, rofs, "rofs");
+  bool ok = readBinaryStruct(in, rofs, "rofs");
   if (!ok) {
     return false;
   }
   std::vector<DigitD0> digitsd0;
 
-  ok = readBinary(in, digitsd0, "digits");
+  ok = readBinaryStruct(in, digitsd0, "digits");
   if (!ok) {
     return false;
   }
@@ -85,7 +86,7 @@ bool DigitWriterV1::write(std::ostream& out,
   if (rofs.empty()) {
     return false;
   }
-  bool ok = impl::binary(out, rofs);
+  bool ok = writeBinaryStruct(out, rofs);
 
   std::vector<DigitD0> digitsd0;
   for (const auto& d : digits) {
@@ -93,7 +94,7 @@ bool DigitWriterV1::write(std::ostream& out,
     digitsd0.back().setSaturated(d.isSaturated());
   }
   gsl::span<const DigitD0> d0(digitsd0);
-  ok &= impl::binary(out, d0);
+  ok &= writeBinaryStruct(out, d0);
   return ok;
 }
 

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV2.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV2.cxx
@@ -1,0 +1,110 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DigitIOV2.h"
+#include <stdexcept>
+#include <vector>
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include <iostream>
+#include <fmt/format.h>
+#include "DigitFileFormat.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "IO.h"
+
+//
+// V2 was prior to the introduction of rofs, so the file format is
+// simply a set of consecutive [nofDigits|list of digits] blocks
+//
+
+namespace o2::mch::io::impl
+{
+void DigitReaderV2::count(std::istream& in, size_t& ntfs, size_t& nrofs, size_t& ndigits)
+{
+  auto dff = digitFileFormats[2];
+  rewind(in);
+  ndigits = 0;
+  nrofs = 0;
+  ntfs = 0;
+  int ndig{0};
+
+  while ((ndig = advance(in, dff.digitSize, "digits")) >= 0) {
+    ndigits += ndig;
+    ++nrofs;
+    ++ntfs;
+  }
+  rewind(in);
+}
+
+bool DigitReaderV2::read(std::istream& in,
+                         std::vector<Digit>& digits,
+                         std::vector<ROFRecord>& rofs)
+{
+  if (in.peek() == EOF) {
+    return false;
+  }
+  // note the input vectors are not cleared as this is the responsability
+  // of the calling class, if need be.
+  int ndigits = readNofItems(in, "digits");
+
+  for (int i = 0; i < ndigits; i++) {
+    uint32_t tfTime;
+    uint16_t nofSamples;
+    uint8_t sat;
+    uint32_t deID;
+    uint32_t padID;
+    uint32_t adc;
+    in.read(reinterpret_cast<char*>(&tfTime), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&nofSamples), sizeof(uint16_t));
+    in.read(reinterpret_cast<char*>(&sat), sizeof(uint8_t));
+    in.read(reinterpret_cast<char*>(&deID), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&padID), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&adc), sizeof(uint32_t));
+    digits.emplace_back(deID, padID, adc, tfTime, nofSamples, sat > 0);
+  }
+
+  rofs.emplace_back(o2::InteractionRecord(0, mCurrentROF), 0, ndigits);
+  ++mCurrentROF;
+  return !in.fail();
+}
+
+void DigitReaderV2::rewind(std::istream& in)
+{
+  DigitReaderImpl::rewind(in);
+  mCurrentROF = 0;
+}
+
+bool DigitWriterV2::write(std::ostream& out,
+                          gsl::span<const Digit> digits,
+                          gsl::span<const ROFRecord> rofs)
+{
+  // V2 format had no notion of rofs, so we strip them
+  for (auto r : rofs) {
+    writeNofItems(out, r.getNEntries());
+    for (int i = r.getFirstIdx(); i <= r.getLastIdx(); i++) {
+      const Digit& d = digits[i];
+      uint32_t tfTime = d.getTime();
+      uint16_t nofSamples = d.getNofSamples();
+      uint32_t deID = d.getDetID();
+      uint32_t padID = d.getPadID();
+      uint32_t adc = d.getADC();
+      uint8_t sat = d.isSaturated();
+      out.write(reinterpret_cast<const char*>(&tfTime), sizeof(uint32_t));
+      out.write(reinterpret_cast<const char*>(&nofSamples), sizeof(uint16_t));
+      out.write(reinterpret_cast<const char*>(&sat), sizeof(uint8_t));
+      out.write(reinterpret_cast<const char*>(&deID), sizeof(uint32_t));
+      out.write(reinterpret_cast<const char*>(&padID), sizeof(uint32_t));
+      out.write(reinterpret_cast<const char*>(&adc), sizeof(uint32_t));
+    }
+  }
+  return !out.fail();
+}
+
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV2.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV2.h
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma once
+
+#include "DigitReaderImpl.h"
+#include "DigitWriterImpl.h"
+#include <utility>
+#include <vector>
+
+/*
+ * Digit file format 0 is storing Digits version D0
+ * with no ROF (i.e. just a set of nDigits|DigitsD0|...)
+ */
+
+namespace o2::mch::io::impl
+{
+/**
+ * Reader for digit file format 0
+ */
+class DigitReaderV2 : public DigitReaderImpl
+{
+ public:
+  void count(std::istream& in, size_t& ntfs, size_t& nrofs, size_t& ndigits) override;
+  bool read(std::istream& in,
+            std::vector<Digit>& digits,
+            std::vector<ROFRecord>& rofs) override;
+  void rewind(std::istream& in);
+
+ private:
+  int mCurrentROF{0};
+};
+
+/**
+ * Writer for digit file format 0
+ */
+struct DigitWriterV2 : public DigitWriterImpl {
+
+  /** write rofs, digits at the current position in the output stream
+  * @param digits vector of Digits, must not be empty
+  * @param rofs vector of ROFRecord, might be empty
+  * @returns true if writing was successull, false otherwise
+  */
+  bool write(std::ostream& out,
+             gsl::span<const Digit> digits,
+             gsl::span<const ROFRecord> rofs) override;
+
+  bool mBinary;
+};
+
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV3.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV3.cxx
@@ -1,0 +1,159 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DigitIOV3.h"
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DigitFileFormat.h"
+#include "DigitReader.h"
+#include <iostream>
+#include "IOStruct.h"
+
+namespace o2::mch::io::impl
+{
+std::pair<int, int> advanceOneEvent(std::istream& in)
+{
+  auto dff = digitFileFormats[3];
+  int nrofs = advance(in, dff.rofSize, "rofs");
+  if (nrofs < 0) {
+    return std::make_pair(-1, -1);
+  }
+  int ndigits = advance(in, dff.digitSize, "digits");
+  return std::make_pair(nrofs, ndigits);
+}
+
+void DigitReaderV3::count(std::istream& in, size_t& ntfs, size_t& nrofs, size_t& ndigits)
+{
+  rewind(in);
+  ndigits = 0;
+  nrofs = 0;
+  ntfs = 0;
+  std::pair<int, int> pairs;
+  std::pair<int, int> invalid{-1, -1};
+
+  while ((pairs = advanceOneEvent(in)) != invalid) {
+    ndigits += pairs.second;
+    nrofs += pairs.first;
+    ++ntfs;
+  }
+  rewind(in);
+}
+
+bool DigitReaderV3::read(std::istream& in,
+                         std::vector<Digit>& digits,
+                         std::vector<ROFRecord>& rofs)
+{
+  if (in.peek() == EOF) {
+    return false;
+  }
+  // note the input vectors are not cleared as this is the responsability
+  // of the calling class, if need be.
+
+  int nrofs = readNofItems(in, "rofs");
+  if (in.fail()) {
+    return false;
+  }
+
+  for (auto i = 0; i < nrofs; i++) {
+    uint16_t bc;
+    uint32_t orbit;
+    uint32_t firstIdx;
+    uint32_t nentries;
+    in.read(reinterpret_cast<char*>(&bc), sizeof(uint16_t));
+    in.read(reinterpret_cast<char*>(&orbit), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&firstIdx), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&nentries), sizeof(uint32_t));
+    rofs.emplace_back(o2::InteractionRecord{bc, orbit}, firstIdx, nentries);
+    if (in.fail()) {
+      return false;
+    }
+  }
+
+  int ndigits = readNofItems(in, "digits");
+  if (in.fail()) {
+    return false;
+  }
+
+  for (int i = 0; i < ndigits; i++) {
+    uint32_t tfTime;
+    uint16_t nofSamples;
+    uint32_t deID;
+    uint32_t padID;
+    uint32_t adc;
+    uint8_t sat;
+    in.read(reinterpret_cast<char*>(&tfTime), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&nofSamples), sizeof(uint16_t));
+    in.read(reinterpret_cast<char*>(&sat), sizeof(uint8_t));
+    in.read(reinterpret_cast<char*>(&deID), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&padID), sizeof(uint32_t));
+    in.read(reinterpret_cast<char*>(&adc), sizeof(uint32_t));
+    digits.emplace_back(deID, padID, adc, tfTime, nofSamples, sat > 0);
+    if (in.fail()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void DigitReaderV3::rewind(std::istream& in)
+{
+  DigitReaderImpl::rewind(in);
+}
+
+bool DigitWriterV3::write(std::ostream& out,
+                          gsl::span<const Digit> digits,
+                          gsl::span<const ROFRecord> rofs)
+{
+  if (rofs.empty()) {
+    return false;
+  }
+  writeNofItems(out, rofs.size());
+  if (out.fail()) {
+    return false;
+  }
+  for (auto r : rofs) {
+    uint16_t bc = r.getBCData().bc;
+    uint32_t orbit = r.getBCData().orbit;
+    uint32_t firstIdx = r.getFirstIdx();
+    uint32_t nentries = r.getNEntries();
+    out.write(reinterpret_cast<const char*>(&bc), sizeof(uint16_t));
+    out.write(reinterpret_cast<const char*>(&orbit), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&firstIdx), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&nentries), sizeof(uint32_t));
+    if (out.fail()) {
+      return false;
+    }
+  }
+
+  writeNofItems(out, digits.size());
+  if (out.fail()) {
+    return false;
+  }
+  for (const auto& d : digits) {
+    uint32_t tfTime = d.getTime();
+    uint16_t nofSamples = d.getNofSamples();
+    uint32_t deID = d.getDetID();
+    uint32_t padID = d.getPadID();
+    uint32_t adc = d.getADC();
+    uint8_t sat = d.isSaturated();
+    out.write(reinterpret_cast<const char*>(&tfTime), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&nofSamples), sizeof(uint16_t));
+    out.write(reinterpret_cast<const char*>(&sat), sizeof(uint8_t));
+    out.write(reinterpret_cast<const char*>(&deID), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&padID), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&adc), sizeof(uint32_t));
+    if (out.fail()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV3.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV3.h
@@ -10,31 +10,33 @@
 
 #pragma once
 
-#include <ostream>
-#include <gsl/span>
-#include <memory>
-
-namespace o2::mch
-{
-class Digit;
-class ROFRecord;
-} // namespace o2::mch
+#include "DigitReaderImpl.h"
+#include <vector>
+#include "DataFormatsMCH/ROFRecord.h"
+#include <utility>
+#include "DigitWriterImpl.h"
 
 namespace o2::mch::io::impl
 {
+class DigitReaderV3 : public DigitReaderImpl
+{
+ public:
+  void count(std::istream& in, size_t& ntfs, size_t& nrofs, size_t& ndigits) override;
+  bool read(std::istream& in,
+            std::vector<Digit>& digits,
+            std::vector<ROFRecord>& rofs) override;
+  void rewind(std::istream& in);
+};
 
-struct DigitWriterImpl {
-  virtual ~DigitWriterImpl() = default;
-
+struct DigitWriterV3 : public DigitWriterImpl {
   /** write rofs, digits at the current position in the output stream
   * @param digits vector of Digits, must not be empty
   * @param rofs vector of ROFRecord, might be empty
   * @returns true if writing was successull, false otherwise
   */
-  virtual bool write(std::ostream& out,
-                     gsl::span<const Digit> digits,
-                     gsl::span<const ROFRecord> rofs) = 0;
+  bool write(std::ostream& out,
+             gsl::span<const Digit> digits,
+             gsl::span<const ROFRecord> rofs) override;
 };
 
-std::unique_ptr<DigitWriterImpl> createDigitWriterImpl(int version);
 } // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.cxx
@@ -14,6 +14,8 @@
 #include <map>
 #include "DigitIOV0.h"
 #include "DigitIOV1.h"
+#include "DigitIOV2.h"
+#include "DigitIOV3.h"
 #include <memory>
 
 namespace o2::mch::io::impl
@@ -26,9 +28,15 @@ std::unique_ptr<DigitReaderImpl> createDigitReaderImpl(int version)
       return std::make_unique<DigitReaderV0>();
     case 1:
       return std::make_unique<DigitReaderV1>();
+    case 2:
+      return std::make_unique<DigitReaderV2>();
+    case 3:
+      return std::make_unique<DigitReaderV3>();
     default:
       break;
   };
+  throw std::invalid_argument(fmt::format("DigitFileFormat version {} not implemented yet",
+                                          version));
   return nullptr;
 }
 
@@ -36,29 +44,6 @@ void DigitReaderImpl::rewind(std::istream& in)
 {
   in.clear();
   in.seekg(sizeof(DigitFileFormat));
-}
-
-int readNofItems(std::istream& in, const char* itemName)
-{
-  int nitems(-1);
-  in.read(reinterpret_cast<char*>(&nitems), sizeof(int));
-  if (in.fail() || nitems < 0) {
-    throw std::length_error(fmt::format("invalid input : cannot get number of {}", itemName));
-  }
-  return nitems;
-}
-
-int advance(std::istream& in, size_t itemByteSize, const char* itemName)
-{
-  if (in.peek() == EOF) {
-    return -1;
-  }
-  // get the number of items
-  int nitems = readNofItems(in, itemName);
-  // move forward of n items
-  auto current = in.tellg();
-  in.seekg(current + static_cast<decltype(current)>(nitems * itemByteSize));
-  return nitems;
 }
 
 } // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.h
@@ -34,30 +34,6 @@ struct DigitReaderImpl {
   void rewind(std::istream& in);
 };
 
-int readNofItems(std::istream& in, const char* itemName);
-
-int advance(std::istream& in, size_t itemByteSize, const char* itemName);
-
-template <typename T>
-bool readBinary(std::istream& in, std::vector<T>& items, const char* itemName)
-{
-  if (in.peek() == EOF) {
-    return false;
-  }
-  // get the number of items
-  int nitems = readNofItems(in, itemName);
-  // get the items if any
-  if (nitems > 0) {
-    auto offset = items.size();
-    items.resize(offset + nitems);
-    in.read(reinterpret_cast<char*>(&items[offset]), nitems * sizeof(T));
-    if (in.fail()) {
-      throw std::length_error(fmt::format("invalid input : cannot read {} {}", nitems, itemName));
-    }
-  }
-  return true;
-}
-
 std::unique_ptr<DigitReaderImpl> createDigitReaderImpl(int version);
 
 } // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitWriterImpl.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitWriterImpl.cxx
@@ -11,6 +11,8 @@
 #include "DigitWriterImpl.h"
 #include "DigitIOV0.h"
 #include "DigitIOV1.h"
+#include "DigitIOV2.h"
+#include "DigitIOV3.h"
 #include <fmt/format.h>
 
 namespace o2::mch::io::impl
@@ -22,6 +24,10 @@ std::unique_ptr<DigitWriterImpl> createDigitWriterImpl(int version)
       return std::make_unique<DigitWriterV0>();
     case 1:
       return std::make_unique<DigitWriterV1>();
+    case 2:
+      return std::make_unique<DigitWriterV2>();
+    case 3:
+      return std::make_unique<DigitWriterV3>();
     default:
       break;
   };
@@ -29,4 +35,5 @@ std::unique_ptr<DigitWriterImpl> createDigitWriterImpl(int version)
                                           version));
   return nullptr;
 }
+
 } // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/IO.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/IO.cxx
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "IO.h"
+#include <stdexcept>
+#include <fmt/format.h>
+#include <iostream>
+
+namespace o2::mch::io::impl
+{
+int readNofItems(std::istream& in, const char* itemName)
+{
+  int nitems(-1);
+  in.read(reinterpret_cast<char*>(&nitems), sizeof(int));
+  if (in.fail() || nitems < 0) {
+    throw std::length_error(fmt::format("invalid input : cannot get number of {}", itemName));
+  }
+  return nitems;
+}
+
+void writeNofItems(std::ostream& out, uint32_t nofItems)
+{
+  out.write(reinterpret_cast<const char*>(&nofItems), sizeof(uint32_t));
+}
+
+int advance(std::istream& in, size_t itemByteSize, const char* itemName)
+{
+  if (in.peek() == EOF) {
+    return -1;
+  }
+  // get the number of items
+  int nitems = readNofItems(in, itemName);
+  // move forward of n items
+  auto current = in.tellg();
+  in.seekg(current + static_cast<decltype(current)>(nitems * itemByteSize));
+  return nitems;
+}
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/IO.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/IO.h
@@ -1,0 +1,22 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma once
+
+#include <iosfwd>
+#include <cstdint>
+
+namespace o2::mch::io::impl
+{
+int readNofItems(std::istream& in, const char* itemName);
+void writeNofItems(std::ostream& out, uint32_t nofItems);
+int advance(std::istream& in, size_t itemByteSize, const char* itemName);
+
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/IOStruct.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/IOStruct.h
@@ -1,0 +1,52 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma once
+
+#include <gsl/span>
+#include <iostream>
+#include "IO.h"
+#include <fmt/format.h>
+
+namespace o2::mch::io::impl
+{
+template <typename T>
+bool writeBinaryStruct(std::ostream& os,
+                       gsl::span<const T> items)
+{
+  uint32_t nofItems = static_cast<uint32_t>(items.size());
+  if (!nofItems) {
+    return !os.bad();
+  }
+  writeNofItems(os, nofItems);
+  os.write(reinterpret_cast<const char*>(items.data()), items.size_bytes());
+  return !os.bad();
+}
+template <typename T>
+bool readBinaryStruct(std::istream& in, std::vector<T>& items, const char* itemName)
+{
+  if (in.peek() == EOF) {
+    return false;
+  }
+  // get the number of items
+  int nitems = readNofItems(in, itemName);
+  // get the items if any
+  if (nitems > 0) {
+    auto offset = items.size();
+    items.resize(offset + nitems);
+    in.read(reinterpret_cast<char*>(&items[offset]), nitems * sizeof(T));
+    if (in.fail()) {
+      throw std::length_error(fmt::format("invalid input : cannot read {} {}", nitems, itemName));
+    }
+  }
+  return true;
+}
+
+} // namespace o2::mch::io::impl

--- a/Detectors/MUON/MCH/DevIO/Digits/testDigitIOV0.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/testDigitIOV0.cxx
@@ -29,6 +29,8 @@
 #include "DigitReaderImpl.h"
 #include "TestFileV0.h"
 #include "DigitD0.h"
+#include "IO.h"
+
 using namespace o2::mch;
 using namespace o2::mch::io;
 


### PR DESCRIPTION
Makes the binary digit files containing the same digits byte-by-byte identical (see https://alice.its.cern.ch/jira/browse/MRRTF-116) which makes comparing them a lot easier :wink: