### PR TITLE
Use span of labels for ITS clusters in tracking

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -117,7 +117,7 @@ inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const int c
 
 inline const gsl::span<const MCCompLabel> ROframe::getClusterLabels(int layerId, const int clId) const
 {
-  gsl::span<const MCCompLabel> sp{mClusterLabels[layerId].data() + mMaxNClusterLabels * clId, mMaxNClusterLabels};
+  gsl::span<const MCCompLabel> sp{mClusterLabels[layerId].data() + mMaxNClusterLabels * clId, static_cast<size_t>(mMaxNClusterLabels)};
   return sp;
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -38,7 +38,7 @@ using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 class ROframe final
 {
  public:
-  ROframe(int ROframeId, int nLayers);
+  ROframe(int ROframeId, int nLayers, int maxNLabels = 3);
   int getROFrameId() const;
   const float3& getPrimaryVertex(const int) const;
   int getPrimaryVerticesNum() const;
@@ -55,8 +55,10 @@ class ROframe final
   const auto& getTrackingFrameInfo() const { return mTrackingFrameInfo; }
 
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
-  const MCCompLabel& getClusterLabels(int layerId, const Cluster& cl) const;
-  const MCCompLabel& getClusterLabels(int layerId, const int clId) const;
+  const MCCompLabel& getClusterFirstLabel(int layerId, const Cluster& cl) const;
+  const MCCompLabel& getClusterFirstLabel(int layerId, const int clId) const;
+  const gsl::span<const MCCompLabel> getClusterLabels(int layerId, const int clId) const;
+  int getFirstClusterIDFromLabel(int layerId, const MCCompLabel& label) const;
   int getClusterExternalIndex(int layerId, const int clId) const;
   std::vector<int> getTracksId(const int layerId, const std::vector<Cluster>& cl);
 
@@ -64,7 +66,7 @@ class ROframe final
   void addClusterToLayer(int layer, T&&... args);
   template <typename... T>
   void addTrackingFrameInfoToLayer(int layer, T&&... args);
-  void addClusterLabelToLayer(int layer, const MCCompLabel label);
+  void addClusterLabelToLayer(int layer, gsl::span<const MCCompLabel>);
   void addClusterExternalIndexToLayer(int layer, const int idx);
   bool hasMCinformation() const;
 
@@ -72,6 +74,7 @@ class ROframe final
 
  private:
   const int mROframeId;
+  const int mMaxNClusterLabels;
   std::vector<float3> mPrimaryVertices;
   std::vector<std::vector<Cluster>> mClusters;
   std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
@@ -102,14 +105,35 @@ inline const TrackingFrameInfo& ROframe::getClusterTrackingFrameInfo(int layerId
   return mTrackingFrameInfo[layerId][cl.clusterId];
 }
 
-inline const MCCompLabel& ROframe::getClusterLabels(int layerId, const Cluster& cl) const
+inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const Cluster& cl) const
 {
-  return mClusterLabels[layerId][cl.clusterId];
+  return mClusterLabels[layerId][mMaxNClusterLabels * cl.clusterId];
 }
 
-inline const MCCompLabel& ROframe::getClusterLabels(int layerId, const int clId) const
+inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const int clId) const
 {
-  return mClusterLabels[layerId][clId];
+  return mClusterLabels[layerId][mMaxNClusterLabels * clId];
+}
+
+inline const gsl::span<const MCCompLabel> ROframe::getClusterLabels(int layerId, const int clId) const
+{
+  gsl::span<const MCCompLabel> sp{mClusterLabels[layerId].data() + mMaxNClusterLabels * clId, mMaxNClusterLabels};
+  return sp;
+}
+
+inline int ROframe::getFirstClusterIDFromLabel(int layerId, const MCCompLabel& label) const
+{
+  // Returns the cluster id of the first label that matches label variable
+  int retVal{-mMaxNClusterLabels};
+  if (!label.isNoise()) {
+    for (size_t i{0}; i < mClusterLabels[layerId].size(); ++i) {
+      if (label == mClusterLabels[layerId][i]) {
+        retVal = i;
+        break;
+      }
+    }
+  }
+  return retVal / mMaxNClusterLabels;
 }
 
 inline int ROframe::getClusterExternalIndex(int layerId, const int clId) const
@@ -121,7 +145,7 @@ inline std::vector<int> ROframe::getTracksId(const int layerId, const std::vecto
 {
   std::vector<int> tracksId;
   for (auto& cluster : cl) {
-    tracksId.push_back(getClusterLabels(layerId, cluster).isNoise() ? -1 : getClusterLabels(layerId, cluster).getTrackID());
+    tracksId.push_back(getClusterFirstLabel(layerId, cluster).isNoise() ? -1 : getClusterFirstLabel(layerId, cluster).getTrackID());
   }
   return tracksId;
 }
@@ -138,7 +162,16 @@ void ROframe::addTrackingFrameInfoToLayer(int layer, T&&... values)
   mTrackingFrameInfo[layer].emplace_back(std::forward<T>(values)...);
 }
 
