### PR TITLE
[EMCAL-630, EMCAL-700] Fix handling of cell indices from module indices

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -392,12 +392,14 @@ class Geometry
   int SuperModuleNumberFromEtaPhi(Double_t eta, Double_t phi) const;
 
   /// \brief Get cell absolute ID number from location module (2 times 2 cells) of a super module
-  /// \param nSupMod super module number
-  /// \param nModule module number
-  /// \param nIphi index of cell in module in phi direction 0 or 1
-  /// \param nIeta index of cell in module in eta direction 0 or 1
+  /// \param supermoduleID super module number
+  /// \param moduleID module number
+  /// \param phiInModule index of cell in module in phi direction 0 or 1
+  /// \param etaInModule index of cell in module in eta direction 0 or 1
   /// \return cell absolute ID number
-  Int_t GetAbsCellId(Int_t nSupMod, Int_t nModule, Int_t nIphi, Int_t nIeta) const;
+  /// \throw InvalidSupermoduleTypeException
+  /// \throw InvalidCellIDException
+  int GetAbsCellId(int supermoduleID, int moduleID, int phiInModule, int etaInModule) const;
 
   /// \brief Check whether a cell number is valid
   /// \param absId input absolute cell ID number to check
@@ -411,17 +413,18 @@ class Geometry
   std::tuple<int, int, int, int> GetCellIndex(Int_t absId) const;
 
   /// \brief Get eta-phi indexes of module in SM
-  /// \param nSupMod super module number, input
-  /// \param nModule module number, input
+  /// \param supermoduleID super module number, input
+  /// \param moduleID module number, input
   /// \return tuple (index in phi direction of module, index in eta direction of module)
-  std::tuple<int, int> GetModulePhiEtaIndexInSModule(Int_t nSupMod, Int_t nModule) const;
+  std::tuple<int, int> GetModulePhiEtaIndexInSModule(int supermoduleID, int moduleID) const;
 
   /// \brief Get eta-phi indexes of cell in SM
-  /// \param nSupMod super module number
-  /// \param nModule module number
-  /// \param nIphi index in phi direction in module
-  /// \param nIeta index in phi direction in module
-  std::tuple<int, int> GetCellPhiEtaIndexInSModule(Int_t nSupMod, Int_t nModule, Int_t nIphi, Int_t nIeta) const;
+  /// \param supermoduleID super module number
+  /// \param moduleID module number
+  /// \param phiInModule index in phi direction in module
+  /// \param etaInModule index in phi direction in module
+  /// \return Position (0 - phi, 1 - eta) of the cell inside teh supermodule
+  std::tuple<int, int> GetCellPhiEtaIndexInSModule(int supermoduleID, int moduleID, int phiInModule, int etaInModule) const;
 
   /// \brief Adapt cell indices in supermodule to online indexing
   /// \param supermoduleID super module number of the channel/cell
@@ -469,15 +472,15 @@ class Geometry
   }
 
   /// \brief Transition from cell indexes (iphi, ieta) to module indexes (iphim, ietam, nModule)
-  /// \param nSupMod super module number
-  /// \param iphi index of cell in phi direction inside super module
-  /// \param ieta index of cell in eta direction inside super module
+  /// \param supermoduleID super module number
+  /// \param phiInSupermodule index of cell in phi direction inside super module
+  /// \param etaInSupermodule index of cell in eta direction inside super module
   /// \return tuple:
   ///               iphim: index of cell in module in phi direction: 0 or 1
   ///               ietam: index of cell in module in eta direction: 0 or 1
   ///               nModule: module number
   ///
