### PR TITLE
MFT: add tracker option for clusters full scan

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -58,6 +58,8 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t LTFseed2BinWin = 3;
   /// RPhi search window bin width for the intermediate points
   Int_t LTFinterBinWin = 3;
+  /// Special version for TED shots and cosmics, with full scan of the clusters
+  bool FullClusterScan = false;
 
   O2ParamDef(MFTTrackingParam, "MFTTracking");
 };

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
@@ -77,7 +77,7 @@ class ROframe
 
   void addRoad();
 
-  void initialize();
+  void initialize(bool fullClusterScan = false);
 
   void sortClusters();
 

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -60,13 +60,15 @@ class Tracker : public TrackerConfig
   void setROFrame(std::uint32_t f) { mROFrame = f; }
   std::uint32_t getROFrame() const { return mROFrame; }
 
-  void initialize();
+  void initialize(bool fullClusterScan = false);
   void initConfig(const MFTTrackingParam& trkParam, bool printConfig = false);
 
  private:
   void findTracks(ROframe&);
   void findTracksLTF(ROframe&);
   void findTracksCA(ROframe&);
+  void findTracksLTFfcs(ROframe&);
+  void findTracksCAfcs(ROframe&);
   void computeCellsInRoad(ROframe&);
   void runForwardInRoad();
   void runBackwardInRoad(ROframe&);
@@ -111,6 +113,9 @@ class Tracker : public TrackerConfig
 
   /// current road for CA algorithm
   Road mRoad;
+
+  /// Special version for TED shots and cosmics, with full scan of the clusters
+  bool mFullClusterScan = false;
 };
 
 //_________________________________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
@@ -34,9 +34,11 @@ Int_t ROframe::getTotalClusters() const
   return Int_t(totalClusters);
 }
 
-void ROframe::initialize()
+void ROframe::initialize(bool fullClusterScan)
 {
-  sortClusters();
+  if (!fullClusterScan) {
+    sortClusters();
+  }
 }
 
 void ROframe::sortClusters()

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -13,7 +13,6 @@
 
 #include "MFTWorkflow/TrackerSpec.h"
 
-#include "MFTTracking/TrackerConfig.h"
 #include "MFTTracking/ROframe.h"
 #include "MFTTracking/IOUtils.h"
 #include "MFTTracking/Tracker.h"
@@ -60,13 +59,13 @@ void TrackerDPL::init(InitContext& ic)
                                                    o2::math_utils::TransformType::T2G));
 
     // tracking configuration parameters
-    auto& mftTrackingParam = MFTTrackingParam::Instance();
+    auto& trackingParam = MFTTrackingParam::Instance();
     // create the tracker: set the B-field, the configuration and initialize
     mTracker = std::make_unique<o2::mft::Tracker>(mUseMC);
     double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
     mTracker->setBz(field->getBz(centerMFT));
-    mTracker->initConfig(mftTrackingParam, true);
-    mTracker->initialize();
+    mTracker->initConfig(trackingParam, true);
+    mTracker->initialize(trackingParam.FullClusterScan);
   } else {
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
@@ -122,6 +121,9 @@ void TrackerDPL::run(ProcessingContext& pc)
   Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
   LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
 
+  // tracking configuration parameters
+  auto& trackingParam = MFTTrackingParam::Instance();
+
   // snippet to convert found tracks to final output tracks with separate cluster indices
   auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx) {
     for (auto& trc : tracks) {
@@ -141,7 +143,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       int nclUsed = ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels, mTracker.get());
       if (nclUsed) {
         event.setROFrameId(roFrame);
-        event.initialize();
+        event.initialize(trackingParam.FullClusterScan);
         LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
         mTracker->setROFrame(roFrame);
         mTracker->clustersToTracks(event);


### PR DESCRIPTION
This option skips all optimizations for scanning the MFT planes for clusters, when building the tracklets (in the CA algorithm) and the seeds (in the LTF algorithm), in order to avoid assumptions about the tracks vertices and allow the reconstruction of tracks from TED shots (mostly horizontal tracks) and from cosmic rays (all kind of inclinations).
For the moment, given as a configuration parameter to the reconstruction workflow:

o2-mft-reco-workflow -b --configKeyValues "MFTTracking.FullClusterScan=true"

to be tested in the coming TED shots and cosmics.