### PR TITLE
MFT: rename macro for dictionary creation; fix dictionary function call; move ClusterPattern init before loop

### DIFF
--- a/Detectors/ITSMFT/MFT/macros/test/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/macros/test/CMakeLists.txt
@@ -8,7 +8,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_test_root_macro(CheckTopologies.C
+o2_add_test_root_macro(CreateDictionaries.C
                        PUBLIC_LINK_LIBRARIES O2::MathUtils
                                              O2::MFTBase
                                              O2::ITSMFTReconstruction

--- a/Detectors/ITSMFT/MFT/macros/test/CreateDictionaries.C
+++ b/Detectors/ITSMFT/MFT/macros/test/CreateDictionaries.C
@@ -1,4 +1,4 @@
-/// \file CheckTopologies.C
+/// \file CreateDictionaries.C
 /// Macros to test the generation of a dictionary of topologies. Three dictionaries are generated: one with signal-cluster only, one with noise-clusters only and one with all the clusters.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
@@ -32,12 +32,13 @@
 #include <unordered_map>
 #endif
 
-void CheckTopologies(std::string clusfile = "mftclusters.root",
-                     std::string hitfile = "o2sim_HitsMFT.root",
-                     std::string collContextfile = "collisioncontext.root",
-                     std::string inputGeom = "",
-                     float checkOutliers = 2. // reject outliers (MC dX or dZ exceeds row/col span by a factor above the threshold)
-)
+void CreateDictionaries(bool saveDeltas = false,
+                        std::string clusfile = "mftclusters.root",
+                        std::string hitfile = "o2sim_HitsMFT.root",
+                        std::string collContextfile = "collisioncontext.root",
+                        std::string inputGeom = "",
+                        float checkOutliers = 2., // reject outliers (MC dX or dZ exceeds row/col span by a factor above the threshold)
+                        float minPtMC = 0.01)     // account only MC hits with pT above threshold
 {
   const int QEDSourceID = 99; // Clusters from this MC source correspond to QED electrons
 
@@ -56,10 +57,18 @@ void CheckTopologies(std::string clusfile = "mftclusters.root",
   std::unordered_map<int, int> hadronicMCMap;            // mapping from MC event entry to hadronic event ID
   std::vector<HitVec*> hitVecPool;
   std::vector<MC2HITS_map> mc2hitVec;
+
+  TFile* fout = nullptr;
+  TNtuple* nt = nullptr;
+  if (saveDeltas) {
+    fout = TFile::Open("CreateDictionaries.root", "recreate");
+    nt = new TNtuple("nt", "hashes ntuple", "hash:dx:dz");
+  }
+
   const o2::steer::DigitizationContext* digContext = nullptr;
   TStopwatch sw;
   sw.Start();
-
+  float minPtMC2 = minPtMC > 0 ? minPtMC * minPtMC : -1;
   // Geometry
   o2::base::GeometryManager::loadGeometry(inputGeom);
   auto gman = o2::mft::GeometryTGeo::Instance();
@@ -207,16 +216,21 @@ void CheckTopologies(std::string clusfile = "mftclusters.root",
           auto hitEntry = mc2hit.find(key);
           if (hitEntry != mc2hit.end()) {
             const auto& hit = (*hitArray)[hitEntry->second];
-            auto locH = gman->getMatrixL2G(chipID) ^ (hit.GetPos()); // inverse conversion from global to local
-            auto locHsta = gman->getMatrixL2G(chipID) ^ (hit.GetPosStart());
-            locH.SetXYZ(0.5 * (locH.X() + locHsta.X()), 0.5 * (locH.Y() + locHsta.Y()), 0.5 * (locH.Z() + locHsta.Z()));
-            const auto locC = o2::itsmft::TopologyDictionary::getClusterCoordinates(cluster, pattern);
-            dX = locH.X() - locC.X();
-            dZ = locH.Z() - locC.Z();
-            if (checkOutliers > 0.) {
-              if (std::abs(dX) > topology.getRowSpan() * o2::itsmft::SegmentationAlpide::PitchRow * checkOutliers ||
-                  std::abs(dZ) > topology.getColumnSpan() * o2::itsmft::SegmentationAlpide::PitchCol * checkOutliers) { // ignore outlier
-                dX = dZ = BuildTopologyDictionary::IgnoreVal;
+            if (minPtMC < 0.f || hit.GetMomentum().Perp2() > minPtMC2) {
+              auto locH = gman->getMatrixL2G(chipID) ^ (hit.GetPos()); // inverse conversion from global to local
+              auto locHsta = gman->getMatrixL2G(chipID) ^ (hit.GetPosStart());
+              locH.SetXYZ(0.5 * (locH.X() + locHsta.X()), 0.5 * (locH.Y() + locHsta.Y()), 0.5 * (locH.Z() + locHsta.Z()));
+              const auto locC = o2::itsmft::TopologyDictionary::getClusterCoordinates(cluster, pattern, false);
+              dX = locH.X() - locC.X();
+              dZ = locH.Z() - locC.Z();
+              if (saveDeltas) {
+                nt->Fill(topology.getHash(), dX, dZ);
+              }
+              if (checkOutliers > 0.) {
+                if (std::abs(dX) > topology.getRowSpan() * o2::itsmft::SegmentationAlpide::PitchRow * checkOutliers ||
+                    std::abs(dZ) > topology.getColumnSpan() * o2::itsmft::SegmentationAlpide::PitchCol * checkOutliers) { // ignore outlier
+                  dX = dZ = BuildTopologyDictionary::IgnoreVal;
+                }
               }
             }
           } else {
@@ -296,5 +310,9 @@ void CheckTopologies(std::string clusfile = "mftclusters.root",
     cSignal->Write();
     sw.Stop();
     sw.Print();
+  }
+  if (saveDeltas) {
+    fout->cd();
+    nt->Write();
   }
 }

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -55,11 +55,11 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
         locXYZ = dict.getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt, false);
+        locXYZ = dict.getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt);
+      locXYZ = dict.getClusterCoordinates(c, patt, false);
     }
     // Transformation to the local --> global
     auto gloXYZ = geom->getMatrixL2G(sensorID) * locXYZ;

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -42,6 +42,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
   int clusterId{0};
   auto first = rof.getFirstEntry();
   auto clusters_in_frame = rof.getROFData(clusters);
+  o2::itsmft::ClusterPattern patt(pattIt);
   for (auto& c : clusters_in_frame) {
     auto sensorID = c.getSensorID();
     int layer = geom->getLayer(sensorID);
@@ -54,7 +55,6 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
       if (!dict.isGroup(pattID)) {
         locXYZ = dict.getClusterCoordinates(c);
       } else {
-        o2::itsmft::ClusterPattern patt(pattIt);
         locXYZ = dict.getClusterCoordinates(c, patt);
       }
     } else {

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -209,7 +209,7 @@ void Tracker::findTracksLTF(ROframe& event)
   Int_t binIndex, clsMinIndex, clsMaxIndex, clsMinIndexS, clsMaxIndexS;
   Int_t extClsIndex;
   Float_t dR2, dR2min, dR2cut = mLTFclsR2Cut;
-  Bool_t hasDisk[constants::mft::DisksNumber], newPoint, seed;
+  Bool_t hasDisk[constants::mft::DisksNumber], newPoint;
 
   Int_t clsInLayer1, clsInLayer2, clsInLayer;
 
@@ -217,10 +217,9 @@ void Tracker::findTracksLTF(ROframe& event)
   TrackElement trackPoints[constants::mft::LayersNumber];
 
   Int_t step = 0;
-  seed = kTRUE;
   layer1 = 0;
 
-  while (seed) {
+  while (true) {
 
     layer2 = (step == 0) ? (constants::mft::LayersNumber - 1) : (layer2 - 1);
     step++;
@@ -504,7 +503,7 @@ void Tracker::computeCellsInRoad(ROframe& event)
         if (nPtsInLayer2 > 1) {
           LOG(INFO) << "BV===== more than one point in road " << mRoad.getRoadId() << " in layer " << layer2 << " : " << nPtsInLayer2 << "\n";
         }
-	*/
+  */
         for (Int_t point2 = 0; point2 < nPtsInLayer2; ++point2) {
 
           clsInLayer2 = mRoad.getClustersIdInLayer(layer2)[point2];


### PR DESCRIPTION
- small fix in the tracker (variable "seed" is always true) 
- rename the macro CheckTopologies.C to CreateDictionaries.C
- fix boolean value argument in the function getClusterCoordinates from the dictionary
- move initialization of ClusterPattern before the loop (do it only once)