### PR TITLE
DPL: hide InputSpan from common headers

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/SimpleSTF.h
+++ b/Detectors/Raw/include/DetectorsRaw/SimpleSTF.h
@@ -19,6 +19,7 @@
 #include <gsl/span>
 #include "Framework/InputRoute.h"
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 
 namespace o2
 {
@@ -44,6 +45,7 @@ struct SimpleSTF {
   std::vector<o2f::InputRoute> schema;
   PartsRef partsRef; // i-th entry is the 1st entry and N parts of multipart for i-th channel in the messages
   Messages messages;
+  o2f::InputSpan span;
   o2f::InputRecord record;
 };
 

--- a/Detectors/Raw/src/SimpleSTF.cxx
+++ b/Detectors/Raw/src/SimpleSTF.cxx
@@ -17,15 +17,19 @@
 using namespace o2::raw;
 
 SimpleSTF::SimpleSTF(std::vector<o2f::InputRoute>&& sch, PartsRef&& pref, Messages&& msg)
-  : schema{std::move(sch)}, partsRef{std::move(pref)}, messages{std::move(msg)}, record{schema, {[this](size_t i, size_t part) {                     // getter for the DataRef of a part in the input "i"
-                                                                                                   auto ref = this->partsRef[i].first + (part << 1); // entry of the header for this part, the payload follows
-                                                                                                   auto header = static_cast<char const*>(this->messages[ref]->data());
-                                                                                                   auto payload = static_cast<char const*>(this->messages[ref + 1]->data());
-                                                                                                   return o2f::DataRef{nullptr, header, payload};
-                                                                                                 },
-                                                                                                 [this](size_t i) { // getter for the nparts in the input "i"
-                                                                                                   return i < partsRef.size() ? partsRef[i].second : 0;
-                                                                                                 },
-                                                                                                 this->partsRef.size()}}
+  : schema{std::move(sch)},
+    partsRef{std::move(pref)},
+    messages{std::move(msg)},
+    span{[this](size_t i, size_t part) {                     // getter for the DataRef of a part in the input "i"
+           auto ref = this->partsRef[i].first + (part << 1); // entry of the header for this part, the payload follows
+           auto header = static_cast<char const*>(this->messages[ref]->data());
+           auto payload = static_cast<char const*>(this->messages[ref + 1]->data());
+           return o2f::DataRef{nullptr, header, payload};
+         },
+         [this](size_t i) { // getter for the nparts in the input "i"
+           return i < partsRef.size() ? partsRef[i].second : 0;
+         },
+         this->partsRef.size()},
+    record{schema, span}
 {
 }

--- a/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
+++ b/Detectors/TPC/workflow/readers/include/TPCReaderWorkflow/TPCSectorCompletionPolicy.h
@@ -17,6 +17,7 @@
 
 #include "Framework/CompletionPolicy.h"
 #include "Framework/InputSpec.h"
+#include "Framework/InputSpan.h"
 #include "Framework/DeviceSpec.h"
 #include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Headers/DataHeaderHelpers.h"
@@ -87,7 +88,7 @@ class TPCSectorCompletionPolicy
       return std::regex_match(device.name.begin(), device.name.end(), std::regex(expression.c_str()));
     };
 
