### PR TITLE
Fix dy calculation in TRD TrackletTransformer

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -42,7 +42,7 @@ class TrackletTransformer
 
   float calculateZ(int padrow);
 
-  float calculateDy(int slope, double oldLorentzAngle, double lorentzAngle, double driftVRatio);
+  float calculateDy(int slope, double lorentzAngle, double driftVRatio);
 
   float calibrateX(double x, double t0Correction);
 
@@ -62,7 +62,6 @@ class TrackletTransformer
   float mXtb0;
 
   float mt0Correction;
-  float mOldLorentzAngle;
   float mLorentzAngle;
   float mDriftVRatio;
 };

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -24,18 +24,15 @@ TrackletTransformer::TrackletTransformer()
 
   // 3 cm
   mXCathode = mGeo->cdrHght();
-  // 2.221
-  // mXAnode = mGeo->anodePos();
   // 3.35
   mXAnode = mGeo->cdrHght() + mGeo->camHght() / 2;
-  // 2.5
+  // 5mm below cathode plane to reduce error propogation from tracklet fit and driftV
   mXDrift = mGeo->cdrHght() - 0.5;
   mXtb0 = -100;
 
   // dummy values for testing. This will change in the future when values are pulled from CCDB
   mt0Correction = -0.279;
-  mOldLorentzAngle = 0.16;
-  mLorentzAngle = -0.14;
+  mLorentzAngle = 0.14;
   mDriftVRatio = 1.1;
 }
 
@@ -77,50 +74,33 @@ float TrackletTransformer::calculateZ(int padrow)
   return rowPos - rowSize / 2. - middleRowPos;
 }
 
-float TrackletTransformer::calculateDy(int slope, double oldLorentzAngle, double lorentzAngle, double driftVRatio)
+float TrackletTransformer::calculateDy(int slope, double lorentzAngle, double driftVRatio)
 {
   double padWidth = mPadPlane->getWidthIPad();
 
   // temporary dummy value in cm/microsecond
   float vDrift = 1.5464f;
-  float driftHeight = mGeo->cdrHght();
 
-  int dYsigned = 0;
+  int slopeSigned = 0;
   if (slope & (1 << (NBITSTRKLSLOPE - 1))) {
-    dYsigned = -((~(slope - 1)) & ((1 << NBITSTRKLSLOPE) - 1));
+    slopeSigned = -((~(slope - 1)) & ((1 << NBITSTRKLSLOPE) - 1));
   } else {
-    dYsigned = slope & ((1 << NBITSTRKLSLOPE) - 1);
+    slopeSigned = slope & ((1 << NBITSTRKLSLOPE) - 1);
   }
+
   // dy = slope * nTimeBins * padWidth * GRANULARITYTRKLSLOPE;
   // nTimeBins should be number of timebins in drift region. 1 timebin is 100 nanosecond
-  double rawDy = dYsigned * ((driftHeight / vDrift) * 10.) * padWidth * GRANULARITYTRKLSLOPE;
+  double rawDy = slopeSigned * ((mXCathode / vDrift) * 10.) * padWidth * GRANULARITYTRKLSLOPE;
 
-  // driftDistance = 3.35
-  float driftDistance = mGeo->cdrHght() + mGeo->camHght();
+  // NOTE: check what drift height is used in calibration code to ensure consistency
+  // NOTE: check sign convention of Lorentz angle
+  // NOTE: confirm the direction in which vDrift is measured/determined. Is it in x or in direction of drift?
+  double lorentzCorrection = TMath::Tan(lorentzAngle) * mXAnode;
 
-  float cmSlope = rawDy / driftDistance;
+  // assuming angle in Bailhache, fig. 4.17 would be positive in our calibration code
+  double calibratedDy = rawDy - lorentzCorrection;
 
-  double calibratedDy = rawDy - (TMath::Tan(lorentzAngle) * driftDistance);
-  calibratedDy += (TMath::Tan(oldLorentzAngle) * driftDistance * driftVRatio) + cmSlope * (driftDistance * (1 - driftVRatio));
-
-  // ALTERNATIVE METHOD
-
-  // double x_anode_hit = driftDistance*driftVRatio/cmSlope;
-  // double y_anode_hit = driftDistance*driftVRatio;
-
-  // double x_Lorentz_drift_hit = TMath::Tan(oldLorentzAngle)*driftDistance*driftVRatio - TMath::Tan(lorentzAngle)*driftDistance;
-  // double y_Lorentz_drift_hit = driftDistance*driftVRatio - driftDistance;
-
-  // double Delta_x_Lorentz_drift_hit = x_anode_hit - x_Lorentz_drift_hit;
-  // double Delta_y_Lorentz_drift_hit = y_anode_hit - y_Lorentz_drift_hit;
-  // double impact_angle_rec = TMath::ATan2(Delta_y_Lorentz_drift_hit,Delta_x_Lorentz_drift_hit);
-
-  // float calibrationShift = TMath::Tan(impact_angle_rec) * driftDistance;
-
-  // LOG(info) << "ORIGINAL: " << calibratedDy;
-  // LOG(info) << "ALTERNATIVE: " << rawDy + calibrationShift;
-
-  return rawDy; // OS: temporary until calibratedDy is checked. Currently it is too far off from rawDy
+  return rawDy;
 }
 
 float TrackletTransformer::calibrateX(double x, double t0Correction)
@@ -145,7 +125,6 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
   uint64_t padrow = tracklet.getPadRow();
   uint64_t column = tracklet.getColumn();
   uint64_t position = tracklet.getPosition();
-  // 0-255 | units:pads/timebin | granularity=1/1000 (signed integer)
   uint64_t slope = tracklet.getSlope();
 
   // calculate raw local chamber space point
@@ -154,8 +133,9 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
   float y = calculateY(hcid, column, position);
   float z = calculateZ(padrow);
 
-  float dy = calculateDy(slope, mOldLorentzAngle, mLorentzAngle, mDriftVRatio);
+  float dy = calculateDy(slope, mLorentzAngle, mDriftVRatio);
   float calibratedX = calibrateX(x, mt0Correction);
+  // NOTE: Correction to y position based on x calibration NOT YET implemented. Need t0.
 
   std::array<float, 3> sectorSpacePoint = transformL2T(hcid, std::array<double, 3>{calibratedX, y, z});
 


### PR DESCRIPTION
This PR fixes the calculation and calibration of the deflection length in `TrackletTransformer`. The previous calculations anticipated pre-calibrated incoming tracklets rather than raw ones. With the incoming tracklets being raw, the calculations are much simpler as no reversal of the previous calibration is required. 

@aschmah, @aberdnikova I have three questions that need to be answered to ensure that the new calculation is correct please:
1. What is the distance in local x-direction over which the Lorentz angle is measured? My expectation would be the 3cm of the drift region, but I recall that we used to use 3.35cm which was the height of the anode plane. I'm not certain if either of those are incorrect to use, but I know for sure that we need to be consistent with regard to this.
2. What sign convention do we use for the Lorentz angle? Alex, I sent you a picture of fig. 4.17 from Bailhache's 2009 thesis. My question is basically whether this angle as it is drawn in the picture would be a positive or negative Lorentz angle in the new code. (This is probably something that could easily be verified later on with residuals)
3. I recall that the vDrift value that is calculated in the calibrations is the component of the velocity in x-direction. Is this still the case? Just wanted to confirm.

Please also let me know if I can help in clearing up any of these questions. Thanks!