### PR TITLE
Fix copy and paste error

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -55,7 +55,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   // the TPC sector completion policy checks when the set of TPC/CLUSTERNATIVE data is complete
   // in addition we require to have input from all other routes
-  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("itstpc-track-matcher",
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("cosmics-matcher",
                                                         o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
                                                         InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
 }


### PR DESCRIPTION
Copy & pasting is very dangerous!
This policy was not working, since the name was not changed to the name of the the actual processor spec.
This is highly misleading, perhaps we should add a sanity check and make the workflow fail if we try to add a policy for a spec that does not exist (@ktf)?

trivial, merging