### PR TITLE
Full system test: disable shm-monitor for StfBuilder as is done automatically for the DPL processes

### DIFF
--- a/prodtests/full-system-test/datadistribution.sh
+++ b/prodtests/full-system-test/datadistribution.sh
@@ -27,5 +27,6 @@ StfBuilder --id stfb --transport shmem \
   --data-source-enable \
   --data-source-preread 5 \
   --shm-no-cleanup on \
+  --shm-monitor false \
   --control=static \
   ${ARGS_ALL}


### PR DESCRIPTION
merging since not tested in CI anyway