### PR TITLE
PWGHF: Updates to DDbar correlation task configurators to allow running on Hyperloop

### DIFF
--- a/Analysis/Tasks/PWGHF/HFCorrelatorD0D0bar.cxx
+++ b/Analysis/Tasks/PWGHF/HFCorrelatorD0D0bar.cxx
@@ -31,7 +31,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   ConfigParamSpec optionDoLikeSign{"doLikeSign", VariantType::Bool, false, {"Run Like-Sign analysis."}};
   ConfigParamSpec optionDoMCccbar{"doMCccbar", VariantType::Bool, false, {"Run MC-Gen dedicated tasks."}};
   ConfigParamSpec optionDoMCGen{"doMCGen", VariantType::Bool, false, {"Run MC-Gen dedicated tasks."}};
-  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, false, {"Run MC-Rec dedicated tasks."}};
+  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, true, {"Run MC-Rec dedicated tasks."}};
   workflowOptions.push_back(optionDoLikeSign);
   workflowOptions.push_back(optionDoMCccbar);
   workflowOptions.push_back(optionDoMCGen);

--- a/Analysis/Tasks/PWGHF/HFCorrelatorD0D0bar.cxx
+++ b/Analysis/Tasks/PWGHF/HFCorrelatorD0D0bar.cxx
@@ -246,7 +246,7 @@ struct HfCorrelatorD0D0barMcRec {
         if (candidate2.isSelD0bar() < selectionFlagD0bar) { //discard candidates not selected as D0bar in inner loop
           continue;
         }
-        flagD0barSignal = candidate2.flagMCMatchRec() == -(1 << DecayType::D0ToPiK); //flagD0barSignal 'true' if candidate2 matched to D0 (particle)
+        flagD0barSignal = candidate2.flagMCMatchRec() == -(1 << DecayType::D0ToPiK); //flagD0barSignal 'true' if candidate2 matched to D0bar (antiparticle)
         if (cutYCandMax >= 0. && std::abs(YD0(candidate2)) > cutYCandMax) {
           continue;
         }

--- a/Analysis/Tasks/PWGHF/HFCorrelatorDplusDminus.cxx
+++ b/Analysis/Tasks/PWGHF/HFCorrelatorDplusDminus.cxx
@@ -31,7 +31,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   ConfigParamSpec optionDoLikeSign{"doLikeSign", VariantType::Bool, false, {"Run Like-Sign analysis."}};
   ConfigParamSpec optionDoMCccbar{"doMCccbar", VariantType::Bool, false, {"Run MC-Gen dedicated tasks."}};
   ConfigParamSpec optionDoMCGen{"doMCGen", VariantType::Bool, false, {"Run MC-Gen dedicated tasks."}};
-  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, false, {"Run MC-Rec dedicated tasks."}};
+  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, true, {"Run MC-Rec dedicated tasks."}};
   workflowOptions.push_back(optionDoLikeSign);
   workflowOptions.push_back(optionDoMCccbar);
   workflowOptions.push_back(optionDoMCGen);

--- a/Analysis/Tasks/PWGHF/taskCorrelationDDbar.cxx
+++ b/Analysis/Tasks/PWGHF/taskCorrelationDDbar.cxx
@@ -34,7 +34,7 @@ using DDbarPairFull = soa::Join<aod::DDbarPair, aod::DDbarRecoInfo>;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   ConfigParamSpec optionDoMCGen{"doMCGen", VariantType::Bool, false, {"Run MC-Gen dedicated tasks."}};
-  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, false, {"Run MC-Rec dedicated tasks."}};
+  ConfigParamSpec optionDoMCRec{"doMCRec", VariantType::Bool, true, {"Run MC-Rec dedicated tasks."}};
   workflowOptions.push_back(optionDoMCGen);
   workflowOptions.push_back(optionDoMCRec);
 }