-inline void ROframe::addClusterLabelToLayer(int layer, const MCCompLabel label) { mClusterLabels[layer].emplace_back(label); }
+inline void ROframe::addClusterLabelToLayer(int layer, const gsl::span<const MCCompLabel> labels)
+{
+  for (int iLabel{0}; iLabel < mMaxNClusterLabels; ++iLabel) {
+    if (iLabel < labels.size()) {
+      mClusterLabels[layer].emplace_back(labels[iLabel]);
+    } else {
+      mClusterLabels[layer].emplace_back();
+    }
+  }
+}
 
 inline void ROframe::addClusterExternalIndexToLayer(int layer, const int idx)
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
@@ -78,7 +78,8 @@ struct FakeTrackInfo {
           mcLabels[iCluster].emplace_back(label);
         }
       }
-
+      bool found = false;
+      // Lookup if any of the labels has already an entry in the occurrences
       for (size_t iOcc{0}; iOcc < occurrences.size(); ++iOcc) {
         std::pair<o2::MCCompLabel, int>& occurrence = occurrences[iOcc];
         for (auto& label : labels) {

--- a/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
@@ -21,7 +21,7 @@ namespace o2
 namespace its
 {
 
-ROframe::ROframe(int ROframeId, int nLayers) : mROframeId{ROframeId}
+ROframe::ROframe(int ROframeId, int nLayers, int maxNLabels) : mROframeId{ROframeId}, mMaxNClusterLabels{maxNLabels}
 {
   mClusters.resize(nLayers);
   mTrackingFrameInfo.resize(nLayers);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackingLinkDef.h
@@ -16,11 +16,17 @@
 
 #pragma link C++ class o2::its::ClusterLines + ;
 #pragma link C++ class o2::its::Tracklet + ;
+#pragma link C++ class o2::its::Cluster + ;
+
+#pragma link C++ class o2::its::TrackITSExt + ;
+#pragma link C++ class o2::its::TrackingFrameInfo + ;
 
 #pragma link C++ class o2::its::VertexerParamConfig + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::VertexerParamConfig> + ;
 
 #pragma link C++ class o2::its::TrackerParamConfig + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper <o2::its::TrackerParamConfig> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::TrackerParamConfig> + ;
+
+#pragma link C++ class o2::its::FakeTrackInfo < 7> + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -258,8 +258,8 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
     auto& currentCluster{mClusters[0][iCurrentLayerClusterIndex]};
     for (unsigned int iNextLayerClusterIndex = 0; iNextLayerClusterIndex < mClusters[1].size(); iNextLayerClusterIndex++) {
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
-      const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
-      const auto& lblCurr = mEvent->getClusterLabels(0, currentCluster.clusterId);
+      const auto& lblNext = mEvent->getClusterFirstLabel(1, nextCluster.clusterId);
+      const auto& lblCurr = mEvent->getClusterFirstLabel(0, currentCluster.clusterId);
       if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb01.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster);
       }
@@ -270,8 +270,8 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
     auto& currentCluster{mClusters[2][iCurrentLayerClusterIndex]};
     for (unsigned int iNextLayerClusterIndex = 0; iNextLayerClusterIndex < mClusters[1].size(); iNextLayerClusterIndex++) {
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
-      const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
-      const auto& lblCurr = mEvent->getClusterLabels(2, currentCluster.clusterId);
+      const auto& lblNext = mEvent->getClusterFirstLabel(1, nextCluster.clusterId);
+      const auto& lblCurr = mEvent->getClusterFirstLabel(2, currentCluster.clusterId);
       if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb12.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster);
       }
@@ -366,8 +366,8 @@ void VertexerTraits::computeMCFiltering()
 {
   assert(mEvent != nullptr);
   for (size_t iTracklet{0}; iTracklet < mComb01.size(); ++iTracklet) {
-    const auto& lbl0 = mEvent->getClusterLabels(0, mClusters[0][mComb01[iTracklet].firstClusterIndex].clusterId);
-    const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb01[iTracklet].secondClusterIndex].clusterId);
+    const auto& lbl0 = mEvent->getClusterFirstLabel(0, mClusters[0][mComb01[iTracklet].firstClusterIndex].clusterId);
+    const auto& lbl1 = mEvent->getClusterFirstLabel(1, mClusters[1][mComb01[iTracklet].secondClusterIndex].clusterId);
     if (!(lbl0.compare(lbl1) == 1 && lbl0.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb01.erase(mComb01.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
@@ -375,8 +375,8 @@ void VertexerTraits::computeMCFiltering()
   }
 
   for (size_t iTracklet{0}; iTracklet < mComb12.size(); ++iTracklet) {
-    const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb12[iTracklet].firstClusterIndex].clusterId);
-    const auto& lbl2 = mEvent->getClusterLabels(2, mClusters[2][mComb12[iTracklet].secondClusterIndex].clusterId);
+    const auto& lbl1 = mEvent->getClusterFirstLabel(1, mClusters[1][mComb12[iTracklet].firstClusterIndex].clusterId);
+    const auto& lbl2 = mEvent->getClusterFirstLabel(2, mClusters[2][mComb12[iTracklet].secondClusterIndex].clusterId);
     if (!(lbl1.compare(lbl2) == 1 && lbl1.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb12.erase(mComb12.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
@@ -693,8 +693,8 @@ void VertexerTraits::filterTrackletsWithMC(std::vector<Tracklet>& tracklets01,
     int removed{0};
     for (size_t iTrackletIndex{0}; iTrackletIndex < indices01[iFoundTrackletIndex]; ++iTrackletIndex) {
       const size_t iTracklet{offset + iTrackletIndex};
-      const auto& lbl0 = mEvent->getClusterLabels(0, mClusters[0][tracklets01[iTracklet].firstClusterIndex].clusterId);
-      const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][tracklets01[iTracklet].secondClusterIndex].clusterId);
+      const auto& lbl0 = mEvent->getClusterFirstLabel(0, mClusters[0][tracklets01[iTracklet].firstClusterIndex].clusterId);
+      const auto& lbl1 = mEvent->getClusterFirstLabel(1, mClusters[1][tracklets01[iTracklet].secondClusterIndex].clusterId);
       if (!(lbl0.compare(lbl1) == 1 && lbl0.getSourceID() == 0)) {
         tracklets01[iTracklet] = Tracklet();
         ++removed;
@@ -711,8 +711,8 @@ void VertexerTraits::filterTrackletsWithMC(std::vector<Tracklet>& tracklets01,
     int removed{0};
     for (size_t iTrackletIndex{0}; iTrackletIndex < indices12[iFoundTrackletIndex]; ++iTrackletIndex) {
       const size_t iTracklet{offset + iTrackletIndex};
-      const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][tracklets12[iTracklet].firstClusterIndex].clusterId);
-      const auto& lbl2 = mEvent->getClusterLabels(2, mClusters[2][tracklets12[iTracklet].secondClusterIndex].clusterId);
+      const auto& lbl1 = mEvent->getClusterFirstLabel(1, mClusters[1][tracklets12[iTracklet].firstClusterIndex].clusterId);
+      const auto& lbl2 = mEvent->getClusterFirstLabel(2, mClusters[2][tracklets12[iTracklet].secondClusterIndex].clusterId);
       if (!(lbl1.compare(lbl2) == 1 && lbl1.getSourceID() == 0)) {
         tracklets12[iTracklet] = Tracklet();
         ++removed;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -280,15 +280,16 @@ void TrackerDPL::run(ProcessingContext& pc)
       }
       roFrame++;
     }
-  } else {
-    ioutils::loadEventData(event, compClusters, pattIt, mDict, labels);
-    // RS: FIXME: this part seems to be not functional !!!
-    event.addPrimaryVertex(0.f, 0.f, 0.f); //FIXME :  run an actual vertex finder !
-    mTracker->clustersToTracks(event);
-    tracks.swap(mTracker->getTracks());
-    copyTracks(tracks, allTracks, allClusIdx);
-    allTrackLabels.swap(mTracker->getTrackLabels()); /// FIXME: assignment ctor is not optimal.
   }
+  //  else {
+  //   // ioutils::loadEventData(event, compClusters, pattIt, mDict, labels);
+  //   // // RS: FIXME: this part seems to be not functional !!!
+  //   // event.addPrimaryVertex(0.f, 0.f, 0.f); //FIXME :  run an actual vertex finder !
+  //   // mTracker->clustersToTracks(event);
+  //   // tracks.swap(mTracker->getTracks());
+  //   // copyTracks(tracks, allTracks, allClusIdx);
+  //   // allTrackLabels.swap(mTracker->getTrackLabels()); /// FIXME: assignment ctor is not optimal.
+  // }
 
   LOG(INFO) << "ITSTracker pushed " << allTracks.size() << " tracks";
   if (mIsMC) {


### PR DESCRIPTION
This is to propose the extension for the tracker to the usage of multiple labels for each cluster.
It happens now that some tracks are actually tagged as fake because at tracking level we were not aware of the multiple labelling for some clusters (especially on layer zero).
Fraction of the false negative is not huge, but still observable (especially for fakes on the first layer):
Before extension:
[fakiness_layer.pdf](https://github.com/AliceO2Group/AliceO2/files/6363795/fakiness_layer.pdf)
After extension:
[fakiness_layer_fixed.pdf](https://github.com/AliceO2Group/AliceO2/files/6363798/fakiness_layer_fixed.pdf)

I had to cherry-pick the modifications from a very messy and out-to-date branch of mines, so I still have to check if this work same way, hence the draft PR. I also commented out some stale/unused methods/blocks that we **might** consider to remove.

Let me know if you have some suggestion in doing this better.
Tagging @shahor02 @mpuccio @iouribelikov to start the discussion.
