### PR TITLE
TPC Digitizer: Respect HBFUtils.firstOrbitSampled

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -92,11 +92,14 @@ class Digitizer
 
   /// Set the start time of the first event
   /// \param time Time of the first event
-  void setStartTime(TimeBin time) { mDigitContainer.setStartTime(time); }
+  void setStartTime(double time);
+
+  /// Set mOutputDigitTimeOffset
+  void setOutputDigitTimeOffset(double offset) { mOutputDigitTimeOffset = offset; }
 
   /// Set the time of the event to be processed
   /// \param time Time of the event
-  void setEventTime(float time) { mEventTime = time; }
+  void setEventTime(double time) { mEventTime = time; }
 
   /// Switch for triggered / continuous readout
   /// \param isContinuous - false for triggered readout, true for continuous readout
@@ -122,10 +125,11 @@ class Digitizer
   void setUseSCDistortions(TFile& finp);
 
  private:
-  DigitContainer mDigitContainer;   ///< Container for the Digits
-  std::unique_ptr<SC> mSpaceCharge; ///< Handler of space-charge distortions
-  Sector mSector = -1;              ///< ID of the currently processed sector
-  float mEventTime = 0.f;           ///< Time of the currently processed event
+  DigitContainer mDigitContainer;    ///< Container for the Digits
+  std::unique_ptr<SC> mSpaceCharge;  ///< Handler of space-charge distortions
+  Sector mSector = -1;               ///< ID of the currently processed sector
+  double mEventTime = 0.f;           ///< Time of the currently processed event
+  double mOutputDigitTimeOffset = 0; ///< Time of the first IR sampled in the digitizer
   // FIXME: whats the reason for hving this static?
   static bool mIsContinuous;      ///< Switch for continuous readout
   bool mUseSCDistortions = false; ///< Flag to switch on the use of space-charge distortions

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -21,6 +21,7 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
 #include "Framework/DeviceSpec.h"
+#include "DetectorsRaw/HBFUtils.h"
 #include "Headers/DataHeader.h"
 #include "TStopwatch.h"
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
@@ -38,7 +39,6 @@
 #include "DetectorsBase/BaseDPLDigitizer.h"
 #include "DetectorsBase/Detector.h"
 #include "CommonDataFormat/RangeReference.h"
-#include "TPCSimulation/SAMPAProcessing.h"
 #include "SimConfig/DigiParams.h"
 #include <filesystem>
 
@@ -368,8 +368,12 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
       mDigitCounter += mDigits.size();
     };
 
-    static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
-    mDigitizer.setStartTime(sampaProcessing.getTimeBinFromTime(irecords[0].getTimeNS() / 1000.f));
+    if (isContinuous) {
+      auto& hbfu = o2::raw::HBFUtils::Instance();
+      double time = hbfu.getFirstIRofTF(o2::InteractionRecord(0, hbfu.orbitFirstSampled)).bc2ns() / 1000.;
+      mDigitizer.setOutputDigitTimeOffset(time);
+      mDigitizer.setStartTime(irecords[0].getTimeNS() / 1000.f);
+    }
 
     TStopwatch timer;
     timer.Start();
@@ -377,11 +381,11 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
-      const float eventTime = irecords[collID].getTimeNS() / 1000.f;
+      const double eventTime = irecords[collID].getTimeNS() / 1000.f;
       LOG(INFO) << "TPC: Event time " << eventTime << " us";
       mDigitizer.setEventTime(eventTime);
       if (!isContinuous) {
-        mDigitizer.setStartTime(sampaProcessing.getTimeBinFromTime(eventTime));
+        mDigitizer.setStartTime(eventTime);
       }
       size_t startSize = mDigitCounter; // digitsAccum->size();
 


### PR DESCRIPTION
This makes the TPC digitization respect firstOrbitSampled in the sense that timebin=0 is defined as the start of the time frame that contains the first sampled orbit. In this way, we can simulate data with large firstOrbit and firstOrbitSampled without havig bogus large timebins, and actually also avoid integer overflows for time bins.
Had to change few variables from float to double for the same reason, since float precision was not enough. Actually not fully sure, this problem might exist in many places, but can be cleaned up later.

Ping @wiechula : Tested it and for me it works. What I did is to change the offset used in the DigitContainer, so I think it should be transparent to the digitization itself. Actually, do we at some point need the absolute correct event time, e.g. for SCD distortions? In any case, event time is kept as it was. Could you check.