### PR TITLE
Improvements to GPU visualization and some related fixes

### DIFF
--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -848,7 +848,7 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMerger* GPUrestrict() merge
   // printf("Tan %f %f (%f %f)\n", atana, atanb, mX - xp, mP[0] - yp);
   const float dS = (xp > 0 ? (atana + atanb) : (atanb - atana)) * r;
   float z0 = dS * mP[3];
-  // printf("Track Z %f (Offset %f), z0 %f, V %f (dS %f, dZds %f, qPt %f)             - Z span %f to %f: diff %f\n", mP[1], mTZOffset, z0, mP[1] - z0, dS, mP[3], mP[4], tz2, tz1, tz2 - tz1);
+  // printf("Track Z %f (Offset %f), z0 %f, V %f (dS %f, dZds %f, qPt %f)             - TZ span %f to %f: diff %f\n", mP[1], mTZOffset, z0, mP[1] - z0, dS, mP[3], mP[4], tz2, tz1, tz2 - tz1);
   if (CAMath::Abs(z0) > 250.f) {
     z0 = z0 > 0 ? 250.f : -250.f;
   }
@@ -859,6 +859,7 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMerger* GPUrestrict() merge
     deltaZ = 0;
     float zMax = CAMath::Max(tz1, tz2);
     float zMin = CAMath::Min(tz1, tz2);
+    // printf("Z Check: Clusters %f %f, min %f max %f vtx %f\n", tz1, tz2, zMin, zMax, mTZOffset);
     if (zMin < 0 && zMin - mTZOffset < -250) {
       deltaZ = zMin - mTZOffset + 250;
     } else if (zMax > 0 && zMax - mTZOffset > 250) {
@@ -869,25 +870,26 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMerger* GPUrestrict() merge
     } else if (zMax > 0 && zMin - mTZOffset < 0) {
       deltaZ = zMin - mTZOffset;
     }
