### PR TITLE
Make sure CMAKE_MODULE_PATH is not reset. Provide second search using arrow_DIR

### DIFF
--- a/dependencies/FindO2arrow.cmake
+++ b/dependencies/FindO2arrow.cmake
@@ -10,10 +10,12 @@
 
 # Simply provide a namespaced alias for the existing target
 
+set(_CMAKE_MODULE_PATH_COPY ${CMAKE_MODULE_PATH}) # Make sure CMAKE_MODULE_PATH is not reset
 find_package(Arrow CONFIG QUIET)
+
 if(NOT Arrow_FOUND)
-        find_package(arrow CONFIG QUIET)
         set(Arrow_DIR ${arrow_DIR})
+        find_package(arrow CONFIG PATHS ${Arrow_DIR} QUIET)
 endif()
 find_package(Gandiva CONFIG PATHS ${Arrow_DIR} QUIET)
 
@@ -36,3 +38,5 @@ find_package_handle_standard_args(O2arrow REQUIRED_VARS arrow_TARGET gandiva_TAR
 
 unset(arrow_TARGET)
 unset(gandiva_TARGET)
+set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH_COPY})
+unset(_CMAKE_MODULE_PATH_COPY)


### PR DESCRIPTION
This PR should enable the use of Arrow 3.0.0.