### PR TITLE
[QC-110] Performance improvements in Dispatcher

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSamplingPolicy.h
@@ -73,7 +73,7 @@ class DataSamplingPolicy
   void setFairMQOutputChannel(std::string);
 
   /// \brief Returns true if this policy requires data with given InputSpec.
-  bool match(const framework::ConcreteDataMatcher& input) const;
+  const framework::OutputSpec* match(const framework::ConcreteDataMatcher& input) const;
   /// \brief Returns true if user-defined conditions of sampling are fulfilled.
   bool decide(const o2::framework::DataRef&);
   /// \brief Returns Output for given InputSpec to pass data forward.

--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -25,6 +25,8 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/Task.h"
 
+#include "DataSampling/DataSamplingHeader.h"
+
 class FairMQDevice;
 
 namespace o2::monitoring
@@ -63,12 +65,13 @@ class Dispatcher : public framework::Task
   framework::Options getOptions();
 
  private:
-  DataSamplingHeader prepareDataSamplingHeader(const DataSamplingPolicy& policy, const framework::DeviceSpec& spec);
+  DataSamplingHeader prepareDataSamplingHeader(const DataSamplingPolicy& policy);
   header::Stack extractAdditionalHeaders(const char* inputHeaderStack) const;
   void reportStats(monitoring::Monitoring& monitoring) const;
-  void send(framework::DataAllocator& dataAllocator, const framework::DataRef& inputData, framework::Output&& output) const;
+  void send(framework::DataAllocator& dataAllocator, const framework::DataRef& inputData, const framework::Output& output) const;
 
   std::string mName;
+  DataSamplingHeader::DeviceIDType mDeviceID = "invalid";
   std::string mReconfigurationSource;
   // policies should be shared between all pipeline threads
   std::vector<std::shared_ptr<DataSamplingPolicy>> mPolicies;

--- a/Utilities/DataSampling/src/DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/src/DataSamplingPolicy.cxx
@@ -103,9 +103,10 @@ DataSamplingPolicy DataSamplingPolicy::fromConfiguration(const ptree& config)
   return policy;
 }
 
-bool DataSamplingPolicy::match(const ConcreteDataMatcher& input) const
+const framework::OutputSpec* DataSamplingPolicy::match(const ConcreteDataMatcher& input) const
 {
-  return mPaths.find(input) != mPaths.end();
+  const auto it = mPaths.find(input);
+  return it != mPaths.end() ? &(it->second) : nullptr;
 }
 
 bool DataSamplingPolicy::decide(const o2::framework::DataRef& dataRef)

--- a/Utilities/DataSampling/src/Dispatcher.cxx
+++ b/Utilities/DataSampling/src/Dispatcher.cxx
@@ -70,30 +70,48 @@ void Dispatcher::init(InitContext& ctx)
                 << policyConfig.second.get_optional<std::string>("id").value_or("") << "'";
     }
   }
