### PR TITLE
If we use a template for the creator callback, we can pass in different track types

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -106,7 +106,10 @@ struct RecoContainer {
   std::unique_ptr<o2::trd::RecoInputContainer> inputsTRD;                        // special struct for TRD tracklets, trigger records
 
   void collectData(o2::framework::ProcessingContext& pc, const DataRequest& request);
-  void createTracks(std::function<bool(const o2::track::TrackParCov&, float, float, GTrackID)> const& creator) const;
+  void createTracks(std::function<bool(const o2::track::TrackParCov&, GTrackID)> const& creator) const;
+  void createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCov&, GTrackID, float, float)> const& creator) const;
+  template <class T>
+  void createTracksVariadic(T creator) const;
   void fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vector<o2::MCCompLabel>& mcinfo) const;
 
   void addITSTracks(o2::framework::ProcessingContext& pc, bool mc);

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -1,0 +1,164 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RecoContainerCreateTracksVariadic.h
+/// \brief Wrapper container for different reconstructed object types
+/// \author ruben.shahoyan@cern.ch
+
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DataFormatsTPC/WorkflowHelper.h"
+#include "DataFormatsTRD/RecoInputContainer.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTOF/Cluster.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsFT0/RecPoints.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/TrackTPCTOF.h"
+#include "ReconstructionDataFormats/MatchInfoTOF.h"
+
+//________________________________________________________
+template <class T>
+void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
+{
+  // We go from most complete tracks to least complete ones, taking into account that some track times
+  // do not bear their own kinematics but just constrain the time
+  // As we get more track types functional, this method should be completed
+  // If user provided function creator returns true, then the track is considered as consumed and its contributing
+  // simpler tracks will not be provided to the creator. If it returns false, the creator will be called also
+  // with this simpler contrubutors.
+  // The creator function is called with track kinematics, track GlobalTrackID and track timing information as 2 floats
+  // which depends on the track time:
+  // 1) For track types containing TimeStampWithError ts it is ts.getTimeStamp(), getTimeStampError()
+  // 2) For tracks with asymmetric time uncertainty, e.g. TPC: as mean time of t0-errBwd,t+errFwd and 0.5(errBwd+errFwd), all in TPC time bins
+  // 3) For tracks whose timing is provided as RO frame: as time in \mus for RO frame start since the start of TF, half-duration of RO window and 0.
+
+  auto start_time = std::chrono::high_resolution_clock::now();
+  constexpr float PS2MUS = 1e-6;
+  std::array<std::vector<uint8_t>, GTrackID::NSources> usedData;
+  auto flagUsed2 = [&usedData](int idx, int src) {
+    if (!usedData[src].empty()) {
+      usedData[src][idx] = 1;
+    }
+  };
+  auto flagUsed = [&usedData, &flagUsed2](const GTrackID gidx) { flagUsed2(gidx.getIndex(), gidx.getSource()); };
+  auto isUsed2 = [&usedData](int idx, int src) { return (!usedData[src].empty()) && (usedData[src][idx] != 0); };
+  auto isUsed = [&usedData, isUsed2](const GTrackID gidx) { return isUsed2(gidx.getIndex(), gidx.getSource()); };
+
+  // create only for those data types which are used
+  const auto& tracksITS = getITSTracks<o2::its::TrackITS>();
+  const auto& tracksTPC = getTPCTracks<o2::tpc::TrackTPC>();
+  const auto& tracksTPCITS = getTPCITSTracks<o2::dataformats::TrackTPCITS>();
+  const auto& tracksTPCTOF = getTPCTOFTracks<o2::dataformats::TrackTPCTOF>();
+  const auto& matchesTPCTOF = getTPCTOFMatches<o2::dataformats::MatchInfoTOF>();
+
+  usedData[GTrackID::ITS].resize(tracksITS.size());                                      // to flag used ITS tracks
+  usedData[GTrackID::TPC].resize(tracksTPC.size());                                      // to flag used TPC tracks
+  usedData[GTrackID::ITSTPC].resize(tracksTPCITS.size());                                // to flag used ITSTPC tracks
+  usedData[GTrackID::TOF].resize(getTOFMatches<o2::dataformats::MatchInfoTOF>().size()); // to flag used ITSTPC-TOF matches
+
+  // ITS-TPC-TOF matches, may refer to ITS-TPC (TODO: something else?) tracks
+  {
+    auto matches = getTOFMatches<o2::dataformats::MatchInfoTOF>(); // thes are just MatchInfoTOF objects, pointing on ITS-TPC match and TOF cl.
+    auto tofClusters = getTOFClusters<o2::tof::Cluster>();
+    if (matches.size() && (!tofClusters.size() || !tracksTPCITS.size())) {
+      throw std::runtime_error(fmt::format("Global-TOF tracks ({}) require ITS-TPC tracks ({}) and TOF clusters ({})",
+                                           matches.size(), tracksTPCITS.size(), tofClusters.size()));
+    }
+    for (unsigned i = 0; i < matches.size(); i++) {
+      const auto& match = matches[i];
+      const auto& tofCl = tofClusters[match.getTOFClIndex()];
+      float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
+      const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
+
+      auto gidx = match.getEvIdxTrack().getIndex(); // this should be corresponding ITS-TPC track
+      if (creator(tracksPool.get(gidx), {i, GTrackID::ITSTPCTOF}, timeTOFMUS, timeErr)) {
+        flagUsed2(i, GTrackID::TOF);
+        flagUsed(gidx); // flag used ITS-TPC tracks
+      }
+    }
+  }
+
+  // ITS-TPC matches, may refer to ITS, TPC (TODO: something else?) tracks
+  {
+    for (unsigned i = 0; i < tracksTPCITS.size(); i++) {
+      const auto& matchTr = tracksTPCITS[i];
+      if (isUsed2(i, GTrackID::ITSTPC)) {
+        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
+        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
+        continue;
+      }
+      if (creator(matchTr, {i, GTrackID::ITSTPC}, matchTr.getTimeMUS().getTimeStamp(), matchTr.getTimeMUS().getTimeStampError())) {
+        flagUsed2(i, GTrackID::ITSTPC);
+        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
+        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
+      }
+    }
+  }
+
+  // TPC-TOF matches, may refer to TPC (TODO: something else?) tracks
+  {
+    if (matchesTPCTOF.size() && !tracksTPCTOF.size()) {
+      throw std::runtime_error(fmt::format("TPC-TOF matched tracks ({}) require TPCTOF matches ({}) and TPCTOF tracks ({})",
+                                           matchesTPCTOF.size(), tracksTPCTOF.size()));
+    }
+    for (unsigned i = 0; i < matchesTPCTOF.size(); i++) {
+      const auto& match = matchesTPCTOF[i];
+      const auto& gidx = match.getEvIdxTrack().getIndex(); // TPC (or other? but w/o ITS) track global idx (FIXME: TOF has to git rid of EvIndex stuff)
+      if (isUsed(gidx)) {                                  // is TPC track already used
+        continue;
+      }
+      const auto& trc = tracksTPCTOF[i];
+      if (creator(trc, {i, GTrackID::TPCTOF}, trc.getTimeMUS().getTimeStamp(), trc.getTimeMUS().getTimeStampError())) {
+        flagUsed(gidx); // flag used TPC tracks
+      }
+    }
+  }
+
+  // TPC only tracks
+  {
+    for (unsigned i = 0; i < tracksTPC.size(); i++) {
+      if (isUsed2(i, GTrackID::TPC)) { // skip used tracks
+        continue;
+      }
+      const auto& trc = tracksTPC[i];
+      if (creator(trc, {i, GTrackID::TPC}, trc.getTime0() + 0.5 * (trc.getDeltaTFwd() - trc.getDeltaTBwd()), 0.5 * (trc.getDeltaTFwd() + trc.getDeltaTBwd()))) {
+        flagUsed2(i, GTrackID::TPC); // flag used TPC tracks
+      }
+    }
+  }
+
+  // ITS only tracks
+  {
+    const auto& rofrs = getITSTracksROFRecords<o2::itsmft::ROFRecord>();
+    for (unsigned irof = 0; irof < rofrs.size(); irof++) {
+      const auto& rofRec = rofrs[irof];
+      float t0 = rofRec.getBCData().differenceInBC(startIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+      int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
+      for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
+        if (isUsed2(it, GTrackID::ITS)) { // skip used tracks
+          continue;
+        }
+        GTrackID gidITS(it, GTrackID::ITS);
+        const auto& trc = getITSTrack<o2::its::TrackITS>(gidITS);
+        if (creator(trc, gidITS, t0, 0.5)) {
+          flagUsed2(it, GTrackID::ITS);
+        }
+      }
+    }
+  }
+  auto current_time = std::chrono::high_resolution_clock::now();
+  LOG(INFO) << "RecoContainer::createTracks took " << std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 1e-6 << " CPU s.";
+}

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -14,22 +14,7 @@
 
 #include <fmt/format.h>
 #include <chrono>
