### PR TITLE
DPL Analysis: add unsigned int types to Variant/Configurable

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -21,6 +21,24 @@
 #include <string>
 #include <cassert>
 
+namespace
+{
+template <typename T>
+constexpr auto isSimpleType()
+{
+  return std::is_same_v<T, int> ||
+         std::is_same_v<T, uint8_t> ||
+         std::is_same_v<T, uint16_t> ||
+         std::is_same_v<T, uint32_t> ||
+         std::is_same_v<T, uint64_t> ||
+         std::is_same_v<T, int64_t> ||
+         std::is_same_v<T, long> ||
+         std::is_same_v<T, float> ||
+         std::is_same_v<T, double> ||
+         std::is_same_v<T, bool>;
+}
+} // namespace
+
 namespace o2::framework
 {
 class ConfigParamStore;
@@ -54,12 +72,7 @@ class ConfigParamRegistry
   {
     assert(mStore.get());
     try {
-      if constexpr (std::is_same_v<T, int> ||
-                    std::is_same_v<T, int64_t> ||
-                    std::is_same_v<T, long> ||
-                    std::is_same_v<T, float> ||
-                    std::is_same_v<T, double> ||
-                    std::is_same_v<T, bool>) {
+      if constexpr (isSimpleType<T>()) {
         return mStore->store().get<T>(key);
       } else if constexpr (std::is_same_v<T, std::string>) {
         return mStore->store().get<std::string>(key);

--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -105,11 +105,7 @@ struct ConfigParamsHelper {
     const char* name = spec.name.c_str();
     const char* help = spec.help.c_str();
 
-    if constexpr (V == VariantType::Int ||
-                  V == VariantType::Int64 ||
-                  V == VariantType::Float ||
-                  V == VariantType::Double ||
-                  V == VariantType::Bool) {
+    if constexpr (isSimpleVariant<V>()) {
       using Type = typename variant_type<V>::type;
       using BoostType = typename std::conditional<V == VariantType::String, std::string, Type>::type;
       auto value = boost::program_options::value<BoostType>();
@@ -120,14 +116,7 @@ struct ConfigParamsHelper {
         value = value->zero_tokens();
       }
       options.add_options()(name, value, help);
-    } else if constexpr (V == VariantType::ArrayInt ||
-                         V == VariantType::ArrayFloat ||
-                         V == VariantType::ArrayDouble ||
-                         V == VariantType::ArrayBool ||
-                         V == VariantType::ArrayString ||
-                         V == VariantType::Array2DInt ||
-                         V == VariantType::Array2DFloat ||
-                         V == VariantType::Array2DDouble) {
+    } else if constexpr (isArray<V>() || isArray2D<V>()) {
       auto value = boost::program_options::value<std::string>();
       value = value->default_value(spec.defaultValue.asString());
       if constexpr (V != VariantType::String) {

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -28,6 +28,10 @@ namespace o2::framework
 
 enum class VariantType : int { Int = 0,
                                Int64,
+                               UInt8,
+                               UInt16,
+                               UInt32,
+                               UInt64,
                                Float,
                                Double,
                                String,
@@ -76,6 +80,11 @@ struct variant_trait : std::integral_constant<VariantType, VariantType::Unknown>
 DECLARE_VARIANT_TRAIT(int, Int);
 DECLARE_VARIANT_TRAIT(long int, Int64);
 DECLARE_VARIANT_TRAIT(long long int, Int64);
+DECLARE_VARIANT_TRAIT(uint8_t, UInt8);
+DECLARE_VARIANT_TRAIT(uint16_t, UInt16);
+DECLARE_VARIANT_TRAIT(uint32_t, UInt32);
+DECLARE_VARIANT_TRAIT(uint64_t, UInt64);
+
 DECLARE_VARIANT_TRAIT(float, Float);
 DECLARE_VARIANT_TRAIT(double, Double);
 DECLARE_VARIANT_TRAIT(bool, Bool);
@@ -152,6 +161,10 @@ struct variant_type {
 
 DECLARE_VARIANT_TYPE(int, Int);
 DECLARE_VARIANT_TYPE(int64_t, Int64);
+DECLARE_VARIANT_TYPE(uint8_t, UInt8);
+DECLARE_VARIANT_TYPE(uint16_t, UInt16);
+DECLARE_VARIANT_TYPE(uint32_t, UInt32);
+DECLARE_VARIANT_TYPE(uint64_t, UInt64);
 DECLARE_VARIANT_TYPE(float, Float);
 DECLARE_VARIANT_TYPE(double, Double);
 DECLARE_VARIANT_TYPE(const char*, String);
@@ -236,7 +249,8 @@ struct variant_helper<S, std::string> {
 /// Variant for configuration parameter storage. Owns stored data.
 class Variant
 {
-  using storage_t = std::aligned_union<8, int, int64_t, const char*, float, double, bool,
+  using storage_t = std::aligned_union<8, int, int64_t, uint8_t, uint16_t, uint32_t, uint64_t,
+                                       const char*, float, double, bool,
                                        int*, float*, double*, bool*,
                                        Array2D<int>, Array2D<float>, Array2D<double>,
                                        LabeledArray<int>, LabeledArray<float>, LabeledArray<double>>::type;

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -53,19 +53,41 @@ enum class VariantType : int { Int = 0,
 template <VariantType V>
 constexpr auto isArray()
 {
-  return (V == VariantType::ArrayBool || V == VariantType::ArrayDouble || V == VariantType::ArrayFloat || V == VariantType::ArrayInt || V == VariantType::ArrayString);
+  return (V == VariantType::ArrayBool ||
+          V == VariantType::ArrayDouble ||
+          V == VariantType::ArrayFloat ||
+          V == VariantType::ArrayInt ||
+          V == VariantType::ArrayString);
 }
 
 template <VariantType V>
 constexpr auto isArray2D()
 {
-  return (V == VariantType::Array2DInt || V == VariantType::Array2DFloat || V == VariantType::Array2DDouble);
+  return (V == VariantType::Array2DInt ||
+          V == VariantType::Array2DFloat ||
+          V == VariantType::Array2DDouble);
 }
 
 template <VariantType V>
 constexpr auto isLabeledArray()
 {
-  return (V == VariantType::LabeledArrayInt || V == VariantType::LabeledArrayFloat || V == VariantType::LabeledArrayDouble);
+  return (V == VariantType::LabeledArrayInt ||
+          V == VariantType::LabeledArrayFloat ||
+          V == VariantType::LabeledArrayDouble);
+}
+
+template <VariantType V>
+constexpr auto isSimpleVariant()
+{
+  return (V == VariantType::Int) ||
+         (V == VariantType::Int64) ||
+         (V == VariantType::UInt8) ||
+         (V == VariantType::UInt16) ||
+         (V == VariantType::UInt32) ||
+         (V == VariantType::UInt64) ||
+         (V == VariantType::Float) ||
+         (V == VariantType::Double) ||
+         (V == VariantType::Bool);
 }
 
 template <typename T>
@@ -285,10 +307,10 @@ class Variant
   }
 
   Variant(const Variant& other);
-  Variant(Variant&& other);
+  Variant(Variant&& other) noexcept;
   ~Variant();
   Variant& operator=(const Variant& other);
-  Variant& operator=(Variant&& other);
+  Variant& operator=(Variant&& other) noexcept;
 
   template <typename T>
   T get() const

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -50,6 +50,18 @@ void BoostOptionsRetriever::update(std::vector<ConfigParamSpec> const& specs,
       case VariantType::Int:
         options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<int>()), help);
         break;
+      case VariantType::UInt8:
+        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint8_t>()), help);
+        break;
+      case VariantType::UInt16:
+        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint16_t>()), help);
+        break;
+      case VariantType::UInt32:
+        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint32_t>()), help);
+        break;
+      case VariantType::UInt64:
+        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint64_t>()), help);
+        break;
       case VariantType::Int64:
         options = options(name, bpo::value<int64_t>()->default_value(spec.defaultValue.get<int64_t>()), help);
         break;

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -44,6 +44,18 @@ void ConfigParamsHelper::populateBoostProgramOptions(
       case VariantType::Int64:
         addConfigSpecOption<VariantType::Int64>(spec, options);
         break;
+      case VariantType::UInt8:
+        addConfigSpecOption<VariantType::UInt8>(spec, options);
+        break;
+      case VariantType::UInt16:
+        addConfigSpecOption<VariantType::UInt16>(spec, options);
+        break;
+      case VariantType::UInt32:
+        addConfigSpecOption<VariantType::UInt32>(spec, options);
+        break;
+      case VariantType::UInt64:
+        addConfigSpecOption<VariantType::UInt64>(spec, options);
+        break;
       case VariantType::Float:
         addConfigSpecOption<VariantType::Float>(spec, options);
         break;

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -36,6 +36,18 @@ void PropertyTreeHelpers::populateDefaults(std::vector<ConfigParamSpec> const& s
         case VariantType::Int:
           pt.put(key, spec.defaultValue.get<int>());
           break;
+        case VariantType::UInt8:
+          pt.put(key, spec.defaultValue.get<uint8_t>());
+          break;
+        case VariantType::UInt16:
+          pt.put(key, spec.defaultValue.get<uint16_t>());
+          break;
+        case VariantType::UInt32:
+          pt.put(key, spec.defaultValue.get<uint32_t>());
+          break;
+        case VariantType::UInt64:
+          pt.put(key, spec.defaultValue.get<uint64_t>());
+          break;
         case VariantType::Int64:
           pt.put(key, spec.defaultValue.get<int64_t>());
           break;
@@ -115,6 +127,18 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
       switch (spec.type) {
         case VariantType::Int:
           pt.put(key, vmap[key].as<int>());
+          break;
+        case VariantType::UInt8:
+          pt.put(key, vmap[key].as<uint8_t>());
+          break;
+        case VariantType::UInt16:
+          pt.put(key, vmap[key].as<uint16_t>());
+          break;
+        case VariantType::UInt32:
+          pt.put(key, vmap[key].as<uint32_t>());
+          break;
+        case VariantType::UInt64:
+          pt.put(key, vmap[key].as<uint64_t>());
           break;
         case VariantType::Int64:
           pt.put(key, vmap[key].as<int64_t>());
@@ -208,6 +232,18 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
       switch (spec.type) {
         case VariantType::Int:
           pt.put(key, (*it).get_value<int>());
+          break;
+        case VariantType::UInt8:
+          pt.put(key, (*it).get_value<uint8_t>());
+          break;
+        case VariantType::UInt16:
+          pt.put(key, (*it).get_value<uint16_t>());
+          break;
+        case VariantType::UInt32:
+          pt.put(key, (*it).get_value<uint32_t>());
+          break;
+        case VariantType::UInt64:
+          pt.put(key, (*it).get_value<uint64_t>());
           break;
         case VariantType::Int64:
           pt.put(key, (*it).get_value<int64_t>());

--- a/Framework/Core/src/Variant.cxx
+++ b/Framework/Core/src/Variant.cxx
@@ -56,6 +56,18 @@ std::ostream& operator<<(std::ostream& oss, Variant const& val)
     case VariantType::Int:
       oss << val.get<int>();
       break;
+    case VariantType::UInt8:
+      oss << val.get<uint8_t>();
+      break;
+    case VariantType::UInt16:
+      oss << val.get<uint16_t>();
+      break;
+    case VariantType::UInt32:
+      oss << val.get<uint32_t>();
+      break;
+    case VariantType::UInt64:
+      oss << val.get<uint64_t>();
+      break;
     case VariantType::Int64:
       oss << val.get<int64_t>();
       break;
@@ -146,7 +158,7 @@ Variant::Variant(const Variant& other) : mType(other.mType)
   }
 }
 
-Variant::Variant(Variant&& other) : mType(other.mType)
+Variant::Variant(Variant&& other) noexcept : mType(other.mType)
 {
   mStore = other.mStore;
   mSize = other.mSize;
@@ -222,7 +234,7 @@ Variant& Variant::operator=(const Variant& other)
   }
 }
 
-Variant& Variant::operator=(Variant&& other)
+Variant& Variant::operator=(Variant&& other) noexcept
 {
   mSize = other.mSize;
   mType = other.mType;

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -319,6 +319,18 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
         case VariantType::Int:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stoi(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
+        case VariantType::UInt8:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint8_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          break;
+        case VariantType::UInt16:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint16_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          break;
+        case VariantType::UInt32:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint32_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          break;
+        case VariantType::UInt64:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stoul(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
+          break;
         case VariantType::Int64:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stol(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -29,6 +29,10 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
 
   auto specs = std::vector<ConfigParamSpec>{
     {"someInt", VariantType::Int, 2, {"some int option"}},
+    {"someUInt8", VariantType::UInt8, static_cast<uint8_t>(2u), {"some uint8 option"}},
+    {"someUInt16", VariantType::UInt16, static_cast<uint16_t>(2u), {"some uint16 option"}},
+    {"someUInt32", VariantType::UInt32, 2u, {"some uint32 option"}},
+    {"someUInt64", VariantType::UInt64, static_cast<uint64_t>(2ul), {"some uint64 option"}},
     {"someInt64", VariantType::Int64, 4ll, {"some int64 option"}},
     {"someBool", VariantType::Bool, false, {"some bool option"}},
     {"someFloat", VariantType::Float, 2.0f, {"some float option"}},
@@ -38,6 +42,10 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
     "test",
     "--someBool",
     "--someInt", "1",
+    "--someUInt8", "1",
+    "--someUInt16", "1",
+    "--someUInt32", "1",
+    "--someUInt64", "1",
     "--someInt64", "50000000000000",
     "--someFloat", "0.5",
     "--someDouble", "0.5",
@@ -50,6 +58,10 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
   bpo::store(parse_command_line(sizeof(args) / sizeof(char*), args, opts), vm);
   bpo::notify(vm);
   BOOST_CHECK(vm["someInt"].as<int>() == 1);
+  BOOST_CHECK(vm["someUInt8"].as<uint8_t>() == '1');
+  BOOST_CHECK(vm["someUInt16"].as<uint16_t>() == 1);
+  BOOST_CHECK(vm["someUInt32"].as<uint32_t>() == 1);
+  BOOST_CHECK(vm["someUInt64"].as<uint64_t>() == 1);
   BOOST_CHECK(vm["someInt64"].as<int64_t>() == 50000000000000ll);
   BOOST_CHECK(vm["someBool"].as<bool>() == true);
   BOOST_CHECK(vm["someString"].as<std::string>() == "foobar");

--- a/Framework/Core/test/test_ConfigParamRegistry.cxx
+++ b/Framework/Core/test/test_ConfigParamRegistry.cxx
@@ -41,6 +41,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anUInt8", bpo::value<uint8_t>()->default_value(1))                  //
+    ("anUInt16", bpo::value<uint16_t>()->default_value(1))                //
+    ("anUInt32", bpo::value<uint32_t>()->default_value(1))                //
+    ("anUInt64", bpo::value<uint64_t>()->default_value(1))                //
     ("anInt64", bpo::value<int64_t>()->default_value(1ll))                //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString,s", bpo::value<std::string>()->default_value("something"))  //
@@ -52,6 +56,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anUInt8", "2",
+                     "--anUInt16", "10",
+                     "--anUInt32", "10",
+                     "--anUInt64", "10",
                      "--anInt64", "50000000000000",
                      "--aBoolean",
                      "-s", "somethingelse",
@@ -60,6 +68,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
                     true);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anUInt8", VariantType::UInt8, static_cast<uint8_t>(1u), {"an uint8 option"}},
+    ConfigParamSpec{"anUInt16", VariantType::UInt16, static_cast<uint16_t>(1u), {"an uint16 option"}},
+    ConfigParamSpec{"anUInt32", VariantType::UInt32, 1u, {"an uint32 option"}},
+    ConfigParamSpec{"anUInt64", VariantType::UInt64, static_cast<uint64_t>(1ul), {"an uint64 option"}},
     ConfigParamSpec{"anInt64", VariantType::Int64, 1ll, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
@@ -82,6 +94,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   BOOST_CHECK_EQUAL(registry.get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(registry.get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(registry.get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(registry.get<uint8_t>("anUInt8"), '2');
+  BOOST_CHECK_EQUAL(registry.get<uint16_t>("anUInt16"), 10);
+  BOOST_CHECK_EQUAL(registry.get<uint32_t>("anUInt32"), 10);
+  BOOST_CHECK_EQUAL(registry.get<uint64_t>("anUInt64"), 10);
   BOOST_CHECK_EQUAL(registry.get<int64_t>("anInt64"), 50000000000000ll);
   BOOST_CHECK_EQUAL(registry.get<bool>("aBoolean"), true);
   BOOST_CHECK_EQUAL(registry.get<std::string>("aString"), "somethingelse");

--- a/Framework/Core/test/test_ConfigParamStore.cxx
+++ b/Framework/Core/test/test_ConfigParamStore.cxx
@@ -31,6 +31,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anUInt8", bpo::value<uint8_t>()->default_value(1))                  //
+    ("anUInt16", bpo::value<uint16_t>()->default_value(1))                //
+    ("anUInt32", bpo::value<uint32_t>()->default_value(1))                //
+    ("anUInt64", bpo::value<uint64_t>()->default_value(1))                //
     ("anInt64", bpo::value<int64_t>()->default_value(1ll))                //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString,s", bpo::value<std::string>()->default_value("something"))  //
@@ -42,6 +46,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anUInt8", "2",
+                     "--anUInt16", "10",
+                     "--anUInt32", "10",
+                     "--anUInt64", "10",
                      "--anInt64", "50000000000000",
                      "--aBoolean",
                      "-s", "somethingelse",
@@ -50,6 +58,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
                     true);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anUInt8", VariantType::UInt8, static_cast<uint8_t>(1u), {"an int option"}},
+    ConfigParamSpec{"anUInt16", VariantType::UInt16, static_cast<uint16_t>(1u), {"an int option"}},
+    ConfigParamSpec{"anUInt32", VariantType::UInt32, 1u, {"an int option"}},
+    ConfigParamSpec{"anUInt64", VariantType::UInt64, static_cast<uint64_t>(1ul), {"an int option"}},
     ConfigParamSpec{"anInt64", VariantType::Int64, 1ll, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
@@ -71,6 +83,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   BOOST_CHECK_EQUAL(store.store().get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(store.store().get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(store.store().get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(store.store().get<uint8_t>("anUInt8"), '2');
+  BOOST_CHECK_EQUAL(store.store().get<uint16_t>("anUInt16"), 10);
+  BOOST_CHECK_EQUAL(store.store().get<uint32_t>("anUInt32"), 10);
+  BOOST_CHECK_EQUAL(store.store().get<uint64_t>("anUInt64"), 10);
   BOOST_CHECK_EQUAL(store.store().get<int64_t>("anInt64"), 50000000000000ll);
   BOOST_CHECK_EQUAL(store.store().get<bool>("aBoolean"), true);
   BOOST_CHECK_EQUAL(store.store().get<std::string>("aString"), "somethingelse");
@@ -87,6 +103,10 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   BOOST_CHECK_EQUAL(store.provenance("aFloat"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("aDouble"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anInt"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anUInt8"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anUInt16"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anUInt32"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anUInt64"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anInt64"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("aBoolean"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("aString"), "fairmq");

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -122,6 +122,21 @@ void optionsTable(const char* label, std::vector<ConfigParamSpec> const& options
           case VariantType::Int:
             ImGui::Text("%d (default)", option.defaultValue.get<int>());
             break;
+          case VariantType::Int64:
+            ImGui::Text("%lld (default)", option.defaultValue.get<int64_t>());
+            break;
+          case VariantType::UInt8:
+            ImGui::Text("%d (default)", option.defaultValue.get<uint8_t>());
+            break;
+          case VariantType::UInt16:
+            ImGui::Text("%d (default)", option.defaultValue.get<uint16_t>());
+            break;
+          case VariantType::UInt32:
+            ImGui::Text("%d (default)", option.defaultValue.get<uint32_t>());
+            break;
+          case VariantType::UInt64:
+            ImGui::Text("%lld (default)", option.defaultValue.get<uint64_t>());
+            break;
           case VariantType::Float:
             ImGui::Text("%f (default)", option.defaultValue.get<float>());
             break;


### PR DESCRIPTION
* 8,16,32 and 64bit unsigned ints are added to Variant
* Update serialization handlers to support these types in ConfigParamSpec and Configurable
* Note that uint8_t is considered a character when parsing command line arguments