### PR TITLE
MFT: Fix array size (spotted with address sanitizer)

### DIFF
--- a/Detectors/ITSMFT/MFT/base/src/Flex.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Flex.cxx
@@ -313,7 +313,7 @@ TGeoVolume* Flex::makeLines(Int_t nbsensors, Double_t length, Double_t widthflex
   auto* layer = new TGeoCompositeShape("layerhole2", layerholesub2);
 
   TGeoBBox* line[25];
-  TGeoTranslation *t[6], *ts[15], *tvdd, *tl[2];
+  TGeoTranslation *t[6], *ts[25], *tvdd, *tl[2];
   TGeoSubtraction* layerl[25];
   TGeoCompositeShape* layern[25];
   Int_t istart, istop;


### PR DESCRIPTION
@frmanso , @rpezzi : as far as I can tell, and according to Address Sanitizer, the `ts` array should be of size 25, not 15. 
(see e.g. line 353)
To be cross-checked ?