### PR TITLE
[MCH] use configurable parameters for MCH tracking

### DIFF
--- a/Detectors/MUON/MCH/Tracking/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Tracking/CMakeLists.txt
@@ -17,4 +17,8 @@ o2_add_library(MCHTracking
         src/TrackFitter.cxx
         src/TrackFinderOriginal.cxx
         src/TrackFinder.cxx
-        PUBLIC_LINK_LIBRARIES O2::Field O2::MCHBase O2::Framework)
+        src/TrackerParam.cxx
+        PUBLIC_LINK_LIBRARIES O2::Field O2::MCHBase O2::Framework O2::CommonUtils)
+
+o2_target_root_dictionary(MCHTracking
+                          HEADERS include/MCHTracking/TrackerParam.h)

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
@@ -49,12 +49,6 @@ class TrackFinder
 
   const std::list<Track>& findTracks(const std::unordered_map<int, std::list<Cluster>>& clusters);
 
-  /// set the flag to try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
-  void findMoreTrackCandidates(bool moreCandidates) { mMoreCandidates = moreCandidates; }
-
-  /// set the flag to refine the tracks in the end using cluster resolution
-  void refineTracks(bool refine) { mRefineTracks = refine; }
-
   /// set the debug level defining the verbosity
   void debug(int debugLevel) { mDebugLevel = debugLevel; }
 
@@ -118,34 +112,17 @@ class TrackFinder
   /// return the chamber to which this plane belong to
   int getChamberId(int plane) { return (plane < 8) ? plane / 2 : 4 + (plane - 8) / 4; }
 
-  /// return the chamber resolution square in x direction
-  static constexpr double chamberResolutionX2() { return SChamberResolutionX * SChamberResolutionX; }
-  /// return the chamber resolution square in y direction
-  static constexpr double chamberResolutionY2() { return SChamberResolutionY * SChamberResolutionY; }
-
-  /// chamber resolution in x direction used as cluster resolution during tracking
-  static constexpr double SChamberResolutionX = 0.2;
-  /// chamber resolution in y direction used as cluster resolution during tracking
-  static constexpr double SChamberResolutionY = 0.2;
-  /// sigma cut to select clusters (local chi2) and tracks (global chi2) during tracking
-  static constexpr double SSigmaCutForTracking = 5.;
-  /// sigma cut to select clusters (local chi2) and tracks (global chi2) during improvement
-  static constexpr double SSigmaCutForImprovement = 4.;
   ///< maximum distance to the track to search for compatible cluster(s) in non bending direction
   static constexpr double SMaxNonBendingDistanceToTrack = 1.;
   ///< maximum distance to the track to search for compatible cluster(s) in bending direction
   static constexpr double SMaxBendingDistanceToTrack = 1.;
-  static constexpr double SNonBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in non bending plane
-  static constexpr double SBendingVertexDispersion = 70.;    ///< vertex dispersion (cm) in bending plane
-  static constexpr double SMinBendingMomentum = 0.8;         ///< minimum value (GeV/c) of momentum in bending plane
+  static constexpr double SMinBendingMomentum = 0.8; ///< minimum value (GeV/c) of momentum in bending plane
   /// z position of the chambers
   static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
                                                   -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
-  /// if true, at least one cluster in the station is requested to validate the track
-  static constexpr bool SRequestStation[5] = {true, true, true, true, true};
   static constexpr int SNDE[10] = {4, 4, 4, 4, 18, 18, 26, 26, 26, 26}; ///< number of DE per chamber
 
   TrackFitter mTrackFitter{}; /// track fitter
@@ -154,10 +131,13 @@ class TrackFinder
 
   std::list<Track> mTracks{}; ///< list of reconstructed tracks
 
-  double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
+  double mChamberResolutionX2 = 0.;      ///< chamber resolution square (cm^2) in x direction
+  double mChamberResolutionY2 = 0.;      ///< chamber resolution square (cm^2) in y direction
+  double mBendingVertexDispersion2 = 0.; ///< vertex dispersion square (cm^2) in y direction
+  double mMaxChi2ForTracking = 0.;       ///< maximum chi2 to accept a cluster candidate during tracking
+  double mMaxChi2ForImprovement = 0.;    ///< maximum chi2 to accept a cluster candidate during improvement
 
-  bool mMoreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
-  bool mRefineTracks = true;    ///< refine the tracks in the end using cluster resolution
+  double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
 
   int mDebugLevel = 0; ///< debug level defining the verbosity
 

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
@@ -42,12 +42,6 @@ class TrackFinderOriginal
   void init(float l3Current, float dipoleCurrent);
   const std::list<Track>& findTracks(const std::array<std::list<Cluster>, 10>* clusters);
 
