### PR TITLE
DPL GUI: improve profiler / debugger support

### DIFF
--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -725,8 +725,10 @@ void displayDriverInfo(DriverInfo const& driverInfo, DriverControl& driverContro
     setenv("O2DEBUGGEDPID", pidStr.c_str(), 1);
 #ifdef __APPLE__
     std::string defaultAppleDebugCommand =
-      "osascript -e 'tell application \"Terminal\" to activate'"
-      " -e 'tell application \"Terminal\" to do script \"lldb -p \" & (system attribute \"O2DEBUGGEDPID\")'";
+      "osascript -e 'tell application \"Terminal\"'"
+      " -e 'activate'"
+      " -e 'do script \"lldb -p \" & (system attribute \"O2DEBUGGEDPID\") & \"; exit\"'"
+      " -e 'end tell'";
     setenv("O2DPLDEBUG", defaultAppleDebugCommand.c_str(), 0);
 #else
     setenv("O2DPLDEBUG", "xterm -hold -e gdb attach $O2DEBUGGEDPID &", 0);
@@ -741,12 +743,13 @@ void displayDriverInfo(DriverInfo const& driverInfo, DriverControl& driverContro
     setenv("O2PROFILEDPID", pidStr.c_str(), 1);
 #ifdef __APPLE__
     auto defaultAppleProfileCommand = fmt::format(
-      "osascript -e 'tell application \"Terminal\" to activate'"
-      " -e 'tell application \"Terminal\" to do script \"xcrun xctrace record --output dpl-profile-{}.trace"
-      " --time-limit 30s --template Time\\\\ Profiler --attach {} "
-      " && open dpl-profile-{}.trace && exit\"'"
-      " && open dpl-driver-profile-{}.trace",
-      pid, pid, pid, pid);
+      "osascript -e 'tell application \"Terminal\"'"
+      " -e 'activate'"
+      " -e 'do script \"xcrun xctrace record --output dpl-profile-{0}.trace"
+      " --time-limit 30s --template Time\\\\ Profiler --attach {0} "
+      " && open dpl-profile-{0}.trace && exit\"'"
+      " -e 'end tell'",
+      pid);
     std::cout << defaultAppleProfileCommand << std::endl;
     setenv("O2DPLPROFILE", defaultAppleProfileCommand.c_str(), 0);
 #else

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -205,7 +205,7 @@ void displayDeviceInspector(DeviceSpec const& spec,
 #ifdef __APPLE__
     std::string defaultAppleDebugCommand =
       "osascript -e 'tell application \"Terminal\" to activate'"
-      " -e 'tell application \"Terminal\" to do script \"lldb -p \" & (system attribute \"O2DEBUGGEDPID\")'";
+      " -e 'tell application \"Terminal\" to do script \"lldb -p \" & (system attribute \"O2DEBUGGEDPID\") & \"; exit\"'";
     setenv("O2DPLDEBUG", defaultAppleDebugCommand.c_str(), 0);
 #else
     setenv("O2DPLDEBUG", "xterm -hold -e gdb attach $O2DEBUGGEDPID &", 0);
@@ -219,12 +219,15 @@ void displayDeviceInspector(DeviceSpec const& spec,
     std::string pid = std::to_string(info.pid);
     setenv("O2PROFILEDPID", pid.c_str(), 1);
 #ifdef __APPLE__
-    std::string defaultAppleProfileCommand =
-      "osascript -e 'tell application \"Terminal\" to activate'"
-      " -e 'tell application \"Terminal\" to do script \"instruments -D dpl-profile-" +
-      pid +
-      ".trace -l 30000 -t Time\\\\ Profiler -p " +
-      pid + " && open dpl-profile-" + pid + ".trace && exit\"'";
+    auto defaultAppleProfileCommand = fmt::format(
+      "osascript -e 'tell application \"Terminal\"'"
+      " -e 'activate'"
+      " -e 'do script \"xcrun xctrace record --output dpl-profile-{0}.trace"
+      " --time-limit 30s --template Time\\\\ Profiler --attach {0} "
+      " && open dpl-profile-{0}.trace && exit\"'"
+      " -e 'end tell'",
+      pid);
+
     setenv("O2DPLPROFILE", defaultAppleProfileCommand.c_str(), 0);
 #else
     setenv("O2DPLPROFILE", "xterm -hold -e perf record -a -g -p $O2PROFILEDPID > perf-$O2PROFILEDPID.data &", 0);


### PR DESCRIPTION
On macOS:

* do not open two terminals when launching debugger / profiler
* avoid spurious opening the wrong profiler stacktrace
* Use xcrun for compatibility with new XCode