### PR TITLE
Matching TPC-only tracks to TRD tracklets

### DIFF
--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -26,7 +26,7 @@ o2_add_library(TRDWorkflow
                        src/TRDTrackingWorkflow.cxx
                        src/EntropyDecoderSpec.cxx
                        src/EntropyEncoderSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowReaders)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowReaders O2::ReconstructionDataFormats O2::TPCWorkflow)
 
                    #o2_target_root_dictionary(TRDWorkflow
                    # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -32,6 +32,7 @@ class TRDGlobalTracking : public o2::framework::Task
   TRDGlobalTracking(bool useMC, bool useTrkltTransf) : mUseMC(useMC), mUseTrackletTransform(useTrkltTransf) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
+  void updateTimeDependentParams();
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
 
@@ -42,12 +43,14 @@ class TRDGlobalTracking : public o2::framework::Task
   std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
   bool mUseTrackletTransform{false};                  ///< if true, output from TrackletTransformer is used instead of uncalibrated Tracklet64 directly
+  float mTPCTBinMUS{.2f};                             ///< width of a TPC time bin in us
+  float mTPCVdrift{2.58f};                            ///< TPC drift velocity (for shifting TPC tracks along Z)
   CalibVDrift mCalibVDrift{};                         ///< steers the vDrift calibration
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, bool useTrkltTransf);
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, bool useTrkltTransf, o2::dataformats::GlobalTrackID::mask_t src);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackWriterSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackWriterSpec.h
@@ -20,8 +20,11 @@ namespace o2
 namespace trd
 {
 
-/// create a processor spec
-framework::DataProcessorSpec getTRDTrackWriterSpec(bool useMC);
+/// writer for matches to ITS-TPC tracks
+framework::DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC);
+
+/// writer for matches with TPC-only tracks
+framework::DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackingWorkflow.h
@@ -14,13 +14,14 @@
 /// @file   TRDTrackingWorkflow.h
 
 #include "Framework/WorkflowSpec.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 
 namespace o2
 {
 namespace trd
 {
 
-framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrackletTransformer);
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrackletTransformer, o2::dataformats::GlobalTrackID::mask_t srcTRD);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
@@ -16,9 +16,12 @@
 #include "GPUTRDTrack.h"
 
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "TRDWorkflow/TRDTrackWriterSpec.h"
 
 using namespace o2::framework;
 using namespace o2::gpu;
