### PR TITLE
[MFT] Standalone vertex matching (time-bracket) & AOD table production

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(
     O2::DataFormatsTPC
     O2::DataFormatsITSMFT
     O2::DataFormatsITS
+    O2::DataFormatsMFT
     O2::DataFormatsFT0
     O2::DataFormatsTOF
     O2::DataFormatsFT0

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -59,6 +59,11 @@ namespace o2::its
 class TrackITS;
 }
 
+namespace o2::mft
+{
+class TrackMFT;
+}
+
 namespace o2::itsmft
 {
 class ROFRecord;
@@ -308,6 +313,18 @@ struct RecoContainer {
   auto getITSClusters() const { return getSpan<o2::itsmft::CompClusterExt>(GTrackID::ITS, CLUSTERS); }
   auto getITSClustersPatterns() const { return getSpan<unsigned char>(GTrackID::ITS, PATTERNS); }
   auto getITSClustersMCLabels() const { return mcITSClusters.get(); }
+
+  // MFT
+  const o2::mft::TrackMFT& getMFTTrack(GTrackID gid) const { return getTrack<o2::mft::TrackMFT>(gid); }
+  auto getMFTTracks() const { return getTracks<o2::mft::TrackMFT>(GTrackID::MFT); }
+  auto getMFTTracksROFRecords() const { return getSpan<o2::itsmft::ROFRecord>(GTrackID::MFT, TRACKREFS); }
+  auto getMFTTracksClusterRefs() const { return getSpan<int>(GTrackID::MFT, INDICES); }
+  auto getMFTTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MFT, MCLABELS); }
+  // MFT clusters
+  //auto getMFTClustersROFRecords() const { return getSpan<o2::itsmft::ROFRecord>(GTrackID::MFT, CLUSREFS); }
+  //auto getMFTClusters() const { return getSpan<o2::itsmft::CompClusterExt>(GTrackID::MFT, CLUSTERS); }
+  //auto getMFTClustersPatterns() const { return getSpan<unsigned char>(GTrackID::MFT, PATTERNS); }
+  //auto getMFTClustersMCLabels() const { return mcMFTClusters.get(); }
 
   // TPC
   const o2::tpc::TrackTPC& getTPCTrack(GTrackID id) const { return getTrack<o2::tpc::TrackTPC>(id); }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -200,6 +200,7 @@ struct RecoContainer {
   std::unique_ptr<o2::trd::RecoInputContainer> inputsTRD;                        // special struct for TRD tracklets, trigger records
 
   void collectData(o2::framework::ProcessingContext& pc, const DataRequest& request);
+  void createTracks(std::function<bool(const o2::track::TrackParCov&, GTrackID)> const& creator) const;
   template <class T>
   void createTracksVariadic(T creator) const;
   void fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vector<o2::MCCompLabel>& mcinfo) const;

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -200,7 +200,9 @@ struct RecoContainer {
 
   void collectData(o2::framework::ProcessingContext& pc, const DataRequest& request);
   void createTracks(std::function<bool(const o2::track::TrackParCov&, GTrackID)> const& creator) const;
+  void createTracks(std::function<bool(const o2::track::TrackParCovFwd&, GTrackID)> const& creator) const;
   void createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCov&, GTrackID, float, float)> const& creator) const;
+  void createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCovFwd&, GTrackID, float, float)> const& creator) const;
   template <class T>
   void createTracksVariadic(T creator) const;
   void fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vector<o2::MCCompLabel>& mcinfo) const;

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -109,6 +109,7 @@ struct DataRequest {
   void requestClusters(o2::dataformats::GlobalTrackID::mask_t src, bool useMC);
 
   void requestITSTracks(bool mc);
+  void requestMFTTracks(bool mc);
   void requestTPCTracks(bool mc);
   void requestITSTPCTracks(bool mc);
   void requestTPCTOFTracks(bool mc);
@@ -199,15 +200,12 @@ struct RecoContainer {
   std::unique_ptr<o2::trd::RecoInputContainer> inputsTRD;                        // special struct for TRD tracklets, trigger records
 
   void collectData(o2::framework::ProcessingContext& pc, const DataRequest& request);
-  void createTracks(std::function<bool(const o2::track::TrackParCov&, GTrackID)> const& creator) const;
-  void createTracks(std::function<bool(const o2::track::TrackParCovFwd&, GTrackID)> const& creator) const;
-  void createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCov&, GTrackID, float, float)> const& creator) const;
-  void createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCovFwd&, GTrackID, float, float)> const& creator) const;
   template <class T>
   void createTracksVariadic(T creator) const;
   void fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vector<o2::MCCompLabel>& mcinfo) const;
 
   void addITSTracks(o2::framework::ProcessingContext& pc, bool mc);
+  void addMFTTracks(o2::framework::ProcessingContext& pc, bool mc);
   void addTPCTracks(o2::framework::ProcessingContext& pc, bool mc);
 
   void addITSTPCTRDTracks(o2::framework::ProcessingContext& pc, bool mc);

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -198,7 +198,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
 
         GTrackID gidMFT(it, GTrackID::MFT);
         const auto& trc = getTrack<o2::mft::TrackMFT>(gidMFT);
-        if (creator(trc, gidMFT, t0, 0.5)) {
+        if (creator(trc, gidMFT, t0, 1.0)) {
           flagUsed2(it, GTrackID::MFT);
         }
       }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -19,6 +19,7 @@
 #include "DataFormatsTRD/RecoInputContainer.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsMFT/TrackMFT.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTOF/Cluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
@@ -59,6 +60,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
 
   // create only for those data types which are used
   const auto tracksITS = getITSTracks();
+  const auto tracksMFT = getMFTTracks();
   const auto tracksTPC = getTPCTracks();
   const auto tracksTPCITS = getTPCITSTracks();
   const auto tracksTPCTOF = getTPCTOFTracks();   // TOF-TPC tracks with refit
@@ -69,6 +71,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   const auto tracksITSTPCTRD = getITSTPCTRDTracks<o2::trd::TrackTRD>();
 
   usedData[GTrackID::ITS].resize(tracksITS.size());                                      // to flag used ITS tracks
+  usedData[GTrackID::MFT].resize(tracksMFT.size());                                      // to flag used MFT tracks
   usedData[GTrackID::TPC].resize(tracksTPC.size());                                      // to flag used TPC tracks
   usedData[GTrackID::ITSTPC].resize(tracksTPCITS.size());                                // to flag used ITSTPC tracks
   usedData[GTrackID::TOF].resize(getTOFMatches().size());                                // to flag used ITSTPC-TOF matches
