### PR TITLE
DPL Analysis: eliminate 50K std::decay_t

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -952,10 +952,11 @@ class Table
     template <typename TI>
     auto getId() const
     {
-      if constexpr (framework::has_type_v<std::decay_t<TI>, bindings_pack_t>) {
-        constexpr auto idx = framework::has_type_at_v<std::decay_t<TI>>(bindings_pack_t{});
+      using decayed = std::decay_t<TI>;
+      if constexpr (framework::has_type_v<decayed, bindings_pack_t>) {
+        constexpr auto idx = framework::has_type_at_v<decayed>(bindings_pack_t{});
         return framework::pack_element_t<idx, external_index_columns_t>::getId();
-      } else if constexpr (std::is_same_v<std::decay_t<TI>, Parent>) {
+      } else if constexpr (std::is_same_v<decayed, Parent>) {
         return this->globalIndex();
       } else {
         return static_cast<int32_t>(-1);

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -194,13 +194,14 @@ class InputRecord
   decltype(auto) get(R binding, int part = 0) const
   {
     DataRef ref{nullptr, nullptr};
+    using decayed = std::decay_t<R>;
     // Get the actual dataref
-    if constexpr (std::is_same_v<std::decay_t<R>, char const*> ||
-                  std::is_same_v<std::decay_t<R>, char*> ||
-                  std::is_same_v<std::decay_t<R>, std::string>) {
+    if constexpr (std::is_same_v<decayed, char const*> ||
+                  std::is_same_v<decayed, char*> ||
+                  std::is_same_v<decayed, std::string>) {
       try {
         int pos = -1;
-        if constexpr (std::is_same_v<std::decay_t<R>, std::string>) {
+        if constexpr (std::is_same_v<decayed, std::string>) {
           pos = getPos(binding.c_str());
         } else {
           pos = getPos(binding);
@@ -210,13 +211,13 @@ class InputRecord
         }
         ref = this->getByPos(pos, part);
       } catch (const std::exception& e) {
-        if constexpr (std::is_same_v<std::decay_t<R>, std::string>) {
+        if constexpr (std::is_same_v<decayed, std::string>) {
           throw runtime_error_f("Unknown argument requested %s - %s", binding.c_str(), e.what());
         } else {
           throw runtime_error_f("Unknown argument requested %s - %s", binding, e.what());
         }
       }
-    } else if constexpr (std::is_same_v<std::decay_t<R>, DataRef>) {
+    } else if constexpr (std::is_same_v<decayed, DataRef>) {
       ref = binding;
     } else {
       static_assert(always_static_assert_v<R>, "Unknown binding type");


### PR DESCRIPTION
Before:

228343 ms: std::__1::decay<$> (290733 times, avg 0 ms)

after:

196083 ms: std::__1::decay<$> (244788 times, avg 0 ms)