### PR TITLE
DPL: fix idling readers

### DIFF
--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -32,11 +32,11 @@ namespace o2::framework
 /// device.
 enum struct StreamingState {
   /// Data is being processed
-  Streaming,
+  Streaming = 0,
   /// End of streaming requested, but not notified
-  EndOfStreaming,
+  EndOfStreaming = 1,
   /// End of streaming notified
-  Idle,
+  Idle = 2,
 };
 
 /// Running state information of a given device


### PR DESCRIPTION
No need to empty the queue at End Of Stream when devices do not
have any data inputs. We can simply switch to the "Idle" state and
hopefully not use any CPU.

Also, make sure we close all the writeable sockets pollers, as they will keep firing events given we are not writing anything. 