### PR TITLE
Add fast LTintegral method and use in TOF-constrained TPC tracks refit

### DIFF
--- a/Common/MathUtils/include/MathUtils/detail/trigonometric.h
+++ b/Common/MathUtils/include/MathUtils/detail/trigonometric.h
@@ -257,6 +257,12 @@ GPUdi() T asin(T x)
 };
 
 template <class T>
+GPUdi() T acos(T x)
+{
+  return o2::gpu::GPUCommonMath::ACos(x);
+};
+
+template <class T>
 GPUdi() T atan(T x)
 {
   return o2::gpu::GPUCommonMath::ATan(x);
@@ -335,6 +341,11 @@ template <>
 GPUdi() double asin(double x)
 {
   return std::asin(x);
+};
+template <>
+GPUdi() double acos(double x)
+{
+  return std::acos(x);
 };
 template <>
 GPUdi() double cos(double x)

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -126,6 +126,8 @@ class PropagatorImpl
   GPUd() const o2::gpu::GPUTPCGMPolynomialField* getGPUField() const { return mGPUField; }
   GPUd() void setBz(value_type bz) { mBz = bz; }
 
+  GPUd() void estimateLTFast(o2::track::TrackLTIntegral& lt, const o2::track::TrackParametrization<value_type>& trc) const;
+
 #ifndef GPUCA_GPUCODE
   static PropagatorImpl* Instance(bool uninitialized = false)
   {

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -537,6 +537,42 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Poin
 
 //____________________________________________________________
 template <typename value_T>
+GPUd() void PropagatorImpl<value_T>::estimateLTFast(o2::track::TrackLTIntegral& lt, const o2::track::TrackParametrization<value_type>& trc) const
+{
+  value_T xdca = 0., ydca = 0., zdca = 0., length = 0.;
+  if (math_utils::detail::abs<value_T>(mBz) > 1e-3) { // helix
+    o2::math_utils::CircleXY<value_T> c;
+    trc.getCircleParamsLoc(mBz, c);
+    auto distC = math_utils::detail::sqrt<value_type>(c.getCenterD2()); // distance from the circle center to origin
+    if (distC > 1.e-3) {
+      auto nrm = (distC - c.rC) / distC;
+      xdca = nrm * c.xC; // coordinates of the DCA to 0,0 in the local frame
+      ydca = nrm * c.yC;
+      auto v0x = trc.getX() - c.xC, v0y = trc.getY() - c.yC, v1x = xdca - c.xC, v1y = ydca - c.yC;
+      auto ang = math_utils::detail::acos<value_type>((v0x * v1x + v0y * v1y) / (c.rC * c.rC));
+      if ((trc.getSign() > 0.f) == (mBz > 0.f)) {
+        ang = -ang;   // we need signeg angle
+        c.rC = -c.rC; // we need signed curvature for zdca
+      }
+      zdca = trc.getZ() + (trc.getSign() > 0. ? c.rC : -c.rC) * trc.getTgl() * ang;
+      length = math_utils::detail::abs<value_type>(c.rC * ang * math_utils::detail::sqrt<value_type>(1. + trc.getTgl() * trc.getTgl()));
+    }
+  } else { // straight line
+    auto csp2 = (1.f - trc.getSnp()) * (1.f + trc.getSnp()), csp = math_utils::detail::sqrt<value_type>(csp2);
+    auto tgp = trc.getSnp() / csp, f = trc.getX() * tgp - trc.getY();
+    xdca = tgp * f * csp2;
+    ydca = -f * csp2;
+    auto dx = xdca - trc.getX(), dy = ydca - trc.getY(), dz = dx * trc.getTgl() / csp;
+    zdca = trc.getZ() + dz;
+    length = math_utils::detail::sqrt<value_type>(dx * dx + dy * dy + dz * dz);
+  }
+  // since we assume the track or its parent comes from the beam-line or decay, add XY(?) distance to it
+  length += math_utils::detail::sqrt<value_type>(xdca * xdca + ydca * ydca);
+  lt.addStep(length, trc.getP2Inv());
+}
+
+//____________________________________________________________
+template <typename value_T>
 GPUd() MatBudget PropagatorImpl<value_T>::getMatBudget(PropagatorImpl<value_type>::MatCorrType corrType, const math_utils::Point3D<value_type>& p0, const math_utils::Point3D<value_type>& p1) const
 {
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -571,11 +571,11 @@ bool MatchTOF::prepareTPCTracks()
     mSideTPC.push_back(trcOrig.hasASideClustersOnly() ? 1 : (trcOrig.hasCSideClustersOnly() ? -1 : 0));
     mExtraTPCFwdTime.push_back((trcOrig.getDeltaTFwd() + 5) * mTPCTBinMUS + extraErr);
 
-    o2::track::TrackLTIntegral intLT0; //mTPCTracksWork.back().getLTIntegralOut(); // we get the integrated length from TPC-ITC outward propagation
     // make a copy of the TPC track that we have to propagate
-    //o2::tpc::TrackTPC* trc = new o2::tpc::TrackTPC(trcTPCOrig); // this would take the TPCout track
-    mTracksWork.emplace_back(std::make_pair(trcOrig.getOuterParam(), timeInfo));
+    mTracksWork.emplace_back(std::make_pair(trcOrig.getOuterParam(), timeInfo)); // RS Why do we creat a track copy before deciding that the track should be propagated?
     auto& trc = mTracksWork.back().first;
+
+    o2::track::TrackLTIntegral intLT0{}; // we get the integrated length from TPC-ITC outward propagation
     auto& intLT = mLTinfos.emplace_back(intLT0);
 
     if (trcOrig.getNClusters() < nclustersMin) {
@@ -588,7 +588,7 @@ bool MatchTOF::prepareTPCTracks()
       continue;
     }
 
-    //    printf("N clusters = %d\n",trcOrig.getNClusters());
+    o2::base::Propagator::Instance()->estimateLTFast(intLT, trc); // init intLT with fast estimate
 
 #ifdef _ALLOW_TOF_DEBUG_
     // propagate to matching Xref

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -57,6 +57,7 @@ class GPUCommonMath
   template <class T>
   GPUhd() static T Abs(T x);
   GPUd() static float ASin(float x);
+  GPUd() static float ACos(float x);
   GPUd() static float ATan(float x);
   GPUd() static float ATan2(float y, float x);
   GPUd() static float Sin(float x);
@@ -388,6 +389,8 @@ GPUhdi() int GPUCommonMath::Abs<int>(int x)
 }
 
 GPUdi() float GPUCommonMath::ASin(float x) { return CHOICE(asinf(x), asinf(x), asin(x)); }
+
+GPUdi() float GPUCommonMath::ACos(float x) { return CHOICE(acosf(x), acosf(x), acos(x)); }
 
 GPUdi() float GPUCommonMath::Log(float x) { return CHOICE(logf(x), logf(x), log(x)); }
 


### PR DESCRIPTION
The time used for the TPC track refit was systematically biased by ~6ns because the LT-integral was calculated from the TPC-out track position instead of integration from the beam-line.

Before:
![tofdiff](https://user-images.githubusercontent.com/7382029/121432254-bb453480-c97a-11eb-820b-b27f2feb911a.png)

After the fix:
![tofdiffcor](https://user-images.githubusercontent.com/7382029/121432307-ca2be700-c97a-11eb-9d37-0df2b8a35594.png)
