### PR TITLE
[MCH] use configurable parameters for MCH clustering

### DIFF
--- a/Detectors/MUON/MCH/Clustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Clustering/CMakeLists.txt
@@ -12,4 +12,9 @@ o2_add_library(MCHClustering
                SOURCES src/ClusterOriginal.cxx
                        src/ClusterFinderOriginal.cxx
                        src/MathiesonOriginal.cxx
-               PUBLIC_LINK_LIBRARIES O2::MCHMappingInterface O2::MCHBase O2::MCHPreClustering O2::Framework)
+                       src/ClusterizerParam.cxx
+               PUBLIC_LINK_LIBRARIES O2::MCHMappingInterface O2::MCHBase O2::MCHPreClustering
+                                     O2::Framework O2::CommonUtils)
+
+o2_target_root_dictionary(MCHClustering
+                          HEADERS include/MCHClustering/ClusterizerParam.h)

--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterFinderOriginal.h
@@ -67,8 +67,6 @@ class ClusterFinderOriginal
   static constexpr int SNFitClustersMax = 3;                     ///< maximum number of clusters fitted at the same time
   static constexpr int SNFitParamMax = 3 * SNFitClustersMax - 1; ///< maximum number of fit parameters
   static constexpr double SLowestCoupling = 1.e-2;               ///< minimum coupling between clusters of pixels and pads
-  static constexpr float SDefaultClusterResolution = 0.2f;       ///< default cluster resolution (cm)
-  static constexpr float SBadClusterResolution = 10.f;           ///< bad (e.g. mono-cathode) cluster resolution (cm)
 
   void resetPreCluster(gsl::span<const Digit>& digits);
   void simplifyPreCluster(std::vector<int>& removedDigits);

--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterizerParam.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterizerParam.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClusterizerParam.h
+/// \brief Configurable parameters for MCH clustering
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MCH_CLUSTERIZERPARAM_H_
+#define ALICEO2_MCH_CLUSTERIZERPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mch
+{
+
+/// Configurable parameters for MCH clustering
+struct ClusterizerParam : public o2::conf::ConfigurableParamHelper<ClusterizerParam> {
+
+  double lowestPadCharge = 4.f * 0.22875f; ///< minimum charge of a pad
+
+  double pitchSt1 = 0.21;    ///< anode-cathode pitch (cm) for station 1
+  double pitchSt2345 = 0.25; ///< anode-cathode pitch (cm) for station 2 to 5
+
+  double mathiesonSqrtKx3St1 = 0.7000;    ///< Mathieson parameter sqrt(K3) in x direction for station 1
+  double mathiesonSqrtKx3St2345 = 0.7131; ///< Mathieson parameter sqrt(K3) in x direction for station 2 to 5
+
+  double mathiesonSqrtKy3St1 = 0.7550;    ///< Mathieson parameter sqrt(K3) in y direction for station 1
+  double mathiesonSqrtKy3St2345 = 0.7642; ///< Mathieson parameter sqrt(K3) in y direction for station 2 to 5
+
+  double defaultClusterResolution = 0.2; ///< default cluster resolution (cm)
+  double badClusterResolution = 10.;     ///< bad (e.g. mono-cathode) cluster resolution (cm)
+
+  O2ParamDef(ClusterizerParam, "MCHClustering");
+};
+
+} // namespace mch
+} // end namespace o2
+
+#endif // ALICEO2_MCH_CLUSTERIZERPARAM_H_

--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -34,6 +34,7 @@
 
 #include <FairMQLogger.h>
 
+#include "MCHClustering/ClusterizerParam.h"
 #include "PadOriginal.h"
 #include "ClusterOriginal.h"
 #include "MathiesonOriginal.h"
@@ -88,19 +89,19 @@ void ClusterFinderOriginal::init(bool run2Config)
   } else {
 
     // minimum charge of pad, pixel and cluster
-    mLowestPadCharge = 4.f * 0.22875f;
+    mLowestPadCharge = ClusterizerParam::Instance().lowestPadCharge;
     mLowestPixelCharge = mLowestPadCharge / 12.;
     mLowestClusterCharge = 2. * mLowestPadCharge;
 
     // Mathieson function for station 1
-    mMathiesons[0].setPitch(0.21);
-    mMathiesons[0].setSqrtKx3AndDeriveKx2Kx4(0.7000);
-    mMathiesons[0].setSqrtKy3AndDeriveKy2Ky4(0.7550);
+    mMathiesons[0].setPitch(ClusterizerParam::Instance().pitchSt1);
+    mMathiesons[0].setSqrtKx3AndDeriveKx2Kx4(ClusterizerParam::Instance().mathiesonSqrtKx3St1);
+    mMathiesons[0].setSqrtKy3AndDeriveKy2Ky4(ClusterizerParam::Instance().mathiesonSqrtKy3St1);
 
     // Mathieson function for other stations
-    mMathiesons[1].setPitch(0.25);
-    mMathiesons[1].setSqrtKx3AndDeriveKx2Kx4(0.7131);
-    mMathiesons[1].setSqrtKy3AndDeriveKy2Ky4(0.7642);
+    mMathiesons[1].setPitch(ClusterizerParam::Instance().pitchSt2345);
+    mMathiesons[1].setSqrtKx3AndDeriveKx2Kx4(ClusterizerParam::Instance().mathiesonSqrtKx3St2345);
+    mMathiesons[1].setSqrtKy3AndDeriveKy2Ky4(ClusterizerParam::Instance().mathiesonSqrtKy3St2345);
   }
 }
 
