### PR TITLE
fix for cpv clusterer

### DIFF
--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/Clusterer.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/Clusterer.h
@@ -34,13 +34,13 @@ class Clusterer
 
   void initialize();
   void process(gsl::span<const Digit> digits, gsl::span<const TriggerRecord> dtr,
-               const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& dmc,
+               const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                std::vector<Cluster>* clusters, std::vector<TriggerRecord>* trigRec,
                o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC);
 
   void makeClusters(gsl::span<const Digit> digits);
   void evalCluProperties(gsl::span<const Digit> digits, std::vector<Cluster>* clusters,
-                         const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& dmc,
+                         const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                          o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC);
 
   float responseShape(float dx, float dz); // Parameterization of EM shower

--- a/Detectors/CPV/reconstruction/src/Clusterer.cxx
+++ b/Detectors/CPV/reconstruction/src/Clusterer.cxx
@@ -36,7 +36,7 @@ void Clusterer::initialize()
 
 //____________________________________________________________________________
 void Clusterer::process(gsl::span<const Digit> digits, gsl::span<const TriggerRecord> dtr,
-                        const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& dmc,
+                        const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                         std::vector<Cluster>* clusters, std::vector<TriggerRecord>* trigRec,
                         o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC)
 {
@@ -314,7 +314,7 @@ void Clusterer::unfoldOneCluster(FullCluster& iniClu, char nMax, gsl::span<int> 
 
 //____________________________________________________________________________
 void Clusterer::evalCluProperties(gsl::span<const Digit> digits, std::vector<Cluster>* clusters,
-                                  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>& dmc,
+                                  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                                   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC)
 {
 
@@ -356,7 +356,7 @@ void Clusterer::evalCluProperties(gsl::span<const Digit> digits, std::vector<Clu
             ++ll;
             continue;
           }
-          gsl::span<const o2::MCCompLabel> spDigList = dmc.getLabels(i);
+          gsl::span<const o2::MCCompLabel> spDigList = dmc->getLabels(i);
           gsl::span<o2::MCCompLabel> spCluList = cluMC->getLabels(labelIndex); //get updated list
           auto digL = spDigList.begin();
           while (digL != spDigList.end()) {

--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -44,7 +44,7 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
     truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("digitsmctr");
   }
 
-  mClusterizer.process(digits, digitsTR, *truthcont, &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont); // Find clusters on digits (pass by ref)
+  mClusterizer.process(digits, digitsTR, truthcont.get(), &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont); // Find clusters on digits (pass by ref)
 
   ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
   ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);


### PR DESCRIPTION
Fix in cpv clusterer: pass the MCTruthContainer pointer to mClusterizer.process instead of reference. 
Problem was de-referencing of null-pointer in some cases:
` [66197:CPVClusterizerSpec]: /home/qon/alice/sw/SOURCES/O2/dev/0/Detectors/CPV/workflow/src/ClusterizerSpec.cxx:46:23: runtime error: reference binding to null pointer of type 'const struct MCTruthContainer'`
