### PR TITLE
Misc. fixes: settable path for collisioncontext, kill CTFwriter for empty grp 

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
@@ -42,6 +42,9 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
     return o2::utils::Str::concat_string(prefix, "_", DIGITS_STRING, d.getName(), ".root");
   }
 
+  // Filename of collision context
+  static std::string getCollisionContextFileName(const std::string_view prefix = "");
+
   // Filename of general run parameters (GRP)
   static std::string getGRPFileName(const std::string_view prefix = STANDARDSIMPREFIX);
 
@@ -121,11 +124,13 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
   static constexpr std::string_view DAT_EXT_STRING = "dat";
   static constexpr std::string_view ALPIDECLUSDICTFILENAME = "dictionary";
   static constexpr std::string_view MATBUDLUT = "matbud";
+  static constexpr std::string_view COLLISIONCONTEXT = "collisioncontext";
 
   // these are configurable paths for some commonly used files
   std::string mDirGRP = "none";    // directory for GRP file ("none" == "")
   std::string mDirGeom = "none";   // directory for geometry file
   std::string mDirMatLUT = "none"; // directory for material LUT
+  std::string mDirCollContext = "none"; // directory for collision context
 
   O2ParamDef(NameConf, "NameConf");
 };

--- a/DataFormats/Detectors/Common/src/NameConf.cxx
+++ b/DataFormats/Detectors/Common/src/NameConf.cxx
@@ -43,6 +43,12 @@ std::string NameConf::getGeomFileName(const std::string_view prefix)
 }
 
 // Filename to store general run parameters (GRP)
+std::string NameConf::getCollisionContextFileName(const std::string_view prefix)
+{
+  return buildFileName(prefix, "", "", COLLISIONCONTEXT, ROOT_EXT_STRING, Instance().mDirCollContext);
+}
+
+// Filename to store general run parameters (GRP)
 std::string NameConf::getGRPFileName(const std::string_view prefix)
 {
   return buildFileName(prefix, "_", STANDARDSIMPREFIX, GRP_STRING, ROOT_EXT_STRING, Instance().mDirGRP);

--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -109,7 +109,7 @@ class DigitizationContext
   // helper functions to save and load a context
   void saveToFile(std::string_view filename) const;
 
-  static DigitizationContext const* loadFromFile(std::string_view filename);
+  static DigitizationContext const* loadFromFile(std::string_view filename = "collisioncontext.root");
 
  private:
   int mNofEntries = 0;

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -65,6 +65,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       }
       run = 0;
     }
+    if (dets.none()) {
+      throw std::invalid_argument("Invalid workflow: no detectors found");
+    }
     auto outmode = configcontext.options().get<std::string>("output-type");
     dictPerDet = configcontext.options().get<bool>("dict-per-det");
     if (outmode == "ctf") {

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -89,7 +89,7 @@ void PrimaryVertexingSpec::init(InitContext& ic)
   mVertexer.setValidateWithIR(mValidateWithIR);
 
   // set bunch filling. Eventually, this should come from CCDB
-  const auto* digctx = o2::steer::DigitizationContext::loadFromFile("collisioncontext.root");
+  const auto* digctx = o2::steer::DigitizationContext::loadFromFile();
   const auto& bcfill = digctx->getBunchFilling();
   mVertexer.setBunchFilling(bcfill);
   mVertexer.init();

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -119,7 +119,7 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   mMatching.setDebugFlag(dbgFlags);
 
   // set bunch filling. Eventually, this should come from CCDB
-  const auto* digctx = o2::steer::DigitizationContext::loadFromFile("collisioncontext.root");
+  const auto* digctx = o2::steer::DigitizationContext::loadFromFile();
   const auto& bcfill = digctx->getBunchFilling();
   mMatching.setBunchFilling(bcfill);
 


### PR DESCRIPTION
* Do not start CTFwriter if detectors mask is empty

* path for collisioncontext can be set via NameConf.mDirCollContext