### PR TITLE
Data Sampling: remove the possibility to use raw FairMQ channel

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -66,8 +66,6 @@ class Dispatcher : public framework::Task
   header::Stack extractAdditionalHeaders(const char* inputHeaderStack) const;
   void reportStats(monitoring::Monitoring& monitoring) const;
   void send(framework::DataAllocator& dataAllocator, const framework::DataRef& inputData, framework::Output&& output) const;
-  void sendFairMQ(FairMQDevice* device, const framework::DataRef& inputData, const std::string& fairMQChannel,
-                  header::Stack&& stack) const;
 
   std::string mName;
   std::string mReconfigurationSource;

--- a/Utilities/DataSampling/src/Dispatcher.cxx
+++ b/Utilities/DataSampling/src/Dispatcher.cxx
@@ -14,7 +14,6 @@
 /// \author Piotr Konopka, piotr.jan.konopka@cern.ch
 
 #include "DataSampling/Dispatcher.h"
-#include "Framework/RawDeviceService.h"
 #include "DataSampling/DataSamplingPolicy.h"
 #include "DataSampling/DataSamplingHeader.h"
 #include "Framework/DataProcessingHeader.h"
@@ -22,11 +21,10 @@
 #include "Framework/Logger.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/InputRecordWalker.h"
-
 #include "Framework/Monitoring.h"
+
 #include <Configuration/ConfigurationInterface.h>
 #include <Configuration/ConfigurationFactory.h>
-#include <fairmq/FairMQDevice.h>
 
 using namespace o2::configuration;
 using namespace o2::monitoring;
@@ -92,14 +90,9 @@ void Dispatcher::run(ProcessingContext& ctx)
           std::move(extractAdditionalHeaders(input.header)),
           std::move(prepareDataSamplingHeader(*policy.get(), ctx.services().get<const DeviceSpec>()))};
 
-        if (!policy->getFairMQOutputChannel().empty()) {
-          sendFairMQ(ctx.services().get<RawDeviceService>().device(), input, policy->getFairMQOutputChannelName(),
-                     std::move(headerStack));
-        } else {
-          Output output = policy->prepareOutput(inputMatcher, input.spec->lifetime);
-          output.metaHeader = std::move(header::Stack{std::move(output.metaHeader), std::move(headerStack)});
-          send(ctx.outputs(), input, std::move(output));
-        }
+        Output output = policy->prepareOutput(inputMatcher, input.spec->lifetime);
+        output.metaHeader = std::move(header::Stack{std::move(output.metaHeader), std::move(headerStack)});
+        send(ctx.outputs(), input, std::move(output));
       }
     }
   }
@@ -156,35 +149,6 @@ void Dispatcher::send(DataAllocator& dataAllocator, const DataRef& inputData, Ou
 {
   const auto* inputHeader = header::get<header::DataHeader*>(inputData.header);
   dataAllocator.snapshot(output, inputData.payload, inputHeader->payloadSize, inputHeader->payloadSerializationMethod);
-}
-
-// ideally this should be in a separate proxy device or use Lifetime::External
-void Dispatcher::sendFairMQ(FairMQDevice* device, const DataRef& inputData, const std::string& fairMQChannel,
-                            header::Stack&& stack) const
-{
-  const auto* dh = header::get<header::DataHeader*>(inputData.header);
-  assert(dh);
-  const auto* dph = header::get<DataProcessingHeader*>(inputData.header);
-  assert(dph);
-
-  header::DataHeader dhout{dh->dataDescription, dh->dataOrigin, dh->subSpecification, dh->payloadSize};
-  dhout.payloadSerializationMethod = dh->payloadSerializationMethod;
-  DataProcessingHeader dphout{dph->startTime, dph->duration};
-  o2::header::Stack headerStack{dhout, dphout, stack};
-
-  auto channelAlloc = o2::pmr::getTransportAllocator(device->Transport());
-  FairMQMessagePtr msgHeaderStack = o2::pmr::getMessage(std::move(headerStack), channelAlloc);
-
-  char* payloadCopy = new char[dh->payloadSize];
-  memcpy(payloadCopy, inputData.payload, dh->payloadSize);
-  auto cleanupFcn = [](void* data, void*) { delete[] reinterpret_cast<char*>(data); };
-  FairMQMessagePtr msgPayload(device->NewMessage(payloadCopy, dh->payloadSize, cleanupFcn, payloadCopy));
-
-  FairMQParts message;
-  message.AddPart(move(msgHeaderStack));
-  message.AddPart(move(msgPayload));
-
-  int64_t bytesSent = device->Send(message, fairMQChannel);
 }
 
 void Dispatcher::registerPolicy(std::unique_ptr<DataSamplingPolicy>&& policy)
@@ -245,20 +209,9 @@ Outputs Dispatcher::getOutputSpecs()
 }
 framework::Options Dispatcher::getOptions()
 {
-  o2::framework::Options options;
-  for (const auto& policy : mPolicies) {
-    if (!policy->getFairMQOutputChannel().empty()) {
-      if (!options.empty()) {
-        throw std::runtime_error("Maximum one policy with raw FairMQ channel is allowed, more have been declared.");
-      }
-      options.push_back({"channel-config", VariantType::String, policy->getFairMQOutputChannel().c_str(), {"Out-of-band channel config"}});
-      LOG(DEBUG) << " - registering output FairMQ channel '" << policy->getFairMQOutputChannel() << "'";
-    }
-  }
-  options.push_back({"period-timer-stats", framework::VariantType::Int, 10 * 1000000, {"Dispatcher's stats timer period"}});
-
-  return options;
+  return {{"period-timer-stats", framework::VariantType::Int, 10 * 1000000, {"Dispatcher's stats timer period"}}};
 }
