### PR TITLE
DPL: add code to enable multithreaded dispatch

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -97,6 +97,8 @@ struct TaskStreamInfo {
   TaskStreamRef id;
   /// The context of the DataProcessor being run by this task
   DataProcessorContext* context;
+  /// The libuv task handle
+  uv_work_t task;
   /// Wether or not this task is running
   bool running = false;
 };

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -567,8 +567,13 @@ bool DataProcessingDevice::ConditionalRun()
       stream.id = streamRef;
       stream.running = true;
       stream.context = &mDataProcessorContexes.at(0);
+#ifdef DPL_ENABLE_THREADING
+      stream.task.data = &handle;
+      uv_queue_work(mState.loop, &stream.task, run_callback, run_completion);
+#else
       run_callback(&handle);
       run_completion(&handle, 0);
+#endif
     } else {
       mWasActive = false;
     }


### PR DESCRIPTION
Dies due to the service registry not being correctly initialised for
multithreaded usage.