### PR TITLE
MCH: avoid using HB packets to compute digits time

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -155,8 +155,8 @@ class DataDecoder
   RawDigitVector mDigits;                               ///< vector of decoded digits
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
 
-  std::optional<uint32_t> mFirstOrbitInRun{0}; ///< first orbit in the processed run
-  SampaTimeFrameStart mSampaTimeFrameStart;    ///< SAMPA bunch-crossing counter at the beiginning of the TF
+  std::optional<uint32_t> mFirstOrbitInRun; ///< first orbit in the processed run
+  SampaTimeFrameStart mSampaTimeFrameStart; ///< SAMPA bunch-crossing counter at the beiginning of the TF
 
   uint32_t mSampaTimeOffset{339986}; ///< SAMPA BC counter value at the beginning of the first orbit in the run
 

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -95,10 +95,8 @@ class DataDecoder
     SampaTimeFrameStart(uint32_t orbit, uint32_t bunchCrossing) : mOrbit(orbit), mBunchCrossing(bunchCrossing) {}
 
     uint32_t mOrbit{0};
-    int32_t mBunchCrossing{0};
+    uint32_t mBunchCrossing{0};
   };
-
-  using SampaTimeFrameStarts = std::unordered_map<uint32_t, std::optional<SampaTimeFrameStart>>;
 
   struct RawDigit {
     o2::mch::Digit digit;
@@ -118,7 +116,7 @@ class DataDecoder
 
   using RawDigitVector = std::vector<RawDigit>;
 
-  DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler, std::string mapCRUfile, std::string mapFECfile, bool ds2manu, bool verbose);
+  DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler, uint32_t sampaBcOffset, std::string mapCRUfile, std::string mapFECfile, bool ds2manu, bool verbose);
 
   void reset();
   void decodeBuffer(gsl::span<const std::byte> buf);
@@ -126,9 +124,9 @@ class DataDecoder
   void setFirstOrbitInRun(uint32_t orbit) { mFirstOrbitInRun = orbit; }
   std::optional<uint32_t> getFirstOrbitInRun() { return mFirstOrbitInRun; }
   void setFirstOrbitInTF(uint32_t orbit);
-  std::optional<uint32_t> getFirstOrbitInTF() { return mFirstOrbitInTF; }
 
-  static uint32_t getSampaBcOffset() { return sSampaTimeOffset; }
+  void setSampaBcOffset(uint32_t offset) { mSampaTimeOffset = offset; }
+  uint32_t getSampaBcOffset() const { return mSampaTimeOffset; }
 
   static int32_t digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2);
   static void computeDigitsTime_(RawDigitVector& digits, SampaTimeFrameStart& sampaTimeFrameStart, bool debug);
@@ -158,10 +156,9 @@ class DataDecoder
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
 
   std::optional<uint32_t> mFirstOrbitInRun{0}; ///< first orbit in the processed run
-  std::optional<uint32_t> mFirstOrbitInTF{0};  ///< first orbit in the processed time frame
   SampaTimeFrameStart mSampaTimeFrameStart;    ///< SAMPA bunch-crossing counter at the beiginning of the TF
 
-  static constexpr uint32_t sSampaTimeOffset = 339986; ///< SAMPA BC counter value at the beginning of the first orbit in the run
+  uint32_t mSampaTimeOffset{339986}; ///< SAMPA BC counter value at the beginning of the first orbit in the run
 
   SampaChannelHandler mChannelHandler;                  ///< optional user function to be called for each decoded SAMPA hit
   std::function<void(o2::header::RDHAny*)> mRdhHandler; ///< optional user function to be called for each RDH

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -82,10 +82,9 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTime)
   uint32_t tfOrbit = 1;
   uint32_t tfBunchCrossing = 0;
 
-  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
-  sampaTimeFrameStarts[digits[0].info.id].emplace(tfOrbit, tfBunchCrossing);
+  DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStarts, false);
+  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing);
@@ -104,10 +103,9 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover)
   uint32_t tfOrbit = 1;
   uint32_t tfBunchCrossing = BCROLLOVER - 100;
 
-  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
-  sampaTimeFrameStarts[digits[0].info.id].emplace(tfOrbit, tfBunchCrossing);
+  DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStarts, false);
+  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing) + BCROLLOVER;
@@ -126,37 +124,14 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover2)
   uint32_t tfOrbit = 1;
   uint32_t tfBunchCrossing = 100;
 
