### PR TITLE
o2-sim: Improve communication between primary server and transport wo…

### DIFF
--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -63,7 +63,7 @@ bool initializeSim(std::string transport, std::string address, std::unique_ptr<F
 {
   // This needs an already running PrimaryServer
   auto factory = FairMQTransportFactory::CreateTransportFactory(transport);
-  auto channel = FairMQChannel{"primary-get", "req", factory};
+  auto channel = FairMQChannel{"o2sim-primserv-info", "req", factory};
   channel.Connect(address);
   channel.Validate();
 
@@ -131,7 +131,7 @@ KernelSetup initSim(std::string transport, std::string primaddress, std::string 
   primchannel->Connect(primaddress);
   primchannel->Validate();
 
-  auto prim_status_channel = new FairMQChannel{"primary-status", "req", factory};
+  auto prim_status_channel = new FairMQChannel{"o2sim-primserv-info", "req", factory};
   prim_status_channel->Connect(primstatusaddress);
   prim_status_channel->Validate();
 
@@ -324,7 +324,7 @@ int main(int argc, char* argv[])
     // we init the simulation first
     std::unique_ptr<FairRunSim> simrun;
     // TODO: take the addresses from somewhere else
-    if (!initializeSim("zeromq", serveraddress, simrun)) {
+    if (!initializeSim("zeromq", serverstatus_address, simrun)) {
       LOG(ERROR) << "Could not initialize simulation";
       return 1;
     }

--- a/run/PrimaryServerState.h
+++ b/run/PrimaryServerState.h
@@ -16,11 +16,33 @@ namespace o2
 
 /// enum to represent state of the O2Sim event/primary server
 enum class O2PrimaryServerState {
-  Initializing = 2,
-  ReadyToServe = 3,
-  WaitingEvent = 4,
-  Idle = 5,
-  Stopped = 6
+  Initializing = 0,
+  ReadyToServe = 1,
+  WaitingEvent = 2,
+  Idle = 3,
+  Stopped = 4
+};
+static const char* PrimStateToString[5] = {"INIT", "SERVING", "WAITEVENT", "IDLE", "STOPPED"};
+
+/// enum class for type of info request
+enum class O2PrimaryServerInfoRequest {
+  Status = 1,
+  Config = 2
+};
+
+/// Struct to be used as payload when making a request
+/// to the primary server
+struct PrimaryChunkRequest {
+  int workerid = -1;
+  int workerpid = -1;
+  int requestid = -1;
+};
+
+/// Struct to be used as header payload when replying to
+/// a worker request.
+struct PrimaryChunkAnswer {
+  O2PrimaryServerState serverstate;
+  bool payload_attached; // whether real payload follows (or server has no work at this moment)
 };
 
 } // namespace o2

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -406,7 +406,7 @@ int main(int argc, char* argv[])
     const std::string config = localconfig;
 
     // copy all arguments into a common vector
-    const int Nargs = argc + 7;
+    const int Nargs = argc + 9;
     const char* arguments[Nargs];
     arguments[0] = name.c_str();
     arguments[1] = "--control";
@@ -415,8 +415,10 @@ int main(int argc, char* argv[])
     arguments[4] = "primary-server";
     arguments[5] = "--mq-config";
     arguments[6] = config.c_str();
+    arguments[7] = "--severity";
+    arguments[8] = "debug";
     for (int i = 1; i < argc; ++i) {
-      arguments[6 + i] = argv[i];
+      arguments[8 + i] = argv[i];
     }
     arguments[Nargs - 1] = nullptr;
     for (int i = 0; i < Nargs; ++i) {
@@ -540,7 +542,9 @@ int main(int argc, char* argv[])
     }
     // we bring down all processes if one of them aborts
     if (WTERMSIG(status) == SIGABRT) {
+      LOG(INFO) << "Problem detected ";
       for (auto p : gChildProcesses) {
+        LOG(INFO) << "KILLING " << p;
         kill(p, SIGTERM);
       }
       cleanup();
@@ -554,7 +558,7 @@ int main(int argc, char* argv[])
   // make sure the rest shuts down
   for (auto p : gChildProcesses) {
     if (p != mergerpid) {
-      LOG(DEBUG) << "SHUTTING DOWN CHILD PROCESS " << p;
+      LOG(INFO) << "SHUTTING DOWN CHILD PROCESS " << p;
       kill(p, SIGTERM);
     }
   }

--- a/run/o2simtopology_template.json
+++ b/run/o2simtopology_template.json
@@ -18,6 +18,19 @@
                         ]
                     },
                     {
+                        "name":"o2sim-primserv-info",
+                        "sockets":[
+                            {
+                                "type":"req",
+                                "method":"connect",
+                                "address":"ipc:///tmp/o2sim-primserv-info_25005#PID#",
+                                "sndBufSize":"1000",
+                                "rcvBufSize":"1000",
+                                "rateLogging":"0"
+                            }
+                        ]
+                    },
+                    {
                         "name":"simdata",
                         "sockets":[
                             {
@@ -48,19 +61,19 @@
                             }
                         ]
                     },
-		            {
-		                "name":"primary-status",
+                    {
+                        "name":"o2sim-primserv-info",
                         "sockets":[
                             {
                                 "type":"rep",
                                 "method":"bind",
-                                "address":"ipc:///tmp/primary-status_25005#PID#",
+                                "address":"ipc:///tmp/o2sim-primserv-info_25005#PID#",
                                 "sndBufSize":1000,
                                 "rcvBufSize":1000,
                                 "rateLogging":0
                             }
                         ]
-		            },
+                    },
                     {
                         "name":"primary-notifications",
                         "sockets":[
@@ -86,6 +99,19 @@
                                 "type":"req",
                                 "method":"connect",
                                 "address":"ipc:///tmp/primary-get_25005#PID#",
+                                "sndBufSize":"1000",
+                                "rcvBufSize":"1000",
+                                "rateLogging":"0"
+                            }
+                        ]
+                    },
+                    {
+                        "name":"o2sim-primserv-info",
+                        "sockets":[
+                            {
+                                "type":"req",
+                                "method":"connect",
+                                "address":"ipc:///tmp/o2sim-primserv-info_25005#PID#",
                                 "sndBufSize":"1000",
                                 "rcvBufSize":"1000",
                                 "rateLogging":"0"


### PR DESCRIPTION
…rkers

More robust communication between primary servery and sim workers:

a) answer req-rep primary channel immediately (even if no work)
   - avoid blocking in request handling
   - also don't need to specify timeouts anymore
b) include server status information as header
   - this may be used by workers to back-off/retry

This solves some stability issues with the sim-as-a-service.
The 2 examples SimAsService_basic / SimAsService_biasing1 now run
stably.