### PR TITLE
Inclusion of CosTheta variable in the helicity reference frame 

### DIFF
--- a/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/HistogramsLibrary.h
@@ -150,6 +150,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     hm->AddHistogram(histClass, "Mass_Pt", "", false, 125, 0.0, 5.0, VarManager::kMass, 100, 0.0, 20.0, VarManager::kPt);
     hm->AddHistogram(histClass, "Eta_Pt", "", false, 125, -2.0, 2.0, VarManager::kEta, 100, 0.0, 20.0, VarManager::kPt);
     hm->AddHistogram(histClass, "Mass_VtxZ", "", true, 30, -15.0, 15.0, VarManager::kVtxZ, 100, 0.0, 20.0, VarManager::kMass);
+    hm->AddHistogram(histClass, "cosThetaHE", "", false, 100, -1.5, 1., VarManager::kCosThetaHE);
     if (subGroupStr.Contains("vertexing-barrel")) {
       hm->AddHistogram(histClass, "Lxy", "", false, 100, 0.0, 10.0, VarManager::kVertexingLxy);
       hm->AddHistogram(histClass, "Lxyz", "", false, 100, 0.0, 10.0, VarManager::kVertexingLxyz);

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -646,8 +646,7 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   double cosTheta = 0;
   if (t1.sign() > 0) {
     cosTheta = zaxis.Dot(v1_CM);
-  }
-  else {
+  } else {
     cosTheta = zaxis.Dot(v2_CM);
   }
   values[kCosThetaHE] = cosTheta;

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -20,6 +20,7 @@
 #include <TString.h>
 #include <Math/Vector4D.h>
 #include <TRandom.h>
+#include <TLorentzVector.h>
 
 #include <vector>
 #include <map>
@@ -129,6 +130,9 @@ class VarManager : public TObject
     kMass,
     kCharge,
     kNBasicTrackVariables,
+    //-----Luca-----//
+    kCosThetaHE,
+    //-----Luca-----//
 
     // Barrel track variables
     kPin,
@@ -634,6 +638,29 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   values[kEta] = v12.Eta();
   values[kPhi] = v12.Phi();
   values[kRap] = -v12.Rapidity();
+  // CosTheta Helicity calculation
+  double px1 = t1.px();
+  double py1 = t1.py();
+  double pz1 = t1.pz();
+  double e1 = TMath::Sqrt(px1*px1 + py1*py1 + pz1*pz1 + m1*m1);
+  double px2 = t2.px();
+  double py2 = t2.py();
+  double pz2 = t2.pz();
+  double e2 = TMath::Sqrt(px2*px2 + py2*py2 + pz2*pz2 + m2*m2);
+  TLorentzVector pMuon1_Lab(px1,py1,pz1,e1);
+  TLorentzVector pMuon2_Lab(px2,py2,pz2,e2);
+  TLorentzVector pDimuon_Lab = pMuon1_Lab + pMuon2_Lab;
+  TVector3 beta = (-1./pDimuon_Lab.E())*pDimuon_Lab.Vect();
+  TLorentzVector pMuon1_CM = pMuon1_Lab;
+  TLorentzVector pMuon2_CM = pMuon2_Lab;
+  pMuon1_CM.Boost(beta);
+  pMuon2_CM.Boost(beta);
+  TVector3 zaxis;
+  zaxis = (pDimuon_Lab.Vect()).Unit();
+  double cosTheta;
+  if(t1.sign() > 0) cosTheta = zaxis.Dot((pMuon1_CM.Vect()).Unit());
+  else cosTheta = zaxis.Dot((pMuon2_CM.Vect()).Unit());
+  values[kCosThetaHE] = cosTheta;
 }
 
 template <typename C, typename T>

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -647,7 +647,7 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   if (t1.sign() > 0)
     cosTheta = zaxis.Dot(v1_CM);
   else
-    cosTheta = zaxis.Dot(v2_CM);  
+    cosTheta = zaxis.Dot(v2_CM);
   values[kCosThetaHE] = cosTheta;
 }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -644,7 +644,7 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   ROOT::Math::XYZVectorF zaxis{(v12.Vect()).Unit()};
 
   double cosTheta = 0;
-  if(t1.sign() > 0)
+  if (t1.sign() > 0)
     cosTheta = zaxis.Dot(v1_CM);
   else
     cosTheta = zaxis.Dot(v2_CM);  

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -642,10 +642,12 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   ROOT::Math::XYZVectorF v1_CM{(boostv12(v1).Vect()).Unit()};
   ROOT::Math::XYZVectorF v2_CM{(boostv12(v2).Vect()).Unit()};
   ROOT::Math::XYZVectorF zaxis{(v12.Vect()).Unit()};
- 
+
   double cosTheta = 0;
-  if(t1.sign() > 0) cosTheta = zaxis.Dot(v1_CM);
-  else cosTheta = zaxis.Dot(v2_CM);  
+  if(t1.sign() > 0)
+    cosTheta = zaxis.Dot(v1_CM);
+  else
+    cosTheta = zaxis.Dot(v2_CM);  
   values[kCosThetaHE] = cosTheta;
 }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -644,10 +644,12 @@ void VarManager::FillPair(T const& t1, T const& t2, float* values, PairCandidate
   ROOT::Math::XYZVectorF zaxis{(v12.Vect()).Unit()};
 
   double cosTheta = 0;
-  if (t1.sign() > 0)
+  if (t1.sign() > 0) {
     cosTheta = zaxis.Dot(v1_CM);
-  else
+  }
+  else {
     cosTheta = zaxis.Dot(v2_CM);
+  }
   values[kCosThetaHE] = cosTheta;
 }
 

--- a/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
+++ b/Analysis/PWGDQ/include/PWGDQCore/VarManager.h
@@ -130,9 +130,7 @@ class VarManager : public TObject
     kMass,
     kCharge,
     kNBasicTrackVariables,
-    //-----Luca-----//
     kCosThetaHE,
-    //-----Luca-----//
 
     // Barrel track variables
     kPin,

--- a/Analysis/PWGDQ/src/VarManager.cxx
+++ b/Analysis/PWGDQ/src/VarManager.cxx
@@ -269,4 +269,6 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kDeltaPhi] = "rad.";
   fgVariableNames[kDeltaPhiSym] = "#Delta#phi";
   fgVariableUnits[kDeltaPhiSym] = "rad.";
+  fgVariableNames[kCosThetaHE] = "cos#it{#theta}";
+  fgVariableUnits[kCosThetaHE] = "";
 }


### PR DESCRIPTION
Inclusion of CosTheta variable in the helicity reference frame. The variable can be calculated for dimuons and electrons.