### PR TITLE
MCH: digits merger implementation

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -159,6 +159,21 @@ class DataDecoder
   void dumpDigits();
   bool getPadMapping(const DsElecId& dsElecId, DualSampaChannelId channel, int& deId, int& dsIddet, int& padId);
   bool addDigit(const DsElecId& dsElecId, DualSampaChannelId channel, const o2::mch::raw::SampaCluster& sc);
+  int32_t getMergerChannelId(const DsElecId& dsElecId, DualSampaChannelId channel);
+  void updateMergerRecord(uint32_t mergerChannelId, uint32_t digitId);
+  bool mergeDigits(uint32_t mergerChannelId, o2::mch::raw::SampaCluster& sc);
+
+  // structure that stores the index of the last decoded digit for a given readout channel,
+  // as well as the time stamp of the last ADC sample of the digit
+  struct MergerChannelRecord {
+    MergerChannelRecord() = default;
+    int32_t digitId{-1};
+    int32_t bcEnd{-1};
+  };
+  static constexpr uint32_t sMaxSolarId = 200 * 8 - 1;
+  static constexpr uint32_t sReadoutChannelsNum = (sMaxSolarId + 1) * 40 * 64;
+  // table storing the digits merging information for each readout channel in the MCH system
+  std::array<MergerChannelRecord, sReadoutChannelsNum> mMergerRecords; ///< merger records for all MCH readout channels
 
   Elec2DetMapper mElec2Det{nullptr};       ///< front-end electronics mapping
   FeeLink2SolarMapper mFee2Solar{nullptr}; ///< CRU electronics mapping

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -142,10 +142,10 @@ class DataDecoder
   uint32_t getSampaBcOffset() const { return mSampaTimeOffset; }
 
   static int32_t digitsTimeDiff(uint32_t orbit1, uint32_t bc1, uint32_t orbit2, uint32_t bc2);
-  static void computeDigitsTime_(RawDigitVector& digits, SampaTimeFrameStart& sampaTimeFrameStart, bool debug);
+  static void computeDigitsTime(RawDigitVector& digits, SampaTimeFrameStart& sampaTimeFrameStart, bool debug);
   void computeDigitsTime()
   {
-    computeDigitsTime_(mDigits, mSampaTimeFrameStart, mDebug);
+    computeDigitsTime(mDigits, mSampaTimeFrameStart, mDebug);
   }
 
   const RawDigitVector& getDigits() const { return mDigits; }
@@ -157,6 +157,8 @@ class DataDecoder
   void init();
   void decodePage(gsl::span<const std::byte> page);
   void dumpDigits();
+  bool getPadMapping(const DsElecId& dsElecId, DualSampaChannelId channel, int& deId, int& dsIddet, int& padId);
+  bool addDigit(const DsElecId& dsElecId, DualSampaChannelId channel, const o2::mch::raw::SampaCluster& sc);
 
   Elec2DetMapper mElec2Det{nullptr};       ///< front-end electronics mapping
   FeeLink2SolarMapper mFee2Solar{nullptr}; ///< CRU electronics mapping

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -173,7 +173,7 @@ class DataDecoder
   static constexpr uint32_t sMaxSolarId = 200 * 8 - 1;
   static constexpr uint32_t sReadoutChannelsNum = (sMaxSolarId + 1) * 40 * 64;
   // table storing the digits merging information for each readout channel in the MCH system
-  std::array<MergerChannelRecord, sReadoutChannelsNum> mMergerRecords; ///< merger records for all MCH readout channels
+  std::vector<MergerChannelRecord> mMergerRecords{sReadoutChannelsNum}; ///< merger records for all MCH readout channels
 
   Elec2DetMapper mElec2Det{nullptr};       ///< front-end electronics mapping
   FeeLink2SolarMapper mFee2Solar{nullptr}; ///< CRU electronics mapping

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -284,7 +284,7 @@ bool DataDecoder::mergeDigits(uint32_t mergerChannelId, o2::mch::raw::SampaClust
     return false;
   }
 
