### PR TITLE
TRD: Move Digit class to DataFormatsTRD

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(DataFormatsTRD
                        src/Tracklet64.cxx
                        src/RawData.cxx
                        src/CTF.cxx
+                       src/Digit.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
 o2_target_root_dictionary(DataFormatsTRD
@@ -23,6 +24,16 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/RawData.h
                        include/DataFormatsTRD/Constants.h
                        include/DataFormatsTRD/CalibratedTracklet.h
+                       include/DataFormatsTRD/HelperMethods.h
                        include/DataFormatsTRD/Hit.h
+                       include/DataFormatsTRD/Digit.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/SignalArray.h)
+
+o2_add_test(Digit
+            COMPONENT_NAME trd
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD
+            SOURCES test/testDigit.cxx
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+            LABELS trd
+)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -18,7 +18,7 @@
 #include <numeric>
 #include "Rtypes.h" // for ClassDef
 
-#include "TRDBase/FeeParam.h"
+#include "DataFormatsTRD/HelperMethods.h"
 #include "DataFormatsTRD/Constants.h"
 #include <gsl/span>
 
@@ -54,9 +54,9 @@ class Digit
   Digit& operator=(const Digit&) = default;
   // Modifiers
   void setROB(int rob) { mROB = rob; }
-  void setROB(int row, int pad) { mROB = FeeParam::getROBfromPad(row, pad); }
+  void setROB(int row, int pad) { mROB = HelperMethods::getROBfromPad(row, pad); }
   void setMCM(int mcm) { mMCM = mcm; }
-  void setMCM(int row, int pad) { mMCM = FeeParam::getMCMfromPad(row, pad); }
+  void setMCM(int row, int pad) { mMCM = HelperMethods::getMCMfromPad(row, pad); }
   void setChannel(int channel) { mChannel = channel; }
   void setDetector(int det) { mDetector = det; }
   void setADC(ArrayADC const& adc) { mADC = adc; }
@@ -64,8 +64,8 @@ class Digit
   // Get methods
   int getDetector() const { return mDetector; }
   int getHCId() const { return mDetector * 2 + (mROB % 2); }
-  int getRow() const { return FeeParam::getPadRowFromMCM(mROB, mMCM); }
-  int getPad() const { return FeeParam::getPadColFromADC(mROB, mMCM, mChannel); }
+  int getRow() const { return HelperMethods::getPadRowFromMCM(mROB, mMCM); }
+  int getPad() const { return HelperMethods::getPadColFromADC(mROB, mMCM, mChannel); }
   int getROB() const { return mROB; }
   int getMCM() const { return mMCM; }
   int getChannel() const { return mChannel; }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_HELPERMETHODS_HH
+#define ALICEO2_TRD_HELPERMETHODS_HH
+
+#include "DataFormatsTRD/Constants.h"
+
+namespace o2
+{
+namespace trd
+{
+
+struct HelperMethods {
+  static int getROBfromPad(int irow, int icol)
+  {
+    return (irow / constants::NMCMROBINROW) * 2 + getColSide(icol);
+  }
+
+  static int getMCMfromPad(int irow, int icol)
+  {
+    if (irow < 0 || icol < 0 || irow > constants::NROWC1 || icol > constants::NCOLUMN) {
+      return -1;
+    }
+    return (icol % (constants::NCOLUMN / 2)) / constants::NCOLMCM + constants::NMCMROBINCOL * (irow % constants::NMCMROBINROW);
+  }
+
+  static int getColSide(int icol)
+  {
+    if (icol < 0 || icol >= constants::NCOLUMN) {
+      return -1;
+    }
+
+    return icol / (constants::NCOLUMN / 2);
+  }
+
+  static int getPadRowFromMCM(int irob, int imcm)
+  {
+    return constants::NMCMROBINROW * (irob / 2) + imcm / constants::NMCMROBINCOL;
+  }
+
+  static int getPadColFromADC(int irob, int imcm, int iadc)
+  {
+    if (iadc < 0 || iadc > constants::NADCMCM) {
+      return -100;
+    }
+    int mcmcol = imcm % constants::NMCMROBINCOL + getROBSide(irob) * constants::NMCMROBINCOL; // MCM column number on ROC [0..7]
+    int padcol = mcmcol * constants::NCOLMCM + constants::NCOLMCM + 1 - iadc;
+    if (padcol < 0 || padcol >= constants::NCOLUMN) {
+      return -1; // this is commented because of reason above OK
+    }
+    return padcol;
+  }
+
+  static int getROBSide(int irob)
+  {
+    if (irob < 0 || irob >= constants::NROBC1) {
+      return -1;
+    }
+    return irob % 2;
+  }
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -23,11 +23,13 @@
 #pragma link C++ class o2::trd::Tracklet64 + ;
 #pragma link C++ class o2::trd::CalibratedTracklet + ;
 #pragma link C++ class o2::trd::Hit + ;
+#pragma link C++ class o2::trd::Digit + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet64> + ;
 #pragma link C++ class std::vector < o2::trd::CalibratedTracklet> + ;
 #pragma link C++ class std::vector < o2::trd::TriggerRecord > +;
 #pragma link C++ class std::vector < o2::trd::LinkRecord > +;
 #pragma link C++ class std::vector < o2::trd::Hit > +;
+#pragma link C++ class std::vector < o2::trd::Digit> + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include <iostream>
 
 namespace o2::trd

--- a/DataFormats/Detectors/TRD/test/testDigit.cxx
+++ b/DataFormats/Detectors/TRD/test/testDigit.cxx
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <numeric>
 
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Constants.h"
 
 namespace o2

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -62,6 +62,7 @@ o2_target_root_dictionary(TRDBase
                                   include/TRDBase/Calibrations.h
                                   include/TRDBase/ChamberNoise.h
                                   include/TRDBase/CalOnlineGainTables.h
+				  include/TRDBase/Digit.h
                                   include/TRDBase/Tracklet.h
                                   include/TRDBase/TrackletTransformer.h)
 

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -13,7 +13,6 @@ o2_add_library(TRDBase
                        src/Geometry.cxx
                        src/GeometryFlat.cxx
                        src/CommonParam.cxx
-                       src/Digit.cxx
                        src/DiffAndTimeStructEstimator.cxx
                        src/SimParam.cxx
                        src/PadResponse.cxx
@@ -47,7 +46,6 @@ o2_target_root_dictionary(TRDBase
                                   include/TRDBase/GeometryFlat.h
                                   include/TRDBase/SimParam.h
                                   include/TRDBase/CommonParam.h
-                                  include/TRDBase/Digit.h
                                   include/TRDBase/PadResponse.h
                                   include/TRDBase/MCLabel.h
                                   include/TRDBase/CalDet.h
@@ -85,13 +83,6 @@ o2_add_test(RawData
             COMPONENT_NAME trd
             PUBLIC_LINK_LIBRARIES O2::TRDBase O2::DataFormatsTRD
             SOURCES test/testRawData.cxx
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
-            LABELS trd
-            )
-o2_add_test(Digit
-            COMPONENT_NAME trd
-            PUBLIC_LINK_LIBRARIES O2::TRDBase O2::DataFormatsTRD
-            SOURCES test/testDigit.cxx
             ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
             LABELS trd
             )

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -1,0 +1,16 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_DIGIT_BACKCOMPAT_H_
+#define ALICEO2_TRD_DIGIT_BACKCOMPAT_H_
+
+#include "DataFormatsTRD/Digit.h"
+
+#endif

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -35,6 +35,7 @@
 #include <fairlogger/Logger.h>
 #include <array>
 
+#include "DataFormatsTRD/HelperMethods.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "TRDBase/Geometry.h"
 #include "TRDBase/PadPlane.h"
@@ -99,7 +100,7 @@ int FeeParam::getPadRowFromMCM(int irob, int imcm)
   // Return on which pad row this mcm sits
   //
 
-  return NMCMROBINROW * (irob / 2) + imcm / NMCMROBINCOL;
+  return HelperMethods::getPadRowFromMCM(irob, imcm);
 }
 
 //_____________________________________________________________________________
@@ -118,15 +119,7 @@ int FeeParam::getPadColFromADC(int irob, int imcm, int iadc)
   // http://wiki.kip.uni-heidelberg.de/ti/TRD/index.php/Image:ROB_MCM_numbering.pdf
   //
 
-  if (iadc < 0 || iadc > NADCMCM) {
-    return -100;
-  }
-  int mcmcol = imcm % NMCMROBINCOL + getROBSide(irob) * NMCMROBINCOL; // MCM column number on ROC [0..7]
-  int padcol = mcmcol * NCOLMCM + NCOLMCM + 1 - iadc;
-  if (padcol < 0 || padcol >= NCOLUMN) {
-    return -1; // this is commented because of reason above OK
-  }
-  return padcol;
+  return HelperMethods::getPadColFromADC(irob, imcm, iadc);
 }
 
 //_____________________________________________________________________________
@@ -155,10 +148,7 @@ int FeeParam::getMCMfromPad(int irow, int icol)
   // Return -1 for error.
   //
 
-  if (irow < 0 || icol < 0 || irow > NROWC1 || icol > NCOLUMN) {
-    return -1;
-  }
-  return (icol % (NCOLUMN / 2)) / NCOLMCM + NMCMROBINCOL * (irow % NMCMROBINROW);
+  return HelperMethods::getMCMfromPad(irow, icol);
 }
 
 //_____________________________________________________________________________
@@ -198,7 +188,7 @@ int FeeParam::getROBfromPad(int irow, int icol)
   //
   // Return on which rob this pad is
   //
-  return (irow / NMCMROBINROW) * 2 + getColSide(icol);
+  return HelperMethods::getROBfromPad(irow, icol);
 }
 
 //_____________________________________________________________________________
@@ -221,12 +211,7 @@ int FeeParam::getROBSide(int irob)
   //
   // Return on which side this rob sits (A side = 0, B side = 1)
   //
-
-  if (irob < 0 || irob >= NROBC1) {
-    return -1;
-  }
-
-  return irob % 2;
+  return HelperMethods::getROBSide(irob);
 }
 
 //_____________________________________________________________________________
@@ -236,11 +221,7 @@ int FeeParam::getColSide(int icol)
   // Return on which side this column sits (A side = 0, B side = 1)
   //
 
-  if (icol < 0 || icol >= NCOLUMN) {
-    return -1;
-  }
-
-  return icol / (NCOLUMN / 2);
+  return HelperMethods::getColSide(icol);
 }
 
 unsigned int FeeParam::aliToExtAli(int rob, int aliid)

