### PR TITLE
TPC: Update laser track drift velocity calibration

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibRawBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibRawBase.h
@@ -453,7 +453,7 @@ inline CalibRawBase::ProcessStatus CalibRawBase::processEventRawReaderCRU(int ev
       return ProcessStatus::NoMoreData;
     } else if (!isPresentEventComplete()) {
       status = ProcessStatus::IncompleteEvent;
-    } else if (mPresentEventNumber == size_t(lastEvent)) {
+    } else if (mPresentEventNumber >= size_t(lastEvent)) {
       status = ProcessStatus::LastEvent;
     }
 
@@ -461,7 +461,7 @@ inline CalibRawBase::ProcessStatus CalibRawBase::processEventRawReaderCRU(int ev
     ++mNevents;
   } else {
     status = ProcessStatus::IncompleteEvent;
-    if (mPresentEventNumber == size_t(lastEvent)) {
+    if (mPresentEventNumber >= size_t(lastEvent)) {
       status = ProcessStatus::LastEvent;
     }
   }

--- a/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
@@ -34,16 +34,20 @@ class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<TrackT
   LaserTracksCalibrator(size_t minEntries) : mMinEntries(minEntries) {}
   ~LaserTracksCalibrator() final = default;
 
-  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->getMatchedPairs() >= mMinEntries; }
+  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->hasEnoughData(mMinEntries); }
   void initOutput() final;
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
 
-  const auto& getDVperSlot() { return mDVperSlot; }
+  const auto& getCalibPerSlot() { return mCalibPerSlot; }
+
+  void setWriteDebug(bool debug = true) { mWriteDebug = debug; }
+  bool getWriteDebug() const { return mWriteDebug; }
 
  private:
-  size_t mMinEntries = 100;
-  std::vector<TimePair> mDVperSlot; ///< drift velocity per slot
+  size_t mMinEntries = 100;                ///< laser tracks of these amount of time frames
+  std::vector<LtrCalibData> mCalibPerSlot; ///< drift velocity per slot
+  bool mWriteDebug = false;                ///< if to save debug trees
 
   ClassDefOverride(LaserTracksCalibrator, 1);
 };

--- a/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
+++ b/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
@@ -12,6 +12,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <string>
 #include <string_view>
+#include <fmt/format.h>
 
 #include "TROOT.h"
 #include "TMath.h"
@@ -68,6 +69,10 @@ TObjArray* drawNoiseAndPedestal(std::string_view pedestalFile, int mode = 0, std
     gROOT->cd();
     f.GetObject("Pedestals", calPedestal);
     f.GetObject("Noise", calNoise);
+    if (!calNoise) {
+      calNoise = new CalDet<float>("Noise");
+      fmt::print("Noise object not found in file {}, creating a dummy object\n", pedestalFile);
+    }
   }
 
   // mode 1 handling

--- a/Detectors/TPC/calibration/macro/drawPulser.C
+++ b/Detectors/TPC/calibration/macro/drawPulser.C
@@ -94,15 +94,15 @@ TObjArray* drawPulser(TString pulserFile, int mode = 0, std::string_view outDir 
     }
 
     if (type == 1) {
-      tMin = 425.f;
-      tMax = 485.f;
+      tMin = 490.f;
+      tMax = 510.f;
       wMin = 0.6;
       wMax = 0.8;
       qMin = 5.f;
       qMax = 500.f;
     }
 
-    auto arrT0 = painter::makeSummaryCanvases(*calT0, 100, tMin, tMax);
+    auto arrT0 = painter::makeSummaryCanvases(*calT0, 300, tMin, tMax);
     auto arrWidth = painter::makeSummaryCanvases(*calWidth, 100, wMin, wMax);
     auto arrQtot = painter::makeSummaryCanvases(*calQtot, 100, qMin, qMax);
 

