### PR TITLE
[MFT] Adds configuration methods to the MFT track fitter

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
@@ -44,7 +44,10 @@ class TrackFitter
   TrackFitter(TrackFitter&&) = delete;
   TrackFitter& operator=(TrackFitter&&) = delete;
 
-  void setBz(float bZ);
+  void setBz(float bZ) { mBZField = bZ; }
+  void setMFTRadLength(float x2X0) { mMFTRadLength = x2X0; }
+  void setVerbosity(float v) { mVerbose = v; }
+  void setTrackModel(float m) { mTrackModel = m; }
 
   bool initTrack(TrackLTF& track, bool outward = false);
   bool fit(TrackLTF& track, bool outward = false);
@@ -55,13 +58,16 @@ class TrackFitter
  private:
   bool computeCluster(TrackLTF& track, int cluster);
 
-  Float_t mBZField;                         // kiloGauss.
+  bool mFieldON = true;
+  Float_t mBZField; // kiloGauss.
+  Float_t mMFTRadLength = 0.1;
+  Int_t mTrackModel = MFTTrackModel::Helix;
+
   static constexpr double SMaxChi2 = 2.e10; ///< maximum chi2 above which the track can be considered as abnormal
   /// default layer thickness in X0 for reconstruction  //FIXME: set values for the MFT
   static constexpr double SLayerThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                      0.035, 0.035, 0.035, 0.035, 0.035};
-
-  bool mFieldON = true;
+  bool mVerbose = false;
 };
 
 // Functions to estimate momentum and charge from track curvature

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -37,29 +37,15 @@ namespace mft
 {
 
 //_________________________________________________________________________________________________
-void TrackFitter::setBz(float bZ)
-{
-  auto& mftTrackingParam = MFTTrackingParam::Instance();
-
-  /// Set the magnetic field for the MFT
-  mBZField = bZ;
-
-  if (mftTrackingParam.verbose) {
-    LOG(INFO) << "Setting Fitter field = " << bZ;
-  }
-}
-
-//_________________________________________________________________________________________________
 bool TrackFitter::fit(TrackLTF& track, bool outward)
 {
 
   /// Fit a track using its attached clusters
   /// Returns false in case of failure
 
-  auto& mftTrackingParam = MFTTrackingParam::Instance();
   auto nClusters = track.getNumberOfPoints();
 
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << "Seed covariances: \n"
               << track.getCovariances() << std::endl
               << std::endl;
@@ -82,7 +68,7 @@ bool TrackFitter::fit(TrackLTF& track, bool outward)
       ncl++;
     }
   }
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     //  Print final covariances? std::cout << "Track covariances:"; track->getCovariances().Print();
     std::cout << "Track Chi2 = " << track.getTrackChi2() << std::endl;
     std::cout << " ***************************** Done fitting *****************************\n";
@@ -95,8 +81,6 @@ bool TrackFitter::fit(TrackLTF& track, bool outward)
 bool TrackFitter::initTrack(TrackLTF& track, bool outward)
 {
 
-  auto& mftTrackingParam = MFTTrackingParam::Instance();
-
   // initialize the starting track parameters and cluster
   double sigmainvQPtsq;
   double chi2invqptquad;
@@ -105,7 +89,7 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
   auto k = TMath::Abs(o2::constants::math::B2C * mBZField);
   auto Hz = std::copysign(1, mBZField);
 
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
     std::cout << "N Clusters = " << nPoints << std::endl;
   }
@@ -149,9 +133,10 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
   track.setPhi(phi0);
   track.setTanl(tanl0);
 
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
-    auto model = (mftTrackingParam.trackmodel == Helix) ? "Helix" : (mftTrackingParam.trackmodel == Quadratic) ? "Quadratic" : "Linear";
+    auto model = (mTrackModel == Helix) ? "Helix" : (mTrackModel == Quadratic) ? "Quadratic"
+                                                                               : "Linear";
     std::cout << "Track Model: " << model << std::endl;
     std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
     std::cout << " Variances: sigma2_x0 = " << TMath::Sqrt(sigmax0sq) << " sigma2_y0 = " << TMath::Sqrt(sigmay0sq) << " sigma2_q/pt = " << TMath::Sqrt(sigmainvQPtsq) << std::endl;
@@ -229,7 +214,6 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
   /// Recompute the parameters adding the cluster constraint with the Kalman filter
   /// Returns false in case of failure
 
