### PR TITLE
Fix typo in PVertexer debris cleanup

### DIFF
--- a/Detectors/Vertexing/src/PVertexer.cxx
+++ b/Detectors/Vertexing/src/PVertexer.cxx
@@ -535,7 +535,7 @@ void PVertexer::reduceDebris(std::vector<PVertex>& vertices, std::vector<int>& t
 
   for (int im = 0; im < nv; im++) { // loop from highest multiplicity to lowest one
     int it = multSort[im];
-    if (it < 0) { // if <0, the vertex was already discarded
+    if (timeSort[it] < 0) { // if <0, the vertex was already discarded
       continue;
     }
 


### PR DESCRIPTION
@davidrohr this is a fix for for the out of bound access seen by address sanitizer, thanks for reporting.
Merging as the fix is trivial.