### PR TITLE
AOD conversion: Correct indexing of MCparticle to MCCollision

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -242,7 +242,7 @@ class AODProducerWorkflowDPL : public Task
                             gsl::span<const o2::MCCompLabel>& mcTruthITS, std::vector<bool>& isStoredITS,
                             gsl::span<const o2::MCCompLabel>& mcTruthMFT, std::vector<bool>& isStoredMFT,
                             gsl::span<const o2::MCCompLabel>& mcTruthTPC, std::vector<bool>& isStoredTPC,
-                            TripletsMap_t& toStore);
+                            TripletsMap_t& toStore, std::vector<std::pair<int, int>> const& mccolidtoeventsource);
 };
 
 /// create a processor spec


### PR DESCRIPTION
MCparticles referred to the original eventIDs
from the Geant transport, whereas they should refer
to the MCcollision AOD table entry.

Thanks to Nazar for discussions.