### PR TITLE
RecoContainer: considers simpler contributors if derived track was rejected

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -77,7 +77,7 @@ struct RecoContainer {
   std::invoke_result<decltype(&o2::tpc::getWorkflowTPCInput), o2::framework::ProcessingContext&, int, bool, bool, unsigned long, bool>::type inputsTPCclusters; // special struct for TPC clusters access
 
   void collectData(o2::framework::ProcessingContext& pc, const DataRequest& request);
-  void createTracks(std::function<void(const o2::track::TrackParCov&, float, float, GTrackID)> const& creator) const;
+  void createTracks(std::function<bool(const o2::track::TrackParCov&, float, float, GTrackID)> const& creator) const;
   void fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vector<o2::MCCompLabel>& mcinfo) const;
 
   void addITSTracks(o2::framework::ProcessingContext& pc, bool mc);

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -482,10 +482,10 @@ void MatchCosmics::createSeeds(const o2::globaltracking::RecoContainer& data)
 
   mSeeds.clear();
 
-  std::function<void(const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID)> creator =
+  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID)> creator =
     [this](const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID) {
       if (std::abs(_tr.getQ2Pt()) > this->mQ2PtCutoff) {
-        return;
+        return true;
       }
       if (_origID.getSource() == GTrackID::TPC) { // convert TPC bins to \mus
         t0 *= this->mTPCTBinMUS;
@@ -498,6 +498,7 @@ void MatchCosmics::createSeeds(const o2::globaltracking::RecoContainer& data)
       }
       terr += this->mMatchParams->timeToleranceMUS;
       mSeeds.emplace_back(TrackSeed{_tr, {t0 - terr, t0 + terr}, _origID, MinusOne});
+      return true;
     };
 
   data.createTracks(creator);

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -151,10 +151,10 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
 
   mTBrackets.clear();
 
-  std::function<void(const o2::track::TrackParCov& _tr, float t0, float terr, GIndex _origID)> creator =
+  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GIndex _origID)> creator =
     [this, &vcont](const o2::track::TrackParCov& _tr, float t0, float terr, GIndex _origID) {
       if (vcont.find(_origID) != vcont.end()) { // track is contributor to vertex, already accounted
-        return;
+        return true;
       }
       if (_origID.getSource() == GIndex::TPC) { // convert TPC bins to \mus
         t0 *= this->mTPCBin2MUS;
@@ -166,6 +166,7 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
         //terr *= this->mMatchParams->nSigmaTError;
       }
       mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});
+      return true;
     };
 
   data.createTracks(creator);


### PR DESCRIPTION
If user provided function creator function returns true, then the track is considered
as consumed and its contributing simpler tracks will not be provided to the creator.
If it returns false, the creator will be called also  with this simpler contributors.