### PR TITLE
Fix the global angular position of staves in OB layers

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -101,10 +101,10 @@ static void configITS(Detector* its)
     {2.24, 2.34, 2.67, 9., 16.42, 12}, // for each inner layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
     {3.01, 3.15, 3.46, 9., 12.18, 16},
     {3.78, 3.93, 4.21, 9., 9.55, 20},
-    {-1, 19.6, -1, 4., 0., 24},  // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
-    {-1, 24.55, -1, 4., 0., 30}, // 30 was 61
-    {-1, 34.39, -1, 7., 0., 42}, // 42 was 88
-    {-1, 39.34, -1, 7., 0., 48}  // 48 was 100
+    {-1, 19.6, -1, 4., 7.5, 24},   // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
+    {-1, 24.55, -1, 4., 6., 30},   // 30 was 61
+    {-1, 34.39, -1, 7., 4.29, 42}, // 42 was 88
+    {-1, 39.34, -1, 7., 3.75, 48}  // 48 was 100
   };
   const int nChipsPerModule = 7;  // For OB: how many chips in a row
   const double zChipGap = 0.01;   // For OB: gap in Z between chips


### PR DESCRIPTION
The angular position of the staves in the Middle and Outer barrel layers was wrongly set to 0, determining a global rotation of the layers along the beam axis. This was fixed by setting a proper starting angle for each MB/OB layer based on blueprints.