@@ -56,12 +56,6 @@ double evaluatePhiByVertex(double xVertex1, double xVertex2, double yVertex1, do
 {
   return RecoDecay::Phi(xVertex2 - xVertex1, yVertex2 - yVertex1);
 }
-/*
-/// definition of axes for THnSparse (dPhi,dEta,pTD,pTDbar) - note: last two axis are dummy, will be replaced later
-const int nBinsSparse[4] = {32,120,10,10};
-const double binMinSparse[4] = {-o2::constants::math::PI / 2.,-6.,0.,0.;  //is the minimum for all the bins
-const double binMaxSparse[4] = {3. * o2::constants::math::PI / 2.,6.,10.,10.};  //is the maximum for all the bins
-*/
 
 // string definitions, used for histogram axis labels
 const TString stringPtD = "#it{p}_{T}^{D} (GeV/#it{c});";
@@ -75,6 +69,23 @@ const TString stringSignal = "signal region;";
 const TString stringSideband = "sidebands;";
 const TString stringMCParticles = "MC gen - D,Dbar particles;";
 const TString stringMCReco = "MC reco - D,Dbar candidates ";
+
+//definition of vectors for standard ptbin and invariant mass configurables
+const int npTBinsCorrelations = 8;
+const double pTBinsCorrelations[npTBinsCorrelations + 1] = {0., 2., 4., 6., 8., 12., 16., 24., 99.};
+auto pTBinsCorrelations_v = std::vector<double>{pTBinsCorrelations, pTBinsCorrelations + npTBinsCorrelations + 1};
+const double signalRegionInnerDefault[npTBinsCorrelations + 1] = {1.75, 1.75, 1.75, 1.75, 1.75, 1.75, 1.75, 1.75};
+const double signalRegionOuterDefault[npTBinsCorrelations + 1] = {1.81, 1.81, 1.81, 1.81, 1.81, 1.81, 1.81, 1.81};
+const double sidebandLeftInnerDefault[npTBinsCorrelations + 1] = {1.84, 1.84, 1.84, 1.84, 1.84, 1.84, 1.84, 1.84};
+const double sidebandLeftOuterDefault[npTBinsCorrelations + 1] = {1.90, 1.90, 1.90, 1.90, 1.90, 1.90, 1.90, 1.90};
+const double sidebandRightInnerDefault[npTBinsCorrelations + 1] = {1.93, 1.93, 1.93, 1.93, 1.93, 1.93, 1.93, 1.93};
+const double sidebandRightOuterDefault[npTBinsCorrelations + 1] = {1.99, 1.99, 1.99, 1.99, 1.99, 1.99, 1.99, 1.99};
+auto signalRegionInner_v = std::vector<double>{signalRegionInnerDefault, signalRegionInnerDefault + npTBinsCorrelations};
+auto signalRegionOuter_v = std::vector<double>{signalRegionOuterDefault, signalRegionOuterDefault + npTBinsCorrelations};
+auto sidebandLeftInner_v = std::vector<double>{sidebandLeftInnerDefault, sidebandLeftInnerDefault + npTBinsCorrelations};
+auto sidebandLeftOuter_v = std::vector<double>{sidebandLeftOuterDefault, sidebandLeftOuterDefault + npTBinsCorrelations};
+auto sidebandRightInner_v = std::vector<double>{sidebandRightInnerDefault, sidebandRightInnerDefault + npTBinsCorrelations};
+auto sidebandRightOuter_v = std::vector<double>{sidebandRightOuterDefault, sidebandRightOuterDefault + npTBinsCorrelations};
 
 /// D-Dbar correlation pair filling task, from pair tables - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
 /// Works on both USL and LS analyses pair tables
@@ -98,14 +109,14 @@ struct HfTaskCorrelationDDbar {
      {"hDeltaPtMaxMinSidebands", stringDDbar + stringSideband + stringDeltaPtMaxMin + "entries", {HistType::kTH1F, {{72, 0., 36.}}}}}};
 
   //pT ranges for correlation plots: the default values are those embedded in hf_cuts_d0_topik (i.e. the mass pT bins), but can be redefined via json files
-  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{o2::analysis::hf_cuts_d0_topik::pTBins_v}, "pT bin limits for correlation plots"};
+  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{pTBinsCorrelations_v}, "pT bin limits for correlation plots"};
   //signal and sideband region edges, to be defined via json file (initialised to empty)
