### PR TITLE
DPL: syntactic sugar for WorkflowOptions

### DIFF
--- a/Framework/Core/include/Framework/ConfigurableHelpers.h
+++ b/Framework/Core/include/Framework/ConfigurableHelpers.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_CONFIGURABLEHELPERS_H_
+#define O2_FRAMEWORK_CONFIGURABLEHELPERS_H_
+
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/Configurable.h"
+#include "Framework/RootConfigParamHelpers.h"
+
+namespace o2::framework
+{
+
+struct ConfigurableHelpers {
+  template <typename T, ConfigParamKind K, typename IP>
+  static bool appendOption(std::vector<ConfigParamSpec>& options, Configurable<T, K, IP>& what)
+  {
+    if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
+      options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<T>>, what.value, {what.help}, what.kind});
+    } else {
+      auto specs = RootConfigParamHelpers::asConfigParamSpecs<T>(what.name, what.value);
+      options.insert(options.end(), specs.begin(), specs.end());
+    }
+    return true;
+  }
+};
+
+} // namespace o2::framework
+#endif //  O2_FRAMEWORK_CONFIGURABLEHELPERS_H_

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -12,6 +12,7 @@
 
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigurableHelpers.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataAllocator.h"
@@ -24,6 +25,8 @@
 #include "Framework/RuntimeError.h"
 #include "Framework/ResourcePolicyHelpers.h"
 #include "Framework/Logger.h"
+#include "Framework/CheckTypes.h"
+#include "Framework/StructToTuple.h"
 
 #include <vector>
 #include <cstring>
@@ -68,8 +71,19 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
 // By default we leave the channel policies unchanged. Notice that the default still include
 // a "match all" policy which uses pub / sub
 // FIXME: add a debug statement saying that the default policy was used?
+
 void defaultConfiguration(std::vector<o2::framework::ChannelConfigurationPolicy>& channelPolicies) {}
-void defaultConfiguration(std::vector<o2::framework::ConfigParamSpec>& globalWorkflowOptions) {}
+void defaultConfiguration(std::vector<o2::framework::ConfigParamSpec>& globalWorkflowOptions)
+{
+  o2::framework::call_if_defined<struct WorkflowOptions>([&](auto* ptr) {
+    ptr = new std::decay_t<decltype(*ptr)>;
+    o2::framework::homogeneous_apply_refs([&globalWorkflowOptions](auto what) {
+      return o2::framework::ConfigurableHelpers::appendOption(globalWorkflowOptions, what);
+    },
+                                          *ptr);
+  });
+}
+
 void defaultConfiguration(std::vector<o2::framework::CompletionPolicy>& completionPolicies) {}
 void defaultConfiguration(std::vector<o2::framework::DispatchPolicy>& dispatchPolicies) {}
 void defaultConfiguration(std::vector<o2::framework::ResourcePolicy>& resourcePolicies) {}

--- a/Framework/Core/src/AnalysisManagers.h
+++ b/Framework/Core/src/AnalysisManagers.h
@@ -18,6 +18,7 @@
 #include "Framework/HistogramRegistry.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/ConfigurableHelpers.h"
 #include "Framework/InitContext.h"
 #include "Framework/RootConfigParamHelpers.h"
 #include "../src/ExpressionHelpers.h"
@@ -368,13 +369,7 @@ template <typename T, ConfigParamKind K, typename IP>
 struct OptionManager<Configurable<T, K, IP>> {
   static bool appendOption(std::vector<ConfigParamSpec>& options, Configurable<T, K, IP>& what)
   {
-    if constexpr (variant_trait_v<typename std::decay<T>::type> != VariantType::Unknown) {
-      options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<T>>, what.value, {what.help}, what.kind});
-    } else {
-      auto specs = RootConfigParamHelpers::asConfigParamSpecs<T>(what.name, what.value);
-      options.insert(options.end(), specs.begin(), specs.end());
-    }
-    return true;
+    return ConfigurableHelpers::appendOption(options, what);
   }
 
   static bool prepare(InitContext& context, Configurable<T, K, IP>& what)

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/ControlService.h"
+#include "Framework/Configurable.h"
 #include "Framework/RunningWorkflowInfo.h"
 #include <FairMQDevice.h>
 #include <InfoLogger/InfoLogger.hxx>
@@ -24,14 +25,13 @@
 using namespace o2::framework;
 using namespace AliceO2::InfoLogger;
 
-void customize(std::vector<ConfigParamSpec>& options)
-{
-  options.push_back(ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}});
-  options.push_back(ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}});
-  options.push_back(ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}});
-  options.push_back(ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}});
-  options.push_back(ConfigParamSpec{"aBool", VariantType::Bool, true, {"a boolean option"}});
-}
+struct WorkflowOptions {
+  Configurable<int> anInt{"anInt", 1, ""};
+  Configurable<float> aFloat{"aFloat", 2.0f, {"a float option"}};
+  Configurable<double> aDouble{"aDouble", 3., {"a double option"}};
+  Configurable<std::string> aString{"aString", "foobar", {"a string option"}};
+  Configurable<bool> aBool{"aBool", true, {"a boolean option"}};
+};
 
 // This completion policy will only be applied to the device called `D` and
 // will process an InputRecord which had any of its constituent updated.


### PR DESCRIPTION
Rather than using the "customise" method, it is now possible do
define WorkflowOptions merely by defining a:

```
struct WorkflowOptions {
  Configurable<T> myConfigurable{name, defaultValue, help};
  ...
};
```

the system will automatically populate the vector of global
options by inspecting the contents of a default constructed WorkflowOptions
object.