### PR TITLE
o2-sim: Stability fix

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Aligner.h
+++ b/Detectors/Base/include/DetectorsBase/Aligner.h
@@ -37,7 +37,7 @@ class Aligner : public o2::conf::ConfigurableParamHelper<Aligner>
 
  private:
   std::string mCCDB = "http://ccdb-test.cern.ch:8080"; // URL for CCDB acces
-  std::string mDetectors = "all";                      // comma-separated list of modules to align, "all" or "none"
+  std::string mDetectors = "none";                     // comma-separated list of modules to align, "all" or "none"
   long mTimeStamp = 0;                                 // assigned TimeStamp or now() if 0
 
   O2ParamDef(Aligner, "align-geom");

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -147,12 +147,12 @@ class O2PrimaryServerDevice final : public FairMQDevice
     static std::vector<std::thread> threads;
     LOG(INFO) << "LAUNCHING STATUS THREAD";
     auto lambda = [this]() {
-      auto& channel = fChannels.at("o2sim-primserv-info").at(0);
-      if (!channel.IsValid()) {
-        LOG(ERROR) << "channel not valid";
-      }
-      std::unique_ptr<FairMQMessage> request(channel.NewSimpleMessage(-1));
       while (mState != O2PrimaryServerState::Stopped) {
+        auto& channel = fChannels.at("o2sim-primserv-info").at(0);
+        if (!channel.IsValid()) {
+          LOG(ERROR) << "channel primserv-info not valid";
+        }
+        std::unique_ptr<FairMQMessage> request(channel.NewSimpleMessage(-1));
         int timeout = 100; // 100ms --> so as not to block and allow for proper termination of this thread
         if (channel.Receive(request, timeout) > 0) {
           LOG(INFO) << "INFO REQUEST RECEIVED";

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -93,7 +93,7 @@ class O2SimDevice final : public FairMQDevice
     std::unique_ptr<FairMQMessage> request(channel.NewSimpleMessage(O2PrimaryServerInfoRequest::Config));
     std::unique_ptr<FairMQMessage> reply(channel.NewMessage());
 
-    int timeoutinMS = 4000; // wait for 4s max --> should be fast reply
+    int timeoutinMS = 60000; // wait for 60s max --> should be fast reply
     if (channel.Send(request, timeoutinMS) > 0) {
       LOG(INFO) << "Waiting for configuration answer ";
       if (channel.Receive(reply, timeoutinMS) > 0) {

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -170,11 +170,11 @@ void sighandler(int signal)
 {
   if (signal == SIGINT || signal == SIGTERM) {
     LOG(INFO) << "o2-sim driver: Signal caught ... clean up and exit";
-    cleanup();
     // forward signal to all children
     for (auto& pid : gChildProcesses) {
       killpg(pid, signal);
     }
+    cleanup();
     exit(0);
   }
 }
@@ -586,7 +586,6 @@ int main(int argc, char* argv[])
   }
 
   LOG(DEBUG) << "ShmManager operation " << o2::utils::ShmManager::Instance().isOperational() << "\n";
-  cleanup();
 
   // do a quick check to see if simulation produced something reasonable
   // (mainly useful for continuous integration / automated testing suite)
@@ -607,5 +606,6 @@ int main(int argc, char* argv[])
     LOG(INFO) << "SIMULATION RETURNED SUCCESFULLY";
   }
 
+  cleanup();
   return returncode;
 }


### PR DESCRIPTION
Trying to address failures in the CI / lxplus-CVFMS, by:

* cleanup up sockets later
* giving more time to initialize (probably reading from CVMFS
  can slow down the init-process)
* set alignment to none by default as Geant4 crashes on the Mac when this
  is switched on