@@ -98,7 +101,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   }
 
   /* // TODO : need trigger input for time info
-  // ITS-TPC-TRD 
+  // ITS-TPC-TRD
   {
     for (unsigned i = 0; i < tracksITSTPCTRD.size(); i++) {
       const auto& track = tracksITSTPCTRD[i];
@@ -107,7 +110,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
         continue;
       }
       if (creator(tracksTPCITS[gidx.getIndex()], {i, GTrackID::ITSTPCTOF}, timeTOFMUS, timeErr)) {
-        flagUsed2(i, GTrackID::TOF); // flag used TOF match // TODO might be not needed 
+        flagUsed2(i, GTrackID::TOF); // flag used TOF match // TODO might be not needed
         flagUsed(gidx); // flag used ITS-TPC tracks
       }
     }
@@ -183,6 +186,26 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
       }
     }
   }
+
+  // MFT only tracks
+  {
+    const auto& rofrs = getMFTTracksROFRecords<o2::itsmft::ROFRecord>();
+    for (unsigned irof = 0; irof < rofrs.size(); irof++) {
+      const auto& rofRec = rofrs[irof];
+      float t0 = rofRec.getBCData().differenceInBC(startIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+      int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
+      for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
+        if (isUsed2(it, GTrackID::MFT)) { // skip used tracks
+          continue;
+        }
+        GTrackID gidMFT(it, GTrackID::MFT);
+        const auto& trc = getMFTTrack<o2::mft::TrackMFT>(gidMFT);
+        if (creator(trc, gidMFT, t0, 0.5)) {
+          flagUsed2(it, GTrackID::MFT);
+        }
+      }
+    }
+  }
   auto current_time = std::chrono::high_resolution_clock::now();
   LOG(INFO) << "RecoContainer::createTracks took " << std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 1e-6 << " CPU s.";
 }
@@ -191,6 +214,12 @@ template <class T>
 inline constexpr auto isITSTrack()
 {
   return std::is_same_v<std::decay_t<T>, o2::its::TrackITS>;
+}
+
+template <class T>
+inline constexpr auto isMFTTrack()
+{
+  return std::is_same_v<std::decay_t<T>, o2::mft::TrackMFT>;
 }
 
 template <class T>

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -134,19 +134,21 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
     }
   }
 
-  // ITS-TPC matches, may refer to ITS, TPC (TODO: something else?) tracks
+  // TPC-TOF matches, may refer to TPC (TODO: something else?) tracks
   {
-    for (unsigned i = 0; i < tracksTPCITS.size(); i++) {
-      const auto& matchTr = tracksTPCITS[i];
-      if (isUsed2(i, GTrackID::ITSTPC)) {
-        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
-        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
+    if (matchesTPCTOF.size() && !tracksTPCTOF.size()) {
+      throw std::runtime_error(fmt::format("TPC-TOF matched tracks ({}) require TPCTOF matches ({}) and TPCTOF tracks ({})",
+                                           matchesTPCTOF.size(), tracksTPCTOF.size()));
+    }
+    for (unsigned i = 0; i < matchesTPCTOF.size(); i++) {
+      const auto& match = matchesTPCTOF[i];
+      const auto& gidx = match.getEvIdxTrack().getIndex(); // TPC (or other? but w/o ITS) track global idx (FIXME: TOF has to git rid of EvIndex stuff)
+      if (isUsed(gidx)) {                                  // is TPC track already used
         continue;
       }
-      if (creator(matchTr, {i, GTrackID::ITSTPC}, matchTr.getTimeMUS().getTimeStamp(), matchTr.getTimeMUS().getTimeStampError())) {
-        flagUsed2(i, GTrackID::ITSTPC);
-        flagUsed(matchTr.getRefITS()); // flag used ITS tracks
-        flagUsed(matchTr.getRefTPC()); // flag used TPC tracks
+      const auto& trc = tracksTPCTOF[i];
+      if (creator(trc, {i, GTrackID::TPCTOF}, trc.getTimeMUS().getTimeStamp(), trc.getTimeMUS().getTimeStampError())) {
+        flagUsed(gidx); // flag used TPC tracks
       }
     }
   }
@@ -158,9 +160,9 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
       if (isUsed2(i, GTrackID::TPC)) { // skip used tracks
         continue;
       }
-      const auto& trc = tracksTPCTOF[i];
-      if (creator(trc, {i, GTrackID::TPCTOF}, trc.getTimeMUS().getTimeStamp(), trc.getTimeMUS().getTimeStampError())) {
-        flagUsed(gidx); // flag used TPC tracks
+      const auto& trc = tracksTPC[i];
+      if (creator(trc, {i, GTrackID::TPC}, trc.getTime0() + 0.5 * (trc.getDeltaTFwd() - trc.getDeltaTBwd()), 0.5 * (trc.getDeltaTFwd() + trc.getDeltaTBwd()))) {
+        flagUsed2(i, GTrackID::TPC); // flag used TPC tracks
       }
     }
   }
@@ -185,45 +187,24 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
     }
   }
 
-  // ITS only tracks
-  {
-    const auto& rofrs = getITSTracksROFRecords<o2::itsmft::ROFRecord>();
-    for (unsigned irof = 0; irof < rofrs.size(); irof++) {
-      const auto& rofRec = rofrs[irof];
-      float t0 = rofRec.getBCData().differenceInBC(startIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
-      int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
-      for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
-        if (isUsed2(it, GTrackID::ITS)) { // skip used tracks
-          continue;
-        }
-        GTrackID gidITS(it, GTrackID::ITS);
-        const auto& trc = getITSTrack<o2::its::TrackITS>(gidITS);
-        if (creator(trc, gidITS, t0, 0.5)) {
-          flagUsed2(it, GTrackID::ITS);
-        }
-      }
-    }
-  }
-
   // MFT only tracks
   {
-    const auto& rofrs = getMFTTracksROFRecords<o2::itsmft::ROFRecord>();
+    const auto& rofrs = getMFTTracksROFRecords();
     for (unsigned irof = 0; irof < rofrs.size(); irof++) {
       const auto& rofRec = rofrs[irof];
       float t0 = rofRec.getBCData().differenceInBC(startIR) * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
       int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
       for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
-        if (isUsed2(it, GTrackID::MFT)) { // skip used tracks
-          continue;
-        }
+
         GTrackID gidMFT(it, GTrackID::MFT);
-        const auto& trc = getMFTTrack<o2::mft::TrackMFT>(gidMFT);
+        const auto& trc = getTrack<o2::mft::TrackMFT>(gidMFT);
         if (creator(trc, gidMFT, t0, 0.5)) {
           flagUsed2(it, GTrackID::MFT);
         }
       }
     }
   }
+
   auto current_time = std::chrono::high_resolution_clock::now();
   LOG(INFO) << "RecoContainer::createTracks took " << std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 1e-6 << " CPU s.";
 }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -198,7 +198,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
 
         GTrackID gidMFT(it, GTrackID::MFT);
         const auto& trc = getTrack<o2::mft::TrackMFT>(gidMFT);
-        if (creator(trc, gidMFT, t0, 1.0)) {
+        if (creator(trc, gidMFT, t0, 0.5)) {
           flagUsed2(it, GTrackID::MFT);
         }
       }

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -594,6 +594,16 @@ void o2::globaltracking::RecoContainer::createTracksWithMatchingTimeInfo(std::fu
   createTracksVariadic([&creator](const o2::track::TrackParCov& _tr, GTrackID _origID, float t0, float terr) { return creator(_tr, _origID, t0, terr); });
 }
 
+void o2::globaltracking::RecoContainer::createTracks(std::function<bool(const o2::track::TrackParCovFwd&, o2::dataformats::GlobalTrackID)> const& creator) const
+{
+  createTracksVariadic([&creator](const o2::track::TrackParCovFwd& _tr, GTrackID _origID, float t0, float terr) { return creator(_tr, _origID); });
+}
+
+void o2::globaltracking::RecoContainer::createTracksWithMatchingTimeInfo(std::function<bool(const o2::track::TrackParCovFwd&, GTrackID, float, float)> const& creator) const
+{
+  createTracksVariadic([&creator](const o2::track::TrackParCovFwd& _tr, GTrackID _origID, float t0, float terr) { return creator(_tr, _origID, t0, terr); });
+}
+
 // get contributors from single detectors
 RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) const
 {

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -614,6 +614,17 @@ void RecoContainer::fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vecto
   }
 }
 
+void o2::globaltracking::RecoContainer::createTracks(std::function<bool(const o2::track::TrackParCov&, o2::dataformats::GlobalTrackID)> const& creator) const
+{
+  createTracksVariadic([&creator](const auto& _tr, GTrackID _origID, float t0, float terr) {
+    if constexpr (std::is_base_of_v<o2::track::TrackParCov, std::decay_t<decltype(_tr)>>) {
+      return creator(_tr, _origID);
+    } else {
+      return false;
+    }
+  });
+}
+
 //________________________________________________________
 // get contributors from single detectors
 RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) const

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -421,11 +421,11 @@ void RecoContainer::addITSTracks(ProcessingContext& pc, bool mc)
 //____________________________________________________________
 void RecoContainer::addMFTTracks(ProcessingContext& pc, bool mc)
 {
-  fwdTracksPool.registerContainer(pc.inputs().get<gsl::span<o2::mft::TrackMFT>>("trackMFT"), GTrackID::MFT);
-  clusRefPool.registerContainer(pc.inputs().get<gsl::span<int>>("trackClIdx"), GTrackID::MFT);
-  tracksROFsPool.registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("trackMFTROF"), GTrackID::MFT);
+  commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::mft::TrackMFT>>("trackMFT"), TRACKS);
+  commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<int>>("trackClIdx"), INDICES);
+  commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("trackMFTROF"), TRACKREFS);
   if (mc) {
-    tracksMCPool.registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackMFTMCTR"), GTrackID::MFT);
+    commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackMFTMCTR"), MCLABELS);
   }
 }
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
@@ -16,7 +16,6 @@
 #define O2_GLOBAL_TRACK_ACCESSOR
 
 #include "ReconstructionDataFormats/Track.h"
-#include "ReconstructionDataFormats/TrackFwd.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonDataFormat/AbstractRefAccessor.h"
 
@@ -25,7 +24,6 @@ namespace o2
 namespace dataformats
 {
 using GlobalTrackAccessor = AbstractRefAccessor<o2::track::TrackParCov, GlobalTrackID::NSources>;
-using GlobalFwdTrackAccessor = AbstractRefAccessor<o2::track::TrackParCovFwd, GlobalTrackID::NSources>;
 }
 } // namespace o2
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
@@ -16,6 +16,7 @@
 #define O2_GLOBAL_TRACK_ACCESSOR
 
 #include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackFwd.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonDataFormat/AbstractRefAccessor.h"
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/GlobalTrackAccessor.h
@@ -25,6 +25,7 @@ namespace o2
 namespace dataformats
 {
 using GlobalTrackAccessor = AbstractRefAccessor<o2::track::TrackParCov, GlobalTrackID::NSources>;
+using GlobalFwdTrackAccessor = AbstractRefAccessor<o2::track::TrackParCovFwd, GlobalTrackID::NSources>;
 }
 } // namespace o2
 

--- a/Detectors/AOD/CMakeLists.txt
+++ b/Detectors/AOD/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(
     O2::ITSMFTWorkflow
     O2::ITStracking
     O2::ITSWorkflow
+    O2::MFTWorkflow
     O2::SimulationDataFormat
     O2::Steer
     O2::TOFWorkflow
@@ -59,6 +60,3 @@ o2_add_executable(
     O2::AnalysisDataModel
     O2::Steer
 )
-
-
-

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -81,6 +81,16 @@ using TracksExtraTable = o2::soa::Table<o2::aod::track::TPCInnerParam,
                                         o2::aod::track::TrackEtaEMCAL,
                                         o2::aod::track::TrackPhiEMCAL>;
 
+using MFTTracksTable = o2::soa::Table<o2::aod::fwdtrack::CollisionId,
+                                      o2::aod::fwdtrack::X,
+                                      o2::aod::fwdtrack::Y,
+                                      o2::aod::fwdtrack::Z,
+                                      o2::aod::fwdtrack::Phi,
+                                      o2::aod::fwdtrack::Tgl,
+                                      o2::aod::fwdtrack::Signed1Pt,
+                                      o2::aod::fwdtrack::NClusters,
+                                      o2::aod::fwdtrack::Chi2>;
+
 using MCParticlesTable = o2::soa::Table<o2::aod::mcparticle::McCollisionId,
                                         o2::aod::mcparticle::PdgCode,
                                         o2::aod::mcparticle::StatusCode,
@@ -134,6 +144,7 @@ class AODProducerWorkflowDPL : public Task
 
  private:
   int mFillTracksITS{1};
+  int mFillTracksMFT{1};
   int mFillTracksTPC{0};
   int mFillTracksITSTPC{1};
   int64_t mTFNumber{-1};
@@ -186,10 +197,13 @@ class AODProducerWorkflowDPL : public Task
   void fillTracksTable(const TTracks& tracks, std::vector<int>& vCollRefs, const TTracksCursor& tracksCursor,
                        const TTracksCovCursor& tracksCovCursor, const TTracksExtraCursor& tracksExtraCursor, int trackType);
 
+  template <typename TTracks, typename TTracksCursor>
+  void fillMFTTracksTable(const TTracks& tracks, std::vector<int>& vCollRefs, const TTracksCursor& tracksCursor);
+
   template <typename MCParticlesCursorType>
   void fillMCParticlesTable(o2::steer::MCKinematicsReader& mcReader, const MCParticlesCursorType& mcParticlesCursor,
-                            gsl::span<const o2::MCCompLabel>& mcTruthITS, gsl::span<const o2::MCCompLabel>& mcTruthTPC,
-                            TripletsMap_t& toStore);
+                            gsl::span<const o2::MCCompLabel>& mcTruthITS, gsl::span<const o2::MCCompLabel>& mcTruthMFT,
+                            gsl::span<const o2::MCCompLabel>& mcTruthTPC, TripletsMap_t& toStore);
 
   void writeTableToFile(TFile* outfile, std::shared_ptr<arrow::Table>& table, const std::string& tableName, uint64_t tfNumber);
 };

--- a/Detectors/AOD/src/AODProducerWorkflow.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflow.cxx
@@ -24,6 +24,7 @@
 #include "GlobalTrackingWorkflow/TrackWriterTPCITSSpec.h"
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
+#include "MFTWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/PublisherSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 
@@ -43,6 +44,7 @@ framework::WorkflowSpec getAODProducerWorkflow(int ignoreWriter)
     o2::vertexing::getPrimaryVertexReaderSpec(useMC),
     o2::globaltracking::getTrackTPCITSReaderSpec(useMC),
     o2::its::getITSTrackReaderSpec(useMC),
+    o2::mft::getMFTTrackReaderSpec(useMC),
     o2::tpc::getTPCTrackReaderSpec(useMC),
     o2::ft0::getDigitReaderSpec(useMC),
     o2::ft0::getReconstructionSpec(useMC),

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -768,15 +768,14 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
       // FIXME: `track<-->vertex` ambiguity is not accounted for in this code
       for (int ti = 0; ti < ntracks; ti++) {
         auto trackIndex = primVerGIs[start + ti];
-        const auto source = trackIndex.getSource();
         // setting collisionID for tracks attached to vertices
-        if (source == GIndex::Source::TPC) {
+        if (src == GIndex::Source::TPC) {
           vCollRefsTPC[trackIndex.getIndex()] = collisionID;
-        } else if (source == GIndex::Source::ITS) {
+        } else if (src == GIndex::Source::ITS) {
           vCollRefsITS[trackIndex.getIndex()] = collisionID;
-        } else if (source == GIndex::Source::MFT) {
+        } else if (src == GIndex::Source::MFT) {
           vCollRefsMFT[trackIndex.getIndex()] = collisionID;
-        } else if (source == GIndex::Source::ITSTPC) {
+        } else if (src == GIndex::Source::ITSTPC) {
           vCollRefsTPCITS[trackIndex.getIndex()] = collisionID;
         } else {
           LOG(WARNING) << "Unsupported track type!";

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -13,6 +13,7 @@
 #include "AODProducerWorkflow/AODProducerWorkflowSpec.h"
 #include "DataFormatsFT0/RecPoints.h"
 #include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsMFT/TrackMFT.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "CommonDataFormat/InteractionRecord.h"
@@ -216,10 +217,30 @@ void AODProducerWorkflowDPL::fillTracksTable(const TTracks& tracks, std::vector<
   }
 }
 
+template <typename TTracks, typename TTracksCursor>
+void AODProducerWorkflowDPL::fillMFTTracksTable(const TTracks& tracks, std::vector<int>& vCollRefs, const TTracksCursor& mftTracksCursor)
+{
+  for (int i = 0; i < tracks.size(); i++) {
+    auto& track = tracks[i];
+    int collisionID = vCollRefs[i];
+
+    mftTracksCursor(0,
+                    collisionID,
+                    track.getX(),
+                    track.getY(),
+                    track.getZ(),
+                    track.getPhi(),
+                    track.getTanl(),
+                    track.getInvQPt(),
+                    track.getNumberOfPoints(),
+                    track.getTrackChi2());
+  }
+}
+
 template <typename MCParticlesCursorType>
 void AODProducerWorkflowDPL::fillMCParticlesTable(o2::steer::MCKinematicsReader& mcReader, const MCParticlesCursorType& mcParticlesCursor,
-                                                  gsl::span<const o2::MCCompLabel>& mcTruthITS, gsl::span<const o2::MCCompLabel>& mcTruthTPC,
-                                                  TripletsMap_t& toStore)
+                                                  gsl::span<const o2::MCCompLabel>& mcTruthITS, gsl::span<const o2::MCCompLabel>& mcTruthMFT,
+                                                  gsl::span<const o2::MCCompLabel>& mcTruthTPC, TripletsMap_t& toStore)
 {
   // mark reconstructed MC particles to store them into the table
   for (auto& mcTruth : mcTruthITS) {
@@ -358,6 +379,7 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
   mTimer.Stop();
 
   mFillTracksITS = ic.options().get<int>("fill-tracks-its");
+  mFillTracksMFT = ic.options().get<int>("fill-tracks-mft");
   mFillTracksTPC = ic.options().get<int>("fill-tracks-tpc");
   mFillTracksITSTPC = ic.options().get<int>("fill-tracks-its-tpc");
   mTFNumber = ic.options().get<int64_t>("aod-timeframe-id");
@@ -369,7 +391,7 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
   }
 
   LOG(INFO) << "Track filling flags are set to: "
-            << "\n ITS = " << mFillTracksITS << "\n TPC = " << mFillTracksTPC << "\n ITSTPC = " << mFillTracksITSTPC;
+            << "\n ITS = " << mFillTracksITS << "\n MFT = " << mFillTracksMFT << "\n TPC = " << mFillTracksTPC << "\n ITSTPC = " << mFillTracksITSTPC;
 
   if (mTruncate != 1) {
     LOG(INFO) << "Truncation is not used!";
@@ -422,12 +444,15 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   auto primVertices = pc.inputs().get<gsl::span<PVertex>>("primVertices");
   auto primVerLabels = pc.inputs().get<gsl::span<o2::MCEventLabel>>("primVerLabels");
   auto tracksITS = pc.inputs().get<gsl::span<o2::its::TrackITS>>("trackITS");
+  auto tracksMFT = pc.inputs().get<gsl::span<o2::mft::TrackMFT>>("trackMFT");
   auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("tracksITSTPC");
   auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
   auto tracksTPCMCTruth = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCMCTruth");
   auto tracksITSMCTruth = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSMCTruth");
+  auto tracksMFTMCTruth = pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackMFTMCTruth");
 
   LOG(DEBUG) << "FOUND " << tracksTPC.size() << " TPC tracks";
+  LOG(DEBUG) << "FOUND " << tracksMFT.size() << " MFT tracks";
   LOG(DEBUG) << "FOUND " << tracksITS.size() << " ITS tracks";
   LOG(DEBUG) << "FOUND " << tracksITSTPC.size() << " ITSTPC tracks";
 
@@ -439,6 +464,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   TableBuilder tracksBuilderS;
   TableBuilder tracksCovBuilderS;
   TableBuilder tracksExtraBuilderS;
+  TableBuilder mftTracksBuilderS;
   TableBuilder mcParticlesBuilderS;
   TableBuilder mcTrackLabelBuilderS;
   TableBuilder fv0aBuilderS;
@@ -454,6 +480,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   auto& tracksBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "TRACK"}) : tracksBuilderS;
   auto& tracksCovBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "TRACKCOV"}) : tracksCovBuilderS;
   auto& tracksExtraBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "TRACKEXTRA"}) : tracksExtraBuilderS;
+  auto& mftTracksBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "MFTTRACK"}) : mftTracksBuilderS;
   auto& mcParticlesBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "MCPARTICLE"}) : mcParticlesBuilderS;
   auto& mcTrackLabelBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "MCTRACKLABEL"}) : mcTrackLabelBuilderS;
   auto& fv0aBuilder = mIgnoreWriter == 0 ? pc.outputs().make<TableBuilder>(Output{"AOD", "FV0A"}) : fv0aBuilderS;
@@ -469,6 +496,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   auto tracksCursor = tracksBuilder.cursor<o2::aodproducer::TracksTable>();
   auto tracksCovCursor = tracksCovBuilder.cursor<o2::aodproducer::TracksCovTable>();
   auto tracksExtraCursor = tracksExtraBuilder.cursor<o2::aodproducer::TracksExtraTable>();
+  auto mftTracksCursor = mftTracksBuilder.cursor<o2::aodproducer::MFTTracksTable>();
   auto mcParticlesCursor = mcParticlesBuilder.cursor<o2::aodproducer::MCParticlesTable>();
   auto mcTrackLabelCursor = mcTrackLabelBuilder.cursor<o2::aod::McTrackLabels>();
   auto fv0aCursor = fv0aBuilder.cursor<o2::aod::FV0As>();
@@ -677,6 +705,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   // initializing vectors for trackID --> collisionID connection
   std::vector<int> vCollRefsITS(tracksITS.size(), -1);
+  std::vector<int> vCollRefsMFT(tracksMFT.size(), -1);
   std::vector<int> vCollRefsTPC(tracksTPC.size(), -1);
   std::vector<int> vCollRefsTPCITS(tracksITSTPC.size(), -1);
 
@@ -731,21 +760,27 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
                      collisionTimeMask);
 
     auto trackRef = primVer2TRefs[collisionID];
-    int start = trackRef.getFirstEntryOfSource(0);
-    int ntracks = trackRef.getEntriesOfSource(0);
-    // FIXME: `track<-->vertex` ambiguity is not accounted for in this code
-    for (int ti = 0; ti < ntracks; ti++) {
-      auto trackIndex = primVerGIs[start + ti];
-      const auto source = trackIndex.getSource();
-      // setting collisionID for tracks attached to vertices
-      if (source == GIndex::Source::TPC) {
-        vCollRefsTPC[trackIndex.getIndex()] = collisionID;
-      } else if (source == GIndex::Source::ITS) {
-        vCollRefsITS[trackIndex.getIndex()] = collisionID;
-      } else if (source == GIndex::Source::ITSTPC) {
-        vCollRefsTPCITS[trackIndex.getIndex()] = collisionID;
-      } else {
-        LOG(WARNING) << "Unsupported track type!";
+    for (auto src : {GIndex::Source::ITS, GIndex::Source::TPC, GIndex::Source::MFT, GIndex::Source::ITSTPC}) {
+      int start = trackRef.getFirstEntryOfSource(src);
+      int ntracks = trackRef.getEntriesOfSource(src);
+      LOG(DEBUG) << " ====> Collision " << collisionID << " ; src = " << src << " : ntracks = " << ntracks;
+
+      // FIXME: `track<-->vertex` ambiguity is not accounted for in this code
+      for (int ti = 0; ti < ntracks; ti++) {
+        auto trackIndex = primVerGIs[start + ti];
+        const auto source = trackIndex.getSource();
+        // setting collisionID for tracks attached to vertices
+        if (source == GIndex::Source::TPC) {
+          vCollRefsTPC[trackIndex.getIndex()] = collisionID;
+        } else if (source == GIndex::Source::ITS) {
+          vCollRefsITS[trackIndex.getIndex()] = collisionID;
+        } else if (source == GIndex::Source::MFT) {
+          vCollRefsMFT[trackIndex.getIndex()] = collisionID;
+        } else if (source == GIndex::Source::ITSTPC) {
+          vCollRefsTPCITS[trackIndex.getIndex()] = collisionID;
+        } else {
+          LOG(WARNING) << "Unsupported track type!";
+        }
       }
     }
     collisionID++;
@@ -783,7 +818,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   // filling mc particles table
   TripletsMap_t toStore;
-  fillMCParticlesTable(mcReader, mcParticlesCursor, tracksITSMCTruth, tracksTPCMCTruth, toStore);
+  fillMCParticlesTable(mcReader, mcParticlesCursor, tracksITSMCTruth, tracksMFTMCTruth, tracksTPCMCTruth, toStore);
   if (mIgnoreWriter) {
     std::shared_ptr<arrow::Table> tableMCParticles = mcParticlesBuilder.finalize();
     std::string tableName("O2mcparticle");
@@ -816,6 +851,27 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
         labelMask |= (0x1 << 15);
       }
       if (mcTruthITS.isNoise()) {
+        labelMask |= (0x1 << 14);
+      }
+      mcTrackLabelCursor(0,
+                         labelID,
+                         labelMask);
+    }
+  }
+
+  if (mFillTracksMFT) {
+    fillMFTTracksTable(tracksMFT, vCollRefsMFT, mftTracksCursor);
+    for (auto& mcTruthMFT : tracksMFTMCTruth) {
+      labelID = std::numeric_limits<uint32_t>::max();
+      // TODO: fill label mask
+      labelMask = 0;
+      if (mcTruthMFT.isValid()) {
+        labelID = toStore.at(Triplet_t(mcTruthMFT.getSourceID(), mcTruthMFT.getEventID(), mcTruthMFT.getTrackID()));
+      }
+      if (mcTruthMFT.isFake()) {
+        labelMask |= (0x1 << 15);
+      }
+      if (mcTruthMFT.isNoise()) {
         labelMask |= (0x1 << 14);
       }
       mcTrackLabelCursor(0,
@@ -894,6 +950,9 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
     std::shared_ptr<arrow::Table> tableTracksExtra = tracksExtraBuilder.finalize();
     tableName = "O2trackextra";
     writeTableToFile(outfile, tableTracksExtra, tableName, tfNumber);
+    std::shared_ptr<arrow::Table> mftTracks = mftTracksBuilder.finalize();
+    tableName = "O2mfttrack";
+    writeTableToFile(outfile, mftTracks, tableName, tfNumber);
     std::shared_ptr<arrow::Table> tableMCTrackLabels = mcTrackLabelBuilder.finalize();
     tableName = "O2mctracklabel";
     writeTableToFile(outfile, tableMCTrackLabels, tableName, tfNumber);
@@ -922,10 +981,12 @@ DataProcessorSpec getAODProducerWorkflowSpec(int mIgnoreWriter)
   inputs.emplace_back("primVertices", "GLO", "PVTX", 0, Lifetime::Timeframe);
   inputs.emplace_back("primVerLabels", "GLO", "PVTX_MCTR", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackITS", "ITS", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackMFT", "MFT", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("tracksITSTPC", "GLO", "TPCITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackTPCMCTruth", "TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackITSMCTruth", "ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackMFTMCTruth", "MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
 
   if (!mIgnoreWriter) {
     outputs.emplace_back(OutputLabel{"O2bc"}, "AOD", "BC", 0, Lifetime::Timeframe);
@@ -936,6 +997,7 @@ DataProcessorSpec getAODProducerWorkflowSpec(int mIgnoreWriter)
     outputs.emplace_back(OutputLabel{"O2track"}, "AOD", "TRACK", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"O2trackcov"}, "AOD", "TRACKCOV", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"O2trackextra"}, "AOD", "TRACKEXTRA", 0, Lifetime::Timeframe);
+    outputs.emplace_back(OutputLabel{"O2mfttrack"}, "AOD", "MFTTRACK", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"O2mcparticle"}, "AOD", "MCPARTICLE", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputLabel{"O2mctracklabel"}, "AOD", "MCTRACKLABEL", 0, Lifetime::Timeframe);
     outputs.emplace_back(OutputSpec{"TFN", "TFNumber"});
@@ -952,6 +1014,7 @@ DataProcessorSpec getAODProducerWorkflowSpec(int mIgnoreWriter)
     AlgorithmSpec{adaptFromTask<AODProducerWorkflowDPL>(mIgnoreWriter)},
     Options{
       ConfigParamSpec{"fill-tracks-its", VariantType::Int, 1, {"Fill ITS tracks into tracks table"}},
+      ConfigParamSpec{"fill-tracks-mft", VariantType::Int, 1, {"Fill MFT tracks into mfttracks table"}},
       ConfigParamSpec{"fill-tracks-tpc", VariantType::Int, 0, {"Fill TPC tracks into tracks table"}},
       ConfigParamSpec{"fill-tracks-its-tpc", VariantType::Int, 1, {"Fill ITS-TPC tracks into tracks table"}},
       ConfigParamSpec{"aod-timeframe-id", VariantType::Int64, -1L, {"Set timeframe number"}},

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -25,6 +25,8 @@ o2_add_library(GlobalTrackingWorkflow
                                      O2::GlobalTrackingWorkflowHelpers
                                      O2::ITStracking
                                      O2::ITSWorkflow
+                                     O2::MFTTracking
+                                     O2::MFTWorkflow
                                      O2::TPCWorkflow
                                      O2::FT0Workflow
                                      O2::ITSMFTWorkflow
@@ -45,7 +47,7 @@ o2_add_executable(vertexing-workflow
                   COMPONENT_NAME primary
                   SOURCES src/primary-vertexing-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow O2::TOFWorkflow O2::TOFWorkflowUtils)
-                
+
 o2_add_executable(vertex-reader-workflow
                   COMPONENT_NAME primary
                   SOURCES src/primary-vertex-reader-workflow.cxx

--- a/Detectors/GlobalTrackingWorkflow/helpers/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/helpers/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(GlobalTrackingWorkflowHelpers
                PRIVATE_LINK_LIBRARIES O2::GlobalTracking # We link all the workflow libs etc as PRIVATE, such that we do not expose tons of headers automatically
                                       O2::ITSWorkflow
                                       O2::ITSMFTWorkflow
+                                      O2::MFTWorkflow
                                       O2::TPCWorkflow
                                       O2::TOFWorkflow
                                       O2::FT0Workflow

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -14,6 +14,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
+#include "MFTWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
 #include "TPCWorkflow/ClusterSharingMapSpec.h"
@@ -50,6 +51,9 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   }
   if (maskClusters[GID::ITS]) {
     specs.emplace_back(o2::itsmft::getITSClusterReaderSpec(maskClustersMC[GID::ITS], true));
+  }
+  if (maskTracks[GID::MFT]) {
+    specs.emplace_back(o2::mft::getMFTTrackReaderSpec(maskTracksMC[GID::MFT]));
   }
   if (maskTracks[GID::TPC]) {
     specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(maskTracksMC[GID::TPC]));

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -116,15 +116,18 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
     if (!_origID.includesDet(DetID::ITS)) {
       return true; // just in case this selection was not done on RecoContainer filling level
     }
-    if constexpr (isITSTrack<decltype(_tr)>()) {
+    if constexpr (isITSTrack<decltype(_tr)>() || isMFTTrack<decltype(_tr)>()) {
       t0 += halfROFITS;  // ITS time is supplied in \mus as beginning of ROF
       terr *= hw2ErrITS; // error is supplied as a half-ROF duration, convert to \mus
     }
     // for all other tracks the time is in \mus with gaussian error
-    if (terr < maxTrackTimeError) {
-      tracks.emplace_back(TrackWithTimeStamp{_tr, {t0, terr}});
-      gids.emplace_back(_origID);
+    if constexpr (std::is_base_of_v<o2::track::TrackParCov, std::decay_t<decltype(_tr)>>) {
+      if (terr < maxTrackTimeError) {
+        tracks.emplace_back(TrackWithTimeStamp{_tr, {t0, terr}});
+        gids.emplace_back(_origID);
+      }
     }
+
     return true;
   };
 

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -116,7 +116,7 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
     if (!_origID.includesDet(DetID::ITS)) {
       return true; // just in case this selection was not done on RecoContainer filling level
     }
-    if constexpr (isITSTrack<decltype(_tr)>() || isMFTTrack<decltype(_tr)>()) {
+    if constexpr (isITSTrack<decltype(_tr)>()) {
       t0 += halfROFITS;  // ITS time is supplied in \mus as beginning of ROF
       terr *= hw2ErrITS; // error is supplied as a half-ROF duration, convert to \mus
     }

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -57,7 +57,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   WorkflowSpec specs;
 
   GID::mask_t alowedSourcesPV = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TOF");
-  GID::mask_t alowedSourcesVT = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TOF,TPC,TPC-TOF");
+  GID::mask_t alowedSourcesVT = GID::getSourcesMask("ITS,MFT,ITS-TPC,ITS-TPC-TOF,TPC,TPC-TOF");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -47,9 +47,9 @@ class Tracker : public TrackerConfig
   void setBz(Float_t bz);
   const Float_t getBz() const { return mBz; }
 
-  std::vector<TrackMFTExt>& getTracks() { return mTracks; }
-  std::vector<TrackLTF>& getTracksLTF() { return mTracksLTF; }
-  o2::dataformats::MCTruthContainer<MCCompLabel>& getTrackLabels() { return mTrackLabels; }
+  auto& getTracks() { return mTracks; }
+  auto& getTracksLTF() { return mTracksLTF; }
+  auto& getTrackLabels() { return mTrackLabels; }
 
   void clustersToTracks(ROframe&, std::ostream& = std::cout);
 
@@ -86,7 +86,7 @@ class Tracker : public TrackerConfig
   std::vector<TrackMFTExt> mTracks;
   std::vector<TrackLTF> mTracksLTF;
   std::vector<Cluster> mClusters;
-  o2::dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;
+  std::vector<MCCompLabel> mTrackLabels;
   std::unique_ptr<o2::mft::TrackFitter> mTrackFitter = nullptr;
 
   Int_t mMaxCellLevel = 0;
@@ -210,7 +210,7 @@ inline void Tracker::computeTracksMClabels(const T& tracks)
       isFakeTrack = true;
       maxOccurrencesValue.setFakeFlag();
     }
-    mTrackLabels.addElement(mTrackLabels.getIndexedSize(), maxOccurrencesValue);
+    mTrackLabels.emplace_back(maxOccurrencesValue);
   }
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(MFTWorkflow
 	                     src/ClusterWriterSpec.cxx
 		                   src/ClusterReaderSpec.cxx
 		                   src/TrackerSpec.cxx
+                       src/TrackReaderSpec.cxx
 		                   src/TrackWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
@@ -23,7 +24,6 @@ o2_add_library(MFTWorkflow
                                      O2::MFTTracking
                                      O2::DataFormatsMFT
                                      O2::ITSMFTWorkflow)
-
 o2_add_executable(reco-workflow
                   SOURCES src/mft-reco-workflow.cxx
                   COMPONENT_NAME mft

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -11,16 +11,16 @@
 o2_add_library(MFTWorkflow
                TARGETVARNAME targetName
                SOURCES src/RecoWorkflow.cxx
-	                     src/ClustererSpec.cxx
-	                     src/ClusterWriterSpec.cxx
-		                   src/ClusterReaderSpec.cxx
-		                   src/TrackerSpec.cxx
+                       src/ClustererSpec.cxx
+                       src/ClusterWriterSpec.cxx
+                       src/ClusterReaderSpec.cxx
+                       src/TrackerSpec.cxx
                        src/TrackReaderSpec.cxx
-		                   src/TrackWriterSpec.cxx
+                       src/TrackWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
                                      O2::SimulationDataFormat
-				     O2::ITSMFTReconstruction
+                                     O2::ITSMFTReconstruction
                                      O2::MFTTracking
                                      O2::DataFormatsMFT
                                      O2::ITSMFTWorkflow)

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackReaderSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackReaderSpec.h
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TrackReaderSpec.h
+
+#ifndef O2_MFT_TRACKREADER
+#define O2_MFT_TRACKREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class TrackReader : public o2::framework::Task
+{
+
+ public:
+  TrackReader(bool useMC = true);
+  ~TrackReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::itsmft::ROFRecord> mROFRec, *mROFRecInp = &mROFRec;
+  std::vector<o2::mft::TrackMFT> mTracks, *mTracksInp = &mTracks;
+  std::vector<int> mClusInd, *mClusIndInp = &mClusInd;
+  std::vector<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+
+  o2::header::DataOrigin mOrigin = o2::header::gDataOriginMFT;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mTrackTreeName = "o2sim";
+  std::string mROFBranchName = "MFTTracksROF";
+  std::string mTrackBranchName = "MFTTrack";
+  std::string mClusIdxBranchName = "MFTTrackClusIdx";
+  std::string mTrackMCTruthBranchName = "MFTTrackMCTruth";
+};
+
+/// create a processor spec
+/// read MFT track data from a root file
+framework::DataProcessorSpec getMFTTrackReaderSpec(bool useMC = true);
+
+} // namespace mft
+} // namespace o2
+
+#endif /* O2_MFT_TRACKREADER */

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackReaderSpec.cxx
@@ -1,0 +1,104 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TrackReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "MFTWorkflow/TrackReaderSpec.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::mft;
+
+namespace o2
+{
+namespace mft
+{
+
+TrackReader::TrackReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void TrackReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("mft-tracks-infile"));
+  connectTree(mInputFileName);
+}
+
+void TrackReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(INFO) << "Pushing " << mTracks.size() << " track in " << mROFRec.size() << " ROFs at entry " << ent;
+  pc.outputs().snapshot(Output{mOrigin, "MFTTrackROF", 0, Lifetime::Timeframe}, mROFRec);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0, Lifetime::Timeframe}, mTracks);
+  pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0, Lifetime::Timeframe}, mClusInd);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void TrackReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mTrackTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mROFBranchName.c_str()));
+
+  mTree->SetBranchAddress(mROFBranchName.c_str(), &mROFRecInp);
+  mTree->SetBranchAddress(mTrackBranchName.c_str(), &mTracksInp);
+  mTree->SetBranchAddress(mClusIdxBranchName.c_str(), &mClusIndInp);
+
+  if (mUseMC) {
+    if (mTree->GetBranch(mTrackMCTruthBranchName.c_str())) {
+      mTree->SetBranchAddress(mTrackMCTruthBranchName.c_str(), &mMCTruthInp);
+    } else {
+      LOG(WARNING) << "MC-truth is missing, message will be empty";
+    }
+  }
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getMFTTrackReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("MFT", "MFTTrackROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("MFT", "TRACKS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("MFT", "TRACKCLSID", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "mft-track-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<TrackReader>(useMC)},
+    Options{
+      {"mft-tracks-infile", VariantType::String, "mfttracks.root", {"Name of the input track file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace mft
+} // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -57,7 +57,7 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                              "MFTTrackMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
-                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "TRACKSROF", 0},
+                                BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "MFTTrackROF", 0},
                                                                                      "MFTTracksROF",
                                                                                      logger},
                                 BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "TRACKSMC2ROF", 0},

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -22,6 +22,8 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 using namespace o2::framework;
+using LabelsType = std::vector<o2::MCCompLabel>;
+using ROFRecLblT = std::vector<o2::itsmft::MC2ROFRecord>;
 
 namespace o2
 {
@@ -51,17 +53,17 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                                                  tracksSizeGetter},
                                 BranchDefinition<std::vector<int>>{InputSpec{"trackClIdx", "MFT", "TRACKCLSID", 0},
                                                                    "MFTTrackClusIdx"},
