### PR TITLE
DPL Analysis: avoid instantiating HistogramRegistry functions per histogram name

### DIFF
--- a/Analysis/Core/include/AnalysisCore/PairCuts.h
+++ b/Analysis/Core/include/AnalysisCore/PairCuts.h
@@ -39,7 +39,7 @@ class PairCuts
   {
     LOGF(info, "Enabled pair cut for %d with value %f", static_cast<int>(particle), cut);
     mCuts[particle] = cut;
-    if (histogramRegistry != nullptr && histogramRegistry->contains("ControlConvResonances") == false) {
+    if (histogramRegistry != nullptr && histogramRegistry->contains(HIST("ControlConvResonances")) == false) {
       histogramRegistry->add("ControlConvResonances", "", {HistType::kTH2F, {{6, -0.5, 5.5, "id"}, {500, -0.5, 0.5, "delta mass"}}});
     }
   }
@@ -50,7 +50,7 @@ class PairCuts
     mTwoTrackDistance = distance;
     mTwoTrackRadius = radius;
 
-    if (histogramRegistry != nullptr && histogramRegistry->contains("TwoTrackDistancePt_0") == false) {
+    if (histogramRegistry != nullptr && histogramRegistry->contains(HIST("TwoTrackDistancePt_0")) == false) {
       histogramRegistry->add("TwoTrackDistancePt_0", "", {HistType::kTH3F, {{100, -0.15, 0.15, "#Delta#eta"}, {100, -0.05, 0.05, "#Delta#varphi^{*}_{min}"}, {20, 0, 10, "#Delta p_{T}"}}});
       histogramRegistry->addClone("TwoTrackDistancePt_0", "TwoTrackDistancePt_1");
     }

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -35,145 +35,32 @@ namespace o2::framework
 {
 //**************************************************************************************************
 /**
- * Static helper class to fill existing root histograms of any type.
- * Contains functionality to fill once per call or a whole (filtered) table at once.
+ * Static helper class to fill root histograms of any type. Contains functionality to fill once per call or a whole (filtered) table at once.
  */
 //**************************************************************************************************
 struct HistFiller {
   // fill any type of histogram (if weight was requested it must be the last argument)
   template <typename T, typename... Ts>
-  static void fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndWeight)
-  {
-    constexpr int nArgs = sizeof...(Ts);
-
-    constexpr bool validTH3 = (std::is_same_v<TH3, T> && (nArgs == 3 || nArgs == 4));
-    constexpr bool validTH2 = (std::is_same_v<TH2, T> && (nArgs == 2 || nArgs == 3));
-    constexpr bool validTH1 = (std::is_same_v<TH1, T> && (nArgs == 1 || nArgs == 2));
-    constexpr bool validTProfile3D = (std::is_same_v<TProfile3D, T> && (nArgs == 4 || nArgs == 5));
-    constexpr bool validTProfile2D = (std::is_same_v<TProfile2D, T> && (nArgs == 3 || nArgs == 4));
-    constexpr bool validTProfile = (std::is_same_v<TProfile, T> && (nArgs == 2 || nArgs == 3));
-
-    constexpr bool validSimpleFill = validTH1 || validTH2 || validTH3 || validTProfile || validTProfile2D || validTProfile3D;
-    // unfortunately we dont know at compile the dimension of THn(Sparse)
-    constexpr bool validComplexFill = std::is_base_of_v<THnBase, T>;
-    constexpr bool validComplexFillStep = std::is_base_of_v<StepTHn, T>;
-
-    if constexpr (validSimpleFill) {
-      hist->Fill(static_cast<double>(positionAndWeight)...);
-    } else if constexpr (validComplexFillStep) {
-      hist->Fill(positionAndWeight...); // first argument in pack is iStep, dimension check is done in StepTHn itself
-    } else if constexpr (validComplexFill) {
-      double tempArray[] = {static_cast<double>(positionAndWeight)...};
-      double weight{1.};
-      constexpr int nArgsMinusOne = nArgs - 1;
-      if (hist->GetNdimensions() == nArgsMinusOne) {
-        weight = tempArray[nArgsMinusOne];
-      } else if (hist->GetNdimensions() != nArgs) {
-        LOGF(FATAL, "The number of arguments in fill function called for histogram %s is incompatible with histogram dimensions.", hist->GetName());
-      }
-      hist->Fill(tempArray, weight);
-    } else {
-      LOGF(FATAL, "The number of arguments in fill function called for histogram %s is incompatible with histogram dimensions.", hist->GetName());
-    }
-  }
+  static void fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndWeight);
 
   // fill any type of histogram with columns (Cs) of a filtered table (if weight is requested it must reside the last specified column)
   template <typename... Cs, typename R, typename T>
-  static void fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2::framework::expressions::Filter& filter)
-  {
-    if constexpr (std::is_base_of_v<StepTHn, T>) {
-      LOGF(FATAL, "Table filling is not (yet?) supported for StepTHn.");
-      return;
-    }
-    auto filtered = o2::soa::Filtered<T>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)};
-    for (auto& t : filtered) {
-      fillHistAny(hist, (*(static_cast<Cs>(t).getIterator()))...);
-    }
-  }
+  static void fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2::framework::expressions::Filter& filter);
 
   // function that returns rough estimate for the size of a histogram in MB
   template <typename T>
