### PR TITLE
GPU Workflow: Add helper class to fill GPUIOPtr from RecoContainer

### DIFF
--- a/Common/MathUtils/include/MathUtils/Cartesian.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian.h
@@ -17,7 +17,7 @@
 
 #include "GPUCommonDef.h"
 #include "GPUCommonRtypes.h"
-#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
+#if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
 #include <Math/SMatrix.h>
 #include <Math/SVector.h>
 #include <Math/GenVector/DisplacementVector3D.h>
@@ -150,7 +150,7 @@ class Rotation2D
 using Rotation2Df_t = Rotation2D<float>;
 using Rotation2Dd_t = Rotation2D<double>;
 
-#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIGPUCODE)
+#if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
 
 class Transform3D : public ROOT::Math::Transform3D
 {
@@ -249,7 +249,7 @@ class Transform3D : public ROOT::Math::Transform3D
 } // namespace math_utils
 } // namespace o2
 
-#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIGPUCODE)
+#if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Df_t& t);
 std::ostream& operator<<(std::ostream& os, const o2::math_utils::Rotation2Dd_t& t);
 

--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -12,7 +12,6 @@ o2_add_library(
   DataFormatsGlobalTracking
   SOURCES src/RecoContainer.cxx
   PUBLIC_LINK_LIBRARIES
-    O2::Framework
     O2::DataFormatsTPC
     O2::DataFormatsITSMFT
     O2::DataFormatsITS
@@ -20,5 +19,7 @@ o2_add_library(
     O2::DataFormatsTOF
     O2::DataFormatsFT0
     O2::ReconstructionDataFormats
-    O2::TRDReconstruction
-    O2::GPUDataTypeHeaders)
+    O2::DataFormatsTRD
+    O2::GPUDataTypeHeaders
+  PRIVATE_LINK_LIBRARIES
+    O2::Framework)

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -32,6 +32,7 @@
 namespace o2::tpc
 {
 using TPCClRefElem = uint32_t;
+struct ClusterNativeAccess;
 namespace internal
 {
 struct getWorkflowTPCInput_ret;
@@ -39,6 +40,9 @@ struct getWorkflowTPCInput_ret;
 } // namespace o2::tpc
 namespace o2::trd
 {
+class Tracklet64;
+class CalibratedTracklet;
+class TriggerRecord;
 struct RecoInputContainer;
 } // namespace o2::trd
 
@@ -239,6 +243,14 @@ struct RecoContainer {
   {
     return miscPool.get_as<U>(id);
   }
+
+  // TPC clusters
+  const o2::tpc::ClusterNativeAccess& getTPCClusters() const;
+
+  // TRD tracklets
+  gsl::span<const o2::trd::Tracklet64> getTRDTracklets() const;
+  gsl::span<const o2::trd::CalibratedTracklet> getTRDCalibratedTracklets() const;
+  gsl::span<const o2::trd::TriggerRecord> getTRDTriggerRecords() const;
 
   // ITS clusters
   template <typename U> // o2::itsmft::ROFRecord

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -15,8 +15,6 @@
 #ifndef ALICEO2_RECO_CONTAINER
 #define ALICEO2_RECO_CONTAINER
 
-#include "Framework/ProcessingContext.h"
-#include "Framework/InputSpec.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "ReconstructionDataFormats/GlobalTrackAccessor.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
@@ -45,6 +43,11 @@ class CalibratedTracklet;
 class TriggerRecord;
 struct RecoInputContainer;
 } // namespace o2::trd
+namespace o2::framework
+{
+class ProcessingContext;
+struct InputSpec;
+} // namespace o2::framework
 
 namespace o2
 {

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -131,6 +131,7 @@ void DataRequest::requestTRDTracklets()
   addInput({"trdtracklets", o2::header::gDataOriginTRD, "TRACKLETS", 0, Lifetime::Timeframe});
   addInput({"trdctracklets", o2::header::gDataOriginTRD, "CTRACKLETS", 0, Lifetime::Timeframe});
   addInput({"trdtriggerrec", o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe});
+  requestMap["trackletTRD"] = false;
 }
 
 void DataRequest::requestFT0RecPoints(bool mc)
@@ -233,6 +234,11 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
   req = reqMap.find("FT0");
   if (req != reqMap.end()) {
     addFT0RecPoints(pc, req->second);
+  }
+
+  req = reqMap.find("trackletTRD");
+  if (req != reqMap.end()) {
+    addTRDTracklets(pc);
   }
 }
 

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -324,6 +324,26 @@ void RecoContainer::addFT0RecPoints(ProcessingContext& pc, bool mc)
   }
 }
 
+const o2::tpc::ClusterNativeAccess& RecoContainer::getTPCClusters() const
+{
+  return inputsTPCclusters->clusterIndex;
+}
+
+gsl::span<const o2::trd::Tracklet64> RecoContainer::getTRDTracklets() const
+{
+  return inputsTRD->mTracklets;
+}
+
+gsl::span<const o2::trd::CalibratedTracklet> RecoContainer::getTRDCalibratedTracklets() const
+{
+  return inputsTRD->mSpacePoints;
+}
+
+gsl::span<const o2::trd::TriggerRecord> RecoContainer::getTRDTriggerRecords() const
+{
+  return inputsTRD->mTriggerRecords;
+}
+
 //__________________________________________________________
 const o2::track::TrackParCov& RecoContainer::getTrackParamOut(GTrackID gidx) const
 {

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -14,6 +14,8 @@
 
 #include <fmt/format.h>
 #include <chrono>
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "DataFormatsTRD/RecoInputContainer.h"

--- a/DataFormats/Detectors/TOF/CMakeLists.txt
+++ b/DataFormats/Detectors/TOF/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(DataFormatsTOF
                        src/CalibInfoCluster.cxx
                        src/CosmicInfo.cxx
                PUBLIC_LINK_LIBRARIES O2::ReconstructionDataFormats
+                                     O2::GPUCommon
                                      Boost::serialization)
 
 o2_target_root_dictionary(DataFormatsTOF
@@ -30,5 +31,4 @@ o2_target_root_dictionary(DataFormatsTOF
                                   include/DataFormatsTOF/CompressedDataFormat.h
                                   include/DataFormatsTOF/CTF.h
                                   include/DataFormatsTOF/CalibInfoCluster.h
-                                  include/DataFormatsTOF/CosmicInfo.h
-				  )
+                                  include/DataFormatsTOF/CosmicInfo.h)

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
@@ -89,6 +89,21 @@ class Cluster : public o2::BaseCluster<float>
     }
     return mPhi;
   }
