### PR TITLE
Add virtual destructors to allow save casting to base class in web socket handling avoiding new / delete mismatch

### DIFF
--- a/Framework/Core/src/HTTPParser.h
+++ b/Framework/Core/src/HTTPParser.h
@@ -87,6 +87,8 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
 
 /// An handler for a websocket message stream.
 struct WebSocketHandler {
+  virtual ~WebSocketHandler() = default;
+
   /// Invoked when all the headers are received.
   virtual void headers(std::map<std::string, std::string> const& headers){};
   /// FIXME: not implemented

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -507,6 +507,7 @@ struct ControlWebSocketHandler : public WebSocketHandler {
     : mContext{context}
   {
   }
+  ~ControlWebSocketHandler() override = default;
 
   /// Invoked at the end of the headers.
   /// as a special header we have "x-dpl-pid" which devices can use


### PR DESCRIPTION
Was failing with address sanitizer