### PR TITLE
Implementation of the ITS Half Barrels

### DIFF
--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -108,7 +108,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   int getNumberOfModules(int lay) const { return mNumberOfModules[lay]; }
   int getNumberOfHalfStaves(int lay) const { return mNumberOfHalfStaves[lay]; }
   int getNumberOfStaves(int lay) const { return mNumberOfStaves[lay]; }
-  int getNumberOfHalfBarrels(int lay) const { return mNumberOfHalfBarrels[lay]; }
+  int getNumberOfHalfBarrels() const { return mNumberOfHalfBarrels; }
   int getNumberOfLayers() const { return mNumberOfLayers; }
   int getChipIndex(int lay, int detInLay) const { return getFirstChipIndex(lay) + detInLay; }
   /// This routine computes the chip index number from the layer, stave, and chip number in stave
@@ -313,7 +313,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 
   /// Determines the number of halfbarrels in the layer
   /// \param lay: layer number, starting from 0
-  int extractNumberOfHalfBarrels(int lay) const;
+  int extractNumberOfHalfBarrels() const;
 
   /// Determines the number of layers in the Geometry
   /// \param lay: layer number, starting from 0
@@ -351,7 +351,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
   Int_t mNumberOfLayers;                        ///< number of layers
-  std::vector<int> mNumberOfHalfBarrels;        ///< the number of halfbarrels/layer(layer)
+  Int_t mNumberOfHalfBarrels;                   ///< number of halfbarrels
   std::vector<int> mNumberOfStaves;             ///< number of staves/layer(layer)
   std::vector<int> mNumberOfHalfStaves;         ///< the number of substaves/stave(layer)
   std::vector<int> mNumberOfModules;            ///< number of modules/substave(layer)

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -108,7 +108,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   int getNumberOfModules(int lay) const { return mNumberOfModules[lay]; }
   int getNumberOfHalfStaves(int lay) const { return mNumberOfHalfStaves[lay]; }
   int getNumberOfStaves(int lay) const { return mNumberOfStaves[lay]; }
-  int getNumberOfHalfBarrels() const { return mNumberOfHalfBarrels; }
+  int getNumberOfHalfBarrels(int lay) const { return mNumberOfHalfBarrels[lay]; }
   int getNumberOfLayers() const { return mNumberOfLayers; }
   int getChipIndex(int lay, int detInLay) const { return getFirstChipIndex(lay) + detInLay; }
   /// This routine computes the chip index number from the layer, stave, and chip number in stave
@@ -311,6 +311,10 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// \param lay: layer number from 0
   int extractNumberOfChipsPerModule(int lay, int& nrow) const;
 
+  /// Determines the number of halfbarrels in the layer
+  /// \param lay: layer number, starting from 0
+  int extractNumberOfHalfBarrels(int lay) const;
+
   /// Determines the number of layers in the Geometry
   /// \param lay: layer number, starting from 0
   int extractNumberOfStaves(int lay) const;
@@ -347,7 +351,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
   Int_t mNumberOfLayers;                        ///< number of layers
-  Int_t mNumberOfHalfBarrels;                   ///< the number of halfbarrels
+  std::vector<int> mNumberOfHalfBarrels;        ///< the number of halfbarrels/layer(layer)
   std::vector<int> mNumberOfStaves;             ///< number of staves/layer(layer)
   std::vector<int> mNumberOfHalfStaves;         ///< the number of substaves/stave(layer)
   std::vector<int> mNumberOfModules;            ///< number of modules/substave(layer)

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -113,26 +113,29 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   int getChipIndex(int lay, int detInLay) const { return getFirstChipIndex(lay) + detInLay; }
   /// This routine computes the chip index number from the layer, stave, and chip number in stave
   /// \param int lay The layer number. Starting from 0.
+  /// \param int hba The halfbarrel number. Starting from 0
   /// \param int sta The stave number. Starting from 0
   /// \param int chipInStave The chip number in the stave. Starting from 0
-  int getChipIndex(int lay, int sta, int detInSta) const;
+  int getChipIndex(int lay, int hba, int sta, int detInSta) const;
 
   /// This routine computes the chip index number from the layer, stave, substave and chip number
   /// in substave
   /// \param int lay The layer number. Starting from 0.
+  /// \param int hba The halfbarrel number. Starting from 0
   /// \param int sta The stave number. Starting from 0
   /// \param int substa The substave number. Starting from 0
   /// \param int chipInSStave The chip number in the sub stave. Starting from 0
-  int getChipIndex(int lay, int sta, int subSta, int detInSubSta) const;
+  int getChipIndex(int lay, int hba, int sta, int subSta, int detInSubSta) const;
 
   /// This routine computes the chip index number from the layer,stave, substave module and
   /// chip number in module.
   /// \param int lay The layer number. Starting from 0.
+  /// \param int hba The halfbarrel number. Starting from 0
   /// \param int sta The stave number. Starting from 0
   /// \param int substa The substave number. Starting from 0
   /// \param int module The module number ...
   /// \param int chipInSStave The chip number in the module. Starting from 0
-  int getChipIndex(int lay, int sta, int subSta, int md, int detInMod) const;
+  int getChipIndex(int lay, int hba, int sta, int subSta, int md, int detInMod) const;
 
   /// This routine computes the layer, stave, substave, module and chip number
   /// given the chip index number
@@ -190,15 +193,15 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
     return o2::base::GeometryManager::getSymbolicName(getDetID(), index);
   }
 
-  const char* getSymbolicName(int lay, int sta, int det) const
+  const char* getSymbolicName(int lay, int hba, int sta, int det) const
   {
     /// return symbolic name of sensor
-    return getSymbolicName(getChipIndex(lay, sta, det));
+    return getSymbolicName(getChipIndex(lay, hba, sta, det));
   }
 
   /// Get the transformation matrix for a given chip (NOT A SENSOR!!!) 'index' by quering the TGeoManager
   TGeoHMatrix* getMatrix(int index) const { return o2::base::GeometryManager::getMatrix(getDetID(), index); }
-  TGeoHMatrix* getMatrix(int lay, int sta, int sens) const { return getMatrix(getChipIndex(lay, sta, sens)); }
+  TGeoHMatrix* getMatrix(int lay, int hba, int sta, int sens) const { return getMatrix(getChipIndex(lay, hba, sta, sens)); }
   bool getOriginalMatrix(int index, TGeoHMatrix& m) const
   {
     /// Get the original (ideal geometry) TGeo matrix for a given chip identified by 'index'
@@ -206,25 +209,25 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
     return o2::base::GeometryManager::getOriginalMatrix(getDetID(), index, m);
   }
 
-  bool getOriginalMatrix(int lay, int sta, int det, TGeoHMatrix& m) const
+  bool getOriginalMatrix(int lay, int hba, int sta, int det, TGeoHMatrix& m) const
   {
     /// Get the original (ideal geometry) TGeo matrix for a given chip identified by 'index'
     /// The method is slow, so it should be used with great care (for caching only)
-    return getOriginalMatrix(getChipIndex(lay, sta, det), m);
+    return getOriginalMatrix(getChipIndex(lay, hba, sta, det), m);
   }
 
-  const Mat3D& getMatrixT2L(int lay, int sta, int det) const { return getMatrixT2L(getChipIndex(lay, sta, det)); }
+  const Mat3D& getMatrixT2L(int lay, int hba, int sta, int det) const { return getMatrixT2L(getChipIndex(lay, hba, sta, det)); }
   const Mat3D& getMatrixSensor(int index) const { return getMatrixL2G(index); }