-  auto& mergerCh = mMergerRecords.at(mergerChannelId);
+  auto& mergerCh = mMergerRecords[mergerChannelId];
 
   // if there is not previous digit for this channel then no merging is possible
   if (mergerCh.digitId < 0) {
@@ -305,7 +305,7 @@ bool DataDecoder::mergeDigits(uint32_t mergerChannelId, o2::mch::raw::SampaClust
   }
 
   // add total charge and number of samples to existing digit
-  auto& digit = mDigits.at(mergerCh.digitId).digit;
+  auto& digit = mDigits[mergerCh.digitId].digit;
   digit.setADC(digit.getADC() + sc.sum());
   uint32_t newNofSamples = digit.getNofSamples() + sc.nofSamples();
   if (newNofSamples > MAXNOFSAMPLES) {
@@ -323,8 +323,8 @@ bool DataDecoder::mergeDigits(uint32_t mergerChannelId, o2::mch::raw::SampaClust
 
 void DataDecoder::updateMergerRecord(uint32_t mergerChannelId, uint32_t digitId)
 {
-  auto& mergerCh = mMergerRecords.at(mergerChannelId);
-  auto& digit = mDigits.at(digitId);
+  auto& mergerCh = mMergerRecords[mergerChannelId];
+  auto& digit = mDigits[digitId];
   mergerCh.digitId = digitId;
   mergerCh.bcEnd = digit.info.bunchCrossing + (digit.info.sampaTime + digit.digit.getNofSamples() - 1) * 4;
 }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -263,7 +263,7 @@ int32_t DataDecoder::getMergerChannelId(const DsElecId& dsElecId, DualSampaChann
 {
   auto solarId = dsElecId.solarId();
   uint32_t dsId = static_cast<uint32_t>(dsElecId.elinkGroupId()) * 5 + dsElecId.elinkIndexInGroup();
-  if (solarId > DataDecoder::sMaxSolarId || dsId >= 40) {
+  if (solarId > DataDecoder::sMaxSolarId || dsId >= 40 || channel >= 64) {
     return -1;
   }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTime)
 
   DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
+  DataDecoder::computeDigitsTime(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing);
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover)
 
   DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
+  DataDecoder::computeDigitsTime(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing) + BCROLLOVER;
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(ComputeDigitsTimeWithRollover2)
 
   DataDecoder::SampaTimeFrameStart sampaTimeFrameStart{tfOrbit, tfBunchCrossing};
 
-  DataDecoder::computeDigitsTime_(digits, sampaTimeFrameStart, false);
+  DataDecoder::computeDigitsTime(digits, sampaTimeFrameStart, false);
 
   int32_t digitTime = static_cast<int32_t>(bunchCrossing) + static_cast<int32_t>(sampaTime * 4) -
                       static_cast<int32_t>(tfBunchCrossing) - BCROLLOVER;

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -19,6 +19,7 @@
 #include <random>
 #include <iostream>
 #include <fstream>
+#include <chrono>
 #include <stdexcept>
 #include <array>
 #include <functional>
@@ -85,6 +86,12 @@ class DataDecoderTask
     auto useDummyElecMap = ic.options().get<bool>("dummy-elecmap");
     mDecoder = new DataDecoder(channelHandler, rdhHandler, sampaBcOffset, mapCRUfile, mapFECfile, ds2manu, mDebug,
                                useDummyElecMap);
+
+    auto stop = [this]() {
+      LOG(INFO) << "decoding duration = " << mTimeDecoding.count() * 1000 / mTFcount << " us / TF";
+      LOG(INFO) << "ROF finder duration = " << mTimeROFFinder.count() * 1000 / mTFcount << " us / TF";
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
   }
 
   //_________________________________________________________________________________________________
@@ -217,6 +224,7 @@ class DataDecoderTask
 
     mDecoder->reset();
 
+    auto tStart = std::chrono::high_resolution_clock::now();
     for (auto&& input : pc.inputs()) {
       if (input.spec->binding == "readout") {
         decodeReadout(input);
@@ -226,6 +234,8 @@ class DataDecoderTask
       }
     }
     mDecoder->computeDigitsTime();
+    auto tEnd = std::chrono::high_resolution_clock::now();
+    mTimeDecoding += tEnd - tStart;
 
     auto& digits = mDecoder->getDigits();
     auto& orbits = mDecoder->getOrbits();
@@ -245,8 +255,11 @@ class DataDecoderTask
     }
 #endif
 
+    tStart = std::chrono::high_resolution_clock::now();
     ROFFinder rofFinder(digits, mFirstTForbit);
     rofFinder.process(mDummyROFs);
+    tEnd = std::chrono::high_resolution_clock::now();
+    mTimeROFFinder += tEnd - tStart;
 
     if (mDebug) {
       rofFinder.dumpOutputDigits();
@@ -273,6 +286,8 @@ class DataDecoderTask
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "DIGITS", 0}, digitsBuffer, digitsSize, freefct, nullptr);
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "DIGITROFS", 0}, rofsBuffer, rofsSize, freefct, nullptr);
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "ORBITS", 0}, orbitsBuffer, orbitsSize, freefct, nullptr);
+
+    mTFcount += 1;
   }
 
  private:
@@ -282,6 +297,11 @@ class DataDecoderTask
   bool mDummyROFs = {false};         /// flag to disable the ROFs finding
   uint32_t mFirstTForbit{0};         /// first orbit of the time frame being processed
   DataDecoder* mDecoder = {nullptr}; /// pointer to the data decoder instance
+
+  uint32_t mTFcount{0};
+
+  std::chrono::duration<double, std::milli> mTimeDecoding{};  ///< timer
+  std::chrono::duration<double, std::milli> mTimeROFFinder{}; ///< timer
 };
 
 //_________________________________________________________________________________________________


### PR DESCRIPTION
This PR introduces the code required for the merging of SAMPA digits in continuous data taking mode, when the detector signals can be into multiple SAMPA acquisition windows that need to be combined in order to recover the full deposited charge.

The merging is performed when the first ADC sample of a given digit follows immediately the last ADC sample of an existing digit from the same readout channel.

To speed up the computations, the decoder keeps a table of references to the last stored digits for each readout channel, as well as the time stamps of the last ADC sample of those digits.  When a new digit is decoded, its time stamp is compared with the last existing digit for the same channel. If the time gap is exactly equal to one ADC clock cycle the new digit is merged into the existing one, otherwise the new digit is stored separately.