### PR TITLE
FV0: simulate CFD threshold and dead-time

### DIFF
--- a/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
+++ b/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
@@ -138,8 +138,8 @@ class Geometry
   static constexpr float sDzHalvesSeparation = 0;              ///< z-position of the right detector part relative to the left part
 
   /// Cell and scintillator constants
-  static constexpr int sNumberOfCellSectors = 4; ///< Number of cell sectors for one half of the detector
-  static constexpr int sNumberOfCellRings = 5;   ///< Number of cell rings
+  static constexpr int sNumberOfCellSectors = 4;                                             ///< Number of cell sectors for one half of the detector
+  static constexpr int sNumberOfCellRings = 5;                                               ///< Number of cell rings
   static constexpr int sNumberOfCells = sNumberOfCellRings * sNumberOfCellSectors * 2;       ///< Number of cells
   static constexpr int sNumberOfReadoutChannels = sNumberOfCells + sNumberOfCellSectors * 2; ///< Number of ch (2 ch per cell in r5)
 

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
@@ -21,17 +21,17 @@ namespace fv0
 {
 // parameters of FV0 digitization / transport simulation
 struct FV0DigParam : public o2::conf::ConfigurableParamHelper<FV0DigParam> {
-  float intrinsicTimeRes = 0.91;       // time resolution
+  // NOTUSED float intrinsicTimeRes = 0.91;       // time resolution
   float photoCathodeEfficiency = 0.23; // quantum efficiency = nOfPhotoE_emitted_by_photocathode / nIncidentPhotons
   float lightYield = 0.01;             // light collection efficiency to be tuned using collision data [1%]
-  float pmtGain = 5e4;                 // value for PMT R5924-70 at default FV0 gain
-  float pmtTransitTime = 9.5;          // PMT response time (corresponds to 1.9 ns rise time)
-  float pmtTransparency = 0.25;        // Transparency of the first dynode of the PMT
-  float shapeConst = 1.18059e-14;      // Crystal ball const parameter
-  float shapeMean = 9.5;               // Crystal ball mean  parameter
-  float shapeAlpha = -6.56586e-01;     // Crystal ball alpha parameter
-  float shapeN = 2.36408e+00;          // Crystal ball N     parameter
-  float shapeSigma = 3.55445;          // Crystal ball sigma parameter
+  // NOTUSED float pmtGain = 5e4;                 // value for PMT R5924-70 at default FV0 gain
+  // NOTUSED float pmtTransitTime = 9.5;          // PMT response time (corresponds to 1.9 ns rise time)
+  // NOTUSED float pmtTransparency = 0.25;        // Transparency of the first dynode of the PMT
+  float shapeConst = 1.18059e-14;  // Crystal ball const parameter
+  float shapeMean = 9.5;           // Crystal ball mean  parameter
+  float shapeAlpha = -6.56586e-01; // Crystal ball alpha parameter
+  float shapeN = 2.36408e+00;      // Crystal ball N     parameter
+  float shapeSigma = 3.55445;      // Crystal ball sigma parameter
   //float timeShiftCfd = 3.3;          // From the cosmic measurements of FV0 [keep it for reference]
   float timeShiftCfd = 5.3;                                                   // TODO: adjust after FV0 with FEE measurements are done
   float singleMipThreshold = 3.0;                                             // in [MeV] of deposited energy
@@ -39,8 +39,6 @@ struct FV0DigParam : public o2::conf::ConfigurableParamHelper<FV0DigParam> {
   UInt_t waveformNbins = 10000;                                               // number of bins for the analog pulse waveform
   float waveformBinWidth = 0.01302;                                           // bin width [ns] for analog pulse waveform
   float avgCfdTimeForMip = 8.63;                                              // in ns to shift the CFD time to zero TODO do ring wise
-  int chargeIntBinMin = (avgCfdTimeForMip - 6.0) / waveformBinWidth;          //Charge integration offset (cfd mean time - 6 ns)
-  int chargeIntBinMax = (avgCfdTimeForMip + 14.0) / waveformBinWidth;         //Charge integration offset (cfd mean time + 14 ns)
   bool isIntegrateFull = false;                                               // Full charge integration widow in 25 ns
   float cfdCheckWindow = 2.5;                                                 // time window for the cfd in ns to trigger the charge integration
   int avgNumberPhElectronPerMip = 201;                                        // avg number of photo-electrons per MIP
@@ -48,7 +46,7 @@ struct FV0DigParam : public o2::conf::ConfigurableParamHelper<FV0DigParam> {
   float mCFDdeadTime = 15.6;                                                  // ns
   float mCFD_trsh = 3.;                                                       // [mV]
   ///Parameters for trigger simulation
-  int adcChargeHighMultTh = 3.0 * 498; //threshold value of ADC charge for high multiplicity trigger
+  int adcChargeHighMultTh = 3 * 498; //threshold value of ADC charge for high multiplicity trigger
 
   O2ParamDef(FV0DigParam, "FV0DigParam");
 };

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
@@ -36,16 +36,17 @@ struct FV0DigParam : public o2::conf::ConfigurableParamHelper<FV0DigParam> {
   float timeShiftCfd = 5.3;            // TODO: adjust after FV0 with FEE measurements are done
   float singleMipThreshold = 3.0;      // in [MeV] of deposited energy
   float singleHitTimeThreshold = 120.0; // in [ns] to skip very slow particles
-  float waveformNbins = 10000;         // number of bins for the analog pulse waveform
-  float waveformBinWidth = 0.01302;    // number of bins for the analog
-  float avgCfdTimeForMip = 8.63;       // in ns to shift the CFD time to zero TODO do ring wise
+  UInt_t waveformNbins = 10000;         // number of bins for the analog pulse waveform
+  float waveformBinWidth = 0.01302;     // bin width [ns] for analog pulse waveform
+  float avgCfdTimeForMip = 8.63;        // in ns to shift the CFD time to zero TODO do ring wise
   int chargeIntBinMin = (avgCfdTimeForMip - 6.0) / waveformBinWidth;          //Charge integration offset (cfd mean time - 6 ns)
   int chargeIntBinMax = (avgCfdTimeForMip + 14.0) / waveformBinWidth;         //Charge integration offset (cfd mean time + 14 ns)
   bool isIntegrateFull = false;                                               // Full charge integration widow in 25 ns
   float cfdCheckWindow = 2.5;                                                 // time window for the cfd in ns to trigger the charge integration
   int avgNumberPhElectronPerMip = 201;                                        // avg number of photo-electrons per MIP
   float globalTimeOfFlight = 315.0 / o2::constants::physics::LightSpeedCm2NS; //TODO check the correct value for distance of FV0 to IP
-
+  float mCFDdeadTime = 15.6;            // ns
+  float mCFD_trsh = 3.;                 // [mV]
   ///Parameters for trigger simulation
   int adcChargeHighMultTh = 3.0 * 498; //threshold value of ADC charge for high multiplicity trigger
 

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/FV0DigParam.h
@@ -33,20 +33,20 @@ struct FV0DigParam : public o2::conf::ConfigurableParamHelper<FV0DigParam> {
   float shapeN = 2.36408e+00;          // Crystal ball N     parameter
   float shapeSigma = 3.55445;          // Crystal ball sigma parameter
   //float timeShiftCfd = 3.3;          // From the cosmic measurements of FV0 [keep it for reference]
-  float timeShiftCfd = 5.3;            // TODO: adjust after FV0 with FEE measurements are done
-  float singleMipThreshold = 3.0;      // in [MeV] of deposited energy
-  float singleHitTimeThreshold = 120.0; // in [ns] to skip very slow particles
-  UInt_t waveformNbins = 10000;         // number of bins for the analog pulse waveform
-  float waveformBinWidth = 0.01302;     // bin width [ns] for analog pulse waveform
-  float avgCfdTimeForMip = 8.63;        // in ns to shift the CFD time to zero TODO do ring wise
+  float timeShiftCfd = 5.3;                                                   // TODO: adjust after FV0 with FEE measurements are done
+  float singleMipThreshold = 3.0;                                             // in [MeV] of deposited energy
+  float singleHitTimeThreshold = 120.0;                                       // in [ns] to skip very slow particles
+  UInt_t waveformNbins = 10000;                                               // number of bins for the analog pulse waveform
+  float waveformBinWidth = 0.01302;                                           // bin width [ns] for analog pulse waveform
+  float avgCfdTimeForMip = 8.63;                                              // in ns to shift the CFD time to zero TODO do ring wise
   int chargeIntBinMin = (avgCfdTimeForMip - 6.0) / waveformBinWidth;          //Charge integration offset (cfd mean time - 6 ns)
   int chargeIntBinMax = (avgCfdTimeForMip + 14.0) / waveformBinWidth;         //Charge integration offset (cfd mean time + 14 ns)
   bool isIntegrateFull = false;                                               // Full charge integration widow in 25 ns
   float cfdCheckWindow = 2.5;                                                 // time window for the cfd in ns to trigger the charge integration
   int avgNumberPhElectronPerMip = 201;                                        // avg number of photo-electrons per MIP
   float globalTimeOfFlight = 315.0 / o2::constants::physics::LightSpeedCm2NS; //TODO check the correct value for distance of FV0 to IP
-  float mCFDdeadTime = 15.6;            // ns
-  float mCFD_trsh = 3.;                 // [mV]
+  float mCFDdeadTime = 15.6;                                                  // ns
+  float mCFD_trsh = 3.;                                                       // [mV]
   ///Parameters for trigger simulation
   int adcChargeHighMultTh = 3.0 * 498; //threshold value of ADC charge for high multiplicity trigger
 

--- a/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
@@ -28,6 +28,8 @@ void Digitizer::clear()
   for (auto& analogSignal : mPmtChargeVsTime) {
     std::fill_n(std::begin(analogSignal), analogSignal.size(), 0);
   }
+  mLastBCCache.clear();
+  mCfdStartIndex.fill(0);
 }
 
 //_______________________________________________________________________
@@ -37,10 +39,11 @@ void Digitizer::init()
   mNBins = FV0DigParam::Instance().waveformNbins;      //Will be computed using detector set-up from CDB
   mBinSize = FV0DigParam::Instance().waveformBinWidth; //Will be set-up from CDB
 
-  mNTimeBinsPerBC = int(o2::constants::lhc::LHCBunchSpacingNS / mBinSize);
+  mNTimeBinsPerBC = std::lround(o2::constants::lhc::LHCBunchSpacingNS / mBinSize); // 1920 bins/BC
 
   for (Int_t detID = 0; detID < Constants::nFv0Channels; detID++) {
     mPmtChargeVsTime[detID].resize(mNBins);
+    mLastBCCache.mPmtChargeVsTime[detID].resize(mNBins);
   }
 
   // set up PMT response function [avg]
@@ -52,13 +55,16 @@ void Digitizer::init()
                               FV0DigParam::Instance().shapeN);
 
   // PMT response per hit [Global]
-  float x = mBinSize / 2.0; /// Calculate at BinCenter
+  double x = mBinSize / 2.0; /// Calculate at BinCenter
   mPmtResponseGlobal.resize(mNBins);
-  for (Int_t j = 0; j < mPmtResponseGlobal.size(); ++j) {
-    mPmtResponseGlobal[j] = signalShapeFn.Eval(x);
+  for (auto& y : mPmtResponseGlobal) {
+    y = signalShapeFn.Eval(x);
     //LOG(INFO)<<x<<"    "<<mPmtResponseGlobal[j];
     x += mBinSize;
   }
+
+  mLastBCCache.clear();
+  mCfdStartIndex.fill(0);
 
   LOG(INFO) << "V0Digitizer::init -> finished";
 }
@@ -76,7 +82,7 @@ void Digitizer::process(const std::vector<o2::fv0::Hit>& hits,
   std::iota(std::begin(hitIdx), std::end(hitIdx), 0);
   std::sort(std::begin(hitIdx), std::end(hitIdx),
             [&hits](int a, int b) { return hits[a].GetTrackID() < hits[b].GetTrackID(); });
-  Int_t parentIdPrev = -10;
+
   // use ordered hits
   for (auto ids : hitIdx) {
     const auto& hit = hits[ids];
@@ -109,14 +115,14 @@ void Digitizer::process(const std::vector<o2::fv0::Hit>& hits,
       }
       Double_t const nPhotons = hitEdep * DP::N_PHOTONS_PER_MEV;
       float const nPhE = SimulateLightYield(detId, nPhotons);
-      float mipFraction = float(nPhE / FV0DigParam::Instance().avgNumberPhElectronPerMip);
+      float const mipFraction = float(nPhE / FV0DigParam::Instance().avgNumberPhElectronPerMip);
       Float_t timeHit = hitTime;
       timeHit += mIntRecord.getTimeNS();
-      o2::InteractionTimeRecord irHit(timeHit);
+      o2::InteractionTimeRecord const irHit(timeHit);
       std::array<o2::InteractionRecord, NBC2Cache> cachedIR;
       int nCachedIR = 0;
       for (int i = BCCacheMin; i < BCCacheMax + 1; i++) {
-        double tNS = timeHit + o2::constants::lhc::LHCBunchSpacingNS * i;
+        double const tNS = timeHit + o2::constants::lhc::LHCBunchSpacingNS * i;
         cachedIR[nCachedIR].setFromNS(tNS);
         if (tNS < 0 && cachedIR[nCachedIR] > irHit) {
           continue; // don't go to negative BC/orbit (it will wrap)
@@ -133,10 +139,8 @@ void Digitizer::createPulse(float mipFraction, int parID, const double hitTime,
                             std::array<o2::InteractionRecord, NBC2Cache> const& cachedIR, int nCachedIR, const int detId)
 {
 
-  bool added[nCachedIR];
-  for (int ir = 0; ir < nCachedIR; ir++) {
-    added[ir] = false;
-  }
+  std::array<bool, NBC2Cache> added;
+  added.fill(false);
 
   for (int ir = 0; ir < NBC2Cache; ir++) {
     auto bcCache = getBCCache(cachedIR[ir]);
@@ -146,7 +150,7 @@ void Digitizer::createPulse(float mipFraction, int parID, const double hitTime,
   }
 
   ///Time of flight subtracted from Hit time //TODO have different TOF according to thr ring number
-  Int_t NBinShift = std::lround((hitTime - FV0DigParam::Instance().globalTimeOfFlight) / FV0DigParam::Instance().waveformBinWidth);
+  Int_t const NBinShift = std::lround((hitTime - FV0DigParam::Instance().globalTimeOfFlight) / FV0DigParam::Instance().waveformBinWidth);
 
   if (NBinShift >= 0 && NBinShift < FV0DigParam::Instance().waveformNbins) {
     mPmtResponseTemp.resize(FV0DigParam::Instance().waveformNbins, 0.);
@@ -180,12 +184,8 @@ void Digitizer::flush(std::vector<o2::fv0::BCData>& digitsBC,
                       std::vector<o2::fv0::DetTrigInput>& digitsTrig,
                       o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>& labels)
 {
-  int nCached = mCache.size();
-  if (nCached < 1) {
-    return;
-  }
-  for (auto bc : mCache) {
-    if (mIntRecord.differenceInBC(bc) > NBC2Cache) { // Build events those are separated by NBC2Cache BCs from current BC
+  for (auto const& bc : mCache) {
+    if (mIntRecord.differenceInBC(bc) > NBC2Cache) { // Build events that are separated by NBC2Cache BCs from current BC
       storeBC(bc, digitsBC, digitsCh, digitsTrig, labels);
       mCache.pop_front();
     } else {
@@ -201,29 +201,31 @@ void Digitizer::storeBC(const BCCache& bc,
                         o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>& labels)
 
 {
-  int first = digitsCh.size();
+  size_t const first = digitsCh.size();
   size_t nStored = 0;
-  double totalCharge = 0;
   double totalChargeAllRing = 0;
   double nSignalInner = 0;
   double nSignalOuter = 0;
 
+  if (mLastBCCache.differenceInBC(bc) != 1) { // if the last buffered BC is not the one before the current BC
+    mLastBCCache.clear();                     // clear the bufffer (mPmtChargeVsTime set to 0s)
+    mCfdStartIndex.fill(0);                   // reset all start indices to 0, i.e., to the beginning of the BC
+  }
+
   for (int iPmt = 0; iPmt < Constants::nFv0Channels; iPmt++) {
-    double cfdWithOffset = SimulateTimeCfd(bc.mPmtChargeVsTime[iPmt]);
+    // run the CFD: this updates the start index for the next BC in case the CFD dead time ends in the next BC
+    double cfdWithOffset = SimulateTimeCfd(mCfdStartIndex[iPmt], mLastBCCache.mPmtChargeVsTime[iPmt], bc.mPmtChargeVsTime[iPmt]);
     double cfdZero = cfdWithOffset - FV0DigParam::Instance().avgCfdTimeForMip;
 
     if (cfdZero < -FV0DigParam::Instance().cfdCheckWindow || cfdZero > FV0DigParam::Instance().cfdCheckWindow) {
       continue;
     }
-    float charge = IntegrateCharge(bc.mPmtChargeVsTime[iPmt]);
-    totalCharge += charge;
-    totalChargeAllRing += charge;
+    float totalCharge = IntegrateCharge(bc.mPmtChargeVsTime[iPmt]);
+    totalChargeAllRing += totalCharge;
     totalCharge *= DP::INV_CHARGE_PER_ADC;
     cfdZero *= DP::INV_TIME_PER_TDCCHANNEL;
 
-    digitsCh.emplace_back(iPmt, static_cast<short int>(std::round(cfdZero)),
-                          static_cast<short int>(std::round(totalCharge)));
-    totalCharge = 0;
+    digitsCh.emplace_back(iPmt, std::lround(cfdZero), std::lround(totalCharge));
     ++nStored;
     //---trigger---
     if (iPmt < 25) {
@@ -232,6 +234,8 @@ void Digitizer::storeBC(const BCCache& bc,
       nSignalOuter++;
     }
   }
+  // save BC information for the CFD detector
+  mLastBCCache = bc;
   if (nStored < 1) {
     return;
   }
@@ -249,8 +253,8 @@ void Digitizer::storeBC(const BCCache& bc,
   triggers.setTriggers(isMinBias, isMinBiasInner, isMinBiasOuter, isHighMult, isDummy, nStored, totalChargeAllRing);
   digitsBC.emplace_back(first, nStored, bc, triggers);
   digitsTrig.emplace_back(bc, isMinBias, isMinBiasInner, isMinBiasOuter, isHighMult, isDummy);
-  int nBC = digitsBC.size();
-  for (const auto& lbl : bc.labels) {
+  size_t const nBC = digitsBC.size();
+  for (auto const& lbl : bc.labels) {
     labels.addElement(nBC, lbl);
   }
 }
@@ -274,8 +278,8 @@ Int_t Digitizer::SimulateLightYield(Int_t pmt, Int_t nPhot) const
 //---------------------------------------------------------------------------
 Float_t Digitizer::IntegrateCharge(const ChannelBCDataF& pulse) const
 {
-  int chargeIntMin = FV0DigParam::Instance().isIntegrateFull ? 0 : FV0DigParam::Instance().chargeIntBinMin;
-  int chargeIntMax = FV0DigParam::Instance().isIntegrateFull ? mNTimeBinsPerBC : FV0DigParam::Instance().chargeIntBinMax;
+  int const chargeIntMin = FV0DigParam::Instance().isIntegrateFull ? 0 : FV0DigParam::Instance().chargeIntBinMin;
+  int const chargeIntMax = FV0DigParam::Instance().isIntegrateFull ? mNTimeBinsPerBC : FV0DigParam::Instance().chargeIntBinMax;
 
   Float_t totalCharge = 0.0f;
   for (int iTimeBin = chargeIntMin; iTimeBin < chargeIntMax; iTimeBin++) {
@@ -286,23 +290,32 @@ Float_t Digitizer::IntegrateCharge(const ChannelBCDataF& pulse) const
   return totalCharge;
 }
 //---------------------------------------------------------------------------
-Float_t Digitizer::SimulateTimeCfd(/*Int_t channel, */ const ChannelBCDataF& pulse) const
+Float_t Digitizer::SimulateTimeCfd(int& startIndex, const ChannelBCDataF& pulseLast, const ChannelBCDataF& pulse) const
 {
   Float_t timeCfd = -1024.0f;
 
-  //auto& bc= mCache[iCache];
-
   if (pulse.empty()) {
+    startIndex = 0;
     return timeCfd;
   }
 
+  Float_t const cfdThrInCoulomb = FV0DigParam::Instance().mCFD_trsh * 1e-3 / 50 * mBinSize * 1e-9; // convert mV into Coulomb assuming 50 Ohm
+
   Int_t const binShift = TMath::Nint(FV0DigParam::Instance().timeShiftCfd / mBinSize);
-  Float_t sigPrev = -pulse[0]; //[0];
-  for (Int_t iTimeBin = 1; iTimeBin < mNTimeBinsPerBC; ++iTimeBin) {
-    Float_t const sigCurrent = (iTimeBin >= binShift ? 5.0f * pulse[iTimeBin - binShift] - pulse[iTimeBin] : -pulse[iTimeBin]);
-    if (sigPrev < 0.0f && sigCurrent >= 0.0f) {
-      timeCfd = Float_t(iTimeBin) * mBinSize;
-      break;
+  Float_t sigPrev = 5 * pulseLast[mNTimeBinsPerBC - binShift - 1] - pulseLast[mNTimeBinsPerBC - 1]; //  CFD output from the last bin of the last BC
+  for (Int_t iTimeBin = 0; iTimeBin < mNTimeBinsPerBC; ++iTimeBin) {
+    Float_t const sigCurrent = 5.0f * (iTimeBin >= binShift ? pulse[iTimeBin - binShift] : pulseLast[mNTimeBinsPerBC - binShift + iTimeBin]) - pulse[iTimeBin];
+    if (iTimeBin >= startIndex && std::abs(pulse[iTimeBin]) > cfdThrInCoulomb) { // enable
+      if (sigPrev < 0.0f && sigCurrent >= 0.0f) {                                // test for zero-crossing
+        timeCfd = Float_t(iTimeBin) * mBinSize;
+        startIndex = iTimeBin + std::lround(FV0DigParam::Instance().mCFDdeadTime / mBinSize); // update startIndex (CFD dead time)
+        if (startIndex < mNTimeBinsPerBC) {
+          startIndex = 0; // dead-time ends in same BC: no impact on the following BC
+        } else {
+          startIndex -= mNTimeBinsPerBC;
+        }
+        break; // only detects the 1st zero-crossing in the BC
+      }
     }
     sigPrev = sigCurrent;
   }
@@ -326,7 +339,7 @@ float Digitizer::getDistFromCellCenter(UInt_t cellId, double hitx, double hity)
 
 float Digitizer::getSignalFraction(float distanceFromXc, bool isFirstChannel)
 {
-  float fraction = sigmoidPmtRing5(distanceFromXc);
+  float const fraction = sigmoidPmtRing5(distanceFromXc);
   if (distanceFromXc > 0) {
     return isFirstChannel ? fraction : (1. - fraction);
   } else {

--- a/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
@@ -201,7 +201,8 @@ void Digitizer::storeBC(const BCCache& bc,
                         o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>& labels)
 
 {
-  size_t const first = digitsCh.size();
+  size_t const nBC = digitsBC.size();   // save before digitsBC is being modified
+  size_t const first = digitsCh.size(); // save before digitsCh is being modified
   size_t nStored = 0;
   double totalChargeAllRing = 0;
   double nSignalInner = 0;
@@ -253,7 +254,6 @@ void Digitizer::storeBC(const BCCache& bc,
   triggers.setTriggers(isMinBias, isMinBiasInner, isMinBiasOuter, isHighMult, isDummy, nStored, totalChargeAllRing);
   digitsBC.emplace_back(first, nStored, bc, triggers);
   digitsTrig.emplace_back(bc, isMinBias, isMinBiasInner, isMinBiasOuter, isHighMult, isDummy);
-  size_t const nBC = digitsBC.size();
   for (auto const& lbl : bc.labels) {
     labels.addElement(nBC, lbl);
   }


### PR DESCRIPTION
@mslupeck @jotwinow please verify that the CFD threshold is correctly set.

For now I use for the threshold

`FV0DigParam::Instance().mCFD_trsh * 1e-3 / 50 * mBinSize * 1e-9 = 7.8120e-16 Coulomb`
 * with `mCFD_trsh = 3 mV` (as for FT0),
 * with `mBinSize = 0.01302 ns`.
 * assuming `50 Ohm` and  that the values in `mPmtChargeVsTime` are in units of Coulomb,