-  const Mat3D& getMatrixSensor(int lay, int sta, int det)
+  const Mat3D& getMatrixSensor(int lay, int hba, int sta, int det)
   {
     // get positioning matrix of the sensor, alias to getMatrixL2G
-    return getMatrixSensor(getChipIndex(lay, sta, det));
+    return getMatrixSensor(getChipIndex(lay, hba, sta, det));
   }
 
-  const Rot2D& getMatrixT2GRot(int lay, int sta, int sens)
+  const Rot2D& getMatrixT2GRot(int lay, int hba, int sta, int sens)
   {
     /// get matrix for tracking to global frame transformation
-    return getMatrixT2GRot(getChipIndex(lay, sta, sens));
+    return getMatrixT2GRot(getChipIndex(lay, hba, sta, sens));
   }
 
   bool isTrackingFrameCached() const { return !mCacheRefX.empty(); }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -103,10 +103,12 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   int getNumberOfChipsPerModule(int lay) const { return mNumberOfChipsPerModule[lay]; }
   int getNumberOfChipsPerHalfStave(int lay) const { return mNumberOfChipsPerHalfStave[lay]; }
   int getNumberOfChipsPerStave(int lay) const { return mNumberOfChipsPerStave[lay]; }
+  int getNumberOfChipsPerHalfBarrel(int lay) const { return mNumberOfChipsPerHalfBarrel[lay]; }
   int getNumberOfChipsPerLayer(int lay) const { return mNumberOfChipsPerLayer[lay]; }
   int getNumberOfModules(int lay) const { return mNumberOfModules[lay]; }
   int getNumberOfHalfStaves(int lay) const { return mNumberOfHalfStaves[lay]; }
   int getNumberOfStaves(int lay) const { return mNumberOfStaves[lay]; }
+  int getNumberOfHalfBarrels(int lay) const { return mNumberOfHalfBarrels[lay]; }
   int getNumberOfLayers() const { return mNumberOfLayers; }
   int getChipIndex(int lay, int detInLay) const { return getFirstChipIndex(lay) + detInLay; }
   /// This routine computes the chip index number from the layer, stave, and chip number in stave
@@ -142,8 +144,22 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// \param int chip The detector number. Starting from 0
   bool getChipId(int index, int& lay, int& sta, int& ssta, int& mod, int& chip) const;
 
+  /// This routine computes the layer, half barrel, stave, substave,
+  /// module and chip number given the chip index number
+  /// \param int index The chip index number, starting from zero.
+  /// \param int lay The layer number. Starting from 0
+  /// \param int hba The half barrel number. Starting from 0
+  /// \param int sta The stave number. Starting from 0
+  /// \param int ssta The halfstave number. Starting from 0
+  /// \param int mod The module number. Starting from 0
+  /// \param int chip The detector number. Starting from 0
+  bool getChipId(int index, int& lay, int& hba, int& sta, int& ssta, int& mod, int& chip) const;
+
   /// Get chip layer, from 0
   int getLayer(int index) const;
+
+  /// Get chip half barrel, from 0
+  int getHalfBarrel(int index) const;
 
   /// Get chip stave, from 0
   int getStave(int index) const;
@@ -237,6 +253,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 
   static const char* getITSVolPattern() { return sVolumeName.c_str(); }
   static const char* getITSLayerPattern() { return sLayerName.c_str(); }
+  static const char* getITSHalfBarrelPattern() { return sHalfBarrelName.c_str(); }
   static const char* getITSWrapVolPattern() { return sWrapperVolumeName.c_str(); }
   static const char* getITSStavePattern() { return sStaveName.c_str(); }
   static const char* getITSHalfStavePattern() { return sHalfStaveName.c_str(); }
@@ -245,6 +262,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static const char* getITSSensorPattern() { return sSensorName.c_str(); }
   static void setITSVolPattern(const char* nm) { sVolumeName = nm; }
   static void setITSLayerPattern(const char* nm) { sLayerName = nm; }
+  static void setITSHalfBarrelPattern(const char* nm) { sHalfBarrelName = nm; }
   static void setITSWrapVolPattern(const char* nm) { sWrapperVolumeName = nm; }
   static void setITSStavePattern(const char* nm) { sStaveName = nm; }
   static void setITSHalfStavePattern(const char* nm) { sHalfStaveName = nm; }
@@ -256,17 +274,20 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// sym name of the layer
   static const char* composeSymNameLayer(int lr);
 
-  /// Sym name of the stave at given layer
-  static const char* composeSymNameStave(int lr, int sta);
+  /// Sym name of the half barrel at given layer
+  static const char* composeSymNameHalfBarrel(int lr, int hba);
 
   /// Sym name of the stave at given layer
-  static const char* composeSymNameHalfStave(int lr, int sta, int ssta);
+  static const char* composeSymNameStave(int lr, int hba, int sta);
 
-  /// Sym name of the substave at given layer/stave
-  static const char* composeSymNameModule(int lr, int sta, int ssta, int mod);
+  /// Sym name of the stave at given layer/halfbarrel
+  static const char* composeSymNameHalfStave(int lr, int hba, int sta, int ssta);
 
-  /// Sym name of the chip in the given layer/stave/substave/module
-  static const char* composeSymNameChip(int lr, int sta, int ssta, int mod, int chip);
+  /// Sym name of the substave at given layer/halfbarrel/stave
+  static const char* composeSymNameModule(int lr, int hba, int sta, int ssta, int mod);
+
+  /// Sym name of the chip in the given layer/halfbarrel/stave/substave/module
+  static const char* composeSymNameChip(int lr, int hba, int sta, int ssta, int mod, int chip);
 
  protected:
   /// Get the transformation matrix of the SENSOR (not necessary the same as the chip)
@@ -289,6 +310,10 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// Also extract the layout: span of module centers in Z and X
   /// \param lay: layer number from 0
   int extractNumberOfChipsPerModule(int lay, int& nrow) const;
+
+  /// Determines the number of halfbarrels in the layer
+  /// \param lay: layer number, starting from 0
+  int extractNumberOfHalfBarrels(int lay) const;
 
   /// Determines the number of layers in the Geometry
   /// \param lay: layer number, starting from 0
