### PR TITLE
Treat FLUKA_VMC like a real plugin

### DIFF
--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -18,16 +18,11 @@ o2_add_library(G4Setup
                PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6
 )
 
-if (FlukaVMC_FOUND)
-  message(STATUS "BUILDING WITH FLUKA")
-  o2_add_library(FLUKASetup
-                 SOURCES src/FlukaConfig.cxx
-       	         PUBLIC_LINK_LIBRARIES MC::FlukaVMC FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6 O2::SimSetup
-	        )
-else()
-  message(STATUS "BUILDING WITHOUT FLUKA")
-endif (FlukaVMC_FOUND)
-	      
+o2_add_library(FLUKASetup
+               SOURCES src/FlukaConfig.cxx
+               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6 O2::SimSetup
+	      )
+
 o2_add_library(SimSetup
                SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx
 	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase
@@ -61,3 +56,4 @@ o2_add_test_root_macro(g4Config.C
                        LABELS simsetup)
 
 o2_data_file(COPY data  DESTINATION Detectors/gconfig/)
+install(FILES src/FlukaRuntimeConfig.macro DESTINATION share/Detectors/gconfig/)

--- a/Detectors/gconfig/src/FlukaRuntimeConfig.macro
+++ b/Detectors/gconfig/src/FlukaRuntimeConfig.macro
@@ -1,0 +1,22 @@
+#include "SimSetup/FlukaParam.h"
+
+TVirtualMC* FlukaRuntimeConfig() {
+  FairRunSim* run = FairRunSim::Instance();
+  TString* gModel = run->GetGeoModel();
+  TFluka* fluka = new TFluka("C++ Interface to Fluka", 0);
+
+  // additional configuration paramters if requested from command line
+  auto& params = o2::FlukaParam::Instance();
+  auto isAct = params.activationSimulation;
+  if (isAct) {
+    LOG(INFO) << "Set special FLUKA parameters for activation simulation";
+    auto hadronCut = params.activationHadronCut;
+    auto inpFile = params.scoringFile;
+    fluka->SetActivationSimulation(true, hadronCut);
+    fluka->SetUserScoringFileName(inpFile.c_str());
+  }
+
+  std::cout << "FLUKA ptr " << fluka << "\n";
+  std::cout << "VMC ptr " << TVirtualMC::GetMC() << "\n";
+  return fluka;
+}

--- a/dependencies/O2FindDependenciesFromAliBuild.cmake
+++ b/dependencies/O2FindDependenciesFromAliBuild.cmake
@@ -154,7 +154,6 @@ function(o2_find_dependencies_from_alibuild)
   protected_set_root(Geant3 GEANT3)
   protected_set_root(Geant4 GEANT4)
   protected_set_root(Geant4VMC GEANT4_VMC)
-  protected_set_root(FlukaVMC FLUKA_VMC)	
   protected_set_root(VGM vgm)
   protected_set_root(HepMC HepMC3)
 


### PR DESCRIPTION
We now don't need to know anything about Fluka_VMC
in order to compile with Fluka support in o2sim.
Setup is completely delegated to the runtime.