### PR TITLE
Generate header providing build-time ENABLE_UPGRADES status

### DIFF
--- a/DataFormats/Detectors/Common/CMakeLists.txt
+++ b/DataFormats/Detectors/Common/CMakeLists.txt
@@ -34,6 +34,12 @@ o2_target_root_dictionary(
           include/DetectorsCommonDataFormats/CTFHeader.h
           include/DetectorsCommonDataFormats/DetMatrixCache.h)
 
+configure_file(UpgradesStatus.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/include/DetectorsCommonDataFormats/UpgradesStatus.h)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/DetectorsCommonDataFormats/UpgradesStatus.h
+        DESTINATION include/DetectorsCommonDataFormats)
+
 o2_add_test(DetID
             SOURCES test/testDetID.cxx
             PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats

--- a/DataFormats/Detectors/Common/UpgradesStatus.h.in
+++ b/DataFormats/Detectors/Common/UpgradesStatus.h.in
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_UPGRADES_STATUS_H
+#define O2_UPGRADES_STATUS_H
+
+// cmake-generated define to make installed headers aware of what was used at build-time
+#cmakedefine ENABLE_UPGRADES
+
+#endif

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetID.h
@@ -30,6 +30,7 @@
 #include "GPUCommonRtypes.h"
 #include "GPUCommonBitSet.h"
 #include "MathUtils/Utils.h"
+#include "DetectorsCommonDataFormats/UpgradesStatus.h"
 #ifndef GPUCA_GPUCODE_DEVICE
 #include "Headers/DataHeader.h"
 #include <array>
@@ -139,6 +140,15 @@ class DetID
   }
 
 #endif // GPUCA_GPUCODE_DEVICE
+
+  static bool upgradesEnabled()
+  {
+#ifdef ENABLE_UPGRADES
+    return true;
+#else
+    return false;
+#endif
+  }
 
  private:
   // are 2 strings equal ? (trick from Giulio)

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/UpgradesStatus.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/UpgradesStatus.h
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_UPGRADES_STATUS_H
+#define O2_UPGRADES_STATUS_H
+#endif
+// dummy header, will be regenerated and installed at built time from UpgradesStatus.h.in

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -565,12 +565,10 @@ constexpr o2::header::DataOrigin gDataOriginTOF{"TOF"};
 constexpr o2::header::DataOrigin gDataOriginTPC{"TPC"};
 constexpr o2::header::DataOrigin gDataOriginTRD{"TRD"};
 constexpr o2::header::DataOrigin gDataOriginZDC{"ZDC"};
-#ifdef ENABLE_UPGRADES
+
 constexpr o2::header::DataOrigin gDataOriginIT3{"IT3"};
 constexpr o2::header::DataOrigin gDataOriginTRK{"TRK"};
 constexpr o2::header::DataOrigin gDataOriginFT3{"FT3"};
-
-#endif
 
 //possible data types
 constexpr o2::header::DataDescription gDataDescriptionAny{"***************"};

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -43,6 +43,7 @@
 #include "FairRunSim.h"
 #include <FairLogger.h>
 #include <algorithm>
+#include "DetectorsCommonDataFormats/UpgradesStatus.h"
 #endif
 
 #ifdef ENABLE_UPGRADES


### PR DESCRIPTION
If the O2 was built with ENABLE_UPGRADES, using installed headers depending on the latter in the compiled macros
leads to the conflicts since the ACLIC is not aware of ENABLE_UPGRADES.
This PR will generate and install a header which defines ENABLE_UPGRADES if it was used at build-time.