-#include "Framework/ProcessingContext.h"
-#include "Framework/InputSpec.h"
-#include "DetectorsCommonDataFormats/DetID.h"
-#include "DataFormatsTPC/WorkflowHelper.h"
-#include "DataFormatsTRD/RecoInputContainer.h"
-#include "DataFormatsGlobalTracking/RecoContainer.h"
-#include "DataFormatsITSMFT/CompCluster.h"
-#include "DataFormatsITS/TrackITS.h"
-#include "DataFormatsTPC/TrackTPC.h"
-#include "DataFormatsTOF/Cluster.h"
-#include "DataFormatsITSMFT/ROFRecord.h"
-#include "DataFormatsFT0/RecPoints.h"
-#include "DataFormatsTRD/TrackTRD.h"
-#include "ReconstructionDataFormats/TrackTPCITS.h"
-#include "ReconstructionDataFormats/TrackTPCTOF.h"
-#include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 
 using namespace o2::globaltracking;
 using namespace o2::framework;
@@ -456,137 +441,14 @@ void RecoContainer::fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vecto
   }
 }
 
-//________________________________________________________
-void RecoContainer::createTracks(std::function<bool(const o2::track::TrackParCov&, float, float, GTrackID)> const& creator) const
+void o2::globaltracking::RecoContainer::createTracks(std::function<bool(const o2::track::TrackParCov&, o2::dataformats::GlobalTrackID)> const& creator) const
 {
-  // We go from most complete tracks to least complete ones, taking into account that some track times
-  // do not bear their own kinematics but just constrain the time
-  // As we get more track types functional, this method should be completed
-  // If user provided function creator returns true, then the track is considered as consumed and its contributing
-  // simpler tracks will not be provided to the creator. If it returns false, the creator will be called also
-  // with this simpler contrubutors.
-  // The creator function is called with track kinematics, track GlobalTrackID and track timing information as 2 floats
-  // which depends on the track time:
-  // 1) For track types containing TimeStampWithError ts it is ts.getTimeStamp(), getTimeStampError()
-  // 2) For tracks with asymmetric time uncertainty, e.g. TPC: as mean time of t0-errBwd,t+errFwd and 0.5(errBwd+errFwd), all in TPC time bins
-  // 3) For tracks whose timing is provided as RO frame: as time in \mus for RO frame start since the start of TF, half-duration of RO window and 0.
+  createTracksVariadic([&creator](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) { return creator(_tr, _origID); });
+}
 
