### PR TITLE
Added missing event selection criteria

### DIFF
--- a/Analysis/Core/include/AnalysisCore/TriggerAliases.h
+++ b/Analysis/Core/include/AnalysisCore/TriggerAliases.h
@@ -31,7 +31,7 @@ enum triggerAliases {
   kNaliases
 };
 
-static const std::string aliasLabels[kNaliases] = {
+static const char* aliasLabels[kNaliases] = {
   "kINT7",
   "kEMC7",
   "kINT7inMUON",

--- a/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/EventSelection.h
@@ -15,46 +15,98 @@
 
 namespace o2::aod
 {
+
+// Bits in eventCuts bitmask in Run2BCInfos table
+// Must be consistent with EventSelectionCut enum in the Run2 converter
+enum Run2EventCuts {
+  kINELgtZERO = 0,
+  kPileupInMultBins,
+  kConsistencySPDandTrackVertices,
+  kTrackletsVsClusters,
+  kNonZeroNContribs,
+  kIncompleteDAQ,
+  kPileUpMV,
+  kTPCPileUp,
+  kTimeRangeCut,
+  kEMCALEDCut,
+  kAliEventCutsAccepted,
+  kIsPileupFromSPD,
+  kIsV0PFPileup,
+  kIsTPCHVdip,
+  kIsTPCLaserWarmUp,
+  kTRDHCO, // Offline TRD cosmic trigger decision
+  kTRDHJT, // Offline TRD jet trigger decision
+  kTRDHSE, // Offline TRD single electron trigger decision
+  kTRDHQU, // Offline TRD quarkonium trigger decision
+  kTRDHEE  // Offline TRD single-electron-in-EMCAL-acceptance trigger decision
+};
+
+// Event selection criteria
+enum EventSelectionFlags {
+  kIsBBV0A = 0,
+  kIsBBV0C,
+  kIsBBFDA,
+  kIsBBFDC,
+  kNoBGV0A,
+  kNoBGV0C,
+  kNoBGFDA,
+  kNoBGFDC,
+  kIsBBT0A,
+  kIsBBT0C,
+  kIsBBZNA,
+  kIsBBZNC,
+  kNoBGZNA,
+  kNoBGZNC,
+  kNoV0MOnVsOfPileup,
+  kNoSPDOnVsOfPileup,
+  kNoV0Casymmetry,
+  kIsGoodTimeRange,
+  kNoIncompleteDAQ,
+  kNoTPCLaserWarmUp,
+  kNoTPCHVdip,
+  kNoPileupFromSPD,
+  kNoV0PFPileup,
+  kNoSPDClsVsTklBG,
+  kNoV0C012vsTklBG,
+  kNsel
+};
+
 // collision-joinable event selection decisions
 namespace evsel
 {
 // TODO bool arrays are not supported? Storing in int32 for the moment
-DECLARE_SOA_COLUMN(Alias, alias, int32_t[kNaliases]); //!
-DECLARE_SOA_COLUMN(BBT0A, bbT0A, bool);               //! beam-beam time in T0A
-DECLARE_SOA_COLUMN(BBT0C, bbT0C, bool);               //! beam-beam time in T0C
-DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool);               //! beam-beam time in V0A
-DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool);               //! beam-beam time in V0C
-DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool);               //! beam-gas time in V0A
-DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool);               //! beam-gas time in V0C
-DECLARE_SOA_COLUMN(BBZNA, bbZNA, bool);               //! beam-beam time in ZNA
-DECLARE_SOA_COLUMN(BBZNC, bbZNC, bool);               //! beam-beam time in ZNC
-DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool);               //! beam-beam time in FDA
-DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool);               //! beam-beam time in FDC
-DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool);               //! beam-gas time in FDA
-DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool);               //! beam-gas time in FDC
-DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int64_t);      //! the nearest FT0 signal
-DECLARE_SOA_DYNAMIC_COLUMN(SEL7, sel7,                //!
-                           [](bool bbV0A, bool bbV0C, bool bbZNA, bool bbZNC) -> bool { return bbV0A && bbV0C && bbZNA && bbZNC; });
-DECLARE_SOA_DYNAMIC_COLUMN(SEL8, sel8, //!
-                           [](bool bbT0A, bool bbT0C, bool bbZNA, bool bbZNC) -> bool { return bbT0A && bbT0C && bbZNA && bbZNC; });
+DECLARE_SOA_COLUMN(Alias, alias, int32_t[kNaliases]);
+DECLARE_SOA_COLUMN(Selection, selection, int32_t[kNsel]);
+DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool);                 //! Beam-beam time in V0A
+DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool);                 //! Beam-beam time in V0C
+DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool);                 //! Beam-gas time in V0A
+DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool);                 //! Beam-gas time in V0C
+DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool);                 //! Beam-beam time in FDA
+DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool);                 //! Beam-beam time in FDC
+DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool);                 //! Beam-gas time in FDA
+DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool);                 //! Beam-gas time in FDC
+DECLARE_SOA_COLUMN(MultRingV0A, multRingV0A, float[5]); //! V0A multiplicity per ring (4 rings in run2, 5 rings in run3)
+DECLARE_SOA_COLUMN(MultRingV0C, multRingV0C, float[4]); //! V0C multiplicity per ring (4 rings in run2)
+DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t); //! Number of SPD clusters in two layers
+DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);        //! Tracklet multiplicity
+DECLARE_SOA_COLUMN(Sel7, sel7, bool);                   //! Event selection decision based on V0A & V0C
+DECLARE_SOA_COLUMN(Sel8, sel8, bool);                   //! Event selection decision based on TVX
+DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int64_t);        //! The nearest FT0 signal
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
-                  evsel::Alias,
-                  evsel::BBT0A, evsel::BBT0C,
+                  evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
-                  evsel::BBZNA, evsel::BBZNC,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::SEL7<evsel::BBV0A, evsel::BBV0C, evsel::BBZNA, evsel::BBZNC>,
-                  evsel::SEL8<evsel::BBT0A, evsel::BBT0C, evsel::BBZNA, evsel::BBZNC>,
+                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
+                  evsel::Sel7, evsel::Sel8,
                   evsel::FoundFT0);
 using EvSel = EvSels::iterator;
 
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!
-                  evsel::Alias,
-                  evsel::BBT0A, evsel::BBT0C,
+                  evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
-                  evsel::BBZNA, evsel::BBZNC,
-                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC);
+                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
+                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters);
 using BcSel = BcSels::iterator;
 } // namespace o2::aod
 

