### PR TITLE
Log only 1st instances of Alpide/GBT errors in ITS/MFT, summarize on EOS

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -273,8 +273,7 @@ class AlpideCoder
 #ifdef ALPIDE_DECODING_STAT
           chipData.setError(ChipStat::NoDataFound);
 #endif
-          LOG(ERROR) << "Expected DataShort or DataLong mask, got : " << dataS;
-          return Error;
+          return unexpectedEOF(fmt::format("Expected DataShort or DataLong mask, got {:x}", dataS));
         }
         expectInp = ExpectChipTrailer | ExpectData | ExpectRegion;
         continue; // end of DATA(SHORT or LONG) processing
@@ -415,7 +414,11 @@ class AlpideCoder
   void resetMap();
 
   ///< error message on unexpected EOF
-  static int unexpectedEOF(const std::string& message);
+  static int unexpectedEOF(const std::string& message)
+  {
+    LOG(DEBUG) << message;
+    return Error;
+  }
 
   // =====================================================================
   //

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -57,11 +57,11 @@ struct ChipStat {
     "Unknow word"                                   // UnknownWord
   };
 
-  uint16_t chipID = 0;
+  uint16_t id = -1;
   size_t nHits = 0;
   std::array<uint32_t, NErrorsDefined> errorCounts = {};
   ChipStat() = default;
-  ChipStat(uint16_t id) : chipID(id) {}
+  ChipStat(uint16_t _id) : id(id) {}
 
   void clear()
   {
@@ -70,19 +70,8 @@ struct ChipStat {
   }
 
   uint32_t getNErrors() const;
-
-  void addErrors(uint32_t mask)
-  {
-    if (mask) {
-      for (int i = NErrorsDefined; i--;) {
-        if (mask & (0x1 << i)) {
-          errorCounts[i]++;
-        }
-      }
-    }
-  }
-
-  void print(bool skipEmpty = true) const;
+  void addErrors(uint32_t mask, uint16_t chID);
+  void print(bool skipNoErr = true, const std::string& pref = "FEEID") const;
 
   ClassDefNV(ChipStat, 1);
 };
@@ -151,7 +140,7 @@ struct GBTLinkDecodingStat {
     packetStates.fill(0);
   }
 
