### PR TITLE
Add missing header to ROOTMAP

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -29,6 +29,7 @@ o2_target_root_dictionary(
           include/SimulationDataFormat/MCTrack.h
           include/SimulationDataFormat/BaseHits.h
           include/SimulationDataFormat/MCTruthContainer.h
+          include/SimulationDataFormat/ConstMCTruthContainer.h
           include/SimulationDataFormat/MCCompLabel.h
           include/SimulationDataFormat/MCEventLabel.h
           include/SimulationDataFormat/TrackReference.h


### PR DESCRIPTION
This was pulled in by dependencies automatically, but will be no longer after #6056.
Trivial, merging