### PR TITLE
DPL: Allow to add Labels as command arguments

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -192,6 +192,7 @@ foreach(t
         InputSpec
         Kernels
         LogParsingHelpers
+        OverrideLabels
         PtrHelpers
         Root2ArrowTable
         RootConfigParamHelpers

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -128,6 +128,9 @@ void overridePipeline(o2::framework::ConfigContext& ctx, std::vector<o2::framewo
 /// Helper used to customize a workflow via a template data processor
 void overrideCloning(o2::framework::ConfigContext& ctx, std::vector<o2::framework::DataProcessorSpec>& workflow);
 
+/// Helper used to add labels to Data Processors
+void overrideLabels(o2::framework::ConfigContext& ctx, std::vector<o2::framework::DataProcessorSpec>& workflow);
+
 // This comes from the framework itself. This way we avoid code duplication.
 int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::ChannelConfigurationPolicy> const& channelPolicies,
@@ -187,6 +190,7 @@ int mainNoCatch(int argc, char** argv)
   o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
   overrideCloning(configContext, specs);
   overridePipeline(configContext, specs);
+  overrideLabels(configContext, specs);
   for (auto& spec : specs) {
     UserCustomizationsHelper::userDefinedCustomization(spec.requiredServices, 0);
   }

--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -36,6 +36,7 @@ std::vector<ConfigParamSpec> WorkflowCustomizationHelpers::requiredWorkflowOptio
                                        ConfigParamSpec{"spawners", VariantType::Int64, 1ll, {"number of parallel spawners to use"}},
                                        ConfigParamSpec{"pipeline", VariantType::String, "", {"override default pipeline size"}},
                                        ConfigParamSpec{"clone", VariantType::String, "", {"clone processors from a template"}},
+                                       ConfigParamSpec{"labels", VariantType::String, "", {"add labels to dataprocessors"}},
                                        ConfigParamSpec{"workflow-suffix", VariantType::String, "", {"suffix to add to all dataprocessors"}},
 
                                        // options for AOD rate limiting

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -2081,6 +2081,71 @@ void overridePipeline(ConfigContext& ctx, WorkflowSpec& workflow)
   }
 }
 
+void overrideLabels(ConfigContext& ctx, WorkflowSpec& workflow)
+{
+  struct LabelsSpec {
+    std::string_view matcher;
+    std::vector<std::string> labels;
+  };
+  std::vector<LabelsSpec> specs;
+
+  auto labelsString = ctx.options().get<std::string>("labels");
+  if (labelsString.empty()) {
+    return;
+  }
+  std::string_view sv{labelsString};
+
+  size_t specStart = 0;
+  size_t specEnd = 0;
+  constexpr char specDelim = ',';
+  constexpr char labelDelim = ':';
+  do {
+    specEnd = sv.find(specDelim, specStart);
+    auto token = sv.substr(specStart, specEnd == std::string_view::npos ? std::string_view::npos : specEnd - specStart);
+    if (token.empty()) {
+      throw std::runtime_error("bad labels definition. Syntax <processor>:<label>[:<label>][,<processor>:<label>[:<label>]");
+    }
+
+    size_t labelDelimPos = token.find(labelDelim);
+    if (labelDelimPos == 0 || labelDelimPos == std::string_view::npos) {
+      throw std::runtime_error("bad labels definition. Syntax <processor>:<label>[:<label>][,<processor>:<label>[:<label>]");
+    }
+    LabelsSpec spec{token.substr(0, labelDelimPos)};
+
+    size_t labelEnd = labelDelimPos + 1;
+    do {
+      size_t labelStart = labelDelimPos + 1;
+      labelEnd = token.find(labelDelim, labelStart);
+      auto label = labelEnd == std::string_view::npos ? token.substr(labelStart) : token.substr(labelStart, labelEnd - labelStart);
+      if (label.empty()) {
+        throw std::runtime_error("bad labels definition. Syntax <processor>:<label>[:<label>][,<processor>:<label>[:<label>]");
+      }
+      spec.labels.emplace_back(label);
+      labelDelimPos = labelEnd;
+    } while (labelEnd != std::string_view::npos);
+
+    specs.push_back(spec);
+    specStart = specEnd + 1;
+  } while (specEnd != std::string_view::npos);
+
+  if (labelsString.empty() == false && specs.empty() == true) {
+    throw std::runtime_error("bad labels definition. Syntax <processor>:<label>[:<label>][,<processor>:<label>[:<label>]");
+  }
+
+  for (auto& spec : specs) {
+    for (auto& processor : workflow) {
+      if (processor.name == spec.matcher) {
+        for (const auto& label : spec.labels) {
+          if (std::find_if(processor.labels.begin(), processor.labels.end(),
+                           [label](const auto& procLabel) { return procLabel.value == label; }) == processor.labels.end()) {
+            processor.labels.push_back({label});
+          }
+        }
+      }
+    }
+  }
+}
+
 /// Helper function to initialise the controller from the command line options.
 void initialiseDriverControl(bpo::variables_map const& varmap,
                              DriverControl& control)