--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -18,8 +18,6 @@
 #pragma link C++ class o2::trd::Geometry + ;
 #pragma link C++ class o2::trd::GeometryBase + ;
 #pragma link C++ class o2::trd::CommonParam + ;
-#pragma link C++ class o2::trd::Digit + ;
-#pragma link C++ class std::vector < o2::trd::Digit > +;
 #pragma link C++ class o2::trd::SimParam + ;
 #pragma link C++ class o2::trd::FeeParam + ;
 #pragma link C++ class o2::trd::CalDet + ;

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -21,9 +21,9 @@
 #include <TLegend.h>
 
 #include "FairLogger.h"
-#include "TRDBase/Digit.h"
 #include "TRDBase/SimParam.h"
 #include "TRDBase/CommonParam.h"
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Constants.h"
 #endif
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -18,7 +18,7 @@
 #include "DataFormatsTRD/CTF.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsTRD/Tracklet64.h"
-#include "TRDBase/Digit.h" // TODO Consider moving to DataFormats
+#include "DataFormatsTRD/Digit.h"
 #include <gsl/span>
 #include <bitset>
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -14,12 +14,12 @@
 #include "TRDSimulation/Detector.h"
 
 #include "TRDBase/Calibrations.h"
-#include "TRDBase/Digit.h"
 #include "TRDBase/MCLabel.h"
 #include "TRDBase/CommonParam.h"
 #include "TRDBase/DiffAndTimeStructEstimator.h"
 #include "TRDSimulation/PileupTool.h"
 
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/SignalArray.h"
 #include "DataFormatsTRD/Constants.h"
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -23,7 +23,7 @@
 #include "DataFormatsTRD/LinkRecord.h"
 #include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Tracklet64.h"
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 //#include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsRaw/RawFileWriter.h"
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -24,9 +24,10 @@
 #include <gsl/span>
 
 #include "TRDBase/FeeParam.h"
