### PR TITLE
Ignore .devcontainer/ and .devcontainer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ compile_commands.json
 
 # IDEs files
 .cproject
+.devcontainer*
 .project
 .idea
 .settings


### PR DESCRIPTION
`.devcontainer.json` and `.devcontainer/*` are configs used by [Visual Studio Code Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).

Hope `.devcontainer*` regex isn't too broad.