### PR TITLE
PWGHF: implement event selection in track-index skim creator

### DIFF
--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -30,7 +30,7 @@ namespace o2::aod
 namespace hf_selcollision
 {
 DECLARE_SOA_COLUMN(WhyRejectColl, whyRejectColl, int); //!
-} // namespace hf_selcollisions
+} // namespace hf_selcollision
 
 DECLARE_SOA_TABLE(HFSelCollision, "AOD", "HFSELCOLLISION", //!
                   hf_selcollision::WhyRejectColl);

--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -57,12 +57,12 @@ using BigTracksPID = soa::Join<BigTracks,
 
 namespace hf_track_index
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, Tracks, "_0"); //!
-DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, Tracks, "_1"); //!
-DECLARE_SOA_INDEX_COLUMN_FULL(Index2, index2, int, Tracks, "_2"); //!
-DECLARE_SOA_INDEX_COLUMN_FULL(Index3, index3, int, Tracks, "_3"); //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, Tracks, "_0");          //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, Tracks, "_1");          //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Index2, index2, int, Tracks, "_2");          //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Index3, index3, int, Tracks, "_3");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(IndexV0, indexV0, int, aod::V0Datas, "_V0"); //!
-DECLARE_SOA_COLUMN(HFflag, hfflag, uint8_t);                      //!
+DECLARE_SOA_COLUMN(HFflag, hfflag, uint8_t);                               //!
 
 DECLARE_SOA_COLUMN(D0ToKPiFlag, d0ToKPiFlag, uint8_t);   //!
 DECLARE_SOA_COLUMN(JpsiToEEFlag, jpsiToEEFlag, uint8_t); //!
