### PR TITLE
Adapt to new namespaced fairmq types

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -48,7 +48,7 @@ namespace o2
 namespace pmr
 {
 
-using FairMQMemoryResource = fair::mq::FairMQMemoryResource;
+using FairMQMemoryResource = fair::mq::MemoryResource;
 using ChannelResource = fair::mq::ChannelResource;
 using namespace fair::mq::pmr;
 

--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -36,8 +36,13 @@
 #include <unistd.h>
 #include <cassert>
 
-class FairMQParts;
-class FairMQChannel;
+namespace fair::mq
+{
+class Parts;
+class Channel;
+}
+using FairMQParts = fair::mq::Parts;
+using FairMQChannel = fair::mq::Channel;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -18,7 +18,11 @@
 #include <string>
 #include <vector>
 
-class FairMQMessage;
+namespace fair::mq
+{
+class Message;
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -15,7 +15,11 @@
 #include "Framework/ServiceHandle.h"
 #include <tuple>
 
-class FairMQRegionInfo;
+namespace fair::mq
+{
+class RegionInfo;
+}
+using FairMQRegionInfo = fair::mq::RegionInfo;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -14,7 +14,11 @@
 #include <string>
 #include <FairMQParts.h>
 
-class FairMQChannel;
+namespace fair::mq
+{
+class Channel;
+}
+using FairMQChannel = fair::mq::Channel;
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -41,8 +41,13 @@
 #include <cstddef>
 
 // Do not change this for a full inclusion of FairMQDevice.
-class FairMQDevice;
-class FairMQMessage;
+namespace fair::mq
+{
+class Device;
+class Message;
+}
+using FairMQDevice = fair::mq::Device;
+using FairMQMessage = fair::mq::Message;
 
 namespace arrow
 {

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -11,8 +11,13 @@
 #ifndef O2_FRAMEWORK_DATAPROCESSOR_H_
 #define O2_FRAMEWORK_DATAPROCESSOR_H_
 
-class FairMQDevice;
-class FairMQParts;
+namespace fair::mq
+{
+class Device;
+class Parts;
+}
+using FairMQDevice = fair::mq::Device;
+using FairMQParts = fair::mq::Parts;
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -24,7 +24,11 @@
 #include <mutex>
 #include <vector>
 
-class FairMQMessage;
+namespace fair::mq
+{
+class Message;
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2::monitoring
 {

--- a/Framework/Core/include/Framework/DispatchControl.h
+++ b/Framework/Core/include/Framework/DispatchControl.h
@@ -15,7 +15,11 @@
 #include <functional>
 #include <string>
 
-class FairMQParts;
+namespace fair::mq
+{
+class Parts;
+}
+using FairMQParts = fair::mq::Parts;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -13,9 +13,18 @@
 
 #include <memory>
 
-class FairMQDevice;
-class FairMQMessage;
-class FairMQTransportFactory;
+namespace fair
+{
+namespace mq
+{
+class Device;
+class Message;
+class TransportFactory;
+}
+}
+using FairMQDevice = fair::mq::Device;
+using FairMQMessage = fair::mq::Message;
+using FairMQTransportFactory = fair::mq::TransportFactory;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -32,7 +32,11 @@
 #include <memory>
 #include <type_traits>
 
-class FairMQMessage;
+namespace fair::mq
+{
+class Message;
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -30,7 +30,11 @@
 #include <unordered_map>
 #include <vector>
 
-class FairMQDevice;
+namespace fair::mq
+{
+class Device;
+}
+using FairMQDevice = fair::mq::Device;
 
 namespace o2
 {
@@ -152,7 +156,7 @@ class MessageContext
   class AlignedMemoryResource : public pmr::FairMQMemoryResource
   {
    public:
-    AlignedMemoryResource(fair::mq::FairMQMemoryResource* other)
+    AlignedMemoryResource(fair::mq::MemoryResource* other)
       : mUpstream(other)
     {
     }
@@ -203,7 +207,7 @@ class MessageContext
     }
 
    private:
-    fair::mq::FairMQMemoryResource* mUpstream = nullptr;
+    fair::mq::MemoryResource* mUpstream = nullptr;
   };
 
   /// ContainerRefObject handles a message object holding an instance of type T

--- a/Framework/Core/include/Framework/PartRef.h
+++ b/Framework/Core/include/Framework/PartRef.h
@@ -13,7 +13,11 @@
 
 #include <memory>
 
-class FairMQMessage;
+namespace fair::mq
+{
+class Message;
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -18,7 +18,14 @@
 #include <string>
 #include <memory>
 
-class FairMQMessage;
+namespace fair
+{
+namespace mq
+{
+class Message;
+}
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/RawDeviceService.h
+++ b/Framework/Core/include/Framework/RawDeviceService.h
@@ -13,7 +13,11 @@
 
 #include "Framework/ServiceHandle.h"
 
-class FairMQDevice;
+namespace fair::mq
+{
+class Device;
+}
+using FairMQDevice = fair::mq::Device;
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -16,7 +16,14 @@
 #include <string>
 #include <memory>
 
-class FairMQMessage;
+namespace fair
+{
+namespace mq
+{
+class Message;
+}
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2::framework
 {

--- a/Framework/Core/src/DataProcessingHelpers.h
+++ b/Framework/Core/src/DataProcessingHelpers.h
@@ -11,7 +11,11 @@
 #ifndef O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
 #define O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
 
-class FairMQDevice;
+namespace fair::mq
+{
+class Device;
+}
+using FairMQDevice = fair::mq::Device;
 
 namespace o2::framework
 {

--- a/Framework/Core/src/FairMQResizableBuffer.h
+++ b/Framework/Core/src/FairMQResizableBuffer.h
@@ -16,7 +16,11 @@
 #include <functional>
 #include <arrow/buffer.h>
 
-class FairMQMessage;
+namespace fair::mq
+{
+class Message;
+}
+using FairMQMessage = fair::mq::Message;
 
 namespace o2
 {

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -23,8 +23,13 @@
 #include <FairRootManager.h>
 #include <FairDetector.h>
 
-class FairMQParts;
-class FairMQChannel;
+namespace fair::mq
+{
+class Parts;
+class Channel;
+}
+using FairMQParts = fair::mq::Parts;
+using FairMQChannel = fair::mq::Channel;
 
 namespace o2
 {

--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -25,7 +25,11 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/Task.h"
 
-class FairMQDevice;
+namespace fair::mq
+{
+class Device;
+}
+using FairMQDevice = fair::mq::Device;
 
 namespace o2::monitoring
 {


### PR DESCRIPTION
@rbx @dennisklein : I have been working to compile O2 with the latest FairMQ, to test with my patch for the mlocking.
That required several other updates / fixes:
- The fairMQ types are now non-napespaced, so all the forward declarations are wrong. This is fixed in this PR for O2. I don't know how we are supposed to merge this. Can we do it incrementally with a green CI? Might be complicated. Or we have to force merge this together with the alidist bump.
- I have checked that fortunately no such changes are needed for QC.
- However DataDistribution needs a similar patch (ping @ironMann) : [dadadistribution.patch.gz](https://github.com/AliceO2Group/AliceO2/files/6831437/dadadistribution.patch.gz)
- I needed to bump FairROOT to 18.6.3, asiofi to 0.5.1 and asio to 1.19.1 in alidist, and make asio a dependency of asiofi.
- FairROOT didn't compile because `fairmq/Socket.h` was not installed by FairMQ, should this file just be installed or will this be fixed somehow else.
With all this together, O2 and DataDistribution compile on the EPN with the latest FairMQ and seem to work.