### PR TITLE
make ccdb-url a ZDC device option, rather than global of w.flow

### DIFF
--- a/Detectors/ZDC/workflow/include/ZDCWorkflow/DigitRecoSpec.h
+++ b/Detectors/ZDC/workflow/include/ZDCWorkflow/DigitRecoSpec.h
@@ -30,23 +30,23 @@ class DigitRecoSpec : public o2::framework::Task
 {
  public:
   DigitRecoSpec();
-  DigitRecoSpec(const int verbosity, const bool debugOut, const std::string& ccdbURL);
+  DigitRecoSpec(const int verbosity, const bool debugOut);
   ~DigitRecoSpec() override = default;
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
 
  private:
-  DigiReco mDR;              // Reconstruction object
-  std::string mccdbHost;     // Alternative ccdb server
-  int mVerbosity = 0;        // Verbosity level during recostruction
-  bool mDebugOut = false;    // Save temporary reconstruction structures on root file
-  bool mInitialized = false; // Connect once to CCDB during initialization
+  DigiReco mDR;                                           // Reconstruction object
+  std::string mccdbHost{"http://ccdb-test.cern.ch:8080"}; // Alternative ccdb server
+  int mVerbosity = 0;                                     // Verbosity level during recostruction
+  bool mDebugOut = false;                                 // Save temporary reconstruction structures on root file
+  bool mInitialized = false;                              // Connect once to CCDB during initialization
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getDigitRecoSpec(const int verbosity, const bool enableDebugOut, const std::string ccdbURL);
+framework::DataProcessorSpec getDigitRecoSpec(const int verbosity, const bool enableDebugOut);
 
 } // namespace zdc
 } // namespace o2

--- a/Detectors/ZDC/workflow/include/ZDCWorkflow/RecoWorkflow.h
+++ b/Detectors/ZDC/workflow/include/ZDCWorkflow/RecoWorkflow.h
@@ -19,7 +19,7 @@ namespace o2
 {
 namespace zdc
 {
-framework::WorkflowSpec getRecoWorkflow(const bool useMC, const bool disableRootInp, const bool disableRootOut, const int verbosity, const bool enableDebugOut, const std::string ccdbURL);
+framework::WorkflowSpec getRecoWorkflow(const bool useMC, const bool disableRootInp, const bool disableRootOut, const int verbosity, const bool enableDebugOut);
 } // namespace zdc
 } // namespace o2
 #endif

--- a/Detectors/ZDC/workflow/include/ZDCWorkflow/ZDCDataReaderDPLSpec.h
+++ b/Detectors/ZDC/workflow/include/ZDCWorkflow/ZDCDataReaderDPLSpec.h
@@ -45,7 +45,7 @@ class ZDCDataReaderDPLSpec : public Task
 {
  public:
   ZDCDataReaderDPLSpec() = default;
-  ZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const std::string& ccdbURL, const bool verifyTrigger);
+  ZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const bool verifyTrigger);
   ~ZDCDataReaderDPLSpec() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -56,7 +56,7 @@ class ZDCDataReaderDPLSpec : public Task
   RawReaderZDC mRawReader;
 };
 
-framework::DataProcessorSpec getZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const std::string& ccdbURL, const bool verifyTrigger);
+framework::DataProcessorSpec getZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const bool verifyTrigger);
 
 } // namespace zdc
 } // namespace o2

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -42,24 +42,18 @@ DigitRecoSpec::DigitRecoSpec()
 {
   mTimer.Stop();
   mTimer.Reset();
-  if (mccdbHost.empty()) {
-    mccdbHost = "http://ccdb-test.cern.ch:8080";
-  }
 }
 
