### PR TITLE
HMPID: Fix several memory errors in the raw writer

### DIFF
--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/HmpidCoder2.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/HmpidCoder2.h
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <vector>
+#include <memory>
 
 #include "Headers/RAWDataHeader.h"
 #include "CommonDataFormat/InteractionRecord.h"
@@ -71,11 +72,11 @@ class HmpidCoder2
   uint32_t* mPadMap;
   int mEventSizePerEquipment[Geo::MAXEQUIPMENTS];
   int mEventPadsPerEquipment[Geo::MAXEQUIPMENTS];
-  int mPailoadBufferDimPerEquipment;
+  int mPayloadBufferDimPerEquipment;
   long mPadsCoded;
   bool mSkipEmptyEvents;
-  std::unique_ptr<uint32_t> mUPayloadBufferPtr;
-  std::unique_ptr<uint32_t> mUPadMap;
+  std::unique_ptr<uint32_t[]> mUPayloadBufferPtr;
+  std::unique_ptr<uint32_t[]> mUPadMap;
 
   LinkSubSpec_t mTheRFWLinks[Geo::MAXEQUIPMENTS];
 

--- a/Detectors/HMPID/simulation/src/HmpidCoder2.cxx
+++ b/Detectors/HMPID/simulation/src/HmpidCoder2.cxx
@@ -40,11 +40,12 @@ HmpidCoder2::HmpidCoder2(int numOfEquipments)
   mNumberOfEquipments = numOfEquipments;
   mVerbose = 0;
   mSkipEmptyEvents = true;
-  mPailoadBufferDimPerEquipment = ((Geo::N_SEGMENTS * (Geo::N_COLXSEGMENT * (Geo::N_DILOGICS * (Geo::N_CHANNELS + 1) + 1) + 1)) + 10);
-  auto UPayloadBufferPtr = std::make_unique<uint32_t[]>(sizeof(uint32_t) * mNumberOfEquipments * mPailoadBufferDimPerEquipment);
-  auto UPadMap = std::make_unique<uint32_t[]>(sizeof(uint32_t) * Geo::N_HMPIDTOTALPADS);
-  mPayloadBufferPtr = UPayloadBufferPtr.get();
-  mPadMap = UPadMap.get();
+  mPayloadBufferDimPerEquipment = ((Geo::N_SEGMENTS * (Geo::N_COLXSEGMENT * (Geo::N_DILOGICS * (Geo::N_CHANNELS + 1) + 1) + 1)) + 10);
+  mUPayloadBufferPtr = std::make_unique<uint32_t[]>(mNumberOfEquipments * mPayloadBufferDimPerEquipment);
+  mUPadMap = std::make_unique<uint32_t[]>(Geo::N_HMPIDTOTALPADS);
+  mPayloadBufferPtr = mUPayloadBufferPtr.get();
+  mPadMap = mUPadMap.get();
+  std::memset(mPadMap, 0, sizeof(uint32_t) * Geo::N_HMPIDTOTALPADS); // Zero the map for the first event
   mBusyTime = 20000; // 1 milli sec
   mHmpidErrorFlag = 0;
   mHmpidFrwVersion = 9;


### PR DESCRIPTION
This solves the segfault I had when running the HMPID raw encoding on the EPN:
- Fix output buffer size, was actually too large, when using `new`/`make_unique<...[]>` one does not need to multiply the size with the type size.
- Misaligned new/delete, since the unique_ptr was defined without `[]`
- Unique ptrs were local variables and thus memory was free immediately.
- Buffer was only reset after processing an event but not before the first event.