-    // if (deltaZ != 0) printf("Moving clusters to TPC Range: Side %f, Shift %f: %f to %f --> %f to %f\n", tz2, deltaZ, tz2 - mTZOffset, tz1 - mTZOffset, tz2 - mTZOffset - deltaZ, tz1 - mTZOffset - deltaZ);
+    // if (deltaZ != 0) printf("Moving clusters to TPC Range: Shift %f in Z: %f to %f --> %f to %f in Z\n", deltaZ, tz2 - mTZOffset, tz1 - mTZOffset, tz2 - mTZOffset - deltaZ, tz1 - mTZOffset - deltaZ);
     mTZOffset += deltaZ;
     mP[1] -= deltaZ;
   } else {
     float deltaT = merger->GetConstantMem()->calibObjects.fastTransform->convDeltaZtoDeltaTimeInTimeFrame(slice, deltaZ);
     mTZOffset += deltaT;
     mP[1] -= deltaZ;
-    const float minT = CAMath::Min(tz1, tz2);
-    const float maxT = CAMath::Max(CAMath::Max(tz1, tz2) - merger->GetConstantMem()->calibObjects.fastTransform->getMaxDriftTime(slice), 0.f);
-    // printf("T Check: max %f min %f (min2 %f) vtx %f\n", maxT, minT, CAMath::Min(tzinner, tz2), mTZOffset);
+    const float maxT = CAMath::Min(tz1, tz2);
+    const float minT = CAMath::Max(tz1, tz2) - merger->GetConstantMem()->calibObjects.fastTransform->getMaxDriftTime(slice);
+    // printf("T Check: Clusters %f %f, min %f max %f vtx %f\n", tz1, tz2, minT, maxT, mTZOffset);
     deltaT = 0.f;
-    if (mTZOffset < maxT) {
-      deltaT = maxT - mTZOffset;
-    }
-    if (mTZOffset > minT) {
+    if (mTZOffset < minT) {
       deltaT = minT - mTZOffset;
+    }
+    if (mTZOffset > maxT) {
+      deltaT = maxT - mTZOffset;
     }
     if (deltaT != 0.f) {
       deltaZ = merger->GetConstantMem()->calibObjects.fastTransform->convDeltaTimeToDeltaZinTimeFrame(slice, deltaT);
+      // printf("Moving clusters to TPC Range: Shift %f in Z: %f to %f --> %f to %f in T\n", deltaZ, tz2 - mTZOffset, tz1 - mTZOffset, tz2 - mTZOffset - deltaT, tz1 - mTZOffset - deltaT);
       mTZOffset += deltaT;
       mP[1] -= deltaZ;
     }

--- a/GPU/GPUTracking/Standalone/CMakeLists.txt
+++ b/GPU/GPUTracking/Standalone/CMakeLists.txt
@@ -150,6 +150,7 @@ include_directories(${GPUTRACKING_DIR}/TPCClusterFinder
                     ${O2_DIR}/Common/MathUtils/include
                     ${O2_DIR}/DataFormats/common/include
                     ${O2_DIR}/DataFormats/Detectors/Common/include
+                    ${O2_DIR}/DataFormats/Detectors/ITSMFT/common/include
                     ${O2_DIR}/DataFormats/Detectors/ITSMFT/ITS/include
                     ${O2_DIR}/DataFormats/Detectors/TOF/include
                     ${O2_DIR}/DataFormats/Detectors/TPC/include

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -2144,7 +2144,9 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
     }
     if (mCfg.drawTOF) {
       SetColorTOF();
+      CHKERR(glPointSize(mCfg.pointSize * (mDrawQualityDownsampleFSAA > 1 ? mDrawQualityDownsampleFSAA : 1) * 2));
       LOOP_SLICE LOOP_COLLISION_COL(drawVertices(mGlDLPoints[0][tTOFCLUSTER][0], GL_POINTS));
+      CHKERR(glPointSize(mCfg.pointSize * (mDrawQualityDownsampleFSAA > 1 ? mDrawQualityDownsampleFSAA : 1)));
     }
     if (mCfg.drawITS) {
       SetColorITS();
@@ -2289,6 +2291,9 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
       }
       SetColorMarked();
       LOOP_SLICE LOOP_COLLISION drawVertices(mGlDLPoints[iSlice][tMARKED][iCol], GL_POINTS);
+      if (mMarkFakeClusters) {
+        CHKERR(glPointSize(mCfg.pointSize * (mDrawQualityDownsampleFSAA > 1 ? mDrawQualityDownsampleFSAA : 1)));
+      }
     }
   }
 #ifndef GPUCA_DISPLAY_OPENGL_CORE

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -1173,12 +1173,12 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
               auto cl = mIOPtrs->mergedTrackHits[track->FirstClusterRef() + lastCluster];
               const auto& cln = mIOPtrs->clustersNative->clustersLinear[cl.num];
               GPUTPCConvertImpl::convert(*mCalib->fastTransform, *mParam, cl.slice, cl.row, cln.getPad(), cln.getTime(), x, y, z);