@@ -453,9 +453,9 @@ DECLARE_SOA_TABLE(HfCandCascBase, "AOD", "HFCANDCASCBASE", //!
                   v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                   v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>);
 /*,
-		  v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-		  v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-		  v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>);
+  v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+  v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+  v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>);
 */
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(HfCandCascExt, HfCandCascBase, "HFCANDCASCEXT", //!

--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -27,6 +27,14 @@ using namespace o2::analysis;
 
 namespace o2::aod
 {
+namespace hf_selcollision
+{
+DECLARE_SOA_COLUMN(WhyRejectColl, whyRejectColl, int); //!
+} // namespace hf_selcollisions
+
+DECLARE_SOA_TABLE(HFSelCollision, "AOD", "HFSELCOLLISION", //!
+                  hf_selcollision::WhyRejectColl);
+
 namespace hf_seltrack
 {
 DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int); //!

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -64,47 +64,47 @@ struct HfProduceSelCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
-  Configurable<bool> b_dovalplots{"b_dovalplots", true, "fill histograms"};
-  Configurable<std::string> s_trigger_class{"trigger_class", "kINT7", "trigger class"};
-  int trigger_class = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, s_trigger_class.value.data()));
+  Configurable<bool> bDoValPlots{"b_dovalplots", true, "fill histograms"};
+  Configurable<std::string> sTriggerClass{"trigger_class", "kINT7", "trigger class"};
+  int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, sTriggerClass.value.data()));
 
   HistogramRegistry registry{
     "registry",
-    {{"h_events", "Events;;entries", {HistType::kTH1F, {{3, 0.5, 3.5}}}}}};
+    {{"hEvents", "Events;;entries", {HistType::kTH1F, {{3, 0.5, 3.5}}}}}};
 
   void init(InitContext const&)
   {
     std::string labels[3] = {"processed collisions", "selected collisions", "rej. trigger class"};
     for (int iBin = 0; iBin < 3; iBin++) {
-      registry.get<TH1>(HIST("h_events"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
+      registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
     }
   }
 
   // event selection
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision)
   {
-    int status_collision = 0;
+    int statusCollision = 0;
 
-    if (b_dovalplots) {
-      registry.get<TH1>(HIST("h_events"))->Fill(1);
+    if (bDoValPlots) {
+      registry.get<TH1>(HIST("hEvents"))->Fill(1);
     }
 
-    if (!collision.alias()[trigger_class]) {
-      status_collision |= BIT(0);
-      if (b_dovalplots) {
-        registry.get<TH1>(HIST("h_events"))->Fill(3);
+    if (!collision.alias()[triggerClass]) {
+      statusCollision |= BIT(0);
+      if (bDoValPlots) {
+        registry.get<TH1>(HIST("hEvents"))->Fill(3);
       }
     }
 
     //TODO: add more event selection criteria
 
     // selected events
-    if (b_dovalplots && status_collision == 0) {
-      registry.get<TH1>(HIST("h_events"))->Fill(2);
+    if (bDoValPlots && statusCollision == 0) {
+      registry.get<TH1>(HIST("hEvents"))->Fill(2);
     }
 
     // fill table row
-    rowSelectedCollision(status_collision);
+    rowSelectedCollision(statusCollision);
   };
 };
 

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -75,8 +75,8 @@ struct HfProduceSelCollisions {
   void init(InitContext const&)
   {
     std::string labels[3] = {"processed collisions", "selected collisions", "rej. trigger class"};
-    for(int iBin=0; iBin<3; iBin++) {
-      registry.get<TH1>(HIST("h_events"))->GetXaxis()->SetBinLabel(iBin+1, labels[iBin].data());
+    for (int iBin = 0; iBin < 3; iBin++) {
+      registry.get<TH1>(HIST("h_events"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
     }
   }
 
@@ -91,7 +91,9 @@ struct HfProduceSelCollisions {
 
     if (!collision.alias()[trigger_class]) {
       status_collision |= BIT(0);
-      registry.get<TH1>(HIST("h_events"))->Fill(3);
+      if (b_dovalplots) {
+        registry.get<TH1>(HIST("h_events"))->Fill(3);
+      }
     }
 
     //TODO: add more event selection criteria

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -297,8 +297,6 @@ struct HFTrackIndexSkimsCreator {
   //Configurable<int> nCollsMax{"nCollsMax", -1, "Max collisions per file"}; //can be added to run over limited collisions per file - for tesing purposes
   Configurable<bool> dovalplots{"dovalplots", true, "fill histograms"};
   Configurable<int> do3prong{"do3prong", 0, "do 3 prong"};
-  // event selection
-  Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
   // vertexing parameters
   Configurable<double> bz{"bz", 5., "magnetic field kG"};
   Configurable<bool> propdca{"propdca", true, "create tracks version propagated to PCA"};
@@ -368,15 +366,6 @@ struct HFTrackIndexSkimsCreator {
     */
 
     //auto centrality = collision.centV0M(); //FIXME add centrality when option for variations to the process function appears
-
-    int trigindex = int{triggerindex};
-    if (trigindex != -1) {
-      uint64_t triggerMask = collision.bc().triggerMask();
-      bool isTriggerClassFired = triggerMask & 1ul << (trigindex - 1);
-      if (!isTriggerClassFired) {
-        return;
-      }
-    }
 
     //FIXME move above process function
     const int n2ProngDecays = hf_cand_prong2::DecayType::N2ProngDecays; // number of 2-prong hadron types

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -356,7 +356,6 @@ struct HfTrackIndexSkimsCreator {
      {"hmassDsToPiKK", "D_{s} candidates;inv. mass (K K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}}},
      {"hmassXicToPKPi", "#Xi_{c} candidates;inv. mass (p K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}}}}};
 
-
   Filter filterSelectTracks = (aod::hf_seltrack::isSelProng > 0 && aod::hf_seltrack::isSelProng < 4);
   Filter filterSelectCollisions = (aod::hf_selcollision::whyRejectColl == 0);
 

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -1046,7 +1046,7 @@ struct HfTrackIndexSkimsCreator {
 /// to run: o2-analysis-weak-decay-indices --aod-file AO2D.root -b | o2-analysis-lambdakzerobuilder -b |
 ///         o2-analysis-trackextension -b | o2-analysis-hf-track-index-skims-creator -b
 
-struct HFTrackIndexSkimsCreatorCascades {
+struct HfTrackIndexSkimsCreatorCascades {
   Produces<aod::HfTrackIndexCasc> rowTrackIndexCasc;
   //  Produces<aod::HfTrackIndexProng2> rowTrackIndexCasc;
 
@@ -1115,9 +1115,12 @@ struct HFTrackIndexSkimsCreatorCascades {
   double massLc = RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus);
   double mass2K0sP{0.}; // WHY HERE?
 
-  using FullTracksExt = soa::Join<aod::FullTracks, aod::TracksExtended>;
+  Filter filterSelectCollisions = (aod::hf_selcollision::whyRejectColl == 0);
 
-  void process(aod::Collision const& collision,
+  using FullTracksExt = soa::Join<aod::FullTracks, aod::TracksExtended>;
+  using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HFSelCollision>>;
+
+  void process(SelectedCollisions::iterator const& collision,
                aod::BCs const& bcs,
                //soa::Filtered<aod::V0Datas> const& V0s,
                aod::V0Datas const& V0s,
@@ -1308,13 +1311,13 @@ struct HFTrackIndexSkimsCreatorCascades {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<HfProduceSelTrack>(cfgc),
-    adaptAnalysisTask<HfTagSelTrack>(cfgc);
-    adaptAnalysisTask<HfTrackIndexSkimsCreator>(cfgc, TaskName{"hf-track-index-skims-creator"})};
+    adaptAnalysisTask<HfTagSelCollisions>(cfgc),
+    adaptAnalysisTask<HfTagSelTrack>(cfgc),
+    adaptAnalysisTask<HfTrackIndexSkimsCreator>(cfgc)};
 
   const bool doLcK0Sp = cfgc.options().get<bool>("do-LcK0Sp");
   if (doLcK0Sp) {
-    workflow.push_back(adaptAnalysisTask<HFTrackIndexSkimsCreatorCascades>(cfgc));
+    workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimsCreatorCascades>(cfgc));
   }
 
   return workflow;

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -109,7 +109,7 @@ struct HfProduceSelCollisions {
 };
 
 /// Track selection
-struct SelectTracks {
+struct HfProduceSelTrack {
 
   // enum for candidate type
   enum CandidateType {
@@ -314,7 +314,7 @@ struct SelectTracks {
 //____________________________________________________________________________________________________________________________________________
 
 /// Pre-selection of 2-prong and 3-prong secondary vertices
-struct HFTrackIndexSkimsCreator {
+struct HfTrackIndexSkimsCreator {
   Produces<aod::HfTrackIndexProng2> rowTrackIndexProng2;
   Produces<aod::HfCutStatusProng2> rowProng2CutStatus;
   Produces<aod::HfTrackIndexProng3> rowTrackIndexProng3;
@@ -1307,14 +1307,14 @@ struct HFTrackIndexSkimsCreatorCascades {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<HfProduceSelCollisions>(cfgc),
-    adaptAnalysisTask<SelectTracks>(cfgc, TaskName{"hf-produce-sel-track"}),
+  WorkflowSpec workflow{
+    adaptAnalysisTask<HfProduceSelTrack>(cfgc),
+    adaptAnalysisTask<HfTrackIndexSkimsCreator>(cfgc);
     adaptAnalysisTask<HFTrackIndexSkimsCreator>(cfgc, TaskName{"hf-track-index-skims-creator"})};
 
   const bool doLcK0Sp = cfgc.options().get<bool>("do-LcK0Sp");
   if (doLcK0Sp) {
-    workflow.push_back(adaptAnalysisTask<HFTrackIndexSkimsCreatorCascades>(cfgc, TaskName{"hf-track-index-skims-cascades-creator"}));
+    workflow.push_back(adaptAnalysisTask<HFTrackIndexSkimsCreatorCascades>(cfgc));
   }
 
   return workflow;

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -59,7 +59,7 @@ using MyTracks = soa::Join<aod::FullTracks, aod::HFSelTrack, aod::TracksExtended
 #define MY_DEBUG_MSG(condition, cmd)
 #endif
 
-/// Event selection 
+/// Event selection
 struct SelectCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
@@ -91,8 +91,8 @@ struct SelectCollisions {
     //TODO: add more event selection criteria
 
     // selected events
-    if(b_dovalplots) {
-        registry.get<TH1>(HIST("h_events"))->Fill(1);
+    if (b_dovalplots) {
+      registry.get<TH1>(HIST("h_events"))->Fill(1);
     }
 
     // fill table row
@@ -350,7 +350,7 @@ struct HFTrackIndexSkimsCreator {
 
 
   Filter filterSelectTracks = (aod::hf_seltrack::isSelProng > 0 && aod::hf_seltrack::isSelProng < 4);
-  Filter filterSelectTracks = (aod::hf_seltrack::isSelProng > 0);
+  Filter filterSelectCollisions = (aod::hf_selcollision::whyRejectColl == 0);
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HFSelCollision>>;
   using SelectedTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::HFSelTrack>>;

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -64,44 +64,19 @@ struct HfTagSelCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
-  Configurable<bool> doValPlots{"doValPlots", true, "fill histograms"};
   Configurable<std::string> triggerClassName{"triggerClassName", "kINT7", "trigger class"};
   int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
-
-  HistogramRegistry registry{
-    "registry",
-    {{"hEvents", "Events;;entries", {HistType::kTH1F, {{3, 0.5, 3.5}}}}}};
-
-  void init(InitContext const&)
-  {
-    std::string labels[3] = {"processed collisions", "selected collisions", "rej. trigger class"};
-    for (int iBin = 0; iBin < 3; iBin++) {
-      registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
-    }
-  }
 
   // event selection
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision)
   {
     int statusCollision = 0;
 
-    if (doValPlots) {
-      registry.get<TH1>(HIST("hEvents"))->Fill(1);
-    }
-
     if (!collision.alias()[triggerClass]) {
       statusCollision |= BIT(0);
-      if (doValPlots) {
-        registry.get<TH1>(HIST("hEvents"))->Fill(3);
-      }
     }
 
     //TODO: add more event selection criteria
-
-    // selected events
-    if (doValPlots && statusCollision == 0) {
-      registry.get<TH1>(HIST("hEvents"))->Fill(2);
-    }
 
     // fill table row
     rowSelectedCollision(statusCollision);

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -18,6 +18,7 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "DetectorsVertexing/DCAFitterN.h"
+#include "AnalysisDataModel/EventSelection.h"
 #include "AnalysisDataModel/HFSecondaryVertex.h"
 #include "AnalysisCore/trackUtilities.h"
 #include "AnalysisCore/HFConfigurables.h"

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -64,9 +64,9 @@ struct HfProduceSelCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
-  Configurable<bool> bDoValPlots{"b_dovalplots", true, "fill histograms"};
-  Configurable<std::string> sTriggerClass{"trigger_class", "kINT7", "trigger class"};
-  int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, sTriggerClass.value.data()));
+  Configurable<bool> doValPlots{"doValPlots", true, "fill histograms"};
+  Configurable<std::string> triggerClassName{"triggerClassName", "kINT7", "trigger class"};
+  int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
 
   HistogramRegistry registry{
     "registry",
@@ -85,13 +85,13 @@ struct HfProduceSelCollisions {
   {
     int statusCollision = 0;
 
-    if (bDoValPlots) {
+    if (doValPlots) {
       registry.get<TH1>(HIST("hEvents"))->Fill(1);
     }
 
     if (!collision.alias()[triggerClass]) {
       statusCollision |= BIT(0);
-      if (bDoValPlots) {
+      if (doValPlots) {
         registry.get<TH1>(HIST("hEvents"))->Fill(3);
       }
     }
@@ -99,7 +99,7 @@ struct HfProduceSelCollisions {
     //TODO: add more event selection criteria
 
     // selected events
-    if (bDoValPlots && statusCollision == 0) {
+    if (doValPlots && statusCollision == 0) {
       registry.get<TH1>(HIST("hEvents"))->Fill(2);
     }
 

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -64,8 +64,19 @@ struct SelectCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
+  Configurable<bool> b_dovalplots{"b_dovalplots", true, "fill histograms"};
   Configurable<std::string> s_trigger_class{"trigger_class", "kINT7", "trigger class"};
   int trigger_class = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, s_trigger_class.value.data()));
+
+  HistogramRegistry registry{
+    "registry",
+    {{"h_events", "Events;;entries", {HistType::kTH1F, {{2, 0.5, 2.5}}}}}};
+
+  void init(InitContext const&)
+  {
+    registry.get<TH1>(HIST("h_events"))->GetXaxis()->SetBinLabel(1, "selected events");
+    registry.get<TH1>(HIST("h_events"))->GetXaxis()->SetBinLabel(2, "rej. trigger class");
+  }
 
   // event selection
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision)
@@ -74,9 +85,15 @@ struct SelectCollisions {
 
     if (!collision.alias()[trigger_class]) {
       status_collision |= BIT(0);
+      registry.get<TH1>(HIST("h_events"))->Fill(2);
     }
 
     //TODO: add more event selection criteria
+
+    // selected events
+    if(b_dovalplots) {
+        registry.get<TH1>(HIST("h_events"))->Fill(1);
+    }
 
     // fill table row
     rowSelectedCollision(status_collision);

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -60,7 +60,7 @@ using MyTracks = soa::Join<aod::FullTracks, aod::HFSelTrack, aod::TracksExtended
 #endif
 
 /// Event selection
-struct HfProduceSelCollisions {
+struct HfTagSelCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
@@ -109,7 +109,7 @@ struct HfProduceSelCollisions {
 };
 
 /// Track selection
-struct HfProduceSelTrack {
+struct HfTagSelTrack {
 
   // enum for candidate type
   enum CandidateType {

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -64,19 +64,44 @@ struct HfTagSelCollisions {
 
   Produces<aod::HFSelCollision> rowSelectedCollision;
 
+  Configurable<bool> doValPlots{"doValPlots", true, "fill histograms"};
   Configurable<std::string> triggerClassName{"triggerClassName", "kINT7", "trigger class"};
   int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
+
+  HistogramRegistry registry{
+    "registry",
+    {{"hEvents", "Events;;entries", {HistType::kTH1F, {{3, 0.5, 3.5}}}}}};
+
+  void init(InitContext const&)
+  {
+    std::string labels[3] = {"processed collisions", "selected collisions", "rej. trigger class"};
+    for (int iBin = 0; iBin < 3; iBin++) {
+      registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
+    }
+  }
 
   // event selection
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision)
   {
     int statusCollision = 0;
 
+    if (doValPlots) {
+      registry.get<TH1>(HIST("hEvents"))->Fill(1);
+    }
+
     if (!collision.alias()[triggerClass]) {
       statusCollision |= BIT(0);
+      if (doValPlots) {
+        registry.get<TH1>(HIST("hEvents"))->Fill(3);
+      }
     }
 
     //TODO: add more event selection criteria
+
+    // selected events
+    if (doValPlots && statusCollision == 0) {
+      registry.get<TH1>(HIST("hEvents"))->Fill(2);
+    }
 
     // fill table row
     rowSelectedCollision(statusCollision);

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -1284,8 +1284,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
     adaptAnalysisTask<HfProduceSelTrack>(cfgc),
-    adaptAnalysisTask<HfTrackIndexSkimsCreator>(cfgc);
-    adaptAnalysisTask<HFTrackIndexSkimsCreator>(cfgc, TaskName{"hf-track-index-skims-creator"})};
+    adaptAnalysisTask<HfTagSelTrack>(cfgc);
+    adaptAnalysisTask<HfTrackIndexSkimsCreator>(cfgc, TaskName{"hf-track-index-skims-creator"})};
 
   const bool doLcK0Sp = cfgc.options().get<bool>("do-LcK0Sp");
   if (doLcK0Sp) {


### PR DESCRIPTION
Add workflow that tags events and store information in a table with a single bitmap used to filter the collisions in the workflow for building the candidates