### PR TITLE
DPL Analysis: fix bug in unassigned grouping

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -370,7 +370,6 @@ struct AnalysisDataProcessorBuilder {
       {
         ++position;
         ++mGroupingElement;
-        (changeShifts<A>(), ...);
         return *this;
       }
 
@@ -410,7 +409,12 @@ struct AnalysisDataProcessorBuilder {
           } else {
             pos = position;
           }
-          pos += shifts[index];
+          if (unassignedGroups[index] > 0) {
+            if ((idValues[index])[pos + shifts[index]] < 0) {
+              ++shifts[index];
+            }
+            pos += shifts[index];
+          }
           if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
             auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
 


### PR DESCRIPTION
* Ensure groups are correctly shifted in presence of several unassigned blocks
* Move shifts increment from `operator++` to `prepareArgument()` to avoid out-of-range access