@@ -2061,8 +2062,8 @@ void ClusterFinderOriginal::setClusterResolution(ClusterStruct& cluster) const
   if (cluster.getChamberId() < 4) {
 
     // do not consider mono-cathode clusters in stations 1 and 2
-    cluster.ex = SDefaultClusterResolution;
-    cluster.ey = SDefaultClusterResolution;
+    cluster.ex = ClusterizerParam::Instance().defaultClusterResolution;
+    cluster.ey = ClusterizerParam::Instance().defaultClusterResolution;
 
   } else {
 
@@ -2083,8 +2084,10 @@ void ClusterFinderOriginal::setClusterResolution(ClusterStruct& cluster) const
     }
 
     // set the cluster resolution accordingly
-    cluster.ex = (itPadNB == mUsedDigits.end()) ? SBadClusterResolution : SDefaultClusterResolution;
-    cluster.ey = (itPadB == mUsedDigits.end()) ? SBadClusterResolution : SDefaultClusterResolution;
+    cluster.ex = (itPadNB == mUsedDigits.end()) ? ClusterizerParam::Instance().badClusterResolution
+                                                : ClusterizerParam::Instance().defaultClusterResolution;
+    cluster.ey = (itPadB == mUsedDigits.end()) ? ClusterizerParam::Instance().badClusterResolution
+                                               : ClusterizerParam::Instance().defaultClusterResolution;
   }
 }
 

--- a/Detectors/MUON/MCH/Clustering/src/ClusterizerParam.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterizerParam.cxx
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClusterizerParam.cxx
+/// \brief Configurable parameters for MCH clustering
+/// \author Philippe Pillot, Subatech
+
+#include "MCHClustering/ClusterizerParam.h"
+
+O2ParamImpl(o2::mch::ClusterizerParam);

--- a/Detectors/MUON/MCH/Clustering/src/MCHClusteringLinkDef.h
+++ b/Detectors/MUON/MCH/Clustering/src/MCHClusteringLinkDef.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mch::ClusterizerParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::mch::ClusterizerParam> + ;
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -78,6 +78,33 @@ o2-mch-preclusters-to-clusters-original-workflow
 
 Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../Base/include/MCHBase/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
 
+Option `--run2-config` allows to configure the clustering to process run2 data.
+
+Option `--config "file.json"` or `--config "file.ini"` allows to change the clustering parameters from a configuration file. This file can be either in JSON or in INI format, as described below:
+
+* Example of configuration file in JSON format:
+```json
+{
+    "MCHClustering": {
+        "lowestPadCharge": "4.",
+        "defaultClusterResolution": "0.4"
+    }
+}
+```
+* Example of configuration file in INI format:
+```ini
+[MCHClustering]
+lowestPadCharge=4.
+defaultClusterResolution=0.4
+```
+
+Option `--configKeyValues "key1=value1;key2=value2;..."` allows to change the clustering parameters from the command line. The parameters changed from the command line will supersede the ones changed from a configuration file.
+
+* Example of parameters changed from the command line:
+```shell
+--configKeyValues "MCHClustering.lowestPadCharge=4.;MCHClustering.defaultClusterResolution=0.4"
+```
+
 ## CTF encoding/decoding
 
 Entropy encoding is done be attaching the `o2-mch-entropy-encoder-workflow` to the output of `DIGITS` and `DIGITROF` data-descriptions, providing `Digit` and `ROFRecord` respectively. Afterwards the encoded data can be stored by the `o2-ctf-writer-workflow`.

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <vector>
 #include <stdexcept>
+#include <string>
 
 #include <gsl/span>
 
@@ -32,6 +33,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 
+#include "CommonUtils/ConfigurableParam.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/Digit.h"
 #include "MCHBase/PreCluster.h"
@@ -55,6 +57,10 @@ class ClusterFinderOriginalTask
     /// Prepare the clusterizer
     LOG(INFO) << "initializing cluster finder";
 
+    auto config = ic.options().get<std::string>("config");
+    if (!config.empty()) {
+      o2::conf::ConfigurableParam::updateFromFile(config, "MCHClustering", true);
+    }
     bool run2Config = ic.options().get<bool>("run2-config");
     mClusterFinder.init(run2Config);
 
@@ -137,7 +143,8 @@ o2::framework::DataProcessorSpec getClusterFinderOriginalSpec()
             OutputSpec{{"clusters"}, "MCH", "CLUSTERS", 0, Lifetime::Timeframe},
             OutputSpec{{"clusterdigits"}, "MCH", "CLUSTERDIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<ClusterFinderOriginalTask>()},
-    Options{{"run2-config", VariantType::Bool, false, {"setup for run2 data"}}}};
+    Options{{"config", VariantType::String, "", {"JSON or INI file with clustering parameters"}},
+            {"run2-config", VariantType::Bool, false, {"setup for run2 data"}}}};
 }
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/preclusters-to-clusters-original-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/preclusters-to-clusters-original-workflow.cxx
@@ -13,13 +13,22 @@
 ///
 /// \author Philippe Pillot, Subatech
 
-#include "Framework/runDataProcessing.h"
-
+#include "CommonUtils/ConfigurableParam.h"
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
+  workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
+                               ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   return WorkflowSpec{o2::mch::getClusterFinderOriginalSpec()};
 }


### PR DESCRIPTION
This moves all the parameters of the original clustering that needs to be adjusted for run3 in a ConfigurableParam object.

For the moment, there are 2 ways to modify these parameters:

from command line with the workflow option --configKeyValues "key1=value1;key2=value2;..."
from a config file (JSON or INI format) with the processor option --config "file.json(ini)"

In the end I imagine they will be taken from the CCDB.
