### PR TITLE
Use `<fairmq/FwdDecls.h>` instead of downstream forward declarations

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -36,8 +36,7 @@
 #include <unistd.h>
 #include <cassert>
 
-class FairMQParts;
-class FairMQChannel;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -15,7 +15,7 @@
 #include "Framework/ServiceHandle.h"
 #include <tuple>
 
-class FairMQRegionInfo;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <FairMQParts.h>
 
-class FairMQChannel;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -41,8 +41,7 @@
 #include <cstddef>
 
 // Do not change this for a full inclusion of FairMQDevice.
-class FairMQDevice;
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace arrow
 {

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -11,8 +11,7 @@
 #ifndef O2_FRAMEWORK_DATAPROCESSOR_H_
 #define O2_FRAMEWORK_DATAPROCESSOR_H_
 
-class FairMQDevice;
-class FairMQParts;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -24,7 +24,7 @@
 #include <mutex>
 #include <vector>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::monitoring
 {

--- a/Framework/Core/include/Framework/DispatchControl.h
+++ b/Framework/Core/include/Framework/DispatchControl.h
@@ -15,7 +15,7 @@
 #include <functional>
 #include <string>
 
-class FairMQParts;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -13,9 +13,7 @@
 
 #include <memory>
 
-class FairMQDevice;
-class FairMQMessage;
-class FairMQTransportFactory;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -32,7 +32,7 @@
 #include <memory>
 #include <type_traits>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -30,7 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
-class FairMQDevice;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/PartRef.h
+++ b/Framework/Core/include/Framework/PartRef.h
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <memory>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/RawDeviceService.h
+++ b/Framework/Core/include/Framework/RawDeviceService.h
@@ -13,7 +13,7 @@
 
 #include "Framework/ServiceHandle.h"
 
-class FairMQDevice;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <memory>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/src/DataProcessingHelpers.h
+++ b/Framework/Core/src/DataProcessingHelpers.h
@@ -11,7 +11,7 @@
 #ifndef O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
 #define O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
 
-class FairMQDevice;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::framework
 {

--- a/Framework/Core/src/FairMQResizableBuffer.h
+++ b/Framework/Core/src/FairMQResizableBuffer.h
@@ -16,7 +16,7 @@
 #include <functional>
 #include <arrow/buffer.h>
 
-class FairMQMessage;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -23,8 +23,7 @@
 #include <FairRootManager.h>
 #include <FairDetector.h>
 
-class FairMQParts;
-class FairMQChannel;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {

--- a/Utilities/DataSampling/include/DataSampling/Dispatcher.h
+++ b/Utilities/DataSampling/include/DataSampling/Dispatcher.h
@@ -25,7 +25,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/Task.h"
 
-class FairMQDevice;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::monitoring
 {


### PR DESCRIPTION
This makes the forward declaration techniques more future-proof towards
renamed typenames in FairMQ, e.g. if forward declared types become a
type alias.

`<fairmq/FwdDecls.h>` is available since FairMQ `v1.4.39`.

---

* This PR supersedes #6657.
* FairMQ bump is proposed in alisw/alidist#3168.