+
+using GTrackID = o2::dataformats::GlobalTrackID;
 
 namespace o2
 {
@@ -27,7 +30,7 @@ namespace trd
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-DataProcessorSpec getTRDTrackWriterSpec(bool useMC)
+DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
 {
   // TODO: not clear if the writer is supposed to write MC labels at some point
   // this is just a dummy definition for the template branch definition below
@@ -42,10 +45,41 @@ DataProcessorSpec getTRDTrackWriterSpec(bool useMC)
     *tracksSize = tracks.size();
   };
 
-  return MakeRootTreeWriterSpec("trd-track-writer",
-                                "trdtracks.root",
+  return MakeRootTreeWriterSpec("trd-track-writer-tpcits",
+                                "trdmatches_itstpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD", 0},
+                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0},
+                                                                           "tracks",
+                                                                           "tracks-branch-name",
+                                                                           1,
+                                                                           tracksLogger},
+                                // NOTE: this branch template is to show how the conditional MC labels can
+                                // be defined, the '0' disables the branch for the moment
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},
+                                                             "labels",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "labels-branch-name"})();
+}
+
+DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC)
+{
+  // TODO: not clear if the writer is supposed to write MC labels at some point
+  // this is just a dummy definition for the template branch definition below
+  // define the correct type and the input specs
+  using LabelsType = std::vector<int>;
+  // force, this will disable the branch for now, can be adjusted in the future
+  useMC = false;
+
+  // A spectator to store the size of the data array for the logger below
+  auto tracksSize = std::make_shared<int>();
+  auto tracksLogger = [tracksSize](std::vector<GPUTRDTrack> const& tracks) {
+    *tracksSize = tracks.size();
+  };
+
+  return MakeRootTreeWriterSpec("trd-track-writer-tpc",
+                                "trdmatches_tpc.root",
+                                "tracksTRD",
+                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", 0},
                                                                            "tracks",
                                                                            "tracks-branch-name",
                                                                            1,

--- a/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackingWorkflow.cxx
@@ -14,28 +14,42 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "GlobalTrackingWorkflowReaders/TrackTPCITSReaderSpec.h"
+#include "TPCWorkflow/TrackReaderSpec.h"
 #include "TRDWorkflow/TRDTrackletReaderSpec.h"
 #include "TRDWorkflow/TRDGlobalTrackingSpec.h"
 #include "TRDWorkflow/TRDTrackWriterSpec.h"
+#include "TRDWorkflow/TRDTrackingWorkflow.h"
+
+using GTrackID = o2::dataformats::GlobalTrackID;
 
 namespace o2
 {
 namespace trd
 {
 
-framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrkltTransf)
+framework::WorkflowSpec getTRDTrackingWorkflow(bool disableRootInp, bool disableRootOut, bool useTrkltTransf, GTrackID::mask_t srcTRD)
 {
   framework::WorkflowSpec specs;
   bool useMC = false;
   if (!disableRootInp) {
-    specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    if (GTrackID::includesSource(GTrackID::Source::ITSTPC, srcTRD)) {
+      specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+    }
+    if (GTrackID::includesSource(GTrackID::Source::TPC, srcTRD)) {
+      specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(useMC));
+    }
     specs.emplace_back(o2::trd::getTRDTrackletReaderSpec(useMC, useTrkltTransf));
   }
 
-  specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC, useTrkltTransf));
+  specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC, useTrkltTransf, srcTRD));
 
   if (!disableRootOut) {
-    specs.emplace_back(o2::trd::getTRDTrackWriterSpec(useMC));
+    if (GTrackID::includesSource(GTrackID::Source::ITSTPC, srcTRD)) {
+      specs.emplace_back(o2::trd::getTRDGlobalTrackWriterSpec(useMC));
+    }
+    if (GTrackID::includesSource(GTrackID::Source::TPC, srcTRD)) {
+      specs.emplace_back(o2::trd::getTRDTPCTrackWriterSpec(useMC));
+    }
   }
   return specs;
 }

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -12,6 +12,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 
 using namespace o2::framework;
 
@@ -26,6 +27,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"use-tracklet-transformer", VariantType::Bool, false, {"Use calibrated tracklets instead raw Tracklet64"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"tracking-sources", VariantType::String, std::string{o2::dataformats::GlobalTrackID::ALL}, {"comma-separated list of sources to use for tracking"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -39,6 +41,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
+  o2::dataformats::GlobalTrackID::mask_t allowedSources = o2::dataformats::GlobalTrackID::getSourcesMask("ITS-TPC,TPC");
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   // write the configuration used for the workflow
@@ -46,8 +49,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto useTrackletTransformer = configcontext.options().get<bool>("use-tracklet-transformer");
+  o2::dataformats::GlobalTrackID::mask_t srcTRD = allowedSources & o2::dataformats::GlobalTrackID::getSourcesMask(configcontext.options().get<std::string>("tracking-sources"));
 
-  auto wf = o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut, useTrackletTransformer);
+  auto wf = o2::trd::getTRDTrackingWorkflow(disableRootInp, disableRootOut, useTrackletTransformer, srcTRD);
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -153,7 +153,7 @@ set(HDRS_INSTALL
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   set(SRCS ${SRCS} Interface/GPUO2InterfaceConfigurableParam.cxx)
   set(HDRS_CINT_O2 ${HDRS_CINT_O2} DataTypes/TPCdEdxCalibrationSplines.h Interface/GPUO2InterfaceConfigurableParam.h)
-  set(HDRS_CINT_O2_ADDITIONAL DataTypes/GPUSettings.h Definitions/GPUSettingsList.h DataTypes/GPUDataTypes.h TRDTracking/GPUTRDTrack.h) # Manual dependencies for ROOT dictionary generation
+  set(HDRS_CINT_O2_ADDITIONAL DataTypes/GPUSettings.h Definitions/GPUSettingsList.h DataTypes/GPUDataTypes.h TRDTracking/GPUTRDTrack.h TRDTracking/GPUTRDO2BaseTrack.h) # Manual dependencies for ROOT dictionary generation
 endif()
 
 # Sources for O2 and for Standalone if requested in config file
@@ -206,7 +206,8 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR CONFIG_O2_EXTENSIONS)
                      Definitions/clusterFinderDefs.h
                      TPCClusterFinder/GPUTPCClusterFinderKernels.h
                      TPCClusterFinder/PackedCharge.h
-                     TPCClusterFinder/GPUTPCCFChainContext.h)
+                     TPCClusterFinder/GPUTPCCFChainContext.h
+                     TRDTracking/GPUTRDO2BaseTrack.h)
 endif()
 
 # Sources only for AliRoot

