### PR TITLE
[MRRTF-109] Add MCH CTF

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -22,3 +22,10 @@ o2_add_executable(convert-bad-channels
                   SOURCES src/convert-bad-channels.cxx
                   COMPONENT_NAME mch
                   PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH Boost::program_options)
+
+o2_add_test(digit
+            SOURCES src/testDigit.cxx
+            PUBLIC_LINK_LIBRARIES O2::MCHBase
+            COMPONENT_NAME mch
+            LABELS muon;mch)
+

--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -9,14 +9,17 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(DataFormatsMCH
-               SOURCES src/TrackMCH.cxx src/Digit.cxx
-	           PUBLIC_LINK_LIBRARIES O2::CommonDataFormat)
+               SOURCES src/TrackMCH.cxx src/Digit.cxx 
+                       src/CTF.cxx src/ROFRecord.cxx
+	           PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
+                                     O2::DetectorsCommonDataFormats)
 
 o2_target_root_dictionary(DataFormatsMCH
                           HEADERS include/DataFormatsMCH/Digit.h
                                   include/DataFormatsMCH/DsChannelGroup.h
                                   include/DataFormatsMCH/ROFRecord.h
-                                  include/DataFormatsMCH/TrackMCH.h)
+                                  include/DataFormatsMCH/TrackMCH.h
+                                  include/DataFormatsMCH/CTF.h)
 
 o2_add_executable(convert-bad-channels
                   SOURCES src/convert-bad-channels.cxx

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTF.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Definitions for MCH CTF data
+
+#ifndef O2_MCH_CTF_H
+#define O2_MCH_CTF_H
+
+#include <vector>
+#include <Rtypes.h>
+#include "DetectorsCommonDataFormats/EncodedBlocks.h"
+#include <iosfwd>
+
+namespace o2
+{
+namespace mch
+{
+
+/// Header for a single CTF
+struct CTFHeader {
+  uint32_t nROFs = 0;      /// number of ROFrames in TF
+  uint32_t nDigits = 0;    /// number of digits in TF
+  uint32_t firstOrbit = 0; /// 1st orbit of TF
+  uint16_t firstBC = 0;    /// 1st BC of TF
+
+  ClassDefNV(CTFHeader, 1);
+};
+
+/// wrapper for the Entropy-encoded clusters of the TF
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 9, uint32_t> {
+
+  static constexpr size_t N = getNBlocks();
+  enum Slots { BLC_bcIncROF,
+               BLC_orbitIncROF,
+               BLC_nDigitsROF,
+               BLC_tfTime,
+               BLC_nSamples,
+               BLC_isSaturated,
+               BLC_detID,
+               BLC_padID,
+               BLC_ADC };
+  ClassDefNV(CTF, 1);
+};
+
+std::ostream& operator<<(std::ostream&, const CTFHeader&);
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
@@ -41,7 +41,7 @@ class Digit
   int32_t getTime() const { return mTFtime; }
 
   void setNofSamples(uint16_t n);
-  uint16_t nofSamples() const;
+  uint16_t getNofSamples() const;
 
   void setSaturated(bool sat);
   bool isSaturated() const;

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
@@ -17,6 +17,7 @@
 #define ALICEO2_MCH_BASE_DIGIT_H_
 
 #include "Rtypes.h"
+#include <iosfwd>
 
 namespace o2
 {
@@ -40,10 +41,10 @@ class Digit
   int32_t getTime() const { return mTFtime; }
 
   void setNofSamples(uint16_t n);
-  uint16_t nofSamples() const { return (mNofSamples & 0x7FFF); }
+  uint16_t nofSamples() const;
 
   void setSaturated(bool sat);
-  bool isSaturated() const { return ((mNofSamples & 0x8000) > 0); }
+  bool isSaturated() const;
 
   int getDetID() const { return mDetID; }
 
@@ -56,12 +57,15 @@ class Digit
  private:
   int32_t mTFtime;      /// time since the beginning of the time frame, in bunch crossing units
   uint16_t mNofSamples; /// number of samples in the signal
+  bool mIsSaturated;    /// whether or not the digit amplitude is above saturation
   int mDetID;           /// ID of the Detection Element to which the digit corresponds to
   int mPadID;           /// PadIndex to which the digit corresponds to
   uint32_t mADC;        /// Amplitude of signal
 
-  ClassDefNV(Digit, 3);
+  ClassDefNV(Digit, 4);
 }; //class Digit
+
+std::ostream& operator<<(std::ostream& os, const Digit& d);
 
 } //namespace mch
 } //namespace o2

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
@@ -18,6 +18,9 @@
 
 #include "CommonDataFormat/InteractionRecord.h"
 #include "CommonDataFormat/RangeReference.h"
+#include <ostream>
+
+#include <iosfwd>
 
 namespace o2
 {
@@ -51,12 +54,20 @@ class ROFRecord
   /// set the number of associated objects and the index of the first one
   void setDataRef(int firstIdx, int nEntries) { mDataRef.set(firstIdx, nEntries); }
 
+  bool operator==(const ROFRecord& other) const
+  {
+    return mBCData == other.mBCData &&
+           mDataRef == other.mDataRef;
+  }
+
  private:
   BCData mBCData{};   ///< interaction record
   DataRef mDataRef{}; ///< reference to the associated objects
 
   ClassDefNV(ROFRecord, 1);
 };
+
+std::ostream& operator<<(std::ostream& os, const ROFRecord& rof);
 
 } // namespace mch
 } // namespace o2

--- a/DataFormats/Detectors/MUON/MCH/src/CTF.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/CTF.cxx
@@ -1,0 +1,24 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <stdexcept>
+#include <cstring>
+#include "DataFormatsMCH/CTF.h"
+#include <iostream>
+
+namespace o2::mch
+{
+std::ostream& operator<<(std::ostream& os, const CTFHeader& ctf)
+{
+  os << fmt::format("nROFS {} nDigits {} firstOrbit {} firstBC {}",
+                    ctf.nROFs, ctf.nDigits, ctf.firstOrbit, ctf.firstBC);
+  return os;
+}
+} // namespace o2::mch

--- a/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
+++ b/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
@@ -20,5 +20,8 @@
 #pragma link C++ class o2::mch::DsChannelGroup + ;
 #pragma link C++ class o2::mch::Digit + ;
 #pragma link C++ class std::vector < o2::mch::Digit> + ;
+#pragma link C++ struct o2::mch::CTFHeader + ;
+#pragma link C++ struct o2::mch::CTF + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::mch::CTFHeader, 9, uint32_t> + ;
 
 #endif

--- a/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
@@ -19,7 +19,7 @@ namespace o2::mch
 std::ostream& operator<<(std::ostream& os, const o2::mch::Digit& d)
 {
   os << fmt::format("DetID {:4d} PadId {:6d} ADC {:10d} TFtime {:10d} NofSamples {:5d} {}",
-                    d.getDetID(), d.getPadID(), d.getADC(), d.getTime(), d.nofSamples(),
+                    d.getDetID(), d.getPadID(), d.getADC(), d.getTime(), d.getNofSamples(),
                     d.isSaturated() ? "(S)" : "");
   return os;
 }
@@ -35,7 +35,7 @@ Digit::Digit(int detid, int pad, uint32_t adc, int32_t time, uint16_t nSamples, 
   setNofSamples(nSamples);
 }
 
