### PR TITLE
DPL: force processing of region callback without waiting for data

### DIFF
--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -23,6 +23,7 @@ typedef struct uv_loop_s uv_loop_t;
 typedef struct uv_timer_s uv_timer_t;
 typedef struct uv_poll_s uv_poll_t;
 typedef struct uv_signal_s uv_signal_t;
+typedef struct uv_async_s uv_async_t;
 
 namespace o2::framework
 {
@@ -78,6 +79,9 @@ struct DeviceState {
   std::vector<uv_poll_t*> activeOutputPollers;
   /// The list of active signal handlers
   std::vector<uv_signal_t*> activeSignals;
+
+  uv_async_t* awakeMainThread = nullptr;
+
   int loopReason = 0;
 };
 


### PR DESCRIPTION
Without this, it is possible that a late arriving event will not be processed
until some data actually arrives on one of the channels, unblocking the event
loop. This should obviate to the problem by triggering an aync libuv event
which will unblock the event loop without the need for data.