### PR TITLE
Fix: QED interaction sampler was using default BC scheme

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -143,6 +143,9 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
       auto qedprefix = ctx.options().get<std::string>("simPrefixQED");
       if (qedprefix.size() > 0) {
         o2::steer::InteractionSampler qedInteractionSampler;
+        if (!bcPatternFile.empty()) {
+          qedInteractionSampler.setBunchFilling(bcPatternFile);
+        }
 
         // get first and last "hadronic" interaction records and let
         // QED events range from the first bunch crossing to the last bunch crossing


### PR DESCRIPTION
QED interaction sampler in the o2-sim-digitization was always using default BC filling schema, even if custom one was provided by `--bcPatternFile pattern.root`. 
Trivial fix, merging.