### PR TITLE
GPU: Add tpcIncreasedMinClustersPerRow option + some fixes

### DIFF
--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -163,6 +163,7 @@ AddOption(disableTPCNoisyPadFilter, bool, false, "", 0, "Disables all TPC noisy 
 AddOption(createO2Output, char, 2, "", 0, "Create Track output in O2 format (2 = skip non-O2 output in GPU track format (reverts to =1 if QA is requested))")
 AddOption(clearO2OutputFromGPU, bool, false, "", 0, "Free the GPU memory used for O2 output after copying to host, prevents further O2 processing on the GPU")
 AddOption(ignoreNonFatalGPUErrors, bool, false, "", 0, "Continue running after having received non fatal GPU errors, e.g. abort due to overflow")
+AddOption(tpcIncreasedMinClustersPerRow, unsigned int, 0, "", 0, "Impose a minimum buffer size for the clustersPerRow during TPC clusterization")
 AddVariable(eventDisplay, GPUCA_NAMESPACE::gpu::GPUDisplayBackend*, nullptr)
 AddSubConfig(GPUSettingsProcessingRTC, rtc)
 AddHelp("help", 'h')

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -381,7 +381,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
   mRec->MemoryScalers()->nTPCHits = mRec->MemoryScalers()->NTPCClusters(mRec->MemoryScalers()->nTPCdigits);
   if (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasNHBFPerTF) {
     unsigned int nHitsBase = mRec->MemoryScalers()->nTPCHits;
-    unsigned int threshold = 30000000 * mIOPtrs.settingsTF->nHBFPerTF / 256;
+    unsigned int threshold = 30000000 / 256 * mIOPtrs.settingsTF->nHBFPerTF;
     mRec->MemoryScalers()->nTPCHits = std::max<unsigned int>(nHitsBase, std::min<unsigned int>(threshold, nHitsBase * 3)); // Increase the buffer size for low occupancy data to compensate for noisy pads creating exceiive clusters
     if (nHitsBase < threshold) {
       float maxFactor = mRec->MemoryScalers()->nTPCHits < threshold ? 2.0 : 1.5;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
@@ -120,6 +120,9 @@ void GPUTPCClusterFinder::SetMaxData(const GPUTrackingInOutPointers& io)
     mNMaxClusterPerRow = std::max<unsigned int>(mNMaxClusterPerRow, std::min<unsigned int>(threshold, mNMaxClusterPerRow * 10)); // Relative increased value up until a threshold, for noisy pads
     mNMaxClusterPerRow = std::max<unsigned int>(mNMaxClusterPerRow, io.settingsTF->nHBFPerTF * 20000 / 256);                     // Absolute increased value, to have a minimum for noisy pads
   }
+  if (mRec->GetProcessingSettings().tpcIncreasedMinClustersPerRow) {
+    mNMaxClusterPerRow = std::max<unsigned int>(mNMaxClusterPerRow, mRec->GetProcessingSettings().tpcIncreasedMinClustersPerRow);
+  }
 
   mBufSize = nextMultipleOf<std::max<int>(GPUCA_MEMALIGN, mScanWorkGroupSize)>(mNMaxDigitsFragment);
   mNBufs = getNSteps(mBufSize);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -89,12 +89,16 @@ if [ $EPNPIPELINES != 0 ]; then
   N_TPCENT=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
   N_TPCITS=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
   N_ITSDEC=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
-  N_EMC=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
+  N_EMC=$(($(expr 7 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 7 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
+  N_TRDENT=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
+  N_TRDTRK=$(($(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) > 0 ? $(expr 3 \* $EPNPIPELINES \* $NGPUS / 4) : 1))
 else
   N_TPCENT=1
   N_TPCITS=1
   N_ITSDEC=1
   N_EMC=1
+  N_TRDENT=1
+  N_TRDTRK=1
 fi
 
 # Input workflow
@@ -130,7 +134,7 @@ WORKFLOW+="o2-gpu-reco-workflow ${ARGS_ALL/--severity $SEVERITY/--severity $SEVE
 WORKFLOW+="o2-tpcits-match-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC --pipeline itstpc-track-matcher:$N_TPCITS | "
 WORKFLOW+="o2-ft0-reco-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC | "
 WORKFLOW+="o2-tof-reco-workflow $ARGS_ALL --input-type $TOF_INPUT --output-type $TOF_OUTPUT --disable-root-input --disable-root-output $DISABLE_MC | "
-WORKFLOW+="o2-trd-tracklet-transformer $ARGS_ALL --disable-root-input --disable-root-output $TRD_TRANSFORMER_CONFIG | "
+WORKFLOW+="o2-trd-tracklet-transformer $ARGS_ALL --disable-root-input --disable-root-output $TRD_TRANSFORMER_CONFIG --pipeline TRDTRACKLETTRANSFORMER:$N_TRDTRK | "
 WORKFLOW+="o2-trd-global-tracking $ARGS_ALL --disable-root-input --disable-root-output $TRD_CONFIG | "
 
 # Workflows disabled in sync mode
@@ -168,7 +172,7 @@ if [ $CTFINPUT == 0 ]; then
   WORKFLOW+="o2-zdc-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-fdd-entropy-encoder-workflow $ARGS_ALL | "
   WORKFLOW+="o2-hmpid-entropy-encoder-workflow $ARGS_ALL | "
-  WORKFLOW+="o2-trd-entropy-encoder-workflow $ARGS_ALL | "
+  WORKFLOW+="o2-trd-entropy-encoder-workflow $ARGS_ALL --pipeline trd-entropy-encoder:$N_TRDENT | "
   WORKFLOW+="o2-tpc-reco-workflow --input-type compressed-clusters-flat --output-type encoded-clusters,disable-writer --pipeline tpc-entropy-encoder:$N_TPCENT $ARGS_ALL | "
 
   WORKFLOW+="o2-tpc-scdcalib-interpolation-workflow $ARGS_ALL --disable-root-output --disable-root-input | "

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -37,6 +37,6 @@ rm -f /dev/shm/*fmq*
 
 tmux \
     new-session "NUMAID=0 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
-    split-window "sleep 30; NUMAID=1 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
-    split-window "sleep 60; SEVERITY=debug numactl --interleave=all $MYDIR/$CMD; echo END; sleep 1000" \; \
+    split-window "sleep 45; NUMAID=1 $MYDIR/dpl-workflow.sh; echo END; sleep 1000" \; \
+    split-window "sleep 90; SEVERITY=debug numactl --interleave=all $MYDIR/$CMD; echo END; sleep 1000" \; \
     select-layout even-vertical


### PR DESCRIPTION
@wiechula : This adds an option `--setConfigKeyValues "GPU_proc.tpcIncreasedMinClustersPerRow=n;"` to raise the allowed number of TPC hits per row to a certain minimum, in case there are extremely noisy pads. Estimating this number reasonable just from the zero-suppression metadata doesn't work reliably, since there is such a huge difference between the rows, and from the metadata I cannot get information for individual rows.
In order to do this properly, I would need to decode the ZS data once / scan the digits once before allocating the buffers, and I want to avoid that extra pass over the data.
I prefer this option over the `memoryScalingFactor` since it affects only the tpc row buffer during clusterization, so it needs much less memory. Of course the `memoryScalingFactor` will still work.
Also, I fixed a bug in this code where the buffer size increase was applied too late, so it did not affect all buffers.