### PR TITLE
DPL: use Resource Manager to optimize shared memory usage

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -46,6 +46,7 @@ o2_add_library(Framework
                        src/DataRelayerHelpers.cxx
                        src/DataSpecUtils.cxx
                        src/DeviceConfigInfo.cxx
+                       src/DevicesManager.cxx
                        src/DeviceMetricsInfo.cxx
                        src/DeviceMetricsHelper.cxx
                        src/DeviceSpec.cxx

--- a/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
+++ b/Framework/Core/include/Framework/ComputingQuotaEvaluator.h
@@ -24,14 +24,16 @@ namespace o2::framework
 
 class ComputingQuotaEvaluator
 {
+ public:
   // Maximum number of offers this evaluator can hold
   static constexpr int MAX_INFLIGHT_OFFERS = 16;
-
- public:
   ComputingQuotaEvaluator(uv_loop_t*);
-  ComputingQuotaOfferRef selectOffer(ComputingQuotaRequest const& request);
+  bool selectOffer(int task, ComputingQuotaRequest const& request);
 
-  void dispose(ComputingQuotaOfferRef offer);
+  /// Consume offers for a given taskId
+  void consume(int taskId, ComputingQuotaConsumer& consumed);
+  /// Dispose offers for a given taskId
+  void dispose(int taskId);
 
   /// All the available offerts
   std::array<ComputingQuotaOffer, MAX_INFLIGHT_OFFERS> mOffers;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -12,7 +12,6 @@
 
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ComputingQuotaOffer.h"
-#include "Framework/ComputingQuotaEvaluator.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DataRelayer.h"
@@ -60,6 +59,7 @@ struct DeviceContext {
   DeviceSpec const* spec = nullptr;
   DeviceState* state = nullptr;
   ComputingQuotaEvaluator* quotaEvaluator = nullptr;
+  DataProcessingStats* stats = nullptr;
 };
 
 struct DataProcessorContext {
@@ -92,8 +92,8 @@ struct TaskStreamRef {
 };
 
 struct TaskStreamInfo {
-  /// The quota offer to be used for the computation
-  ComputingQuotaOfferRef offer;
+  /// The id of this stream
+  TaskStreamRef id;
   /// The context of the DataProcessor being run by this task
   DataProcessorContext* context;
   /// Wether or not this task is running
@@ -105,7 +105,7 @@ struct TaskStreamInfo {
 class DataProcessingDevice : public FairMQDevice
 {
  public:
-  DataProcessingDevice(RunningWorkflowInfo const& runningWorkflow, RunningDeviceRef ref, ServiceRegistry&, DeviceState& state);
+  DataProcessingDevice(RunningDeviceRef ref, ServiceRegistry&);
   void Init() final;
   void InitTask() final;
   void PreRun() final;
@@ -158,7 +158,7 @@ class DataProcessingDevice : public FairMQDevice
   bool mWasActive = false;                                       /// Whether or not the device was active at last iteration.
   std::vector<uv_work_t> mHandles;                               /// Handles to use to schedule work.
   std::vector<TaskStreamInfo> mStreams;                          /// Information about the task running in the associated mHandle.
-  ComputingQuotaEvaluator mQuotaEvaluator;                       /// The component which evaluates if the offer can be used to run a task
+  ComputingQuotaEvaluator& mQuotaEvaluator;                      /// The component which evaluates if the offer can be used to run a task
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataProcessingStats.h
+++ b/Framework/Core/include/Framework/DataProcessingStats.h
@@ -34,6 +34,7 @@ struct DataProcessingStats {
   std::atomic<int> lastElapsedTimeMs = 0;
   std::atomic<int> lastProcessedSize = 0;
   std::atomic<int> totalProcessedSize = 0;
+  std::atomic<int> totalSigusr1 = 0;
 
   std::atomic<uint64_t> lastSlowMetricSentTimestamp = 0; /// The timestamp of the last time we sent slow metrics
   std::atomic<uint64_t> lastMetricFlushedTimestamp = 0;  /// The timestamp of the last time we actually flushed metrics

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -21,6 +21,7 @@ class StringContext;
 class ArrowContext;
 class RawBufferContext;
 class ServiceRegistry;
+class DeviceState;
 
 /// Helper class to send messages from a contex at the end
 /// of a computation.

--- a/Framework/Core/include/Framework/DeviceController.h
+++ b/Framework/Core/include/Framework/DeviceController.h
@@ -11,6 +11,8 @@
 #ifndef O2_FRAMEWORK_DEVICECONTROLLER_H_
 #define O2_FRAMEWORK_DEVICECONTROLLER_H_
 
+#include <cstddef>
+
 namespace o2::framework
 {
 
@@ -19,6 +21,7 @@ struct WSDPLHandler;
 struct DeviceController {
   DeviceController(WSDPLHandler* handler);
   void hello();
+  void write(const char* message, size_t s);
 
   WSDPLHandler* mHandler;
 };

--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -11,6 +11,8 @@
 #define O2_FRAMEWORK_DEVICESTATE_H_
 
 #include "Framework/ChannelInfo.h"
+#include "Framework/ComputingQuotaOffer.h"
+
 #include <vector>
 #include <string>
 #include <map>
@@ -57,6 +59,14 @@ struct DeviceState {
   std::vector<InputChannelInfo> inputChannelInfos;
   StreamingState streaming = StreamingState::Streaming;
   bool quitRequested = false;
+
+  /// ComputingQuotaOffers which have not yet been
+  /// evaluated by the ComputingQuotaEvaluator
+  std::vector<ComputingQuotaOffer> pendingOffers;
+  /// ComputingQuotaOffers which should be removed
+  /// from the queue.
+  std::vector<ComputingQuotaConsumer> offerConsumers;
+
   // The libuv event loop which serves this device.
   uv_loop_t* loop = nullptr;
   // The list of active timers which notify this device.

--- a/Framework/Core/include/Framework/DevicesManager.h
+++ b/Framework/Core/include/Framework/DevicesManager.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_DEVICESMANAGER_H_
+#define O2_FRAMEWORK_DEVICESMANAGER_H_
+
+#include "Framework/DeviceControl.h"
+#include "Framework/DeviceInfo.h"
+#include "Framework/DeviceSpec.h"
+#include <string>
+#include <vector>
+
+namespace o2::framework
+{
+
+struct DeviceIndex {
+  int index;
+};
+struct DeviceControl;
+
+struct DeviceMessageHandle {
+  DeviceIndex ref;
+  std::string message;
+};
+
+struct DevicesManager {
+  void queueMessage(char const* receiver, char const* msg);
+  void flush();
+
+  std::vector<DeviceControl>& controls;
+  std::vector<DeviceInfo>& infos;
+  std::vector<DeviceSpec>& specs;
+  std::vector<DeviceMessageHandle> messages;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DEVICESMANAGER_H_

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -600,6 +600,7 @@ auto sendRelayerMetrics(ServiceRegistry& registry, DataProcessingStats& stats) -
                     .addTag(Key::Subsystem, Value::DPL));
   monitoring.send(Metric{stats.totalProcessedSize, "total_processed_input_size_byte"}
                     .addTag(Key::Subsystem, Value::DPL));
+  monitoring.send(Metric{stats.totalSigusr1.load(), "total_sigusr1"}.addTag(Key::Subsystem, Value::DPL));
   monitoring.send(Metric{(stats.lastProcessedSize.load() / (stats.lastElapsedTimeMs.load() ? stats.lastElapsedTimeMs.load() : 1) / 1000),
                          "processing_rate_mb_s"}
                     .addTag(Key::Subsystem, Value::DPL));

--- a/Framework/Core/src/DPLWebSocket.cxx
+++ b/Framework/Core/src/DPLWebSocket.cxx
@@ -12,6 +12,7 @@
 #include "Framework/RuntimeError.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceController.h"
+#include "Framework/DevicesManager.h"
 #include "DriverServerContext.h"
 #include "DriverClientContext.h"
 #include "HTTPParser.h"

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -82,9 +82,9 @@ void on_idle_timer(uv_timer_t* handle)
   state->loopReason |= DeviceState::TIMER_EXPIRED;
 }
 
-DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWorkflow, RunningDeviceRef ref, ServiceRegistry& registry, DeviceState& state)
-  : mSpec{runningWorkflow.devices[ref.index]},
-    mState{state},
+DataProcessingDevice::DataProcessingDevice(RunningDeviceRef ref, ServiceRegistry& registry)
+  : mSpec{registry.get<RunningWorkflowInfo const>().devices[ref.index]},
+    mState{registry.get<DeviceState>()},
     mInit{mSpec.algorithm.onInit},
     mStatefulProcess{nullptr},
     mStatelessProcess{mSpec.algorithm.onProcess},
@@ -92,7 +92,7 @@ DataProcessingDevice::DataProcessingDevice(RunningWorkflowInfo const& runningWor
     mConfigRegistry{nullptr},
     mAllocator{&mTimingInfo, &registry, mSpec.outputs},
     mServiceRegistry{registry},
-    mQuotaEvaluator{state.loop}
+    mQuotaEvaluator{registry.get<ComputingQuotaEvaluator>()}
 {
   /// FIXME: move erro handling to a service?
   if (mError != nullptr) {
@@ -145,7 +145,11 @@ void run_completion(uv_work_t* handle, int status)
 {
   TaskStreamInfo* task = (TaskStreamInfo*)handle->data;
   DataProcessorContext& context = *task->context;
-  context.deviceContext->quotaEvaluator->dispose(task->offer);
+  for (auto& consumer : context.deviceContext->state->offerConsumers) {
+    context.deviceContext->quotaEvaluator->consume(task->id.index, consumer);
+  }
+  context.deviceContext->state->offerConsumers.clear();
+  context.deviceContext->quotaEvaluator->dispose(task->id.index);
   task->running = false;
   ZoneScopedN("run_completion");
 }
@@ -306,8 +310,34 @@ void on_signal_callback(uv_signal_t* handle, int signum)
 {
   ZoneScopedN("Signal callaback");
   LOG(debug) << "Signal " << signum << " received.";
-  DeviceState* state = (DeviceState*)handle->data;
-  state->loopReason |= DeviceState::SIGNAL_ARRIVED;
+  DeviceContext* context = (DeviceContext*)handle->data;
+  context->state->loopReason |= DeviceState::SIGNAL_ARRIVED;
+  size_t ri = 0;
+  while (ri != context->quotaEvaluator->mOffers.size()) {
+    auto& offer = context->quotaEvaluator->mOffers[ri];
+    // We were already offered some sharedMemory, so we
+    // do not consider the offer.
+    // FIXME: in principle this should account for memory
+    //        available and being offered, however we
+    //        want to get out of the woods for now.
+    if (offer.valid && offer.sharedMemory != 0) {
+      return;
+    }
+    ri++;
+  }
+  // Find the first empty offer and have 1GB of shared memory there
+  for (size_t i = 0; i < context->quotaEvaluator->mOffers.size(); ++i) {
+    auto& offer = context->quotaEvaluator->mOffers[i];
+    if (offer.valid == false) {
+      offer.cpu = 0;
+      offer.memory = 0;
+      offer.sharedMemory = 1000000000;
+      offer.valid = true;
+      offer.user = -1;
+      break;
+    }
+  }
+  context->stats->totalSigusr1 += 1;
 }
 
 void DataProcessingDevice::InitTask()
@@ -330,7 +360,7 @@ void DataProcessingDevice::InitTask()
   // is no data pending to be processed.
   uv_signal_t* sigusr1Handle = (uv_signal_t*)malloc(sizeof(uv_signal_t));
   uv_signal_init(mState.loop, sigusr1Handle);
-  sigusr1Handle->data = &mState;
+  sigusr1Handle->data = &mDeviceContext;
   uv_signal_start(sigusr1Handle, on_signal_callback, SIGUSR1);
 
   // We add a timer only in case a channel poller is not there.
@@ -433,6 +463,7 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceCont
   deviceContext.spec = &mSpec;
   deviceContext.state = &mState;
   deviceContext.quotaEvaluator = &mQuotaEvaluator;
+  deviceContext.stats = &mStats;
 
   context.relayer = mRelayer;
   context.registry = &mServiceRegistry;
@@ -462,6 +493,25 @@ void DataProcessingDevice::PostRun()
 
 void DataProcessingDevice::Reset() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Reset); }
 
+namespace
+{
+/// Move offers from the pending list to the actual available offers
+void updateOffers(std::array<ComputingQuotaOffer, ComputingQuotaEvaluator::MAX_INFLIGHT_OFFERS>& store, std::vector<ComputingQuotaOffer>& offers)
+{
+  for (auto& storeOffer : store) {
+    if (offers.empty()) {
+      return;
+    }
+    if (storeOffer.valid == true) {
+      continue;
+    }
+    auto& offer = offers.back();
+    storeOffer = offer;
+    offers.pop_back();
+  }
+}
+} // namespace
+
 bool DataProcessingDevice::ConditionalRun()
 {
   // This will block for the correct delay (or until we get data
@@ -483,6 +533,9 @@ bool DataProcessingDevice::ConditionalRun()
     TracyPlot("loopReason", (int64_t)(uint64_t)mState.loopReason);
 
     mState.loopReason = DeviceState::NO_REASON;
+    if (!mState.pendingOffers.empty()) {
+      updateOffers(mQuotaEvaluator.mOffers, mState.pendingOffers);
+    }
 
     // A new state was requested, we exit.
     if (NewStatePending()) {
@@ -525,10 +578,10 @@ bool DataProcessingDevice::ConditionalRun()
     // Deciding wether to run or not can be done by passing a request to
     // the evaluator. In this case, the request is always satisfied and
     // we run on whatever resource is available.
-    ComputingQuotaOfferRef offer = mQuotaEvaluator.selectOffer(mSpec.resourcePolicy.request);
+    bool enough = mQuotaEvaluator.selectOffer(streamRef.index, mSpec.resourcePolicy.request);
 
-    if (offer.index != -1) {
-      stream.offer = offer;
+    if (enough) {
+      stream.id = streamRef;
       stream.running = true;
       stream.context = &mDataProcessorContexes.at(0);
       run_callback(&handle);

--- a/Framework/Core/src/DeviceController.cxx
+++ b/Framework/Core/src/DeviceController.cxx
@@ -31,4 +31,12 @@ void DeviceController::hello()
   mHandler->write(outputs);
 }
 
+void DeviceController::write(char const* message, size_t s)
+{
+  LOGP(INFO, "Saying {} to device", message);
+  std::vector<uv_buf_t> outputs;
+  encode_websocket_frames(outputs, message, s, WebSocketOpCode::Binary, 0);
+  mHandler->write(outputs);
+}
+
 } // namespace o2::framework

--- a/Framework/Core/src/DevicesManager.cxx
+++ b/Framework/Core/src/DevicesManager.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DevicesManager.h"
+#include "Framework/RuntimeError.h"
+#include "Framework/Logger.h"
+#include "Framework/DeviceController.h"
+
+namespace o2::framework
+{
+
+void DevicesManager::queueMessage(char const* target, char const* message)
+{
+  for (int di = 0; di < specs.size(); ++di) {
+    if (specs[di].id == target) {
+      messages.push_back({di, message});
+    }
+  }
+}
+
+void DevicesManager::flush()
+{
+  for (auto& handle : messages) {
+    auto controller = controls[handle.ref.index].controller;
+    // Device might not be started yet, by the time we write to it.
+    if (!controller) {
+      LOGP(INFO, "Controller for {} not yet available.", specs[handle.ref.index].name);
+      continue;
+    }
+    controller->write(handle.message.c_str(), handle.message.size());
+  }
+
+  auto checkIfController = [this](DeviceMessageHandle const& handle) {
+    return this->controls[handle.ref.index].controller != nullptr;
+  };
+  auto it = std::remove_if(messages.begin(), messages.end(), checkIfController);
+  auto r = std::distance(it, messages.end());
+  messages.erase(it, messages.end());
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DriverServerContext.h
+++ b/Framework/Core/src/DriverServerContext.h
@@ -12,9 +12,9 @@
 #define O2_FRAMEWORK_DRIVERSERVERCONTEXT_H_
 
 #include "Framework/DeviceInfo.h"
-#include "Framework/DeviceControl.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/DeviceSpec.h"
+#include "Framework/DeviceControl.h"
 #include "Framework/DeviceMetricsInfo.h"
 #include "Framework/ServiceSpec.h"
 

--- a/Framework/Core/src/ResourcePolicy.cxx
+++ b/Framework/Core/src/ResourcePolicy.cxx
@@ -18,6 +18,7 @@ namespace o2::framework
 std::vector<ResourcePolicy> ResourcePolicy::createDefaultPolicies()
 {
   return {
+    ResourcePolicyHelpers::sharedMemoryBoundTask("internal-dpl-aod-reader.*", 300000000),
     ResourcePolicyHelpers::trivialTask(".*")};
 }
 

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -14,6 +14,7 @@
 #include "Framework/ConfigParamsHelper.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ConfigContext.h"
+#include "Framework/ComputingQuotaEvaluator.h"
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Plugins.h"
@@ -25,6 +26,7 @@
 #include "Framework/DeviceConfigInfo.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceState.h"
+#include "Framework/DevicesManager.h"
 #include "Framework/DebugGUI.h"
 #include "Framework/LocalRootFileService.h"
 #include "Framework/LogParsingHelpers.h"
@@ -1009,11 +1011,13 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
     // when the runner is done.
     std::unique_ptr<SimpleRawDeviceService> simpleRawDeviceService;
     std::unique_ptr<DeviceState> deviceState;
+    ComputingQuotaEvaluator quotaEvaluator{loop};
 
     auto afterConfigParsingCallback = [&simpleRawDeviceService,
                                        &runningWorkflow,
                                        ref,
                                        &spec,
+                                       &quotaEvaluator,
                                        &serviceRegistry,
                                        &deviceState,
                                        &errorPolicy,
@@ -1026,11 +1030,13 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
       serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<RawDeviceService>(simpleRawDeviceService.get()));
       serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<DeviceSpec>(&spec));
       serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<RunningWorkflowInfo const>(&runningWorkflow));
+      serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<ComputingQuotaEvaluator>(&quotaEvaluator));
+      serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<DeviceState>(deviceState.get()));
 
       // The decltype stuff is to be able to compile with both new and old
       // FairMQ API (one which uses a shared_ptr, the other one a unique_ptr.
       decltype(r.fDevice) device;
-      device = std::move(make_matching<decltype(device), DataProcessingDevice>(runningWorkflow, ref, serviceRegistry, *deviceState.get()));
+      device = std::move(make_matching<decltype(device), DataProcessingDevice>(ref, serviceRegistry));
       dynamic_cast<DataProcessingDevice*>(device.get())->SetErrorPolicy(errorPolicy);
 
       serviceRegistry.get<RawDeviceService>().setDevice(device.get());
@@ -1118,6 +1124,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
   RunningWorkflowInfo runningWorkflow;
   DeviceInfos infos;
   DeviceControls controls;
+  DevicesManager* devicesManager = new DevicesManager{controls, infos, runningWorkflow.devices};
   DeviceExecutions deviceExecutions;
   DataProcessorInfos dataProcessorInfos = previousDataProcessorInfos;
 
@@ -1193,9 +1200,12 @@ int runStateMachine(DataProcessorSpecs const& workflow,
   std::vector<ServicePreSchedule> preScheduleCallbacks;
   std::vector<ServicePostSchedule> postScheduleCallbacks;
 
+  serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<DevicesManager>(devicesManager));
+
   // This is to make sure we can process metrics, commands, configuration
   // changes coming from websocket (or even via any standard uv_stream_t, I guess).
   DriverServerContext serverContext;
+  serverContext.registry = &serviceRegistry;
   serverContext.loop = loop;
   serverContext.controls = &controls;
   serverContext.infos = &infos;
@@ -1487,7 +1497,8 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                               driverInfo.port,
                                               dataProcessorInfos,
                                               runningWorkflow.devices,
-                                              deviceExecutions, controls,
+                                              deviceExecutions,
+                                              controls,
                                               driverInfo.uniqueWorkflowId);
         } catch (o2::framework::RuntimeErrorRef& ref) {
           auto& err = o2::framework::error_from_ref(ref);
@@ -1545,6 +1556,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
         // Run any pending libUV event loop, block if
         // any, so that we do not consume CPU time when the driver is
         // idle.
+        devicesManager->flush();
         uv_run(loop, once ? UV_RUN_ONCE : UV_RUN_NOWAIT);
         once = true;
         // Calculate what we should do next and eventually

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -248,8 +248,8 @@ void displayDeviceInspector(DeviceSpec const& spec,
   }
 #endif
   if (control.controller) {
-    if (ImGui::Button("Say hello")) {
-      control.controller->hello();
+    if (ImGui::Button("Offer resources")) {
+      control.controller->write("/shm-mem 1000", strlen("/shm-mem 1000"));
     }
   }
 


### PR DESCRIPTION
AOD reader will now require some shared memory quota to be given
to it before it starts doing anything.

The system will keep track of how much shared memory was allocated,
and report back when it's being released (in form of a metric).