### PR TITLE
Store det.mask in gGeoMnager and use in misalignment

### DIFF
--- a/Detectors/Base/src/Aligner.cxx
+++ b/Detectors/Base/src/Aligner.cxx
@@ -47,8 +47,9 @@ void Aligner::applyAlignment(long timestamp, DetID::mask_t addMask) const
   ccdbmgr.setURL(getCCDB());
   ccdbmgr.setTimestamp(timestamp);
   LOGP(INFO, "applying geometry alignment from {} for timestamp {}", getCCDB(), timestamp);
+  DetID::mask_t detGeoMask(gGeoManager->GetUniqueID());
   for (auto id = DetID::First; id <= DetID::Last; id++) {
-    if (!msk[id]) {
+    if (!msk[id] || (detGeoMask.any() && !detGeoMask[id])) {
       continue;
     }
     std::string path = o2::base::NameConf::getAlignmentPath({id});

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -96,13 +96,18 @@ void O2MCApplicationBase::ConstructGeometry()
 {
   // fill the mapping
   mModIdToName.clear();
+  o2::detectors::DetID::mask_t dmask{};
   for (int i = 0; i < fModules->GetEntries(); ++i) {
     auto mod = static_cast<FairModule*>(fModules->At(i));
     if (mod) {
       mModIdToName[mod->GetModId()] = mod->GetName();
+      int did = o2::detectors::DetID::nameToID(mod->GetName());
+      if (did >= 0) {
+        dmask |= o2::detectors::DetID::getMask(did);
+      }
     }
   }
-
+  gGeoManager->SetUniqueID(dmask.to_ulong());
   FairMCApplication::ConstructGeometry();
 
   std::ofstream voltomodulefile("MCStepLoggerVolMap.dat");


### PR DESCRIPTION
`gGeoManager->GetUniqueID()` will provide the mask of added detectors, only volumes actually present
in the geometry will be misaligned when loading the geometry