### PR TITLE
Alice 3: embedding FT3 inner disks in BP vacuum

### DIFF
--- a/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/GeometryTGeo.h
+++ b/Detectors/Upgrades/ALICE3/FT3/base/include/FT3Base/GeometryTGeo.h
@@ -90,6 +90,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 
   void Print(Option_t* opt = "") const;
   static const char* getFT3VolPattern() { return sVolumeName.c_str(); }
+  static const char* getFT3InnerVolPattern() { return sInnerVolumeName.c_str(); }
   static const char* getFT3LayerPattern() { return sLayerName.c_str(); }
   static const char* getFT3ChipPattern() { return sChipName.c_str(); }
   static const char* getFT3SensorPattern() { return sSensorName.c_str(); }
@@ -102,10 +103,11 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
  protected:
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
-  Int_t mNumberOfLayers;          ///< number of layers
-  static std::string sVolumeName; ///< Mother volume name
-  static std::string sLayerName;  ///< Layer name
-  static std::string sChipName;   ///< Chip name
+  Int_t mNumberOfLayers;               ///< number of layers
+  static std::string sInnerVolumeName; ///< Mother inner volume name
+  static std::string sVolumeName;      ///< Mother volume name
+  static std::string sLayerName;       ///< Layer name
+  static std::string sChipName;        ///< Chip name
 
   static std::string sSensorName; ///< Sensor name
 

--- a/Detectors/Upgrades/ALICE3/FT3/base/src/GeometryTGeo.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/base/src/GeometryTGeo.cxx
@@ -49,10 +49,11 @@ ClassImp(o2::ft3::GeometryTGeo);
 
 std::unique_ptr<o2::ft3::GeometryTGeo> GeometryTGeo::sInstance;
 
-std::string GeometryTGeo::sVolumeName = "FT3V";      ///< Mother volume name
-std::string GeometryTGeo::sLayerName = "FT3Layer";   ///< Layer name
-std::string GeometryTGeo::sChipName = "FT3Chip";     ///< Sensor name
-std::string GeometryTGeo::sSensorName = "FT3Sensor"; ///< Sensor name
+std::string GeometryTGeo::sVolumeName = "FT3V";          ///< Mother volume name
+std::string GeometryTGeo::sInnerVolumeName = "FT3Inner"; ///< Mother inner volume name
+std::string GeometryTGeo::sLayerName = "FT3Layer";       ///< Layer name
+std::string GeometryTGeo::sChipName = "FT3Chip";         ///< Sensor name
+std::string GeometryTGeo::sSensorName = "FT3Sensor";     ///< Sensor name
 
 //__________________________________________________________________________
 GeometryTGeo::GeometryTGeo(bool build, int loadTrans) : o2::itsmft::GeometryTGeo(DetID::FT3)

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/include/FT3Simulation/Detector.h
@@ -87,7 +87,6 @@ class Detector : public o2::base::DetImpl<Detector>
     return nullptr;
   }
 
- public:
   /// Has to be called after each event to reset the containers
   void Reset() override;
 
@@ -152,6 +151,7 @@ class Detector : public o2::base::DetImpl<Detector>
   Detector& operator=(const Detector&);
 
   std::vector<std::vector<FT3Layer>> mLayers;
+  bool mIsPipeActivated = true; //! If Alice 3 pipe is present append inner disks to vacuum volume to avoid overlaps
 
   template <typename Det>
   friend class o2::base::DetImpl;


### PR DESCRIPTION
@rpezzi this workaround will append the FT3 inner disks to the embeddingvacuum voulme inside the BP if it is enabled.
I gave a quick look to the output with one PbPb event, hits on those disks seem to be restored.
Let me know if something is not working as expected.
![photo_2021-07-21_14-42-31](https://user-images.githubusercontent.com/4990252/126490206-65b82c0b-dd07-4861-966e-ffb261a93e74.jpg)
![photo_2021-07-21_14-42-27](https://user-images.githubusercontent.com/4990252/126490215-20969928-12c2-4b75-b40c-656a21f51efc.jpg)
  