### PR TITLE
CPV: Never take ownership CCDB objects

### DIFF
--- a/Detectors/CPV/simulation/include/CPVSimulation/RawWriter.h
+++ b/Detectors/CPV/simulation/include/CPVSimulation/RawWriter.h
@@ -81,9 +81,13 @@ class RawWriter
   FileFor_t mFileFor = FileFor_t::kFullDet;                       ///< Granularity of the output files
   std::string mOutputLocation = "./";                             ///< Rawfile name
   std::string mCcdbUrl = "http://ccdb-test.cern.ch:8080";         ///< CCDB Url
-  std::unique_ptr<CalibParams> mCalibParams;                      ///< CPV calibration
-  std::unique_ptr<Pedestals> mPedestals;                          ///< CPV pedestals
-  std::unique_ptr<BadChannelMap> mBadMap;                         ///< CPV bad channel map
+  std::unique_ptr<CalibParams> mCalibParamsTst;                   ///< CPV calibration
+  std::unique_ptr<Pedestals> mPedestalsTst;                       ///< CPV pedestals
+  std::unique_ptr<BadChannelMap> mBadMapTst;                      ///< CPV bad channel map
+  CalibParams* mCalibParams = nullptr;                            ///< CPV calibration
+  Pedestals* mPedestals = nullptr;                                ///< CPV pedestals
+  BadChannelMap* mBadMap = nullptr;                               ///< CPV bad channel map
+
   std::vector<char> mPayload;                                     ///< Payload to be written
   gsl::span<o2::cpv::Digit> mDigits;                              ///< Digits input vector - must be in digitized format including the time response
   std::unique_ptr<o2::raw::RawFileWriter> mRawWriter;             ///< Raw writer

--- a/Detectors/CPV/simulation/src/RawWriter.cxx
+++ b/Detectors/CPV/simulation/src/RawWriter.cxx
@@ -46,9 +46,11 @@ void RawWriter::init()
       LOG(ERROR) << "Host " << mCcdbUrl << " is not reachable!!!";
     }
     LOG(INFO) << "Using dummy calibration";
-    mCalibParams = std::make_unique<o2::cpv::CalibParams>(1);
+    mCalibParamsTst = std::make_unique<o2::cpv::CalibParams>(1);
+    mCalibParams = mCalibParamsTst.get();
     //mBadMap = std::make_unique<o2::cpv::BadChannelMap>(1);
-    mPedestals = std::make_unique<o2::cpv::Pedestals>(1);
+    mPedestalsTst = std::make_unique<o2::cpv::Pedestals>(1);
+    mPedestals = mPedestalsTst.get();
   } else {
     ccdbMgr.setCaching(true);                     //make local cache of remote objects
     ccdbMgr.setLocalObjectValidityChecking(true); //query objects from remote site only when local one is not valid
@@ -59,10 +61,11 @@ void RawWriter::init()
     ccdbMgr.setTimestamp(o2::ccdb::getCurrentTimestamp());
 
     LOG(INFO) << "CCDB: Reading o2::cpv::CalibParams from CPV/Calib/Gains";
-    mCalibParams.reset(ccdbMgr.get<o2::cpv::CalibParams>("CPV/Calib/Gains"));
+    mCalibParams = ccdbMgr.get<o2::cpv::CalibParams>("CPV/Calib/Gains");
     if (!mCalibParams) {
       LOG(ERROR) << "Cannot get o2::cpv::CalibParams from CCDB. using dummy calibration!";
-      mCalibParams = std::make_unique<o2::cpv::CalibParams>(1);
+      mCalibParamsTst = std::make_unique<o2::cpv::CalibParams>(1);
+      mCalibParams = mCalibParamsTst.get();
     }
 
     /*
@@ -75,10 +78,11 @@ void RawWriter::init()
     */
 
     LOG(INFO) << "CCDB: Reading o2::cpv::Pedestals from CPV/Calib/Pedestals";
-    mPedestals.reset(ccdbMgr.get<o2::cpv::Pedestals>("CPV/Calib/Pedestals"));
+    mPedestals = ccdbMgr.get<o2::cpv::Pedestals>("CPV/Calib/Pedestals");
     if (!mPedestals) {
       LOG(ERROR) << "Cannot get o2::cpv::Pedestals from CCDB. using dummy calibration!";
-      mPedestals = std::make_unique<o2::cpv::Pedestals>(1);
+      mPedestalsTst = std::make_unique<o2::cpv::Pedestals>(1);
+      mPedestals = mPedestalsTst.get();
     }
     LOG(INFO) << "Task configuration is done.";
   }


### PR DESCRIPTION
@peressounko @sevdokim The CCDB objects obtained by BasicCDBManager are owned by its cache, and in future, when the CDB will be provided by the framework, they will be owned by the framework.
Therefore, one should never overtake their ownership, for instance by creating a `unique_ptr` from them.
This is a quick fix, which I am merging since currently it breaks the o2. In principle, there is no need for local "test" calibration objects: if the CDB is not accessible, you cannot run. But, for the tests you can have you local cdb with whatever objects you want, see https://docs.google.com/document/d/1_GM6yY7ejVEIRi1y8Ooc9ongrGgZyCiks6Ca0OAEav8 from https://github.com/AliceO2Group/AliceO2/tree/dev/CCDB.