--- a/GPU/GPUTracking/DataTypes/GPUTRDDef.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDDef.h
@@ -28,11 +28,10 @@ class AliTrackerBase;
 #else
 namespace o2
 {
-namespace track
+namespace gpu
 {
-template <typename>
-class TrackParametrizationWithError;
-} // namespace dataformats
+class GPUTRDO2BaseTrack;
+} // namespace gpu
 namespace base
 {
 template <typename>
@@ -57,7 +56,7 @@ typedef AliExternalTrackParam TRDBaseTrack;
 class GPUTPCGMTrackParam;
 typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #elif defined(TRD_TRACK_TYPE_O2)
-typedef o2::track::TrackParametrizationWithError<float> TRDBaseTrack;
+typedef o2::gpu::GPUTRDO2BaseTrack TRDBaseTrack;
 class GPUTPCGMTrackParam;
 typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #endif

--- a/GPU/GPUTracking/DataTypes/GPUTRDDef.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDDef.h
@@ -28,9 +28,10 @@ class AliTrackerBase;
 #else
 namespace o2
 {
-namespace dataformats
+namespace track
 {
-class TrackTPCITS;
+template <typename>
+class TrackParametrizationWithError;
 } // namespace dataformats
 namespace base
 {
@@ -56,7 +57,7 @@ typedef AliExternalTrackParam TRDBaseTrack;
 class GPUTPCGMTrackParam;
 typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #elif defined(TRD_TRACK_TYPE_O2)
-typedef o2::dataformats::TrackTPCITS TRDBaseTrack;
+typedef o2::track::TrackParametrizationWithError<float> TRDBaseTrack;
 class GPUTPCGMTrackParam;
 typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #endif

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
@@ -18,9 +18,10 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::gpu::TPCdEdxCalibrationSplines + ;
-#pragma link C++ class o2::gpu::trackInterface < o2::track::TrackParCov> + ;
-#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>> + ;
-#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>>> + ;
+#pragma link C++ class o2::gpu::GPUTRDO2BaseTrack + ;
+#pragma link C++ class o2::gpu::trackInterface < o2::gpu::GPUTRDO2BaseTrack> + ;
+#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::gpu::GPUTRDO2BaseTrack>> + ;
+#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::gpu::GPUTRDO2BaseTrack>>> + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsO2 + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRec + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessing + ;

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
@@ -18,9 +18,9 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::gpu::TPCdEdxCalibrationSplines + ;
-#pragma link C++ class o2::gpu::trackInterface < o2::dataformats::TrackTPCITS> + ;
-#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::dataformats::TrackTPCITS>> + ;
-#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::dataformats::TrackTPCITS>>> + ;
+#pragma link C++ class o2::gpu::trackInterface < o2::track::TrackParCov> + ;
+#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>> + ;
+#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>>> + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsO2 + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRec + ;
 #pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessing + ;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -140,6 +140,7 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
 #include "DataFormatsTPC/TrackTPC.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DetectorsBase/Propagator.h"
+#include "GPUTRDO2BaseTrack.h"
 #include <cmath>
 
 namespace GPUCA_NAMESPACE
@@ -149,12 +150,12 @@ namespace gpu
 {
 
 template <>
-class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
+class trackInterface<GPUTRDO2BaseTrack> : public GPUTRDO2BaseTrack
 {
  public:
-  trackInterface<o2::track::TrackParCov>() = default;
-  trackInterface<o2::track::TrackParCov>(const o2::track::TrackParCov& param) = delete;
-  trackInterface<o2::track::TrackParCov>(const o2::dataformats::TrackTPCITS& trkItsTpc, float vDrift) : o2::track::TrackParCov(trkItsTpc.getParamOut())
+  trackInterface<GPUTRDO2BaseTrack>() = default;
+  trackInterface<GPUTRDO2BaseTrack>(const GPUTRDO2BaseTrack& param) = delete;
+  trackInterface<GPUTRDO2BaseTrack>(const o2::dataformats::TrackTPCITS& trkItsTpc, float vDrift) : GPUTRDO2BaseTrack(trkItsTpc.getParamOut())
   {
     mTime = trkItsTpc.getTimeMUS().getTimeStamp();
     mTimeAddMax = trkItsTpc.getTimeMUS().getTimeStampError();
@@ -163,7 +164,7 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
     mRefTPC = trkItsTpc.getRefTPC();
     updateCov(std::pow(trkItsTpc.getTimeMUS().getTimeStampError() * vDrift, 2), o2::track::CovLabels::kSigZ2); // account for time uncertainty by increasing sigmaZ2
   }
-  trackInterface<o2::track::TrackParCov>(const o2::tpc::TrackTPC& trkTpc, float tbWidth, float vDrift, unsigned int iTrk) : o2::track::TrackParCov(trkTpc.getParamOut())
+  trackInterface<GPUTRDO2BaseTrack>(const o2::tpc::TrackTPC& trkTpc, float tbWidth, float vDrift, unsigned int iTrk) : GPUTRDO2BaseTrack(trkTpc.getParamOut())
   {
     mRefTPC = {iTrk, o2::dataformats::GlobalTrackID::TPC};
     mTime = trkTpc.getTime0() * tbWidth;
@@ -190,8 +191,8 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
       setCov(cov[i], i);
     }
   }
-  trackInterface<o2::track::TrackParCov>(const GPUTPCGMMergedTrack& trk) { set(trk.OuterParam().X, trk.OuterParam().alpha, trk.OuterParam().P, trk.OuterParam().C); }
-  trackInterface<o2::track::TrackParCov>(const GPUTPCGMTrackParam::GPUTPCOuterParam& param) { set(param.X, param.alpha, param.P, param.C); }
+  trackInterface<GPUTRDO2BaseTrack>(const GPUTPCGMMergedTrack& trk) { set(trk.OuterParam().X, trk.OuterParam().alpha, trk.OuterParam().P, trk.OuterParam().C); }
+  trackInterface<GPUTRDO2BaseTrack>(const GPUTPCGMTrackParam::GPUTPCOuterParam& param) { set(param.X, param.alpha, param.P, param.C); }
 
   const float* getPar() const { return getParams(); }
   float getTime() const { return mTime; }
@@ -204,7 +205,7 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
 
   bool CheckNumericalQuality() const { return true; }
 
-  typedef o2::track::TrackParCov baseClass;
+  typedef GPUTRDO2BaseTrack baseClass;
 
  private:
   o2::dataformats::GlobalTrackID mRefTPC; // reference on TPC track entry in its original container
@@ -227,7 +228,7 @@ class propagatorInterface<o2::base::Propagator>
   bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, maxSnp, maxStep); }
   int getPropagatedYZ(float x, float& projY, float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
 
-  void setTrack(trackInterface<o2::track::TrackParCov>* trk) { mParam = trk; }
+  void setTrack(trackInterface<GPUTRDO2BaseTrack>* trk) { mParam = trk; }
   void setFitInProjections(bool flag) {}
 
   float getAlpha() { return (mParam) ? mParam->getAlpha() : 99999.f; }
@@ -253,7 +254,7 @@ class propagatorInterface<o2::base::Propagator>
   }
   bool rotate(float alpha) { return (mParam) ? mParam->rotate(alpha) : false; }
 
-  trackInterface<o2::track::TrackParCov>* mParam{nullptr};
+  trackInterface<GPUTRDO2BaseTrack>* mParam{nullptr};
   o2::base::Propagator* mProp{o2::base::Propagator::Instance()};
 };
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDO2BaseTrack.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDO2BaseTrack.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTRDO2BaseTrack.h
+/// \author Ole Schmidt
+
+#ifndef GPUTRDO2BASETRACK_H
+#define GPUTRDO2BASETRACK_H
+
+#include "ReconstructionDataFormats/Track.h"
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+class GPUTRDO2BaseTrack : public o2::track::TrackParCov
+{
+ public:
+  GPUTRDO2BaseTrack() = default;
+  GPUTRDO2BaseTrack(const o2::track::TrackParCov& t) : o2::track::TrackParCov(t) {}
+
+ private:
+  // dummy class to avoid problems, see https://github.com/AliceO2Group/AliceO2/pull/5969#issuecomment-827475822
+  ClassDefNV(GPUTRDO2BaseTrack, 1);
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
@@ -227,7 +227,7 @@ namespace gpu
 template class GPUTRDTrack_t<trackInterface<AliExternalTrackParam>>;
 #endif
 #ifdef GPUCA_O2_LIB // Instantiate O2 track version
-template class GPUTRDTrack_t<trackInterface<o2::track::TrackParCov>>;
+template class GPUTRDTrack_t<trackInterface<o2::gpu::GPUTRDO2BaseTrack>>;
 #endif
 #endif
 template class GPUTRDTrack_t<trackInterface<GPUTPCGMTrackParam>>; // Always instatiate GM track version

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrack.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrack.h
@@ -20,6 +20,18 @@
 struct GPUTRDTrackDataRecord;
 class AliHLTExternalTrackParam;
 
+namespace o2
+{
+namespace tpc
+{
+class TrackTPC;
+}
+namespace dataformats
+{
+class TrackTPCITS;
+}
+} // namespace o2
+
 //_____________________________________________________________________________
 #if (defined(__CINT__) || defined(__ROOTCINT__)) && !defined(__CLING__)
 namespace GPUCA_NAMESPACE
@@ -48,6 +60,10 @@ class GPUTRDTrack_t : public T
   GPUTRDTrack_t(const typename T::baseClass& t) = delete;
   GPUd() GPUTRDTrack_t(const GPUTRDTrack_t& t);
   GPUd() GPUTRDTrack_t(const AliHLTExternalTrackParam& t);
+#ifndef GPUCA_GPUCODE
+  GPUd() GPUTRDTrack_t(const o2::dataformats::TrackTPCITS& t, float vDrift);
+  GPUd() GPUTRDTrack_t(const o2::tpc::TrackTPC& t, float tbWidth, float vDrift, unsigned int iTrk);
+#endif
   GPUd() GPUTRDTrack_t(const T& t);
   GPUd() GPUTRDTrack_t& operator=(const GPUTRDTrack_t& t);
 
@@ -99,6 +115,9 @@ class GPUTRDTrack_t : public T
   int mAttachedTracklets[kNLayers]; // IDs for attached tracklets sorted by layer
   bool mIsFindable[kNLayers];       // number of layers where tracklet should exist
   bool mIsStopped;                  // track ends in TRD
+
+ private:
+  GPUd() void Initialize();
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -118,7 +118,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() bool CheckTrackTRDCandidate(const TRDTRK& trk) const;
   GPUd() int LoadTrack(const TRDTRK& trk, const int label = -1, const int* nTrkltsOffline = nullptr, const int labelOffline = -1, int tpcTrackId = -1, bool checkTrack = true);
 
-  GPUd() int GetCollisionID(float trkTime) const;
+  GPUd() int GetCollisionIDs(TRDTRK& trk, int* collisionIds) const;
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);
   static GPUd() bool ConvertTrkltToSpacePoint(const GPUTRDGeometry& geo, GPUTRDTrackletWord& trklt, GPUTRDSpacePointInternal& sp);
   GPUd() bool CalculateSpacePoints(int iCollision = 0);
@@ -156,6 +156,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() void SetMaxEta(float maxEta) { mMaxEta = maxEta; }
   GPUd() void SetExtraRoadY(float extraRoadY) { mExtraRoadY = extraRoadY; }
   GPUd() void SetRoadZ(float roadZ) { mRoadZ = roadZ; }
+  GPUd() void SetTPCVdrift(float vDrift) { mTPCVdrift = vDrift; }
 
   GPUd() AliMCEvent* GetMCEvent() const { return mMCEvent; }
   GPUd() bool GetIsDebugOutputOn() const { return mDebugOutput; }
@@ -222,12 +223,12 @@ class GPUTRDTracker_t : public GPUProcessor
   float mAngleToDyC; // parameterization for conversion track angle -> tracklet deflection
   /// ---- end error parametrization ----
   bool mDebugOutput;                  // store debug output
-  float mTimeWindow;                  // max. deviation of the ITS-TPC track time w.r.t. TRD trigger record time stamp (in us, default is 100 ns)
   static CONSTEXPR float sRadialOffset GPUCA_CPP11_INIT(= -0.1f); // due to (possible) mis-calibration of t0 -> will become obsolete when tracklet conversion is done outside of the tracker
   float mMaxEta;                      // TPC tracks with higher eta are ignored
   float mExtraRoadY;                  // addition to search road in r-phi to account for not exact radial match of tracklets and tracks in first iteration
   float mRoadZ;                       // in z, a constant search road is used
   float mZCorrCoefNRC;                // tracklet z-position depends linearly on track dip angle
+  float mTPCVdrift;                   // TPC drift velocity used for shifting TPC tracks along Z
   AliMCEvent* mMCEvent;               //! externaly supplied optional MC event
   GPUTRDTrackerDebug<TRDTRK>* mDebug; // debug output
 };


