### PR TITLE
Complete RecoContainer support of TRD tracks, use TRD in P/S-Vertexing

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -44,6 +44,7 @@ namespace o2::trd
 class Tracklet64;
 class CalibratedTracklet;
 class TriggerRecord;
+class TrackTriggerRecord;
 //class TrackTRD;
 struct RecoInputContainer;
 } // namespace o2::trd
@@ -300,7 +301,12 @@ struct RecoContainer {
     return getObject<U>(gid, TRACKS);
   }
 
-  o2::MCCompLabel getTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
+  o2::MCCompLabel getTrackMCLabel(GTrackID id) const
+  {
+    //RS FIXME: THIS IS TEMPORARY: some labels are still not implemented: in this case return dummy label
+    return commonPool[id.getSource()].getSize(MCLABELS) ? getObject<o2::MCCompLabel>(id, MCLABELS) : o2::MCCompLabel{};
+    //return getObject<o2::MCCompLabel>(id, MCLABELS);
+  }
 
   //--------------------------------------------
   // fetch track param
@@ -359,6 +365,11 @@ struct RecoContainer {
   {
     return getTracks<U>(GTrackID::ITSTPCTRD);
   }
+  auto getITSTPCTRDTriggers() const
+  {
+    return getSpan<o2::trd::TrackTriggerRecord>(GTrackID::ITSTPCTRD, TRACKREFS);
+  }
+
   // TPC-TRD
   template <class U>
   auto getTPCTRDTrack(GTrackID id) const
@@ -369,6 +380,10 @@ struct RecoContainer {
   auto getTPCTRDTracks() const
   {
     return getTracks<U>(GTrackID::TPCTRD);
+  }
+  auto getTPCTRDTriggers() const
+  {
+    return getSpan<o2::trd::TrackTriggerRecord>(GTrackID::TPCTRD, TRACKREFS);
   }
   // TRD tracklets
   gsl::span<const o2::trd::Tracklet64> getTRDTracklets() const;

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -107,8 +107,9 @@ void DataRequest::requestTPCTOFTracks(bool mc)
 void DataRequest::requestITSTPCTRDTracks(bool mc)
 {
   addInput({"trackITSTPCTRD", "TRD", "MATCHTRD_GLO", 0, Lifetime::Timeframe});
+  addInput({"trigITSTPCTRD", "TRD", "TRKTRG_GLO", 0, Lifetime::Timeframe});
   if (mc) {
-    LOG(ERROR) << "TRD Tracks does not support MC truth";
+    LOG(WARNING) << "TRD Tracks does not support MC truth, dummy label will be returned";
   }
   requestMap["trackITSTPCTRD"] = false;
 }
@@ -116,8 +117,9 @@ void DataRequest::requestITSTPCTRDTracks(bool mc)
 void DataRequest::requestTPCTRDTracks(bool mc)
 {
   addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", 0, Lifetime::Timeframe});
+  addInput({"trigTPCTRD", "TRD", "TRKTRG_TPC", 0, Lifetime::Timeframe});
   if (mc) {
-    LOG(ERROR) << "TRD Tracks does not support MC truth";
+    LOG(WARNING) << "TRD Tracks does not support MC truth, dummy label will be returned";
   }
   requestMap["trackTPCTRD"] = false;
 }
@@ -471,12 +473,14 @@ void RecoContainer::addITSTPCTracks(ProcessingContext& pc, bool mc)
 void RecoContainer::addITSTPCTRDTracks(ProcessingContext& pc, bool mc)
 {
   commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTRD>>("trackITSTPCTRD"), TRACKS);
+  commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigITSTPCTRD"), TRACKREFS);
 }
 
 //__________________________________________________________
 void RecoContainer::addTPCTRDTracks(ProcessingContext& pc, bool mc)
 {
   commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTRD>>("trackTPCTRD"), TRACKS);
+  commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigTPCTRD"), TRACKREFS);
 }
 
 //__________________________________________________________

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrackTRD.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrackTRD.h
@@ -36,9 +36,7 @@ static_assert(sizeof(o2::dataformats::GlobalTrackID) == sizeof(unsigned int));
 template <>
 GPUdi() o2::dataformats::GlobalTrackID GPUTRDTrack_t<trackInterface<GPUTRDO2BaseTrack>>::getRefGlobalTrackId() const
 {
-  o2::dataformats::GlobalTrackID retVal;
-  retVal.setRaw(mRefGlobalTrackId);
-  return retVal;
+  return o2::dataformats::GlobalTrackID{mRefGlobalTrackId};
 }
 template <>
 GPUdi() void GPUTRDTrack_t<trackInterface<GPUTRDO2BaseTrack>>::setRefGlobalTrackId(o2::dataformats::GlobalTrackID id)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrackTriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TrackTriggerRecord.h
@@ -36,6 +36,7 @@ class TrackTriggerRecord
   // setters (currently class members are set at the time of creation, if there is need to change them afterwards setters can be added below)
 
   // getters
