### PR TITLE
DPL: cleanup AODReaderHelpers.cxx

### DIFF
--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -30,7 +30,6 @@
 
 #include <Monitoring/Monitoring.h>
 
-#include <ROOT/RDataFrame.hxx>
 #include <TGrid.h>
 #include <TFile.h>
 #include <TTreeCache.h>


### PR DESCRIPTION
RDataFrame is not actually needed.