### PR TITLE
DPL: Limit DataOrigin to 4 characters (not 16) when dumping

### DIFF
--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -500,13 +500,13 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     } else if (in(State::IN_INPUT_BINDING)) {
       binding = s;
     } else if (in(State::IN_INPUT_ORIGIN)) {
-      origin.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
+      origin.runtimeInit(s.c_str(), std::min(s.size(), 4UL));
     } else if (in(State::IN_INPUT_DESCRIPTION)) {
       description.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_OUTPUT_BINDING)) {
       binding = s;
     } else if (in(State::IN_OUTPUT_ORIGIN)) {
-      origin.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
+      origin.runtimeInit(s.c_str(), std::min(s.size(), 4UL));
     } else if (in(State::IN_OUTPUT_DESCRIPTION)) {
       description.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_OPTION_NAME)) {
@@ -695,7 +695,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       auto origin = DataSpecUtils::getOptionalOrigin(input);
       if (origin.has_value()) {
         w.Key("origin");
-        w.String(origin->str, strnlen(origin->str, 16));
+        w.String(origin->str, strnlen(origin->str, 4));
       }
       auto description = DataSpecUtils::getOptionalDescription(input);
       if (description.has_value()) {


### PR DESCRIPTION
DataOrigin can take max. 4 characters. If it uses all 4, it misses a string termination character, thus the dump contains e.g. this:
```
            "name": "MERGER-MultiNodeLocal1l-0",
            "inputs": [
                {
                    "binding": "timer-publish",
                    "origin": "MRGR\u00012541_221\n\u001F,
                    "description": "timer-MultiNodeL",
                    "subspec": 65536,
                    "lifetime": 4
                },
                {
```
...which prevents it from being correctly read, as the origin becomes larger than 4.