-  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
-  sampaTimeFrameStarts[digits[0].info.id].emplace(tfOrbit, tfBunchCrossing);
+  DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStarts, false);
+  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing) - BCROLLOVER;
 
   BOOST_CHECK_EQUAL(digits[0].getTime(), digitTime);
-}
-
-BOOST_AUTO_TEST_CASE(ComputeDigitsTimeNoTFStart)
-{
-  uint32_t sampaTime = 10;
-  uint32_t bunchCrossing = BCINORBIT - 100;
-  uint32_t orbit = 1;
-
-  std::vector<RawDigit> digits = makeDigitsVector(sampaTime, bunchCrossing, orbit);
-
-  uint32_t tfOrbit = 1;
-  uint32_t tfBunchCrossing = 0;
-
-  std::unordered_map<uint32_t, std::optional<DataDecoder::SampaTimeFrameStart>> sampaTimeFrameStarts;
-  sampaTimeFrameStarts[digits[0].info.id + 1].emplace(tfOrbit, tfBunchCrossing);
-
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStarts, false);
-
-  int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
-                      static_cast<int32_t>(tfBunchCrossing);
-
-  BOOST_CHECK_EQUAL(digits[0].getTime(), DataDecoder::tfTimeInvalid);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -73,7 +73,7 @@ class DataDecoderTask
     RdhHandler rdhHandler;
 
     auto ds2manu = ic.options().get<bool>("ds2manu");
-    auto sampaBcOffset = ic.options().get<bool>("sampa-bc-offset");
+    auto sampaBcOffset = ic.options().get<int>("sampa-bc-offset");
     mDebug = ic.options().get<bool>("debug");
     mCheckROFs = ic.options().get<bool>("check-rofs");
     mDummyROFs = ic.options().get<bool>("dummy-rofs");

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -34,6 +34,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "DPLUtils/DPLRawParser.h"
+#include "CommonConstants/LHCConstants.h"
 
 #include "DataFormatsMCH/Digit.h"
 #include "MCHRawCommon/DataFormats.h"
@@ -42,6 +43,8 @@
 #include "MCHRawElecMap/Mapper.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHWorkflow/DataDecoderSpec.h"