@@ -325,23 +350,26 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
  protected:
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
-  Int_t mNumberOfLayers;                       ///< number of layers
-  std::vector<int> mNumberOfStaves;            ///< number of staves/layer(layer)
-  std::vector<int> mNumberOfHalfStaves;        ///< the number of substaves/stave(layer)
-  std::vector<int> mNumberOfModules;           ///< number of modules/substave(layer)
-  std::vector<int> mNumberOfChipsPerModule;    ///< number of chips per module (group of chips on substaves)
-  std::vector<int> mNumberOfChipRowsPerModule; ///< number of chips rows per module (relevant for OB modules)
-  std::vector<int> mNumberOfChipsPerHalfStave; ///< number of chips per substave
-  std::vector<int> mNumberOfChipsPerStave;     ///< number of chips per stave
-  std::vector<int> mNumberOfChipsPerLayer;     ///< number of chips per stave
-  std::vector<int> mLastChipIndex;             ///< max ID of the detctor in the layer
-  std::array<char, MAXLAYERS> mLayerToWrapper; ///< Layer to wrapper correspondence
+  Int_t mNumberOfLayers;                        ///< number of layers
+  std::vector<int> mNumberOfHalfBarrels;        ///< the number of halfbarrels/layer(layer)
+  std::vector<int> mNumberOfStaves;             ///< number of staves/layer(layer)
+  std::vector<int> mNumberOfHalfStaves;         ///< the number of substaves/stave(layer)
+  std::vector<int> mNumberOfModules;            ///< number of modules/substave(layer)
+  std::vector<int> mNumberOfChipsPerModule;     ///< number of chips per module (group of chips on substaves)
+  std::vector<int> mNumberOfChipRowsPerModule;  ///< number of chips rows per module (relevant for OB modules)
+  std::vector<int> mNumberOfChipsPerHalfStave;  ///< number of chips per substave
+  std::vector<int> mNumberOfChipsPerStave;      ///< number of chips per stave
+  std::vector<int> mNumberOfChipsPerHalfBarrel; ///< number of chips per halfbarrel
+  std::vector<int> mNumberOfChipsPerLayer;      ///< number of chips per stave
+  std::vector<int> mLastChipIndex;              ///< max ID of the detctor in the layer
+  std::array<char, MAXLAYERS> mLayerToWrapper;  ///< Layer to wrapper correspondence
 
   std::vector<float> mCacheRefX;     ///< sensors tracking plane reference X
   std::vector<float> mCacheRefAlpha; ///< sensors tracking plane reference alpha
 
   static std::string sVolumeName;        ///< Mother volume name
   static std::string sLayerName;         ///< Layer name
+  static std::string sHalfBarrelName;    ///< HalfBarrel name
   static std::string sStaveName;         ///< Stave name
   static std::string sHalfStaveName;     ///< HalfStave name
   static std::string sModuleName;        ///< Module name

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -108,7 +108,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   int getNumberOfModules(int lay) const { return mNumberOfModules[lay]; }
   int getNumberOfHalfStaves(int lay) const { return mNumberOfHalfStaves[lay]; }
   int getNumberOfStaves(int lay) const { return mNumberOfStaves[lay]; }
-  int getNumberOfHalfBarrels(int lay) const { return mNumberOfHalfBarrels[lay]; }
+  int getNumberOfHalfBarrels() const { return mNumberOfHalfBarrels; }
   int getNumberOfLayers() const { return mNumberOfLayers; }
   int getChipIndex(int lay, int detInLay) const { return getFirstChipIndex(lay) + detInLay; }
   /// This routine computes the chip index number from the layer, stave, and chip number in stave
@@ -311,10 +311,6 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   /// \param lay: layer number from 0
   int extractNumberOfChipsPerModule(int lay, int& nrow) const;
 
-  /// Determines the number of halfbarrels in the layer
-  /// \param lay: layer number, starting from 0
-  int extractNumberOfHalfBarrels(int lay) const;
-
   /// Determines the number of layers in the Geometry
   /// \param lay: layer number, starting from 0
   int extractNumberOfStaves(int lay) const;
@@ -351,7 +347,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
   Int_t mNumberOfLayers;                        ///< number of layers
-  std::vector<int> mNumberOfHalfBarrels;        ///< the number of halfbarrels/layer(layer)
+  Int_t mNumberOfHalfBarrels;                   ///< the number of halfbarrels
   std::vector<int> mNumberOfStaves;             ///< number of staves/layer(layer)
   std::vector<int> mNumberOfHalfStaves;         ///< the number of substaves/stave(layer)
   std::vector<int> mNumberOfModules;            ///< number of modules/substave(layer)

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -260,7 +260,7 @@ bool GeometryTGeo::getChipId(int index, int& lay, int& hba, int& sta, int& hsta,
 {
   lay = getLayer(index);
   index -= getFirstChipIndex(lay);
-  hba = mNumberOfHalfBarrels[lay] > 0 ? index / mNumberOfChipsPerHalfBarrel[lay] : -1;
+  hba = mNumberOfHalfBarrels > 0 ? index / mNumberOfChipsPerHalfBarrel[lay] : -1;
   index %= mNumberOfChipsPerHalfBarrel[lay];
   sta = index / mNumberOfChipsPerStave[lay];
   index %= mNumberOfChipsPerStave[lay];
@@ -335,7 +335,7 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(int index) const
   path +=
     Form("%s%d_1/", GeometryTGeo::getITSLayerPattern(), lay);
 
-  if (mNumberOfHalfBarrels[lay] > 0) {
+  if (mNumberOfHalfBarrels > 0) {
     path += Form("%s%d_%d/", GeometryTGeo::getITSHalfBarrelPattern(), lay, hba);
   }
   path +=
@@ -393,7 +393,6 @@ void GeometryTGeo::Build(int loadTrans)
   }
 
   mNumberOfStaves.resize(mNumberOfLayers);
-  mNumberOfHalfBarrels.resize(mNumberOfLayers);
   mNumberOfHalfStaves.resize(mNumberOfLayers);
   mNumberOfModules.resize(mNumberOfLayers);
   mNumberOfChipsPerModule.resize(mNumberOfLayers);
@@ -405,8 +404,8 @@ void GeometryTGeo::Build(int loadTrans)
   mLastChipIndex.resize(mNumberOfLayers);
   int numberOfChips = 0;
 
+  mNumberOfHalfBarrels = 2;
   for (int i = 0; i < mNumberOfLayers; i++) {
-    mNumberOfHalfBarrels[i] = extractNumberOfHalfBarrels(i);
     mNumberOfStaves[i] = extractNumberOfStaves(i);
     mNumberOfHalfStaves[i] = extractNumberOfHalfStaves(i);
     mNumberOfModules[i] = extractNumberOfModules(i);
@@ -414,7 +413,7 @@ void GeometryTGeo::Build(int loadTrans)
     mNumberOfChipsPerHalfStave[i] = mNumberOfChipsPerModule[i] * Max(1, mNumberOfModules[i]);
     mNumberOfChipsPerStave[i] = mNumberOfChipsPerHalfStave[i] * Max(1, mNumberOfHalfStaves[i]);
     mNumberOfChipsPerLayer[i] = mNumberOfChipsPerStave[i] * mNumberOfStaves[i];
-    mNumberOfChipsPerHalfBarrel[i] = mNumberOfChipsPerLayer[i] / Max(1, mNumberOfHalfBarrels[i]);
+    mNumberOfChipsPerHalfBarrel[i] = mNumberOfChipsPerLayer[i] / Max(1, mNumberOfHalfBarrels);
     numberOfChips += mNumberOfChipsPerLayer[i];
     mLastChipIndex[i] = numberOfChips - 1;
   }
@@ -553,36 +552,11 @@ int GeometryTGeo::extractNumberOfLayers()
 }
 
 //__________________________________________________________________________
-int GeometryTGeo::extractNumberOfHalfBarrels(int lay) const
-{
-  int numberOfHalfBarrels = 0;
-  char laynam[30];
-  snprintf(laynam, 30, "%s%d", getITSLayerPattern(), lay);
-  TGeoVolume* volLr = gGeoManager->GetVolume(laynam);
-  if (!volLr) {
-    LOG(FATAL) << "can't find " << laynam << " volume";
-    return -1;
-  }
-
-  // Loop on all layer nodes, count HalfBarrel volumes by checking names
-  int nNodes = volLr->GetNodes()->GetEntries();
-  for (int j = 0; j < nNodes; j++) {
-    // LOG(INFO) << "L" << lay << " " << j << " of " << nNodes << " "
-    //           << volLr->GetNodes()->At(j)->GetName() << " "
-    //           << getITSHalfBarrelPattern() << " -> " << numberOfHalfBarrels;
-    if (strstr(volLr->GetNodes()->At(j)->GetName(), getITSHalfBarrelPattern())) {
-      numberOfHalfBarrels++;
-    }
-  }
-  return numberOfHalfBarrels;
-}
-
-//__________________________________________________________________________
 int GeometryTGeo::extractNumberOfStaves(int lay) const
 {
   int numberOfStaves = 0;
   char hbarnam[30];
-  if (mNumberOfHalfBarrels[lay] == 0) {
+  if (mNumberOfHalfBarrels == 0) {
     snprintf(hbarnam, 30, "%s%d", getITSLayerPattern(), lay);
   } else {
     snprintf(hbarnam, 30, "%s%d", getITSHalfBarrelPattern(), lay);
@@ -603,7 +577,7 @@ int GeometryTGeo::extractNumberOfStaves(int lay) const
       numberOfStaves++;
     }
   }
-  return mNumberOfHalfBarrels[lay] > 0 ? (numberOfStaves * mNumberOfHalfBarrels[lay]) : numberOfStaves;
+  return mNumberOfHalfBarrels > 0 ? (numberOfStaves * mNumberOfHalfBarrels) : numberOfStaves;
 }
 
 //__________________________________________________________________________

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -54,6 +54,7 @@ o2::its::GeometryTGeo::~GeometryTGeo() = default;
 
 std::string GeometryTGeo::sVolumeName = "ITSV";               ///< Mother volume name
 std::string GeometryTGeo::sLayerName = "ITSULayer";           ///< Layer name
+std::string GeometryTGeo::sHalfBarrelName = "ITSUHalfBarrel"; ///< HalfBarrel name
 std::string GeometryTGeo::sStaveName = "ITSUStave";           ///< Stave name
 std::string GeometryTGeo::sHalfStaveName = "ITSUHalfStave";   ///< HalfStave name
 std::string GeometryTGeo::sModuleName = "ITSUModule";         ///< Module name
@@ -138,6 +139,17 @@ int GeometryTGeo::getLayer(int index) const
     lay++;
   }
   return lay;