--- a/Framework/Core/test/test_OverrideLabels.cxx
+++ b/Framework/Core/test/test_OverrideLabels.cxx
@@ -1,0 +1,94 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework OverrideLabels
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+// We prevent runDataProcessing from starting a workflow
+#define main anything_else_than_main
+#include "Framework/runDataProcessing.h"
+#undef main
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const&) { return {}; }
+
+using namespace o2::framework;
+
+// Mockup for a workflow with labels as args. It will behave as expected only in single-threaded code!!!
+static std::vector<ConfigParamSpec> specs;
+static ConfigParamRegistry registry{nullptr};
+std::unique_ptr<o2::framework::ConfigContext> mockupLabels(std::string labelArg)
+{
+  // FIXME: Ugly... We need to fix ownership and make sure the ConfigContext
+  //        either owns or shares ownership of the registry.
+  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  specs = WorkflowCustomizationHelpers::requiredWorkflowOptions();
+  specs.push_back(ConfigParamSpec{"labels", VariantType::String, std::move(labelArg), {"labels specification"}});
+  auto store = std::make_unique<ConfigParamStore>(specs, std::move(retrievers));
+  store->preload();
+  store->activate();
+  registry = ConfigParamRegistry(std::move(store));
+  auto context = std::make_unique<ConfigContext>(registry, 0, nullptr);
+  return context;
+}
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(OverrideLabels)
+{
+  {
+    // invalid format
+    WorkflowSpec workflow{{"A"}};
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A:"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels(":A"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A:asdf,:"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A:asdf,:A"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A:asdf,B:"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A:asdf,B"), workflow), std::runtime_error);
+    BOOST_CHECK_THROW(overrideLabels(*mockupLabels("A,B:asdf"), workflow), std::runtime_error);
+  }
+  {
+    // one processor, one label
+    WorkflowSpec workflow{{"A"}};
+    auto ctx = mockupLabels("A:abc");
+    overrideLabels(*ctx, workflow);
+    BOOST_CHECK_EQUAL(workflow[0].labels[0].value, "abc");
+  }
+  {
+    // many processors, many labels
+    WorkflowSpec workflow{{"A"}, {"B"}, {"C"}};
+    auto ctx = mockupLabels("A:a1:a2,B:b1,C:c1:c2:c3");
+    overrideLabels(*ctx, workflow);
+    BOOST_CHECK_EQUAL(workflow[0].labels[0].value, "a1");
+    BOOST_CHECK_EQUAL(workflow[0].labels[1].value, "a2");
+    BOOST_CHECK_EQUAL(workflow[1].labels[0].value, "b1");
+    BOOST_CHECK_EQUAL(workflow[2].labels[0].value, "c1");
+    BOOST_CHECK_EQUAL(workflow[2].labels[1].value, "c2");
+    BOOST_CHECK_EQUAL(workflow[2].labels[2].value, "c3");
+  }
+  {
+    // duplicate labels in arg
+    WorkflowSpec workflow{{"A"}};
+    auto ctx = mockupLabels("A:a1:a1");
+    overrideLabels(*ctx, workflow);
+    BOOST_CHECK_EQUAL(workflow[0].labels.size(), 1);
+    BOOST_CHECK_EQUAL(workflow[0].labels[0].value, "a1");
+  }
+  {
+    // duplicate labels - one in WF, one in arg
+    WorkflowSpec workflow{{"A"}};
+    workflow[0].labels.push_back({"a1"});
+    auto ctx = mockupLabels("A:a1");
+    overrideLabels(*ctx, workflow);
+    BOOST_CHECK_EQUAL(workflow[0].labels.size(), 1);
+    BOOST_CHECK_EQUAL(workflow[0].labels[0].value, "a1");
+  }
+}


### PR DESCRIPTION
With this we can pass `DataProcessorLabels` to `DataProcessor` at runtime.

This is will help with adding AliECS-related labels (such as in https://github.com/AliceO2Group/AliceO2/pull/6417 ) at workflow template generation time. By that, we will be able enforce different template output for DPL proxies which connect AliECS- and ODC-controlled parts of O2 (e.g. calibration), and different for proxies which send data within AliECS-controlled environment (e.g. output proxy to STFS).