### PR TITLE
Misc. fixes for secondary vertexing

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1235,12 +1235,12 @@ float MatchTPCITS::getPredictedChi2NoZ(const o2::track::TrackParCov& trITS, cons
 
   //  if (std::abs(trITS.getAlpha() - trTPC.getAlpha()) > FLT_EPSILON) {
   //    LOG(ERROR) << "The reference Alpha of the tracks differ: "
-  //	       << trITS.getAlpha() << " : " << trTPC.getAlpha();
+  //        << trITS.getAlpha() << " : " << trTPC.getAlpha();
   //    return 2. * o2::track::HugeF;
   //  }
   //  if (std::abs(trITS.getX() - trTPC.getX()) > FLT_EPSILON) {
   //    LOG(ERROR) << "The reference X of the tracks differ: "
-  //	       << trITS.getX() << " : " << trTPC.getX();
+  //        << trITS.getX() << " : " << trTPC.getX();
   //    return 2. * o2::track::HugeF;
   //  }
   MatrixDSym4 covMat;
@@ -1455,10 +1455,13 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
     return false;
   }
 
-  // we need to update the LTOF integral by the distance to the "primary vertex"
+  // We need to update the LTOF integral by the distance to the "primary vertex"
+  // We want to leave the track at the the position of its last update, so we do a fast propagation on the TrackPar copy of trfit,
+  // and since for the LTOF calculation the material effects are irrelevant, we skip material corrections
   const o2::dataformats::VertexBase vtxDummy; // at the moment using dummy vertex: TODO use MeanVertex constraint instead
-  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(),
-                                  maxStep, mUseMatCorrFlag, nullptr, &trfit.getLTIntegralOut())) {
+  o2::track::TrackPar trpar(trfit);
+  if (!propagator->propagateToDCA(vtxDummy.getXYZ(), trpar, propagator->getNominalBz(),
+                                  maxStep, MatCorrType::USEMatCorrNONE, nullptr, &trfit.getLTIntegralOut())) {
     LOG(ERROR) << "LTOF integral might be incorrect";
   }
 
@@ -1865,7 +1868,7 @@ int MatchTPCITS::checkABSeedFromLr(int lrSeed, int seedID, ABTrackLinksList& lli
         /*
         const auto lab = mITSClsLabels->getLabels(clID)[0];                                           // tmp
         LOG(INFO) << "cl " << cntc++ << " ClLbl:" << lab << " TrcLbl" << lblTrc << " chi2 = " << chi2 << " chipGID: " << lad.chips[chipID].id; // tmp
-	*/
+ */
         if (chi2 > mParams->cutABTrack2ClChi2) {
           continue;
         }
@@ -1883,7 +1886,7 @@ int MatchTPCITS::checkABSeedFromLr(int lrSeed, int seedID, ABTrackLinksList& lli
           if (lrTgt < llist.lowestLayer) {
             llist.lowestLayer = lrTgt; // update lowest layer reached
           }
-          //	  printf("Added chi2 %.3f @ lr %d as %d\n",link.chi2, lrTgt, lnkID); // tmp tmp
+          //   printf("Added chi2 %.3f @ lr %d as %d\n",link.chi2, lrTgt, lnkID); // tmp tmp
         }
       }
     }
@@ -2140,7 +2143,7 @@ float MatchTPCITS::correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTP
     float xTgt;
     auto propagator = o2::base::Propagator::Instance();
     if (!trc.getXatLabR(r, xTgt, propagator->getNominalBz(), o2::track::DirInward) ||
-	!propagator->PropagateToXBxByBz(trc, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
+ !propagator->PropagateToXBxByBz(trc, xTgt, MaxSnp, 2., mUseMatCorrFlag)) {
       return -1;
     }
   }

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -115,6 +115,7 @@ class PVertexer
   void initMeanVertexConstraint();
   void applyConstraint(VertexSeed& vtxSeed) const;
   bool upscaleSigma(VertexSeed& vtxSeed) const;
