### PR TITLE
[ALICE3] [FT3] Adds configurable geometry for forward tracker simulation

### DIFF
--- a/Detectors/Upgrades/ALICE3/FT3/base/CMakeLists.txt
+++ b/Detectors/Upgrades/ALICE3/FT3/base/CMakeLists.txt
@@ -10,7 +10,9 @@
 
 o2_add_library(FT3Base
                SOURCES src/GeometryTGeo.cxx
+               SOURCES src/FT3BaseParam.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::ITSMFTBase)
 
 o2_target_root_dictionary(FT3Base
-                          HEADERS include/FT3Base/GeometryTGeo.h)
+                          HEADERS include/FT3Base/GeometryTGeo.h
+                          HEADERS include/FT3Base/FT3BaseParam.h)

--- a/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
+++ b/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
@@ -25,8 +25,7 @@ namespace ft3
 
 enum FT3Geometry {
   Default = 0,
-  Telescope = 1,
-  External = 2
+  Telescope = 1
 };
 
 struct FT3BaseParam : public o2::conf::ConfigurableParamHelper<FT3BaseParam> {
@@ -36,14 +35,14 @@ struct FT3BaseParam : public o2::conf::ConfigurableParamHelper<FT3BaseParam> {
 
   // FT3Geometry::Telescope parameters
   Int_t nLayers = 10;
-  Float_t z0 = -16.0; // First layer z position
-  Float_t zLength = 263.0;
+  Float_t z0 = -16.0;      // First layer z position
+  Float_t zLength = 263.0; // Distance between first and last layers
   Float_t etaIn = 4.5;
   Float_t etaOut = 1.5;
   Float_t Layerx2X0 = 0.01;
 
   // FT3Geometry::External file
-  std::string configFile = "";
+  std::string configFile = ""; // Overrides geoModel parameter when provided
 
   O2ParamDef(FT3BaseParam, "FT3Base");
 };

--- a/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
+++ b/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/FT3BaseParam.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_FT3_BASEPARAM_H_
+#define ALICEO2_FT3_BASEPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace ft3
+{
+
+// **
+// ** Parameters for FT3 base configuration
+// **
+
+enum FT3Geometry {
+  Default = 0,
+  Telescope = 1,
+  External = 2
+};
+
+struct FT3BaseParam : public o2::conf::ConfigurableParamHelper<FT3BaseParam> {
+  // Geometry Builder parameters
+
+  Int_t geoModel = FT3Geometry::Default;
+
+  // FT3Geometry::Telescope parameters
+  Int_t nLayers = 10;
+  Float_t z0 = -16.0; // First layer z position
+  Float_t zLength = 263.0;
+  Float_t etaIn = 4.5;
+  Float_t etaOut = 1.5;
+  Float_t Layerx2X0 = 0.01;
+
+  // FT3Geometry::External file
+  std::string configFile = "";
+
+  O2ParamDef(FT3BaseParam, "FT3Base");
+};
+
+} // end namespace ft3
+} // end namespace o2
+
+#endif // ALICEO2_FT3_BASEPARAM_H_

--- a/Detectors/Upgrades/ALICE3/FT3/base/src/FT3BaseParam.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/base/src/FT3BaseParam.cxx
@@ -8,14 +8,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::ft3::GeometryTGeo;
-#pragma link C++ class o2::ft3::FT3BaseParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::ft3::FT3BaseParam> + ;
-
-#endif
+#include "FT3Base/FT3BaseParam.h"
+O2ParamImpl(o2::ft3::FT3BaseParam);

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
@@ -24,6 +24,7 @@
 #include "TGeoManager.h"                      // for gGeoManager, TGeoManager (ptr only)
 #include "TLorentzVector.h"                   // for TLorentzVector
 #include "TVector3.h"                         // for TVector3
+#include "FT3Base/FT3BaseParam.h"
 
 class FairVolume;
 class TGeoVolume;
@@ -110,8 +111,9 @@ class Detector : public o2::base::DetImpl<Detector>
   /// Returns the number of layers
   Int_t getNumberOfLayers() const { return mNumberOfLayers; }
 