+  float getR() const // Cluster Radius (it is the same in sector and global frame)
+  {
+    if (mR == RadiusOutOfRange) {
+      return o2::gpu::CAMath::Sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
+    }
+    return mR;
+  }
+
+  float getPhi() const // Cluster Phi in sector frame
+  {
+    if (mPhi == PhiOutOfRange) {
+      return o2::gpu::CAMath::ATan2(getY(), getX());
+    }
+    return mPhi;
+  }
 
   void setR(float value) { mR = value; }
   void setPhi(float value) { mPhi = value; }

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Cluster.h
@@ -14,13 +14,15 @@
 #ifndef ALICEO2_TOF_CLUSTER_H
 #define ALICEO2_TOF_CLUSTER_H
 
+#include "GPUCommonRtypes.h"
+#include "GPUCommonMath.h"
 #include "ReconstructionDataFormats/BaseCluster.h"
-#include <boost/serialization/base_object.hpp> // for base_object
-#include <TMath.h>
-#include <cstdlib>
 #include "CommonConstants/LHCConstants.h"
+#ifndef GPUCA_GPUCODE
+#include <boost/serialization/base_object.hpp> // for base_object
+#include <cstdlib>
 #include <vector>
-#include "Rtypes.h"
+#endif
 
 namespace o2
 {
@@ -36,7 +38,7 @@ class Cluster : public o2::BaseCluster<float>
   static constexpr float PhiOutOfRange = 9999;    // used to check if phi was already calculated or not
 
   static constexpr int NPADSXSECTOR = 8736;
-  static constexpr Double_t BC_TIME_INPS_INV = 1.E-3 / o2::constants::lhc::LHCBunchSpacingNS;
+  static constexpr double BC_TIME_INPS_INV = 1.E-3 / o2::constants::lhc::LHCBunchSpacingNS;
 
  public:
   enum { kUpLeft = 0,    // 2^0, 1st bit
@@ -75,7 +77,7 @@ class Cluster : public o2::BaseCluster<float>
   float getR() // Cluster Radius (it is the same in sector and global frame)
   {
     if (mR == RadiusOutOfRange) {
-      mR = TMath::Sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
+      mR = o2::gpu::CAMath::Sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
     }
     return mR;
   }
@@ -83,7 +85,7 @@ class Cluster : public o2::BaseCluster<float>
   float getPhi() // Cluster Phi in sector frame
   {
     if (mPhi == PhiOutOfRange) {
-      mPhi = TMath::ATan2(getY(), getX());
+      mPhi = o2::gpu::CAMath::ATan2(getY(), getX());
     }
     return mPhi;
   }
@@ -138,7 +140,9 @@ class Cluster : public o2::BaseCluster<float>
   ClassDefNV(Cluster, 4);
 };
 
+#ifndef GPUCA_GPUCODE
 std::ostream& operator<<(std::ostream& os, Cluster& c);
+#endif
 } // namespace tof
 
 /// Defining o2::tof::Cluster explicitly as messageable

--- a/DataFormats/Detectors/TOF/src/Cluster.cxx
+++ b/DataFormats/Detectors/TOF/src/Cluster.cxx
@@ -26,8 +26,8 @@ Cluster::Cluster(std::int16_t sensid, float x, float y, float z, float sy2, floa
 {
 
   // caching R and phi
-  mR = TMath::Sqrt(x * x + y * y);
-  mPhi = TMath::ATan2(y, x);
+  mR = o2::gpu::CAMath::Sqrt(x * x + y * y);
+  mPhi = o2::gpu::CAMath::ATan2(y, x);
 }
 //______________________________________________________________________
 int Cluster::getNumOfContributingChannels() const

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RecoInputContainer.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RecoInputContainer.h
@@ -22,6 +22,8 @@
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "CommonConstants/LHCConstants.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
 
 #include "GPUDataTypes.h"
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
@@ -12,12 +12,14 @@
 #define ALICEO2_BASE_BASECLUSTER_H
 
 #include <MathUtils/Cartesian.h>
-#include <TObject.h>
+#include "GPUCommonRtypes.h"
+#ifndef GPUCA_GPUCODE
+#include "DetectorsCommonDataFormats/DetMatrixCache.h"
 #include <bitset>
 #include <iomanip>
 #include <ios>
 #include <iosfwd>
-#include "DetectorsCommonDataFormats/DetMatrixCache.h"
+#endif
 
 namespace o2
 {
@@ -64,6 +66,7 @@ class BaseCluster
   T getSigmaYZ() const { return mSigmaYZ; }
   math_utils::Point3D<T> getXYZ() const { return mPos; }
   math_utils::Point3D<T>& getXYZ() { return mPos; }
+#ifndef GPUCA_GPUCODE
   // position in local frame, no check for matrices cache validity
   math_utils::Point3D<T> getXYZLoc(const o2::detectors::DetMatrixCache& dm) const { return dm.getMatrixT2L(mSensorID)(mPos); }
   // position in global frame, no check for matrices cache validity
@@ -72,6 +75,7 @@ class BaseCluster
   // much faster for barrel detectors than using full 3D matrix.
   // no check for matrices cache validity
   math_utils::Point3D<T> getXYZGloRot(const o2::detectors::DetMatrixCache& dm) const { return dm.getMatrixT2GRot(mSensorID)(mPos); }
+#endif
   // get sensor id
   std::int16_t getSensorID() const { return mSensorID; }
   // get count field
@@ -116,6 +120,7 @@ class BaseCluster
   ClassDefNV(BaseCluster, 2);
 };
 
+#ifndef GPUCA_GPUCODE
 template <class T>
 std::ostream& operator<<(std::ostream& os, const BaseCluster<T>& c)
 {
@@ -126,5 +131,6 @@ std::ostream& operator<<(std::ostream& os, const BaseCluster<T>& c)
      << ") cnt:" << std::setw(4) << +c.getCount() << " bits:" << std::bitset<8>(c.getBits());
   return os;
 }
+#endif
 } // namespace o2
 #endif

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackID.h
@@ -71,6 +71,7 @@ class GlobalTrackID : public AbstractRef<25, 5, 2>
   static constexpr std::string_view NONE{"none"};                        ///< keywork for no sources
   static constexpr std::string_view ALL{"all"};                          ///< keywork for all sources
 #endif