-                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"labels", "MFT", "TRACKSMCTR", 0},
-                                                                                                     "MFTTrackMCTruth",
-                                                                                                     (useMC ? 1 : 0), // one branch if mc labels enabled
-                                                                                                     ""},
+                                BranchDefinition<LabelsType>{InputSpec{"labels", "MFT", "TRACKSMCTR", 0},
+                                                             "MFTTrackMCTruth",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""},
                                 BranchDefinition<std::vector<o2::itsmft::ROFRecord>>{InputSpec{"ROframes", "MFT", "TRACKSROF", 0},
                                                                                      "MFTTracksROF",
                                                                                      logger},
-                                BranchDefinition<std::vector<o2::itsmft::MC2ROFRecord>>{InputSpec{"MC2ROframes", "MFT", "TRACKSMC2ROF", 0},
-                                                                                        "MFTTracksMC2ROF",
-                                                                                        (useMC ? 1 : 0), // one branch if mc labels enabled
-                                                                                        ""})();
+                                BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "MFT", "TRACKSMC2ROF", 0},
+                                                             "MFTTracksMC2ROF",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""})();
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -93,7 +93,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   // the output vector however is created directly inside the message memory thus avoiding copy by
   // snapshot
   auto rofsinput = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "TRACKSROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "MFTTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
 
   LOG(INFO) << "MFTTracker pulled " << compClusters.size() << " compressed clusters in "
             << rofsinput.size() << " RO frames";
