### PR TITLE
Fix file name building

### DIFF
--- a/DataFormats/Detectors/Common/src/NameConf.cxx
+++ b/DataFormats/Detectors/Common/src/NameConf.cxx
@@ -21,7 +21,7 @@ std::string NameConf::buildFileName(const std::string_view prefix, const std::st
                                     const std::string_view extension, const std::string_view optDir)
 {
   if (o2::utils::Str::pathIsDirectory(prefix)) { // if path is directory, just add to default name, ignoring optional directory optDir argument
-    return o2::utils::Str::concat_string(prefix, "/", defPrefix, delimiter, defName, extension);
+    return o2::utils::Str::concat_string(prefix, "/", defPrefix, delimiter, defName, '.', extension);
   } else if (!prefix.empty() && o2::utils::Str::pathExists(prefix)) { // explicit file path is provided, use it directly
     return std::string(prefix);
   }


### PR DESCRIPTION
@sawenzel I found an error when trying to load the geometry with `o2::base::GeometryManager::loadGeometry(...)` passing only the directory path
```
[INFO] Loading geometry FAIRGeom from .//o2sim_geometryroot
Error in <TFile::TFile>: file .//o2sim_geometryroot does not exist
[FATAL] Failed to open file .//o2sim_geometryroot
```
This PR should fix the filename creation.