### PR TITLE
Fix 2 minor issues when reading TRD tracks

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -90,20 +90,20 @@ void DataRequest::requestTPCTOFTracks(bool mc)
 
 void DataRequest::requestITSTPCTRDTracks(bool mc)
 {
-  addInput({"trackTRDTPCITS", "TRD", "MATCHTRD_GLO", 0, Lifetime::Timeframe});
+  addInput({"trackITSTPCTRD", "TRD", "MATCHTRD_GLO", 0, Lifetime::Timeframe});
   if (mc) {
     LOG(ERROR) << "TRD Tracks does not support MC truth";
   }
-  requestMap["trackTRDTPCITS"] = false;
+  requestMap["trackITSTPCTRD"] = false;
 }
 
 void DataRequest::requestTPCTRDTracks(bool mc)
 {
-  addInput({"trackTRDTPC", "TRD", "MATCHTRD_TPC", 0, Lifetime::Timeframe});
+  addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", 0, Lifetime::Timeframe});
   if (mc) {
     LOG(ERROR) << "TRD Tracks does not support MC truth";
   }
-  requestMap["trackTRDTPC"] = false;
+  requestMap["trackTPCTRD"] = false;
 }
 
 void DataRequest::requestTOFMatches(bool mc)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackReaderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackReaderSpec.h
@@ -13,9 +13,7 @@
 
 /// @file   TRDTrackReaderSpec.h
 
-#include "GPUO2Interface.h"
-#include "GPUTRDDef.h"
-#include "GPUTRDTrack.h"
+#include "DataFormatsTRD/TrackTRD.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -54,7 +52,7 @@ class TRDTrackReader : public Task
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
   std::string mFileName = "";
-  std::vector<o2::gpu::GPUTRDTrack> mTracks, *mTracksPtr = &mTracks;
+  std::vector<o2::trd::TrackTRD> mTracks, *mTracksPtr = &mTracks;
 };
 
 /// read TPC-TRD matched tracks from a root file

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -23,6 +23,7 @@
 #include "TPCBase/ParameterElectronics.h"
 #include "TPCBase/ParameterGas.h"
 #include "DataFormatsTRD/RecoInputContainer.h"
+#include "DataFormatsTRD/TrackTRD.h"
 
 // GPU header
 #include "GPUReconstruction.h"
@@ -152,8 +153,8 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   //mTracker->DumpTracks();
 
   // finished tracking, now collect the output
-  std::vector<GPUTRDTrack> tracksOutITSTPC(nTracksLoadedITSTPC);
-  std::vector<GPUTRDTrack> tracksOutTPC(nTracksLoadedTPC);
+  std::vector<TrackTRD> tracksOutITSTPC(nTracksLoadedITSTPC);
+  std::vector<TrackTRD> tracksOutTPC(nTracksLoadedTPC);
   if (mTracker->NTracks() != nTracksLoadedITSTPC + nTracksLoadedTPC) {
     LOGF(FATAL, "Got %i matched tracks in total whereas %i ITS-TPC + %i TPC = %i tracks were loaded as input", mTracker->NTracks(), nTracksLoadedITSTPC, nTracksLoadedTPC, nTracksLoadedITSTPC + nTracksLoadedTPC);
   }

--- a/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackWriterSpec.cxx
@@ -11,9 +11,7 @@
 /// @file  TRDTrackWriterSpec.cxx
 
 #include <vector>
-#include "GPUO2Interface.h"
-#include "GPUTRDDef.h"
-#include "GPUTRDTrack.h"
+#include "DataFormatsTRD/TrackTRD.h"
 
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TRDWorkflow/TRDTrackWriterSpec.h"
@@ -41,18 +39,18 @@ DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
 
   // A spectator to store the size of the data array for the logger below
   auto tracksSize = std::make_shared<int>();
-  auto tracksLogger = [tracksSize](std::vector<GPUTRDTrack> const& tracks) {
+  auto tracksLogger = [tracksSize](std::vector<o2::trd::TrackTRD> const& tracks) {
     *tracksSize = tracks.size();
   };
 
   return MakeRootTreeWriterSpec("trd-track-writer-tpcits",
                                 "trdmatches_itstpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0},
-                                                                           "tracks",
-                                                                           "tracks-branch-name",
-                                                                           1,
-                                                                           tracksLogger},
+                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0},
+                                                                                 "tracks",
+                                                                                 "tracks-branch-name",
+                                                                                 1,
+                                                                                 tracksLogger},
                                 // NOTE: this branch template is to show how the conditional MC labels can
                                 // be defined, the '0' disables the branch for the moment
                                 BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},
@@ -72,18 +70,18 @@ DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC)
 
   // A spectator to store the size of the data array for the logger below
   auto tracksSize = std::make_shared<int>();
-  auto tracksLogger = [tracksSize](std::vector<GPUTRDTrack> const& tracks) {
+  auto tracksLogger = [tracksSize](std::vector<o2::trd::TrackTRD> const& tracks) {
     *tracksSize = tracks.size();
   };
 
   return MakeRootTreeWriterSpec("trd-track-writer-tpc",
                                 "trdmatches_tpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<GPUTRDTrack>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", 0},
-                                                                           "tracks",
-                                                                           "tracks-branch-name",
-                                                                           1,
-                                                                           tracksLogger},
+                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", 0},
+                                                                                 "tracks",
+                                                                                 "tracks-branch-name",
+                                                                                 1,
+                                                                                 tracksLogger},
                                 // NOTE: this branch template is to show how the conditional MC labels can
                                 // be defined, the '0' disables the branch for the moment
                                 BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},


### PR DESCRIPTION
- I had a typo in the input name in the map in the RecoContainer, so it would just ignore the TRD tracks.
- Now using o2::trd::TrackTRD instead of o2::gpu::GPUTRDTrack as type in the TRD track readers / writers. The type is the same, just an alias, but the `is_messageable` struct is only defined for the `TrackTRD` in the `TrackTRD.h`, so deserialization as span fails when the data is shipped as `std::vector<GPUTRDTrack>`, since that is shipped as ROOT-serialized object.