### PR TITLE
DPL: make topology creation customizable

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -95,6 +95,7 @@ o2_add_library(Framework
                        src/TableBuilder.cxx
                        src/TableConsumer.cxx
                        src/TableTreeHelpers.cxx
+                       src/TopologyPolicy.cxx
                        src/TextDriverClient.cxx
                        src/DataInputDirector.cxx
                        src/DataOutputDirector.cxx

--- a/Framework/Core/include/Framework/TopologyPolicy.h
+++ b/Framework/Core/include/Framework/TopologyPolicy.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_TOPOLOGYPOLICY_H_
+#define O2_FRAMEWORK_TOPOLOGYPOLICY_H_
+
+#include <functional>
+#include <vector>
+
+namespace o2::framework
+{
+struct DataProcessorSpec;
+
+struct TopologyPolicy {
+  using DataProcessorMatcher = std::function<bool(DataProcessorSpec const& device)>;
+  using DependencyChecker = std::function<bool(DataProcessorSpec const& dependent, DataProcessorSpec const& ascendant)>;
+  DataProcessorMatcher matcher;
+  DependencyChecker checkDependency;
+  static std::vector<TopologyPolicy> createDefaultPolicies();
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_TOPOLOGYPOLICY_H_

--- a/Framework/Core/src/TopologyPolicy.cxx
+++ b/Framework/Core/src/TopologyPolicy.cxx
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/TopologyPolicy.h"
+#include <string>
+
+namespace o2::framework
+{
+
+struct TopologyPolicyHelpers {
+  static TopologyPolicy::DataProcessorMatcher matchAll();
+  static TopologyPolicy::DataProcessorMatcher matchByName(std::string const& name);
+  static TopologyPolicy::DependencyChecker dataDependency();
+  static TopologyPolicy::DependencyChecker alwaysDependent();
+};
+
+TopologyPolicy::DataProcessorMatcher TopologyPolicyHelpers::matchAll()
+{
+  return [](DataProcessorSpec const& spec) {
+    return true;
+  };
+}
+
+TopologyPolicy::DataProcessorMatcher TopologyPolicyHelpers::matchByName(std::string const& name)
+{
+  return [name](DataProcessorSpec const& spec) {
+    return spec.name == name;
+  };
+}
+
+TopologyPolicy::DependencyChecker TopologyPolicyHelpers::dataDependency()
+{
+  return [](DataProcessorSpec const& a, DataProcessorSpec const& b) {
+    for (size_t ii = 0; ii < a.inputs.size(); ++ii) {
+      for (size_t oi = 0; oi < b.outputs.size(); ++oi) {
+        try {
+          if (DataSpecUtils::match(a.inputs[ii], b.outputs[oi])) {
+            return true;
+          }
+        } catch (...) {
+          continue;
+        }
+      }
+    }
+    return false;
+  };
+}
+
+TopologyPolicy::DependencyChecker TopologyPolicyHelpers::alwaysDependent()
+{
+  return [](DataProcessorSpec const& dependent, DataProcessorSpec const& ancestor) {
+    if (dependent.name == ancestor.name) {
+      return false;
+    }
+    return true;
+  };
+}
+
+std::vector<TopologyPolicy> TopologyPolicy::createDefaultPolicies()
+{
+  return {
+    {TopologyPolicyHelpers::matchByName("output-proxy"), TopologyPolicyHelpers::alwaysDependent()},
+    {TopologyPolicyHelpers::matchAll(), TopologyPolicyHelpers::dataDependency()}};
+}
+
+} // namespace o2::framework


### PR DESCRIPTION
Notice that supporting workflow merging prevents having the topology
policies defined on a per workflow level, because we need all of them
in the final topological sort. Still better than hardcoding "dpl-output-proxy"
in the runDataProcessing.cxx part.