### PR TITLE
[MCH] prepare setup for run3

### DIFF
--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
@@ -51,7 +51,7 @@ class ClusterFinderOriginal
   ClusterFinderOriginal(ClusterFinderOriginal&&) = delete;
   ClusterFinderOriginal& operator=(ClusterFinderOriginal&&) = delete;
 
-  void init();
+  void init(bool run2Config);
   void deinit();
   void reset();
 
@@ -63,15 +63,12 @@ class ClusterFinderOriginal
   const std::vector<Digit>& getUsedDigits() const { return mUsedDigits; }
 
  private:
-  static constexpr double SDistancePrecision = 1.e-3;                   ///< precision used to check overlaps and so on (cm)
-  static constexpr double SLowestPadCharge = 4.f * 0.22875f;            ///< minimum charge of a pad
-  static constexpr double SLowestPixelCharge = SLowestPadCharge / 12.;  ///< minimum charge of a pixel
-  static constexpr double SLowestClusterCharge = 2. * SLowestPadCharge; ///< minimum charge of a cluster
-  static constexpr int SNFitClustersMax = 3;                            ///< maximum number of clusters fitted at the same time
-  static constexpr int SNFitParamMax = 3 * SNFitClustersMax - 1;        ///< maximum number of fit parameters
-  static constexpr double SLowestCoupling = 1.e-2;                      ///< minimum coupling between clusters of pixels and pads
-  static constexpr float SDefaultClusterResolution = 0.2f;              ///< default cluster resolution (cm)
-  static constexpr float SBadClusterResolution = 10.f;                  ///< bad (e.g. mono-cathode) cluster resolution (cm)
+  static constexpr double SDistancePrecision = 1.e-3;            ///< precision used to check overlaps and so on (cm)
+  static constexpr int SNFitClustersMax = 3;                     ///< maximum number of clusters fitted at the same time
+  static constexpr int SNFitParamMax = 3 * SNFitClustersMax - 1; ///< maximum number of fit parameters
+  static constexpr double SLowestCoupling = 1.e-2;               ///< minimum coupling between clusters of pixels and pads
+  static constexpr float SDefaultClusterResolution = 0.2f;       ///< default cluster resolution (cm)
+  static constexpr float SBadClusterResolution = 10.f;           ///< bad (e.g. mono-cathode) cluster resolution (cm)
 
   void resetPreCluster(gsl::span<const Digit>& digits);
   void simplifyPreCluster(std::vector<int>& removedDigits);
@@ -113,6 +110,13 @@ class ClusterFinderOriginal
   void updatePads(const double fitParam[SNFitParamMax + 1], int nParamUsed);
 
   void setClusterResolution(ClusterStruct& cluster) const;
+
+  /// function to reinterpret digit ADC as charge
+  std::function<double(uint32_t)> mADCToCharge = [](uint32_t adc) { return static_cast<double>(adc); };
+
+  double mLowestPadCharge = 0.;     ///< minimum charge of a pad
+  double mLowestPixelCharge = 0.;   ///< minimum charge of a pixel
+  double mLowestClusterCharge = 0.; ///< minimum charge of a cluster
 
   std::unique_ptr<MathiesonOriginal[]> mMathiesons; ///< Mathieson functions for station 1 and the others
   MathiesonOriginal* mMathieson = nullptr;          ///< pointer to the Mathieson function currently used

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -55,7 +55,8 @@ class ClusterFinderOriginalTask
     /// Prepare the clusterizer
     LOG(INFO) << "initializing cluster finder";
 
-    mClusterFinder.init();
+    bool run2Config = ic.options().get<bool>("run2-config");
+    mClusterFinder.init(run2Config);
 
     /// Print the timer and clear the clusterizer when the processing is over
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, [this]() {
@@ -136,7 +137,7 @@ o2::framework::DataProcessorSpec getClusterFinderOriginalSpec()
             OutputSpec{{"clusters"}, "MCH", "CLUSTERS", 0, Lifetime::Timeframe},
             OutputSpec{{"clusterdigits"}, "MCH", "CLUSTERDIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<ClusterFinderOriginalTask>()},
-    Options{}};
+    Options{{"run2-config", VariantType::Bool, false, {"setup for run2 data"}}}};
 }
 
 } // end namespace mch


### PR DESCRIPTION
This is to prepare the change of configuration between run2 and run3. 

For run2 config, the plan is to keep the parameters hardcoded as it is now, since they are not supposed to be changed.

For run3 config, the plan is to set these parameters via another class (ConstantParam or ConfigurableParam). For the Mathieson functions the parameterizations should be in common with the detector response in MC (currently tuned for run2 still).
