### PR TITLE
Compatibility to boost 1.76

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/testUserLogicEndpointDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testUserLogicEndpointDecoder.cxx
@@ -32,7 +32,7 @@
 #include <fstream>
 #include <iostream>
 #include <boost/test/data/test_case.hpp>
-#include <boost/mpl/list_c.hpp>
+#include <boost/mpl/list.hpp>
 
 using namespace o2::mch::raw;
 namespace bdata = boost::unit_test::data;


### PR DESCRIPTION
Why was `list_c.hpp` used? This doesn't work with boost > 1.75, `list.hpp` works for me, and is also the one mentioned in the boost manual: https://www.boost.org/doc/libs/1_76_0/libs/mpl/doc/refmanual/list.html