### PR TITLE
Event filter: Add first implementation of event filter for HF

### DIFF
--- a/Analysis/EventFiltering/CMakeLists.txt
+++ b/Analysis/EventFiltering/CMakeLists.txt
@@ -32,3 +32,8 @@ o2_add_dpl_workflow(diffraction-filter
                     SOURCES PWGUD/diffractionFilter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::AnalysisCore O2::CutHolder
                     COMPONENT_NAME Analysis)
+
+o2_add_dpl_workflow(hf-filter
+                    SOURCES HfFilter.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
+                    COMPONENT_NAME Analysis)

--- a/Analysis/EventFiltering/CMakeLists.txt
+++ b/Analysis/EventFiltering/CMakeLists.txt
@@ -34,6 +34,6 @@ o2_add_dpl_workflow(diffraction-filter
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(hf-filter
-                    SOURCES HFFilter.cxx
+                    SOURCES PWGHF/HFFilter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)

--- a/Analysis/EventFiltering/CMakeLists.txt
+++ b/Analysis/EventFiltering/CMakeLists.txt
@@ -34,6 +34,6 @@ o2_add_dpl_workflow(diffraction-filter
                     COMPONENT_NAME Analysis)
 
 o2_add_dpl_workflow(hf-filter
-                    SOURCES HfFilter.cxx
+                    SOURCES HFFilter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::AnalysisDataModel O2::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)

--- a/Analysis/EventFiltering/HfFilter.cxx
+++ b/Analysis/EventFiltering/HfFilter.cxx
@@ -35,14 +35,17 @@ namespace {
 
   static const std::vector<std::string> HfTriggerNames{"highPt", "beauty", "femto"};
 
-  static const double massPi = RecoDecay::getMassPDG(211);
-  static const double massK = RecoDecay::getMassPDG(321);
-  static const double massProton = RecoDecay::getMassPDG(2212);
-  static const double massDzero = RecoDecay::getMassPDG(421);
-  static const double massDplus = RecoDecay::getMassPDG(411);
-  static const double massDs = RecoDecay::getMassPDG(431);
-  static const double massLc = RecoDecay::getMassPDG(4122);
-  static const double massBplus = RecoDecay::getMassPDG(511);
+  static const float massPi = RecoDecay::getMassPDG(211);
+  static const float massK = RecoDecay::getMassPDG(321);
+  static const float massProton = RecoDecay::getMassPDG(2212);
+  static const float massD0 = RecoDecay::getMassPDG(421);
+  static const float massDPlus = RecoDecay::getMassPDG(411);
+  static const float massDs = RecoDecay::getMassPDG(431);
+  static const float massLc = RecoDecay::getMassPDG(4122);
+  static const float massBPlus = RecoDecay::getMassPDG(511);
+  static const float massB0 = RecoDecay::getMassPDG(521);
+  static const float massBs = RecoDecay::getMassPDG(531);
+  static const float massLb = RecoDecay::getMassPDG(5122);
 
 } // namespace
 
@@ -60,7 +63,10 @@ struct HfFilter {
 
   Configurable<float> ptThreshold2Prong{"ptThreshold2Prong", 5., "pT treshold for high pT 2-prong candidates for kHighPt triggers in GeV/c"};
   Configurable<float> ptThreshold3Prong{"ptThreshold3Prong", 5., "pT treshold for high pT 3-prong candidates for kHighPt triggers in GeV/c"};
-  Configurable<float> deltaMassBplus{"deltaMassBplus", 0.3, "invariant-mass delta with respect to the B+ mass"};
+  Configurable<float> deltaMassBPlus{"deltaMassBPlus", 0.3, "invariant-mass delta with respect to the B+ mass"};
+  Configurable<float> deltaMassB0{"deltaMassB0", 0.3, "invariant-mass delta with respect to the B0 mass"};
+  Configurable<float> deltaMassBs{"deltaMassBs", 0.3, "invariant-mass delta with respect to the Bs mass"};
+  Configurable<float> deltaMassLb{"deltaMassLb", 0.3, "invariant-mass delta with respect to the Lb mass"};
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
@@ -69,7 +75,7 @@ struct HfFilter {
     registry.add("fProcessedEvents", "HF - event filtered", HistType::kTH1F, {{4, -0.5, 4.5, "Event counter"}});
     std::array<std::string, 4> eventTitles = {"rejected", "w/ high-#it{p}_{T} candidate", "w/ beauty candidate", "w/ femto candidate"};
     for(size_t iBin=0; iBin<eventTitles.size(); iBin++) {
-      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());      
+      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());
     }
   }
 