-  Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>(), "Inner values of signal region vs pT"};
-  Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>(), "Outer values of signal region vs pT"};
-  Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>(), "Inner values of left sideband vs pT"};
-  Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", std::vector<double>(), "Outer values of left sideband vs pT"};
-  Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", std::vector<double>(), "Inner values of right sideband vs pT"};
-  Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>(), "Outer values of right sideband vs pT"};
+  Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>{signalRegionInner_v}, "Inner values of signal region vs pT"};
+  Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>{signalRegionOuter_v}, "Outer values of signal region vs pT"};
+  Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>{sidebandLeftInner_v}, "Inner values of left sideband vs pT"};
+  Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", std::vector<double>{sidebandLeftOuter_v}, "Outer values of left sideband vs pT"};
+  Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", std::vector<double>{sidebandRightInner_v}, "Inner values of right sideband vs pT"};
+  Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>{sidebandRightOuter_v}, "Outer values of right sideband vs pT"};
 
   void init(o2::framework::InitContext&)
   {
@@ -199,14 +210,14 @@ struct HfTaskCorrelationDDbarMcRec {
      {"hCorrel2DVsPtSidebandsMCRecBkgBkg", stringMCReco + "BkgBkg" + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtDbar + "entries", {HistType::kTHnSparseD, {{32, -o2::constants::math::PI / 2., 3. * o2::constants::math::PI / 2.}, {120, -6., 6.}, {10, 0., 10.}, {10, 0., 10.}}}}}}; //note: axes 3 and 4 (the pT) are updated in the init()
 
   //pT ranges for correlation plots: the default values are those embedded in hf_cuts_d0_topik (i.e. the mass pT bins), but can be redefined via json files
-  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{o2::analysis::hf_cuts_d0_topik::pTBins_v}, "pT bin limits for correlation plots"};
+  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{pTBinsCorrelations_v}, "pT bin limits for correlation plots"};
   //signal and sideband region edges, to be defined via json file (initialised to empty)
-  Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>(), "Inner values of signal region vs pT"};
-  Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>(), "Outer values of signal region vs pT"};
-  Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>(), "Inner values of left sideband vs pT"};
-  Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", std::vector<double>(), "Outer values of left sideband vs pT"};
-  Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", std::vector<double>(), "Inner values of right sideband vs pT"};
-  Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>(), "Outer values of right sideband vs pT"};
+  Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>{signalRegionInner_v}, "Inner values of signal region vs pT"};
+  Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>{signalRegionOuter_v}, "Outer values of signal region vs pT"};
+  Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>{sidebandLeftInner_v}, "Inner values of left sideband vs pT"};
+  Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", std::vector<double>{sidebandLeftOuter_v}, "Outer values of left sideband vs pT"};
+  Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", std::vector<double>{sidebandRightInner_v}, "Inner values of right sideband vs pT"};
+  Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>{sidebandRightOuter_v}, "Outer values of right sideband vs pT"};
 
   void init(o2::framework::InitContext&)
   {
@@ -337,7 +348,7 @@ struct HfTaskCorrelationDDbarMcGen {
      {"hDeltaPtMaxMinMCGen", stringMCParticles + stringDeltaPtMaxMin + "entries", {HistType::kTH1F, {{72, 0., 36.}}}}}};
 
   //pT ranges for correlation plots: the default values are those embedded in hf_cuts_d0_topik (i.e. the mass pT bins), but can be redefined via json files
-  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{o2::analysis::hf_cuts_d0_topik::pTBins_v}, "pT bin limits for correlation plots"};
+  Configurable<std::vector<double>> binsCorrelations{"ptBinsForCorrelations", std::vector<double>{pTBinsCorrelations_v}, "pT bin limits for correlation plots"};
 
   void init(o2::framework::InitContext&)
   {


### PR DESCRIPTION
@vkucera, @ginnocen, in this PR I added a couple of workarounds to allow running the DDbar task with the current Hyperloop interface, following some discussions on its technicalities and current limitations:

- it seems that it's not possible to define arrays in the task configuration (those that in HF we usually pass via json, like the pTbins), but only modify values of array elements which were already defined inside the task. This is an issue for my code since I have some mass-window array which I initialise as empty in the task, and then directly pass via json file. So, I explicitely define the arrays (even with semi-dummy values) in order to have available the array structure in the task configuration panel of hyperloop interface
- it also seems that there's no way of defining 'global' flags as the 'isMC' (or in my case, isMCGen, isMCRec, etc.). For my case, it is not possible to activate all the ConfigParamSpec as kTRUE, so that all the tasks defined in the same file are run, since I have several options for running, but filling always the same tables, hence I have to only run one specific option at a time. Thus, as a temporary solution unless this is hopefully fixed centrally, I have set the default values of all ConfigParamSpec to 'false' and left only that for MC-reco mode as 'true', so that at least I am able to run the task in that specific more (the most important for now). Let me know in case this solution wouldn't work.