### PR TITLE
Due to G4 the alignment must be applied in the MCApplication::MisalignGeometry

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Aligner.h
+++ b/Detectors/Base/include/DetectorsBase/Aligner.h
@@ -37,7 +37,7 @@ class Aligner : public o2::conf::ConfigurableParamHelper<Aligner>
 
  private:
   std::string mCCDB = "http://ccdb-test.cern.ch:8080"; // URL for CCDB acces
-  std::string mDetectors = "none";                     // comma-separated list of modules to align, "all" or "none"
+  std::string mDetectors = "all";                      // comma-separated list of modules to align, "all" or "none"
   long mTimeStamp = 0;                                 // assigned TimeStamp or now() if 0
 
   O2ParamDef(Aligner, "align-geom");

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <SimConfig/SimConfig.h>
 #include <DetectorsBase/Detector.h>
+#include "DetectorsBase/Aligner.h"
 #include <CommonUtils/ShmManager.h>
 #include <cassert>
 #include <SimulationDataFormat/MCEventHeader.h>
@@ -145,6 +146,10 @@ bool O2MCApplicationBase::MisalignGeometry()
   auto& confref = o2::conf::SimConfig::Instance();
   auto geomfile = o2::base::NameConf::getGeomFileName(confref.getOutPrefix());
   gGeoManager->Export(geomfile.c_str());
+
+  // apply alignment for included detectors AFTER exporting ideal geometry
+  auto& aligner = o2::base::Aligner::Instance();
+  aligner.applyAlignment(0);
 
   // return original return value of misalignment procedure
   return true;

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -113,7 +113,7 @@ FairRunSim* o2sim_init(bool asservice)
     auto& modulelist = o2::conf::SimConfig::Instance().getActiveDetectors();
     for (const auto& md : modulelist) {
       int id = o2::detectors::DetID::nameToID(md.c_str());
-      if (id>=o2::detectors::DetID::First) {
+      if (id >= o2::detectors::DetID::First) {
         detMask |= o2::detectors::DetID::getMask(id);
       }
     }
@@ -121,7 +121,7 @@ FairRunSim* o2sim_init(bool asservice)
     // don't include detectors which are not activated
     auto& aligner = o2::base::Aligner::Instance();
     if (aligner.getDetectorsMask().any()) {
-      aligner.setValue(fmt::format("{}.mDetectors",aligner.getName()), o2::detectors::DetID::getNames(detMask,','));
+      aligner.setValue(fmt::format("{}.mDetectors", aligner.getName()), o2::detectors::DetID::getNames(detMask, ','));
     }
   }
 


### PR DESCRIPTION
* Move alignment application to MCApplication::MisalignGeometry()
since for the G4 VMC this should be done before the G4Root processing.
* Re-enable applying misalignment by default.