+}
+
+//__________________________________________________________________________
+int GeometryTGeo::getHalfBarrel(int index) const
+{
+  int lay = 0;
+  while (index > mLastChipIndex[lay]) {
+    lay++;
+  }
+  index -= getFirstChipIndex(lay);
+  return index / mNumberOfChipsPerHalfBarrel[lay];
 }
 
 //__________________________________________________________________________
@@ -244,35 +256,59 @@ bool GeometryTGeo::getChipId(int index, int& lay, int& sta, int& hsta, int& mod,
 }
 
 //__________________________________________________________________________
+bool GeometryTGeo::getChipId(int index, int& lay, int& hba, int& sta, int& hsta, int& mod, int& chip) const
+{
+  lay = getLayer(index);
+  index -= getFirstChipIndex(lay);
+  hba = mNumberOfHalfBarrels[lay] > 0 ? index / mNumberOfChipsPerHalfBarrel[lay] : -1;
+  index %= mNumberOfChipsPerHalfBarrel[lay];
+  sta = index / mNumberOfChipsPerStave[lay];
+  index %= mNumberOfChipsPerStave[lay];
+  hsta = mNumberOfHalfStaves[lay] > 0 ? index / mNumberOfChipsPerHalfStave[lay] : -1;
+  index %= mNumberOfChipsPerHalfStave[lay];
+  mod = mNumberOfModules[lay] > 0 ? index / mNumberOfChipsPerModule[lay] : -1;
+  chip = index % mNumberOfChipsPerModule[lay];
+
+  return kTRUE;
+}
+
+//__________________________________________________________________________
 const char* GeometryTGeo::composeSymNameLayer(int lr)
 {
   return Form("%s/%s%d", composeSymNameITS(), getITSLayerPattern(), lr);
 }
 
 //__________________________________________________________________________
-const char* GeometryTGeo::composeSymNameStave(int lr, int stave)
+const char* GeometryTGeo::composeSymNameHalfBarrel(int lr, int hbarrel)
 {
-  return Form("%s/%s%d", composeSymNameLayer(lr), getITSStavePattern(), stave);
+  return hbarrel >= 0 ? Form("%s/%s%d", composeSymNameLayer(lr), getITSHalfBarrelPattern(), hbarrel)
+                      : composeSymNameLayer(lr);
 }
 
 //__________________________________________________________________________
-const char* GeometryTGeo::composeSymNameHalfStave(int lr, int stave, int substave)
+const char* GeometryTGeo::composeSymNameStave(int lr, int hbarrel, int stave)
 {
-  return substave >= 0 ? Form("%s/%s%d", composeSymNameStave(lr, stave), getITSHalfStavePattern(), substave)
-                       : composeSymNameStave(lr, stave);
+  return Form("%s/%s%d", composeSymNameHalfBarrel(lr, hbarrel), getITSStavePattern(), stave);
 }
 
 //__________________________________________________________________________
-const char* GeometryTGeo::composeSymNameModule(int lr, int stave, int substave, int mod)
+const char* GeometryTGeo::composeSymNameHalfStave(int lr, int hba, int stave, int substave)
 {
-  return mod >= 0 ? Form("%s/%s%d", composeSymNameHalfStave(lr, stave, substave), getITSModulePattern(), mod)
-                  : composeSymNameHalfStave(lr, stave, substave);
+  return substave >= 0 ? Form("%s/%s%d", composeSymNameStave(lr, hba, stave), getITSHalfStavePattern(), substave)
+                       : composeSymNameStave(lr, hba, stave);
 }
 
 //__________________________________________________________________________
-const char* GeometryTGeo::composeSymNameChip(int lr, int sta, int substave, int mod, int chip)
+const char* GeometryTGeo::composeSymNameModule(int lr, int hba, int stave, int substave, int mod)
 {
-  return Form("%s/%s%d", composeSymNameModule(lr, sta, substave, mod), getITSChipPattern(), chip);
+  return mod >= 0 ? Form("%s/%s%d", composeSymNameHalfStave(lr, hba, stave, substave), getITSModulePattern(), mod)
+                  : composeSymNameHalfStave(lr, hba, stave, substave);
+}
+
+//__________________________________________________________________________
+const char* GeometryTGeo::composeSymNameChip(int lr, int hba, int sta, int substave, int mod, int chip)
+{
+  return Form("%s/%s%d", composeSymNameModule(lr, hba, sta, substave, mod), getITSChipPattern(), chip);
 }
 
 //__________________________________________________________________________
@@ -285,8 +321,8 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(int index) const
   //
   // Therefore we need to add a shift
 
-  int lay, stav, sstav, mod, chipInMod;
-  getChipId(index, lay, stav, sstav, mod, chipInMod);
+  int lay, hba, stav, sstav, mod, chipInMod;
+  getChipId(index, lay, hba, stav, sstav, mod, chipInMod);
 
   int wrID = mLayerToWrapper[lay];
 
@@ -297,7 +333,13 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(int index) const
   }
 
   path +=