@@ -196,7 +196,7 @@ DataProcessorSpec getTrackerSpec(bool useMC)
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MFT", "TRACKS", 0, Lifetime::Timeframe);
-  outputs.emplace_back("MFT", "TRACKSROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MFT", "MFTTrackROF", 0, Lifetime::Timeframe);
   outputs.emplace_back("MFT", "TRACKCLSID", 0, Lifetime::Timeframe);
 
   if (useMC) {

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -109,8 +109,8 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   //std::vector<o2::mft::TrackMFTExt> tracks;
   auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"MFT", "TRACKCLSID", 0, Lifetime::Timeframe});
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> trackLabels;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> allTrackLabels;
+  std::vector<o2::MCCompLabel> trackLabels;
+  std::vector<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::mft::TrackLTF> tracksLTF;
   std::vector<o2::mft::TrackCA> tracksCA;
   auto& allTracksMFT = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
@@ -152,8 +152,9 @@ void TrackerDPL::run(ProcessingContext& pc)
         if (mUseMC) {
           mTracker->computeTracksMClabels(tracksLTF);
           mTracker->computeTracksMClabels(tracksCA);
-          trackLabels = mTracker->getTrackLabels(); /// FIXME: assignment ctor is not optimal.
-          allTrackLabels.mergeAtBack(trackLabels);
+          trackLabels.swap(mTracker->getTrackLabels());
+          std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
+          trackLabels.clear();
         }
 
         LOG(INFO) << "Found tracks LTF: " << tracksLTF.size();

