### PR TITLE
Digitization: Prevent race conditions when updating GRP

### DIFF
--- a/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
@@ -23,6 +23,12 @@
 #include <string>
 #include "DetectorsRaw/HBFUtils.h"
 
+// this is for some process synchronization, since
+// we need to prevent writing concurrently to the same global GRP file
+#include <boost/interprocess/sync/named_semaphore.hpp>
+#include <boost/filesystem.hpp>
+#include <unordered_map> // for the hashing utility
+
 using namespace o2::framework;
 
 namespace o2
@@ -50,26 +56,39 @@ class GRPDPLUpdatedTask
   {
     const std::string grpName = "GRP";
 
-    TFile flGRP(mGRPFileName.c_str(), "update");
-    if (flGRP.IsZombie()) {
-      LOG(ERROR) << "Failed to open in update mode " << mGRPFileName;
-      return;
-    }
-    std::unique_ptr<GRP> grp(static_cast<GRP*>(flGRP.GetObjectChecked(grpName.c_str(), GRP::Class())));
-    for (auto det : sDetList) { // get readout mode data from different detectors
-      auto roMode = pc.inputs().get<o2::parameters::GRPObject::ROMode>(det.getName());
-      if (!(roMode & o2::parameters::GRPObject::PRESENT)) {
-        LOG(ERROR) << "Detector " << det.getName() << " is read out while processor set ABSENT";
-        continue;
+    // a standardized semaphore convention --> taking the current execution path should be enough
+    const auto semname = boost::filesystem::current_path().string() + mGRPFileName;
+    std::hash<std::string> hasher;
+    const auto semhashedstring = "alice_grp_" + std::to_string(hasher(semname));
+    try {
+      boost::interprocess::named_semaphore sem(boost::interprocess::open_or_create_t{}, semhashedstring.c_str(), 1);
+      sem.wait(); // wait until we can enter (no one else there)
+
+      TFile flGRP(mGRPFileName.c_str(), "update");
+      if (flGRP.IsZombie()) {
+        LOG(ERROR) << "Failed to open in update mode " << mGRPFileName;
+        return;
       }
-      grp->setDetROMode(det, roMode);
+      std::unique_ptr<GRP> grp(static_cast<GRP*>(flGRP.GetObjectChecked(grpName.c_str(), GRP::Class())));
+      for (auto det : sDetList) { // get readout mode data from different detectors
+        auto roMode = pc.inputs().get<o2::parameters::GRPObject::ROMode>(det.getName());
+        if (!(roMode & o2::parameters::GRPObject::PRESENT)) {
+          LOG(ERROR) << "Detector " << det.getName() << " is read out while processor set ABSENT";
+          continue;
+        }
+        grp->setDetROMode(det, roMode);
+      }
+      grp->setFirstOrbit(o2::raw::HBFUtils::Instance().orbitFirst);
+      grp->setNHBFPerTF(o2::raw::HBFUtils::Instance().nHBFPerTF);
+      LOG(INFO) << "Updated GRP in " << mGRPFileName << " for detectors RO mode and 1st orbit of the run";
+      grp->print();
+      flGRP.WriteObjectAny(grp.get(), grp->Class(), grpName.c_str());
+      flGRP.Close();
+
+      sem.post(); // here we are done; put to green for others waiting
+    } catch (boost::interprocess::interprocess_exception e) {
+      LOG(ERROR) << "Caught semaphore exception " << e.what();
     }
-    grp->setFirstOrbit(o2::raw::HBFUtils::Instance().orbitFirst);
-    grp->setNHBFPerTF(o2::raw::HBFUtils::Instance().nHBFPerTF);
-    LOG(INFO) << "Updated GRP in " << mGRPFileName << " for detectors RO mode and 1st orbit of the run";
-    grp->print();
-    flGRP.WriteObjectAny(grp.get(), grp->Class(), grpName.c_str());
-    flGRP.Close();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
 


### PR DESCRIPTION
Multiple digitization workflows might execute in parallel
and so we need to protect writing to the common GRP file