-  std::tuple<Int_t, Int_t, Int_t> GetModuleIndexesFromCellIndexesInSModule(Int_t nSupMod, Int_t iphi, Int_t ieta) const;
+  std::tuple<int, int, int> GetModuleIndexesFromCellIndexesInSModule(int supermoduleID, int phiInSupermodule, int etaInSupermodule) const;
 
   /// \brief Transition from super module number (nSupMod) and cell indexes (ieta,iphi) to cell absolute ID number.
   /// \param nSupMod super module number

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -594,18 +594,26 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
       } else {
         // changed SM Type, redefine the [2*i+1] Boundaries
         tmpSMType = GetSMType(2 * i);
-        if (GetSMType(2 * i) == EMCAL_STANDARD) {
-          mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + kfSupermodulePhiWidth;
-        } else if (GetSMType(2 * i) == EMCAL_HALF) {
-          mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 2, mIPDistance);
-        } else if (GetSMType(2 * i) == EMCAL_THIRD) {
-          mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 3, mIPDistance);
-        } else if (GetSMType(2 * i) == DCAL_STANDARD) { // jump the gap
-          mPhiBoundariesOfSM[2 * i] = (mDCALPhiMin - mArm1PhiMin) * TMath::DegToRad() + mPhiBoundariesOfSM[0];
-          mPhiBoundariesOfSM[2 * i + 1] = (mDCALPhiMin - mArm1PhiMin) * TMath::DegToRad() + mPhiBoundariesOfSM[1];
-        } else if (GetSMType(2 * i) == DCAL_EXT) {
-          mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 3, mIPDistance);
-        }
+        switch (GetSMType(2 * i)) {
+          case EMCAL_STANDARD:
+            mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + kfSupermodulePhiWidth;
+            break;
+          case EMCAL_HALF:
+            mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 2, mIPDistance);
+            break;
+          case EMCAL_THIRD:
+            mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 3, mIPDistance);
+            break;
+          case DCAL_STANDARD:
+            mPhiBoundariesOfSM[2 * i] = (mDCALPhiMin - mArm1PhiMin) * TMath::DegToRad() + mPhiBoundariesOfSM[0];
+            mPhiBoundariesOfSM[2 * i + 1] = (mDCALPhiMin - mArm1PhiMin) * TMath::DegToRad() + mPhiBoundariesOfSM[1];
+            break;
+          case DCAL_EXT:
+            mPhiBoundariesOfSM[2 * i + 1] = mPhiBoundariesOfSM[2 * i] + 2. * TMath::ATan2((mParSM[1]) / 3, mIPDistance);
+            break;
+          default:
+            break;
+        };
       }
       mPhiCentersOfSM[i] = (mPhiBoundariesOfSM[2 * i] + mPhiBoundariesOfSM[2 * i + 1]) / 2.;
       mPhiCentersOfSMSec[i] = mPhiBoundariesOfSM[2 * i] + TMath::ATan2(mParSM[1], mIPDistance);
@@ -614,7 +622,7 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
 
   // inner extend in eta (same as outer part) for DCal (0.189917), //calculated from the smallest gap (1# cell to the
   // 80-degree-edge),
