### PR TITLE
o2sim: Cleanup tmp files

### DIFF
--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -64,8 +64,18 @@ std::string getMergerLogName()
   return str.str();
 }
 
+void remove_tmp_files()
+{
+  // remove all (known) socket files in /tmp
+  // using the naming convention /tmp/o2sim-.*PID
+  std::stringstream command;
+  command << "rm /tmp/o2sim-*" << getpid();
+  auto rc = system(command.str().c_str()); // a solution based on std::filesystem may be preferred but is longer
+}
+
 void cleanup()
 {
+  remove_tmp_files();
   o2::utils::ShmManager::Instance().release();
 
   // special mode in which we dump the output from various

--- a/run/o2simtopology_template.json
+++ b/run/o2simtopology_template.json
@@ -10,7 +10,7 @@
                             {
                                 "type":"req",
                                 "method":"connect",
-                                "address":"ipc:///tmp/primary-get_25005#PID#",
+                                "address":"ipc:///tmp/o2sim-primary-get_25005#PID#",
                                 "sndBufSize":"100000",
                                 "rcvBufSize":"100000",
                                 "rateLogging":"0"
@@ -36,7 +36,7 @@
                             {
                                 "type":"push",
                                 "method":"connect",
-                                "address":"ipc:///tmp/hitmerger-simdata_25009#PID#",
+                                "address":"ipc:///tmp/o2sim-hitmerger-simdata_25009#PID#",
                                 "sndBufSize":1000,
                                 "rcvBufSize":1000,
                                 "rateLogging":0
@@ -54,7 +54,7 @@
                             {
                                 "type":"rep",
                                 "method":"bind",
-                                "address":"ipc:///tmp/primary-get_25005#PID#",
+                                "address":"ipc:///tmp/o2sim-primary-get_25005#PID#",
                                 "sndBufSize":100000,
                                 "rcvBufSize":100000,
                                 "rateLogging":0
@@ -98,7 +98,7 @@
                             {
                                 "type":"req",
                                 "method":"connect",
-                                "address":"ipc:///tmp/primary-get_25005#PID#",
+                                "address":"ipc:///tmp/o2sim-primary-get_25005#PID#",
                                 "sndBufSize":"1000",
                                 "rcvBufSize":"1000",
                                 "rateLogging":"0"
@@ -124,7 +124,7 @@
                             {
                                 "type":"pull",
                                 "method":"bind",
-                                "address":"ipc:///tmp/hitmerger-simdata_25009#PID#",
+                                "address":"ipc:///tmp/o2sim-hitmerger-simdata_25009#PID#",
                                 "sndBufSize":1000,
                                 "rcvBufSize":1000,
                                 "rateLogging":0


### PR DESCRIPTION
This should (finally) avoid spilling the tmp
folder with simulation socket leftovers.