### PR TITLE
[O2-2419] No exe in libraries please

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -20,7 +20,6 @@ o2_add_library(TPCWorkflow
                        src/ZSSpec.cxx
                        src/CalibProcessingHelper.cxx
                        src/ClusterSharingMapSpec.cxx
-                       src/FileReaderWorkflow.cxx
                        src/CalDetMergerPublisherSpec.cxx
                        src/KryptonClustererSpec.cxx
                        src/IDCToVectorSpec.cxx

--- a/Detectors/ZDC/raw/CMakeLists.txt
+++ b/Detectors/ZDC/raw/CMakeLists.txt
@@ -10,13 +10,19 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(ZDCRaw
-               SOURCES src/DumpRaw.cxx
-	               src/raw-parser.cxx
-		       src/RawReaderZDC.cxx
-               PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::ZDCBase O2::ZDCSimulation
-	       			     O2::DataFormatsZDC O2::CCDB O2::SimConfig O2::DPLUtils
-				     O2::DetectorsRaw O2::Headers)
-
+               SOURCES
+                 src/DumpRaw.cxx
+                 src/RawReaderZDC.cxx
+               PUBLIC_LINK_LIBRARIES
+                 O2::CCDB
+                 O2::DPLUtils
+                 O2::DataFormatsZDC
+                 O2::DetectorsRaw
+                 O2::Headers
+                 O2::SimConfig
+                 O2::SimulationDataFormat
+                 O2::ZDCBase
+                 O2::ZDCSimulation)
 
 o2_target_root_dictionary(ZDCRaw
                           HEADERS include/ZDCRaw/DumpRaw.h)
@@ -24,10 +30,11 @@ o2_target_root_dictionary(ZDCRaw
 o2_add_executable(raw-parser
                   COMPONENT_NAME zdc
                   SOURCES src/raw-parser.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
-		                        O2::DPLUtils
-					O2::ZDCSimulation
-					O2::ZDCRaw
-                                        O2::DetectorsRaw
-                                        O2::DetectorsCommonDataFormats
-                                        O2::CommonUtils)
+                  PUBLIC_LINK_LIBRARIES
+                    O2::CommonUtils
+                    O2::DPLUtils
+                    O2::DetectorsCommonDataFormats
+                    O2::DetectorsRaw
+                    O2::Framework
+                    O2::ZDCRaw
+                    O2::ZDCSimulation)

--- a/Detectors/ZDC/workflow/CMakeLists.txt
+++ b/Detectors/ZDC/workflow/CMakeLists.txt
@@ -47,7 +47,7 @@ o2_add_executable(digits-reco
                   SOURCES src/zdc-reco-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow O2::ZDCReconstruction)
 
-o2_add_executable(write-reco
-                  COMPONENT_NAME zdc
-                  SOURCES src/ZDCRecoWriterDPLSpec.cxx
-                  PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow)
+# o2_add_executable(write-reco
+#                   COMPONENT_NAME zdc
+#                   SOURCES src/ZDCRecoWriterDPLSpec.cxx
+#                   PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow)

--- a/Detectors/ZDC/workflow/CMakeLists.txt
+++ b/Detectors/ZDC/workflow/CMakeLists.txt
@@ -47,7 +47,7 @@ o2_add_executable(digits-reco
                   SOURCES src/zdc-reco-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow O2::ZDCReconstruction)
 
-# o2_add_executable(write-reco
-#                   COMPONENT_NAME zdc
-#                   SOURCES src/ZDCRecoWriterDPLSpec.cxx
-#                   PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow)
+o2_add_executable(write-reco
+                  COMPONENT_NAME zdc
+                  SOURCES src/reco-writer-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::ZDCWorkflow)

--- a/Detectors/ZDC/workflow/src/reco-writer-workflow.cxx
+++ b/Detectors/ZDC/workflow/src/reco-writer-workflow.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ZDCWorkflow/ZDCRecoWriterDPLSpec.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "disable-mc",
+      o2::framework::VariantType::Bool,
+      false,
+      {"disable MC propagation even if available"}});
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  if (useMC) {
+    LOG(WARNING) << "ZDC reconstruction does not support MC labels at the moment";
+  }
+  WorkflowSpec specs{o2::zdc::getZDCRecoWriterDPLSpec()};
+  return std::move(specs);
+}


### PR DESCRIPTION
Executables (e.g. those sources that include `runDataProcessing.h` and thus have a `main` function defined) should not be included in libraries.

This fix should solve the 
```
Undefined symbols for architecture x86_64:
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```
error in macro compilations on macOS.

Let's see how the tests go...

@cortesep note that following the removal of the `raw-parser` source from the `ZDCRaw` library I had to comment out the `zdc-write-reco` from `Detectors/ZDC/workflow/CMakeLists.txt`. You cannot turn a WorkflowSpec directly into an executable without e.g. defining `defineDataProcessing`. So, assuming the tests go green for this PR, you'd need to modify that `CMakeLists.txt` to recover your `zdc-write-reco` executable. 