### PR TITLE
trd fix corrupt data at end of digits

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -9,11 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   CruRawReader.h
-/// @author Sean Murray
-/// @brief  Cru raw data reader, this is the part that parses the raw data
-//          it runs on the flp(pre compression) or on the epn(pre tracklet64 array generation)
-//          it hands off blocks of cru pay load to the parsers.
+// Cru raw data reader, this is the part that parses the raw data
+// it runs on the flp(pre compression) or on the epn(pre tracklet64 array generation)
+// it hands off blocks of cru pay load to the parsers.
 
 #ifndef O2_TRD_CRURAWREADER
 #define O2_TRD_CRURAWREADER
@@ -60,12 +58,13 @@ class CruRawReader
 
   void checkSummary();
   void resetCounters();
-  void configure(bool byteswap, bool verbose, bool headerverbose, bool dataverbose)
+  void configure(bool byteswap, bool fixdigitcorruption, bool verbose, bool headerverbose, bool dataverbose)
   {
     mByteSwap = byteswap;
     mVerbose = verbose;
     mHeaderVerbose = headerverbose;
     mDataVerbose = dataverbose;
+    mFixDigitEndCorruption = fixdigitcorruption;
   }
   void setBlob(bool returnblob) { mReturnBlob = returnblob; }; //set class to produce blobs and not vectors. (compress vs pass through)`
   void setDataBuffer(const char* val)
@@ -130,6 +129,7 @@ class CruRawReader
   bool mHeaderVerbose{false};
   bool mDataVerbose{false};
   bool mByteSwap{false};
+  bool mFixDigitEndCorruption{false};
   const char* mDataBuffer = nullptr;
   static const uint32_t mMaxHBFBufferSize = o2::trd::constants::HBFBUFFERMAX;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; //this holds the O2 payload held with in the HBFs to pass to parsing.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -35,7 +35,7 @@ namespace o2::trd
 class DataReaderTask : public Task
 {
  public:
-  DataReaderTask(bool compresseddata, bool byteswap, bool verbose, bool headerverbose, bool dataverbose) : mCompressedData(compresseddata), mByteSwap(byteswap), mVerbose(verbose), mHeaderVerbose(headerverbose), mDataVerbose(dataverbose) {}
+  DataReaderTask(bool compresseddata, bool byteswap, bool fixdigitendcorruption, bool verbose, bool headerverbose, bool dataverbose) : mCompressedData(compresseddata), mByteSwap(byteswap), mFixDigitEndCorruption(fixdigitendcorruption), mVerbose(verbose), mHeaderVerbose(headerverbose), mDataVerbose(dataverbose) {}
   ~DataReaderTask() override = default;
   void init(InitContext& ic) final;
   void sendData(ProcessingContext& pc, bool blankframe = false);
@@ -57,6 +57,7 @@ class DataReaderTask : public Task
                                //  o2::header::DataDescription mDataDesc; // Data description of the incoming data
   std::string mDataDesc;
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
+  bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -292,6 +292,14 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
         LOG(info) << "mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend;
       }
       digitwordsread = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, currentdetector, cleardigits, mByteSwap, mVerbose, mHeaderVerbose, mDataVerbose);
+      if (digitwordsread != std::distance(linkstart, linkend)) {
+        //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
+        if (mFixDigitEndCorruption) {
+          digitwordsread = std::distance(linkstart, linkend);
+        } else {
+          LOG(warn) << "read digits but data still left on the link digitwordsread:" << digitwordsread << " and link length:" << std::distance(linkstart, linkend);
+        }
+      }
       mTotalDigitsFound += mDigitsParser.getDigitsFound();
       if (mVerbose) {
         LOG(info) << "digitwordsread : " << digitwordsread << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend;

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -35,6 +35,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"trd-datareader-dataverbose", VariantType::Bool, false, {"Enable verbose data info"}},
     {"trd-datareader-compresseddata", VariantType::Bool, false, {"The incoming data is compressed or not"}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
+    {"trd-datareader-fixdigitcorruptdata", VariantType::Bool, false, {"Fix the erroneous data at the end of digits"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -58,6 +59,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto headerverbose = cfgc.options().get<bool>("trd-datareader-headerverbose");
   auto dataverbose = cfgc.options().get<bool>("trd-datareader-dataverbose");
   auto askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
+  auto fixdigitcorruption = cfgc.options().get<bool>("trd-datareader-fixdigitcorruptdata");
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
@@ -65,7 +67,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   //outputs.emplace_back("TRD", "FLPSTAT", 0, Lifetime::Timeframe);
   LOG(info) << "enablebyteswap :" << byteswap;
   AlgorithmSpec algoSpec;
-  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(compresseddata, byteswap, verbose, headerverbose, dataverbose)};
+  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(compresseddata, byteswap, fixdigitcorruption, verbose, headerverbose, dataverbose)};
 
   WorkflowSpec workflow;
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -122,7 +122,7 @@ void DataReaderTask::run(ProcessingContext& pc)
           }
           mReader.setDataBuffer(payloadIn);
           mReader.setDataBufferSize(payloadInSize);
-          mReader.configure(mByteSwap, mVerbose, mHeaderVerbose, mDataVerbose);
+          mReader.configure(mByteSwap, mFixDigitEndCorruption, mVerbose, mHeaderVerbose, mDataVerbose);
           mReader.run();
           if (mVerbose) {
             LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";


### PR DESCRIPTION
add option trd-datareader-fixdigitcorruptdata
Jump over the data corruption at the end of the digit data.
This should be temporary and is default false.