-    Form("%s%d_1/%s%d_%d/", GeometryTGeo::getITSLayerPattern(), lay, GeometryTGeo::getITSStavePattern(), lay, stav);
+    Form("%s%d_1/", GeometryTGeo::getITSLayerPattern(), lay);
+
+  if (mNumberOfHalfBarrels[lay] > 0) {
+    path += Form("%s%d_%d/", GeometryTGeo::getITSHalfBarrelPattern(), lay, hba);
+  }
+  path +=
+    Form("%s%d_%d/", GeometryTGeo::getITSStavePattern(), lay, stav);
 
   if (mNumberOfHalfStaves[lay] > 0) {
     path += Form("%s%d_%d/", GeometryTGeo::getITSHalfStavePattern(), lay, sstav);
@@ -351,17 +393,20 @@ void GeometryTGeo::Build(int loadTrans)
   }
 
   mNumberOfStaves.resize(mNumberOfLayers);
+  mNumberOfHalfBarrels.resize(mNumberOfLayers);
   mNumberOfHalfStaves.resize(mNumberOfLayers);
   mNumberOfModules.resize(mNumberOfLayers);
   mNumberOfChipsPerModule.resize(mNumberOfLayers);
   mNumberOfChipRowsPerModule.resize(mNumberOfLayers);
   mNumberOfChipsPerHalfStave.resize(mNumberOfLayers);
   mNumberOfChipsPerStave.resize(mNumberOfLayers);
+  mNumberOfChipsPerHalfBarrel.resize(mNumberOfLayers);
   mNumberOfChipsPerLayer.resize(mNumberOfLayers);
   mLastChipIndex.resize(mNumberOfLayers);
   int numberOfChips = 0;
 
   for (int i = 0; i < mNumberOfLayers; i++) {
+    mNumberOfHalfBarrels[i] = extractNumberOfHalfBarrels(i);
     mNumberOfStaves[i] = extractNumberOfStaves(i);
     mNumberOfHalfStaves[i] = extractNumberOfHalfStaves(i);
     mNumberOfModules[i] = extractNumberOfModules(i);
@@ -369,6 +414,7 @@ void GeometryTGeo::Build(int loadTrans)
     mNumberOfChipsPerHalfStave[i] = mNumberOfChipsPerModule[i] * Max(1, mNumberOfModules[i]);
     mNumberOfChipsPerStave[i] = mNumberOfChipsPerHalfStave[i] * Max(1, mNumberOfHalfStaves[i]);
     mNumberOfChipsPerLayer[i] = mNumberOfChipsPerStave[i] * mNumberOfStaves[i];
+    mNumberOfChipsPerHalfBarrel[i] = mNumberOfChipsPerLayer[i] / Max(1, mNumberOfHalfBarrels[i]);
     numberOfChips += mNumberOfChipsPerLayer[i];
     mLastChipIndex[i] = numberOfChips - 1;
   }
@@ -507,9 +553,9 @@ int GeometryTGeo::extractNumberOfLayers()
 }
 
 //__________________________________________________________________________
-int GeometryTGeo::extractNumberOfStaves(int lay) const
+int GeometryTGeo::extractNumberOfHalfBarrels(int lay) const
 {
-  int numberOfStaves = 0;
+  int numberOfHalfBarrels = 0;
   char laynam[30];
   snprintf(laynam, 30, "%s%d", getITSLayerPattern(), lay);
   TGeoVolume* volLr = gGeoManager->GetVolume(laynam);
@@ -518,17 +564,46 @@ int GeometryTGeo::extractNumberOfStaves(int lay) const
     return -1;
   }
 
-  // Loop on all layer nodes, count Stave volumes by checking names
+  // Loop on all layer nodes, count HalfBarrel volumes by checking names
   int nNodes = volLr->GetNodes()->GetEntries();
   for (int j = 0; j < nNodes; j++) {
     // LOG(INFO) << "L" << lay << " " << j << " of " << nNodes << " "
     //           << volLr->GetNodes()->At(j)->GetName() << " "
+    //           << getITSHalfBarrelPattern() << " -> " << numberOfHalfBarrels;
+    if (strstr(volLr->GetNodes()->At(j)->GetName(), getITSHalfBarrelPattern())) {
+      numberOfHalfBarrels++;
+    }
+  }
+  return numberOfHalfBarrels;
+}
+
+//__________________________________________________________________________
+int GeometryTGeo::extractNumberOfStaves(int lay) const
+{
+  int numberOfStaves = 0;
+  char hbarnam[30];
+  if (mNumberOfHalfBarrels[lay] == 0) {
+    snprintf(hbarnam, 30, "%s%d", getITSLayerPattern(), lay);
+  } else {
+    snprintf(hbarnam, 30, "%s%d", getITSHalfBarrelPattern(), lay);
+  }
+  TGeoVolume* volHb = gGeoManager->GetVolume(hbarnam);
+  if (!volHb) {
+    LOG(FATAL) << "can't find " << hbarnam << " volume";
+    return -1;
+  }
+
+  // Loop on all half barrel nodes, count Stave volumes by checking names
+  int nNodes = volHb->GetNodes()->GetEntries();
+  for (int j = 0; j < nNodes; j++) {
+    // LOG(INFO) << "L" << lay << " " << j << " of " << nNodes << " "
+    //           << volHb->GetNodes()->At(j)->GetName() << " "
     //           << getITSStavePattern() << " -> " << numberOfStaves;
-    if (strstr(volLr->GetNodes()->At(j)->GetName(), getITSStavePattern())) {
+    if (strstr(volHb->GetNodes()->At(j)->GetName(), getITSStavePattern())) {
       numberOfStaves++;
     }
   }
-  return numberOfStaves;
+  return mNumberOfHalfBarrels[lay] > 0 ? (numberOfStaves * mNumberOfHalfBarrels[lay]) : numberOfStaves;
 }
 
 //__________________________________________________________________________

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -91,15 +91,15 @@ void GeometryTGeo::adopt(GeometryTGeo* raw)
 }
 
 //__________________________________________________________________________
-int GeometryTGeo::getChipIndex(int lay, int sta, int chipInStave) const
+int GeometryTGeo::getChipIndex(int lay, int hba, int sta, int chipInStave) const
 {
-  return getFirstChipIndex(lay) + mNumberOfChipsPerStave[lay] * sta + chipInStave;
+  return getFirstChipIndex(lay) + mNumberOfChipsPerHalfBarrel[lay] * hba + mNumberOfChipsPerStave[lay] * sta + chipInStave;
 }
 
 //__________________________________________________________________________
-int GeometryTGeo::getChipIndex(int lay, int sta, int substa, int chipInSStave) const
+int GeometryTGeo::getChipIndex(int lay, int hba, int sta, int substa, int chipInSStave) const
 {
-  int n = getFirstChipIndex(lay) + mNumberOfChipsPerStave[lay] * sta + chipInSStave;
+  int n = getFirstChipIndex(lay) + mNumberOfChipsPerHalfBarrel[lay] * hba + mNumberOfChipsPerStave[lay] * sta + chipInSStave;
   if (mNumberOfHalfStaves[lay] && substa > 0) {
     n += mNumberOfChipsPerHalfStave[lay] * substa;
   }
@@ -107,12 +107,12 @@ int GeometryTGeo::getChipIndex(int lay, int sta, int substa, int chipInSStave) c
 }
 
 //__________________________________________________________________________
