### PR TITLE
[WIP] DPL: match channel only for part 0, reuse later

### DIFF
--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -29,6 +29,8 @@ struct Output {
   header::DataOrigin origin;
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec = 0;
+  header::DataHeader::SplitPayloadIndexType splitIndex = 0;
+  header::DataHeader::SplitPayloadPartsType splitTotal = 1;
   enum Lifetime lifetime = Lifetime::Timeframe;
   header::Stack metaHeader = {};
 
@@ -47,6 +49,12 @@ struct Output {
   Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l,
          header::Stack&& stack)
     : origin(o), description(d), subSpec(s), lifetime(l), metaHeader(std::move(stack))
+  {
+  }
+
+  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l,
+         header::Stack&& stack, header::DataHeader::SplitPayloadIndexType si, header::DataHeader::SplitPayloadPartsType st)
+    : origin(o), description(d), subSpec(s), lifetime(l), metaHeader(std::move(stack)), splitIndex(si), splitTotal(st)
   {
   }
 

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -101,6 +101,8 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
   dh.payloadSerializationMethod = method;
   dh.tfCounter = mTimingInfo->tfCounter;
   dh.firstTForbit = mTimingInfo->firstTFOrbit;
+  dh.splitPayloadParts = spec.splitTotal;
+  dh.splitPayloadIndex = spec.splitIndex;
 
   DataProcessingHeader dph{mTimingInfo->timeslice, 1};
   auto& context = mRegistry->get<MessageContext>();
@@ -112,7 +114,14 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
 void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Output& spec,
                                      o2::header::SerializationMethod serializationMethod)
 {
-  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  // fixme: this will break if user calls it in the following way:
+  //  1) part 0 to channel A
+  //  2) part 0 to channel B
+  //  3) part 1 to channel A
+  static std::string channel;
+  if (spec.splitIndex == 0) {
+    channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  } // else: use the previously established channel
   auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod, 0);
 
   // FIXME: this is kind of ugly, we know that we can change the content of the


### PR DESCRIPTION
@ktf This is what we wrote yesterday.
It allows me to get additional 5% improvement (35% to 40%) in Dispatcher. However, I think there is actually a way to break it (see the comment in the code), so I am not so sure we should merge it, given that the performance benefit is not too big.