-  void print(bool skipEmpty = true) const;
+  void print(bool skipNoErr = true) const;
 
   ClassDefNV(GBTLinkDecodingStat, 2);
 };

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -61,7 +61,7 @@ struct ChipStat {
   size_t nHits = 0;
   std::array<uint32_t, NErrorsDefined> errorCounts = {};
   ChipStat() = default;
-  ChipStat(uint16_t _id) : id(id) {}
+  ChipStat(uint16_t _id) : id(_id) {}
 
   void clear()
   {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -135,15 +135,15 @@ class ChipPixelData
   void swap(ChipPixelData& other)
   {
     // swap content of two objects
-    mPixels.swap(other.mPixels);
-    std::swap(mROFrame, other.mROFrame);
     std::swap(mROFlags, other.mROFlags);
-    std::swap(mTrigger, other.mTrigger);
-    std::swap(mInteractionRecord, other.mInteractionRecord);
     std::swap(mChipID, other.mChipID);
-    // strictly speaking, swapping the data below is not needed
-    std::swap(mStartID, other.mStartID);
-    std::swap(mFirstUnmasked, other.mFirstUnmasked);
+    std::swap(mROFrame, other.mROFrame);
+    std::swap(mFirstUnmasked, other.mFirstUnmasked); // strictly speaking, not needed
+    std::swap(mStartID, other.mStartID);             // strictly speaking, not needed
+    std::swap(mTrigger, other.mTrigger);
+    std::swap(mErrors, other.mErrors);
+    std::swap(mInteractionRecord, other.mInteractionRecord);
+    mPixels.swap(other.mPixels);
   }
 
   void maskFiredInSample(const ChipPixelData& sample)

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -85,7 +85,7 @@ class RawPixelDecoder final : public PixelReader
   void setVerbosity(int v);
   int getVerbosity() const { return mVerbosity; }
 
-  void printReport(bool decstat = false, bool skipEmpty = true) const;
+  void printReport(bool decstat = true, bool skipNoErr = true) const;
 
   void clearStat();
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -85,7 +85,7 @@ struct RawDecodingStat {
     errorCounts.fill(0);
   }
 
-  void print(bool skipEmpty = true) const
+  void print(bool skipNoErr = true) const
   {
     printf("\nDecoding statistics\n");
     printf("%llu bytes for %llu RUs processed in %llu pages for %llu triggers\n", (ULL)nBytesProcessed, (ULL)nRUsProcessed,
@@ -97,7 +97,7 @@ struct RawDecodingStat {
     }
     printf("Decoding errors: %d\n", nErr);
     for (int i = 0; i < NErrorsDefined; i++) {
-      if (!skipEmpty || errorCounts[i]) {
+      if (!skipNoErr || errorCounts[i]) {
         printf("%-70s: %d\n", ErrNames[i].data(), errorCounts[i]);
       }
     }

--- a/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/AlpideCoder.cxx
@@ -12,8 +12,6 @@
 /// \brief Implementation of the ALPIDE data decoding/encoding
 
 #include "ITSMFTReconstruction/AlpideCoder.h"
-#include <TClass.h>
-#include <TFile.h>
 
 using namespace o2::itsmft;
 
@@ -145,11 +143,4 @@ void AlpideCoder::resetMap()
   // reset map of hits for current chip
   mFirstInRow.clear();
   mPix2Encode.clear();
-}
-
-//_____________________________________
-int AlpideCoder::unexpectedEOF(const std::string& message)
-{
-  LOG(ERROR) << message;
-  return Error;
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -19,22 +19,6 @@ using namespace o2::itsmft;
 constexpr std::array<std::string_view, ChipStat::NErrorsDefined> ChipStat::ErrNames;
 
 ///_________________________________________________________________
-/// print chip decoding statistics
-void ChipStat::print(bool skipEmpty) const
-{
-  uint32_t nErr = 0;
-  for (int i = NErrorsDefined; i--;) {
-    nErr += errorCounts[i];
-  }
-  LOGF(INFO, "Chip#%5d NHits: %9zu  errors: %u", chipID, nHits, nErr);
-  for (int i = 0; i < NErrorsDefined; i++) {
-    if (!skipEmpty || errorCounts[i]) {
-      LOGF(INFO, "%-70s: %u", ErrNames[i].data(), errorCounts[i]);
-    }
-  }
-}
-
-///_________________________________________________________________
 uint32_t ChipStat::getNErrors() const
 {
   uint32_t nerr = 0;
@@ -46,23 +30,59 @@ uint32_t ChipStat::getNErrors() const
 
 ///_________________________________________________________________
 /// print link decoding statistics
-void GBTLinkDecodingStat::print(bool skipEmpty) const
+void ChipStat::addErrors(uint32_t mask, uint16_t id)
+{
+  if (mask) {
+    for (int i = NErrorsDefined; i--;) {
+      if (mask & (0x1 << i)) {
+        if (!errorCounts[i]) {
+          LOGP(ERROR, "New error registered on the link: chip#{}: {}", id, ErrNames[i]);
+        }
+        errorCounts[i]++;
+      }
+    }
+  }
+}
+
+///_________________________________________________________________
+/// print chip decoding statistics
+void ChipStat::print(bool skipNoErr, const std::string& pref) const
+{
+  uint32_t nErr = 0;
+  for (int i = NErrorsDefined; i--;) {
+    nErr += errorCounts[i];
+  }
+  if (!skipNoErr || nErr) {
+    LOGP(INFO, "{}#{:x} NHits: {}  errors: {}", pref.c_str(), id, nHits, nErr);
+    for (int i = 0; i < NErrorsDefined; i++) {
+      if (!skipNoErr || errorCounts[i]) {
+        LOGP(INFO, "Err.: {}: {}", ErrNames[i].data(), errorCounts[i]);
+      }
+    }
+  }
+}
+
+///_________________________________________________________________
+/// print link decoding statistics
+void GBTLinkDecodingStat::print(bool skipNoErr) const
 {
   int nErr = 0;
   for (int i = NErrorsDefined; i--;) {
     nErr += errorCounts[i];
   }
-  LOGF(INFO, "GBTLink#0x%d Packet States Statistics (total packets: %d, triggers: %d)", ruLinkID, nPackets, nTriggers);
-  for (int i = 0; i < GBTDataTrailer::MaxStateCombinations; i++) {
-    if (packetStates[i]) {
-      std::bitset<GBTDataTrailer::NStatesDefined> patt(i);
-      LOGF(INFO, "counts for triggers B[%s] : %d", patt.to_string().c_str(), packetStates[i]);
+  if (!skipNoErr || nErr) {
+    LOGP(INFO, "FEEID#{%s} Packet States Statistics (total packets: {}, triggers: {})", ruLinkID, nPackets, nTriggers);
+    for (int i = 0; i < GBTDataTrailer::MaxStateCombinations; i++) {
+      if (packetStates[i]) {
+        std::bitset<GBTDataTrailer::NStatesDefined> patt(i);
+        LOGP(INFO, "counts for triggers B{:s}: {}", patt.to_string().c_str(), packetStates[i]);
+      }
     }
-  }
-  LOGF(INFO, "Decoding errors: %u", nErr);
-  for (int i = 0; i < NErrorsDefined; i++) {
-    if (!skipEmpty || errorCounts[i]) {
-      LOGF(INFO, "%-70s: %u", ErrNames[i].data(), errorCounts[i]);
+    LOGP(INFO, "Decoding errors: {}", nErr);
+    for (int i = 0; i < NErrorsDefined; i++) {
+      if (!skipNoErr || errorCounts[i]) {
+        LOGF(INFO, "{<}: {}", ErrNames[i].data(), errorCounts[i]);
+      }
     }
   }
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -32,6 +32,7 @@ using RDH = o2::header::RAWDataHeader;
 /// create link with given ids
 GBTLink::GBTLink(uint16_t _cru, uint16_t _fee, uint8_t _ep, uint8_t _idInCru, uint16_t _chan) : idInCRU(_idInCru), cruID(_cru), feeID(_fee), endPointID(_ep), channelID(_chan)
 {
+  chipStat.id = _fee;
 }
 
 ///_________________________________________________________________
@@ -40,8 +41,10 @@ std::string GBTLink::describe() const
 {
   std::stringstream ss;
   ss << "Link cruID=0x" << std::hex << std::setw(4) << std::setfill('0') << cruID << std::dec
-     << "/lID=" << int(idInCRU) << "/feeID=0x" << std::hex << std::setw(4) << std::setfill('0') << feeID << std::dec
-     << " lanes: " << std::bitset<28>(lanes).to_string();
+     << "/lID=" << int(idInCRU) << "/feeID=0x" << std::hex << std::setw(4) << std::setfill('0') << feeID << std::dec;
+  if (lanes) {
+    ss << " lanes: " << std::bitset<28>(lanes).to_string();
+  }
   return ss.str();
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -140,7 +140,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDH(const RDH& rdh)
   ErrorType err = NoError;
   if (!RDHUtils::checkRDH(rdh, true)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrNoRDHAtStart]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrNoRDHAtStart] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNoRDHAtStart];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrNoRDHAtStart);
@@ -157,7 +157,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDH(const RDH& rdh)
   }
   if ((RDHUtils::getPacketCounter(rdh) > packetCounter + 1) && packetCounter >= 0) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPacketCounterJump]
                  << " : jump from " << int(packetCounter) << " to " << int(RDHUtils::getPacketCounter(rdh));
     }
@@ -175,7 +175,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDHStop(const RDH& rdh)
   if (format == NewFormat && lastRDH && RDHUtils::getHeartBeatOrbit(*lastRDH) != RDHUtils::getHeartBeatOrbit(rdh) // new HB starts
       && !RDHUtils::getStop(*lastRDH)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrPageNotStopped]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrPageNotStopped] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPageNotStopped];
       RDHUtils::printRDH(*lastRDH);
       RDHUtils::printRDH(rdh);
@@ -192,7 +192,7 @@ GBTLink::ErrorType GBTLink::checkErrorsRDHStopPageEmpty(const RDH& rdh)
 {
   if (format == NewFormat && RDHUtils::getStop(rdh) && RDHUtils::getMemorySize(rdh) != sizeof(RDH) + sizeof(GBTDiagnostic)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrStopPageNotEmpty]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrStopPageNotEmpty] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrStopPageNotEmpty];
       RDHUtils::printRDH(rdh);
     }
@@ -207,9 +207,9 @@ GBTLink::ErrorType GBTLink::checkErrorsRDHStopPageEmpty(const RDH& rdh)
 GBTLink::ErrorType GBTLink::checkErrorsTriggerWord(const GBTTrigger* gbtTrg)
 {
   if (!gbtTrg->isTriggerWord()) { // check trigger word
-    gbtTrg->printX();
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrigger]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrigger] == 1) {
+      gbtTrg->printX();
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTTrigger];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrMissingGBTTrigger);
@@ -232,8 +232,8 @@ GBTLink::ErrorType GBTLink::checkErrorsHeaderWord(const GBTDataHeader* gbtH)
 {
   if (!gbtH->isDataHeader()) { // check header word
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader]++;
-    gbtH->printX();
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader] == 1) {
+      gbtH->printX();
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTHeader];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrMissingGBTHeader);
@@ -248,8 +248,8 @@ GBTLink::ErrorType GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
 {
   if (!gbtH->isDataHeader()) { // check header word
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader]++;
-    gbtH->printX();
     if (verbosity >= VerboseErrors) {
+      gbtH->printX();
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTHeader];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrMissingGBTHeader);
@@ -259,7 +259,7 @@ GBTLink::ErrorType GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
   // RSTODO: this makes sense only for old format, where every trigger has its RDH
   if (gbtH->packetIdx != cnt) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt] << ": diff in GBT header "
                  << gbtH->packetIdx << " and RDH page " << cnt << " counters";
     }
