### PR TITLE
[QC-585] Improve logs and metrics in Mergers

### DIFF
--- a/Utilities/Mergers/include/Mergers/IntegratingMerger.h
+++ b/Utilities/Mergers/include/Mergers/IntegratingMerger.h
@@ -60,8 +60,8 @@ class IntegratingMerger : public framework::Task
   std::unique_ptr<monitoring::Monitoring> mCollector;
 
   // stats
-  int mTotalObjectsMerged = 0;
-  int mObjectsMerged = 0;
+  int mTotalDeltasMerged = 0;
+  int mDeltasMerged = 0;
 };
 
 } // namespace o2::mergers

--- a/Utilities/Mergers/include/Mergers/MergeInterface.h
+++ b/Utilities/Mergers/include/Mergers/MergeInterface.h
@@ -32,7 +32,7 @@ class MergeInterface
   // make sure that all entries are correctly deleted as well.
   virtual ~MergeInterface() = default;
 
-  /// \brief Custom merge function. Can return a number of merged entries/bins/etc for statistics.
+  /// \brief Custom merge function.
   virtual void merge(MergeInterface* const other) = 0; // const argument
 
   ClassDef(MergeInterface, 0);

--- a/Utilities/Mergers/include/Mergers/MergeInterface.h
+++ b/Utilities/Mergers/include/Mergers/MergeInterface.h
@@ -32,7 +32,7 @@ class MergeInterface
   // make sure that all entries are correctly deleted as well.
   virtual ~MergeInterface() = default;
 
-  /// \brief Custom merge function.
+  /// \brief Custom merge method.
   virtual void merge(MergeInterface* const other) = 0; // const argument
 
   ClassDef(MergeInterface, 0);

--- a/Utilities/Mergers/include/Mergers/MergerConfig.h
+++ b/Utilities/Mergers/include/Mergers/MergerConfig.h
@@ -16,6 +16,8 @@
 ///
 /// \author Piotr Konopka, piotr.jan.konopka@cern.ch
 
+#include <string>
+
 namespace o2::mergers
 {
 
@@ -57,6 +59,7 @@ struct MergerConfig {
   ConfigEntry<MergedObjectTimespan> mergedObjectTimespan = {MergedObjectTimespan::FullHistory};
   ConfigEntry<PublicationDecision> publicationDecision = {PublicationDecision::EachNSeconds, 10};
   ConfigEntry<TopologySize, int> topologySize = {TopologySize::NumberOfLayers, 1};
+  std::string monitoringUrl = "infologger:///debug?qc";
 };
 
 } // namespace o2::mergers