-  Double_t innerExtandedPhi =
+  const double INNNER_EXTENDED_PHI =
     1.102840997; // calculated from the smallest gap (1# cell to the 80-degree-edge), too complicatd to explain...
   mDCALInnerExtandedEta = -TMath::Log(
     TMath::Tan((TMath::Pi() / 2. - 8 * mTrd1Angle * TMath::DegToRad() +
@@ -624,20 +632,27 @@ void Geometry::DefineEMC(std::string_view mcname, std::string_view mctitle)
   mEMCALPhiMax = mArm1PhiMin;
   mDCALPhiMax = mDCALPhiMin; // DCAl extention will not be included
   for (Int_t i = 0; i < mNumberOfSuperModules; i += 2) {
-    if (GetSMType(i) == EMCAL_STANDARD) {
-      mEMCALPhiMax += 20.;
-    } else if (GetSMType(i) == EMCAL_HALF) {
-      mEMCALPhiMax += mPhiSuperModule / 2. + innerExtandedPhi;
-    } else if (GetSMType(i) == EMCAL_THIRD) {
-      mEMCALPhiMax += mPhiSuperModule / 3. + 4.0 * innerExtandedPhi / 3.0;
-    } else if (GetSMType(i) == DCAL_STANDARD) {
-      mDCALPhiMax += 20.;
-      mDCALStandardPhiMax = mDCALPhiMax;
-    } else if (GetSMType(i) == DCAL_EXT) {
-      mDCALPhiMax += mPhiSuperModule / 3. + 4.0 * innerExtandedPhi / 3.0;
-    } else {
-      LOG(ERROR) << "Unkown SM Type!!\n";
-    }
+    switch (GetSMType(i)) {
+      case EMCAL_STANDARD:
+        mEMCALPhiMax += 20.;
+        break;
+      case EMCAL_HALF:
+        mEMCALPhiMax += mPhiSuperModule / 2. + INNNER_EXTENDED_PHI;
+        break;
+      case EMCAL_THIRD:
+        mEMCALPhiMax += mPhiSuperModule / 3. + 4.0 * INNNER_EXTENDED_PHI / 3.0;
+        break;
+      case DCAL_STANDARD:
+        mDCALPhiMax += 20.;
+        mDCALStandardPhiMax = mDCALPhiMax;
+        break;
+      case DCAL_EXT:
+        mDCALPhiMax += mPhiSuperModule / 3. + 4.0 * INNNER_EXTENDED_PHI / 3.0;
+        break;
+      default:
+        LOG(ERROR) << "Unkown SM Type!!\n";
+        break;
+    };
   }
   // for compatible reason
   // if(fNumberOfSuperModules == 4) {fEMCALPhiMax = fArm1PhiMax ;}
@@ -716,26 +731,33 @@ int Geometry::GetAbsCellId(int supermoduleID, int moduleID, int phiInModule, int
   // 0 <= absid   < fNCells
   int cellid = 0; // have to change from 0 to fNCells-1
   for (int i = 0; i < supermoduleID; i++) {
-    if (GetSMType(i) == EMCAL_STANDARD) {
-      cellid += mNCellsInSupMod;
-    } else if (GetSMType(i) == EMCAL_HALF) {
-      cellid += mNCellsInSupMod / 2;
-    } else if (GetSMType(i) == EMCAL_THIRD) {
-      cellid += mNCellsInSupMod / 3;
-    } else if (GetSMType(i) == DCAL_STANDARD) {
-      cellid += 2 * mNCellsInSupMod / 3;
-    } else if (GetSMType(i) == DCAL_EXT) {
-      cellid += mNCellsInSupMod / 3;
-    } else {
-      throw InvalidSupermoduleTypeException();
-    }
+    switch (GetSMType(i)) {
+      case EMCAL_STANDARD:
+        cellid += mNCellsInSupMod;
+        break;
+      case EMCAL_HALF:
+        cellid += mNCellsInSupMod / 2;
+        break;
+      case EMCAL_THIRD:
+        cellid += mNCellsInSupMod / 3;
+        break;
+      case DCAL_STANDARD:
+        cellid += 2 * mNCellsInSupMod / 3;
+        break;
+      case DCAL_EXT:
+        cellid += mNCellsInSupMod / 3;
+        break;
+      default:
+        throw InvalidSupermoduleTypeException();
+    };
   }
 
   cellid += mNCellsInModule * moduleID;
   cellid += mNPHIdiv * phiInModule;
   cellid += etaInModule;
-  if (!CheckAbsCellId(cellid))
+  if (!CheckAbsCellId(cellid)) {
     throw InvalidCellIDException(cellid);
+  }
 
   return cellid;
 }
@@ -749,9 +771,8 @@ std::tuple<int, int, int> Geometry::GetModuleIndexesFromCellIndexesInSModule(int
       moduleID = moduleEta * nModulesInSMPhi + modulePhi;
   int etaInModule = etaInSupermodule % mNETAdiv,
       phiInModule = phiInSupermodule % mNPHIdiv;
-  phiInModule = phiInSupermodule % mNPHIdiv;
-  return std::make_tuple(modulePhi, moduleEta, moduleID);
-  //return std::make_tuple(phiInModule, etaInModule, moduleID);
+  //return std::make_tuple(modulePhi, moduleEta, moduleID);
+  return std::make_tuple(phiInModule, etaInModule, moduleID);
 }
 
 Int_t Geometry::GetAbsCellIdFromCellIndexes(Int_t nSupMod, Int_t iphi, Int_t ieta) const
@@ -903,13 +924,17 @@ Int_t Geometry::GetAbsCellIdFromEtaPhi(Double_t eta, Double_t phi) const
   phi = TVector2::Phi_0_2pi(phi);
   Double_t phiLoc = phi - mPhiCentersOfSMSec[nSupMod / 2];
   Int_t nphi = mPhiCentersOfCells.size();
-  if (GetSMType(nSupMod) == EMCAL_HALF) {
-    nphi /= 2;
-  } else if (GetSMType(nSupMod) == EMCAL_THIRD) {
-    nphi /= 3;
-  } else if (GetSMType(nSupMod) == DCAL_EXT) {
-    nphi /= 3;
-  }
+  switch (GetSMType(nSupMod)) {
+    case EMCAL_HALF:
+      nphi /= 2;
+    case EMCAL_THIRD:
+    case DCAL_EXT:
+      nphi /= 3;
+      break;
+    default:
+      // All other supermodules have full number of cells in phi
+      break;
+  };
 
   Double_t dmin = TMath::Abs(mPhiCentersOfCells[0] - phiLoc),
            d = 0.;
@@ -973,19 +998,23 @@ std::tuple<int, int, int, int> Geometry::CalculateCellIndex(Int_t absId) const
   for (nSupMod = -1; test >= 0;) {
     nSupMod++;
     tmp = test;
-    if (GetSMType(nSupMod) == EMCAL_STANDARD) {
-      test -= mNCellsInSupMod;
-    } else if (GetSMType(nSupMod) == EMCAL_HALF) {
-      test -= mNCellsInSupMod / 2;
-    } else if (GetSMType(nSupMod) == EMCAL_THIRD) {
-      test -= mNCellsInSupMod / 3;
-    } else if (GetSMType(nSupMod) == DCAL_STANDARD) {
-      test -= 2 * mNCellsInSupMod / 3;
-    } else if (GetSMType(nSupMod) == DCAL_EXT) {
-      test -= mNCellsInSupMod / 3;
-    } else {
-      throw InvalidSupermoduleTypeException();
-    }
+    switch (GetSMType(nSupMod)) {
+      case EMCAL_STANDARD:
+        test -= mNCellsInSupMod;
+        break;
+      case EMCAL_HALF:
+        test -= mNCellsInSupMod / 2;
+        break;
+      case DCAL_STANDARD:
+        test -= 2 * mNCellsInSupMod / 3;
+        break;
+      case EMCAL_THIRD:
+      case DCAL_EXT:
+        test -= mNCellsInSupMod / 3;
+        break;
+      default:
+        throw InvalidSupermoduleTypeException();
+    };
   }
 
   Int_t nModule = tmp / mNCellsInModule;
@@ -1007,16 +1036,18 @@ Int_t Geometry::GetSuperModuleNumber(Int_t absId) const { return std::get<0>(Get
 std::tuple<int, int> Geometry::GetModulePhiEtaIndexInSModule(int supermoduleID, int moduleID) const
 {
   int nModulesInPhi = -1;
-  if (GetSMType(supermoduleID) == EMCAL_HALF) {
-    nModulesInPhi = mNPhi / 2; // halfSM
-  } else if (GetSMType(supermoduleID) == EMCAL_THIRD) {
-    nModulesInPhi = mNPhi / 3; // 1/3 SM
-  } else if (GetSMType(supermoduleID) == DCAL_EXT) {
-    nModulesInPhi = mNPhi / 3; // 1/3 SM
-  } else {
-    nModulesInPhi = mNPhi; // full SM
-  }
-
+  switch (GetSMType(supermoduleID)) {
+    case EMCAL_HALF:
+      nModulesInPhi = mNPhi / 2; // halfSM
+      break;
+    case EMCAL_THIRD:
+    case DCAL_EXT:
+      nModulesInPhi = mNPhi / 3; // 1/3 SM
+      break;
+    default:
+      nModulesInPhi = mNPhi; // full SM
+      break;
+  };
   return std::make_tuple(int(moduleID % nModulesInPhi), int(moduleID / nModulesInPhi));
 }
 

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -199,7 +199,8 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           continue;
         };
 
-        int CellID = mGeometry->GetAbsCellIdFromCellIndexes(iSM, iRow, iCol);
+        auto [phishift, etashift] = mGeometry->ShiftOnlineToOfflineCellIndexes(iSM, iRow, iCol);
+        int CellID = mGeometry->GetAbsCellIdFromCellIndexes(iSM, phishift, etashift);
 
         // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
         CaloFitResults fitResults;


### PR DESCRIPTION
The function GetModuleIndexesFromCellIndexesInSModule
is returning the position of the module instead of
the position of the cell inside the module. Together
with the module ID the information is redundant and
useless, while what is actually needed is the position
of the cell within the module.