### PR TITLE
MCHRaw: Introduce a few new types to clarify some interfaces.

### DIFF
--- a/Detectors/MUON/MCH/Raw/Common/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Common/CMakeLists.txt
@@ -9,10 +9,14 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(MCHRawCommon
-        SOURCES src/SampaHeader.cxx src/SampaCluster.cxx
-        PUBLIC_LINK_LIBRARIES fmt::fmt Microsoft.GSL::GSL Boost::boost O2::Headers O2::CommonConstants
-        O2::DetectorsRaw
-        PRIVATE_LINK_LIBRARIES O2::MCHRawImplHelpers)
+               SOURCES src/DataFormats.cxx
+                       src/SampaBunchCrossingCounter.cxx
+                       src/SampaCluster.cxx
+                       src/SampaHeader.cxx
+               PUBLIC_LINK_LIBRARIES fmt::fmt Microsoft.GSL::GSL Boost::boost
+                                     O2::Headers O2::CommonConstants
+                                     O2::DetectorsRaw
+               PRIVATE_LINK_LIBRARIES O2::MCHRawImplHelpers)
 
 if(BUILD_TESTING)
         add_subdirectory(test)

--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/DataFormats.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/DataFormats.h
@@ -12,6 +12,7 @@
 #define O2_MCH_RAW_DATA_FORMATS_H
 
 #include <cstdint>
+#include <iosfwd>
 
 namespace o2::mch::raw
 {
@@ -29,6 +30,38 @@ struct ChargeSumMode {
 struct SampleMode {
   bool operator()() const { return false; }
 };
+
+template <typename FORMAT>
+struct isUserLogicFormat; // only defined (on purpose) for two types below
+
+template <>
+struct isUserLogicFormat<UserLogicFormat> {
+  static constexpr bool value = true;
+};
+
+template <>
+struct isUserLogicFormat<BareFormat> {
+  static constexpr bool value = false;
+};
+
+template <typename CHARGESUM>
+struct isChargeSumMode; // only defined (on purpose) for two types below
+
+template <>
+struct isChargeSumMode<ChargeSumMode> {
+  static constexpr bool value = true;
+};
+
+template <>
+struct isChargeSumMode<SampleMode> {
+  static constexpr bool value = false;
+};
+
+using uint5_t = uint8_t;
+using uint6_t = uint8_t;
+
+using SampaChannelAddress = uint5_t; // 0..31 channel of a Sampa
+using DualSampaChannelId = uint6_t;  // 0..63 channel of a *Dual* Sampa
 
 using uint10_t = uint16_t;
 using uint20_t = uint32_t;
@@ -82,6 +115,16 @@ struct FEEID {
   };
 };
 
-}; // namespace o2::mch::raw
+template <typename CHARGESUM>
+uint16_t extraFeeIdChargeSumMask();
+
+template <int VERSION>
+uint16_t extraFeeIdVersionMask();
+
+template <typename FORMAT>
+uint8_t linkRemapping(uint8_t linkID);
+
+std::ostream& operator<<(std::ostream& os, const FEEID& f);
+} // namespace o2::mch::raw
 
 #endif

