### PR TITLE
PID: rename default PID tables and tasks

### DIFF
--- a/Analysis/ALICE3/src/alice3-pidTOF.cxx
+++ b/Analysis/ALICE3/src/alice3-pidTOF.cxx
@@ -36,15 +36,15 @@ struct ALICE3pidTOFTask {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
   using Coll = aod::Collisions;
   // Tables to produce
-  Produces<o2::aod::pidRespTOFEl> tablePIDEl;
-  Produces<o2::aod::pidRespTOFMu> tablePIDMu;
-  Produces<o2::aod::pidRespTOFPi> tablePIDPi;
-  Produces<o2::aod::pidRespTOFKa> tablePIDKa;
-  Produces<o2::aod::pidRespTOFPr> tablePIDPr;
-  Produces<o2::aod::pidRespTOFDe> tablePIDDe;
-  Produces<o2::aod::pidRespTOFTr> tablePIDTr;
-  Produces<o2::aod::pidRespTOFHe> tablePIDHe;
-  Produces<o2::aod::pidRespTOFAl> tablePIDAl;
+  Produces<o2::aod::pidTOFFullEl> tablePIDEl;
+  Produces<o2::aod::pidTOFFullMu> tablePIDMu;
+  Produces<o2::aod::pidTOFFullPi> tablePIDPi;
+  Produces<o2::aod::pidTOFFullKa> tablePIDKa;
+  Produces<o2::aod::pidTOFFullPr> tablePIDPr;
+  Produces<o2::aod::pidTOFFullDe> tablePIDDe;
+  Produces<o2::aod::pidTOFFullTr> tablePIDTr;
+  Produces<o2::aod::pidTOFFullHe> tablePIDHe;
+  Produces<o2::aod::pidTOFFullAl> tablePIDAl;
   Parameters resoParameters{1};
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
@@ -221,9 +221,9 @@ struct ALICE3pidTOFTaskQA {
 
   void process(aod::Collision const& collision,
                soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov,
-                         aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                         aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                         aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
+                         aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                         aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe,
+                         aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl,
                          aod::TrackSelection> const& tracks)
   {
     // Computing Multiplicity first

--- a/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -41,8 +41,8 @@ DECLARE_SOA_TABLE(HFSelTrack, "AOD", "HFSELTRACK", //!
 using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra, HFSelTrack>;
 using BigTracksMC = soa::Join<BigTracks, McTrackLabels>;
 using BigTracksPID = soa::Join<BigTracks,
-                               aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi, aod::pidRespTPCKa, aod::pidRespTPCPr,
-                               aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi, aod::pidRespTOFKa, aod::pidRespTOFPr>;
+                               aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
+                               aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>;
 
 // FIXME: this is a workaround until we get the index columns to work with joins.
 

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/PIDResponse.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/PIDResponse.h
@@ -27,11 +27,11 @@ namespace o2::aod
 
 namespace pidtofbeta
 {
-DECLARE_SOA_COLUMN(Beta, beta, float);           //!
-DECLARE_SOA_COLUMN(BetaError, betaerror, float); //!
+DECLARE_SOA_COLUMN(Beta, beta, float);           //! TOF beta
+DECLARE_SOA_COLUMN(BetaError, betaerror, float); //! Uncertainty on the TOF beta
 //
-DECLARE_SOA_COLUMN(ExpBetaEl, expbetael, float);           //!
-DECLARE_SOA_COLUMN(ExpBetaElError, expbetaelerror, float); //!
+DECLARE_SOA_COLUMN(ExpBetaEl, expbetael, float);           //! Expected beta of electron
+DECLARE_SOA_COLUMN(ExpBetaElError, expbetaelerror, float); //! Expected uncertainty on the beta of electron
 //
 DECLARE_SOA_COLUMN(SeparationBetaEl, separationbetael, float); //!
 DECLARE_SOA_DYNAMIC_COLUMN(DiffBetaEl, diffbetael,             //!
@@ -41,23 +41,23 @@ DECLARE_SOA_DYNAMIC_COLUMN(DiffBetaEl, diffbetael,             //!
 namespace pidtof
 {
 // Expected times
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffEl, tofExpSignalDiffEl, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffEl, tofExpSignalDiffEl, //! Difference between signal and expected for electron
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffMu, tofExpSignalDiffMu, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffMu, tofExpSignalDiffMu, //! Difference between signal and expected for muon
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffPi, tofExpSignalDiffPi, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffPi, tofExpSignalDiffPi, //! Difference between signal and expected for pion
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffKa, tofExpSignalDiffKa, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffKa, tofExpSignalDiffKa, //! Difference between signal and expected for kaon
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffPr, tofExpSignalDiffPr, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffPr, tofExpSignalDiffPr, //! Difference between signal and expected for proton
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffDe, tofExpSignalDiffDe, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffDe, tofExpSignalDiffDe, //! Difference between signal and expected for deuteron
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffTr, tofExpSignalDiffTr, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffTr, tofExpSignalDiffTr, //! Difference between signal and expected for triton
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffHe, tofExpSignalDiffHe, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffHe, tofExpSignalDiffHe, //! Difference between signal and expected for helium3
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
-DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffAl, tofExpSignalDiffAl, //!
+DECLARE_SOA_DYNAMIC_COLUMN(TOFExpSignalDiffAl, tofExpSignalDiffAl, //! Difference between signal and expected for alpha
                            [](float nsigma, float sigma) -> float { return nsigma * sigma; });
 // Expected sigma
 DECLARE_SOA_COLUMN(TOFExpSigmaEl, tofExpSigmaEl, float); //!
@@ -118,50 +118,50 @@ DEFINE_UNWRAP_NSIGMA_COLUMN(TOFNSigmaAl, tofNSigmaAl); //!
 
 } // namespace pidtof_tiny
 
-DECLARE_SOA_TABLE(pidRespTOFbeta, "AOD", "pidRespTOFbeta", //!
+DECLARE_SOA_TABLE(pidTOFbeta, "AOD", "pidTOFbeta", //! Table of the TOF beta
                   pidtofbeta::Beta, pidtofbeta::BetaError,
                   pidtofbeta::ExpBetaEl, pidtofbeta::ExpBetaElError,
                   pidtofbeta::SeparationBetaEl,
                   pidtofbeta::DiffBetaEl<pidtofbeta::Beta, pidtofbeta::ExpBetaEl>);
 
 // Per particle tables
-DECLARE_SOA_TABLE(pidRespTOFEl, "AOD", "pidRespTOFEl", //!
+DECLARE_SOA_TABLE(pidTOFFullEl, "AOD", "pidTOFFullEl", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for electron
                   pidtof::TOFExpSignalDiffEl<pidtof::TOFNSigmaEl, pidtof::TOFExpSigmaEl>, pidtof::TOFExpSigmaEl, pidtof::TOFNSigmaEl);
-DECLARE_SOA_TABLE(pidRespTOFMu, "AOD", "pidRespTOFMu", //!
+DECLARE_SOA_TABLE(pidTOFFullMu, "AOD", "pidTOFFullMu", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for muon
                   pidtof::TOFExpSignalDiffMu<pidtof::TOFNSigmaMu, pidtof::TOFExpSigmaMu>, pidtof::TOFExpSigmaMu, pidtof::TOFNSigmaMu);
-DECLARE_SOA_TABLE(pidRespTOFPi, "AOD", "pidRespTOFPi", //!
+DECLARE_SOA_TABLE(pidTOFFullPi, "AOD", "pidTOFFullPi", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for pion
                   pidtof::TOFExpSignalDiffPi<pidtof::TOFNSigmaPi, pidtof::TOFExpSigmaPi>, pidtof::TOFExpSigmaPi, pidtof::TOFNSigmaPi);
-DECLARE_SOA_TABLE(pidRespTOFKa, "AOD", "pidRespTOFKa", //!
+DECLARE_SOA_TABLE(pidTOFFullKa, "AOD", "pidTOFFullKa", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for kaon
                   pidtof::TOFExpSignalDiffKa<pidtof::TOFNSigmaKa, pidtof::TOFExpSigmaKa>, pidtof::TOFExpSigmaKa, pidtof::TOFNSigmaKa);
-DECLARE_SOA_TABLE(pidRespTOFPr, "AOD", "pidRespTOFPr", //!
+DECLARE_SOA_TABLE(pidTOFFullPr, "AOD", "pidTOFFullPr", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for proton
                   pidtof::TOFExpSignalDiffPr<pidtof::TOFNSigmaPr, pidtof::TOFExpSigmaPr>, pidtof::TOFExpSigmaPr, pidtof::TOFNSigmaPr);
-DECLARE_SOA_TABLE(pidRespTOFDe, "AOD", "pidRespTOFDe", //!
+DECLARE_SOA_TABLE(pidTOFFullDe, "AOD", "pidTOFFullDe", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for deuteron
                   pidtof::TOFExpSignalDiffDe<pidtof::TOFNSigmaDe, pidtof::TOFExpSigmaDe>, pidtof::TOFExpSigmaDe, pidtof::TOFNSigmaDe);
-DECLARE_SOA_TABLE(pidRespTOFTr, "AOD", "pidRespTOFTr", //!
+DECLARE_SOA_TABLE(pidTOFFullTr, "AOD", "pidTOFFullTr", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for triton
                   pidtof::TOFExpSignalDiffTr<pidtof::TOFNSigmaTr, pidtof::TOFExpSigmaTr>, pidtof::TOFExpSigmaTr, pidtof::TOFNSigmaTr);
-DECLARE_SOA_TABLE(pidRespTOFHe, "AOD", "pidRespTOFHe", //!
+DECLARE_SOA_TABLE(pidTOFFullHe, "AOD", "pidTOFFullHe", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for helium3
                   pidtof::TOFExpSignalDiffHe<pidtof::TOFNSigmaHe, pidtof::TOFExpSigmaHe>, pidtof::TOFExpSigmaHe, pidtof::TOFNSigmaHe);
-DECLARE_SOA_TABLE(pidRespTOFAl, "AOD", "pidRespTOFAl", //!
+DECLARE_SOA_TABLE(pidTOFFullAl, "AOD", "pidTOFFullAl", //! Table of the TOF (full) response with expected signal, expected resolution and Nsigma for alpha
                   pidtof::TOFExpSignalDiffAl<pidtof::TOFNSigmaAl, pidtof::TOFExpSigmaAl>, pidtof::TOFExpSigmaAl, pidtof::TOFNSigmaAl);
 
 // Tiny size tables
-DECLARE_SOA_TABLE(pidRespTOFTEl, "AOD", "pidRespTOFTEl", //!
+DECLARE_SOA_TABLE(pidTOFEl, "AOD", "pidTOFEl", //! Table of the TOF response with binned Nsigma for electron
                   pidtof_tiny::TOFNSigmaStoreEl, pidtof_tiny::TOFNSigmaEl<pidtof_tiny::TOFNSigmaStoreEl>);
-DECLARE_SOA_TABLE(pidRespTOFTMu, "AOD", "pidRespTOFTMu", //!
+DECLARE_SOA_TABLE(pidTOFMu, "AOD", "pidTOFMu", //! Table of the TOF response with binned Nsigma for muon
                   pidtof_tiny::TOFNSigmaStoreMu, pidtof_tiny::TOFNSigmaMu<pidtof_tiny::TOFNSigmaStoreMu>);
-DECLARE_SOA_TABLE(pidRespTOFTPi, "AOD", "pidRespTOFTPi", //!
+DECLARE_SOA_TABLE(pidTOFPi, "AOD", "pidTOFPi", //! Table of the TOF response with binned Nsigma for pion
                   pidtof_tiny::TOFNSigmaStorePi, pidtof_tiny::TOFNSigmaPi<pidtof_tiny::TOFNSigmaStorePi>);
-DECLARE_SOA_TABLE(pidRespTOFTKa, "AOD", "pidRespTOFTKa", //!
+DECLARE_SOA_TABLE(pidTOFKa, "AOD", "pidTOFKa", //! Table of the TOF response with binned Nsigma for kaon
                   pidtof_tiny::TOFNSigmaStoreKa, pidtof_tiny::TOFNSigmaKa<pidtof_tiny::TOFNSigmaStoreKa>);
-DECLARE_SOA_TABLE(pidRespTOFTPr, "AOD", "pidRespTOFTPr", //!
+DECLARE_SOA_TABLE(pidTOFPr, "AOD", "pidTOFPr", //! Table of the TOF response with binned Nsigma for proton
                   pidtof_tiny::TOFNSigmaStorePr, pidtof_tiny::TOFNSigmaPr<pidtof_tiny::TOFNSigmaStorePr>);
-DECLARE_SOA_TABLE(pidRespTOFTDe, "AOD", "pidRespTOFTDe", //!
+DECLARE_SOA_TABLE(pidTOFDe, "AOD", "pidTOFDe", //! Table of the TOF response with binned Nsigma for deuteron
                   pidtof_tiny::TOFNSigmaStoreDe, pidtof_tiny::TOFNSigmaDe<pidtof_tiny::TOFNSigmaStoreDe>);
-DECLARE_SOA_TABLE(pidRespTOFTTr, "AOD", "pidRespTOFTTr", //!
+DECLARE_SOA_TABLE(pidTOFTr, "AOD", "pidTOFTr", //! Table of the TOF response with binned Nsigma for triton
                   pidtof_tiny::TOFNSigmaStoreTr, pidtof_tiny::TOFNSigmaTr<pidtof_tiny::TOFNSigmaStoreTr>);
-DECLARE_SOA_TABLE(pidRespTOFTHe, "AOD", "pidRespTOFTHe", //!
+DECLARE_SOA_TABLE(pidTOFHe, "AOD", "pidTOFHe", //! Table of the TOF response with binned Nsigma for helium3
                   pidtof_tiny::TOFNSigmaStoreHe, pidtof_tiny::TOFNSigmaHe<pidtof_tiny::TOFNSigmaStoreHe>);
-DECLARE_SOA_TABLE(pidRespTOFTAl, "AOD", "pidRespTOFTAl", //!
+DECLARE_SOA_TABLE(pidTOFAl, "AOD", "pidTOFAl", //! Table of the TOF response with binned Nsigma for alpha
                   pidtof_tiny::TOFNSigmaStoreAl, pidtof_tiny::TOFNSigmaAl<pidtof_tiny::TOFNSigmaStoreAl>);
 
 namespace pidtpc
@@ -240,43 +240,43 @@ DEFINE_UNWRAP_NSIGMA_COLUMN(TPCNSigmaAl, tpcNSigmaAl); //!
 } // namespace pidtpc_tiny
 
 // Per particle tables
-DECLARE_SOA_TABLE(pidRespTPCEl, "AOD", "pidRespTPCEl", //!
+DECLARE_SOA_TABLE(pidTPCFullEl, "AOD", "pidTPCFullEl", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for electron
                   pidtpc::TPCExpSignalDiffEl<pidtpc::TPCNSigmaEl, pidtpc::TPCExpSigmaEl>, pidtpc::TPCExpSigmaEl, pidtpc::TPCNSigmaEl);
-DECLARE_SOA_TABLE(pidRespTPCMu, "AOD", "pidRespTPCMu", //!
+DECLARE_SOA_TABLE(pidTPCFullMu, "AOD", "pidTPCFullMu", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for muon
                   pidtpc::TPCExpSignalDiffMu<pidtpc::TPCNSigmaMu, pidtpc::TPCExpSigmaMu>, pidtpc::TPCExpSigmaMu, pidtpc::TPCNSigmaMu);
-DECLARE_SOA_TABLE(pidRespTPCPi, "AOD", "pidRespTPCPi", //!
+DECLARE_SOA_TABLE(pidTPCFullPi, "AOD", "pidTPCFullPi", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for pion
                   pidtpc::TPCExpSignalDiffPi<pidtpc::TPCNSigmaPi, pidtpc::TPCExpSigmaPi>, pidtpc::TPCExpSigmaPi, pidtpc::TPCNSigmaPi);
-DECLARE_SOA_TABLE(pidRespTPCKa, "AOD", "pidRespTPCKa", //!
+DECLARE_SOA_TABLE(pidTPCFullKa, "AOD", "pidTPCFullKa", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for kaon
                   pidtpc::TPCExpSignalDiffKa<pidtpc::TPCNSigmaKa, pidtpc::TPCExpSigmaKa>, pidtpc::TPCExpSigmaKa, pidtpc::TPCNSigmaKa);
-DECLARE_SOA_TABLE(pidRespTPCPr, "AOD", "pidRespTPCPr", //!
+DECLARE_SOA_TABLE(pidTPCFullPr, "AOD", "pidTPCFullPr", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for proton
                   pidtpc::TPCExpSignalDiffPr<pidtpc::TPCNSigmaPr, pidtpc::TPCExpSigmaPr>, pidtpc::TPCExpSigmaPr, pidtpc::TPCNSigmaPr);
-DECLARE_SOA_TABLE(pidRespTPCDe, "AOD", "pidRespTPCDe", //!
+DECLARE_SOA_TABLE(pidTPCFullDe, "AOD", "pidTPCFullDe", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for deuteron
                   pidtpc::TPCExpSignalDiffDe<pidtpc::TPCNSigmaDe, pidtpc::TPCExpSigmaDe>, pidtpc::TPCExpSigmaDe, pidtpc::TPCNSigmaDe);
-DECLARE_SOA_TABLE(pidRespTPCTr, "AOD", "pidRespTPCTr", //!
+DECLARE_SOA_TABLE(pidTPCFullTr, "AOD", "pidTPCFullTr", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for triton
                   pidtpc::TPCExpSignalDiffTr<pidtpc::TPCNSigmaTr, pidtpc::TPCExpSigmaTr>, pidtpc::TPCExpSigmaTr, pidtpc::TPCNSigmaTr);
-DECLARE_SOA_TABLE(pidRespTPCHe, "AOD", "pidRespTPCHe", //!
+DECLARE_SOA_TABLE(pidTPCFullHe, "AOD", "pidTPCFullHe", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for helium3
                   pidtpc::TPCExpSignalDiffHe<pidtpc::TPCNSigmaHe, pidtpc::TPCExpSigmaHe>, pidtpc::TPCExpSigmaHe, pidtpc::TPCNSigmaHe);
-DECLARE_SOA_TABLE(pidRespTPCAl, "AOD", "pidRespTPCAl", //!
+DECLARE_SOA_TABLE(pidTPCFullAl, "AOD", "pidTPCFullAl", //! Table of the TPC (full) response with expected signal, expected resolution and Nsigma for alpha
                   pidtpc::TPCExpSignalDiffAl<pidtpc::TPCNSigmaAl, pidtpc::TPCExpSigmaAl>, pidtpc::TPCExpSigmaAl, pidtpc::TPCNSigmaAl);
 
 // Tiny size tables
-DECLARE_SOA_TABLE(pidRespTPCTEl, "AOD", "pidRespTPCTEl", //!
+DECLARE_SOA_TABLE(pidTPCEl, "AOD", "pidTPCEl", //! Table of the TPC response with binned Nsigma for electron
                   pidtpc_tiny::TPCNSigmaStoreEl, pidtpc_tiny::TPCNSigmaEl<pidtpc_tiny::TPCNSigmaStoreEl>);
-DECLARE_SOA_TABLE(pidRespTPCTMu, "AOD", "pidRespTPCTMu", //!
+DECLARE_SOA_TABLE(pidTPCMu, "AOD", "pidTPCMu", //! Table of the TPC response with binned Nsigma for muon
                   pidtpc_tiny::TPCNSigmaStoreMu, pidtpc_tiny::TPCNSigmaMu<pidtpc_tiny::TPCNSigmaStoreMu>);
-DECLARE_SOA_TABLE(pidRespTPCTPi, "AOD", "pidRespTPCTPi", //!
+DECLARE_SOA_TABLE(pidTPCPi, "AOD", "pidTPCPi", //! Table of the TPC response with binned Nsigma for pion
                   pidtpc_tiny::TPCNSigmaStorePi, pidtpc_tiny::TPCNSigmaPi<pidtpc_tiny::TPCNSigmaStorePi>);
-DECLARE_SOA_TABLE(pidRespTPCTKa, "AOD", "pidRespTPCTKa", //!
+DECLARE_SOA_TABLE(pidTPCKa, "AOD", "pidTPCKa", //! Table of the TPC response with binned Nsigma for kaon
                   pidtpc_tiny::TPCNSigmaStoreKa, pidtpc_tiny::TPCNSigmaKa<pidtpc_tiny::TPCNSigmaStoreKa>);
-DECLARE_SOA_TABLE(pidRespTPCTPr, "AOD", "pidRespTPCTPr", //!
+DECLARE_SOA_TABLE(pidTPCPr, "AOD", "pidTPCPr", //! Table of the TPC response with binned Nsigma for proton
                   pidtpc_tiny::TPCNSigmaStorePr, pidtpc_tiny::TPCNSigmaPr<pidtpc_tiny::TPCNSigmaStorePr>);
-DECLARE_SOA_TABLE(pidRespTPCTDe, "AOD", "pidRespTPCTDe", //!
+DECLARE_SOA_TABLE(pidTPCDe, "AOD", "pidTPCDe", //! Table of the TPC response with binned Nsigma for deuteron
                   pidtpc_tiny::TPCNSigmaStoreDe, pidtpc_tiny::TPCNSigmaDe<pidtpc_tiny::TPCNSigmaStoreDe>);
-DECLARE_SOA_TABLE(pidRespTPCTTr, "AOD", "pidRespTPCTTr", //!
+DECLARE_SOA_TABLE(pidTPCTr, "AOD", "pidTPCTr", //! Table of the TPC response with binned Nsigma for triton
                   pidtpc_tiny::TPCNSigmaStoreTr, pidtpc_tiny::TPCNSigmaTr<pidtpc_tiny::TPCNSigmaStoreTr>);
-DECLARE_SOA_TABLE(pidRespTPCTHe, "AOD", "pidRespTPCTHe", //!
+DECLARE_SOA_TABLE(pidTPCHe, "AOD", "pidTPCHe", //! Table of the TPC response with binned Nsigma for helium3
                   pidtpc_tiny::TPCNSigmaStoreHe, pidtpc_tiny::TPCNSigmaHe<pidtpc_tiny::TPCNSigmaStoreHe>);
-DECLARE_SOA_TABLE(pidRespTPCTAl, "AOD", "pidRespTPCTAl", //!
+DECLARE_SOA_TABLE(pidTPCAl, "AOD", "pidTPCAl", //! Table of the TPC response with binned Nsigma for alpha
                   pidtpc_tiny::TPCNSigmaStoreAl, pidtpc_tiny::TPCNSigmaAl<pidtpc_tiny::TPCNSigmaStoreAl>);
 
 #undef DEFINE_UNWRAP_NSIGMA_COLUMN

--- a/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTOF.h
+++ b/Analysis/DataModel/include/AnalysisDataModel/PID/PIDTOF.h
@@ -113,7 +113,7 @@ class ExpTimes
   float GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
 
   /// Gets the number of sigmas with respect the expected time
-  float GetSeparation(const DetectorResponse& response, const Coll& col, const Trck& trk) const { return (trk.tofSignal() - col.collisionTime() * 1000.f - GetExpectedSignal(col, trk)) / GetExpectedSigma(response, col, trk); }
+  float GetSeparation(const DetectorResponse& response, const Coll& col, const Trck& trk) const { return trk.tofSignal() > 0.f ? (trk.tofSignal() - col.collisionTime() * 1000.f - GetExpectedSignal(col, trk)) / GetExpectedSigma(response, col, trk) : -999.f; }
 };
 
 //_________________________________________________________________________

--- a/Analysis/DataModel/src/aodDataModelGraph.cxx
+++ b/Analysis/DataModel/src/aodDataModelGraph.cxx
@@ -259,12 +259,12 @@ int main(int, char**)
   displayEntity<Run2BCInfos>();
 
   displayEntities<Tracks, TracksCov, TracksExtra, TracksExtended, TrackSelection,
-                  pidRespTOFEl, pidRespTOFMu, pidRespTOFPi,
-                  pidRespTOFKa, pidRespTOFPr, pidRespTOFDe,
-                  pidRespTOFTr, pidRespTOFHe, pidRespTOFAl,
-                  pidRespTPCEl, pidRespTPCMu, pidRespTPCPi,
-                  pidRespTPCKa, pidRespTPCPr, pidRespTPCDe,
-                  pidRespTPCTr, pidRespTPCHe, pidRespTPCAl>();
+                  pidTOFFullEl, pidTOFFullMu, pidTOFFullPi,
+                  pidTOFFullKa, pidTOFFullPr, pidTOFFullDe,
+                  pidTOFFullTr, pidTOFFullHe, pidTOFFullAl,
+                  pidTPCFullEl, pidTPCFullMu, pidTPCFullPi,
+                  pidTPCFullKa, pidTPCFullPr, pidTPCFullDe,
+                  pidTPCFullTr, pidTPCFullHe, pidTPCFullAl>();
   displayEntity<UnassignedTracks>();
   displayEntity<UnassignedMFTTracks>();
 

--- a/Analysis/Tasks/PID/CMakeLists.txt
+++ b/Analysis/Tasks/PID/CMakeLists.txt
@@ -25,8 +25,8 @@ o2_add_dpl_workflow(pid-tof-qa-mc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2_add_dpl_workflow(pid-tof-tiny
-                    SOURCES pidTOFtiny.cxx
+o2_add_dpl_workflow(pid-tof-full
+                    SOURCES pidTOFFull.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
@@ -37,8 +37,8 @@ o2_add_dpl_workflow(pid-tpc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2_add_dpl_workflow(pid-tpc-tiny
-                    SOURCES pidTPCtiny.cxx
+o2_add_dpl_workflow(pid-tpc-full
+                    SOURCES pidTPCFull.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/Analysis/Tasks/PID/pidTOF.cxx
+++ b/Analysis/Tasks/PID/pidTOF.cxx
@@ -11,7 +11,7 @@
 ///
 /// \file   pidTOF.cxx
 /// \author Nicolo' Jacazio
-/// \brief  Task to produce PID tables for TOF split for each particle.
+/// \brief  Task to produce PID tables for TOF split for each particle with only the Nsigma information.
 ///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
 ///
 
@@ -43,15 +43,15 @@ struct tofPid {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
   using Coll = aod::Collisions;
   // Tables to produce
-  Produces<o2::aod::pidRespTOFEl> tablePIDEl;
-  Produces<o2::aod::pidRespTOFMu> tablePIDMu;
-  Produces<o2::aod::pidRespTOFPi> tablePIDPi;
-  Produces<o2::aod::pidRespTOFKa> tablePIDKa;
-  Produces<o2::aod::pidRespTOFPr> tablePIDPr;
-  Produces<o2::aod::pidRespTOFDe> tablePIDDe;
-  Produces<o2::aod::pidRespTOFTr> tablePIDTr;
-  Produces<o2::aod::pidRespTOFHe> tablePIDHe;
-  Produces<o2::aod::pidRespTOFAl> tablePIDAl;
+  Produces<o2::aod::pidTOFEl> tablePIDEl;
+  Produces<o2::aod::pidTOFMu> tablePIDMu;
+  Produces<o2::aod::pidTOFPi> tablePIDPi;
+  Produces<o2::aod::pidTOFKa> tablePIDKa;
+  Produces<o2::aod::pidTOFPr> tablePIDPr;
+  Produces<o2::aod::pidTOFDe> tablePIDDe;
+  Produces<o2::aod::pidTOFTr> tablePIDTr;
+  Produces<o2::aod::pidTOFHe> tablePIDHe;
+  Produces<o2::aod::pidTOFAl> tablePIDAl;
   // Detector response and input parameters
   DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -78,12 +78,13 @@ struct tofPid {
     for (DeviceSpec device : workflows.devices) {
       for (auto input : device.inputs) {
         auto enableFlag = [&input](const std::string particle, Configurable<int>& flag) {
-          const std::string table = "pidRespTOF" + particle;
+          const std::string table = "pidTOF" + particle;
           if (input.matcher.binding == table) {
             if (flag < 0) {
               flag.value = 1;
               LOG(INFO) << "Auto-enabling table: " + table;
             } else if (flag > 0) {
+              flag.value = 1;
               LOG(INFO) << "Table enabled: " + table;
             } else {
               LOG(INFO) << "Table disabled: " + table;
@@ -142,8 +143,16 @@ struct tofPid {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
-                responsePID.GetSeparation(response, trk.collision(), trk));
+          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          if (separation <= o2::aod::pidtof_tiny::binned_min) {
+            table(o2::aod::pidtof_tiny::lower_bin);
+          } else if (separation >= o2::aod::pidtof_tiny::binned_max) {
+            table(o2::aod::pidtof_tiny::upper_bin);
+          } else if (separation >= 0) {
+            table(separation / o2::aod::pidtof_tiny::bin_width + 0.5f);
+          } else {
+            table(separation / o2::aod::pidtof_tiny::bin_width - 0.5f);
+          }
         }
       }
     };
@@ -210,14 +219,6 @@ struct tofPidQa {
   template <uint8_t i>
   void addParticleHistos()
   {
-    // Exp signal
-    histos.add(hexpected[i].data(), Form(";#it{p} (GeV/#it{c});t_{exp}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 2e6}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected[i])));
-
-    // T-Texp
-    histos.add(hexpected_diff[i].data(), Form(";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp}(%s))", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {nBinsDelta, MinDelta, MaxDelta}});
-    makelogaxis(histos.get<TH2>(HIST(hexpected_diff[i])));
-
     // NSigma
     histos.add(hnsigma[i].data(), Form(";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {nBinsNSigma, MinNSigma, MaxNSigma}});
     makelogaxis(histos.get<TH2>(HIST(hnsigma[i])));
@@ -248,17 +249,15 @@ struct tofPidQa {
   }
 
   template <uint8_t i, typename T>
-  void fillParticleHistos(const T& t, const float tof, const float exp_diff, const float nsigma)
+  void fillParticleHistos(const T& t, const float nsigma)
   {
-    histos.fill(HIST(hexpected[i]), t.p(), tof - exp_diff);
-    histos.fill(HIST(hexpected_diff[i]), t.p(), exp_diff);
     histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
   }
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov,
-                                                          aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                                          aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                                                          aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
+                                                          aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
+                                                          aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe,
+                                                          aod::pidTOFTr, aod::pidTOFHe, aod::pidTOFAl,
                                                           aod::TrackSelection> const& tracks)
   {
     const float collisionTime_ps = collision.collisionTime() * 1000.f;
@@ -283,15 +282,15 @@ struct tofPidQa {
       histos.fill(HIST("event/pt"), t.pt());
       histos.fill(HIST("event/ptreso"), t.p(), t.sigma1Pt() * t.pt() * t.pt());
       //
-      fillParticleHistos<0>(t, tof, t.tofExpSignalDiffEl(), t.tofNSigmaEl());
-      fillParticleHistos<1>(t, tof, t.tofExpSignalDiffMu(), t.tofNSigmaMu());
-      fillParticleHistos<2>(t, tof, t.tofExpSignalDiffPi(), t.tofNSigmaPi());
-      fillParticleHistos<3>(t, tof, t.tofExpSignalDiffKa(), t.tofNSigmaKa());
-      fillParticleHistos<4>(t, tof, t.tofExpSignalDiffPr(), t.tofNSigmaPr());
-      fillParticleHistos<5>(t, tof, t.tofExpSignalDiffDe(), t.tofNSigmaDe());
-      fillParticleHistos<6>(t, tof, t.tofExpSignalDiffTr(), t.tofNSigmaTr());
-      fillParticleHistos<7>(t, tof, t.tofExpSignalDiffHe(), t.tofNSigmaHe());
-      fillParticleHistos<8>(t, tof, t.tofExpSignalDiffAl(), t.tofNSigmaAl());
+      fillParticleHistos<0>(t, t.tofNSigmaEl());
+      fillParticleHistos<1>(t, t.tofNSigmaMu());
+      fillParticleHistos<2>(t, t.tofNSigmaPi());
+      fillParticleHistos<3>(t, t.tofNSigmaKa());
+      fillParticleHistos<4>(t, t.tofNSigmaPr());
+      fillParticleHistos<5>(t, t.tofNSigmaDe());
+      fillParticleHistos<6>(t, t.tofNSigmaTr());
+      fillParticleHistos<7>(t, t.tofNSigmaHe());
+      fillParticleHistos<8>(t, t.tofNSigmaAl());
     }
   }
 };

--- a/Analysis/Tasks/PID/pidTOFFull.cxx
+++ b/Analysis/Tasks/PID/pidTOFFull.cxx
@@ -9,9 +9,9 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file   pidTPCtiny.cxx
+/// \file   pidTOFFull.cxx
 /// \author Nicolo' Jacazio
-/// \brief  Task to produce PID tables for TPC split for each particle with only the Nsigma information.
+/// \brief  Task to produce PID tables for TOF split for each particle.
 ///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
 ///
 
@@ -22,7 +22,7 @@
 #include "ReconstructionDataFormats/Track.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "AnalysisDataModel/PID/PIDResponse.h"
-#include "AnalysisDataModel/PID/PIDTPC.h"
+#include "AnalysisDataModel/PID/PIDTOF.h"
 #include "AnalysisDataModel/TrackSelectionTables.h"
 
 using namespace o2;
@@ -33,33 +33,32 @@ using namespace o2::track;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{{"add-qa", VariantType::Int, 0, {"Produce TPC PID QA histograms"}}};
+  std::vector<ConfigParamSpec> options{{"add-qa", VariantType::Int, 0, {"Produce TOF PID QA histograms"}}};
   std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h"
 
-struct tpcPidTiny {
-  using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
+struct tofPidFull {
+  using Trks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
   using Coll = aod::Collisions;
   // Tables to produce
-  Produces<o2::aod::pidRespTPCTEl> tablePIDEl;
-  Produces<o2::aod::pidRespTPCTMu> tablePIDMu;
-  Produces<o2::aod::pidRespTPCTPi> tablePIDPi;
-  Produces<o2::aod::pidRespTPCTKa> tablePIDKa;
-  Produces<o2::aod::pidRespTPCTPr> tablePIDPr;
-  Produces<o2::aod::pidRespTPCTDe> tablePIDDe;
-  Produces<o2::aod::pidRespTPCTTr> tablePIDTr;
-  Produces<o2::aod::pidRespTPCTHe> tablePIDHe;
-  Produces<o2::aod::pidRespTPCTAl> tablePIDAl;
+  Produces<o2::aod::pidTOFFullEl> tablePIDEl;
+  Produces<o2::aod::pidTOFFullMu> tablePIDMu;
+  Produces<o2::aod::pidTOFFullPi> tablePIDPi;
+  Produces<o2::aod::pidTOFFullKa> tablePIDKa;
+  Produces<o2::aod::pidTOFFullPr> tablePIDPr;
+  Produces<o2::aod::pidTOFFullDe> tablePIDDe;
+  Produces<o2::aod::pidTOFFullTr> tablePIDTr;
+  Produces<o2::aod::pidTOFFullHe> tablePIDHe;
+  Produces<o2::aod::pidTOFFullAl> tablePIDAl;
   // Detector response and input parameters
   DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
-  Configurable<std::string> signalname{"param-signal", "BetheBloch", "Name of the parametrization for the expected signal, used in both file and CCDB mode"};
-  Configurable<std::string> sigmaname{"param-sigma", "TPCReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
+  Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
   Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
-  Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC", "Path of the TPC parametrization on the CCDB"};
+  Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TOF", "Path of the TOF parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
   // Configuration flags to include and exclude particle hypotheses
   Configurable<int> pidEl{"pid-el", -1, {"Produce PID information for the Electron mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
@@ -79,12 +78,13 @@ struct tpcPidTiny {
     for (DeviceSpec device : workflows.devices) {
       for (auto input : device.inputs) {
         auto enableFlag = [&input](const std::string particle, Configurable<int>& flag) {
-          const std::string table = "pidRespTPCT" + particle;
+          const std::string table = "pidTOFFull" + particle;
           if (input.matcher.binding == table) {
             if (flag < 0) {
               flag.value = 1;
               LOG(INFO) << "Auto-enabling table: " + table;
             } else if (flag > 0) {
+              flag.value = 1;
               LOG(INFO) << "Table enabled: " + table;
             } else {
               LOG(INFO) << "Table disabled: " + table;
@@ -110,26 +110,21 @@ struct tpcPidTiny {
     // Not later than now objects
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
     //
+    const std::vector<float> p = {0.008, 0.008, 0.002, 40.0};
+    response.SetParameters(DetectorResponse::kSigma, p);
     const std::string fname = paramfile.value;
     if (!fname.empty()) { // Loading the parametrization from file
-      LOG(INFO) << "Loading exp. signal parametrization from file" << fname << ", using param: " << signalname.value;
-      response.LoadParamFromFile(fname.data(), signalname.value, DetectorResponse::kSignal);
-
       LOG(INFO) << "Loading exp. sigma parametrization from file" << fname << ", using param: " << sigmaname.value;
       response.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
     } else { // Loading it from CCDB
-      std::string path = ccdbPath.value + "/" + signalname.value;
-      LOG(INFO) << "Loading exp. signal parametrization from CCDB, using path: " << path << " for timestamp " << timestamp.value;
-      response.LoadParam(DetectorResponse::kSignal, ccdb->getForTimeStamp<Parametrization>(path, timestamp.value));
-
-      path = ccdbPath.value + "/" + sigmaname.value;
+      std::string path = ccdbPath.value + "/" + sigmaname.value;
       LOG(INFO) << "Loading exp. sigma parametrization from CCDB, using path: " << path << " for timestamp " << timestamp.value;
       response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(path, timestamp.value));
     }
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = o2::pid::tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = tof::ExpTimes<Coll::iterator, Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -148,16 +143,8 @@ struct tpcPidTiny {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
-          if (separation <= o2::aod::pidtpc_tiny::binned_min) {
-            table(o2::aod::pidtpc_tiny::lower_bin);
-          } else if (separation >= o2::aod::pidtpc_tiny::binned_max) {
-            table(o2::aod::pidtpc_tiny::upper_bin);
-          } else if (separation >= 0) {
-            table(separation / o2::aod::pidtpc_tiny::bin_width + 0.5f);
-          } else {
-            table(separation / o2::aod::pidtpc_tiny::bin_width - 0.5f);
-          }
+          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
+                responsePID.GetSeparation(response, trk.collision(), trk));
         }
       }
     };
@@ -173,7 +160,8 @@ struct tpcPidTiny {
   }
 };
 
-struct tpcPidTinyQa {
+struct tofPidFullQa {
+
   static constexpr int Np = 9;
   static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
   static constexpr std::string_view hexpected[Np] = {"expected/El", "expected/Mu", "expected/Pi",
@@ -187,13 +175,23 @@ struct tpcPidTinyQa {
                                                    "nsigma/Tr", "nsigma/He", "nsigma/Al"};
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
 
+  Configurable<int> logAxis{"logAxis", 1, "Flag to use a log momentum axis"};
   Configurable<int> nBinsP{"nBinsP", 400, "Number of bins for the momentum"};
-  Configurable<float> MinP{"MinP", 0, "Minimum momentum in range"};
-  Configurable<float> MaxP{"MaxP", 20, "Maximum momentum in range"};
+  Configurable<float> MinP{"MinP", 0.1f, "Minimum momentum in range"};
+  Configurable<float> MaxP{"MaxP", 5.f, "Maximum momentum in range"};
+  Configurable<int> nBinsDelta{"nBinsDelta", 200, "Number of bins for the Delta"};
+  Configurable<float> MinDelta{"MinDelta", -1000.f, "Minimum Delta in range"};
+  Configurable<float> MaxDelta{"MaxDelta", 1000.f, "Maximum Delta in range"};
+  Configurable<int> nBinsNSigma{"nBinsNSigma", 200, "Number of bins for the NSigma"};
+  Configurable<float> MinNSigma{"MinNSigma", -10.f, "Minimum NSigma in range"};
+  Configurable<float> MaxNSigma{"MaxNSigma", 10.f, "Maximum NSigma in range"};
 
   template <typename T>
   void makelogaxis(T h)
   {
+    if (logAxis == 0) {
+      return;
+    }
     const int nbins = h->GetNbinsX();
     double binp[nbins + 1];
     double max = h->GetXaxis()->GetBinUpEdge(nbins);
@@ -214,24 +212,30 @@ struct tpcPidTinyQa {
   void addParticleHistos()
   {
     // Exp signal
-    histos.add(hexpected[i].data(), Form(";#it{p} (GeV/#it{c});d#it{E}/d#it{x}_(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 1000}});
+    histos.add(hexpected[i].data(), Form(";#it{p} (GeV/#it{c});t_{exp}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 2e6}});
     makelogaxis(histos.get<TH2>(HIST(hexpected[i])));
 
-    // Signal - Expected signal
-    histos.add(hexpected_diff[i].data(), Form(";#it{p} (GeV/#it{c});;d#it{E}/d#it{x} - d#it{E}/d#it{x}(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {1000, -500, 500}});
+    // T-Texp
+    histos.add(hexpected_diff[i].data(), Form(";#it{p} (GeV/#it{c});(t-t_{evt}-t_{exp}(%s))", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {nBinsDelta, MinDelta, MaxDelta}});
     makelogaxis(histos.get<TH2>(HIST(hexpected_diff[i])));
 
     // NSigma
-    histos.add(hnsigma[i].data(), Form(";#it{p} (GeV/#it{c});N_{#sigma}^{TPC}(%s)", pT[i]), kTH2F, {{nBinsP, MinP, MaxP}, {200, -10, 10}});
+    histos.add(hnsigma[i].data(), Form(";#it{p} (GeV/#it{c});N_{#sigma}^{TOF}(%s)", pT[i]), HistType::kTH2F, {{nBinsP, MinP, MaxP}, {nBinsNSigma, MinNSigma, MaxNSigma}});
     makelogaxis(histos.get<TH2>(HIST(hnsigma[i])));
   }
 
   void init(o2::framework::InitContext&)
   {
     // Event properties
-    histos.add("event/vertexz", ";Vtx_{z} (cm);Entries", kTH1F, {{100, -20, 20}});
-    histos.add("event/tpcsignal", ";#it{p} (GeV/#it{c});TPC Signal", kTH2F, {{nBinsP, MinP, MaxP}, {1000, 0, 1000}});
-    makelogaxis(histos.get<TH2>(HIST("event/tpcsignal")));
+    histos.add("event/vertexz", ";Vtx_{z} (cm);Entries", HistType::kTH1F, {{100, -20, 20}});
+    histos.add("event/colltime", ";Collision time (ps);Entries", HistType::kTH1F, {{100, -2000, 2000}});
+    histos.add("event/tofsignal", ";#it{p} (GeV/#it{c});TOF Signal", HistType::kTH2F, {{nBinsP, MinP, MaxP}, {10000, 0, 2e6}});
+    makelogaxis(histos.get<TH2>(HIST("event/tofsignal")));
+    histos.add("event/eta", ";#it{#eta};Entries", HistType::kTH1F, {{100, -2, 2}});
+    histos.add("event/length", ";Track length (cm);Entries", HistType::kTH1F, {{100, 0, 500}});
+    histos.add("event/pt", ";#it{p}_{T} (GeV/#it{c});Entries", HistType::kTH1F, {{nBinsP, MinP, MaxP}});
+    histos.add("event/p", ";#it{p} (GeV/#it{c});Entries", HistType::kTH1F, {{nBinsP, MinP, MaxP}});
+    histos.add("event/ptreso", ";#it{p} (GeV/#it{c});Entries", HistType::kTH2F, {{nBinsP, MinP, MaxP}, {100, 0, 0.1}});
 
     addParticleHistos<0>();
     addParticleHistos<1>();
@@ -245,42 +249,59 @@ struct tpcPidTinyQa {
   }
 
   template <uint8_t i, typename T>
-  void fillParticleHistos(const T& t, const float nsigma)
+  void fillParticleHistos(const T& t, const float tof, const float exp_diff, const float nsigma)
   {
+    histos.fill(HIST(hexpected[i]), t.p(), tof - exp_diff);
+    histos.fill(HIST(hexpected_diff[i]), t.p(), exp_diff);
     histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
   }
 
-  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra,
-                                                          aod::pidRespTPCTEl, aod::pidRespTPCTMu, aod::pidRespTPCTPi,
-                                                          aod::pidRespTPCTKa, aod::pidRespTPCTPr, aod::pidRespTPCTDe,
-                                                          aod::pidRespTPCTTr, aod::pidRespTPCTHe, aod::pidRespTPCTAl,
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov,
+                                                          aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                                          aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe,
+                                                          aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl,
                                                           aod::TrackSelection> const& tracks)
   {
+    const float collisionTime_ps = collision.collisionTime() * 1000.f;
     histos.fill(HIST("event/vertexz"), collision.posZ());
+    histos.fill(HIST("event/colltime"), collisionTime_ps);
 
     for (auto t : tracks) {
-      // const float mom = t.p();
-      const float mom = t.tpcInnerParam();
-      histos.fill(HIST("event/tpcsignal"), mom, t.tpcSignal());
       //
-      fillParticleHistos<0>(t, t.tpcNSigmaEl());
-      fillParticleHistos<1>(t, t.tpcNSigmaMu());
-      fillParticleHistos<2>(t, t.tpcNSigmaPi());
-      fillParticleHistos<3>(t, t.tpcNSigmaKa());
-      fillParticleHistos<4>(t, t.tpcNSigmaPr());
-      fillParticleHistos<5>(t, t.tpcNSigmaDe());
-      fillParticleHistos<6>(t, t.tpcNSigmaTr());
-      fillParticleHistos<7>(t, t.tpcNSigmaHe());
-      fillParticleHistos<8>(t, t.tpcNSigmaAl());
+      if (t.tofSignal() < 0) { // Skipping tracks without TOF
+        continue;
+      }
+      if (!t.isGlobalTrack()) {
+        continue;
+      }
+
+      const float tof = t.tofSignal() - collisionTime_ps;
+
+      //
+      histos.fill(HIST("event/tofsignal"), t.p(), t.tofSignal());
+      histos.fill(HIST("event/eta"), t.eta());
+      histos.fill(HIST("event/length"), t.length());
+      histos.fill(HIST("event/pt"), t.pt());
+      histos.fill(HIST("event/ptreso"), t.p(), t.sigma1Pt() * t.pt() * t.pt());
+      //
+      fillParticleHistos<0>(t, tof, t.tofExpSignalDiffEl(), t.tofNSigmaEl());
+      fillParticleHistos<1>(t, tof, t.tofExpSignalDiffMu(), t.tofNSigmaMu());
+      fillParticleHistos<2>(t, tof, t.tofExpSignalDiffPi(), t.tofNSigmaPi());
+      fillParticleHistos<3>(t, tof, t.tofExpSignalDiffKa(), t.tofNSigmaKa());
+      fillParticleHistos<4>(t, tof, t.tofExpSignalDiffPr(), t.tofNSigmaPr());
+      fillParticleHistos<5>(t, tof, t.tofExpSignalDiffDe(), t.tofNSigmaDe());
+      fillParticleHistos<6>(t, tof, t.tofExpSignalDiffTr(), t.tofNSigmaTr());
+      fillParticleHistos<7>(t, tof, t.tofExpSignalDiffHe(), t.tofNSigmaHe());
+      fillParticleHistos<8>(t, tof, t.tofExpSignalDiffAl(), t.tofNSigmaAl());
     }
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  auto workflow = WorkflowSpec{adaptAnalysisTask<tpcPidTiny>(cfgc)};
+  auto workflow = WorkflowSpec{adaptAnalysisTask<tofPidFull>(cfgc)};
   if (cfgc.options().get<int>("add-qa")) {
-    workflow.push_back(adaptAnalysisTask<tpcPidTinyQa>(cfgc));
+    workflow.push_back(adaptAnalysisTask<tofPidFullQa>(cfgc));
   }
   return workflow;
 }

--- a/Analysis/Tasks/PID/pidTOFbeta.cxx
+++ b/Analysis/Tasks/PID/pidTOFbeta.cxx
@@ -32,7 +32,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 struct pidTOFTaskBeta {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collision;
-  Produces<aod::pidRespTOFbeta> tablePIDBeta;
+  Produces<aod::pidTOFbeta> tablePIDBeta;
   tof::Beta<Coll, Trks::iterator, PID::Electron> responseElectron;
   Configurable<float> expreso{"tof-expreso", 80, "Expected resolution for the computation of the expected beta"};
 
@@ -126,7 +126,7 @@ struct pidTOFTaskQABeta {
     histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
   }
 
-  void process(soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::pidRespTOFbeta, aod::TrackSelection>::iterator const& track)
+  void process(soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::pidTOFbeta, aod::TrackSelection>::iterator const& track)
   {
     //
     if (track.tofSignal() < 0) { // Skipping tracks without TOF

--- a/Analysis/Tasks/PID/pidTPC.cxx
+++ b/Analysis/Tasks/PID/pidTPC.cxx
@@ -11,7 +11,7 @@
 ///
 /// \file   pidTPC.cxx
 /// \author Nicolo' Jacazio
-/// \brief  Task to produce PID tables for TPC split for each particle.
+/// \brief  Task to produce PID tables for TPC split for each particle with only the Nsigma information.
 ///         Only the tables for the mass hypotheses requested are filled, the others are sent empty.
 ///
 
@@ -43,15 +43,15 @@ struct tpcPid {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Coll = aod::Collisions;
   // Tables to produce
-  Produces<o2::aod::pidRespTPCEl> tablePIDEl;
-  Produces<o2::aod::pidRespTPCMu> tablePIDMu;
-  Produces<o2::aod::pidRespTPCPi> tablePIDPi;
-  Produces<o2::aod::pidRespTPCKa> tablePIDKa;
-  Produces<o2::aod::pidRespTPCPr> tablePIDPr;
-  Produces<o2::aod::pidRespTPCDe> tablePIDDe;
-  Produces<o2::aod::pidRespTPCTr> tablePIDTr;
-  Produces<o2::aod::pidRespTPCHe> tablePIDHe;
-  Produces<o2::aod::pidRespTPCAl> tablePIDAl;
+  Produces<o2::aod::pidTPCEl> tablePIDEl;
+  Produces<o2::aod::pidTPCMu> tablePIDMu;
+  Produces<o2::aod::pidTPCPi> tablePIDPi;
+  Produces<o2::aod::pidTPCKa> tablePIDKa;
+  Produces<o2::aod::pidTPCPr> tablePIDPr;
+  Produces<o2::aod::pidTPCDe> tablePIDDe;
+  Produces<o2::aod::pidTPCTr> tablePIDTr;
+  Produces<o2::aod::pidTPCHe> tablePIDHe;
+  Produces<o2::aod::pidTPCAl> tablePIDAl;
   // Detector response and input parameters
   DetectorResponse response;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -79,12 +79,13 @@ struct tpcPid {
     for (DeviceSpec device : workflows.devices) {
       for (auto input : device.inputs) {
         auto enableFlag = [&input](const std::string particle, Configurable<int>& flag) {
-          const std::string table = "pidRespTPC" + particle;
+          const std::string table = "pidTPC" + particle;
           if (input.matcher.binding == table) {
             if (flag < 0) {
               flag.value = 1;
               LOG(INFO) << "Auto-enabling table: " + table;
             } else if (flag > 0) {
+              flag.value = 1;
               LOG(INFO) << "Table enabled: " + table;
             } else {
               LOG(INFO) << "Table disabled: " + table;
@@ -148,8 +149,16 @@ struct tpcPid {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
-                responsePID.GetSeparation(response, trk.collision(), trk));
+          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          if (separation <= o2::aod::pidtpc_tiny::binned_min) {
+            table(o2::aod::pidtpc_tiny::lower_bin);
+          } else if (separation >= o2::aod::pidtpc_tiny::binned_max) {
+            table(o2::aod::pidtpc_tiny::upper_bin);
+          } else if (separation >= 0) {
+            table(separation / o2::aod::pidtpc_tiny::bin_width + 0.5f);
+          } else {
+            table(separation / o2::aod::pidtpc_tiny::bin_width - 0.5f);
+          }
         }
       }
     };
@@ -237,17 +246,15 @@ struct tpcPidQa {
   }
 
   template <uint8_t i, typename T>
-  void fillParticleHistos(const T& t, const float mom, const float exp_diff, const float nsigma)
+  void fillParticleHistos(const T& t, const float nsigma)
   {
-    histos.fill(HIST(hexpected[i]), mom, t.tpcSignal() - exp_diff);
-    histos.fill(HIST(hexpected_diff[i]), mom, exp_diff);
     histos.fill(HIST(hnsigma[i]), t.p(), nsigma);
   }
 
   void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra,
-                                                          aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                          aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                          aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
+                                                          aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
+                                                          aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
+                                                          aod::pidTPCTr, aod::pidTPCHe, aod::pidTPCAl,
                                                           aod::TrackSelection> const& tracks)
   {
     histos.fill(HIST("event/vertexz"), collision.posZ());
@@ -257,15 +264,15 @@ struct tpcPidQa {
       const float mom = t.tpcInnerParam();
       histos.fill(HIST("event/tpcsignal"), mom, t.tpcSignal());
       //
-      fillParticleHistos<0>(t, mom, t.tpcExpSignalDiffEl(), t.tpcNSigmaEl());
-      fillParticleHistos<1>(t, mom, t.tpcExpSignalDiffMu(), t.tpcNSigmaMu());
-      fillParticleHistos<2>(t, mom, t.tpcExpSignalDiffPi(), t.tpcNSigmaPi());
-      fillParticleHistos<3>(t, mom, t.tpcExpSignalDiffKa(), t.tpcNSigmaKa());
-      fillParticleHistos<4>(t, mom, t.tpcExpSignalDiffPr(), t.tpcNSigmaPr());
-      fillParticleHistos<5>(t, mom, t.tpcExpSignalDiffDe(), t.tpcNSigmaDe());
-      fillParticleHistos<6>(t, mom, t.tpcExpSignalDiffTr(), t.tpcNSigmaTr());
-      fillParticleHistos<7>(t, mom, t.tpcExpSignalDiffHe(), t.tpcNSigmaHe());
-      fillParticleHistos<8>(t, mom, t.tpcExpSignalDiffAl(), t.tpcNSigmaAl());
+      fillParticleHistos<0>(t, t.tpcNSigmaEl());
+      fillParticleHistos<1>(t, t.tpcNSigmaMu());
+      fillParticleHistos<2>(t, t.tpcNSigmaPi());
+      fillParticleHistos<3>(t, t.tpcNSigmaKa());
+      fillParticleHistos<4>(t, t.tpcNSigmaPr());
+      fillParticleHistos<5>(t, t.tpcNSigmaDe());
+      fillParticleHistos<6>(t, t.tpcNSigmaTr());
+      fillParticleHistos<7>(t, t.tpcNSigmaHe());
+      fillParticleHistos<8>(t, t.tpcNSigmaAl());
     }
   }
 };

--- a/Analysis/Tasks/PID/qaTOFMC.cxx
+++ b/Analysis/Tasks/PID/qaTOFMC.cxx
@@ -143,10 +143,10 @@ struct pidTOFTaskQA {
 
   void process(aod::Collision const& collision,
                soa::Join<aod::Tracks, aod::TracksExtra,
-                         aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                         aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                         aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
-                         aod::McTrackLabels, aod::pidRespTOFbeta> const& tracks,
+                         aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                         aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe,
+                         aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl,
+                         aod::McTrackLabels, aod::pidTOFbeta> const& tracks,
                aod::McParticles& mcParticles)
   {
     if (collision.numContrib() < nMinNumberOfContributors) {

--- a/Analysis/Tasks/PWGDQ/filterPP.cxx
+++ b/Analysis/Tasks/PWGDQ/filterPP.cxx
@@ -60,15 +60,15 @@ DECLARE_SOA_TABLE(DQBarrelTrackCuts, "AOD", "DQBARRELCUTS", dqppfilter::IsBarrel
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
 using MyEventsSelected = soa::Join<aod::Collisions, aod::EvSels, aod::DQEventCuts>;
 using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection,
-                                 aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                 aod::pidRespTPCKa, aod::pidRespTPCPr,
-                                 aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                 aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFbeta>;
+                                 aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                 aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                 aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
 using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection,
-                                         aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                         aod::pidRespTPCKa, aod::pidRespTPCPr,
-                                         aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                         aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFbeta,
+                                         aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                         aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                         aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                         aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta,
                                          aod::DQBarrelTrackCuts>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;

--- a/Analysis/Tasks/PWGDQ/tableMaker.cxx
+++ b/Analysis/Tasks/PWGDQ/tableMaker.cxx
@@ -46,10 +46,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 #include "Framework/runDataProcessing.h"
 
 using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection,
-                                 aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                 aod::pidRespTPCKa, aod::pidRespTPCPr,
-                                 aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                 aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFbeta>;
+                                 aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                 aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                 aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels, aod::Cents>;
 using MyEventsNoCent = soa::Join<aod::Collisions, aod::EvSels>;
 using MyMuons = aod::Muons;

--- a/Analysis/Tasks/PWGDQ/v0selector.cxx
+++ b/Analysis/Tasks/PWGDQ/v0selector.cxx
@@ -42,8 +42,8 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
 
-//using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection, aod::pidRespTPC, aod::pidRespTOF, aod::pidRespTOFbeta>;
-using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTOFbeta>;
+//using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksExtended, aod::TrackSelection, aod::pidTPC, aod::pidTOF, aod::pidTOFbeta>;
+using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTOFbeta>;
 
 struct v0selector {
 

--- a/Analysis/Tasks/PWGLF/NucleiSpectraTask.cxx
+++ b/Analysis/Tasks/PWGLF/NucleiSpectraTask.cxx
@@ -61,7 +61,7 @@ struct NucleiSpecraTask {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
 
-  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPCHe, aod::pidRespTOFHe, aod::TrackSelection>>;
+  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullHe, aod::pidTOFFullHe, aod::TrackSelection>>;
 
   void process(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision, aod::BCsWithTimestamps const&, TrackCandidates const& tracks)
   {

--- a/Analysis/Tasks/PWGLF/spectraTOF.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOF.cxx
@@ -69,10 +69,10 @@ struct tofSpectra {
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   Filter trackFilterTOF = (aod::track::tofSignal > 0.f); // Skip tracks without TOF
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                                  aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                                                  aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
-                                                  aod::pidRespTOFbeta, aod::TrackSelection>>;
+                                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                                  aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe,
+                                                  aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl,
+                                                  aod::pidTOFbeta, aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)
   {

--- a/Analysis/Tasks/PWGLF/spectraTOFtiny.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTOFtiny.cxx
@@ -63,9 +63,9 @@ struct tofSpectraTiny {
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   Filter trackFilterTOF = (aod::track::tofSignal > 0.f); // Skip tracks without TOF
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTOFTEl, aod::pidRespTOFTMu, aod::pidRespTOFTPi,
-                                                  aod::pidRespTOFTKa, aod::pidRespTOFTPr, aod::pidRespTOFTDe,
-                                                  aod::pidRespTOFTTr, aod::pidRespTOFTHe, aod::pidRespTOFTAl,
+                                                  aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
+                                                  aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe,
+                                                  aod::pidTOFTr, aod::pidTOFHe, aod::pidTOFAl,
                                                   aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)

--- a/Analysis/Tasks/PWGLF/spectraTPC.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPC.cxx
@@ -90,9 +90,9 @@ struct tpcSpectra {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                  aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                  aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
+                                                  aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                                  aod::pidTPCFullTr, aod::pidTPCFullHe, aod::pidTPCFullAl,
                                                   aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)
@@ -149,12 +149,12 @@ struct tpcPidQaSignalwTof {
   Filter trackFilterTOF = (aod::track::tofSignal > 0.f); // Skip tracks without TOF
 
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                  aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                  aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
-                                                  aod::pidRespTOFEl, aod::pidRespTOFMu, aod::pidRespTOFPi,
-                                                  aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFDe,
-                                                  aod::pidRespTOFTr, aod::pidRespTOFHe, aod::pidRespTOFAl,
+                                                  aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                                  aod::pidTPCFullTr, aod::pidTPCFullHe, aod::pidTPCFullAl,
+                                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                                  aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe,
+                                                  aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl,
                                                   aod::TrackSelection>>;
   void process(TrackCandidates::iterator const& track)
   {

--- a/Analysis/Tasks/PWGLF/spectraTPCPiKaPr.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPCPiKaPr.cxx
@@ -62,7 +62,7 @@ struct tpcSpectraPiKaPr {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCPi, aod::pidRespTPCKa, aod::pidRespTPCPr,
+                                                  aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
                                                   aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)

--- a/Analysis/Tasks/PWGLF/spectraTPCtiny.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPCtiny.cxx
@@ -62,9 +62,9 @@ struct tpcSpectraTiny {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCTEl, aod::pidRespTPCTMu, aod::pidRespTPCTPi,
-                                                  aod::pidRespTPCTKa, aod::pidRespTPCTPr, aod::pidRespTPCTDe,
-                                                  aod::pidRespTPCTTr, aod::pidRespTPCTHe, aod::pidRespTPCTAl,
+                                                  aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
+                                                  aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
+                                                  aod::pidTPCTr, aod::pidTPCHe, aod::pidTPCAl,
                                                   aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)

--- a/Analysis/Tasks/PWGLF/spectraTPCtinyPiKaPr.cxx
+++ b/Analysis/Tasks/PWGLF/spectraTPCtinyPiKaPr.cxx
@@ -62,7 +62,7 @@ struct tpcSpectraTinyPiKaPr {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCTPi, aod::pidRespTPCTKa, aod::pidRespTPCTPr,
+                                                  aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
                                                   aod::TrackSelection>>;
 
   void process(TrackCandidates::iterator const& track)

--- a/Analysis/Tasks/SkimmingTutorials/spectraNucleiProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraNucleiProvider.cxx
@@ -50,8 +50,8 @@ struct NucleiSpectraProviderTask {
   Filter trackFilter = (nabs(aod::track::eta) < trackEtaCut) && (aod::track::isGlobalTrack == (uint8_t) true) && (aod::track::pt > trackPtCut);
 
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCPi, aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCHe,
-                                                  aod::pidRespTOFPi, aod::pidRespTOFKa, aod::pidRespTOFPr, aod::pidRespTOFHe,
+                                                  aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullHe,
+                                                  aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullHe,
                                                   aod::TrackSelection>>;
   void process(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision, TrackCandidates const& tracks)
   {

--- a/Analysis/Tasks/SkimmingTutorials/spectraNucleiReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraNucleiReference.cxx
@@ -61,7 +61,7 @@ struct NucleiSpectraReferenceTask {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
 
-  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::pidRespTPCHe, aod::pidRespTOFHe, aod::TrackSelection>>;
+  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullHe, aod::pidTOFFullHe, aod::TrackSelection>>;
 
   void process(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision, aod::BCsWithTimestamps const&, TrackCandidates const& tracks)
   {

--- a/Analysis/Tasks/SkimmingTutorials/spectraTPCProvider.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraTPCProvider.cxx
@@ -89,9 +89,9 @@ struct TPCSpectraProviderTask {
   Filter trackFilter = (nabs(aod::track::eta) < trackEtaCut) && (aod::track::pt > trackPtCut) && (aod::track::isGlobalTrack == (uint8_t) true);
 
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                  aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                  aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
+                                                  aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                                  aod::pidTPCFullTr, aod::pidTPCFullHe, aod::pidTPCFullAl,
                                                   aod::TrackSelection>>;
   void process(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision, TrackCandidates const& tracks)
   {

--- a/Analysis/Tasks/SkimmingTutorials/spectraTPCReference.cxx
+++ b/Analysis/Tasks/SkimmingTutorials/spectraTPCReference.cxx
@@ -86,9 +86,9 @@ struct TPCSpectraReferenceTask {
   }
 
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra,
-                                                  aod::pidRespTPCEl, aod::pidRespTPCMu, aod::pidRespTPCPi,
-                                                  aod::pidRespTPCKa, aod::pidRespTPCPr, aod::pidRespTPCDe,
-                                                  aod::pidRespTPCTr, aod::pidRespTPCHe, aod::pidRespTPCAl,
+                                                  aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                                  aod::pidTPCFullTr, aod::pidTPCFullHe, aod::pidTPCFullAl,
                                                   aod::TrackSelection>>;
   void process(soa::Filtered<aod::Collisions>::iterator const& collision, TrackCandidates const& tracks)
   {


### PR DESCRIPTION
- Use the compressed nsigma tables as the default (no labels)
- The extended table is labelled as Full

- Rename extended PID response tasks with Full tag
- Rename tiny task without labels