### PR TITLE
PID: extend QA, add parametrizations for the TOF

### DIFF
--- a/Analysis/ALICE3/CMakeLists.txt
+++ b/Analysis/ALICE3/CMakeLists.txt
@@ -15,7 +15,22 @@ o2_add_dpl_workflow(alice3-trackselection
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2_add_dpl_workflow(alice3-trackextension
+                    SOURCES src/alice3-trackextension.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2_add_dpl_workflow(alice3-qa-multiplicity
+                    SOURCES src/alice3-qa-multiplicity.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2_add_dpl_workflow(alice3-pid-rich-qa
                     SOURCES src/pidRICHqa.cxx
+                    PUBLIC_LINK_LIBRARIES O2::AnalysisDataModel O2::AnalysisCore O2::ALICE3Analysis
+                    COMPONENT_NAME Analysis)
+
+o2_add_dpl_workflow(alice3-pid-tof
+                    SOURCES src/alice3-pidTOF.cxx
                     PUBLIC_LINK_LIBRARIES O2::AnalysisDataModel O2::AnalysisCore O2::ALICE3Analysis
                     COMPONENT_NAME Analysis)

--- a/Analysis/ALICE3/include/ALICE3Analysis/RICH.h
+++ b/Analysis/ALICE3/include/ALICE3Analysis/RICH.h
@@ -25,22 +25,23 @@ namespace o2::aod
 {
 namespace alice3rich
 {
-DECLARE_SOA_INDEX_COLUMN(Track, track);
-DECLARE_SOA_COLUMN(RICHSignal, richSignal, float);
-DECLARE_SOA_COLUMN(RICHSignalError, richSignalError, float);
-DECLARE_SOA_COLUMN(RICHDeltaEl, richDeltaEl, float);
-DECLARE_SOA_COLUMN(RICHDeltaMu, richDeltaMu, float);
-DECLARE_SOA_COLUMN(RICHDeltaPi, richDeltaPi, float);
-DECLARE_SOA_COLUMN(RICHDeltaKa, richDeltaKa, float);
-DECLARE_SOA_COLUMN(RICHDeltaPr, richDeltaPr, float);
-DECLARE_SOA_COLUMN(RICHNsigmaEl, richNsigmaEl, float);
-DECLARE_SOA_COLUMN(RICHNsigmaMu, richNsigmaMu, float);
-DECLARE_SOA_COLUMN(RICHNsigmaPi, richNsigmaPi, float);
-DECLARE_SOA_COLUMN(RICHNsigmaKa, richNsigmaKa, float);
-DECLARE_SOA_COLUMN(RICHNsigmaPr, richNsigmaPr, float);
+DECLARE_SOA_INDEX_COLUMN(Track, track);                      //!
+DECLARE_SOA_COLUMN(RICHSignal, richSignal, float);           //!
+DECLARE_SOA_COLUMN(RICHSignalError, richSignalError, float); //!
+DECLARE_SOA_COLUMN(RICHDeltaEl, richDeltaEl, float);         //!
+DECLARE_SOA_COLUMN(RICHDeltaMu, richDeltaMu, float);         //!
+DECLARE_SOA_COLUMN(RICHDeltaPi, richDeltaPi, float);         //!
+DECLARE_SOA_COLUMN(RICHDeltaKa, richDeltaKa, float);         //!
+DECLARE_SOA_COLUMN(RICHDeltaPr, richDeltaPr, float);         //!
+DECLARE_SOA_COLUMN(RICHNsigmaEl, richNsigmaEl, float);       //!
+DECLARE_SOA_COLUMN(RICHNsigmaMu, richNsigmaMu, float);       //!
+DECLARE_SOA_COLUMN(RICHNsigmaPi, richNsigmaPi, float);       //!
+DECLARE_SOA_COLUMN(RICHNsigmaKa, richNsigmaKa, float);       //!
+DECLARE_SOA_COLUMN(RICHNsigmaPr, richNsigmaPr, float);       //!
 } // namespace alice3rich
 
-DECLARE_SOA_TABLE(RICHs, "AOD", "RICH",
+DECLARE_SOA_TABLE(RICHs, "AOD", "RICH", //!
+                  o2::soa::Index<>,
                   alice3rich::TrackId,
                   alice3rich::RICHSignal,
                   alice3rich::RICHSignalError,

--- a/Analysis/ALICE3/src/alice3-qa-multiplicity.cxx
+++ b/Analysis/ALICE3/src/alice3-qa-multiplicity.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+/// \author Nicolo' Jacazio <nicolo.jacazio@cern.ch>, CERN
+
+// O2 includes
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct ALICE3MultTask {
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
+
+  Configurable<float> MinEta{"MinEta", -0.8f, "Minimum eta in range"};
+  Configurable<float> MaxEta{"MaxEta", 0.8f, "Maximum eta in range"};
+  Configurable<float> MaxMult{"MaxMult", 1000.f, "Maximum multiplicity in range"};
+
+  void init(InitContext&)
+  {
+    histos.add("multiplicity/numberOfTracks", ";Reconstructed tracks", kTH1D, {{(int)MaxMult, 0, MaxMult}});
+  }
+
+  void process(const o2::aod::Collision& collision, const o2::aod::Tracks& tracks)
+  {
+    if (collision.numContrib() < 2) {
+      return;
+    }
+
+    int nTracks = 0;
+    for (const auto& track : tracks) {
+      if (track.eta() < MinEta || track.eta() > MaxEta) {
+        continue;
+      }
+      nTracks++;
+    }
+
+    histos.fill(HIST("multiplicity/numberOfTracks"), nTracks);
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<ALICE3MultTask>(cfgc)};
+}

--- a/Analysis/ALICE3/src/alice3-trackextension.cxx
+++ b/Analysis/ALICE3/src/alice3-trackextension.cxx
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Task performing basic track selection for the ALICE3.
+//
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "AnalysisDataModel/TrackSelectionTables.h"
+#include "AnalysisCore/trackUtilities.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct TrackExtensionTask {
+  Configurable<float> magField{"magField", 5.f, "Magnetic field for the propagation to the primary vertex in kG"};
+  Produces<aod::TracksExtended> extendedTrackQuantities;
+
+  void process(aod::Collision const& collision, aod::FullTracks const& tracks)
+  {
+    std::array<float, 2> dca{1e10f, 1e10f};
+    for (auto& track : tracks) {
+      auto trackPar = getTrackPar(track);
+      trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, magField, &dca);
+      extendedTrackQuantities(dca[0], dca[1]);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<TrackExtensionTask>(cfgc)};
+}

--- a/Analysis/ALICE3/src/alice3-trackselection.cxx
+++ b/Analysis/ALICE3/src/alice3-trackselection.cxx
@@ -13,7 +13,6 @@
 /// \brief  Track selection for the ALICE3 studies
 ///
 
-#include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
 #include "AnalysisCore/TrackSelection.h"
@@ -29,18 +28,49 @@ using namespace o2::framework::expressions;
  * Produce track filter table.
  */
 //****************************************************************************************
-struct TrackSelectionTask {
+struct Alice3TrackSelectionTask {
   Produces<aod::TrackSelection> filterTable;
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
+
+  Configurable<float> MaxDCAxy{"MaxDCAxy", 0.1f, "Maximum DCAxy"};
+  Configurable<float> MinEta{"MinEta", -0.8f, "Minimum eta in range"};
+  Configurable<float> MaxEta{"MaxEta", 0.8f, "Maximum eta in range"};
 
   void init(InitContext&)
   {
+    histos.add("selection", "Selection process;Check;Entries", HistType::kTH1F, {{10, -0.5, 9.5}});
+    histos.get<TH1>(HIST("selection"))->GetXaxis()->SetBinLabel(1, "Tracks read");
+    histos.get<TH1>(HIST("selection"))->GetXaxis()->SetBinLabel(2, "DCAxy");
+    histos.get<TH1>(HIST("selection"))->GetXaxis()->SetBinLabel(3, "Eta");
+    histos.add("dcaXY/selected", "Selected;DCA_{xy} (cm);Entries", HistType::kTH1F, {{100, -5, 5}});
+    histos.add("dcaXY/nonselected", "Not selected;DCA_{xy} (cm);Entries", HistType::kTH1F, {{100, -5, 5}});
+    histos.add("eta/selected", "Selected;#eta;Entries", HistType::kTH1F, {{100, -2, 2}});
+    histos.add("eta/nonselected", "Not selected;#eta;Entries", HistType::kTH1F, {{100, -2, 2}});
   }
 
   void process(soa::Join<aod::FullTracks, aod::TracksExtended> const& tracks)
   {
+    filterTable.reserve(tracks.size());
     for (auto& track : tracks) {
-      filterTable(kTRUE,
-                  kTRUE);
+      histos.fill(HIST("selection"), 0);
+      histos.fill(HIST("dcaXY/nonselected"), track.dcaXY());
+      histos.fill(HIST("eta/nonselected"), track.eta());
+
+      uint8_t sel = true;
+      if (abs(track.dcaXY()) > MaxDCAxy) {
+        histos.fill(HIST("selection"), 1);
+        sel = false;
+      }
+      if (track.eta() < MinEta || track.eta() > MaxEta) {
+        histos.fill(HIST("selection"), 2);
+        sel = false;
+      }
+      if (sel) {
+        histos.fill(HIST("dcaXY/selected"), track.dcaXY());
+        histos.fill(HIST("eta/selected"), track.eta());
+      }
+
+      filterTable(sel, sel);
     }
   }
 };
@@ -52,6 +82,6 @@ struct TrackSelectionTask {
 //****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<TrackSelectionTask>(cfgc, TaskName{"track-selection"})};
+  WorkflowSpec workflow{adaptAnalysisTask<Alice3TrackSelectionTask>(cfgc)};
   return workflow;
 }

--- a/Analysis/ALICE3/src/pidRICHqa.cxx
+++ b/Analysis/ALICE3/src/pidRICHqa.cxx
@@ -22,26 +22,51 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
+namespace o2::aod
+{
+
+namespace indices
+{
+DECLARE_SOA_INDEX_COLUMN(Track, track);
+DECLARE_SOA_INDEX_COLUMN(RICH, rich);
+} // namespace indices
+
+DECLARE_SOA_INDEX_TABLE_USER(RICHTracksIndex, Tracks, "RICHTRK", indices::TrackId, indices::RICHId);
+} // namespace o2::aod
+
+struct RICHindexbuilder {
+  Builds<o2::aod::RICHTracksIndex> ind;
+  void init(o2::framework::InitContext&)
+  {
+  }
+};
+
 struct pidRICHQAMC {
-  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
   Configurable<int> pdgCode{"pdgCode", 0, "pdg code of the particles to accept"};
   Configurable<int> useOnlyPhysicsPrimary{"useOnlyPhysicsPrimary", 1,
                                           "Whether to use only physical primary particles."};
   Configurable<float> minLength{"minLength", 0, "Minimum length of accepted tracks (cm)"};
   Configurable<float> maxLength{"maxLength", 1000, "Maximum length of accepted tracks (cm)"};
-  Configurable<int> nBinsP{"nBinsP", 100, "Number of momentum bins"};
+  Configurable<float> minEta{"minEta", -1.4, "Minimum eta of accepted tracks"};
+  Configurable<float> maxEta{"maxEta", 1.4, "Maximum eta of accepted tracks"};
+  Configurable<int> nBinsP{"nBinsP", 500, "Number of momentum bins"};
   Configurable<float> minP{"minP", 0.01, "Minimum momentum plotted (GeV/c)"};
   Configurable<float> maxP{"maxP", 100, "Maximum momentum plotted (GeV/c)"};
   Configurable<int> nBinsNsigma{"nBinsNsigma", 600, "Number of Nsigma bins"};
-  Configurable<float> minNsigma{"minNsigma", -10.f, "Minimum Nsigma plotted"};
-  Configurable<float> maxNsigma{"maxNsigma", 10.f, "Maximum Nsigma plotted"};
+  Configurable<float> minNsigma{"minNsigma", -100.f, "Minimum Nsigma plotted"};
+  Configurable<float> maxNsigma{"maxNsigma", 100.f, "Maximum Nsigma plotted"};
   Configurable<int> nBinsDelta{"nBinsDelta", 100, "Number of delta bins"};
   Configurable<float> minDelta{"minDelta", -1.f, "Minimum delta plotted (rad)"};
   Configurable<float> maxDelta{"maxDelta", 1.f, "Maximum delta plotted (rad)"};
+  Configurable<int> logAxis{"logAxis", 1, "Flag to use a log momentum axis"};
 
   template <typename T>
   void makelogaxis(T h)
   {
+    if (logAxis == 0) {
+      return;
+    }
     const int nbins = h->GetNbinsX();
     double binp[nbins + 1];
     double max = h->GetXaxis()->GetBinUpEdge(nbins);
@@ -60,26 +85,29 @@ struct pidRICHQAMC {
 
   void init(o2::framework::InitContext&)
   {
-    AxisSpec momAxis{nBinsP.value, minP.value, maxP.value};
-    AxisSpec nsigmaAxis{nBinsNsigma.value, minNsigma.value, maxNsigma.value};
-    AxisSpec deltaAxis{nBinsDelta.value, minDelta.value, maxDelta.value};
+    AxisSpec momAxis{nBinsP, minP, maxP};
+    AxisSpec nsigmaAxis{nBinsNsigma, minNsigma, maxNsigma};
+    AxisSpec deltaAxis{nBinsDelta, minDelta, maxDelta};
 
+    histos.add("event/vertexz", ";Vtx_{z} (cm);Entries", kTH1F, {{100, -20, 20}});
     histos.add("p/Unselected", "Unselected;#it{p} (GeV/#it{c})", kTH1F, {momAxis});
     histos.add("p/Prim", "Primaries;#it{p} (GeV/#it{c})", kTH1F, {momAxis});
     histos.add("p/Sec", "Secondaries;#it{p} (GeV/#it{c})", kTH1F, {momAxis});
     histos.add("pt/Unselected", "Unselected;#it{p} (GeV/#it{c})", kTH1F, {momAxis});
-    histos.add("qa/signal", ";#theta (rad)", kTH1F, {{100, 0, 1}});
-    histos.add("qa/signalerror", ";#theta (rad)", kTH1F, {{100, 0, 1}});
+    histos.add("qa/signal", ";Cherenkov angle (rad)", kTH1F, {{100, 0, 1}});
+    histos.add("qa/signalerror", ";Cherenkov angle (rad)", kTH1F, {{100, 0, 1}});
+    histos.add("qa/signalvsP", ";#it{p} (GeV/#it{c});Cherenkov angle (rad)", kTH2F, {momAxis, {1000, 0, 0.3}});
     histos.add("qa/deltaEl", ";#it{p} (GeV/#it{c});#Delta(e) (rad)", kTH2F, {momAxis, deltaAxis});
     histos.add("qa/deltaMu", ";#it{p} (GeV/#it{c});#Delta(#mu) (rad)", kTH2F, {momAxis, deltaAxis});
     histos.add("qa/deltaPi", ";#it{p} (GeV/#it{c});#Delta(#pi) (rad)", kTH2F, {momAxis, deltaAxis});
     histos.add("qa/deltaKa", ";#it{p} (GeV/#it{c});#Delta(K) (rad)", kTH2F, {momAxis, deltaAxis});
     histos.add("qa/deltaPr", ";#it{p} (GeV/#it{c});#Delta(p) (rad)", kTH2F, {momAxis, deltaAxis});
-    histos.add("qa/nsigmaEl", ";#it{p} (GeV/#it{c});n#sigma(e)", kTH2F, {momAxis, nsigmaAxis});
-    histos.add("qa/nsigmaMu", ";#it{p} (GeV/#it{c});n#sigma(#mu)", kTH2F, {momAxis, nsigmaAxis});
-    histos.add("qa/nsigmaPi", ";#it{p} (GeV/#it{c});n#sigma(#pi)", kTH2F, {momAxis, nsigmaAxis});
-    histos.add("qa/nsigmaKa", ";#it{p} (GeV/#it{c});n#sigma(K)", kTH2F, {momAxis, nsigmaAxis});
-    histos.add("qa/nsigmaPr", ";#it{p} (GeV/#it{c});n#sigma(p)", kTH2F, {momAxis, nsigmaAxis});
+    histos.add("qa/nsigmaEl", ";#it{p} (GeV/#it{c});N_{#sigma}^{RICH}(e)", kTH2F, {momAxis, nsigmaAxis});
+    histos.add("qa/nsigmaMu", ";#it{p} (GeV/#it{c});N_{#sigma}^{RICH}(#mu)", kTH2F, {momAxis, nsigmaAxis});
+    histos.add("qa/nsigmaPi", ";#it{p} (GeV/#it{c});N_{#sigma}^{RICH}(#pi)", kTH2F, {momAxis, nsigmaAxis});
+    histos.add("qa/nsigmaKa", ";#it{p} (GeV/#it{c});N_{#sigma}^{RICH}(K)", kTH2F, {momAxis, nsigmaAxis});
+    histos.add("qa/nsigmaPr", ";#it{p} (GeV/#it{c});N_{#sigma}^{RICH}(p)", kTH2F, {momAxis, nsigmaAxis});
+    makelogaxis(histos.get<TH2>(HIST("qa/signalvsP")));
     makelogaxis(histos.get<TH2>(HIST("qa/deltaEl")));
     makelogaxis(histos.get<TH2>(HIST("qa/deltaMu")));
     makelogaxis(histos.get<TH2>(HIST("qa/deltaPi")));
@@ -92,50 +120,58 @@ struct pidRICHQAMC {
     makelogaxis(histos.get<TH2>(HIST("qa/nsigmaPr")));
   }
 
-  void process(const aod::Tracks& tracks,
-               const aod::TracksExtra& tracksExtra,
+  using Trks = soa::Join<aod::Tracks, aod::RICHTracksIndex, aod::TracksExtra>;
+  void process(const Trks& tracks,
                const aod::McTrackLabels& labels,
-               const aod::RICHs& tracks_rich,
-               const aod::McParticles& mcParticles)
+               const aod::RICHs&,
+               const aod::McParticles& mcParticles,
+               const aod::Collisions& colls)
   {
-    for (const auto& t : tracks_rich) {
-      const auto track = t.track();
-      const auto trackExtra = tracksExtra.iteratorAt(track.globalIndex());
-      if (trackExtra.length() < minLength.value) {
+    for (const auto& col : colls) {
+      histos.fill(HIST("event/vertexz"), col.posZ());
+    }
+    for (const auto& track : tracks) {
+      if (!track.has_rich()) {
         continue;
       }
-      if (trackExtra.length() > maxLength.value) {
+      if (track.length() < minLength) {
+        continue;
+      }
+      if (track.length() > maxLength) {
+        continue;
+      }
+      if (track.eta() > maxEta || track.eta() < minEta) {
         continue;
       }
       const auto mcParticle = labels.iteratorAt(track.globalIndex()).mcParticle();
-      if (pdgCode.value != 0 && abs(mcParticle.pdgCode()) != pdgCode.value) {
+      if (pdgCode != 0 && abs(mcParticle.pdgCode()) != pdgCode) {
         continue;
       }
-      if (useOnlyPhysicsPrimary.value == 1 && !MC::isPhysicalPrimary(mcParticles, mcParticle)) { // Selecting primaries
+      if (useOnlyPhysicsPrimary == 1 && !MC::isPhysicalPrimary(mcParticles, mcParticle)) { // Selecting primaries
         histos.fill(HIST("p/Sec"), track.p());
         continue;
       }
       histos.fill(HIST("p/Prim"), track.p());
       histos.fill(HIST("p/Unselected"), track.p());
       histos.fill(HIST("pt/Unselected"), track.pt());
-      histos.fill(HIST("qa/signal"), t.richSignal());
-      histos.fill(HIST("qa/signalerror"), t.richSignalError());
-      histos.fill(HIST("qa/deltaEl"), track.p(), t.richDeltaEl());
-      histos.fill(HIST("qa/deltaMu"), track.p(), t.richDeltaMu());
-      histos.fill(HIST("qa/deltaPi"), track.p(), t.richDeltaPi());
-      histos.fill(HIST("qa/deltaKa"), track.p(), t.richDeltaKa());
-      histos.fill(HIST("qa/deltaPr"), track.p(), t.richDeltaPr());
-      histos.fill(HIST("qa/nsigmaEl"), track.p(), t.richNsigmaEl());
-      histos.fill(HIST("qa/nsigmaMu"), track.p(), t.richNsigmaMu());
-      histos.fill(HIST("qa/nsigmaPi"), track.p(), t.richNsigmaPi());
-      histos.fill(HIST("qa/nsigmaKa"), track.p(), t.richNsigmaKa());
-      histos.fill(HIST("qa/nsigmaPr"), track.p(), t.richNsigmaPr());
+      histos.fill(HIST("qa/signal"), track.rich().richSignal());
+      histos.fill(HIST("qa/signalerror"), track.rich().richSignalError());
+      histos.fill(HIST("qa/signalvsP"), track.p(), track.rich().richSignal());
+      histos.fill(HIST("qa/deltaEl"), track.p(), track.rich().richDeltaEl());
+      histos.fill(HIST("qa/deltaMu"), track.p(), track.rich().richDeltaMu());
+      histos.fill(HIST("qa/deltaPi"), track.p(), track.rich().richDeltaPi());
+      histos.fill(HIST("qa/deltaKa"), track.p(), track.rich().richDeltaKa());
+      histos.fill(HIST("qa/deltaPr"), track.p(), track.rich().richDeltaPr());
+      histos.fill(HIST("qa/nsigmaEl"), track.p(), track.rich().richNsigmaEl());
+      histos.fill(HIST("qa/nsigmaMu"), track.p(), track.rich().richNsigmaMu());
+      histos.fill(HIST("qa/nsigmaPi"), track.p(), track.rich().richNsigmaPi());
+      histos.fill(HIST("qa/nsigmaKa"), track.p(), track.rich().richNsigmaKa());
+      histos.fill(HIST("qa/nsigmaPr"), track.p(), track.rich().richNsigmaPr());
     }
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<pidRICHQAMC>(cfg, "pidRICH-qa")};
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<RICHindexbuilder>(cfg), adaptAnalysisTask<pidRICHQAMC>(cfg, TaskName{"pidRICH-qa"})};
 }

--- a/Analysis/DataModel/CMakeLists.txt
+++ b/Analysis/DataModel/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_target_root_dictionary(AnalysisDataModel
                                   include/AnalysisDataModel/PID/DetectorResponse.h
                                   include/AnalysisDataModel/PID/PIDTOF.h
                                   include/AnalysisDataModel/PID/TOFReso.h
+                                  include/AnalysisDataModel/PID/TOFResoALICE3.h
                                   include/AnalysisDataModel/PID/PIDTPC.h
                                   include/AnalysisDataModel/PID/BetheBloch.h
                                   include/AnalysisDataModel/PID/TPCReso.h
@@ -38,5 +39,10 @@ o2_add_executable(pidparam-tpc-bethe-bloch
 
 o2_add_executable(pidparam-tof-reso
                   SOURCES src/handleParamTOFReso.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel
+                 )
+
+o2_add_executable(pidparam-tof-reso-alice3
+                  SOURCES src/handleParamTOFResoALICE3.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel
                  )

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/BetheBloch.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/BetheBloch.h
@@ -20,6 +20,7 @@
 
 #include "TPCSimulation/Detector.h"
 #include "AnalysisDataModel/PID/ParamBase.h"
+#include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tpc
 {
@@ -35,6 +36,17 @@ class BetheBloch : public Parametrization
   }
   ClassDef(BetheBloch, 1);
 };
+
+float BetheBlochParam(const float& momentum, const float& mass, const float& charge, const Parameters& parameters)
+{
+  return parameters[5] * o2::tpc::Detector::BetheBlochAleph(momentum / mass, parameters[0], parameters[1], parameters[2], parameters[3], parameters[4]) * pow(charge, parameters[6]);
+}
+
+template <o2::track::PID::ID id, typename T>
+float BetheBlochParamTrack(const T& track, const Parameters& parameters)
+{
+  return BetheBlochParam(track.tpcInnerParam(), o2::track::pid_constants::sMasses[id], (float)o2::track::pid_constants::sCharges[id], parameters);
+}
 
 } // namespace o2::pid::tpc
 

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/DetectorResponse.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/DetectorResponse.h
@@ -69,7 +69,7 @@ class DetectorResponse
   /// Getter for the value of the parametrization
   /// \param ptype parametrization type
   /// \param x array with parameters
-  virtual pidvar_t operator()(const Param_t ptype, const pidvar_t* x) const { return mParam[ptype]->operator()(x); }
+  pidvar_t operator()(const Param_t ptype, const pidvar_t* x) const { return mParam[ptype]->operator()(x); }
 
  private:
   /// Parametrizations for the expected signal and sigma
@@ -86,7 +86,6 @@ inline void DetectorResponse::LoadParamFromFile(const TString fname, const TStri
   f.GetObject(pname, mParam[ptype]);
   f.Close();
   mParam[ptype]->Print();
-  mParam[ptype]->PrintParametrization();
 }
 
 inline void DetectorResponse::SetParameters(const DetectorResponse::Param_t ptype, std::vector<pidvar_t> p)

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTOF.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTOF.h
@@ -107,7 +107,7 @@ class ExpTimes
   static float ComputeExpectedTime(const float& tofExpMom, const float& length, const float& massZ);
 
   /// Gets the expected signal of the track of interest under the PID assumption
-  float GetExpectedSignal(const Coll& col, const Trck& trk) const { return ComputeExpectedTime(trk.tofExpMom() / kCSPEED, trk.length(), o2::track::PID::getMass2Z(id)); }
+  static float GetExpectedSignal(const Coll& col, const Trck& trk) { return ComputeExpectedTime(trk.tofExpMom() / kCSPEED, trk.length(), o2::track::PID::getMass2Z(id)); }
 
   /// Gets the expected resolution of the measurement
   float GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
@@ -131,7 +131,7 @@ float ExpTimes<Coll, Trck, id>::GetExpectedSigma(const DetectorResponse& respons
   if (trk.tofSignal() <= 0) {
     return -999.f;
   }
-  const float x[4] = {trk.p(), trk.tofSignal(), col.collisionTimeRes() * 1000.f, o2::track::PID::getMass2Z(id)};
+  const float x[7] = {trk.p(), trk.tofSignal(), col.collisionTimeRes() * 1000.f, o2::track::PID::getMass2Z(id), trk.length(), trk.sigma1Pt(), trk.pt()};
   return response(response.kSigma, x);
   // return response(response.kSigma, const Coll& col, const Trck& trk, id);
 }

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/ParamBase.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/ParamBase.h
@@ -28,19 +28,23 @@ namespace o2::pid
 using pidvar_t = float;
 
 /// \brief Class to handle the parameters of a given detector response
-class Parameters : public TObject
+class Parameters : public TNamed
 {
  public:
   /// Default constructor
   Parameters() = default;
 
   /// Parametric constructor
-  /// \param npar Number of parameters in the container
-  Parameters(unsigned int npar) : mPar(std::vector<pidvar_t>(npar)){};
+  /// \param size Number of parameters in the container
+  Parameters(unsigned int size) : mPar(std::vector<pidvar_t>(size)){};
+
+  /// Parametric constructor
+  /// \param size Number of parameters in the container
+  Parameters(const TString name, unsigned int size) : TNamed(name, name), mPar(std::vector<pidvar_t>(size)){};
 
   /// Parametric constructor
   /// \param params Parameters to initialize the container
-  Parameters(const std::vector<pidvar_t> params) : mPar{} { SetParameters(params); };
+  Parameters(const TString name, const std::vector<pidvar_t> params) : TNamed(name, name), mPar{} { SetParameters(params); };
 
   /// Default destructor
   ~Parameters() override = default;
@@ -54,12 +58,25 @@ class Parameters : public TObject
   /// \param param array with parameters
   void SetParameters(const pidvar_t* params) { std::copy(params, params + mPar.size(), mPar.begin()); }
 
-  /// Setter for the parameter, using an array
-  /// \param params array with parameters
+  /// Setter for the parameter, using a vector
+  /// \param params vector with parameters
   void SetParameters(const std::vector<pidvar_t> params);
 
+  /// Setter for the parameter, using a parameter object
+  /// \param params parameter object with parameters
+  void SetParameters(const Parameters params) { SetParameters(params.mPar); };
+
+  /// Setter for the parameter, using a parameter pointer
+  /// \param params pointer to parameter object with parameters
+  void SetParameters(const Parameters* params) { SetParameters(params->mPar); };
+
   /// Printer of the parameter values
-  void PrintParameters() const;
+  virtual void Print(Option_t* option = "") const override;
+
+  /// Loader from file
+  /// \param FileName name of the input file
+  /// \param ParamName name of the input object
+  void LoadParamFromFile(const TString FileName, const TString ParamName);
 
   /// Getter for the parameters
   /// \return returns an array of parameters
@@ -72,7 +89,7 @@ class Parameters : public TObject
   /// Getter of the parameter at position i
   /// \param i index of the parameter to get
   /// \return returns the parameter value at position i
-  pidvar_t operator[](unsigned int i) const { return mPar[i]; }
+  pidvar_t operator[](const unsigned int i) const { return mPar[i]; }
 
  private:
   /// Vector of the parameter
@@ -91,12 +108,12 @@ class Parametrization : public TNamed
   /// Parametric constructor
   /// \param name Name (and title) of the parametrization
   /// \param size Number of parameters of the parametrization
-  Parametrization(TString name, unsigned int size) : TNamed(name, name), mParameters{size} {};
+  Parametrization(TString name, unsigned int size) : TNamed(name, name), mParameters(name + "Parameters", size){};
 
   /// Parametric constructor
   /// \param name Name (and title) of the parametrization
   /// \param params Parameters of the parametrization
-  Parametrization(TString name, const std::vector<pidvar_t> params) : TNamed(name, name), mParameters{params} {};
+  Parametrization(TString name, const std::vector<pidvar_t> params) : TNamed(name, name), mParameters{name + "Parameters", params} {};
 
   /// Default destructor
   ~Parametrization() override = default;
@@ -105,20 +122,32 @@ class Parametrization : public TNamed
   /// \param x array of variables to use in order to compute the return value
   virtual pidvar_t operator()(const pidvar_t* x) const;
 
-  /// Printer for parameters
-  void PrintParametrization() const;
+  /// Printer for the parametrization
+  virtual void Print(Option_t* option = "") const override;
+
+  /// Loader from file
+  /// \param FileName name of the input file
+  /// \param ParamName name of the input object
+  void LoadParamFromFile(const TString FileName, const TString ParamName);
 
   /// Setter for the parameter at position iparam
   /// \param iparam index in the array of the parameters
   /// \param value value of the parameter at position iparam
   void SetParameter(const unsigned int iparam, const pidvar_t value) { mParameters.SetParameter(iparam, value); }
 
-  /// Setter for the parameter, using an array
-  /// \param params array with parameters
-  void SetParameters(const std::vector<pidvar_t> params) { mParameters.SetParameters(params); }
+  /// Setter for the parameter, using a vector, a parameter object or a pointer to a parameter object
+  /// \param params vector, parameter object, pointer to parameter object with parameters
+  template <typename T>
+  void SetParameters(const T params)
+  {
+    mParameters.SetParameters(params);
+  }
 
   /// Getter for the parameters
   Parameters GetParameters() const { return mParameters; }
+
+  /// Getter for the parameters
+  void GetParameters(Parameters*& parameters) { parameters = &mParameters; }
 
  protected:
   /// Parameters of the parametrization

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/TOFReso.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/TOFReso.h
@@ -18,10 +18,9 @@
 #ifndef O2_ANALYSIS_PID_TOFRESO_H_
 #define O2_ANALYSIS_PID_TOFRESO_H_
 
-// Root includes
-#include "TMath.h"
 // O2 includes
 #include "AnalysisDataModel/PID/ParamBase.h"
+#include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tof
 {
@@ -42,10 +41,26 @@ class TOFReso : public Parametrization
     const float mass = x[3];
     const float dpp = mParameters[0] + mParameters[1] * mom + mParameters[2] * mass / mom; // mean relative pt resolution;
     const float sigma = dpp * time / (1. + mom * mom / (mass * mass));
-    return TMath::Sqrt(sigma * sigma + mParameters[3] * mParameters[3] / mom / mom + mParameters[4] * mParameters[4] + evtimereso * evtimereso);
+    return sqrt(sigma * sigma + mParameters[3] * mParameters[3] / mom / mom + mParameters[4] * mParameters[4] + evtimereso * evtimereso);
   }
   ClassDef(TOFReso, 1);
 };
+
+float TOFResoParam(const float& momentum, const float& time, const float& evtimereso, const float& mass, const Parameters& parameters)
+{
+  if (momentum <= 0) {
+    return -999;
+  }
+  const float dpp = parameters[0] + parameters[1] * momentum + parameters[2] * mass / momentum; // mean relative pt resolution;
+  const float sigma = dpp * time / (1. + momentum * momentum / (mass * mass));
+  return sqrt(sigma * sigma + parameters[3] * parameters[3] / momentum / momentum + parameters[4] * parameters[4] + evtimereso * evtimereso);
+}
+
+template <o2::track::PID::ID id, typename C, typename T>
+float TOFResoParamTrack(const C& collision, const T& track, const Parameters& parameters)
+{
+  return TOFResoParam(track.p(), track.tofSignal(), collision.collisionTimeRes() * 1000.f, o2::track::pid_constants::sMasses[id], parameters);
+}
 
 } // namespace o2::pid::tof
 

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/TOFResoALICE3.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/TOFResoALICE3.h
@@ -1,0 +1,85 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   TOFResoALICE3.h
+/// \author Nicolo' Jacazio
+/// \since  11/03/2021
+/// \brief  Implementation for the TOF PID response of the expected times resolution
+///
+
+#ifndef O2_ANALYSIS_PID_TOFRESOALICE3_H_
+#define O2_ANALYSIS_PID_TOFRESOALICE3_H_
+
+// O2 includes
+#include "AnalysisDataModel/PID/ParamBase.h"
+#include "ReconstructionDataFormats/PID.h"
+
+namespace o2::pid::tof
+{
+
+class TOFResoALICE3 : public Parametrization
+{
+ public:
+  TOFResoALICE3() : Parametrization("TOFResoALICE3", 1){};
+  ~TOFResoALICE3() override = default;
+  float operator()(const float* x) const override
+  {
+    const float p = abs(x[0]);
+    if (p <= 0) {
+      return -999;
+    }
+
+    /** get info **/
+    const float time = x[1];
+    const float evtimereso = x[2];
+    const float mass = x[3];
+    const float L = x[4];
+    const float p2 = p * p;
+    // const float ep = x[5] * x[6];
+    const float ep = x[5] * p2;
+    const float Lc = L / 0.0299792458f;
+    // const float Lc = L / 29.9792458f;
+
+    const float mass2 = mass * mass;
+    const float etexp = Lc * mass2 / p2 / sqrt(mass2 + p2) * ep;
+    return sqrt(etexp * etexp + mParameters[0] * mParameters[0] + evtimereso * evtimereso);
+  }
+  ClassDef(TOFResoALICE3, 1);
+};
+
+float TOFResoALICE3Param(const float& momentum, const float& momentumError, const float& evtimereso, const float& length, const float& mass, const Parameters& parameters)
+{
+  if (momentum <= 0) {
+    return -999;
+  }
+
+  const float p2 = momentum * momentum;
+  const float Lc = length / 0.0299792458f;
+  const float mass2 = mass * mass;
+  const float ep = momentumError * momentum;
+  // const float ep = momentumError * p2;
+  const float etexp = Lc * mass2 / p2 / sqrt(mass2 + p2) * ep;
+  return sqrt(etexp * etexp + parameters[0] * parameters[0] + evtimereso * evtimereso);
+}
+
+template <o2::track::PID::ID id, typename C, typename T>
+float TOFResoALICE3ParamTrack(const C& collision, const T& track, const Parameters& parameters)
+{
+  const float BETA = tan(0.25f * static_cast<float>(M_PI) - 0.5f * atan(track.tgl()));
+  const float sigmaP = sqrt(pow(track.pt(), 2) * pow(track.sigma1Pt(), 2) + (BETA * BETA - 1.f) / (BETA * (BETA * BETA + 1.f)) * (track.tgl() / sqrt(track.tgl() * track.tgl() + 1.f) - 1.f) * pow(track.sigmaTgl(), 2));
+  // const float sigmaP = std::sqrt( track.getSigma1Pt2() ) * track.pt();
+  return TOFResoALICE3Param(track.p(), sigmaP, collision.collisionTimeRes() * 1000.f, track.length(), o2::track::pid_constants::sMasses[id], parameters);
+  // return TOFResoALICE3Param(track.p(), track.sigma1Pt(), collision.collisionTimeRes() * 1000.f, track.length(), o2::track::pid_constants::sMasses[id], parameters);
+}
+
+} // namespace o2::pid::tof
+
+#endif

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/TPCReso.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/TPCReso.h
@@ -19,6 +19,7 @@
 #define O2_ANALYSIS_PID_TPCRESO_H_
 
 #include "AnalysisDataModel/PID/ParamBase.h"
+#include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tpc
 {
@@ -35,6 +36,17 @@ class TPCReso : public Parametrization
   }
   ClassDef(TPCReso, 1);
 };
+
+float TPCResoParam(const float& signal, const float& npoints, const Parameters& parameters)
+{
+  return signal * parameters[0] * (npoints > 0 ? sqrt(1. + parameters[1] / npoints) : 1.f);
+}
+
+template <o2::track::PID::ID id, typename T>
+float TPCResoParamTrack(const T& track, const Parameters& parameters)
+{
+  return TPCResoParam(track.tpcSignal(), (float)track.tpcNClsFound(), parameters);
+}
 
 } // namespace o2::pid::tpc
 

--- a/Analysis/DataModel/src/AnalysisDataModelLinkDef.h
+++ b/Analysis/DataModel/src/AnalysisDataModelLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class o2::pid::Parametrization + ;
 
 #pragma link C++ class o2::pid::tof::TOFReso + ;
+#pragma link C++ class o2::pid::tof::TOFResoALICE3 + ;
 
 #pragma link C++ class o2::pid::tpc::BetheBloch + ;
 #pragma link C++ class o2::pid::tpc::TPCReso + ;

--- a/Analysis/DataModel/src/ParamBase.cxx
+++ b/Analysis/DataModel/src/ParamBase.cxx
@@ -18,6 +18,7 @@
 
 #include "AnalysisDataModel/PID/ParamBase.h"
 #include "Framework/Logger.h"
+#include "TFile.h"
 
 namespace o2::pid
 {
@@ -25,17 +26,32 @@ namespace o2::pid
 void Parameters::SetParameters(const std::vector<pidvar_t> params)
 {
   if (mPar.size() != params.size()) {
-    LOG(fatal) << "Updating parametrization size!";
+    LOG(fatal) << "Updating parametrization size! Trying to fit a parametrization of size " << params.size() << " into one of size " << mPar.size();
   }
   mPar.assign(params.begin(), params.end());
 }
 
-void Parameters::PrintParameters() const
+void Parameters::Print(Option_t* options) const
 {
+  LOG(info) << "Parameters '" << fName << "'";
   for (unsigned int i = 0; i < size(); i++) {
     LOG(info) << "Parameter " << i << "/" << size() - 1 << " is " << mPar[i];
   }
 };
+
+void Parameters::LoadParamFromFile(const TString FileName, const TString ParamName)
+{
+  TFile f(FileName, "READ");
+  if (!f.Get(ParamName)) {
+    LOG(fatal) << "Did not find parameters " << ParamName << " in file " << FileName;
+  }
+  LOG(info) << "Loading parameters " << ParamName << " from TFile " << FileName;
+  Parameters* p;
+  f.GetObject(ParamName, p);
+  f.Close();
+  SetParameters(p);
+  Print();
+}
 
 pidvar_t Parametrization::operator()(const pidvar_t* x) const
 {
@@ -43,10 +59,24 @@ pidvar_t Parametrization::operator()(const pidvar_t* x) const
   return -999.999f;
 }
 
-void Parametrization::PrintParametrization() const
+void Parametrization::Print(Option_t* options) const
 {
-  LOG(info) << "Parametrization " << fName;
-  mParameters.PrintParameters();
+  LOG(info) << "Parametrization '" << fName << "'";
+  mParameters.Print(options);
 };
+
+void Parametrization::LoadParamFromFile(const TString FileName, const TString ParamName)
+{
+  TFile f(FileName, "READ");
+  if (!f.Get(ParamName)) {
+    LOG(fatal) << "Did not find parameters " << ParamName << " in file " << FileName;
+  }
+  LOG(info) << "Loading parameters " << ParamName << " from TFile " << FileName;
+  Parametrization* p;
+  f.GetObject(ParamName, p);
+  f.Close();
+  SetParameters(p->mParameters);
+  Print();
+}
 
 } // namespace o2::pid

--- a/Analysis/DataModel/src/handleParamTOFResoALICE3.cxx
+++ b/Analysis/DataModel/src/handleParamTOFResoALICE3.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file   handleParamTOFReso.cxx
+/// \file   handleParamTOFResoALICE3.cxx
 /// \author Nicolo' Jacazio
 /// \since  2020-06-22
 /// \brief  A simple tool to produce Bethe Bloch parametrization objects for the TOF PID Response
@@ -19,7 +19,7 @@
 #include <boost/program_options.hpp>
 #include <FairLogger.h>
 #include "TFile.h"
-#include "AnalysisDataModel/PID/TOFReso.h"
+#include "AnalysisDataModel/PID/TOFResoALICE3.h"
 
 using namespace o2::pid::tof;
 namespace bpo = boost::program_options;
@@ -28,19 +28,15 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
 {
   options.add_options()(
     "url,u", bpo::value<std::string>()->default_value("http://ccdb-test.cern.ch:8080"), "URL of the CCDB database")(
-    "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TOF"), "CCDB path for storage/retrieval")(
+    "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/ALICE3/PID/TOF"), "CCDB path for storage/retrieval")(
     "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity")(
     "stop,S", bpo::value<long>()->default_value(4108971600000), "Stop timestamp of object validity")(
     "delete-previous,delete_previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
     "save-to-file,file,f,o", bpo::value<std::string>()->default_value(""), "Option to save parametrization to file instead of uploading to ccdb")(
     "read-from-file,i", bpo::value<std::string>()->default_value(""), "Option to get parametrization from a file")(
-    "reso-name,n", bpo::value<std::string>()->default_value("TOFReso"), "Name of the parametrization object")(
+    "reso-name,n", bpo::value<std::string>()->default_value("TOFResoALICE3"), "Name of the parametrization object")(
     "mode,m", bpo::value<unsigned int>()->default_value(1), "Working mode: 0 push 1 pull and test")(
-    "p0", bpo::value<float>()->default_value(0.008f), "Parameter 0 of the TOF resolution")(
-    "p1", bpo::value<float>()->default_value(0.008f), "Parameter 1 of the TOF resolution")(
-    "p2", bpo::value<float>()->default_value(0.002f), "Parameter 2 of the TOF resolution")(
-    "p3", bpo::value<float>()->default_value(40.0f), "Parameter 3 of the TOF resolution")(
-    "p4", bpo::value<float>()->default_value(60.0f), "Parameter 4 of the TOF resolution: average TOF resolution")(
+    "p0", bpo::value<float>()->default_value(20.0f), "Parameter 0 of the TOF resolution: average TOF resolution")(
     "verbose,v", bpo::value<int>()->default_value(0), "Verbose level 0, 1")(
     "help,h", "Produce help message.");
   try {
@@ -81,7 +77,7 @@ int main(int argc, char* argv[])
     LOG(WARNING) << "CCDB host " << url << " is not reacheable, cannot go forward";
     return 1;
   }
-  TOFReso* reso = nullptr;
+  TOFResoALICE3* reso = nullptr;
   const std::string reso_name = vm["reso-name"].as<std::string>();
   if (mode == 0) { // Push mode
     LOG(INFO) << "Handling TOF parametrization in create mode";
@@ -95,8 +91,8 @@ int main(int argc, char* argv[])
       f.Close();
     }
     if (!reso) {
-      reso = new TOFReso();
-      const std::vector<float> resoparams = {vm["p0"].as<float>(), vm["p1"].as<float>(), vm["p2"].as<float>(), vm["p3"].as<float>(), vm["p4"].as<float>()};
+      reso = new TOFResoALICE3();
+      const std::vector<float> resoparams = {vm["p0"].as<float>()};
       reso->SetParameters(resoparams);
     }
     reso->Print();
@@ -125,7 +121,7 @@ int main(int argc, char* argv[])
   } else { // Pull and test mode
     LOG(INFO) << "Handling TOF parametrization in test mode";
     const float x[7] = {1, 1, 1, 1, 1, 1, 1}; // mom, time, ev. reso, mass, length, sigma1pt, pt
-    reso = api.retrieveFromTFileAny<TOFReso>(path + "/" + reso_name, metadata, -1, headers);
+    reso = api.retrieveFromTFileAny<TOFResoALICE3>(path + "/" + reso_name, metadata, -1, headers);
     reso->Print();
     LOG(INFO) << "TOF expected resolution at p=" << x[0] << " GeV/c "
               << " and mass " << x[3] << ":" << reso->operator()(x);

--- a/Analysis/DataModel/src/handleParamTPCBetheBloch.cxx
+++ b/Analysis/DataModel/src/handleParamTPCBetheBloch.cxx
@@ -29,12 +29,22 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
 {
   options.add_options()(
     "url,u", bpo::value<std::string>()->default_value("http://ccdb-test.cern.ch:8080"), "URL of the CCDB database")(
+    "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TPC"), "CCDB path for storage/retrieval")(
     "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity")(
     "stop,S", bpo::value<long>()->default_value(4108971600000), "Stop timestamp of object validity")(
-    "delete-previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
-    "save-to-file,f", bpo::value<std::string>()->default_value(""), "Option to save parametrization to file instead of uploading to ccdb")(
-    "read-from-file", bpo::value<std::string>()->default_value(""), "Option to get parametrization from a file")(
-    "mode,m", bpo::value<unsigned int>()->default_value(0), "Working mode: 0 push 1 pull and test")(
+    "delete-previous,delete_previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
+    "save-to-file,file,f,o", bpo::value<std::string>()->default_value(""), "Option to save parametrization to file instead of uploading to ccdb")(
+    "read-from-file,i", bpo::value<std::string>()->default_value(""), "Option to get parametrization from a file")(
+    "exp-name,n", bpo::value<std::string>()->default_value("BetheBloch"), "Name of the parametrization object")(
+    "reso-name,n", bpo::value<std::string>()->default_value("TPCReso"), "Name of the parametrization object")(
+    "mode,m", bpo::value<unsigned int>()->default_value(1), "Working mode: 0 push 1 pull and test")(
+    "p0", bpo::value<float>()->default_value(0.0320981), "Parameter 0 of the TPC expected value")(
+    "p1", bpo::value<float>()->default_value(19.9768), "Parameter 1 of the TPC expected value")(
+    "p2", bpo::value<float>()->default_value(2.52666e-16), "Parameter 2 of the TPC expected value")(
+    "p3", bpo::value<float>()->default_value(2.72123), "Parameter 3 of the TPC expected value")(
+    "p4", bpo::value<float>()->default_value(6.08092), "Parameter 4 of the TPC expected value")(
+    "p5", bpo::value<float>()->default_value(50.f), "Parameter 5 of the TPC expected value")(
+    "p6", bpo::value<float>()->default_value(2.3), "Parameter 6 of the TPC expected value")(
     "verbose,v", bpo::value<int>()->default_value(0), "Verbose level 0, 1")(
     "help,h", "Produce help message.");
   try {
@@ -65,7 +75,7 @@ int main(int argc, char* argv[])
   }
 
   const unsigned int mode = vm["mode"].as<unsigned int>();
-  const std::string path = "Analysis/PID/TPC";
+  const std::string path = vm["ccdb-path"].as<std::string>();
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string>* headers;
   o2::ccdb::CcdbApi api;
@@ -75,23 +85,25 @@ int main(int argc, char* argv[])
     LOG(WARNING) << "CCDB host " << url << " is not reacheable, cannot go forward";
     return 1;
   }
+  BetheBloch* bb = nullptr;
+  TPCReso* reso = nullptr;
+  const std::string exp_name = vm["exp-name"].as<std::string>();
+  const std::string reso_name = vm["reso-name"].as<std::string>();
   if (mode == 0) { // Push mode
-    BetheBloch* bb = nullptr;
-    TPCReso* reso = nullptr;
+    LOG(INFO) << "Handling TPC parametrization in create mode";
     const std::string input_file_name = vm["read-from-file"].as<std::string>();
-
     if (!input_file_name.empty()) {
       TFile f(input_file_name.data(), "READ");
       if (!f.IsOpen()) {
         LOG(WARNING) << "Input file " << input_file_name << " is not reacheable, cannot get param from file";
       }
-      f.GetObject("BetheBloch", bb);
-      f.GetObject("TPCReso", reso);
+      f.GetObject(exp_name.c_str(), bb);
+      f.GetObject(reso_name.c_str(), reso);
       f.Close();
     }
     if (!bb) {
       bb = new BetheBloch();
-      const std::vector<float> bbparams = {0.0320981, 19.9768, 2.52666e-16, 2.72123, 6.08092, 50.f, 2.3};
+      const std::vector<float> bbparams = {vm["p0"].as<float>(), vm["p1"].as<float>(), vm["p2"].as<float>(), vm["p3"].as<float>(), vm["p4"].as<float>(), vm["p5"].as<float>(), vm["p6"].as<float>()};
       bb->SetParameters(bbparams);
     }
     if (!reso) {
@@ -99,14 +111,19 @@ int main(int argc, char* argv[])
       const std::vector<float> resoparams = {0.07, 0.0};
       reso->SetParameters(resoparams);
     }
+    bb->Print();
     const std::string fname = vm["save-to-file"].as<std::string>();
     if (!fname.empty()) { // Saving it to file
+      LOG(INFO) << "Saving parametrization to file " << fname;
       TFile f(fname.data(), "RECREATE");
       bb->Write();
+      bb->GetParameters().Write();
       reso->Write();
+      reso->GetParameters().Write();
       f.ls();
       f.Close();
     } else { // Saving it to CCDB
+      LOG(INFO) << "Saving parametrization to CCDB " << path;
 
       long start = vm["start"].as<long>();
       long stop = vm["stop"].as<long>();
@@ -114,16 +131,22 @@ int main(int argc, char* argv[])
       if (vm["delete-previous"].as<int>()) {
         api.truncate(path);
       }
-      api.storeAsTFileAny(bb, path + "/BetheBloch", metadata, start, stop);
-      api.storeAsTFileAny(reso, path + "/TPCReso", metadata, start, stop);
+      api.storeAsTFileAny(bb, path + "/" + exp_name, metadata, start, stop);
+      o2::pid::Parameters* params;
+      bb->GetParameters(params);
+      api.storeAsTFileAny(params, path + "/Parameters/" + exp_name, metadata, start, stop);
+      api.storeAsTFileAny(reso, path + "/" + reso_name, metadata, start, stop);
+      reso->GetParameters(params);
+      api.storeAsTFileAny(params, path + "/Parameters/" + reso_name, metadata, start, stop);
     }
   } else { // Pull and test mode
+    LOG(INFO) << "Handling TPC parametrization in test mode";
     const float x[2] = {1, 1};
-    BetheBloch* bb = api.retrieveFromTFileAny<BetheBloch>(path + "/BetheBloch", metadata, -1, headers);
-    bb->PrintParametrization();
+    BetheBloch* bb = api.retrieveFromTFileAny<BetheBloch>(path + "/" + exp_name, metadata, -1, headers);
+    bb->Print();
     LOG(INFO) << "BetheBloch " << bb->operator()(x);
-    TPCReso* reso = api.retrieveFromTFileAny<TPCReso>(path + "/TPCReso", metadata, -1, headers);
-    reso->PrintParametrization();
+    TPCReso* reso = api.retrieveFromTFileAny<TPCReso>(path + "/" + reso_name, metadata, -1, headers);
+    reso->Print();
     LOG(INFO) << "TPCReso " << reso->operator()(x);
   }
 

--- a/Analysis/Tasks/PID/CMakeLists.txt
+++ b/Analysis/Tasks/PID/CMakeLists.txt
@@ -8,6 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+# TOF
+
 o2_add_dpl_workflow(pid-tof
                     SOURCES pidTOF.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
@@ -18,10 +20,17 @@ o2_add_dpl_workflow(pid-tof-beta
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2_add_dpl_workflow(pid-tof-qa-mc
+                    SOURCES qaTOFMC.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2_add_dpl_workflow(pid-tof-tiny
                     SOURCES pidTOF_tiny.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+# TPC
 
 o2_add_dpl_workflow(pid-tpc
                     SOURCES pidTPC.cxx
@@ -30,5 +39,12 @@ o2_add_dpl_workflow(pid-tpc
 
 o2_add_dpl_workflow(pid-tpc-tiny
                     SOURCES pidTPC_tiny.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+# HMPID
+
+o2_add_dpl_workflow(pid-hmpid-qa
+                    SOURCES qaHMPID.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)

--- a/Analysis/Tasks/PID/pidTPC.cxx
+++ b/Analysis/Tasks/PID/pidTPC.cxx
@@ -91,7 +91,7 @@ struct pidTPCTaskSplit {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = o2::pid::tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();

--- a/Analysis/Tasks/PID/pidTPC_tiny.cxx
+++ b/Analysis/Tasks/PID/pidTPC_tiny.cxx
@@ -91,7 +91,7 @@ struct pidTPCTaskTiny {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = o2::pid::tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();

--- a/Analysis/Tasks/PID/qaHMPID.cxx
+++ b/Analysis/Tasks/PID/qaHMPID.cxx
@@ -1,0 +1,99 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// O2 includes
+#include "ReconstructionDataFormats/Track.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "AnalysisDataModel/TrackSelectionTables.h"
+#include "AnalysisCore/MC.h"
+#include "AnalysisDataModel/TrackSelectionTables.h"
+#include "AnalysisDataModel/TrackSelectionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct pidHMPIDQA {
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
+  Configurable<int> nBinsP{"nBinsP", 500, "Number of momentum bins"};
+  Configurable<float> minP{"minP", 0.01, "Minimum momentum plotted (GeV/c)"};
+  Configurable<float> maxP{"maxP", 10, "Maximum momentum plotted (GeV/c)"};
+  Configurable<float> maxDCA{"maxDCA", 3, "Maximum DCA xy use for the plot (cm)"};
+
+  template <typename T>
+  void makelogaxis(T h)
+  {
+    // return;
+    const int nbins = h->GetNbinsX();
+    double binp[nbins + 1];
+    double max = h->GetXaxis()->GetBinUpEdge(nbins);
+    double min = h->GetXaxis()->GetBinLowEdge(1);
+    if (min <= 0) {
+      min = 0.00001;
+    }
+    double lmin = TMath::Log10(min);
+    double ldelta = (TMath::Log10(max) - lmin) / ((double)nbins);
+    for (int i = 0; i < nbins; i++) {
+      binp[i] = TMath::Exp(TMath::Log(10) * (lmin + i * ldelta));
+    }
+    binp[nbins] = max + 1;
+    h->GetXaxis()->Set(nbins, binp);
+  }
+
+  void init(o2::framework::InitContext&)
+  {
+    AxisSpec momAxis{nBinsP, minP, maxP};
+    histos.add("qa/signalvsP", ";#it{p} (GeV/#it{c});Cherenkov angle (rad)", kTH2F, {momAxis, {1000, 0, 1}});
+    histos.add("distance/selected", ";HMPID distance", kTH1F, {{100, 0, 20}});
+    histos.add("distance/nonselected", ";HMPID distance", kTH1F, {{100, 0, 20}});
+    histos.add("qmip/selected", ";HMPID mip charge (ADC)", kTH1F, {{100, 0, 4000}});
+    histos.add("qmip/nonselected", ";HMPID mip charge (ADC)", kTH1F, {{100, 0, 4000}});
+    histos.add("nphotons/selected", ";HMPID number of detected photons", kTH1F, {{100, 0, 1000}});
+    histos.add("nphotons/nonselected", ";HMPID number of detected photons", kTH1F, {{100, 0, 1000}});
+  }
+
+  using TrackCandidates = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksExtended, aod::TrackSelection>;
+  void process(const TrackCandidates& tracks,
+               const aod::HMPIDs& hmpids,
+               const aod::Collisions& colls)
+  {
+    for (const auto& t : hmpids) {
+
+      if (t.track_as<TrackCandidates>().isGlobalTrack() != (uint8_t) true) {
+        continue;
+      }
+      if (abs(t.track_as<TrackCandidates>().dcaXY()) > maxDCA) {
+        continue;
+      }
+      histos.fill(HIST("distance/nonselected"), t.hmpidDistance());
+      histos.fill(HIST("qmip/nonselected"), t.hmpidQMip());
+      histos.fill(HIST("nphotons/nonselected"), t.hmpidNPhotons());
+      if (t.hmpidDistance() > 5.f) {
+        continue;
+      }
+      if (t.hmpidQMip() < 120.f) {
+        continue;
+      }
+      histos.fill(HIST("distance/selected"), t.hmpidDistance());
+      histos.fill(HIST("qmip/selected"), t.hmpidQMip());
+      histos.fill(HIST("nphotons/selected"), t.hmpidNPhotons());
+      histos.fill(HIST("qa/signalvsP"), t.track_as<TrackCandidates>().p(), t.hmpidSignal());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
+{
+  WorkflowSpec workflow{adaptAnalysisTask<pidHMPIDQA>(cfg, TaskName{"pidHMPID-qa"})};
+  return workflow;
+}

--- a/Analysis/Tasks/PID/qaTOFMC.cxx
+++ b/Analysis/Tasks/PID/qaTOFMC.cxx
@@ -102,7 +102,7 @@ struct pidTOFTaskQA {
 
   void init(o2::framework::InitContext&)
   {
-    histos.add("event/T0", ";Tracks with TOF;T0 (ps);Counts", HistType::kTH2F, {{1000, 0, 100}, {1000, -600, 600}});
+    histos.add("event/T0", ";Tracks with TOF;T0 (ps);Counts", HistType::kTH2F, {{1000, 0, 1000}, {1000, -1000, 1000}});
     histos.add(hnsigma[pid_type].data(), Form(";#it{p}_{T} (GeV/#it{c});N_{#sigma}^{TOF}(%s)", pT[pid_type]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {2000, -30, 30}});
     makelogaxis(histos.get<TH2>(HIST(hnsigma[pid_type])));
     histos.add(hnsigmaprm[pid_type].data(), Form("Primary;#it{p}_{T} (GeV/#it{c});N_{#sigma}^{TOF}(%s)", pT[pid_type]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {2000, -30, 30}});

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -486,6 +486,7 @@ namespace hmpid
 DECLARE_SOA_INDEX_COLUMN(Track, track);                  //!
 DECLARE_SOA_COLUMN(HMPIDSignal, hmpidSignal, float);     //!
 DECLARE_SOA_COLUMN(HMPIDDistance, hmpidDistance, float); //!
+DECLARE_SOA_COLUMN(HMPIDNPhotons, hmpidNPhotons, short); //!
 DECLARE_SOA_COLUMN(HMPIDQMip, hmpidQMip, short);         //!
 } // namespace hmpid
 
@@ -494,6 +495,7 @@ DECLARE_SOA_TABLE(HMPIDs, "AOD", "HMPID", //!
                   hmpid::TrackId,
                   hmpid::HMPIDSignal,
                   hmpid::HMPIDDistance,
+                  hmpid::HMPIDNPhotons,
                   hmpid::HMPIDQMip);
 using HMPID = HMPIDs::iterator;
 


### PR DESCRIPTION
- Add TOF calibration for ALICE3
- Add handler for Alice 3 param
- Update RICH QA task
- Add HMPID QA task
- Add task for FAST PID response
- Add beta in TOF QA task
- Remove fast and qa tasks
- Extend TOF task with Fast PID and more QA
- Add fast TPC response
- Add fast implementation in PID response of TPC and TOF
- Update TOF task for QA
- Update TPC param handler
- Add number of photons detected to the HMPID table
- Delegating track selection in QA to dedicated task
- Add ALICE3 track extension task
- Add ALICE3 task for multiplicity
- Add separate task for the TOF beta
- Update RICH table to build indices, use indeces in RICH QA task

Update PID param. handlers
- Writing TOF reso parameters and saving them to the CCDB
- Add ALICE3 PID TOF response

PID tasks:
- Add QA tasks to split task
- Add expected resolution and for the event time resolution plot to the QA of ALICE3 TOF PID
- Add cut on minimum TOF multiplicity for QA