### PR TITLE
[CMake] Fix CMP0115 warnings with CMake 3.20

### DIFF
--- a/Analysis/Tasks/PWGLF/CMakeLists.txt
+++ b/Analysis/Tasks/PWGLF/CMakeLists.txt
@@ -59,32 +59,32 @@ o2_add_dpl_workflow(nuclei-spectra
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(lambdakzerobuilder
-                    SOURCES lambdakzerobuilder
+                    SOURCES lambdakzerobuilder.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(lambdakzeroanalysis
-                    SOURCES lambdakzeroanalysis
+                    SOURCES lambdakzeroanalysis.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(lambdakzerofinder
-                    SOURCES lambdakzerofinder
+                    SOURCES lambdakzerofinder.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(cascadebuilder
-                    SOURCES cascadebuilder
+                    SOURCES cascadebuilder.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(cascadeanalysis
-                    SOURCES cascadeanalysis
+                    SOURCES cascadeanalysis.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(cascadefinder
-                    SOURCES cascadefinder
+                    SOURCES cascadefinder.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 


### PR DESCRIPTION
Not critical but avoids screen-polluting warnings at cmake configuration stage.

> cmake --help-policy CMP0115

CMP0115
-------

Source file extensions must be explicit.

In CMake 3.19 and below, if a source file could not be found by the name
specified, it would append a list of known extensions to the name to see
if the file with the extension could be found. For example, this would allow
the user to run:

 add_executable(exe main)

and put ``main.c`` in the executable without specifying the
extension.

Starting in CMake 3.20, CMake prefers all source files to have
their extensions
explicitly listed:

 add_executable(exe main.c)

The ``OLD`` behavior for this policy is to implicitly append
known extensions
to source files if they can't be found. The ``NEW`` behavior
of this policy is
to not append known extensions and require them to be
explicit.

This policy was introduced in CMake version 3.20.  CMake
version 3.20.1
warns when the policy is not set and uses ``OLD`` behavior.
Use the
``cmake_policy()`` command to set it to ``OLD`` or ``NEW``
explicitly.

.. note::
  The ``OLD`` behavior of a policy is
    ``deprecated by definition``
      and may be removed in a future version of CMake.