### PR TITLE
jobutils: Fix propagation of return codes

### DIFF
--- a/Utilities/Tools/jobutils.sh
+++ b/Utilities/Tools/jobutils.sh
@@ -111,7 +111,8 @@ taskwrapper() {
   # the command might be a complex block: For the timing measurement below
   # it is better to execute this as a script
   SCRIPTNAME="${logfile}_tmp.sh"
-  echo "${command}; echo \"TASK-EXIT-CODE: $?\"" > ${SCRIPTNAME}
+  echo "${command};" > ${SCRIPTNAME}
+  echo 'RC=$?; echo "TASK-EXIT-CODE: ${RC}"; exit ${RC}' >> ${SCRIPTNAME}
   chmod +x ${SCRIPTNAME}
 
   # this gives some possibility to customize the wrapper


### PR DESCRIPTION
A recently introduced bug is fixed. Unfortunately,
$? was not escaped correctly, leading to a premature expansion
if is value.