### PR TITLE
Introduce Resource management

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -31,6 +31,7 @@ o2_add_library(Framework
                        src/CommonMessageBackends.cxx
                        src/CompletionPolicy.cxx
                        src/CompletionPolicyHelpers.cxx
+                       src/ComputingQuotaEvaluator.cxx
                        src/ComputingResourceHelpers.cxx
                        src/ConfigContext.cxx
                        src/ControlService.cxx
@@ -85,6 +86,8 @@ o2_add_library(Framework
                        src/RCombinedDS.cxx
                        src/ReadoutAdapter.cxx
                        src/ResourcesMonitoringHelper.cxx
+                       src/ResourcePolicy.cxx
+                       src/ResourcePolicyHelpers.cxx
                        src/ServiceRegistry.cxx
                        src/SimpleResourceManager.cxx
                        src/SimpleRawDeviceService.cxx

--- a/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
+++ b/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_COMPUTINGQUOTAEVALUATOR_H_
+#define O2_COMPUTINGQUOTAEVALUATOR_H_
+
+#include "Framework/ComputingQuotaOffer.h"
+
+#include <cstdint>
+#include <functional>
+#include <array>
+
+typedef struct uv_loop_s uv_loop_t;
+
+namespace o2::framework
+{
+
+
+class ComputingQuotaEvaluator
+{
+  // Maximum number of offers this evaluator can hold
+  static constexpr int MAX_INFLIGHT_OFFERS = 16;
+
+ public:
+  ComputingQuotaEvaluator(uv_loop_t*);
+  ComputingQuotaOfferRef selectOffer(ComputingQuotaRequest const& request);
+
+  void dispose(ComputingQuotaOfferRef offer);
+
+  /// All the available offerts
+  std::array<ComputingQuotaOffer, MAX_INFLIGHT_OFFERS> mOffers;
+  /// Information about a given computing offer (e.g. when it was started to be used)
+  std::array<ComputingQuotaInfo, MAX_INFLIGHT_OFFERS> mInfos;
+  uv_loop_t* mLoop;
+};
+
+} // namespace o2::framework
+
+#endif // O2_COMPUTINGQUOTAEVALUATOR_H_

--- a/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
+++ b/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
@@ -22,7 +22,6 @@ typedef struct uv_loop_s uv_loop_t;
 namespace o2::framework
 {
 
-
 class ComputingQuotaEvaluator
 {
   // Maximum number of offers this evaluator can hold

--- a/Framework/Core/include/Framework/ComputingQuotaOffer.h
+++ b/Framework/Core/include/Framework/ComputingQuotaOffer.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_COMPUTINGQUOTAOFFER_H_
+#define O2_COMPUTINGQUOTAOFFER_H_
+
+#include <functional>
+#include <cstdint>
+#include <cstddef>
+
+namespace o2::framework
+{
+
+struct ComputingQuotaOfferRef {
+  int index;
+};
+
+struct ComputingQuotaOffer {
+  /// How many cores it can use
+  int cpu = 0;
+  /// How much memory it can use
+  int64_t memory = 0;
+  /// How much shared memory it can allocate
+  int64_t sharedMemory = 0;
+  /// How much runtime it can use before giving back the resource
+  /// in milliseconds.
+  int64_t runtime = 0;
+  /// Whether or not the offer is being used
+  bool used;
+  /// Whether or not the offer is valid
+  bool valid;
+};
+
+struct ComputingQuotaInfo {
+  // When the offer was received
+  size_t received = 0;
+  // First time it was used
+  size_t firstUsed = 0;
+  // Last time it was used
+  size_t lastUsed = 0;
+};
+
+/// A request is a function which evaluates to true if the offer
+/// is ok for running. The higher the return value, the
+/// better match is the given resource for the computation.
+using ComputingQuotaRequest = std::function<int8_t(ComputingQuotaOffer const&)>;
+
+} // namespace o2::framework
+
+#endif // O2_COMPUTINGQUOTAOFFER_H_

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -11,6 +11,8 @@
 #define FRAMEWORK_DATAPROCESSING_DEVICE_H
 
 #include "Framework/AlgorithmSpec.h"
+#include "Framework/ComputingQuotaOffer.h"
+#include "Framework/ComputingQuotaEvaluator.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DataRelayer.h"
@@ -30,12 +32,14 @@
 
 #include <memory>
 #include <mutex>
+#include <uv.h>
 
 namespace o2::framework
 {
 
 struct InputChannelInfo;
 struct DeviceState;
+struct ComputingQuotaEvaluator;
 
 /// Context associated to a given DataProcessor.
 /// For the time being everything points to
@@ -45,6 +49,18 @@ struct DeviceState;
 /// thread instances for what makes sense to have
 /// per thread and relax the locks.
 class DataProcessingDevice;
+
+/// Context associated to a device. In principle
+/// multiple DataProcessors can run on a Device (even if we
+/// do not do it for now).
+struct DeviceContext {
+  // These are pointers to the one owned by the DataProcessingDevice
+  // and therefore require actual locking
+  DataProcessingDevice* device = nullptr;
+  DeviceSpec const* spec = nullptr;
+  DeviceState* state = nullptr;
+  ComputingQuotaEvaluator* quotaEvaluator = nullptr;
+};
 
 struct DataProcessorContext {
   // These are specific of a given context and therefore
@@ -57,13 +73,7 @@ struct DataProcessorContext {
   // be accessed without a lock.
 
   // FIXME: move stuff here from the list below... ;-)
-
-  // These are pointers to the one owned by the DataProcessingDevice
-  // and therefore require actual locking
-  DataProcessingDevice* device = nullptr;
-  DeviceSpec const* spec = nullptr;
-  DeviceState* state = nullptr;
-
+  DeviceContext* deviceContext = nullptr;
   DataRelayer* relayer = nullptr;
   ServiceRegistry* registry = nullptr;
   std::vector<DataRelayer::RecordAction>* completed = nullptr;
@@ -75,6 +85,19 @@ struct DataProcessorContext {
   AlgorithmSpec::ErrorCallback* error = nullptr;
 
   std::function<void(o2::framework::RuntimeErrorRef e, InputRecord& record)>* errorHandling = nullptr;
+};
+
+struct TaskStreamRef {
+  int index = -1;
+};
+
+struct TaskStreamInfo {
+  /// The quota offer to be used for the computation
+  ComputingQuotaOfferRef offer;
+  /// The context of the DataProcessor being run by this task
+  DataProcessorContext* context;
+  /// Wether or not this task is running
+  bool running = false;
 };
 
 /// A device actually carrying out all the DPL
@@ -101,9 +124,10 @@ class DataProcessingDevice : public FairMQDevice
 
  protected:
   void error(const char* msg);
-  void fillContext(DataProcessorContext& context);
+  void fillContext(DataProcessorContext& context, DeviceContext& deviceContext);
 
  private:
+  DeviceContext mDeviceContext;
   /// The specification used to create the initial state of this device
   DeviceSpec const& mSpec;
   /// The current internal state of this device.
@@ -132,6 +156,9 @@ class DataProcessingDevice : public FairMQDevice
   std::mutex mRegionInfoMutex;
   enum TerminationPolicy mErrorPolicy = TerminationPolicy::WAIT; /// What to do when an error arises
   bool mWasActive = false;                                       /// Whether or not the device was active at last iteration.
+  std::vector<uv_work_t> mHandles;                               /// Handles to use to schedule work.
+  std::vector<TaskStreamInfo> mStreams;                          /// Information about the task running in the associated mHandle.
+  ComputingQuotaEvaluator mQuotaEvaluator;                       /// The component which evaluates if the offer can be used to run a task
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -23,6 +23,7 @@
 #include "Framework/OutputRoute.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/DispatchPolicy.h"
+#include "Framework/ResourcePolicy.h"
 #include "Framework/ServiceSpec.h"
 
 #include <vector>
@@ -36,7 +37,9 @@ namespace o2::framework
 /// Concrete description of the device which will actually run
 /// a DataProcessor.
 struct DeviceSpec {
+  /// The name of the associated DataProcessorSpec
   std::string name;
+  /// The id of the device, including time-pipelining and suffix
   std::string id;
   std::string channelPrefix;
   std::vector<InputChannelSpec> inputChannels;
@@ -59,6 +62,9 @@ struct DeviceSpec {
   /// The completion policy to use for this device.
   CompletionPolicy completionPolicy;
   DispatchPolicy dispatchPolicy;
+  /// Policy on when the available resources are enough to run
+  /// a computation.
+  ResourcePolicy resourcePolicy;
   ComputingResource resource;
   unsigned short resourceMonitoringInterval;
 };

--- a/Framework/Core/include/Framework/DriverInfo.h
+++ b/Framework/Core/include/Framework/DriverInfo.h
@@ -25,6 +25,7 @@
 #include "Framework/DeviceMetricsInfo.h"
 #include "Framework/LogParsingHelpers.h"
 #include "DataProcessorInfo.h"
+#include "ResourcePolicy.h"
 
 namespace o2::framework
 {
@@ -96,6 +97,10 @@ struct DriverInfo {
   /// These are the policies which can be applied to decide when complete
   /// objects/messages are sent out
   std::vector<DispatchPolicy> dispatchPolicies;
+
+  /// These are the policies which can be applied to decide when there
+  /// is enough resources to process data.
+  std::vector<ResourcePolicy> resourcePolicies;
   /// The argc with which the driver was started.
   int argc;
   /// The argv with which the driver was started.

--- a/Framework/Core/include/Framework/ResourcePolicy.h
+++ b/Framework/Core/include/Framework/ResourcePolicy.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_RESOURCEPOLICY_H_
+#define O2_FRAMEWORK_RESOURCEPOLICY_H_
+
+#include "Framework/ComputingQuotaOffer.h"
+#include <functional>
+#include <string>
+
+namespace o2::framework
+{
+struct DeviceSpec;
+
+/// A policy which specify how a device matched by
+/// @a matcher should react to a given offer by specifying
+/// a given @a request.
+struct ResourcePolicy {
+  using Matcher = std::function<bool(DeviceSpec const& device)>;
+
+  static std::vector<ResourcePolicy> createDefaultPolicies();
+
+  std::string name;
+  Matcher matcher;
+  ComputingQuotaRequest request;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_RESOURCEPOLICY_H_

--- a/Framework/Core/include/Framework/ResourcePolicyHelpers.h
+++ b/Framework/Core/include/Framework/ResourcePolicyHelpers.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_RESOURCEPOLICYHELPERS_H_
+#define O2_FRAMEWORK_RESOURCEPOLICYHELPERS_H_
+
+#include "Framework/ResourcePolicy.h"
+#include <functional>
+#include <string>
+
+namespace o2::framework
+{
+
+struct ResourcePolicyHelpers {
+  static ResourcePolicy trivialTask(char const* taskMatcher);
+  static ResourcePolicy cpuBoundTask(char const* taskMatcher, int maxCPUs = 1);
+  static ResourcePolicy sharedMemoryBoundTask(char const* taskMatcher, int maxMemory);
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_RESOURCEPOLICYHELPERS_H_

--- a/Framework/Core/src/ComputingQuotaEvaluator.cxx
+++ b/Framework/Core/src/ComputingQuotaEvaluator.cxx
@@ -1,0 +1,87 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ComputingQuotaEvaluator.h"
+#include <uv.h>
+
+namespace o2::framework
+{
+
+ComputingQuotaEvaluator::ComputingQuotaEvaluator(uv_loop_t* loop)
+  : mLoop{loop}
+{
+  // The first offer is valid, but does not contain any resource
+  // so this will only work with some device which does not require
+  // any CPU. Notice this will have troubles if a given DPL process
+  // runs for more than a year.
+  mOffers[0] = {
+    0,
+    0,
+    0,
+    -1,
+    false,
+    true};
+  mInfos[0] = {
+    uv_now(loop),
+    0,
+    0};
+}
+
+ComputingQuotaOfferRef ComputingQuotaEvaluator::selectOffer(ComputingQuotaRequest const& evaluator)
+{
+  int8_t bestOfferScore = -1;
+  int bestOfferIndex = -1;
+
+  for (int i = 0; i != mOffers.size(); ++i) {
+    auto& offer = mOffers[i];
+    auto& info = mInfos[i];
+
+    // Ignore:
+    // - Invalid offers
+    // - Used offers
+    // - Expired offers
+    if (offer.valid == false) {
+      continue;
+    }
+    if (offer.used == true) {
+      continue;
+    }
+    if (offer.runtime > 0 && offer.runtime + info.received < uv_now(mLoop)) {
+      continue;
+    }
+    int score = evaluator(offer);
+    if (score > bestOfferScore) {
+      bestOfferScore = score;
+      bestOfferIndex = i;
+    }
+    if (score == 127) {
+      break;
+    }
+  }
+
+  if (bestOfferScore < 0) {
+    return ComputingQuotaOfferRef{-1};
+  }
+  auto& selected = mOffers[bestOfferIndex];
+  auto& info = mInfos[bestOfferIndex];
+  selected.used = true;
+  if (info.firstUsed == 0) {
+    info.firstUsed = uv_now(mLoop);
+  }
+  info.lastUsed = uv_now(mLoop);
+  return ComputingQuotaOfferRef{bestOfferIndex};
+}
+
+void ComputingQuotaEvaluator::dispose(ComputingQuotaOfferRef offer)
+{
+  mOffers[offer.index].used = false;
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -33,6 +33,7 @@
 #include "Framework/SourceInfoHeader.h"
 #include "Framework/Logger.h"
 #include "Framework/DriverClient.h"
+#include "Framework/Monitoring.h"
 #include "PropertyTreeHelpers.h"
 #include "DataProcessingStatus.h"
 #include "DataProcessingHelpers.h"
@@ -466,37 +467,10 @@ bool DataProcessingDevice::ConditionalRun()
     if (NewStatePending()) {
       shouldNotWait = true;
     }
+    TracyPlot("shouldNotWait", (int)shouldNotWait);
     uv_run(mState.loop, shouldNotWait ? UV_RUN_NOWAIT : UV_RUN_ONCE);
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::METRICS_MUST_FLUSH) {
-      LOG(debug) << "New metric to be sent";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::SIGNAL_ARRIVED) {
-      LOG(debug) << "Signal arrived";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_SOCKET_POLLED) {
-      LOG(debug) << "Socket polled";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_INCOMING) {
-      LOG(debug) << "Data read";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::DATA_OUTGOING) {
-      LOG(debug) << "Data written";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::WS_COMMUNICATION) {
-      LOG(debug) << "Communication with WS";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::TIMER_EXPIRED) {
-      LOG(debug) << "Timer expired";
-    }
-    if (mDataProcessorContexes.at(0).state->loopReason & DeviceState::WS_CONNECTED) {
-      LOG(debug) << "WS Connected";
-    }
-    if (shouldNotWait) {
-      LOG(debug) << "Should not wait";
-    }
-    if ((mDataProcessorContexes.at(0).state->loopReason == DeviceState::NO_REASON) && (shouldNotWait == false)) {
-      LOG(debug) << "Unknown reason to trigger the loop";
-    }
+    TracyPlot("loopReason", (int64_t)(uint64_t)mState.loopReason);
+
     mDataProcessorContexes.at(0).state->loopReason = DeviceState::NO_REASON;
 
     // A new state was requested, we exit.

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -14,6 +14,7 @@
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/ChannelMatching.h"
 #include "Framework/ControlService.h"
+#include "Framework/ComputingQuotaEvaluator.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/DataProcessor.h"
 #include "Framework/DataSpecUtils.h"
@@ -90,7 +91,8 @@ DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWor
     mError{mSpec.algorithm.onError},
     mConfigRegistry{nullptr},
     mAllocator{&mTimingInfo, &registry, mSpec.outputs},
-    mServiceRegistry{registry}
+    mServiceRegistry{registry},
+    mQuotaEvaluator{state.loop}
 {
   /// FIXME: move erro handling to a service?
   if (mError != nullptr) {
@@ -120,6 +122,9 @@ DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWor
       }
     };
   }
+  // One task for now.
+  mStreams.resize(1);
+  mHandles.resize(1);
 }
 
 // Callback to execute the processing. Notice how the data is
@@ -128,8 +133,8 @@ DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWor
 void run_callback(uv_work_t* handle)
 {
   ZoneScopedN("run_callback");
-  std::vector<DataProcessorContext>* contexes = (std::vector<DataProcessorContext>*)handle->data;
-  DataProcessorContext& context = contexes->at(0);
+  TaskStreamInfo* task = (TaskStreamInfo*)handle->data;
+  DataProcessorContext& context = *task->context;
   DataProcessingDevice::doPrepare(context);
   DataProcessingDevice::doRun(context);
   //  FrameMark;
@@ -138,6 +143,10 @@ void run_callback(uv_work_t* handle)
 // Once the processing in a thread is done, this is executed on the main thread.
 void run_completion(uv_work_t* handle, int status)
 {
+  TaskStreamInfo* task = (TaskStreamInfo*)handle->data;
+  DataProcessorContext& context = *task->context;
+  context.deviceContext->quotaEvaluator->dispose(task->offer);
+  task->running = false;
   ZoneScopedN("run_completion");
 }
 
@@ -413,16 +422,17 @@ void DataProcessingDevice::InitTask()
   // required parts in the DataProcessorContext. Eventually we should
   // do so on a per thread basis, with fine grained locks.
   mDataProcessorContexes.resize(1);
-  this->fillContext(mDataProcessorContexes.at(0));
+  this->fillContext(mDataProcessorContexes.at(0), mDeviceContext);
 }
 
-void DataProcessingDevice::fillContext(DataProcessorContext& context)
+void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceContext& deviceContext)
 {
   context.wasActive = &mWasActive;
 
-  context.device = this;
-  context.spec = &mSpec;
-  context.state = &mState;
+  deviceContext.device = this;
+  deviceContext.spec = &mSpec;
+  deviceContext.state = &mState;
+  deviceContext.quotaEvaluator = &mQuotaEvaluator;
 
   context.relayer = mRelayer;
   context.registry = &mServiceRegistry;
@@ -433,6 +443,7 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context)
   context.statefulProcess = &mStatefulProcess;
   context.statelessProcess = &mStatelessProcess;
   context.error = &mError;
+  context.deviceContext = &deviceContext;
   /// Callback for the error handling
   context.errorHandling = &mErrorHandling;
 }
@@ -462,8 +473,8 @@ bool DataProcessingDevice::ConditionalRun()
     TracyPlot("past activity", (int64_t)mWasActive);
     mServiceRegistry.get<DriverClient>().flushPending();
     auto shouldNotWait = (mWasActive &&
-                          (mDataProcessorContexes.at(0).state->streaming != StreamingState::Idle) && (mState.activeSignals.empty())) ||
-                         (mDataProcessorContexes.at(0).state->streaming == StreamingState::EndOfStreaming);
+                          (mState.streaming != StreamingState::Idle) && (mState.activeSignals.empty())) ||
+                         (mState.streaming == StreamingState::EndOfStreaming);
     if (NewStatePending()) {
       shouldNotWait = true;
     }
@@ -471,7 +482,7 @@ bool DataProcessingDevice::ConditionalRun()
     uv_run(mState.loop, shouldNotWait ? UV_RUN_NOWAIT : UV_RUN_ONCE);
     TracyPlot("loopReason", (int64_t)(uint64_t)mState.loopReason);
 
-    mDataProcessorContexes.at(0).state->loopReason = DeviceState::NO_REASON;
+    mState.loopReason = DeviceState::NO_REASON;
 
     // A new state was requested, we exit.
     if (NewStatePending()) {
@@ -491,12 +502,43 @@ bool DataProcessingDevice::ConditionalRun()
       }
     }
   }
-  // Synchronous execution of the callbacks. This will be moved in the
-  // moved in the on_socket_polled once we have threading in place.
-  uv_work_t handle;
-  handle.data = &mDataProcessorContexes;
-  run_callback(&handle);
-  run_completion(&handle, 0);
+
+  assert(mStreams.size() == mHandles.size());
+  /// Decide which task to use
+  TaskStreamRef streamRef{-1};
+  for (int ti = 0; ti < mStreams.size(); ti++) {
+    auto& taskInfo = mStreams[ti];
+    if (taskInfo.running) {
+      continue;
+    }
+    streamRef.index = ti;
+  }
+  // We have an empty stream, let's check if we have enough
+  // resources for it to run something
+  if (streamRef.index != -1) {
+    // Synchronous execution of the callbacks. This will be moved in the
+    // moved in the on_socket_polled once we have threading in place.
+    auto& handle = mHandles[streamRef.index];
+    auto& stream = mStreams[streamRef.index];
+    handle.data = &mStreams[streamRef.index];
+
+    // Deciding wether to run or not can be done by passing a request to
+    // the evaluator. In this case, the request is always satisfied and
+    // we run on whatever resource is available.
+    ComputingQuotaOfferRef offer = mQuotaEvaluator.selectOffer(mSpec.resourcePolicy.request);
+
+    if (offer.index != -1) {
+      stream.offer = offer;
+      stream.running = true;
+      stream.context = &mDataProcessorContexes.at(0);
+      run_callback(&handle);
+      run_completion(&handle, 0);
+    } else {
+      mWasActive = false;
+    }
+  } else {
+    mWasActive = false;
+  }
   FrameMark;
   return true;
 }
@@ -519,13 +561,13 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
   // expect to receive an EndOfStream signal. Thus we do not wait for these
   // to be completed. In the case of data source devices, as they do not have
   // real data input channels, they have to signal EndOfStream themselves.
-  context.allDone = std::any_of(context.state->inputChannelInfos.begin(), context.state->inputChannelInfos.end(), [](const auto& info) {
+  context.allDone = std::any_of(context.deviceContext->state->inputChannelInfos.begin(), context.deviceContext->state->inputChannelInfos.end(), [](const auto& info) {
     return info.state != InputChannelState::Pull;
   });
   // Whether or not all the channels are completed
-  for (size_t ci = 0; ci < context.spec->inputChannels.size(); ++ci) {
-    auto& channel = context.spec->inputChannels[ci];
-    auto& info = context.state->inputChannelInfos[ci];
+  for (size_t ci = 0; ci < context.deviceContext->spec->inputChannels.size(); ++ci) {
+    auto& channel = context.deviceContext->spec->inputChannels[ci];
+    auto& info = context.deviceContext->state->inputChannelInfos[ci];
 
     if (info.state != InputChannelState::Completed && info.state != InputChannelState::Pull) {
       context.allDone = false;
@@ -535,7 +577,7 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
     }
     int64_t result = -2;
     if (info.channel == nullptr) {
-      info.channel = &context.device->GetChannel(channel.name, 0);
+      info.channel = &context.deviceContext->device->GetChannel(channel.name, 0);
     }
     auto& socket = info.channel->GetSocket();
     // If we have pending events from a previous iteration,
@@ -581,14 +623,14 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
 
 void DataProcessingDevice::doRun(DataProcessorContext& context)
 {
-  auto switchState = [& registry = context.registry,
-                      &state = context.state](StreamingState newState) {
+  auto switchState = [&registry = context.registry,
+                      &state = context.deviceContext->state](StreamingState newState) {
     LOG(debug) << "New state " << (int)newState << " old state " << (int)state->streaming;
     state->streaming = newState;
     registry->get<ControlService>().notifyStreamingState(state->streaming);
   };
 
-  if (context.state->streaming == StreamingState::Idle) {
+  if (context.deviceContext->state->streaming == StreamingState::Idle) {
     return;
   }
 
@@ -613,12 +655,12 @@ void DataProcessingDevice::doRun(DataProcessorContext& context)
   // callback and return false. Notice that what happens next is actually
   // dependent on the callback, not something which is controlled by the
   // framework itself.
-  if (context.allDone == true && context.state->streaming == StreamingState::Streaming) {
+  if (context.allDone == true && context.deviceContext->state->streaming == StreamingState::Streaming) {
     switchState(StreamingState::EndOfStreaming);
     *context.wasActive = true;
   }
 
-  if (context.state->streaming == StreamingState::EndOfStreaming) {
+  if (context.deviceContext->state->streaming == StreamingState::EndOfStreaming) {
     // We keep processing data until we are Idle.
     // FIXME: not sure this is the correct way to drain the queues, but
     // I guess we will see.
@@ -631,8 +673,8 @@ void DataProcessingDevice::doRun(DataProcessorContext& context)
     context.registry->get<CallbackService>()(CallbackService::Id::EndOfStream, eosContext);
     context.registry->postEOSCallbacks(eosContext);
 
-    for (auto& channel : context.spec->outputChannels) {
-      DataProcessingHelpers::sendEndOfStream(*context.device, channel);
+    for (auto& channel : context.deviceContext->spec->outputChannels) {
+      DataProcessingHelpers::sendEndOfStream(*context.deviceContext->device, channel);
     }
     // This is needed because the transport is deleted before the device.
     context.relayer->clear();
@@ -656,12 +698,12 @@ void DataProcessingDevice::ResetTask()
 void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts& parts, InputChannelInfo& info)
 {
   ZoneScopedN("DataProcessingDevice::handleData");
-  assert(context.spec->inputChannels.empty() == false);
+  assert(context.deviceContext->spec->inputChannels.empty() == false);
   assert(parts.Size() > 0);
 
   // Initial part. Let's hide all the unnecessary and have
   // simple lambdas for each of the steps I am planning to have.
-  assert(!context.spec->inputs.empty());
+  assert(!context.deviceContext->spec->inputs.empty());
 
   enum struct InputType {
     Invalid,
@@ -842,8 +884,8 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
   // This is needed to convert from a pair of pointers to an actual DataRef
   // and to make sure the ownership is moved from the cache in the relayer to
   // the execution.
-  auto fillInputs = [& relayer = context.relayer,
-                     &spec = context.spec,
+  auto fillInputs = [&relayer = context.relayer,
+                     &spec = context.deviceContext->spec,
                      &currentSetOfInputs](TimesliceSlot slot) -> InputRecord {
     currentSetOfInputs = std::move(relayer->getInputsForTimeslice(slot));
     auto getter = [&currentSetOfInputs](size_t i, size_t partindex) -> DataRef {
@@ -924,8 +966,8 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
   // to the next one in the daisy chain.
   // FIXME: do it in a smarter way than O(N^2)
   auto forwardInputs = [&reportError,
-                        &spec = context.spec,
-                        &device = context.device, &currentSetOfInputs](TimesliceSlot slot, InputRecord& record) {
+                        &spec = context.deviceContext->spec,
+                        &device = context.deviceContext->device, &currentSetOfInputs](TimesliceSlot slot, InputRecord& record) {
     ZoneScopedN("forward inputs");
     assert(record.size() == currentSetOfInputs.size());
     // we collect all messages per forward in a map and send them together
@@ -997,8 +1039,8 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     }
   };
 
-  auto switchState = [& control = context.registry->get<ControlService>(),
-                      &state = context.state](StreamingState newState) {
+  auto switchState = [&control = context.registry->get<ControlService>(),
+                      &state = context.deviceContext->state](StreamingState newState) {
     state->streaming = newState;
     control.notifyStreamingState(state->streaming);
   };
@@ -1047,7 +1089,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     }
     if (action.op == CompletionPolicy::CompletionOp::Discard) {
       context.registry->postDispatchingCallbacks(processContext);
-      if (context.spec->forwards.empty() == false) {
+      if (context.deviceContext->spec->forwards.empty() == false) {
         forwardInputs(action.slot, record);
         continue;
       }
@@ -1057,7 +1099,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     uint64_t tStart = uv_hrtime();
     preUpdateStats(action, record, tStart);
     try {
-      if (context.state->quitRequested == false) {
+      if (context.deviceContext->state->quitRequested == false) {
 
         if (*context.statefulProcess) {
           ZoneScopedN("statefull process");
@@ -1090,7 +1132,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     // we keep them for next message arriving.
     if (action.op == CompletionPolicy::CompletionOp::Consume) {
       context.registry->postDispatchingCallbacks(processContext);
-      if (context.spec->forwards.empty() == false) {
+      if (context.deviceContext->spec->forwards.empty() == false) {
         forwardInputs(action.slot, record);
       }
 #ifdef TRACY_ENABLE
@@ -1101,9 +1143,9 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     }
   }
   // We now broadcast the end of stream if it was requested
-  if (context.state->streaming == StreamingState::EndOfStreaming) {
-    for (auto& channel : context.spec->outputChannels) {
-      DataProcessingHelpers::sendEndOfStream(*context.device, channel);
+  if (context.deviceContext->state->streaming == StreamingState::EndOfStreaming) {
+    for (auto& channel : context.deviceContext->spec->outputChannels) {
+      DataProcessingHelpers::sendEndOfStream(*context.deviceContext->device, channel);
     }
     switchState(StreamingState::Idle);
   }

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -737,6 +737,7 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
                                                        std::vector<ChannelConfigurationPolicy> const& channelPolicies,
                                                        std::vector<CompletionPolicy> const& completionPolicies,
                                                        std::vector<DispatchPolicy> const& dispatchPolicies,
+                                                       std::vector<ResourcePolicy> const& resourcePolicies,
                                                        std::vector<DeviceSpec>& devices,
                                                        ResourceManager& resourceManager,
                                                        std::string const& uniqueWorkflowId,
@@ -815,6 +816,17 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
         device.dispatchPolicy = policy;
         break;
       }
+    }
+    bool hasPolicy = false;
+    for (auto& policy : resourcePolicies) {
+      if (policy.matcher(device) == true) {
+        device.resourcePolicy = policy;
+        hasPolicy = true;
+        break;
+      }
+    }
+    if (hasPolicy == false) {
+      throw runtime_error_f("Unable to find a resource policy for %s", device.id.c_str());
     }
   }
 

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -45,6 +45,7 @@ struct DeviceSpecHelpers {
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
     std::vector<CompletionPolicy> const& completionPolicies,
     std::vector<DispatchPolicy> const& dispatchPolicies,
+    std::vector<ResourcePolicy> const& resourcePolicies,
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
@@ -64,8 +65,11 @@ struct DeviceSpecHelpers {
     std::string const& channelPrefix = "")
   {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
+    std::vector<ResourcePolicy> resourcePolicies = ResourcePolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies,
-                                   dispatchPolicies, devices, resourceManager, uniqueWorkflowId, optimizeTopology, resourcesMonitoringInterval, channelPrefix);
+                                   dispatchPolicies, resourcePolicies, devices,
+                                   resourceManager, uniqueWorkflowId, optimizeTopology,
+                                   resourcesMonitoringInterval, channelPrefix);
   }
 
   /// Helper to provide the channel configuration string for an input channel

--- a/Framework/Core/src/ResourcePolicy.cxx
+++ b/Framework/Core/src/ResourcePolicy.cxx
@@ -1,0 +1,24 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ResourcePolicy.h"
+#include "Framework/ResourcePolicyHelpers.h"
+#include <vector>
+
+namespace o2::framework
+{
+
+std::vector<ResourcePolicy> ResourcePolicy::createDefaultPolicies()
+{
+  return {
+    ResourcePolicyHelpers::trivialTask(".*")};
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/ResourcePolicyHelpers.cxx
+++ b/Framework/Core/src/ResourcePolicyHelpers.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ResourcePolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "ResourcesMonitoringHelper.h"
+
+#include <string>
+#include <regex>
+
+namespace o2::framework
+{
+
+/// A trivial task is a task which will execute regardless of
+/// the resources available.
+ResourcePolicy ResourcePolicyHelpers::trivialTask(char const* s)
+{
+  return ResourcePolicy{
+    "trivial",
+    [matcher = std::regex(s)](DeviceSpec const& spec) -> bool {
+      return std::regex_match(spec.name, matcher);
+    },
+    [](ComputingQuotaOffer const&) { return 127; }};
+}
+
+ResourcePolicy ResourcePolicyHelpers::cpuBoundTask(char const* s, int maxCPUs)
+{
+  return ResourcePolicy{
+    "cpu-bound",
+    [matcher = std::regex(s)](DeviceSpec const& spec) -> bool {
+      return std::regex_match(spec.name, matcher);
+    },
+    [maxCPUs](ComputingQuotaOffer const& offer) -> int8_t { return offer.cpu >= maxCPUs ? 127 : 0; }};
+}
+
+ResourcePolicy ResourcePolicyHelpers::sharedMemoryBoundTask(char const* s, int maxSharedMemory)
+{
+  return ResourcePolicy{
+    "shm-bound",
+    [matcher = std::regex(s)](DeviceSpec const& spec) -> bool {
+      return std::regex_match(spec.name, matcher);
+    },
+    [maxSharedMemory](ComputingQuotaOffer const& offer) -> int8_t { return offer.sharedMemory >= maxSharedMemory ? 127 : 0; }};
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1358,6 +1358,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                                             driverInfo.channelPolicies,
                                                             driverInfo.completionPolicies,
                                                             driverInfo.dispatchPolicies,
+                                                            driverInfo.resourcePolicies,
                                                             runningWorkflow.devices,
                                                             *resourceManager,
                                                             driverInfo.uniqueWorkflowId,
@@ -2028,6 +2029,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
            std::vector<ChannelConfigurationPolicy> const& channelPolicies,
            std::vector<CompletionPolicy> const& completionPolicies,
            std::vector<DispatchPolicy> const& dispatchPolicies,
+           std::vector<ResourcePolicy> const& resourcePolicies,
            std::vector<ConfigParamSpec> const& currentWorkflowOptions,
            o2::framework::ConfigContext& configContext)
 {
@@ -2269,6 +2271,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   driverInfo.channelPolicies = channelPolicies;
   driverInfo.completionPolicies = completionPolicies;
   driverInfo.dispatchPolicies = dispatchPolicies;
+  driverInfo.resourcePolicies = resourcePolicies;
   driverInfo.argc = argc;
   driverInfo.argv = argv;
   driverInfo.batch = varmap["no-batch"].defaulted() ? varmap["batch"].as<bool>() : false;


### PR DESCRIPTION
In order to limit the amount of resources used by a DPL workflow,
DPL now has the concept of a resource quota that the task can use.
The default behavior is to ignore quota, but this will change to a mode
where a task can run only if enough CPU quota is available.

This should also allow improving the behavior of the shared memory based rate
limiting, by letting the reader know how much it is allowed to read ahead
before pausing to reduce memory pressure (right now there is a race
condition due to the fact that the "memory used" memory might come too late,
for the driver to be able to stop the reader).
