### PR TITLE
[MCH] move *all* pixels to be kept at the beginning

### DIFF
--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
@@ -91,7 +91,6 @@ class ClusterFinderOriginal
   double mlem(const std::vector<double>& coef, const std::vector<double>& prob, int nIter);
   void findCOG(const TH2D& histMLEM, double xy[2]) const;
   void refinePixelArray(const double xyCOG[2], size_t nPixMax, double& xMin, double& xMax, double& yMin, double& yMax);
-  void shiftPixelsToKeep(double charge);
   void cleanPixelArray(double threshold, std::vector<double>& prob);
 
   int fit(const std::vector<const std::vector<int>*>& clustersOfPixels, const double fitRange[2][2], double fitParam[SNFitParamMax + 1]);

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -1125,12 +1125,11 @@ void ClusterFinderOriginal::refinePixelArray(const double xyCOG[2], size_t nPixM
   yMin = std::numeric_limits<double>::max();
   yMax = -std::numeric_limits<double>::max();
 
-  // sort pixels according to the charge and move all pixels that must be kept at the begining
-  shiftPixelsToKeep(10000.);
+  // sort pixels according to the charge and move all pixels that must be kept at the beginning
   std::stable_sort(mPixels.begin(), mPixels.end(), [](const PadOriginal& pixel1, const PadOriginal& pixel2) {
-    return pixel1.charge() > pixel2.charge();
+    return (pixel1.status() == PadOriginal::kMustKeep && pixel2.status() != PadOriginal::kMustKeep) ||
+           (pixel1.status() == pixel2.status() && pixel1.charge() > pixel2.charge());
   });
-  shiftPixelsToKeep(-10000.);
   double pixMinCharge = TMath::Min(0.01 * mPixels.front().charge(), 100. * SLowestPixelCharge);
 
   // define the half-size and shift of the new pixels depending on the direction of splitting
@@ -1215,19 +1214,6 @@ void ClusterFinderOriginal::refinePixelArray(const double xyCOG[2], size_t nPixM
     mPixels.emplace_back(mPixels.front());
     mPixels.back().setx(xMin);
     mPixels.back().sety(xyCOG[1]);
-  }
-}
-
-//_________________________________________________________________________________________________
-void ClusterFinderOriginal::shiftPixelsToKeep(double charge)
-{
-  /// add the given charge to the pixels tagged as kMustKeep
-  /// (just a trick to put them in front when sorting pixels by charge)
-
-  for (auto& pixel : mPixels) {
-    if (pixel.status() == PadOriginal::kMustKeep) {
-      pixel.setCharge(pixel.charge() + charge);
-    }
   }
 }
 


### PR DESCRIPTION
The main purpose of this little fix is to remove a dependence of the algorithm on the average pad charge, which will be different between run2 and run3 (different gain and calibration). It has negligible effect (<‰) on the reconstructed clusters and tracks in the reference data sample.