+
 size_t Dispatcher::numberOfPolicies()
 {
   return mPolicies.size();

--- a/Utilities/DataSampling/test/test_DataSampling.cxx
+++ b/Utilities/DataSampling/test/test_DataSampling.cxx
@@ -16,9 +16,6 @@
 #include "DataSampling/DataSampling.h"
 #include "DataSampling/Dispatcher.h"
 #include "DataSampling/DataSamplingPolicy.h"
-#include "Framework/DataProcessingHeader.h"
-#include "Framework/ExternalFairMQDeviceProxy.h"
-#include "DataSampling/DataSamplingReadoutAdapter.h"
 #include "Framework/DataSpecUtils.h"
 
 #include "Headers/DataHeader.h"
@@ -169,37 +166,6 @@ BOOST_AUTO_TEST_CASE(DataSamplingTimePipelineFlow)
   BOOST_CHECK_EQUAL(disp->outputs.size(), 3);
   BOOST_CHECK(disp->algorithm.onInit != nullptr);
   BOOST_CHECK_EQUAL(disp->maxInputTimeslices, 3);
-}
-
-BOOST_AUTO_TEST_CASE(DataSamplingFairMq)
-{
-  WorkflowSpec workflow{
-    specifyExternalFairMQDeviceProxy(
-      "readout-proxy",
-      Outputs{{"TPC", "RAWDATA"}},
-      "fake-channel-config",
-      dataSamplingReadoutAdapter({"TPC", "RAWDATA"}))};
-
-  std::string configFilePath = std::string(getenv("O2_ROOT")) + "/share/tests/test_DataSampling.json";
-  DataSampling::GenerateInfrastructure(workflow, "json:/" + configFilePath);
-
-  auto disp = std::find_if(workflow.begin(), workflow.end(),
-                           [](const DataProcessorSpec& d) {
-                             return d.name.find("Dispatcher") != std::string::npos;
-                           });
-  BOOST_REQUIRE(disp != workflow.end());
-
-  auto input = std::find_if(disp->inputs.begin(), disp->inputs.end(),
-                            [](const InputSpec& in) {
-                              return DataSpecUtils::match(in, ConcreteDataMatcher{DataOrigin("TPC"), DataDescription("RAWDATA"), 0}) && in.lifetime == Lifetime::Timeframe;
-                            });
-  BOOST_CHECK(input != disp->inputs.end());
-
-  auto channelConfig = std::find_if(disp->options.begin(), disp->options.end(),
-                                    [](const ConfigParamSpec& opt) {
-                                      return opt.name == "channel-config";
-                                    });
-  BOOST_REQUIRE(channelConfig != disp->options.end());
 }
 
 BOOST_AUTO_TEST_CASE(InputSpecsForPolicy)

--- a/Utilities/DataSampling/test/test_DataSampling.json
+++ b/Utilities/DataSampling/test/test_DataSampling.json
@@ -12,8 +12,7 @@
       "active": "true",
       "machines": [],
       "query": "clusters:TPC/RAWDATA",
-      "samplingConditions": [],
-      "fairMQOutput": "name=data,type=push,method=bind,address=tcp://127.0.0.1:26525,rateLogging=1"
+      "samplingConditions": []
     }
   ]
 }


### PR DESCRIPTION
This was needed only in early implementation to feed Data Dump with data, which has been recently removed as well.