### PR TITLE
Have to use FATAL message to catch failure condition in workflow unit…

### DIFF
--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -35,7 +35,7 @@ using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed)"; \
   }
 
 // this function is only used to do the static checks for API return types

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -38,7 +38,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed)"; \
   }
 
 using DataHeader = o2::header::DataHeader;

--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -18,7 +18,7 @@ using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                                                      \
   if ((condition) == false) {                                                                        \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed at )" << __FILE__ << ":" << __LINE__; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed at )" << __FILE__ << ":" << __LINE__; \
   }
 
 // This is how you can define your processing in a declarative way

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -62,7 +62,7 @@ using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed)"; \
   }
 
 constexpr size_t nPipelines = 3;

--- a/Framework/Core/test/test_Task.cxx
+++ b/Framework/Core/test/test_Task.cxx
@@ -15,7 +15,7 @@
 
 #define ASSERT_ERROR(condition)                                                                      \
   if ((condition) == false) {                                                                        \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed at )" << __FILE__ << ":" << __LINE__; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed at )" << __FILE__ << ":" << __LINE__; \
   }
 
 using namespace o2::framework;

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -31,7 +31,7 @@ using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
-    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+    LOG(FATAL) << R"(Test condition ")" #condition R"(" failed)"; \
   }
 
 const int gTreeSize = 10; // elements in the test tree


### PR DESCRIPTION
… tests

At some point the logic in the DPL driver has changed and the workflow
does not terminate with an error code if a device has messages of severity
ERROR.