### PR TITLE
Fix in MFT tracking: set cluster pattern in the loop

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -42,7 +42,6 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
   int clusterId{0};
   auto first = rof.getFirstEntry();
   auto clusters_in_frame = rof.getROFData(clusters);
-  o2::itsmft::ClusterPattern patt(pattIt);
   for (auto& c : clusters_in_frame) {
     auto sensorID = c.getSensorID();
     int layer = geom->getLayer(sensorID);
@@ -55,6 +54,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
       if (!dict.isGroup(pattID)) {
         locXYZ = dict.getClusterCoordinates(c);
       } else {
+        o2::itsmft::ClusterPattern patt(pattIt);
         locXYZ = dict.getClusterCoordinates(c, patt);
       }
     } else {


### PR DESCRIPTION
Merging trivial hot-fix.
@bovulpes this is a fix for https://github.com/AliceO2Group/AliceO2/pull/6394/files#r650428238, otherwise MFT reco w/o dictionary failes with:
````
#9  0x00007f43c4aa57ed in o2::mft::ioutils::loadROFrameData (rof=..., event=..., clusters=..., pattIt=..., dict=..., mcLabels=0x19c56920, tracker=0x7f43a1aeb010)
    at /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx:61
61            o2::itsmft::ClusterPattern patt(pattIt);
(gdb) down
#8  o2::itsmft::ClusterPattern::ClusterPattern<gsl::details::span_iterator<unsigned char const> > (this=<optimized out>, pattIt=...)
    at /home/shahoian/alice/sw/SOURCES/O2/dev/0/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h:56
56          mBitmap[0] = *pattIt++;
(gdb)
#7  gsl::details::span_iterator<unsigned char const>::operator++ (this=<optimized out>) at /home/shahoian/alice/sw/ubuntu2004_x86-64/ms_gsl/3.1.0-local1/include/gsl/span:161
161                 ++*this;
(gdb)
#6  gsl::details::span_iterator<unsigned char const>::operator++ (this=<optimized out>) at /home/shahoian/alice/sw/ubuntu2004_x86-64/ms_gsl/3.1.0-local1/include/gsl/span:152
152                 Expects(begin_ && current_ && end_);
````