### PR TITLE
Avoid inclusion of Vc/Vc in RandomRing

### DIFF
--- a/Common/MathUtils/include/MathUtils/RandomRing.h
+++ b/Common/MathUtils/include/MathUtils/RandomRing.h
@@ -28,21 +28,19 @@
 #ifndef ALICEO2_MATHUTILS_RANDOMRING_H_
 #define ALICEO2_MATHUTILS_RANDOMRING_H_
 
-#include "Vc/Vc"
 #include <array>
 
 #include "TF1.h"
 #include "TRandom.h"
 #include <functional>
 
-using float_v = Vc::float_v;
 
 namespace o2
 {
 namespace math_utils
 {
 
-template <size_t N = float_v::size() * 100000>
+template <size_t N = 4 * 100000>
 class RandomRing
 {
  public:
@@ -92,10 +90,15 @@ class RandomRing
   /// used for vectorised programming and increases the buffer
   /// position by the size of the vector
   /// @return vector with random values
-  float_v getNextValueVc()
+  template <typename VcType>
+  VcType getNextValueVc()
   {
-    const float_v value = float_v(&mRandomNumbers[mRingPosition]);
-    mRingPosition += float_v::size();
+    // This function is templated so that we don't need to include the <Vc/Vc> header
+    // within this header file (to reduce memory problems during compilation).
+    // The hope is that the calling user calls this with a
+    // correct Vc type (Vc::float_v) in a source file.
+    const VcType value = VcType(&mRandomNumbers[mRingPosition]);
+    mRingPosition += VcType::size();
     if (mRingPosition >= mRandomNumbers.size()) {
       mRingPosition = 0;
     }

--- a/Detectors/FIT/FDD/simulation/include/FDDSimulation/Digitizer.h
+++ b/Detectors/FIT/FDD/simulation/include/FDDSimulation/Digitizer.h
@@ -35,8 +35,8 @@ class Digitizer
 {
 
  private:
-  typedef math_utils::RandomRing<float_v::size() * DigitizationParameters::PheRRSize> HitRandomRingType;
-  typedef math_utils::RandomRing<float_v::size() * DigitizationParameters::HitRRSize> PheRandomRingType;
+  typedef math_utils::RandomRing</*float_v::size()*/ 4 * DigitizationParameters::PheRRSize> HitRandomRingType;
+  typedef math_utils::RandomRing</*float_v::size()*/ 4 * DigitizationParameters::HitRRSize> PheRandomRingType;
 
   using ChannelBCDataF = std::array<float, NTimeBinsPerBC>;
 

--- a/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Digitizer.cxx
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <Vc/Vc>
 
 using namespace o2::math_utils;
 using namespace o2::fdd;
@@ -138,7 +139,7 @@ void Digitizer::createPulse(int nPhE, int parID, double timeHit, std::array<o2::
         q += Vc::float_v::Size;
         Vc::prefetchForOneRead(q);
         workVc.load(p);
-        workVc += mRndGainVar.getNextValueVc() * charge * pmtVc;
+        workVc += mRndGainVar.getNextValueVc<Vc::float_v>() * charge * pmtVc;
         workVc.store(p);
         p += Vc::float_v::Size;
         Vc::prefetchForOneRead(p);

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Digitizer.h
@@ -37,7 +37,7 @@ class Digitizer
 {
  private:
   using DP = DigitizationConstants;
-  typedef math_utils::RandomRing<float_v::size() * DP::NOISE_RANDOM_RING_SIZE> NoiseRandomRingType;
+  typedef math_utils::RandomRing</*float_v::size()*/ 4 * DP::NOISE_RANDOM_RING_SIZE> NoiseRandomRingType;
 
  public:
   Digitizer(Int_t mode = 0) : mMode(mode), mRndGaus(NoiseRandomRingType::RandomType::Gaus), mNumNoiseSamples(), mNoiseSamples(), mSincTable(), mSignalTable(), mSignalCache() { initParameters(); }
@@ -109,13 +109,15 @@ class Digitizer
     return mSignalTable[index] + rem * (mSignalTable[index + 1] - mSignalTable[index]);
   }
 
-  inline Vc::float_v signalFormVc(Vc::float_v x) const
+  template <typename VcType>
+  inline VcType signalFormVc(VcType x) const
   { // table lookup for the signal shape (SIMD version)
+    // implemented as template function, so that we don't need to include <Vc/Vc> here
     auto const y = x / DigitizationParameters::Instance().mBunchWidth * DP::SIGNAL_TABLE_SIZE;
-    Vc::float_v::IndexType const index = Vc::floor(y);
+    typename VcType::IndexType const index = floor(y);
     auto const rem = y - index;
-    Vc::float_v val(0);
-    for (size_t i = 0; i < float_v::size(); ++i) {
+    VcType val(0);
+    for (size_t i = 0; i < VcType::size(); ++i) {
       if (y[i] < 0.0f) {
         continue;
       }
@@ -159,40 +161,6 @@ class Digitizer
   ClassDefNV(Digitizer, 2);
 };
 
-// signal shape function
-template <typename Float>
-Float signalForm_i(Float x)
-{
-  using namespace std;
-  Float const a = -0.45458;
-  Float const b = -0.83344945;
-  return x > Float(0) ? -(exp(b * x) - exp(a * x)) / Float(7.8446501) : Float(0);
-  //return -(exp(-0.83344945 * x) - exp(-0.45458 * x)) * (x >= 0) / 7.8446501; // Maximum should be 7.0/250 mV
-};
-
-// integrated signal shape function
-inline float signalForm_integral(float x)
-{
-  using namespace std;
-  double const a = -0.45458;
-  double const b = -0.83344945;
-  if (x < 0) {
-    x = 0;
-  }
-  return -(exp(b * x) / b - exp(a * x) / a) / 7.8446501;
-};
-
-// SIMD version of the integrated signal shape function
-inline Vc::float_v signalForm_integralVc(Vc::float_v x)
-{
-  auto const mask = (x >= 0.0f);
-  Vc::float_v arg(0);
-  arg.assign(x, mask); // branchless if
-  Vc::float_v const a(-0.45458f);
-  Vc::float_v const b(-0.83344945f);
-  Vc::float_v result = -(Vc::exp(b * arg) / b - Vc::exp(a * arg) / a) / 7.8446501f;
-  return result;
-};
 } // namespace ft0
 } // namespace o2
 


### PR DESCRIPTION
Inclusion of Vc/Vc is argued to cause
gcc10 to take lot's of memory leading to crashes
in the CI.

In this particular case, I think we can avoid
the inclusion of Vc/Vc in headers and leave
it it to the source files to do so.
(But this might not always be possible);