+  static constexpr mask_t MASK_ALL = (1u << NSources) - 1;
 
   // methods for detector level manipulations
   GPUd() static constexpr DetID::mask_t getSourceDetectorsMask(int i);

--- a/DataFormats/Reconstruction/src/GlobalTrackID.cxx
+++ b/DataFormats/Reconstruction/src/GlobalTrackID.cxx
@@ -35,7 +35,7 @@ GlobalTrackID::mask_t GlobalTrackID::getSourcesMask(const std::string_view srcLi
     return mask;
   }
   if (ss.find(ALL) != std::string::npos) {
-    mask = (0x1u << NSources) - 1;
+    mask = MASK_ALL;
     return mask;
   }
   std::replace(ss.begin(), ss.end(), ' ', ',');

--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -22,7 +22,7 @@
 #include <TObject.h> // for TObject
 #include <string_view>
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "FairLogger.h" // for LOG
+#include "GPUCommonLogger.h" // for LOG
 #include "MathUtils/Cartesian.h"
 #include "DetectorsBase/MatCell.h"
 #include <mutex>

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -53,10 +53,14 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static GeometryTGeo* Instance()
   {
     // get (create if needed) a unique instance of the object
+#ifdef GPUCA_STANDALONE
+    return nullptr; // TODO: DR: Obviously wrong, but to make it compile for now
+#else
     if (!sInstance) {
       sInstance = std::unique_ptr<GeometryTGeo>(new GeometryTGeo(true, 0));
     }
     return sInstance.get();
+#endif
   }
 
   // adopt the unique instance from external raw pointer (to be used only to read saved instance from file)
@@ -74,7 +78,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   );
 
   /// Default destructor
-  ~GeometryTGeo() override = default;
+  ~GeometryTGeo() override;
 
   GeometryTGeo(const GeometryTGeo& src) = delete;
   GeometryTGeo& operator=(const GeometryTGeo& geom) = delete;
@@ -345,7 +349,9 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static std::string sWrapperVolumeName; ///< Wrapper volume name
 
  private:
+#ifndef GPUCA_STANDALONE
   static std::unique_ptr<o2::its::GeometryTGeo> sInstance; ///< singletone instance
+#endif
 
   ClassDefOverride(GeometryTGeo, 1); // ITS geometry based on TGeo
 };

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -49,6 +49,7 @@ using Segmentation = o2::itsmft::SegmentationAlpide;
 ClassImp(o2::its::GeometryTGeo);
 
 std::unique_ptr<o2::its::GeometryTGeo> GeometryTGeo::sInstance;
+o2::its::GeometryTGeo::~GeometryTGeo() = default;
 
 std::string GeometryTGeo::sVolumeName = "ITSV";               ///< Mother volume name
 std::string GeometryTGeo::sLayerName = "ITSULayer";           ///< Layer name

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -13,7 +13,7 @@
 
 #include "Rtypes.h"
 #include "CommonConstants/LHCConstants.h"
