### PR TITLE
TPC: add device to decode IDCs per CRU, laser vdrift calibration, trigger info decoding, unreated fixes

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/IDC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/IDC.h
@@ -32,6 +32,8 @@ static constexpr uint32_t DataWordSizeBits = 256;                               
 static constexpr uint32_t DataWordSizeBytes = DataWordSizeBits / 8;             ///< size of header word and data words in bytes
 static constexpr uint32_t IDCvalueBits = 25;                                    ///< number of bits used for one IDC value
 static constexpr uint32_t IDCvalueBitsMask = (uint32_t(1) << IDCvalueBits) - 1; ///< bitmask for 25 bit word
+static constexpr uint32_t SignificantBits = 2;                                  ///< number of bits used for floating point precision
+static constexpr float FloatConversion = 1.f / float(1 << SignificantBits);     ///< conversion factor from integer representation to float
 
 /// header definition of the IDCs
 /// The header is a 256 bit word
@@ -105,6 +107,11 @@ struct Container {
   Header header;              ///< IDC data header
   Data channelData[Channels]; ///< data values for all channels in each link
 
+  bool hasLink(const uint32_t link)
+  {
+    return (header.linkMask & (1 << link));
+  }
+
   uint32_t getChannelValue(const uint32_t link, const uint32_t channel) const
   {
     return channelData[channel].getLinkValue(link);
@@ -113,6 +120,16 @@ struct Container {
   void setChannelValue(const uint32_t link, const uint32_t channel, uint32_t value)
   {
     channelData[channel].setLinkValue(link, value);
+  }
+
+  float getChannelValueFloat(const uint32_t link, const uint32_t channel) const
+  {
+    return float(channelData[channel].getLinkValue(link)) * FloatConversion;
+  }
+
+  void setChannelValueFloat(const uint32_t link, const uint32_t channel, float value)
+  {
+    channelData[channel].setLinkValue(link, uint32_t((value + 0.5f * FloatConversion) / FloatConversion));
   }
 };
 } // namespace o2::tpc::idc

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/LaserTrack.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/LaserTrack.h
@@ -14,11 +14,10 @@
 #include <string>
 #include <gsl/span>
 
+#include "CommonConstants/MathConstants.h"
 #include "ReconstructionDataFormats/Track.h"
 
-namespace o2
-{
-namespace tpc
+namespace o2::tpc
 {
 /// \class LaserTrack
 /// This is the definition of the TPC Laser Track
@@ -26,10 +25,14 @@ namespace tpc
 class LaserTrack : public o2::track::TrackPar
 {
  public:
-  static constexpr int NumberOfTracks = 336; ///< Total number of laser tracks
-  static constexpr int RodsPerSide = 6;      ///< Number of laser rods per side
-  static constexpr int BundlesPerRod = 4;    ///< number of micro-mirror bundle per laser rod
-  static constexpr int TracksPerBundle = 7;  ///< number of micro-mirrors per bundle
+  static constexpr int NumberOfTracks = 336;                                                   ///< Total number of laser tracks
+  static constexpr int RodsPerSide = 6;                                                        ///< Number of laser rods per side
+  static constexpr int BundlesPerRod = 4;                                                      ///< number of micro-mirror bundle per laser rod
+  static constexpr int TracksPerBundle = 7;                                                    ///< number of micro-mirrors per bundle
+  static constexpr float SectorSpanRad = o2::constants::math::SectorSpanRad;                   ///< secotor width in rad
+  static constexpr std::array<float, 2> FirstRodPhi{2.f * SectorSpanRad, 1.f * SectorSpanRad}; ///< phi pos of first laser rod, A-, C-Side
+  static constexpr float RodDistancePhi = 3.f * SectorSpanRad;                                 ///< phi distance of laser Rods
+  static constexpr std::array<float, 4> CoarseBundleZPos{243.5, 165.5, 82, 11.5};              ///< coarse z-position of the laser bundles
 
   LaserTrack() = default;
   LaserTrack(int id, float x, float alpha, const std::array<float, o2::track::kNParams>& par) : mID(id), o2::track::TrackPar(x, alpha, par) { ; }
@@ -99,6 +102,5 @@ class LaserTrackContainer
   ClassDefNV(LaserTrackContainer, 1);
 };
 
-} // namespace tpc
-} // namespace o2
+} // namespace o2::tpc
 #endif

--- a/Detectors/TPC/base/include/TPCBase/RDHUtils.h
+++ b/Detectors/TPC/base/include/TPCBase/RDHUtils.h
@@ -24,6 +24,7 @@ namespace rdh_utils
 using o2::raw::RDHUtils;
 using FEEIDType = uint16_t;
 static constexpr FEEIDType UserLogicLinkID = 15;
