### PR TITLE
Raw: make the output directory creation more robust.

### DIFF
--- a/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
@@ -104,18 +104,11 @@ void digi2raw(const std::string& inpName, const std::string& outDir, bool filePe
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);
 
+  o2::raw::assertOutputDirectory(outDir);
+
   std::string outDirName(outDir);
   if (outDirName.back() != '/') {
     outDirName += '/';
-  }
-
-  // if needed, create output directory
-  if (!std::filesystem::exists(outDirName)) {
-    if (!std::filesystem::create_directories(outDirName)) {
-      LOG(FATAL) << "could not create output directory " << outDirName;
-    } else {
-      LOG(INFO) << "created output directory " << outDirName;
-    }
   }
 
   m2r.readDigits(outDirName, inpName);

--- a/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
+++ b/Detectors/FIT/FT0/simulation/src/digi2raw.cxx
@@ -106,17 +106,11 @@ void digi2raw(const std::string& inpName, const std::string& outDir, int verbosi
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);
 
+  o2::raw::assertOutputDirectory(outDir);
+
   std::string outDirName(outDir);
   if (outDirName.back() != '/') {
     outDirName += '/';
-  }
-  // if needed, create output directory
-  if (!std::filesystem::exists(outDirName)) {
-    if (!std::filesystem::create_directories(outDirName)) {
-      LOG(FATAL) << "could not create output directory " << outDirName;
-    } else {
-      LOG(INFO) << "created output directory " << outDirName;
-    }
   }
 
   m2r.readDigits(outDirName, inpName);

--- a/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
@@ -106,17 +106,11 @@ void digit2raw(const std::string& inpName, const std::string& outDir, int verbos
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);
 
+  o2::raw::assertOutputDirectory(outDir);
+
   std::string outDirName(outDir);
   if (outDirName.back() != '/') {
     outDirName += '/';
-  }
-  // if needed, create output directory
-  if (!std::filesystem::exists(outDirName)) {
-    if (!std::filesystem::create_directories(outDirName)) {
-      LOG(FATAL) << "could not create output directory " << outDirName;
-    } else {
-      LOG(INFO) << "created output directory " << outDirName;
-    }
   }
 
   m2r.convertDigitsToRaw(outDirName, inpName);

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -79,22 +79,22 @@ class RawFileWriter
   /// Single GBT link helper
   struct LinkData {
     static constexpr int MarginToFlush = 10 * sizeof(RDHAny); // flush superpage if free space left <= this margin
-    RDHAny rdhCopy;                                          // RDH with the running info of the last RDH seen
-    IR updateIR;                                          // IR at which new HBF needs to be created
-    int lastRDHoffset = -1;                               // position of last RDH in the link buffer
-    bool startOfRun = true;                               // to signal if this is the 1st HBF of the run or not
-    uint8_t packetCounter = 0;                            // running counter
-    uint16_t pageCnt = 0;                                 // running counter
-    LinkSubSpec_t subspec = 0;                            // subspec according to DataDistribution
-    bool discardData = false;                             // discard data if true (e.g. desired max IR reached)
+    RDHAny rdhCopy;                                           // RDH with the running info of the last RDH seen
+    IR updateIR;                                              // IR at which new HBF needs to be created
+    int lastRDHoffset = -1;                                   // position of last RDH in the link buffer
+    bool startOfRun = true;                                   // to signal if this is the 1st HBF of the run or not
+    uint8_t packetCounter = 0;                                // running counter
+    uint16_t pageCnt = 0;                                     // running counter
+    LinkSubSpec_t subspec = 0;                                // subspec according to DataDistribution
+    bool discardData = false;                                 // discard data if true (e.g. desired max IR reached)
     //
     size_t nTFWritten = 0;    // number of TFs written
     size_t nRDHWritten = 0;   // number of RDHs written
     size_t nBytesWritten = 0; // number of bytes written
     //
-    std::string fileName{};                // file name associated with this link
-    std::vector<char> buffer;              // buffer to accumulate superpage data
-    RawFileWriter* writer = nullptr;       // pointer on the parent writer
+    std::string fileName{};          // file name associated with this link
+    std::vector<char> buffer;        // buffer to accumulate superpage data
+    RawFileWriter* writer = nullptr; // pointer on the parent writer
 
     PayloadCache cacheBuffer;         // used for caching in case of async. data input
     std::unique_ptr<TTree> cacheTree; // tree to store the cache
@@ -141,7 +141,6 @@ class RawFileWriter
       nRDHWritten++;
       return pushBack(reinterpret_cast<const char*>(&rdh), sizeof(RDHAny), false);
     }
-
   };
   //=====================================================================================
   // If addData was called with given IR for at least 1 link, then it should be called for all links, even it with empty payload