-              ZOffset = mCalib->fastTransform->convTimeToZinTimeFrame(slice, track->GetParam().GetTZOffset(), mParam->par.continuousMaxTimeBin);
+              ZOffset = mCalib->fastTransform->convVertexTimeToZOffset(slice, track->GetParam().GetTZOffset(), mParam->par.continuousMaxTimeBin);
             } else {
               uint8_t sector, row;
               auto cln = track->getCluster(mIOPtrs->outputClusRefsTPCO2, lastCluster, *mIOPtrs->clustersNative, sector, row);
               GPUTPCConvertImpl::convert(*mCalib->fastTransform, *mParam, sector, row, cln.getPad(), cln.getTime(), x, y, z);
-              ZOffset = mCalib->fastTransform->convTimeToZinTimeFrame(slice, track->getTime0(), mParam->par.continuousMaxTimeBin);
+              ZOffset = mCalib->fastTransform->convVertexTimeToZOffset(slice, track->getTime0(), mParam->par.continuousMaxTimeBin);
             }
           }
         } else {

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -998,6 +998,14 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
       size_t startCountInner = mVertexBuffer[iSlice].size();
       bool drawing = false;
 
+      if constexpr (std::is_same_v<T, o2::tpc::TrackTPC>) {
+        if (mIOPtrs->tpcLinkTOF && mIOPtrs->tpcLinkTOF[i] != -1 && mIOPtrs->nTOFClusters) {
+          int cid = mIOPtrs->tpcLinkTOF[i];
+          mVertexBuffer[iSlice].emplace_back(mGlobalPosTOF[cid].x, mGlobalPosTOF[cid].y, mProjectXY ? 0 : mGlobalPosTOF[cid].z);
+          mGlobalPosTOF[cid].w = tTOFATTACHED;
+        }
+      }
+
       if constexpr (std::is_same_v<T, GPUTPCGMMergedTrack>) {
         if (mTrackFilter && mChain) {
           if (mTrackFilter == 2 && (!trdTracker().PreCheckTrackTRDCandidate(*track) || !trdTracker().CheckTrackTRDCandidate((GPUTRDTrackGPU)*track))) {

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -2167,15 +2167,13 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime)
   if (mCfg.drawClusters) {
     if (mCfg.drawTRD) {
       SetColorTRD();
+      CHKERR(glLineWidth(mCfg.lineWidth * (mDrawQualityDownsampleFSAA > 1 ? mDrawQualityDownsampleFSAA : 1) * 2));
       LOOP_SLICE LOOP_COLLISION_COL(drawVertices(mGlDLPoints[iSlice][tTRDCLUSTER][iCol], GL_LINES));
-      if (mCfg.drawFinal) {
-        if (mCfg.colorClusters) {
-          SetColorFinal();
-        }
-        LOOP_SLICE LOOP_COLLISION_COL(drawVertices(mGlDLPoints[iSlice][tTRDATTACHED][iCol], GL_POINTS));
-      } else {
-        LOOP_SLICE LOOP_COLLISION_COL(drawVertices(mGlDLPoints[iSlice][tTRDATTACHED][iCol], GL_LINES));
+      if (mCfg.drawFinal && mCfg.colorClusters) {
+        SetColorFinal();
       }
+      LOOP_SLICE LOOP_COLLISION_COL(drawVertices(mGlDLPoints[iSlice][tTRDATTACHED][iCol], GL_LINES));
+      CHKERR(glLineWidth(mCfg.lineWidth * (mDrawQualityDownsampleFSAA > 1 ? mDrawQualityDownsampleFSAA : 1)));
     }
     if (mCfg.drawTOF) {
       SetColorTOF();

--- a/GPU/GPUTracking/display/GPUDisplay.h
+++ b/GPU/GPUTracking/display/GPUDisplay.h
@@ -105,11 +105,11 @@ class GPUDisplay
  private:
   static constexpr int NSLICES = GPUChainTracking::NSLICES;
 
-  static constexpr const int N_POINTS_TYPE = 13;
+  static constexpr const int N_POINTS_TYPE = 15;
   static constexpr const int N_POINTS_TYPE_TPC = 9;
   static constexpr const int N_POINTS_TYPE_TRD = 2;
-  static constexpr const int N_POINTS_TYPE_TOF = 1;
-  static constexpr const int N_POINTS_TYPE_ITS = 1;
+  static constexpr const int N_POINTS_TYPE_TOF = 2;
+  static constexpr const int N_POINTS_TYPE_ITS = 2;
   static constexpr const int N_LINES_TYPE = 7;
   static constexpr const int N_FINAL_TYPE = 4;
   static constexpr int TRACK_TYPE_ID_LIMIT = 100;
@@ -125,7 +125,9 @@ class GPUDisplay
                     tTRDCLUSTER = 9,
                     tTRDATTACHED = 10,
                     tTOFCLUSTER = 11,
-                    tITSCLUSTER = 12 };
+                    tTOFATTACHED = 12,
+                    tITSCLUSTER = 13,
+                    tITSATTACHED = 14 };
   enum LineTypes { RESERVED = 0 /*1 -- 6 = INITLINK to GLOBALTRACK*/ };
 
   typedef std::tuple<GLsizei, GLsizei, int> vboList;

--- a/GPU/GPUTracking/display/GPUDisplay.h
+++ b/GPU/GPUTracking/display/GPUDisplay.h
@@ -248,6 +248,8 @@ class GPUDisplay
   vboList DrawSeeds(const GPUTPCTracker& tracker);
   vboList DrawTracklets(const GPUTPCTracker& tracker);
   vboList DrawTracks(const GPUTPCTracker& tracker, int global);
+  void DrawTrackITS(int trackId, int iSlice);
+  GPUDisplay::vboList DrawFinalITS();
   template <class T>
   void DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, std::array<vecpod<int>, 2>& trackList, threadVertexBuffer& threadBuffer);
   vboList DrawGrid(const GPUTPCTracker& tracker);
@@ -355,6 +357,7 @@ class GPUDisplay
   int mCurrentClustersITS = 0;
   int mCurrentClustersTOF = 0;
   std::vector<int> mTRDTrackIds;
+  std::vector<bool> mITSStandaloneTracks;
 
   int mGlDLrecent = 0;
   int mUpdateDLList = 0;
@@ -387,6 +390,7 @@ class GPUDisplay
   HighResTimer mTimerFPS, mTimerDisplay, mTimerDraw;
   vboList mGlDLLines[NSLICES][N_LINES_TYPE];
   vecpod<std::array<vboList, N_FINAL_TYPE>> mGlDLFinal[NSLICES];
+  vboList mGlDLFinalITS;
   vecpod<vboList> mGlDLPoints[NSLICES][N_POINTS_TYPE];
   vboList mGlDLGrid[NSLICES];
   vboList mGlDLGridTRD[NSLICES / 2];

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -50,6 +50,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
         ioPtr.itsClusterMC = ITSClsLabels;
       }
     }
+    //LOG(info) << "Got " << ioPtr.nItsClusters << " ITS Clusters";
   }
   if (maskTrk[GID::ITS] && ioPtr.nItsTracks == 0) {
     const auto& ITSTracksArray = recoCont.getITSTracks<o2::its::TrackITS>();
@@ -66,6 +67,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
         ioPtr.itsTrackMC = ITSTrkLabels.data();
       }
     }
