### PR TITLE
Fix: don't write clusters when using upstream clusters

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -40,7 +40,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   if (!upstreamClusters) {
     specs.emplace_back(o2::its::getClustererSpec(useMC));
   }
-  if (!disableRootOutput) {
+  if (!(disableRootOutput || upstreamClusters)) {
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
   }
   if (useCAtracker) {


### PR DESCRIPTION
I found a small bug that prevents running the ITS tracking workflow starting from an existing cluster file.
@shahor02 @mpuccio @mconcas 