### PR TITLE
Adding std vector header

### DIFF
--- a/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.h
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.h
@@ -14,6 +14,7 @@
 #include "DigitFileFormat.h"
 #include <fmt/format.h>
 #include <memory>
+#include <vector>
 
 namespace o2::mch
 {


### PR DESCRIPTION
Fixing a compilation error, need to include vector header.
modified:   Detectors/MUON/MCH/DevIO/Digits/DigitReaderImpl.h

Obviously not an issue on all systems but encountering it on Ubuntu 18.04.
Should be changed anyhow for consistency.