--- a/Analysis/Tasks/eventSelection.cxx
+++ b/Analysis/Tasks/eventSelection.cxx
@@ -9,7 +9,6 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/ConfigParamSpec.h"
-
 using namespace o2;
 using namespace o2::framework;
 
@@ -26,6 +25,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 #include "AnalysisCore/TriggerAliases.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "CommonConstants/LHCConstants.h"
+
+using namespace o2::aod;
 
 struct EvSelParameters {
   // time-of-flight offset
@@ -55,16 +56,35 @@ struct EvSelParameters {
   float fFDCBGlower = -fFDCDist - 2.0; // ns
   float fFDCBGupper = -fFDCDist + 2.0; // ns
 
-  float fZNABBlower = -2.0; // ns
-  float fZNABBupper = 2.0;  // ns
-  float fZNCBBlower = -2.0; // ns
-  float fZNCBBupper = 2.0;  // ns
+  float fZNABBlower = -2.0;  // ns
+  float fZNABBupper = 2.0;   // ns
+  float fZNCBBlower = -2.0;  // ns
+  float fZNCBBupper = 2.0;   // ns
+  float fZNABGlower = 5.0;   // ns
+  float fZNABGupper = 100.0; // ns
+  float fZNCBGlower = 5.0;   // ns
+  float fZNCBGupper = 100.0; // ns
 
   // TODO rough cuts to be adjusted
   float fT0ABBlower = -2.0; // ns
   float fT0ABBupper = 2.0;  // ns
   float fT0CBBlower = -2.0; // ns
   float fT0CBBupper = 2.0;  // ns
+
+  // Default values from AliOADBTriggerAnalysis constructor
+  // TODO store adjusted values period-by-period in CCDB
+  float fSPDClsVsTklA = 65.f;
+  float fSPDClsVsTklB = 4.f;
+  float fV0C012vsTklA = 150.f;
+  float fV0C012vsTklB = 20.f;
+  float fV0MOnVsOfA = -59.56f;
+  float fV0MOnVsOfB = 5.22f;
+  float fSPDOnVsOfA = -5.62f;
+  float fSPDOnVsOfB = 0.85f;
+  float fV0CasymA = -25.f;
+  float fV0CasymB = 0.15f;
+
+  bool applySelection[kNsel] = {0};
 };
 
 struct BcSelectionTask {
@@ -104,6 +124,7 @@ struct BcSelectionTask {
       alias[al.first] |= (triggerMaskNext50 & al.second) > 0;
     }
 
+    // get timing info from ZDC, FV0, FT0 and FDD
     float timeZNA = bc.has_zdc() ? bc.zdc().timeZNA() : -999.f;
     float timeZNC = bc.has_zdc() ? bc.zdc().timeZNC() : -999.f;
     float timeV0A = bc.has_fv0a() ? bc.fv0a().time() : -999.f;
@@ -118,39 +139,193 @@ struct BcSelectionTask {
     LOGF(debug, "timeFDA=%f timeFDC=%f", timeFDA, timeFDC);
     LOGF(debug, "timeT0A=%f timeT0C=%f", timeT0A, timeT0C);
 
-    bool bbZNA = timeZNA > par.fZNABBlower && timeZNA < par.fZNABBupper;
-    bool bbZNC = timeZNC > par.fZNCBBlower && timeZNC < par.fZNCBBupper;
+    // applying timing selections
     bool bbV0A = timeV0A > par.fV0ABBlower && timeV0A < par.fV0ABBupper;
     bool bbV0C = timeV0C > par.fV0CBBlower && timeV0C < par.fV0CBBupper;
-    bool bgV0A = timeV0A > par.fV0ABGlower && timeV0A < par.fV0ABGupper;
-    bool bgV0C = timeV0C > par.fV0CBGlower && timeV0C < par.fV0CBGupper;
-    bool bbFDA = timeFDA > par.fFDABBlower && timeFDA < par.fFDABBupper;
-    bool bbFDC = timeFDC > par.fFDCBBlower && timeFDC < par.fFDCBBupper;
+    bool bgV0A = timeFDA > par.fFDABBlower && timeFDA < par.fFDABBupper;
+    bool bgV0C = timeFDC > par.fFDCBBlower && timeFDC < par.fFDCBBupper;
+    bool bbFDA = timeV0A > par.fV0ABGlower && timeV0A < par.fV0ABGupper;
+    bool bbFDC = timeV0C > par.fV0CBGlower && timeV0C < par.fV0CBGupper;
     bool bgFDA = timeFDA > par.fFDABGlower && timeFDA < par.fFDABGupper;
     bool bgFDC = timeFDC > par.fFDCBGlower && timeFDC < par.fFDCBGupper;
-    bool bbT0A = timeT0A > par.fT0ABBlower && timeT0A < par.fT0ABBupper;
-    bool bbT0C = timeT0C > par.fT0CBBlower && timeT0C < par.fT0CBBupper;
+
+    // fill time-based selection criteria
+    int32_t selection[kNsel] = {0}; // TODO switch to bool array
+    selection[kIsBBV0A] = bbV0A;
+    selection[kIsBBV0C] = bbV0C;
+    selection[kIsBBFDA] = bgV0A;
+    selection[kIsBBFDC] = bgV0C;
+    selection[kNoBGV0A] = !bbFDA;
+    selection[kNoBGV0C] = !bbFDC;
+    selection[kNoBGFDA] = !bgFDA;
+    selection[kNoBGFDC] = !bgFDC;
+    selection[kIsBBT0A] = timeT0A > par.fT0ABBlower && timeT0A < par.fT0ABBupper;
+    selection[kIsBBT0C] = timeT0C > par.fT0CBBlower && timeT0C < par.fT0CBBupper;
+    selection[kIsBBZNA] = timeZNA > par.fZNABBlower && timeZNA < par.fZNABBupper;
+    selection[kIsBBZNC] = timeZNC > par.fZNCBBlower && timeZNC < par.fZNCBBupper;
+    selection[kNoBGZNA] = !(fabs(timeZNA) > par.fZNABGlower && fabs(timeZNA < par.fZNABGupper));
+    selection[kNoBGZNC] = !(fabs(timeZNC) > par.fZNCBGlower && fabs(timeZNC < par.fZNCBGupper));
+
+    // Calculate V0 multiplicity per ring
+    float multRingV0A[5] = {0.};
+    float multRingV0C[4] = {0.};
+    float multV0A = 0;
+    float multV0C = 0;
+    if (bc.has_fv0a()) {
+      for (int ring = 0; ring < 4; ring++) { // TODO adjust for Run3 V0A
+        for (int sector = 0; sector < 8; sector++) {
+          multRingV0A[ring] += bc.fv0a().amplitude()[ring * 8 + sector];
+        }
+        multV0A += multRingV0A[ring];
+      }
+    }
+
+    if (bc.has_fv0c()) {
+      for (int ring = 0; ring < 4; ring++) {
+        for (int sector = 0; sector < 8; sector++) {
+          multRingV0C[ring] += bc.fv0c().amplitude()[ring * 8 + sector];
+        }
+        multV0C += multRingV0C[ring];
+      }
+    }
+    uint32_t spdClusters = bc.spdClustersL0() + bc.spdClustersL1();
+
+    // Calculate pileup and background related selection flags
+    float multV0C012 = multRingV0C[0] + multRingV0C[1] + multRingV0C[2];
+    float ofV0M = multV0A + multV0C;
+    float onV0M = bc.v0TriggerChargeA() + bc.v0TriggerChargeC();
+    float ofSPD = bc.spdFiredChipsL0() + bc.spdFiredChipsL1();
+    float onSPD = bc.spdFiredFastOrL0() + bc.spdFiredFastOrL1();
+    selection[kNoV0MOnVsOfPileup] = onV0M > par.fV0MOnVsOfA + par.fV0MOnVsOfB * ofV0M;
+    selection[kNoSPDOnVsOfPileup] = onSPD > par.fSPDOnVsOfA + par.fSPDOnVsOfB * ofSPD;
+    selection[kNoV0Casymmetry] = multRingV0C[3] > par.fV0CasymA + par.fV0CasymB * multV0C012;
+
+    // copy remaining selection decisions from eventCuts
+    uint32_t eventCuts = bc.eventCuts();
+    selection[kIsGoodTimeRange] = (eventCuts & 1 << aod::kTimeRangeCut) > 0;
+    selection[kNoIncompleteDAQ] = (eventCuts & 1 << aod::kIncompleteDAQ) > 0;
+    selection[kNoTPCLaserWarmUp] = (eventCuts & 1 << aod::kIsTPCLaserWarmUp) == 0;
+    selection[kNoTPCHVdip] = (eventCuts & 1 << aod::kIsTPCHVdip) == 0;
+    selection[kNoPileupFromSPD] = (eventCuts & 1 << aod::kIsPileupFromSPD) == 0;
+    selection[kNoV0PFPileup] = (eventCuts & 1 << aod::kIsV0PFPileup) == 0;
 
     // Fill bc selection columns
-    bcsel(alias, bbT0A, bbT0C, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC);
+    bcsel(alias, selection,
+          bbV0A, bbV0C, bgV0A, bgV0C,
+          bbFDA, bbFDC, bgFDA, bgFDC,
+          multRingV0A, multRingV0C, spdClusters);
   }
 };
 
 struct EventSelectionTask {
   Produces<aod::EvSels> evsel;
+  Configurable<std::string> syst{"syst", "PbPb", "pp, pPb, Pbp, PbPb, XeXe"}; // TODO determine from AOD metadata or from CCDB
+  Configurable<int> muonSelection{"muonSelection", 0, "0 - barrel, 1 - muon selection with pileup cuts, 2 - muon selection without pileup cuts"};
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
+  Partition<aod::Tracks> tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
+  EvSelParameters par;
+
+  void init(InitContext&)
+  {
+    // TODO store selection criteria in CCDB
+    TString systStr = syst.value;
+    if (systStr == "PbPb" || systStr == "XeXe") {
+      par.applySelection[kIsBBV0A] = 1;
+      par.applySelection[kIsBBV0C] = 1;
+      par.applySelection[kIsBBZNA] = 1;
+      par.applySelection[kIsBBZNC] = 1;
+      if (!muonSelection) {
+        par.applySelection[kIsGoodTimeRange] = 0; // TODO: not good for run 244918 for some reason - to be checked
+        par.applySelection[kNoTPCHVdip] = 1;
+      }
+    } else if (systStr == "pp") {
+      par.applySelection[kIsGoodTimeRange] = 1;
+      par.applySelection[kNoIncompleteDAQ] = 1;
+      par.applySelection[kIsBBV0A] = 1;
+      par.applySelection[kIsBBV0C] = 1;
+      par.applySelection[kNoV0C012vsTklBG] = 1;
+      par.applySelection[kNoV0Casymmetry] = 1;
+      if (muonSelection != 2) {
+        par.applySelection[kNoSPDClsVsTklBG] = 1;
+        par.applySelection[kNoV0MOnVsOfPileup] = 1;
+        par.applySelection[kNoSPDOnVsOfPileup] = 1;
+        par.applySelection[kNoPileupFromSPD] = 1;
+      }
+      if (!muonSelection) {
+        par.applySelection[kIsGoodTimeRange] = 1;
+        par.applySelection[kNoTPCHVdip] = 1;
+      }
+    } else if (systStr == "pPb") {
+      par.applySelection[kNoIncompleteDAQ] = 1;
+      par.applySelection[kIsBBV0A] = 1;
+      par.applySelection[kIsBBV0C] = 1;
+      par.applySelection[kNoV0C012vsTklBG] = 1;
+      par.applySelection[kNoV0Casymmetry] = 1;
+      par.applySelection[kNoBGZNA] = 1;
+      if (muonSelection != 2) {
+        par.applySelection[kNoSPDClsVsTklBG] = 1;
+        par.applySelection[kNoV0MOnVsOfPileup] = 1;
+        par.applySelection[kNoSPDOnVsOfPileup] = 1;
+        par.applySelection[kNoPileupFromSPD] = 1;
+      }
+      if (!muonSelection) {
+        par.applySelection[kIsGoodTimeRange] = 1;
+        par.applySelection[kNoTPCHVdip] = 1;
+      }
+    } else if (systStr == "Pbp") {
+      par.applySelection[kNoIncompleteDAQ] = 1;
+      par.applySelection[kIsBBV0A] = 1;
+      par.applySelection[kIsBBV0C] = 1;
+      par.applySelection[kNoV0C012vsTklBG] = 1;
+      par.applySelection[kNoV0Casymmetry] = 1;
+      par.applySelection[kNoBGZNC] = 1;
+      if (muonSelection != 2) {
+        par.applySelection[kNoSPDClsVsTklBG] = 1;
+        par.applySelection[kNoV0MOnVsOfPileup] = 1;
+        par.applySelection[kNoSPDOnVsOfPileup] = 1;
+        par.applySelection[kNoPileupFromSPD] = 1;
+      }
+      if (!muonSelection) {
+        par.applySelection[kIsGoodTimeRange] = 1;
+        par.applySelection[kNoTPCHVdip] = 1;
+      }
+    }
+  }
 
   using BCsWithBcSels = soa::Join<aod::BCs, aod::BcSels>;
-
-  void process(aod::Collision const& col, BCsWithBcSels const& bcs)
+  void process(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
+    // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
     for (int i = 0; i < kNaliases; i++) {
       alias[i] = bc.alias()[i];
     }
-    bool bbZNA = bc.bbZNA();
-    bool bbZNC = bc.bbZNC();
+
+    // copy selection decisions from bcsel table
+    int32_t selection[kNsel] = {0};
+    for (int i = 0; i < kNsel; i++) {
+      selection[i] = bc.selection()[i];
+    }
+
+    // calculate multiplicity per ring and V0C012 multiplicity
+    float multRingV0A[5] = {0.};
+    float multRingV0C[4] = {0.};
+    for (int i = 0; i < 5; i++) {
+      multRingV0A[i] = bc.multRingV0A()[i];
+    }
+    for (int i = 0; i < 4; i++) {
+      multRingV0C[i] = bc.multRingV0C()[i];
+    }
+    float multV0C012 = bc.multRingV0C()[0] + bc.multRingV0C()[1] + bc.multRingV0C()[2];
+
+    // applying selections depending on the number of tracklets
+    int nTkl = tracklets.size();
+    uint32_t spdClusters = bc.spdClusters();
+    selection[kNoSPDClsVsTklBG] = spdClusters < par.fSPDClsVsTklA + nTkl * par.fSPDClsVsTklB;
+    selection[kNoV0C012vsTklBG] = !(nTkl < 6 && multV0C012 > par.fV0C012vsTklA + nTkl * par.fV0C012vsTklB);
+
+    // copy beam-beam and beam-gas flags from bcsel table
     bool bbV0A = bc.bbV0A();
     bool bbV0C = bc.bbV0C();
     bool bgV0A = bc.bgV0A();
@@ -159,19 +334,28 @@ struct EventSelectionTask {
     bool bbFDC = bc.bbFDC();
     bool bgFDA = bc.bgFDA();
     bool bgFDC = bc.bgFDC();
-    bool bbT0A = bc.bbT0A();
-    bool bbT0C = bc.bbT0C();
 
-    if (isMC) {
-      bbZNA = 1;
-      bbZNC = 1;
+    // apply int7-like selections
+    bool sel7 = 1;
+    for (int i = 0; i < kNsel; i++) {
+      sel7 &= par.applySelection[i] ? selection[i] : 1;
     }
-    // Fill event selection columns
+
+    // TODO apply other cuts for sel8
+    // TODO introduce sel1 etc?
+    // TODO introduce array of sel[0]... sel[8] or similar?
+    bool sel8 = selection[kIsBBT0A] & selection[kIsBBT0C];
+
     int64_t foundFT0 = -1; // this column is not used in run2 analysis
-    evsel(alias, bbT0A, bbT0C, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC, foundFT0);
+    evsel(alias, selection,
+          bbV0A, bbV0C, bgV0A, bgV0C,
+          bbFDA, bbFDC, bgFDA, bgFDC,
+          multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
+          foundFT0);
   }
 };
 
+// TODO adjust Run3 event selection task
 struct EventSelectionTaskRun3 {
   Produces<aod::EvSels> evsel;
 
@@ -223,8 +407,6 @@ struct EventSelectionTaskRun3 {
       timeC = ft0.timeC();
     }
 
-    bool bbZNA = 1;
-    bool bbZNC = 1;
     bool bbV0A = 0;
     bool bbV0C = 0;
     bool bgV0A = 0;
@@ -237,9 +419,21 @@ struct EventSelectionTaskRun3 {
     bool bbT0C = timeC > par.fT0CBBlower && timeC < par.fT0CBBupper;
 
     int32_t alias[kNaliases] = {0};
+    int32_t selection[kNsel] = {0};
+    uint32_t nTkl = 0;
+    float multRingV0A[5] = {0.};
+    float multRingV0C[4] = {0.};
+    uint32_t spdClusters = 0;
+    bool sel7 = 1;
+    bool sel8 = bbT0A & bbT0C;
+
     // Fill event selection columns
     // saving FT0 row index (foundFT0) for further analysis
-    evsel(alias, bbT0A, bbT0C, bbV0A, bbV0C, bgV0A, bgV0C, bbZNA, bbZNC, bbFDA, bbFDC, bgFDA, bgFDC, foundFT0);
+    evsel(alias, selection,
+          bbV0A, bbV0C, bgV0A, bgV0C,
+          bbFDA, bbFDC, bgFDA, bgFDC,
+          multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
+          foundFT0);
   }
 };
 

--- a/Analysis/Tasks/eventSelectionQa.cxx
+++ b/Analysis/Tasks/eventSelectionQa.cxx
@@ -12,7 +12,9 @@
 #include "Framework/AnalysisDataModel.h"
 #include "AnalysisDataModel/EventSelection.h"
 #include "AnalysisCore/TriggerAliases.h"
+#include "Framework/HistogramRegistry.h"
 #include "TH1F.h"
+#include "TH2F.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -24,7 +26,7 @@ struct EventSelectionQaPerBc {
   void init(InitContext&)
   {
     for (int i = 0; i < kNaliases; i++) {
-      hFiredAliases->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i].data());
+      hFiredAliases->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i]);
     }
   }
 