+
+  auto spec = ctx.services().get<const DeviceSpec>();
+  mDeviceID.runtimeInit(spec.id.substr(0, DataSamplingHeader::deviceIDTypeSize).c_str());
 }
 
 void Dispatcher::run(ProcessingContext& ctx)
 {
-  for (const auto& input : InputRecordWalker(ctx.inputs())) {
+  // todo: consider matching (and deciding) in completion policy to save some time
+  //  it is not trivial though, we would have to share state with the customize() method,
+  //  which is not possible atm.
 
-    const auto* inputHeader = header::get<header::DataHeader*>(input.header);
+  for (auto inputIt = ctx.inputs().begin(); inputIt != ctx.inputs().end(); inputIt++) {
+
+    const DataRef& firstPart = inputIt.getByPos(0);
+    if (firstPart.header == nullptr) {
+      continue;
+    }
+    const auto* inputHeader = header::get<header::DataHeader*>(firstPart.header);
     ConcreteDataMatcher inputMatcher{inputHeader->dataOrigin, inputHeader->dataDescription, inputHeader->subSpecification};
 
     for (auto& policy : mPolicies) {
-      // todo: consider getting the outputSpec in match to improve performance
-      // todo: consider matching (and deciding) in completion policy to save some time
+      if (auto route = policy->match(inputMatcher); route != nullptr && policy->decide(firstPart)) {
+        auto dsheader = prepareDataSamplingHeader(*policy);
+        for (const auto& part : inputIt) {
+          if (part.header != nullptr) {
+            // We copy every header which is not DataHeader or DataProcessingHeader,
+            // so that custom data-dependent headers are passed forward,
+            // and we add a DataSamplingHeader.
+            header::Stack headerStack{
+              std::move(extractAdditionalHeaders(part.header)),
+              dsheader};
 
-      if (policy->match(inputMatcher) && policy->decide(input)) {
-        // We copy every header which is not DataHeader or DataProcessingHeader,
-        // so that custom data-dependent headers are passed forward,
-        // and we add a DataSamplingHeader.
-        header::Stack headerStack{
-          std::move(extractAdditionalHeaders(input.header)),
-          std::move(prepareDataSamplingHeader(*policy.get(), ctx.services().get<const DeviceSpec>()))};
-
-        Output output = policy->prepareOutput(inputMatcher, input.spec->lifetime);
-        output.metaHeader = std::move(header::Stack{std::move(output.metaHeader), std::move(headerStack)});
-        send(ctx.outputs(), input, std::move(output));
+            auto routeAsConcreteDataType = DataSpecUtils::asConcreteDataTypeMatcher(*route);
+            Output output{
+              routeAsConcreteDataType.origin,
+              routeAsConcreteDataType.description,
+              inputMatcher.subSpec,
+              part.spec->lifetime,
+              std::move(headerStack)};
+            send(ctx.outputs(), part, output);
+          }
+        }
       }
     }
   }
@@ -117,18 +135,15 @@ void Dispatcher::reportStats(Monitoring& monitoring) const
   monitoring.send({dispatcherTotalAcceptedMessages, "Dispatcher_messages_passed"});
 }
 
-DataSamplingHeader Dispatcher::prepareDataSamplingHeader(const DataSamplingPolicy& policy, const DeviceSpec& spec)
+DataSamplingHeader Dispatcher::prepareDataSamplingHeader(const DataSamplingPolicy& policy)
 {
   uint64_t sampleTime = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-
-  DataSamplingHeader::DeviceIDType id;
-  id.runtimeInit(spec.id.substr(0, DataSamplingHeader::deviceIDTypeSize).c_str());
 
   return {
     sampleTime,
     policy.getTotalAcceptedMessages(),
     policy.getTotalEvaluatedMessages(),
-    id};
+    mDeviceID};
 }
 
 header::Stack Dispatcher::extractAdditionalHeaders(const char* inputHeaderStack) const
@@ -146,7 +161,7 @@ header::Stack Dispatcher::extractAdditionalHeaders(const char* inputHeaderStack)
   return headerStack;
 }
 
-void Dispatcher::send(DataAllocator& dataAllocator, const DataRef& inputData, Output&& output) const
+void Dispatcher::send(DataAllocator& dataAllocator, const DataRef& inputData, const Output& output) const
 {
   const auto* inputHeader = header::get<header::DataHeader*>(inputData.header);
   dataAllocator.snapshot(output, inputData.payload, inputHeader->payloadSize, inputHeader->payloadSerializationMethod);


### PR DESCRIPTION
The Dispatcher::run() performs 45% faster with these changes for 1000 parts and 10% random sampling.
highlights:
 - match inputs, not parts
 - const ref instead of move ref in Dispatcher::send()
 - reuse the found output route when matching
 - compute deviceID once
 - decide once per input (not part) and policy
 - create DataSamplingHeader once per policy

These are all the fixes which don't touch the framework.