### PR TITLE
CTF writer: optionally accumulate CTFs until min-file-size obtained

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -16,17 +16,27 @@ Example of usage:
 o2-its-reco-workflow --entropy-encoding | o2-ctf-writer-workflow --onlyDet ITS
 ```
 
+For the storage optimization reason one can request multiple CTFs stored in the same output file (as entries of the `ctf` tree):
+```bash
+o2-ctf-writer --min-file-size <min> --max-file-size <max> ...
+```
+will accumulate CTFs in entries of the same tree/file until its size fits exceeds `min` and does not exceed `max` (`max` check is disabled if `max<=min`) or EOS received.
+
 ## CTF reader workflow
 
 `o2-ctf-reader-workflow` should be the 1st workflow in the piped chain of CTF processing.
-At the moment accepts as an input a single file produced by the `o2-ctf-writer-workflow`, reads data for all detectors present in it
-(the list can be narrowd by `--onlyDet arg (=none)` and `--skipDet arg (=none)` comma-separated lists), decode them using decoder provided
-by detector and injects to DPL.
+At the moment accepts as an input a comma-separated list of CTF files produced by the `o2-ctf-writer-workflow`, reads data for all detectors present in it
+(the list can be narrowed by `--onlyDet arg (=none)` and `--skipDet arg (=none)` comma-separated lists), decode them using decoder provided
+by detector and injects to DPL. In case of multiple entries in the CTF tree, they all will be read in row.
 
 Example of usage:
 ```bash
 o2-ctf-reader-workflow --onlyDet ITS --ctf-input o2_ctf_0000000000.root  | o2-its-reco-workflow --trackerCA --clusters-from-upstream --disable-mc
 ```
+
+With `--delay <s>` a delay of `s` seconds will be introduced between injections of consecutive CTFs (if >1).
+One can loop over the input by providing `--loop <N=1>` option.
+
 
 ## Support for externally provided encoding dictionaries
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
@@ -23,7 +23,8 @@ namespace ctf
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, bool doCTF = true, bool doDict = false, bool dictPerDet = false);
+framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, bool doCTF = true,
+                                              bool doDict = false, bool dictPerDet = false, size_t smn = 0, size_t szmx = 0);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -72,10 +72,15 @@ class CTFReaderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
 
  private:
+  void openCTFFile(const std::string& flname);
+
   DetID::mask_t mDets;             // detectors
   std::vector<std::string> mInput; // input files
-  uint32_t mTFCounter = 0;
+  std::unique_ptr<TFile> mCTFFile;
+  std::unique_ptr<TTree> mCTFTree;
+  uint32_t mCTFCounter = 0;
   size_t mNextToProcess = 0;
+  int mCurrEntry = 0;
   int mLoops = 1;
   int mLoopsCounter = 0;
   int mDelayMUS = 0;
@@ -98,42 +103,51 @@ void CTFReaderSpec::init(InitContext& ic)
 }
 
 ///_______________________________________
+void CTFReaderSpec::openCTFFile(const std::string& flname)
+{
+  mCTFFile.reset(TFile::Open(flname.c_str()));
+  if (!mCTFFile->IsOpen() || mCTFFile->IsZombie()) {
+    LOG(ERROR) << "Failed to open file " << flname;
+    throw std::runtime_error("failed to open CTF file");
+  }
+  mCTFTree.reset((TTree*)mCTFFile->Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
+  if (!mCTFTree) {
+    throw std::runtime_error("failed to load CTF tree");
+  }
+  mCurrEntry = 0;
+}
+
+///_______________________________________
 void CTFReaderSpec::run(ProcessingContext& pc)
 {
   if (mNextToProcess >= mInput.size()) {
     return;
   }
-  if (mDelayMUS && mTFCounter > 0) {
+  if (mDelayMUS && mCTFCounter > 0) {
     usleep(mDelayMUS);
   }
 
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
-  std::string inputFile = o2::utils::Str::concat_string(mCTFDir, mInput[mNextToProcess]);
-  LOG(INFO) << "Reading CTF input " << mNextToProcess << ' ' << inputFile;
 
-  TFile flIn(inputFile.c_str());
-  if (!flIn.IsOpen() || flIn.IsZombie()) {
-    LOG(ERROR) << "Failed to open file " << inputFile;
-    throw std::runtime_error("failed to open CTF file");
-  }
-  std::unique_ptr<TTree> tree((TTree*)flIn.Get(std::string(o2::base::NameConf::CTFTREENAME).c_str()));
-  if (!tree) {
-    throw std::runtime_error("failed to load CTF tree");
+  if (!mCTFTree) { // there is still a tree open with multiple entries
+    std::string inputFile = o2::utils::Str::concat_string(mCTFDir, mInput[mNextToProcess]);
+    LOG(INFO) << "Reading CTF input " << mNextToProcess << ' ' << inputFile;
+    openCTFFile(inputFile);
   }
   CTFHeader ctfHeader;
-  if (!readFromTree(*tree, "CTFHeader", ctfHeader)) {
+  if (!readFromTree(*(mCTFTree.get()), "CTFHeader", ctfHeader, mCurrEntry)) {
     throw std::runtime_error("did not find CTFHeader");
   }
   LOG(INFO) << ctfHeader;
 
-  auto setFirstTFOrbit = [&](const std::string& label) {
+  auto setFirstTFOrbit = [&pc, &ctfHeader, this](const std::string& label) {
     auto* hd = pc.outputs().findMessageHeader({label});
     if (!hd) {
       throw std::runtime_error(o2::utils::Str::concat_string("failed to find output message header for ", label));
     }
     hd->firstTForbit = ctfHeader.firstTForbit;
-    hd->tfCounter = mTFCounter;
+    hd->tfCounter = this->mCTFCounter;
   };
 
   // send CTF Header
@@ -146,128 +160,134 @@ void CTFReaderSpec::run(ProcessingContext& pc)
   det = DetID::ITS;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::itsmft::CTF));
-    o2::itsmft::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::itsmft::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::MFT;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::itsmft::CTF));
-    o2::itsmft::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::itsmft::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::TPC;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::tpc::CTF));
-    o2::tpc::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::tpc::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::TRD;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::trd::CTF));
-    o2::trd::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::trd::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::FT0;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::ft0::CTF));
-    o2::ft0::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::ft0::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::FV0;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::fv0::CTF));
-    o2::fv0::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::fv0::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::FDD;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::fdd::CTF));
-    o2::fdd::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::fdd::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::TOF;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::tof::CTF));
-    o2::tof::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::tof::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::MID;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mid::CTF));
-    o2::mid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::mid::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::MCH;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::mch::CTF));
-    o2::mch::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::mch::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::EMC;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::emcal::CTF));
-    o2::emcal::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::emcal::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::PHS;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::phos::CTF));
-    o2::phos::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::phos::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::CPV;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::cpv::CTF));
-    o2::cpv::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::cpv::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::ZDC;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::zdc::CTF));
-    o2::zdc::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::zdc::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   det = DetID::HMP;
   if (detsTF[det]) {
     auto& bufVec = pc.outputs().make<std::vector<o2::ctf::BufferType>>({det.getName()}, sizeof(o2::hmpid::CTF));
-    o2::hmpid::CTF::readFromTree(bufVec, *(tree.get()), det.getName());
+    o2::hmpid::CTF::readFromTree(bufVec, *(mCTFTree.get()), det.getName(), mCurrEntry);
     setFirstTFOrbit(det.getName());
   }
 
   mTimer.Stop();
-  LOGF(INFO, "Read CTF %s in %.3e s", inputFile.c_str(), mTimer.CpuTime() - cput);
+  LOGP(INFO, "Read CTF#{} ({} of {} in {}) in {:.3f} s", mCTFCounter, mCurrEntry, mCTFTree->GetEntries(), mCTFFile->GetName(), mTimer.CpuTime() - cput);
 
-  bool moreToProcess = true;
-  if (++mNextToProcess >= mInput.size()) {
-    if (++mLoopsCounter >= mLoops) {
-      moreToProcess = false;
-    } else {
-      mNextToProcess = 0;
-      LOG(INFO) << "Starting new loop " << mNextToProcess << " of " << mLoops;
+  bool moreToProcess = (++mCurrEntry < mCTFTree->GetEntries());
+  if (!moreToProcess) { // this file is done, check if there are other files
+    mCTFTree.reset();
+    mCTFFile->Close();
+    mCTFFile.reset();
+    moreToProcess = true;
+    if (++mNextToProcess >= mInput.size()) {
+      if (++mLoopsCounter >= mLoops) {
+        moreToProcess = false;
+      } else {
+        mNextToProcess = 0;
+        LOG(INFO) << "Starting new loop " << mNextToProcess << " of " << mLoops;
+      }
     }
   }
 
-  mTFCounter++;
+  mCTFCounter++;
 
   if (!moreToProcess) {
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-    LOGF(INFO, "CTF reading total timing: Cpu: %.3e Real: %.3e s for %u TFs in %d loops",
-         mTimer.CpuTime(), mTimer.RealTime(), mTFCounter, mLoops);
+    LOGP(INFO, "CTF reading total timing: Cpu: {:.3f} Real: {:.3f} s for {} TFs in {} loops",
+         mTimer.CpuTime(), mTimer.RealTime(), mCTFCounter, mLoops);
   }
 }
 

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -33,6 +33,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"dict-per-det", VariantType::Bool, false, {"create dictionary file per detector"}});
   options.push_back(ConfigParamSpec{"grpfile", VariantType::String, o2::base::NameConf::getGRPFileName(), {"name of the grp file"}});
   options.push_back(ConfigParamSpec{"no-grp", VariantType::Bool, false, {"do not read GRP file"}});
+  options.push_back(ConfigParamSpec{"min-file-size", VariantType::Int64, 0l, {"accumulate CTFs until given file size reached"}});
+  options.push_back(ConfigParamSpec{"max-file-size", VariantType::Int64, 0l, {"if > 0, avoid exceeding given file size in accumulation mode"}});
   options.push_back(ConfigParamSpec{"output-type", VariantType::String, "ctf", {"output types: ctf (per TF) or dict (create dictionaries) or both or none"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
   std::swap(workflowOptions, options);
@@ -47,6 +49,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   long run = 0;
   bool doCTF = true, doDict = false, dictPerDet = false;
+  size_t szMin = 0, szMax = 0;
+
   if (!configcontext.helpOnCommandLine()) {
     bool noGRP = configcontext.options().get<bool>("no-grp");
     auto onlyDet = configcontext.options().get<std::string>("onlyDet");
@@ -85,7 +89,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     } else {
       throw std::invalid_argument("Invalid output-type");
     }
+    szMin = configcontext.options().get<int64_t>("min-file-size");
+    szMax = configcontext.options().get<int64_t>("max-file-size");
   }
-  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, doCTF, doDict, dictPerDet)};
+  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, doCTF, doDict, dictPerDet, szMin, szMax)};
   return std::move(specs);
 }


### PR DESCRIPTION
* `o2-ctf-writer-workflow` called with options `--min-file-size <min=0> --max-file-size <max=0>`
will accumulate CTFs in entries of the same tree/file until its size exceeds
`min-file-size` (but not `max-file-size` if it is > `min-file-size` ).

* `o2-ctf-reader-workflow` will read all entries of each CTF file.