+static constexpr FEEIDType IDCLinkID = 20;
 
 /// compose feeid from cru, endpoint and link
 static constexpr FEEIDType getFEEID(const FEEIDType cru, const FEEIDType endpoint, const FEEIDType link) { return FEEIDType((cru << 7) | ((endpoint & 1) << 6) | (link & 0x3F)); }

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -21,6 +21,8 @@ o2_add_library(TPCCalibration
                        src/DigitDump.cxx
                        src/DigitDumpParam.cxx
                        src/CalibPadGainTracks.cxx
+                       src/CalibLaserTracks.cxx
+                       src/LaserTracksCalibrator.cxx
                        src/IDCAverageGroup.cxx
                        src/IDCGroup.cxx
                        src/IDCGroupHelperRegion.cxx
@@ -29,7 +31,7 @@ o2_add_library(TPCCalibration
                        src/IDCFourierTransform.cxx
                        src/RobustAverage.cxx
                        src/IDCCCDBHelper.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase O2::DetectorsCalibration
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL)
 
@@ -44,6 +46,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/DigitDumpParam.h
                                   include/TPCCalibration/CalibPadGainTracks.h
                                   include/TPCCalibration/FastHisto.h
+                                  include/TPCCalibration/CalibLaserTracks.h
+                                  include/TPCCalibration/LaserTracksCalibrator.h
                                   include/TPCCalibration/IDCAverageGroup.h
                                   include/TPCCalibration/IDCGroup.h
                                   include/TPCCalibration/IDCGroupHelperRegion.h

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibLaserTracks.h
@@ -1,0 +1,128 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibLaserTracks.h
+/// \brief calibration using laser tracks
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+
+#ifndef TPC_CalibLaserTracks_H_
+#define TPC_CalibLaserTracks_H_
+
+#include <gsl/span>
+
+#include "CommonConstants/MathConstants.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTPC/LaserTrack.h"
+
+namespace o2::tpc
+{
+
+using o2::track::TrackPar;
+using o2::track::TrackParCov;
+
+struct TimePair {
+  float x1{0.f};
+  float x2{0.f};
+  float time{0.f};
+};
+
+class CalibLaserTracks
+{
+ public:
+  CalibLaserTracks()
+  {
+    mLaserTracks.loadTracksFromFile();
+    updateParameters();
+  }
+
+  CalibLaserTracks(const CalibLaserTracks& other) : mTriggerPos{other.mTriggerPos},
+                                                    mBz{other.mBz},
+                                                    mDriftV{other.mDriftV},
+                                                    mZbinWidth{other.mZbinWidth},
+                                                    mTFtime{other.mTFtime},
+                                                    mDVall{other.mDVall},
+                                                    mZmatchPairsTF{other.mZmatchPairsTF},
+                                                    mZmatchPairs{other.mZmatchPairs},
+                                                    mDVperTF{other.mDVperTF},
+                                                    mWriteDebugTree{other.mWriteDebugTree}
+  {
+  }
+
+  ~CalibLaserTracks() = default;
+
+  void fill(const gsl::span<const TrackTPC> tracks);
+  void fill(std::vector<TrackTPC> const& tracks);
+  void processTrack(const TrackTPC& track);
+
+  int findLaserTrackID(TrackPar track, int side = -1);
+  static float getPhiNearbySectorEdge(const TrackPar& param);
+  static float getPhiNearbyLaserRod(const TrackPar& param, int side);
+
+  /// trigger position for track z position correction
+  void setTriggerPos(int triggerPos) { mTriggerPos = triggerPos; }
+
+  /// merge data with other calibration object
+  void merge(const CalibLaserTracks* other);
+
+  /// End processing of this TF
+  void endTF();
+
+  /// Finalize full processing
+  void finalize();
+
+  /// print information
+  void print() const;
+
+  /// check amount of data (to be improved)
+  bool hasEnoughData() const { return mZmatchPairs.size() > 100; }
+
+  /// number of associated laser tracks
+  size_t getMatchedPairs() const { return mZmatchPairs.size(); }
+
+  /// time frame time of presently processed time frame
+  /// should be called before calling processTrack(s)
+  void setTFtime(float tfTime) { mTFtime = tfTime; }
+  float getTFtime() const { return mTFtime; }
+
+  void setWriteDebugTree(bool write) { mWriteDebugTree = write; }
+  bool getWriteDebugTree() const { return mWriteDebugTree; }
+
+  /// extract DV correction and T0 offset
+  TimePair fit(const std::vector<TimePair>& trackMatches) const;
+
+  /// sort TimePoint vectors
+  void sort(std::vector<TimePair>& trackMatches);
+
+  /// drift velocity fit information for full data set
+  const TimePair& getDVall() { return mDVall; }
+
+ private:
+  int mTriggerPos{0};                                            ///< trigger position, if < 0 it treats it as the CE position
+  float mBz{0.5};                                                ///< Bz field in kGaus
+  float mDriftV{0};                                              ///< drift velocity used during reconstruction
+  float mZbinWidth{0};                                           ///< width of a bin in us
+  float mTFtime{0};                                              ///< time of present TF
+  TimePair mDVall{};                                             ///< fit result over all accumulated data
+  std::vector<TimePair> mZmatchPairsTF;                          ///< ideal vs. mesured z poitions for associated laser tracks in present time frame
+  std::vector<TimePair> mZmatchPairs;                            ///< ideal vs. mesured z poitions for associated laser tracks assumulated over all time frames
+  std::vector<TimePair> mDVperTF;                                ///< drift velocity and time offset per TF
+  bool mWriteDebugTree{false};                                   ///< create debug output tree
+  LaserTrackContainer mLaserTracks;                              //!< laser track data base
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugStream; //!< debug output streamer
+
+  /// update reconstruction parameters
+  void updateParameters();
+
+  ClassDefNV(CalibLaserTracks, 1);
+};
+
+} // namespace o2::tpc
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/DigitDump.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/DigitDump.h
@@ -137,6 +137,9 @@ class DigitDump : public CalibRawBase
   /// End event function
   void endEvent() final;
 
+  /// check duplicates and remove the if removeDuplicates is true
+  void checkDuplicates(bool removeDuplicates = false);
+
  private:
   std::unique_ptr<CalPad> mPedestal{}; ///< CalDet object with pedestal information
   std::unique_ptr<CalPad> mNoise{};    ///< CalDet object with noise

--- a/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file LaserTracksCalibrator.h
+/// \brief time slot calibration using laser tracks
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+
+#ifndef TPC_LaserTracksCalibrator_H_
+#define TPC_LaserTracksCalibrator_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+
+#include "TPCCalibration/CalibLaserTracks.h"
+
+namespace o2::tpc
+{
+
+class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<TrackTPC, CalibLaserTracks>
+{
+  using TFType = uint64_t;
+  using Slot = o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks>;
+
+ public:
+  LaserTracksCalibrator() = default;
+  LaserTracksCalibrator(size_t minEntries) : mMinEntries(minEntries) {}
+  ~LaserTracksCalibrator() final = default;
+
+  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->getMatchedPairs() >= mMinEntries; }
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+
+  const auto& getDVperSlot() { return mDVperSlot; }
+
+ private:
+  size_t mMinEntries = 100;
+  std::vector<TimePair> mDVperSlot; ///< drift velocity per slot
+
+  ClassDefOverride(LaserTracksCalibrator, 1);
+};
+} // namespace o2::tpc
+#endif

--- a/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
+++ b/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
@@ -9,6 +9,9 @@
 // or submit itself to any jurisdiction.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <string>
+#include <string_view>
+
 #include "TROOT.h"
 #include "TMath.h"
 #include "TH2.h"
