### PR TITLE
AO2D: extend writing of tracks and particles

### DIFF
--- a/Analysis/Tasks/PID/qaTOFMC.cxx
+++ b/Analysis/Tasks/PID/qaTOFMC.cxx
@@ -61,7 +61,7 @@ struct pidTOFTaskQA {
                                                         "nsigmaMCprm/Ka", "nsigmaMCprm/Pr", "nsigmaMCprm/De",
                                                         "nsigmaMCprm/Tr", "nsigmaMCprm/He", "nsigmaMCprm/Al"};
   static constexpr const char* pT[Np] = {"e", "#mu", "#pi", "K", "p", "d", "t", "^{3}He", "#alpha"};
-  static constexpr int PDGs[Np] = {11, 13, 211, 321, 2212, 1, 1, 1, 1};
+  static constexpr int PDGs[Np] = {11, 13, 211, 321, 2212, 1000010020, 1000010030, 1000020030};
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::QAObject};
 
   Configurable<int> nBinsP{"nBinsP", 400, "Number of bins for the momentum"};

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -405,8 +405,8 @@ void AODProducerWorkflowDPL::fillMCParticlesTable(o2::steer::MCKinematicsReader&
         const float eta = 0.5f * TMath::Log((mom + pZ) / (mom - pZ));
         if (TMath::Abs(eta) > 0.9) {
           if (TMath::Abs((mom - pZ) / pZ) <= limit) {
-            pX = truncateFloatFraction(TMath::Sqrt((1.f + limit) * (1.f + limit) - 1.f) * pZ * 0.5, mMcParticleMom);
-            pY = truncateFloatFraction(TMath::Sqrt((1.f + limit) * (1.f + limit) - 1.f) * pZ * 0.5, mMcParticleMom);
+            pX = truncateFloatFraction(TMath::Sqrt((1.f + limit) * (1.f + limit) - 1.f) * pZ * 0.70710678, mMcParticleMom);
+            pY = truncateFloatFraction(TMath::Sqrt((1.f + limit) * (1.f + limit) - 1.f) * pZ * 0.70710678, mMcParticleMom);
           }
           if (TMath::Abs(energy - pZ) < limit) {
             energy = truncateFloatFraction(pZ + limit, mMcParticleMom);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -254,7 +254,7 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
             }
             const float mass = o2::constants::physics::MassPionCharged; // default pid = pion
             if (tofInt.getTOF(o2::track::PID::Pion) > 0.f) {
-              const float expBeta = (intLen / tofInt.getTOF(o2::track::PID::Pion) / cSpeed);
+              const float expBeta = (intLen / (tofInt.getTOF(o2::track::PID::Pion) * cSpeed));
               extraInfoHolder.tofExpMom = mass * expBeta / std::sqrt(1.f - expBeta * expBeta);
             }
           }

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -249,16 +249,14 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
             const auto& tofInt = tofMatch.getLTIntegralOut();
             float intLen = tofInt.getL();
             extraInfoHolder.length = intLen;
-            extraInfoHolder.tofSignal = tofMatch.getSignal();
-            float mass = o2::constants::physics::MassPionCharged; // default pid = pion
-            float expSig = tofInt.getTOF(o2::track::PID::Pion);
-            float expMom = 0.f;
-            if (expSig > 0 && interactionTime > 0) {
-              float tof = expSig - interactionTime;
-              float expBeta = (intLen / tof / cSpeed);
-              expMom = mass * expBeta / std::sqrt(1.f - expBeta * expBeta);
+            if (interactionTime > 0) {
+              extraInfoHolder.tofSignal = static_cast<float>(tofMatch.getSignal() - interactionTime);
             }
-            extraInfoHolder.tofExpMom = expMom;
+            const float mass = o2::constants::physics::MassPionCharged; // default pid = pion
+            if (tofInt.getTOF(o2::track::PID::Pion) > 0.f) {
+              const float expBeta = (intLen / tofInt.getTOF(o2::track::PID::Pion) / cSpeed);
+              extraInfoHolder.tofExpMom = mass * expBeta / std::sqrt(1.f - expBeta * expBeta);
+            }
           }
           if (src == GIndex::Source::TPCTRD || src == GIndex::Source::ITSTPCTRD) {
             const auto& trdOrig = data.getTrack<o2::trd::TrackTRD>(src, contributorsGID[src].getIndex());

--- a/Detectors/TOF/reconstruction/CMakeLists.txt
+++ b/Detectors/TOF/reconstruction/CMakeLists.txt
@@ -15,20 +15,22 @@ o2_add_library(TOFReconstruction
                	       src/DecoderBase.cxx
                        src/Decoder.cxx
                        src/CTFCoder.cxx
+                       src/EventTimeMaker.cxx
                        src/CosmicProcessor.cxx
                PUBLIC_LINK_LIBRARIES O2::TOFBase O2::DataFormatsTOF
                                      O2::SimulationDataFormat
                                      O2::CommonDataFormat
                                      O2::DataFormatsTOF
                                      O2::rANS O2::DPLUtils
-				     O2::TOFCalibration O2::DetectorsRaw)
+                                     O2::TOFCalibration O2::DetectorsRaw)
 
 o2_target_root_dictionary(TOFReconstruction
                           HEADERS include/TOFReconstruction/DataReader.h
                                   include/TOFReconstruction/Clusterer.h
                                   include/TOFReconstruction/ClustererTask.h
                                   include/TOFReconstruction/Encoder.h
-               			  include/TOFReconstruction/DecoderBase.h
+                                  include/TOFReconstruction/DecoderBase.h
                                   include/TOFReconstruction/Decoder.h
                                   include/TOFReconstruction/CTFCoder.h
+                                  include/TOFReconstruction/EventTimeMaker.h
                                   include/TOFReconstruction/CosmicProcessor.h)

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/EventTimeMaker.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/EventTimeMaker.h
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file EventTimeMaker.h
+/// \brief Definition of the TOF event time maker
+
+#ifndef ALICEO2_TOF_EVENTTIMEMAKER_H
+#define ALICEO2_TOF_EVENTTIMEMAKER_H
+
+namespace o2
+{
+
+namespace tof
+{
+
+struct eventTimeContainer {
+  eventTimeContainer(const float& e) : eventTime{e} {};
+  float eventTime = 0.f;
+};
+
+template <typename tTracks>
+eventTimeContainer evTimeMaker(const tTracks& tracks)
+{
+  for (auto track : tracks) {
+    track.tofSignal();
+  }
+  return eventTimeContainer{0};
+}
+
+} // namespace tof
+} // namespace o2
+
+#endif /* ALICEO2_TOF_EVENTTIMEMAKER_H */

--- a/Detectors/TOF/reconstruction/src/EventTimeMaker.cxx
+++ b/Detectors/TOF/reconstruction/src/EventTimeMaker.cxx
@@ -1,0 +1,24 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file EventTimeMaker.cxx
+/// \brief Implementation of the TOF event time maker
+
+#include "TOFReconstruction/EventTimeMaker.h"
+
+namespace o2
+{
+
+namespace tof
+{
+
+} // namespace tof
+} // namespace o2


### PR DESCRIPTION
- Introduce hack to allow using expression columns for eta and y
- Fix TOF information writing
- Minor addition to analysis code
- Add dummy class for event time determination from TOF (to be used in the TOF PID Response)