### PR TITLE
Grep logfile always as ascii file not as binary in jobutils.sh

### DIFF
--- a/Utilities/Tools/jobutils.sh
+++ b/Utilities/Tools/jobutils.sh
@@ -182,10 +182,10 @@ taskwrapper() {
              -e \"libc++abi.*terminating\"          \
              -e \"There was a crash.\""
       
-    grepcommand="grep -H ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES} >> encountered_exceptions_list 2>/dev/null"
+    grepcommand="grep -a -H ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES} >> encountered_exceptions_list 2>/dev/null"
     eval ${grepcommand}
     
-    grepcommand="grep -h --count ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES} 2>/dev/null"
+    grepcommand="grep -a -h --count ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES} 2>/dev/null"
     # using eval here since otherwise the pattern is translated to a
     # a weirdly quoted stringlist
     RC=$(eval ${grepcommand})
@@ -196,7 +196,7 @@ taskwrapper() {
     if [ "$RC" != "" -a "$RC" != "0" ]; then
       echo "Detected critical problem in logfile $logfile"
       if [ "${JOBUTILS_PRINT_ON_ERROR}" ]; then
-        grepcommand="grep -H -A 2 -B 2 ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES}"
+        grepcommand="grep -a -H -A 2 -B 2 ${pattern} $logfile ${JOBUTILS_JOB_SUPERVISEDFILES}"
         eval ${grepcommand}
       fi
 
@@ -375,7 +375,7 @@ taskwrapper() {
   # ?? should directly exit here?
   wait $PID || QUERY_RC_FROM_LOG="ON"
   # query return code from log (seems to be safer as sometimes the wait issues "PID" not a child of this shell)
-  RC=$(grep "TASK-EXIT-CODE:" ${logfile} | awk '//{print $2}')
+  RC=$(grep -a "TASK-EXIT-CODE:" ${logfile} | awk '//{print $2}')
   RC_ACUM=$((RC_ACUM+RC))
   if [ "${RC}" -eq "0" ]; then
     if [ ! "${JOBUTILS_JOB_SKIPCREATEDONE}" ]; then


### PR DESCRIPTION
@sawenzel : This should solve the failures in the full CI.
What happens is that somehow binary characters make it into the log in the CI (No idea why it doesn't happen when I run it locally).
When I was checking the logfile, I copy and pasted it from the web interface, which apparently stripped these characters, so I didn't see the problem.
Also no idea when this was introduced and why it was merged despite full CI apparently reproducibly failing...