### PR TITLE
rANS: allow encoders/decoders with empty dictionaries

### DIFF
--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -60,7 +60,7 @@ class CTFCoderBase
   void createCoder(OpType op, const o2::rans::FrequencyTable& freq, uint8_t probabilityBits, int slot)
   {
     if (!freq.size()) {
-      LOG(WARNING) << "Empty dictionary for slot " << slot << ", " << (op == OpType::Encoder ? "encoding" : "decoding") << " will assume literal symbols only";
+      LOG(WARNING) << "Empty dictionary provided for slot " << slot << ", " << (op == OpType::Encoder ? "encoding" : "decoding") << " will assume literal symbols only";
     }
 
     switch (op) {

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -59,6 +59,10 @@ class CTFCoderBase
   template <typename S>
   void createCoder(OpType op, const o2::rans::FrequencyTable& freq, uint8_t probabilityBits, int slot)
   {
+    if (!freq.size()) {
+      LOG(WARNING) << "Empty dictionary for slot " << slot << ", " << (op == OpType::Encoder ? "encoding" : "decoding") << " will assume literal symbols only";
+    }
+
     switch (op) {
       case OpType::Encoder:
         mCoders[slot].reset(new o2::rans::LiteralEncoder64<S>(freq, probabilityBits));

--- a/Utilities/rANS/include/rANS/internal/ReverseSymbolLookupTable.h
+++ b/Utilities/rANS/include/rANS/internal/ReverseSymbolLookupTable.h
@@ -38,11 +38,6 @@ class ReverseSymbolLookupTable
   {
     LOG(trace) << "start building reverse symbol lookup table";
 
-    if (stats.size() == 1) {
-      LOG(warning) << "SymbolStatistics of empty message passed to " << __func__;
-      return;
-    }
-
     mLut.resize(bitsToRange(probabilityBits));
     // go over all symbols
     for (auto symbolIT = std::begin(stats); symbolIT != std::end(stats); ++symbolIT) {
@@ -68,6 +63,10 @@ class ReverseSymbolLookupTable
                 << "elements: " << mLut.size() << ", "
                 << "sizeB: " << mLut.size() * sizeof(typename std::decay_t<decltype(mLut)>::value_type) << "}";
 #endif
+
+    if (stats.size() == 1) {
+      LOG(warning) << "SymbolStatistics of empty message passed to " << __func__;
+    }
 
     LOG(trace) << "done building reverse symbol lookup table";
   };

--- a/Utilities/rANS/include/rANS/internal/SymbolStatistics.h
+++ b/Utilities/rANS/include/rANS/internal/SymbolStatistics.h
@@ -122,11 +122,6 @@ SymbolStatistics::SymbolStatistics(const Source_IT begin, const Source_IT end, i
   RANSTimer t;
   t.start();
 
-  if (begin == end) {
-    LOG(debug) << "Passed empty message to " << __func__; // RS this is ok for empty columns
-    return;
-  }
-
   // if we did not calculate renormalization size, calculate it.
   if (scaleBits == 0) {
     mScaleBits = [&, this]() {
@@ -158,8 +153,8 @@ SymbolStatistics::SymbolStatistics(const Source_IT begin, const Source_IT end, i
   buildCumulativeFrequencyTable();
   rescale();
 
-  assert(mFrequencyTable.size() > 1);
-  assert(mCumulativeFrequencyTable.size() > 2);
+  assert(mFrequencyTable.size() > 0);
+  assert(mCumulativeFrequencyTable.size() > 1);
   assert(mCumulativeFrequencyTable.size() - mFrequencyTable.size() == 1);
 
   t.stop();
@@ -172,6 +167,10 @@ SymbolStatistics::SymbolStatistics(const Source_IT begin, const Source_IT end, i
               << "frequencyTableSizeB: " << mFrequencyTable.size() * sizeof(typename std::decay_t<decltype(mFrequencyTable)>::value_type) << ", "
               << "CumulativeFrequencyTableSizeB: " << mCumulativeFrequencyTable.size() * sizeof(typename std::decay_t<decltype(mCumulativeFrequencyTable)>::value_type) << "}";
 #endif
+
+  if (begin == end) {                                     // we do this check only after the adding the escape symbol
+    LOG(debug) << "Passed empty message to " << __func__; // RS this is ok for empty columns
+  }
 
   LOG(trace) << "done building symbol statistics";
 }


### PR DESCRIPTION
@MichaelLettrich in some rare cases the certain columns might not get any entries to build dictionaries. Currently in such cases the rANS crashes both in decoding and encoding, instead of using literals only. 
This PR fixes it (tested on data where I impose zero stat on the dictionary using a hack). I am pretty sure the fix is correct for the encoder, but please check the decoder part, the logic there is less trivial 