### PR TITLE
Missing CMake entry in #6305

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -109,6 +109,11 @@ o2_add_executable(calib-dedx
                   SOURCES src/tpc-calib-dEdx.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
+o2_add_executable(miptrack-filter
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-miptrack-filter.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
 o2_add_test(workflow
             COMPONENT_NAME tpc
             LABELS tpc workflow


### PR DESCRIPTION
In my last pull request (#6305), I forgot to add the CMake entry to build one of the workflows I wrote. This PR corrects this.