### PR TITLE
Fix invalid iterator use UB

### DIFF
--- a/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Digitizer.cxx
@@ -206,7 +206,8 @@ void Digitizer::flush(std::vector<o2::fv0::BCData>& digitsBC,
                       std::vector<o2::fv0::DetTrigInput>& digitsTrig,
                       o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>& labels)
 {
-  for (auto const& bc : mCache) {
+  while (!mCache.empty()) {
+    auto const& bc = mCache.front();
     if (mIntRecord.differenceInBC(bc) > NBC2Cache) { // Build events that are separated by NBC2Cache BCs from current BC
       storeBC(bc, digitsBC, digitsCh, digitsTrig, labels);
       mCache.pop_front();


### PR DESCRIPTION
`mCache.pop_front()` invalidates iterators to the first element. Here, the current loop iterator value is always¹ iterator to the first element, so, in loop exit condition comparison against past-the-end iterator, the loop iterator will be invalid. Using invalid iterators in comparison may have undefined behavior.

---
1) Before invalidation