-  auto start_time = std::chrono::high_resolution_clock::now();
-  constexpr float PS2MUS = 1e-6;
-  std::array<std::vector<uint8_t>, GTrackID::NSources> usedData;
-  auto flagUsed2 = [&usedData](int idx, int src) {
-    if (!usedData[src].empty()) {
-      usedData[src][idx] = 1;
-    }
-  };
-  auto flagUsed = [&usedData, &flagUsed2](const GTrackID gidx) { flagUsed2(gidx.getIndex(), gidx.getSource()); };
-  auto isUsed2 = [&usedData](int idx, int src) { return (!usedData[src].empty()) && (usedData[src][idx] != 0); };
-  auto isUsed = [&usedData, isUsed2](const GTrackID gidx) { return isUsed2(gidx.getIndex(), gidx.getSource()); };
-
-  // create only for those data types which are used
-  const auto& tracksITS = getITSTracks<o2::its::TrackITS>();
-  const auto& tracksTPC = getTPCTracks<o2::tpc::TrackTPC>();
-  const auto& tracksTPCITS = getTPCITSTracks<o2d::TrackTPCITS>();
-  const auto& tracksTPCTOF = getTPCTOFTracks<o2d::TrackTPCTOF>();
-  const auto& matchesTPCTOF = getTPCTOFMatches<o2d::MatchInfoTOF>();
-
-  usedData[GTrackID::ITS].resize(tracksITS.size());       // to flag used ITS tracks
-  usedData[GTrackID::TPC].resize(tracksTPC.size());       // to flag used TPC tracks
-  usedData[GTrackID::ITSTPC].resize(tracksTPCITS.size()); // to flag used ITSTPC tracks
-  usedData[GTrackID::TOF].resize(getTOFMatches<o2d::MatchInfoTOF>().size()); // to flag used ITSTPC-TOF matches
-
-  // ITS-TPC-TOF matches, may refer to ITS-TPC (TODO: something else?) tracks
-  {
-    auto matches = getTOFMatches<o2d::MatchInfoTOF>(); // thes are just MatchInfoTOF objects, pointing on ITS-TPC match and TOF cl.
-    auto tofClusters = getTOFClusters<o2::tof::Cluster>();
-    if (matches.size() && (!tofClusters.size() || !tracksTPCITS.size())) {
-      throw std::runtime_error(fmt::format("Global-TOF tracks ({}) require ITS-TPC tracks ({}) and TOF clusters ({})",
-                                           matches.size(), tracksTPCITS.size(), tofClusters.size()));
-    }
-    for (unsigned i = 0; i < matches.size(); i++) {
-      const auto& match = matches[i];
-      const auto& tofCl = tofClusters[match.getTOFClIndex()];
-      float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
-      const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
-
-      auto gidx = match.getEvIdxTrack().getIndex(); // this should be corresponding ITS-TPC track
-      if (creator(tracksPool.get(gidx), timeTOFMUS, timeErr, {i, GTrackID::ITSTPCTOF})) {
-        flagUsed2(i, GTrackID::TOF);
-        flagUsed(gidx); // flag used ITS-TPC tracks
-      }
-    }
-  }
-
-  // ITS-TPC matches, may refer to ITS, TPC (TODO: something else?) tracks
-  {
-    for (unsigned i = 0; i < tracksTPCITS.size(); i++) {
-      const auto& matchTr = tracksTPCITS[i];
-      if (isUsed2(i, GTrackID::ITSTPC)) {
-        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
-        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
-        continue;
-      }
-      if (creator(matchTr, matchTr.getTimeMUS().getTimeStamp(), matchTr.getTimeMUS().getTimeStampError(), {i, GTrackID::ITSTPC})) {
-        flagUsed2(i, GTrackID::ITSTPC);
-        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
-        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
-      }
-    }
-  }
-
-  // TPC-TOF matches, may refer to TPC (TODO: something else?) tracks
-  {
-    if (matchesTPCTOF.size() && !tracksTPCTOF.size()) {
-      throw std::runtime_error(fmt::format("TPC-TOF matched tracks ({}) require TPCTOF matches ({}) and TPCTOF tracks ({})",
-                                           matchesTPCTOF.size(), tracksTPCTOF.size()));
-    }
-    for (unsigned i = 0; i < matchesTPCTOF.size(); i++) {
-      const auto& match = matchesTPCTOF[i];
-      const auto& gidx = match.getEvIdxTrack().getIndex(); // TPC (or other? but w/o ITS) track global idx (FIXME: TOF has to git rid of EvIndex stuff)
-      if (isUsed(gidx)) {                                  // is TPC track already used
-        continue;
-      }
-      const auto& trc = tracksTPCTOF[i];
-      if (creator(trc, trc.getTimeMUS().getTimeStamp(), trc.getTimeMUS().getTimeStampError(), {i, GTrackID::TPCTOF})) {
-        flagUsed(gidx); // flag used TPC tracks
-      }
-    }
-  }
-
-  // TPC only tracks
-  {
-    for (unsigned i = 0; i < tracksTPC.size(); i++) {
-      if (isUsed2(i, GTrackID::TPC)) { // skip used tracks
-        continue;
-      }
-      const auto& trc = tracksTPC[i];
-      if (creator(trc, trc.getTime0() + 0.5 * (trc.getDeltaTFwd() - trc.getDeltaTBwd()), 0.5 * (trc.getDeltaTFwd() + trc.getDeltaTBwd()), {i, GTrackID::TPC})) {
-        flagUsed2(i, GTrackID::TPC); // flag used TPC tracks
-      }
-    }
-  }
-
-  // ITS only tracks
-  {
-    const auto& rofrs = getITSTracksROFRecords<o2::itsmft::ROFRecord>();
-    for (unsigned irof = 0; irof < rofrs.size(); irof++) {
-      const auto& rofRec = rofrs[irof];
-      float t0 = rofRec.getBCData().differenceInBC(startIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
-      int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
-      for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
-        if (isUsed2(it, GTrackID::ITS)) { // skip used tracks
-          continue;
-        }
-        GTrackID gidITS(it, GTrackID::ITS);
-        const auto& trc = getITSTrack<o2::its::TrackITS>(gidITS);
-        if (creator(trc, t0, 0.5, gidITS)) {
-          flagUsed2(it, GTrackID::ITS);
-        }
-      }
-    }
-  }
-  auto current_time = std::chrono::high_resolution_clock::now();
-  LOG(INFO) << "RecoContainer::createTracks took " << std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 1e-6 << " CPU s.";
+void o2::globaltracking::RecoContainer::createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCov&, GTrackID, float, float)> const& creator) const
+{
+  createTracksVariadic([&creator](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) { return creator(_tr, _origID, t0, terr); });
 }
 
 // get contributors from single detectors

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -483,8 +483,8 @@ void MatchCosmics::createSeeds(const o2::globaltracking::RecoContainer& data)
 
   mSeeds.clear();
 