-  void buildBasicFT3(int nLayers = 10, Float_t z_first = -16.0, Float_t z_length = 263, Float_t etaIn = -4.5, Float_t etaOut = -1.5, Float_t Layerx2X0 = 0.01);
+  void buildBasicFT3(const FT3BaseParam& param);
   void buildFT3V1();
+  void buildFT3FromFile(std::string);
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
@@ -117,6 +117,8 @@ class Detector : public o2::base::DetImpl<Detector>
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 
+  void exportLayout();
+
  protected:
   std::vector<Int_t> mLayerID;
   std::vector<std::vector<TString>> mLayerName;

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
@@ -118,7 +118,7 @@ class Detector : public o2::base::DetImpl<Detector>
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 
  protected:
-  std::vector<std::vector<Int_t>> mLayerID;
+  std::vector<Int_t> mLayerID;
   std::vector<std::vector<TString>> mLayerName;
   Int_t mNumberOfLayers;
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Layer.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Layer.h
@@ -34,7 +34,7 @@ class FT3Layer : public TObject
   FT3Layer() = default;
 
   // Sample layer constructor
-  FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerName, Float_t z, Float_t rIn, Float_t rOut, Float_t sensorThickness, Float_t Layerx2X0);
+  FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerName, Float_t z, Float_t rIn, Float_t rOut, Float_t Layerx2X0);
 
   /// Copy constructor
   FT3Layer(const FT3Layer&) = default;
@@ -56,7 +56,6 @@ class FT3Layer : public TObject
   Double_t mInnerRadius;     ///< Inner radius of this layer
   Double_t mOuterRadius;     ///< Outer radius of this layer
   Double_t mZ;               ///< Z position of the layer
-  Double_t mSensorThickness; ///< Sensor thickness
   Double_t mChipThickness;   ///< Chip thickness
   Double_t mx2X0;            ///< Layer material budget x/X0
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Layer.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/FT3Layer.h
@@ -45,6 +45,12 @@ class FT3Layer : public TObject
   /// Default destructor
   ~FT3Layer() override;
 
+  /// getters
+  auto getInnerRadius() const { return mInnerRadius; }
+  auto getOuterRadius() const { return mOuterRadius; }
+  auto getZ() const { return mZ; }
+  auto getx2X0() const { return mx2X0; }
+
   /// Creates the actual Layer and places inside its mother volume
   /// \param motherVolume the TGeoVolume owing the volume structure
   virtual void createLayer(TGeoVolume* motherVolume);

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
@@ -117,6 +117,29 @@ void Detector::buildFT3FromFile(std::string configFileName)
 }
 
 //_________________________________________________________________________________________________
+void Detector::exportLayout()
+{
+  // Export FT3 Layout description to file. One line per disk
+  // z_layer r_in r_out Layerx2X0
+
+  std::string configFileName = "FT3_layout.cfg";
+
+  LOG(INFO) << "Exporting FT3 Detector layout to " << configFileName;
+
+  std::ofstream fOut(configFileName.c_str(), std::ios::out);
+  if (!fOut) {
+    printf("Cannot open file\n");
+    return;
+  }
+  fOut << "#   z_layer   r_in   r_out   Layerx2X0" << std::endl;
+  for (auto layers_dir : mLayers) {
+    for (auto layer : layers_dir) {
+      fOut << layer.getZ() << "  " << layer.getInnerRadius() << "  " << layer.getOuterRadius() << "  " << layer.getx2X0() << std::endl;
+    }
+  }
+}
+
+//_________________________________________________________________________________________________
 void Detector::buildBasicFT3(const FT3BaseParam& param)
 {
   // Build a basic parametrized FT3 detector with nLayers equally spaced between z_first and z_first+z_length
@@ -224,6 +247,7 @@ Detector::Detector(Bool_t active)
         break;
     }
   }
+  exportLayout();
 }
 
 //_________________________________________________________________________________________________

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -39,7 +39,7 @@ ClassImp(FT3Layer);
 
 FT3Layer::~FT3Layer() = default;
 
