### PR TITLE
[EMCAL-699] Add RCU trailer also for links without payload

### DIFF
--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -177,8 +177,9 @@ bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
     }
 
     if (!payload.size()) {
-      LOG(DEBUG) << "Payload buffer has size 0" << std::endl;
-      continue;
+      // [EMCAL-699] No payload found in SRU
+      // Still the link is not completely ignored but a trailer with 0-payloadsize is added
+      LOG(DEBUG) << "Payload buffer has size 0 - only write empty trailer" << std::endl;
     }
     LOG(DEBUG) << "Payload buffer has size " << payload.size();
 


### PR DESCRIPTION
In case a link does not contain data for a given
event, still a RCU trailer with the SRU configuration,
L1 phase and payload size 0 needs to be added
according to the implementation in the SRU
firmware.