### PR TITLE
MCH: do not throw exception when linkID equals 15

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
@@ -46,11 +46,11 @@ class UserLogicEndpointDecoder : public PayloadDecoder<UserLogicEndpointDecoder<
                            std::function<std::optional<uint16_t>(FeeLinkId id)> fee2SolarMapper,
                            DecodedDataHandlers decodedDataHandlers);
 
-  /** @name Main interface 
+  /** @name Main interface
     */
   ///@{
 
-  /** @brief Append the equivalent n 64-bits words 
+  /** @brief Append the equivalent n 64-bits words
     * bytes size (=n) must be a multiple of 8
     *
     * @return the number of bytes used in the bytes span
@@ -118,6 +118,15 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
     ULHeaderWord<VERSION> ulword{word};
 
     int gbt = ulword.linkID;
+
+    // The User Logic uses the condition gbt=15 to identify special control and diagnostics words
+    // that are generated internally and do not contain data coming from the front-end electronics.
+    if (gbt == 15) {
+      // TODO: the exact format of the UL control words is still being defined and tested,
+      // hence proper decoding will be implemented once the format is finalized.
+      // For the moment we simply avoid throwing an exception when linkID is equal to 15
+      continue;
+    }
 
     if (gbt < 0 || gbt > 11) {
       SampaErrorHandler handler = mDecodedDataHandlers.sampaErrorHandler;

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
@@ -126,15 +126,15 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
       // hence proper decoding will be implemented once the format is finalized.
       // For the moment we simply avoid throwing an exception when linkID is equal to 15
       continue;
-    }
-
-    if (gbt < 0 || gbt > 11) {
-      SampaErrorHandler handler = mDecodedDataHandlers.sampaErrorHandler;
-      if (handler) {
-        DsElecId dsId{static_cast<uint16_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(0)};
-        handler(dsId, -1, ErrorBadLinkID);
-      } else {
-        throw fmt::format("warning : out-of-range gbt {} word={:08X}\n", gbt, word);
+    } else {
+      if (gbt < 0 || gbt > 11) {
+        SampaErrorHandler handler = mDecodedDataHandlers.sampaErrorHandler;
+        if (handler) {
+          DsElecId dsId{static_cast<uint16_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(0)};
+          handler(dsId, -1, ErrorBadLinkID);
+        } else {
+          throw fmt::format("warning : out-of-range gbt {} word={:08X}\n", gbt, word);
+        }
       }
     }
 


### PR DESCRIPTION
In the UserLogic data, the linkID=15 condition is used to identify special control and diagnostics words that are generated internally and do not contain data coming from the front-end electronics.

The exact format of those control words is not yet finalized, hence this PR does not introduce any specific decoding yet.
Instead, it simply avoids throwing an exception when the linkID=15 condition is found.