### PR TITLE
Option to scale global material density for systematic studies

### DIFF
--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -10,9 +10,9 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(SimConfig
-               SOURCES src/SimConfig.cxx 
-                       src/SimCutParams.cxx		       
-                       src/SimUserDecay.cxx		       
+               SOURCES src/SimConfig.cxx
+                       src/SimParams.cxx
+                       src/SimUserDecay.cxx
                        src/DigiParams.cxx src/G4Params.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
@@ -21,9 +21,9 @@ o2_add_library(SimConfig
 
 o2_target_root_dictionary(SimConfig
                           HEADERS include/SimConfig/SimConfig.h
-                                  include/SimConfig/SimCutParams.h
+                                  include/SimConfig/SimParams.h
                                   include/SimConfig/SimUserDecay.h
-				  include/SimConfig/DigiParams.h
+		include/SimConfig/DigiParams.h
                                   include/SimConfig/G4Params.h)
 
 o2_add_test(Config

--- a/Common/SimConfig/include/SimConfig/SimParams.h
+++ b/Common/SimConfig/include/SimConfig/SimParams.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_SIMCONFIG_SIMCUTPARAM_H_
-#define O2_SIMCONFIG_SIMCUTPARAM_H_
+#ifndef O2_SIMCONFIG_SIMPARAM_H_
+#define O2_SIMCONFIG_SIMPARAM_H_
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
@@ -33,8 +33,18 @@ struct SimCutParams : public o2::conf::ConfigurableParamHelper<SimCutParams> {
   float maxRTrackingZDC = 50; // R-cut applied in the tunnel leading to ZDC when z > beampipeZ (custom stepping function)
   float tunnelZ = 1900;       // Z-value from where we apply maxRTrackingZDC (default value taken from standard "hall" dimensions)
 
+  float globalDensityFactor = 1.f; // global factor that scales all material densities for systematic studies
+
   O2ParamDef(SimCutParams, "SimCutParams");
 };
+
+// parameter influencing material manager
+struct SimMaterialParams : public o2::conf::ConfigurableParamHelper<SimMaterialParams> {
+  float globalDensityFactor = 1.f;
+
+  O2ParamDef(SimMaterialParams, "SimMaterialParams");
+};
+
 } // namespace conf
 } // namespace o2
 

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -19,6 +19,8 @@
 
 #pragma link C++ class o2::conf::SimCutParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimCutParams> + ;
+#pragma link C++ class o2::conf::SimMaterialParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimMaterialParams> + ;
 
 #pragma link C++ class o2::conf::SimUserDecay + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimUserDecay> + ;

--- a/Common/SimConfig/src/SimParams.cxx
+++ b/Common/SimConfig/src/SimParams.cxx
@@ -13,8 +13,9 @@
  * SimCutParams.cxx
  *
  *  Created on: Feb 18, 2019
- *      Author: sandro
+ *      Author: Sandro Wenzel
  */
 
-#include "SimConfig/SimCutParams.h"
+#include "SimConfig/SimParams.h"
 O2ParamImpl(o2::conf::SimCutParams);
+O2ParamImpl(o2::conf::SimMaterialParams);

--- a/Common/SimConfig/test/testSimCutParam.cxx
+++ b/Common/SimConfig/test/testSimCutParam.cxx
@@ -13,7 +13,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
-#include "SimConfig/SimCutParams.h"
+#include "SimConfig/SimParams.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::conf;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -17,7 +17,7 @@
 #include "DetectorsBase/Detector.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "SimulationDataFormat/MCTrack.h"
-#include "SimConfig/SimCutParams.h"
+#include "SimConfig/SimParams.h"
 
 #include "FairDetector.h" // for FairDetector
 #include "FairLogger.h"   // for FairLogger

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -202,6 +202,11 @@ class MaterialManager
   // print out all registered media
   void printMedia() const;
 
+  /// set the density scaling factor
+  void setDensityScalingFactor(float f) { mDensityFactor = f; }
+  /// set the density scaling factor
+  float getDensityScalingFactor() const { return mDensityFactor; }
+
   /// print all tracking media inside a logical volume (specified by name)
   /// and all of its daughters
   static void printContainingMedia(std::string const& volumename);

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -65,7 +65,6 @@ void MaterialManager::Material(const char* modname, Int_t imat, const char* name
   TString uniquename = modname;
   uniquename.Append("_");
   uniquename.Append(name);
-
   if (TVirtualMC::GetMC()) {
     // Check this!!!
     int kmat = -1;

--- a/Detectors/Passive/src/Cave.cxx
+++ b/Detectors/Passive/src/Cave.cxx
@@ -25,7 +25,7 @@
 #include "DetectorsBase/Detector.h"
 #include "DetectorsPassive/Cave.h"
 #include "SimConfig/SimConfig.h"
-#include "SimConfig/SimCutParams.h"
+#include "SimConfig/SimParams.h"
 #include <TRandom.h>
 #include "FairLogger.h"
 #include "TGeoManager.h"

--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -22,7 +22,7 @@
 #include <FairMCApplication.h>
 #include "Rtypes.h" // for Int_t, Bool_t, Double_t, etc
 #include <TVirtualMC.h>
-#include "SimConfig/SimCutParams.h"
+#include "SimConfig/SimParams.h"
 
 namespace o2
 {

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -16,6 +16,7 @@
 #include <Generators/PDG.h>
 #include "SimulationDataFormat/MCEventHeader.h"
 #include <SimConfig/SimConfig.h>
+#include <SimConfig/SimParams.h>
 #include <CommonUtils/ConfigurableParam.h>
 #include <CommonUtils/RngHelper.h>
 #include <TStopwatch.h>
@@ -126,6 +127,10 @@ FairRunSim* o2sim_init(bool asservice)
     }
   }
 
+  // set global density scaling factor
+  auto& matmgr = o2::base::MaterialManager::Instance();
+  matmgr.setDensityScalingFactor(o2::conf::SimMaterialParams::Instance().globalDensityFactor);
+
   // run init
   run->Init();
 
@@ -181,7 +186,6 @@ FairRunSim* o2sim_init(bool asservice)
 
   // print summary about cuts and processes used
   std::ofstream cutfile(o2::base::NameConf::getCutProcFileName(confref.getOutPrefix()));
-  auto& matmgr = o2::base::MaterialManager::Instance();
   matmgr.printCuts(cutfile);
   matmgr.printProcesses(cutfile);
 


### PR DESCRIPTION
Use `--configKeyValues SimMaterialParams.globalDensityFactor=xx`

renaming SimCutParams.h -> SimParams.h; This header now
hosts more than one parameter for transport simulation.