-uint16_t Digit::nofSamples() const
+uint16_t Digit::getNofSamples() const
 {
   return mNofSamples;
 }

--- a/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
@@ -10,9 +10,19 @@
 
 #include "DataFormatsMCH/Digit.h"
 #include <cmath>
+#include <fmt/format.h>
+#include <iostream>
 
 namespace o2::mch
 {
+
+std::ostream& operator<<(std::ostream& os, const o2::mch::Digit& d)
+{
+  os << fmt::format("DetID {:4d} PadId {:6d} ADC {:10d} TFtime {:10d} NofSamples {:5d} {}",
+                    d.getDetID(), d.getPadID(), d.getADC(), d.getTime(), d.nofSamples(),
+                    d.isSaturated() ? "(S)" : "");
+  return os;
+}
 
 bool closeEnough(double x, double y, double eps = 1E-6)
 {
@@ -20,25 +30,33 @@ bool closeEnough(double x, double y, double eps = 1E-6)
 }
 
 Digit::Digit(int detid, int pad, uint32_t adc, int32_t time, uint16_t nSamples, bool saturated)
-  : mTFtime(time), mDetID(detid), mPadID(pad), mADC(adc)
+  : mTFtime(time), mNofSamples(nSamples), mIsSaturated(saturated), mDetID(detid), mPadID(pad), mADC(adc)
 {
   setNofSamples(nSamples);
-  setSaturated(saturated);
+}
+
+uint16_t Digit::nofSamples() const
+{
+  return mNofSamples;
+}
+
+bool Digit::isSaturated() const
+{
+  return mIsSaturated;
 }
 
 void Digit::setNofSamples(uint16_t n)
 {
-  uint16_t sat = mNofSamples & 0x8000;
-  mNofSamples = (n & 0x7FFF) + sat;
+  constexpr uint64_t max10bits = (static_cast<uint64_t>(1) << 10);
+  if (static_cast<uint64_t>(n) >= max10bits) {
+    throw std::invalid_argument("mch digit nofsamples must fit within 10 bits");
+  }
+  mNofSamples = n;
 }
 
 void Digit::setSaturated(bool sat)
 {
-  if (sat) {
-    mNofSamples |= 0x8000;
-  } else {
-    mNofSamples &= 0x7FFF;
-  }
+  mIsSaturated = sat;
 }
 
 bool Digit::operator==(const Digit& other) const

--- a/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
@@ -1,0 +1,23 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include <fmt/format.h>
+#include <iostream>
+
+namespace o2::mch
+{
+std::ostream& operator<<(std::ostream& os, const ROFRecord& rof)
+{
+  os << fmt::format("{} FirstIdx: {:5d} LastIdx: {:5d}",
+                    rof.getBCData().asString(), rof.getFirstIdx(), rof.getLastIdx());
+  return os;
+}
+} // namespace o2::mch

--- a/DataFormats/Detectors/MUON/MCH/src/testDigit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/testDigit.cxx
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/test/tools/old/interface.hpp>
+#define BOOST_TEST_MODULE MCH Digit
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include "DataFormatsMCH/Digit.h"
+
+int dummyDetId{712};
+int dummyPadId{0};
+unsigned long dummyADC{0};
+uint32_t dummyTime{0};
+uint16_t dummyNofSamples{0};
+
+BOOST_AUTO_TEST_CASE(NofSamplesMustFitWithin10Bits)
+{
+  BOOST_CHECK_THROW(o2::mch::Digit d(dummyDetId, dummyPadId, dummyADC, dummyTime, 1025), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(DefaultConstructorMakesNonSaturatedDigit)
+{
+  o2::mch::Digit d(dummyDetId, dummyPadId, dummyADC, dummyTime, dummyNofSamples);
+  BOOST_CHECK(d.isSaturated() == false);
+}
+
+std::vector<uint16_t> nsamples{
+  1 << 0,
+  1 << 1,
+  1 << 2,
+  1 << 3,
+  1 << 4,
+  1 << 5,
+  1 << 6,
+  1 << 7,
+  1 << 8,
+  1 << 9};
+
+BOOST_DATA_TEST_CASE(DefaultConstructorNofSamplesIsInvariant,
+                     boost::unit_test::data::make(nsamples), nofSamples)
+{
+  o2::mch::Digit d(dummyDetId, dummyPadId, dummyADC, dummyTime, nofSamples);
+  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+}
+
+BOOST_DATA_TEST_CASE(SetSaturatedDoesNotAffectPublicNofSamples,
+                     boost::unit_test::data::make(nsamples), nofSamples)
+{
+  o2::mch::Digit d(dummyDetId, dummyPadId, dummyADC, dummyTime, nofSamples);
+
+  BOOST_TEST_INFO("setting saturation to true");
+  d.setSaturated(true);
+  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+
+  BOOST_TEST_INFO("setting saturation to false");
+  d.setSaturated(false);
+  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+}

--- a/DataFormats/Detectors/MUON/MCH/src/testDigit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/testDigit.cxx
@@ -50,7 +50,7 @@ BOOST_DATA_TEST_CASE(DefaultConstructorNofSamplesIsInvariant,
                      boost::unit_test::data::make(nsamples), nofSamples)
 {
   o2::mch::Digit d(dummyDetId, dummyPadId, dummyADC, dummyTime, nofSamples);
-  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+  BOOST_CHECK_EQUAL(d.getNofSamples(), nofSamples);
 }
 
 BOOST_DATA_TEST_CASE(SetSaturatedDoesNotAffectPublicNofSamples,
@@ -60,9 +60,9 @@ BOOST_DATA_TEST_CASE(SetSaturatedDoesNotAffectPublicNofSamples,
 
   BOOST_TEST_INFO("setting saturation to true");
   d.setSaturated(true);
-  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+  BOOST_CHECK_EQUAL(d.getNofSamples(), nofSamples);
 
   BOOST_TEST_INFO("setting saturation to false");
   d.setSaturated(false);
-  BOOST_CHECK_EQUAL(d.nofSamples(), nofSamples);
+  BOOST_CHECK_EQUAL(d.getNofSamples(), nofSamples);
 }

--- a/Detectors/CTF/CMakeLists.txt
+++ b/Detectors/CTF/CMakeLists.txt
@@ -23,21 +23,21 @@ o2_add_test(tpc
             SOURCES test/test_ctf_io_tpc.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-          
+ 
 o2_add_test(ft0
             PUBLIC_LINK_LIBRARIES O2::FT0Reconstruction
                                   O2::DataFormatsFT0
             SOURCES test/test_ctf_io_ft0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-          
+ 
 o2_add_test(fv0
             PUBLIC_LINK_LIBRARIES O2::FV0Reconstruction
                                   O2::DataFormatsFV0
             SOURCES test/test_ctf_io_fv0.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	    
+ 
 o2_add_test(fdd
             PUBLIC_LINK_LIBRARIES O2::FDDReconstruction
                                   O2::DataFormatsFDD
@@ -58,15 +58,21 @@ o2_add_test(mid
                                   O2::MIDCTF
             SOURCES test/test_ctf_io_mid.cxx
             COMPONENT_NAME ctf
-            LABELS ctf)
-          
+            LABELS ctf;muon;mid)
+
+o2_add_test(mch
+            PUBLIC_LINK_LIBRARIES O2::MCHCTF
+            SOURCES test/test_ctf_io_mch.cxx
+            COMPONENT_NAME ctf
+            LABELS ctf;muon;mch)
+
 o2_add_test(emcal
             PUBLIC_LINK_LIBRARIES O2::DataFormatsEMCAL
                                   O2::EMCALReconstruction
             SOURCES test/test_ctf_io_emcal.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	  
+ 
 o2_add_test(phos
             PUBLIC_LINK_LIBRARIES O2::DataFormatsPHOS
                                   O2::PHOSReconstruction
@@ -80,14 +86,14 @@ o2_add_test(cpv
             SOURCES test/test_ctf_io_cpv.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	    
+ 
 o2_add_test(zdc
             PUBLIC_LINK_LIBRARIES O2::DataFormatsZDC
                                   O2::ZDCReconstruction
             SOURCES test/test_ctf_io_zdc.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-	    
+ 
 o2_add_test(trd
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::DataFormatsTRD
@@ -95,7 +101,7 @@ o2_add_test(trd
             SOURCES test/test_ctf_io_trd.cxx
             COMPONENT_NAME ctf
             LABELS ctf)
-    
+ 
 o2_add_test(hmpid
             PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                                   O2::DataFormatsHMP

--- a/Detectors/CTF/test/test_ctf_io_mch.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mch.cxx
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHCTFIO
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "MCHCTF/CTFCoder.h"
+#include "DataFormatsMCH/CTF.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/Digit.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <cstring>
+
+using namespace o2::mch;
+
+BOOST_AUTO_TEST_CASE(CTFTest, *boost::unit_test::enabled())
+{
+  std::vector<ROFRecord> rofs;
+  std::vector<Digit> digs;
+  TStopwatch sw;
+  sw.Start();
+  o2::InteractionRecord ir0(3, 5), ir(ir0);
+
+  for (int irof = 0; irof < 1000; irof++) {
+    ir += 1 + gRandom->Integer(200);
+    int nch = 0;
+    while (nch == 0) {
+      nch = gRandom->Poisson(20);
+    }
+    int start = digs.size();
+    for (int ich = 0; ich < nch; ich++) {
+      int16_t detID = 100 + gRandom->Integer(1025 - 100);
+      int16_t padID = gRandom->Integer(28672);
+      int32_t tfTime = ir.differenceInBC(ir0);
+      uint32_t adc = gRandom->Integer(1024 * 1024);
+      uint16_t nsamp = gRandom->Integer(1024);
+      auto& d = digs.emplace_back(detID, padID, adc, tfTime, nsamp);
+      bool sat = gRandom->Rndm() > 0.9;
+      d.setSaturated(sat);
+    }
+    rofs.emplace_back(ir, start, nch);
+  }
+
+  sw.Start();
+  std::vector<o2::ctf::BufferType> vec;
+  {
+    CTFCoder coder;
+    coder.encode(vec, rofs, digs); // compress
+  }
+  sw.Stop();
+  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+
+  // writing
+  {
+    sw.Start();
+    auto* ctfImage = o2::mch::CTF::get(vec.data());
+    TFile flOut("test_ctf_mch.root", "recreate");
+    TTree ctfTree(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    ctfImage->print();
+    ctfImage->appendToTree(ctfTree, "MCH");
+    ctfTree.Write();
+    sw.Stop();
+    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+  }
+
+  // reading
+  vec.clear();
+  {
+    sw.Start();
+    TFile flIn("test_ctf_mch.root");
+    std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+    BOOST_CHECK(tree);
+    o2::mch::CTF::readFromTree(vec, *(tree.get()), "MCH");
+    sw.Stop();
+    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+  }
+
+  std::vector<ROFRecord> rofsD;
+  std::vector<Digit> digsD;
+
+  sw.Start();
+  const auto ctfImage = o2::mch::CTF::getImage(vec.data());
+  {
+    CTFCoder coder;
+    coder.decode(ctfImage, rofsD, digsD); // decompress
+  }
+  sw.Stop();
+  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+
+  LOG(INFO) << " BOOST_CHECK rofsD.size() " << rofsD.size() << " rofs.size() " << rofs.size()
+            << " BOOST_CHECK(digsD.size() " << digsD.size() << " digs.size()) " << digs.size();
+
+  BOOST_TEST(rofs == rofsD, boost::test_tools::per_element());
+  BOOST_TEST(digs == digsD, boost::test_tools::per_element());
+}

--- a/Detectors/CTF/workflow/CMakeLists.txt
+++ b/Detectors/CTF/workflow/CMakeLists.txt
@@ -33,6 +33,7 @@ o2_add_library(CTFWorkflow
                                      O2::FV0Workflow
                                      O2::FDDWorkflow
                                      O2::TOFWorkflow
+                                     O2::MCHWorkflow
                                      O2::MIDWorkflow
                                      O2::EMCALWorkflow
                                      O2::PHOSWorkflow

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -31,6 +31,7 @@
 #include "DataFormatsFDD/CTF.h"
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
+#include "DataFormatsMCH/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
@@ -196,6 +197,13 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mid::CTF));
     o2::mid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    setFirstTFOrbit(det.getName());
+  }
+
+  det = DetID::MCH;
+  if (detsTF[det]) {
+    auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mch::CTF));
+    o2::mch::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
     setFirstTFOrbit(det.getName());
   }
 

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -16,7 +16,6 @@
 #include "Framework/InputSpec.h"
 #include "CTFWorkflow/CTFWriterSpec.h"
 
-#include "DataFormatsParameters/GRPObject.h"
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsCommonDataFormats/EncodedBlocks.h"
@@ -30,6 +29,7 @@
 #include "DataFormatsFDD/CTF.h"
 #include "DataFormatsTOF/CTF.h"
 #include "DataFormatsMID/CTF.h"
+#include "DataFormatsMCH/CTF.h"
 #include "DataFormatsEMCAL/CTF.h"
 #include "DataFormatsPHOS/CTF.h"
 #include "DataFormatsCPV/CTF.h"
@@ -226,6 +226,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
   processDet<o2::fv0::CTF>(pc, DetID::FV0, header, treeOut.get());
   processDet<o2::fdd::CTF>(pc, DetID::FDD, header, treeOut.get());
   processDet<o2::mid::CTF>(pc, DetID::MID, header, treeOut.get());
+  processDet<o2::mch::CTF>(pc, DetID::MCH, header, treeOut.get());
   processDet<o2::emcal::CTF>(pc, DetID::EMC, header, treeOut.get());
   processDet<o2::phos::CTF>(pc, DetID::PHS, header, treeOut.get());
   processDet<o2::cpv::CTF>(pc, DetID::CPV, header, treeOut.get());
@@ -301,6 +302,7 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::fv0::CTF>(DetID::FV0, header);
   storeDictionary<o2::fdd::CTF>(DetID::FDD, header);
   storeDictionary<o2::mid::CTF>(DetID::MID, header);
+  storeDictionary<o2::mch::CTF>(DetID::MCH, header);
   storeDictionary<o2::emcal::CTF>(DetID::EMC, header);
   storeDictionary<o2::phos::CTF>(DetID::PHS, header);
   storeDictionary<o2::cpv::CTF>(DetID::CPV, header);

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -29,6 +29,7 @@
 #include "FDDWorkflow/EntropyDecoderSpec.h"
 #include "TOFWorkflowUtils/EntropyDecoderSpec.h"
 #include "MIDWorkflow/EntropyDecoderSpec.h"
+#include "MCHWorkflow/EntropyDecoderSpec.h"
 #include "EMCALWorkflow/EntropyDecoderSpec.h"
 #include "PHOSWorkflow/EntropyDecoderSpec.h"
 #include "CPVWorkflow/EntropyDecoderSpec.h"
@@ -102,6 +103,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   if (dets[DetID::MID]) {
     specs.push_back(o2::mid::getEntropyDecoderSpec());
+  }
+  if (dets[DetID::MCH]) {
+    specs.push_back(o2::mch::getEntropyDecoderSpec());
   }
   if (dets[DetID::EMC]) {
     specs.push_back(o2::emcal::getEntropyDecoderSpec());

--- a/Detectors/MUON/MCH/CTF/CMakeLists.txt
+++ b/Detectors/MUON/MCH/CTF/CMakeLists.txt
@@ -8,17 +8,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Contour)
-add_subdirectory(Mapping)
-add_subdirectory(PreClustering)
-add_subdirectory(Geometry)
-add_subdirectory(Clustering)
-add_subdirectory(Simulation)
-add_subdirectory(Tracking)
-add_subdirectory(Raw)
-add_subdirectory(CTF)
-add_subdirectory(Workflow)
-add_subdirectory(Conditions)
-add_subdirectory(Calibration)
-add_subdirectory(DevIO)
+o2_add_library(MCHCTF
+               SOURCES src/CTFCoder.cxx src/CTFHelper.cxx
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH
+                                     O2::MCHBase
+                                     O2::DetectorsBase
+                                     O2::CommonDataFormat
+				                     O2::DetectorsCommonDataFormats
+                                     O2::rANS
+                                     ms_gsl::ms_gsl)

--- a/Detectors/MUON/MCH/CTF/CMakeLists.txt
+++ b/Detectors/MUON/MCH/CTF/CMakeLists.txt
@@ -14,6 +14,6 @@ o2_add_library(MCHCTF
                                      O2::MCHBase
                                      O2::DetectorsBase
                                      O2::CommonDataFormat
-				                     O2::DetectorsCommonDataFormats
+                                     O2::DetectorsCommonDataFormats
                                      O2::rANS
                                      ms_gsl::ms_gsl)

--- a/Detectors/MUON/MCH/CTF/README.md
+++ b/Detectors/MUON/MCH/CTF/README.md
@@ -1,0 +1,78 @@
+<!-- doxy
+\page refMUONMCHCTF MCH CTF encoding library
+/doxy -->
+
+# MCH CTF
+
+This directory contains the classes to handle entropy encoding and decoding of 
+MCH digits (and their associated ROFRecord).
+
+# Circular test
+
+To idea of this test is to check that digits data stays unaltered when they go
+through the encoding/decoding processing.  
+
+```
+circular-test.sh [NROFPERTF] [NTF] [OCC] [SEED]
+```
+
+The [circular-test.sh](./test/circular-test.sh) script performs for a given set of
+{ number of timeframes, number of rofs per timeframe, occupancy, seed }, a
+variation of the operations described below.
+
+## Generate random digits and write them (debug binary format)
+
+```
+o2-mch-digits-random-generator-workflow -b
+  --nof-rofs-per-tf 3 
+  --max-nof-tfs 5
+  --occupancy 0.01 
+  --seed 1 
+| o2-mch-digits-writer-workflow -b 
+  --binary-file-format 1 
+  --outfile digits_ref_rof_3_tf_5_occ_0.01_seed_1.data
+```
+
+Note the `--seed` option that _must_ be non-zero if you want to get
+reproducible results when running several times.
+
+
+## Read those digits and encode them in a CTF
+
+```
+o2-mch-digits-file-reader-workflow -b
+  --infile digits_ref.data
+| o2-mch-entropy-encoder-workflow -b 
+| o2-ctf-writer-workflow -b 
+  --onlyDet MCH --no-grp
+```
+
+## Read back the CTF, decode the digits, write them
+
+```
+o2-ctf-reader-workflow -b 
+  --ctf-input o2_ctf_run00000000_orbit0000000000_tf0000000000.root 
+| o2-mch-digits-writer-workflow -b 
+  --binary-file-format 1 
+  --outfile digits.data
+```
+
+## Dump the written digits in text form
+
+```
+o2-mch-digits-file-reader-workflow -b 
+  --infile digits_ref.data
+| o2-mch-digits-writer-workflow -b 
+  --no-file 
+  --txt
+  --print-digits
+```
+
+## Compare digits before after ctf encoding/decoding
+
+```
+ls -al digits.*data
+shasum -a 256 digits*.data
+```
+
+

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -1,0 +1,163 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MCH digit data
+
+#ifndef O2_MCH_CTFCODER_H
+#define O2_MCH_CTFCODER_H
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <array>
+#include "DataFormatsMCH/CTF.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/Digit.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/CTFCoderBase.h"
+#include "MCHCTF/CTFHelper.h"
+#include "rANS/rans.h"
+
+class TTree;
+
+namespace o2
+{
+namespace mch
+{
+
+class CTFCoder : public o2::ctf::CTFCoderBase
+{
+ public:
+  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MCH) {}
+  ~CTFCoder() = default;
+
+  /// entropy-encode data to buffer with CTF
+  template <typename VEC>
+  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData);
+
+  /// entropy decode data from buffer with CTF
+  template <typename VROF, typename VCOL>
+  void decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec);
+
+  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+
+ private:
+  void appendToTree(TTree& tree, CTF& ec);
+  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<Digit>& digVec);
+};
+
+/// entropy-encode clusters to buffer with CTF
+template <typename VEC>
+void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData)
+{
+  using MD = o2::ctf::Metadata::OptStore;
+  // what to do which each field: see o2::ctd::Metadata explanation
+  constexpr MD optField[CTF::getNBlocks()] = {
+    MD::EENCODE, // BLC_bcIncROF
+    MD::EENCODE, // BLC_orbitIncROF
+    MD::EENCODE, // BLC_nDigitsROF
+    MD::EENCODE, // BLC_tfTime
+    MD::EENCODE, // BLC_nSamples
+    MD::EENCODE, // BLC_isSaturated
+    MD::EENCODE, // BLC_detID
+    MD::EENCODE, // BLC_padID
+    MD::EENCODE  // BLC_ADC
+  };
+  CTFHelper helper(rofData, digData);
+
+  // book output size with some margin
+  auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
+  buff.resize(szIni);
+
+  auto ec = CTF::create(buff);
+  using ECB = CTF::base;
+
+  ec->setHeader(helper.createHeader());
+  ec->getANSHeader().majorVersion = 0;
+  ec->getANSHeader().minorVersion = 1;
+  // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+#define ENCODEMCH(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
+  // clang-format off
+  ENCODEMCH(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,     0);
+  ENCODEMCH(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF,  0);
+  ENCODEMCH(helper.begin_nDigitsROF(),  helper.end_nDigitsROF(),   CTF::BLC_nDigitsROF,   0);
+
+  ENCODEMCH(helper.begin_tfTime(),      helper.end_tfTime(),       CTF::BLC_tfTime,       0);
+  ENCODEMCH(helper.begin_nSamples(),    helper.end_nSamples(),     CTF::BLC_nSamples,     0);
+  ENCODEMCH(helper.begin_isSaturated(), helper.end_isSaturated(),  CTF::BLC_isSaturated,  0);
+  ENCODEMCH(helper.begin_detID(),       helper.end_detID(),        CTF::BLC_detID,        0);
+  ENCODEMCH(helper.begin_padID(),       helper.end_padID(),        CTF::BLC_padID,        0);
+  ENCODEMCH(helper.begin_ADC()  ,       helper.end_ADC(),          CTF::BLC_ADC,          0);
+  // clang-format on
+  //  CTF::get(buff.data())->print(getPrefix());
+}
+
+/// decode entropy-encoded clusters to standard compact clusters
+template <typename VROF, typename VCOL>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
+{
+  auto header = ec.getHeader();
+  ec.print(getPrefix());
+
+  std::vector<uint16_t> bcInc, nSamples;
+  std::vector<uint32_t> orbitInc, ADC, nDigits;
+  std::vector<int32_t> tfTime;
+  std::vector<int16_t> detID, padID;
+  std::vector<uint8_t> isSaturated;
+
+#define DECODEMCH(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
+  // clang-format off
+  DECODEMCH(bcInc,       CTF::BLC_bcIncROF);
+  DECODEMCH(orbitInc,    CTF::BLC_orbitIncROF);
+  DECODEMCH(nDigits,     CTF::BLC_nDigitsROF);
+
+  DECODEMCH(tfTime,      CTF::BLC_tfTime);
+  DECODEMCH(nSamples,    CTF::BLC_nSamples);
+  DECODEMCH(isSaturated, CTF::BLC_isSaturated);
+  DECODEMCH(detID,       CTF::BLC_detID);
+  DECODEMCH(padID,       CTF::BLC_padID);
+  DECODEMCH(ADC,         CTF::BLC_ADC);
+  // clang-format on
+  //
+  rofVec.clear();
+  digVec.clear();
+  rofVec.reserve(header.nROFs);
+  digVec.reserve(header.nDigits);
+
+  uint32_t firstEntry = 0, rofCount = 0, digCount = 0;
+  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+
+  for (uint32_t irof = 0; irof < header.nROFs; irof++) {
+    // restore ROFRecord
+    if (orbitInc[irof]) {  // non-0 increment => new orbit
+      ir.bc = bcInc[irof]; // bcInc has absolute meaning
+      ir.orbit += orbitInc[irof];
+    } else {
+      ir.bc += bcInc[irof];
+    }
+
+    firstEntry = digVec.size();
+    for (auto ic = 0; ic < nDigits[irof]; ic++) {
+      digVec.emplace_back(Digit{detID[digCount], padID[digCount], ADC[digCount], tfTime[digCount], nSamples[digCount]});
+      digVec.back().setSaturated(isSaturated[digCount]);
+      digCount++;
+    }
+    rofVec.emplace_back(ROFRecord{ir, int(firstEntry), static_cast<int>(nDigits[irof])});
+  }
+  assert(rofVec.size() == header.nROFs);
+  assert(digCount == header.nDigits);
+}
+
+} // namespace mch
+} // namespace o2
+
+#endif // O2_MCH_CTFCODER_H

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -142,7 +142,7 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_nSamples, Digit, uint16_t>::_Iter;
-    value_type operator*() const { return mData[mIndex].nofSamples(); }
+    value_type operator*() const { return mData[mIndex].getNofSamples(); }
   };
 
   //_______________________________________________

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -1,0 +1,217 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MCH CTF creation
+
+#ifndef O2_MCH_CTF_HELPER_H
+#define O2_MCH_CTF_HELPER_H
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/CTF.h"
+#include <gsl/span>
+
+namespace o2
+{
+namespace mch
+{
+
+class CTFHelper
+{
+
+ public:
+  CTFHelper(const gsl::span<const o2::mch::ROFRecord>& rofData, const gsl::span<const o2::mch::Digit>& digData)
+    : mROFData(rofData), mDigData(digData) {}
+
+  CTFHeader createHeader()
+  {
+    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mDigData.size()), 0, 0};
+    if (mROFData.size()) {
+      h.firstOrbit = mROFData[0].getBCData().orbit;
+      h.firstBC = mROFData[0].getBCData().bc;
+    }
+    return h;
+  }
+
+  size_t getSize() const { return mROFData.size() * sizeof(o2::mch::ROFRecord) + mDigData.size() * sizeof(o2::mch::Digit); }
+
+  //>>> =========================== ITERATORS ========================================
+
+  template <typename I, typename D, typename T, int M = 1>
+  class _Iter
+  {
+   public:
+    using difference_type = int64_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::random_access_iterator_tag;
+
+    _Iter(const gsl::span<const D>& data, bool end = false) : mData(data), mIndex(end ? M * data.size() : 0){};
+    _Iter() = default;
+
+    const I& operator++()
+    {
+      ++mIndex;
+      return (I&)(*this);
+    }
+
+    const I& operator--()
+    {
+      mIndex--;
+      return (I&)(*this);
+    }
+
+    difference_type operator-(const I& other) const { return mIndex - other.mIndex; }
+
+    difference_type operator-(size_t idx) const { return mIndex - idx; }
+
+    const I& operator-(size_t idx)
+    {
+      mIndex -= idx;
+      return (I&)(*this);
+    }
+
+    bool operator!=(const I& other) const { return mIndex != other.mIndex; }
+    bool operator==(const I& other) const { return mIndex == other.mIndex; }
+    bool operator>(const I& other) const { return mIndex > other.mIndex; }
+    bool operator<(const I& other) const { return mIndex < other.mIndex; }
+
+   protected:
+    gsl::span<const D> mData{};
+    size_t mIndex = 0;
+  };
+
+  //_______________________________________________
+  // BC difference wrt previous if in the same orbit, otherwise the abs.value.
+  // For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_bcIncROF : public _Iter<Iter_bcIncROF, ROFRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_bcIncROF, ROFRecord, uint16_t>::_Iter;
+    value_type operator*() const
+    {
+      if (mIndex) {
+        if (mData[mIndex].getBCData().orbit == mData[mIndex - 1].getBCData().orbit) {
+          return mData[mIndex].getBCData().bc - mData[mIndex - 1].getBCData().bc;
+        } else {
+          return mData[mIndex].getBCData().bc;
+        }
+      }
+      return 0;
+    }
+  };
+
+  //_______________________________________________
+  // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
+  class Iter_orbitIncROF : public _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_orbitIncROF, ROFRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mIndex ? mData[mIndex].getBCData().orbit - mData[mIndex - 1].getBCData().orbit : 0; }
+  };
+
+  //_______________________________________________
+  // Number of entries in the ROF
+  class Iter_nDigitsROF : public _Iter<Iter_nDigitsROF, ROFRecord, uint32_t>
+  {
+   public:
+    using _Iter<Iter_nDigitsROF, ROFRecord, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getNEntries(); }
+  };
+
+  //_______________________________________________
+  class Iter_tfTime : public _Iter<Iter_tfTime, Digit, int32_t>
+  {
+   public:
+    using _Iter<Iter_tfTime, Digit, int32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getTime(); }
+  };
+
+  //_______________________________________________
+  class Iter_nSamples : public _Iter<Iter_nSamples, Digit, uint16_t>
+  {
+   public:
+    using _Iter<Iter_nSamples, Digit, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].nofSamples(); }
+  };
+
+  //_______________________________________________
+  class Iter_isSaturated : public _Iter<Iter_isSaturated, Digit, uint8_t>
+  {
+   public:
+    using _Iter<Iter_isSaturated, Digit, uint8_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].isSaturated(); }
+  };
+
+  //_______________________________________________
+  class Iter_detID : public _Iter<Iter_detID, Digit, int16_t>
+  {
+   public:
+    using _Iter<Iter_detID, Digit, int16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getDetID(); }
+  };
+
+  //_______________________________________________
+  class Iter_padID : public _Iter<Iter_padID, Digit, int16_t>
+  {
+   public:
+    using _Iter<Iter_padID, Digit, int16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPadID(); }
+  };
+
+  //_______________________________________________
+  class Iter_ADC : public _Iter<Iter_ADC, Digit, uint32_t>
+  {
+   public:
+    using _Iter<Iter_ADC, Digit, uint32_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getADC(); }
+  };
+
+  //<<< =========================== ITERATORS ========================================
+
+  Iter_bcIncROF begin_bcIncROF() const { return Iter_bcIncROF(mROFData, false); }
+  Iter_bcIncROF end_bcIncROF() const { return Iter_bcIncROF(mROFData, true); }
+
+  Iter_orbitIncROF begin_orbitIncROF() const { return Iter_orbitIncROF(mROFData, false); }
+  Iter_orbitIncROF end_orbitIncROF() const { return Iter_orbitIncROF(mROFData, true); }
+
+  Iter_nDigitsROF begin_nDigitsROF() const { return Iter_nDigitsROF(mROFData, false); }
+  Iter_nDigitsROF end_nDigitsROF() const { return Iter_nDigitsROF(mROFData, true); }
+
+  Iter_tfTime begin_tfTime() const { return Iter_tfTime(mDigData, false); }
+  Iter_tfTime end_tfTime() const { return Iter_tfTime(mDigData, true); }
+
+  Iter_nSamples begin_nSamples() const { return Iter_nSamples(mDigData, false); }
+  Iter_nSamples end_nSamples() const { return Iter_nSamples(mDigData, true); }
+
+  Iter_isSaturated begin_isSaturated() const { return Iter_isSaturated(mDigData, false); }
+  Iter_isSaturated end_isSaturated() const { return Iter_isSaturated(mDigData, true); }
+
+  Iter_detID begin_detID() const { return Iter_detID(mDigData, false); }
+  Iter_detID end_detID() const { return Iter_detID(mDigData, true); }
+
+  Iter_padID begin_padID() const { return Iter_padID(mDigData, false); }
+  Iter_padID end_padID() const { return Iter_padID(mDigData, true); }
+
+  Iter_ADC begin_ADC() const { return Iter_ADC(mDigData, false); }
+  Iter_ADC end_ADC() const { return Iter_ADC(mDigData, true); }
+
+ private:
+  const gsl::span<const o2::mch::ROFRecord> mROFData;
+  const gsl::span<const o2::mch::Digit> mDigData;
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
@@ -1,0 +1,81 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFCoder.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief class for entropy encoding/decoding of MCH  data
+
+#include "MCHCTF/CTFCoder.h"
+#include "CommonUtils/StringUtils.h"
+#include <TTree.h>
+
+using namespace o2::mch;
+
+///___________________________________________________________________________________
+// Register encoded data in the tree (Fill is not called, will be done by caller)
+void CTFCoder::appendToTree(TTree& tree, CTF& ec)
+{
+  ec.appendToTree(tree, mDet.getName());
+}
+
+///___________________________________________________________________________________
+// extract and decode data from the tree
+void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<Digit>& digVec)
+{
+  assert(entry >= 0 && entry < tree.GetEntries());
+  CTF ec;
+  ec.readFromTree(tree, mDet.getName(), entry);
+  decode(ec, rofVec, digVec);
+}
+
+///________________________________
+void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  const auto* ctf = CTF::get(buff.data());
+
+  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
+    o2::rans::FrequencyTable ft;
+    auto bl = ctf->getBlock(slot);
+    auto md = ctf->getMetadata(slot);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return std::move(ft);
+  };
+  auto getProbBits = [ctf](CTF::Slots slot) -> int {
+    return ctf->getMetadata(slot).probabilityBits;
+  };
+
+  // just to get types
+  uint16_t bcInc, nDigits, nSamples;
+  uint32_t orbitInc, ADC;
+  int32_t tfTime;
+  int16_t detID, padID;
+  uint8_t isSaturated;
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+
+  // clang-format off
+  MAKECODER(bcInc,       CTF::BLC_bcIncROF); 
+  MAKECODER(orbitInc,    CTF::BLC_orbitIncROF);
+  MAKECODER(nDigits,     CTF::BLC_nDigitsROF);
+  MAKECODER(tfTime,      CTF::BLC_tfTime);
+  MAKECODER(nSamples,    CTF::BLC_nSamples);
+  MAKECODER(isSaturated, CTF::BLC_isSaturated);
+  MAKECODER(detID,       CTF::BLC_detID);
+  MAKECODER(padID,       CTF::BLC_padID);
+  MAKECODER(ADC,         CTF::BLC_ADC);
+  // clang-format on
+}

