### PR TITLE
reduce downscale noise

### DIFF
--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
@@ -80,7 +80,8 @@ class Digitizer
   const static int mNdE = 156;
 
   //noise above threshold probability within read-out window
-  float mProbNoise = 1e-5;
+  //FIX ME, added suppression by 100 to make noise not dominant source of digits
+  float mProbNoise = 1e-5/100;
   //sum_i 1/padcount_i where i is the detelemID
   float mInvPadSum = 0.0450832;
   float mNormProbNoise = mProbNoise / mInvPadSum;

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -200,7 +200,7 @@ void Digitizer::generateNoiseDigits()
       int padid = gRandom->Integer(nNoisyPads + 1);
       // FIXME
       time = int(time / 25.); //not clear if ok
-      digits.emplace_back(detID, padid, 0.6, time);
+      digits.emplace_back(detID, padid, 1, time);
       //just to roun adbove threshold when added
       MCCompLabel label(-1, eventID, srcID, true);
       mcTruthOutputContainer.addElement(digits.size() - 1, label);


### PR DESCRIPTION
@aphecetche : I made these two simple small changes to avoid crashes in the precluster and too many noise digits. One has to get back to it later, but at least, it should run with the preclusterer for the moment. 