### PR TITLE
Some fixes in digitization

### DIFF
--- a/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
@@ -57,16 +57,36 @@ class GRPDPLUpdatedTask
     const std::string grpName = "GRP";
 
     // a standardized semaphore convention --> taking the current execution path should be enough
-    const auto semname = boost::filesystem::current_path().string() + mGRPFileName;
-    std::hash<std::string> hasher;
-    const auto semhashedstring = "alice_grp_" + std::to_string(hasher(semname));
+    // (the user enables this via O2_USEGRP_SEMA environment)
+    bool use_sema = false;
+    boost::interprocess::named_semaphore* sem = nullptr;
+    if (auto semaname = getenv("O2_USEGRP_SEMA")) {
+      try {
+        const auto semname = boost::filesystem::current_path().string() + mGRPFileName;
+        std::hash<std::string> hasher;
+        const auto semhashedstring = "alice_grp_" + std::to_string(hasher(semname));
+        sem = new boost::interprocess::named_semaphore(boost::interprocess::open_or_create_t{}, semhashedstring.c_str(), 1);
+      } catch (std::exception e) {
+        LOG(WARN) << "Exception occurred during GRP semaphore setup; Continuing without";
+        sem = nullptr;
+      }
+    }
     try {
-      boost::interprocess::named_semaphore sem(boost::interprocess::open_or_create_t{}, semhashedstring.c_str(), 1);
-      sem.wait(); // wait until we can enter (no one else there)
+      if (sem) {
+        sem->wait(); // wait until we can enter (no one else there)
+      }
+
+      auto postSem = [sem] {
+        if (sem) {
+          sem->post();
+          delete sem;
+        }
+      };
 
       TFile flGRP(mGRPFileName.c_str(), "update");
       if (flGRP.IsZombie()) {
         LOG(ERROR) << "Failed to open in update mode " << mGRPFileName;
+        postSem();
         return;
       }
       std::unique_ptr<GRP> grp(static_cast<GRP*>(flGRP.GetObjectChecked(grpName.c_str(), GRP::Class())));
@@ -85,7 +105,7 @@ class GRPDPLUpdatedTask
       flGRP.WriteObjectAny(grp.get(), grp->Class(), grpName.c_str());
       flGRP.Close();
 
-      sem.post(); // here we are done; put to green for others waiting
+      postSem();
     } catch (boost::interprocess::interprocess_exception e) {
       LOG(ERROR) << "Caught semaphore exception " << e.what();
     }

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -170,6 +170,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option to disable MC truth
   workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable  mc-truth"}});
 
+  // option to disable INI file writing
+  workflowOptions.push_back(ConfigParamSpec{"disable-write-ini", o2::framework::VariantType::Bool, false, {"disable  INI config write"}});
+
   // option to use/not use CCDB for TOF
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
 
@@ -392,8 +395,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   ConfigurableParam::setValue("DigiParams", "mctruth", mctruth);
 
   // write the configuration used for the digitizer workflow
+  // (In the case, in which we call multiple processes to do digitization,
+  //  only one of them should write this file ... but take the complete configKeyValue line)
   if (ismaster) {
-    o2::conf::ConfigurableParam::writeINI(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE));
+    if (!configcontext.options().get<bool>("disable-write-ini")) {
+      o2::conf::ConfigurableParam::writeINI(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE));
+    }
   }
 
   // onlyDet takes precedence on skipDet


### PR DESCRIPTION
use semaphore protection only when asked

allow not writing the *.ini config file