### PR TITLE
Bug fix in computing angular position of step supports on IB Side C End Wheels

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -633,8 +633,8 @@ void V3Services::ibEndWheelSideC(const Int_t iLay, TGeoVolume* endWheel, const T
   static const Double_t sEndWCStepHoleZdist = 4.0 * sMm;
 
   static const Double_t sEndWCStepHolePhi[3] = {30.0, 22.5, 18.0}; // Deg
-  static const Double_t sEndWCStepHolePhi0[2] = {9.5, 10.5};       // Deg
-  static const Double_t sEndWCStepYlow = 7.0 * sMm;
+  static const Double_t sEndWCStepHolePhi0[2] = {9.5, 10.5}; // Deg - Lay 1-2
+  static const Double_t sEndWCStepYlow = 7.0 * sMm; // Lay 0 only
 
   // Local variables
   Double_t xlen, ylen, zlen;
@@ -763,7 +763,10 @@ void V3Services::ibEndWheelSideC(const Int_t iLay, TGeoVolume* endWheel, const T
   endWheel->AddNode(endWheelCVol, 1, new TGeoCombiTrans(0, 0, -zpos, new TGeoRotation("", 0, 180, 0)));
 
   // The position of the Steps is given wrt the holes (see eg. ALIITSUP0187)
-  dphi = sEndWCStepHolePhi0[iLay];
+  if (iLay == 0)
+    dphi = (sEndWCStepYlow / sEndWCStepYdispl[iLay]) * TMath::RadToDeg();
+  else
+    dphi = sEndWCStepHolePhi0[iLay - 1];
 
   Int_t numberOfStaves = GeometryTGeo::Instance()->getNumberOfStaves(iLay);
   zpos += (static_cast<TGeoBBox*>(stepCVol->GetShape()))->GetDZ();

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -633,8 +633,8 @@ void V3Services::ibEndWheelSideC(const Int_t iLay, TGeoVolume* endWheel, const T
   static const Double_t sEndWCStepHoleZdist = 4.0 * sMm;
 
   static const Double_t sEndWCStepHolePhi[3] = {30.0, 22.5, 18.0}; // Deg
-  static const Double_t sEndWCStepHolePhi0[2] = {9.5, 10.5}; // Deg - Lay 1-2
-  static const Double_t sEndWCStepYlow = 7.0 * sMm; // Lay 0 only
+  static const Double_t sEndWCStepHolePhi0[2] = {9.5, 10.5};       // Deg - Lay 1-2
+  static const Double_t sEndWCStepYlow = 7.0 * sMm;                // Lay 0 only
 
   // Local variables
   Double_t xlen, ylen, zlen;

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -763,10 +763,11 @@ void V3Services::ibEndWheelSideC(const Int_t iLay, TGeoVolume* endWheel, const T
   endWheel->AddNode(endWheelCVol, 1, new TGeoCombiTrans(0, 0, -zpos, new TGeoRotation("", 0, 180, 0)));
 
   // The position of the Steps is given wrt the holes (see eg. ALIITSUP0187)
-  if (iLay == 0)
+  if (iLay == 0) {
     dphi = (sEndWCStepYlow / sEndWCStepYdispl[iLay]) * TMath::RadToDeg();
-  else
+  } else {
     dphi = sEndWCStepHolePhi0[iLay - 1];
+  }
 
   Int_t numberOfStaves = GeometryTGeo::Instance()->getNumberOfStaves(iLay);
   zpos += (static_cast<TGeoBBox*>(stepCVol->GetShape()))->GetDZ();


### PR DESCRIPTION
The angular position of the carbon step supports inside the IB End Wheels was erroneously computed. On the blueprints the position of the first element is directly expressed in degrees for Layers 1 and 2, while for Layer 0 the same starting position is given as linear distance from the middle plane. In the old code this starting position of the first element for Layer 0 was mistakenly taken from the list of angles for Layer 1 and 2. The new code fixes the error by computing the angular starting position from the linear displacement. (Many thanks to Laurent Aphecetche for spotting the issue - actually as an out-of-bound error - see https://alice.its.cern.ch/jira/browse/O2-2402)