-  static double getSize(std::shared_ptr<T>& hist, double fillFraction = 1.)
-  {
-    double size{0.};
-    if constexpr (std::is_base_of_v<TH1, T>) {
-      size = hist->GetNcells() * (HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2()->fN) ? sizeof(double) : 0.));
-    } else if constexpr (std::is_base_of_v<THn, T>) {
-      size = hist->GetNbins() * (HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2() != -1.) ? sizeof(double) : 0.));
-    } else if constexpr (std::is_base_of_v<THnSparse, T>) {
-      // THnSparse has massive overhead and should only be used when histogram is large and a very small fraction of bins is filled
-      double nBinsTotal = 1.;
-      int compCoordSize = 0; // size required to store a compact coordinate representation
-      for (int d = 0; d < hist->GetNdimensions(); ++d) {
-        int nBins = hist->GetAxis(d)->GetNbins() + 2;
-        nBinsTotal *= nBins;
-
-        // number of bits needed to store compact coordinates
-        int b = 1;
-        while (nBins /= 2) {
-          ++b;
-        }
-        compCoordSize += b;
-      }
-      compCoordSize = (compCoordSize + 7) / 8; // turn bits into bytes
-
-      // THnSparse stores the data in an array of chunks (THnSparseArrayChunk), each containing a fixed number of bins (e.g. 1024 * 16)
-      double nBinsFilled = fillFraction * nBinsTotal;
-      int nCunks = ceil(nBinsFilled / hist->GetChunkSize());
-      int chunkOverhead = sizeof(THnSparseArrayChunk);
-
-      // each chunk holds array of compact bin-coordinates and an array of bin content (+ one of bin error if requested)
-      double binSize = compCoordSize + HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2() != -1.) ? sizeof(double) : 0.);
-      size = nCunks * (chunkOverhead + hist->GetChunkSize() * binSize);
-      // since THnSparse must keep track of all the stored bins, it stores a map that
-      // relates the compact bin coordinates (or a hash thereof) to a linear index
-      // this index determines in which chunk and therein at which position to find / store bin coordinate and content
-      size += nBinsFilled * 3 * sizeof(Long64_t); // hash, key, value; not sure why 3 are needed here...
-    }
-    return size / 1048576.;
-  }
+  static double getSize(std::shared_ptr<T>& hist, double fillFraction = 1.);
 
  private:
   // helper function to determine base element size of histograms (in bytes)
-  // the complicated casting gymnastics are needed here since we only store the interface types in the registry
   template <typename T>
-  static int getBaseElementSize(T* ptr)
-  {
-    if constexpr (std::is_base_of_v<TH1, T> || std::is_base_of_v<THnSparse, T>) {
-      return getBaseElementSize<TArrayD, TArrayF, TArrayC, TArrayI, TArrayC, TArrayL>(ptr);
-    } else {
-      return getBaseElementSize<double, float, int, short, char, long>(ptr);
-    }
-  }
+  static int getBaseElementSize(T* ptr);
 
   template <typename T, typename Next, typename... Rest, typename P>
-  static int getBaseElementSize(P* ptr)
-  {
-    if (auto size = getBaseElementSize<T>(ptr)) {
-      return size;
-    }
-    return getBaseElementSize<Next, Rest...>(ptr);
-  }
+  static int getBaseElementSize(P* ptr);
 
   template <typename B, typename T>
