### PR TITLE
Adding DPL parser tool for raw page sequences provided by DPL input.

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -76,6 +76,7 @@ foreach(t
         RootTreeWriter
         RawParser
         DPLRawParser
+        DPLRawPageSequencer
         )
   o2_add_test(${t}
               SOURCES test/test_${t}.cxx

--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(DPLUtils
                        src/RawParser.cxx
                        test/DPLBroadcasterMerger.cxx
                        test/DPLOutputTest.cxx
+                       test/RawPageTestData.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework)
 
 o2_add_executable(raw-proxy
@@ -54,12 +55,6 @@ o2_add_test(DPLOutput
             LABELS long dplutils
             COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 
-o2_add_test(RootTreeWriter
-            SOURCES test/test_RootTreeWriter.cxx
-            PUBLIC_LINK_LIBRARIES O2::DPLUtils
-            COMPONENT_NAME DPLUtils
-            LABELS dplutils)
-
 o2_add_test(RootTreeWriterWorkflow
             NO_BOOST_TEST
             SOURCES test/test_RootTreeWriterWorkflow.cxx
@@ -76,17 +71,18 @@ o2_add_test(RootTreeReader
             LABELS dplutils
             COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 
-o2_add_test(RawParser
-            SOURCES test/test_RawParser.cxx
-            PUBLIC_LINK_LIBRARIES O2::DPLUtils
-            COMPONENT_NAME DPLUtils
-            LABELS dplutils)
 
-o2_add_test(DPLRawParser
-            SOURCES test/test_DPLRawParser.cxx
-            PUBLIC_LINK_LIBRARIES O2::DPLUtils
-            COMPONENT_NAME DPLUtils
-            LABELS dplutils)
+foreach(t
+        RootTreeWriter
+        RawParser
+        DPLRawParser
+        )
+  o2_add_test(${t}
+              SOURCES test/test_${t}.cxx
+              PUBLIC_LINK_LIBRARIES O2::DPLUtils
+              COMPONENT_NAME DPLUtils
+              LABELS dplutils)
+endforeach()
 
 if (TARGET benchmark::benchmark)
 foreach(b

--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -88,6 +88,7 @@ endforeach()
 if (TARGET benchmark::benchmark)
 foreach(b
         RawParser
+        DPLRawPageSequencer
         )
   o2_add_test(benchmark_${b} NAME test_Framework_benchmark_${b}
               SOURCES test/benchmark_${b}.cxx

--- a/Framework/Utils/include/DPLUtils/DPLRawPageSequencer.h
+++ b/Framework/Utils/include/DPLUtils/DPLRawPageSequencer.h
@@ -1,0 +1,167 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_UTILS_DPLRAWPAGESEQUENCER_H
+#define FRAMEWORK_UTILS_DPLRAWPAGESEQUENCER_H
+
+/// @file   DPLRawPageSequencer.h
+/// @author Matthias Richter
+/// @since  2021-07-09
+/// @brief  A parser and sequencer utility for raw pages within DPL input
+
+#include "DPLUtils/RawParser.h"
+#include "Framework/DataRef.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Logger.h"
+#include "Framework/InputRecordWalker.h"
+#include "Headers/DataHeader.h"
+#include <utility> // std::declval
+
+namespace o2::framework
+{
+class InputRecord;
+
+/// @class DPLRawPageSequencer
+/// @brief This utility handles transparently the DPL inputs and triggers
+/// a customizable action on sequences of consecutive raw pages following
+/// similar RDH features, e.g. the same FEE ID.
+///
+/// A DPL processor will receive raw pages accumulated on three levels:
+///   1) the DPL processor has one or more input route(s)
+///   2) multiple parts per input route (split payloads or multiple input
+///      specs matching the same route spec
+///   3) variable number of raw pages in one payload
+///
+/// The DPLRawPageSequencer loops transparently over all inputs matching
+/// the optional filter, and partitions input buffers into sequences of
+/// raw pages matching the provided predicate by binary search.
+///
+/// Note: binary search requires that all raw pages must have a fixed
+/// length, only the last page can be shorter.
+///
+/// Usage:
+///   auto isSameRdh = [](const char* left, const char* right) -> bool {
+///     // implement the condition here
+///     return left == right;
+///   };
+///   std::vector<std::pair<const char*, size_t>> pages;
+///   auto insertPages = [&pages](const char* ptr, size_t n) -> void {
+///     // as an example, the sequences are simply stored in a vector
+///     pages.emplace_back(ptr, n);
+///   };
+///   DPLRawPageSequencer(inputs)(isSameRdh, insertPages);
+///
+/// TODO:
+///   - support configurable page length
+class DPLRawPageSequencer
+{
+ public:
+  using rawparser_type = RawParser<8192>;
+  using buffer_type = typename rawparser_type::buffer_type;
+
+  DPLRawPageSequencer() = delete;
+  DPLRawPageSequencer(InputRecord& inputs, std::vector<InputSpec> filterSpecs = {}) : mInput(inputs, filterSpecs) {}
+
+  template <typename Predicate, typename Inserter>
+  void operator()(Predicate&& pred, Inserter&& inserter)
+  {
+    return binary(std::forward<Predicate>(pred), std::forward<Inserter>(inserter));
+  }
+
+  template <typename Predicate, typename Inserter>
+  void binary(Predicate pred, Inserter inserter)
+  {
+    for (auto const& ref : mInput) {
+      auto size = DataRefUtils::getPayloadSize(ref);
+      auto const pageSize = rawparser_type::max_size;
+      auto nPages = size / pageSize + (size % pageSize ? 1 : 0);
+      if (nPages == 0) {
+        continue;
+      }
+      // FIXME: automatic type from inserter/predicate?
+      const char* iterator = ref.payload;
+
+      auto check = [&pred, &pageSize, payload = ref.payload](size_t left, size_t right) -> bool {
+        return pred(payload + left * pageSize, payload + right * pageSize);
+      };
+      auto insert = [&inserter, &pageSize, payload = ref.payload](size_t pos, size_t n) -> void {
+        inserter(payload + pos * pageSize, n);
+      };
+      // binary search the next different page based on the check predicate
+      auto search = [&check](size_t first, size_t n) -> size_t {
+        auto count = n;
+        auto pos = first;
+        while (count > 0) {
+          auto step = count / 2;
+          if (check(first, pos + step)) {
+            // still the same
+            pos += step;
+            count = n - (pos - first);
+          } else {
+            if (step == 1) {
+              pos += step;
+              break;
+            }
+            count = step;
+          }
+        }
+        return pos;
+      };
+
+      size_t p = 0;
+      do {
+        // insert the full block if the last RDH matches the position
+        if (check(p, nPages - 1)) {
+          insert(p, nPages - p);
+          break;
+        }
+        auto q = search(p, nPages - p);
+        insert(p, q - p);
+        p = q;
+      } while (p < nPages);
+      // if payloads are consecutive in memory we could apply this algorithm even over
+      // O2 message boundaries
+    }
+  }
+
+  template <typename Predicate, typename Inserter>
+  void forward(Predicate check, Inserter inserter)
+  {
+    for (auto const& ref : mInput) {
+      auto size = DataRefUtils::getPayloadSize(ref);
+      o2::framework::RawParser parser(ref.payload, size);
+      const char* ptr = nullptr;
+      int count = 0;
+      for (auto it = parser.begin(); it != parser.end(); it++) {
+        const char* current = reinterpret_cast<const char*>(it.raw());
+        if (ptr == nullptr) {
+          ptr = current;
+        } else if (check(ptr, current) == false) {
+          if (count) {
+            inserter(ptr, count);
+          }
+          count = 0;
+          ptr = current;
+        }
+        count++;
+      }
+      if (count) {
+        inserter(ptr, count);
+      }
+    }
+  }
+
+ private:
+  InputRecordWalker mInput;
+};
+
+} // namespace o2::framework
+
+#endif //FRAMEWORK_UTILS_DPLRAWPAGESEQUENCER_H

--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -353,7 +353,7 @@ class RawParser
 {
  public:
   using buffer_type = unsigned char;
-  size_t max_size = MAX_SIZE;
+  static size_t const max_size = MAX_SIZE;
   using self_type = RawParser<MAX_SIZE>;
 
   RawParser() = delete;

--- a/Framework/Utils/test/RawPageTestData.cxx
+++ b/Framework/Utils/test/RawPageTestData.cxx
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RawPageTestData.cxx
+/// @author Matthias Richter
+/// @since  2021-06-21
+/// @brief  Raw page test data generator
+
+#include "RawPageTestData.h"
+#include "Headers/Stack.h"
+#include <random>
+
+namespace o2::framework
+{
+namespace test
+{
+
+DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHeader> const& dataheaders, AmendRawDataHeader amendRdh)
+{
+  // Create the routes we want for the InputRecord
+  size_t i = 0;
+  auto createRoute = [&i](std::string const& source, InputSpec const& spec) {
+    return InputRoute{
+      spec,
+      i++,
+      source};
+  };
+
+  std::vector<InputRoute> schema;
+  for (auto const& spec : inputspecs) {
+    auto routename = spec.binding + "_source";
+    schema.emplace_back(createRoute(routename, spec));
+  }
+
+  std::random_device rd;
+  std::uniform_int_distribution<> testvals(0, 42);
+  auto randval = [&rd, &testvals]() {
+    return testvals(rd);
+  };
+  std::vector<int> checkValues;
+  DataSet::Messages messages;
+
+  auto initRawPage = [&checkValues, &amendRdh](char* buffer, size_t size, auto value) {
+    char* wrtptr = buffer;
+    while (wrtptr < buffer + size) {
+      auto* header = reinterpret_cast<RAWDataHeader*>(wrtptr);
+      *header = RAWDataHeader();
+      if (amendRdh) {
+        amendRdh(*header);
+      }
+      header->offsetToNext = PAGESIZE;
+      *reinterpret_cast<decltype(value)*>(wrtptr + header->headerSize) = value;
+      wrtptr += PAGESIZE;
+      checkValues.emplace_back(value);
+      ++value;
+    }
+  };
+
+  auto createMessage = [&messages, &initRawPage, &randval](DataHeader dh) {
+    DataProcessingHeader dph{0, 1};
+    Stack stack{dh, dph};
+    if (dh.splitPayloadParts == 0 || dh.splitPayloadIndex == 0) {
+      // add new message collection
+      messages.emplace_back();
+    }
+    messages.back().emplace_back(std::make_unique<std::vector<char>>(stack.size()));
+    memcpy(messages.back().back()->data(), stack.data(), messages.back().back()->size());
+    messages.back().emplace_back(std::make_unique<std::vector<char>>(dh.payloadSize));
+    int value = randval();
+    initRawPage(messages.back().back()->data(), messages.back().back()->size(), value);
+  };
+
+  // create messages for the provided dataheaders
+  for (auto header : dataheaders) {
+    for (DataHeader::SplitPayloadIndexType index = 0; index == 0 || index < header.splitPayloadParts; index++) {
+      header.splitPayloadIndex = index;
+      createMessage(header);
+    }
+  }
+
+  return {std::move(schema), std::move(messages), std::move(checkValues)};
+}
+
+} // namespace test
+} // namespace o2::framework

--- a/Framework/Utils/test/RawPageTestData.h
+++ b/Framework/Utils/test/RawPageTestData.h
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RawPageTestData.h
+/// @author Matthias Richter
+/// @since  2021-06-21
+/// @brief  Raw page test data generator
+
+#ifndef FRAMEWORK_UTILS_RAWPAGETESTDATA_H
+#define FRAMEWORK_UTILS_RAWPAGETESTDATA_H
+
+#include "Framework/InputRecord.h"
+#include "Framework/InputSpan.h"
+#include "Headers/RAWDataHeader.h"
+#include "Headers/DataHeader.h"
+#include <vector>
+#include <memory>
+
+using DataHeader = o2::header::DataHeader;
+using Stack = o2::header::Stack;
+using RAWDataHeaderV6 = o2::header::RAWDataHeaderV6;
+
+namespace o2::framework
+{
+namespace test
+{
+using RAWDataHeader = RAWDataHeaderV6;
+static const size_t PAGESIZE = 8192;
+
+/// @class DataSet
+/// @brief Simple helper struct to keep the InputRecord and ownership of messages
+///        together with some test data.
+struct DataSet {
+  // not nice with the double vector but for quick unit test ok
+  using Messages = std::vector<std::vector<std::unique_ptr<std::vector<char>>>>;
+  DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v)
+    : schema{std::move(s)},
+      messages{std::move(m)},
+      span{[this](size_t i, size_t part) {
+             auto header = static_cast<char const*>(this->messages[i].at(2 * part)->data());
+             auto payload = static_cast<char const*>(this->messages[i].at(2 * part + 1)->data());
+             return DataRef{nullptr, header, payload};
+           },
+           [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()},
+      record{schema, span},
+      values{std::move(v)}
+  {
+  }
+
+  std::vector<InputRoute> schema;
+  Messages messages;
+  InputSpan span;
+  InputRecord record;
+  std::vector<int> values;
+};
+
+using AmendRawDataHeader = std::function<void(RAWDataHeader&)>;
+DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHeader> const& dataheaders, AmendRawDataHeader amendRdh = nullptr);
+
+} // namespace test
+} // namespace o2::framework
+#endif // FRAMEWORK_UTILS_RAWPAGETESTDATA_H

--- a/Framework/Utils/test/benchmark_DPLRawPageSequencer.cxx
+++ b/Framework/Utils/test/benchmark_DPLRawPageSequencer.cxx
@@ -1,0 +1,103 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   benchmark_DPLRawPageSequencer.h
+/// @author Matthias Richter
+/// @since  2021-07-21
+/// @brief  Unit test for the DPL raw page sequencer utility
+
+#include <benchmark/benchmark.h>
+
+#include "DPLUtils/DPLRawPageSequencer.h"
+#include "RawPageTestData.h"
+#include <random>
+#include <vector>
+
+using namespace o2::framework;
+auto const PAGESIZE = test::PAGESIZE;
+
+auto createData(int nPages)
+{
+  const int nParts = 16;
+  std::vector<InputSpec> inputspecs = {
+    InputSpec{"tpc", "TPC", "RAWDATA", 0, Lifetime::Timeframe}};
+
+  std::vector<DataHeader> dataheaders;
+  dataheaders.emplace_back("RAWDATA", "TPC", 0, nPages * PAGESIZE, 0, nParts);
+
+  std::random_device rd;
+  std::uniform_int_distribution<> lengthDist(1, nPages);
+  auto randlength = [&rd, &lengthDist]() {
+    return lengthDist(rd);
+  };
+
+  int rdhCount = 0;
+  // whenever a new id is created, it is done from the current counter
+  // position, so we also have the possibility to calculate the length
+  std::vector<uint16_t> fees;
+  auto nextlength = randlength();
+  auto createFEEID = [&rdhCount, &fees, &nPages, &randlength, &nextlength]() {
+    if (rdhCount % nPages == 0 || rdhCount - fees.back() > nextlength) {
+      fees.emplace_back(rdhCount);
+      nextlength = randlength();
+    }
+    return fees.back();
+  };
+  auto amendRdh = [&rdhCount, createFEEID](test::RAWDataHeader& rdh) {
+    rdh.feeId = createFEEID();
+    rdhCount++;
+  };
+
+  return test::createData(inputspecs, dataheaders, amendRdh);
+}
+
+static void BM_DPLRawPageSequencerBinary(benchmark::State& state)
+{
+  auto isSameRdh = [](const char* left, const char* right) -> bool {
+    if (left == right) {
+      return true;
+    }
+
+    return reinterpret_cast<test::RAWDataHeader const*>(left)->feeId == reinterpret_cast<test::RAWDataHeader const*>(right)->feeId;
+  };
+  std::vector<std::pair<const char*, size_t>> pages;
+  auto insertPages = [&pages](const char* ptr, size_t n) -> void {
+    pages.emplace_back(ptr, n);
+  };
+  auto dataset = createData(state.range(0));
+  for (auto _ : state) {
+    DPLRawPageSequencer(dataset.record).binary(isSameRdh, insertPages);
+  }
+}
+
+static void BM_DPLRawPageSequencerForward(benchmark::State& state)
+{
+  auto isSameRdh = [](const char* left, const char* right) -> bool {
+    if (left == right) {
+      return true;
+    }
+
+    return reinterpret_cast<test::RAWDataHeader const*>(left)->feeId == reinterpret_cast<test::RAWDataHeader const*>(right)->feeId;
+  };
+  std::vector<std::pair<const char*, size_t>> pages;
+  auto insertPages = [&pages](const char* ptr, size_t n) -> void {
+    pages.emplace_back(ptr, n);
+  };
+  auto dataset = createData(state.range(0));
+  for (auto _ : state) {
+    DPLRawPageSequencer(dataset.record).forward(isSameRdh, insertPages);
+  }
+}
+
+BENCHMARK(BM_DPLRawPageSequencerBinary)->Arg(64)->Arg(512)->Arg(1024);
+BENCHMARK(BM_DPLRawPageSequencerForward)->Arg(64)->Arg(512)->Arg(1024);
+
+BENCHMARK_MAIN();

--- a/Framework/Utils/test/test_DPLRawPageSequencer.cxx
+++ b/Framework/Utils/test/test_DPLRawPageSequencer.cxx
@@ -1,0 +1,114 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   test_DPLRawPageSequencer.h
+/// @author Matthias Richter
+/// @since  2021-07-09
+/// @brief  Unit test for the DPL raw page sequencer utility
+
+#define BOOST_TEST_MODULE Test Framework Utils DPLRawPageSequencer
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DPLUtils/DPLRawPageSequencer.h"
+#include "RawPageTestData.h"
+#include "Framework/InputRecord.h"
+#include "Headers/DataHeader.h"
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <random>
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+auto const PAGESIZE = test::PAGESIZE;
+
+BOOST_AUTO_TEST_CASE(test_DPLRawPageSequencer)
+{
+  const int nPages = 64;
+  const int nParts = 16;
+  std::vector<InputSpec> inputspecs = {
+    InputSpec{"tpc", "TPC", "RAWDATA", 0, Lifetime::Timeframe}};
+
+  std::vector<DataHeader> dataheaders;
+  dataheaders.emplace_back("RAWDATA", "TPC", 0, nPages * PAGESIZE, 0, nParts);
+
+  std::random_device rd;
+  std::uniform_int_distribution<> lengthDist(1, nPages);
+  auto randlength = [&rd, &lengthDist]() {
+    return lengthDist(rd);
+  };
+
+  int rdhCount = 0;
+  // whenever a new id is created, it is done from the current counter
+  // position, so we also have the possibility to calculate the length
+  std::vector<uint16_t> feeids;
+  auto nextlength = randlength();
+  auto createFEEID = [&rdhCount, &feeids, &nPages, &randlength, &nextlength]() {
+    if (rdhCount % nPages == 0 || rdhCount - feeids.back() > nextlength) {
+      feeids.emplace_back(rdhCount);
+      nextlength = randlength();
+    }
+    return feeids.back();
+  };
+  auto amendRdh = [&rdhCount, createFEEID](test::RAWDataHeader& rdh) {
+    rdh.feeId = createFEEID();
+    rdhCount++;
+  };
+
+  auto dataset = test::createData(inputspecs, dataheaders, amendRdh);
+  InputRecord& inputs = dataset.record;
+  BOOST_REQUIRE(dataset.messages.size() > 0);
+  BOOST_REQUIRE(dataset.messages[0].at(0) != nullptr);
+  BOOST_REQUIRE(inputs.size() > 0);
+  BOOST_CHECK((*inputs.begin()).header == dataset.messages[0].at(0)->data());
+  BOOST_REQUIRE(rdhCount == nPages * nParts);
+  DPLRawPageSequencer parser(inputs);
+
+  auto isSameRdh = [](const char* left, const char* right) -> bool {
+    if (left == right) {
+      return true;
+    }
+    if (left == nullptr || right == nullptr) {
+      return true;
+    }
+
+    return reinterpret_cast<test::RAWDataHeader const*>(left)->feeId == reinterpret_cast<test::RAWDataHeader const*>(right)->feeId;
+  };
+  std::vector<std::pair<const char*, size_t>> pages;
+  auto insertPages = [&pages](const char* ptr, size_t n) -> void {
+    pages.emplace_back(ptr, n);
+  };
+  parser(isSameRdh, insertPages);
+
+  // a second parsing step based on forward search
+  std::vector<std::pair<const char*, size_t>> pagesByForwardSearch;
+  auto insertForwardPages = [&pagesByForwardSearch](const char* ptr, size_t n) -> void {
+    pagesByForwardSearch.emplace_back(ptr, n);
+  };
+  DPLRawPageSequencer(inputs).forward(isSameRdh, insertForwardPages);
+
+  LOG(INFO) << "called RDH amend: " << rdhCount;
+  LOG(INFO) << "created " << feeids.size() << " id(s), got " << pages.size() << " page(s)";
+  BOOST_REQUIRE(pages.size() == feeids.size());
+  BOOST_REQUIRE(pages.size() == pagesByForwardSearch.size());
+
+  feeids.emplace_back(rdhCount);
+  auto lastId = feeids.front();
+  for (auto i = 0; i < pages.size(); i++) {
+    auto length = feeids[i + 1] - feeids[i];
+    BOOST_CHECK_MESSAGE(pages[i].second == length, "sequence " << i << " at " << feeids[i] << " length " << length << ": got " << pages[i].second);
+    BOOST_CHECK_MESSAGE(pages[i].first == pagesByForwardSearch[i].first && pages[i].second == pagesByForwardSearch[i].second,
+                        "mismatch with forward search at sequence " << i
+                                                                    << " [" << (void*)pages[i].first << "," << (void*)pagesByForwardSearch[i].first << "]"
+                                                                    << " [" << pages[i].second << "," << pagesByForwardSearch[i].second << "]");
+  }
+}

--- a/Framework/Utils/test/test_DPLRawParser.cxx
+++ b/Framework/Utils/test/test_DPLRawParser.cxx
@@ -14,133 +14,36 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include "DPLUtils/DPLRawParser.h"
+#include "RawPageTestData.h"
 #include "Framework/InputRecord.h"
-#include "Framework/InputSpan.h"
 #include "Framework/WorkflowSpec.h" // o2::framework::select
 #include "Headers/DataHeader.h"
-#include "Headers/Stack.h"
 #include <vector>
 #include <memory>
 #include <iostream>
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
-using Stack = o2::header::Stack;
-using RAWDataHeaderV4 = o2::header::RAWDataHeaderV4;
-
-static const size_t PAGESIZE = 8192;
-
-// simple helper struct to keep the InputRecord and ownership of messages
-struct DataSet {
-  // not nice with the double vector but for quick unit test ok
-  using Messages = std::vector<std::vector<std::unique_ptr<std::vector<char>>>>;
-  DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v)
-    : schema{std::move(s)},
-      messages{std::move(m)},
-      span{[this](size_t i, size_t part) {
-             BOOST_REQUIRE(i < this->messages.size());
-             BOOST_REQUIRE(part < this->messages[i].size() / 2);
-             auto header = static_cast<char const*>(this->messages[i].at(2 * part)->data());
-             auto payload = static_cast<char const*>(this->messages[i].at(2 * part + 1)->data());
-             return DataRef{nullptr, header, payload};
-           },
-           [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()},
-      record{schema, span},
-      values{std::move(v)}
-  {
-    BOOST_REQUIRE(messages.size() == schema.size());
-  }
-
-  std::vector<InputRoute> schema;
-  Messages messages;
-  InputSpan span;
-  InputRecord record;
-  std::vector<int> values;
-};
+auto const PAGESIZE = test::PAGESIZE;
+using DataSet = test::DataSet;
 
 DataSet createData()
 {
-  // Create the routes we want for the InputRecord
   std::vector<InputSpec> inputspecs = {
     InputSpec{"tpc0", "TPC", "RAWDATA", 0, Lifetime::Timeframe},
     InputSpec{"its1", "ITS", "RAWDATA", 0, Lifetime::Timeframe},
     InputSpec{"its1", "ITS", "RAWDATA", 1, Lifetime::Timeframe}};
 
-  size_t i = 0;
-  auto createRoute = [&i](const char* source, InputSpec& spec) {
-    return InputRoute{
-      spec,
-      i++,
-      source};
-  };
-
-  std::vector<InputRoute> schema = {
-    createRoute("tpc_source", inputspecs[0]),
-    createRoute("its_source", inputspecs[1]),
-    createRoute("tof_source", inputspecs[2])};
-
-  std::vector<int> checkValues;
-  DataSet::Messages messages;
-
-  auto initRawPage = [&checkValues](char* buffer, size_t size, int value) {
-    char* wrtptr = buffer;
-    while (wrtptr < buffer + size) {
-      auto* header = reinterpret_cast<RAWDataHeaderV4*>(wrtptr);
-      *header = RAWDataHeaderV4();
-      header->offsetToNext = PAGESIZE;
-      *reinterpret_cast<decltype(value)*>(wrtptr + header->headerSize) = value;
-      wrtptr += PAGESIZE;
-      checkValues.emplace_back(value);
-      ++value;
-    }
-  };
-
-  auto createMessage = [&messages, &initRawPage](DataHeader dh, int value) {
-    DataProcessingHeader dph{0, 1};
-    Stack stack{dh, dph};
-    if (dh.splitPayloadParts == 0 || dh.splitPayloadIndex == 0) {
-      // add new message collection
-      messages.emplace_back();
-    }
-    messages.back().emplace_back(std::make_unique<std::vector<char>>(stack.size()));
-    memcpy(messages.back().back()->data(), stack.data(), messages.back().back()->size());
-    messages.back().emplace_back(std::make_unique<std::vector<char>>(dh.payloadSize));
-    initRawPage(messages.back().back()->data(), messages.back().back()->size(), value);
-  };
-
   // we create message for the 3 input routes, the messages have different page size
   // and the second messages has 3 parts, each with the same page size
   // the test value is written as payload after the RDH and all values are cached for
   // later checking when parsing the data set
-  DataHeader dh1;
-  dh1.dataDescription = "RAWDATA";
-  dh1.dataOrigin = "TPC";
-  dh1.subSpecification = 0;
-  dh1.payloadSerializationMethod = o2::header::gSerializationMethodNone;
-  dh1.payloadSize = 5 * PAGESIZE;
-  DataHeader dh2;
-  dh2.dataDescription = "RAWDATA";
-  dh2.dataOrigin = "ITS";
-  dh2.subSpecification = 0;
-  dh2.payloadSerializationMethod = o2::header::gSerializationMethodNone;
-  dh2.payloadSize = 3 * PAGESIZE;
-  dh2.splitPayloadParts = 3;
-  dh2.splitPayloadIndex = 0;
-  DataHeader dh3;
-  dh3.dataDescription = "RAWDATA";
-  dh3.dataOrigin = "ITS";
-  dh3.subSpecification = 1;
-  dh3.payloadSerializationMethod = o2::header::gSerializationMethodNone;
-  dh3.payloadSize = 4 * PAGESIZE;
-  createMessage(dh1, 10);
-  createMessage(dh2, 20);
-  dh2.splitPayloadIndex++;
-  createMessage(dh2, 23);
-  dh2.splitPayloadIndex++;
-  createMessage(dh2, 26);
-  createMessage(dh3, 30);
+  std::vector<DataHeader> dataheaders;
+  dataheaders.emplace_back("RAWDATA", "TPC", 0, 5 * PAGESIZE);
+  dataheaders.emplace_back("RAWDATA", "ITS", 0, 3 * PAGESIZE, 0, 3);
+  dataheaders.emplace_back("RAWDATA", "ITS", 1, 4 * PAGESIZE);
 
-  return {std::move(schema), std::move(messages), std::move(checkValues)};
+  return test::createData(inputspecs, dataheaders);
 }
 
 BOOST_AUTO_TEST_CASE(test_DPLRawParser)
@@ -157,8 +60,8 @@ BOOST_AUTO_TEST_CASE(test_DPLRawParser)
   for (auto it = parser.begin(), end = parser.end(); it != end; ++it, ++count) {
     LOG(INFO) << "data " << count << " " << *((int*)it.data());
     // now check the iterator API
-    // retrieving RDH v4
-    auto const* rdh = it.get_if<o2::header::RAWDataHeaderV4>();
+    // retrieving RDH
+    auto const* rdh = it.get_if<test::RAWDataHeader>();
     // retrieving the raw pointer of the page
     auto const* raw = it.raw();
     // retrieving payload pointer of the page
@@ -168,10 +71,10 @@ BOOST_AUTO_TEST_CASE(test_DPLRawParser)
     // offset of payload in the raw page
     size_t offset = it.offset();
     BOOST_REQUIRE(rdh != nullptr);
-    BOOST_REQUIRE(offset == sizeof(o2::header::RAWDataHeaderV4));
+    BOOST_REQUIRE(offset == sizeof(test::RAWDataHeader));
     BOOST_REQUIRE(payload == raw + offset);
     BOOST_REQUIRE(*reinterpret_cast<int const*>(payload) == dataset.values[count]);
-    BOOST_REQUIRE(payloadSize == PAGESIZE - sizeof(o2::header::RAWDataHeaderV4));
+    BOOST_REQUIRE(payloadSize == PAGESIZE - sizeof(test::RAWDataHeader));
     auto const* dh = it.o2DataHeader();
     if (last != dh) {
       // this is a special wrapper to print the RDU info and table header, this will


### PR DESCRIPTION
The DPLRawPageSequencer can be used to find sequences of consecutive
raw pages with a similar property, e.g. the FEE ID. The actual check
and callback to handle a sequence can be provided by lambda functions.

The raw pages within one buffer/message are expected to have the full
length except the last page which can be smaller. The fixed spacing
allows fast scanning by binary search.

Corresponding unit test is emulating variable-length sequences of
raw pages.

Before merging:
- [x] enhance class documentation
- [x] make the unit tests independent of``DetectorsRaw`