### PR TITLE
Fixing typo on MB support shelf name

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -1803,7 +1803,7 @@ void V3Services::mbEndWheelSideC(const Int_t iLay, TGeoVolume* mother, const TGe
   ringUpperVol->SetFillColor(kBlue);
   ringUpperVol->SetLineColor(kBlue);
 
-  TGeoVolume* shelfVol = new TGeoVolume(Form("OBEndWheelAShelf%d", nLay), shelfSh, medCarbon);
+  TGeoVolume* shelfVol = new TGeoVolume(Form("OBEndWheelCShelf%d", nLay), shelfSh, medCarbon);
   shelfVol->SetFillColor(kBlue);
   shelfVol->SetLineColor(kBlue);
 


### PR DESCRIPTION
The MB support shelfs on side C were wrongly named as the ones on side A (probably a cut&paste error). The name is now correctly fixed (NB: there is no problem at all with their geometry, just the name)