### PR TITLE
[MRRTF-122] Add MCH to FST

### DIFF
--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterFinderOriginalSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterFinderOriginalSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getClusterFinderOriginalSpec();
+o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* name = "ClusterFinderOriginal");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getPreClusterFinderSpec();
+o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* name = "PreClusterFinder");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -133,10 +133,10 @@ class ClusterFinderOriginalTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getClusterFinderOriginalSpec()
+o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* name)
 {
   return DataProcessorSpec{
-    "ClusterFinderOriginal",
+    name,
     Inputs{InputSpec{"preclusterrofs", "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"preclusters", "MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
            InputSpec{"digits", "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -186,11 +186,11 @@ class PreClusterFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getPreClusterFinderSpec()
+o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* name)
 {
   std::string helpstr = "[off/error/fatal] check that all digits are included in pre-clusters";
   return DataProcessorSpec{
-    "PreClusterFinder",
+    name,
     Inputs{InputSpec{"digitrofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
            InputSpec{"digits", "MCH", "DIGITS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"preclusterrofs"}, "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
@@ -219,10 +219,10 @@ class TrackAtVertexTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackAtVertexSpec()
+o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* name)
 {
   return DataProcessorSpec{
-    "TrackAtVertex",
+    name,
     Inputs{InputSpec{"vertices", "MCH", "VERTICES", 0, Lifetime::Timeframe},
            InputSpec{"rofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
            InputSpec{"tracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackAtVertexSpec();
+o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* name = "TrackAtVertex");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -160,10 +160,10 @@ class TrackFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackFinderSpec()
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* name)
 {
   return DataProcessorSpec{
-    "TrackFinder",
+    name,
     Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderSpec();
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* name = "TrackFinder");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.cxx
@@ -110,10 +110,10 @@ class VertexSamplerSpec
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getVertexSamplerSpec()
+o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* name)
 {
   return DataProcessorSpec{
-    "VertexSampler",
+    name,
     Inputs{InputSpec{"rofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
            // track and cluster messages are there just to keep things synchronized
            InputSpec{"tracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.h
@@ -24,8 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getVertexSamplerSpec();
-
+o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* name = "VertexSampler");
 } // end namespace mch
 } // end namespace o2
 

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -49,12 +49,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
-  specs.emplace_back(o2::mch::getPreClusterFinderSpec());
-  specs.emplace_back(o2::mch::getClusterFinderOriginalSpec());
+  specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder"));
+  specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
-  specs.emplace_back(o2::mch::getTrackFinderSpec());
-  specs.emplace_back(o2::mch::getVertexSamplerSpec());
-  specs.emplace_back(o2::mch::getTrackAtVertexSpec());
+  specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder"));
+  specs.emplace_back(o2::mch::getVertexSamplerSpec("mch-vertex-sampler"));
+  specs.emplace_back(o2::mch::getTrackAtVertexSpec("mch-track-at-vertex"));
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -32,7 +32,7 @@ if [ $NUMAGPUIDS != 0 ]; then
 fi
 
 # Set some individual workflow arguments depending on configuration
-CTF_DETECTORS=ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV,ZDC,FDD,HMP,FV0,TRD
+CTF_DETECTORS=ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV,ZDC,FDD,HMP,FV0,TRD,MCH
 CTF_DIR=
 CTF_DICT_DIR=
 GPU_INPUT=zsraw
@@ -104,7 +104,7 @@ if [ $CTFINPUT == 1 ]; then
   if [ ! -z $CTF_DICT_DIR ] ; then CTF_DICT=" --ctf-dict ${CTF_DICT_DIR}/ctf_dictionary.root"; fi
   WORKFLOW="o2-ctf-reader-workflow --ctf-input ${CTFName}  ${CTF_DICT} --onlyDet $CTF_DETECTORS $ARGS_ALL  | "
 elif [ $EXTINPUT == 1 ]; then
-  WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"FLP:FLP/DISTSUBTIMEFRAME/0;B:TPC/RAWDATA;C:ITS/RAWDATA;D:TOF/RAWDATA;D:MFT/RAWDATA;E:FT0/RAWDATA;F:MID/RAWDATA;G:EMC/RAWDATA;H:PHS/RAWDATA;I:CPV/RAWDATA;J:ZDC/RAWDATA;K:HMP/RAWDATA;L:FDD/RAWDATA;M:TRD/RAWDATA;N:FV0/RAWDATA\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=0\" | "
+  WORKFLOW="o2-dpl-raw-proxy $ARGS_ALL --dataspec \"FLP:FLP/DISTSUBTIMEFRAME/0;B:TPC/RAWDATA;C:ITS/RAWDATA;D:TOF/RAWDATA;D:MFT/RAWDATA;E:FT0/RAWDATA;F:MID/RAWDATA;G:EMC/RAWDATA;H:PHS/RAWDATA;I:CPV/RAWDATA;J:ZDC/RAWDATA;K:HMP/RAWDATA;L:FDD/RAWDATA;M:TRD/RAWDATA;N:FV0/RAWDATA;O:MCH/RAWDATA\" --channel-config \"name=readout-proxy,type=pull,method=connect,address=ipc://@$INRAWCHANNAME,transport=shmem,rateLogging=0\" | "
 else
   WORKFLOW="o2-raw-file-reader-workflow --detect-tf0 $ARGS_ALL --configKeyValues \"HBFUtils.nHBFPerTF=$NHBPERTF;\" --delay $TFDELAY --loop $NTIMEFRAMES --max-tf 0 --input-conf rawAll.cfg | "
 fi
@@ -116,6 +116,7 @@ if [ $CTFINPUT == 0 ]; then
   WORKFLOW+="o2-ft0-flp-dpl-workflow $ARGS_ALL --disable-root-output | "
   WORKFLOW+="o2-fv0-flp-dpl-workflow $ARGS_ALL --disable-root-output | "
   WORKFLOW+="o2-mid-raw-to-digits-workflow $ARGS_ALL | "
+  WORKFLOW+="o2-mch-raw-to-digits-workflow $ARGS_ALL | "
   WORKFLOW+="o2-tof-compressor $ARGS_ALL | "
   WORKFLOW+="o2-fdd-flp-dpl-workflow --disable-root-output $ARGS_ALL | "
   WORKFLOW+="o2-trd-datareader $ARGS_ALL | "
@@ -136,6 +137,7 @@ if [ $SYNCMODE == 0 ]; then
 
   WORKFLOW+="o2-tof-matcher-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC | "
   WORKFLOW+="o2-mid-reco-workflow $ARGS_ALL --disable-root-output $DISABLE_MC | "
+  WORKFLOW+="o2-mch-reco-workflow $ARGS_ALL | "
   WORKFLOW+="o2-mft-reco-workflow $ARGS_ALL --clusters-from-upstream $DISABLE_MC --disable-root-output | "
   WORKFLOW+="o2-primary-vertexing-workflow $ARGS_ALL $DISABLE_MC --disable-root-input --disable-root-output --validate-with-ft0 | "
   WORKFLOW+="o2-secondary-vertexing-workflow $ARGS_ALL --disable-root-input --disable-root-output | "
@@ -157,6 +159,7 @@ if [ $CTFINPUT == 0 ]; then
   WORKFLOW+="o2-ft0-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-fv0-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-mid-entropy-encoder-workflow $ARGS_ALL | "
+  WORKFLOW+="o2-mch-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-phos-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-cpv-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-emcal-entropy-encoder-workflow $ARGS_ALL | "

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -111,6 +111,7 @@ taskwrapper fddraw.log o2-fdd-digit2raw --file-per-link  -o raw/FDD
 taskwrapper tpcraw.log o2-tpc-digits-to-rawzs  --file-for link  -i tpcdigits.root -o raw/TPC
 taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --tof-raw-file-for link --output-type raw --tof-raw-outdir raw/TOF
 taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --mid-raw-perlink
+taskwrapper mchraw.log o2-mch-digits-to-raw --input-file mchdigits.root --output-dir raw/MCH --file-per-link
 taskwrapper emcraw.log o2-emcal-rawcreator --file-for link -o raw/EMC
 taskwrapper phsraw.log o2-phos-digi2raw  --file-for link -o raw/PHS
 taskwrapper cpvraw.log o2-cpv-digi2raw  --file-for link -o raw/CPV


### PR DESCRIPTION
Note that the last tracking part (extrap to vertex) is far from final
and will be updated in a forthcoming PR (in prep) where FwdTracks
will be added to AODs and extrapolation will be part of the AOD
producer.
Currently the vertex information that is used is completely fake (coming
from a vertex sampler that is used for debugging when using Run2 data).