-  /// set the flag to try to find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
-  void findMoreTrackCandidates(bool moreCandidates) { mMoreCandidates = moreCandidates; }
-
-  /// set the flag to refine the tracks in the end using cluster resolution
-  void refineTracks(bool refine) { mRefineTracks = refine; }
-
   /// set the debug level defining the verbosity
   void debug(int debugLevel) { mDebugLevel = debugLevel; }
 
@@ -82,44 +76,30 @@ class TrackFinderOriginal
   template <class... Args>
   void print(Args... args) const;
 
-  /// return the chamber resolution square in x direction
-  static constexpr double chamberResolutionX2() { return SChamberResolutionX * SChamberResolutionX; }
-  /// return the chamber resolution square in y direction
-  static constexpr double chamberResolutionY2() { return SChamberResolutionY * SChamberResolutionY; }
-
-  /// chamber resolution in x direction used as cluster resolution during tracking
-  static constexpr double SChamberResolutionX = 0.2;
-  /// chamber resolution in y direction used as cluster resolution during tracking
-  static constexpr double SChamberResolutionY = 0.2;
-  /// sigma cut to select clusters (local chi2) and tracks (global chi2) during tracking
-  static constexpr double SSigmaCutForTracking = 5.;
-  /// sigma cut to select clusters (local chi2) and tracks (global chi2) during improvement
-  static constexpr double SSigmaCutForImprovement = 4.;
   /// maximum distance to the track to search for compatible cluster(s) in non bending direction
   static constexpr double SMaxNonBendingDistanceToTrack = 1.;
   /// maximum distance to the track to search for compatible cluster(s) in bending direction
   static constexpr double SMaxBendingDistanceToTrack = 1.;
-  static constexpr double SNonBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in non bending plane
-  static constexpr double SBendingVertexDispersion = 70.;    ///< vertex dispersion (cm) in bending plane
-  static constexpr double SMinBendingMomentum = 0.8;         ///< minimum value (GeV/c) of momentum in bending plane
+  static constexpr double SMinBendingMomentum = 0.8; ///< minimum value (GeV/c) of momentum in bending plane
   /// z position of the chambers
   static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
                                                   -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
-  /// if true, at least one cluster in the station is requested to validate the track
-  static constexpr bool SRequestStation[5] = {true, true, true, true, true};
 
   TrackFitter mTrackFitter{}; /// track fitter
 
   const std::array<std::list<Cluster>, 10>* mClusters = nullptr; ///< pointer to the lists of clusters
   std::list<Track> mTracks{};                                    ///< list of reconstructed tracks
 
-  double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
+  double mChamberResolutionX2 = 0.;      ///< chamber resolution square (cm^2) in x direction
+  double mChamberResolutionY2 = 0.;      ///< chamber resolution square (cm^2) in y direction
+  double mBendingVertexDispersion2 = 0.; ///< vertex dispersion square (cm^2) in y direction
+  double mMaxChi2ForTracking = 0.;       ///< maximum chi2 to accept a cluster candidate during tracking
+  double mMaxChi2ForImprovement = 0.;    ///< maximum chi2 to accept a cluster candidate during improvement
 
-  bool mMoreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
-  bool mRefineTracks = true;    ///< refine the tracks in the end using cluster resolution
+  double mMaxMCSAngle2[10]{}; ///< maximum angle dispersion due to MCS
 
   int mDebugLevel = 0; ///< debug level defining the verbosity
 

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
@@ -39,6 +39,9 @@ class TrackFitter
 
   void initField(float l3Current, float dipoleCurrent);
 
+  /// Set the vertex dispersion in y direction used for the track covariance seed
+  void setBendingVertexDispersion(double ey) { mBendingVertexDispersion2 = ey * ey; }
+
   /// Enable/disable the smoother (and the saving of related parameters)
   void smoothTracks(bool smooth) { mSmooth = smooth; }
   /// Return the smoother enable/disable flag
@@ -65,14 +68,15 @@ class TrackFitter
   void smoothTrack(Track& track, bool finalize);
   void runSmoother(const TrackParam& previousParam, TrackParam& param);
 
-  static constexpr double SMaxChi2 = 2.e10;               ///< maximum chi2 above which the track can be considered as abnormal
-  static constexpr double SBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in bending plane
+  static constexpr double SMaxChi2 = 2.e10; ///< maximum chi2 above which the track can be considered as abnormal
   /// z position of the chambers
   static constexpr double SDefaultChamberZ[10] = {-526.16, -545.24, -676.4, -695.4, -967.5,
                                                   -998.5, -1276.5, -1307.5, -1406.6, -1437.6};
   /// default chamber thickness in X0 for reconstruction
   static constexpr double SChamberThicknessInX0[10] = {0.065, 0.065, 0.075, 0.075, 0.035,
                                                        0.035, 0.035, 0.035, 0.035, 0.035};