--- a/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
@@ -56,11 +56,12 @@ class VertexTrackMatcher
                std::vector<VRef>& vtxRefs);      // references on these tracks
 
  private:
-  void updateTPCTimeDependentParams();
+  void updateTimeDependentParams();
   void extractTracks(const o2::globaltracking::RecoContainer& data, const std::unordered_map<GIndex, bool>& vcont);
 
   std::vector<TrackTBracket> mTBrackets;
   float mITSROFrameLengthMUS = 0;       ///< ITS RO frame in mus
+  float mMFTROFrameLengthMUS = 0;       ///< MFT RO frame in mus
   float mMaxTPCDriftTimeMUS = 0;
   float mTPCBin2MUS = 0;
   const o2::vertexing::PVertexerParams* mPVParams = nullptr;

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -170,8 +170,8 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
       t0 += 0.5 * this->mITSROFrameLengthMUS; // ITS time is supplied in \mus as beginning of ROF
       terr *= this->mITSROFrameLengthMUS;     // error is supplied as a half-ROF duration, convert to \mus
     } else if (isMFTTrack<decltype(_tr)>()) {
-      t0 += this->mMFTROFrameLengthMUS;
-      terr *= 0.5 * this->mMFTROFrameLengthMUS;
+      t0 += 0.5 * this->mMFTROFrameLengthMUS;
+      terr *= this->mMFTROFrameLengthMUS;
     }
     // for all other tracks the time is in \mus with gaussian error
     mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -171,7 +171,7 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
     } else if (isITSTrack<decltype(_tr)>()) {
       t0 += 0.5 * this->mITSROFrameLengthMUS; // ITS time is supplied in \mus as beginning of ROF
       terr *= this->mITSROFrameLengthMUS;     // error is supplied as a half-ROF duration, convert to \mus
-    } else if (isMFTTrack<decltype(_tr)>()) {
+    } else if (isMFTTrack<decltype(_tr)>()) { // Same for MFT
       t0 += 0.5 * this->mMFTROFrameLengthMUS;
       terr *= this->mMFTROFrameLengthMUS;
     }

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -46,11 +46,13 @@ void VertexTrackMatcher::updateTimeDependentParams()
     std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     mITSROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::ITS) ? alpParams.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParams.roFrameLengthTrig * 1.e-3;