--- a/Utilities/Mergers/src/FullHistoryMerger.cxx
+++ b/Utilities/Mergers/src/FullHistoryMerger.cxx
@@ -34,7 +34,6 @@ FullHistoryMerger::FullHistoryMerger(const MergerConfig& config, const header::D
   : mConfig(config),
     mSubSpec(subSpec)
 {
-  mCollector = monitoring::MonitoringFactory::Get("infologger:///debug?mergers");
 }
 
 FullHistoryMerger::~FullHistoryMerger()
@@ -46,6 +45,8 @@ FullHistoryMerger::~FullHistoryMerger()
 
 void FullHistoryMerger::init(framework::InitContext& ictx)
 {
+  mCollector = monitoring::MonitoringFactory::Get(mConfig.monitoringUrl);
+  mCollector->addGlobalTag(monitoring::tags::Key::Subsystem, monitoring::tags::Value::Mergers);
 }
 
 void FullHistoryMerger::run(framework::ProcessingContext& ctx)
@@ -96,7 +97,7 @@ void FullHistoryMerger::updateCache(const DataRef& ref)
 
 void FullHistoryMerger::mergeCache()
 {
-  LOG(INFO) << "Merging " << mCache.size() + 1 << " objects.";
+  LOG(DEBUG) << "Merging " << mCache.size() + 1 << " objects.";
 
   mMergedObject = object_store_helpers::extractObjectFrom(mFirstObjectSerialized.second);
   assert(!std::holds_alternative<std::monostate>(mMergedObject));
@@ -132,9 +133,13 @@ void FullHistoryMerger::publish(framework::DataAllocator& allocator)
   } else if (std::holds_alternative<MergeInterfacePtr>(mMergedObject)) {
     allocator.snapshot(framework::OutputRef{MergerBuilder::mergerOutputBinding(), mSubSpec},
                        *std::get<MergeInterfacePtr>(mMergedObject));
+    LOG(INFO) << "Published the merged object containing " << mCache.size() + 1 << " incomplete objects. "
+              << mUpdatesReceived << " updates were received during the last cycle.";
   } else if (std::holds_alternative<TObjectPtr>(mMergedObject)) {
     allocator.snapshot(framework::OutputRef{MergerBuilder::mergerOutputBinding(), mSubSpec},
                        *std::get<TObjectPtr>(mMergedObject));
+    LOG(INFO) << "Published the merged object containing " << mCache.size() + 1 << " incomplete objects. "
+              << mUpdatesReceived << " updates were received during the last cycle.";
   } else {
     throw std::runtime_error("mMergedObject' variant has no value.");
   }

--- a/Utilities/Mergers/src/IntegratingMerger.cxx
+++ b/Utilities/Mergers/src/IntegratingMerger.cxx
@@ -22,11 +22,8 @@
 
 #include "Framework/InputRecordWalker.h"
 #include "Framework/Logger.h"
-//#include "Framework/DataRef.h"
 
-//using namespace o2;
 using namespace o2::framework;
-//using namespace std::chrono;
 
 namespace o2::mergers
 {
@@ -35,12 +32,12 @@ IntegratingMerger::IntegratingMerger(const MergerConfig& config, const header::D
   : mConfig(config),
     mSubSpec(subSpec)
 {
-  mCollector = monitoring::MonitoringFactory::Get("infologger:///debug?qc");
-  //  mCollector->enableProcessMonitoring();
 }
 
 void IntegratingMerger::init(framework::InitContext& ictx)
 {
+  mCollector = monitoring::MonitoringFactory::Get(mConfig.monitoringUrl);
+  mCollector->addGlobalTag(monitoring::tags::Key::Subsystem, monitoring::tags::Value::Mergers);
 }
 
 void IntegratingMerger::run(framework::ProcessingContext& ctx)
@@ -66,7 +63,7 @@ void IntegratingMerger::run(framework::ProcessingContext& ctx)
       } else {
         throw std::runtime_error("mMergedObject' variant has no value.");
       }
-      mObjectsMerged++;
+      mDeltasMerged++;
     }
   }
 
@@ -82,22 +79,27 @@ void IntegratingMerger::run(framework::ProcessingContext& ctx)
 
 void IntegratingMerger::publish(framework::DataAllocator& allocator)
 {
+  mTotalDeltasMerged += mDeltasMerged;
+
   if (std::holds_alternative<std::monostate>(mMergedObject)) {
     LOG(INFO) << "Nothing to publish yet";
   } else if (std::holds_alternative<MergeInterfacePtr>(mMergedObject)) {
     allocator.snapshot(framework::OutputRef{MergerBuilder::mergerOutputBinding(), mSubSpec},
                        *std::get<MergeInterfacePtr>(mMergedObject));
+    LOG(INFO) << "Published the merged object with " << mTotalDeltasMerged << " deltas in total,"
+              << " including " << mDeltasMerged << " in the last cycle.";
   } else if (std::holds_alternative<TObjectPtr>(mMergedObject)) {
     allocator.snapshot(framework::OutputRef{MergerBuilder::mergerOutputBinding(), mSubSpec},
                        *std::get<TObjectPtr>(mMergedObject));
+    LOG(INFO) << "Published the merged object with " << mTotalDeltasMerged << " deltas in total,"
+              << " including " << mDeltasMerged << " in the last cycle.";
   } else {
     throw std::runtime_error("mMergedObject' variant has no value.");
   }
 
-  mTotalObjectsMerged += mObjectsMerged;
-  mCollector->send({mTotalObjectsMerged, "total_objects_merged"}, monitoring::DerivedMetricMode::RATE);
-  mCollector->send({mObjectsMerged, "objects_merged_since_last_publication"});
-  mObjectsMerged = 0;
+  mCollector->send({mTotalDeltasMerged, "total_deltas_merged"}, monitoring::DerivedMetricMode::RATE);
+  mCollector->send({mDeltasMerged, "deltas_merged_since_last_publication"});
+  mDeltasMerged = 0;
 }
 
 } // namespace o2::mergers


### PR DESCRIPTION
1. Mergers will allow to specify the Monitoring backend.
2. More precise nomenclature in the logs and metrics.
3. Log when publishing objects
4. Initializing Monitoring moved to init()

@Barthelemy I decided not to count total number of entries inside histograms/trees for now, because it would require a larger effort. I would have to change MergeInterface (and synchronize the change in QC) and recursively browse objects which are not merged, but also copied (we copy the first object, the rest are merged), which would introduce some overhead. I am not sure if it's worth it.