@@ -100,7 +106,7 @@ struct HfFilter {
       }
 
       for (auto track : tracks) { // start loop over tracks
-        
+
         if(track.globalIndex() == trackPos.globalIndex() || track.globalIndex() == trackNeg.globalIndex()) {
           continue;
         }
@@ -108,8 +114,8 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if(!keepEvent[kBeauty]) {
-          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massDzero, massPi});
-          if(abs(massCandB - massBplus) <= deltaMassBplus) {
+          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi});
+          if(abs(massCandB - massBPlus) <= deltaMassBPlus) {
             keepEvent[kBeauty] = true;
           }
         }
@@ -119,7 +125,68 @@ struct HfFilter {
       } // end loop over tracks
     } // end loop over 2-prong candidates
 
+    for (auto& cand3Prong : cand3Prongs) { // start loop over 2 prongs
+
+      bool isDPlus = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DPlusToPiKPi);
+      bool isDs = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DsToPiKK);
+      bool isLc = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::LcToPKPi);
+      if(!isDPlus && !isDs && !isLc) { // check if it's a D+, Ds+ or Lc+ 
+        continue;
+      }
+
+      auto trackFirst = cand3Prong.index0_as<aod::BigTracks>();
+      auto trackSecond = cand3Prong.index1_as<aod::BigTracks>();
+      auto trackThird = cand3Prong.index2_as<aod::BigTracks>();
+      std::array<float, 3> pVecFirst = {trackFirst.px(), trackFirst.py(), trackFirst.pz()};
+      std::array<float, 3> pVecSecond = {trackSecond.px(), trackSecond.py(), trackSecond.pz()};
+      std::array<float, 3> pVecThird = {trackThird.px(), trackThird.py(), trackThird.pz()};
+
+      auto pVec3Prong = RecoDecay::PVec(pVecFirst, pVecSecond, pVecThird);
+      auto pt3Prong = RecoDecay::Pt(pVec3Prong);
+      if(pt3Prong >= ptThreshold3Prong) {
+        keepEvent[kHighPt] = true;
+      }
+
+      for (auto track : tracks) { // start loop over tracks
+
+        if(track.globalIndex() == trackFirst.globalIndex() || track.globalIndex() == trackSecond.globalIndex() || track.globalIndex() == trackThird.globalIndex()) {
+          continue;
+        }
+
+        std::array<float, 3> pVecFourth = {track.px(), track.py(), track.pz()};
+
+        int iHypo=0;
+        bool specieCharmHypos[3] = {isDPlus, isDs, isLc};
+        float massCharmHypos[3] = {massDPlus, massDs, massLc};
+        float massBeautyHypos[3] = {massB0, massBs, massLb};
+        float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
+        while(!keepEvent[kBeauty] && iHypo < 3) {
+          if(specieCharmHypos[iHypo]) {
+            auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
+            if(abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
+              keepEvent[kBeauty] = true;
+            }
+          }
+          iHypo++;
+        }
+
+        // TODO: add momentum correlation with a track for femto
+
+      } // end loop over tracks
+    } // end loop over 3-prong candidates
+
     tags(keepEvent[kHighPt], keepEvent[kBeauty], keepEvent[kFemto]);
+
+    if(!keepEvent[kHighPt] && !keepEvent[kBeauty] && !keepEvent[kFemto]) {
+      registry.get<TH1>(HIST("fProcessedEvents"))->Fill(1);
+    }
+    else {
+      for(int iTrigger=0; iTrigger<kNtriggersHF; iTrigger++) {
+        if(keepEvent[iTrigger]) {
+          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger+2);
+        }
+      }
+    }
   }
 };
 

--- a/Analysis/EventFiltering/HfFilter.cxx
+++ b/Analysis/EventFiltering/HfFilter.cxx
@@ -9,6 +9,11 @@
 // or submit itself to any jurisdiction.
 // O2 includes
 
+/// \file HfFilter.cxx
+/// \brief task for selection of events with HF signals
+///
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
@@ -19,36 +24,40 @@
 
 #include "AnalysisDataModel/HFSecondaryVertex.h"
 #include "AnalysisDataModel/HFCandidateSelectionTables.h"
-#include "AnalysisCore/TrackSelectorPID.h"
 
 #include <cmath>
 #include <string>
 
