### PR TITLE
Fix misaligned malloc / operator delete

### DIFF
--- a/Common/Utils/include/CommonUtils/StringUtils.h
+++ b/Common/Utils/include/CommonUtils/StringUtils.h
@@ -108,8 +108,10 @@ static inline bool pathIsDirectory(const std::string_view p)
 
 static inline std::string getFullPath(const std::string_view p)
 {
-  std::unique_ptr<char[]> real_path(realpath(p.data(), nullptr));
-  return std::string(real_path.get());
+  char* real_path = realpath(p.data(), nullptr);
+  std::string retVal(real_path);
+  free(real_path);
+  return std::move(retVal);
 }
 
 static inline std::string rectifyDirectory(const std::string& _dir)


### PR DESCRIPTION
@shahor02 : FYI: Debugging the HMPID raw writer crash I came accros this memory issue, which is in your code.
You must not pass the return value of `realpath` to a `unique_ptr`, since `realpath` allocates via `malloc`, but `unique_ptr` deallocates using `operator delete()`, which does not match. The memory must be released using `free`.