### PR TITLE
Fix invalid headers sent by TOF and add some protection in header parsing

### DIFF
--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -100,6 +100,7 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
     auto dataProcessingHeaderOut = *DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(firstPart);
     headerOut.dataDescription = "CRAWDATA";
     headerOut.payloadSize = 0;
+    headerOut.splitPayloadParts = 1;
 
     /** initialise output message **/
     auto bufferSize = mOutputBufferSize >= 0 ? mOutputBufferSize + subspecBufferSize[subspec] : std::abs(mOutputBufferSize);

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -793,6 +793,11 @@ void DataProcessingDevice::handleData(DataProcessorContext& context, FairMQParts
       // If splitPayloadParts = 0, we assume that means there is only one (header, payload)
       // pair.
       size_t finalSplitPayloadIndex = hi + (dh->splitPayloadParts > 0 ? dh->splitPayloadParts : 1);
+      if (finalSplitPayloadIndex > results.size()) {
+        LOGP(error, "DataHeader::splitPayloadParts invalid");
+        results[hi] = InputType::Invalid;
+        continue;
+      }
       for (; hi < finalSplitPayloadIndex; ++hi) {
         results[hi] = InputType::Data;
       }


### PR DESCRIPTION
This PR together with #5765 fixes the crashes I reported in the Full System Test with DataDistribution recently.