-namespace {
+namespace
+{
 
-  enum HfTriggers {
-    kHighPt = 0,
-    kBeauty,
-    kFemto,
-    kNtriggersHF
-  };
+enum HfTriggers {
+  kHighPt = 0,
+  kBeauty,
+  kFemto,
+  kNtriggersHF
+};
 
-  static const std::vector<std::string> HfTriggerNames{"highPt", "beauty", "femto"};
+static const std::vector<std::string> HfTriggerNames{"highPt", "beauty", "femto"};
 
-  static const float massPi = RecoDecay::getMassPDG(211);
-  static const float massK = RecoDecay::getMassPDG(321);
-  static const float massProton = RecoDecay::getMassPDG(2212);
-  static const float massD0 = RecoDecay::getMassPDG(421);
-  static const float massDPlus = RecoDecay::getMassPDG(411);
-  static const float massDs = RecoDecay::getMassPDG(431);
-  static const float massLc = RecoDecay::getMassPDG(4122);
-  static const float massBPlus = RecoDecay::getMassPDG(511);
-  static const float massB0 = RecoDecay::getMassPDG(521);
-  static const float massBs = RecoDecay::getMassPDG(531);
-  static const float massLb = RecoDecay::getMassPDG(5122);
+enum BeautyCandType {
+  kBeauty3Prong = 0, // combination of charm 2-prong and pion
+  kBeauty4Prong      // combination of charm 3-prong and pion
+};
+
+static const float massPi = RecoDecay::getMassPDG(211);
+static const float massK = RecoDecay::getMassPDG(321);
+static const float massProton = RecoDecay::getMassPDG(2212);
+static const float massD0 = RecoDecay::getMassPDG(421);
+static const float massDPlus = RecoDecay::getMassPDG(411);
+static const float massDs = RecoDecay::getMassPDG(431);
+static const float massLc = RecoDecay::getMassPDG(4122);
+static const float massBPlus = RecoDecay::getMassPDG(511);
+static const float massB0 = RecoDecay::getMassPDG(521);
+static const float massBs = RecoDecay::getMassPDG(531);
+static const float massLb = RecoDecay::getMassPDG(5122);
 
 } // namespace
-
 
 using namespace o2;
 using namespace o2::framework;
@@ -56,27 +65,60 @@ using namespace o2::framework::expressions;
 using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong2;
 using namespace o2::aod::hf_cand_prong3;
+using namespace o2::analysis::hf_cuts_single_track;
 
 struct HfFilter {
 
   Produces<aod::HfFilters> tags;
 
-  Configurable<float> ptThreshold2Prong{"ptThreshold2Prong", 5., "pT treshold for high pT 2-prong candidates for kHighPt triggers in GeV/c"};
-  Configurable<float> ptThreshold3Prong{"ptThreshold3Prong", 5., "pT treshold for high pT 3-prong candidates for kHighPt triggers in GeV/c"};
+  // parameters for high-pT triggers
+  Configurable<float> pTThreshold2Prong{"pTThreshold2Prong", 5., "pT treshold for high pT 2-prong candidates for kHighPt triggers in GeV/c"};
+  Configurable<float> pTThreshold3Prong{"pTThreshold3Prong", 5., "pT treshold for high pT 3-prong candidates for kHighPt triggers in GeV/c"};
+
+  // parameters for beauty triggers
   Configurable<float> deltaMassBPlus{"deltaMassBPlus", 0.3, "invariant-mass delta with respect to the B+ mass"};
   Configurable<float> deltaMassB0{"deltaMassB0", 0.3, "invariant-mass delta with respect to the B0 mass"};
   Configurable<float> deltaMassBs{"deltaMassBs", 0.3, "invariant-mass delta with respect to the Bs mass"};
   Configurable<float> deltaMassLb{"deltaMassLb", 0.3, "invariant-mass delta with respect to the Lb mass"};
+  Configurable<std::vector<double>> pTBinsTrack{"pTBinsTrack", std::vector<double>{hf_cuts_single_track::pTBinsTrack_v}, "track pT bin limits for DCAXY pT-depentend cut"};
+  Configurable<LabeledArray<double>> cutsTrackBeauty3Prong{"cutsTrackBeauty3Prong", {hf_cuts_single_track::cutsTrack[0], npTBinsTrack, nCutVarsTrack, pTBinLabelsTrack, cutVarLabelsTrack}, "Single-track selections per pT bin for 3-prong beauty candidates"};
+  Configurable<LabeledArray<double>> cutsTrackBeauty4Prong{"cutsTrackBeauty4Prong", {hf_cuts_single_track::cutsTrack[0], npTBinsTrack, nCutVarsTrack, pTBinLabelsTrack, cutVarLabelsTrack}, "Single-track selections per pT bin for 4-prong beauty candidates"};
+
+  // array of single-track cuts for pion
+  std::array<LabeledArray<double>, 2> cutsSingleTrackBeauty;
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
   void init(o2::framework::InitContext&)
   {
+
+    cutsSingleTrackBeauty = {cutsTrackBeauty3Prong, cutsTrackBeauty4Prong};
+
     registry.add("fProcessedEvents", "HF - event filtered", HistType::kTH1F, {{4, -0.5, 4.5, "Event counter"}});
     std::array<std::string, 4> eventTitles = {"rejected", "w/ high-#it{p}_{T} candidate", "w/ beauty candidate", "w/ femto candidate"};
-    for(size_t iBin=0; iBin<eventTitles.size(); iBin++) {
-      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());
+    for (size_t iBin = 0; iBin < eventTitles.size(); iBin++) {
+      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin + 1, eventTitles[iBin].data());
     }
+  }
+
+  /// Single-track cuts for 2-prongs or 3-prongs
+  /// \param track is a track
+  /// \return true if track passes all cuts
+  template <typename T>
+  bool isSelectedTrack(const T& track, const int candType)
+  {
+    auto pTBinTrack = findBin(pTBinsTrack, track.pt());
+    if (pTBinTrack == -1) {
+      return false;
+    }
+
+    if (std::abs(track.dcaPrim0()) < cutsSingleTrackBeauty[candType].get(pTBinTrack, "min_dcaxytoprimary")) {
+      return false; //minimum DCAxy
+    }
+    if (std::abs(track.dcaPrim0()) > cutsSingleTrackBeauty[candType].get(pTBinTrack, "max_dcaxytoprimary")) {
+      return false; //maximum DCAxy
+    }
+    return true;
   }
 
   void process(aod::Collision const& collision,
@@ -88,9 +130,9 @@ struct HfFilter {
     bool keepEvent[kNtriggersHF]{false};
     //
 
-    for (auto& cand2Prong : cand2Prongs) { // start loop over 2 prongs
+    for (const auto& cand2Prong : cand2Prongs) { // start loop over 2 prongs
 
-      if(!TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_prong2::DecayType::D0ToPiK)) { // check if it's a D0
+      if (!TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_prong2::DecayType::D0ToPiK)) { // check if it's a D0
         continue;
       }
 
@@ -101,36 +143,38 @@ struct HfFilter {
 
       auto pVec2Prong = RecoDecay::PVec(pVecPos, pVecNeg);
       auto pt2Prong = RecoDecay::Pt(pVec2Prong);
-      if(pt2Prong >= ptThreshold2Prong) {
+      if (pt2Prong >= pTThreshold2Prong) {
         keepEvent[kHighPt] = true;
       }
 
-      for (auto track : tracks) { // start loop over tracks
+      for (const auto& track : tracks) { // start loop over tracks
 
-        if(track.globalIndex() == trackPos.globalIndex() || track.globalIndex() == trackNeg.globalIndex()) {
+        if (track.globalIndex() == trackPos.globalIndex() || track.globalIndex() == trackNeg.globalIndex()) {
           continue;
         }
 
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
-        if(!keepEvent[kBeauty]) {
-          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
-          if(abs(massCandB - massBPlus) <= deltaMassBPlus) {
-            keepEvent[kBeauty] = true;
+        if (!keepEvent[kBeauty]) {
+          if (isSelectedTrack(track, kBeauty3Prong)) {
+            auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
+            if (abs(massCandB - massBPlus) <= deltaMassBPlus) {
+              keepEvent[kBeauty] = true;
+            }
           }
         }
 
         // TODO: add momentum correlation with a track for femto
 
       } // end loop over tracks
-    } // end loop over 2-prong candidates
+    }   // end loop over 2-prong candidates
 
-    for (auto& cand3Prong : cand3Prongs) { // start loop over 2 prongs
+    for (const auto& cand3Prong : cand3Prongs) { // start loop over 3 prongs
 
       bool isDPlus = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DPlusToPiKPi);
       bool isDs = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DsToPiKK);
       bool isLc = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::LcToPKPi);
-      if(!isDPlus && !isDs && !isLc) { // check if it's a D+, Ds+ or Lc+ 
+      if (!isDPlus && !isDs && !isLc) { // check if it's a D+, Ds+ or Lc+
         continue;
       }
 
@@ -145,28 +189,28 @@ struct HfFilter {
 
       auto pVec3Prong = RecoDecay::PVec(pVecFirst, pVecSecond, pVecThird);
       auto pt3Prong = RecoDecay::Pt(pVec3Prong);
-      if(pt3Prong >= ptThreshold3Prong) {
+      if (pt3Prong >= pTThreshold3Prong) {
         keepEvent[kHighPt] = true;
       }
 
-      for (auto track : tracks) { // start loop over tracks
+      for (const auto& track : tracks) { // start loop over tracks
 
-        if(track.globalIndex() == trackFirst.globalIndex() || track.globalIndex() == trackSecond.globalIndex() || track.globalIndex() == trackThird.globalIndex()) {
+        if (track.globalIndex() == trackFirst.globalIndex() || track.globalIndex() == trackSecond.globalIndex() || track.globalIndex() == trackThird.globalIndex()) {
           continue;
         }
 
         std::array<float, 3> pVecFourth = {track.px(), track.py(), track.pz()};
 
-        int iHypo=0;
+        int iHypo = 0;
         bool specieCharmHypos[3] = {isDPlus, isDs, isLc};
         float massCharmHypos[3] = {massDPlus, massDs, massLc};
         float massBeautyHypos[3] = {massB0, massBs, massLb};
         float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
-        if(track.signed1Pt() * sign3Prong < 0) {
-          while(!keepEvent[kBeauty] && iHypo < 3) {
-            if(specieCharmHypos[iHypo]) {
+        if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong)) {
+          while (!keepEvent[kBeauty] && iHypo < 3) {
+            if (specieCharmHypos[iHypo]) {
               auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
-              if(abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
+              if (abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
                 keepEvent[kBeauty] = true;
               }
             }
@@ -177,17 +221,16 @@ struct HfFilter {
         // TODO: add momentum correlation with a track for femto
 
       } // end loop over tracks
-    } // end loop over 3-prong candidates
+    }   // end loop over 3-prong candidates
 
     tags(keepEvent[kHighPt], keepEvent[kBeauty], keepEvent[kFemto]);
 
-    if(!keepEvent[kHighPt] && !keepEvent[kBeauty] && !keepEvent[kFemto]) {
+    if (!keepEvent[kHighPt] && !keepEvent[kBeauty] && !keepEvent[kFemto]) {
       registry.get<TH1>(HIST("fProcessedEvents"))->Fill(1);
-    }
-    else {
-      for(int iTrigger=0; iTrigger<kNtriggersHF; iTrigger++) {
-        if(keepEvent[iTrigger]) {
-          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger+2);
+    } else {
+      for (int iTrigger = 0; iTrigger < kNtriggersHF; iTrigger++) {
+        if (keepEvent[iTrigger]) {
+          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger + 2);
         }
       }
     }

--- a/Analysis/EventFiltering/HfFilter.cxx
+++ b/Analysis/EventFiltering/HfFilter.cxx
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+// O2 includes
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "filterTables.h"
+
+#include "AnalysisDataModel/HFSecondaryVertex.h"
+#include "AnalysisDataModel/HFCandidateSelectionTables.h"
+#include "AnalysisCore/TrackSelectorPID.h"
+
+#include <cmath>
+#include <string>
+
+namespace {
+
+  enum HfTriggers {
+    kHighPt = 0,
+    kBeauty,
+    kFemto,
+    kNtriggersHF
+  };
+
+  static const std::vector<std::string> HfTriggerNames{"highPt", "beauty", "femto"};
+
+  static const double massPi = RecoDecay::getMassPDG(211);
+  static const double massK = RecoDecay::getMassPDG(321);
+  static const double massProton = RecoDecay::getMassPDG(2212);
+  static const double massDzero = RecoDecay::getMassPDG(421);
+  static const double massDplus = RecoDecay::getMassPDG(411);
+  static const double massDs = RecoDecay::getMassPDG(431);
+  static const double massLc = RecoDecay::getMassPDG(4122);
+  static const double massBplus = RecoDecay::getMassPDG(511);
+
+} // namespace
+
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod::hf_cand;
+using namespace o2::aod::hf_cand_prong2;
+using namespace o2::aod::hf_cand_prong3;
+
+struct HfFilter {
+
+  Produces<aod::HfFilters> tags;
+
+  Configurable<float> ptThreshold2Prong{"ptThreshold2Prong", 5., "pT treshold for high pT 2-prong candidates for kHighPt triggers in GeV/c"};
+  Configurable<float> ptThreshold3Prong{"ptThreshold3Prong", 5., "pT treshold for high pT 3-prong candidates for kHighPt triggers in GeV/c"};
+  Configurable<float> deltaMassBplus{"deltaMassBplus", 0.3, "invariant-mass delta with respect to the B+ mass"};
+
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+
+  void init(o2::framework::InitContext&)
+  {
+    registry.add("fProcessedEvents", "HF - event filtered", HistType::kTH1F, {{4, -0.5, 4.5, "Event counter"}});
+    std::array<std::string, 4> eventTitles = {"rejected", "w/ high-#it{p}_{T} candidate", "w/ beauty candidate", "w/ femto candidate"};
+    for(size_t iBin=0; iBin<eventTitles.size(); iBin++) {
+      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());      
+    }
+  }
+
+  void process(aod::Collision const& collision,
+               aod::HfTrackIndexProng2 const& cand2Prongs,
+               aod::HfTrackIndexProng3 const& cand3Prongs,
+               aod::BigTracks const& tracks)
+  {
+    // collision process loop
+    bool keepEvent[kNtriggersHF]{false};
+    //
+
+    for (auto& cand2Prong : cand2Prongs) { // start loop over 2 prongs
+
+      if(!TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_prong2::DecayType::D0ToPiK)) { // check if it's a D0
+        continue;
+      }
+
+      auto trackPos = cand2Prong.index0_as<aod::BigTracks>(); // positive daughter
+      auto trackNeg = cand2Prong.index1_as<aod::BigTracks>(); // negative daughter
+      std::array<float, 3> pVecPos = {trackPos.px(), trackPos.py(), trackPos.pz()};
+      std::array<float, 3> pVecNeg = {trackNeg.px(), trackNeg.py(), trackNeg.pz()};
+
+      auto pVec2Prong = RecoDecay::PVec(pVecPos, pVecNeg);
+      auto pt2Prong = RecoDecay::Pt(pVec2Prong);
+      if(pt2Prong >= ptThreshold2Prong) {
+        keepEvent[kHighPt] = true;
+      }
+
+      for (auto track : tracks) { // start loop over tracks
+        
+        if(track.globalIndex() == trackPos.globalIndex() || track.globalIndex() == trackNeg.globalIndex()) {
+          continue;
+        }
+
+        std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
+
+        if(!keepEvent[kBeauty]) {
+          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massDzero, massPi});
+          if(abs(massCandB - massBplus) <= deltaMassBplus) {
+            keepEvent[kBeauty] = true;
+          }
+        }
+
+        // TODO: add momentum correlation with a track for femto
+
+      } // end loop over tracks
+    } // end loop over 2-prong candidates
+
+    tags(keepEvent[kHighPt], keepEvent[kBeauty], keepEvent[kFemto]);
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HfFilter>(cfg)};
+}

--- a/Analysis/EventFiltering/HfFilter.cxx
+++ b/Analysis/EventFiltering/HfFilter.cxx
@@ -114,7 +114,7 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if(!keepEvent[kBeauty]) {
-          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi});
+          auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
           if(abs(massCandB - massBPlus) <= deltaMassBPlus) {
             keepEvent[kBeauty] = true;
           }
@@ -141,6 +141,8 @@ struct HfFilter {
       std::array<float, 3> pVecSecond = {trackSecond.px(), trackSecond.py(), trackSecond.pz()};
       std::array<float, 3> pVecThird = {trackThird.px(), trackThird.py(), trackThird.pz()};
 
+      float sign3Prong = trackFirst.signed1Pt() * trackSecond.signed1Pt() * trackThird.signed1Pt();
+
       auto pVec3Prong = RecoDecay::PVec(pVecFirst, pVecSecond, pVecThird);
       auto pt3Prong = RecoDecay::Pt(pVec3Prong);
       if(pt3Prong >= ptThreshold3Prong) {
@@ -160,14 +162,16 @@ struct HfFilter {
         float massCharmHypos[3] = {massDPlus, massDs, massLc};
         float massBeautyHypos[3] = {massB0, massBs, massLb};
         float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
-        while(!keepEvent[kBeauty] && iHypo < 3) {
-          if(specieCharmHypos[iHypo]) {
-            auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
-            if(abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
-              keepEvent[kBeauty] = true;
+        if(track.signed1Pt() * sign3Prong < 0) {
+          while(!keepEvent[kBeauty] && iHypo < 3) {
+            if(specieCharmHypos[iHypo]) {
+              auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
+              if(abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
+                keepEvent[kBeauty] = true;
+              }
             }
+            iHypo++;
           }
-          iHypo++;
         }
 
         // TODO: add momentum correlation with a track for femto

--- a/Analysis/EventFiltering/HfFilter.cxx
+++ b/Analysis/EventFiltering/HfFilter.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 // O2 includes
 
-/// \file HfFilter.cxx
+/// \file HFFilter.cxx
 /// \brief task for selection of events with HF signals
 ///
 /// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
@@ -110,6 +110,7 @@ struct HfFilter {
   Configurable<float> deltaMassB0{"deltaMassB0", 0.3, "invariant-mass delta with respect to the B0 mass"};
   Configurable<float> deltaMassBs{"deltaMassBs", 0.3, "invariant-mass delta with respect to the Bs mass"};
   Configurable<float> deltaMassLb{"deltaMassLb", 0.3, "invariant-mass delta with respect to the Lb mass"};
+  Configurable<float> pTMinBeautyBachelor{"pTMinBeautyBachelor", 0.5, "minumum pT for bachelor pion track used to build b-hadron candidates"};
   Configurable<std::vector<double>> pTBinsTrack{"pTBinsTrack", std::vector<double>{pTBinsTrack_v}, "track pT bin limits for DCAXY pT-depentend cut"};
   Configurable<LabeledArray<double>> cutsTrackBeauty3Prong{"cutsTrackBeauty3Prong", {cutsTrack[0], npTBinsTrack, nCutVarsTrack, pTBinLabelsTrack, cutVarLabelsTrack}, "Single-track selections per pT bin for 3-prong beauty candidates"};
   Configurable<LabeledArray<double>> cutsTrackBeauty4Prong{"cutsTrackBeauty4Prong", {cutsTrack[0], npTBinsTrack, nCutVarsTrack, pTBinLabelsTrack, cutVarLabelsTrack}, "Single-track selections per pT bin for 4-prong beauty candidates"};
@@ -191,7 +192,7 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if (!keepEvent[kBeauty]) {
-          if (isSelectedTrack(track, kBeauty3Prong)) {
+          if (isSelectedTrack(track, kBeauty3Prong) && track.pt() >= pTMinBeautyBachelor) { // TODO: add more single track cuts
             auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
             if (std::abs(massCandB - massBPlus) <= deltaMassBPlus) {
               keepEvent[kBeauty] = true;
@@ -241,7 +242,7 @@ struct HfFilter {
         float massCharmHypos[3] = {massDPlus, massDs, massLc};
         float massBeautyHypos[3] = {massB0, massBs, massLb};
         float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
-        if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong)) {
+        if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong) && track.pt() >= pTMinBeautyBachelor) { // TODO: add more single track cuts
           while (!keepEvent[kBeauty] && iHypo < 3) {
             if (specieCharmHypos[iHypo]) {
               auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});

--- a/Analysis/EventFiltering/PWGHF/HFFilter.cxx
+++ b/Analysis/EventFiltering/PWGHF/HFFilter.cxx
@@ -192,7 +192,7 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if (!keepEvent[kBeauty]) {
-          if (isSelectedTrack(track, kBeauty3Prong) && track.pt() >= pTMinBeautyBachelor) { // TODO: add more single track cuts
+          if (isSelectedTrack(track, kBeauty3Prong) && track.pt() >= pTMinBeautyBachelor) {               // TODO: add more single track cuts
             auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
             if (std::abs(massCandB - massBPlus) <= deltaMassBPlus) {
               keepEvent[kBeauty] = true;

--- a/Analysis/EventFiltering/PWGHF/HFFilter.cxx
+++ b/Analysis/EventFiltering/PWGHF/HFFilter.cxx
@@ -247,14 +247,13 @@ struct HfFilter {
         float massBeautyHypos[3] = {massB0, massBs, massLb};
         float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
         if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong)) { // TODO: add more single track cuts
-          while (!keepEvent[kBeauty] && iHypo < 3) {
+          for (int iHypo{0}; iHypo < 3 && !keepEvent[kBeauty]; ++iHypo) {
             if (specieCharmHypos[iHypo]) {
               auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
               if (std::abs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
                 keepEvent[kBeauty] = true;
               }
             }
-            iHypo++;
           }
         }
 
@@ -268,7 +267,7 @@ struct HfFilter {
     if (!keepEvent[kHighPt] && !keepEvent[kBeauty] && !keepEvent[kFemto]) {
       registry.get<TH1>(HIST("fProcessedEvents"))->Fill(1);
     } else {
-      for (int iTrigger = 0; iTrigger < kNtriggersHF; iTrigger++) {
+      for (int iTrigger{0}; iTrigger < kNtriggersHF; iTrigger++) {
         if (keepEvent[iTrigger]) {
           registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger + 2);
         }

--- a/Analysis/EventFiltering/PWGHF/HFFilter.cxx
+++ b/Analysis/EventFiltering/PWGHF/HFFilter.cxx
@@ -20,7 +20,7 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
 
-#include "filterTables.h"
+#include "../filterTables.h"
 
 #include "AnalysisDataModel/HFSecondaryVertex.h"
 #include "AnalysisDataModel/HFCandidateSelectionTables.h"
@@ -138,7 +138,11 @@ struct HfFilter {
   template <typename T>
   bool isSelectedTrack(const T& track, const int candType)
   {
-    auto pTBinTrack = findBin(pTBinsTrack, track.pt());
+    auto pT = track.pt();
+    if(pT < pTMinBeautyBachelor) {
+      return false;
+    }
+    auto pTBinTrack = findBin(pTBinsTrack, pT);
     if (pTBinTrack == -1) {
       return false;
     }
@@ -192,7 +196,7 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if (!keepEvent[kBeauty]) {
-          if (isSelectedTrack(track, kBeauty3Prong) && track.pt() >= pTMinBeautyBachelor) {               // TODO: add more single track cuts
+          if (isSelectedTrack(track, kBeauty3Prong)) { // TODO: add more single track cuts
             auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
             if (std::abs(massCandB - massBPlus) <= deltaMassBPlus) {
               keepEvent[kBeauty] = true;
@@ -242,7 +246,7 @@ struct HfFilter {
         float massCharmHypos[3] = {massDPlus, massDs, massLc};
         float massBeautyHypos[3] = {massB0, massBs, massLb};
         float deltaMassHypos[3] = {deltaMassB0, deltaMassBs, deltaMassLb};
-        if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong) && track.pt() >= pTMinBeautyBachelor) { // TODO: add more single track cuts
+        if (track.signed1Pt() * sign3Prong < 0 && isSelectedTrack(track, kBeauty4Prong)) { // TODO: add more single track cuts
           while (!keepEvent[kBeauty] && iHypo < 3) {
             if (specieCharmHypos[iHypo]) {
               auto massCandB = RecoDecay::M(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});

--- a/Analysis/EventFiltering/PWGHF/HFFilter.cxx
+++ b/Analysis/EventFiltering/PWGHF/HFFilter.cxx
@@ -139,7 +139,7 @@ struct HfFilter {
   bool isSelectedTrack(const T& track, const int candType)
   {
     auto pT = track.pt();
-    if(pT < pTMinBeautyBachelor) {
+    if (pT < pTMinBeautyBachelor) {
       return false;
     }
     auto pTBinTrack = findBin(pTBinsTrack, pT);
@@ -196,7 +196,7 @@ struct HfFilter {
         std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
 
         if (!keepEvent[kBeauty]) {
-          if (isSelectedTrack(track, kBeauty3Prong)) { // TODO: add more single track cuts
+          if (isSelectedTrack(track, kBeauty3Prong)) {                                                    // TODO: add more single track cuts
             auto massCandB = RecoDecay::M(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi}); // TODO: retrieve D0-D0bar hypothesis to pair with proper signed track
             if (std::abs(massCandB - massBPlus) <= deltaMassBPlus) {
               keepEvent[kBeauty] = true;

--- a/Analysis/EventFiltering/filterTables.h
+++ b/Analysis/EventFiltering/filterTables.h
@@ -26,6 +26,11 @@ DECLARE_SOA_COLUMN(He4, hasHe4, bool); //!
 // diffraction
 DECLARE_SOA_COLUMN(DG, hasDG, bool); //! Double Gap events, DG
 
+// heavy flavours
+DECLARE_SOA_COLUMN(HfHighPt, hasHfHighPt, bool); //! high-pT charm hadron
+DECLARE_SOA_COLUMN(HfBeauty, hasHfBeauty, bool); //! beauty hadron
+DECLARE_SOA_COLUMN(HfFemto, hasHfFemto, bool);   //! charm-hadron - N pair
+
 } // namespace filtering
 
 // nuclei
@@ -38,12 +43,18 @@ DECLARE_SOA_TABLE(DiffractionFilters, "AOD", "DiffFilters", //! Diffraction filt
                   filtering::DG);
 using DiffractionFilter = DiffractionFilters::iterator;
 
+// heavy flavours
+DECLARE_SOA_TABLE(HfFilters, "AOD", "HF Filters", //!
+                  filtering::HfHighPt, filtering::HfBeauty, filtering::HfFemto);
+
+using HfFilter = HfFilters::iterator;
+
 /// List of the available filters, the description of their tables and the name of the tasks
-constexpr int NumberOfFilters{2};
-constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters"};
-constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters"};
-constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter"};
-constexpr o2::framework::pack<NucleiFilters, DiffractionFilters> FiltersPack;
+constexpr int NumberOfFilters{3};
+constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "HeavyFlavourFilters"};
+constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "HFFilters"};
+constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-hf-filter"};
+constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, HfFilters> FiltersPack;
 static_assert(o2::framework::pack_size(FiltersPack) == NumberOfFilters);
 
 template <typename T, typename C>


### PR DESCRIPTION
This PR implements the first version of the event-filtering task for HF observables. Currently it supports the selection of events containing high-pT charm hadrons and with beauty hadrons. Please feel free to comment @mpuccio @strogolo @ginnocen @vkucera 