### PR TITLE
[MCH] fixed memory leak in pedestals decoder

### DIFF
--- a/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
@@ -87,6 +87,29 @@ static bool isValidDeID(int deId)
   return false;
 }
 
+static void patchPage(gsl::span<const std::byte> rdhBuffer, bool verbose)
+{
+  static int sNrdhs = 0;
+  auto& rdhAny = *reinterpret_cast<RDH*>(const_cast<std::byte*>(&(rdhBuffer[0])));
+  sNrdhs++;
+
+  auto existingFeeId = o2::raw::RDHUtils::getFEEID(rdhAny);
+  if (existingFeeId == 0) {
+    // early versions of raw data did not set the feeId
+    // which we need to select the right decoder
+    auto cruId = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF;
+    auto flags = o2::raw::RDHUtils::getCRUID(rdhAny) & 0xFF00;
+    auto endpoint = o2::raw::RDHUtils::getEndPointID(rdhAny);
+    uint32_t feeId = cruId * 2 + endpoint + flags;
+    o2::raw::RDHUtils::setFEEID(rdhAny, feeId);
+  }
+
+  if (verbose) {
+    std::cout << "RDH number " << sNrdhs << "--\n";
+    o2::raw::RDHUtils::printRDH(rdhAny);
+  }
+};
+
 //=======================
 // Data decoder
 class PedestalsTask
@@ -140,6 +163,7 @@ class PedestalsTask
   void reset()
   {
     mDigits.clear();
+    mErrors.clear();
   }
 
   //_________________________________________________________________________________________________
@@ -155,6 +179,9 @@ class PedestalsTask
     auto channelHandler = [&](DsElecId dsElecId, uint8_t channel, o2::mch::raw::SampaCluster sc) {
       auto solarId = dsElecId.solarId();
       auto dsId = dsElecId.elinkId();
+      if (mDebug) {
+        std::cout << "New digit: SOLAR " << (int)solarId << "  DS " << (int)dsId << "  CH " << (int)channel << std::endl;
+      }
 
       mDigits.emplace_back(o2::mch::calibration::PedestalDigit(solarId, dsId, channel, sc.bunchCrossing, 0, sc.samples));
       ++ndigits;
@@ -166,6 +193,8 @@ class PedestalsTask
 
       mErrors.emplace_back(o2::mch::DecoderError(solarId, dsId, chip, error));
     };
+
+    patchPage(page, mDebug);
 
     if (mDebug) {
       auto& rdhAny = *reinterpret_cast<RDH*>(const_cast<std::byte*>(&(page[0])));
@@ -328,8 +357,8 @@ class PedestalsTask
 
     // create the output message
     auto freefct = [](void* data, void*) { free(data); };
-    pc.outputs().adoptChunk(Output{"MCH", "PDIGITS", 0}, digitsBuffer, digitsSize, freefct, nullptr);
-    //pc.outputs().adoptChunk(Output{"MCH", "ERRORS", 0}, errorsBuffer, errorsSize, freefct, nullptr);
+    pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "PDIGITS", 0}, digitsBuffer, digitsSize, freefct, nullptr);
+    pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "ERRORS", 0}, errorsBuffer, errorsSize, freefct, nullptr);
 
     logStats();
   }
@@ -391,7 +420,8 @@ o2::framework::DataProcessorSpec getMCHPedestalDecodingSpec(std::string inputSpe
   return DataProcessorSpec{
     getMCHPedestalDecodingDeviceName(),
     o2::framework::select(inputSpec.c_str()),
-    Outputs{OutputSpec{"MCH", "PDIGITS", 0, Lifetime::Timeframe} /*, OutputSpec{"MCH", "ERRORS", 0, Lifetime::Timeframe}*/},
+    Outputs{OutputSpec{header::gDataOriginMCH, "PDIGITS", 0, Lifetime::Timeframe},
+            OutputSpec{header::gDataOriginMCH, "ERRORS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<o2::mch::raw::PedestalsTask>(inputSpec)},
     Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
             {"logging-interval", VariantType::Int, 0, {"time interval in seconds between logging messages (set to zero to disable)"}},


### PR DESCRIPTION
The memory leak occurred when encountering decoding errors.
In this case the vector of error messages was continuously filled and never cleared.