-  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID)> creator =
-    [this](const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID) {
+  auto creator =
+    [this](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) {
       if (std::abs(_tr.getQ2Pt()) > this->mQ2PtCutoff) {
         return true;
       }
@@ -502,7 +502,7 @@ void MatchCosmics::createSeeds(const o2::globaltracking::RecoContainer& data)
       return true;
     };
 
-  data.createTracks(creator);
+  data.createTracksWithMatchingTimeInfo(creator);
 
   LOG(INFO) << "collected " << mSeeds.size() << " seeds";
 }

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -600,7 +600,7 @@ bool MatchTPCITS::prepareTPCData()
     mTPCTrkLabels = inp.getTPCTracksMCLabels();
   }
 
-  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID)> creator = [this](const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID) {
+  auto creator = [this](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) {
     auto srcID = _origID.getSource();
     if (srcID == GTrackID::ITS) { // we don't need ITS here
       return true;                // we don't need TPC tracks
@@ -628,7 +628,7 @@ bool MatchTPCITS::prepareTPCData()
     return true;
   };
 
-  inp.createTracks(creator);
+  inp.createTracksWithMatchingTimeInfo(creator);
 
   float maxTime = 0;
   int nITSROFs = mITSROFTimes.size();

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -110,8 +110,8 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
   auto halfROFITS = 0.5 * mITSROFrameLengthMUS;
   auto hw2ErrITS = 2.f / std::sqrt(12.f) * mITSROFrameLengthMUS; // conversion from half-width to error for ITS
 
-  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID)> creator =
-    [maxTrackTimeError, hw2ErrITS, halfROFITS, &tracks, &gids](const o2::track::TrackParCov& _tr, float t0, float terr, GTrackID _origID) {
+  auto creator =
+    [maxTrackTimeError, hw2ErrITS, halfROFITS, &tracks, &gids](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) {
       if (!_origID.includesDet(DetID::ITS)) {
         return true; // just in case this selection was not done on RecoContainer filling level
       }
@@ -127,7 +127,7 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
       return true;
     };
 
-  recoData.createTracks(creator); // create track sample considered for vertexing
+  recoData.createTracksWithMatchingTimeInfo(creator); // create track sample considered for vertexing
   if (mUseMC) {
     recoData.fillTrackMCLabels(gids, tracksMCInfo);
   }

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -151,8 +151,8 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
 
   mTBrackets.clear();
 
-  std::function<bool(const o2::track::TrackParCov& _tr, float t0, float terr, GIndex _origID)> creator =
-    [this, &vcont](const o2::track::TrackParCov& _tr, float t0, float terr, GIndex _origID) {
+  auto creator =
+    [this, &vcont](const o2::track::TrackParCov& _tr, GIndex _origID, float t0, float terr) {
       if (vcont.find(_origID) != vcont.end()) { // track is contributor to vertex, already accounted
         return true;
       }
@@ -169,7 +169,7 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
       return true;
     };
 
-  data.createTracks(creator);
+  data.createTracksWithMatchingTimeInfo(creator);
 
   // sort in increasing min.time
   std::sort(mTBrackets.begin(), mTBrackets.end(), [](const TrackTBracket& a, const TrackTBracket& b) { return a.tBracket.getMin() < b.tBracket.getMin(); });

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -55,6 +55,16 @@ template <typename T>
 class PropagatorImpl;
 class MatLayerCylSet;
 } // namespace base
+namespace track
+{
+#ifdef GPUCA_NOCOMPAT
+template <typename value_T>
+class TrackParametrizationWithError;
+using TrackParCov = TrackParametrizationWithError<float>;
+#else
+class TrackParCov;
+#endif
+} // namespace track
 namespace trd
 {
 class GeometryFlat;
@@ -264,6 +274,14 @@ struct GPUTrackingInOutPointers {
   unsigned int nOutputClusRefsTPCO2 = 0;
   const o2::MCCompLabel* outputTracksTPCO2MC = nullptr;
   const o2::tpc::CompressedClustersFlat* tpcCompressedClusters = nullptr;
+
+  // TPC links
+  int* tpcLinkITS = nullptr;
+  int* tpcLinkTRD = nullptr;
+  int* tpcLinkTOF = nullptr;
+  const o2::track::TrackParCov** globalTracks = nullptr;
+  float* globalTrackTimes = nullptr;
+  unsigned int nGlobalTracks = 0;
 
   // TRD
   const GPUTRDTrackletWord* trdTracklets = nullptr;


### PR DESCRIPTION
The first commit in this PR replaces the std::function by a template parameter, such that we can pass different track types to the callback.
In this way we avoid having to follow the GID afterwards.

The drawback is that the `createTracks` must be moved into a header, otherwise the template cannot work. (I also think we cannot instantiate it explicitly, due to the lambda with the auto.)
I have left in the old `createTracks` in the cxx for backward compatibility, and if the user doesn't need the variadic callback, he can use the normal function, but in that case will always just get the `TrackParCov`.

OK, to be precise, I also renamed the old function into `createTracksWithMatchingTimeInfo` and created a clone without the time info, since I was confused by the time, so I think one should request it explicitly.

The second commit is then just an example how I want to use it, taken from my current development branch. It is for reading input tracks to the GPU workflow, and for the visualization I need both the track parameters and the time, so for the TPC track I can fetch the time directly from the `o2::tpc::TrackTPC` object that is passed in.