### PR TITLE
Check/enforce that all links got AddData call in every IR it processed

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -168,6 +168,11 @@ It proveds the ``RDH`` of the page for which it is called, information if the pr
 Some detectors signal the end of the HBF by adding an empty CRU page containing just a header with ``RDH.stop=1`` while others may simply set the ``RDH.stop=1`` in the last CRU page of the HBF (it may appear to be also the 1st and the only page of the HBF and may or may not contain the payload).
 This behaviour is steered by ``writer.setAddSeparateHBFStopPage(bool v)`` switch. By default end of the HBF is signaled on separate page.
 
+RawFileWriter will check for every bc/orbit for which at least 1 link was filled by the detector if all other registered links also got `addData` call.
+If not, it will be enforced internally with 0 payload and `trigger` and `detField` RDH fields provided in the 1st addData call of this IR.
+This may be pose a problem in case detector needs to insert some header even for 0-size payloads.
+In this case it is detector's responsibility to make sure that all links receive their proper `addData` call for every IR.
+
 Extra arguments:
 
 * `preformatted` (default: false): The behaviour described above can be modified by providing an extra argument in the `addData` method

--- a/Detectors/Raw/test/testRawReaderWriter.cxx
+++ b/Detectors/Raw/test/testRawReaderWriter.cxx
@@ -84,6 +84,7 @@ struct TestRawWriter { // simple class to create detector payload for multiple l
     writer.setCarryOverCallBack(this); // we want that writer to ask the detector code how to split large payloads
 
     writer.setApplyCarryOverToLastPage(true); // call CarryOver method also for the last chunk
+    writer.doLazinessCheck(false);            // do not apply auto-completion since the test mixes preformatted links filled per HBF and standard links filled per IR.
   }
 
   //_________________________________________________________________

--- a/Detectors/TPC/workflow/src/ZSSpec.cxx
+++ b/Detectors/TPC/workflow/src/ZSSpec.cxx
@@ -126,6 +126,7 @@ DataProcessorSpec getZSEncoderSpec(std::vector<int> const& tpcSectors, bool outR
         writer.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TPC)); // must be set explicitly
         uint32_t rdhV = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
         writer.useRDHVersion(rdhV);
+        writer.doLazinessCheck(false); // LazinessCheck is not thread-safe
         std::string outDir = "./";
         const unsigned int defaultLink = rdh_utils::UserLogicLinkID;
         enum LinksGrouping { All,

--- a/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
@@ -139,6 +139,7 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   if (fileFor != "link") { // in case >1 link goes to the file, we must cache to preserve the TFs ordering
     writer.useCaching();
   }
+  writer.doLazinessCheck(false); // LazinessCheck is not thread-safe
 
   // ===| set up branch addresses |=============================================
   std::vector<Digit>* vDigitsPerSectorCollection[Sector::MAXSECTOR] = {nullptr}; // container that keeps Digits per sector


### PR DESCRIPTION
RawFileWriter will check for every IR for which at least 1 link was filled by detector
if all other registered links also got `addData` call. If not, it will be enforced internally
with 0 payload and `trigger` and `detField` RDH fields provided in the 1st `addData` call of this IR.
This may be pose a problem in case detector needs to insert some header even for 0-size payloads.
In this case it is detector responsibility to make sure that all links receive their proper
`addData` call for every IR.

For the record: currently the following detectors have missing addData calls (numbers for 5 pbpb events + QED from FST):
````
grep 'RawFileWriter forced' *log
emcraw.log:[WARN] RawFileWriter forced 29 dummy addData calls in 3 IRs for links which did not receive data
ft0raw.log:[WARN] RawFileWriter forced 17561 dummy addData calls in 1087 IRs for links which did not receive data
fv0raw.log:[WARN] RawFileWriter forced 54 dummy addData calls in 1193 IRs for links which did not receive data
zdcraw.log:[WARN] RawFileWriter forced 300 dummy addData calls in 20 IRs for links which did not receive data
````
