### PR TITLE
DPL Analysis: avoid instantiating HistFactory functions for each TU

### DIFF
--- a/Analysis/Core/src/CorrelationContainer.cxx
+++ b/Analysis/Core/src/CorrelationContainer.cxx
@@ -26,7 +26,7 @@
 #include "TCanvas.h"
 #include "TF1.h"
 #include "THn.h"
-#include "Framework/HistogramRegistry.h"
+#include "Framework/HistogramSpec.h"
 
 using namespace o2::framework;
 

--- a/Analysis/Core/src/CorrelationContainer.cxx
+++ b/Analysis/Core/src/CorrelationContainer.cxx
@@ -710,7 +710,7 @@ TH2* CorrelationContainer::getSumOfRatios(CorrelationContainer* mixed, Correlati
       //
       //     for (Int_t x=1; x<=mixedTwoD->GetNbinsX(); x++)
       //       for (Int_t y=1; y<=mixedTwoD->GetNbinsY(); y++)
-      // 	mixedTwoD->SetBinContent(x, y, histMixedproj->GetBinContent(y));
+      //       mixedTwoD->SetBinContent(x, y, histMixedproj->GetBinContent(y));
 
       //       delete histMixedproj;
 
@@ -725,8 +725,8 @@ TH2* CorrelationContainer::getSumOfRatios(CorrelationContainer* mixed, Correlati
         }
         // tracksSame->Scale(tracksMixed->Integral() / tracksSame->Integral());
 
-        // 	new TCanvas; tracksSame->DrawClone("SURF1");
-        // 	new TCanvas; tracksMixed->DrawClone("SURF1");
+        // new TCanvas; tracksSame->DrawClone("SURF1");
+        // new TCanvas; tracksMixed->DrawClone("SURF1");
 
         // some code to judge the relative contribution of the different correlation functions to the overall uncertainty
         Double_t sums[] = {0, 0, 0};
@@ -759,11 +759,11 @@ TH2* CorrelationContainer::getSumOfRatios(CorrelationContainer* mixed, Correlati
         LOGF(info, "The correlation function %d %d has uncertainties %f %f %f (Ratio S/M %f)", multBin, vertexBin, errors[0], errors[1], errors[2], (errors[1] > 0) ? errors[0] / errors[1] : -1);
         // code to draw contributions
         /*
-	TH1* proj = tracksSame->ProjectionX("projx", tracksSame->GetYaxis()->FindBin(-1.59), tracksSame->GetYaxis()->FindBin(1.59));
-	proj->SetTitle(Form("Bin %d", vertexBin));
-	proj->SetLineColor(vertexBin);
-	proj->DrawCopy((vertexBin > 1) ? "SAME" : "");
-	*/
+        TH1* proj = tracksSame->ProjectionX("projx", tracksSame->GetYaxis()->FindBin(-1.59), tracksSame->GetYaxis()->FindBin(1.59));
+        proj->SetTitle(Form("Bin %d", vertexBin));
+        proj->SetLineColor(vertexBin);
+        proj->DrawCopy((vertexBin > 1) ? "SAME" : "");
+        */
 
         if (!totalTracks) {
           totalTracks = (TH2*)tracksSame->Clone("totalTracks");
@@ -773,7 +773,7 @@ TH2* CorrelationContainer::getSumOfRatios(CorrelationContainer* mixed, Correlati
 
         totalEvents += eventSameAll->GetBinContent(vertexBin, multBin);
 
-        // 	new TCanvas; tracksMixed->DrawCopy("SURF1");
+        //   new TCanvas; tracksMixed->DrawCopy("SURF1");
       }
 
       delete tracksSame;
@@ -1676,11 +1676,11 @@ void CorrelationContainer::extendTrackingEfficiency(Bool_t verbose)
 void CorrelationContainer::Scale(Double_t factor)
 {
   // scales all contained histograms by the given factor
-  
+
   for (Int_t i=0; i<4; i++)
     if (mTrackHist[i])
       mTrackHist[i]->Scale(factor);
-  
+
   mEventHist->Scale(factor);
   mTrackHistEfficiency->Scale(factor);
 }*/

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -106,6 +106,7 @@ o2_add_library(Framework
                        src/WSDriverClient.cxx
                        src/runDataProcessing.cxx
                        src/ExternalFairMQDeviceProxy.cxx
+                       src/HistogramSpec.cxx
                        src/HistogramRegistry.cxx
                        src/StepTHn.cxx
                        src/Base64.cxx

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -20,177 +20,19 @@
 #include "Framework/OutputSpec.h"
 #include "Framework/SerializationMethods.h"
 #include "Framework/TableBuilder.h"
+#include "Framework/RuntimeError.h"
+
+#include <TDataMember.h>
+#include <TDataType.h>
+
+#include <deque>
+
+class TList;
 
 #define HIST(name) CONST_STR(name)
 
 namespace o2::framework
 {
-
-//**************************************************************************************************
-/**
- * Static helper class to generate histograms from the specifications.
- * Also provides functions to obtain pointer to the created histogram casted to the correct alternative of the std::variant HistPtr that is used in HistogramRegistry.
- */
-//**************************************************************************************************
-struct HistFactory {
-
-  // create histogram of type T with the axes defined in HistogramSpec
-  template <typename T>
-  static std::unique_ptr<T> createHist(const HistogramSpec& histSpec)
-  {
-    constexpr std::size_t MAX_DIM{10};
-    const std::size_t nAxes{histSpec.config.axes.size()};
-    if (nAxes == 0 || nAxes > MAX_DIM) {
-      LOGF(FATAL, "The histogram specification contains no (or too many) axes.");
-      return nullptr;
-    }
-
-    int nBins[MAX_DIM]{0};
-    double lowerBounds[MAX_DIM]{0.};
-    double upperBounds[MAX_DIM]{0.};
-
-    // first figure out number of bins and dimensions
-    for (std::size_t i = 0; i < nAxes; i++) {
-      nBins[i] = (histSpec.config.axes[i].nBins) ? *histSpec.config.axes[i].nBins : histSpec.config.axes[i].binEdges.size() - 1;
-      lowerBounds[i] = histSpec.config.axes[i].binEdges.front();
-      upperBounds[i] = histSpec.config.axes[i].binEdges.back();
-    }
-
-    // create histogram
-    std::unique_ptr<T> hist{generateHist<T>(histSpec.name, histSpec.title, nAxes, nBins, lowerBounds, upperBounds, histSpec.config.nSteps)};
-    if (!hist) {
-      LOGF(FATAL, "The number of dimensions specified for histogram %s does not match the type.", histSpec.name);
-      return nullptr;
-    }
-
-    // set axis properties
-    for (std::size_t i = 0; i < nAxes; i++) {
-      TAxis* axis{getAxis(i, hist.get())};
-      if (axis) {
-        if (histSpec.config.axes[i].title) {
-          axis->SetTitle((*histSpec.config.axes[i].title).data());
-        }
-
-        // this helps to have axes not only called 0,1,2... in ndim histos
-        if constexpr (std::is_base_of_v<THnBase, T>) {
-          if (histSpec.config.axes[i].name) {
-            axis->SetName((std::string(axis->GetName()) + "-" + *histSpec.config.axes[i].name).data());
-          }
-        }
-
-        // move the bin edges in case a variable binning was requested
-        if (!histSpec.config.axes[i].nBins) {
-          if (!std::is_sorted(std::begin(histSpec.config.axes[i].binEdges), std::end(histSpec.config.axes[i].binEdges))) {
-            LOGF(FATAL, "The bin edges in histogram %s are not in increasing order!", histSpec.name);
-            return nullptr;
-          }
-          axis->Set(nBins[i], histSpec.config.axes[i].binEdges.data());
-        }
-      }
-    }
-    if (histSpec.callSumw2) {
-      hist->Sumw2();
-    }
-    return hist;
-  }
-
-  // create histogram and return it casted to the correct alternative held in HistPtr variant
-  template <typename T>
-  static HistPtr createHistVariant(const HistogramSpec& histSpec)
-  {
-    if (auto hist = castToVariant(createHist<T>(histSpec))) {
-      return *hist;
-    } else {
-      throw runtime_error("Histogram was not created properly.");
-    }
-  }
-
-  // runtime version of the above
-  static HistPtr createHistVariant(const HistogramSpec& histSpec)
-  {
-    if (histSpec.config.type == HistType::kUndefinedHist) {
-      throw runtime_error("Histogram type was not specified.");
-    } else {
-      return HistogramCreationCallbacks.at(histSpec.config.type)(histSpec);
-    }
-  }
-
-  // helper function to get the axis via index for any type of root histogram
-  template <typename T>
-  static TAxis* getAxis(const int i, T* hist)
-  {
-    if constexpr (std::is_base_of_v<THnBase, T> || std::is_base_of_v<StepTHn, T>) {
-      return hist->GetAxis(i);
-    } else {
-      if (i == 0) {
-        return hist->GetXaxis();
-      } else if (i == 1) {
-        return hist->GetYaxis();
-      } else if (i == 2) {
-        return hist->GetZaxis();
-      } else {
-        return nullptr;
-      }
-    }
-  }
-
- private:
-  static const std::map<HistType, std::function<HistPtr(const HistogramSpec&)>> HistogramCreationCallbacks;
-
-  // helper function to generate the actual histograms
-  template <typename T>
-  static T* generateHist(const std::string& name, const std::string& title, const std::size_t nDim,
-                         const int nBins[], const double lowerBounds[], const double upperBounds[], const int nSteps = 1)
-  {
-    if constexpr (std::is_base_of_v<StepTHn, T>) {
-      return new T(name.data(), title.data(), nSteps, nDim, nBins, lowerBounds, upperBounds);
-    } else if constexpr (std::is_base_of_v<THnBase, T>) {
-      return new T(name.data(), title.data(), nDim, nBins, lowerBounds, upperBounds);
-    } else if constexpr (std::is_base_of_v<TH3, T>) {
-      return (nDim != 3) ? nullptr
-                         : new T(name.data(), title.data(), nBins[0], lowerBounds[0],
-                                 upperBounds[0], nBins[1], lowerBounds[1], upperBounds[1],
-                                 nBins[2], lowerBounds[2], upperBounds[2]);
-    } else if constexpr (std::is_base_of_v<TH2, T>) {
-      return (nDim != 2) ? nullptr
-                         : new T(name.data(), title.data(), nBins[0], lowerBounds[0],
-                                 upperBounds[0], nBins[1], lowerBounds[1], upperBounds[1]);
-    } else if constexpr (std::is_base_of_v<TH1, T>) {
-      return (nDim != 1)
-               ? nullptr
-               : new T(name.data(), title.data(), nBins[0], lowerBounds[0], upperBounds[0]);
-    }
-    return nullptr;
-  }
-
-  // helper function to cast the actual histogram type (e.g. TH2F) to the correct interface type (e.g. TH2) that is stored in the HistPtr variant
-  template <typename T>
-  static std::optional<HistPtr> castToVariant(std::shared_ptr<TObject> obj)
-  {
-    if (obj->InheritsFrom(T::Class())) {
-      return std::static_pointer_cast<T>(obj);
-    }
-    return std::nullopt;
-  }
-
-  template <typename T, typename Next, typename... Rest>
-  static std::optional<HistPtr> castToVariant(std::shared_ptr<TObject> obj)
-  {
-    if (auto hist = castToVariant<T>(obj)) {
-      return hist;
-    }
-    return castToVariant<Next, Rest...>(obj);
-  }
-
-  static std::optional<HistPtr> castToVariant(std::shared_ptr<TObject> obj)
-  {
-    if (obj) {
-      // TProfile3D is TH3, TProfile2D is TH2, TH3 is TH1, TH2 is TH1, TProfile is TH1
-      return castToVariant<THn, THnSparse, TProfile3D, TH3, TProfile2D, TH2, TProfile, TH1, StepTHn>(obj);
-    }
-    return std::nullopt;
-  }
-};
 
 //**************************************************************************************************
 /**

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -10,29 +10,10 @@
 
 #include "Framework/HistogramRegistry.h"
 #include <regex>
+#include <TList.h>
 
 namespace o2::framework
 {
-
-// define histogram callbacks for runtime histogram creation
-#define CALLB(HType)                                            \
-  {                                                             \
-    k##HType,                                                   \
-      [](HistogramSpec const& histSpec) {                       \
-        return HistFactory::createHistVariant<HType>(histSpec); \
-      }                                                         \
-  }
-
-const std::map<HistType, std::function<HistPtr(const HistogramSpec&)>> HistFactory::HistogramCreationCallbacks{
-  CALLB(TH1D), CALLB(TH1F), CALLB(TH1I), CALLB(TH1C), CALLB(TH1S),
-  CALLB(TH2D), CALLB(TH2F), CALLB(TH2I), CALLB(TH2C), CALLB(TH2S),
-  CALLB(TH3D), CALLB(TH3F), CALLB(TH3I), CALLB(TH3C), CALLB(TH3S),
-  CALLB(THnD), CALLB(THnF), CALLB(THnI), CALLB(THnC), CALLB(THnS), CALLB(THnL),
-  CALLB(THnSparseD), CALLB(THnSparseF), CALLB(THnSparseI), CALLB(THnSparseC), CALLB(THnSparseS), CALLB(THnSparseL),
-  CALLB(TProfile), CALLB(TProfile2D), CALLB(TProfile3D),
-  CALLB(StepTHnF), CALLB(StepTHnD)};
-
-#undef CALLB
 
 // create histogram from specification and insert it into the registry
 void HistogramRegistry::insert(const HistogramSpec& histSpec)
@@ -193,8 +174,19 @@ void HistogramRegistry::print(bool showAxisDetails)
         } else if constexpr (std::is_base_of_v<TH1, T>) {
           nDim = hist->GetDimension();
         }
+        TAxis* axis{nullptr};
         for (int d = 0; d < nDim; ++d) {
-          TAxis* axis = HistFactory::getAxis(d, hist.get());
+          if constexpr (std::is_base_of_v<THnBase, T> || std::is_base_of_v<StepTHn, T>) {
+            axis = hist->GetAxis(d);
+          } else {
+            if (d == 0) {
+              axis = hist->GetXaxis();
+            } else if (d == 1) {
+              axis = hist->GetYaxis();
+            } else if (d == 2) {
+              axis = hist->GetZaxis();
+            }
+          }
           LOGF(INFO, "- Axis %d: %-20s (%d bins)", d, axis->GetTitle(), axis->GetNbins());
         }
       }

--- a/Framework/Core/src/HistogramSpec.cxx
+++ b/Framework/Core/src/HistogramSpec.cxx
@@ -1,0 +1,226 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/HistogramSpec.h"
+#include "Framework/RuntimeError.h"
+
+namespace o2::framework
+{
+
+// main function for creating arbirtary histograms
+template <typename T>
+std::unique_ptr<T> HistFactory::createHist(const HistogramSpec& histSpec)
+{
+  constexpr std::size_t MAX_DIM{10};
+  const std::size_t nAxes{histSpec.config.axes.size()};
+  if (nAxes == 0 || nAxes > MAX_DIM) {
+    LOGF(FATAL, "The histogram specification contains no (or too many) axes.");
+    return nullptr;
+  }
+
+  int nBins[MAX_DIM]{0};
+  double lowerBounds[MAX_DIM]{0.};
+  double upperBounds[MAX_DIM]{0.};
+
+  // first figure out number of bins and dimensions
+  for (std::size_t i = 0; i < nAxes; i++) {
+    nBins[i] = (histSpec.config.axes[i].nBins) ? *histSpec.config.axes[i].nBins : histSpec.config.axes[i].binEdges.size() - 1;
+    lowerBounds[i] = histSpec.config.axes[i].binEdges.front();
+    upperBounds[i] = histSpec.config.axes[i].binEdges.back();
+  }
+
+  // create histogram
+  std::unique_ptr<T> hist{generateHist<T>(histSpec.name, histSpec.title, nAxes, nBins, lowerBounds, upperBounds, histSpec.config.nSteps)};
+  if (!hist) {
+    LOGF(FATAL, "The number of dimensions specified for histogram %s does not match the type.", histSpec.name);
+    return nullptr;
+  }
+
+  // set axis properties
+  for (std::size_t i = 0; i < nAxes; i++) {
+    TAxis* axis{getAxis(i, hist.get())};
+    if (axis) {
+      if (histSpec.config.axes[i].title) {
+        axis->SetTitle((*histSpec.config.axes[i].title).data());
+      }
+
+      // this helps to have axes not only called 0,1,2... in ndim histos
+      if constexpr (std::is_base_of_v<THnBase, T>) {
+        if (histSpec.config.axes[i].name) {
+          axis->SetName((std::string(axis->GetName()) + "-" + *histSpec.config.axes[i].name).data());
+        }
+      }
+
+      // move the bin edges in case a variable binning was requested
+      if (!histSpec.config.axes[i].nBins) {
+        if (!std::is_sorted(std::begin(histSpec.config.axes[i].binEdges), std::end(histSpec.config.axes[i].binEdges))) {
+          LOGF(FATAL, "The bin edges in histogram %s are not in increasing order!", histSpec.name);
+          return nullptr;
+        }
+        axis->Set(nBins[i], histSpec.config.axes[i].binEdges.data());
+      }
+    }
+  }
+  if (histSpec.callSumw2) {
+    hist->Sumw2();
+  }
+  return hist;
+}
+
+// create histogram and return it casted to the correct alternative held in HistPtr variant
+template <typename T>
+HistPtr HistFactory::createHistVariant(const HistogramSpec& histSpec)
+{
+  if (auto hist = castToVariant(createHist<T>(histSpec))) {
+    return *hist;
+  } else {
+    throw runtime_error("Histogram was not created properly.");
+  }
+}
+
+// runtime version of the above
+HistPtr HistFactory::createHistVariant(const HistogramSpec& histSpec)
+{
+  if (histSpec.config.type == HistType::kUndefinedHist) {
+    throw runtime_error("Histogram type was not specified.");
+  } else {
+    return HistogramCreationCallbacks.at(histSpec.config.type)(histSpec);
+  }
+}
+
+// helper function to get the axis via index for any type of root histogram
+template <typename T>
+TAxis* HistFactory::getAxis(const int i, T* hist)
+{
+  if constexpr (std::is_base_of_v<THnBase, T> || std::is_base_of_v<StepTHn, T>) {
+    return hist->GetAxis(i);
+  } else {
+    if (i == 0) {
+      return hist->GetXaxis();
+    } else if (i == 1) {
+      return hist->GetYaxis();
+    } else if (i == 2) {
+      return hist->GetZaxis();
+    } else {
+      return nullptr;
+    }
+  }
+}
+
+// helper function to generate the actual histograms
+template <typename T>
+T* HistFactory::generateHist(const std::string& name, const std::string& title, const std::size_t nDim,
+                             const int nBins[], const double lowerBounds[], const double upperBounds[], const int nSteps)
+{
+  if constexpr (std::is_base_of_v<StepTHn, T>) {
+    return new T(name.data(), title.data(), nSteps, nDim, nBins, lowerBounds, upperBounds);
+  } else if constexpr (std::is_base_of_v<THnBase, T>) {
+    return new T(name.data(), title.data(), nDim, nBins, lowerBounds, upperBounds);
+  } else if constexpr (std::is_base_of_v<TH3, T>) {
+    return (nDim != 3) ? nullptr
+                       : new T(name.data(), title.data(), nBins[0], lowerBounds[0],
+                               upperBounds[0], nBins[1], lowerBounds[1], upperBounds[1],
+                               nBins[2], lowerBounds[2], upperBounds[2]);
+  } else if constexpr (std::is_base_of_v<TH2, T>) {
+    return (nDim != 2) ? nullptr
+                       : new T(name.data(), title.data(), nBins[0], lowerBounds[0],
+                               upperBounds[0], nBins[1], lowerBounds[1], upperBounds[1]);
+  } else if constexpr (std::is_base_of_v<TH1, T>) {
+    return (nDim != 1)
+             ? nullptr
+             : new T(name.data(), title.data(), nBins[0], lowerBounds[0], upperBounds[0]);
+  }
+  return nullptr;
+}
+
+// helper function to cast the actual histogram type (e.g. TH2F) to the correct interface type (e.g. TH2) that is stored in the HistPtr variant
+template <typename T>
+std::optional<HistPtr> HistFactory::castToVariant(std::shared_ptr<TObject> obj)
+{
+  if (obj->InheritsFrom(T::Class())) {
+    return std::static_pointer_cast<T>(obj);
+  }
+  return std::nullopt;
+}
+
+template <typename T, typename Next, typename... Rest>
+std::optional<HistPtr> HistFactory::castToVariant(std::shared_ptr<TObject> obj)
+{
+  if (auto hist = castToVariant<T>(obj)) {
+    return hist;
+  }
+  return castToVariant<Next, Rest...>(obj);
+}
+
+std::optional<HistPtr> HistFactory::castToVariant(std::shared_ptr<TObject> obj)
+{
+  if (obj) {
+    // TProfile3D is TH3, TProfile2D is TH2, TH3 is TH1, TH2 is TH1, TProfile is TH1
+    return castToVariant<THn, THnSparse, TProfile3D, TH3, TProfile2D, TH2, TProfile, TH1, StepTHn>(obj);
+  }
+  return std::nullopt;
+}
+
+// explicitly instantiate createHist templates for all histogram types
+#define EXPIMPL(HType) \
+  template std::unique_ptr<HType> HistFactory::createHist<HType>(const HistogramSpec& histSpec);
+EXPIMPL(TH1D);
+EXPIMPL(TH1F);
+EXPIMPL(TH1I);
+EXPIMPL(TH1C);
+EXPIMPL(TH1S);
+EXPIMPL(TH2D);
+EXPIMPL(TH2F);
+EXPIMPL(TH2I);
+EXPIMPL(TH2C);
+EXPIMPL(TH2S);
+EXPIMPL(TH3D);
+EXPIMPL(TH3F);
+EXPIMPL(TH3I);
+EXPIMPL(TH3C);
+EXPIMPL(TH3S);
+EXPIMPL(THnD);
+EXPIMPL(THnF);
+EXPIMPL(THnI);
+EXPIMPL(THnC);
+EXPIMPL(THnS);
+EXPIMPL(THnL);
+EXPIMPL(THnSparseD);
+EXPIMPL(THnSparseF);
+EXPIMPL(THnSparseI);
+EXPIMPL(THnSparseC);
+EXPIMPL(THnSparseS);
+EXPIMPL(THnSparseL);
+EXPIMPL(TProfile);
+EXPIMPL(TProfile2D);
+EXPIMPL(TProfile3D);
+EXPIMPL(StepTHnF);
+EXPIMPL(StepTHnD)
+#undef EXPIMPL
+
+// define histogram callbacks for runtime histogram creation
+#define CALLB(HType)                                            \
+  {                                                             \
+    k##HType,                                                   \
+      [](HistogramSpec const& histSpec) {                       \
+        return HistFactory::createHistVariant<HType>(histSpec); \
+      }                                                         \
+  }
+const std::map<HistType, std::function<HistPtr(const HistogramSpec&)>> HistFactory::HistogramCreationCallbacks{
+  CALLB(TH1D), CALLB(TH1F), CALLB(TH1I), CALLB(TH1C), CALLB(TH1S),
+  CALLB(TH2D), CALLB(TH2F), CALLB(TH2I), CALLB(TH2C), CALLB(TH2S),
+  CALLB(TH3D), CALLB(TH3F), CALLB(TH3I), CALLB(TH3C), CALLB(TH3S),
+  CALLB(THnD), CALLB(THnF), CALLB(THnI), CALLB(THnC), CALLB(THnS), CALLB(THnL),
+  CALLB(THnSparseD), CALLB(THnSparseF), CALLB(THnSparseI), CALLB(THnSparseC), CALLB(THnSparseS), CALLB(THnSparseL),
+  CALLB(TProfile), CALLB(TProfile2D), CALLB(TProfile3D),
+  CALLB(StepTHnF), CALLB(StepTHnD)};
+#undef CALLB
+
+} // namespace o2::framework


### PR DESCRIPTION
- move histogram creation code to HistogramSpec.cxx
- instantiate histogram creation templates only once