### PR TITLE
CcdbApi: Option to build/use local cache on the fly

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -345,9 +345,9 @@ class CcdbApi //: public DatabaseInterface
    * A helper function to extract object from a local ROOT file
    * @param filename name of ROOT file
    * @param cl The TClass object describing the serialized type
-   * @return raw pointer to created object
+   * @return raw pointer to created object (and headers of answer)
    */
-  void* extractFromLocalFile(std::string const& filename, std::type_info const& tinfo) const;
+  void* extractFromLocalFile(std::string const& filename, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const;
 
   /**
    * Helper function to download binary content from alien:// storage


### PR DESCRIPTION
Offering a mode - useful for GRID - in which
we save downloaded objects into a given CCDB disc
store, thereby creating a local cache as we go.

This local store can be used to reduce the number
of network queries, as well as to know exactly which
objects have been requested by whom.

The cache can also be distributed with the software stack
in case someone doesn't have network access or credentials.

The usage is:

```
export ALICEO2_CCDB_LOCALCACHE=$pwd/.ccdb
process1
process2
```

where `process1` and `process2` would both build and use
the local cache located in the .ccdb folder (depending on the order).

Limitations:
- only to be used when all processes query for the same
  timestamp (typically the case for a single GRID job)