-DigitRecoSpec::DigitRecoSpec(const int verbosity, const bool debugOut, const std::string& ccdbURL)
-  : mVerbosity(verbosity), mDebugOut(debugOut), mccdbHost(ccdbURL)
+DigitRecoSpec::DigitRecoSpec(const int verbosity, const bool debugOut)
+  : mVerbosity(verbosity), mDebugOut(debugOut)
 {
-  if (mccdbHost.empty()) {
-    mccdbHost = "http://ccdb-test.cern.ch:8080";
-  }
   mTimer.Stop();
   mTimer.Reset();
 }
 
 void DigitRecoSpec::init(o2::framework::InitContext& ic)
 {
-  // At this stage we cannot access the CCDB yet
+  mccdbHost = ic.options().get<std::string>("ccdb-url");
 }
 
 void DigitRecoSpec::run(ProcessingContext& pc)
@@ -188,7 +182,7 @@ void DigitRecoSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-framework::DataProcessorSpec getDigitRecoSpec(const int verbosity = 0, const bool enableDebugOut = false, const std::string ccdbURL = "")
+framework::DataProcessorSpec getDigitRecoSpec(const int verbosity = 0, const bool enableDebugOut = false)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("trig", "ZDC", "DIGITSBC", 0, Lifetime::Timeframe);
@@ -204,7 +198,8 @@ framework::DataProcessorSpec getDigitRecoSpec(const int verbosity = 0, const boo
     "zdc-digi-reco",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<DigitRecoSpec>(verbosity, enableDebugOut, ccdbURL)}};
+    AlgorithmSpec{adaptFromTask<DigitRecoSpec>(verbosity, enableDebugOut)},
+    o2::framework::Options{{"ccdb-url", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}}}};
 }
 
 } // namespace zdc

--- a/Detectors/ZDC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ZDC/workflow/src/RecoWorkflow.cxx
@@ -20,13 +20,13 @@ namespace o2
 namespace zdc
 {
 
-framework::WorkflowSpec getRecoWorkflow(const bool useMC, const bool disableRootInp, const bool disableRootOut, const int verbosity, const bool enableDebugOut, const std::string ccdbURL)
+framework::WorkflowSpec getRecoWorkflow(const bool useMC, const bool disableRootInp, const bool disableRootOut, const int verbosity, const bool enableDebugOut)
 {
   framework::WorkflowSpec specs;
   if (!disableRootInp) {
     specs.emplace_back(o2::zdc::getDigitReaderSpec(useMC));
   }
-  specs.emplace_back(o2::zdc::getDigitRecoSpec(verbosity, enableDebugOut, ccdbURL));
+  specs.emplace_back(o2::zdc::getDigitRecoSpec(verbosity, enableDebugOut));
   if (!disableRootOut) {
     specs.emplace_back(o2::zdc::getZDCRecoWriterDPLSpec());
   }

--- a/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
+++ b/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
@@ -19,13 +19,14 @@ namespace o2
 namespace zdc
 {
 
-ZDCDataReaderDPLSpec::ZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const std::string& ccdbURL, const bool verifyTrigger)
-  : mRawReader(rawReader), mccdbHost(ccdbURL), mVerifyTrigger(verifyTrigger)
+ZDCDataReaderDPLSpec::ZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const bool verifyTrigger)
+  : mRawReader(rawReader), mVerifyTrigger(verifyTrigger)
 {
 }
 
 void ZDCDataReaderDPLSpec::init(InitContext& ic)
 {
+  mccdbHost = ic.options().get<std::string>("ccdb-url");
   o2::ccdb::BasicCCDBManager::instance().setURL(mccdbHost);
 }
 
@@ -64,7 +65,7 @@ void ZDCDataReaderDPLSpec::run(ProcessingContext& pc)
   mRawReader.makeSnapshot(pc);
 }
 