@@ -52,37 +54,54 @@ struct EventSelectionQaPerBc {
 };
 
 struct EventSelectionQaPerCollision {
-  OutputObj<TH1F> hTimeV0Aall{TH1F("hTimeV0Aall", "", 200, -50., 50.)};
-  OutputObj<TH1F> hTimeV0Call{TH1F("hTimeV0Call", "", 200, -50., 50.)};
-  OutputObj<TH1F> hTimeZNAall{TH1F("hTimeZNAall", "", 250, -25., 25.)};
-  OutputObj<TH1F> hTimeZNCall{TH1F("hTimeZNCall", "", 250, -25., 25.)};
-  OutputObj<TH1F> hTimeT0Aall{TH1F("hTimeT0Aall", "", 200, -10., 10.)};
-  OutputObj<TH1F> hTimeT0Call{TH1F("hTimeT0Call", "", 200, -10., 10.)};
-  OutputObj<TH1F> hTimeFDAall{TH1F("hTimeFDAall", "", 1000, -100., 100.)};
-  OutputObj<TH1F> hTimeFDCall{TH1F("hTimeFDCall", "", 1000, -100., 100.)};
-  OutputObj<TH1F> hTimeV0Aacc{TH1F("hTimeV0Aacc", "", 200, -50., 50.)};
-  OutputObj<TH1F> hTimeV0Cacc{TH1F("hTimeV0Cacc", "", 200, -50., 50.)};
-  OutputObj<TH1F> hTimeZNAacc{TH1F("hTimeZNAacc", "", 250, -25., 25.)};
-  OutputObj<TH1F> hTimeZNCacc{TH1F("hTimeZNCacc", "", 250, -25., 25.)};
-  OutputObj<TH1F> hTimeT0Aacc{TH1F("hTimeT0Aacc", "", 200, -10., 10.)};
-  OutputObj<TH1F> hTimeT0Cacc{TH1F("hTimeT0Cacc", "", 200, -10., 10.)};
-  OutputObj<TH1F> hTimeFDAacc{TH1F("hTimeFDAacc", "", 1000, -100., 100.)};
-  OutputObj<TH1F> hTimeFDCacc{TH1F("hTimeFDCacc", "", 1000, -100., 100.)};
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
 
+  void init(InitContext&)
+  {
+    // TODO read low/high flux info from configurable or OADB metadata
+    bool isLowFlux = 1;
+    for (int i = 0; i < kNaliases; i++) {
+      histos.add(Form("%s/hTimeV0Aall", aliasLabels[i]), "All events;V0A;Entries", kTH1F, {{200, -50., 50.}});
+      histos.add(Form("%s/hTimeV0Call", aliasLabels[i]), "All events;V0C;Entries", kTH1F, {{200, -50., 50.}});
+      histos.add(Form("%s/hTimeZNAall", aliasLabels[i]), "All events;ZNA;Entries", kTH1F, {{250, -25., 25.}});
+      histos.add(Form("%s/hTimeZNCall", aliasLabels[i]), "All events;ZNC;Entries", kTH1F, {{250, -25., 25.}});
+      histos.add(Form("%s/hTimeT0Aall", aliasLabels[i]), "All events;T0A;Entries", kTH1F, {{200, -10., 10.}});
+      histos.add(Form("%s/hTimeT0Call", aliasLabels[i]), "All events;T0C;Entries", kTH1F, {{200, -10., 10.}});
+      histos.add(Form("%s/hTimeFDAall", aliasLabels[i]), "All events;FDA;Entries", kTH1F, {{1000, -100., 100.}});
+      histos.add(Form("%s/hTimeFDCall", aliasLabels[i]), "All events;FDC;Entries", kTH1F, {{1000, -100., 100.}});
+      histos.add(Form("%s/hTimeV0Aacc", aliasLabels[i]), "Accepted events;V0A;Entries", kTH1F, {{200, -50., 50.}});
+      histos.add(Form("%s/hTimeV0Cacc", aliasLabels[i]), "Accepted events;V0C;Entries", kTH1F, {{200, -50., 50.}});
+      histos.add(Form("%s/hTimeZNAacc", aliasLabels[i]), "Accepted events;ZNA;Entries", kTH1F, {{250, -25., 25.}});
+      histos.add(Form("%s/hTimeZNCacc", aliasLabels[i]), "Accepted events;ZNC;Entries", kTH1F, {{250, -25., 25.}});
+      histos.add(Form("%s/hTimeT0Aacc", aliasLabels[i]), "Accepted events;T0A;Entries", kTH1F, {{200, -10., 10.}});
+      histos.add(Form("%s/hTimeT0Cacc", aliasLabels[i]), "Accepted events;T0C;Entries", kTH1F, {{200, -10., 10.}});
+      histos.add(Form("%s/hTimeFDAacc", aliasLabels[i]), "Accepted events;FDA;Entries", kTH1F, {{1000, -100., 100.}});
+      histos.add(Form("%s/hTimeFDCacc", aliasLabels[i]), "Accepted events;FDC;Entries", kTH1F, {{1000, -100., 100.}});
+      histos.add(Form("%s/hSPDClsVsTklAll", aliasLabels[i]), "All events;n tracklets;n clusters", kTH2F, {{200, 0., isLowFlux ? 200. : 6000.}, {100, 0., isLowFlux ? 100. : 20000.}});
+      histos.add(Form("%s/hV0C012vsTklAll", aliasLabels[i]), "All events;n tracklets;V0C012 multiplicity", kTH2F, {{150, 0., 150.}, {150, 0., 600.}});
+      histos.add(Form("%s/hV0MOnVsOfAll", aliasLabels[i]), "All events;Offline V0M;Online V0M", kTH2F, {{200, 0., isLowFlux ? 1000. : 50000.}, {400, 0., isLowFlux ? 8000. : 40000.}});
+      histos.add(Form("%s/hSPDOnVsOfAll", aliasLabels[i]), "All events;Offline FOR;Online FOR", kTH2F, {{300, 0., isLowFlux ? 300. : 1200.}, {300, 0., isLowFlux ? 300. : 1200.}});
+      histos.add(Form("%s/hV0C3vs012All", aliasLabels[i]), "All events;V0C012 multiplicity;V0C3 multiplicity", kTH2F, {{200, 0., 800.}, {300, 0., 300.}});
+      histos.add(Form("%s/hSPDClsVsTklAcc", aliasLabels[i]), "Accepted events;n tracklets;n clusters", kTH2F, {{200, 0., isLowFlux ? 200. : 6000.}, {100, 0., isLowFlux ? 100. : 20000.}});
+      histos.add(Form("%s/hV0C012vsTklAcc", aliasLabels[i]), "Accepted events;n tracklets;V0C012 multiplicity", kTH2F, {{150, 0., 150.}, {150, 0., 600.}});
+      histos.add(Form("%s/hV0MOnVsOfAcc", aliasLabels[i]), "Accepted events;Offline V0M;Online V0M", kTH2F, {{200, 0., isLowFlux ? 1000. : 50000.}, {400, 0., isLowFlux ? 8000. : 40000.}});
+      histos.add(Form("%s/hSPDOnVsOfAcc", aliasLabels[i]), "Accepted events;Offline FOR;Online FOR", kTH2F, {{300, 0., isLowFlux ? 300. : 1200.}, {300, 0., isLowFlux ? 300. : 1200.}});
+      histos.add(Form("%s/hV0C3vs012Acc", aliasLabels[i]), "Accepted events;V0C012 multiplicity;V0C3 multiplicity", kTH2F, {{200, 0., 800.}, {300, 0., 300.}});
+    }
+    histos.print();
+  }
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Configurable<int> selection{"sel", 7, "trigger: 7 - sel7, 8 - sel8"};
 
-  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Run2MatchedSparse>::iterator const& col,
+  using BCsWithRun2Infos = soa::Join<aod::BCs, aod::Run2BCInfos>;
+  void process(soa::Join<aod::EvSels, aod::Run2MatchedSparse>::iterator const& col,
+               BCsWithRun2Infos const& bcs,
                aod::Zdcs const& zdcs,
                aod::FV0As const& fv0as,
                aod::FV0Cs const& fv0cs,
                aod::FT0s ft0s,
                aod::FDDs fdds)
   {
-    if (!isMC && !col.alias()[kINT7]) {
-      return;
-    }
-
     float timeZNA = col.has_zdc() ? col.zdc().timeZNA() : -999.f;
     float timeZNC = col.has_zdc() ? col.zdc().timeZNC() : -999.f;
     float timeV0A = col.has_fv0a() ? col.fv0a().time() : -999.f;
@@ -92,14 +111,47 @@ struct EventSelectionQaPerCollision {
     float timeFDA = col.has_fdd() ? col.fdd().timeA() : -999.f;
     float timeFDC = col.has_fdd() ? col.fdd().timeC() : -999.f;
 
-    hTimeV0Aall->Fill(timeV0A);
-    hTimeV0Call->Fill(timeV0C);
-    hTimeZNAall->Fill(timeZNA);
-    hTimeZNCall->Fill(timeZNC);
-    hTimeT0Aall->Fill(timeT0A);
-    hTimeT0Call->Fill(timeT0C);
-    hTimeFDAall->Fill(timeFDA);
-    hTimeFDCall->Fill(timeFDC);
+    auto bc = col.bc_as<BCsWithRun2Infos>();
+    float ofSPD = bc.spdFiredChipsL0() + bc.spdFiredChipsL1();
+    float onSPD = bc.spdFiredFastOrL0() + bc.spdFiredFastOrL1();
+    float chargeV0M = bc.v0TriggerChargeA() + bc.v0TriggerChargeC();
+    float multV0A = col.multRingV0A()[0] + col.multRingV0A()[1] + col.multRingV0A()[2] + col.multRingV0A()[3] + col.multRingV0A()[4];
+    float multV0C = col.multRingV0C()[0] + col.multRingV0C()[1] + col.multRingV0C()[2] + col.multRingV0C()[3];
+    float multV0M = multV0A + multV0C;
+    float multRingV0C3 = col.multRingV0C()[3];
+    float multRingV0C012 = multV0C - multRingV0C3;
+
+    // Filling only kINT7 histos for the moment
+    // need dynamic histo names in the fill function
+    if (isMC || col.alias()[kINT7]) {
+      histos.fill(HIST("kINT7/hTimeV0Aall"), timeV0A);
+      histos.fill(HIST("kINT7/hTimeV0Call"), timeV0C);
+      histos.fill(HIST("kINT7/hTimeZNAall"), timeZNA);
+      histos.fill(HIST("kINT7/hTimeZNCall"), timeZNC);
+      histos.fill(HIST("kINT7/hTimeT0Aall"), timeT0A);
+      histos.fill(HIST("kINT7/hTimeT0Call"), timeT0C);
+      histos.fill(HIST("kINT7/hTimeFDAall"), timeFDA);
+      histos.fill(HIST("kINT7/hTimeFDCall"), timeFDC);
+      histos.fill(HIST("kINT7/hSPDClsVsTklAll"), col.spdClusters(), col.nTracklets());
+      histos.fill(HIST("kINT7/hSPDOnVsOfAll"), ofSPD, onSPD);
+      histos.fill(HIST("kINT7/hV0MOnVsOfAll"), multV0M, chargeV0M);
+      histos.fill(HIST("kINT7/hV0C3vs012All"), multRingV0C012, multRingV0C3);
+      histos.fill(HIST("kINT7/hV0C012vsTklAll"), col.nTracklets(), multRingV0C012);
+
+      LOGF(info, "selection[kIsBBV0A]=%i", col.selection()[aod::kIsBBV0A]);
+      LOGF(info, "selection[kIsBBV0C]=%i", col.selection()[aod::kIsBBV0C]);
+      LOGF(info, "selection[kIsBBZNA]=%i", col.selection()[aod::kIsBBZNA]);
+      LOGF(info, "selection[kIsBBZNC]=%i", col.selection()[aod::kIsBBZNC]);
+      LOGF(info, "selection[kNoTPCHVdip]=%i", col.selection()[aod::kNoTPCHVdip]);
+      LOGF(info, "selection[kIsGoodTimeRange]=%i", col.selection()[aod::kIsGoodTimeRange]);
+      LOGF(info, "selection[kNoIncompleteDAQ]=%i", col.selection()[aod::kNoIncompleteDAQ]);
+      LOGF(info, "selection[kNoV0C012vsTklBG]=%i", col.selection()[aod::kNoV0C012vsTklBG]);
+      LOGF(info, "selection[kNoV0Casymmetry]=%i", col.selection()[aod::kNoV0Casymmetry]);
+      LOGF(info, "selection[kNoSPDClsVsTklBG]=%i", col.selection()[aod::kNoSPDClsVsTklBG]);
+      LOGF(info, "selection[kNoV0MOnVsOfPileup]=%i", col.selection()[aod::kNoV0MOnVsOfPileup]);
+      LOGF(info, "selection[kNoSPDOnVsOfPileup]=%i", col.selection()[aod::kNoSPDOnVsOfPileup]);
+      LOGF(info, "selection[kNoPileupFromSPD]=%i", col.selection()[aod::kNoPileupFromSPD]);
+    }
 
     if (selection == 7 && !col.sel7()) {
       return;
@@ -113,14 +165,21 @@ struct EventSelectionQaPerCollision {
       LOGF(fatal, "Unknown selection type! Use `--sel 7` or `--sel 8`");
     }
 
-    hTimeV0Aacc->Fill(timeV0A);
-    hTimeV0Cacc->Fill(timeV0C);
-    hTimeZNAacc->Fill(timeZNA);
-    hTimeZNCacc->Fill(timeZNC);
-    hTimeT0Aacc->Fill(timeT0A);
-    hTimeT0Cacc->Fill(timeT0C);
-    hTimeFDAacc->Fill(timeFDA);
-    hTimeFDCacc->Fill(timeFDC);
+    if (isMC || col.alias()[kINT7]) {
+      histos.fill(HIST("kINT7/hTimeV0Aacc"), timeV0A);
+      histos.fill(HIST("kINT7/hTimeV0Cacc"), timeV0C);
+      histos.fill(HIST("kINT7/hTimeZNAacc"), timeZNA);
+      histos.fill(HIST("kINT7/hTimeZNCacc"), timeZNC);
+      histos.fill(HIST("kINT7/hTimeT0Aacc"), timeT0A);
+      histos.fill(HIST("kINT7/hTimeT0Cacc"), timeT0C);
+      histos.fill(HIST("kINT7/hTimeFDAacc"), timeFDA);
+      histos.fill(HIST("kINT7/hTimeFDCacc"), timeFDC);
+      histos.fill(HIST("kINT7/hSPDClsVsTklAcc"), col.spdClusters(), col.nTracklets());
+      histos.fill(HIST("kINT7/hSPDOnVsOfAcc"), ofSPD, onSPD);
+      histos.fill(HIST("kINT7/hV0MOnVsOfAcc"), multV0M, chargeV0M);
+      histos.fill(HIST("kINT7/hV0C3vs012Acc"), multRingV0C012, multRingV0C3);
+      histos.fill(HIST("kINT7/hV0C012vsTklAcc"), col.nTracklets(), multRingV0C012);
+    }
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -753,16 +753,25 @@ using Cascade = Cascades::iterator;
 // ---- Run 2 tables ----
 namespace run2
 {
-DECLARE_SOA_COLUMN(EventCuts, eventCuts, uint32_t);                 //!
-DECLARE_SOA_COLUMN(TriggerMaskNext50, triggerMaskNext50, uint64_t); //!
-DECLARE_SOA_COLUMN(SPDClustersL0, spdClustersL0, uint16_t);         //!
-DECLARE_SOA_COLUMN(SPDClustersL1, spdClustersL1, uint16_t);         //!
+DECLARE_SOA_COLUMN(EventCuts, eventCuts, uint32_t);                   //!
+DECLARE_SOA_COLUMN(TriggerMaskNext50, triggerMaskNext50, uint64_t);   //!
+DECLARE_SOA_COLUMN(L0TriggerInputMask, l0TriggerInputMask, uint32_t); //!
+DECLARE_SOA_COLUMN(SPDClustersL0, spdClustersL0, uint16_t);           //!
+DECLARE_SOA_COLUMN(SPDClustersL1, spdClustersL1, uint16_t);           //!
+DECLARE_SOA_COLUMN(SPDFiredChipsL0, spdFiredChipsL0, uint16_t);       //!
+DECLARE_SOA_COLUMN(SPDFiredChipsL1, spdFiredChipsL1, uint16_t);       //!
+DECLARE_SOA_COLUMN(SPDFiredFastOrL0, spdFiredFastOrL0, uint16_t);     //!
+DECLARE_SOA_COLUMN(SPDFiredFastOrL1, spdFiredFastOrL1, uint16_t);     //!
+DECLARE_SOA_COLUMN(V0TriggerChargeA, v0TriggerChargeA, uint16_t);     //!
+DECLARE_SOA_COLUMN(V0TriggerChargeC, v0TriggerChargeC, uint16_t);     //!
 } // namespace run2
 
-DECLARE_SOA_TABLE(Run2BCInfos, "AOD", "RUN2BCINFO", //!
-                  run2::EventCuts, run2::TriggerMaskNext50,
-                  run2::SPDClustersL0, run2::SPDClustersL1);
-
+DECLARE_SOA_TABLE(Run2BCInfos, "AOD", "RUN2BCINFO", run2::EventCuts, //!
+                  run2::TriggerMaskNext50, run2::L0TriggerInputMask,
+                  run2::SPDClustersL0, run2::SPDClustersL1,
+                  run2::SPDFiredChipsL0, run2::SPDFiredChipsL1,
+                  run2::SPDFiredFastOrL0, run2::SPDFiredFastOrL1,
+                  run2::V0TriggerChargeA, run2::V0TriggerChargeC);
 using Run2BCInfo = Run2BCInfos::iterator;
 
 // ---- MC tables ----


### PR DESCRIPTION
Draft: merge when new Run2-converted data with relevant event selection variables is available

Main changes:
* Added missing columns in Run2BcInfo table
* Added enum Run2EventCuts to access corresponding bits in eventCuts bitmask in Run2BCInfos table
* Added several columns (multiplicity per V0 ring, spd clusters, nTracklets) in evsel and bcsel tables used in event selection decisions
* Added enum EventSelectionFlags corresponding to all possible selection criteria used in event selection
* Applying selections from eventCuts bitmask
* Applying selections based on raw quantities (V0 online-vs-offline multiplicity, V0 rings, spd clusters, FO chips, nTracklets etc)
* Storing corresponding cuts in EvSelParameters (TODO: move to CCDB)
* evsel decisions for individual cuts are stored in relevant bits of the "selection" column
* Calculating sel7 decisions based on par.applySelection array depending on the colliding system (TODO: move applySelection to CCDB)
* Switched to histogram registry in the eventSelectioQa task. Added new qa histograms per alias.
