### PR TITLE
[ITS-tracking] Use MCTruthContainer to manage MC labels

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -55,8 +55,10 @@ class ROframe final
   const auto& getTrackingFrameInfo() const { return mTrackingFrameInfo; }
 
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
-  const MCCompLabel& getClusterLabels(int layerId, const Cluster& cl) const;
-  const MCCompLabel& getClusterLabels(int layerId, const int clId) const;
+  const MCCompLabel& getClusterFirstLabel(int layerId, const Cluster& cl) const;
+  const MCCompLabel& getClusterFirstLabel(int layerId, const int clId) const;
+  gsl::span<o2::MCCompLabel> getClusterLabels(int layerId, const int clId) const;
+  gsl::span<o2::MCCompLabel> getClusterLabels(int layerId, const Cluster& cl) const;
   int getClusterExternalIndex(int layerId, const int clId) const;
   std::vector<int> getTracksId(const int layerId, const std::vector<Cluster>& cl);
 
@@ -64,7 +66,7 @@ class ROframe final
   void addClusterToLayer(int layer, T&&... args);
   template <typename... T>
   void addTrackingFrameInfoToLayer(int layer, T&&... args);
-  void addClusterLabelToLayer(int layer, const MCCompLabel label);
+  void setMClabelsContainer(const dataformats::MCTruthContainer<MCCompLabel>* ptr);
   void addClusterExternalIndexToLayer(int layer, const int idx);
   bool hasMCinformation() const;
 
@@ -72,10 +74,10 @@ class ROframe final
 
  private:
   const int mROframeId;
+  o2::dataformats::MCTruthContainer<MCCompLabel>* mMClabels = nullptr;
   std::vector<float3> mPrimaryVertices;
   std::vector<std::vector<Cluster>> mClusters;
   std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
-  std::vector<std::vector<MCCompLabel>> mClusterLabels;
   std::vector<std::vector<int>> mClusterExternalIndices;
 };
 
@@ -102,14 +104,24 @@ inline const TrackingFrameInfo& ROframe::getClusterTrackingFrameInfo(int layerId
   return mTrackingFrameInfo[layerId][cl.clusterId];
 }
 
-inline const MCCompLabel& ROframe::getClusterLabels(int layerId, const Cluster& cl) const
+inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const Cluster& cl) const
 {
-  return mClusterLabels[layerId][cl.clusterId];
+  return getClusterFirstLabel(layerId, cl.clusterId);
 }
 
-inline const MCCompLabel& ROframe::getClusterLabels(int layerId, const int clId) const
+inline const MCCompLabel& ROframe::getClusterFirstLabel(int layerId, const int clId) const
 {
-  return mClusterLabels[layerId][clId];
+  return *(mMClabels->getLabels(getClusterExternalIndex(layerId, clId)).begin());
+}
+
+inline gsl::span<o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const int clId) const
+{
+  return mMClabels->getLabels(getClusterExternalIndex(layerId, clId));
+}
+
+inline gsl::span<o2::MCCompLabel> ROframe::getClusterLabels(int layerId, const Cluster& cl) const
+{
+  return getClusterLabels(layerId, cl.clusterId);
 }
 
 inline int ROframe::getClusterExternalIndex(int layerId, const int clId) const
@@ -121,7 +133,7 @@ inline std::vector<int> ROframe::getTracksId(const int layerId, const std::vecto
 {
   std::vector<int> tracksId;
   for (auto& cluster : cl) {
-    tracksId.push_back(getClusterLabels(layerId, cluster).isNoise() ? -1 : getClusterLabels(layerId, cluster).getTrackID());
+    tracksId.push_back(getClusterFirstLabel(layerId, cluster).isNoise() ? -1 : getClusterFirstLabel(layerId, cluster).getTrackID());
   }
   return tracksId;
 }
@@ -138,7 +150,10 @@ void ROframe::addTrackingFrameInfoToLayer(int layer, T&&... values)
   mTrackingFrameInfo[layer].emplace_back(std::forward<T>(values)...);
 }
 