@@ -402,13 +401,13 @@ class RawFileWriter
   int mVerbosity = 0;
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   int mUseRDHVersion = RDHUtils::getVersion<o2::header::RAWDataHeader>(); // by default, use default version
-  int mSuperPageSize = 1024 * 1024; // super page size
-  bool mStartTFOnNewSPage = true;   // every TF must start on a new SPage
-  bool mDontFillEmptyHBF = false;   // skipp adding empty HBFs (uness it must have TF flag)
-  bool mAddSeparateHBFStopPage = true; // HBF stop is added on a separate CRU page
-  bool mUseRDHStop = true;             // detector uses STOP in RDH
-  bool mCRUDetector = true;            // Detector readout via CRU ( RORC if false)
-  bool mApplyCarryOverToLastPage = false; // call CarryOver method also for last chunk and overwrite modified trailer
+  int mSuperPageSize = 1024 * 1024;                                       // super page size
+  bool mStartTFOnNewSPage = true;                                         // every TF must start on a new SPage
+  bool mDontFillEmptyHBF = false;                                         // skipp adding empty HBFs (uness it must have TF flag)
+  bool mAddSeparateHBFStopPage = true;                                    // HBF stop is added on a separate CRU page
+  bool mUseRDHStop = true;                                                // detector uses STOP in RDH
+  bool mCRUDetector = true;                                               // Detector readout via CRU ( RORC if false)
+  bool mApplyCarryOverToLastPage = false;                                 // call CarryOver method also for last chunk and overwrite modified trailer
 
   //>> caching --------------
   bool mCachingStage = false; // signal that current data should be cached
@@ -425,7 +424,14 @@ class RawFileWriter
   bool mDoLazinessCheck = true;
 
   ClassDefNV(RawFileWriter, 1);
-}; // namespace raw
+};
+
+/** Ensure (i.e. create if needed) directory
+ * @param outDirName : output path to be asserted
+ *
+ * Log a FATAL if the directory does not exist and can not be created
+ */
+void assertOutputDirectory(std::string_view outDirName);
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -740,10 +740,10 @@ void o2::raw::assertOutputDirectory(std::string_view outDirName)
     if (!std::filesystem::exists(outDirName)) {
       LOG(FATAL) << "could not create output directory " << outDirName;
     }
-  }
 #else
     if (!std::filesystem::create_directories(outDirName)) {
       LOG(FATAL) << "could not create output directory " << outDirName;
     }
 #endif
+  }
 }

--- a/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
@@ -97,11 +97,7 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
   // if needed, create output directory
   if (!std::filesystem::exists(outDir)) {
     if (createParentDir) {
-      if (!std::filesystem::create_directories(outDir)) {
-        LOG(FATAL) << "could not create output directory " << outDir;
-      } else {
-        LOG(INFO) << "created output directory " << outDir;
-      }
+      o2::raw::assertOutputDirectory(outDir);
     } else {
       LOGP(error, "Requested output directory '{}' does not exists, consider removing '-n'", outDir);
       exit(1);

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -129,17 +129,11 @@ void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsN
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);
 
+  o2::raw::assertOutputDirectory(outDir);
+
   std::string outDirName(outDir);
   if (outDirName.back() != '/') {
     outDirName += '/';
-  }
-  // if needed, create output directory
-  if (!std::filesystem::exists(outDirName)) {
-    if (!std::filesystem::create_directories(outDirName)) {
-      LOG(FATAL) << "could not create output directory " << outDirName;
-    } else {
-      LOG(INFO) << "created output directory " << outDirName;
-    }
   }
 
   mc2raw.setTrackletHCHeader(trackletHCHeader);

--- a/Detectors/ZDC/simulation/src/digi2raw.cxx
+++ b/Detectors/ZDC/simulation/src/digi2raw.cxx
@@ -153,17 +153,11 @@ void digi2raw(const std::string& inpName, const std::string& outDir, int verbosi
   wr.setSuperPageSize(superPageSizeInB);
   wr.useRDHVersion(rdhV);
 
+  o2::raw::assertOutputDirectory(outDir);
+
   std::string outDirName(outDir);
   if (outDirName.back() != '/') {
     outDirName += '/';
-  }
-  // if needed, create output directory
-  if (!std::filesystem::exists(outDirName)) {
-    if (!std::filesystem::create_directories(outDirName)) {
-      LOG(FATAL) << "could not create output directory " << outDirName;
-    } else {
-      LOG(INFO) << "created output directory " << outDirName;
-    }
   }
 
   d2r.setModuleConfig(moduleConfig);


### PR DESCRIPTION
Turns out that `std::filesystem::create_directories` on some platforms/compilers does not return true even when actually
creating the directory. So this PR changes a bit the logic used to force creation of output directory : call `std::filesystem::create_directories` but do not rely on the boolean return value. Make an explicit `std::filesystem::exists` call instead.

Discovered that while trying to get the FST working on macOS. The symptom was that the rawXXX.log showed a fatal due to the impossibility to create the raw/XXX directory. But in fact the directory was created just fine. 

