### PR TITLE
[CPV] Fix for CPV/RawReaderMemory to handle HBF orbits properly

### DIFF
--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/RawFormats.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/RawFormats.h
@@ -101,7 +101,7 @@ class CpvHeader
   bool isOK() const { return (mBytes[9] == 0xe0) && (mBytes[10] == 0) && (mBytes[11] == 0) && (mBytes[12] == 0) && (mBytes[13] == 0) && (mBytes[14] == 0) && (mBytes[15] == 0); }
   bool isNoDataExpected() const { return mBytes[1] & 0b00100000; }
   bool isDataContinued() const { return mBytes[1] & 0b0100000; }
-  uint16_t bc() const { return mBytes[2] + ((mBytes[3] & 0x0f) << 8); }
+  uint16_t bc() const { return static_cast<uint16_t>(mBytes[2]) + static_cast<uint16_t>((mBytes[3] & 0x0f) << 8); }
   uint32_t orbit() const { return mBytes[4] + (mBytes[5] << 8) + (mBytes[6] << 16) + (mBytes[7] << 24); }
 
  public:

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/RawReaderMemory.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/RawReaderMemory.h
@@ -119,6 +119,7 @@ class RawReaderMemory
   bool mPayloadInitialized = false;       ///< Payload for current page initialized
   uint32_t mCurrentHBFOrbit = 0;          ///< Current orbit of HBF
   bool mStopBitWasNotFound;               ///< True if StopBit was not found but HBF orbit changed
+  bool mIsJustInited = false;             ///< True if init() was just called
 
   ClassDefNV(RawReaderMemory, 2);
 };

--- a/Detectors/CPV/reconstruction/src/RawDecoder.cxx
+++ b/Detectors/CPV/reconstruction/src/RawDecoder.cxx
@@ -67,7 +67,8 @@ RawErrorType_t RawDecoder::readChannels()
       nDigitsAddedFromLastHeader = 0;
       if (currentOrbit != header.orbit()) { //bad cpvheader
         LOG(ERROR) << "RawDecoder::readChannels() : "
-                   << "currentOrbit != header.orbit()";
+                   << "currentOrbit(=" << currentOrbit
+                   << ") != header.orbit()(=" << header.orbit() << ")";
         mErrors.emplace_back(5, 0, 0, 0, kCPVHEADER_INVALID); //5 is non-existing link with general errors
         skipUntilNextHeader = true;
       }

--- a/Detectors/CPV/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/CPV/reconstruction/src/RawReaderMemory.cxx
@@ -51,6 +51,7 @@ void RawReaderMemory::init()
   mPayloadInitialized = false;
   mCurrentHBFOrbit = 0;
   mStopBitWasNotFound = false;
+  mIsJustInited = true;
 }
 
 //Read the next pages until the stop bit is found or new HBF reached
@@ -95,11 +96,12 @@ RawErrorType_t RawReaderMemory::nextPage()
     mCurrentPosition += RDHDecoder::getOffsetToNext(rawHeader); //moving on
     return RawErrorType_t::kNOT_CPV_RDH;
   }
-  if (mCurrentHBFOrbit != 0 || mStopBitWasNotFound) { //reading first time after init() or stopbit was not found
+  if (mIsJustInited || mStopBitWasNotFound) { //reading first time after init() or stopbit was not found
     mCurrentHBFOrbit = RDHDecoder::getHeartBeatOrbit(rawHeader);
     mRawHeader = rawHeader; //save RDH of first page as mRawHeader
     mRawHeaderInitialized = true;
     mStopBitWasNotFound = false; //reset this flag as we start to read again
+    mIsJustInited = false;
   } else if (mCurrentHBFOrbit != RDHDecoder::getHeartBeatOrbit(rawHeader)) {
     //next HBF started but we didn't find stop bit.
     mStopBitWasNotFound = true;

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -247,7 +247,7 @@ o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getRawToDigitConverterS
                                           outputs,
                                           o2::framework::adaptFromTask<o2::cpv::reco_workflow::RawToDigitConverterSpec>(),
                                           o2::framework::Options{
-                                            {"pedestal", o2::framework::VariantType::Bool, false, {"If true then do not subtract pedestals from digits"}},
+                                            {"pedestal", o2::framework::VariantType::Bool, false, {"do not subtract pedestals from digits"}},
                                             {"ccdb-url", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}},
                                           }};
 }

--- a/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
@@ -34,9 +34,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-    {"pedestal", o2::framework::VariantType::Bool, false, {"pedestal run? if true then don't subtract pedestals from digits"}},
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
-    //{"ccdb-url", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"path to CCDB like http://ccdb-test.cern.ch:8080"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }


### PR DESCRIPTION
Changes are supposed to remove bug https://alice.its.cern.ch/jira/browse/O2-2426 and properly handle HBF orbit at the beginning of reading procedure. Also configuration of CPV RawToDigitsConverterSpec is fixed: it was not possible to use --pedestal flag due to ambiguous config parameters.