+
+  double mBendingVertexDispersion2 = 4900.; ///< vertex dispersion square (cm^2) in y direction
 
   bool mSmooth = false; ///< switch ON/OFF the smoother
 

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackerParam.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackerParam.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackerParam.h
+/// \brief Configurable parameters for MCH tracking
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MCH_TRACKERPARAM_H_
+#define ALICEO2_MCH_TRACKERPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mch
+{
+
+/// Configurable parameters for MCH tracking
+struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
+
+  double chamberResolutionX = 0.2; ///< chamber resolution (cm) in x used as cluster resolution during tracking
+  double chamberResolutionY = 0.2; ///< chamber resolution (cm) in y used as cluster resolution during tracking
+
+  double sigmaCutForTracking = 5.;    ///< to select clusters (local chi2) and tracks (global chi2) during tracking
+  double sigmaCutForImprovement = 4.; ///< to select clusters (local chi2) and tracks (global chi2) during improvement
+
+  double nonBendingVertexDispersion = 70.; ///< vertex dispersion (cm) in non bending plane
+  double bendingVertexDispersion = 70.;    ///< vertex dispersion (cm) in bending plane
+
+  /// if true, at least one cluster in the station is requested to validate the track
+  bool requestStation[5] = {true, true, true, true, true};
+
+  bool moreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
+  bool refineTracks = true;    ///< refine the tracks in the end using cluster resolution
+
+  O2ParamDef(TrackerParam, "MCHTracking");
+};
+
+} // namespace mch
+} // end namespace o2
+
+#endif // ALICEO2_MCH_TRACKERPARAM_H_

--- a/Detectors/MUON/MCH/Tracking/src/MCHTrackingLinkDef.h
+++ b/Detectors/MUON/MCH/Tracking/src/MCHTrackingLinkDef.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mch::TrackerParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::mch::TrackerParam> + ;
+
+#endif