--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/SampaBunchCrossingCounter.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/SampaBunchCrossingCounter.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_SAMPA_TIME_H
+#define O2_MCH_RAW_SAMPA_TIME_H
+
+#include "MCHRawCommon/DataFormats.h"
+#include <tuple>
+
+/** SampaBunchCrossingCounter is the internal Sampa counter at 40MHz,
+  * and coded in 20 bits */
+
+namespace o2::mch::raw
+{
+
+uint20_t sampaBunchCrossingCounter(uint32_t orbit, uint16_t bc, uint32_t firstOrbit);
+
+std::tuple<uint32_t, uint16_t> orbitBC(uint20_t bunchCrossing, uint32_t firstOrbit);
+
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/SampaHeader.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/SampaHeader.h
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include "MCHRawCommon/DataFormats.h"
 
 namespace o2
 {
@@ -67,7 +68,7 @@ class SampaHeader
                        SampaPacketType pkt,
                        uint16_t numWords,
                        uint8_t h,
-                       uint8_t ch,
+                       SampaChannelAddress ch,
                        uint32_t bx,
                        bool dp);
 
@@ -91,7 +92,7 @@ class SampaHeader
   SampaPacketType packetType() const;
   uint16_t nof10BitWords() const;
   uint8_t chipAddress() const;
-  uint8_t channelAddress() const;
+  SampaChannelAddress channelAddress() const;
   uint32_t bunchCrossingCounter() const;
   bool payloadParity() const;
   ///@}
@@ -105,7 +106,7 @@ class SampaHeader
   void packetType(SampaPacketType pkt);
   void nof10BitWords(uint16_t nofwords);
   void chipAddress(uint8_t h);
-  void channelAddress(uint8_t ch);
+  void channelAddress(SampaChannelAddress ch);
   void bunchCrossingCounter(uint32_t bx);
   void payloadParity(bool dp);
   ///@}
@@ -135,8 +136,11 @@ constexpr bool isSampaSync(uint64_t w)
 /// The 50-bits Sampa SYNC word.
 SampaHeader sampaSync();
 
+/// Heartbeat packet
+SampaHeader sampaHeartbeat(uint8_t elinkId, uint20_t bunchCrossing);
+
 /// Return channel number (0..63)
-uint8_t channelNumber64(const SampaHeader& sh);
+DualSampaChannelId getDualSampaChannelId(const SampaHeader& sh);
 
 /// packetTypeName returns a string representation of the given packet type.
 std::string packetTypeName(SampaPacketType pkt);

--- a/Detectors/MUON/MCH/Raw/Common/src/DataFormats.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/src/DataFormats.cxx
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHRawCommon/DataFormats.h"
+#include <fmt/format.h>
+#include <iostream>
+
+namespace o2::mch::raw
+{
+
+template <>
+uint16_t extraFeeIdChargeSumMask<ChargeSumMode>()
+{
+  FEEID f{0};
+  f.chargeSum = 1;
+  return f.word;
+}
+
+template <>
+uint16_t extraFeeIdChargeSumMask<SampleMode>()
+{
+  return 0;
+}
+template <int VERSION>
+uint16_t extraFeeIdVersionMask()
+{
+  FEEID f{0};
+  f.ulFormatVersion = VERSION;
+  return f.word;
+}
+
+template uint16_t extraFeeIdVersionMask<0>();
+template uint16_t extraFeeIdVersionMask<1>();
+
+template <>
+uint8_t linkRemapping<UserLogicFormat>(uint8_t linkID)
+{
+  return 15;
+}
+
+template <>
+uint8_t linkRemapping<BareFormat>(uint8_t linkID)
+{
+  return linkID;
+}
+
+std::ostream& operator<<(std::ostream& os, const FEEID& f)
+{
+  os << fmt::format("FEEID {} [id:{},chargeSum:{} ulVersion:{}]",
+                    f.word, f.id, f.chargeSum, f.ulFormatVersion);
+  return os;
+}
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Common/src/SampaBunchCrossingCounter.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/src/SampaBunchCrossingCounter.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHRawCommon/SampaBunchCrossingCounter.h"
+#include "CommonConstants/LHCConstants.h"
+#include "NofBits.h"
+
+using namespace o2::constants::lhc;
+
+namespace o2::mch::raw
+{
+
+constexpr int BCINORBIT = o2::constants::lhc::LHCMaxBunches;
+
+uint20_t sampaBunchCrossingCounter(uint32_t orbit, uint16_t bc,
+                                   uint32_t firstOrbit)
+{
+  orbit -= firstOrbit;
+  auto bunchCrossingCounter = (orbit * LHCMaxBunches + bc) % ((1 << 20) - 1);
+  impl::assertNofBits("bunchCrossingCounter", bunchCrossingCounter, 20);
+  return bunchCrossingCounter;
+}
+
+std::tuple<uint32_t, uint16_t> orbitBC(uint20_t bunchCrossingCounter,
+                                       uint32_t firstOrbit)
+{
+  impl::assertNofBits("bunchCrossingCounter", bunchCrossingCounter, 20);
+  uint32_t orbit = bunchCrossingCounter / LHCMaxBunches + firstOrbit;
+  int32_t bc = bunchCrossingCounter % LHCMaxBunches;
+  return {orbit, bc};
+}
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Common/test/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Common/test/CMakeLists.txt
@@ -20,6 +20,12 @@ o2_add_test(sampa-cluster
             LABELS "muon;mch;raw"
             PUBLIC_LINK_LIBRARIES O2::MCHRawCommon Boost::boost)
 
+o2_add_test(sampa-bx-count
+            SOURCES testSampaBunchCrossingCounter.cxx
+            COMPONENT_NAME mchraw
+            LABELS "muon;mch;raw"
+            PUBLIC_LINK_LIBRARIES O2::MCHRawCommon Boost::boost)
+
 if(benchmark_FOUND)
   o2_add_executable(sampa-header
                     COMPONENT_NAME mch

--- a/Detectors/MUON/MCH/Raw/Common/test/testSampaBunchCrossingCounter.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/test/testSampaBunchCrossingCounter.cxx
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Laurent Aphecetche
+
+#define BOOST_TEST_MODULE Test MCHRaw SampaBunchCrossingCounter
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "MCHRawCommon/SampaBunchCrossingCounter.h"
+
+using namespace o2::mch::raw;
+
+constexpr uint32_t BXMAX = (1 << 20) - 1;
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(sampatime)
+
+BOOST_AUTO_TEST_CASE(SampaBunchCrossingCounterToIRConversionMustThrowIfBxDoesNotFitIn20Bits)
+{
+  uint32_t bx = BXMAX + 1;
+  BOOST_CHECK_THROW(orbitBC(bx, 0),
+                    std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(SampaBunchCrossingCounterToIRConversionMustNotThrowIfBxFitIn20Bits)
+{
+  uint32_t bx = BXMAX;
+  BOOST_CHECK_NO_THROW(orbitBC(bx, 0));
+}
+
+BOOST_AUTO_TEST_CASE(SampaBunchCrossingCounterSpansABitLessThan294Orbits)
+{
+  uint32_t bx = BXMAX;
+  auto [orbit, bc] = orbitBC(bx, 0);
+  BOOST_CHECK_EQUAL(orbit, 294);
+  BOOST_CHECK_EQUAL(bc, 759);
+}
+
+BOOST_AUTO_TEST_CASE(Orbit294BC759MakesSampaBXCounterRolloverFromFirstOrbitZero)
+{
+  auto bx = sampaBunchCrossingCounter(294, 759, 0);
+  BOOST_CHECK_EQUAL(bx, 0);
+}
+
+BOOST_AUTO_TEST_CASE(Orbit294BC759MakesSampaBXCounterRolloverFromAnyFirstOrbit)
+{
+  uint32_t firstOrbit = 12345;
+  auto bx = sampaBunchCrossingCounter(294 + firstOrbit, 759, firstOrbit);
+  BOOST_CHECK_EQUAL(bx, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Common/test/testSampaHeader.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/test/testSampaHeader.cxx
@@ -275,5 +275,12 @@ BOOST_AUTO_TEST_CASE(CheckHeaderParity4)
   BOOST_CHECK_EQUAL(computeHeaderParity4(0x1722e9f00327d), 1); // 101101 P1
 }
 
+BOOST_AUTO_TEST_CASE(CreateHearbeat)
+{
+  SampaHeader h = sampaHeartbeat(0, 0);
+  BOOST_CHECK_EQUAL(h.isHeartbeat(), true);
+  h = sampaHeartbeat(39, 12345);
+  BOOST_CHECK_EQUAL(h.isHeartbeat(), true);
+}
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
@@ -9,9 +9,20 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(MCHRawDecoder
-        SOURCES src/PageDecoder.cxx src/DataDecoder.cxx src/ROFFinder.cxx src/RDHManip.cxx src/OrbitInfo.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHRawCommon O2::MCHBase O2::MCHMappingInterface O2::MCHMappingImpl4 O2::MCHRawElecMap
-                              O2::DetectorsRaw O2::DataFormatsMCH
+        SOURCES src/BareELinkDecoder.cxx
+                src/DataDecoder.cxx
+                src/OrbitInfo.cxx
+                src/PageDecoder.cxx
+                src/ROFFinder.cxx
+                src/UserLogicElinkDecoder.cxx
+                src/RDHManip.cxx
+        PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
+                              O2::MCHBase
+                              O2::MCHMappingImpl4
+                              O2::MCHMappingInterface
+                              O2::MCHRawCommon
+                              O2::MCHRawElecMap
+                              O2::DataFormatsMCH
         PRIVATE_LINK_LIBRARIES O2::MCHRawImplHelpers)
 
 if(BUILD_TESTING)

--- a/Detectors/MUON/MCH/Raw/Decoder/README.md
+++ b/Detectors/MUON/MCH/Raw/Decoder/README.md
@@ -29,7 +29,7 @@ data page that you want to decode :
 
     while(some_data_is_available) {
     // get some memory buffer from somewhere ...
-    buffer = ... 
+    buffer = ...
 
     // decode that buffer
     pageDecode(buffer);
@@ -54,9 +54,10 @@ constant bytes, i.e. the input buffer is read-only) and a
 
 ## SampaChannelHandler
 
-The `SampaChannelHandler` is  a function, that takes a dual sampa
-identifier (in electronics realm, aka solar,group,index tuple), a channel
-identifier within that dual sampa, a `SampaCluster` and returns nothing, i.e. :
+The `SampaChannelHandler` is  a function, that takes a dual sampa identifier
+(in electronics realm, aka solar,group,index tuple), a channel identifier
+within that dual sampa (in the 0..63 range), a `SampaCluster` and returns
+nothing, i.e. :
 
 > A word of caution here about the naming. A `SampaCluster` is a group of raw
 > data samples of *one* dual sampa channel, and has nothing to do with a
@@ -64,7 +65,7 @@ identifier within that dual sampa, a `SampaCluster` and returns nothing, i.e. :
 
 ```.cpp
 using SampaChannelHandler = std::function<void(DsElecId dsId,
-                                               uint8_t channel,
+                                               DualSampaChannelId channel,
                                                SampaCluster)>;
 ```
 
@@ -73,7 +74,7 @@ finds in the data.
 A very simple example would be a function to dump the SampaClusters :
 
 ```.cpp
-SampaChannelHandler handlePacket(DsElecId dsId, uint8_t channel, SampaCluster sc) {
+SampaChannelHandler handlePacket(DsElecId dsId, DualSampaChannelId channel, SampaCluster sc) {
     std::cout << fmt::format("{}-ch-{}-ts-{}-q-{}", asString(dsId), channel, sc.timestamp, sc.chargeSum));
 }
 // (note that this particular function only correctly handles the SampaCluster in ChargeSum Mode)

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -88,6 +88,15 @@ class DataDecoder
     }
 
     bool operator==(const SampaInfo&) const;
+    bool operator<(const SampaInfo& rhs) const
+    {
+      if (id < rhs.id) {
+        return true;
+      } else if (time < rhs.time) {
+        return true;
+      }
+      return false;
+    }
   };
 
   struct SampaTimeFrameStart {
@@ -116,7 +125,10 @@ class DataDecoder
 
   using RawDigitVector = std::vector<RawDigit>;
 
-  DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler, uint32_t sampaBcOffset, std::string mapCRUfile, std::string mapFECfile, bool ds2manu, bool verbose);
+  DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler,
+              uint32_t sampaBcOffset,
+              std::string mapCRUfile, std::string mapFECfile,
+              bool ds2manu, bool verbose, bool useDummyElecMap);
 
   void reset();
   void decodeBuffer(gsl::span<const std::byte> buf);
@@ -166,11 +178,14 @@ class DataDecoder
   bool mDebug{false};
   bool mDs2manu{false};
   uint32_t mOrbit{0};
+  bool mUseDummyElecMap{false};
 };
 
 bool operator<(const DataDecoder::RawDigit& d1, const DataDecoder::RawDigit& d2);
 
 std::ostream& operator<<(std::ostream& os, const DataDecoder::RawDigit& d);
+
+std::string asString(const DataDecoder::RawDigit& d);
 
 } // namespace raw
 } // namespace mch

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DecodedDataHandlers.h
@@ -23,9 +23,9 @@ namespace mch
 namespace raw
 {
 /// A SampaChannelHandler is a function that takes a pair to identify
-/// a readout sampa channel and a SampaCluster containing the channel data.
+/// a readout dual sampa channel and a SampaCluster containing the channel data.
 using SampaChannelHandler = std::function<void(DsElecId dsId,
-                                               uint8_t channel,
+                                               DualSampaChannelId channel,
                                                SampaCluster)>;
 
 /// A SampaHeartBeatHandler is a function that takes a chip index and

--- a/Detectors/MUON/MCH/Raw/Decoder/src/BareELinkDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/BareELinkDecoder.cxx
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "BareElinkDecoder.h"
+
+namespace o2::mch::raw
+{
+template <>
+void BareElinkDecoder<ChargeSumMode>::sendCluster()
+{
+  SampaChannelHandler handler = mDecodedDataHandlers.sampaChannelHandler;
+  if (handler) {
+    handler(mDsId, getDualSampaChannelId(mSampaHeader),
+            SampaCluster(mTimestamp, mSampaHeader.bunchCrossingCounter(), mClusterSum, mClusterSize));
+  }
+}
+
+template <>
+void BareElinkDecoder<SampleMode>::sendCluster()
+{
+  SampaChannelHandler handler = mDecodedDataHandlers.sampaChannelHandler;
+  if (handler) {
+    handler(mDsId, getDualSampaChannelId(mSampaHeader),
+            SampaCluster(mTimestamp, mSampaHeader.bunchCrossingCounter(), mSamples));
+  }
+  mSamples.clear();
+}
+template <>
+void BareElinkDecoder<ChargeSumMode>::changeToReadingData()
+{
+  changeState(State::ReadingClusterSum, 20);
+}
+
+template <>
+void BareElinkDecoder<SampleMode>::changeToReadingData()
+{
+  changeState(State::ReadingSample, 10);
+}
+
+std::string bitBufferString(const std::bitset<50>& bs, int imax)
+{
+  std::string s;
+  for (int i = 0; i < 64; i++) {
+    if ((static_cast<uint64_t>(1) << i) > imax) {
+      break;
+    }
+    if (bs.test(i)) {
+      s += "1";
+    } else {
+      s += "0";
+    }
+  }
+  return s;
+}
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Decoder/src/BareElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/BareElinkDecoder.h
@@ -48,7 +48,7 @@ class BareElinkDecoder
   /// handle the Sampa packets and decoding errors
   BareElinkDecoder(DsElecId dsId, DecodedDataHandlers decodedDataHandlers);
 
-  /** @name Main interface 
+  /** @name Main interface
   */
   ///@{
 
@@ -134,24 +134,7 @@ class BareElinkDecoder
 
 constexpr int HEADERSIZE = 50;
 
-namespace
-{
-std::string bitBufferString(const std::bitset<50>& bs, int imax)
-{
-  std::string s;
-  for (int i = 0; i < 64; i++) {
-    if ((static_cast<uint64_t>(1) << i) > imax) {
-      break;
-    }
-    if (bs.test(i)) {
-      s += "1";
-    } else {
-      s += "0";
-    }
-  }
-  return s;
-}
-} // namespace
+std::string bitBufferString(const std::bitset<50>& bs, int imax);
 
 template <typename CHARGESUM>
 BareElinkDecoder<CHARGESUM>::BareElinkDecoder(DsElecId dsId,
@@ -424,27 +407,6 @@ std::ostream& operator<<(std::ostream& os, const o2::mch::raw::BareElinkDecoder<
   return os;
 }
 
-template <>
-void BareElinkDecoder<ChargeSumMode>::sendCluster()
-{
-  SampaChannelHandler handler = mDecodedDataHandlers.sampaChannelHandler;
-  if (handler) {
-    handler(mDsId, channelNumber64(mSampaHeader),
-            SampaCluster(mTimestamp, mSampaHeader.bunchCrossingCounter(), mClusterSum, mClusterSize));
-  }
-}
-
-template <>
-void BareElinkDecoder<SampleMode>::sendCluster()
-{
-  SampaChannelHandler handler = mDecodedDataHandlers.sampaChannelHandler;
-  if (handler) {
-    handler(mDsId, channelNumber64(mSampaHeader),
-            SampaCluster(mTimestamp, mSampaHeader.bunchCrossingCounter(), mSamples));
-  }
-  mSamples.clear();
-}
-
 template <typename CHARGESUM>
 void BareElinkDecoder<CHARGESUM>::sendHBPacket()
 {
@@ -452,18 +414,6 @@ void BareElinkDecoder<CHARGESUM>::sendHBPacket()
   if (handler) {
     handler(mDsId, mSampaHeader.chipAddress() % 2, mSampaHeader.bunchCrossingCounter());
   }
-}
-
-template <>
-void BareElinkDecoder<ChargeSumMode>::changeToReadingData()
-{
-  changeState(State::ReadingClusterSum, 20);
-}
-
-template <>
-void BareElinkDecoder<SampleMode>::changeToReadingData()
-{
-  changeState(State::ReadingSample, 10);
 }
 
 } // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "UserLogicElinkDecoder.h"
+
+namespace o2::mch::raw
+{
+
+template <>
+void UserLogicElinkDecoder<SampleMode>::prepareAndSendCluster()
+{
+  if (mDecodedDataHandlers.sampaChannelHandler) {
+    SampaCluster sc(mClusterTime, mSampaHeader.bunchCrossingCounter(), mSamples);
+    sendCluster(sc);
+  }
+  mSamples.clear();
+}
+
+template <>
+void UserLogicElinkDecoder<ChargeSumMode>::prepareAndSendCluster()
+{
+  if (mSamples.size() != 2) {
+    throw std::invalid_argument(fmt::format("expected sample size to be 2 but it is {}", mSamples.size()));
+  }
+  if (mDecodedDataHandlers.sampaChannelHandler) {
+    uint32_t q = (((static_cast<uint32_t>(mSamples[1]) & 0x3FF) << 10) | (static_cast<uint32_t>(mSamples[0]) & 0x3FF));
+    SampaCluster sc(mClusterTime, mSampaHeader.bunchCrossingCounter(), q, mClusterSize);
+    sendCluster(sc);
+  }
+  mSamples.clear();
+}
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
@@ -25,6 +25,7 @@
 #include <stdexcept>
 #include <vector>
 #include <sstream>
+#include <set>
 
 namespace o2::mch::raw
 {
@@ -336,10 +337,10 @@ void UserLogicElinkDecoder<CHARGESUM>::sendCluster(const SampaCluster& sc) const
   debugHeader() << (*this) << " --> "
                 << fmt::format(" calling channelHandler for {} ch {} = {}\n",
                                o2::mch::raw::asString(mDsId),
-                               channelNumber64(mSampaHeader),
+                               getDualSampaChannelId(mSampaHeader),
                                o2::mch::raw::asString(sc));
 #endif
-  mDecodedDataHandlers.sampaChannelHandler(mDsId, channelNumber64(mSampaHeader), sc);
+  mDecodedDataHandlers.sampaChannelHandler(mDsId, getDualSampaChannelId(mSampaHeader), sc);
 }
 
 template <typename CHARGESUM>
@@ -429,30 +430,6 @@ void UserLogicElinkDecoder<CHARGESUM>::sendHBPacket()
   if (handler) {
     handler(mDsId, mSampaHeader.chipAddress() % 2, mSampaHeader.bunchCrossingCounter());
   }
-}
-
-template <>
-void UserLogicElinkDecoder<SampleMode>::prepareAndSendCluster()
-{
-  if (mDecodedDataHandlers.sampaChannelHandler) {
-    SampaCluster sc(mClusterTime, mSampaHeader.bunchCrossingCounter(), mSamples);
-    sendCluster(sc);
-  }
-  mSamples.clear();
-}
-
-template <>
-void UserLogicElinkDecoder<ChargeSumMode>::prepareAndSendCluster()
-{
-  if (mSamples.size() != 2) {
-    throw std::invalid_argument(fmt::format("expected sample size to be 2 but it is {}", mSamples.size()));
-  }
-  if (mDecodedDataHandlers.sampaChannelHandler) {
-    uint32_t q = (((static_cast<uint32_t>(mSamples[1]) & 0x3FF) << 10) | (static_cast<uint32_t>(mSamples[0]) & 0x3FF));
-    SampaCluster sc(mClusterTime, mSampaHeader.bunchCrossingCounter(), q, mClusterSize);
-    sendCluster(sc);
-  }
-  mSamples.clear();
 }
 
 template <typename CHARGESUM>

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testBareElinkDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testBareElinkDecoder.cxx
@@ -27,7 +27,7 @@ using ::operator<<;
 
 SampaChannelHandler handlePacketPrint(std::string_view msg)
 {
-  return [msg](DsElecId dsId, uint8_t channel, SampaCluster sc) {
+  return [msg](DsElecId dsId, DualSampaChannelId channel, SampaCluster sc) {
     std::stringstream s;
     s << dsId;
     std::cout << fmt::format("{} {} ch={:2d} ", msg, s.str(), channel);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(Decoding10)
   int npackets{0};
   auto helper = handlePacketPrint("Decoding10:");
 
-  auto hp = [&npackets, helper](DsElecId dsId, uint8_t channel, SampaCluster sh) {
+  auto hp = [&npackets, helper](DsElecId dsId, DualSampaChannelId channel, SampaCluster sh) {
     npackets++;
     helper(dsId, channel, sh);
   };
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(Decoding20)
   int npackets{0};
   auto helper = handlePacketPrint("Decoding20:");
 
-  auto hp = [&npackets, helper](DsElecId dsId, uint8_t channel, SampaCluster sh) {
+  auto hp = [&npackets, helper](DsElecId dsId, DualSampaChannelId channel, SampaCluster sh) {
     npackets++;
     helper(dsId, channel, sh);
   };

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
@@ -26,26 +26,6 @@ using namespace o2::mch::raw;
 
 const char* sampaClusterFormat = "{}-CH{}-{}";
 
-template <typename FORMAT>
-struct isUserLogicFormat {
-  static constexpr bool value = false;
-};
-
-template <>
-struct isUserLogicFormat<UserLogicFormat> {
-  static constexpr bool value = true;
-};
-
-template <typename CHARGESUM>
-struct isChargeSumMode {
-  static constexpr bool value = false;
-};
-
-template <>
-struct isChargeSumMode<ChargeSumMode> {
-  static constexpr bool value = true;
-};
-
 // Create a vector of SampaCluster from a string d
 // where d is of the form ts-#-bc-#-cs-#-q-# or
 // ts-#-bc-#-cs-#-q-#-#-# ...

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -79,8 +79,9 @@ class DataDecoderTask
     mDummyROFs = ic.options().get<bool>("dummy-rofs");
     auto mapCRUfile = ic.options().get<std::string>("cru-map");
     auto mapFECfile = ic.options().get<std::string>("fec-map");
-
-    mDecoder = new DataDecoder(channelHandler, rdhHandler, sampaBcOffset, mapCRUfile, mapFECfile, ds2manu, mDebug);
+    auto useDummyElecMap = ic.options().get<bool>("dummy-elecmap");
+    mDecoder = new DataDecoder(channelHandler, rdhHandler, sampaBcOffset, mapCRUfile, mapFECfile, ds2manu, mDebug,
+                               useDummyElecMap);
   }
 
   //_________________________________________________________________________________________________
@@ -259,6 +260,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec)
     Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
             {"cru-map", VariantType::String, "", {"custom CRU mapping"}},
             {"fec-map", VariantType::String, "", {"custom FEC mapping"}},
+            {"dummy-elecmap", VariantType::Bool, false, {"use dummy electronic mapping (for debug, temporary)"}},
             {"ds2manu", VariantType::Bool, false, {"convert channel numbering from Run3 to Run1-2 order"}},
             {"sampa-bc-offset", VariantType::Int, 339986, {"SAMPA bunch-crossing counter at the beginning of the run"}},
             {"check-rofs", VariantType::Bool, false, {"perform consistency checks on the output ROFs"}},


### PR DESCRIPTION
In particular the channel was ambiguous as it could be a sampa channel
(0..31) or a dual sampa channel (0..63).

Also moved a few template definitions from .h to .cxx to fix clang-tidy
misc-definitions-in-headers warning (to avoid potential ODR violations).

And also add a dummy-elecmap option to the DataDecoder (to be able to test
decoding on the full detector, not only the part that is currently
installed and operational)