+    //LOG(info) << "Got " << ioPtr.nItsTracks << " ITS Tracks";
   }
 
   if (maskTrk[GID::ITSTPC] && ioPtr.nTracksTPCITSO2 == 0) {
@@ -74,6 +76,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       ioPtr.nTracksTPCITSO2 = trkITSTPC.size();
       ioPtr.tracksTPCITSO2 = trkITSTPC.data();
     }
+    //LOG(info) << "Got " << ioPtr.nTracksTPCITSO2 << " ITS-TPC Tracks";
   }
 
   if (maskCl[GID::TOF] && ioPtr.nTOFClusters == 0) {
@@ -82,6 +85,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       ioPtr.nTOFClusters = tofClusters.size();
       ioPtr.tofClusters = tofClusters.data();
     }
+    //LOG(info) << "Got " << ioPtr.nTOFClusters << " TOF Clusters";
   }
 
   if (maskMatch[GID::TOF] && ioPtr.nTOFMatches == 0) {
@@ -90,6 +94,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       ioPtr.nTOFMatches = tofMatches.size();
       ioPtr.tofMatches = tofMatches.data();
     }
+    //LOG(info) << "Got " << ioPtr.nTOFMatches << " TOF Matches";
   }
 
   if (maskMatch[GID::TPCTOF] && ioPtr.nTPCTOFMatches == 0) {
@@ -98,26 +103,35 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       ioPtr.nTPCTOFMatches = tpctofMatches.size();
       ioPtr.tpctofMatches = tpctofMatches.data();
     }
+    //LOG(info) << "Got " << ioPtr.nTPCTOFMatches << " TPC-TOF Matches";
   }
 
   if (maskCl[GID::TRD]) {
     // o2::trd::getRecoInputContainer(pc, &ioPtr, &recoCont, useMC); // TODO: use this helper here
+    //LOG(info) << "Got " << ioPtr.nTRDTracklets << " TRD Tracklets";
   }
 
   if (maskTrk[GID::ITSTPCTRD] && ioPtr.nTRDTracksITSTPCTRD == 0) {
     const auto& trdTracks = recoCont.getITSTPCTRDTracks<o2::trd::TrackTRD>();
-    ioPtr.nTRDTracksITSTPCTRD = trdTracks.size();
-    ioPtr.trdTracksITSTPCTRD = trdTracks.data();
+    if (trdTracks.size()) {
+      ioPtr.nTRDTracksITSTPCTRD = trdTracks.size();
+      ioPtr.trdTracksITSTPCTRD = trdTracks.data();
+    }
+    //LOG(info) << "Got " << ioPtr.nTRDTracksITSTPCTRD << " ITS-TPC-TRD Tracks";
   }
 
   if (maskTrk[GID::TPCTRD] && ioPtr.nTRDTracksTPCTRD == 0) {
     const auto& trdTracks = recoCont.getTPCTRDTracks<o2::trd::TrackTRD>();
-    ioPtr.nTRDTracksTPCTRD = trdTracks.size();
-    ioPtr.trdTracksTPCTRD = trdTracks.data();
+    if (trdTracks.size()) {
+      ioPtr.nTRDTracksTPCTRD = trdTracks.size();
+      ioPtr.trdTracksTPCTRD = trdTracks.data();
+    }
+    //LOG(info) << "Got " << ioPtr.nTRDTracksTPCTRD << " TPC-TRD Tracks";
   }
 
   if (maskCl[GID::TPC] && ioPtr.clustersNative == nullptr) {
     ioPtr.clustersNative = &recoCont.getTPCClusters();
+    //LOG(info) << "Got " << ioPtr.clustersNative->nClustersTotal << " TPC Clusters";
   }
 
   if (maskTrk[GID::TPC] && ioPtr.nOutputTracksTPCO2 == 0) {
@@ -136,24 +150,41 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       ioPtr.tpcLinkITS = retVal->tpcLinkITS.data();
     }
     if (ioPtr.nTOFClusters && (ioPtr.nTOFMatches || ioPtr.nTPCTOFMatches)) {
-      retVal->tpcLinkTRD.resize(ioPtr.nOutputTracksTPCO2, -1);
-      ioPtr.tpcLinkTRD = retVal->tpcLinkTRD.data();
-    }
-    if (ioPtr.nTRDTracksITSTPCTRD || ioPtr.nTRDTracksTPCTRD) {
       retVal->tpcLinkTOF.resize(ioPtr.nOutputTracksTPCO2, -1);
       ioPtr.tpcLinkTOF = retVal->tpcLinkTOF.data();
     }
