### PR TITLE
Extend detectors CTFHeader by format version and dict. timestamp

### DIFF
--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/CTF.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/CTF.h
@@ -28,13 +28,13 @@ namespace cpv
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers
   uint32_t nClusters = 0;  /// number of referred cells
   uint32_t firstOrbit = 0; /// orbit of 1st trigger
   uint16_t firstBC = 0;    /// bc of 1st trigger
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/DataFormats/Detectors/Common/CMakeLists.txt
+++ b/DataFormats/Detectors/Common/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(DetectorsCommonDataFormats
                        src/NameConf.cxx
                        src/EncodedBlocks.cxx
                        src/CTFHeader.cxx
+                       src/CTFDictHeader.cxx
                PUBLIC_LINK_LIBRARIES
                ROOT::Core
                ROOT::Geom
@@ -33,6 +34,7 @@ o2_target_root_dictionary(
           include/DetectorsCommonDataFormats/NameConf.h
           include/DetectorsCommonDataFormats/EncodedBlocks.h
           include/DetectorsCommonDataFormats/CTFHeader.h
+          include/DetectorsCommonDataFormats/CTFDictHeader.h
           include/DetectorsCommonDataFormats/DetMatrixCache.h)
 
 configure_file(UpgradesStatus.h.in

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFDictHeader.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFDictHeader.h
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CTFDictHeader.h
+/// \brief Header: timestamps and format version for detector CTF dictionary
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef _ALICEO2_CTFDICTHEADER_H
+#define _ALICEO2_CTFDICTHEADER_H
+
+#include <Rtypes.h>
+#include <string>
+
+namespace o2
+{
+namespace ctf
+{
+
+/// Detector header base
+struct CTFDictHeader {
+  uint32_t dictTimeStamp = 0; // dictionary creation time (seconds since epoch) / hash
+  uint8_t majorVersion = 1;
+  uint8_t minorVersion = 0;
+
+  bool isValidDictTimeStamp() const { return dictTimeStamp != 0; }
+  bool operator==(const CTFDictHeader& o) const
+  {
+    return dictTimeStamp == o.dictTimeStamp && majorVersion == o.majorVersion && minorVersion == o.minorVersion;
+  }
+  bool operator!=(const CTFDictHeader& o) const
+  {
+    return dictTimeStamp != o.dictTimeStamp || majorVersion != o.majorVersion || minorVersion != o.minorVersion;
+  }
+  std::string asString() const;
+
+  ClassDefNV(CTFDictHeader, 1);
+};
+
+} // namespace ctf
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -24,6 +24,7 @@
 #include "TTree.h"
 #include "CommonUtils/StringUtils.h"
 #include "Framework/Logger.h"
+#include "DetectorsCommonDataFormats/CTFDictHeader.h"
 
 namespace o2
 {

--- a/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
+++ b/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
@@ -1,0 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CTFDictHeader.cxx
+/// \brief Header: timestamps and format version for detector CTF dictionary
+/// \author ruben.shahoyan@cern.ch
+
+#include "DetectorsCommonDataFormats/CTFDictHeader.h"
+#include <ctime>
+#include <sstream>
+#include <iomanip>
+
+using namespace o2::ctf;
+
+std::string CTFDictHeader::asString() const
+{
+  std::time_t temp = dictTimeStamp;
+  std::tm* t = std::gmtime(&temp);
+  std::stringstream ss;
+  ss << "Dict. v" << int(majorVersion) << '.' << int(minorVersion) << " from " << std::put_time(t, "%Y-%m-%d %I:%M:%S %p");
+  return ss.str();
+}

--- a/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
@@ -31,6 +31,7 @@
 
 #pragma link C++ class o2::ctf::CTFHeader + ;
 #pragma link C++ class o2::ctf::Registry + ;
+#pragma link C++ class o2::ctf::CTFDictHeader + ;
 #pragma link C++ class o2::ctf::Block < uint32_t> + ;
 #pragma link C++ class o2::ctf::Block < uint16_t> + ;
 #pragma link C++ class o2::ctf::Block < uint8_t> + ;

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
@@ -28,13 +28,13 @@ namespace emcal
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers
   uint32_t nCells = 0;     /// number of referred cells
   uint32_t firstOrbit = 0; /// orbit of 1st trigger
   uint16_t firstBC = 0;    /// bc of 1st trigger
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/CTF.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/CTF.h
@@ -26,12 +26,12 @@ namespace fdd
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers in TF
   uint32_t firstOrbit = 0; /// 1st orbit of TF
   uint16_t firstBC = 0;    /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// Intermediate, compressed but not yet entropy-encoded digits

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/CTF.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/CTF.h
@@ -26,12 +26,12 @@ namespace ft0
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;     /// number of triggers in TF
   uint32_t firstOrbit = 0;    /// 1st orbit of TF
   uint16_t firstBC = 0;       /// 1st BC of TF
   uint16_t triggerGate = 192; // trigger gate used at encoding
-  ClassDefNV(CTFHeader, 2);
+  ClassDefNV(CTFHeader, 3);
 };
 
 /// Intermediate, compressed but not yet entropy-encoded digits

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/CTF.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/CTF.h
@@ -26,12 +26,12 @@ namespace fv0
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers in TF
   uint32_t firstOrbit = 0; /// 1st orbit of TF
   uint16_t firstBC = 0;    /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// Intermediate, compressed but not yet entropy-encoded digits

--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/CTF.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/CTF.h
@@ -26,13 +26,13 @@ namespace hmpid
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers
   uint32_t nDigits = 0;    /// number of digits
   uint32_t firstOrbit = 0; /// orbit of 1st trigger
   uint16_t firstBC = 0;    /// bc of 1st trigger
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CTF.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CTF.h
@@ -29,7 +29,7 @@ class ROFRecord;
 class CompClusterExt;
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nROFs = 0;         /// number of ROFrame in TF
   uint32_t nClusters = 0;     /// number of clusters in TF
   uint32_t nChips = 0;        /// number of fired chips in TF : this is for the version with chipInc stored once per new chip
@@ -37,7 +37,7 @@ struct CTFHeader {
   uint32_t firstOrbit = 0;    /// 1st orbit of TF
   uint16_t firstBC = 0;       /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// Compressed but not yet entropy-encoded clusters

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/CTF.h
@@ -27,13 +27,13 @@ namespace mch
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nROFs = 0;      /// number of ROFrames in TF
   uint32_t nDigits = 0;    /// number of digits in TF
   uint32_t firstOrbit = 0; /// 1st orbit of TF
   uint16_t firstBC = 0;    /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/CTF.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/CTF.h
@@ -28,13 +28,13 @@ namespace mid
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nROFs = 0;      /// number of ROFrames in TF
   uint32_t nColumns = 0;   /// number of referred columns in TF
   uint32_t firstOrbit = 0; /// 1st orbit of TF
   uint16_t firstBC = 0;    /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/CTF.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/CTF.h
@@ -28,13 +28,13 @@ namespace phos
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers
   uint32_t nCells = 0;     /// number of referred cells
   uint32_t firstOrbit = 0; /// orbit of 1st trigger
   uint16_t firstBC = 0;    /// bc of 1st trigger
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CTF.h
@@ -29,14 +29,14 @@ class ROFRecord;
 class CompClusterExt;
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nROFs = 0;         /// number of ROFrame in TF
   uint32_t nDigits = 0;       /// number of digits in TF
   uint32_t nPatternBytes = 0; /// number of bytes for explict patterns
   uint32_t firstOrbit = 0;    /// 1st orbit of TF
   uint16_t firstBC = 0;       /// 1st BC of TF
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// Compressed but not yet entropy-encoded infos

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CTF.h
@@ -24,11 +24,11 @@ namespace o2
 namespace tpc
 {
 
-struct CTFHeader : public CompressedClustersCounters {
+struct CTFHeader : public ctf::CTFDictHeader, public CompressedClustersCounters {
   enum : uint32_t { CombinedColumns = 0x1 };
   uint32_t flags = 0;
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CTF.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CTF.h
@@ -26,7 +26,7 @@ namespace trd
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;  /// number of triggers
   uint32_t nTracklets = 0; /// number of tracklets
   uint32_t nDigits = 0;    /// number of digits
@@ -34,7 +34,7 @@ struct CTFHeader {
   uint16_t firstBC = 0;    /// bc of 1st trigger
   uint16_t format = 0;     /// format word to be added to tracklet
 
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/CTF.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/CTF.h
@@ -29,7 +29,7 @@ namespace zdc
 {
 
 /// Header for a single CTF
-struct CTFHeader {
+struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t nTriggers = 0;                        /// number of triggers
   uint32_t nChannels = 0;                        /// number of referred channels
   uint32_t nEOData = 0;                          /// number of end-of-orbit data objects (pedestal + scalers)
@@ -37,7 +37,7 @@ struct CTFHeader {
   uint32_t firstOrbitEOData = 0;                 /// orbit of 1st end-of-orbit data
   uint16_t firstBC = 0;                          /// bc of 1st trigger
   std::array<uint16_t, NChannels> firstScaler{}; // inital scaler values
-  ClassDefNV(CTFHeader, 1);
+  ClassDefNV(CTFHeader, 2);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -61,8 +61,15 @@ std::unique_ptr<TFile> CTFCoderBase::loadDictionaryTreeFile(const std::string& d
     if (!mayFail) {
       throw std::runtime_error("did not find CTFHeader with needed detector");
     }
-  } else {
-    LOG(INFO) << "Found CTF dictionary for " << mDet.getName() << " in " << dictPath;
   }
   return fileDict;
+}
+
+void CTFCoderBase::checkDictVersion(const CTFDictHeader& h) const
+{
+  if (h.isValidDictTimeStamp()) { // external dictionary was used
+    if (h.isValidDictTimeStamp() && h != mExtHeader) {
+      throw std::runtime_error(fmt::format("Mismatch in {} CTF dictionary: need {}, provided {}", mDet.getName(), h.asString(), mExtHeader.asString()));
+    }
+  }
 }

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
@@ -80,6 +80,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -88,7 +89,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ENCODECPV(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
   ENCODECPV(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
   ENCODECPV(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
-  
+
   ENCODECPV(helper.begin_posX(),        helper.end_posX(),           CTF::BLC_posX,         0);
   ENCODECPV(helper.begin_posZ(),        helper.end_posZ(),           CTF::BLC_posZ,         0);
   ENCODECPV(helper.begin_energy(),      helper.end_energy(),         CTF::BLC_energy,       0);
@@ -102,6 +103,7 @@ template <typename VTRG, typename VCLUSTER>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, entries, posX, posZ;
   std::vector<uint32_t> orbitInc;

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFHelper.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFHelper.h
@@ -33,7 +33,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigData.size()), uint32_t(mCluData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigData.size()), uint32_t(mCluData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;
       h.firstBC = mTrigData[0].getBCData().bc;

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -80,6 +80,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -88,7 +89,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ENCODEEMC(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
   ENCODEEMC(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
   ENCODEEMC(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
-  
+
   ENCODEEMC(helper.begin_towerID(),     helper.end_towerID(),      CTF::BLC_towerID,     0);
   ENCODEEMC(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
   ENCODEEMC(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
@@ -101,7 +102,8 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
 template <typename VTRG, typename VCELL>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
 {
-  auto header = ec.getHeader();
+  const auto& header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, entries, energy, cellTime, tower;
   std::vector<uint32_t> orbitInc;

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -33,7 +33,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;
       h.firstBC = mTrigData[0].getBCData().bc;

--- a/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
+++ b/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
@@ -93,6 +93,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Digit>& digitVec, const g
   using ECB = CTF::base;
 
   ec->setHeader(cd.header);
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -117,11 +118,12 @@ void CTFCoder::decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec)
 {
   CompressedDigits cd;
   cd.header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cd.header));
   ec.print(getPrefix());
 #define DECODEFDD(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
   DECODEFDD(cd.trigger,   CTF::BLC_trigger);
-  DECODEFDD(cd.bcInc,     CTF::BLC_bcInc); 
+  DECODEFDD(cd.bcInc,     CTF::BLC_bcInc);
   DECODEFDD(cd.orbitInc,  CTF::BLC_orbitInc);
   DECODEFDD(cd.nChan,     CTF::BLC_nChan);
 

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
@@ -96,6 +96,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Digit>& digitVec, const g
   using ECB = CTF::base;
 
   ec->setHeader(cd.header);
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -120,6 +121,7 @@ void CTFCoder::decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec)
 {
   CompressedDigits cd;
   cd.header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cd.header));
   ec.print(getPrefix());
 #define DECODEFT0(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off

--- a/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
@@ -91,6 +91,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& digitVec, const 
   using ECB = CTF::base;
 
   ec->setHeader(cd.header);
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -113,10 +114,11 @@ void CTFCoder::decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec)
 {
   CompressedDigits cd;
   cd.header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cd.header));
   ec.print(getPrefix());
 #define DECODEFV0(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEFV0(cd.bcInc,     CTF::BLC_bcInc); 
+  DECODEFV0(cd.bcInc,     CTF::BLC_bcInc);
   DECODEFV0(cd.orbitInc,  CTF::BLC_orbitInc);
   DECODEFV0(cd.nChan,     CTF::BLC_nChan);
 

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
@@ -81,6 +81,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -89,7 +90,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const
   ENCODEHMP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
   ENCODEHMP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
   ENCODEHMP(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
-  
+
   ENCODEHMP(helper.begin_ChID(),         helper.end_ChID(),          CTF::BLC_ChID,         0);
   ENCODEHMP(helper.begin_Q(),            helper.end_Q(),             CTF::BLC_Q,            0);
   ENCODEHMP(helper.begin_Ph(),           helper.end_Ph(),            CTF::BLC_Ph,           0);
@@ -105,6 +106,7 @@ template <typename VTRG, typename VDIG>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, q;
   std::vector<uint32_t> orbitInc, entriesDig;

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
@@ -44,7 +44,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigRec.size()), uint32_t(mDigData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigRec.size()), uint32_t(mDigData.size()), 0, 0};
     if (mTrigRec.size()) {
       h.firstOrbit = mTrigRec[0].getOrbit();
       h.firstBC = mTrigRec[0].getBc();

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -93,6 +93,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, co
   using ECB = CTF::base;
 
   ec->setHeader(cc.header);
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -119,6 +120,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPA
 {
   CompressedClusters cc;
   cc.header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cc.header));
   ec.print(getPrefix());
 #define DECODEITSMFT(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
@@ -126,7 +128,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPA
   DECODEITSMFT(cc.bcIncROF,     CTF::BLCbcIncROF);
   DECODEITSMFT(cc.orbitIncROF,  CTF::BLCorbitIncROF);
   DECODEITSMFT(cc.nclusROF,     CTF::BLCnclusROF);
-  //    
+  //
   DECODEITSMFT(cc.chipInc,      CTF::BLCchipInc);
   DECODEITSMFT(cc.chipMul,      CTF::BLCchipMul);
   DECODEITSMFT(cc.row,          CTF::BLCrow);
@@ -187,7 +189,7 @@ void CTFCoder::decompress(const CompressedClusters& cc, VROF& rofRecVec, VCLUS& 
     }
     // << this is the version with chipInc stored once per new chip
 
-    /* 
+    /*
     // >> this is the version with chipInc stored for every pixel, requires entropy compression dealing with repeating symbols
     for (uint32_t icl = 0; icl < cc.nclusROF[irof]; icl++) {
     auto& clus = cclusVec[clCount];

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -83,6 +83,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, cons
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -107,6 +108,7 @@ template <typename VROF, typename VCOL>
 void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
 
   std::vector<uint16_t> bcInc, nSamples;

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -35,7 +35,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mDigData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mROFData.size()), uint32_t(mDigData.size()), 0, 0};
     if (mROFData.size()) {
       h.firstOrbit = mROFData[0].getBCData().orbit;
       h.firstBC = mROFData[0].getBCData().bc;

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -81,6 +81,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, cons
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -103,6 +104,7 @@ template <typename VROF, typename VCOL>
 void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& colVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, entries, pattern;
   std::vector<uint32_t> orbitInc;

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
@@ -35,7 +35,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mROFData.size()), uint32_t(mColData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mROFData.size()), uint32_t(mColData.size()), 0, 0};
     if (mROFData.size()) {
       h.firstOrbit = mROFData[0].interactionRecord.orbit;
       h.firstBC = mROFData[0].interactionRecord.bc;

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
@@ -80,6 +80,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -88,7 +89,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ENCODEPHS(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
   ENCODEPHS(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
   ENCODEPHS(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
-  
+
   ENCODEPHS(helper.begin_packedID(),    helper.end_packedID(),     CTF::BLC_packedID,    0);
   ENCODEPHS(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
   ENCODEPHS(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
@@ -101,7 +102,8 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
 template <typename VTRG, typename VCELL>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
 {
-  auto header = ec.getHeader();
+  const auto& header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, entries, energy, cellTime, packedID;
   std::vector<uint32_t> orbitInc;

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
@@ -33,7 +33,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;
       h.firstBC = mTrigData[0].getBCData().bc;

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -93,6 +93,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRe
   using ECB = CTF::base;
 
   ec->setHeader(cc.header);
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -121,6 +122,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT&
   CompressedInfos cc;
   ec.print(getPrefix());
   cc.header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cc.header));
 #define DECODETOF(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
   DECODETOF(cc.bcIncROF,     CTF::BLCbcIncROF);
@@ -128,7 +130,7 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT&
   DECODETOF(cc.ndigROF,      CTF::BLCndigROF);
   DECODETOF(cc.ndiaROF,      CTF::BLCndiaROF);
   DECODETOF(cc.ndiaCrate,    CTF::BLCndiaCrate);
-  
+
   DECODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc);
   DECODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc);
   DECODETOF(cc.stripID,      CTF::BLCstripID);

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -212,7 +212,9 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   if (mCombineColumns) {
     flags |= CTFHeader::CombinedColumns;
   }
-  ec->setHeader(CTFHeader{reinterpret_cast<const CompressedClustersCounters&>(ccl), flags});
+  ec->setHeader(CTFHeader{0, 1, 0, // dummy timestamp, version 1.0
+                          ccl, flags});
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
 
@@ -295,8 +297,9 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   CompressedClusters cc;
   CompressedClustersCounters& ccCount = cc;
   auto& header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   checkDataDictionaryConsistency(header);
-  ccCount = reinterpret_cast<const CompressedClustersCounters&>(header);
+  ccCount = static_cast<const CompressedClustersCounters&>(header);
   CompressedClustersFlat* ccFlat = nullptr;
   size_t sizeCFlatBody = alignSize(ccFlat);
   size_t sz = sizeCFlatBody + estimateSize(cc);                                             // total size of the buffVec accounting for the alignment

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -88,6 +88,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -120,6 +121,7 @@ template <typename VTRG, typename VTRK, typename VDIG>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcInc, HCIDTrk, posTrk, CIDDig, ADCDig;
   std::vector<uint32_t> orbitInc, entriesTrk, entriesDig, pidTrk;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -49,7 +49,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigRec.size()), uint32_t(mTrkData.size()), uint32_t(mDigData.size()), 0, 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigRec.size()), uint32_t(mTrkData.size()), uint32_t(mDigData.size()), 0, 0, 0};
     if (mTrigRec.size()) {
       h.firstOrbit = mTrigRec[0].getBCData().orbit;
       h.firstBC = mTrigRec[0].getBCData().bc;

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
@@ -87,6 +87,7 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& trigData, const 
   using ECB = CTF::base;
 
   ec->setHeader(helper.createHeader());
+  assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
@@ -116,6 +117,7 @@ template <typename VTRG, typename VCHAN, typename VPED>
 void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec)
 {
   auto header = ec.getHeader();
+  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix());
   std::vector<uint16_t> bcIncTrig, moduleTrig, nchanTrig, chanData, pedData, scalerInc, triggersHL, channelsHL;
   std::vector<uint32_t> orbitIncTrig, orbitIncEOD;

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFHelper.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFHelper.h
@@ -39,7 +39,8 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{uint32_t(mTrigData.size()), uint32_t(mChanData.size()), uint32_t(mEOData.size()), 0, 0, 0};
+    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+                uint32_t(mTrigData.size()), uint32_t(mChanData.size()), uint32_t(mEOData.size()), 0, 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].ir.orbit;
       h.firstBC = mTrigData[0].ir.bc;

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -131,6 +131,10 @@ if [ $ENABLE_GPU_TEST != "0" ]; then
   STAGES+=" WITHGPU"
 fi
 STAGES+=" ASYNC"
+
+# give a possibility to run the FST with external existing dictionary (i.e. with CREATECTFDICT=0 full_system_test.sh)
+[ ! -z "$CREATECTFDICT" ] && SYNCMODEDOCTFDICT="$CREATECTFDICT" || SYNCMODEDOCTFDICT=1
+
 for STAGE in $STAGES; do
   logfile=reco_${STAGE}.log
 
@@ -151,7 +155,7 @@ for STAGE in $STAGES; do
     export CTFINPUT=1
     export SAVECTF=0
   else
-    export CREATECTFDICT=1
+    export CREATECTFDICT=$SYNCMODEDOCTFDICT
     export GPUTYPE=CPU
     export SYNCMODE=1
     export HOSTMEMSIZE=$TPCTRACKERSCRATCHMEMORY


### PR DESCRIPTION
Every external dictionary will store in the `CTFHeader::CTFDictHeader` the format version and its creation time. When encoding with such dictionary the CTFDictHeader will be assigned to CTF detector header, when decoding: throw exception if the dictionary CTFDictHeader does not match to that of the CTF header.