-inline void ROframe::addClusterLabelToLayer(int layer, const MCCompLabel label) { mClusterLabels[layer].emplace_back(label); }
+inline void ROframe::setMClabelsContainer(const dataformats::MCTruthContainer<MCCompLabel>* ptr)
+{
+  mMClabels = const_cast<dataformats::MCTruthContainer<MCCompLabel>*>(ptr);
+}
 
 inline void ROframe::addClusterExternalIndexToLayer(int layer, const int idx)
 {
@@ -150,20 +165,22 @@ inline void ROframe::clear()
   for (unsigned int iL = 0; iL < mClusters.size(); ++iL) {
     mClusters[iL].clear();
     mTrackingFrameInfo[iL].clear();
-    mClusterLabels[iL].clear();
+    // mClusterLabels[iL].clear();
     mClusterExternalIndices[iL].clear();
   }
   mPrimaryVertices.clear();
+  mMClabels = nullptr;
 }
 
 inline bool ROframe::hasMCinformation() const
 {
-  for (const auto& vect : mClusterLabels) {
-    if (!vect.empty()) {
-      return true;
-    }
-  }
-  return false;
+  // for (const auto& vect : mClusterLabels) {
+  //   if (!vect.empty()) {
+  //     return true;
+  //   }
+  // }
+  // return false;
+  return mMClabels;
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/StandaloneDebugger.h
@@ -59,7 +59,7 @@ struct FakeTrackInfo {
       if (extIndex == -1) {
         continue;
       }
-      o2::MCCompLabel mcLabel = event.getClusterLabels(iCluster, extIndex);
+      o2::MCCompLabel mcLabel = *(event.getClusterLabels(iCluster, extIndex).begin());
       bool found = false;
 
       for (size_t iOcc{0}; iOcc < occurrences.size(); ++iOcc) {
@@ -95,7 +95,7 @@ struct FakeTrackInfo {
       if (extIndex == -1) {
         continue;
       }
-      o2::MCCompLabel lbl = event.getClusterLabels(iCluster, extIndex);
+      o2::MCCompLabel lbl = *(event.getClusterLabels(iCluster, extIndex).begin());
       if (lbl == mainLabel && occurrences[0].second > 1 && !lbl.isNoise()) { // if we have MaxClusters fake clusters -> occurrences[0].second = 1
         clusStatuses[iCluster] = 1;
       } else {

--- a/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx
@@ -25,7 +25,7 @@ ROframe::ROframe(int ROframeId, int nLayers) : mROframeId{ROframeId}
 {
   mClusters.resize(nLayers);
   mTrackingFrameInfo.resize(nLayers);
-  mClusterLabels.resize(nLayers);
+  // mClusterLabels.resize(nLayers);
   mClusterExternalIndices.resize(nLayers);
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/StandaloneDebugger.cxx
@@ -40,8 +40,8 @@ StandaloneDebugger::~StandaloneDebugger()
 // Monte carlo oracle part
 int StandaloneDebugger::getEventId(int firstClusterId, int secondClusterId, ROframe* event)
 {
-  o2::MCCompLabel lblClus0 = event->getClusterLabels(0, firstClusterId);
-  o2::MCCompLabel lblClus1 = event->getClusterLabels(1, secondClusterId);
+  o2::MCCompLabel lblClus0 = *(event->getClusterLabels(0, firstClusterId).begin());
+  o2::MCCompLabel lblClus1 = *(event->getClusterLabels(1, secondClusterId).begin());
   return lblClus0.compare(lblClus1) == 1 ? lblClus0.getEventID() : -1;
 }
 
@@ -54,8 +54,8 @@ void StandaloneDebugger::fillCombinatoricsTree(std::array<std::vector<Cluster>, 
   assert(mTreeStream != nullptr);
 
   for (auto& combination : comb01) {
-    o2::MCCompLabel lblClus0 = event->getClusterLabels(0, clusters[0][combination.firstClusterIndex].clusterId);
-    o2::MCCompLabel lblClus1 = event->getClusterLabels(1, clusters[1][combination.secondClusterIndex].clusterId);
+    o2::MCCompLabel lblClus0 = *(event->getClusterLabels(0, clusters[0][combination.firstClusterIndex].clusterId).begin());
+    o2::MCCompLabel lblClus1 = *(event->getClusterLabels(1, clusters[1][combination.secondClusterIndex].clusterId).begin());
     float c0z{clusters[0][combination.firstClusterIndex].zCoordinate};
     float c1z{clusters[1][combination.secondClusterIndex].zCoordinate};
     unsigned char isValidated{lblClus0.compare(lblClus1) == 1};
@@ -72,8 +72,8 @@ void StandaloneDebugger::fillCombinatoricsTree(std::array<std::vector<Cluster>, 
   }
 
   for (auto& combination : comb12) {
-    o2::MCCompLabel lblClus1 = event->getClusterLabels(1, clusters[1][combination.secondClusterIndex].clusterId);
-    o2::MCCompLabel lblClus2 = event->getClusterLabels(2, clusters[2][combination.secondClusterIndex].clusterId);
+    o2::MCCompLabel lblClus1 = *(event->getClusterLabels(1, clusters[1][combination.secondClusterIndex].clusterId).begin());
+    o2::MCCompLabel lblClus2 = *(event->getClusterLabels(2, clusters[2][combination.secondClusterIndex].clusterId).begin());
     float c1z{clusters[1][combination.firstClusterIndex].zCoordinate};
     float c2z{clusters[2][combination.secondClusterIndex].zCoordinate};
     unsigned char isValidated{lblClus1.compare(lblClus2) == 1};
@@ -100,9 +100,9 @@ void StandaloneDebugger::fillTrackletSelectionTree(std::array<std::vector<Cluste
   assert(mTreeStream != nullptr);
   int id = event->getROFrameId();
   for (auto& trackletPair : allowedTracklets) {
-    o2::MCCompLabel lblClus0 = event->getClusterLabels(0, clusters[0][comb01[trackletPair[0]].firstClusterIndex].clusterId);
-    o2::MCCompLabel lblClus1 = event->getClusterLabels(1, clusters[1][comb01[trackletPair[0]].secondClusterIndex].clusterId);
-    o2::MCCompLabel lblClus2 = event->getClusterLabels(2, clusters[2][comb12[trackletPair[1]].secondClusterIndex].clusterId);
+    o2::MCCompLabel lblClus0 = *(event->getClusterLabels(0, clusters[0][comb01[trackletPair[0]].firstClusterIndex].clusterId).begin());
+    o2::MCCompLabel lblClus1 = *(event->getClusterLabels(1, clusters[1][comb01[trackletPair[0]].secondClusterIndex].clusterId).begin());
+    o2::MCCompLabel lblClus2 = *(event->getClusterLabels(2, clusters[2][comb12[trackletPair[1]].secondClusterIndex].clusterId).begin());
     unsigned char isValidated{lblClus0.compare(lblClus1) == 1 && lblClus0.compare(lblClus2) == 1};
     float deltaPhi{comb01[trackletPair[0]].phiCoordinate - comb12[trackletPair[1]].phiCoordinate};
     float deltaTanLambda{comb01[trackletPair[0]].tanLambda - comb12[trackletPair[1]].tanLambda};

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -258,8 +258,8 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
     auto& currentCluster{mClusters[0][iCurrentLayerClusterIndex]};
     for (unsigned int iNextLayerClusterIndex = 0; iNextLayerClusterIndex < mClusters[1].size(); iNextLayerClusterIndex++) {
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
-      const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
-      const auto& lblCurr = mEvent->getClusterLabels(0, currentCluster.clusterId);
+      const auto& lblNext = *(mEvent->getClusterLabels(1, nextCluster.clusterId).begin());
+      const auto& lblCurr = *(mEvent->getClusterLabels(0, currentCluster.clusterId).begin());
       if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb01.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster);
       }
@@ -270,8 +270,8 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
     auto& currentCluster{mClusters[2][iCurrentLayerClusterIndex]};
     for (unsigned int iNextLayerClusterIndex = 0; iNextLayerClusterIndex < mClusters[1].size(); iNextLayerClusterIndex++) {
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
-      const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
-      const auto& lblCurr = mEvent->getClusterLabels(2, currentCluster.clusterId);
+      const auto& lblNext = *(mEvent->getClusterLabels(1, nextCluster.clusterId).begin());
+      const auto& lblCurr = *(mEvent->getClusterLabels(2, currentCluster.clusterId).begin());
       if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb12.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster);
       }
@@ -366,8 +366,8 @@ void VertexerTraits::computeMCFiltering()
 {
   assert(mEvent != nullptr);
   for (size_t iTracklet{0}; iTracklet < mComb01.size(); ++iTracklet) {
-    const auto& lbl0 = mEvent->getClusterLabels(0, mClusters[0][mComb01[iTracklet].firstClusterIndex].clusterId);
-    const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb01[iTracklet].secondClusterIndex].clusterId);
+    const auto& lbl0 = *(mEvent->getClusterLabels(0, mClusters[0][mComb01[iTracklet].firstClusterIndex].clusterId).begin());
+    const auto& lbl1 = *(mEvent->getClusterLabels(1, mClusters[1][mComb01[iTracklet].secondClusterIndex].clusterId).begin());
     if (!(lbl0.compare(lbl1) == 1 && lbl0.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb01.erase(mComb01.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
@@ -375,8 +375,8 @@ void VertexerTraits::computeMCFiltering()
   }
 
   for (size_t iTracklet{0}; iTracklet < mComb12.size(); ++iTracklet) {
-    const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb12[iTracklet].firstClusterIndex].clusterId);
-    const auto& lbl2 = mEvent->getClusterLabels(2, mClusters[2][mComb12[iTracklet].secondClusterIndex].clusterId);
+    const auto& lbl1 = *(mEvent->getClusterLabels(1, mClusters[1][mComb12[iTracklet].firstClusterIndex].clusterId).begin());
+    const auto& lbl2 = *(mEvent->getClusterLabels(2, mClusters[2][mComb12[iTracklet].secondClusterIndex].clusterId).begin());
     if (!(lbl1.compare(lbl2) == 1 && lbl1.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb12.erase(mComb12.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
@@ -693,8 +693,8 @@ void VertexerTraits::filterTrackletsWithMC(std::vector<Tracklet>& tracklets01,
     int removed{0};
     for (size_t iTrackletIndex{0}; iTrackletIndex < indices01[iFoundTrackletIndex]; ++iTrackletIndex) {
       const size_t iTracklet{offset + iTrackletIndex};
-      const auto& lbl0 = mEvent->getClusterLabels(0, mClusters[0][tracklets01[iTracklet].firstClusterIndex].clusterId);
-      const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][tracklets01[iTracklet].secondClusterIndex].clusterId);
+      const auto& lbl0 = *(mEvent->getClusterLabels(0, mClusters[0][tracklets01[iTracklet].firstClusterIndex].clusterId).begin());
+      const auto& lbl1 = *(mEvent->getClusterLabels(1, mClusters[1][tracklets01[iTracklet].secondClusterIndex].clusterId).begin());
       if (!(lbl0.compare(lbl1) == 1 && lbl0.getSourceID() == 0)) {
         tracklets01[iTracklet] = Tracklet();
         ++removed;
@@ -711,8 +711,8 @@ void VertexerTraits::filterTrackletsWithMC(std::vector<Tracklet>& tracklets01,
     int removed{0};
     for (size_t iTrackletIndex{0}; iTrackletIndex < indices12[iFoundTrackletIndex]; ++iTrackletIndex) {
       const size_t iTracklet{offset + iTrackletIndex};
-      const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][tracklets12[iTracklet].firstClusterIndex].clusterId);
-      const auto& lbl2 = mEvent->getClusterLabels(2, mClusters[2][tracklets12[iTracklet].secondClusterIndex].clusterId);
+      const auto& lbl1 = *(mEvent->getClusterLabels(1, mClusters[1][tracklets12[iTracklet].firstClusterIndex].clusterId).begin());
+      const auto& lbl2 = *(mEvent->getClusterLabels(2, mClusters[2][tracklets12[iTracklet].secondClusterIndex].clusterId).begin());
       if (!(lbl1.compare(lbl2) == 1 && lbl1.getSourceID() == 0)) {
         tracklets12[iTracklet] = Tracklet();
         ++removed;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -197,17 +197,15 @@ void TrackerDPL::run(ProcessingContext& pc)
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
       int ncl = trc.getNumberOfClusters(), nclf = 0;
-      uint8_t patt = 0;
       for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
         auto clid = trc.getClusterIndex(ic);
         if (clid >= 0) {
           allClusIdx.push_back(clid + offset);
           nclf++;
-          patt |= 0x1 << ic;
         }
       }
       assert(ncl == nclf);
-      trc.setPattern(patt);
+      LOG(WARN) << trc.getPattern();
       allTracks.emplace_back(trc);
     }
   };

--- a/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
+++ b/Detectors/Upgrades/ALICE3/TRK/macros/ALICE3toAO2D.C
@@ -428,7 +428,7 @@ void ALICE3toAO2D()
       event.addTrackingFrameInfoToLayer(layer, xyz[0], xyz[1], xyz[2], r, phi, std::array<float, 2>{0.f, xyz[2]},
                                         std::array<float, 3>{0.0005f * 0.0005f, 0.f, 0.0005f * 0.0005f});
       event.addClusterToLayer(layer, xyz[0], xyz[1], xyz[2], event.getClustersOnLayer(layer).size());
-      event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
+      // event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
       event.addClusterExternalIndexToLayer(layer, id++);
     }
     roFrame = iEvent;

--- a/macro/run_trac_alice3.C
+++ b/macro/run_trac_alice3.C
@@ -175,7 +175,7 @@ void run_trac_alice3(const string hitsFileName = "o2sim_HitsTRK.root")
       event.addTrackingFrameInfoToLayer(layer, xyz[0], xyz[1], xyz[2], r, phi, std::array<float, 2>{0.f, xyz[2]},
                                         std::array<float, 3>{0.0005f * 0.0005f, 0.f, 0.0005f * 0.0005f});
       event.addClusterToLayer(layer, xyz[0], xyz[1], xyz[2], event.getClustersOnLayer(layer).size());
-      event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
+      // event.addClusterLabelToLayer(layer, o2::MCCompLabel(hit.GetTrackID(), iEvent, iEvent, false));
       event.addClusterExternalIndexToLayer(layer, id++);
       if (mapPDG.find(hit.GetTrackID()) == mapPDG.end()) {
         mapPDG[hit.GetTrackID()] = particle();


### PR DESCRIPTION
This is a frist try to use MCTruthContainer directly. Open for discussion.

TODO:
- [x] Generalize fake tagging algorithm to cope with multiple labels
- [x] Extend MClabels comparison logic wherever it is used
- [x] Test consistency and debug (high pt cutoff in efficiency?)

These are 1000 pp events with minimum track length = 7 clusters.
Current state (AliceO2/dev):
![pp_eff_dev](https://user-images.githubusercontent.com/4990252/122187265-2e750c00-ce8f-11eb-97fe-fb20a78e22a0.png)

With this PR:
![pp_eff_mcTruthContainer](https://user-images.githubusercontent.com/4990252/122187299-36cd4700-ce8f-11eb-96c8-e1f1a8f19cf4.png)

Difference is subtle but non zero.