-int GeometryTGeo::getChipIndex(int lay, int sta, int substa, int md, int chipInMod) const
+int GeometryTGeo::getChipIndex(int lay, int hba, int sta, int substa, int md, int chipInMod) const
 {
   if (mNumberOfHalfStaves[lay] == 0) {
-    return getChipIndex(lay, md, chipInMod);
+    return getChipIndex(lay, substa, md, chipInMod);
   } else {
-    int n = getFirstChipIndex(lay) + mNumberOfChipsPerStave[lay] * sta + chipInMod;
+    int n = getFirstChipIndex(lay) + mNumberOfChipsPerHalfBarrel[lay] * hba + mNumberOfChipsPerStave[lay] * sta + chipInMod;
     if (mNumberOfHalfStaves[lay] && substa > 0) {
       n += mNumberOfChipsPerHalfStave[lay] * substa;
     }

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -260,7 +260,7 @@ bool GeometryTGeo::getChipId(int index, int& lay, int& hba, int& sta, int& hsta,
 {
   lay = getLayer(index);
   index -= getFirstChipIndex(lay);
-  hba = mNumberOfHalfBarrels > 0 ? index / mNumberOfChipsPerHalfBarrel[lay] : -1;
+  hba = mNumberOfHalfBarrels[lay] > 0 ? index / mNumberOfChipsPerHalfBarrel[lay] : -1;
   index %= mNumberOfChipsPerHalfBarrel[lay];
   sta = index / mNumberOfChipsPerStave[lay];
   index %= mNumberOfChipsPerStave[lay];
@@ -335,7 +335,7 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(int index) const
   path +=
     Form("%s%d_1/", GeometryTGeo::getITSLayerPattern(), lay);
 
-  if (mNumberOfHalfBarrels > 0) {
+  if (mNumberOfHalfBarrels[lay] > 0) {
     path += Form("%s%d_%d/", GeometryTGeo::getITSHalfBarrelPattern(), lay, hba);
   }
   path +=
@@ -393,6 +393,7 @@ void GeometryTGeo::Build(int loadTrans)
   }
 
   mNumberOfStaves.resize(mNumberOfLayers);
+  mNumberOfHalfBarrels.resize(mNumberOfLayers);
   mNumberOfHalfStaves.resize(mNumberOfLayers);
   mNumberOfModules.resize(mNumberOfLayers);
   mNumberOfChipsPerModule.resize(mNumberOfLayers);
@@ -404,8 +405,8 @@ void GeometryTGeo::Build(int loadTrans)
   mLastChipIndex.resize(mNumberOfLayers);
   int numberOfChips = 0;
 
-  mNumberOfHalfBarrels = 2;
   for (int i = 0; i < mNumberOfLayers; i++) {
+    mNumberOfHalfBarrels[i] = extractNumberOfHalfBarrels(i);
     mNumberOfStaves[i] = extractNumberOfStaves(i);
     mNumberOfHalfStaves[i] = extractNumberOfHalfStaves(i);
     mNumberOfModules[i] = extractNumberOfModules(i);
@@ -413,7 +414,7 @@ void GeometryTGeo::Build(int loadTrans)
     mNumberOfChipsPerHalfStave[i] = mNumberOfChipsPerModule[i] * Max(1, mNumberOfModules[i]);
     mNumberOfChipsPerStave[i] = mNumberOfChipsPerHalfStave[i] * Max(1, mNumberOfHalfStaves[i]);
     mNumberOfChipsPerLayer[i] = mNumberOfChipsPerStave[i] * mNumberOfStaves[i];
-    mNumberOfChipsPerHalfBarrel[i] = mNumberOfChipsPerLayer[i] / Max(1, mNumberOfHalfBarrels);
+    mNumberOfChipsPerHalfBarrel[i] = mNumberOfChipsPerLayer[i] / Max(1, mNumberOfHalfBarrels[i]);
     numberOfChips += mNumberOfChipsPerLayer[i];
     mLastChipIndex[i] = numberOfChips - 1;
   }
@@ -552,11 +553,36 @@ int GeometryTGeo::extractNumberOfLayers()
 }
 
 //__________________________________________________________________________
+int GeometryTGeo::extractNumberOfHalfBarrels(int lay) const
+{
+  int numberOfHalfBarrels = 0;
+  char laynam[30];
+  snprintf(laynam, 30, "%s%d", getITSLayerPattern(), lay);
+  TGeoVolume* volLr = gGeoManager->GetVolume(laynam);
+  if (!volLr) {
+    LOG(FATAL) << "can't find " << laynam << " volume";
+    return -1;
+  }
+
+  // Loop on all layer nodes, count HalfBarrel volumes by checking names
+  int nNodes = volLr->GetNodes()->GetEntries();
+  for (int j = 0; j < nNodes; j++) {
+    // LOG(INFO) << "L" << lay << " " << j << " of " << nNodes << " "
+    //           << volLr->GetNodes()->At(j)->GetName() << " "
+    //           << getITSHalfBarrelPattern() << " -> " << numberOfHalfBarrels;
+    if (strstr(volLr->GetNodes()->At(j)->GetName(), getITSHalfBarrelPattern())) {
+      numberOfHalfBarrels++;
+    }
+  }
+  return numberOfHalfBarrels;
+}
+
+//__________________________________________________________________________
 int GeometryTGeo::extractNumberOfStaves(int lay) const
 {
   int numberOfStaves = 0;
   char hbarnam[30];
-  if (mNumberOfHalfBarrels == 0) {
+  if (mNumberOfHalfBarrels[lay] == 0) {
     snprintf(hbarnam, 30, "%s%d", getITSLayerPattern(), lay);
   } else {
     snprintf(hbarnam, 30, "%s%d", getITSHalfBarrelPattern(), lay);
@@ -577,7 +603,7 @@ int GeometryTGeo::extractNumberOfStaves(int lay) const
       numberOfStaves++;
     }
   }
-  return mNumberOfHalfBarrels > 0 ? (numberOfStaves * mNumberOfHalfBarrels) : numberOfStaves;
+  return mNumberOfHalfBarrels[lay] > 0 ? (numberOfStaves * mNumberOfHalfBarrels[lay]) : numberOfStaves;
 }
 
 //__________________________________________________________________________

--- a/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
+++ b/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
@@ -45,7 +45,7 @@ void ITSMisaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     pars = generateMisalignment(xLay, yLay, zLay, psiLay, thetaLay, phiLay);
     params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
 
-    for (int ihb = 0; ihb < geom->getNumberOfHalfBarrels(ilr); ihb++) {
+    for (int ihb = 0; ihb < geom->getNumberOfHalfBarrels(); ihb++) {
       symname = geom->composeSymNameHalfBarrel(ilr, ihb);
       pars = generateMisalignment(xSta, ySta, zSta, psiSta, thetaSta, phiSta);
       params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);

--- a/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
+++ b/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
@@ -45,20 +45,26 @@ void ITSMisaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
     pars = generateMisalignment(xLay, yLay, zLay, psiLay, thetaLay, phiLay);
     params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
 
-    for (int ist = 0; ist < geom->getNumberOfStaves(ilr); ist++) {
-      symname = geom->composeSymNameStave(ilr, ist);
+    for (int ihb = 0; ihb < geom->getNumberOfHalfBarrels(ilr); ihb++) {
+      symname = geom->composeSymNameHalfBarrel(ilr, ihb);
       pars = generateMisalignment(xSta, ySta, zSta, psiSta, thetaSta, phiSta);
       params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
 
-      for (int ihst = 0; ihst < geom->getNumberOfHalfStaves(ilr); ihst++) {
-        symname = geom->composeSymNameHalfStave(ilr, ist, ihst);
-        pars = generateMisalignment(xHSt, yHSt, zHSt, psiHSt, thetaHSt, phiHSt);
+      for (int ist = 0; ist < geom->getNumberOfStaves(ilr) / 2; ist++) {
+        symname = geom->composeSymNameStave(ilr, ihb, ist);
+        pars = generateMisalignment(xSta, ySta, zSta, psiSta, thetaSta, phiSta);
         params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
 
-        for (int imd = 0; imd < geom->getNumberOfModules(ilr); imd++) {
-          symname = geom->composeSymNameModule(ilr, ist, ihst, imd);
-          pars = generateMisalignment(xMod, yMod, zMod, psiMod, thetaMod, phiMod);
+        for (int ihst = 0; ihst < geom->getNumberOfHalfStaves(ilr); ihst++) {
+          symname = geom->composeSymNameHalfStave(ilr, ihb, ist, ihst);
+          pars = generateMisalignment(xHSt, yHSt, zHSt, psiHSt, thetaHSt, phiHSt);
           params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
+
+          for (int imd = 0; imd < geom->getNumberOfModules(ilr); imd++) {
+            symname = geom->composeSymNameModule(ilr, ihb, ist, ihst, imd);
+            pars = generateMisalignment(xMod, yMod, zMod, psiMod, thetaMod, phiMod);
+            params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
+          }
         }
       }
     }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -183,39 +183,50 @@ class Detector : public o2::base::DetImpl<Detector>
   /// \param lastUID on output, UID of the last volume
   void addAlignableVolumesLayer(Int_t lr, TString& parent, Int_t& lastUID) const;
 
+  /// Add alignable Half Barrel volumes
+  /// \param lr layer number
+  /// \param hb half barrel number
+  /// \param parent path of the parent volume
+  /// \param lastUID on output, UID of the last volume
+  void addAlignableVolumesHalfBarrel(Int_t lr, Int_t hb, TString& parent, Int_t& lastUID) const;
+
   /// Add alignable Stave volumes
   /// \param lr layer number
+  /// \param hb half barrel number
   /// \param st stave number
   /// \param parent path of the parent volume
   /// \param lastUID on output, UID of the last volume
-  void addAlignableVolumesStave(Int_t lr, Int_t st, TString& parent, Int_t& lastUID) const;
+  void addAlignableVolumesStave(Int_t lr, Int_t hb, Int_t st, TString& parent, Int_t& lastUID) const;
 
   /// Add alignable HalfStave volumes
   /// \param lr layer number
+  /// \param hb half barrel number
   /// \param st stave number
   /// \param hst half stave number
   /// \param parent path of the parent volume
   /// \param lastUID on output, UID of the last volume
-  void addAlignableVolumesHalfStave(Int_t lr, Int_t st, Int_t hst, TString& parent, Int_t& lastUID) const;
+  void addAlignableVolumesHalfStave(Int_t lr, Int_t hb, Int_t st, Int_t hst, TString& parent, Int_t& lastUID) const;
 
   /// Add alignable Module volumes
   /// \param lr layer number
+  /// \param hb half barrel number
   /// \param st stave number
   /// \param hst half stave number
   /// \param md module number
   /// \param parent path of the parent volume
   /// \param lastUID on output, UID of the last volume
-  void addAlignableVolumesModule(Int_t lr, Int_t st, Int_t hst, Int_t md, TString& parent, Int_t& lastUID) const;
+  void addAlignableVolumesModule(Int_t lr, Int_t hb, Int_t st, Int_t hst, Int_t md, TString& parent, Int_t& lastUID) const;
 
   /// Add alignable Chip volumes
   /// \param lr layer number
+  /// \param hb half barrel number
   /// \param st stave number
   /// \param hst half stave number
   /// \param md module number
   /// \param ch chip number
   /// \param parent path of the parent volume
   /// \param lastUID on output, UID of the last volume
-  void addAlignableVolumesChip(Int_t lr, Int_t st, Int_t hst, Int_t md, Int_t ch, TString& parent,
+  void addAlignableVolumesChip(Int_t lr, Int_t hb, Int_t st, Int_t hst, Int_t md, Int_t ch, TString& parent,
                                Int_t& lastUID) const;
 
   /// Return Chip Volume UID

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
@@ -39,7 +39,8 @@ class V3Layer : public V11Geometry
 {
 
  public:
-  enum { kStave,
+  enum { kHalfBarrel,
+         kStave,
          kHalfStave,
          kModule,
          kChip,
@@ -86,6 +87,8 @@ class V3Layer : public V11Geometry
   Double_t getOBModuleZLength() const { return mOBModuleZLength; };
 
   Int_t getChipType() const { return mChipTypeID; }
+
+  Int_t getNumberOfHalfBarrelsPerParent() const { return mHierarchy[kHalfBarrel]; }
 
   Int_t getNumberOfStavesPerParent() const { return mHierarchy[kStave]; }
 
@@ -145,12 +148,15 @@ class V3Layer : public V11Geometry
   virtual void createLayer(TGeoVolume* motherVolume);
 
  private:
-  /// Creates the actual Layer and places inside its mother volume
+  /// Creates a half barrel
+  TGeoVolume* createHalfBarrel();
+
+  /// Creates a "turbo" half barrel
   /// A so-called "turbo" layer is a layer where staves overlap in phi
   /// User can set width and tilt angle, no check is performed here
   /// to avoid volume overlaps
   /// \param motherVolume The TGeoVolume owing the volume structure
-  void createLayerTurbo(TGeoVolume* motherVolume);
+  TGeoVolume* createHalfBarrelTurbo();
 
   /// Computes the inner radius of the air container for the Turbo configuration
   /// as the radius of either the circle tangent to the stave or the circle

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1051,24 +1051,55 @@ void Detector::addAlignableVolumesLayer(int lr, TString& parent, Int_t& lastUID)
   }
 
   const V3Layer* lrobj = mGeometry[lr];
-  Int_t nstaves = lrobj->getNumberOfStavesPerParent();
-  for (int st = 0; st < nstaves; st++) {
-    addAlignableVolumesStave(lr, st, path, lastUID);
+  Int_t nhbarrel = lrobj->getNumberOfHalfBarrelsPerParent();
+  Int_t start = nhbarrel > 0 ? 0 : -1;
+  for (Int_t hb = start; hb < nhbarrel; hb++) {
+    addAlignableVolumesHalfBarrel(lr, hb, path, lastUID);
   }
 
   return;
 }
 
-void Detector::addAlignableVolumesStave(Int_t lr, Int_t st, TString& parent, Int_t& lastUID) const
+void Detector::addAlignableVolumesHalfBarrel(Int_t lr, Int_t hb, TString& parent, Int_t& lastUID) const
+{
+  //
+  // Add alignable volumes for a Half barrel and its daughters
+  //
+  // Created:      28 Jun 2021  Mario Sitta First version (based on similar methods)
+  //
+
+  TString path = parent;
+  if (hb >= 0) {
+    path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSHalfBarrelPattern(), lr, hb);
+    TString sname = GeometryTGeo::composeSymNameHalfBarrel(lr, hb);
+
+    LOG(DEBUG) << "Add " << sname << " <-> " << path;
+
+    if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
+      LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
+    }
+  }
+
+  const V3Layer* lrobj = mGeometry[lr];
+  Int_t nstaves = lrobj->getNumberOfStavesPerParent();
+  for (int st = 0; st < nstaves; st++) {
+    addAlignableVolumesStave(lr, hb, st, path, lastUID);
+  }
+
+  return;
+}
+
+void Detector::addAlignableVolumesStave(Int_t lr, Int_t hb, Int_t st, TString& parent, Int_t& lastUID) const
 {
   //
   // Add alignable volumes for a Stave and its daughters
   //
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
   //
 
   TString path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSStavePattern(), lr, st);
-  TString sname = GeometryTGeo::composeSymNameStave(lr, st);
+  TString sname = GeometryTGeo::composeSymNameStave(lr, hb, st);
 
   LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
@@ -1080,24 +1111,25 @@ void Detector::addAlignableVolumesStave(Int_t lr, Int_t st, TString& parent, Int
   Int_t nhstave = lrobj->getNumberOfHalfStavesPerParent();
   Int_t start = nhstave > 0 ? 0 : -1;
   for (Int_t sst = start; sst < nhstave; sst++) {
-    addAlignableVolumesHalfStave(lr, st, sst, path, lastUID);
+    addAlignableVolumesHalfStave(lr, hb, st, sst, path, lastUID);
   }
 
   return;
 }
 
-void Detector::addAlignableVolumesHalfStave(Int_t lr, Int_t st, Int_t hst, TString& parent, Int_t& lastUID) const
+void Detector::addAlignableVolumesHalfStave(Int_t lr, Int_t hb, Int_t st, Int_t hst, TString& parent, Int_t& lastUID) const
 {
   //
   // Add alignable volumes for a HalfStave (if any) and its daughters
   //
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
   //
 
   TString path = parent;
   if (hst >= 0) {
     path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSHalfStavePattern(), lr, hst);
-    TString sname = GeometryTGeo::composeSymNameHalfStave(lr, st, hst);
+    TString sname = GeometryTGeo::composeSymNameHalfStave(lr, hb, st, hst);
 
     LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
@@ -1110,24 +1142,25 @@ void Detector::addAlignableVolumesHalfStave(Int_t lr, Int_t st, Int_t hst, TStri
   Int_t nmodules = lrobj->getNumberOfModulesPerParent();
   Int_t start = nmodules > 0 ? 0 : -1;
   for (Int_t md = start; md < nmodules; md++) {
-    addAlignableVolumesModule(lr, st, hst, md, path, lastUID);
+    addAlignableVolumesModule(lr, hb, st, hst, md, path, lastUID);
   }
 
   return;
 }
 
-void Detector::addAlignableVolumesModule(Int_t lr, Int_t st, Int_t hst, Int_t md, TString& parent, Int_t& lastUID) const
+void Detector::addAlignableVolumesModule(Int_t lr, Int_t hb, Int_t st, Int_t hst, Int_t md, TString& parent, Int_t& lastUID) const
 {
   //
   // Add alignable volumes for a Module (if any) and its daughters
   //
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
   //
 
   TString path = parent;
   if (md >= 0) {
     path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSModulePattern(), lr, md);
-    TString sname = GeometryTGeo::composeSymNameModule(lr, st, hst, md);
+    TString sname = GeometryTGeo::composeSymNameModule(lr, hb, st, hst, md);
 
     LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
@@ -1139,23 +1172,24 @@ void Detector::addAlignableVolumesModule(Int_t lr, Int_t st, Int_t hst, Int_t md
   const V3Layer* lrobj = mGeometry[lr];
   Int_t nchips = lrobj->getNumberOfChipsPerParent();
   for (Int_t ic = 0; ic < nchips; ic++) {
-    addAlignableVolumesChip(lr, st, hst, md, ic, path, lastUID);
+    addAlignableVolumesChip(lr, hb, st, hst, md, ic, path, lastUID);
   }
 
   return;
 }
 
-void Detector::addAlignableVolumesChip(Int_t lr, Int_t st, Int_t hst, Int_t md, Int_t ch, TString& parent,
+void Detector::addAlignableVolumesChip(Int_t lr, Int_t hb, Int_t st, Int_t hst, Int_t md, Int_t ch, TString& parent,
                                        Int_t& lastUID) const
 {
   //
   // Add alignable volumes for a Chip
   //
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
   //
 
   TString path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSChipPattern(), lr, ch);
-  TString sname = GeometryTGeo::composeSymNameChip(lr, st, hst, md, ch);
+  TString sname = GeometryTGeo::composeSymNameChip(lr, hb, st, hst, md, ch);
   Int_t modUID = chipVolUID(lastUID++);
 
   LOG(DEBUG) << "Add " << sname << " <-> " << path;

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -343,12 +343,13 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
     TLorentzVector positionStop;
     fMC->TrackPosition(positionStop);
     // Retrieve the indices with the volume path
-    int stave(0), halfstave(0), chipinmodule(0), module;
+    int halfbarrel(0), stave(0), halfstave(0), chipinmodule(0), module;
     fMC->CurrentVolOffID(1, chipinmodule);
     fMC->CurrentVolOffID(2, module);
     fMC->CurrentVolOffID(3, halfstave);
     fMC->CurrentVolOffID(4, stave);
-    int chipindex = mGeometryTGeo->getChipIndex(lay, stave, halfstave, module, chipinmodule);
+    fMC->CurrentVolOffID(5, halfbarrel);
+    int chipindex = mGeometryTGeo->getChipIndex(lay, halfbarrel, stave, halfstave, module, chipinmodule);
 
     Hit* p = addHit(stack->GetCurrentTrackNumber(), chipindex, mTrackData.mPositionStart.Vect(), positionStop.Vect(),
                     mTrackData.mMomentumStart.Vect(), mTrackData.mMomentumStart.E(), positionStop.T(),

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1037,18 +1037,13 @@ void Detector::addAlignableVolumesLayer(int lr, TString& parent, Int_t& lastUID)
   // Add alignable volumes for a Layer and its daughters
   //
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      06 Jul 2021  Mario Sitta Do not set Layer as alignable volume
   //
 
   TString wrpV =
     mWrapperLayerId[lr] != -1 ? Form("%s%d_1", GeometryTGeo::getITSWrapVolPattern(), mWrapperLayerId[lr]) : "";
   TString path = Form("%s/%s/%s%d_1", parent.Data(), wrpV.Data(), GeometryTGeo::getITSLayerPattern(), lr);
   TString sname = GeometryTGeo::composeSymNameLayer(lr);
-
-  LOG(DEBUG) << "Add " << sname << " <-> " << path;
-
-  if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
-    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
-  }
 
   const V3Layer* lrobj = mGeometry[lr];
   Int_t nhbarrel = lrobj->getNumberOfHalfBarrelsPerParent();


### PR DESCRIPTION
The Half Barrels, an intermediate level of volumes between the Layer and the Stave, has been implemented in the ITS geometry tree. Now each Layer is composed by two Half Barrels, each one containing half of the Staves previously placed directly into the Layer volume. This structure is more realistic with respect to the real world and allow for a better misalignment of all involved elements. Anyway it should be noted that the Staves and all their subvolumes do not change their global position in the world reference system: simply they are now daughters of the Half Barrel volume which in turn is a daughter of the Layer volume.
New methods in the GeometryTGeo class were introduced to handle this new volume level, while where needed the existing methods in the GeometryTGeo and Detector classes were adapted to take into account this new level in the volume tree. The construction of the Layer geometry in the V3Layer class was changed too to actually implement the Half Barrel volumes.
In this implementation only the Staves and their own services are part of the Half Barrels. Work is in progress to include in the new volumes also those parts of the supporting structures which belong to the Half Barrels in the physical ITS.