### PR TITLE
Less verbose output from analysis-validation task

### DIFF
--- a/Analysis/Tasks/validation.cxx
+++ b/Analysis/Tasks/validation.cxx
@@ -64,7 +64,6 @@ struct ValidationTask {
       hfC1PtSnp->Fill(track.c1PtSnp());
       hfC1PtTgl->Fill(track.c1PtTgl());
       hfC1Pt21Pt2->Fill(track.c1Pt21Pt2());
-      LOGF(info, "track tgl  ss   s%f", track.tgl());
     }
   }
 };


### PR DESCRIPTION
This was leading to extremely large log-files. If some screen information is
needed, please consider making the output outside of the loop or only
when debugging.