### PR TITLE
[TRD] remove tabs and trailing whitespaces

### DIFF
--- a/DataFormats/Detectors/TRD/test/testDigit.cxx
+++ b/DataFormats/Detectors/TRD/test/testDigit.cxx
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(TRDDigit_test)
   Digit x(10, 6, 0, 2);
   testDigitDetRowPad(x, 10, 12, NCOLMCM - 1);
 
-  /* 
+  /*
   * The below is left in, it helps to remove confusion when debugging
  for(int rob=0;rob<8;rob++)for(int mcm=0;mcm<16;mcm++)for(int channel=0;channel<21;channel++){
   std::cout << "Digit e(0,"<<rob<<"," << mcm <<","<< channel<<");" << std::endl;

--- a/Detectors/TRD/README.md
+++ b/Detectors/TRD/README.md
@@ -2,7 +2,7 @@
 \page refDetectorsTRD TRD
 /doxy -->
 
-# TRD 
+# TRD
 
 <!-- doxy
 * \subpage refDetectorsTRDsimulation

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -61,7 +61,7 @@ o2_target_root_dictionary(TRDBase
                                   include/TRDBase/Calibrations.h
                                   include/TRDBase/ChamberNoise.h
                                   include/TRDBase/CalOnlineGainTables.h
-				  include/TRDBase/Digit.h
+                                  include/TRDBase/Digit.h
                                   include/TRDBase/Tracklet.h
                                   include/TRDBase/TrackletTransformer.h)
 

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -201,7 +201,7 @@ void OCDB2CCDBTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/
 
   /*
 AliTRDCalTrapConfig has a print command that outputs the list of trapconfigs stored.
-AliTRDCalTrapConfig->Print() .... and you get the stuff below via AliInfo, but I can seem to get it right to parse this so 
+AliTRDCalTrapConfig->Print() .... and you get the stuff below via AliInfo, but I can seem to get it right to parse this so
 its all going here unfortunately ....
 
 */
@@ -289,38 +289,38 @@ its all going here unfortunately ....
 
   /*
 THESE ARE THE ONES NOT CURRENTLY INCLUDED.
-trd_ddchamberStatus        
-trd_gaschromatographXe  
-trd_gasOverpressure  
+trd_ddchamberStatus
+trd_gaschromatographXe
+trd_gasOverpressure
 trd_hvDriftImon
-MonitoringData  
-PIDLQ    
-trd_envTemp              
-trd_gasCO2              
+MonitoringData
+PIDLQ
+trd_envTemp
+trd_gasCO2
 trd_hvDriftUmon
-PIDLQ1D  
-trd_gaschromatographCO2  
-trd_gasH2O              
-trd_hvAnodeImon     
+PIDLQ1D
+trd_gaschromatographCO2
+trd_gasH2O
+trd_hvAnodeImon
 TrkAttach
-PIDNN    
-PHQ      PIDThresholds  
+PIDNN
+PHQ      PIDThresholds
 
 This pulls stuff from DCS I should hopefully not need this stuff for simulation.
-DCS                            
+DCS
 AliTRDSensorArray descends from AliTRDDCSSensorArray
-trd_gaschromatographN2   
-trd_gasO2               
-trd_goofieHv         
-trd_goofiePressure  
+trd_gaschromatographN2
+trd_gasO2
+trd_goofieHv
+trd_goofiePressure
 trd_hvAnodeUmon
-trd_goofieN2        
-trd_goofieTemp      
-trd_goofieCO2        
-trd_goofiePeakArea  
-trd_goofieVelocity  
-trd_goofieGain       
-trd_goofiePeakPos   
+trd_goofieN2
+trd_goofieTemp
+trd_goofieCO2
+trd_goofiePeakArea
+trd_goofieVelocity
+trd_goofieGain
+trd_goofiePeakPos
 */
   return;
 }

--- a/Detectors/TRD/base/macros/PrintTrapConfig.C
+++ b/Detectors/TRD/base/macros/PrintTrapConfig.C
@@ -235,7 +235,7 @@ void PrintTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/alic
 
   /*
 AliTRDCalTrapConfig has a print command that outputs the list of trapconfigs stored.
-AliTRDCalTrapConfig->Print() .... and you get the stuff below via AliInfo, but I can seem to get it right to parse this so 
+AliTRDCalTrapConfig->Print() .... and you get the stuff below via AliInfo, but I can seem to get it right to parse this so
 its all going here unfortunately ....
 
 */
