### PR TITLE
Improvements for 8 GPU full system test on EPN

### DIFF
--- a/prodtests/full-system-test/datadistribution.sh
+++ b/prodtests/full-system-test/datadistribution.sh
@@ -15,7 +15,7 @@ export DATADIST_FILE_READ_COUNT=$NTIMEFRAMES
 export TF_DIR=./raw/timeframe
 export TFRATE=$(awk "BEGIN {printf \"%.6f\",1/$TFDELAY}")
 
-ARGS_ALL="--session default --severity $SEVERITY --shm-segment-size $SHMSIZE --no-cleanup"
+ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id 2 --shm-segment-size 1000000 --no-cleanup"
 
 StfBuilder --id stfb --transport shmem \
   --dpl-channel-name dpl-chan --channel-config "name=dpl-chan,type=push,method=bind,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=1" \

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -19,6 +19,9 @@ fi
 if [ $NORATELOG == 1 ]; then
   ARGS_ALL+=" --fairmq-rate-logging 0"
 fi
+if [ $NUMAGPUIDS != 0 ]; then
+  ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
+fi
 
 # Set some individual workflow arguments depending on configuration
 CTF_DETECTORS=ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV,ZDC,FDD

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -36,7 +36,7 @@ fi
 rm -f /dev/shm/*fmq*
 
 tmux \
-    new-session "NUMAID=0 numactl --membind 0 --cpunodebind 0 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
-    split-window "sleep 30; NUMAID=1 numactl --membind 1 --cpunodebind 1 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
+    new-session "NUMAID=0 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
+    split-window "sleep 30; NUMAID=1 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
     split-window "sleep 60; SEVERITY=debug numactl --interleave=all $MYDIR/$CMD; echo END; sleep 1000" \; \
     select-layout even-vertical


### PR DESCRIPTION
- Use --child-driver to pass the `numactl` command.
- Use a small dummy shm-segment for StfBuilder, such that it cannot incorrectly pin the main segments.