+  bool relateTrackToMeanVertex(o2::track::TrackParCov& trc, float vtxErr2) const;
 
   template <typename TR>
   void createTracksPool(const TR& tracks, gsl::span<const o2d::GlobalTrackID> gids);
@@ -216,8 +217,7 @@ void PVertexer::createTracksPool(const TR& tracks, gsl::span<const o2d::GlobalTr
   for (uint32_t i = 0; i < ntGlo; i++) {
     int id = sortedTrackID[i];
     o2::track::TrackParCov trc = tracks[id];
-    if (!trc.propagateToDCA(mMeanVertex, mBz, &dca, mPVParams->dcaTolerance) ||
-        dca.getY() * dca.getY() / (dca.getSigmaY2() + vtxErr2) > mPVParams->pullIniCut) {
+    if (!relateTrackToMeanVertex(trc, vtxErr2)) {
       continue;
     }
     auto& tvf = mTracksPool.emplace_back(trc, tracks[id].getTimeMUS(), id, gids[id], mPVParams->addTimeSigma2, mPVParams->addZSigma2);

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -82,7 +82,7 @@ class SVertexer
 
  private:
   bool checkV0(TrackCand& seed0, TrackCand& seed1, int iP, int iN, int ithread);
-  int checkCascades(float r2v0, float p2v0, int avoidTrackID, int posneg, int ithread);
+  int checkCascades(float r2v0, std::array<float, 3> pV0, float p2v0, int avoidTrackID, int posneg, int ithread);
   void setupThreads();
   void buildT2V(const o2::globaltracking::RecoContainer& recoTracks);
   void updateTimeDependentParams();

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -52,6 +52,7 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
 
   float maxDCAXYCasc = 0.3; // max DCA of cascade to PV in XY // TODO RS: shall we use real chi2 to vertex?
   float maxDCAZCasc = 0.3;  // max DCA of cascade to PV in Z
+  float minCosPACasc = 0.7; ///< min cos of PA to PV for cascade candidates
 
   // cuts on different V0 PID params
   float pidCutsPhoton[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.60, 0.0};   // Photon

--- a/Detectors/Vertexing/src/PVertexer.cxx
+++ b/Detectors/Vertexing/src/PVertexer.cxx
@@ -954,6 +954,15 @@ SeedHistoTZ PVertexer::buildHistoTZ(const VertexingInput& input)
 }
 
 //______________________________________________
+bool PVertexer::relateTrackToMeanVertex(o2::track::TrackParCov& trc, float vtxErr2) const
+{
+  o2d::DCA dca;
+  return o2::base::Propagator::Instance()->propagateToDCA(mMeanVertex, trc, mBz, 2.0f,
+                                                          o2::base::Propagator::MatCorrType::USEMatCorrLUT, &dca, nullptr, 0, mPVParams->dcaTolerance) &&
+         (dca.getY() * dca.getY() / (dca.getSigmaY2() + vtxErr2) < mPVParams->pullIniCut);
+}
+
+//______________________________________________
 void PVertexer::doDBScanDump(const VertexingInput& input, gsl::span<const o2::MCCompLabel> lblTracks)
 {
   // dump tracks for T-Z clusters identified by the DBScan

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -295,16 +295,16 @@ bool SVertexer::checkV0(TrackCand& seedP, TrackCand& seedN, int iP, int iN, int 
   if (!added) {
     return false;
   }
-
   auto& v0 = mV0sTmp[ithread].back();
+
   // check cascades
   if (checkForCascade) {
     int nCascAdded = 0;
     if (hypCheckStatus[HypV0::Lambda]) {
-      nCascAdded += checkCascades(r2v0, p2V0, iN, NEG, ithread);
+      nCascAdded += checkCascades(r2v0, pV0, p2V0, iN, NEG, ithread);
     }
     if (hypCheckStatus[HypV0::AntiLambda]) {
-      nCascAdded += checkCascades(r2v0, p2V0, iP, POS, ithread);
+      nCascAdded += checkCascades(r2v0, pV0, p2V0, iP, POS, ithread);
     }
     if (!nCascAdded && rejectIfNotCascade) { // v0 would be accepted only if it creates a cascade
       mV0sTmp[ithread].pop_back();
@@ -316,7 +316,7 @@ bool SVertexer::checkV0(TrackCand& seedP, TrackCand& seedN, int iP, int iN, int 
 }
 
 //__________________________________________________________________
-int SVertexer::checkCascades(float r2v0, float p2V0, int avoidTrackID, int posneg, int ithread)
+int SVertexer::checkCascades(float r2v0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, int ithread)
 {
   // check last added V0 for belonging to cascade
   auto& fitterCasc = mFitterCasc[ithread];
@@ -343,7 +343,7 @@ int SVertexer::checkCascades(float r2v0, float p2V0, int avoidTrackID, int posne
     int candC = 0;
     const auto& cascXYZ = fitterCasc.getPCACandidatePos(candC);
     // make sure the cascade radius is smaller than that of the vertex
-    float dxc = cascXYZ[0] - pv.getX(), dyc = cascXYZ[1] - pv.getY(), r2casc = dxc * dxc + dyc * dyc;
+    float dxc = cascXYZ[0] - pv.getX(), dyc = cascXYZ[1] - pv.getY(), dzc = cascXYZ[2] - pv.getZ(), r2casc = dxc * dxc + dyc * dyc;
     if (r2v0 - r2casc < mMinR2DiffV0Casc || r2casc < mMinR2ToMeanVertex) {
       continue;
     }
@@ -360,12 +360,16 @@ int SVertexer::checkCascades(float r2v0, float p2V0, int avoidTrackID, int posne
     trNeut.getPxPyPzGlo(pNeut);
     trBach.getPxPyPzGlo(pBach);
     std::array<float, 3> pCasc = {pNeut[0] + pBach[0], pNeut[1] + pBach[1], pNeut[2] + pBach[2]};
-    auto prodPPos = pCasc[0] * cascXYZ[0] + pCasc[1] * cascXYZ[1] + pCasc[2] * cascXYZ[2];
+    auto prodPPos = pV0[0] * dxc + pV0[1] * dyc + pV0[2] * dzc;
     if (prodPPos < 0.) { // causality cut
       continue;
     }
-    float p2Bach = pBach[0] * pBach[0] + pBach[1] * pBach[1] + pBach[2] * pBach[2];
     float pt2Casc = pCasc[0] * pCasc[0] + pCasc[1] * pCasc[1], p2Casc = pt2Casc + pCasc[2] * pCasc[2];
+    float cosPA = (pCasc[0] * dxc + pCasc[1] * dyc + pCasc[2] * dzc) / std::sqrt(p2Casc * (r2casc + dzc * dzc));
+    if (cosPA < mSVParams->minCosPACasc) {
+      continue;
+    }
+    float p2Bach = pBach[0] * pBach[0] + pBach[1] * pBach[1] + pBach[2] * pBach[2];
     float ptCasc = std::sqrt(pt2Casc);
     bool goodHyp = false;
     for (int ipid = 0; ipid < NHypCascade; ipid++) {
@@ -386,7 +390,7 @@ int SVertexer::checkCascades(float r2v0, float p2V0, int avoidTrackID, int posne
       mCascadesTmp[ithread].pop_back();
       continue;
     }
-    casc.setCosPA(dca.getY());
+    casc.setCosPA(cosPA);
     casc.setVertexID(v0.getVertexID());
     casc.setDCA(fitterCasc.getChi2AtPCACandidate());
   }


### PR DESCRIPTION
* ITS-TPC matched should leave matched tracks at X last update point in order to not bias the e.loss correction if it is secondary.
* PVertexer relate prim.tracks candidates to meanVertex applying mat.corr.
* Fix in cascades casuality cuts, store cosPA