### PR TITLE
Reduce number of analysis compile jobs, since the CI runs out of memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set_property(GLOBAL PROPERTY REPORT_UNDEFINED_PROPERTIES)
 
 cmake_host_system_information(RESULT _totalmem QUERY TOTAL_PHYSICAL_MEMORY)
-math(EXPR _total_analysis_jobs ${_totalmem}/8000)
+math(EXPR _total_analysis_jobs "(${_totalmem}-4096)/10240")
+if(_total_analysis_jobs LESS_EQUAL 0)
+  set(_total_analysis_jobs 1)
+endif()
 set(ANALYSIS_COMPILE_POOL ${_total_analysis_jobs} CACHE STRING "How many parallel analysis compilation jobs")
 set_property(GLOBAL PROPERTY JOB_POOLS analysis=${ANALYSIS_COMPILE_POOL})
 


### PR DESCRIPTION
@ktf @TimoWilken : I have seen recently that again several compiles in the CI fail due to running out of memory when compiling the analysis. This reduces the number of jobs slightly, hope it helps. As said many times, I believe we need CI servers with more memory in the long run.