@@ -329,38 +329,38 @@ its all going here unfortunately ....
 
   /*
 THESE ARE THE ONES NOT CURRENTLY INCLUDED.
-trd_ddchamberStatus        
-trd_gaschromatographXe  
-trd_gasOverpressure  
+trd_ddchamberStatus
+trd_gaschromatographXe
+trd_gasOverpressure
 trd_hvDriftImon
-MonitoringData  
-PIDLQ    
-trd_envTemp              
-trd_gasCO2              
+MonitoringData
+PIDLQ
+trd_envTemp
+trd_gasCO2
 trd_hvDriftUmon
-PIDLQ1D  
-trd_gaschromatographCO2  
-trd_gasH2O              
-trd_hvAnodeImon     
+PIDLQ1D
+trd_gaschromatographCO2
+trd_gasH2O
+trd_hvAnodeImon
 TrkAttach
-PIDNN    
-PHQ      PIDThresholds  
+PIDNN
+PHQ      PIDThresholds
 
 This pulls stuff from DCS I should hopefully not need this stuff for simulation.
-DCS                            
+DCS
 AliTRDSensorArray descends from AliTRDDCSSensorArray
-trd_gaschromatographN2   
-trd_gasO2               
-trd_goofieHv         
-trd_goofiePressure  
+trd_gaschromatographN2
+trd_gasO2
+trd_goofieHv
+trd_goofiePressure
 trd_hvAnodeUmon
-trd_goofieN2        
-trd_goofieTemp      
-trd_goofieCO2        
-trd_goofiePeakArea  
-trd_goofieVelocity  
-trd_goofieGain       
-trd_goofiePeakPos   
+trd_goofieN2
+trd_goofieTemp
+trd_goofieCO2
+trd_goofiePeakArea
+trd_goofieVelocity
+trd_goofieGain
+trd_goofiePeakPos
 */
   return;
 }

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -96,7 +96,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ENCODETRD(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
   ENCODETRD(helper.begin_entriesTrk(),   helper.end_entriesTrk(),    CTF::BLC_entriesTrk,   0);
   ENCODETRD(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
-  
+
   ENCODETRD(helper.begin_HCIDTrk(),      helper.end_HCIDTrk(),       CTF::BLC_HCIDTrk,      0);
   ENCODETRD(helper.begin_padrowTrk(),    helper.end_padrowTrk(),     CTF::BLC_padrowTrk,    0);
   ENCODETRD(helper.begin_colTrk(),       helper.end_colTrk(),        CTF::BLC_colTrk,       0);

--- a/Detectors/TRD/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TRD/reconstruction/src/CTFCoder.cxx
@@ -66,7 +66,7 @@ void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::
 
 #define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
   // clang-format off
-  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
   MAKECODER(entriesTrk, CTF::BLC_entriesTrk);
   MAKECODER(entriesDig, CTF::BLC_entriesDig);

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -9,7 +9,7 @@
 # submit itself to any jurisdiction.
 
 
-#add_compile_options(-O0 -g -fPIC) 
+#add_compile_options(-O0 -g -fPIC)
 
 o2_add_library(TRDSimulation
                TARGETVARNAME targetName
@@ -17,8 +17,8 @@ o2_add_library(TRDSimulation
                        src/TRsim.cxx
                        src/Digitizer.cxx
                        src/TRDSimParams.cxx
-                       src/TrapConfig.cxx 
-                       src/TrapConfigHandler.cxx 
+                       src/TrapConfig.cxx
+                       src/TrapConfigHandler.cxx
                        src/TrapSimulator.cxx
                        src/Trap2CRU.cxx
                        src/PileupTool.cxx
@@ -28,7 +28,7 @@ o2_target_root_dictionary(TRDSimulation
                           HEADERS include/TRDSimulation/Detector.h
                                   include/TRDSimulation/TRsim.h
                                   include/TRDSimulation/Digitizer.h
-				                  include/TRDSimulation/TRDSimParams.h
+                                  include/TRDSimulation/TRDSimParams.h
                                   include/TRDSimulation/TrapConfig.h
                                   include/TRDSimulation/TrapConfigHandler.h
                                   include/TRDSimulation/Trap2CRU.h
@@ -49,7 +49,7 @@ o2_add_executable(trap2raw
                                         O2::DetectorsRaw
                                         O2::DetectorsCommonDataFormats
                                         O2::CommonUtils
-										O2::DataFormatsTRD
+                                        O2::DataFormatsTRD
                                         Boost::program_options)
 
 o2_add_test(PileupTool

--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -32,17 +32,17 @@ o2-trd-trap2raw
 ```
 This will convert the tracklets and digits in the current directory to a series of files containing the raw data as it would appear coming out of the cru.
 There are multiple options :
-- -d [ --input-file-digits ] default of trddigits.root  
+- -d [ --input-file-digits ] default of trddigits.root
                                         input Trapsim digits file, empty string to have no digits.
 - -t [ --input-file-tracklets ] default of trdtracklets.root
                                         input Trapsim tracklets file
--   -l [ --fileper ] how to distrbute the data into raw files. 
-	- all : 1 raw file 
-	- halfcru : 1 file per cru end point, so 2 files per cru. 
-	- cru : one file per cru 
-    - sm: one file per supermodule 
+-   -l [ --fileper ] how to distrbute the data into raw files.
+    - all : 1 raw file
+    - halfcru : 1 file per cru end point, so 2 files per cru.
+    - cru : one file per cru
+    - sm: one file per supermodule
 -  -o [ --output-dir ]  output directory for raw data defaults to local directory
--  -x [ --trackletHCHeader ] include tracklet half chamber header (for run3, and not in run2) 
+-  -x [ --trackletHCHeader ] include tracklet half chamber header (for run3, and not in run2)
 -  -e [ --no-empty-hbf ] do not create empty HBF pages (except for HBF starting TF)
 -  -r [ --rdh-version ] rdh version in use default of 6
 -  --configKeyValues arg                 comma-separated configKeyValues

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -95,7 +95,7 @@ void Trap2CRU::sortDataToLinks()
     if (trig.getNumberOfDigits() != 0) {
       LOG(debug) << " sorting digits from : " << trig.getFirstDigit() << " till " << trig.getFirstDigit() + trig.getNumberOfDigits();
       std::stable_sort(mDigitsIndex.begin() + trig.getFirstDigit(), mDigitsIndex.begin() + trig.getNumberOfDigits() + trig.getFirstDigit(), //,digitcompare);
-                       [this](const uint32_t i, const uint32_t j) { 
+                       [this](const uint32_t i, const uint32_t j) {
              uint32_t hcida = mDigits[i].getDetector() * 2 + (mDigits[i].getROB() % 2);
              uint32_t hcidb = mDigits[j].getDetector() * 2 + (mDigits[j].getROB() % 2);
              if(hcida!=hcidb){return hcida<hcidb;}

--- a/Detectors/TRD/simulation/src/TrapConfig.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfig.cxx
@@ -1064,7 +1064,7 @@ void TrapConfig::configureOnlineGains()
     for (int iDet = 0; iDet < nDets; ++iDet) {
       //const int MaxRows = Geometry::getStack(iDet) == 2 ? NROWC0 : NROWC1;
       int MaxCols = NCOLUMN;
-      //	CalOnlineGainTableROC gainTbl = mGainTable.getGainTableROC(iDet);
+      //CalOnlineGainTableROC gainTbl = mGainTable.getGainTableROC(iDet);
       const int nRobs = Geometry::getStack(iDet) == 2 ? Geometry::ROBmaxC0() : Geometry::ROBmaxC1();
 
       for (int rob = 0; rob < nRobs; ++rob) {

--- a/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
@@ -496,7 +496,7 @@ void TrapConfigHandler::configureDRange(int det)
 
         // cout << "maxdefl: " << maxDeflAngle << ", localPhi " << localPhi << endl;
         // cout << "r " << r << ", m" << m << ", c " << c << ", min angle: " << localPhi-maxDeflAngle << ", max: " << localPhi+maxDeflAngle
-        // 	<< ", min int: " << dyMinInt << ", max int: " << dyMaxInt << endl;
+        //<< ", min int: " << dyMinInt << ", max int: " << dyMaxInt << endl;
         int dest = 1 << 10 | r << 7 | m;
         int lutAddr = TrapSimulator::mgkDmemAddrDeflCutStart + 2 * c;
         mFeeParam->getDyRange(det, r, m, c, dyMinInt, dyMaxInt);

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -989,7 +989,7 @@ int TrapSimulator::getRawStream(std::vector<uint32_t>& buf, uint32_t offset, uns
   }
 
   // Produce ADC mask : nncc cccm mmmm mmmm mmmm mmmm mmmm 1100
-  // 				n : unused , c : ADC count, m : selected ADCs
+  // n : unused , c : ADC count, m : selected ADCs
   if (rawVer >= 3 &&
       (mTrapConfig->getTrapReg(TrapConfig::kC15CPUA, mDetector, mRobPos, mMcmPos) & (1 << 13))) { // check for zs flag in TRAP configuration
     int nActiveADC = 0;                                                                           // number numberOverFlowWordsWritten activated ADC bits in a word


### PR DESCRIPTION
This should make the space checker happy for the code in Detectors/TRD and DataFormats/Detectors/TRD such that one does not have to add additional cosmetic commits to other PRs which clutter them (https://github.com/AliceO2Group/AliceO2/pull/6168)
I did not touch Detectors/TRD/doc.