### PR TITLE
ITS tracking will produce output with reconstructed IRFrames (IR brackets)

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -92,6 +92,7 @@ class VtxTrackRef;
 class V0;
 class Cascade;
 class TrackCosmics;
+class IRFrame;
 } // namespace o2::dataformats
 
 namespace o2
@@ -134,6 +135,8 @@ struct DataRequest {
   void requestPrimaryVertertices(bool mc);
   void requestPrimaryVerterticesTMP(bool mc);
   void requestSecondaryVertertices(bool mc);
+
+  void requestIRFramesITS();
 };
 
 // Helper class to requested data.
@@ -159,6 +162,7 @@ struct RecoContainer {
     INDICES,
     MCLABELS,      // track labels
     MCLABELSEXTRA, // additonal labels, like TOF clusters matching label (not sure TOF really needs it)
+    VARIA,         // misc data, which does not fit to other categories
     NCOMMONSLOTS
   };
 
@@ -233,6 +237,8 @@ struct RecoContainer {
   void addPVertices(o2::framework::ProcessingContext& pc, bool mc);
   void addPVerticesTMP(o2::framework::ProcessingContext& pc, bool mc);
   void addSVertices(o2::framework::ProcessingContext& pc, bool);
+
+  void addIRFramesITS(o2::framework::ProcessingContext& pc);
 
   // custom getters
 
@@ -412,6 +418,9 @@ struct RecoContainer {
   auto getCosmicTrackMCLabel(int i) const { return cosmPool.get_as<o2::MCCompLabel>(COSM_TRACKS_MC, i); }
   auto getCosmicTracks() const { return cosmPool.getSpan<o2::dataformats::TrackCosmics>(COSM_TRACKS); }
   auto getCosmicTrackMCLabels() const { return cosmPool.getSpan<o2::MCCompLabel>(COSM_TRACKS_MC); }
+
+  // IRFrames where ITS was reconstructed and tracks were seen (e.g. sync.w-flow mult. selection)
+  auto getIRFramesITS() const { return getSpan<o2::dataformats::IRFrame>(GTrackID::ITS, VARIA); }
 };
 
 } // namespace globaltracking

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -16,6 +16,7 @@
 #include <chrono>
 #include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 #include "CommonDataFormat/TimeStamp.h"
+#include "CommonDataFormat/IRFrame.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
 #include "ReconstructionDataFormats/PrimaryVertex.h"
@@ -41,6 +42,12 @@ void DataRequest::addInput(const InputSpec&& isp)
   if (std::find(inputs.begin(), inputs.end(), isp) == inputs.end()) {
     inputs.emplace_back(isp);
   }
+}
+
+void DataRequest::requestIRFramesITS()
+{
+  addInput({"IRFramesITS", "ITS", "IRFRAMES", 0, Lifetime::Timeframe});
+  requestMap["IRFramesITS"] = false;
 }
 
 void DataRequest::requestITSTracks(bool mc)
@@ -359,6 +366,11 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
   if (req != reqMap.end()) {
     addSVertices(pc, req->second);
   }
+
+  req = reqMap.find("IRFramesITS");
+  if (req != reqMap.end()) {
+    addIRFramesITS(pc);
+  }
 }
 
 //____________________________________________________________
@@ -417,6 +429,12 @@ void RecoContainer::addITSTracks(ProcessingContext& pc, bool mc)
   if (mc) {
     commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSMCTR"), MCLABELS);
   }
+}
+
+//____________________________________________________________
+void RecoContainer::addIRFramesITS(ProcessingContext& pc)
+{
+  commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("IRFramesITS"), VARIA);
 }
 
 //____________________________________________________________

