### PR TITLE
Do not consider type {DPL/EOS} as unknown in the raw proxy

### DIFF
--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -277,7 +277,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, boo
           break;
         }
       }
-      if (indexDone == false) {
+      if (indexDone == false && !DataSpecUtils::match(query, "DPL", "EOS", 0)) {
         unmatchedDescriptions.emplace_back(DataSpecUtils::describe(query));
       }
     }

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -32,6 +32,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(
     ConfigParamSpec{
       "number-of-events,n", VariantType::Int, 10, {"number of events to process"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "output-proxy-only", VariantType::Bool, false, {"create only the workflow up to output proxy"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -201,5 +204,10 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     channelConfig.c_str(),
     converter));
 
+  if (config.options().get<bool>("output-proxy-only")) {
+    // remove the input proxy and checker from the workflow
+    workflow.pop_back();
+    workflow.pop_back();
+  }
   return workflow;
 }


### PR DESCRIPTION
DPL output proxy automatically adds message of type {DPL/EOS} to forward
end-of-stream on all output channels. If another DPL workflow connects
via raw proxy, it handles the channel info headers and can ignore the
actual message.

Also adding an option to test_ExternalFairMQDeviceWorkflow which allows
to drop the subscriber part of the test and instead connect the raw proxy.