+    LOG(INFO) << "VertexTrackMatcher::ITSROFrameLengthMUS = " << mITSROFrameLengthMUS;
   }
   if (mMFTROFrameLengthMUS == 0) {
     std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
     mMFTROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::MFT) ? alpParams.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParams.roFrameLengthTrig * 1.e-3;
+    LOG(INFO) << "VertexTrackMatcher::MFTROFrameLengthMUS = " << mMFTROFrameLengthMUS;
   }
 }
 

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -184,9 +184,13 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
         retVal->tpcLinkTOF[match.getTrackIndex()] = match.getTOFClIndex();
       }
     }
-    retVal->globalTracks.emplace_back(&trk);
-    retVal->globalTrackTimes.emplace_back(time);
-    return true;
+    if constexpr (std::is_base_of_v<o2::track::TrackParCov, std::decay_t<decltype(trk)>>) {
+      retVal->globalTracks.emplace_back(&trk);
+      retVal->globalTrackTimes.emplace_back(time);
+      return true;
+    } else {
+      return false;
+    }
   };
   recoCont.createTracksVariadic(creator);
   if (maskTrk[GID::TPC] && retVal->tpcLinkTRD.size()) {


### PR DESCRIPTION
This PR introduces MFT standalone tracks into VertexTrackMatcher / o2-primary-vertexing-workflow.

Example for a simple ITS-based primary vertex workflow with MFT standalone tracks association:
> `$ o2-primary-vertexing-workflow --vertexing-sources ITS --vetex-track-matching-sources  ITS,MFT`

Features and fixes for future PR(s):
- Select vertex candidates by track propagation. At the moment track-vertex association happens by time compatibility;
- ~~Incorporation of MFT standalone tracks on AOD producer workflow~~
