### PR TITLE
DPL: allow introspection of running workflow from InitContext

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -23,6 +23,7 @@
 #include "Framework/TimingInfo.h"
 #include "Framework/TerminationPolicy.h"
 #include "Framework/Tracing.h"
+#include "Framework/RunningWorkflowInfo.h"
 
 #include <fairmq/FairMQDevice.h>
 #include <fairmq/FairMQParts.h>
@@ -81,7 +82,7 @@ struct DataProcessorContext {
 class DataProcessingDevice : public FairMQDevice
 {
  public:
-  DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry&, DeviceState& state);
+  DataProcessingDevice(RunningWorkflowInfo const& runningWorkflow, RunningDeviceRef ref, ServiceRegistry&, DeviceState& state);
   void Init() final;
   void InitTask() final;
   void PreRun() final;

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -7,8 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_DEVICESPEC_H
-#define FRAMEWORK_DEVICESPEC_H
+#ifndef O2_FRAMEWORK_DEVICESPEC_H_
+#define O2_FRAMEWORK_DEVICESPEC_H_
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ComputingResource.h"
@@ -30,9 +30,7 @@
 #include <map>
 #include <utility>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 /// Concrete description of the device which will actually run
@@ -65,6 +63,5 @@ struct DeviceSpec {
   unsigned short resourceMonitoringInterval;
 };
 
-} // namespace framework
-} // namespace o2
-#endif
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DEVICESPEC_H_

--- a/Framework/Core/include/Framework/RunningWorkflowInfo.h
+++ b/Framework/Core/include/Framework/RunningWorkflowInfo.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_RUNNINGWORKFLOWINFO_H_
+#define O2_FRAMEWORK_RUNNINGWORKFLOWINFO_H_
+
+#include "Framework/DeviceSpec.h"
+#include <vector>
+
+namespace o2::framework
+{
+
+struct RunningDeviceRef {
+  size_t index; // Index in the RunningWorkflowInfo::devices vector;
+};
+
+/// Information about the running workflow
+struct RunningWorkflowInfo {
+  std::vector<DeviceSpec> devices;
+};
+
+} // namespace o2::framework
+#endif // RunningWorkflowInfo

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -78,15 +78,15 @@ void idle_timer(uv_timer_t* handle)
   ZoneScopedN("Idle timer");
 }
 
-DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry& registry, DeviceState& state)
-  : mSpec{spec},
+DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWorkflow, RunningDeviceRef ref, ServiceRegistry& registry, DeviceState& state)
+  : mSpec{runningWorkflow.devices[ref.index]},
     mState{state},
-    mInit{spec.algorithm.onInit},
+    mInit{mSpec.algorithm.onInit},
     mStatefulProcess{nullptr},
-    mStatelessProcess{spec.algorithm.onProcess},
-    mError{spec.algorithm.onError},
+    mStatelessProcess{mSpec.algorithm.onProcess},
+    mError{mSpec.algorithm.onError},
     mConfigRegistry{nullptr},
-    mAllocator{&mTimingInfo, &registry, spec.outputs},
+    mAllocator{&mTimingInfo, &registry, mSpec.outputs},
     mServiceRegistry{registry}
 {
   /// FIXME: move erro handling to a service?

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -12,6 +12,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/ControlService.h"
+#include "Framework/RunningWorkflowInfo.h"
 #include <FairMQDevice.h>
 #include <InfoLogger/InfoLogger.hxx>
 
@@ -42,8 +43,9 @@ void customize(std::vector<CompletionPolicy>& policies)
 
 AlgorithmSpec simplePipe(std::string const& what, int minDelay)
 {
-  return AlgorithmSpec{adaptStateful([what, minDelay]() {
+  return AlgorithmSpec{adaptStateful([what, minDelay](RunningWorkflowInfo const& runningWorkflow) {
     srand(getpid());
+    LOG(INFO) << "There are " << runningWorkflow.devices.size() << "  devices in the workflow";
     return adaptStateless([what, minDelay](DataAllocator& outputs, RawDeviceService& device) {
       device.device()->WaitFor(std::chrono::seconds(rand() % 2));
       auto& bData = outputs.make<int>(OutputRef{what}, 1);


### PR DESCRIPTION
By doing something like:

  auto &workflow = initContext.get<RunningWorkflowInfo const>();

a given device can inspect the topology and act accordingly.