-  auto& mftTrackingParam = MFTTrackingParam::Instance();
   const auto& clx = track.getXCoordinates()[cluster];
   const auto& cly = track.getYCoordinates()[cluster];
   const auto& clz = track.getZCoordinates()[cluster];
@@ -241,7 +225,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
     LOG(INFO) << "track.getZ() = " << track.getZ() << " ; newClusterZ = " << clz << " ==> Skipping point.";
     return true;
   }
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << "computeCluster:     X = " << clx << " Y = " << cly << " Z = " << clz << " nCluster = " << cluster << std::endl;
   }
 
@@ -269,8 +253,8 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
     NDisksMS = (startingLayerID % 2 == 0) ? (newLayerID - startingLayerID + 1) / 2 : (newLayerID - startingLayerID) / 2;
   }
 
-  auto MFTDiskThicknessInX0 = mftTrackingParam.MFTRadLength / 5.0;
-  if (mftTrackingParam.verbose) {
+  auto MFTDiskThicknessInX0 = mMFTRadLength / 5.0;
+  if (mVerbose) {
     std::cout << "startingLayerID = " << startingLayerID << " ; "
               << "newLayerID = " << newLayerID << " ; ";
     std::cout << "cl.getZ() = " << clz << " ; ";
@@ -282,12 +266,12 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
     track.addMCSEffect(-1, NDisksMS * MFTDiskThicknessInX0);
   }
 
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << "  BeforeExtrap: X = " << track.getX() << " Y = " << track.getY() << " Z = " << track.getZ() << " Tgl = " << track.getTanl() << "  Phi = " << track.getPhi() << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
   }
 
   // Propagate track to the z position of the new cluster
-  switch (mftTrackingParam.trackmodel) {
+  switch (mTrackModel) {
     case Linear:
       track.propagateToZlinear(clz);
       break;
@@ -303,7 +287,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
       break;
   }
 
-  if (mftTrackingParam.verbose) {
+  if (mVerbose) {
     std::cout << "   AfterExtrap: X = " << track.getX() << " Y = " << track.getY() << " Z = " << track.getZ() << " Tgl = " << track.getTanl() << "  Phi = " << track.getPhi() << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
   }
 
@@ -312,7 +296,7 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster)
   const std::array<float, 2>& cov = {sigmaX2, sigmaY2};
 
   if (track.update(pos, cov)) {
-    if (mftTrackingParam.verbose) {
+    if (mVerbose) {
       std::cout << "   New Cluster: X = " << clx << " Y = " << cly << " Z = " << clz << std::endl;
       std::cout << "   AfterKalman: X = " << track.getX() << " Y = " << track.getY() << " Z = " << track.getZ() << " Tgl = " << track.getTanl() << "  Phi = " << track.getPhi() << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
       std::cout << std::endl;

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -135,8 +135,7 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
 
   if (mVerbose) {
     std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
-    auto model = (mTrackModel == Helix) ? "Helix" : (mTrackModel == Quadratic) ? "Quadratic"
-                                                                               : "Linear";
+    auto model = (mTrackModel == Helix) ? "Helix" : (mTrackModel == Quadratic) ? "Quadratic" : "Linear";
     std::cout << "Track Model: " << model << std::endl;
     std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " qpt = " << 1.0 / track.getInvQPt() << std::endl;
     std::cout << " Variances: sigma2_x0 = " << TMath::Sqrt(sigmax0sq) << " sigma2_y0 = " << TMath::Sqrt(sigmay0sq) << " sigma2_q/pt = " << TMath::Sqrt(sigmainvQPtsq) << std::endl;

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -44,6 +44,10 @@ void Tracker::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
 
+  mTrackFitter->setMFTRadLength(trkParam.MFTRadLength);
+  mTrackFitter->setVerbosity(trkParam.verbose);
+  mTrackFitter->setTrackModel(trkParam.trackmodel);
+
   mMinTrackPointsLTF = trkParam.MinTrackPointsLTF;
   mMinTrackPointsCA = trkParam.MinTrackPointsCA;
   mMinTrackStationsLTF = trkParam.MinTrackStationsLTF;


### PR DESCRIPTION
Changes in this PR allows one to instantiate and configure the fitter in standalone macros, for debugging and development purposes. I.e. the fitter configuration drops its dependence on the O2 command line options. Now the fitter is configured by the mft tracker class, who process all configurations from the command line. 