--- a/Detectors/MUON/MCH/Tracking/src/TrackFitter.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFitter.cxx
@@ -143,7 +143,7 @@ void TrackFitter::initTrack(const Cluster& cl1, const Cluster& cl2, TrackParam& 
   // Inverse bending momentum (vertex resolution + bending slope resolution + 10% error on dipole parameters+field)
   if (TrackExtrap::isFieldON()) {
     lastParamCov(4, 4) =
-      ((SBendingVertexDispersion * SBendingVertexDispersion +
+      ((mBendingVertexDispersion2 +
         (cl1.getZ() * cl1.getZ() * lastParamCov(2, 2) + cl2.getZ() * cl2.getZ() * 1000. * cl1Ey2) / dZ / dZ) /
          bendingImpact / bendingImpact +
        0.1 * 0.1) *

--- a/Detectors/MUON/MCH/Tracking/src/TrackerParam.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackerParam.cxx
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackerParam.cxx
+/// \brief Configurable parameters for MCH tracking
+/// \author Philippe Pillot, Subatech
+
+#include "MCHTracking/TrackerParam.h"
+
+O2ParamImpl(o2::mch::TrackerParam);

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -94,14 +94,14 @@ The `o2-mch-clusters-transformer-workflow` takes as input the list of all cluste
 
 It sends the list of the same clusters, but converted in global reference frame, with the data description "GLOBALCLUSTERS".
 
-To test it one can use e.g. a sampler-transformer-sink pipeline as such : 
+To test it one can use e.g. a sampler-transformer-sink pipeline as such :
 
-``` 
-o2-mch-clusters-sampler-workflow 
+```
+o2-mch-clusters-sampler-workflow
     -b --nEventsPerTF 1000 --infile someclusters.data |
-o2-mch-clusters-transformer-workflow  
-    -b --geometry Detectors/MUON/MCH/Geometry/Test/ideal-geometry-o2.json | 
-o2-mch-clusters-sink-workflow 
+o2-mch-clusters-transformer-workflow
+    -b --geometry Detectors/MUON/MCH/Geometry/Test/ideal-geometry-o2.json |
+o2-mch-clusters-sink-workflow
     -b --txt --outfile global-clusters.txt --no-digits --global
 ```
 

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -117,9 +117,34 @@ Take as input the list of all clusters ([ClusterStruct](../Base/include/MCHBase/
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
-Option `--moreCandidates` allows to enable the search for more track candidates in stations 4 & 5.
-
 Option `--debug x` allows to enable the debug level x (0 = no debug, 1 or 2).
+
+Option `--config "file.json"` or `--config "file.ini"` allows to change the tracking parameters from a configuration file. This file can be either in JSON or in INI format, as described below:
+
+* Example of configuration file in JSON format:
+```json
+{
+    "MCHTracking": {
+        "chamberResolutionY": "0.1",
+        "requestStation[1]": "false",
+        "moreCandidates": "true"
+    }
+}
+```
+* Example of configuration file in INI format:
+```ini
+[MCHTracking]
+chamberResolutionY=0.1
+requestStation[1]=false
+moreCandidates=true
+```
+
+Option `--configKeyValues "key1=value1;key2=value2;..."` allows to change the tracking parameters from the command line. The parameters changed from the command line will supersede the ones changed from a configuration file.
+
+* Example of parameters changed from the command line:
+```shell
+--configKeyValues "MCHTracking.chamberResolutionY=0.1;MCHTracking.requestStation[1]=false;MCHTracking.moreCandidates=true"
+```
 
 ### New track finder
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -19,6 +19,7 @@
 #include <array>
 #include <list>
 #include <stdexcept>
+#include <string>
 
 #include <gsl/span>
 
@@ -31,6 +32,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "CommonUtils/ConfigurableParam.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/ClusterBlock.h"
@@ -59,13 +61,11 @@ class TrackFinderTask
 
     auto l3Current = ic.options().get<float>("l3Current");
     auto dipoleCurrent = ic.options().get<float>("dipoleCurrent");
+    auto config = ic.options().get<std::string>("config");
+    if (!config.empty()) {
+      o2::conf::ConfigurableParam::updateFromFile(config, "MCHTracking", true);
+    }
     mTrackFinder.init(l3Current, dipoleCurrent);
-
-    auto moreCandidates = ic.options().get<bool>("moreCandidates");
-    mTrackFinder.findMoreTrackCandidates(moreCandidates);
-
-    auto refineTracks = !ic.options().get<bool>("noRefinement");
-    mTrackFinder.refineTracks(refineTracks);
 
     auto debugLevel = ic.options().get<int>("debug");
     mTrackFinder.debug(debugLevel);
@@ -156,8 +156,7 @@ o2::framework::DataProcessorSpec getTrackFinderOriginalSpec()
     AlgorithmSpec{adaptFromTask<TrackFinderTask>()},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
-            {"moreCandidates", VariantType::Bool, false, {"Find more track candidates"}},
-            {"noRefinement", VariantType::Bool, false, {"Disable the track refinement"}},
+            {"config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
             {"debug", VariantType::Int, 0, {"debug level"}}}};
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <list>
 #include <stdexcept>
+#include <string>
 
 #include <gsl/span>
 
@@ -31,6 +32,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "CommonUtils/ConfigurableParam.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/ClusterBlock.h"
@@ -59,13 +61,11 @@ class TrackFinderTask
 
     auto l3Current = ic.options().get<float>("l3Current");
     auto dipoleCurrent = ic.options().get<float>("dipoleCurrent");
+    auto config = ic.options().get<std::string>("config");
+    if (!config.empty()) {
+      o2::conf::ConfigurableParam::updateFromFile(config, "MCHTracking", true);
+    }
     mTrackFinder.init(l3Current, dipoleCurrent);
-
-    auto moreCandidates = ic.options().get<bool>("moreCandidates");
-    mTrackFinder.findMoreTrackCandidates(moreCandidates);
-
-    auto refineTracks = !ic.options().get<bool>("noRefinement");
-    mTrackFinder.refineTracks(refineTracks);
 
     auto debugLevel = ic.options().get<int>("debug");
     mTrackFinder.debug(debugLevel);
@@ -154,8 +154,7 @@ o2::framework::DataProcessorSpec getTrackFinderSpec()
     AlgorithmSpec{adaptFromTask<TrackFinderTask>()},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
-            {"moreCandidates", VariantType::Bool, false, {"Find more track candidates"}},
-            {"noRefinement", VariantType::Bool, false, {"Disable the track refinement"}},
+            {"config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
             {"debug", VariantType::Int, 0, {"debug level"}}}};
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
@@ -13,13 +13,22 @@
 ///
 /// \author Philippe Pillot, Subatech
 
-#include "Framework/runDataProcessing.h"
-
+#include "CommonUtils/ConfigurableParam.h"
 #include "TrackFinderOriginalSpec.h"
 
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
+  workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
+                               ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   return WorkflowSpec{o2::mch::getTrackFinderOriginalSpec()};
 }

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
@@ -13,13 +13,22 @@
 ///
 /// \author Philippe Pillot, Subatech
 
-#include "Framework/runDataProcessing.h"
-
+#include "CommonUtils/ConfigurableParam.h"
 #include "TrackFinderSpec.h"
 
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
+  workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
+                               ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   return WorkflowSpec{o2::mch::getTrackFinderSpec()};
 }


### PR DESCRIPTION
I moved in the configurable parameters only the ones that I know from run2 will need to be adjusted depending on the running condition.

For the moment, there are 2 ways to modify these parameters:
- from command line with the workflow option --configKeyValues "key1=value1;key2=value2;..."
- from a config file (JSON or INI format) with the processor option --config "file.json(ini)"

In the end I imagine they will be taken from the CCDB.