-#include "TRDBase/Digit.h"
 #include "TRDSimulation/Digitizer.h"
 #include "TRDSimulation/TrapConfig.h"
+
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/RawData.h"
 #include "DataFormatsTRD/Constants.h"

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -28,7 +28,7 @@
 #include "fairlogger/Logger.h"
 
 //to pull in the digitzer incomnig data.
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include "TRDSimulation/Digitizer.h"
 #include <SimulationDataFormat/MCCompLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletWriterSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletWriterSpec.h
@@ -11,7 +11,7 @@
 #ifndef O2_TRDTRAPSIMULATORTRACKLETWRITER_H
 #define O2_TRDTRAPSIMULATORTRACKLETWRITER_H
 
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TRDBase/MCLabel.h"
 #include "TRDBase/Tracklet.h"

--- a/Detectors/TRD/workflow/src/TRDDigitReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitReaderSpec.cxx
@@ -28,7 +28,7 @@
 #include <SimulationDataFormat/IOMCTruthContainerView.h>
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include "TRDBase/Digit.h" // for the Digit type
+#include "DataFormatsTRD/Digit.h" // for the Digit type
 #include "TRDSimulation/TrapSimulator.h"
 #include "TRDSimulation/Digitizer.h"
 #include "TRDSimulation/Detector.h" // for the Hit type

