### PR TITLE
[EMCAL-703] Add optional settable subspecification for raw to digits output

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -15,6 +15,7 @@
 #include "Framework/Task.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "Headers/DataHeader.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/Mapper.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
@@ -37,8 +38,8 @@ class RawToCellConverterSpec : public framework::Task
 {
  public:
   /// \brief Constructor
-  /// \param propagateMC If true the MCTruthContainer is propagated to the output
-  RawToCellConverterSpec() : framework::Task(){};
+  /// \param subspecification Output subspecification for parallel running on multiple nodes
+  RawToCellConverterSpec(int subspecification) : framework::Task(), mSubspecification(subspecification){};
 
   /// \brief Destructor
   ~RawToCellConverterSpec() override;
@@ -63,28 +64,43 @@ class RawToCellConverterSpec : public framework::Task
   void setMaxErrorMessages(int maxMessages) { mMaxErrorMessages = maxMessages; }
 
   void setNoiseThreshold(int thresold) { mNoiseThreshold = thresold; }
-  int getNoiseThreshold() { return mNoiseThreshold; }
+  int getNoiseThreshold() const { return mNoiseThreshold; }
+
+  /// \brief Set ID of the subspecification
+  /// \param subspecification
+  ///
+  /// Can be used to define differenciate between output in case
+  /// different processors run in parallel (i.e. on different FLPs)
+  void setSubspecification(header::DataHeader::SubSpecificationType subspecification) { mSubspecification = subspecification; }
+
+  /// \brief Get ID of the subspecification
+  /// \return subspecification
+  ///
+  /// Can be used to define differenciate between output in case
+  /// different processors run in parallel (i.e. on different FLPs)
+  header::DataHeader::SubSpecificationType getSubspecification() const { return mSubspecification; }
 
  private:
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
   void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const;
 
-  int mNoiseThreshold = 0;                                      ///< Noise threshold in raw fit
-  int mNumErrorMessages = 0;                                    ///< Current number of error messages
-  int mErrorMessagesSuppressed = 0;                             ///< Counter of suppressed error messages
-  int mMaxErrorMessages = 100;                                  ///< Max. number of error messages
-  o2::emcal::Geometry* mGeometry = nullptr;                     ///!<! Geometry pointer
-  std::unique_ptr<o2::emcal::MappingHandler> mMapper = nullptr; ///!<! Mapper
-  std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;         ///!<! Raw fitter
-  std::vector<o2::emcal::Cell> mOutputCells;                    ///< Container with output cells
-  std::vector<o2::emcal::TriggerRecord> mOutputTriggerRecords;  ///< Container with output cells
-  std::vector<ErrorTypeFEE> mOutputDecoderErrors;               ///< Container with decoder errors
+  header::DataHeader::SubSpecificationType mSubspecification = 0; ///< Subspecification for output channels
+  int mNoiseThreshold = 0;                                        ///< Noise threshold in raw fit
+  int mNumErrorMessages = 0;                                      ///< Current number of error messages
+  int mErrorMessagesSuppressed = 0;                               ///< Counter of suppressed error messages
+  int mMaxErrorMessages = 100;                                    ///< Max. number of error messages
+  Geometry* mGeometry = nullptr;                                  ///!<! Geometry pointer
+  std::unique_ptr<MappingHandler> mMapper = nullptr;              ///!<! Mapper
+  std::unique_ptr<CaloRawFitter> mRawFitter;                      ///!<! Raw fitter
+  std::vector<Cell> mOutputCells;                                 ///< Container with output cells
+  std::vector<TriggerRecord> mOutputTriggerRecords;               ///< Container with output cells
+  std::vector<ErrorTypeFEE> mOutputDecoderErrors;                 ///< Container with decoder errors
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec
 ///
 /// Refer to RawToCellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF);
+framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF, int subspecification);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -47,7 +47,8 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \brief create the workflow for EMCAL reconstruction
 /// \param propagateMC If true MC labels are propagated to the output files
 /// \param askDISTSTF If true the Raw->Cell converter subscribes to FLP/DISTSUBTIMEFRAME