-    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask](framework::CompletionPolicy::InputSet inputs) -> framework::CompletionPolicy::CompletionOp {
+    auto callback = [bRequireAll = mRequireAll, inputMatchers = mInputMatchers, externalInputMatchers = mExternalInputMatchers, pTpcSectorMask = mTpcSectorMask](framework::InputSpan const& inputs) -> framework::CompletionPolicy::CompletionOp {
       unsigned long tpcSectorMask = pTpcSectorMask ? *pTpcSectorMask : 0xFFFFFFFFF;
       std::bitset<NSectors> validSectors = 0;
       bool haveMatchedInput = false;

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -65,6 +65,7 @@ o2_add_library(Framework
                        src/GraphvizHelpers.cxx
                        src/HTTPParser.cxx
                        src/InputRecord.cxx
+                       src/InputSpan.cxx
                        src/InputSpec.cxx
                        src/OutputSpec.cxx
                        src/LifetimeHelpers.cxx

--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -11,7 +11,6 @@
 #define FRAMEWORK_COMPLETIONPOLICY_H
 
 #include "Framework/DataRef.h"
-#include "Framework/InputSpan.h"
 
 #include <functional>
 #include <string>
@@ -24,6 +23,7 @@ namespace framework
 
 struct DeviceSpec;
 struct InputRecord;
+struct InputSpan;
 
 /// Policy to describe what to do for a matching DeviceSpec
 /// whenever a new message arrives. The InputRecord being passed to
@@ -50,8 +50,7 @@ struct CompletionPolicy {
 
   using Matcher = std::function<bool(DeviceSpec const& device)>;
   using InputSetElement = DataRef;
-  using InputSet = InputSpan const&;
-  using Callback = std::function<CompletionOp(InputSet)>;
+  using Callback = std::function<CompletionOp(InputSpan const&)>;
 
   /// Name of the policy itself.
   std::string name = "";

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -14,7 +14,6 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/InputRoute.h"
 #include "Framework/TypeTraits.h"
-#include "Framework/InputSpan.h"
 #include "Framework/TableConsumer.h"
 #include "Framework/Traits.h"
 #include "Framework/RuntimeError.h"
@@ -41,6 +40,7 @@ namespace framework
 {
 
 struct InputSpec;
+struct InputSpan;
 
 /// @class InputRecord
 /// @brief The input API of the Data Processing Layer
@@ -99,7 +99,7 @@ class InputRecord
   using DataHeader = o2::header::DataHeader;
 
   InputRecord(std::vector<InputRoute> const& inputs,
-              InputSpan&& span);
+              InputSpan& span);
 
   /// A deleter type to be used with unique_ptr, which can be marked that
   /// it does not own the underlying resource and thus should not delete it.
@@ -177,30 +177,9 @@ class InputRecord
   int getPos(const char* name) const;
   int getPos(const std::string& name) const;
 
-  DataRef getByPos(int pos, int part = 0) const
-  {
-    if (pos >= mSpan.size() || pos < 0) {
-      throw runtime_error_f("Unknown message requested at position %d", pos);
-    }
-    if (part > 0 && part >= getNofParts(pos)) {
-      throw runtime_error_f("Invalid message part index at %d:%d", pos, part);
-    }
-    if (pos >= mInputsSchema.size()) {
-      throw runtime_error_f("Unknown schema at position %d", pos);
-    }
-    auto ref = mSpan.get(pos, part);
-    ref.spec = &mInputsSchema[pos].matcher;
-    return ref;
-  }
+  DataRef getByPos(int pos, int part = 0) const;
 
-  size_t getNofParts(int pos) const
-  {
-    if (pos < 0 || pos >= mSpan.size()) {
-      return 0;
-    }
-    return mSpan.getNofParts(pos);
-  }
-
+  size_t getNofParts(int pos) const;
   /// Get the object of specified type T for the binding R.
   /// If R is a string like object, we look up by name the InputSpec and
   /// return the data associated to the given label.
@@ -459,10 +438,7 @@ class InputRecord
   /// @return the total number of inputs in the InputRecord. Notice that these will include
   /// both valid and invalid inputs (i.e. inputs which have not arrived yet), depending
   /// on the CompletionPolicy you have (using the default policy all inputs will be valid).
-  size_t size() const
-  {
-    return mSpan.size();
-  }
+  size_t size() const;
 
   /// @return the total number of valid inputs in the InputRecord.
   /// Invalid inputs might happen if the CompletionPolicy allows
@@ -650,7 +626,7 @@ class InputRecord
 
  private:
   std::vector<InputRoute> const& mInputsSchema;
-  InputSpan mSpan;
+  InputSpan& mSpan;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/InputSpan.h
+++ b/Framework/Core/include/Framework/InputSpan.h
@@ -13,9 +13,10 @@
 #include "Framework/DataRef.h"
 #include <functional>
 
-namespace o2
-{
-namespace framework
+extern template class std::function<o2::framework::DataRef(size_t)>;
+extern template class std::function<o2::framework::DataRef(size_t, size_t)>;
+
+namespace o2::framework
 {
 
 /// Mapping helper between the store of all inputs being processed and the
@@ -33,30 +34,18 @@ class InputSpan
   /// @a getter is the mapping between an element of the span referred by
   /// index and the buffer associated.
   /// @a size is the number of elements in the span.
-  InputSpan(std::function<DataRef(size_t)> getter, size_t size)
-    : mGetter{}, mNofPartsGetter{}, mSize{size}
-  {
-    mGetter = [getter](size_t index, size_t) -> DataRef {
-      return getter(index);
-    };
-  }
+  InputSpan(std::function<DataRef(size_t)> getter, size_t size);
 
   /// @a getter is the mapping between an element of the span referred by
   /// index and the buffer associated.
   /// @a size is the number of elements in the span.
-  InputSpan(std::function<DataRef(size_t, size_t)> getter, size_t size)
-    : mGetter{getter}, mNofPartsGetter{}, mSize{size}
-  {
-  }
+  InputSpan(std::function<DataRef(size_t, size_t)> getter, size_t size);
 
   /// @a getter is the mapping between an element of the span referred by
   /// index and the buffer associated.
   /// @nofPartsGetter is the getter for the number of parts associated with an index
   /// @a size is the number of elements in the span.
-  InputSpan(std::function<DataRef(size_t, size_t)> getter, std::function<size_t(size_t)> nofPartsGetter, size_t size)
-    : mGetter{getter}, mNofPartsGetter{nofPartsGetter}, mSize{size}
-  {
-  }
+  InputSpan(std::function<DataRef(size_t, size_t)> getter, std::function<size_t(size_t)> nofPartsGetter, size_t size);
 
   /// @a i-th element of the InputSpan
   DataRef get(size_t i, size_t partidx = 0) const
@@ -250,7 +239,6 @@ class InputSpan
   size_t mSize;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
 #endif // FRAMEWORK_INPUTSSPAN_H

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -10,6 +10,7 @@
 
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/InputSpan.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/CompilerBuiltins.h"
 #include "Framework/Logger.h"
@@ -30,7 +31,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByNameOrigin(std::string const& 
 
   auto originReceived = std::make_shared<std::vector<uint64_t>>();
 
-  auto callback = [originReceived, origin, op](CompletionPolicy::InputSet inputRefs) -> CompletionPolicy::CompletionOp {
+  auto callback = [originReceived, origin, op](InputSpan const& inputRefs) -> CompletionPolicy::CompletionOp {
     // update list of the start times of inputs with origin @origin
     for (auto& ref : inputRefs) {
       if (ref.header != nullptr) {
@@ -72,7 +73,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
   auto matcher = [name](DeviceSpec const& device) -> bool {
     return std::regex_match(device.name.begin(), device.name.end(), std::regex(name));
   };
-  auto callback = [op](CompletionPolicy::InputSet) -> CompletionPolicy::CompletionOp {
+  auto callback = [op](InputSpan const&) -> CompletionPolicy::CompletionOp {
     return op;
   };
   switch (op) {
@@ -94,7 +95,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
 
 CompletionPolicy CompletionPolicyHelpers::consumeWhenAll(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](InputSpan const& inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header == nullptr) {
         return CompletionPolicy::CompletionOp::Wait;
@@ -107,7 +108,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAll(const char* name, Compl
 
 CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](InputSpan const& inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header != nullptr) {
         return CompletionPolicy::CompletionOp::Consume;
@@ -120,7 +121,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(const char* name, Compl
 
 CompletionPolicy CompletionPolicyHelpers::processWhenAny(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](InputSpan const& inputs) -> CompletionPolicy::CompletionOp {
     size_t present = 0;
     for (auto& input : inputs) {
       if (input.header != nullptr) {

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -15,6 +15,7 @@
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/DataRef.h"
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/Logger.h"
 #include "Framework/PartRef.h"
@@ -474,7 +475,8 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
     auto nPartsGetter = [&partial](size_t idx) {
       return partial[idx].size();
     };
-    auto action = mCompletionPolicy.callback({getter, nPartsGetter, static_cast<size_t>(partial.size())});
+    InputSpan span{getter, nPartsGetter, static_cast<size_t>(partial.size())};
+    auto action = mCompletionPolicy.callback(span);
     switch (action) {
       case CompletionPolicy::CompletionOp::Consume:
       case CompletionPolicy::CompletionOp::Process:

--- a/Framework/Core/src/InputSpan.cxx
+++ b/Framework/Core/src/InputSpan.cxx
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/InputSpan.h"
+
+template class std::function<o2::framework::DataRef(size_t)>;
+template class std::function<o2::framework::DataRef(size_t, size_t)>;
+
+namespace o2::framework
+{
+InputSpan::InputSpan(std::function<DataRef(size_t)> getter, size_t size)
+  : mGetter{}, mNofPartsGetter{}, mSize{size}
+{
+  mGetter = [getter](size_t index, size_t) -> DataRef {
+    return getter(index);
+  };
+}
+
+InputSpan::InputSpan(std::function<DataRef(size_t, size_t)> getter, size_t size)
+  : mGetter{getter}, mNofPartsGetter{}, mSize{size}
+{
+}
+
+InputSpan::InputSpan(std::function<DataRef(size_t, size_t)> getter, std::function<size_t(size_t)> nofPartsGetter, size_t size)
+  : mGetter{getter}, mNofPartsGetter{nofPartsGetter}, mSize{size}
+{
+}
+
+} // namespace o2::framework

--- a/Framework/Core/test/benchmark_InputRecord.cxx
+++ b/Framework/Core/test/benchmark_InputRecord.cxx
@@ -15,6 +15,7 @@
 #include "Framework/DataRelayer.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include <Monitoring/Monitoring.h>
 #include <fairmq/FairMQTransportFactory.h>
 #include <cstring>
@@ -45,7 +46,8 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
     createRoute("z_source", spec3)};
   // First of all we test if an empty registry behaves as expected, raising a
   // bunch of exceptions.
-  InputRecord emptyRecord(schema, {[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0});
+  InputSpan span{[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0};
+  InputRecord emptyRecord(schema, span);
 
   std::vector<void*> inputs;
 
@@ -78,8 +80,8 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   createEmpty();
-  InputSpan span{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
-  InputRecord record{schema, std::move(span)};
+  InputSpan span2{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
+  InputRecord record{schema, span2};
 
   for (auto _ : state) {
     // Checking we can get the whole ref by name

--- a/Framework/Core/test/test_CompletionPolicy.cxx
+++ b/Framework/Core/test/test_CompletionPolicy.cxx
@@ -17,6 +17,8 @@
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Headers/DataHeader.h"
 #include "Headers/NameHeader.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/InputSpan.h"
 #include "Headers/Stack.h"
 
 using namespace o2::framework;
@@ -40,7 +42,7 @@ BOOST_AUTO_TEST_CASE(TestCompletionPolicy_callback)
     return true;
   };
 
-  auto callback = [&stack](CompletionPolicy::InputSet inputRefs) {
+  auto callback = [&stack](InputSpan const& inputRefs) {
     for (auto const& ref : inputRefs) {
       auto const* header = CompletionPolicyHelpers::getHeader<o2::header::DataHeader>(ref);
       BOOST_CHECK_EQUAL(header, reinterpret_cast<o2::header::DataHeader*>(stack.data()));
@@ -54,7 +56,7 @@ BOOST_AUTO_TEST_CASE(TestCompletionPolicy_callback)
   policies.emplace_back("test", matcher, callback);
 
   CompletionPolicy::InputSetElement ref{nullptr, reinterpret_cast<const char*>(stack.data()), nullptr};
-  CompletionPolicy::InputSet inputs{[&ref](size_t) { return ref; }, 1};
+  InputSpan const& inputs{[&ref](size_t) { return ref; }, 1};
   for (auto& policy : policies) {
     policy.callback(inputs);
   }

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
@@ -46,7 +47,10 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
     createRoute("z_source", spec3)};
   // First of all we test if an empty registry behaves as expected, raising a
   // bunch of exceptions.
-  InputRecord emptyRecord(schema, {[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0});
+  InputSpan span{
+    [](size_t) { return DataRef{nullptr, nullptr, nullptr}; },
+    0};
+  InputRecord emptyRecord(schema, span);
 
   BOOST_CHECK_EXCEPTION(emptyRecord.get("x"), RuntimeErrorRef, any_exception);
   BOOST_CHECK_EXCEPTION(emptyRecord.get("y"), RuntimeErrorRef, any_exception);
@@ -87,8 +91,8 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   createEmpty();
-  InputSpan span{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
-  InputRecord record{schema, std::move(span)};
+  InputSpan span2{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
+  InputRecord record{schema, span2};
 
   // Checking we can get the whole ref by name
   BOOST_CHECK_NO_THROW(record.get("x"));

--- a/Framework/Core/test/test_InputRecordWalker.cxx
+++ b/Framework/Core/test/test_InputRecordWalker.cxx
@@ -13,6 +13,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include "Framework/InputRecordWalker.h"
 #include "Framework/WorkflowSpec.h" // o2::framework::select
 #include "Framework/DataRefUtils.h"
@@ -38,14 +39,15 @@ struct DataSet {
   using Messages = std::vector<TaggedSet>;
   using CheckType = std::vector<std::string>;
   DataSet(std::vector<InputRoute>&& s, Messages&& m, CheckType&& v)
-    : schema{std::move(s)}, messages{std::move(m)}, record{schema, {[this](size_t i, size_t part) {
-                                                                      BOOST_REQUIRE(i < this->messages.size());
-                                                                      BOOST_REQUIRE(part < this->messages[i].second.size() / 2);
-                                                                      auto header = static_cast<char const*>(this->messages[i].second.at(2 * part)->data());
-                                                                      auto payload = static_cast<char const*>(this->messages[i].second.at(2 * part + 1)->data());
-                                                                      return DataRef{nullptr, header, payload};
-                                                                    },
-                                                                    [this](size_t i) { return i < this->messages.size() ? messages[i].second.size() / 2 : 0; }, this->messages.size()}},
+    : schema{std::move(s)}, messages{std::move(m)}, span{[this](size_t i, size_t part) {
+                                                           BOOST_REQUIRE(i < this->messages.size());
+                                                           BOOST_REQUIRE(part < this->messages[i].second.size() / 2);
+                                                           auto header = static_cast<char const*>(this->messages[i].second.at(2 * part)->data());
+                                                           auto payload = static_cast<char const*>(this->messages[i].second.at(2 * part + 1)->data());
+                                                           return DataRef{nullptr, header, payload};
+                                                         },
+                                                         [this](size_t i) { return i < this->messages.size() ? messages[i].second.size() / 2 : 0; }, this->messages.size()},
+      record{schema, span},
       values{std::move(v)}
   {
     BOOST_REQUIRE(messages.size() == schema.size());
@@ -53,6 +55,7 @@ struct DataSet {
 
   std::vector<InputRoute> schema;
   Messages messages;
+  InputSpan span;
   InputRecord record;
   CheckType values;
 };

--- a/Framework/Utils/test/test_DPLRawParser.cxx
+++ b/Framework/Utils/test/test_DPLRawParser.cxx
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include "DPLUtils/DPLRawParser.h"
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include "Framework/WorkflowSpec.h" // o2::framework::select
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
@@ -33,14 +34,17 @@ struct DataSet {
   // not nice with the double vector but for quick unit test ok
   using Messages = std::vector<std::vector<std::unique_ptr<std::vector<char>>>>;
   DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v)
-    : schema{std::move(s)}, messages{std::move(m)}, record{schema, {[this](size_t i, size_t part) {
-                                                                      BOOST_REQUIRE(i < this->messages.size());
-                                                                      BOOST_REQUIRE(part < this->messages[i].size() / 2);
-                                                                      auto header = static_cast<char const*>(this->messages[i].at(2 * part)->data());
-                                                                      auto payload = static_cast<char const*>(this->messages[i].at(2 * part + 1)->data());
-                                                                      return DataRef{nullptr, header, payload};
-                                                                    },
-                                                                    [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()}},
+    : schema{std::move(s)},
+      messages{std::move(m)},
+      span{[this](size_t i, size_t part) {
+             BOOST_REQUIRE(i < this->messages.size());
+             BOOST_REQUIRE(part < this->messages[i].size() / 2);
+             auto header = static_cast<char const*>(this->messages[i].at(2 * part)->data());
+             auto payload = static_cast<char const*>(this->messages[i].at(2 * part + 1)->data());
+             return DataRef{nullptr, header, payload};
+           },
+           [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()},
+      record{schema, span},
       values{std::move(v)}
   {
     BOOST_REQUIRE(messages.size() == schema.size());
@@ -48,6 +52,7 @@ struct DataSet {
 
   std::vector<InputRoute> schema;
   Messages messages;
+  InputSpan span;
   InputRecord record;
   std::vector<int> values;
 };

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -21,6 +21,7 @@
 #include <fairmq/FairMQTransportFactory.h>
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
 #include "Framework/DataRef.h"
 #include "Framework/DataRefUtils.h"
 #include "DPLUtils/RootTreeWriter.h"
@@ -218,10 +219,10 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   auto getter = [&store](size_t i) -> DataRef {
     return DataRef{nullptr, static_cast<char const*>(store[2 * i]->GetData()), static_cast<char const*>(store[2 * i + 1]->GetData())};
   };
-
+  InputSpan span{getter, store.size() / 2};
   InputRecord inputs{
     schema,
-    InputSpan{getter, store.size() / 2}};
+    span};
 
   writer(inputs);
   writer.close();


### PR DESCRIPTION
InputSpan usage of std::function causes an avalanche of template
instantiantions, resulting (at least) in a rather large slowdown
of Framework/Core compilation. With this patch we go from

 Compilation (452 times):
   Parsing (frontend):         1686.8 s
   Codegen & opts (backend):   1120.7 s

to

 Compilation (452 times):
   Parsing (frontend):         1441.4 s
   Codegen & opts (backend):    842.8 s