### PR TITLE
Workarounds for fmt 8.0.0

### DIFF
--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -271,7 +271,7 @@ struct CorrelationTask {
     LOGF(info, "Tracks for collision: %d | Vertex: %.1f | INT7: %d | V0M: %.1f", tracks.size(), collision.posZ(), collision.sel7(), collision.centV0M());
 
     if (std::abs(collision.posZ()) > cfgCutVertex) {
-      LOGF(warning, "Unexpected: Vertex %f outside of cut %f", collision.posZ(), cfgCutVertex);
+      LOGF(warning, "Unexpected: Vertex %f outside of cut %f", collision.posZ(), (float)cfgCutVertex);
     }
 
     int bSign = 1; // TODO magnetic field from CCDB

--- a/Analysis/Tutorials/src/configurableObjects.cxx
+++ b/Analysis/Tutorials/src/configurableObjects.cxx
@@ -78,7 +78,10 @@ struct ConfigurableObjectDemo {
 
   void process(aod::Collision const&, aod::Tracks const& tracks)
   {
-    LOGF(INFO, "Cut1: %.3f; Cut2: %.3f", cut, mutable_cut);
+    std::stringstream tmpcut, tmpmutable_cut;
+    tmpcut << cut;
+    tmpmutable_cut << mutable_cut;
+    LOGF(INFO, "Cut1: %s; Cut2: %s", tmpcut.str(), tmpmutable_cut.str());
 
     for (auto const& track : tracks) {
       if (track.globalIndex() % 500 == 0) {

--- a/Analysis/Tutorials/src/eventMixing.cxx
+++ b/Analysis/Tutorials/src/eventMixing.cxx
@@ -157,12 +157,12 @@ struct MixedEventsPartitionedTracks {
 
       for (auto& [t1, t2] : combinations(CombinationsFullIndexPolicy(leftPhi1, leftPhi2))) {
         if (t1.phiraw() >= (float)philow || t2.phiraw() >= (float)philow) {
-          LOGF(info, "WRONG Mixed event left tracks pair: (%d, %d) from events (%d, %d), phi: (%.3f. %.3f) < %.3f", t1.index(), t2.index(), c1.index(), c2.index(), t1.phiraw(), t2.phiraw(), philow);
+          LOGF(info, "WRONG Mixed event left tracks pair: (%d, %d) from events (%d, %d), phi: (%.3f. %.3f) < %.3f", t1.index(), t2.index(), c1.index(), c2.index(), t1.phiraw(), t2.phiraw(), (float)philow);
         }
       }
       for (auto& [t1, t2] : combinations(CombinationsFullIndexPolicy(rightPhi1, rightPhi2))) {
         if (t1.phiraw() < (float)phiup || t2.phiraw() < (float)phiup) {
-          LOGF(info, "WRONG Mixed event right tracks pair: (%d, %d) from events (%d, %d), phi: (%.3f. %.3f) >= %.3f", t1.index(), t2.index(), c1.index(), c2.index(), t1.phiraw(), t2.phiraw(), phiup);
+          LOGF(info, "WRONG Mixed event right tracks pair: (%d, %d) from events (%d, %d), phi: (%.3f. %.3f) >= %.3f", t1.index(), t2.index(), c1.index(), c2.index(), t1.phiraw(), t2.phiraw(), (float)phiup);
         }
       }
     }

--- a/Analysis/Tutorials/src/filters.cxx
+++ b/Analysis/Tutorials/src/filters.cxx
@@ -83,10 +83,10 @@ struct SpawnExtendedTables {
   void process(soa::Filtered<aod::Collisions>::iterator const& collision, soa::Filtered<soa::Join<aod::Tracks, aod::TPhi>> const& tracks)
   {
     LOGF(INFO, "Collision: %d [N = %d out of %d], -%.1f < %.3f < %.1f",
-         collision.globalIndex(), tracks.size(), tracks.tableSize(), vtxZ, collision.posZ(), vtxZ);
+         collision.globalIndex(), tracks.size(), tracks.tableSize(), (float)vtxZ, collision.posZ(), (float)vtxZ);
     for (auto& track : tracks) {
       LOGF(INFO, "id = %d; eta:  %.3f < %.3f < %.3f; phi: %.3f < %.3f < %.3f; pt: %.3f < %.3f < %.3f",
-           track.collisionId(), etalow, track.eta(), etaup, philow, track.nphi(), phiup, ptlow, track.pt(), ptup);
+           track.collisionId(), (float)etalow, track.eta(), (float)etaup, philow, track.nphi(), phiup, (float)ptlow, track.pt(), (float)ptup);
     }
   }
 };

--- a/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/PageDecoder.cxx
@@ -50,7 +50,7 @@ struct PayloadDecoderImpl<BareFormat, CHARGESUM, 0> {
   {
     auto solarId = fee2solar(feeLinkId);
     if (!solarId.has_value()) {
-      throw std::logic_error(fmt::format("{} could not get solarId from feelinkid={}\n", __PRETTY_FUNCTION__, feeLinkId));
+      throw std::logic_error(fmt::format("{} could not get solarId from feelinkid={}\n", __PRETTY_FUNCTION__, asString(feeLinkId)));
     }
     return std::move(BareGBTDecoder<CHARGESUM>(solarId.value(), decodedDataHandlers));
   }


### PR DESCRIPTION
@ktf : This makes O2 compile with fmt, I think the cause for all the issues is that the ostream << operator overload is not automatically taken for fmt::formatter<T>, no idea why. Either something is broken in fmt, or we have to implement the fmt::formatter<T>.

Anyway, it is only few lines, so perhaps we can merge it as is and clean it up later?