### PR TITLE
Avoid data copy in the DPL output proxy

### DIFF
--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -98,7 +98,10 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   }
 
   Inputs sinkInputs = {InputSpec{"external", "TST", "DATA", 0, Lifetime::Timeframe}};
-  workflow.emplace_back(std::move(specifyFairMQDeviceOutputProxy("dpl-sink", sinkInputs, channelConfig.c_str())));
+  auto channelSelector = [](InputSpec const&, const std::unordered_map<std::string, std::vector<FairMQChannel>>&) -> std::string {
+    return "downstream";
+  };
+  workflow.emplace_back(std::move(specifyFairMQDeviceMultiOutputProxy("dpl-sink", sinkInputs, channelConfig.c_str(), channelSelector)));
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // a simple checker process subscribing to the output of the input proxy


### PR DESCRIPTION
This is a demonstrator to use forward routes of the DataProcessingDevice,
which allows to remove handling of messages in the processing callback
There is no need to do processing of the messages except keeping a copy
of the last DataProcessingHeader which is needed to forward EOS.

The remaining issue to be discussed is how to define these external forward
routes. ServiceRegistry is providing access to DeviceSpec, but this is a
const object.