+    if (ioPtr.nTRDTracksITSTPCTRD || ioPtr.nTRDTracksTPCTRD) {
+      retVal->tpcLinkTRD.resize(ioPtr.nOutputTracksTPCO2, -1);
+      ioPtr.tpcLinkTRD = retVal->tpcLinkTRD.data();
+    }
+    //LOG(info) << "Got " << ioPtr.nOutputTracksTPCO2 << " TPC Tracks";
   }
 
-  auto creator = [&recoCont, &retVal](auto& trk, GID gid, float time, float) {
-    if constexpr (isTPCTrack<decltype(trk)>()) {
+  auto creator = [&ioPtr, &recoCont, &retVal](auto& trk, GID gid, float time, float) {
+    if (gid.getSource() == GID::ITSTPCTOF) {
+      const auto& match = recoCont.getTOFMatches<o2::dataformats::MatchInfoTOF>()[gid.getIndex()];
+      const auto& trkItsTPC = ioPtr.tracksTPCITSO2[match.getTrackIndex()];
+      retVal->tpcLinkTOF[trkItsTPC.getRefTPC().getIndex()] = match.getTOFClIndex();
+      retVal->tpcLinkITS[trkItsTPC.getRefTPC().getIndex()] = trkItsTPC.getRefITS().getIndex();
+    } else if constexpr (isTPCTrack<decltype(trk)>()) {
       time = trk.getTime0();
+    } else if constexpr (isTPCITSTrack<decltype(trk)>()) {
+      retVal->tpcLinkITS[trk.getRefTPC().getIndex()] = trk.getRefITS().getIndex();
+    } else if constexpr (isTPCTOFTrack<decltype(trk)>()) {
+      const auto& match = ioPtr.tofMatches[trk.getRefMatch()];
+      retVal->tpcLinkTOF[match.getTrackIndex()] = match.getTOFClIndex();
     }
     retVal->globalTracks.emplace_back(&trk);
     retVal->globalTrackTimes.emplace_back(time);
     return true;
   };
   recoCont.createTracksVariadic(creator);
+  for (unsigned int i = 0; i < ioPtr.nTRDTracksTPCTRD; i++) { // TODO: This should be handled by the createTracks logic, but so far it lacks the TRD tracks
+    retVal->tpcLinkTRD[ioPtr.trdTracksTPCTRD[i].GetTPCtrackId()] = i;
+  }
+  for (unsigned int i = 0; i < ioPtr.nTRDTracksITSTPCTRD; i++) {
+    retVal->tpcLinkTRD[ioPtr.tracksTPCITSO2[ioPtr.trdTracksITSTPCTRD[i].GetTPCtrackId()].getRefTPC().getIndex()] = i | 0x40000000;
+  }
   ioPtr.globalTracks = retVal->globalTracks.data();
   ioPtr.globalTrackTimes = retVal->globalTrackTimes.data();
 

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -566,8 +566,7 @@ DataProcessorSpec getGPURecoWorkflowSpec(gpuworkflow::CompletionPolicyData* poli
               if (verbosity) {
                 end = std::chrono::high_resolution_clock::now();
                 std::chrono::duration<double> elapsed_seconds = end - start;
-                LOG(INFO) << "Allocation time for " << name << " (" << size << " bytes)"
-                          << ": " << elapsed_seconds.count() << "s";
+                LOG(INFO) << "Allocation time for " << name << " (" << size << " bytes)" << ": " << elapsed_seconds.count() << "s";
               }
               return (buffer.second = buffer.first->get().data()) + offset;
             };

--- a/GPU/Workflow/src/O2GPUDPLDisplay.cxx
+++ b/GPU/Workflow/src/O2GPUDPLDisplay.cxx
@@ -40,8 +40,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
     {"enable-mc", o2::framework::VariantType::Bool, false, {"enable visualization of MC data"}},
-    {"display-clusters", VariantType::String, "TPC,TRD", {"comma-separated list of clusters to display"}},
-    {"display-tracks", VariantType::String, "TPC", {"comma-separated list of tracks to display"}},
+    {"display-clusters", VariantType::String, "ITS,TPC,TRD,TOF", {"comma-separated list of clusters to display"}},
+    {"display-tracks", VariantType::String, "TPC,ITS,ITS-TPC,TPC-TRD,ITS-TPC-TRD,TPC-TOF,ITS-TPC-TOF", {"comma-separated list of tracks to display"}},
     {"read-from-files", o2::framework::VariantType::Bool, false, {"comma-separated list of tracks to display"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"Disable root input overriding read-from-files"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};

--- a/GPU/Workflow/src/O2GPUDPLDisplay.cxx
+++ b/GPU/Workflow/src/O2GPUDPLDisplay.cxx
@@ -117,6 +117,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool useMC = cfgc.options().get<bool>("enable-mc");
   GlobalTrackID::mask_t srcTrk = GlobalTrackID::getSourcesMask(cfgc.options().get<std::string>("display-tracks"));
   GlobalTrackID::mask_t srcCl = GlobalTrackID::getSourcesMask(cfgc.options().get<std::string>("display-clusters"));
+  if (!srcTrk.any() && !srcCl.any()) {
+    throw std::runtime_error("No input configured");
+  }
   std::shared_ptr<DataRequest> dataRequest = std::make_shared<DataRequest>();
   dataRequest->requestTracks(srcTrk, useMC);
   dataRequest->requestClusters(srcCl, useMC);

--- a/GPU/Workflow/src/O2GPUDPLDisplay.cxx
+++ b/GPU/Workflow/src/O2GPUDPLDisplay.cxx
@@ -97,6 +97,7 @@ void O2GPUDPLDisplaySpec::run(ProcessingContext& pc)
   decltype(o2::trd::getRecoInputContainer(pc, &ptrs, &recoData)) trdInputContainer;
   if (mClMask[GlobalTrackID::TRD]) {
     trdInputContainer = std::move(o2::trd::getRecoInputContainer(pc, &ptrs, &recoData)); // TODO: Get rid of this, to be done inside the fillIOPtr, but first needs some changes in RecoInputContainer
+    //LOG(info) << "Got " << ptrs.nTRDTracklets << " TRD Tracklets";
   }
 
   mDisplay->show(&ptrs);


### PR DESCRIPTION
New features:
- Better visualization of TOF hits and TRD tracklets.
- Can show TPC tracks propagated to ITS, TRD, TOF
- Can either just connect the hits in all detectors, or propagate the track parameters
- Can show this in triggered events, or in timeframes, where the latter shifts the other detectors corresponding to the TPC when just converting t to z linearly.
- And a fix to the TPC track time estimate in the TPC tracking.

This is how it looks like now:
<img width="1920" alt="screenshot1" src="https://user-images.githubusercontent.com/9131638/117555284-3060d980-b05e-11eb-993b-cf725827d19a.png">

In order to run:
```
o2-gpu-display --read-from-files --display-clusters ITS,TPC,TRD,TOF --display-tracks TPC,ITS,ITS-TPC,TPC-TRD,ITS-TPC-TRD,TPC-TOF,ITS-TPC-TOF --configKeyValues "GPU_global.continuousMaxTimeBin=2000"
```
(Needs sim challenge data + trd reco, MaxTimeBin should be set to a reasonable value, otherwise it takes it from GRP which is quite huge)