-/// \param enableDigitsPrinter If true
+/// \param enableDigitsPrinter If true then the simple digits printer is added as dummy task
+/// \param subspecification Subspecification in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
 /// \return EMCAL reconstruction workflow for the configuration provided
@@ -55,8 +56,9 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool askDISTSTF = true,
                                     bool enableDigitsPrinter = false,
-                                    std::string const& cfgInput = "digits",    //
-                                    std::string const& cfgOutput = "clusters", //
+                                    int subspecification = 0,
+                                    std::string const& cfgInput = "digits",
+                                    std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,
                                     bool disableRootOutput = false);
 } // namespace reco_workflow

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -275,19 +275,19 @@ bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) 
 void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", 0, framework::Lifetime::Timeframe}, cells);
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", 0, framework::Lifetime::Timeframe}, triggers);
-  ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", 0, framework::Lifetime::Timeframe}, decodingErrors);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification, framework::Lifetime::Timeframe}, cells);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification, framework::Lifetime::Timeframe}, triggers);
+  ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification, framework::Lifetime::Timeframe}, decodingErrors);
 }
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF)
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF, int subspecification)
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
   std::vector<o2::framework::OutputSpec> outputs;
 
-  outputs.emplace_back(originEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back(originEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back(originEMC, "DECODERERR", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(originEMC, "CELLS", subspecification, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(originEMC, "CELLSTRGR", subspecification, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(originEMC, "DECODERERR", subspecification, o2::framework::Lifetime::Timeframe);
 
   std::vector<o2::framework::InputSpec> inputs{{"stf", o2::framework::ConcreteDataTypeMatcher{originEMC, o2::header::gDataDescriptionRawData}, o2::framework::Lifetime::Optional}};
   if (askDISTSTF) {
@@ -297,7 +297,7 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
   return o2::framework::DataProcessorSpec{"EMCALRawToCellConverterSpec",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(),
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(subspecification),
                                           o2::framework::Options{
                                             {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}},
                                             {"maxmessage", o2::framework::VariantType::Int, 100, {"Max. amout of error messages to be displayed"}}}};

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -48,6 +48,7 @@ namespace reco_workflow
 o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         bool askDISTSTF,
                                         bool enableDigitsPrinter,
+                                        int subspecification,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
@@ -169,7 +170,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
-      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF));
+      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, subspecification));
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -37,7 +37,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not initialize root file writers"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
-    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}}};
+    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
+    {"subspecification", o2::framework::VariantType::Int, 0, {"Subspecification in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
 
@@ -61,11 +62,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  auto wf = o2::emcal::reco_workflow::getWorkflow(!cfgc.options().get<bool>("disable-mc"), //
+  auto wf = o2::emcal::reco_workflow::getWorkflow(!cfgc.options().get<bool>("disable-mc"),
                                                   !cfgc.options().get<bool>("ignore-dist-stf"),
-                                                  cfgc.options().get<bool>("enable-digits-printer"), //
-                                                  cfgc.options().get<std::string>("input-type"),     //
-                                                  cfgc.options().get<std::string>("output-type"),    //
+                                                  cfgc.options().get<bool>("enable-digits-printer"),
+                                                  cfgc.options().get<int>("subspecification"),
+                                                  cfgc.options().get<std::string>("input-type"),
+                                                  cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),
                                                   cfgc.options().get<bool>("disable-root-output"));
 


### PR DESCRIPTION
- Add option to define subspecification for the output
  specs of the raw to cell converter (default: 0) and
  propagate it into the class in order to send to the
  proper subspecification in the snapshot function
- Steer subspecification via the workflow option
  subspecification

Needed in order to run the workflow on the two FLPs
in parallel. In case of running offline or on the EPN the
default subspecification (0) should be used.