@@ -271,7 +271,7 @@ GBTLink::ErrorType GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
     //if (cnt) { // makes sens for old format only
     if (gbtH->packetIdx) {
       statistics.errorCounts[GBTLinkDecodingStat::ErrNonZeroPageAfterStop]++;
-      if (verbosity >= VerboseErrors) {
+      if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrNonZeroPageAfterStop] == 1) {
         LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNonZeroPageAfterStop]
                    << ": Non-0 page counter (" << cnt << ") while all lanes were stopped";
       }
@@ -288,8 +288,8 @@ GBTLink::ErrorType GBTLink::checkErrorsActiveLanes(int cbl)
 {
   if (~cbl & lanesActive) { // are there wrong lanes?
     statistics.errorCounts[GBTLinkDecodingStat::ErrInvalidActiveLanes]++;
-    std::bitset<32> expectL(cbl), gotL(lanesActive);
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrInvalidActiveLanes] == 1) {
+      std::bitset<32> expectL(cbl), gotL(lanesActive);
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrInvalidActiveLanes] << ' '
                  << gotL << " vs " << expectL << " skip page";
     }
@@ -306,7 +306,7 @@ GBTLink::ErrorType GBTLink::checkErrorsGBTData(int cablePos)
   lanesWithData |= 0x1 << cablePos;    // flag that the data was seen on this lane
   if (lanesStop & (0x1 << cablePos)) { // make sure stopped lanes do not transmit the data
     statistics.errorCounts[GBTLinkDecodingStat::ErrDataForStoppedLane]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrDataForStoppedLane] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrDataForStoppedLane]
                  << cablePos;
     }
