### PR TITLE
Ensure MFT digits are decoded in chipID increasing order

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -54,7 +54,7 @@ class RawPixelDecoder final : public PixelReader
   void init() final {}
   bool getNextChipData(ChipPixelData& chipData) final;
   ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) final;
-
+  void ensureChipOrdering() {}
   void startNewTF(o2::framework::InputRecord& inputs);
 
   int decodeNextTrigger() final;
@@ -114,6 +114,7 @@ class RawPixelDecoder final : public PixelReader
   std::unordered_map<uint32_t, LinkEntry> mSubsSpec2LinkID; // link subspec to link entry in the pool mapping
   std::vector<RUDecodeData> mRUDecodeVec;                   // set of active RUs
   std::array<short, Mapping::getNRUs()> mRUEntry;           // entry of the RU with given SW ID in the mRUDecodeVec
+  std::vector<ChipPixelData*> mOrderedChipsPtr;             // special ordering helper used for the MFT (its chipID is not contiguous in RU)
   std::string mSelfName;                        // self name
   header::DataOrigin mUserDataOrigin = o2::header::gDataOriginInvalid; // alternative user-provided data origin to pick
   header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -114,8 +114,9 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
     }
 
   } while (mNLinksDone < mGBTLinks.size());
+
+  ensureChipOrdering();
   mTimerDecode.Stop();
-  // LOG(INFO) << "Chips Fired: " << mNChipsFiredROF << " NPixels: " << mNPixelsFiredROF << " at IR " << mInteractionRecord << " of HBF " << mInteractionRecordHB;
   return nLinksWithData;
 }
 
@@ -268,9 +269,7 @@ ChipPixelData* RawPixelDecoder<Mapping>::getNextChipData(std::vector<ChipPixelDa
     auto& ru = mRUDecodeVec[mCurRUDecodeID];
     if (ru.lastChipChecked < ru.nChipsFired) {
       auto& chipData = ru.chipsData[ru.lastChipChecked++];
-      if constexpr (std::is_same<Mapping, ChipMappingITS>::value) {
-        assert(mLastReadChipID < chipData.getChipID());
-      }
+      assert(mLastReadChipID < chipData.getChipID());
       mLastReadChipID = chipData.getChipID();
       chipDataVec[mLastReadChipID].swap(chipData);
       return &chipDataVec[mLastReadChipID];
@@ -292,13 +291,66 @@ bool RawPixelDecoder<Mapping>::getNextChipData(ChipPixelData& chipData)
     auto& ru = mRUDecodeVec[mCurRUDecodeID];
     if (ru.lastChipChecked < ru.nChipsFired) {
       auto& ruchip = ru.chipsData[ru.lastChipChecked++];
-      if constexpr (std::is_same<Mapping, ChipMappingITS>::value) {
-        assert(mLastReadChipID < chipData.getChipID());
-      }
+      assert(mLastReadChipID < chipData.getChipID());
       mLastReadChipID = chipData.getChipID();
       chipData.swap(ruchip);
       return true;
     }
+  }
+  // will need to decode new trigger
+  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+    return false;
+  }
+  return getNextChipData(chipData); // is it ok to use recursion here?
+}
+
+///______________________________________________________________________
+template <>
+void RawPixelDecoder<ChipMappingMFT>::ensureChipOrdering()
+{
+  // define looping order, if mCurRUDecodeID < mRUDecodeVec.size(), this means that decodeNextTrigger() was called before
+  if (mCurRUDecodeID < mRUDecodeVec.size()) { // define sort order
+    for (; mCurRUDecodeID < mRUDecodeVec.size(); mCurRUDecodeID++) {
+      auto& ru = mRUDecodeVec[mCurRUDecodeID];
+      while (ru.lastChipChecked < ru.nChipsFired) {
+        mOrderedChipsPtr.push_back(&ru.chipsData[ru.lastChipChecked++]);
+      }
+    }
+    // sort in decreasing order
+    std::sort(mOrderedChipsPtr.begin(), mOrderedChipsPtr.end(), [](const ChipPixelData* a, const ChipPixelData* b) { return a->getChipID() > b->getChipID(); });
+  }
+}
+
+///______________________________________________________________________
+template <>
+ChipPixelData* RawPixelDecoder<ChipMappingMFT>::getNextChipData(std::vector<ChipPixelData>& chipDataVec)
+{
+  if (!mOrderedChipsPtr.empty()) {
+    auto chipData = *mOrderedChipsPtr.back();
+    assert(mLastReadChipID < chipData.getChipID());
+    mLastReadChipID = chipData.getChipID();
+    chipDataVec[mLastReadChipID].swap(chipData);
+    mOrderedChipsPtr.pop_back();
+    return &chipDataVec[mLastReadChipID];
+  }
+  // will need to decode new trigger
+  if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode
+    return nullptr;
+  }
+  return getNextChipData(chipDataVec);
+}
+
+///______________________________________________________________________
+template <>
+bool RawPixelDecoder<ChipMappingMFT>::getNextChipData(ChipPixelData& chipData)
+{
+  if (!mOrderedChipsPtr.empty()) {
+    auto ruChip = *mOrderedChipsPtr.back();
+    assert(mLastReadChipID < ruChip.getChipID());
+    mLastReadChipID = ruChip.getChipID();
+    ruChip.swap(chipData);
+    mOrderedChipsPtr.pop_back();
+    return true;
   }
   // will need to decode new trigger
   if (!mDecodeNextAuto || !decodeNextTrigger()) { // no more data to decode


### PR DESCRIPTION
@bovulpes @rpezzi here is it. I see 1% overhead due to the sorting (tested on 100 TFs with 70 pbpb events).