--- a/Detectors/TPC/calibration/macro/dumpDigits.C
+++ b/Detectors/TPC/calibration/macro/dumpDigits.C
@@ -32,6 +32,7 @@ void dumpDigits(std::vector<std::string_view> fileInfos, TString outputFileName 
   dig.setTimeBinRange(firstTimeBin, lastTimeBin);
   dig.setNoiseThreshold(noiseThreshold);
   dig.setSkipIncompleteEvents(false);
+  dig.checkDuplicates(true);
 
   CalibRawBase::ProcessStatus status = CalibRawBase::ProcessStatus::Ok;
   for (const auto& fileInfo : fileInfos) {

--- a/Detectors/TPC/calibration/src/DigitDump.cxx
+++ b/Detectors/TPC/calibration/src/DigitDump.cxx
@@ -186,6 +186,9 @@ void DigitDump::checkDuplicates(bool removeDuplicates)
 
   for (size_t iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
     auto& digits = mDigits[iSec];
+    if (!digits.size()) {
+      continue;
+    }
 
     size_t nDuplicates = 0;
     if (removeDuplicates) {

--- a/Detectors/TPC/calibration/src/LaserTracksCalibrator.cxx
+++ b/Detectors/TPC/calibration/src/LaserTracksCalibrator.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "Framework/Logger.h"
+#include <fmt/format.h>
 
 #include "TPCCalibration/LaserTracksCalibrator.h"
 
@@ -17,7 +17,7 @@ using namespace o2::tpc;
 
 void LaserTracksCalibrator::initOutput()
 {
-  mDVperSlot.clear();
+  mCalibPerSlot.clear();
 }
 
 //______________________________________________________________________________
@@ -27,7 +27,7 @@ void LaserTracksCalibrator::finalizeSlot(Slot& slot)
   calibLaser.finalize();
   calibLaser.print();
 
-  mDVperSlot.emplace_back(calibLaser.getDVall());
+  mCalibPerSlot.emplace_back(calibLaser.getCalibData());
 }
 
 //______________________________________________________________________________
@@ -36,5 +36,13 @@ LaserTracksCalibrator::Slot& LaserTracksCalibrator::emplaceNewSlot(bool front, T
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
   slot.setContainer(std::make_unique<CalibLaserTracks>());
+  auto& calibLaser = *slot.getContainer();
+  //calibLaser.setTFtimes(tstart, tend);
+
+  if (mWriteDebug) {
+    calibLaser.setWriteDebugTree(mWriteDebug);
+    calibLaser.setDebugOutputName(fmt::format("CalibLaserTracks_debug_{}_{}.root", tstart, tend));
+  }
+
   return slot;
 }

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -34,7 +34,9 @@
 #pragma link C++ class o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks> +;
 #pragma link C++ class o2::calibration::TimeSlotCalibration<o2::tpc::TrackTPC, o2::tpc::CalibLaserTracks> +;
 #pragma link C++ class o2::tpc::TimePair +;
+#pragma link C++ class o2::tpc::LtrCalibData +;
 #pragma link C++ class std::vector<o2::tpc::TimePair> +;
+#pragma link C++ class std::vector<o2::tpc::LtrCalibData> +;
 #pragma link C++ class o2::tpc::IDCGroup +;
 #pragma link C++ class o2::tpc::IDCGroupHelperRegion +;
 #pragma link C++ class o2::tpc::IDCGroupHelperSector +;

--- a/Detectors/TPC/monitor/macro/RunSimpleEventDisplay.C
+++ b/Detectors/TPC/monitor/macro/RunSimpleEventDisplay.C
@@ -580,7 +580,7 @@ void Next(int eventNumber = -1)
     }
     case Status::NoMoreData: {
       std::cout << "No more data to be read\n";
-      return;
+      //return;
       break;
     }
     case Status::NoReaders: {

--- a/Detectors/TPC/monitor/macro/startMonitor
+++ b/Detectors/TPC/monitor/macro/startMonitor
@@ -82,7 +82,11 @@ if [[ $fileInfo =~ : ]]; then
   timeBins=${fileInfo#*:}
   timeBins=${timeBins%%:*}
 else
-  fileInfo=${fileInfo}:${timeBins}
+  fileInfo=${fileInfo}:${lastTimeBin}
+fi
+
+if [[ $lastTimeBin -gt $timeBins ]]; then
+  timeBins=$lastTimeBin
 fi
 
 # ===| command building and execution |=========================================

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawProcessingHelpers.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawProcessingHelpers.h
@@ -25,7 +25,7 @@ namespace raw_processing_helpers
 
 using ADCCallback = std::function<bool(int cru, int rowInSector, int padInRow, int timeBin, float adcValue)>;
 
-bool processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t orbit, uint32_t referenceOrbit, ADCCallback fillADC, bool useTimeBin = false);
+bool processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t orbit, uint32_t referenceOrbit, uint32_t syncOffsetReference, ADCCallback fillADC, bool useTimeBin = false);
 
 } // namespace raw_processing_helpers
 } // namespace tpc

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReaderCRU.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReaderCRU.h
@@ -138,6 +138,26 @@ class ADCRawData
   /// overloading output stream operator to output ADCRawData
   friend std::ostream& operator<<(std::ostream& output, const ADCRawData& rawData);
 
+  /// reset
+  void reset()
+  {
+    mOutputStream = 0;
+    mNumTimeBins = 0;
+    for (auto& data : mADCRaw) {
+      data.clear();
+    }
+  }
+
+  bool hasData() const
+  {
+    for (auto& data : mADCRaw) {
+      if (data.size()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
  private:
   uint32_t mOutputStream{0};           // variable to set the output stream for the << operator
   uint32_t mNumTimeBins{0};            // variable to set the number of timebins for the << operator
@@ -357,12 +377,15 @@ class RawReaderCRUEventSync
           return false;
         }
         if (rawDataType == RAWDataType::GBT) {
-          return link.isComplete();
+          if (!link.isComplete()) {
+            return false;
+          }
         }
         if (rawDataType == RAWDataType::LinkZS) {
-          return link.HBEndSeen;
+          if (link.IsPresent && !link.HBEndSeen) {
+            return false;
+          }
         }
-        return false;
       }
       return true;
     }