@@ -324,14 +324,16 @@ GBTLink::ErrorType GBTLink::checkErrorsGBTDataID(const GBTData* gbtD)
   if (gbtD->isData()) {
     return NoError;
   }
-  if (gbtD->isCableDiagnostic()) {
-    printCableDiagnostic((GBTCableDiagnostic*)gbtD);
-  } else if (gbtD->isStatus()) {
-    printCableStatus((GBTCableStatus*)gbtD);
-  }
-  LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrGBTWordNotRecognized];
-  gbtD->printX(true);
   statistics.errorCounts[GBTLinkDecodingStat::ErrGBTWordNotRecognized]++;
+  if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrGBTWordNotRecognized] == 1) {
+    if (gbtD->isCableDiagnostic()) {
+      printCableDiagnostic((GBTCableDiagnostic*)gbtD);
+    } else if (gbtD->isStatus()) {
+      printCableStatus((GBTCableStatus*)gbtD);
+    }
+    gbtD->printX(true);
+    LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrGBTWordNotRecognized];
+  }
   return Skip;
 }
 
@@ -342,7 +344,7 @@ GBTLink::ErrorType GBTLink::checkErrorsTrailerWord(const GBTDataTrailer* gbtT)
   if (!gbtT->isDataTrailer()) {
     gbtT->printX();
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrailer]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrailer] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTTrailer];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrMissingGBTTrailer);
@@ -359,7 +361,7 @@ GBTLink::ErrorType GBTLink::checkErrorsPacketDoneMissing(const GBTDataTrailer* g
 {
   if (!gbtT->packetDone && notEnd) { // Done may be missing only in case of carry-over to new CRU page
     statistics.errorCounts[GBTLinkDecodingStat::ErrPacketDoneMissing]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrPacketDoneMissing] == 1) {
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPacketDoneMissing];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrPacketDoneMissing);
@@ -377,8 +379,8 @@ GBTLink::ErrorType GBTLink::checkErrorsLanesStops()
   if ((lanesActive & ~lanesStop)) {
     if (RDHUtils::getTriggerType(*lastRDH) != o2::trigger::SOT) { // only SOT trigger allows unstopped lanes?
       statistics.errorCounts[GBTLinkDecodingStat::ErrUnstoppedLanes]++;
-      std::bitset<32> active(lanesActive), stopped(lanesStop);
-      if (verbosity >= VerboseErrors) {
+      if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrUnstoppedLanes] == 1) {
+        std::bitset<32> active(lanesActive), stopped(lanesStop);
         LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrUnstoppedLanes]
                    << " | active: " << active << " stopped: " << stopped;
       }