### PR DESCRIPTION
This is WIP and not yet ready to be merged!

Implemented changes:

- created TRD track interface for `o2::track::TrackParCov` type instead of `o2::dataformats::TrackTPCITS`. TRD tracks can be created from both TPC-only tracks and from ITS-TPC matched tracks
- in case of TPC-only tracks which are not CE-crossing and for which thus the vertex is not known a-priori the TRD trigger records are searched for compatible collision candidates. The track following is done for each collision and the track with the lowest chi2 is stored
- in order to not have to refit the tracks for each collision not the track is shifted in z but instead the tracklet is shifted before the update and the chi2 calculation

What still needs to be done:

- the winner track needs to be refitted if it is matched to tracklets from a different collision than its initial estimate
- the logic in the `TRDGlobalTrackingSpec` needs to be adapted such that both ITS-TPC tracks and TPC-only tracks or just one or the other can be used as input
- the TRD tracks need to get global track IDs which point to the seed (TPC or ITS and TPC tracks)
- disable debug output again

@davidrohr If I want to look at the output tracks of the tracking which is stored in a tree called `tracksTRD` in the file `trdtracks.root` and I do `tracksTRD->Draw("tracks.mNTracklets")` I get a complaint from root: 
`Error in <TInterpreter::AutoParse>: Error parsing payload code for class o2::track::TrackParametrizationWithError with content: [...]`
I have adjusted the `GPUTrackingLinkDef_O2.h` for the new interface. Before when I used `TrackTPCITS` (which also inherits from `TrackParCov`) the root interpreter did not complain. Do you have an idea what might be the reason?