--- a/DataFormats/common/CMakeLists.txt
+++ b/DataFormats/common/CMakeLists.txt
@@ -15,13 +15,14 @@ o2_add_library(CommonDataFormat
                        src/FlatHisto2D.cxx
                        src/AbstractRefAccessor.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonConstants O2::GPUCommon
-                                     ROOT::Core FairRoot::Base Microsoft.GSL::GSL)
+                                     ROOT::Core FairRoot::Base O2::MathUtils Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(CommonDataFormat
                           HEADERS include/CommonDataFormat/TimeStamp.h
                                   include/CommonDataFormat/EvIndex.h
                                   include/CommonDataFormat/RangeReference.h
                                   include/CommonDataFormat/InteractionRecord.h
+                                  include/CommonDataFormat/IRFrame.h
                                   include/CommonDataFormat/BunchFilling.h
                                   include/CommonDataFormat/AbstractRef.h
                                   include/CommonDataFormat/FlatHisto1D.h

--- a/DataFormats/common/include/CommonDataFormat/IRFrame.h
+++ b/DataFormats/common/include/CommonDataFormat/IRFrame.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IRFrame.h
+/// \brief Class to delimit start and end IR of certain time period
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_IRFRAME_H
+#define ALICEO2_IRFRAME_H
+
+#include "MathUtils/Primitive2D.h"
+#include "CommonDataFormat/InteractionRecord.h"
+
+namespace o2
+{
+namespace dataformats
+{
+
+// Bracket of 2 IRs.
+// We could just alias it to the bracket specialization, but this would create
+// problems with fwd.declaration
+struct IRFrame : public o2::math_utils::detail::Bracket<o2::InteractionRecord> {
+  using o2::math_utils::detail::Bracket<o2::InteractionRecord>::Bracket;
+  ClassDefNV(IRFrame, 1);
+};
+
+} // namespace dataformats
+} // namespace o2
+
+#endif

--- a/DataFormats/common/src/CommonDataFormatLinkDef.h
+++ b/DataFormats/common/src/CommonDataFormatLinkDef.h
@@ -48,6 +48,10 @@
 #pragma link C++ class o2::InteractionTimeRecord + ;
 #pragma link C++ class o2::BunchFilling + ;
 
+#pragma link C++ class o2::math_utils::detail::Bracket < o2::InteractionRecord> + ;
+#pragma link C++ class o2::dataformats::IRFrame + ;
+#pragma link C++ class std::vector < o2::dataformats::IRFrame> + ;
+
 #pragma link C++ class o2::dataformats::FlatHisto1D < float> + ;
 #pragma link C++ class o2::dataformats::FlatHisto1D < double> + ;
 #pragma link C++ class o2::dataformats::FlatHisto1D_f + ;

--- a/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
+++ b/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
@@ -33,6 +33,7 @@ class InputHelper
   static int addInputSpecsPVertex(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, bool mc);
   static int addInputSpecsSVertex(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs);
   static int addInputSpecsCosmics(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, bool mc);
+  static int addInputSpecsIRFramesITS(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs);
 };
 
 } // namespace globaltracking

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -14,6 +14,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
+#include "ITSWorkflow/IRFrameReaderSpec.h"
 #include "MFTWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/ClusterReaderSpec.h"
@@ -119,5 +120,15 @@ int InputHelper::addInputSpecsCosmics(const o2::framework::ConfigContext& config
     return 0;
   }
   specs.emplace_back(o2::globaltracking::getTrackCosmicsReaderSpec(mc));
+  return 0;
+}
+
+// attach vector of ITS reconstructed IRFrames
+int InputHelper::addInputSpecsIRFramesITS(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs)
+{
+  if (configcontext.options().get<bool>("disable-root-input")) {
+    return 0;
+  }
+  specs.emplace_back(o2::its::getIRFrameReaderSpec());
   return 0;
 }

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -16,9 +16,11 @@ o2_add_library(ITSWorkflow
                        src/TrackerSpec.cxx
                        src/CookedTrackerSpec.cxx
                        src/TrackWriterSpec.cxx
+                       src/IRFrameWriterSpec.cxx
+                       src/IRFrameReaderSpec.cxx
                        src/TrackReaderSpec.cxx
-		       src/VertexReaderSpec.cxx
-	       PUBLIC_LINK_LIBRARIES O2::Framework
+                       src/VertexReaderSpec.cxx
+         PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
                                      O2::DataFormatsITS
                                      O2::SimulationDataFormat

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/IRFrameReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/IRFrameReaderSpec.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   IRFramesReaderSpec.h
+
+#ifndef O2_ITS_IRFRAMES_READER
+#define O2_ITS_IRFRAMES_READER
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+/// create a processor spec
+/// read ITS IRFrames data from a root file
+framework::DataProcessorSpec getIRFrameReaderSpec();
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/IRFrameWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/IRFrameWriterSpec.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   IRFrameWriterSpec.h
+
+#ifndef O2_ITS_IRFRAMEWRITER
+#define O2_ITS_IRFRAMEWRITER
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+/// create a processor spec
+/// write IRFrames for which ITS was reconstructed and tracks found
+o2::framework::DataProcessorSpec getIRFrameWriterSpec();
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -23,12 +23,13 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
 
 #include "Field/MagneticField.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
 #include "ITSBase/GeometryTGeo.h"
-
+#include "CommonDataFormat/IRFrame.h"
 #include "ITStracking/ROframe.h"
 #include "ITStracking/IOUtils.h"
 #include "ITStracking/Vertexer.h"
@@ -125,6 +126,10 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
   auto& tracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
   auto& clusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
+  auto& irFrames = pc.outputs().make<std::vector<o2::dataformats::IRFrame>>(Output{"ITS", "IRFRAMES", 0, Lifetime::Timeframe});
+
+  const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance(); // RS: this should come from CCDB
+  int nBCPerTF = mTracker.getContinuousMode() ? alpParams.roFrameLengthInBC : alpParams.roFrameLengthTrig;
 
   gsl::span<const unsigned char>::iterator pattIt = patterns.begin();
   for (auto& rof : rofs) {
@@ -178,6 +183,9 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
     }
     mTracker.setVertices(vtxVecLoc);
     mTracker.process(compClusters, it, mDict, tracks, clusIdx, rof);
+    if (tracks.size()) {
+      irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1);
+    }
   }
 
   LOG(INFO) << "ITSCookedTracker pushed " << tracks.size() << " tracks";
