### PR TITLE
Added option for MFT standalone tracking to use a cone for the LTF an…

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -60,6 +60,10 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t LTFinterBinWin = 3;
   /// Special version for TED shots and cosmics, with full scan of the clusters
   bool FullClusterScan = false;
+  /// road for LTF algo : cylinder or cone (default)
+  Bool_t LTFConeRadius = kFALSE;
+  /// road for CA algo : cylinder or cone (default)
+  Bool_t CAConeRadius = kFALSE;
 
   O2ParamDef(MFTTrackingParam, "MFTTracking");
 };

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
@@ -54,6 +54,8 @@ class TrackerConfig
   Float_t mPhiBinSize = constants::index_table::PhiMax / 50.;
   Float_t mInverseRBinSize = 50. / (constants::index_table::RMax - constants::index_table::RMin);
   Float_t mInversePhiBinSize = 50. / constants::index_table::PhiMax;
+  Bool_t mLTFConeRadius = kFALSE;
+  Bool_t mCAConeRadius = kFALSE;
 
  private:
   ClassDefNV(TrackerConfig, 1);

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -59,6 +59,8 @@ void Tracker::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
   mROADclsR2Cut = mROADclsRCut * mROADclsRCut;
   mLTFseed2BinWin = trkParam.LTFseed2BinWin;
   mLTFinterBinWin = trkParam.LTFinterBinWin;
+  mLTFConeRadius = trkParam.LTFConeRadius;
+  mCAConeRadius = trkParam.CAConeRadius;
 
   mRBins = trkParam.RBins;
   mPhiBins = trkParam.PhiBins;
@@ -219,6 +221,7 @@ void Tracker::findTracksLTF(ROframe& event)
   Int_t binR_proj, binPhi_proj, bin;
   Int_t binIndex, clsMinIndex, clsMaxIndex, clsMinIndexS, clsMaxIndexS;
   Int_t extClsIndex;
+  Float_t dz = 0., dRCone = 1.;
   Float_t dR2, dR2min, dR2cut = mLTFclsR2Cut;
   Bool_t hasDisk[constants::mft::DisksNumber], newPoint;
 
@@ -276,8 +279,12 @@ void Tracker::findTracksLTF(ROframe& event)
 
             newPoint = kTRUE;
 
+            //check if road is a cylinder or a cone
+            dz = constants::mft::LayerZCoordinate()[layer2] - constants::mft::LayerZCoordinate()[layer1];
+            dRCone = 1 + dz * constants::mft::InverseLayerZCoordinate()[layer1];
+
             // loop over the bins in the search window
-            dR2min = dR2cut;
+            dR2min = mLTFConeRadius ? dR2cut * dRCone * dRCone : dR2cut;
             for (auto& bin : mBins[layer1][layer - 1][cluster1.indexTableBin]) {
 
               getBinClusterRange(event, layer, bin, clsMinIndex, clsMaxIndex);
@@ -502,7 +509,8 @@ void Tracker::findTracksCA(ROframe& event)
   Int_t roadId, nPointDisks;
   Int_t binR_proj, binPhi_proj, bin;
   Int_t binIndex, clsMinIndex, clsMaxIndex, clsMinIndexS, clsMaxIndexS;
-  Float_t dR2, dR2cut = mROADclsR2Cut;
+  Float_t dz = 0., dRCone = 1.;
+  Float_t dR2, dR2min, dR2cut = mROADclsR2Cut;
   Bool_t hasDisk[constants::mft::DisksNumber];
 
   Int_t clsInLayer1, clsInLayer2, clsInLayer;
@@ -543,6 +551,12 @@ void Tracker::findTracksCA(ROframe& event)
 
             for (Int_t layer = (layer1 + 1); layer <= (layer2 - 1); ++layer) {
 
+              //check if road is a cylinder or a cone
+              dz = constants::mft::LayerZCoordinate()[layer2] - constants::mft::LayerZCoordinate()[layer1];
+              dRCone = 1 + dz * constants::mft::InverseLayerZCoordinate()[layer1];
+
+              dR2min = mLTFConeRadius ? dR2cut * dRCone * dRCone : dR2cut;
+
               // loop over the bins in the search window
               for (auto& bin : mBins[layer1][layer - 1][cluster1.indexTableBin]) {
 
@@ -557,7 +571,7 @@ void Tracker::findTracksCA(ROframe& event)
 
                   dR2 = getDistanceToSeed(cluster1, cluster2, cluster);
                   // add all points within a radius dR2cut
-                  if (dR2 >= dR2cut) {
+                  if (dR2 >= dR2min) {
                     continue;
                   }
 


### PR DESCRIPTION
Added an option for the MFT standalone tracking to use a cone for track finding in the LTF and CA algos. Default is the previous cylinder option.