### PR TITLE
ZDC Digits2Raw: labels are not guaranteed to be present

### DIFF
--- a/Detectors/ZDC/simulation/src/Digits2Raw.cxx
+++ b/Detectors/ZDC/simulation/src/Digits2Raw.cxx
@@ -98,7 +98,9 @@ void Digits2Raw::processDigits(const std::string& outDir, const std::string& fil
     return;
   }
 
-  digiTree->SetBranchStatus("ZDCDigitLabel*", 0);
+  if (digiTree->GetBranchStatus("ZDCDigitLabels")) {
+    digiTree->SetBranchStatus("ZDCDigitLabel*", 0);
+  }
 
   for (int ient = 0; ient < digiTree->GetEntries(); ient++) {
     digiTree->GetEntry(ient);


### PR DESCRIPTION
A fix to suppress the `Warning in <TTree::SetBranchStatus>: No branch name is matching wildcard -> ZDCDigitLabel*`
trivial, merging