-  static int getBaseElementSize(T* ptr)
-  {
-    if constexpr (std::is_base_of_v<THn, T>) {
-      if (dynamic_cast<THnT<B>*>(ptr)) {
-        return sizeof(B);
-      }
-    } else if constexpr (std::is_base_of_v<THnSparse, T>) {
-      if (dynamic_cast<THnSparseT<B>*>(ptr)) {
-        TDataMember* dm = B::Class()->GetDataMember("fArray");
-        return dm ? dm->GetDataType()->Size() : 0;
-      }
-    } else if constexpr (std::is_base_of_v<TH1, T>) {
-      if (auto arrayPtr = dynamic_cast<B*>(ptr)) {
-        return sizeof(arrayPtr->At(0));
-      }
-    }
-    return 0;
-  };
+  static int getBaseElementSize(T* ptr);
 };
 
 //**************************************************************************************************
@@ -183,20 +70,11 @@ struct HistFiller {
 //**************************************************************************************************
 class HistogramRegistry
 {
-  //**************************************************************************************************
-  /**
-   * HistogramName object providing the associated hash and a first guess for the index in the registry.
-   */
-  //**************************************************************************************************
+  // HistogramName class providing the associated hash and a first guess for the index in the registry
   struct HistName {
     // ctor for histogram names that are already hashed at compile time via HIST("myHistName")
     template <char... chars>
-    constexpr HistName(const ConstStr<chars...>& hashedHistName)
-      : str(hashedHistName.str),
-        hash(hashedHistName.hash),
-        idx(hash & REGISTRY_BITMASK)
-    {
-    }
+    constexpr HistName(const ConstStr<chars...>& hashedHistName);
     char const* const str{};
     const uint32_t hash{};
     const uint32_t idx{};
@@ -204,23 +82,11 @@ class HistogramRegistry
    protected:
     friend class HistogramRegistry;
     // ctor that does the hashing at runtime (for internal use only)
-    constexpr HistName(char const* const name)
-      : str(name),
-        hash(compile_time_hash(name)),
-        idx(hash & REGISTRY_BITMASK)
-    {
-    }
+    constexpr HistName(char const* const name);
   };
 
  public:
-  HistogramRegistry(char const* const name, std::vector<HistogramSpec> histSpecs = {}, OutputObjHandlingPolicy policy = OutputObjHandlingPolicy::AnalysisObject, bool sortHistos = true, bool createRegistryDir = false)
-    : mName(name), mPolicy(policy), mRegistryKey(), mRegistryValue(), mSortHistos(sortHistos), mCreateRegistryDir(createRegistryDir)
-  {
-    mRegistryKey.fill(0u);
-    for (auto& histSpec : histSpecs) {
-      insert(histSpec);
-    }
-  }
+  HistogramRegistry(char const* const name, std::vector<HistogramSpec> histSpecs = {}, OutputObjHandlingPolicy policy = OutputObjHandlingPolicy::AnalysisObject, bool sortHistos = true, bool createRegistryDir = false);
 
   // functions to add histograms to the registry
   void add(const HistogramSpec& histSpec);
@@ -231,66 +97,30 @@ class HistogramRegistry
   // function to query if name is already in use
   bool contains(const HistName& histName);
 
-  // gets the underlying histogram pointer
-  // we cannot automatically infer type here so it has to be explicitly specified
-  // -> get<TH1>(), get<TH2>(), get<TH3>(), get<THn>(), get<THnSparse>(), get<TProfile>(), get<TProfile2D>(), get<TProfile3D>()
-  /// @return the histogram registered with name @a name
+  // get the underlying histogram pointer
   template <typename T>
-  std::shared_ptr<T>& get(const HistName& histName)
-  {
-    if (auto histPtr = std::get_if<std::shared_ptr<T>>(&mRegistryValue[getHistIndex(histName)])) {
-      return *histPtr;
-    } else {
-      throw runtime_error_f(R"(Histogram type specified in get<>(HIST("%s")) does not match the actual type of the histogram!)", histName.str);
-    }
-  }
+  std::shared_ptr<T>& get(const HistName& histName);
 
-  /// @return the histogram registered with name @a name
+  // get the underlying histogram pointer
   template <typename T>
-  auto& operator()(const HistName& histName)
-  {
-    return get<T>(histName);
-  }
+  auto& operator()(const HistName& histName);
 
-  /// @return the associated OutputSpec
-  OutputSpec const spec()
-  {
-    header::DataDescription desc{};
-    auto lhash = compile_time_hash(mName.c_str());
-    std::memset(desc.str, '_', 16);
-    std::stringstream s;
-    s << std::hex << lhash;
-    s << std::hex << mTaskHash;
-    s << std::hex << reinterpret_cast<uint64_t>(this);
-    std::memcpy(desc.str, s.str().c_str(), 12);
-    return OutputSpec{OutputLabel{mName}, "ATSK", desc, 0};
-  }
+  // return the OutputSpec associated to the HistogramRegistry
+  OutputSpec const spec();
 
-  OutputRef ref()
-  {
-    return OutputRef{std::string{mName}, 0, o2::header::Stack{OutputObjHeader{mPolicy, OutputObjSourceType::HistogramRegistrySource, mTaskHash}}};
-  }
+  OutputRef ref();
 
-  void setHash(uint32_t hash)
-  {
-    mTaskHash = hash;
-  }
+  void setHash(uint32_t hash);
 
   TList* operator*();
 
   // fill hist with values
   template <typename... Ts>
-  void fill(const HistName& histName, Ts&&... positionAndWeight)
-  {
-    std::visit([&positionAndWeight...](auto&& hist) { HistFiller::fillHistAny(hist, std::forward<Ts>(positionAndWeight)...); }, mRegistryValue[getHistIndex(histName)]);
-  }
+  void fill(const HistName& histName, Ts&&... positionAndWeight);
 
   // fill hist with content of (filtered) table columns
   template <typename... Cs, typename T>
-  void fill(const HistName& histName, const T& table, const o2::framework::expressions::Filter& filter)
-  {
-    std::visit([&table, &filter](auto&& hist) { HistFiller::fillHistAny<Cs...>(hist, table, filter); }, mRegistryValue[getHistIndex(histName)]);
-  }
+  void fill(const HistName& histName, const T& table, const o2::framework::expressions::Filter& filter);
 
   // get rough estimate for size of histogram stored in registry
   double getSize(const HistName& histName, double fillFraction = 1.);
@@ -310,40 +140,14 @@ class HistogramRegistry
 
   // clone an existing histogram and insert it into the registry
   template <typename T>
-  void insertClone(const HistName& histName, const std::shared_ptr<T>& originalHist)
-  {
-    validateHistName(histName.str, histName.hash);
-    for (auto i = 0u; i < MAX_REGISTRY_SIZE; ++i) {
-      TObject* rawPtr = nullptr;
-      std::visit([&](const auto& sharedPtr) { rawPtr = sharedPtr.get(); }, mRegistryValue[imask(histName.idx + i)]);
-      if (!rawPtr) {
-        registerName(histName.str);
-        mRegistryKey[imask(histName.idx + i)] = histName.hash;
-        mRegistryValue[imask(histName.idx + i)] = std::shared_ptr<T>(static_cast<T*>(originalHist->Clone(histName.str)));
-        lookup += i;
-        return;
-      }
-    }
-    LOGF(FATAL, R"(Internal array of HistogramRegistry "%s" is full.)", mName);
-  }
+  void insertClone(const HistName& histName, const std::shared_ptr<T>& originalHist);
 
   // helper function that checks if histogram name can be used in registry
   void validateHistName(const char* name, const uint32_t hash);
 
   // helper function to find the histogram position in the registry
   template <typename T>
-  uint32_t getHistIndex(const T& histName)
-  {
-    if (O2_BUILTIN_LIKELY(histName.hash == mRegistryKey[histName.idx])) {
-      return histName.idx;
-    }
-    for (auto i = 1u; i < MAX_REGISTRY_SIZE; ++i) {
-      if (histName.hash == mRegistryKey[imask(histName.idx + i)]) {
-        return imask(histName.idx + i);
-      }
-    }
-    throw runtime_error_f(R"(Could not find histogram "%s" in HistogramRegistry "%s"!)", histName.str, mName.data());
-  }
+  uint32_t getHistIndex(const T& histName);
 
   constexpr uint32_t imask(uint32_t i) const
   {
@@ -373,6 +177,215 @@ class HistogramRegistry
   std::array<uint32_t, MAX_REGISTRY_SIZE> mRegistryKey{};
   std::array<HistPtr, MAX_REGISTRY_SIZE> mRegistryValue{};
 };
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+// Implementation of HistFiller template functions.
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+
+template <typename T, typename... Ts>
+void HistFiller::fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndWeight)
+{
+  constexpr int nArgs = sizeof...(Ts);
+
+  constexpr bool validTH3 = (std::is_same_v<TH3, T> && (nArgs == 3 || nArgs == 4));
+  constexpr bool validTH2 = (std::is_same_v<TH2, T> && (nArgs == 2 || nArgs == 3));
+  constexpr bool validTH1 = (std::is_same_v<TH1, T> && (nArgs == 1 || nArgs == 2));
+  constexpr bool validTProfile3D = (std::is_same_v<TProfile3D, T> && (nArgs == 4 || nArgs == 5));
+  constexpr bool validTProfile2D = (std::is_same_v<TProfile2D, T> && (nArgs == 3 || nArgs == 4));
+  constexpr bool validTProfile = (std::is_same_v<TProfile, T> && (nArgs == 2 || nArgs == 3));
+
+  constexpr bool validSimpleFill = validTH1 || validTH2 || validTH3 || validTProfile || validTProfile2D || validTProfile3D;
+  // unfortunately we dont know at compile the dimension of THn(Sparse)
+  constexpr bool validComplexFill = std::is_base_of_v<THnBase, T>;
+  constexpr bool validComplexFillStep = std::is_base_of_v<StepTHn, T>;
+
+  if constexpr (validSimpleFill) {
+    hist->Fill(static_cast<double>(positionAndWeight)...);
+  } else if constexpr (validComplexFillStep) {
+    hist->Fill(positionAndWeight...); // first argument in pack is iStep, dimension check is done in StepTHn itself
+  } else if constexpr (validComplexFill) {
+    double tempArray[] = {static_cast<double>(positionAndWeight)...};
+    double weight{1.};
+    constexpr int nArgsMinusOne = nArgs - 1;
+    if (hist->GetNdimensions() == nArgsMinusOne) {
+      weight = tempArray[nArgsMinusOne];
+    } else if (hist->GetNdimensions() != nArgs) {
+      LOGF(FATAL, "The number of arguments in fill function called for histogram %s is incompatible with histogram dimensions.", hist->GetName());
+    }
+    hist->Fill(tempArray, weight);
+  } else {
+    LOGF(FATAL, "The number of arguments in fill function called for histogram %s is incompatible with histogram dimensions.", hist->GetName());
+  }
+}
+
+template <typename... Cs, typename R, typename T>
+void HistFiller::fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2::framework::expressions::Filter& filter)
+{
+  if constexpr (std::is_base_of_v<StepTHn, T>) {
+    LOGF(FATAL, "Table filling is not (yet?) supported for StepTHn.");
+    return;
+  }
+  auto filtered = o2::soa::Filtered<T>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)};
+  for (auto& t : filtered) {
+    fillHistAny(hist, (*(static_cast<Cs>(t).getIterator()))...);
+  }
+}
+
+template <typename T>
+double HistFiller::getSize(std::shared_ptr<T>& hist, double fillFraction)
+{
+  double size{0.};
+  if constexpr (std::is_base_of_v<TH1, T>) {
+    size = hist->GetNcells() * (HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2()->fN) ? sizeof(double) : 0.));
+  } else if constexpr (std::is_base_of_v<THn, T>) {
+    size = hist->GetNbins() * (HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2() != -1.) ? sizeof(double) : 0.));
+  } else if constexpr (std::is_base_of_v<THnSparse, T>) {
+    // THnSparse has massive overhead and should only be used when histogram is large and a very small fraction of bins is filled
+    double nBinsTotal = 1.;
+    int compCoordSize = 0; // size required to store a compact coordinate representation
+    for (int d = 0; d < hist->GetNdimensions(); ++d) {
+      int nBins = hist->GetAxis(d)->GetNbins() + 2;
+      nBinsTotal *= nBins;
+
+      // number of bits needed to store compact coordinates
+      int b = 1;
+      while (nBins /= 2) {
+        ++b;
+      }
+      compCoordSize += b;
+    }
+    compCoordSize = (compCoordSize + 7) / 8; // turn bits into bytes
+
+    // THnSparse stores the data in an array of chunks (THnSparseArrayChunk), each containing a fixed number of bins (e.g. 1024 * 16)
+    double nBinsFilled = fillFraction * nBinsTotal;
+    int nCunks = ceil(nBinsFilled / hist->GetChunkSize());
+    int chunkOverhead = sizeof(THnSparseArrayChunk);
+
+    // each chunk holds array of compact bin-coordinates and an array of bin content (+ one of bin error if requested)
+    double binSize = compCoordSize + HistFiller::getBaseElementSize(hist.get()) + ((hist->GetSumw2() != -1.) ? sizeof(double) : 0.);
+    size = nCunks * (chunkOverhead + hist->GetChunkSize() * binSize);
+    // since THnSparse must keep track of all the stored bins, it stores a map that
+    // relates the compact bin coordinates (or a hash thereof) to a linear index
+    // this index determines in which chunk and therein at which position to find / store bin coordinate and content
+    size += nBinsFilled * 3 * sizeof(Long64_t); // hash, key, value; not sure why 3 are needed here...
+  }
+  return size / 1048576.;
+}
+
+template <typename T>
+int HistFiller::getBaseElementSize(T* ptr)
+{
+  if constexpr (std::is_base_of_v<TH1, T> || std::is_base_of_v<THnSparse, T>) {
+    return getBaseElementSize<TArrayD, TArrayF, TArrayC, TArrayI, TArrayC, TArrayL>(ptr);
+  } else {
+    return getBaseElementSize<double, float, int, short, char, long>(ptr);
+  }
+}
+
+template <typename T, typename Next, typename... Rest, typename P>
+int HistFiller::getBaseElementSize(P* ptr)
+{
+  if (auto size = getBaseElementSize<T>(ptr)) {
+    return size;
+  }
+  return getBaseElementSize<Next, Rest...>(ptr);
+}
+
+template <typename B, typename T>
+int HistFiller::getBaseElementSize(T* ptr)
+{
+  if constexpr (std::is_base_of_v<THn, T>) {
+    if (dynamic_cast<THnT<B>*>(ptr)) {
+      return sizeof(B);
+    }
+  } else if constexpr (std::is_base_of_v<THnSparse, T>) {
+    if (dynamic_cast<THnSparseT<B>*>(ptr)) {
+      TDataMember* dm = B::Class()->GetDataMember("fArray");
+      return dm ? dm->GetDataType()->Size() : 0;
+    }
+  } else if constexpr (std::is_base_of_v<TH1, T>) {
+    if (auto arrayPtr = dynamic_cast<B*>(ptr)) {
+      return sizeof(arrayPtr->At(0));
+    }
+  }
+  return 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+// Implementation of HistogramRegistry template functions.
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+
+template <char... chars>
+constexpr HistogramRegistry::HistName::HistName(const ConstStr<chars...>& hashedHistName)
+  : str(hashedHistName.str),
+    hash(hashedHistName.hash),
+    idx(hash & REGISTRY_BITMASK)
+{
+}
+
+template <typename T>
+std::shared_ptr<T>& HistogramRegistry::get(const HistName& histName)
+{
+  if (auto histPtr = std::get_if<std::shared_ptr<T>>(&mRegistryValue[getHistIndex(histName)])) {
+    return *histPtr;
+  } else {
+    throw runtime_error_f(R"(Histogram type specified in get<>(HIST("%s")) does not match the actual type of the histogram!)", histName.str);
+  }
+}
+
+template <typename T>
+auto& HistogramRegistry::operator()(const HistName& histName)
+{
+  return get<T>(histName);
+}
+
+template <typename T>
+void HistogramRegistry::insertClone(const HistName& histName, const std::shared_ptr<T>& originalHist)
+{
+  validateHistName(histName.str, histName.hash);
+  for (auto i = 0u; i < MAX_REGISTRY_SIZE; ++i) {
+    TObject* rawPtr = nullptr;
+    std::visit([&](const auto& sharedPtr) { rawPtr = sharedPtr.get(); }, mRegistryValue[imask(histName.idx + i)]);
+    if (!rawPtr) {
+      registerName(histName.str);
+      mRegistryKey[imask(histName.idx + i)] = histName.hash;
+      mRegistryValue[imask(histName.idx + i)] = std::shared_ptr<T>(static_cast<T*>(originalHist->Clone(histName.str)));
+      lookup += i;
+      return;
+    }
+  }
+  LOGF(FATAL, R"(Internal array of HistogramRegistry "%s" is full.)", mName);
+}
+
+template <typename T>
+uint32_t HistogramRegistry::getHistIndex(const T& histName)
+{
+  if (O2_BUILTIN_LIKELY(histName.hash == mRegistryKey[histName.idx])) {
+    return histName.idx;
+  }
+  for (auto i = 1u; i < MAX_REGISTRY_SIZE; ++i) {
+    if (histName.hash == mRegistryKey[imask(histName.idx + i)]) {
+      return imask(histName.idx + i);
+    }
+  }
+  throw runtime_error_f(R"(Could not find histogram "%s" in HistogramRegistry "%s"!)", histName.str, mName.data());
+}
+
+template <typename... Ts>
+void HistogramRegistry::fill(const HistName& histName, Ts&&... positionAndWeight)
+{
+  std::visit([&positionAndWeight...](auto&& hist) { HistFiller::fillHistAny(hist, std::forward<Ts>(positionAndWeight)...); }, mRegistryValue[getHistIndex(histName)]);
+}
+
+template <typename... Cs, typename T>
+void HistogramRegistry::fill(const HistName& histName, const T& table, const o2::framework::expressions::Filter& filter)
+{
+  std::visit([&table, &filter](auto&& hist) { HistFiller::fillHistAny<Cs...>(hist, table, filter); }, mRegistryValue[getHistIndex(histName)]);
+}
 
 } // namespace o2::framework
 #endif // FRAMEWORK_HISTOGRAMREGISTRY_H_

