### PR TITLE
TRD: Better handling of labels at the digitizer

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/SignalArray.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/SignalArray.h
@@ -15,7 +15,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 
 #include <array>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace o2
@@ -26,7 +26,7 @@ namespace trd
 struct SignalArray {
   double firstTBtime;                               // first TB time
   std::array<float, constants::TIMEBINS> signals{}; // signals
-  std::unordered_map<int, int> trackIds;            // tracks Ids associated to the signal
+  std::unordered_set<int> trackIds;                 // tracks Ids associated to the signal
   std::vector<o2::MCCompLabel> labels;              // labels associated to the signal
   bool isDigit = false;                             // flag a signal converted to a digit
   bool isShared = false;                            // flag if converted digit is shared (copied)

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -54,6 +54,7 @@ class Digitizer
 
   void process(std::vector<Hit> const&);
   void flush(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
+  void dumpLabels(const SignalContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void pileup();
   void setEventTime(double timeNS) { mTime = timeNS; }
   void setTriggerTime(double t) { mCurrentTriggerTime = t; }
@@ -85,16 +86,8 @@ class Digitizer
 
   double mTime = 0.;               // time in nanoseconds of the hits currently being processed
   double mCurrentTriggerTime = 0.; // time in nanoseconds of the current trigger
-  //
-  int mEventID = 0;
-  int mSrcID = 0;
-
-  enum EventType {
-    kFirstEvent,
-    kPileupEvent,
-    kTriggerFired,
-    kEmbeddingEvent
-  };
+  int mEventID = 0;                // event id
+  int mSrcID = 0;                  // source id
 
   // Digitization parameters
   static constexpr float AmWidth = Geometry::amThick();    // Width of the amplification region
@@ -122,9 +115,9 @@ class Digitizer
   int triggerEventProcessing(DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   SignalContainer addSignalsFromPileup();
   void clearContainers();
-  bool convertHits(const int, const std::vector<Hit>&, SignalContainer&, int thread = 0);     // True if hit-to-signal conversion is successful
-  bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                // True if signal-to-ADC conversion is successful
-  void addLabel(const o2::trd::Hit& hit, std::vector<o2::trd::MCLabel>&, std::unordered_map<int, int>&);
+  bool convertHits(const int, const std::vector<Hit>&, SignalContainer&, int thread = 0);              // True if hit-to-signal conversion is successful
+  bool convertSignalsToADC(SignalContainer&, DigitContainer&, int thread = 0);                         // True if signal-to-ADC conversion is successful
+  void addLabel(const int&, std::vector<MCLabel>&, std::unordered_set<int>&);                          // add a MC label, check if trackId is already registered
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 
   // Helpers for signal handling

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -90,6 +90,7 @@ void Digitizer::setSimulationParameters()
 
 void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<MCLabel>& labels)
 {
+  size_t idx = labels.getIndexedSize();
   if (mPileupSignals.size() > 0) {
     // Add the signals, all chambers are keept in the same signal container
     SignalContainer smc = addSignalsFromPileup();
@@ -98,14 +99,7 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
       if (!status) {
         LOG(WARN) << "TRD conversion of signals to digits failed";
       }
-      for (const auto& iter : smc) {
-        if (iter.second.isDigit) {
-          labels.addElements(labels.getIndexedSize(), iter.second.labels);
-          if (iter.second.isShared) {
-            labels.addElements(labels.getIndexedSize(), iter.second.labels); // shared digit is a copy of the previous one, need to add the same labels again
-          }
-        }
-      }
+      dumpLabels(smc, labels);
     }
   } else {
     // since we don't have any pileup signals just flush the signals for each chamber
@@ -115,17 +109,22 @@ void Digitizer::flush(DigitContainer& digits, o2::dataformats::MCTruthContainer<
       if (!status) {
         LOG(WARN) << "TRD conversion of signals to digits failed";
       }
-      for (const auto& iter : smc) {
-        if (iter.second.isDigit) {
-          labels.addElements(labels.getIndexedSize(), iter.second.labels);
-          if (iter.second.isShared) {
-            labels.addElements(labels.getIndexedSize(), iter.second.labels); // shared digit is a copy of the previous one, need to add the same labels again
-          }
-        }
-      }
+      dumpLabels(smc, labels);
     }
   }
   clearContainers();
+}
+
+void Digitizer::dumpLabels(const SignalContainer& smc, o2::dataformats::MCTruthContainer<MCLabel>& labels)
+{
+  for (const auto& iter : smc) {
+    if (iter.second.isDigit) {
+      labels.addElements(labels.getIndexedSize(), iter.second.labels);
+      if (iter.second.isShared) {
+        labels.addElements(labels.getIndexedSize(), iter.second.labels); // shared digit is a copy of the previous one, need to add the same labels again
+      }
+    }
+  }
 }
 
 SignalContainer Digitizer::addSignalsFromPileup()
@@ -372,7 +371,7 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
         auto& trackIds = currentSignalData.trackIds;
         auto& labels = currentSignalData.labels;
         currentSignalData.firstTBtime = mTime;
-        addLabel(hit, labels, trackIds); // add a label record only if needed
+        addLabel(hit.GetTrackID(), labels, trackIds); // add a label record only if needed
 
         // add signal with crosstalk for the non-central pads only
         if (colPos != colE) {
@@ -395,11 +394,11 @@ bool Digitizer::convertHits(const int det, const std::vector<Hit>& hits, SignalC
   return true;
 }
 
-void Digitizer::addLabel(const o2::trd::Hit& hit, std::vector<o2::trd::MCLabel>& labels, std::unordered_map<int, int>& trackIds)
+void Digitizer::addLabel(const int& trackId, std::vector<o2::trd::MCLabel>& labels, std::unordered_set<int>& trackIds)
 {
-  if (trackIds[hit.GetTrackID()] == 0) {
-    trackIds[hit.GetTrackID()] = 1;
-    MCLabel label(hit.GetTrackID(), getEventID(), getSrcID());
+  if (trackIds.count(trackId) == 0) {
+    trackIds.insert(trackId);
+    MCLabel label(trackId, getEventID(), getSrcID());
     labels.push_back(label);
   }
 }


### PR DESCRIPTION
Just minor changes:

- Use a `unordered_set` instead of `unordered_map` to keep track of already recorded track ids.
- Add a short method for a repetitive action.