### PR TITLE
TRD raw reader can dump to file

### DIFF
--- a/Detectors/TRD/reconstruction/CMakeLists.txt
+++ b/Detectors/TRD/reconstruction/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(TRDReconstruction
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsTPC
+                                     O2::TRDWorkflowIO
                                      O2::ReconstructionDataFormats
                                      O2::DetectorsRaw
                                      O2::rANS

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -22,6 +22,8 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/Logger.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
+#include "TRDWorkflowIO/TRDDigitWriterSpec.h"
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -36,6 +38,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"trd-datareader-compresseddata", VariantType::Bool, false, {"The incoming data is compressed or not"}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"trd-datareader-fixdigitcorruptdata", VariantType::Bool, false, {"Fix the erroneous data at the end of digits"}},
+    {"enable-root-output", VariantType::Bool, false, {"Write the data to file"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -89,6 +92,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     outputs,
     algoSpec,
     Options{}});
+
+  if (cfgc.options().get<bool>("enable-root-output")) {
+    workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));
+    workflow.emplace_back(o2::trd::getTRDTrackletWriterSpec(false));
+  }
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, workflow);

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDDigitWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDDigitWriterSpec.h
@@ -22,7 +22,7 @@ struct DataProcessorSpec;
 namespace trd
 {
 
-o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth = true);
+o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth = true, bool writeTrigRec = true);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
@@ -29,7 +29,7 @@ namespace trd
 template <typename T>
 using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth)
+o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth, bool writeTrigRec)
 {
   using InputSpec = framework::InputSpec;
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
@@ -75,7 +75,7 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth)
                                 // setting a custom callback for closing the writer
                                 MakeRootTreeWriterSpec::CustomClose(finishWriting),
                                 BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS"}, "TRDDigit"},
-                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord"},
+                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord", (writeTrigRec ? 1 : 0)},
                                 std::move(labelsdef))();
 }
 


### PR DESCRIPTION
It is an option which can be enabled to directly compare the tracklets/digits read from raw files with the ones that come from the simulation. Can help to debug MC->raw conversion.
The trigger records will only be added to trdtracklets.root and not to trddigits.root file, because we have different data descriptions for the trigger records associated with the digits (`TRGRDIG`) and the tracklets (`TRKTRGRD`), although the data type is the same (`o2::trd::TriggerRecord`). This is needed, because the trigger records are both an input and an output for the TRAP simulation. And since the input cannot be changed we have to create a new message and that needs a new description.