### PR TITLE
Bug fix: use correct index over neighbour boards

### DIFF
--- a/Detectors/MUON/MID/Clustering/src/PreClustersDE.cxx
+++ b/Detectors/MUON/MID/Clustering/src/PreClustersDE.cxx
@@ -43,7 +43,7 @@ std::vector<int> PreClustersDE::getNeighbours(int icolumn, int idx) const
   }
   const BP& pcB = mPreClustersBP[icolumn][idx];
   for (int ib = 0; ib < mPreClustersBP[icolumn + 1].size(); ++ib) {
-    const BP& neigh = mPreClustersBP[icolumn + 1][idx];
+    const BP& neigh = mPreClustersBP[icolumn + 1][ib];
     if (neigh.area.getYmin() > pcB.area.getYmax()) {
       continue;
     }


### PR DESCRIPTION
A vector index in a loop was wrong. This caused an out-of-bound issue.