### PR TITLE
TRD fix: event time is relative to TF start

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RecoInputContainer.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RecoInputContainer.h
@@ -69,7 +69,11 @@ inline auto getRecoInputContainer(o2::framework::ProcessingContext& pc, o2::gpu:
   for (unsigned int iEv = 0; iEv < retVal->mNTriggerRecords; ++iEv) {
     const auto& trg = retVal->mTriggerRecords[iEv];
     retVal->trdTriggerIndices.push_back(trg.getFirstTracklet());
-    auto evTime = trg.getBCData().differenceInBC(inputTracks->startIR) * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
+    //auto evTime = trg.getBCData().differenceInBC(inputTracks->startIR) * o2::constants::lhc::LHCBunchSpacingNS; // event time in ns
+    // TODO at the moment the InteractionRecord contained in the TRD TriggerRecord stores the time relative to the beginning of the TF
+    // Other detectors are storing the absolute time, so that the event time needs to be shifted (as it is done in the commented line above)
+    // Should this be changed? Which format is expected from the real data?
+    auto evTime = trg.getBCData().toLong() * o2::constants::lhc::LHCBunchSpacingNS;                             // event time in ns
     retVal->trdTriggerTimes.push_back(evTime * 1e-3);                                                           // event time in us
   }
 


### PR DESCRIPTION
Hi @shahor02 and @sawenzel 
I created a simulation with multiple TFs using the O2DPG tools. When running the TRD tracking for that simulation I noticed that matches are only found for the first TF. This was because the event time calculated from the TRD trigger records was based on the assumption that it is stored as an absolute time, but instead it is stored relative to the beginning of the TF.
I think other detectors use an absolute time. Is there a policy if one should use absolute or relative time?
Cheers,
Ole
ping @aberdnikova : this is the reason why you saw the TFs without any angular residuals