### PR TITLE
[rANS] Fix missing Encoder normalization initialization in Constructor

### DIFF
--- a/Utilities/rANS/include/rANS/internal/EncoderBase.h
+++ b/Utilities/rANS/include/rANS/internal/EncoderBase.h
@@ -72,7 +72,7 @@ EncoderBase<coder_T, stream_T, source_T>::EncoderBase(encoderSymbolTable_t&& e, 
 
 template <typename coder_T, typename stream_T, typename source_T>
 EncoderBase<coder_T, stream_T, source_T>::EncoderBase(const FrequencyTable& frequencies,
-                                                      size_t symbolTablePrecission)
+                                                      size_t symbolTablePrecission) : mSymbolTablePrecission{symbolTablePrecission}
 {
   SymbolStatistics stats{frequencies, mSymbolTablePrecission};
   mSymbolTablePrecission = stats.getSymbolTablePrecision();


### PR DESCRIPTION
Fixes missing initialization of the symbol table precision that caused that all rANS encoders always initialized the dictionary normalized to the minimal number of bits. In some cases this caused wrong results in the decoder, as another normalization was used for the dictionary there.