+
+//#define MCH_RAW_DATADECODER_DEBUG_DIGIT_TIME 1
 
 namespace o2
 {
@@ -72,6 +75,7 @@ class DataDecoderTask
     mDebug = ic.options().get<bool>("debug");
     mCheckROFs = ic.options().get<bool>("check-rofs");
     mDummyROFs = ic.options().get<bool>("dummy-rofs");
+    mNHBPerTF = ic.options().get<int>("nhb-per-tf");
     auto mapCRUfile = ic.options().get<std::string>("cru-map");
     auto mapFECfile = ic.options().get<std::string>("fec-map");
 
@@ -84,9 +88,16 @@ class DataDecoderTask
   {
     const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
     mFirstTForbit = dh->firstTForbit;
-    mDecoder->setFirstTForbit(mFirstTForbit);
+
+    if (!mDecoder->getFirstOrbitInRun()) {
+      uint32_t firstRunOrbit = mFirstTForbit - dh->tfCounter * mNHBPerTF;
+      mDecoder->setFirstOrbitInRun(firstRunOrbit);
+    }
+    mDecoder->setFirstOrbitInTF(mFirstTForbit);
+
     if (mDebug) {
-      std::cout << "[DataDecoderSpec::run] first orbit is " << mFirstTForbit << std::endl;
+      std::cout << "[DataDecoderSpec::run] first run orbit is " << mDecoder->getFirstOrbitInRun().value() << std::endl;
+      std::cout << "[DataDecoderSpec::run] first TF orbit is " << mDecoder->getFirstOrbitInTF().value() << std::endl;
     }
 
     // get the input buffer
@@ -133,7 +144,10 @@ class DataDecoderTask
 
     const RDH* rdh = reinterpret_cast<const RDH*>(raw);
     mFirstTForbit = o2::raw::RDHUtils::getHeartBeatOrbit(rdh);
-    mDecoder->setFirstTForbit(mFirstTForbit);
+    if (!mDecoder->getFirstOrbitInRun()) {
+      mDecoder->setFirstOrbitInRun(mFirstTForbit);
+    }
+    mDecoder->setFirstOrbitInTF(mFirstTForbit);
 
     gsl::span<const std::byte> buffer(reinterpret_cast<const std::byte*>(raw), payloadSize);
     mDecoder->decodeBuffer(buffer);
@@ -142,6 +156,8 @@ class DataDecoderTask
   //_________________________________________________________________________________________________
   void run(framework::ProcessingContext& pc)
   {
+    static int32_t deltaMax = 0;
+
     auto createBuffer = [&](auto& vec, size_t& size) {
       size = vec.empty() ? 0 : sizeof(*(vec.begin())) * vec.size();
       char* buf = nullptr;
@@ -171,7 +187,25 @@ class DataDecoderTask
     }
     mDecoder->computeDigitsTime();
 
-    ROFFinder rofFinder(mDecoder->getDigits(), mFirstTForbit);
+    auto& digits = mDecoder->getDigits();
+    auto& orbits = mDecoder->getOrbits();
+
+#ifdef MCH_RAW_DATADECODER_DEBUG_DIGIT_TIME
+    constexpr int BCINORBIT = o2::constants::lhc::LHCMaxBunches;
+    int32_t bcMax = mNHBPerTF * 3564 - 1;
+    for (auto d : digits) {
+      if (d.getTime() < 0 || d.getTime() > bcMax) {
+        int32_t delta = d.getTime() - bcMax;
+        if (delta > deltaMax) {
+          deltaMax = delta;
+          std::cout << "Max digit time exceeded: TF ORBIT " << mDecoder->getFirstOrbitInTF().value() << "  DE# " << d.getDetID() << " PadId " << d.getPadID() << " ADC " << d.getADC()
+                    << " time " << d.getTime() << " (" << bcMax << ", delta=" << delta << ")" << std::endl;
+        }
+      }
+    }
+#endif
+
+    ROFFinder rofFinder(digits, mFirstTForbit);
     rofFinder.process(mDummyROFs);
 
     if (mDebug) {
@@ -183,8 +217,6 @@ class DataDecoderTask
       rofFinder.isRofTimeMonotonic();
       rofFinder.isDigitsTimeAligned();
     }
-
-    auto& orbits = mDecoder->getOrbits();
 
     // send the output buffer via DPL
     size_t digitsSize, rofsSize, orbitsSize;
@@ -208,6 +240,7 @@ class DataDecoderTask
   bool mDebug = {false};             /// flag to enable verbose output
   bool mCheckROFs = {false};         /// flag to enable consistency checks on the output ROFs
   bool mDummyROFs = {false};         /// flag to disable the ROFs finding
+  int mNHBPerTF{0};                  /// number of orbits in each TF
   uint32_t mFirstTForbit{0};         /// first orbit of the time frame being processed
   DataDecoder* mDecoder = {nullptr}; /// pointer to the data decoder instance
 };
@@ -227,6 +260,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec)
             {"cru-map", VariantType::String, "", {"custom CRU mapping"}},
             {"fec-map", VariantType::String, "", {"custom FEC mapping"}},
             {"ds2manu", VariantType::Bool, false, {"convert channel numbering from Run3 to Run1-2 order"}},
+            {"nhb-per-tf", VariantType::Int, 128, {"number of orbits in each TF"}},
             {"check-rofs", VariantType::Bool, false, {"perform consistency checks on the output ROFs"}},
             {"dummy-rofs", VariantType::Bool, false, {"disable the ROFs finding algorithm"}}}};
 }


### PR DESCRIPTION
This PR introduces a computation of the MCH Digits time is based on the orbits information in each Time Frame.

The SAMPA BC counter at the beginning of a given TF is estimated by counting the total number of orbits elapsed since the beginning of the run.

The computation assumes that the SAMPA BC counters are simultaneously reset via a dedicated trigger signal some time before the beginning of the run.

Two details in the code will need to be reviewed/corrected in the future:
* there is currently no way of reliably obtaining the number of orbits per time frame from the O2 framework, so for the moment this parameter can be specified from the command line and defaults to 128
* the Digit time computation requires a calibration constant representing the value of the SAMPA BC counters at the beginning of the first orbit in the run. This constant is currently implemented as a static data member the DataDecoder class, but it probably deserves a better place. It is also not yet clear whether this value will change over time, in which case a CDDB entry will be needed.