-#include "DetectorsRaw/HBFUtils.h"
+//#include "DetectorsRaw/HBFUtils.h"
 
 namespace o2
 {

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -279,9 +279,9 @@ class Geo
   static Int_t getECHFromCH(int chan) { return CHAN_TO_ELCHAN[chan]; }
   static Int_t getCHFromECH(int echan) { return ELCHAN_TO_CHAN[echan]; }
 
- private:
   static void Init();
 
+ private:
   static Int_t getSector(const Float_t* pos);
   static Int_t getPlate(const Float_t* pos);
   static Int_t getPadZ(const Float_t* pos);

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -31,6 +31,9 @@ Float_t Geo::mPadPosition[NSECTORS][NPLATES][NMAXNSTRIP][NPADZ][NPADX][3];
 
 void Geo::Init()
 {
+  if (!mToBeIntit) {
+    return;
+  }
   LOG(INFO) << "tof::Geo: Initialization of TOF rotation parameters";
 
   if (!gGeoManager) {

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFFEElightConfig.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFFEElightConfig.h
@@ -13,6 +13,7 @@
 
 #include "Rtypes.h"
 #include "TOFBase/Geo.h"
+#include <array>
 
 using namespace o2::tof;
 

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFFEElightReader.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFFEElightReader.h
@@ -49,7 +49,7 @@ struct TOFFEElightInfo {
   bool getChannelEnabled(int idx) { return idx < Geo::NCHANNELS ? mChannelEnabled[idx] : false; }
   int getMatchingWindow(int idx) { return idx < Geo::NCHANNELS ? mMatchingWindow[idx] : 0; }
   int getLatencyWindow(int idx) { return idx < Geo::NCHANNELS ? mLatencyWindow[idx] : 0; }
-  uint getTriggerMask(int ddl) { return ddl < TOFFEElightConfig::NTRIGGERMAPS ? mTriggerMask[ddl] : 0; }
+  uint64_t getTriggerMask(int ddl) { return ddl < TOFFEElightConfig::NTRIGGERMAPS ? mTriggerMask[ddl] : 0; }
 
   ClassDefNV(TOFFEElightInfo, 1);
 };

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -108,7 +108,7 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
       // check if the fired pad are close in space
       LOG(DEBUG) << "phi difference = " << iphi - iphi2;
       LOG(DEBUG) << "eta difference = " << ieta - ieta2;
-      if ((TMath::Abs(iphi - iphi2) > 1) || (TMath::Abs(ieta - ieta2) > 1)) {
+      if ((std::abs(iphi - iphi2) > 1) || (std::abs(ieta - ieta2) > 1)) {
         continue;
       }
 
@@ -271,8 +271,8 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
   Geo::rotateToSector(pos, c.getSector());
   c.setXYZ(pos[2], pos[0], pos[1]); // storing coordinates in sector frame: note that the rotation above puts z in pos[1], the radial coordinate in pos[2], and the tangent coordinate in pos[0] (this is to match the TOF residual system, where we don't use the radial component), so we swap their positions.
 
-  c.setR(TMath::Sqrt(pos[0] * pos[0] + pos[1] * pos[1])); // it is the R in the sector frame
-  c.setPhi(TMath::ATan2(pos[1], pos[0]));
+  c.setR(std::sqrt(pos[0] * pos[0] + pos[1] * pos[1])); // it is the R in the sector frame
+  c.setPhi(std::atan2(pos[1], pos[0]));
 
   float errY2 = Geo::XPAD * Geo::XPAD * inv12;
   float errZ2 = Geo::ZPAD * Geo::ZPAD * inv12;

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFDigitWriterSplitterSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/TOFDigitWriterSplitterSpec.h
@@ -21,6 +21,7 @@
 #include "TOFBase/Digit.h"
 #include "Framework/Logger.h"
 #include <TTree.h>
+#include <TFile.h>
 #include <gsl/span>
 
 using namespace o2::framework;

--- a/GPU/Common/GPUCommonRtypes.h
+++ b/GPU/Common/GPUCommonRtypes.h
@@ -16,6 +16,7 @@
 
 #if defined(GPUCA_STANDALONE) || (defined(GPUCA_O2_LIB) && !defined(GPUCA_O2_INTERFACE)) || defined(GPUCA_GPULIBRARY) // clang-format off
   #if !defined(ROOT_Rtypes) && !defined(__CLING__)
+    #define GPUCOMMONRTYPES_H_ACTIVE
     #define ClassDef(name,id)
     #define ClassDefNV(name, id)
     #define ClassDefOverride(name, id)

--- a/GPU/Common/GPUROOTCartesianFwd.h
+++ b/GPU/Common/GPUROOTCartesianFwd.h
@@ -58,7 +58,7 @@ template <typename T, int I>
 struct GPUPoint3D;
 } // namespace detail
 
-#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
+#if (!defined(GPUCA_STANDALONE) || !defined(DGPUCA_NO_ROOT)) && !defined(GPUCA_GPUCODE) && !defined(GPUCOMMONRTYPES_H_ACTIVE)
 template <typename T>
 using Point2D = ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
 template <typename T>

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -278,8 +278,11 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::GPUUtils
                                        O2::DataFormatsTPC
+                                       O2::DataFormatsTOF
                                        O2::TPCBase
                                        O2::TRDBase
+                                       O2::TOFBase
+                                       O2::ITSBase
                                        O2::ITStracking
                                        O2::TPCFastTransformation
                                        O2::DetectorsRaw

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -47,6 +47,8 @@ namespace constants
 namespace o2
 {
 class MCCompLabel;
+template <typename T>
+class BaseCluster;
 namespace base
 {
 template <typename T>
@@ -60,11 +62,26 @@ class GeometryFlat;
 namespace dataformats
 {
 class TrackTPCITS;
+class MatchInfoTOF;
 template <class T>
 class MCTruthContainer;
 template <class T>
 class ConstMCTruthContainerView;
 } // namespace dataformats
+namespace itsmft
+{
+class CompClusterExt;
+class ROFRecord;
+class TopologyDictionary;
+} // namespace itsmft
+namespace its
+{
+class TrackITS;
+} // namespace its
+namespace tof
+{
+class Cluster;
+} // namespace tof
 } // namespace o2
 
 namespace GPUCA_NAMESPACE
@@ -183,6 +200,7 @@ struct GPUCalibObjectsTemplate {
   typename S<TPCdEdxCalibrationSplines>::type* dEdxSplines = nullptr;
   typename S<TPCPadGainCalib>::type* tpcPadGain = nullptr;
   typename S<o2::base::PropagatorImpl<float>>::type* o2Propagator = nullptr;
+  typename S<o2::itsmft::TopologyDictionary>::type* itsPatternDict = nullptr;
 };
 typedef GPUCalibObjectsTemplate<DefaultPtr> GPUCalibObjects; // NOTE: These 2 must have identical layout since they are memcopied
 typedef GPUCalibObjectsTemplate<ConstPtr> GPUCalibObjectsConst;
@@ -215,8 +233,9 @@ struct GPUTrackingInOutDigits {
 struct GPUTrackingInOutPointers {
   GPUTrackingInOutPointers() = default;
   GPUTrackingInOutPointers(const GPUTrackingInOutPointers&) = default;
-  static constexpr unsigned int NSLICES = GPUDataTypes::NSLICES;
 
+  // TPC
+  static constexpr unsigned int NSLICES = GPUDataTypes::NSLICES;
   const GPUTrackingInOutZS* tpcZS = nullptr;
   const GPUTrackingInOutDigits* tpcPackedDigits = nullptr;
   const GPUTPCClusterData* clusterData[NSLICES] = {nullptr};
@@ -245,8 +264,8 @@ struct GPUTrackingInOutPointers {
   unsigned int nOutputClusRefsTPCO2 = 0;
   const o2::MCCompLabel* outputTracksTPCO2MC = nullptr;
   const o2::tpc::CompressedClustersFlat* tpcCompressedClusters = nullptr;
-  const o2::dataformats::TrackTPCITS* tracksTPCITSO2 = nullptr;
-  unsigned int nTracksTPCITSO2 = 0;
+
+  // TRD
   const GPUTRDTrackletWord* trdTracklets = nullptr;
   const GPUTRDSpacePoint* trdSpacePoints = nullptr;
   unsigned int nTRDTracklets = 0;
@@ -255,6 +274,34 @@ struct GPUTrackingInOutPointers {
   const float* trdTriggerTimes = nullptr;
   const int* trdTrackletIdxFirst = nullptr;
   unsigned int nTRDTriggerRecords = 0;
+
+  // TOF
+  const o2::tof::Cluster* tofClusters = nullptr;
+  unsigned int nTOFClusters = 0;
+  const o2::dataformats::MatchInfoTOF* tofMatches = nullptr;
+  unsigned int nTOFMatches = 0;
+  const o2::dataformats::MatchInfoTOF* tpctofMatches = nullptr;
+  unsigned int nTPCTOFMatches = 0;
+
+  // ITS
+  const o2::itsmft::CompClusterExt* itsCompClusters = nullptr;
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* itsClusterMC = nullptr;
+  const o2::BaseCluster<float>* itsClusters = nullptr;
+  unsigned int nItsClusters = 0;
+  const o2::itsmft::ROFRecord* itsClusterROF = nullptr;
+  unsigned int nItsClusterROF = 0;
+  const o2::its::TrackITS* itsTracks = nullptr;
+  const o2::MCCompLabel* itsTrackMC = nullptr;
+  unsigned int nItsTracks = 0;
+  const int* itsTrackClusIdx = nullptr;
+  const o2::itsmft::ROFRecord* itsTrackROF = nullptr;
+  unsigned int nItsTrackROF = 0;
+
+  // TPC-ITS
+  const o2::dataformats::TrackTPCITS* tracksTPCITSO2 = nullptr;
+  unsigned int nTracksTPCITSO2 = 0;
+
+  // Common
   const GPUSettingsTF* settingsTF = nullptr;
 };
 #else

--- a/GPU/GPUTracking/DataTypes/GPUTRDDef.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDDef.h
@@ -89,11 +89,6 @@ class GPUTRDTracker_t;
 typedef GPUTRDTracker_t<GPUTRDTrack, GPUTRDPropagator> GPUTRDTracker;
 typedef GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU> GPUTRDTrackerGPU;
 
-#if defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_ALIROOT_LIB) && !defined(__CLING__) && !defined(__ROOTCLING__) && !defined(G__ROOT)
-#define Error(...)
-#define Warning(...)
-#define Info(...)
-#endif
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -183,6 +183,8 @@ AddOption(pointSize, float, 2.0f, "", 0, "Set point size")
 AddOption(lineWidth, float, 1.4f, "", 0, "Set line width")
 AddOption(drawTPC, bool, true, "", 0, "Enable drawing TPC data")
 AddOption(drawTRD, bool, true, "", 0, "Enabale drawing TRD data")
+AddOption(drawTOF, bool, true, "", 0, "Enabale drawing TOF data")
+AddOption(drawITS, bool, true, "", 0, "Enabale drawing ITS data")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -88,7 +88,7 @@ struct GPUO2InterfaceConfiguration {
   GPUSettingsQA configQA;
   GPUInterfaceSettings configInterface;
   GPURecoStepConfiguration configWorkflow;
-  GPUCalibObjects configCalib;
+  GPUCalibObjectsConst configCalib;
 
   GPUSettingsO2 ReadConfigurableParam();
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceDisplay.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceDisplay.cxx
@@ -31,7 +31,7 @@ GPUO2InterfaceDisplay::GPUO2InterfaceDisplay(const GPUO2InterfaceConfiguration* 
   mParam.reset(new GPUParam);
   mParam->SetDefaults(&config->configGRP, &config->configReconstruction, &config->configProcessing, nullptr);
   mParam->par.earlyTpcTransform = 0;
-  mDisplay.reset(new GPUDisplay(mBackend.get(), nullptr, nullptr, mParam.get(), (const GPUCalibObjectsConst*)&mConfig->configCalib, &mConfig->configDisplay));
+  mDisplay.reset(new GPUDisplay(mBackend.get(), nullptr, nullptr, mParam.get(), &mConfig->configCalib, &mConfig->configDisplay));
 }
 
 GPUO2InterfaceDisplay::~GPUO2InterfaceDisplay() = default;

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -151,6 +151,7 @@ include_directories(${GPUTRACKING_DIR}/TPCClusterFinder
                     ${O2_DIR}/DataFormats/common/include
                     ${O2_DIR}/DataFormats/Detectors/Common/include
                     ${O2_DIR}/DataFormats/Detectors/ITSMFT/ITS/include
+                    ${O2_DIR}/DataFormats/Detectors/TOF/include
                     ${O2_DIR}/DataFormats/Detectors/TPC/include
                     ${O2_DIR}/DataFormats/Detectors/TRD/include
                     ${O2_DIR}/DataFormats/Headers/include
@@ -160,12 +161,15 @@ include_directories(${GPUTRACKING_DIR}/TPCClusterFinder
                     ${O2_DIR}/DataFormats/simulation/include
                     ${O2_DIR}/Detectors/Base/include
                     ${O2_DIR}/Detectors/Base/src
+                    ${O2_DIR}/Detectors/ITSMFT/common/base/include
+                    ${O2_DIR}/Detectors/ITSMFT/ITS/base/include
                     ${O2_DIR}/Detectors/ITSMFT/ITS/tracking/include
                     ${O2_DIR}/Detectors/ITSMFT/ITS/tracking/cuda/include
                     ${O2_DIR}/Detectors/ITSMFT/ITS/tracking/cuda/src
                     ${O2_DIR}/Detectors/ITSMFT/ITS/tracking/hip/include
                     ${O2_DIR}/Detectors/ITSMFT/ITS/tracking/hip/src
                     ${O2_DIR}/Detectors/Raw/include
+                    ${O2_DIR}/Detectors/TOF/base/include
                     ${O2_DIR}/Detectors/TPC/base/include
                     ${O2_DIR}/Detectors/TRD/base/include
                     ${O2_DIR}/Detectors/TRD/base/src)

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -1300,7 +1300,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::AdjustSector(PROP* prop, TRDTRK* t) c
 
   if (CAMath::Abs(y) > 2.f * yMax) {
     if (ENABLE_INFO) {
-      Info("AdjustSector", "Track %i with pT = %f crossing two sector boundaries at x = %f", t->GetTPCtrackId(), t->getPt(), t->getX());
+      GPUInfo("AdjustSector: Track %i with pT = %f crossing two sector boundaries at x = %f", t->GetTPCtrackId(), t->getPt(), t->getX());
     }
     return false;
   }

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -11,6 +11,10 @@
 /// \file GPUDisplay.cxx
 /// \author David Rohr
 
+#ifndef GPUCA_NO_ROOT
+#include "Rtypes.h" // Include ROOT header first, to use ROOT and disable replacements
+#endif
+
 #include "GPUDisplay.h"
 
 #ifdef GPUCA_BUILD_EVENT_DISPLAY

--- a/GPU/GPUTracking/display/GPUDisplay.h
+++ b/GPU/GPUTracking/display/GPUDisplay.h
@@ -105,9 +105,11 @@ class GPUDisplay
  private:
   static constexpr int NSLICES = GPUChainTracking::NSLICES;
 
-  static constexpr const int N_POINTS_TYPE = 11;
+  static constexpr const int N_POINTS_TYPE = 13;
   static constexpr const int N_POINTS_TYPE_TPC = 9;
   static constexpr const int N_POINTS_TYPE_TRD = 2;
+  static constexpr const int N_POINTS_TYPE_TOF = 1;
+  static constexpr const int N_POINTS_TYPE_ITS = 1;
   static constexpr const int N_LINES_TYPE = 7;
   static constexpr const int N_FINAL_TYPE = 4;
   static constexpr int TRACK_TYPE_ID_LIMIT = 100;
@@ -121,7 +123,9 @@ class GPUDisplay
                     tFINALTRACK = 7,
                     tMARKED = 8,
                     tTRDCLUSTER = 9,
-                    tTRDATTACHED = 10 };
+                    tTRDATTACHED = 10,
+                    tTOFCLUSTER = 11,
+                    tITSCLUSTER = 12 };
   enum LineTypes { RESERVED = 0 /*1 -- 6 = INITLINK to GLOBALTRACK*/ };
 
   typedef std::tuple<GLsizei, GLsizei, int> vboList;
@@ -210,6 +214,8 @@ class GPUDisplay
   void showInfo(const char* info);
   void ActivateColor();
   void SetColorTRD();
+  void SetColorTOF();
+  void SetColorITS();
   void SetColorClusters();
   void SetColorInitLinks();
   void SetColorLinks();
@@ -234,7 +240,8 @@ class GPUDisplay
   void drawPointLinestrip(int iSlice, int cid, int id, int id_limit = TRACK_TYPE_ID_LIMIT);
   vboList DrawClusters(int iSlice, int select, int iCol);
   vboList DrawSpacePointsTRD(int iSlice, int select, int iCol);
-  vboList DrawSpacePointsTRD(const GPUTPCTracker& tracker, int select, int iCol);
+  vboList DrawSpacePointsTOF(int iSlice, int select, int iCol);
+  vboList DrawSpacePointsITS(int iSlice, int select, int iCol);
   vboList DrawLinks(const GPUTPCTracker& tracker, int id, bool dodown = false);
   vboList DrawSeeds(const GPUTPCTracker& tracker);
   vboList DrawTracklets(const GPUTPCTracker& tracker);
@@ -330,13 +337,21 @@ class GPUDisplay
   std::unique_ptr<float4[]> mGlobalPosPtr;
   std::unique_ptr<float4[]> mGlobalPosPtrTRD;
   std::unique_ptr<float4[]> mGlobalPosPtrTRD2;
+  std::unique_ptr<float4[]> mGlobalPosPtrITS;
+  std::unique_ptr<float4[]> mGlobalPosPtrTOF;
   float4* mGlobalPos;
   float4* mGlobalPosTRD;
   float4* mGlobalPosTRD2;
+  float4* mGlobalPosITS;
+  float4* mGlobalPosTOF;
   int mNMaxClusters = 0;
   int mNMaxSpacePointsTRD = 0;
+  int mNMaxClustersITS = 0;
+  int mNMaxClustersTOF = 0;
   int mCurrentClusters = 0;
   int mCurrentSpacePointsTRD = 0;
+  int mCurrentClustersITS = 0;
+  int mCurrentClustersTOF = 0;
   std::vector<int> mTRDTrackIds;
 
   int mGlDLrecent = 0;

--- a/GPU/GPUTracking/display/GPUDisplayKeys.cxx
+++ b/GPU/GPUTracking/display/GPUDisplayKeys.cxx
@@ -60,7 +60,7 @@ const char* HelpText[] = {
   "[ALT] / [CTRL] / [m]          Focus camera on origin / orient y-axis upwards (combine with [SHIFT] to lock) / Cycle through modes",
   "[RCTRL] / [RALT]              Rotate model instead of camera / rotate TPC around beamline",
   "[1] ... [8] / [N]             Enable display of clusters, preseeds, seeds, starthits, tracklets, tracks, global tracks, merged tracks / Show assigned clusters in colors"
-  "[F1] / [F2]                   Enable / disable drawing of TPC / TRD"
+  "[F1] / [F2] / [F3] / [F4]     Enable / disable drawing of TPC / TRD / TOF / ITS"
   // FREE: none
   // Test setting: ^ --> mHideUnmatchedClusters
 };
@@ -324,6 +324,10 @@ void GPUDisplay::HandleKeyRelease(unsigned char key)
     mCfg.drawTPC ^= 1;
   } else if (key == mBackend->KEY_F2) {
     mCfg.drawTRD ^= 1;
+  } else if (key == mBackend->KEY_F3) {
+    mCfg.drawTOF ^= 1;
+  } else if (key == mBackend->KEY_F4) {
+    mCfg.drawITS ^= 1;
   } else if (key == 't') {
     GPUInfo("Taking screenshot");
     static int nScreenshot = 1;

--- a/GPU/GPUTracking/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/qa/GPUQA.cxx
@@ -14,7 +14,7 @@
 #define QA_DEBUG 0
 #define QA_TIMING 0
 
-#include "Rtypes.h"
+#include "Rtypes.h" // Include ROOT header first, to use ROOT and disable replacements
 
 #include "TH1F.h"
 #include "TH2F.h"

--- a/GPU/Workflow/CMakeLists.txt
+++ b/GPU/Workflow/CMakeLists.txt
@@ -49,6 +49,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2"
           TARGETVARNAME targetName
           SOURCES src/O2GPUDPLDisplay.cxx
           PUBLIC_LINK_LIBRARIES O2::GPUO2Interface
+                                O2::GPUWorkflowHelper
                                 O2::DataFormatsGlobalTracking
                                 O2::TPCFastTransformation
                                 O2::TRDBase

--- a/GPU/Workflow/CMakeLists.txt
+++ b/GPU/Workflow/CMakeLists.txt
@@ -53,6 +53,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2"
                                 O2::DataFormatsGlobalTracking
                                 O2::TPCFastTransformation
                                 O2::TRDBase
+                                O2::TOFBase
                                 O2::TPCReconstruction
                                 O2::GlobalTrackingWorkflowHelpers)
   target_include_directories(${targetName} PUBLIC "include")

--- a/GPU/Workflow/CMakeLists.txt
+++ b/GPU/Workflow/CMakeLists.txt
@@ -56,3 +56,5 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2"
                                 O2::GlobalTrackingWorkflowHelpers)
   target_include_directories(${targetName} PUBLIC "include")
 endif()
+
+add_subdirectory(helper)

--- a/GPU/Workflow/helper/CMakeLists.txt
+++ b/GPU/Workflow/helper/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_library(GPUWorkflowHelper
+               SOURCES src/GPUWorkflowHelper.cxx
+               TARGETVARNAME targetName
+               PUBLIC_LINK_LIBRARIES O2::Framework
+                                     O2::DataFormatsGlobalTracking
+                                     O2::GPUDataTypeHeaders
+                                     O2::GPUO2Interface
+                                     O2::ITStracking)

--- a/GPU/Workflow/helper/include/GPUWorkflowHelper/GPUWorkflowHelper.h
+++ b/GPU/Workflow/helper/include/GPUWorkflowHelper/GPUWorkflowHelper.h
@@ -1,0 +1,33 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_GPU_WORKFLOW_HELPER_H
+#define O2_GPU_WORKFLOW_HELPER_H
+
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "GPUDataTypes.h"
+#include <memory>
+
+namespace o2::gpu
+{
+
+class GPUWorkflowHelper
+{
+  using GID = o2::dataformats::GlobalTrackID;
+
+ public:
+  struct tmpDataContainer;
+  static std::unique_ptr<const tmpDataContainer> fillIOPtr(GPUTrackingInOutPointers& ioPtr, const o2::globaltracking::RecoContainer& recoCont, const GPUCalibObjectsConst* calib = nullptr, GID::mask_t maskCl = GID::MASK_ALL, GID::mask_t maskTrk = GID::MASK_ALL, GID::mask_t maskMatch = GID::MASK_ALL);
+};
+
+} // namespace o2::gpu
+
+#endif

--- a/GPU/Workflow/helper/include/GPUWorkflowHelper/GPUWorkflowHelper.h
+++ b/GPU/Workflow/helper/include/GPUWorkflowHelper/GPUWorkflowHelper.h
@@ -25,7 +25,7 @@ class GPUWorkflowHelper
 
  public:
   struct tmpDataContainer;
-  static std::unique_ptr<const tmpDataContainer> fillIOPtr(GPUTrackingInOutPointers& ioPtr, const o2::globaltracking::RecoContainer& recoCont, const GPUCalibObjectsConst* calib = nullptr, GID::mask_t maskCl = GID::MASK_ALL, GID::mask_t maskTrk = GID::MASK_ALL, GID::mask_t maskMatch = GID::MASK_ALL);
+  static std::shared_ptr<const tmpDataContainer> fillIOPtr(GPUTrackingInOutPointers& ioPtr, const o2::globaltracking::RecoContainer& recoCont, bool useMC, const GPUCalibObjectsConst* calib = nullptr, GID::mask_t maskCl = GID::MASK_ALL, GID::mask_t maskTrk = GID::MASK_ALL, GID::mask_t maskMatch = GID::MASK_ALL);
 };
 
 } // namespace o2::gpu

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GPUWorkflowHelper/GPUWorkflowHelper.h"
+#include "ITStracking/IOUtils.h"
+using namespace o2::globaltracking;
+using namespace o2::gpu;
+
+struct GPUWorkflowHelper::tmpDataContainer {
+  std::vector<o2::BaseCluster<float>> ITSClustersArray;
+};
+
+std::unique_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fillIOPtr(GPUTrackingInOutPointers& ioPtr, const o2::globaltracking::RecoContainer& recoCont, const GPUCalibObjectsConst* calib, o2::dataformats::GlobalTrackID::mask_t maskCl, o2::dataformats::GlobalTrackID::mask_t maskTrk, o2::dataformats::GlobalTrackID::mask_t maskMatch)
+{
+  auto retVal = std::make_unique<tmpDataContainer>();
+
+  if (maskCl[GID::ITS] && ioPtr.nItsClusters == 0) {
+    const auto& ITSClusterROFRec = recoCont.getITSClustersROFRecords<o2::itsmft::ROFRecord>();
+    const auto& clusITS = recoCont.getITSClusters<o2::itsmft::CompClusterExt>();
+    if (clusITS.size() && ITSClusterROFRec.size()) {
+      if (calib && calib->itsPatternDict) {
+        const auto& patterns = recoCont.getITSClustersPatterns();
+        auto pattIt = patterns.begin();
+        retVal->ITSClustersArray.reserve(clusITS.size());
+        o2::its::ioutils::convertCompactClusters(clusITS, pattIt, retVal->ITSClustersArray, *calib->itsPatternDict);
+        ioPtr.itsClusters = retVal->ITSClustersArray.data();
+      }
+      const auto& ITSClsLabels = recoCont.mcITSClusters.get();
+      ioPtr.nItsClusters = clusITS.size();
+      ioPtr.itsCompClusters = clusITS.data();
+      ioPtr.nItsClusterROF = ITSClusterROFRec.size();
+      ioPtr.itsClusterROF = ITSClusterROFRec.data();
+      ioPtr.itsClusterMC = ITSClsLabels;
+    }
+  }
+  if (maskTrk[GID::ITS] && ioPtr.nItsTracks == 0) {
+    const auto& ITSTracksArray = recoCont.getITSTracks<o2::its::TrackITS>();
+    const auto& ITSTrackROFRec = recoCont.getITSTracksROFRecords<o2::itsmft::ROFRecord>();
+    if (ITSTracksArray.size() && ITSTrackROFRec.size()) {
+      const auto& ITSTrackClusIdx = recoCont.getITSTracksClusterRefs();
+      const auto& ITSTrkLabels = recoCont.getITSTracksMCLabels();
+      ioPtr.nItsTracks = ITSTracksArray.size();
+      ioPtr.itsTracks = ITSTracksArray.data();
+      ioPtr.itsTrackClusIdx = ITSTrackClusIdx.data();
+      ioPtr.nItsTrackROF = ITSTrackROFRec.size();
+      ioPtr.itsTrackROF = ITSTrackROFRec.data();
+      ioPtr.itsTrackMC = ITSTrkLabels.data();
+    }
+  }
+
+  if (maskTrk[GID::ITSTPC] && ioPtr.nTracksTPCITSO2 == 0) {
+    const auto& trkITSTPC = recoCont.getTPCITSTracks<o2d::TrackTPCITS>();
+    if (trkITSTPC.size()) {
+      ioPtr.nTracksTPCITSO2 = trkITSTPC.size();
+      ioPtr.tracksTPCITS = trkITSTPC.data();
+    }
+  }
+
+  if (maskCl[GID::TOF] && ioPtr.nTOFClusters == 0) {
+    const auto& tofClusters = recoCont.getTOFClusters<o2::tof::Cluster>();
+    if (tofClusters.size()) {
+      ioPtr.nTOFClusters = tofClusters.size();
+      ioPtr.tofClusters = tofClusters.data();
+    }
+  }
+
+  if (maskMatch[GID::TOF] && ioPtr.nTOFMatches == 0) {
+    const auto& tofMatches = recoCont.getTOFMatches<o2::dataformats::MatchInfoTOF>();
+    if (tofMatches.size()) {
+      ioPtr.nTOFMatches = tofMatches.size();
+      ioPtr.tofMatches = tofMatches.data();
+    }
+  }
+
+  if (maskMatch[GID::TPCTOF] && ioPtr.nTPCTOFMatches == 0) {
+    const auto& tpctofMatches = recoCont.getTPCTOFMatches<o2::dataformats::MatchInfoTOF>();
+    if (tpctofMatches.size()) {
+      ioPtr.nTPCTOFMatches = tpctofMatches.size();
+      ioPtr.tpctofMatches = tpctofMatches.data();
+    }
+  }
+
+  return std::move(retVal);
+}

--- a/GPU/Workflow/include/GPUWorkflow/O2GPUDPLDisplay.h
+++ b/GPU/Workflow/include/GPUWorkflow/O2GPUDPLDisplay.h
@@ -23,6 +23,10 @@ namespace o2::globaltracking
 {
 struct DataRequest;
 }
+namespace o2::itsmft
+{
+class TopologyDictionary;
+}
 
 namespace o2::gpu
 {
@@ -47,6 +51,7 @@ class O2GPUDPLDisplaySpec : public o2::framework::Task
   std::unique_ptr<GPUO2InterfaceConfiguration> mConfig;
   std::unique_ptr<TPCFastTransform> mFastTransform;
   std::unique_ptr<o2::trd::GeometryFlat> mTrdGeo;
+  std::unique_ptr<o2::itsmft::TopologyDictionary> mITSDict;
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
 };
 

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -735,7 +735,7 @@ DataProcessorSpec getGPURecoWorkflowSpec(gpuworkflow::CompletionPolicyData* poli
         processAttributes->qa->cleanup();
       }
       timer.Stop();
-      LOG(INFO) << "TPC CATracker time for this TF " << timer.CpuTime() - cput << " s (cpu), " << timer.RealTime() - realt << " s (wall)";
+      LOG(INFO) << "GPU Reoncstruction time for this TF " << timer.CpuTime() - cput << " s (cpu), " << timer.RealTime() - realt << " s (wall)";
     };
 
     return processingFct;

--- a/GPU/Workflow/src/O2GPUDPLDisplay.cxx
+++ b/GPU/Workflow/src/O2GPUDPLDisplay.cxx
@@ -99,6 +99,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec specs;
 
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
   bool useMC = cfgc.options().get<bool>("enable-mc");
   GlobalTrackID::mask_t srcTrk = GlobalTrackID::getSourcesMask(cfgc.options().get<std::string>("display-tracks"));
   GlobalTrackID::mask_t srcCl = GlobalTrackID::getSourcesMask(cfgc.options().get<std::string>("display-clusters"));


### PR DESCRIPTION
@martenole FYI: This will become a "complete" (as much as possible) converter to extract the data from the RecoContainer and fill the GPU ioPtr, since it will be needed for more track types anyway. It will also contain a map indicating which TPCITS track supersedes which TPC track using the RecoContainer::createTracks (not yet there).

So you will be able to use it instead of your `if (std::find(loadedTPCtracks.begin(), loadedTPCtracks.end(), iTrk) != loadedTPCtracks.end()) {` method eventually, usage will be similar to the TRD::RecoInputContainer.

Then, we can remove the TPC and ITSTPC tracks from the TRD::RecoInputContainer. The tracklets need to remain there. Actually, RecoContainer is using the TRD::RecoInputContainer to fetch them.

(`static std::unique_ptr<const tmpDataContainer> fillIOPtr(GPUTrackingInOutPointers& ioPtr, const o2::globaltracking::RecoContainer& recoCont, const GPUCalibObjectsConst* calib = nullptr, GID::mask_t maskCl = GID::MASK_ALL, GID::mask_t maskTrk = GID::MASK_ALL);` is all this is about)