### PR TITLE
FT0: correct treatment of missing TF

### DIFF
--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
@@ -53,6 +53,7 @@ class FT0DataReaderDPLSpec : public Task
         if (dh->payloadSize == 0) {
           LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+          mRawReader.makeSnapshot(pc); // send empty output
           return;
         }
       }

--- a/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
@@ -54,6 +54,7 @@ class FITDataReaderDPLSpec : public Task
         if (dh->payloadSize == 0) {
           LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+          mRawReader.makeSnapshot(pc); // send empty output
           return;
         }
       }

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
@@ -84,8 +84,11 @@ void DataDecoderTask::run(framework::ProcessingContext& pc)
   //  decodeReadout(pc);
   // decodeRawFile(pc);
 
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mDigits);
+  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mIntReco);
+
+  LOG(DEBUG) << "Writing   Digitis=" << mDeco->mDigits.size() << "/" << mTotalDigits << " Frame=" << mTotalFrames << " IntRec " << mDeco->mIntReco;
   mExTimer.elapseMes("Decoding... Digits decoded = " + std::to_string(mTotalDigits) + " Frames received = " + std::to_string(mTotalFrames));
-  return;
 }
 
 void DataDecoderTask::endOfStream(framework::EndOfStreamContext& ec)
@@ -192,12 +195,7 @@ void DataDecoderTask::decodeTF(framework::ProcessingContext& pc)
     }
     mTotalFrames++;
   }
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mDigits);
-  pc.outputs().snapshot(o2::framework::Output{"HMP", "INTRECORDS", 0, o2::framework::Lifetime::Timeframe}, mDeco->mIntReco);
-
   mTotalDigits += mDeco->mDigits.size();
-  LOG(DEBUG) << "Writing   Digitis=" << mDeco->mDigits.size() << "/" << mTotalDigits << " Frame=" << mTotalFrames << " IntRec " << mDeco->mIntReco;
-  return;
 }
 
 //_________________________________________________________________________________________________


### PR DESCRIPTION
Also applied similar fix to HMPID DataDecoderSpec, though it is not clear if this class it going to be supported.