### PR TITLE
Fix some of the ALICE 3 geometry issues

### DIFF
--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -111,20 +111,20 @@ void Detector::configITS(Detector* its)
 
   std::vector<std::array<double, 2>> layers;
   const int nLayers{12};
-  layers.emplace_back(std::array<double, 2>{0.5f, 15.f});
-  layers.emplace_back(std::array<double, 2>{1.2f, 15.f});
-  layers.emplace_back(std::array<double, 2>{2.5f, 15.f});
-  layers.emplace_back(std::array<double, 2>{3.75f, 62.f});
-  layers.emplace_back(std::array<double, 2>{7.f, 62.f});
-  layers.emplace_back(std::array<double, 2>{12.f, 62.f});
-  layers.emplace_back(std::array<double, 2>{20.f, 62.f});
-  layers.emplace_back(std::array<double, 2>{30.f, 62.f});
-  layers.emplace_back(std::array<double, 2>{45.f, 132.f});
-  layers.emplace_back(std::array<double, 2>{60.f, 132.f});
-  layers.emplace_back(std::array<double, 2>{80.f, 132.f});
-  layers.emplace_back(std::array<double, 2>{100.f, 132.f});
+  layers.emplace_back(std::array<double, 2>{0.5f, 30.f});
+  layers.emplace_back(std::array<double, 2>{1.2f, 30.f});
+  layers.emplace_back(std::array<double, 2>{2.5f, 30.f});
+  layers.emplace_back(std::array<double, 2>{3.75f, 124.f});
+  layers.emplace_back(std::array<double, 2>{7.f, 124.f});
+  layers.emplace_back(std::array<double, 2>{12.f, 124.f});
+  layers.emplace_back(std::array<double, 2>{20.f, 124.f});
+  layers.emplace_back(std::array<double, 2>{30.f, 124.f});
+  layers.emplace_back(std::array<double, 2>{45.f, 264.f});
+  layers.emplace_back(std::array<double, 2>{60.f, 264.f});
+  layers.emplace_back(std::array<double, 2>{80.f, 264.f});
+  layers.emplace_back(std::array<double, 2>{100.f, 264.f});
 
-  std::array<float, 12> sensorThicknesses = {50.e-4, 50.e-4, 50.e-4, 50.e-4, 50.e-3, 50.e-3, 50.e-3, 50.e-3, 50.e-3, 50.e-3, 50.e-3, 50.e-3};
+  std::array<float, 12> sensorThicknesses = {100.e-4, 100.e-4, 100.e-4, 100.e-4, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3};
   its->setStaveModelOB(o2::trk::Detector::kOBModel2);
   // its->createOuterBarrel(false);
 

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -126,7 +126,6 @@ void Detector::configITS(Detector* its)
 
   std::array<float, 12> sensorThicknesses = {100.e-4, 100.e-4, 100.e-4, 100.e-4, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3, 100.e-3};
   its->setStaveModelOB(o2::trk::Detector::kOBModel2);
-  // its->createOuterBarrel(false);
 
   auto idLayer{0};
   for (auto& layerData : layers) {

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -144,7 +144,7 @@ void build_geometry(FairRunSim* run = nullptr)
 #ifdef ENABLE_UPGRADES
   // upgraded beampipe at the interaction point (IP)
   if (isActivated("A3IP")) {
-    run->AddModule(new o2::passive::Alice3Pipe("A3IP", "Alice 3 beam pipe", !isActivated("TRK"), 0.48f, 0.015f, 44.4f, 3.7f, 0.05f, 44.4f));
+    run->AddModule(new o2::passive::Alice3Pipe("A3IP", "Alice 3 beam pipe", !isActivated("TRK"), 0.48f, 0.015f, 1000.f, 3.7f, 0.05f, 1000.f));
   }
 #endif
 


### PR DESCRIPTION
Hi @sawenzel @qgp,

I just fixed some default values for the geometry of ALICE 3. I kindly need your approval and merge.

@rpezzi  I am stll trying to do the fix for FT3 escavations in vacuum volume. Unfortunately tentatives so far failed for some yet  unknown reason.
Difference with TRK is that I have to apply a transformation (z-translations) to the shapes of inner disk-holes and somehow this breaks the geometry streaming on file. For TRK it works because all the holes are centered in 0,0,0 and transformations are not required. I'll investigate a bit more on that.