--- a/Detectors/MUON/MCH/CTF/src/CTFHelper.cxx
+++ b/Detectors/MUON/MCH/CTF/src/CTFHelper.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CTFHelper.cxx
+/// \author ruben.shahoyan@cern.ch
+/// \brief  Helper for MCH CTF creation
+
+#include "MCHCTF/CTFHelper.h"

--- a/Detectors/MUON/MCH/CTF/test/circular-test.sh
+++ b/Detectors/MUON/MCH/CTF/test/circular-test.sh
@@ -1,0 +1,221 @@
+#!/bin/sh
+
+get_cmd_write_digits() {
+	if [ $# -eq 0 ]; then
+		echo "must at least specify the destination of the dump"
+		return
+	fi
+	local dest=$1
+	local output=$2
+  local format=${3:-missing}
+	local opt=""
+	local cmd=""
+
+	if [ "$dest" = "binary" ]; then
+		opt="--binary-file-format $format"
+	elif [ "$dest" = "text" ]; then
+		opt="--txt"
+	elif [ "$dest" = "screen" ]; then
+		opt="--txt"
+	else
+		echo "dest=$dest is not one of {binary,text,screen}"
+		return
+	fi
+
+	cmd="o2-mch-digits-writer-workflow -b "
+	cmd+=" $opt"
+	if [ $output ]; then
+		cmd+=" --outfile $output"
+	else
+		cmd+=" --no-file"
+	fi
+	echo $cmd
+}
+
+run_workflow() {
+	local cmd=$1
+	local msg=$2
+	local verbose=$3
+
+  if [ ! -z $VERBOSE ]; then
+    verbose="verbose"
+  fi
+
+	cmd+=" | o2-dpl-run --run -b"
+
+	echo "#############"
+	echo "# $2"
+	echo "$cmd"
+	echo "#############"
+
+	if [ "$verbose" = "verbose" ]; then
+		eval $cmd
+	else
+		eval $cmd &>/dev/null
+	fi
+}
+
+generate_digits() {
+	local NROFPERTOF=${1:-1}
+	local NTF=${2:-1}
+	local OCC=${3:-0.0001}
+  local SEED=${4:-1}
+  local digitFile=${5:-UNKNOWN}
+  local format=${6:-3}
+	local cmd=""
+
+	cmd="o2-mch-digits-random-generator-workflow -b "
+	cmd+="--nof-rofs-per-tf $NROFPERTF "
+	cmd+="--max-nof-tfs $NTF "
+	cmd+="--occupancy $OCC "
+	cmd+="--seed $SEED "
+	cmd+="| "
+	cmd+=$(get_cmd_write_digits binary $digitFile $format)
+ 
+	run_workflow $cmd "Generate random digits and save them" verbose
+}
+
+dump_digits() {
+	if [ $# -eq 0 ]; then
+		echo "must specify the name of the digit file to dump"
+		return
+	fi
+	local digitFile=${1:-digits.dump}
+	local dest=${2:-invalid}
+	local output=$3
+  local format=$4
+	local cmd=""
+  local verbose=""
+
+  if [ "$dest" = "screen" ]; then
+    verbose=verbose
+  fi
+
+	cmd="o2-mch-digits-file-reader-workflow -b --infile $digitFile | "
+	cmd+=$(get_cmd_write_digits $dest $output $format)
+
+	run_workflow $cmd "Dump digits" $verbose
+}
+
+create_ctf() {
+	if [ $# -eq 0 ]; then
+		echo "must specify the name of the digit file to compress"
+		return
+	fi
+	local digitsFile=$1
+	local outputType=${2:-ctf}
+	local cmd=""
+
+	cmd="o2-mch-digits-file-reader-workflow --infile ${digitsFile} -b | "
+	cmd+="o2-mch-entropy-encoder-workflow -b |"
+	cmd+="o2-ctf-writer-workflow --onlyDet MCH --no-grp --output-type $outputType -b"
+
+	run_workflow $cmd "Read digits and create $outputType"
+}
+
+get_ctfs() {
+	if [ $# -eq 0 ]; then
+		echo "must specify the number of tfs to look for"
+		return
+	fi
+	local ntf=$1
+	local ctfs=""
+  local run=0
+  local orbit=0
+
+	for tf in $(seq 0 $(($ntf - 1))); do
+		ctfs+=$(printf "o2_ctf_run%08d_orbit%010d_tf%010d.root " $run $orbit $tf)
+	done
+	ctfs=$(echo $ctfs | sed 's/.$//') # remove trailing coma
+
+	echo "$ctfs"
+}
+
+read_ctf() {
+	if [ $# -lt 2 ]; then
+		echo "must specify the CTF(s) to read and output digit filename"
+		return
+	fi
+	local ctfs=$1
+	local ctfdigitfile=$2
+  local format=$3
+	local cmd=""
+
+	cmd="o2-ctf-reader-workflow --onlyDet MCH --ctf-input ${ctfs} -b | "
+	cmd+=$(get_cmd_write_digits binary $ctfdigitfile $format)
+
+	run_workflow $cmd "Read CTF and write digits"
+}
+
+NROFPERTF=${1:-128}
+NTF=${2:-1}
+OCC=${3:-0.1}
+SEED=${4:-1}
+BINARY_FILE_FORMAT=${5:-3}
+textDump=0
+
+COUNT=$(( $NROFPERTF * $NTF * $OCC * 1064008 ))
+COUNT=$(echo $COUNT | awk '{print int($0)}')
+
+if [ $COUNT -lt 100000 ]; then
+  # activate text dump if we don't have too many digits
+  textDump=1 
+fi
+
+refdigits=digits_ref_rof_${NROFPERTF}_tf_${NTF}_occ_${OCC}_seed_${SEED}
+
+# Generate digits
+generate_digits $NROFPERTF $NTF $OCC $SEED $refdigits.orig.data $BINARY_FILE_FORMAT
+
+# Dump the digits to verify sample-sink couple
+dump_digits ${refdigits}.orig.data binary ${refdigits}.check.data $BINARY_FILE_FORMAT
+
+echo '# Remove dictionary data if any'
+rm -f ctf_dictionary.root
+
+# read Digits and create CTF(s) files
+create_ctf ${refdigits}.orig.data
+
+ctfs=$(get_ctfs $NTF)
+
+# read CTF and write digits
+read_ctf $ctfs ${refdigits}.ctf.data $BINARY_FILE_FORMAT
+
+# # Dump the digits on screen'
+# dump_digits ${refdigits}.ctf.data screen
+
+mkdir nodict && pushd nodict
+
+# Read digits and encode them, but only write out the frequencies dictionary
+create_ctf ../${refdigits}.orig.data dict
+
+# Read digits and encode them in a CTF with external dict
+create_ctf ../${refdigits}.orig.data
+
+ctfs=$(get_ctfs $NTF)
+
+# read CTF and write digits
+read_ctf $ctfs ${refdigits}.nodict.ctf.data $BINARY_FILE_FORMAT
+
+popd
+
+if [ $textDump -eq 1 ]; then
+# Make a text version of all digit files
+  for d in $(find . -name "digits*"); 
+  do
+    dump_digits $d text $d.txt
+  done
+fi
+
+echo '# Compare digits before after ctf encoding/decoding'
+if [ $textDump -eq 1 ]; then
+  echo '# Text versions'
+  find . -name "digits*.txt" -exec shasum -a 256 {} \; | sort
+fi
+echo '# Binary versions'
+find . -name "digits*.data" -exec shasum -a 256 {} \; | sort
+
+echo '# Sizes'
+find . -name '*ctf_*' -exec ls -alh {} \;
+find . -name 'digits*.data' -exec ls -alh {} \;
+

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV0.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV0.cxx
@@ -80,7 +80,7 @@ bool DigitWriterV0::write(std::ostream& out,
     std::vector<DigitD0> digitsd0;
     for (int i = r.getFirstIdx(); i <= r.getLastIdx(); i++) {
       const Digit& d = digits[i];
-      digitsd0.push_back(DigitD0{d.getTime(), d.nofSamples(), d.getDetID(), d.getPadID(), d.getADC()});
+      digitsd0.push_back(DigitD0{d.getTime(), d.getNofSamples(), d.getDetID(), d.getPadID(), d.getADC()});
       digitsd0.back().setSaturated(d.isSaturated());
     }
     gsl::span<const DigitD0> d0(digitsd0);

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
@@ -89,7 +89,7 @@ bool DigitWriterV1::write(std::ostream& out,
 
   std::vector<DigitD0> digitsd0;
   for (const auto& d : digits) {
-    digitsd0.push_back(DigitD0{d.getTime(), d.nofSamples(), d.getDetID(), d.getPadID(), d.getADC()});
+    digitsd0.push_back(DigitD0{d.getTime(), d.getNofSamples(), d.getDetID(), d.getPadID(), d.getADC()});
     digitsd0.back().setSaturated(d.isSaturated());
   }
   gsl::span<const DigitD0> d0(digitsd0);

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitWriter.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitWriter.cxx
@@ -31,7 +31,7 @@ template <>
 std::string asString(o2::mch::Digit d)
 {
   return fmt::format("DetID {:4d} PadId {:10d} ADC {:10d} TFtime {:10d} NofSamples {:5d} {}",
-                     d.getDetID(), d.getPadID(), d.getADC(), d.getTime(), d.nofSamples(),
+                     d.getDetID(), d.getPadID(), d.getADC(), d.getTime(), d.getNofSamples(),
                      d.isSaturated() ? "(S)" : "");
 }
 template <typename T>

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -10,11 +10,12 @@
 
 o2_add_library(MCHWorkflow
                SOURCES src/DataDecoderSpec.cxx src/PreClusterFinderSpec.cxx src/ClusterFinderOriginalSpec.cxx
+               src/EntropyDecoderSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHRawDecoder Boost::program_options
                                      O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface
                                      O2::MCHPreClustering O2::MCHMappingImpl4 O2::MCHRawElecMap O2::MCHBase
-                                     O2::DataFormatsMCH O2::MCHClustering)
+                                     O2::DataFormatsMCH O2::MCHClustering O2::MCHCTF)
 
 o2_add_executable(
         cru-page-reader-workflow
@@ -130,3 +131,8 @@ o2_add_executable(
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHGeometryTransformer)
 
+o2_add_executable(
+        entropy-encoder-workflow
+        SOURCES src/entropy-encoder-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -9,6 +9,7 @@
 * [Raw to digits](#raw-to-digits)
 * [Preclustering](#preclustering)
 * [Clustering](#clustering)
+* [CTF encoding/decoding](#ctf-encodingdecoding)
 * [Local to global cluster transformation](#local-to-global-cluster-transformation)
 * [Tracking](#tracking)
   * [Original track finder](#original-track-finder)
@@ -76,6 +77,16 @@ o2-mch-preclusters-to-clusters-original-workflow
 ```
 
 Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
+
+## CTF encoding/decoding
+
+Entropy encoding is done be attaching the `o2-mch-entropy-encoder-workflow` to the output of `DIGITS` and `DIGITROF` data-descriptions, providing `Digit` and `ROFRecord` respectively. Afterwards the encoded data can be stored by the `o2-ctf-writer-workflow`.
+
+```shell
+o2-raw-file-reader-workflow --input-conf raw/MCH/MCHraw.cfg | o2-mch-raw-to-digits-workflow  | o2-mch-entropy-encoder-workflow | o2-ctf-writer-workflow --onlyDet MCH
+```
+
+The decoding is done automatically by the `o2-ctf-reader-workflow`.
 
 ## Local to global cluster transformation
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.h
+/// @brief  Convert CTF (EncodedBlocks) to MCH {Digit,ROFRecord} stream
+
+#ifndef O2_MCH_ENTROPYDECODER_SPEC
+#define O2_MCH_ENTROPYDECODER_SPEC
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mch
+{
+/// create a processor spec
+framework::DataProcessorSpec getEntropyDecoderSpec();
+
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   EntropyDecoderSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "MCHWorkflow/EntropyDecoderSpec.h"
+#include "Framework/Task.h"
+#include "MCHCTF/CTFCoder.h"
+#include <TStopwatch.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mch
+{
+
+class EntropyDecoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyDecoderSpec();
+  ~EntropyDecoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mch::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyDecoderSpec::EntropyDecoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("ctf-dict");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+  }
+}
+
+void EntropyDecoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+
+  auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
+
+  auto& rofs = pc.outputs().make<std::vector<o2::mch::ROFRecord>>(OutputRef{"rofs"});
+  auto& digits = pc.outputs().make<std::vector<o2::mch::Digit>>(OutputRef{"digits"});
+
+  // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
+  const auto ctfImage = o2::mch::CTF::getImage(buff.data());
+  mCTFCoder.decode(ctfImage, rofs, digits);
+
+  mTimer.Stop();
+  LOG(INFO) << "Decoded " << digits.size() << " MCH digits in " << rofs.size() << " ROFRecords in " << mTimer.CpuTime() - cput << " s";
+}
+
+void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MCH Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyDecoderSpec()
+{
+  std::vector<OutputSpec> outputs{
+    OutputSpec{{"rofs"}, "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
+    OutputSpec{{"digits"}, "MCH", "DIGITS", 0, Lifetime::Timeframe}};
+
+  return DataProcessorSpec{
+    "mch-entropy-decoder",
+    Inputs{InputSpec{"ctf", "MCH", "CTFDATA", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},
+    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -1,0 +1,120 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "MCHCTF/CTFCoder.h"
+#include <TStopwatch.h>
+#include <vector>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mch
+{
+
+class EntropyEncoderSpec : public o2::framework::Task
+{
+ public:
+  EntropyEncoderSpec();
+  ~EntropyEncoderSpec() override = default;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::mch::CTFCoder mCTFCoder;
+  TStopwatch mTimer;
+};
+
+EntropyEncoderSpec::EntropyEncoderSpec()
+{
+  mTimer.Stop();
+  mTimer.Reset();
+}
+
+void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
+{
+  std::string dictPath = ic.options().get<std::string>("ctf-dict");
+  if (!dictPath.empty() && dictPath != "none") {
+    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+  }
+}
+
+void EntropyEncoderSpec::run(ProcessingContext& pc)
+{
+  auto cput = mTimer.CpuTime();
+  mTimer.Start(false);
+  auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
+  auto digits = pc.inputs().get<gsl::span<o2::mch::Digit>>("digits");
+
+  auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MCH", "CTFDATA", 0, Lifetime::Timeframe});
+  mCTFCoder.encode(buffer, rofs, digits);
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  //  eeb->print();
+  mTimer.Stop();
+  LOG(INFO) << fmt::format("Created encoded data ({} digits and {} rofs) of size {} ({:5.1f} MB) for MCH in {:5.1f} s ",
+                           digits.size(), rofs.size(), eeb->size(), eeb->size() / 1024.0 / 1024, mTimer.CpuTime() - cput);
+}
+
+void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(INFO, "MCH Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+DataProcessorSpec getEntropyEncoderSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("rofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "mch-entropy-encoder",
+    inputs,
+    Outputs{{"MCH", "CTFDATA", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
+    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"Path to pre-computed CTF encoding dictionary to be used for encoding"}}}};
+}
+
+} // namespace mch
+} // namespace o2
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::mch::getEntropyEncoderSpec());
+  return wf;
+}


### PR DESCRIPTION
A small variation on the heavy lifting work done by Ruben.
  
Compared to @shahor02 version (see #5740) this one :
  
- encodes separately the digit saturation information (which has been promoted to its own data member in the digit structure itself)
- only export `EntropyDecoderSpec.h` (as `EntropyEncoderSpec` is only required by `entropy-encoder-workflow.cxx` it has been merged with it)
- add a `--no-grp` option to `ctf-reader-workflow` to be able to work without a prior simulation (only valid if using also `--onlyDet` option, of course)

Note that this PR also adds a `circular-test.sh`script which generates random digits, encode them and read them back, checking the digits actually stay the same. That script actually depends on code from #5932 and #5950