### PR TITLE
A utility to engineer collision structures in a timeframe

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -127,7 +127,7 @@ class DigitizationContext
   std::vector<o2::InteractionTimeRecord> mEventRecordsWithQED;
   std::vector<std::vector<o2::steer::EventPart>> mEventPartsWithQED;
 
-  o2::BunchFilling mBCFilling; // patter of active BCs
+  o2::BunchFilling mBCFilling; // pattern of active BCs
 
   std::vector<std::string> mSimPrefixes;             // identifiers to the hit sim products; the key corresponds to the source ID of event record
   std::string mQEDSimPrefix;                         // prefix for QED production/contribution

--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -23,7 +23,7 @@ using namespace o2::steer;
 void DigitizationContext::printCollisionSummary(bool withQED) const
 {
   std::cout << "Summary of DigitizationContext --\n";
-  std::cout << "Parts per collision " << mMaxPartNumber << "\n";
+  std::cout << "Maximal parts per collision " << mMaxPartNumber << "\n";
   std::cout << "Collision parts taken from simulations specified by prefix:\n";
   for (int p = 0; p < mSimPrefixes.size(); ++p) {
     std::cout << "Part " << p << " : " << mSimPrefixes[p] << "\n";
@@ -54,10 +54,6 @@ void DigitizationContext::printCollisionSummary(bool withQED) const
 void DigitizationContext::setSimPrefixes(std::vector<std::string> const& prefixes)
 {
   mSimPrefixes = prefixes;
-  // the number should correspond to the number of parts
-  if (mSimPrefixes.size() != mMaxPartNumber) {
-    std::cerr << "Inconsistent number of simulation prefixes and part numbers";
-  }
 }
 
 bool DigitizationContext::initSimChains(o2::detectors::DetID detid, std::vector<TChain*>& simchains) const

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -17,6 +17,11 @@ o2_add_library(Steer
                                      O2::SimulationDataFormat
                                      O2::DetectorsCommonDataFormats)
 
+o2_add_executable(colcontexttool
+                  COMPONENT_NAME steer
+                  SOURCES src/CollisionContextTool.cxx
+                  PUBLIC_LINK_LIBRARIES Boost::program_options O2::Algorithm O2::Steer O2::SimulationDataFormat)
+
 o2_target_root_dictionary(Steer
                           HEADERS include/Steer/InteractionSampler.h
                                   include/Steer/HitProcessingManager.h


### PR DESCRIPTION
Going beyond what was possible until now
via SimReader:

* make collision contexts of arbitrary timelength

  `o2-steer-colcontexttool -i bkg,50000 --tflength 10`
  (generated a context for 10ms timeframes and 50kHz interaction rate)

* allow to inject only into every N-th background event

  `o2-steer-colcontexttool -i bkg,50000 sgn,@0:e5`
  (injects signals into every 5-th background event)

* allow to inject respecting a minimal time distance between signal events

  `o2-steer-colcontexttool -i bkg,50000 sgn,@0:d10000`
  (injects signals into background but minimally 10000ns apart)

* allow to overlay arbitrary interactions (without matching of vertex)

  `o2-steer-colcontexttool -i bkg,50000 sgn,40000`
  (2 unrelated collisions, the first one at 50kHz the second one at 40kHz)

* allow to inject multiple signal events

  `o2-steer-colcontexttool -i bkg,50000 sgn1,@0:e1 sgn2,@0:e1`
  (injects 2 signals into every background event)

The tool can be upgraded to allow editing of existing contexts, etc. in the future.
One can also treat QED events in this new fashion without special treatment in digitizers.

To use the tool, simply generate a context with it before digitization
```
o2-sim -n ... -o bkg
o2-sim ... -o sgn
o2-steer-colcontexttool -i bkg,40000 sgn,@0:e2
o2-sim-digitizer-workflow --incontext collisioncontext.root --sims bkg
```