-FT3Layer::FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerName, Float_t z, Float_t rIn, Float_t rOut, Float_t sensorThickness, Float_t Layerx2X0)
+FT3Layer::FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerName, Float_t z, Float_t rIn, Float_t rOut, Float_t Layerx2X0)
 {
   // Creates a simple parametrized EndCap layer covering the given
   // pseudorapidity range at the z layer position
@@ -48,17 +48,13 @@ FT3Layer::FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerNam
   mLayerName = layerName;
   mZ = layerDirection ? std::abs(z) : -std::abs(z);
   mx2X0 = Layerx2X0;
-  mSensorThickness = sensorThickness;
   mInnerRadius = rIn;
   mOuterRadius = rOut;
 
   LOG(INFO) << " Using silicon Radiation Length =  " << 9.5 << " to emulate layer radiation length.";
 
   mChipThickness = Layerx2X0 * 9.5;
-  if (mChipThickness < mSensorThickness) {
-    LOG(INFO) << " WARNING: Chip cannot be thinner than sensor. Setting minimal chip thickness.";
-    mChipThickness = mSensorThickness;
-  }
+
   LOG(INFO) << "Creating FT3 Layer " << mLayerNumber << ": z = " << mZ << " ; R_in = " << mInnerRadius << " ; R_out = " << mOuterRadius << " ; ChipThickness = " << mChipThickness;
 }
 
@@ -69,7 +65,7 @@ void FT3Layer::createLayer(TGeoVolume* motherVolume)
 
     std::string chipName = o2::ft3::GeometryTGeo::getFT3ChipPattern() + std::to_string(mLayerNumber),
                 sensName = Form("%s_%d_%d", GeometryTGeo::getFT3SensorPattern(), mDirection, mLayerNumber);
-    TGeoTube* sensor = new TGeoTube(mInnerRadius, mOuterRadius, mSensorThickness / 2);
+    TGeoTube* sensor = new TGeoTube(mInnerRadius, mOuterRadius, mChipThickness / 2);
     TGeoTube* chip = new TGeoTube(mInnerRadius, mOuterRadius, mChipThickness / 2);
     TGeoTube* layer = new TGeoTube(mInnerRadius, mOuterRadius, mChipThickness / 2);
 

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/FT3Layer.cxx
@@ -50,12 +50,12 @@ FT3Layer::FT3Layer(Int_t layerDirection, Int_t layerNumber, std::string layerNam
   mx2X0 = Layerx2X0;
   mInnerRadius = rIn;
   mOuterRadius = rOut;
+  auto Si_X0 = 9.5;
+  mChipThickness = Layerx2X0 * Si_X0;
 
-  LOG(INFO) << " Using silicon Radiation Length =  " << 9.5 << " to emulate layer radiation length.";
-
-  mChipThickness = Layerx2X0 * 9.5;
-
-  LOG(INFO) << "Creating FT3 Layer " << mLayerNumber << ": z = " << mZ << " ; R_in = " << mInnerRadius << " ; R_out = " << mOuterRadius << " ; ChipThickness = " << mChipThickness;
+  LOG(INFO) << "Creating FT3 Layer " << mLayerNumber << " ; direction " << mDirection;
+  LOG(INFO) << "   Using silicon X0 = " << Si_X0 << " to emulate layer radiation length.";
+  LOG(INFO) << "   Layer z = " << mZ << " ; R_in = " << mInnerRadius << " ; R_out = " << mOuterRadius << " ; x2X0 = " << mx2X0 << " ; ChipThickness = " << mChipThickness;
 }
 
 void FT3Layer::createLayer(TGeoVolume* motherVolume)


### PR DESCRIPTION
FT3 configurable parameters allows one to select between 1) the static "official" geometry (default), 2) a parametrized & configurable conical telescope or 3) an arbitrary tracker defined by an external file (one line per disk, each line containing "z_layer r_in r_out Layerx2X0"  ). 

Conical telescope (this builds a symmetric telescope, with identical layers on +-z positions):
>     o2-sim -m FT3 -n 10 --configKeyValues "FT3Base.geoModel=1; FT3Base.zLength = 263.0 ; FT3Base.etaIn = 4.5; FT3Base.etaOut = 1.5;  FT3Base Layerx2X0 = 0.01; " 

From external file (Providing a "FT3Base.configFile" overrides "FT3Base.geoModel" configuration).
>    o2-sim --configKeyValues "FT3Base.configFile=my_fwd_detector.cfg; " -m FT3 -n 10






