### PR TITLE
Add unassigned tracks as the last entry of the Vtx->Track refs

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/VtxTrackRef.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/VtxTrackRef.h
@@ -47,8 +47,8 @@ class VtxTrackRef : public RangeReference<int, int>
     }
   }
 
-  void print() const;
-  std::string asString() const;
+  void print(bool skipEmpty = true) const;
+  std::string asString(bool skipEmpty = true) const;
 
   // get 1st of entry of indices for given source
   int getFirstEntryOfSource(int s) const
@@ -73,15 +73,18 @@ class VtxTrackRef : public RangeReference<int, int>
     }
   }
 
+  void setVtxID(int i) { mVtxID = i; }
+  int getVtxID() const { return mVtxID; }
+
   // set the last +1 element index and finalize all references
   void setEnd(int end);
 
  private:
   using RangeReference<int, int>::RangeReference;
-
+  int mVtxID = -1; // vertex ID. The reference for unassigned tracks will have it negative!
   std::array<int, VtxTrackIndex::Source::NSources - 1> mFirstEntrySource{0};
 
-  ClassDefNV(VtxTrackRef, 1);
+  ClassDefNV(VtxTrackRef, 2);
 };
 
 std::ostream& operator<<(std::ostream& os, const o2::dataformats::VtxTrackRef& v);

--- a/DataFormats/Reconstruction/src/VtxTrackRef.cxx
+++ b/DataFormats/Reconstruction/src/VtxTrackRef.cxx
@@ -21,19 +21,22 @@
 
 using namespace o2::dataformats;
 
-std::string VtxTrackRef::asString() const
+std::string VtxTrackRef::asString(bool skipEmpty) const
 {
-  std::string str = fmt::format("1st entry: {:d} ", getFirstEntry());
+  std::string str = mVtxID < 0 ? "Orphan " : fmt::format("Vtx {:3d}", mVtxID);
+  fmt::format(" : 1st entry: {:d} ", getFirstEntry());
   for (int i = 0; i < VtxTrackIndex::NSources; i++) {
-    str += fmt::format(", N{:s} : {:d}", VtxTrackIndex::getSourceName(i), getEntriesOfSource(i));
+    if (!skipEmpty || getEntriesOfSource(i)) {
+      str += fmt::format(", N{:s} : {:d}", VtxTrackIndex::getSourceName(i), getEntriesOfSource(i));
+    }
   }
   return str;
 }
 
 // set the last +1 element index and finalize all references
-void VtxTrackRef::print() const
+void VtxTrackRef::print(bool skipEmpty) const
 {
-  LOG(INFO) << asString();
+  LOG(INFO) << asString(skipEmpty);
 }
 
 // set the last +1 element index and check consistency

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -156,7 +156,7 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
   };
 
   std::unordered_map<GIndex, std::pair<int, int>> tmap;
-  int nv = vtxRefs.size();
+  int nv = vtxRefs.size() - 1; // The last entry is for unassigned tracks, ignore them
   for (int i = 0; i < 2; i++) {
     mTracksPool[i].clear();
     mVtxFirstTrack[i].clear();


### PR DESCRIPTION
The indices of unassigned tracks will be added in the end of the vector<VtxTrackIndex>
sent by the VertexTrackMatcher (PVTX_TRMTC DataDescription) and will be referenced
by an extra (last) element of the vector<VtxTrackRef> (sent as PVTX_TRMTCREFS DataDescription).

Therefore, for the TF with N vertices found the size of the vector<VtxTrackRef> will be N+1.

A getter VtxTrackRef::getVtxID() is added and it will return -1 for this special entry collecting
unassigned tracks.
