### PR TITLE
MatchTPCITS: fix leftover declaration of variable

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -891,7 +891,7 @@ void MatchTPCITS::doMatching(int sec)
     // estimate ITS 1st ROframe bin this track may match to: TPC track are sorted according to their
     // timeMax, hence the timeMax - MaxmNTPCBinsFullDrift are non-decreasing
     auto tmn = trefTPC.tBracket.getMax() - maxTDriftSafe;
-    int itsROBin = mITSTriggered ? time2ITSROFrameTrig(tmn, itsROBin) : time2ITSROFrameCont(tmn);
+    itsROBin = mITSTriggered ? time2ITSROFrameTrig(tmn, itsROBin) : time2ITSROFrameCont(tmn);
 
     if (itsROBin >= int(timeStartITS.size())) { // time of TPC track exceeds the max time of ITS in the cache
       break;


### PR DESCRIPTION
See [dc091dba2e910273d38d0a4dac48963b427f2adf](https://github.com/AliceO2Group/AliceO2/commit/dc091dba2e910273d38d0a4dac48963b427f2adf#diff-8c62d5a75a9feda276cb54c4b14c362ebf2abfb202303179ea94c87b473a5ac7R888-R894) which tried to move the declaration of itsROBin out of the loop