### PR TITLE
TRD Bugfix: TPC track id is overwritten during loading

### DIFF
--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -124,7 +124,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   for (int iTrk = 0; iTrk < mChainTracking->mIOPtrs.nTracksTPCITSO2; ++iTrk) {
     const auto& trkITSTPC = mChainTracking->mIOPtrs.tracksTPCITSO2[iTrk];
     GPUTRDTrack trkLoad(trkITSTPC, mTPCVdrift);
-    if (mTracker->LoadTrack(trkLoad)) {
+    if (mTracker->LoadTrack(trkLoad, -1, nullptr, -1, iTrk)) {
       continue;
     }
     loadedTPCtracks.push_back(trkITSTPC.getRefTPC());
@@ -139,7 +139,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     }
     const auto& trkTpc = mChainTracking->mIOPtrs.outputTracksTPCO2[iTrk];
     GPUTRDTrack trkLoad(trkTpc, mTPCTBinMUS, mTPCVdrift, iTrk);
-    if (mTracker->LoadTrack(trkLoad)) {
+    if (mTracker->LoadTrack(trkLoad, -1, nullptr, -1, iTrk)) {
       continue;
     }
     ++nTracksLoadedTPC;


### PR DESCRIPTION
@martenole : This is a minor workaround/bugfix. As is currently in the code, the tpcLabel is always overwritten during LoadTrack, so it must be passed in explicitly, or better we should clean up that LoadTrack function. It is not really needed to merge this, but if it takes a while to clean it up we can also merge this in the meantime.

Also, for O2 we might want to store the GlobalTrackID in here, instead of an integer. Although I am not 100% sure how to do that in a transparent way. Since the GlobalTrackID is essentially a 32 bit integer, we could also just keep the integer here, and cast it to the global id and back in the getter for the O2 version of the track.

Then, looking at the tracks, I saw that actually many TRD tracks are stored with 0 tracklets attached. What is the reasoning behind this? I think they should be filtered out.