--- a/Framework/Core/include/Framework/StringHelpers.h
+++ b/Framework/Core/include/Framework/StringHelpers.h
@@ -86,7 +86,6 @@ template <char... chars>
 struct ConstStr {
   static constexpr char str[] = {chars..., '\0'};
   static constexpr uint32_t hash = compile_time_hash_from_literal(str);
-  static constexpr uint32_t idx = hash & 0x1FF;
 };
 
 template <typename>

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -15,6 +15,46 @@
 namespace o2::framework
 {
 
+constexpr HistogramRegistry::HistName::HistName(char const* const name)
+  : str(name),
+    hash(compile_time_hash(name)),
+    idx(hash & REGISTRY_BITMASK)
+{
+}
+
+HistogramRegistry::HistogramRegistry(char const* const name, std::vector<HistogramSpec> histSpecs, OutputObjHandlingPolicy policy, bool sortHistos, bool createRegistryDir)
+  : mName(name), mPolicy(policy), mRegistryKey(), mRegistryValue(), mSortHistos(sortHistos), mCreateRegistryDir(createRegistryDir)
+{
+  mRegistryKey.fill(0u);
+  for (auto& histSpec : histSpecs) {
+    insert(histSpec);
+  }
+}
+
+// return the OutputSpec associated to the HistogramRegistry
+OutputSpec const HistogramRegistry::spec()
+{
+  header::DataDescription desc{};
+  auto lhash = compile_time_hash(mName.data());
+  std::memset(desc.str, '_', 16);
+  std::stringstream s;
+  s << std::hex << lhash;
+  s << std::hex << mTaskHash;
+  s << std::hex << reinterpret_cast<uint64_t>(this);
+  std::memcpy(desc.str, s.str().data(), 12);
+  return OutputSpec{OutputLabel{mName}, "ATSK", desc, 0};
+}
+
+OutputRef HistogramRegistry::ref()
+{
+  return OutputRef{std::string{mName}, 0, o2::header::Stack{OutputObjHeader{mPolicy, OutputObjSourceType::HistogramRegistrySource, mTaskHash}}};
+}
+
+void HistogramRegistry::setHash(uint32_t hash)
+{
+  mTaskHash = hash;
+}
+
 // create histogram from specification and insert it into the registry
 void HistogramRegistry::insert(const HistogramSpec& histSpec)
 {

--- a/Framework/Core/test/test_StringHelpers.cxx
+++ b/Framework/Core/test/test_StringHelpers.cxx
@@ -32,7 +32,6 @@ void printString(const T& constStr)
   std::cout << "ConstStr:" << std::endl;
   std::cout << "str -> " << constStr.str << std::endl;
   std::cout << "hash -> " << constStr.hash << std::endl;
-  std::cout << "idx  -> " << constStr.idx << std::endl;
 };
 
 BOOST_AUTO_TEST_CASE(StringHelpersConstStr)


### PR DESCRIPTION
- allow to construct HistName objects from compile-time hashed names
- make HistName a nested class in HistogramRegistry since it has no meaning in global scope
- remove compile-time calculation of index in ConstStr<> since it is very registry specific
- don't inline all the functions