### PR TITLE
Remove leftover count increment

### DIFF
--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -243,11 +243,8 @@ std::vector<Digit>& EventStorage::getDigits(InteractionRecord& ir)
 
 void EventStorage::printIR()
 {
-  std::string records;
-  int count = 0;
   for (int count = 0; count < mEventRecords.size(); ++count) {
     LOG(info) << "[" << count << "]" << mEventRecords[count].getBCData() << " ";
-    count++;
   }
 }
 


### PR DESCRIPTION
Looks like it was forgotten when the code switched from range-based for loops b1d7bff365b78cbde6b087376b7704f3d9d6e744
std::string records; seems to have never been used