### PR TITLE
DPL Analysis: Handle unassigned (-1) index in grouping

### DIFF
--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -33,6 +33,7 @@ auto sliceByColumn(char const* key,
                    std::shared_ptr<arrow::Table> const& input,
                    T fullSize,
                    std::vector<arrow::Datum>* slices,
+                   std::vector<int32_t>* vals = nullptr,
                    std::vector<uint64_t>* offsets = nullptr)
 {
   arrow::Datum value_counts;
@@ -49,6 +50,11 @@ auto sliceByColumn(char const* key,
   auto count = 0;
 
   auto size = values.length();
+  if (vals != nullptr) {
+    for (auto i = 0; i < size; ++i) {
+      vals->push_back(values.Value(i));
+    }
+  }
 
   auto makeSlice = [&](T count) {
     slices->emplace_back(arrow::Datum{input->Slice(offset, count)});

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(ArrowDirectSlicing)
 
   std::vector<arrow::Datum> slices;
   std::vector<uint64_t> offsts;
-  auto status = sliceByColumn("fID", b_e.asArrowTable(), 20, &slices, &offsts);
+  auto status = sliceByColumn("fID", b_e.asArrowTable(), 20, &slices, nullptr, &offsts);
   for (auto i = 0u; i < 5; ++i) {
     auto tbl = arrow::util::get<std::shared_ptr<arrow::Table>>(slices[i].value);
     auto ca = tbl->GetColumnByName("fArr");

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(TestSlicingFramework)
 
   std::vector<uint64_t> offsets;
   std::vector<arrow::Datum> slices;
-  auto status = sliceByColumn<int32_t>("x", table, 12, &slices, &offsets);
+  auto status = sliceByColumn<int32_t>("x", table, 12, &slices, nullptr, &offsets);
   BOOST_REQUIRE(status.ok());
   BOOST_REQUIRE_EQUAL(slices.size(), 12);
   std::array<int, 12> sizes{0, 4, 1, 0, 1, 2, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
Allows using grouping with Run3 simulations (requires #6223).