### PR TITLE
trivial fix to suppress the snprintf warning

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -41,7 +41,7 @@ class Geo
   static void getVolumeIndices(Int_t index, Int_t* detId); // Get volume index from channel index
 
   static void getPos(Int_t* det, Float_t* pos);
-  static void getVolumePath(const Int_t* ind, Char_t* path);
+  static std::string getVolumePath(const Int_t* ind);
   static Int_t getStripNumberPerSM(Int_t iplate, Int_t istrip);
   static void getStripAndModule(Int_t iStripPerSM, Int_t& iplate, Int_t& istrip); // Return the module and strip per module corresponding to the strip number per SM
 

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -11,8 +11,10 @@
 #include "TOFBase/Geo.h"
 #include "TGeoManager.h"
 #include "TMath.h"
-#include "FairLogger.h"
+#include "Framework/Logger.h"
 #include "DetectorsBase/GeometryManager.h"
+#include "CommonUtils/StringUtils.h"
+#include <string>
 
 ClassImp(o2::tof::Geo);
 
@@ -42,7 +44,6 @@ void Geo::Init()
   }
 
   int det[5];
-  Char_t path[200];
   for (Int_t isector = 0; isector < NSECTORS; isector++) {
     det[0] = isector;
     for (Int_t iplate = 0; iplate < NPLATES; iplate++) {
@@ -59,8 +60,7 @@ void Geo::Init()
             det[3] = ipadz;
             for (Int_t ipadx = 0; ipadx < NPADX; ipadx++) {
               det[4] = ipadx;
-              getVolumePath(det, path);
-              gGeoManager->cd(path);
+              gGeoManager->cd(getVolumePath(det).c_str());
               TGeoHMatrix global;
               global = *gGeoManager->GetCurrentMatrix();
               const Double_t* tr = global.GetTranslation();
@@ -145,23 +145,17 @@ void Geo::Init()
   mToBeIntit = kFALSE;
 }
 
-void Geo::getVolumePath(const Int_t* ind, Char_t* path)
+std::string Geo::getVolumePath(const Int_t* ind)
 {
   //--------------------------------------------------------------------
   // This function returns the volume path of a given pad
   //--------------------------------------------------------------------
   Int_t sector = ind[0];
 
-  const Int_t kSize = 100;
-
-  Char_t string1[kSize];
-  Char_t string2[kSize];
-  Char_t string3[kSize];
-
   Int_t icopy = -1;
   icopy = sector;
 
-  snprintf(string1, kSize, "/cave_1/barrel_1/B077_1/BSEGMO%i_1/BTOF%i_1", icopy, icopy);
+  auto string1 = fmt::format("/cave_1/barrel_1/B077_1/BSEGMO{:i}_1/BTOF{:i}_1", icopy, icopy);
 
   Bool_t fgHoles = kTRUE;
 
@@ -183,20 +177,19 @@ void Geo::getVolumePath(const Int_t* ind, Char_t* path)
     icopy = istrip + NSTRIPC + 2 * NSTRIPB + NSTRIPA;
   }
   icopy++;
-  snprintf(string2, kSize, "FTOA_0/FLTA_0/FSTR_%i", icopy);
+  auto string2 = fmt::format("FTOA_0/FLTA_0/FSTR_{:d}", icopy);
   if (fgHoles && (sector == 13 || sector == 14 || sector == 15)) {
     if (iplate < 2) {
-      snprintf(string2, kSize, "FTOB_0/FLTB_0/FSTR_%i", icopy);
+      string2 = fmt::format("FTOB_0/FLTB_0/FSTR_{:d}", icopy);
     }
     if (iplate > 2) {
-      snprintf(string2, kSize, "FTOC_0/FLTC_0/FSTR_%i", icopy);
+      string2 = fmt::format("FTOC_0/FLTC_0/FSTR_{:d}", icopy);
     }
   }
 
   Int_t padz = ind[3] + 1;
   Int_t padx = ind[4] + 1;
-  snprintf(string3, kSize, "FPCB_1/FSEN_1/FSEZ_%i/FPAD_%i", padz, padx);
-  snprintf(path, 2 * kSize, "%s/%s/%s", string1, string2, string3);
+  return o2::utils::Str::concat_string(string1, '/', string2, '/', fmt::format("FPCB_1/FSEN_1/FSEZ_{:d}/FPAD_{:d}", padz, padx));
 }
 
 void Geo::getPos(Int_t* det, Float_t* pos)


### PR DESCRIPTION
@noferini this is to fix the warning mentioned here: https://alice-talk.web.cern.ch/t/o2-on-ubuntu-with-werror-gives-some-error-s-directive-output-may-be-truncated/981

Trivial, merging