@@ -208,6 +216,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
   outputs.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "IRFRAMES", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/ITS/workflow/src/IRFrameReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/IRFrameReaderSpec.cxx
@@ -1,0 +1,101 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   IRFrameReaderSpec.cxx
+
+#include <vector>
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "ITSWorkflow/IRFrameReaderSpec.h"
+#include "CommonDataFormat/IRFrame.h"
+#include "CommonUtils/StringUtils.h"
+#include "TFile.h"
+#include "TTree.h"
+
+using namespace o2::framework;
+using namespace o2::its;
+
+namespace o2
+{
+namespace its
+{
+
+class IRFrameReaderSpec : public o2::framework::Task
+{
+ public:
+  IRFrameReaderSpec() = default;
+  ~IRFrameReaderSpec() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  std::vector<o2::dataformats::IRFrame> mIRF, *mIRFInp = &mIRF;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mTreeName = "o2sim";
+  std::string mBranchName = "IRFrames";
+};
+
+void IRFrameReaderSpec::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("its-irframe-infile"));
+  connectTree(mInputFileName);
+}
+
+void IRFrameReaderSpec::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(INFO) << "Pushing " << mIRF.size() << " IR-frames in at entry " << ent;
+  pc.outputs().snapshot(Output{"ITS", "IRFRAMES", 0, Lifetime::Timeframe}, mIRF);
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void IRFrameReaderSpec::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mBranchName.c_str()));
+
+  mTree->SetBranchAddress(mBranchName.c_str(), &mIRFInp);
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getIRFrameReaderSpec()
+{
+  std::vector<OutputSpec> outputSpec;
+
+  return DataProcessorSpec{
+    "its-irframe-reader",
+    Inputs{},
+    Outputs{{"ITS", "IRFRAMES", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<IRFrameReaderSpec>()},
+    Options{
+      {"its-irframe-infile", VariantType::String, "o2_its_irframe.root", {"Name of the input IRFrames file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/IRFrameWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/IRFrameWriterSpec.cxx
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   IRFrameWriterSpec.cxx
+
+#include <vector>
+
+#include "ITSWorkflow/IRFrameWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "CommonDataFormat/IRFrame.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace its
+{
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getIRFrameWriterSpec()
+{
+  return MakeRootTreeWriterSpec("its-irframe-writer",
+                                "o2_its_irframe.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with reconstructed ITS IR Frames"},
+                                BranchDefinition<std::vector<o2::dataformats::IRFrame>>{InputSpec{"irfr", "ITS", "IRFRAMES", 0}, "IRFrames"})();
+}
+
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -13,6 +13,7 @@
 #include "ITSWorkflow/RecoWorkflow.h"
 #include "ITSWorkflow/ClustererSpec.h"
 #include "ITSWorkflow/ClusterWriterSpec.h"
+#include "ITSWorkflow/IRFrameWriterSpec.h"
 #include "ITSWorkflow/TrackerSpec.h"
 #include "ITSWorkflow/CookedTrackerSpec.h"
 #include "ITSWorkflow/TrackWriterSpec.h"
@@ -42,14 +43,13 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   }
   if (!disableRootOutput) {
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
+    specs.emplace_back(o2::its::getTrackWriterSpec(useMC));
+    specs.emplace_back(o2::its::getIRFrameWriterSpec());
   }
   if (useCAtracker) {
     specs.emplace_back(o2::its::getTrackerSpec(useMC, trmode, dtype));
   } else {
     specs.emplace_back(o2::its::getCookedTrackerSpec(useMC));
-  }
-  if (!disableRootOutput) {
-    specs.emplace_back(o2::its::getTrackWriterSpec(useMC));
   }
 
   if (eencode) {


### PR DESCRIPTION
* IRFrame: class to hold a bracket of InteractionRecords

* ITS tracking will produce output with reconstructed IRFrames (IR brackets)
The `vector<IRFrame>` will contain the 1st and the last IRs of the ITS strobe which was reconstructed (in the sync. workflow conditioned by mult. selection) and produced at least 1 track.

* Attach IRFrame to RecoContainer and InputHelper
````
Usage:
dataRequest->requestIRFramesITS(); // in the spec which needs it
o2::globaltracking::InputHelper::addInputSpecsIRFramesITS(configcontext, specs); // in the workflow building

alternatively, one can add the reader directly:
#include "ITSWorkflow/IRFrameReaderSpec.h"
 ...
specs.emplace_back(o2::its::getIRFrameReaderSpec());
recoContainer.getIRFramesITS() to access the span of IRFrame objects.
````

@martenole @davidrohr here is it. I wanted to attach it to the TRDtracker but I see that at the moment it does not use the InputHelper. Are you planning to?