--- a/Detectors/TRD/workflow/src/TRDDigitWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitWriterSpec.cxx
@@ -14,7 +14,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include <SimulationDataFormat/ConstMCTruthContainer.h>
 #include <SimulationDataFormat/IOMCTruthContainerView.h>

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -26,7 +26,7 @@
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/Hit.h"
-#include "TRDBase/Digit.h" // for the Digit type
+#include "DataFormatsTRD/Digit.h" // for the Digit type
 #include "TRDBase/Calibrations.h"
 #include "TRDSimulation/Digitizer.h"
 #include "TRDSimulation/Detector.h" // for the Hit type

--- a/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
@@ -15,7 +15,7 @@
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
 #include "TRDWorkflow/TRDTrackletWriterSpec.h"
-#include "TRDBase/Digit.h"
+#include "DataFormatsTRD/Digit.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TRDBase/MCLabel.h"
 #include "DataFormatsTRD/TriggerRecord.h"

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -27,9 +27,9 @@
 #include "fairlogger/Logger.h"
 #include "CCDB/BasicCCDBManager.h"
 
-#include "TRDBase/Digit.h"
 #include "TRDBase/Calibrations.h"
 #include "TRDSimulation/TRDSimParams.h"
+#include "DataFormatsTRD/Digit.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 
 using namespace o2::framework;


### PR DESCRIPTION
For moving the Digit clas to DataFormatsTRD, HelperMethods is added in DataFormatsTRD. Otherwise, a cyclic dependency appears between TRDBase and DataFormatTRD.