### PR TITLE
[MRRTF-126] Add MCH reco workflow

### DIFF
--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -9,14 +9,24 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+# MCHWorkflow library is (at least) needed by Detectors/CTF/workflow
 o2_add_library(MCHWorkflow
-               SOURCES src/DataDecoderSpec.cxx src/PreClusterFinderSpec.cxx src/ClusterFinderOriginalSpec.cxx
-               src/EntropyDecoderSpec.cxx
-               TARGETVARNAME targetName
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHRawDecoder Boost::program_options
-                                     O2::MCHRawImplHelpers RapidJSON::RapidJSON O2::MCHMappingInterface
-                                     O2::MCHPreClustering O2::MCHMappingImpl4 O2::MCHRawElecMap O2::MCHBase
-                                     O2::DataFormatsMCH O2::MCHClustering O2::MCHCTF O2::SimulationDataFormat)
+               SOURCES
+                   src/EntropyDecoderSpec.cxx
+                   src/DataDecoderSpec.cxx
+                   src/PreClusterFinderSpec.cxx
+                   src/ClusterFinderOriginalSpec.cxx
+               PUBLIC_LINK_LIBRARIES
+                   O2::CommonUtils
+                   O2::DPLUtils
+                   O2::DataFormatsParameters
+                   O2::DetectorsRaw
+                   O2::MCHCTF
+                   O2::MCHClustering
+                   O2::MCHPreClustering
+                   O2::MCHRawCommon
+                   O2::MCHRawDecoder
+               )
 
 o2_add_executable(
         cru-page-reader-workflow
@@ -24,6 +34,7 @@ o2_add_executable(
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsRaw O2::DPLUtils Boost::program_options)
 
+# to be deprecated : use DevIO/digits-writer instead
 o2_add_executable(
         digits-sink-workflow
         SOURCES src/digits-sink-workflow.cxx
@@ -101,7 +112,18 @@ o2_add_executable(
         clusters-to-tracks-workflow
         SOURCES src/TrackFinderSpec.cxx src/clusters-to-tracks-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHTracking)
+        PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Framework O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
+
+o2_add_executable(
+        clusters-transformer-workflow
+        SOURCES src/clusters-transformer-workflow.cxx src/ClusterTransformerSpec.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+           O2::DetectorsBase
+           O2::Framework
+           O2::MCHBase
+           O2::MCHGeometryTransformer
+        )
 
 o2_add_executable(
         vertex-sampler-workflow
@@ -134,13 +156,27 @@ o2_add_executable(
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHTracking)
 
 o2_add_executable(
-        clusters-transformer-workflow
-        SOURCES src/clusters-transformer-workflow.cxx
-        COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHGeometryTransformer)
-
-o2_add_executable(
         entropy-encoder-workflow
         SOURCES src/entropy-encoder-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+
+o2_add_executable(
+        reco-workflow
+        SOURCES
+            src/ClusterTransformerSpec.cxx
+            src/TrackAtVertexSpec.cxx
+            src/TrackFinderSpec.cxx
+            src/VertexSamplerSpec.cxx
+            src/reco-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+            O2::MCHGeometryTransformer
+            O2::MCHTracking
+            O2::MCHWorkflow
+        )
+
+o2_add_executable(tracks-file-dumper
+  SOURCES src/tracks-file-dumper.cxx
+  COMPONENT_NAME mch
+  PUBLIC_LINK_LIBRARIES fmt::fmt Boost::program_options O2::MCHBase)

--- a/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.cxx
@@ -1,0 +1,113 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ClusterTransformerSpec.h"
+
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Logger.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "MCHBase/ClusterBlock.h"
+#include "MCHGeometryTransformer/Transformations.h"
+#include "MathUtils/Cartesian.h"
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace std;
+using namespace o2::framework;
+namespace fs = std::filesystem;
+
+namespace o2::mch
+{
+
+// convert all clusters from local to global reference frames
+void local2global(geo::TransformationCreator transformation,
+                  gsl::span<const ClusterStruct> localClusters,
+                  std::vector<ClusterStruct, o2::pmr::polymorphic_allocator<ClusterStruct>>& globalClusters)
+{
+  int i{0};
+  globalClusters.insert(globalClusters.end(), localClusters.begin(), localClusters.end());
+  for (auto& c : localClusters) {
+    auto deId = c.getDEId();
+    o2::math_utils::Point3D<float> local{c.x, c.y, c.z};
+    auto t = transformation(deId);
+    auto global = t(local);
+    auto& gcluster = globalClusters[i];
+    gcluster.x = global.x();
+    gcluster.y = global.y();
+    gcluster.z = global.z();
+    i++;
+  }
+}
+
+class ClusterTransformerTask
+{
+ public:
+  void init(InitContext& ic)
+  {
+    auto geoFile = ic.options().get<std::string>("geometry");
+    std::string ext = fs::path(geoFile).extension();
+    std::transform(ext.begin(), ext.begin(), ext.end(), [](unsigned char c) { return std::tolower(c); });
+
+    if (ext == ".json") {
+      std::ifstream in(geoFile);
+      if (!in.is_open()) {
+        throw std::invalid_argument("cannot open geometry file" + geoFile);
+      }
+      transformation = o2::mch::geo::transformationFromJSON(in);
+    } else if (ext == ".root") {
+      o2::base::GeometryManager::loadGeometry(geoFile);
+      transformation = o2::mch::geo::transformationFromTGeoManager(*gGeoManager);
+    } else {
+      throw std::invalid_argument("Geometry can only be in JSON or Root format");
+    }
+  }
+
+  // read the clusters (assumed to be in local reference frame) and
+  // tranform them into master reference frame.
+  void run(ProcessingContext& pc)
+  {
+    // get the input clusters
+    auto localClusters = pc.inputs().get<gsl::span<ClusterStruct>>("clusters");
+
+    // create the output message
+    auto& globalClusters = pc.outputs().make<std::vector<ClusterStruct>>(OutputRef{"globalclusters"});
+
+    local2global(transformation, localClusters, globalClusters);
+  }
+
+ public:
+  o2::mch::geo::TransformationCreator transformation;
+};
+
+DataProcessorSpec getClusterTransformerSpec()
+{
+  std::string inputConfig = fmt::format("rofs:MCH/CLUSTERROFS;clusters:MCH/CLUSTERS");
+  return DataProcessorSpec{
+    "mch-clusters-transformer",
+    Inputs{o2::framework::select(inputConfig.c_str())},
+    Outputs{OutputSpec{{"globalclusters"}, "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<ClusterTransformerTask>()},
+    Options{
+      {"geometry", VariantType::String, o2::base::NameConf::getGeomFileName(), {"input geometry file (JSON or Root format)"}}}};
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_WORKFLOW_CLUSTER_TRANSFORMER_SPEC_H
+#define O2_MCH_WORKFLOW_CLUSTER_TRANSFORMER_SPEC_H
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mch
+{
+o2::framework::DataProcessorSpec getClusterTransformerSpec();
+};
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVtxStruct.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVtxStruct.h
@@ -1,0 +1,27 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_TRACK_AT_VTX_STRUCT_H
+#define O2_MCH_TRACK_AT_VTX_STRUCT_H
+
+#include "MCHBase/TrackBlock.h"
+
+namespace o2::mch
+{
+struct TrackAtVtxStruct {
+  TrackParamStruct paramAtVertex{};
+  double dca = 0.;
+  double rAbs = 0.;
+  int mchTrackIdx = 0;
+};
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -21,8 +21,12 @@
 #include <list>
 #include <stdexcept>
 #include <string>
+#include <filesystem>
 
 #include <gsl/span>
+
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 #include "Framework/CallbackService.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -60,8 +64,21 @@ class TrackFinderTask
 
     LOG(INFO) << "initializing track finder";
 
-    auto l3Current = ic.options().get<float>("l3Current");
-    auto dipoleCurrent = ic.options().get<float>("dipoleCurrent");
+    const auto& options = ic.options();
+
+    float l3Current{-3000};
+    float dipoleCurrent{-6000};
+
+    auto grpFile = ic.options().get<std::string>("grp-file");
+    if (std::filesystem::exists(grpFile)) {
+      const auto grp = o2::parameters::GRPObject::loadFrom(grpFile);
+      l3Current = grp->getL3Current();
+      dipoleCurrent = grp->getDipoleCurrent();
+    } else {
+      l3Current = ic.options().get<float>("l3Current");
+      dipoleCurrent = ic.options().get<float>("dipoleCurrent");
+    }
+
     auto config = ic.options().get<std::string>("config");
     if (!config.empty()) {
       o2::conf::ConfigurableParam::updateFromFile(config, "MCHTracking", true);
@@ -155,6 +172,7 @@ o2::framework::DataProcessorSpec getTrackFinderSpec()
     AlgorithmSpec{adaptFromTask<TrackFinderTask>()},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
+            {"grp-file", VariantType::String, o2::base::NameConf::getGRPFileName(), {"Name of the grp file"}},
             {"config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
             {"debug", VariantType::Int, 0, {"debug level"}}}};
 }

--- a/Detectors/MUON/MCH/Workflow/src/clusters-transformer-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-transformer-workflow.cxx
@@ -9,88 +9,26 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <fstream>
-#include <chrono>
-#include <vector>
+#include "ClusterTransformerSpec.h"
 
-#include "Framework/CallbackService.h"
-#include "Framework/ConfigParamRegistry.h"
-#include "Framework/ControlService.h"
-#include "Framework/DataProcessorSpec.h"
-#include "Framework/Lifetime.h"
-#include "Framework/Output.h"
-#include "Framework/Task.h"
-#include "Framework/Logger.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/Variant.h"
+#include "Framework/WorkflowSpec.h"
 
-#include "MCHBase/ClusterBlock.h"
-#include "Framework/runDataProcessing.h"
-#include "MCHGeometryTransformer/Transformations.h"
-#include "MathUtils/Cartesian.h"
-
-using namespace std;
-using namespace o2::framework;
-using namespace o2::mch;
-
-// convert all clusters from local to global reference frames
-void local2global(geo::TransformationCreator transformation,
-                  gsl::span<const ClusterStruct> localClusters,
-                  std::vector<ClusterStruct, o2::pmr::polymorphic_allocator<ClusterStruct>>& globalClusters)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  int i{0};
-  globalClusters.insert(globalClusters.end(), localClusters.begin(), localClusters.end());
-  for (auto& c : localClusters) {
-    auto deId = c.getDEId();
-    o2::math_utils::Point3D<float> local{c.x, c.y, c.z};
-    auto t = transformation(deId);
-    auto global = t(local);
-    auto& gcluster = globalClusters[i];
-    gcluster.x = global.x();
-    gcluster.y = global.y();
-    gcluster.z = global.z();
-    i++;
-  }
+  workflowOptions.emplace_back("configKeyValues",
+                               o2::framework::VariantType::String, "",
+                               o2::framework::ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
 }
 
-class ClusterTransformerTask
+#include "Framework/runDataProcessing.h"
+
+o2::framework::WorkflowSpec defineDataProcessing(const o2::framework::ConfigContext& configContext)
 {
- public:
-  void init(InitContext& ic)
-  {
-    auto geoFile = ic.options().get<std::string>("geometry");
-    std::ifstream in(geoFile);
-    if (!in.is_open()) {
-      throw std::invalid_argument("cannot open geometry file" + geoFile);
-    }
-    transformation = o2::mch::geo::transformationFromJSON(in);
-  }
-
-  // read the clusters (assumed to be in local reference frame) and
-  // tranform them into master reference frame.
-  void run(ProcessingContext& pc)
-  {
-    // get the input clusters
-    auto localClusters = pc.inputs().get<gsl::span<ClusterStruct>>("clusters");
-
-    // create the output message
-    auto& globalClusters = pc.outputs().make<std::vector<ClusterStruct>>(OutputRef{"globalclusters"});
-
-    local2global(transformation, localClusters, globalClusters);
-  }
-
- public:
-  o2::mch::geo::TransformationCreator transformation;
-};
-
-WorkflowSpec defineDataProcessing(const ConfigContext& cc)
-{
-  std::string inputConfig = fmt::format("rofs:MCH/CLUSTERROFS;clusters:MCH/CLUSTERS");
-
-  return WorkflowSpec{
-    DataProcessorSpec{
-      "mch-clusters-transformer",
-      Inputs{o2::framework::select(inputConfig.c_str())},
-      Outputs{OutputSpec{{"globalclusters"}, "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
-      AlgorithmSpec{adaptFromTask<ClusterTransformerTask>()},
-      Options{
-        {"geometry", VariantType::String, "geometry-o2.json", {"input geometry (json format)"}}}}};
+  o2::conf::ConfigurableParam::updateFromString(configContext.options().get<std::string>("configKeyValues"));
+  return o2::framework::WorkflowSpec{o2::mch::getClusterTransformerSpec()};
 }

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ClusterTransformerSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/Logger.h"
+#include "Framework/Variant.h"
+#include "Framework/WorkflowSpec.h"
+#include "MCHWorkflow/ClusterFinderOriginalSpec.h"
+#include "MCHWorkflow/PreClusterFinderSpec.h"
+#include "TrackAtVertexSpec.h"
+#include "TrackAtVertexSpec.h"
+#include "TrackFinderSpec.h"
+#include "TrackFitterSpec.h"
+#include "VertexSamplerSpec.h"
+
+using o2::framework::ConfigContext;
+using o2::framework::ConfigParamSpec;
+using o2::framework::VariantType;
+using o2::framework::WorkflowSpec;
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  // auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
+
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  specs.emplace_back(o2::mch::getPreClusterFinderSpec());
+  specs.emplace_back(o2::mch::getClusterFinderOriginalSpec());
+  specs.emplace_back(o2::mch::getClusterTransformerSpec());
+  specs.emplace_back(o2::mch::getTrackFinderSpec());
+  specs.emplace_back(o2::mch::getVertexSamplerSpec());
+  specs.emplace_back(o2::mch::getTrackAtVertexSpec());
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  // write the configuration used for the reco workflow
+  o2::conf::ConfigurableParam::writeINI("o2mchrecoflow_configuration.ini");
+
+  return specs;
+}

--- a/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
@@ -1,0 +1,161 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "boost/program_options.hpp"
+#include <iostream>
+#include <fstream>
+#include <fmt/format.h>
+#include "TrackAtVtxStruct.h"
+#include "MCHBase/TrackBlock.h"
+#include <gsl/span>
+#include "DataFormatsMCH/TrackMCH.h"
+#include "MCHBase/ClusterBlock.h"
+
+namespace po = boost::program_options;
+
+using o2::mch::ClusterStruct;
+using o2::mch::TrackAtVtxStruct;
+using o2::mch::TrackMCH;
+
+template <typename T>
+bool readBinaryStruct(std::istream& in, int nitems, std::vector<T>& items, const char* itemName)
+{
+  if (in.peek() == EOF) {
+    return false;
+  }
+  // get the items if any
+  if (nitems > 0) {
+    auto offset = items.size();
+    items.resize(offset + nitems);
+    in.read(reinterpret_cast<char*>(&items[offset]), nitems * sizeof(T));
+    if (in.fail()) {
+      throw std::length_error(fmt::format("invalid input : cannot read {} {}", nitems, itemName));
+    }
+  }
+  return true;
+}
+
+void dump(std::ostream& os, const o2::mch::TrackParamStruct& t)
+{
+  auto pt2 = t.px * t.px + t.py * t.py;
+  auto p2 = t.pz * t.pz + pt2;
+  auto pt = std::sqrt(pt2);
+  auto p = std::sqrt(p2);
+  os << fmt::format("({:s}) p {:7.2f} pt {:7.2f}", t.sign == -1 ? "-" : "+", p, pt);
+}
+
+void dump(std::ostream& os, gsl::span<o2::mch::TrackAtVtxStruct> tracksAtVertex)
+{
+  for (const auto& tv : tracksAtVertex) {
+    os << fmt::format("id {:4d} ", tv.mchTrackIdx);
+    dump(os, tv.paramAtVertex);
+    os << fmt::format(" dca {:7.2f} rabs {:7.2f}", tv.dca, tv.rAbs)
+       << "\n";
+  }
+}
+
+/**
+ * o2-mch-tracks-file-dumper is a small helper program to inspect
+ * track binary files (mch custom binary format for debug only)
+ */
+
+int main(int argc, char* argv[])
+{
+  std::string inputFile;
+  po::variables_map vm;
+  po::options_description options("options");
+
+  // clang-format off
+  // clang-format off
+  options.add_options()
+      ("help,h", "produce help message")
+      ("infile,i", po::value<std::string>(&inputFile)->required(), "input file name")
+      ;
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(options);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).run(), vm);
+
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return 2;
+  }
+
+  try {
+    po::notify(vm);
+  } catch (boost::program_options::error& e) {
+    std::cout << "Error: " << e.what() << "\n";
+    exit(1);
+  }
+
+  std::ifstream in(inputFile.c_str());
+  if (!in.is_open()) {
+    std::cerr << "cannot open input file " << inputFile << "\n";
+    return 3;
+  }
+
+  while (in.good()) {
+    int nofTracksAtVertex{-1};
+    int nofTracks{-1};
+    int nofAttachedClusters{-1};
+    // read the number of tracks at vertex, MCH tracks and attached clusters
+    if (!in.read(reinterpret_cast<char*>(&nofTracksAtVertex), sizeof(int))) {
+      return -1;
+    }
+    if (!in.read(reinterpret_cast<char*>(&nofTracks), sizeof(int))) {
+      return -1;
+    }
+    if (!in.read(reinterpret_cast<char*>(&nofAttachedClusters), sizeof(int))) {
+      return -1;
+    }
+    std::cout << fmt::format("=== nof MCH tracks: {:2d} at vertex: {:2d} w/ {:4d} attached clusters\n",
+                             nofTracks, nofTracksAtVertex, nofAttachedClusters);
+    std::vector<TrackAtVtxStruct> tracksAtVertex;
+    std::vector<TrackMCH> tracks;
+    std::vector<ClusterStruct> clusters;
+    // read the tracks, tracks at vertex and clusters (mind the reverse order of tracks
+    // compared to the numbers above)
+    if (!readBinaryStruct<TrackAtVtxStruct>(in, nofTracksAtVertex, tracksAtVertex, "TracksAtVertex")) {
+      return -1;
+    }
+    if (!readBinaryStruct<TrackMCH>(in, nofTracks, tracks, "Tracks")) {
+      return -1;
+    }
+    if (!readBinaryStruct<ClusterStruct>(in, nofAttachedClusters, clusters, "AttachedClusters")) {
+      return -1;
+    }
+
+    dump(std::cout, tracksAtVertex);
+  }
+  return 0;
+}
+
+//     for (const auto& rof : rofs) {
+//
+//       // get the MCH tracks, attached clusters and corresponding tracks at vertex (if any)
+//       auto eventClusters = getEventTracksAndClusters(rof, tracks, clusters, eventTracks);
+//       auto eventTracksAtVtx = getEventTracksAtVtx(tracksAtVtx, tracksAtVtxOffset);
+//
+//       // write the number of tracks at vertex, MCH tracks and attached clusters
+//       int nEventTracksAtVtx = eventTracksAtVtx.size() / sizeof(TrackAtVtxStruct);
+//       mOutputFile.write(reinterpret_cast<char*>(&nEventTracksAtVtx), sizeof(int));
+//       int nEventTracks = eventTracks.size();
+//       mOutputFile.write(reinterpret_cast<char*>(&nEventTracks), sizeof(int));
+//       int nEventClusters = eventClusters.size();
+//       mOutputFile.write(reinterpret_cast<char*>(&nEventClusters), sizeof(int));
+//
+//       // write the tracks at vertex, MCH tracks and attached clusters
+//       mOutputFile.write(eventTracksAtVtx.data(), eventTracksAtVtx.size());
+//       mOutputFile.write(reinterpret_cast<const char*>(eventTracks.data()), eventTracks.size() * sizeof(TrackMCH));
+//       mOutputFile.write(reinterpret_cast<const char*>(eventClusters.data()), eventClusters.size_bytes());
+//     }


### PR DESCRIPTION
It's just wrapping existing workflows from digits to tracks. The idea is to use this one in FST (in an upcoming PR) (instead of e.g. having to pipe the individual workflows we've been using so far).

The cluster transformation workflow has been given its own include so it can indeed be included in the new reco-workflow.

The TrackFinder and TrackAtVertex workflows get a new option `--grp-file` to read (field data) from GRP by default. For debugging/expert usage and regain previous behaviour, you have to point `--grp-file` to a non-existing file.

Also introduce `o2-mch-tracks-file-dumper` to get a textual dump of (intermediate) track binary files.