--- a/Detectors/TPC/reconstruction/src/RawProcessingHelpers.cxx
+++ b/Detectors/TPC/reconstruction/src/RawProcessingHelpers.cxx
@@ -22,7 +22,7 @@
 using namespace o2::tpc;
 
 //______________________________________________________________________________
-bool raw_processing_helpers::processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t orbit, uint32_t referenceOrbit, ADCCallback fillADC, bool useTimeBin)
+bool raw_processing_helpers::processZSdata(const char* data, size_t size, rdh_utils::FEEIDType feeId, uint32_t orbit, uint32_t referenceOrbit, uint32_t syncOffsetReference, ADCCallback fillADC, bool useTimeBin)
 {
   const auto& mapper = Mapper::instance();
 
@@ -78,8 +78,8 @@ bool raw_processing_helpers::processZSdata(const char* data, size_t size, rdh_ut
     const uint32_t numberOfWords = zsdata->getDataWords();
     assert(expectedWords == numberOfWords);
 
-    const uint32_t bunchCrossingHeader = zsdata->getBunchCrossing();
-    uint32_t syncOffset = header.syncOffsetBC % 16;
+    const uint32_t bunchCrossingHeader = zsdata->getBunchCrossing() + syncOffsetReference;
+    uint32_t syncOffset = header.syncOffsetBC;
 
     if (useTimeBin) {
       const uint32_t timebinHeader = (header.syncOffsetCRUCycles << 8) | header.syncOffsetBC;

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -25,6 +25,7 @@ o2_add_library(TPCWorkflow
                        src/IDCToVectorSpec.cxx
                        src/CalibdEdxSpec.cxx
                        src/MIPTrackFilterSpec.cxx
+                       src/LaserTrackFilterSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction
@@ -64,9 +65,19 @@ o2_add_executable(calib-pedestal
                   SOURCES src/tpc-calib-pedestal.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
+o2_add_executable(laser-tracks-calibrator
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-laser-tracks-calibrator.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
 o2_add_executable(calib-laser-tracks
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-calib-laser-tracks.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(laser-track-filter
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-laser-track-filter.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_executable(integrate-idc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/LaserTrackFilterSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/LaserTrackFilterSpec.h
@@ -1,0 +1,29 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_LaserTrackFilterSpec_H
+#define O2_TPC_LaserTrackFilterSpec_H
+
+/// @file   LaserTrackFilterSpec.h
+/// @brief  Device to filter out laser tracks
+
+#include "Framework/DataProcessorSpec.h"
+
+using namespace o2::framework;
+
+namespace o2::tpc
+{
+
+DataProcessorSpec getLaserTrackFilter();
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/workflow/src/CalDetMergerPublisherSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalDetMergerPublisherSpec.cxx
@@ -110,8 +110,12 @@ class CalDetMergerPublisherSpec : public o2::framework::Task
   {
     LOGP(info, "endOfStream");
 
-    dumpCalibData();
-    sendOutput(ec.outputs());
+    if (mReceivedLanes.count() == mLanesToExpect) {
+      dumpCalibData();
+      sendOutput(ec.outputs());
+    } else {
+      LOGP(info, "Received lanes {} does not match expected lanes {}, object already sent", mReceivedLanes.count(), mLanesToExpect);
+    }
     ec.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
 

--- a/Detectors/TPC/workflow/src/LaserTrackFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/LaserTrackFilterSpec.cxx
@@ -1,0 +1,105 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   LaserTrackFilterSpec.cxx
+/// @brief  Device to filter out laser tracks
+
+#include <algorithm>
+#include <iterator>
+
+#include "DataFormatsTPC/TrackTPC.h"
+#include "TPCCalibration/CalibLaserTracks.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+
+using namespace o2::framework;
+
+namespace o2::tpc
+{
+
+class LaserTrackFilterDevice : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    const auto tracks = pc.inputs().get<gsl::span<TrackTPC>>("tracks");
+    std::copy_if(tracks.begin(), tracks.end(), std::back_inserter(mLaserTracks),
+                 [this](const auto& track) { return isLaserTrackCandidate(track); });
+
+    LOGP(info, "Filtered {} laser track candidates out of {} total tpc tracks", mLaserTracks.size(), tracks.size());
+
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+  }
+
+ private:
+  std::vector<TrackTPC> mLaserTracks;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    output.snapshot(Output{"TPC", "LASERTRACKS", 0}, mLaserTracks);
+    mLaserTracks.clear();
+  }
+
+  bool isLaserTrackCandidate(const TrackTPC& track)
+  {
+    if (track.getP() < 1) {
+      return false;
+    }
+
+    if (track.getNClusters() < 80) {
+      //return false;
+    }
+
+    if (track.hasBothSidesClusters()) {
+      return false;
+    }
+
+    const auto& parOutLtr = track.getOuterParam();
+    if (parOutLtr.getX() < 220) {
+      return false;
+    }
+
+    const int side = track.hasCSideClusters();
+    if (!CalibLaserTracks::hasNearbyLaserRod(parOutLtr, side)) {
+      return false;
+    }
+
+    return true;
+  }
+};
+
+DataProcessorSpec getLaserTrackFilter()
+{
+  using device = o2::tpc::LaserTrackFilterDevice;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("TPC", "LASERTRACKS", 0, o2::framework::Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "tpc-laser-track-filter",
+    Inputs{{"tracks", "TPC", "TRACKS", 0}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{}};
+}
+
+} // namespace o2::tpc

--- a/Detectors/TPC/workflow/src/tpc-laser-track-filter.cxx
+++ b/Detectors/TPC/workflow/src/tpc-laser-track-filter.cxx
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "TPCWorkflow/LaserTrackFilterSpec.h"
+#include "DataFormatsTPC/TrackTPC.h"
+
+using namespace o2::framework;
+using namespace o2::tpc;
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-laser-track-filter", CompletionPolicy::CompletionOp::Consume));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"enable-writer", VariantType::Bool, false, {"selection string input specs"}},
+  };
+
+  std::swap(workflowOptions, options);
+}
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+
+  using namespace o2::tpc;
+
+  WorkflowSpec workflow;
+  workflow.emplace_back(getLaserTrackFilter());
+
+  if (config.options().get<bool>("enable-writer")) {
+    const char* processName = "tpc-laser-track-writer";
+    const char* defaultFileName = "tpc-laser-tracks.root";
+    const char* defaultTreeName = "tpcrec";
+
+    //branch definitions for RootTreeWriter spec
+    using TrackOutputType = std::vector<o2::tpc::TrackTPC>;
+
+    // a spectator callback which will be invoked by the tree writer with the extracted object
+    // we are using it for printing a log message
+    auto logger = BranchDefinition<TrackOutputType>::Spectator([](TrackOutputType const& tracks) {
+      LOG(INFO) << "writing " << tracks.size() << " track(s)";
+    });
+    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", "LASERTRACKS", 0}, //
+                                                       "TPCTracks", "track-branch-name",                  //
+                                                       1,                                                 //
+                                                       logger};                                           //
+
+    workflow.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,
+                                              std::move(tracksdef))());
+  }
+
+  return workflow;
+}

--- a/Detectors/TPC/workflow/src/tpc-laser-tracks-calibrator.cxx
+++ b/Detectors/TPC/workflow/src/tpc-laser-tracks-calibrator.cxx
@@ -10,9 +10,10 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/DataProcessorSpec.h"
-#include "TPCWorkflow/CalibLaserTracksSpec.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/CompletionPolicyHelpers.h"
+
+#include "TPCWorkflow/LaserTracksCalibratorSpec.h"
 
 using namespace o2::framework;
 
@@ -20,31 +21,22 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-calib-laser-tracks", CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-laser-tracks-calibrator", CompletionPolicy::CompletionOp::Consume));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing
-void customize(std::vector<ConfigParamSpec>& workflowOptions)
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{
-    {"input-spec", VariantType::String, "input:TPC/TRACKS", {"selection string input specs"}},
-    {"use-filtered-tracks", VariantType::Bool, false, {"use prefiltered laser tracks as input"}},
-  };
-
-  std::swap(workflowOptions, options);
+  // option allowing to set parameters
 }
 
 // ------------------------------------------------------------------
 
 #include "Framework/runDataProcessing.h"
 
-WorkflowSpec defineDataProcessing(ConfigContext const& config)
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
-  std::string inputSpec = config.options().get<std::string>("input-spec");
-  if (config.options().get<bool>("use-filtered-tracks")) {
-    inputSpec = "input:TPC/LASERTRACKS";
-  }
-  specs.emplace_back(o2::tpc::getCalibLaserTracks(inputSpec));
+  specs.emplace_back(o2::tpc::getLaserTracksCalibrator());
   return specs;
 }


### PR DESCRIPTION
* add device to pre-filter laser track candiates
  (tpc-laser-track-filter)
* split device for
  - simple local processing (tpc-calib-laser-tracks)
  - distributed processing (tpc-laser-tracks-calibrator)
* new struct for calibration data storage
* drift velocity calibration separately for A-/C-Side
* code cleanup