@@ -47,10 +50,15 @@ TObjArray* drawNoiseAndPedestal(std::string_view pedestalFile, int mode = 0, std
 
   if (pedestalFile.find("cdb") != std::string::npos) {
     auto& cdb = CDBInterface::instance();
-    if (pedestalFile == "cdb-test") {
+    if (pedestalFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
-    } else if (pedestalFile == "cdb-prod") {
+    } else if (pedestalFile.find("cdb-prod") == 0) {
       cdb.setURL("");
+    }
+    const auto timePos = pedestalFile.find("@");
+    if (timePos != std::string_view::npos) {
+      std::cout << "set time stamp " << std::stol(pedestalFile.substr(timePos + 1).data()) << "\n";
+      cdb.setTimeStamp(std::stol(pedestalFile.substr(timePos + 1).data()));
     }
     calPedestal = &cdb.getPedestals();
     calNoise = &cdb.getNoise();

--- a/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
@@ -1,0 +1,296 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibLaserTracks.cxx
+/// \brief calibration using laser tracks
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+
+#include "MathUtils/Utils.h"
+#include "TPCBase/ParameterGas.h"
+#include "TPCBase/ParameterElectronics.h"
+#include "TPCCalibration/CalibLaserTracks.h"
+#include "TLinearFitter.h"
+
+using namespace o2::tpc;
+void CalibLaserTracks::fill(std::vector<TrackTPC> const& tracks)
+{
+  fill(gsl::span(tracks.data(), tracks.size()));
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::fill(const gsl::span<const TrackTPC> tracks)
+{
+  for (const auto& track : tracks) {
+    processTrack(track);
+  }
+
+  endTF();
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::processTrack(const TrackTPC& track)
+{
+  if (track.hasBothSidesClusters()) {
+    return;
+  }
+
+  auto parOutAtLtr = track.getOuterParam();
+
+  // track should have been alreay propagated close to the laser mirrors
+  if (parOutAtLtr.getX() < 220) {
+    return;
+  }
+
+  // recalculate z position based on trigger or CE position
+  float zTrack = parOutAtLtr.getZ();
+
+  // TODO: calculation has to be improved
+  if (mTriggerPos < 0) {
+    // use CE for time 0
+    const float zOffset = (track.getTime0() + mTriggerPos) * mZbinWidth * mDriftV + 250;
+    //printf("time0: %.2f, trigger pos: %d, zTrack: %.2f, zOffset: %.2f\n", track.getTime0(), mTriggerPos, zTrack, zOffset);
+    zTrack += zOffset;
+    parOutAtLtr.setZ(zTrack);
+  } else if (mTriggerPos > 0) {
+  }
+
+  if (std::abs(zTrack) > 300) {
+    return;
+  }
+
+  // try association with ideal laser track and rotate parameters
+  const int side = track.hasCSideClusters();
+  const int laserTrackID = findLaserTrackID(parOutAtLtr, side);
+  if (laserTrackID < 0 || laserTrackID >= LaserTrack::NumberOfTracks) {
+    return;
+  }
+
+  LaserTrack ltr = mLaserTracks.getTrack(laserTrackID);
+  parOutAtLtr.rotateParam(ltr.getAlpha());
+  parOutAtLtr.propagateParamTo(ltr.getX(), mBz);
+
+  mZmatchPairsTF.emplace_back(TimePair{ltr.getZ(), parOutAtLtr.getZ(), mTFtime});
+
+  if (mWriteDebugTree) {
+    if (!mDebugStream) {
+      mDebugStream = std::make_unique<o2::utils::TreeStreamRedirector>("CalibLaserTracks_debug.root", "recreate");
+    }
+
+    *mDebugStream << "ltrMatch"
+                  << "ltr=" << ltr              // matched ideal laser track
+                  << "trOutLtr=" << parOutAtLtr // track rotated and propagated to ideal track position
+                  << "\n";
+  }
+}
+
+//______________________________________________________________________________
+int CalibLaserTracks::findLaserTrackID(TrackPar outerParam, int side)
+{
+  //const auto phisec = getPhiNearbySectorEdge(outerParam);
+  const auto phisec = getPhiNearbyLaserRod(outerParam, side);
+  if (!outerParam.rotateParam(phisec)) {
+    return -1;
+  }
+
+  if (side < 0) {
+    side = outerParam.getZ() < 0;
+  }
+  const int rod = std::nearbyint((phisec - LaserTrack::FirstRodPhi[side]) / LaserTrack::RodDistancePhi);
+  //printf("\n\nside: %i\n", side);
+  const auto xyzGlo = outerParam.getXYZGlo();
+  auto phi = std::atan2(xyzGlo.Y(), xyzGlo.X());
+  o2::math_utils::bringTo02Pi(phi);
+  //printf("rod:  %d (phisec: %.2f, phi: %.2f\n", rod, phisec, phi);
+  int bundle = -1;
+  int beam = -1;
+  float mindist = 1000;
+
+  const auto outerParamZ = std::abs(outerParam.getZ());
+  //printf("outerParamZ: %.2f\n", outerParamZ);
+  for (size_t i = 0; i < LaserTrack::CoarseBundleZPos.size(); ++i) {
+    const float dist = std::abs(outerParamZ - LaserTrack::CoarseBundleZPos[i]);
+    //printf("laserZ: %.2f (%.2f, %.2f)\n", LaserTrack::CoarseBundleZPos[i], dist, mindist);
+    if (dist < mindist) {
+      mindist = dist;
+      bundle = i;
+    }
+  }
+
+  if (bundle < 0) {
+    return -1;
+  }
+
+  //printf("bundle: %i\n", bundle);
+
+  const auto outerParamsInBundle = mLaserTracks.getTracksInBundle(side, rod, bundle);
+  mindist = 1000;
+  for (int i = 0; i < outerParamsInBundle.size(); ++i) {
+    const auto louterParam = outerParamsInBundle[i];
+    if (i == 0) {
+      outerParam.propagateParamTo(louterParam.getX(), mBz);
+    }
+    const float dist = std::abs(outerParam.getSnp() - louterParam.getSnp());
+    if (dist < mindist) {
+      mindist = dist;
+      beam = i;
+    }
+  }
+
+  //printf("beam: %i (%.4f)\n", beam, mindist);
+  if (mindist > 0.01) {
+    return -1;
+  }
+
+  const int trackID = LaserTrack::NumberOfTracks / 2 * side +
+                      LaserTrack::BundlesPerRod * LaserTrack::TracksPerBundle * rod +
+                      LaserTrack::TracksPerBundle * bundle +
+                      beam;
+
+  //printf("trackID: %d\n", trackID);
+
+  return trackID;
+}
+
+//______________________________________________________________________________
+float CalibLaserTracks::getPhiNearbySectorEdge(const TrackPar& param)
+{
+  // rotate to nearest laser bundle
+  const auto xyzGlo = param.getXYZGlo();
+  auto phi = std::atan2(xyzGlo.Y(), xyzGlo.X());
+  o2::math_utils::bringTo02PiGen(phi);
+  const auto phisec = std::nearbyint(phi / LaserTrack::SectorSpanRad) * LaserTrack::SectorSpanRad;
+  //printf("%.2f : %.2f\n", phi, phisec);
+  return (phisec);
+}
+
+//______________________________________________________________________________
+float CalibLaserTracks::getPhiNearbyLaserRod(const TrackPar& param, int side)
+{
+  const auto xyzGlo = param.getXYZGlo();
+  auto phi = std::atan2(xyzGlo.Y(), xyzGlo.X()) - LaserTrack::FirstRodPhi[side % 2];
+  o2::math_utils::bringTo02PiGen(phi);
+  phi = std::nearbyint(phi / LaserTrack::RodDistancePhi) * LaserTrack::RodDistancePhi + LaserTrack::FirstRodPhi[side % 2];
+  o2::math_utils::bringTo02PiGen(phi);
+  //printf("%.2f : %.2f\n", phi, phisec);
+  return phi;
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::updateParameters()
+{
+  const auto& gasParam = ParameterGas::Instance();
+  const auto& electronicsParam = ParameterElectronics::Instance();
+  mDriftV = gasParam.DriftV;
+  mZbinWidth = electronicsParam.ZbinWidth;
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::merge(const CalibLaserTracks* other)
+{
+  if (!other) {
+    return;
+  }
+  mZmatchPairs.insert(mZmatchPairs.end(), mZmatchPairsTF.begin(), mZmatchPairsTF.end());
+  mDVperTF.insert(mDVperTF.end(), other->mDVperTF.begin(), other->mDVperTF.end());
+
+  sort(mZmatchPairs);
+  sort(mDVperTF);
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::endTF()
+{
+  if (!mZmatchPairsTF.size()) {
+    return;
+  }
+
+  mZmatchPairs.insert(mZmatchPairs.end(), mZmatchPairsTF.begin(), mZmatchPairsTF.end());
+
+  auto fitResult = fit(mZmatchPairsTF);
+  mDVperTF.emplace_back(fitResult);
+
+  if (mDebugStream) {
+    (*mDebugStream) << "tfData"
+                    << "tfTime=" << mTFtime
+                    << "zPairs=" << mZmatchPairsTF
+                    << "dvFit=" << fitResult
+                    << "\n";
+  }
+
+  mZmatchPairsTF.clear();
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::finalize()
+{
+  mDVall = fit(mZmatchPairs);
+
+  if (mDebugStream) {
+    (*mDebugStream) << "finalData"
+                    << "zPairs=" << mZmatchPairs
+                    << "fitPairs=" << mDVperTF
+                    << "fullFit=" << mDVall
+                    << "\n";
+  }
+
+  sort(mZmatchPairs);
+  sort(mDVperTF);
+}
+
+//______________________________________________________________________________
+TimePair CalibLaserTracks::fit(const std::vector<TimePair>& trackMatches) const
+{
+  if (!trackMatches.size()) {
+    return TimePair();
+  }
+
+  static TLinearFitter fit(2, "pol1");
+  fit.StoreData(false);
+  fit.ClearPoints();
+
+  float meanTime = 0;
+  for (const auto& point : trackMatches) {
+    double x = point.x1;
+    double y = point.x2;
+    fit.AddPoint(&x, y);
+
+    meanTime += point.time;
+  }
+
+  meanTime /= float(trackMatches.size());
+
+  const float robustFraction = 0.9;
+  const int minPoints = 6;
+
+  if (trackMatches.size() < size_t(minPoints / robustFraction)) {
+    return TimePair({0, 0, meanTime});
+  }
+
+  //fit.EvalRobust(robustFraction);
+  fit.Eval();
+
+  TimePair retVal;
+  retVal.x1 = float(fit.GetParameter(0));
+  retVal.x2 = float(fit.GetParameter(1));
+  retVal.time = meanTime;
+
+  return retVal;
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::sort(std::vector<TimePair>& trackMatches)
+{
+  std::sort(mZmatchPairs.begin(), mZmatchPairs.end(), [](const auto& first, const auto& second) { return first.time < second.time; });
+}
+
+//______________________________________________________________________________
+void CalibLaserTracks::print() const
+{
+}

--- a/Detectors/TPC/calibration/src/DigitDump.cxx
+++ b/Detectors/TPC/calibration/src/DigitDump.cxx
@@ -103,8 +103,12 @@ void DigitDump::sortDigits()
       if (a.getTimeStamp() < b.getTimeStamp()) {
         return true;
       }
-      if ((a.getTimeStamp() == b.getTimeStamp()) && (a.getRow() < b.getRow())) {
-        return true;
+      if (a.getTimeStamp() == b.getTimeStamp()) {
+        if (a.getRow() < b.getRow()) {
+          return true;
+        } else if (a.getRow() == b.getRow()) {
+          return a.getPad() < b.getPad();
+        }
       }
       return false;
     });
@@ -164,4 +168,35 @@ void DigitDump::initInputOutput()
     setupOutputTree();
   }
   mInitialized = true;
+}
+
+//______________________________________________________________________________
+void DigitDump::checkDuplicates(bool removeDuplicates)
+{
+  auto isEqual = [](const Digit& a, const Digit& b) {
+    return (a.getTimeStamp() == b.getTimeStamp()) && (a.getRow() == b.getRow()) && (a.getPad() == b.getPad());
+  };
+
+  sortDigits();
+  for (size_t iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
+    auto& digits = mDigits[iSec];
+    const auto nDigits = digits.size();
+    if (nDigits < 2) {
+      continue;
+    }
+
+    for (auto iDigit = nDigits - 2; iDigit--;) {
+      auto& dig = digits[iDigit];
+      auto& digPrev = digits[iDigit + 1];
+
+      if (isEqual(dig, digPrev)) {
+        if (removeDuplicates) {
+          digits.erase(digits.begin() + iDigit + 1);
+          LOGP(warning, "dig found twice at sector {:2}, cru {:3}, row {:3}, pad {:3}, time {:6}, ADC {:.2} (previous: {:.2}), removing it", iSec, dig.getCRU(), dig.getRow(), dig.getPad(), dig.getTimeStamp(), dig.getChargeFloat(), digPrev.getChargeFloat());
+        } else {
+          LOGP(warning, "dig found twice at sector {:2}, cru {:3}, row {:3}, pad {:3}, time {:6}, ADC {:.2} (previous: {:.2})", iSec, dig.getCRU(), dig.getRow(), dig.getPad(), dig.getTimeStamp(), dig.getChargeFloat(), digPrev.getChargeFloat());
+        }
+      }
+    }
+  }
 }

--- a/Detectors/TPC/calibration/src/LaserTracksCalibrator.cxx
+++ b/Detectors/TPC/calibration/src/LaserTracksCalibrator.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/Logger.h"
+
+#include "TPCCalibration/LaserTracksCalibrator.h"
+
+using namespace o2::tpc;
+
+void LaserTracksCalibrator::initOutput()
+{
+  mDVperSlot.clear();
+}
+
+//______________________________________________________________________________
+void LaserTracksCalibrator::finalizeSlot(Slot& slot)
+{
+  auto& calibLaser = *slot.getContainer();
+  calibLaser.finalize();
+  calibLaser.print();
+
+  mDVperSlot.emplace_back(calibLaser.getDVall());
+}
+
+//______________________________________________________________________________
+LaserTracksCalibrator::Slot& LaserTracksCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<CalibLaserTracks>());
+  return slot;
+}

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -28,6 +28,12 @@
 #pragma link C++ class o2::tpc::CalibPadGainTracks;
 #pragma link C++ class o2::tpc::FastHisto<float> +;
 #pragma link C++ class o2::tpc::FastHisto<unsigned int> +;
+#pragma link C++ class o2::tpc::CalibLaserTracks +;
+#pragma link C++ class o2::tpc::LaserTracksCalibrator +;
+#pragma link C++ class o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks> +;
+#pragma link C++ class o2::calibration::TimeSlotCalibration<o2::tpc::TrackTPC, o2::tpc::CalibLaserTracks> +;
+#pragma link C++ class o2::tpc::TimePair +;
+#pragma link C++ class std::vector<o2::tpc::TimePair> +;
 #pragma link C++ class o2::tpc::IDCGroup +;
 #pragma link C++ class o2::tpc::IDCGroupHelperRegion +;
 #pragma link C++ class o2::tpc::IDCGroupHelperSector +;

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawProcessingHelpers.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawProcessingHelpers.h
@@ -24,7 +24,7 @@ namespace raw_processing_helpers
 
 using ADCCallback = std::function<bool(int cru, int rowInSector, int padInRow, int timeBin, float adcValue)>;
 
-bool processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t globalBCoffset, ADCCallback fillADC, bool useTimeBin = false);
+bool processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t orbit, uint32_t referenceOrbit, ADCCallback fillADC, bool useTimeBin = false);
 
 } // namespace raw_processing_helpers
 } // namespace tpc

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -62,6 +62,11 @@ o2_add_executable(calib-pedestal
                   SOURCES src/tpc-calib-pedestal.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
+o2_add_executable(calib-laser-tracks
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-calib-laser-tracks.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
 o2_add_executable(integrate-idc
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-integrate-idc.cxx

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(TPCWorkflow
                        src/FileReaderWorkflow.cxx
                        src/CalDetMergerPublisherSpec.cxx
                        src/KryptonClustererSpec.cxx
+                       src/IDCToVectorSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction
@@ -89,6 +90,11 @@ o2_add_executable(file-reader
 o2_add_executable(krypton-clusterer
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-krypton-clusterer.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(idc-to-vector
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-idc-to-vector.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_test(workflow

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibLaserTracksSpec.h
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+#define O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+
+/// @file   CalibLaserTracksSpec.h
+/// @brief  Device to run tpc laser track calibration
+
+#include "TPCCalibration/CalibLaserTracks.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+using namespace o2::framework;
+
+namespace o2::tpc
+{
+
+class CalibLaserTracksDevice : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    mCalib.setWriteDebugTree(ic.options().get<bool>("write-debug"));
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto data = pc.inputs().get<gsl::span<TrackTPC>>("input");
+    //LOG(INFO) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+    mCalib.fill(data);
+    sendOutput(pc.outputs());
+    //const auto& infoVec = mCalib->getLHCphaseInfoVector();
+    //LOG(INFO) << "Created " << infoVec.size() << " objects for TF " << tfcounter;
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOGP(info, "CalibLaserTracksDevice::endOfStream: Finalizing calibration");
+    mCalib.finalize();
+    const auto& dvData = mCalib.getDVall();
+    LOGP(info, "T0 offset: {}, dv correction factor: {}", dvData.x1, dvData.x2);
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  CalibLaserTracks mCalib;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+  }
+};
+
+DataProcessorSpec getCalibLaserTracks()
+{
+  using device = o2::tpc::CalibLaserTracksDevice;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{"TPC", "LtrZmatch"});
+  return DataProcessorSpec{
+    "tpc-calib-laser-tracks",
+    Inputs{{"input", "TPC", "TRACKS"}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{
+      //{"tf-per-slot", VariantType::Int, 5, {"number of TFs per calibration time slot"}},
+      {"write-debug", VariantType::Bool, false, {"write a debug output tree."}},
+    }};
+}
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/include/TPCWorkflow/IDCToVectorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/IDCToVectorSpec.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   IDCToVectorSpec.h
+/// @author Jens Wiechula
+/// @brief  Processor to convert IDCs to a vector for each pad in a CRU
+
+#ifndef TPC_IDCToVectorSpec_H_
+#define TPC_IDCToVectorSpec_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include <string_view>
+
+namespace o2::tpc
+{
+
+/// create a processor spec
+/// convert IDC raw values to a vector for each pad in a CRU
+o2::framework::DataProcessorSpec getIDCToVectorSpec(const std::string inputSpec, std::vector<uint32_t> const& crus);
+
+} // end namespace o2::tpc
+
+#endif //TPC_IDCToVectorSpec_H_

--- a/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/LaserTracksCalibratorSpec.h
@@ -1,0 +1,112 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+#define O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+
+/// @file   CalibLaserTracksSpec.h
+/// @brief  Device to run tpc laser track calibration
+
+#include "TPCCalibration/LaserTracksCalibrator.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+using namespace o2::framework;
+
+namespace o2::tpc
+{
+
+class LaserTracksCalibratorDevice : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    int minEnt = std::max(300, ic.options().get<int>("min-entries"));
+    int slotL = ic.options().get<int>("tf-per-slot");
+    int delay = ic.options().get<int>("max-delay");
+    mCalibrator = std::make_unique<LaserTracksCalibrator>(minEnt);
+    mCalibrator->setSlotLength(slotL);
+    mCalibrator->setMaxSlotsDelay(delay);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto data = pc.inputs().get<gsl::span<TrackTPC>>("input");
+    LOG(INFO) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+    mCalibrator->process(tfcounter, data);
+    sendOutput(pc.outputs());
+    //const auto& infoVec = mCalibrator->getLHCphaseInfoVector();
+    //LOG(INFO) << "Created " << infoVec.size() << " objects for TF " << tfcounter;
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOG(INFO) << "Finalizing calibration";
+    constexpr uint64_t INFINITE_TF = 0xffffffffffffffff;
+    mCalibrator->checkSlotsToFinalize(INFINITE_TF);
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  std::unique_ptr<LaserTracksCalibrator> mCalibrator;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+    using clbUtils = o2::calibration::Utils;
+    const auto& object = mCalibrator->getDVperSlot();
+
+    o2::ccdb::CcdbObjectInfo w;
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&object, &w);
+
+    w.setPath("TPC/Calib/LaserTracks");
+    w.setStartValidityTimestamp(object.front().time);
+    w.setEndValidityTimestamp(object.back().time);
+
+    LOG(INFO) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+              << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TPC_CalibLtr", 0}, *image.get()); // vector<char>
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TPC_CalibLtr", 0}, w);            // root-serialized
+    mCalibrator->initOutput();
+  }
+};
+
+DataProcessorSpec getCalibLaserTracks()
+{
+  using device = o2::tpc::LaserTracksCalibratorDevice;
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TPC_CalibLtr"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TPC_CalibLtr"});
+  return DataProcessorSpec{
+    "tpc-calib-laser-tracks",
+    Inputs{{"input", "TPC", "TRACKS"}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{
+      {"tf-per-slot", VariantType::Int, 5, {"number of TFs per calibration time slot"}},
+      {"max-delay", VariantType::Int, 3, {"number of slots in past to consider"}},
+      {"min-entries", VariantType::Int, 500, {"minimum number of entries to fit single time slot"}},
+    }};
+}
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
+++ b/Detectors/TPC/workflow/src/IDCToVectorSpec.cxx
@@ -1,0 +1,371 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include "fmt/format.h"
+
+#include "TFile.h"
+#include "DetectorsRaw/RDHUtils.h"
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/InputRecordWalker.h"
+#include "DPLUtils/RawParser.h"
+#include "Headers/DataHeader.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "DataFormatsTPC/Constants.h"
+#include "CommonConstants/LHCConstants.h"
+
+#include "DataFormatsTPC/Defs.h"
+#include "DataFormatsTPC/IDC.h"
+#include "TPCBase/Utils.h"
+#include "TPCBase/RDHUtils.h"
+#include "TPCBase/Mapper.h"
+
+using namespace o2::framework;
+using o2::constants::lhc::LHCMaxBunches;
+using o2::header::gDataOriginTPC;
+using o2::tpc::constants::LHCBCPERTIMEBIN;
+using RDHUtils = o2::raw::RDHUtils;
+
+namespace o2::tpc
+{
+
+class IDCToVectorDevice : public o2::framework::Task
+{
+ public:
+  using FEEIDType = rdh_utils::FEEIDType;
+  IDCToVectorDevice(const std::vector<uint32_t>& crus) : mCRUs(crus) {}
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    // set up ADC value filling
+    if (ic.options().get<bool>("write-debug")) {
+      mDebugStream = std::make_unique<o2::utils::TreeStreamRedirector>("idc_vector_debug.root", "recreate");
+    }
+    const auto pedestalFile = ic.options().get<std::string>("pedestal-file");
+    if (pedestalFile.length()) {
+      LOGP(info, "Setting pedestal file: {}", pedestalFile);
+      auto calPads = utils::readCalPads(pedestalFile, "Pedestals,Noise");
+      if (calPads.size() != 2) {
+        LOGP(error, "Pedestals and noise not loaded correctly, size {} != 2", calPads.size());
+      } else {
+        for (auto p : calPads) {
+          mNoisePedestal.emplace_back(p);
+        }
+      }
+    }
+
+    initIDC();
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    std::vector<InputSpec> filter = {{"check", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, "RAWDATA"}, Lifetime::Timeframe}}; // TODO: Change to IDC when changed in DD
+    const auto& mapper = Mapper::instance();
+
+    uint32_t heartbeatOrbit = 0;
+    uint32_t heartbeatBC = 0;
+    uint32_t tfCounter = 0;
+    bool first = true;
+
+    for (auto const& ref : InputRecordWalker(pc.inputs(), filter)) {
+      const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      // ---| extract hardware information to do the processing |---
+      const auto feeId = (FEEIDType)dh->subSpecification;
+      const auto link = rdh_utils::getLink(feeId);
+      const uint32_t cruID = rdh_utils::getCRU(feeId);
+      const auto endPoint = rdh_utils::getEndPoint(feeId);
+      tfCounter = dh->tfCounter;
+
+      // only select IDCs
+      // ToDo: cleanup once IDCs will be propagated not as RAWDATA, but IDC.
+      if (link != rdh_utils::IDCLinkID) {
+        continue;
+      }
+      LOGP(info, "IDC Processing firstTForbit {:9}, tfCounter {:5}, run {:6}, feeId {:6} ({:3}/{}/{:2})", dh->firstTForbit, dh->tfCounter, dh->runNumber, feeId, cruID, endPoint, link);
+
+      if (std::find(mCRUs.begin(), mCRUs.end(), cruID) == mCRUs.end()) {
+        LOGP(error, "IDC CRU {:3} not configured in CRUs, skipping", cruID);
+        continue;
+      }
+
+      const CRU cru(cruID);
+      const int sector = cru.sector();
+      const auto& partInfo = mapper.getPartitionInfo(cru.partition());
+      const int fecLinkOffsetCRU = (partInfo.getNumberOfFECs() + 1) / 2;
+      const int fecSectorOffset = partInfo.getSectorFECOffset();
+      const GlobalPadNumber regionPadOffset = Mapper::GLOBALPADOFFSET[cru.region()];
+      const GlobalPadNumber numberPads = Mapper::PADSPERREGION[cru.region()];
+      int sampaOnFEC{}, channelOnSAMPA{};
+      auto& idcVec = mIDCvectors[cruID];
+      auto& infoVec = mIDCInfos[cruID];
+
+      CalPad* pedestals = nullptr;
+      if (mNoisePedestal.size() && mNoisePedestal[0]) {
+        pedestals = mNoisePedestal[0].get();
+      }
+
+      // ---| data loop |---
+      const gsl::span<const char> raw = pc.inputs().get<gsl::span<char>>(ref);
+      o2::framework::RawParser parser(raw.data(), raw.size());
+      for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+        const auto size = it.size();
+        assert(size == sizeof(idc::Container));
+        auto data = it.data();
+        auto& idcs = *((idc::Container*)(data));
+        const uint32_t orbit = idcs.header.heartbeatOrbit;
+        const uint32_t bc = idcs.header.heartbeatBC;
+        //LOGP(info, "IDC Procssing orbit/BC: {:9}/{:4}", orbit, bc);
+
+        auto infoIt = std::find(infoVec.begin(), infoVec.end(), orbit);
+        if (!infoVec.size()) {
+          infoVec.emplace_back(orbit, bc);
+          infoIt = infoVec.end() - 1;
+          //} else if (!infoVec.back().matches(orbit, bc)) {
+        } else if (infoIt == infoVec.end()) {
+          auto& lastInfo = infoVec.back();
+          if ((orbit - lastInfo.heartbeatOrbit) != mNOrbitsIDC) {
+            LOGP(error, "received packet with invalid jump in idc orbit ({} - {} == {} != {})", orbit, lastInfo.heartbeatOrbit, orbit - lastInfo.heartbeatOrbit, mNOrbitsIDC);
+          }
+          infoVec.emplace_back(orbit, bc);
+          infoIt = infoVec.end() - 1;
+        }
+
+        // check if end poit was already processed
+        auto& lastInfo = *infoIt;
+        if (lastInfo.wasEPseen(endPoint)) {
+          LOGP(info, "Already received another data packet for CRU {}, ep {}, orbit {}, bc {}", cruID, endPoint, orbit, bc);
+          continue;
+        }
+
+        lastInfo.setEPseen(endPoint);
+        // idc value offset in present time frame
+        const size_t idcOffset = std::distance(infoVec.begin(), infoIt);
+
+        // TODO: for debugging, remove later
+        /*
+        auto* rdhPtr = it.get_if<o2::header::RAWDataHeaderV6>();
+        const auto feeId2 = (FEEIDType)RDHUtils::getFEEID(*rdhPtr);
+        const auto link2 = rdh_utils::getLink(feeId2);
+        const uint32_t cruID2 = rdh_utils::getCRU(feeId2);
+        const auto endPoint2 = rdh_utils::getEndPoint(feeId2);
+        const auto detField = RDHUtils::getDetectorField(*rdhPtr);
+        LOGP(info, "processing IDCs for CRU {}, ep {}, feeId {:6} ({:3}/{}/{:2}), detField: {}, orbit {}, bc {}, idcOffset {}, idcVec size {}, epSeen {:02b}", cruID, endPoint, feeId2, cruID2, endPoint2, link2, detField, orbit, bc, idcOffset, idcVec.size(), lastInfo.epSeen);
+        */
+
+        const float norm = 1. / float(mTimeStampsPerIntegrationInterval);
+        for (uint32_t iLink = 0; iLink < idc::Links; ++iLink) {
+          if (!idcs.hasLink(iLink)) {
+            continue;
+          }
+          const int fecInSector = iLink + endPoint * fecLinkOffsetCRU + fecSectorOffset;
+
+          for (uint32_t iChannel = 0; iChannel < idc::Channels; ++iChannel) {
+            auto val = idcs.getChannelValueFloat(iLink, iChannel);
+            Mapper::getSampaAndChannelOnFEC(cruID, iChannel, sampaOnFEC, channelOnSAMPA);
+            const GlobalPadNumber padInSector = mapper.globalPadNumber(fecInSector, sampaOnFEC, channelOnSAMPA);
+            if (pedestals) {
+              val -= pedestals->getValue(sector, padInSector) * mTimeStampsPerIntegrationInterval;
+              val *= norm;
+            }
+            const GlobalPadNumber padInRegion = padInSector - regionPadOffset;
+            const GlobalPadNumber vectorPosition = padInRegion + idcOffset * numberPads;
+            // TODO: for debugging, remove later
+            //auto rawVal = idcs.getChannelValue(iLink, iChannel);
+            //auto rawValF = idcs.getChannelValueFloat(iLink, iChannel);
+            //LOGP(info, "filling channel {}, link {}, fecLinkOffsetCRU {:2}, fecSectorOffset {:3}, fecInSector {:3}, idcVec[{} ({})] = {} ({} / {})", iChannel, iLink, fecLinkOffsetCRU, fecSectorOffset, fecInSector, vectorPosition, padInRegion, val, rawVal, rawValF);
+            idcVec[vectorPosition] = val;
+          }
+        }
+      }
+    }
+
+    if (mDebugStream) {
+      writeDebugOutput(tfCounter);
+    }
+    snapshotIDCs(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOGP(info, "endOfStream");
+    ec.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+    if (mDebugStream) {
+      mDebugStream->Close();
+    }
+  }
+
+ private:
+  /// IDC information for each cru
+  struct IDCInfo {
+    IDCInfo() = default;
+    IDCInfo(const IDCInfo&) = default;
+    IDCInfo(uint32_t orbit, uint16_t bc) : heartbeatOrbit(orbit), heartbeatBC(bc) {}
+
+    uint32_t heartbeatOrbit{0};
+    uint16_t heartbeatBC{0};
+    uint16_t epSeen{0};
+
+    bool operator==(const uint32_t orbit) const { return (heartbeatOrbit == orbit); }
+    bool operator==(const IDCInfo& inf) const { return (inf.heartbeatOrbit == heartbeatOrbit) && (inf.heartbeatBC == heartbeatBC) && (inf.epSeen == epSeen); }
+    void setEPseen(uint32_t ep) { epSeen |= uint16_t(1 << ep); }
+    bool wasEPseen(uint32_t ep) const { return epSeen & uint16_t(1 << ep); }
+    bool matches(uint32_t orbit, int16_t bc) const { return ((heartbeatOrbit == orbit) && (heartbeatBC == bc)); }
+    bool hasBothEPs() const { return epSeen == 3; }
+  };
+
+  const int mNOrbitsIDC{12};                                                                    ///< number of orbits over which IDCs are integrated, TODO: take from IDC header
+  const int mTimeStampsPerIntegrationInterval{(LHCMaxBunches * mNOrbitsIDC) / LHCBCPERTIMEBIN}; ///< number of time stamps for each integration interval (5346)
+  const uint32_t mMaxIDCPerTF{uint32_t(std::ceil(256.f / mNOrbitsIDC))};                        ///< maximum number of IDCs expected per TF, TODO: better way to get max number of orbits
+  std::vector<uint32_t> mCRUs;                                                                  ///< CRUs expected for this device
+  std::unordered_map<uint32_t, std::vector<float>> mIDCvectors;                                 ///< decoded IDCs per cru for each pad in the region over all IDC packets in the TF
+  std::unordered_map<uint32_t, std::vector<IDCInfo>> mIDCInfos;                                 ///< IDC packet information within the TF
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugStream;                                ///< debug output streamer
+  std::vector<std::unique_ptr<CalPad>> mNoisePedestal{};                                        ///< noise and pedestal values
+
+  //____________________________________________________________________________
+  void snapshotIDCs(DataAllocator& output)
+  {
+    LOGP(info, "snapshotIDCs");
+
+    // check integrety of data between CRUs
+    size_t orbitsInTF = 0;
+    std::vector<IDCInfo> const* infVecComp = nullptr;
+    std::vector<uint64_t> orbitBCInfo;
+
+    for (const auto& [cru, infVec] : mIDCInfos) {
+
+      for (const auto& inf : infVec) {
+        if (!inf.hasBothEPs()) {
+          LOGP(fatal, "IDC CRU {:3}: data missing at ({:8}, {:4}) for one or both end points {:02b}", cru, inf.heartbeatOrbit, inf.heartbeatBC, inf.epSeen);
+        }
+      }
+
+      if (!infVecComp) {
+        infVecComp = &infVec;
+        orbitsInTF = infVec.size();
+        std::for_each(infVec.begin(), infVec.end(), [&orbitBCInfo](const auto& inf) { orbitBCInfo.emplace_back((uint64_t(inf.heartbeatOrbit) << 32) + uint64_t(inf.heartbeatBC)); });
+        continue;
+      }
+
+      if (orbitsInTF != infVec.size()) {
+        LOGP(fatal, "IDC CRU {:3}: unequal number of IDC values {} != {}", cru, orbitsInTF, infVec.size());
+      }
+
+      if (!std::equal(infVecComp->begin(), infVecComp->end(), infVec.begin())) {
+        LOGP(fatal, "IDC CRU {:3}: mismatch in orbits");
+      }
+    }
+
+    // send data
+    for (auto& [cru, idcVec] : mIDCvectors) {
+      idcVec.resize(Mapper::PADSPERREGION[CRU(cru).region()] * orbitsInTF);
+      const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+      output.snapshot(Output{gDataOriginTPC, "IDCVECTOR", subSpec}, idcVec);
+      output.snapshot(Output{gDataOriginTPC, "IDCORBITS", subSpec}, orbitBCInfo);
+    }
+
+    // clear output
+    initIDC();
+  }
+
+  //____________________________________________________________________________
+  void initIDC()
+  {
+    for (const auto cruID : mCRUs) {
+      const CRU cru(cruID);
+      const GlobalPadNumber numberPads = Mapper::PADSPERREGION[cru.region()] * mMaxIDCPerTF;
+      auto& idcVec = mIDCvectors[cruID];
+      idcVec.resize(numberPads);
+      std::fill(idcVec.begin(), idcVec.end(), -1.f);
+
+      auto& infosCRU = mIDCInfos[cruID];
+      infosCRU.clear();
+    }
+  }
+
+  //____________________________________________________________________________
+  void writeDebugOutput(uint32_t tfCounter)
+  {
+    const auto& mapper = Mapper::instance();
+
+    mDebugStream->GetFile()->cd();
+    auto& stream = (*mDebugStream) << "idcs";
+    uint32_t seen = 0;
+    for (auto cru : mCRUs) {
+      if (mIDCInfos.find(cru) == mIDCInfos.end()) {
+        continue;
+      }
+      auto& infos = mIDCInfos[cru];
+      auto& idcVec = mIDCvectors[cru];
+
+      for (int i = 0; i < infos.size(); ++i) {
+        auto& info = infos[i];
+
+        auto idcFirst = idcVec.begin() + i * Mapper::PADSPERREGION[cru];
+        auto idcLast = idcFirst + Mapper::PADSPERREGION[cru];
+        std::vector<float> idcs(idcFirst, idcLast);
+        std::vector<short> cpad(idcs.size());
+        std::vector<short> row(idcs.size());
+        for (int ipad = 0; ipad < idcs.size(); ++ipad) {
+          const auto& padPos = mapper.padPos(ipad + Mapper::GLOBALPADOFFSET[cru % 10]);
+          row[ipad] = (short)padPos.getRow();
+          const short pads = (short)mapper.getNumberOfPadsInRowSector(row[ipad]);
+          cpad[ipad] = (short)padPos.getPad() - pads / 2;
+        }
+        float mean = std::accumulate(idcs.begin(), idcs.end(), 0.f) / float(idcs.size());
+
+        stream << "cru=" << cru
+               << "epSeen=" << info.epSeen
+               << "tfCounter=" << tfCounter
+               << "orbit=" << info.heartbeatOrbit
+               << "bc=" << info.heartbeatBC
+               << "idcs=" << idcs
+               << "cpad=" << cpad
+               << "row=" << row
+               << "idc_mean=" << mean
+               << "\n";
+      }
+    }
+  }
+};
+
+o2::framework::DataProcessorSpec getIDCToVectorSpec(const std::string inputSpec, std::vector<uint32_t> const& crus)
+{
+  using device = o2::tpc::IDCToVectorDevice;
+
+  std::vector<OutputSpec> outputs;
+  for (const uint32_t cru : crus) {
+    const header::DataHeader::SubSpecificationType subSpec{cru << 7};
+    outputs.emplace_back(gDataOriginTPC, "IDCVECTOR", subSpec, Lifetime::Timeframe);
+    outputs.emplace_back(gDataOriginTPC, "IDCORBITS", subSpec, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    fmt::format("tpc-idc-to-vector"),
+    select(inputSpec.data()),
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>(crus)},
+    Options{
+      {"write-debug", VariantType::Bool, false, {"write a debug output tree."}},
+      {"pedestal-file", VariantType::String, "", {"file with pedestals and noise for zero suppression"}},
+    } // end Options
+  };  // end DataProcessorSpec
+}
+} // namespace o2::tpc

--- a/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
@@ -49,6 +49,9 @@ class TPCDigitDumpDevice : public o2::framework::Task
     mUseOldSubspec = ic.options().get<bool>("use-old-subspec");
     const bool createOccupancyMaps = ic.options().get<bool>("create-occupancy-maps");
     mForceQuit = ic.options().get<bool>("force-quit");
+    mCheckDuplicates = ic.options().get<bool>("check-for-duplicates");
+    mRemoveDuplicates = ic.options().get<bool>("remove-duplicates");
+
     if (mUseOldSubspec) {
       LOGP(info, "Using old subspecification (CruId << 16) | ((LinkId + 1) << (CruEndPoint == 1 ? 8 : 0))");
     }
@@ -134,13 +137,20 @@ class TPCDigitDumpDevice : public o2::framework::Task
   bool mCalibDumped{false};
   bool mUseOldSubspec{false};
   bool mForceQuit{false};
+  bool mCheckDuplicates{false};
+  bool mRemoveDuplicates{false};
   uint64_t mActiveSectors{0};  ///< bit mask of active sectors
   std::vector<int> mSectors{}; ///< tpc sector configuration
 
   //____________________________________________________________________________
   void snapshotDigits(DataAllocator& output)
   {
-    mDigitDump.sortDigits();
+    if (mCheckDuplicates || mRemoveDuplicates) {
+      // iplicityly sorts
+      mDigitDump.checkDuplicates(mRemoveDuplicates);
+    } else {
+      mDigitDump.sortDigits();
+    }
     for (auto isector : mSectors) {
       o2::tpc::TPCSectorHeader header{isector};
       header.activeSectors = mActiveSectors;
@@ -180,6 +190,8 @@ DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, s
       {"force-quit", VariantType::Bool, false, {"force quit after max-events have been reached"}},
       {"pedestal-file", VariantType::String, "", {"file with pedestals and noise for zero suppression"}},
       {"create-occupancy-maps", VariantType::Bool, false, {"create occupancy maps and store them to local root file for debugging"}},
+      {"check-for-duplicates", VariantType::Bool, false, {"check if duplicate digits exist and only report them"}},
+      {"remove-duplicates", VariantType::Bool, false, {"check if duplicate digits exist and remove them"}},
     } // end Options
   };  // end DataProcessorSpec
 }

--- a/Detectors/TPC/workflow/src/tpc-calib-laser-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-laser-tracks.cxx
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "TPCWorkflow/CalibLaserTracksSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(o2::tpc::getCalibLaserTracks());
+  return specs;
+}

--- a/Detectors/TPC/workflow/src/tpc-idc-to-vector.cxx
+++ b/Detectors/TPC/workflow/src/tpc-idc-to-vector.cxx
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <string>
+#include <fmt/format.h>
+
+#include "Algorithm/RangeTokenizer.h"
+#include "Framework/WorkflowSpec.h"
+//#include "Framework/DataProcessorSpec.h"
+//#include "Framework/DataSpecUtils.h"
+#include "Framework/ControlService.h"
+//#include "Framework/InputRecordWalker.h"
+//#include "Framework/Logger.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TPCBase/CRU.h"
+#include "TPCWorkflow/IDCToVectorSpec.h"
+
+using namespace o2::framework;
+using namespace o2::tpc;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-idc-to-vector", CompletionPolicy::CompletionOp::Consume));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::string sectorDefault = "0-" + std::to_string(CRU::MaxCRU - 1);
+  int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
+
+  std::vector<ConfigParamSpec> options{
+    {"input-spec", VariantType::String, "A:TPC/RAWDATA", {"selection string input specs"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCCalibPedestal.FirstTimeBin=10;...')"}},
+    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"crus", VariantType::String, sectorDefault.c_str(), {"List of TPC sectors, comma separated ranges, e.g. 0-3,7,9-15"}},
+  };
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+
+  using namespace o2::tpc;
+
+  // set up configuration
+  o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
+  o2::conf::ConfigurableParam::writeINI("o2tpcidc_configuration.ini");
+
+  const std::string inputSpec = config.options().get<std::string>("input-spec");
+
+  const auto crus = o2::RangeTokenizer::tokenize<uint32_t>(config.options().get<std::string>("crus"));
+
+  WorkflowSpec workflow;
+
+  workflow.emplace_back(getIDCToVectorSpec(inputSpec, crus));
+
+  return workflow;
+}

--- a/Detectors/TPC/workflow/src/tpc-krypton-clusterer.cxx
+++ b/Detectors/TPC/workflow/src/tpc-krypton-clusterer.cxx
@@ -27,7 +27,6 @@
 #include "TPCReconstruction/KrCluster.h"
 #include "TPCBase/Sector.h"
 #include "TPCWorkflow/KryptonClustererSpec.h"
-#include "TPCWorkflow/KryptonClustererSpec.h"
 
 using namespace o2::framework;
 using namespace o2::tpc;


### PR DESCRIPTION
This commit contains various unrelated things
* decoder for integrated digital currents
* trigger information decoding in LinkZS, trigger info usage to be finalized, for the moment only skip trigger information to allow for decoding of LinksZS data
* v-drift calibration using laser tracks. Still work in progress.
* some more unrelated fixes