### PR TITLE
TRD add Krypton cluster finder

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(DataFormatsTRD
                        src/CompressedDigit.cxx
                        src/CTF.cxx
                        src/Digit.cxx
+                       src/KrCluster.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
 o2_target_root_dictionary(DataFormatsTRD
@@ -32,6 +33,8 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/HelperMethods.h
                        include/DataFormatsTRD/Hit.h
                        include/DataFormatsTRD/Digit.h
+                       include/DataFormatsTRD/KrCluster.h
+                       include/DataFormatsTRD/KrClusterTriggerRecord.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/CalVdriftExB.h
                        include/DataFormatsTRD/SignalArray.h

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -74,6 +74,8 @@ class Digit
 
   ArrayADC const& getADC() const { return mADC; }
   ADC_t getADCsum() const { return std::accumulate(mADC.begin(), mADC.end(), (ADC_t)0); }
+  // returns the max ADC value and sets idx to the time bin with the largest ADC value
+  ADC_t getADCmax(int& idx) const;
 
   bool operator==(const Digit& o) const
   {

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -68,10 +68,16 @@ struct HelperMethods {
     return irob % 2;
   }
 
+  static int getSector(int det)
+  {
+    return det / constants::NCHAMBERPERSEC;
+  }
+
   static int getStack(int det)
   {
     return det % (constants::NSTACK * constants::NLAYER) / constants::NLAYER;
   }
+
   static int getLayer(int det)
   {
     return det % constants::NLAYER;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/KrCluster.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/KrCluster.h
@@ -1,0 +1,92 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file KrCluster.h
+/// \brief A cluster formed from digits during TRD Krypton calibration
+
+#ifndef O2_TRD_KRCLUSTER_H
+#define O2_TRD_KRCLUSTER_H
+
+#include "Rtypes.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class KrCluster
+{
+ public:
+  KrCluster() = default;
+  KrCluster(const KrCluster&) = default;
+  ~KrCluster() = default;
+
+  void setGlobalPadID(int det, int row, int col);
+  void setAdcData(int adcSum, int adcRms, int adcMaxA, int adcMaxB, int adcEoT, int adcIntegral, int adcSumTrunc);
+  void setTimeData(int timeMaxA, int timeMaxB, int timeRms);
+  void setClusterSizeData(int rowSize, int colSize, int timeSize, int nAdcs);
+
+  // identify global pad number (row and column with the maximum ADC value contained in the cluster)
+  int getDetector() const { return mDet; }
+  int getSector() const { return HelperMethods::getSector(mDet); }
+  int getStack() const { return HelperMethods::getStack(mDet); }
+  int getLayer() const { return HelperMethods::getLayer(mDet); }
+  int getRow() const { return mRow; }
+  int getColumn() const { return mCol; }
+
+  // ADC related members
+  int getAdcSum() const { return mAdcSum; }
+  int getAdcRms() const { return mAdcRms; }
+  int getAdcMaxA() const { return mAdcMaxA; }
+  int getAdcMaxB() const { return mAdcMaxB; }
+  int getAdcSumEoverT() const { return mAdcSumEoverT; }
+  int getAdcIntegral() const { return mAdcIntegral; }
+  int getAdcSumTruncated() const { return mAdcSumTruncated; }
+
+  // cluster size
+  int getClSizeRow() const { return mDeltaRow; }
+  int getClSizeCol() const { return mDeltaCol; }
+  int getClSizeTime() const { return mDeltaTime; }
+  int getClSize() const { return mClusterSize; }
+
+  // time bin related members
+  int getTimeMaxA() const { return mTimeMaxA; }
+  int getTimeMaxB() const { return mTimeMaxB; }
+  int getTimeRms() const { return mTimeRms; }
+
+ private:
+  uint16_t mDet;             ///< chamber number [0..539]
+  uint16_t mAdcSum;          ///< sum of all ADCs contributing to this cluster (baseline subtracted)
+  uint16_t mAdcRms;          ///< RMS of the ADCs constributing to this cluster
+  uint16_t mAdcMaxA;         ///< sum of the ADCs of the first maximum
+  uint16_t mAdcMaxB;         ///< sum of the ADCs of the second maximum (the contribution from the first maximum is subtracted here)
+  uint16_t mAdcSumEoverT;    ///< same as mAdcSum, but ADCs below KrClusterFinder::mMinAdcClEoverT are ignored
+  uint16_t mAdcIntegral;     ///< integral of the Landau fit for all time bins
+  uint16_t mAdcSumTruncated; ///< same as mAdcSum, but only ADCs close to the RMS are counted
+  uint8_t mRow;              ///< pad row number contributing max ADC value contained in this cluster [0..15]
+  uint8_t mCol;              ///< pad column number contributing max ADC value contained in this cluster [0..143]
+  uint8_t mDeltaRow;         ///< cluster size in row direction
+  uint8_t mDeltaCol;         ///< cluster size in column direction
+  uint8_t mDeltaTime;        ///< cluster size in time bin direction
+  uint8_t mClusterSize;      ///< number of ADC values contributing to the cluster (ADC needs to be above KrClusterFinder::mMinAdcClContrib)
+  uint8_t mTimeMaxA;         ///< time bin of the first maximum
+  uint8_t mTimeMaxB;         ///< time bin of the second maximum
+  uint8_t mTimeRms;          ///< RMS of the time bins for ADCs contributing to this cluster
+
+  ClassDefNV(KrCluster, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_KRCLUSTER_H

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/KrClusterTriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/KrClusterTriggerRecord.h
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_KRCLSTRIGGERRECORD_H
+#define ALICEO2_TRD_KRCLSTRIGGERRECORD_H
+
+#include "Rtypes.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// \class KrClusterTriggerRecord
+/// \brief Mapping of found Kr clusters to BC information which is taken from the TRD digits
+/// \author Ole Schmidt
+
+class KrClusterTriggerRecord
+{
+  using BCData = o2::InteractionRecord;
+
+ public:
+  KrClusterTriggerRecord() = default;
+  KrClusterTriggerRecord(BCData bcData, int nEntries) : mBCData(bcData), mNClusters(nEntries) {}
+
+  // setters (currently class members are set at the time of creation, if there is need to change them afterwards setters can be added below)
+
+  // getters
+  int getNumberOfClusters() const { return mNClusters; }
+  BCData getBCData() const { return mBCData; }
+
+ private:
+  BCData mBCData; ///< bunch crossing data
+  int mNClusters; ///< number of Kr clusters
+
+  ClassDefNV(KrClusterTriggerRecord, 1);
+};
+} // namespace trd
+} // namespace o2
+
+#endif // ALICEO2_TRD_KRCLSTRIGGERRECORD_H

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -26,6 +26,8 @@
 #pragma link C++ class o2::trd::CalibratedTracklet + ;
 #pragma link C++ class o2::trd::Hit + ;
 #pragma link C++ class o2::trd::Digit + ;
+#pragma link C++ class o2::trd::KrCluster + ;
+#pragma link C++ class o2::trd::KrClusterTriggerRecord + ;
 #pragma link C++ class o2::trd::AngularResidHistos + ;
 #pragma link C++ class o2::trd::CalVdriftExB + ;
 #pragma link C++ class o2::trd::CompressedDigit + ;
@@ -37,6 +39,8 @@
 #pragma link C++ class std::vector < o2::trd::Hit > +;
 #pragma link C++ class std::vector < o2::trd::Digit> + ;
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
+#pragma link C++ class std::vector < o2::trd::KrCluster> + ;
+#pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 
 #pragma link C++ struct o2::trd::CTFHeader + ;
 #pragma link C++ struct o2::trd::CTF + ;

--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -11,6 +11,7 @@
 
 #include "DataFormatsTRD/Digit.h"
 #include <iostream>
+#include <algorithm>
 
 namespace o2::trd
 {
@@ -58,6 +59,13 @@ bool Digit::isSharedDigit() const
   } else {
     return 0;
   }
+}
+
+ADC_t Digit::getADCmax(int& idx) const
+{
+  auto itMax = std::max_element(mADC.begin(), mADC.end());
+  idx = std::distance(mADC.begin(), itMax);
+  return *itMax;
 }
 
 std::ostream& operator<<(std::ostream& stream, const Digit& d)

--- a/DataFormats/Detectors/TRD/src/KrCluster.cxx
+++ b/DataFormats/Detectors/TRD/src/KrCluster.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file KrCluster.cxx
+/// \brief A cluster formed from digits during TRD Krypton calibration
+
+#include "DataFormatsTRD/KrCluster.h"
+
+using namespace o2::trd;
+
+void KrCluster::setGlobalPadID(int det, int row, int col)
+{
+  mDet = det;
+  mRow = row;
+  mCol = col;
+}
+
+void KrCluster::setAdcData(int adcSum, int adcRms, int adcMaxA, int adcMaxB, int adcEoT, int adcIntegral, int adcSumTrunc)
+{
+  mAdcSum = adcSum;
+  mAdcRms = adcRms;
+  mAdcMaxA = adcMaxA;
+  mAdcMaxB = adcMaxB;
+  mAdcSumEoverT = adcEoT;
+  mAdcIntegral = adcIntegral;
+  mAdcSumTruncated = adcSumTrunc;
+}
+
+void KrCluster::setTimeData(int timeMaxA, int timeMaxB, int timeRms)
+{
+  mTimeMaxA = timeMaxA;
+  mTimeMaxB = timeMaxB;
+  mTimeRms = timeRms;
+}
+
+void KrCluster::setClusterSizeData(int rowSize, int colSize, int timeSize, int nAdcs)
+{
+  mDeltaRow = rowSize;
+  mDeltaCol = colSize;
+  mDeltaTime = timeSize;
+  mClusterSize = nAdcs;
+}

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(TRDCalibration
                SOURCES src/TrackBasedCalib.cxx
                        src/CalibratorVdExB.cxx
+                       src/KrClusterFinder.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsGlobalTracking
@@ -22,4 +23,5 @@ o2_add_library(TRDCalibration
 
  o2_target_root_dictionary(TRDCalibration
                            HEADERS include/TRDCalibration/TrackBasedCalib.h
-                                   include/TRDCalibration/CalibratorVdExB.h)
+                                   include/TRDCalibration/CalibratorVdExB.h
+                                   include/TRDCalibration/KrClusterFinder.h)

--- a/Detectors/TRD/calibration/include/TRDCalibration/KrClusterFinder.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/KrClusterFinder.h
@@ -1,0 +1,112 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file KrClusterFinder.h
+/// \brief The TRD Krypton cluster finder from digits
+/// \author Ole Schmidt
+
+#ifndef O2_TRD_KRCLUSTERFINDER_H
+#define O2_TRD_KRCLUSTERFINDER_H
+
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/KrCluster.h"
+#include "DataFormatsTRD/KrClusterTriggerRecord.h"
+
+#include "Rtypes.h"
+#include "TF1.h"
+#include "Fit/Fitter.h"
+#include "Fit/FitResult.h"
+
+#include <memory>
+#include <gsl/span>
+
+namespace o2
+{
+
+namespace trd
+{
+
+class KrClusterFinder
+{
+
+ public:
+  KrClusterFinder() = default;
+  KrClusterFinder(const KrClusterFinder&) = delete;
+  ~KrClusterFinder() = default;
+
+  struct LandauChi2Functor {
+    double operator()(const double* par) const;
+    std::vector<float> x; ///< the number of the time bin
+    std::vector<float> y; ///< ADC sum per time bin
+    int xLowerBound;
+    int xUpperBound;
+  };
+
+  /// Initialization
+  void init();
+
+  // Reset output containers
+  void reset();
+
+  /// Provide digits and trigger records as input
+  void setInput(const gsl::span<const Digit>& digitsIn, const gsl::span<const TriggerRecord>& trigRecIn);
+
+  /// Find clusters in the digit ADC data.
+  /// We start with finding the maximum ADC value in a chamber. We store the ADC value, the time bin within the corresponding digit
+  /// and the pad row and pad column of that digit. Afterwards we cluster around that maximum, discarding digits more than 1 pad row
+  /// or more than 2 pad columns away. In time bin direction there are no limits for other ADC values to contribute to the cluster.
+  /// Each ADC value is added maximum to a single cluster: ADCs connected to one cluster are flagged as used and disregarded
+  /// in the following iterations for the given detector. Also ADC below a threshold (mMinAdcClContrib) are ignored.
+  /// The cluster size is defined in three dimensions (row, column, time bin), for each dimension from the lowermost constituent ADC
+  /// to the uppermost constituent ADC.
+  /// Different ADC sums are calculated from the constituent ADCs.
+  /// Afterwards the main Krypton peak is identified (maxAdcA and maxTbA) and also we try to find the second Kr peak (maxAdcB, maxTbB).
+  /// Quality checks indicate the validity of those two maxima (shape, ordering, ADC size)
+  /// A Landau fit to the ADC vs time bins values for a cluster provide the ADC sums for the two Kr peaks.
+  /// The clusters don't necessarily need to fullfill all quality criteria (e.g. the Landau fit may fail). But these clusters are
+  /// stored anyway, as they can be filtered out later at the analysis stage.
+  void findClusters();
+
+  /// Calculate some statistics for the given cluster constituent ADC values
+  double getRms(const std::vector<uint64_t>& adcIndices, int itTrunc, double nRmsTrunc, int minAdc, double& rmsTime, uint32_t& sumAdc) const;
+
+  /// Output
+  const std::vector<KrCluster>& getKrClusters() const { return mKrClusters; }
+  const std::vector<KrClusterTriggerRecord>& getKrTrigRecs() const { return mTrigRecs; }
+
+ private:
+  // input
+  gsl::span<const Digit> mDigits;                 ///< the TRD digits
+  gsl::span<const TriggerRecord> mTriggerRecords; ///< the TRD trigger records
+  // output
+  std::vector<KrCluster> mKrClusters{};            ///< the Kr clusters
+  std::vector<KrClusterTriggerRecord> mTrigRecs{}; ///< number of Kr clusters and interaction record of first trigger per time frame
+  // helpers
+  LandauChi2Functor mLandauChi2Functor;                                         ///< stores the binned ADC data and provides a chi2 estimate
+  std::shared_ptr<ROOT::Fit::FitResult> mFitResult{new ROOT::Fit::FitResult()}; ///< pointer to the results of the Landau fit
+  ROOT::Fit::Fitter mFitter{mFitResult};                                        ///< an instance of the ROOT fitter
+  std::array<double, 3> mInitialFitParams{};                                    ///< initial fit parameters for the Landau fit
+  std::unique_ptr<TF1> mFuncLandauFit;                                          ///< helper function to approximate the binned ADC data with a Landau distribution
+  // settings
+  const int mBaselineAdc{10};        ///< ADC baseline for each pad (can maybe be moved into Constants.h)
+  const int mMinAdcForMax{70};       ///< minimum ADC value that can be considered for a maximum
+  const int mMinAdcClContrib{40};    ///< minimum ADC value that can contribute to a cluster
+  const int mMinAdcForSecondMax{50}; ///< threshold for a second maximum inside a cluster
+  const int mMinAdcClEoverT{60};     ///< energy threshold for ADC value
+
+  ClassDefNV(KrClusterFinder, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_KRCLUSTERFINDER_H

--- a/Detectors/TRD/calibration/src/KrClusterFinder.cxx
+++ b/Detectors/TRD/calibration/src/KrClusterFinder.cxx
@@ -1,0 +1,411 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file KrClusterFinder.cxx
+/// \brief The TRD Krypton cluster finder from digits
+/// \author Alexander Schmah, Ole Schmidt
+
+#include "TRDCalibration/KrClusterFinder.h"
+#include "Math/IntegratorOptions.h"
+#include <fairlogger/Logger.h>
+
+#include <limits>
+
+using namespace o2::trd;
+using namespace o2::trd::constants;
+
+double KrClusterFinder::LandauChi2Functor::operator()(const double* par) const
+{
+  // provides chi2 estimate comparing y[] to par[0] * TMath::Landau(x[], par[1], par[2])
+  // par[0] : amplitude
+  // par[1] : location parameter (approximately most probable value)
+  // par[2] : sigma
+  double retVal = 0;
+  for (unsigned int i = xLowerBound; i <= xUpperBound; ++i) {
+    if (fabs(y[i]) < 1e-3f) {
+      // exclude bins with zero errors like in TH1::Fit
+      // the standard bin error is the square root of its content
+      continue;
+    }
+    retVal += TMath::Power(y[i] - par[0] * TMath::Landau(x[i], par[1], par[2]), 2) / y[i];
+  }
+  return retVal;
+}
+
+double KrClusterFinder::getRms(const std::vector<uint64_t>& adcIndices, int itTrunc, double nRmsTrunc, int minAdc, double& rmsTime, uint32_t& sumAdc) const
+{
+  double rmsAdc = 1e7;
+  double meanAdc = -10.;
+  rmsTime = 1e7;
+  double meanTime = -10.f;
+
+  for (int it = 0; it < itTrunc; ++it) {
+    // iterations for truncated mean
+    sumAdc = 0;
+    uint32_t sumAdc2 = 0;
+    uint32_t sumTime = 0;
+    uint32_t sumTime2 = 0;
+    uint32_t sumWeights = 0;
+    for (const auto& adcIdx : adcIndices) {
+      int iTb = adcIdx % TIMEBINS;
+      int iDigit = adcIdx / TIMEBINS;
+      int adc = mDigits[iDigit].getADC()[iTb] - mBaselineAdc;
+      if (adc < minAdc) {
+        continue;
+      }
+      if (fabs(adc - meanAdc) < nRmsTrunc * rmsAdc) {
+        sumAdc += adc;
+        sumAdc2 += adc * adc;
+        sumWeights += 1;
+        sumTime += iTb;
+        sumTime2 += iTb * iTb;
+      }
+    }
+    if (sumWeights > 0) {
+      auto sumWeightsInv = 1. / sumWeights;
+      meanAdc = sumAdc * sumWeightsInv;
+      rmsAdc = TMath::Sqrt(sumWeightsInv * (sumAdc2 - 2. * meanAdc * sumAdc + sumWeights * meanAdc * meanAdc));
+      meanTime = sumTime * sumWeightsInv;
+      rmsTime = TMath::Sqrt(sumWeightsInv * (sumTime2 - 2. * meanTime * sumTime + sumWeights * meanTime * meanTime));
+    }
+  }
+  return rmsAdc;
+}
+
+void KrClusterFinder::init()
+{
+  mFitter.SetFCN<LandauChi2Functor>(3, mLandauChi2Functor, mInitialFitParams.data());
+  mFitter.Config().ParSettings(0).SetLimits(0., 1.e5);
+  mFitter.Config().ParSettings(1).SetLimits(0., 30.);
+  mFitter.Config().ParSettings(2).SetLimits(1.e-3, 20.);
+  mFuncLandauFit = std::make_unique<TF1>(
+    "fLandauFit", [&](double* x, double* par) { return par[0] * TMath::Landau(x[0], par[1], par[2]); }, 0., static_cast<double>(TIMEBINS), 3);
+}
+
+void KrClusterFinder::reset()
+{
+  mKrClusters.clear();
+  mTrigRecs.clear();
+}
+
+void KrClusterFinder::setInput(const gsl::span<const Digit>& digitsIn, const gsl::span<const TriggerRecord>& trigRecIn)
+{
+  mDigits = digitsIn;
+  mTriggerRecords = trigRecIn;
+}
+
+void KrClusterFinder::findClusters()
+{
+  int nClsTotal = 0;
+  int nClsDropped = 0;
+  int nClsInvalidFit = 0;
+  /*
+  The input digits and trigger records are provided on a per time frame basis.
+  The cluster finding is performed for each trigger. In order to not copy the
+  input data we sort the digits for each trigger by their detector ID and keep
+  the sorted indices in the digitIdxArray.
+  */
+  std::vector<uint64_t> digitIdxArray(mDigits.size());
+  std::iota(digitIdxArray.begin(), digitIdxArray.end(), 0);
+  for (const auto& trig : mTriggerRecords) {
+    // sort the digits of given trigger record by detector ID
+    const auto& digits = mDigits; // this reference is only needed to be able to pass it to the lambda for sorting
+    std::stable_sort(std::begin(digitIdxArray) + trig.getFirstDigit(), std::begin(digitIdxArray) + trig.getNumberOfDigits() + trig.getFirstDigit(),
+                     [&digits](uint64_t i, uint64_t j) { return digits[i].getDetector() < digits[j].getDetector(); });
+
+    /*
+    Count number of digits per detector:
+    For each detector we need to know the number of digits.
+    We fill the array idxFirstDigitInDet with the total number of digits
+    up to given detector. So we start at 0 for detector 0 and end up with
+    the total number of digits in entry 540. Thus the number of digits in
+    detector iDet can be calculated with:
+    idxFirstDigitInDet[iDet+1] - idxFirstDigitInDet[iDet]
+    Note, that for a global index one needs to add trig.getFirstDigit()
+    */
+    int currDet = 0;
+    int nextDet = 0;
+    int digitCounter = 0;
+    std::array<unsigned int, MAXCHAMBER + 1> idxFirstDigitInDet{};
+    auto idxHelperPtr = &(idxFirstDigitInDet.data()[1]);
+    idxHelperPtr[-1] = 0;
+    for (int iDigit = trig.getFirstDigit(); iDigit < trig.getFirstDigit() + trig.getNumberOfDigits(); ++iDigit) {
+      if (mDigits[digitIdxArray[iDigit]].getDetector() > currDet) {
+        nextDet = mDigits[digitIdxArray[iDigit]].getDetector();
+        for (int iDet = currDet; iDet < nextDet; ++iDet) {
+          idxHelperPtr[iDet] = digitCounter;
+        }
+        currDet = nextDet;
+      }
+      ++digitCounter;
+    }
+    for (int iDet = currDet; iDet <= MAXCHAMBER; ++iDet) {
+      idxHelperPtr[iDet] = digitCounter;
+    }
+
+    // the cluster search is done on a per detector basis
+    for (int iDet = 0; iDet < MAXCHAMBER; ++iDet) {
+      unsigned int nDigitsInDet = idxFirstDigitInDet[iDet + 1] - idxFirstDigitInDet[iDet];
+      std::vector<bool> isAdcUsed(nDigitsInDet * TIMEBINS); // keep track of the ADC values which have already been checked or added to a cluster
+      std::vector<bool> isDigitUsed(nDigitsInDet);          // keep track of the digits which have already been processed
+      bool continueClusterSearch = true;
+      // the following loop searches for one cluster at a time in iDet
+      while (continueClusterSearch) {
+
+        // start by finding the max ADC value in all digits of iDet
+        uint16_t adcMax = 0;
+        int tbMax = 0;
+        int rowMax = 0;
+        int colMax = 0;
+        unsigned int iDigitMax = 0;
+        for (int iDigit = 0; iDigit < nDigitsInDet; ++iDigit) {
+          if (isDigitUsed[iDigit]) {
+            // if a maximum has been found for this digit then all ADCs above threshold are already flagged as used
+            continue;
+          }
+          uint64_t digitIdx = trig.getFirstDigit() + idxFirstDigitInDet[iDet] + iDigit; // global index for array of all digits (mDigits)
+          int tbMaxADC = -1;
+          auto maxAdcInDigit = mDigits[digitIdx].getADCmax(tbMaxADC);
+          if (maxAdcInDigit > adcMax) {
+            // potentially found a maximum
+            tbMax = tbMaxADC;
+            rowMax = mDigits[digitIdx].getPadRow();
+            colMax = mDigits[digitIdx].getPadCol();
+            iDigitMax = iDigit;
+            adcMax = maxAdcInDigit;
+          }
+        }
+        if (adcMax < mMinAdcForMax) {
+          // the maximum ADC value is below the threshold, go to next chamber
+          break;
+        }
+
+        // cluster around max ADC value
+        int lowerTb = TIMEBINS;
+        int upperTb = 0;
+        int lowerCol = NCOLUMN;
+        int upperCol = 0;
+        int lowerRow = NROWC1;
+        int upperRow = 0;
+        int nUsedADCsInCl = 0;
+        std::vector<uint64_t> constituentAdcIndices;
+        for (unsigned int iDigit = 0; iDigit < nDigitsInDet; ++iDigit) {
+          uint64_t digitIdx = trig.getFirstDigit() + idxFirstDigitInDet[iDet] + iDigit; // global index for array of all digits (mDigits)
+          int row = mDigits[digitIdx].getPadRow();
+          if (std::abs(row - rowMax) > 1) {
+            continue;
+          }
+          int col = mDigits[digitIdx].getPadCol();
+          if (std::abs(col - colMax) > 2) {
+            continue;
+          }
+          bool addedAdc = false;
+          for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
+            if (isAdcUsed[iDigit * TIMEBINS + iTb]) {
+              continue;
+            }
+            // flag this ADC value as used, regardless of whether or not it is added to the cluster
+            // (if it is below the threshold it won't be used for another cluster anyway)
+            isAdcUsed[iDigit * TIMEBINS + iTb] = true;
+            if (mDigits[digitIdx].getADC()[iTb] > mMinAdcClContrib) {
+              addedAdc = true;
+              if (iTb < lowerTb) {
+                lowerTb = iTb;
+              }
+              if (iTb > upperTb) {
+                upperTb = iTb;
+              }
+              ++nUsedADCsInCl;
+            }
+            constituentAdcIndices.push_back(digitIdx * TIMEBINS + iTb); // also add ADC values below threshold here
+          }
+          if (addedAdc) {
+            isDigitUsed[iDigit] = true;
+            if (row < lowerRow) {
+              lowerRow = row;
+            }
+            if (row > upperRow) {
+              upperRow = row;
+            }
+            if (col < lowerCol) {
+              lowerCol = col;
+            }
+            if (col > upperCol) {
+              upperCol = col;
+            }
+          }
+        }
+
+        // determine cluster size
+        int clSizeTime = upperTb - lowerTb;
+        int clSizeRow = upperRow - lowerRow;
+        int clSizeCol = upperCol - lowerCol;
+
+        if (nUsedADCsInCl > 0) {
+          // after this cluster is processed, continue looking for another one in iDet
+          continueClusterSearch = true;
+        }
+
+        // sum up ADC values (total sum, sum per time bin, total sum for ADCs above energy threshold)
+        std::array<int, TIMEBINS> sumPerTb{};
+        int sumOfAllTimeBins = 0;
+        int sumOfAllTimeBinsAboveThreshold = 0;
+        for (const auto idx : constituentAdcIndices) {
+          auto iTb = idx % TIMEBINS;
+          auto iDigit = idx / TIMEBINS;
+          sumOfAllTimeBins += mDigits[iDigit].getADC()[iTb] - mBaselineAdc;
+          sumPerTb[iTb] += mDigits[iDigit].getADC()[iTb] - mBaselineAdc;
+          if (mDigits[iDigit].getADC()[iTb] > mMinAdcClEoverT) {
+            sumOfAllTimeBinsAboveThreshold += mDigits[iDigit].getADC()[iTb] - mBaselineAdc;
+          }
+        }
+
+        uint32_t sumOfAdcTrunc;
+        double rmsTimeTrunc;
+        auto rmsAdcClusterTrunc = getRms(constituentAdcIndices, 2, 3., static_cast<uint32_t>(mMinAdcClEoverT * .95), rmsTimeTrunc, sumOfAdcTrunc);
+
+        // ADC value and time bin of first maximum
+        int maxAdcA = -1;
+        int maxTbA = -1;
+        mLandauChi2Functor.x.clear();
+        mLandauChi2Functor.y.clear();
+        for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
+          mLandauChi2Functor.x.push_back((float)iTb);
+          mLandauChi2Functor.y.push_back(sumPerTb[iTb]);
+          if (sumPerTb[iTb] < mMinAdcForMax) {
+            continue;
+          }
+          if (sumPerTb[iTb] > maxAdcA) {
+            maxAdcA = sumPerTb[iTb];
+            maxTbA = iTb;
+          }
+        }
+        mLandauChi2Functor.xLowerBound = maxAdcA - 1;
+        mLandauChi2Functor.xUpperBound = maxAdcA + 2;
+
+        // ADC value and time bin of second maximum (if there is one)
+        int maxAdcB = -1;
+        int maxTbB = -1;
+        for (int iTb = 2; iTb < TIMEBINS - 2; ++iTb) { // we need to check the neighbouring two bins, so ignore the outermost two bins in the search for a second maximum
+          if (std::abs(maxTbA - iTb) < 3 || sumPerTb[iTb] < mMinAdcForSecondMax) {
+            // we are too close to the first maximum (or the ADC value is not too small)
+            continue;
+          }
+          if (sumPerTb[iTb] > maxAdcB) {
+            // check neighbours
+            if (sumPerTb[iTb - 1] < sumPerTb[iTb] &&
+                sumPerTb[iTb - 2] < sumPerTb[iTb] &&
+                sumPerTb[iTb + 1] < sumPerTb[iTb] &&
+                sumPerTb[iTb + 2] < sumPerTb[iTb]) {
+              maxAdcB = sumPerTb[iTb];
+              maxTbB = iTb;
+            }
+          }
+        }
+
+        // quality checks for maxima
+        bool isBadA = false;
+        bool isBadB = false;
+        if (maxAdcA < 0 || maxTbA <= 1 || maxTbA >= (TIMEBINS - 2)) {
+          isBadA = true;
+        }
+        if (maxAdcB < 0) {
+          // second maximum must be inside the time acceptance by construction
+          isBadB = true;
+        }
+        if (!isBadA) {
+          // we have a good first maximum, let's check its shape
+          if ((sumPerTb[maxTbA - 1] / static_cast<double>(maxAdcA)) < 0.1 || (sumPerTb[maxTbA + 1] / static_cast<double>(maxAdcA)) < 0.25) {
+            isBadA = true;
+          }
+        }
+        if (!isBadB) {
+          // we have a good second maximum, let's check its shape
+          if ((sumPerTb[maxTbB - 1] / static_cast<double>(maxAdcB)) < 0.1 || (sumPerTb[maxTbB + 1] / static_cast<double>(maxAdcB)) < 0.25) {
+            isBadB = true;
+          }
+        }
+        if (!isBadA && !isBadB) {
+          // we have two maxima, check order and size
+          if (maxTbA > maxTbB || maxAdcA <= maxAdcB) {
+            isBadA = true;
+            isBadB = true;
+          }
+        }
+
+        if (clSizeCol > 0 && clSizeTime > 3 && clSizeTime < TIMEBINS) {
+          mFitter.Config().ParSettings(0).SetValue(maxAdcA);
+          mFitter.Config().ParSettings(1).SetValue(maxTbA);
+          mFitter.Config().ParSettings(2).SetValue(.5);
+          bool fitOK = mFitter.FitFCN();
+          if (!fitOK) {
+            ++nClsInvalidFit;
+          }
+          mFuncLandauFit->SetParameters(mFitResult->GetParams()[0], mFitResult->GetParams()[1], mFitResult->GetParams()[2]);
+          double integralLandauFit = fitOK ? mFuncLandauFit->Integral(0., static_cast<double>(TIMEBINS), 1.e-9) : 0.;
+
+          double rmsTime;
+          uint32_t rmsSumAdc;
+          auto rmsAdc = getRms(constituentAdcIndices, 1, 2.5, mMinAdcClContrib, rmsTime, rmsSumAdc);
+
+          double sumAdcA = 0.;
+          double sumAdcB = 0.;
+          if (!isBadA && !isBadB) {
+            // use the Landau fit to the first peak to extrapolate the energy of larger time bins (close time bins are evaluated from the array directly)
+            // for the second peak the Landau fit is used to subtract the energy from the first peak
+            for (int iTb = 0; iTb < TIMEBINS; ++iTb) {
+              if (iTb < (maxTbB - 2)) {
+                sumAdcA += mLandauChi2Functor.y[iTb];
+              } else {
+                sumAdcA += mFuncLandauFit->Eval(mLandauChi2Functor.x[iTb]);
+                sumAdcB += mLandauChi2Functor.y[iTb] - mFuncLandauFit->Eval(mLandauChi2Functor.x[iTb]);
+              }
+            }
+          }
+          // create Kr cluster
+          if (sumOfAllTimeBins <= std::numeric_limits<uint16_t>::max() &&
+              sumOfAllTimeBinsAboveThreshold <= std::numeric_limits<uint16_t>::max() &&
+              integralLandauFit <= std::numeric_limits<uint16_t>::max() &&
+              sumAdcA <= std::numeric_limits<uint16_t>::max() &&
+              sumAdcB <= std::numeric_limits<uint16_t>::max() &&
+              rmsAdc <= std::numeric_limits<uint16_t>::max() &&
+              rmsTime <= std::numeric_limits<uint8_t>::max() &&
+              nUsedADCsInCl <= std::numeric_limits<uint8_t>::max() &&
+              sumOfAdcTrunc <= std::numeric_limits<uint16_t>::max()) {
+            if (maxTbA < 0) {
+              maxTbA = tbMax;
+            }
+            if (maxTbB < 0) {
+              maxTbB = 2 * TIMEBINS + 5; // larger than any maximum time bin we can have
+            }
+            KrCluster cluster;
+            cluster.setGlobalPadID(iDet, rowMax, colMax);
+            cluster.setAdcData(sumOfAllTimeBins, (int)rmsAdc, (int)sumAdcA, (int)sumAdcB, sumOfAllTimeBinsAboveThreshold, (int)integralLandauFit, sumOfAdcTrunc);
+            cluster.setTimeData(maxTbA, maxTbB, (int)rmsTime);
+            cluster.setClusterSizeData(clSizeRow, clSizeCol, clSizeTime, nUsedADCsInCl);
+            mKrClusters.push_back(cluster);
+            ++nClsTotal;
+          } else {
+            //mFitResult->Print(std::cout);
+            ++nClsDropped;
+            LOG(DEBUG) << "Kr cluster cannot be added because values are out of range";
+            LOGF(DEBUG, "sumOfAllTimeBins(%i), sumAdcA(%f), sumAdcB(%f), clSizeRow(%i), clSizeCol(%i), clSizeTime(%i), maxTbA(%i), maxTbB(%i)", sumOfAllTimeBins, sumAdcA, sumAdcB, clSizeRow, clSizeCol, clSizeTime, maxTbA, maxTbB);
+            LOGF(DEBUG, "rmsAdc(%f), rmsTime(%f), nUsedADCsInCl(%i), sumOfAllTimeBinsAboveThreshold(%i), integralLandauFit(%f), sumOfAdcTrunc(%u)", rmsAdc, rmsTime, nUsedADCsInCl, sumOfAllTimeBinsAboveThreshold, integralLandauFit, sumOfAdcTrunc);
+          }
+        }
+      } // end cluster search
+    }   // end detector loop
+  }     // end trigger loop
+
+  // we don't need the exact BC time, just use first interaction record within this TF
+  mTrigRecs.emplace_back(mTriggerRecords[0].getBCData(), nClsTotal);
+  LOGF(INFO, "Number of Kr clusters with a) invalid fit (%i) b) out-of-range values which were dropped (%i)", nClsInvalidFit, nClsDropped);
+}

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TRDWorkflow
                        src/EntropyDecoderSpec.cxx
                        src/EntropyEncoderSpec.cxx
                        src/TrackBasedCalibSpec.cxx
+                       src/KrClustererSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO)
 
@@ -51,6 +52,11 @@ o2_add_executable(trd-vdrift-exb
 o2_add_executable(entropy-encoder-workflow
                   SOURCES src/entropy-encoder-workflow.cxx
                   COMPONENT_NAME trd
+                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
+
+o2_add_executable(kr-clusterer
+                  COMPONENT_NAME trd
+                  SOURCES src/trd-kr-clusterer.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
 
 if (OpenMP_CXX_FOUND)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/KrClustererSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/KrClustererSpec.h
@@ -9,16 +9,28 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef O2_TRD_KRCLUSTERERSPEC_H
+#define O2_TRD_KRCLUSTERERSPEC_H
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+/// \file   KrClustererSpec.h
+/// \brief Steers the TRD Krypton cluster finder
+/// \author Ole Schmidt
 
-#pragma link C++ class o2::trd::CalibratorVdExB + ;
-#pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos, o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::trd::TrackBasedCalib + ;
-#pragma link C++ class o2::trd::KrClusterFinder + ;
+// input TRD digits, TRD trigger records
+// output Kr clusters
 
-#endif
+#include "Framework/DataProcessorSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+/// create a processor spec
+framework::DataProcessorSpec getKrClustererSpec(bool digitTrigRec);
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_KRCLUSTERERSPEC_H

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TRDWorkflowIO
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackReaderSpec.cxx
                        src/TRDCalibWriterSpec.cxx
+                       src/KrClusterWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)
 
 

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/KrClusterWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/KrClusterWriterSpec.h
@@ -9,16 +9,25 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef O2_TRD_KRWRITERSPEC_H
+#define O2_TRD_KRWRITERSPEC_H
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+}
+} // namespace o2
 
-#pragma link C++ class o2::trd::CalibratorVdExB + ;
-#pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos, o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::trd::TrackBasedCalib + ;
-#pragma link C++ class o2::trd::KrClusterFinder + ;
+namespace o2
+{
+namespace trd
+{
 
-#endif
+o2::framework::DataProcessorSpec getKrClusterWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRD_KRWRITERSPEC_H

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDDigitReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDDigitReaderSpec.h
@@ -29,23 +29,21 @@ namespace trd
 class TRDDigitReaderSpec : public o2::framework::Task
 {
  public:
-  TRDDigitReaderSpec(int channels, bool useMC) : mUseMC(useMC) {}
+  TRDDigitReaderSpec(bool useMC) : mUseMC(useMC) {}
   ~TRDDigitReaderSpec() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
 
  private:
-  int mState = 0;
   bool mUseMC = false;
   std::unique_ptr<TFile> mFile = nullptr;
-  std::string mInputFileName = "";
   std::string mDigitTreeName = "o2sim";
   std::string mDigitBranchName = "TRDDigit";
   std::string mTriggerRecordBranchName = "TriggerRecord";
   std::string mMCLabelsBranchName = "TRDMCLabels";
 };
 
-o2::framework::DataProcessorSpec getTRDDigitReaderSpec(int channels, bool useMC);
+o2::framework::DataProcessorSpec getTRDDigitReaderSpec(bool useMC);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/io/src/KrClusterWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/KrClusterWriterSpec.cxx
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "TRDWorkflowIO/KrClusterWriterSpec.h"
+#include "DataFormatsTRD/KrCluster.h"
+#include "DataFormatsTRD/KrClusterTriggerRecord.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getKrClusterWriterSpec()
+{
+
+  return framework::MakeRootTreeWriterSpec("TRDKrClWriter",
+                                           "trdkrclusters.root",
+                                           "krClusters",
+                                           BranchDefinition<std::vector<o2::trd::KrCluster>>{InputSpec{"clusters", "TRD", "KRCLUSTER"}, "KrCluster"},
+                                           BranchDefinition<std::vector<o2::trd::KrClusterTriggerRecord>>{InputSpec{"trigRecs", "TRD", "TRGKRCLS"}, "TriggerRecord"})();
+};
+
+} // end namespace trd
+} // end namespace o2

--- a/Detectors/TRD/workflow/src/KrClustererSpec.cxx
+++ b/Detectors/TRD/workflow/src/KrClustererSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   KrClustererSpec.cxx
+/// \brief DPL device for running the TRD Krypton cluster finder
+/// \author Ole Schmidt
+
+#include "TRDWorkflow/KrClustererSpec.h"
+#include "TRDCalibration/KrClusterFinder.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "TStopwatch.h"
+#include <fairlogger/Logger.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDKrClustererDevice : public Task
+{
+ public:
+  TRDKrClustererDevice() = default;
+  ~TRDKrClustererDevice() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
+
+ private:
+  o2::trd::KrClusterFinder mKrClFinder;
+};
+
+void TRDKrClustererDevice::init(InitContext& ic)
+{
+  mKrClFinder.init();
+}
+
+void TRDKrClustererDevice::run(ProcessingContext& pc)
+{
+  TStopwatch timer;
+
+  const auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
+  const auto triggerRecords = pc.inputs().get<gsl::span<TriggerRecord>>("triggerRecords");
+
+  mKrClFinder.reset();
+  mKrClFinder.setInput(digits, triggerRecords);
+  timer.Start();
+  mKrClFinder.findClusters();
+  timer.Stop();
+
+  LOGF(INFO, "TRD Krypton cluster finder total timing: Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
+  LOGF(INFO, "Found %lu Kr clusters in %lu input trigger records.", mKrClFinder.getKrClusters().size(), triggerRecords.size());
+
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "KRCLUSTER", 0, Lifetime::Timeframe}, mKrClFinder.getKrClusters());
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGKRCLS", 0, Lifetime::Timeframe}, mKrClFinder.getKrTrigRecs());
+}
+
+void TRDKrClustererDevice::endOfStream(EndOfStreamContext& ec)
+{
+  LOG(INFO) << "Done with the cluster finding (EoS received)";
+}
+
+DataProcessorSpec getKrClustererSpec(bool digitTrigRec)
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("digits", o2::header::gDataOriginTRD, "DIGITS", 0, Lifetime::Timeframe);
+  if (digitTrigRec) {
+    inputs.emplace_back("triggerRecords", o2::header::gDataOriginTRD, "TRGRDIG", 0, Lifetime::Timeframe);
+  } else {
+    inputs.emplace_back("triggerRecords", o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
+  }
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "KRCLUSTER", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRGKRCLS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "trd-kr-clusterer",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDKrClustererDevice>()},
+    Options{}};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -97,7 +97,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootInput = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   if (!disableRootInput) {
-    specs.emplace_back(o2::trd::getTRDDigitReaderSpec(1, useMC));
+    specs.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC));
   }
   specs.emplace_back(o2::trd::getTRDTrapSimulatorSpec(useMC));
   if (!disableRootOutput) {

--- a/Detectors/TRD/workflow/src/trd-kr-clusterer.cxx
+++ b/Detectors/TRD/workflow/src/trd-kr-clusterer.cxx
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "TRDWorkflow/KrClustererSpec.h"
+#include "TRDWorkflowIO/TRDDigitReaderSpec.h"
+#include "TRDWorkflowIO/KrClusterWriterSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2trdkrcluster_workflow_configuration.ini");
+
+  o2::framework::WorkflowSpec specs;
+
+  bool useDigitTrigRec = false;
+
+  // input
+  if (!configcontext.options().get<bool>("disable-root-input")) {
+    specs.emplace_back(o2::trd::getTRDDigitReaderSpec(false));
+    useDigitTrigRec = true;
+  }
+
+  // processing devices
+  specs.emplace_back(o2::trd::getKrClustererSpec(useDigitTrigRec));
+
+  // output devices
+  if (!configcontext.options().get<bool>("disable-root-output")) {
+    specs.emplace_back(o2::trd::getKrClusterWriterSpec());
+  }
+
+  return specs;
+}


### PR DESCRIPTION
Based on the macro of @aschmah but fully revised. An executable `o2-trd-kr-clusterer` is added which takes as input TRD digits and trigger records and provides Krypton clusters.
Two concerns:
- The ROOT fit produces some log messages which I did not manage yet to turn off. This needs to be fixed before it can be used in production
- The TRDDigitReaderSpec provides the trigger records with the description `TRGRDIG` while the raw reader uses `TRKTRGRD`. A switch for both descriptions needs to be added depending on whether or not ROOT file input enabled
Adding this as draft PR for now.