-framework::DataProcessorSpec getZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const std::string& ccdbURL, const bool verifyTrigger)
+framework::DataProcessorSpec getZDCDataReaderDPLSpec(const RawReaderZDC& rawReader, const bool verifyTrigger)
 {
   LOG(INFO) << "DataProcessorSpec initDataProcSpec() for RawReaderZDC";
   std::vector<OutputSpec> outputSpec;
@@ -73,8 +74,8 @@ framework::DataProcessorSpec getZDCDataReaderDPLSpec(const RawReaderZDC& rawRead
     "zdc-datareader-dpl",
     o2::framework::select("TF:ZDC/RAWDATA"),
     outputSpec,
-    adaptFromTask<ZDCDataReaderDPLSpec>(rawReader, ccdbURL, verifyTrigger),
-    Options{}};
+    adaptFromTask<ZDCDataReaderDPLSpec>(rawReader, verifyTrigger),
+    Options{{"ccdb-url", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}}}};
 }
 } // namespace zdc
 } // namespace o2

--- a/Detectors/ZDC/workflow/src/o2-zdc-raw2digits.cxx
+++ b/Detectors/ZDC/workflow/src/o2-zdc-raw2digits.cxx
@@ -23,7 +23,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"dump-blocks-process", VariantType::Bool, false, {"enable dumping of event blocks at processor side"}},
     {"dump-blocks-reader", VariantType::Bool, false, {"enable dumping of event blocks at reader side"}},
     {"disable-root-output", VariantType::Bool, false, {"disable root-files output writers"}},
-    {"ccdb-url", VariantType::String, "http://ccdb-test.cern.ch:8080", {"url of CCDB"}},
     {"not-check-trigger", VariantType::Bool, false, {"avoid to check trigger condition during conversion"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
@@ -41,7 +40,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto dumpProcessor = configcontext.options().get<bool>("dump-blocks-process");
   auto dumpReader = configcontext.options().get<bool>("dump-blocks-reader");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
-  auto ccdbURL = configcontext.options().get<std::string>("ccdb-url");
   auto checkTrigger = true;
   auto notCheckTrigger = configcontext.options().get<bool>("not-check-trigger");
   if (notCheckTrigger) {
@@ -51,7 +49,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   WorkflowSpec specs;
-  specs.emplace_back(o2::zdc::getZDCDataReaderDPLSpec(o2::zdc::RawReaderZDC{dumpReader}, ccdbURL, checkTrigger));
+  specs.emplace_back(o2::zdc::getZDCDataReaderDPLSpec(o2::zdc::RawReaderZDC{dumpReader}, checkTrigger));
   //  if (useProcess) {
   //    specs.emplace_back(o2::zdc::getZDCDataProcessDPLSpec(dumpProcessor));
   //  }

--- a/Detectors/ZDC/workflow/src/zdc-reco-workflow.cxx
+++ b/Detectors/ZDC/workflow/src/zdc-reco-workflow.cxx
@@ -24,7 +24,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}});
   workflowOptions.push_back(ConfigParamSpec{"verbosity", VariantType::Int, 0, {"verbosity level"}});
   workflowOptions.push_back(ConfigParamSpec{"enable-debug-output", VariantType::Bool, false, {"enable debug tree output"}});
-  workflowOptions.push_back(ConfigParamSpec{"ccdb-url", VariantType::String, "http://ccdb-test.cern.ch:8080", {"url of CCDB"}});
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
 }
@@ -46,8 +45,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto verbosity = configcontext.options().get<int>("verbosity");
   auto enableDebugOut = configcontext.options().get<bool>("enable-debug-output");
-  auto ccdbURL = configcontext.options().get<std::string>("ccdb-url");
 
   LOG(INFO) << "WorkflowSpec getRecoWorkflow useMC " << useMC;
-  return std::move(o2::zdc::getRecoWorkflow(useMC, disableRootInp, disableRootOut, verbosity, enableDebugOut, ccdbURL));
+  return std::move(o2::zdc::getRecoWorkflow(useMC, disableRootInp, disableRootOut, verbosity, enableDebugOut));
 }


### PR DESCRIPTION
@cortesep, @davidrohr , I am changing this since the global option of ZDC workflow conflicts with device option of CPV.
Will merge after the local test is passed.