@@ -388,9 +390,9 @@ GBTLink::ErrorType GBTLink::checkErrorsLanesStops()
   }
   // make sure all active lanes (except those in time-out) have sent some data
   if ((~lanesWithData & lanesActive) != lanesTimeOut) {
-    std::bitset<32> withData(lanesWithData), active(lanesActive), timeOut(lanesTimeOut);
     statistics.errorCounts[GBTLinkDecodingStat::ErrNoDataForActiveLane]++;
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrNoDataForActiveLane] == 1) {
+      std::bitset<32> withData(lanesWithData), active(lanesActive), timeOut(lanesTimeOut);
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNoDataForActiveLane]
                  << " | with data: " << withData << " active: " << active << " timeOut: " << timeOut;
     }
@@ -406,8 +408,8 @@ GBTLink::ErrorType GBTLink::checkErrorsDiagnosticWord(const GBTDiagnostic* gbtD)
 {
   if (RDHUtils::getMemorySize(lastRDH) != sizeof(RDH) + sizeof(GBTDiagnostic) || !gbtD->isDiagnosticWord()) { //
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingDiagnosticWord]++;
-    gbtD->printX();
-    if (verbosity >= VerboseErrors) {
+    if (verbosity >= VerboseErrors || statistics.errorCounts[GBTLinkDecodingStat::ErrMissingDiagnosticWord] == 1) {
+      gbtD->printX();
       LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingDiagnosticWord];
     }
     errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrMissingDiagnosticWord);

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -53,7 +53,7 @@ void RUDecodeData::setROFInfo(ChipPixelData* chipData, const GBTLink* lnk)
 void RUDecodeData::fillChipStatistics(int icab, const ChipPixelData* chipData)
 {
   cableLinkPtr[icab]->chipStat.nHits += chipData->getData().size();
-  cableLinkPtr[icab]->chipStat.addErrors(chipData->getErrorFlags());
+  cableLinkPtr[icab]->chipStat.addErrors(chipData->getErrorFlags(), chipData->getChipID());
 }
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -40,7 +40,7 @@ RawPixelDecoder<Mapping>::RawPixelDecoder()
 ///______________________________________________________________
 ///
 template <class Mapping>
-void RawPixelDecoder<Mapping>::printReport(bool decstat, bool skipEmpty) const
+void RawPixelDecoder<Mapping>::printReport(bool decstat, bool skipNoErr) const
 {
   LOGF(INFO, "%s Decoded %zu hits in %zu non-empty chips in %u ROFs with %d threads", mSelfName, mNPixelsFired, mNChipsFired, mROFCounter, mNThreads);
   double cpu = 0, real = 0;
@@ -60,11 +60,10 @@ void RawPixelDecoder<Mapping>::printReport(bool decstat, bool skipEmpty) const
        mDecodeNextAuto ? "AutoDecode" : "ExternalCall");
 
   if (decstat) {
-    LOG(INFO) << "GBT Links decoding statistics";
+    LOG(INFO) << "GBT Links decoding statistics" << (skipNoErr ? " (only links with errors are reported)" : "");
     for (auto& lnk : mGBTLinks) {
-      LOG(INFO) << lnk.describe();
-      lnk.statistics.print(skipEmpty);
-      lnk.chipStat.print(skipEmpty);
+      lnk.statistics.print(skipNoErr);
+      lnk.chipStat.print(skipNoErr);
     }
   }
 }


### PR DESCRIPTION
* LOG only 1st instance of new Alpide decoding error, show full report in the end.
Direct logging of decoding errors from AlpideCoder is changed to DEBUG level. Instead, each time a new Alpide decoding error type on the given GBT link is encountered for the 1st time, a LOG(ERROR) will be produced.
The decoded->printReport in the EOS of STFDecoder will be now called with per link decoding statistics
with skipEmpy option, showing statistics and errors only for links which registered some error.

* Log only 1st instance of new GBT link decoding error.
Error message will be produces at 1st encounter of given error type on given GBT link.
The full error summary with error counts will be printed on EOS.
