### PR TITLE
[OCTRL-496] AliECS dump: allow to preserve raw FMQ channels

### DIFF
--- a/Framework/Core/include/Framework/O2ControlLabels.h
+++ b/Framework/Core/include/Framework/O2ControlLabels.h
@@ -26,6 +26,10 @@ namespace ecs
 // Effectively, it allows us to declare cross-machine channels, e.g. for QC.
 const extern DataProcessorLabel uniqueProxyLabel;
 
+// This label makes AliECS templates use the originally declared addresses for raw FairMQ channels.
+// Thus, AliECS will not perform host and port allocation automatically. It takes priority over `uniqueProxyLabel`.
+const extern DataProcessorLabel preserveRawChannelsLabel;
+
 } // namespace ecs
 } // namespace o2::framework
 

--- a/Framework/Core/src/O2ControlLabels.cxx
+++ b/Framework/Core/src/O2ControlLabels.cxx
@@ -13,6 +13,6 @@
 namespace o2::framework::ecs
 {
 
-const DataProcessorLabel uniqueProxyLabel = {"o2-control-unique-proxy"};
-
+const DataProcessorLabel uniqueProxyLabel = {"ecs-unique-proxy"};
+const DataProcessorLabel preserveRawChannelsLabel = {"ecs-preserve-raw-channels"};
 }


### PR DESCRIPTION
This will allow us to use raw FairMQ channels (such as in proxies) with originally specified addresses in AliECS worfklow templates. This is required for workflows which run partially with ODC and partially with AliECS. The first does not have automatic port/machine assignment, thus we have to set them manually.