### PR TITLE
Fixes for AMD HIP

### DIFF
--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -40,11 +40,11 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
 
   install(FILES ${HDRS} DESTINATION include/GPU)
 
-  o2_add_test(GPUsortHIP NAME test_GPUsortHIP
-                  SOURCES test/testGPUsortHIP.hip.cxx
-                  PUBLIC_LINK_LIBRARIES O2::GPUCommon hip::host hip::device hip::hipcub roc::rocthrust
-                  COMPONENT_NAME GPU
-                  LABELS gpu)
+#  o2_add_test(GPUsortHIP NAME test_GPUsortHIP
+#                  SOURCES test/testGPUsortHIP.hip.cxx
+#                  PUBLIC_LINK_LIBRARIES O2::GPUCommon hip::host hip::device hip::hipcub roc::rocthrust
+#                  COMPONENT_NAME GPU
+#                  LABELS gpu)
 endif()
 
 if(ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")

--- a/GPU/GPUTracking/Global/GPUChainTrackingSliceTracker.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingSliceTracker.cxx
@@ -147,9 +147,6 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
   bool error = false;
   GPUCA_OPENMP(parallel for if(!doGPU && GetProcessingSettings().ompKernels != 1) num_threads(mRec->SetAndGetNestedLoopOmpFactor(!doGPU, NSLICES)))
   for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
-    if (mRec->GetDeviceType() == GPUReconstruction::DeviceType::HIP) {
-      SynchronizeGPU(); // BUG: Workaround for probable bug in AMD runtime, crashes randomly if not synchronized here
-    }
     GPUTPCTracker& trk = processors()->tpcTrackers[iSlice];
     GPUTPCTracker& trkShadow = doGPU ? processorsShadow()->tpcTrackers[iSlice] : trk;
     int useStream = (iSlice % mRec->NStreams());


### PR DESCRIPTION
Reverts a workaround that is no longer needed with the ROCm 4.1 we use now.
Disables a CTest, since that is incompatible to the gcc 10.2 bump we want to do. This must be done in a slightly different way.
The hip-clang compiler must not create binaries, so we must embed the ctest in a library and run it from there. The problem is that otherwise the hip-clang will only provide the CXXABI of the gcc it was compiled with, which might be lower than our GCC, and then it fails to link the executable to libraries build with our GCC (as happened with libInfologger in alisw/alidist#2668). For this single test one could find another workaround, but I do not think that this makes sense, since the problem might pop up again.