+  const auto& getTrackRefs() const { return mTrackDataRange; }
   int getFirstTrack() const { return mTrackDataRange.getFirstEntry(); }
   int getNumberOfTracks() const { return mTrackDataRange.getEntries(); }
   BCData getBCData() const { return mBCData; }

--- a/DataFormats/common/include/CommonDataFormat/AbstractRef.h
+++ b/DataFormats/common/include/CommonDataFormat/AbstractRef.h
@@ -52,6 +52,7 @@ class AbstractRef
   GPUdDefault() AbstractRef() = default;
 
   GPUdi() AbstractRef(Idx_t idx, Src_t src) { set(idx, src); }
+  GPUdi() AbstractRef(Base_t raw) : mRef(raw) {}
 
   GPUdDefault() AbstractRef(const AbstractRef& src) = default;
   //

--- a/DataFormats/common/include/CommonDataFormat/RangeReference.h
+++ b/DataFormats/common/include/CommonDataFormat/RangeReference.h
@@ -39,6 +39,7 @@ class RangeReference
   }
   GPUd() void clear() { set(0, 0); }
   GPUd() FirstEntry getFirstEntry() const { return mFirstEntry; }
+  GPUd() FirstEntry getEntriesBound() const { return mFirstEntry + mEntries; }
   GPUd() NElem getEntries() const { return mEntries; }
   GPUd() void setFirstEntry(FirstEntry ent) { mFirstEntry = ent; }
   GPUd() void setEntries(NElem n) { mEntries = n; }
@@ -83,6 +84,7 @@ class RangeRefComp
   GPUd() static constexpr Base getMaxEntries() { return MaskN; }
   GPUhd() int getFirstEntry() const { return mData >> NBitsN; }
   GPUhd() int getEntries() const { return mData & ((0x1 << NBitsN) - 1); }
+  GPUhd() int getEntriesBound() const { return getFirstEntry() + getEntries(); }
   GPUhd() void setFirstEntry(int ent) { mData = (Base(ent) << NBitsN) | (mData & MaskN); }
   GPUhd() void setEntries(int n) { mData = (mData & MaskR) | (Base(n) & MaskN); }
   GPUhd() void changeEntriesBy(int inc) { setEntries(getEntries() + inc); }

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -56,8 +56,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
 
-  GID::mask_t allowedSourcesPV = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TOF");
-  GID::mask_t allowedSourcesVT = GID::getSourcesMask("ITS,MFT,ITS-TPC,ITS-TPC-TOF,TPC,TPC-TOF");
+  GID::mask_t allowedSourcesPV = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF");
+  GID::mask_t allowedSourcesVT = GID::getSourcesMask("ITS,MFT,TPC,ITS-TPC,,TPC-TOF,TPC-TRD,ITS-TPC-TRD,ITS-TPC-TOF");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -51,7 +51,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
-  GID::mask_t alowedSources = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TOF,TPC-TOF");
+  GID::mask_t alowedSources = GID::getSourcesMask("ITS,ITS-TPC,TPC-TRD,TPC-TOF,ITS-TPC-TRD,ITS-TPC-TOF");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));

--- a/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
@@ -61,7 +61,7 @@ void TRDTrackReader::connectTree(const std::string& filename)
   mTree.reset((TTree*)mFile->Get("tracksTRD"));
   assert(mTree);
   mTree->SetBranchAddress("tracks", &mTracksPtr);
-  mTree->SetBranchAddress("trackTrig", &mTrigRecPtr);
+  mTree->SetBranchAddress("trgrec", &mTrigRecPtr);
   LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
 

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -104,7 +104,6 @@ void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoDa
     for (int iv = ivStart; iv < nv; iv++) {
       const auto& vto = vtxOrdBrack[iv];
       auto res = tro.tBracket.isOutside(vto.tBracket);
-
       if (res == TBracket::Below) {                                       // vertex preceeds the track
         if (tro.tBracket.getMin() > vto.tBracket.getMin() + maxVtxSpan) { // all following vertices will be preceeding all following tracks times
           ivStart = ++iv;
@@ -118,16 +117,16 @@ void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoDa
       // track matches to vertex, register
       vtxList.push_back(vto.origID); // flag matching vertex
     }
-    if (vtxList.size() > 1) { // did track match to multiple vertices?
-      nAmbiguous++;
+    if (vtxList.size()) {
+      nAssigned++;
       for (auto v : vtxList) {
         tmpMap[v].emplace_back(tro.origID).setAmbiguous();
       }
-    }
-    if (vtxList.empty()) {
-      orphans.emplace_back(tro.origID); // register unassigned track
+      if (vtxList.size() > 1) { // did track match to multiple vertices?
+        nAmbiguous++;
+      }
     } else {
-      nAssigned++;
+      orphans.emplace_back(tro.origID); // register unassigned track
     }
   }
 


### PR DESCRIPTION
* Full support of TRD tracks in RecoContainer
(MCLabels are not yet available, so dummy MCCompLabel temporarily returned on MC label query)
* Add TRD tracks to primary and secondary vertexing
* misc related fixes for
