### PR TITLE
Fix in ITS digits->raw conversion

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
@@ -202,19 +202,14 @@ void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, st
   int lnkAssign[3][MaxLinksPerRU] = {
     // requested link cabling for IB, MB and OB
     /* // uncomment this to have 1 link per RU
-    {9, 0, 0}, // IB
-    {16, 0, 0}, // MB
-    {28, 0, 0} // OB
+    {9, 0, 0},  // IB
+    {28, 0, 0}, // MB
+    {28, 0, 0}  // OB
      */
-    /* //  uncomment this to have 3 link per RU
-    {3, 3, 3}, // IB
-    {5, 5, 6}, // MB
-    {9, 9, 10} // OB
-    */
     // partition according to https://indico.cern.ch/event/907685/contributions/3818967/attachments/2019436/3376161/20200411_SOX_EOX_Proposal.pdf
-    {3, 3, 3},  // IB
-    {8, 8, 0},  // MB
-    {14, 14, 0} // OB
+    {3, 3, 3},   // IB
+    {14, 14, 0}, // MB
+    {14, 14, 0}  // OB
   };
   std::vector<std::vector<int>> defRU{// number of RUs per CRU at each layer
                                       {6, 6},

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -173,7 +173,7 @@ class ChipMappingITS
   uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
   ///< convert cable iterator ID to the position on the ActiveLanes word in the GBT.header for given RU type; MFT lanes position compatible
-  uint8_t cablePos(uint8_t ruType, uint8_t id) const { return id; }
+  uint8_t cablePos(uint8_t ruType, uint8_t id) const { return mCablePos[ruType][id]; }
 
   ///< get number of chips served by single cable on given RU type
   int getNChipsPerCable(int ruType) { return NChipsPerCableSB[ruType]; }
@@ -297,7 +297,8 @@ class ChipMappingITS
   int mChipInfoEntrySB[NSubB] = {0};
 
   std::vector<uint8_t> mCableHW2SW[NSubB];       ///< table of cables HW to SW conversion for each RU type
-  std::vector<uint8_t> mCableHW2Pos[NSubB];      ///< table of cables positions in the ActiveLanes mask for each RU type
+  std::vector<uint8_t> mCableHW2Pos[NSubB];      ///< table of cables positions in the ActiveLanes mask for each RU type (HW numbering)
+  std::vector<uint8_t> mCablePos[NSubB];         ///< table of cables positions in the ActiveLanes mask for each RU type (sequential numbering)
   std::vector<uint8_t> mCableHWFirstChip[NSubB]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
 
   std::array<int, NSubB> mCablesOnStaveSB = {0}; ///< pattern of cables per stave of sub-barrel

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingITS.cxx
@@ -71,6 +71,7 @@ ChipMappingITS::ChipMappingITS()
   // IB: single cable per chip
   int ctrChip = 0;
   mChipInfoEntrySB[IB] = ctrChip;
+  mCablePos[IB].resize(NChipsPerStaveSB[IB], 0xff);
   mCableHW2SW[IB].resize(NChipsPerStaveSB[IB], 0xff);
   mCableHW2Pos[IB].resize(NChipsPerStaveSB[IB], 0xff);
   mCableHWFirstChip[IB].resize(NChipsPerStaveSB[IB], 0xff);
@@ -97,10 +98,10 @@ ChipMappingITS::ChipMappingITS()
   const int chipsOnCable = 7;
   for (int bid = MB; bid <= OB; bid++) { // MB and OB staves have similar layout
     mChipInfoEntrySB[bid] = ctrChip;
-    mCableHW2SW[bid].resize(0xff, 0xff);
-    mCableHW2Pos[bid].resize(0xff, 0xff);
-    mCableHWFirstChip[bid].resize(0xff, 0xff);
-
+    mCablePos[bid].resize(NChipsPerStaveSB[bid], 0xff);
+    mCableHW2SW[bid].resize(NChipsPerStaveSB[bid], 0xff);
+    mCableHW2Pos[bid].resize(NChipsPerStaveSB[bid], 0xff);
+    mCableHWFirstChip[bid].resize(NChipsPerStaveSB[bid], 0xff);
     for (int i = 0; i < NChipsPerStaveSB[bid]; i++) {
       auto& cInfo = mChipsInfo[ctrChip++];
       int hstave = i / (NChipsPerStaveSB[bid] / 2);
@@ -124,6 +125,17 @@ ChipMappingITS::ChipMappingITS()
       if (cInfo.chipOnCable == 0) {
         mCableHWFirstChip[bid][cInfo.cableHW] = cInfo.moduleSW * NChipsPerModuleSB[bid];
       }
+    }
+  }
+  for (int bid = 0; bid < NSubB; bid++) {
+    int pos = 0;
+    for (int ic = 0; ic < 32; ic++) {
+      if (mCablesOnStaveSB[bid] & (0x1 << ic)) {
+        mCablePos[bid][pos++] = ic;
+      }
+    }
+    if (pos != NCablesPerStaveSB[bid]) {
+      throw std::runtime_error(fmt::format("counted number of cables {} does not match expected {} on subBarel{}", pos, NCablesPerStaveSB[bid], bid));
     }
   }
 


### PR DESCRIPTION
Due to the problem in the cables mapping the digits of half-stave 0 on the ITS
layers 3 and 4 were not encoded/decoded