### PR TITLE
Use createTracksVariadic instead of createTracksWithMatchingTimeInfo

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -43,7 +43,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   // which depends on the track time:
   // 1) For track types containing TimeStampWithError ts it is ts.getTimeStamp(), getTimeStampError()
   // 2) For tracks with asymmetric time uncertainty, e.g. TPC: as mean time of t0-errBwd,t+errFwd and 0.5(errBwd+errFwd), all in TPC time bins
-  // 3) For tracks whose timing is provided as RO frame: as time in \mus for RO frame start since the start of TF, half-duration of RO window and 0.
+  // 3) For tracks whose timing is provided as RO frame: as time in \mus for RO frame start since the start of TF, half-duration of RO window.
 
   auto start_time = std::chrono::high_resolution_clock::now();
   constexpr float PS2MUS = 1e-6;
@@ -84,7 +84,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
       const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
 
       auto gidx = match.getEvIdxTrack().getIndex(); // this should be corresponding ITS-TPC track
-      if (creator(tracksPool.get(gidx), {i, GTrackID::ITSTPCTOF}, timeTOFMUS, timeErr)) {
+      if (creator(tracksTPCITS[gidx.getIndex()], {i, GTrackID::ITSTPCTOF}, timeTOFMUS, timeErr)) {
         flagUsed2(i, GTrackID::TOF);
         flagUsed(gidx); // flag used ITS-TPC tracks
       }
@@ -162,3 +162,45 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   auto current_time = std::chrono::high_resolution_clock::now();
   LOG(INFO) << "RecoContainer::createTracks took " << std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 1e-6 << " CPU s.";
 }
+
+template <class T>
+inline constexpr auto isITSTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::its::TrackITS>;
+}
+
+template <class T>
+inline constexpr auto isTPCTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::tpc::TrackTPC>;
+}
+
+template <class T>
+inline constexpr auto isTRDTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::trd::TrackTRD>;
+}
+
+template <class T>
+inline constexpr auto isTPCTOFTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::dataformats::TrackTPCTOF>;
+}
+
+template <class T>
+inline constexpr auto isTPCITSTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::dataformats::TrackTPCITS>;
+}
+
+template <class T>
+inline constexpr auto isTPCTRDTOFTrack()
+{
+  return false;
+} // to be implemented
+
+template <class T>
+inline constexpr auto isITSTPCTRDTOFTrack()
+{
+  return false;
+} // to be implemented

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -428,7 +428,6 @@ class MatchTPCITS
                             std::array<int, MaxLadderCand>& lad2Check) const;
   int findLaddersToCheckBOff(int ilr, int lad0, const o2::math_utils::IntervalXYf_t& trcLinPar, float errYFrac,
                              std::array<int, MatchTPCITS::MaxLadderCand>& lad2Check) const;
-
   bool prepareTPCData();
   bool prepareITSData();
   bool prepareFITData();

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -10,6 +10,7 @@
 
 #include "GlobalTracking/MatchCosmics.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 #include "GPUO2InterfaceRefit.h"
 #include "ReconstructionDataFormats/GlobalTrackAccessor.h"
 #include "DataFormatsITSMFT/CompCluster.h"
@@ -483,26 +484,26 @@ void MatchCosmics::createSeeds(const o2::globaltracking::RecoContainer& data)
 
   mSeeds.clear();
 
-  auto creator =
-    [this](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) {
-      if (std::abs(_tr.getQ2Pt()) > this->mQ2PtCutoff) {
-        return true;
-      }
-      if (_origID.getSource() == GTrackID::TPC) { // convert TPC bins to \mus
-        t0 *= this->mTPCTBinMUS;
-        terr *= this->mTPCTBinMUS;
-      } else if (_origID.getSource() == GTrackID::ITS) { // error is supplied a half-ROF duration, convert to \mus
-        t0 += 0.5 * mITSROFrameLengthMUS;                // time 0 is supplied as beginning of ROF
-        terr *= mITSROFrameLengthMUS;
-      } else {
-        terr *= this->mMatchParams->nSigmaTError;
-      }
-      terr += this->mMatchParams->timeToleranceMUS;
-      mSeeds.emplace_back(TrackSeed{_tr, {t0 - terr, t0 + terr}, _origID, MinusOne});
+  auto creator = [this](auto& _tr, GTrackID _origID, float t0, float terr) {
+    if (std::abs(_tr.getQ2Pt()) > this->mQ2PtCutoff) {
       return true;
-    };
+    }
+    if constexpr (isTPCTrack<decltype(_tr)>()) {
+      // unconstrained TPC track, with t0 = TrackTPC.getTime0+0.5*(DeltaFwd-DeltaBwd) and terr = 0.5*(DeltaFwd+DeltaBwd) in TimeBins
+      t0 *= this->mTPCTBinMUS;
+      terr *= this->mTPCTBinMUS;
+    } else if (isITSTrack<decltype(_tr)>()) {
+      t0 += 0.5 * this->mITSROFrameLengthMUS; // time 0 is supplied as beginning of ROF in \mus
+      terr *= this->mITSROFrameLengthMUS;     // error is supplied a half-ROF duration, convert to \mus
+    } else {                                  // all other tracks are provided with time and its gaussian error in \mus
+      terr *= this->mMatchParams->nSigmaTError;
+    }
+    terr += this->mMatchParams->timeToleranceMUS;
+    mSeeds.emplace_back(TrackSeed{_tr, {t0 - terr, t0 + terr}, _origID, MinusOne});
+    return true;
+  };
 
-  data.createTracksWithMatchingTimeInfo(creator);
+  data.createTracksVariadic(creator);
 
   LOG(INFO) << "collected " << mSeeds.size() << " seeds";
 }

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -197,7 +197,6 @@ void PVertexer::createTracksPool(const TR& tracks, gsl::span<const o2d::GlobalTr
   mTracksPool.reserve(ntGlo);
   // check all containers
   float vtxErr2 = 0.5 * (mMeanVertex.getSigmaX2() + mMeanVertex.getSigmaY2());
-  float pullIniCut = 9.; // RS FIXME  pullIniCut should be a parameter
   o2d::DCA dca;
 
   for (uint32_t i = 0; i < ntGlo; i++) {

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -146,7 +146,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
   }
 
   auto creator = [&recoCont, &retVal](auto& trk, GID gid, float time, float) {
-    if constexpr (std::is_same_v<std::decay_t<decltype(trk)>, o2::tpc::TrackTPC>) {
+    if constexpr (isTPCTrack<decltype(trk)>()) {
       time = trk.getTime0();
     }
     retVal->globalTracks.emplace_back(&trk);


### PR DESCRIPTION
* Add some isXXXTrack template aliases to RecoContainerCreateTracksVariadic
  + fix to use isTPCTrack alias in GPUWorkflowHelper

*  Use createTracksVariadic instead of createTracksWithMatchingTimeInfo
    TPC-ITS matcher
    Cosmics matcher
    PVertexer
    PVertex - track matcher
