### PR TITLE
TRD Make TrackletHCHeader optional

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -324,12 +324,22 @@ bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header)
 {
   bool goodheader = true;
   if (header.one != 1) {
+    LOG(warn) << "Sanity check tracklethcheader.one is not 1";
     goodheader = false;
   }
   if (header.supermodule > 17) {
+    LOG(warn) << "Sanity check tracklethcheader.supermodule>17";
     goodheader = false;
   }
   //if(header.format != )  only certain format versions are permitted come back an fill in if needed.
+  if (header.layer > 6) {
+    LOG(warn) << "Sanity check tracklethcheader.laywer>6";
+    goodheader = false;
+  }
+  if (header.stack > 5) {
+    LOG(warn) << "Sanity check tracklethcheader.stack>5";
+    goodheader = false;
+  }
   return goodheader;
 }
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -58,13 +58,14 @@ class CruRawReader
 
   void checkSummary();
   void resetCounters();
-  void configure(bool byteswap, bool fixdigitcorruption, bool verbose, bool headerverbose, bool dataverbose)
+  void configure(bool byteswap, bool fixdigitcorruption, int tracklethcheader, bool verbose, bool headerverbose, bool dataverbose)
   {
     mByteSwap = byteswap;
     mVerbose = verbose;
     mHeaderVerbose = headerverbose;
     mDataVerbose = dataverbose;
     mFixDigitEndCorruption = fixdigitcorruption;
+    mTrackletHCHeaderState = tracklethcheader;
   }
   void setBlob(bool returnblob) { mReturnBlob = returnblob; }; //set class to produce blobs and not vectors. (compress vs pass through)`
   void setDataBuffer(const char* val)
@@ -130,6 +131,8 @@ class CruRawReader
   bool mDataVerbose{false};
   bool mByteSwap{false};
   bool mFixDigitEndCorruption{false};
+  int mTrackletHCHeaderState{0};
+
   const char* mDataBuffer = nullptr;
   static const uint32_t mMaxHBFBufferSize = o2::trd::constants::HBFBUFFERMAX;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; //this holds the O2 payload held with in the HBFs to pass to parsing.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -35,7 +35,7 @@ namespace o2::trd
 class DataReaderTask : public Task
 {
  public:
-  DataReaderTask(bool compresseddata, bool byteswap, bool fixdigitendcorruption, bool verbose, bool headerverbose, bool dataverbose) : mCompressedData(compresseddata), mByteSwap(byteswap), mFixDigitEndCorruption(fixdigitendcorruption), mVerbose(verbose), mHeaderVerbose(headerverbose), mDataVerbose(dataverbose) {}
+  DataReaderTask(bool compresseddata, bool byteswap, bool fixdigitendcorruption, int tracklethcheader, bool verbose, bool headerverbose, bool dataverbose) : mCompressedData(compresseddata), mByteSwap(byteswap), mFixDigitEndCorruption(fixdigitendcorruption), mTrackletHCHeaderState(tracklethcheader), mVerbose(verbose), mHeaderVerbose(headerverbose), mDataVerbose(dataverbose) {}
   ~DataReaderTask() override = default;
   void init(InitContext& ic) final;
   void sendData(ProcessingContext& pc, bool blankframe = false);
@@ -49,12 +49,14 @@ class DataReaderTask : public Task
                                          // they will internally produce a vector of digits and a vector tracklets and associated indexing.
                                          // TODO templatise this and 2 versions of datareadertask, instantiated with the relevant parser.
 
-  bool mVerbose{false};        // verbos output general debuggign and info output.
-  bool mDataVerbose{false};    // verbose output of data unpacking
-  bool mHeaderVerbose{false};  // verbose output of headers
-  bool mCompressedData{false}; // are we dealing with the compressed data from the flp (send via option)
-  bool mByteSwap{true};        // whether we are to byteswap the incoming data, mc is not byteswapped, raw data is (too be changed in cru at some point)
-                               //  o2::header::DataDescription mDataDesc; // Data description of the incoming data
+  bool mVerbose{false};          // verbos output general debuggign and info output.
+  bool mDataVerbose{false};      // verbose output of data unpacking
+  bool mHeaderVerbose{false};    // verbose output of headers
+  bool mCompressedData{false};   // are we dealing with the compressed data from the flp (send via option)
+  bool mByteSwap{true};          // whether we are to byteswap the incoming data, mc is not byteswapped, raw data is (too be changed in cru at some point)
+                                 //  o2::header::DataDescription mDataDesc; // Data description of the incoming data
+  int mTrackletHCHeaderState{0}; // what to do about tracklethcheader, 0 never there, 2 always there, 1 there iff tracklet data, i.e. only there if next word is *not* endmarker 10001000.
+
   std::string mDataDesc;
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
   bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -36,7 +36,7 @@ class TrackletsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, uint32_t feeid, int robside, int detector, int stack, int layer, bool cleardigits = false, bool disablebyteswap = false, bool verbose = true, bool headerverbose = false, bool dataverbose = false) //, std::array<uint32_t, 15>& lengths) // change to calling per link.
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, uint32_t feeid, int robside, int detector, int stack, int layer, bool cleardigits = false, bool disablebyteswap = false, int usetracklethcheader = 0, bool verbose = true, bool headerverbose = false, bool dataverbose = false)
   {
     mStartParse = start;
     mEndParse = end;
@@ -52,6 +52,7 @@ class TrackletsParser
     mDataWordsParsed = 0;
     mTrackletsFound = 0;
     mPaddingWordsCounter = 0;
+    mTrackletHCHeaderState = usetracklethcheader; //what to with the tracklet half chamber header 0,1,2
     //    mTracklets.clear();
     return Parse();
   };
@@ -96,6 +97,7 @@ class TrackletsParser
   bool mVerbose{false};     // user verbose output, put debug statement in output from commandline.
   bool mHeaderVerbose{false};
   bool mDataVerbose{false};
+  int mTrackletHCHeaderState{0}; //what to with the tracklet half chamber header 0,1,2
 
   bool mIgnoreTrackletHCHeader{false}; // Is the data with out the tracklet HC Header? defaults to having it in.
   bool mByteOrderFix{false};           // simulated data is not byteswapped, real is, so deal with it accodringly.

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -251,7 +251,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
       if (mVerbose) {
         LOG(info) << "mem copy with offset of : " << cruhbfstartoffset << " parsing tracklets with linkstart: " << linkstart << " ending at : " << linkend;
       }
-      trackletwordsread = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, halfchamberside, currentdetector, stack, layer, cleardigits, mByteSwap, mVerbose, mHeaderVerbose, mDataVerbose); // this will read up to the tracnklet end marker.
+      trackletwordsread = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, halfchamberside, currentdetector, stack, layer, cleardigits, mByteSwap, mTrackletHCHeaderState, mVerbose, mHeaderVerbose, mDataVerbose); // this will read up to the tracklet end marker.
       if (mVerbose) {
         LOG(info) << "trackletwordsread:" << trackletwordsread << "  mem copy with offset of : " << cruhbfstartoffset << " parsing with linkstart: " << linkstart << " ending at : " << linkend;
       }

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -39,6 +39,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"trd-datareader-fixdigitcorruptdata", VariantType::Bool, false, {"Fix the erroneous data at the end of digits"}},
     {"enable-root-output", VariantType::Bool, false, {"Write the data to file"}},
+    {"tracklethcheader", VariantType::Int, 0, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -63,6 +64,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto dataverbose = cfgc.options().get<bool>("trd-datareader-dataverbose");
   auto askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
   auto fixdigitcorruption = cfgc.options().get<bool>("trd-datareader-fixdigitcorruptdata");
+  auto tracklethcheader = cfgc.options().get<int>("tracklethcheader");
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
@@ -70,7 +72,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   //outputs.emplace_back("TRD", "FLPSTAT", 0, Lifetime::Timeframe);
   LOG(info) << "enablebyteswap :" << byteswap;
   AlgorithmSpec algoSpec;
-  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(compresseddata, byteswap, fixdigitcorruption, verbose, headerverbose, dataverbose)};
+  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(compresseddata, byteswap, fixdigitcorruption, tracklethcheader, verbose, headerverbose, dataverbose)};
 
   WorkflowSpec workflow;
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -122,7 +122,7 @@ void DataReaderTask::run(ProcessingContext& pc)
           }
           mReader.setDataBuffer(payloadIn);
           mReader.setDataBufferSize(payloadInSize);
-          mReader.configure(mByteSwap, mFixDigitEndCorruption, mVerbose, mHeaderVerbose, mDataVerbose);
+          mReader.configure(mByteSwap, mFixDigitEndCorruption, mTrackletHCHeaderState, mVerbose, mHeaderVerbose, mDataVerbose);
           mReader.run();
           if (mVerbose) {
             LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -55,7 +55,7 @@ class Trap2CRU
   uint32_t buildHalfCRUHeader(HalfCRUHeader& header, const uint32_t bc, const uint32_t halfcru); // build the half cru header holding the lengths of all links amongst other things.
   void linkSizePadding(uint32_t linksize, uint32_t& crudatasize, uint32_t& padding);             // pad the link data stream to align with 256 bit words.
   void openInputFiles();
-  void setTrackletHCHeader(bool tracklethcheader) { mUseTrackletHCHeader = tracklethcheader; }
+  void setTrackletHCHeader(int tracklethcheader) { mUseTrackletHCHeader = tracklethcheader; }
   bool isTrackletOnLink(int link, int trackletpos); // is the current tracklet on the the current link
   bool isDigitOnLink(int link, int digitpos);       // is the current digit on the current link
   int buildDigitRawData(const int digitstartindex, const int digitendindex, const int mcm, const int rob, const uint32_t triggercount);
@@ -88,7 +88,7 @@ class Trap2CRU
   //HalfCRUHeader mHalfCRUHeader;
   //TrackletMCMHeader mTrackletMCMHeader;
   // TrackletMCMData mTrackletMCMData;
-  bool mUseTrackletHCHeader{false};
+  int mUseTrackletHCHeader{0};
   std::vector<char> mRawData; // store for building data event for a single half cru
   uint32_t mRawDataPos = 0;
   char* mRawDataPtr{nullptr};

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -661,10 +661,16 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& triggerrecord, cons
       if (isTrackletOnLink(linkid, mCurrentTracklet) || isDigitOnLink(linkid, mCurrentDigit)) {
         // we have some data somewhere for this link
         //write tracklet half chamber header irrespective of there being tracklet data
-        int hcheaderwords = writeTrackletHCHeader(triggercount, linkid);
-        linkwordswritten += hcheaderwords;
-        rawwords += hcheaderwords;
-
+        if (mUseTrackletHCHeader != 0) {
+          if (isTrackletOnLink(linkid, mCurrentTracklet) || mUseTrackletHCHeader == 2) {
+            //write tracklethcheader if there is tracklet data or if we always have tracklethcheader
+            //first part of the if statement handles the mUseTrackletHCHeader==1 option
+            int hcheaderwords = writeTrackletHCHeader(triggercount, linkid);
+            linkwordswritten += hcheaderwords;
+            rawwords += hcheaderwords;
+          }
+          //else do nothing as we dont want/have tracklethcheader
+        }
         while (isTrackletOnLink(linkid, mCurrentTracklet) && mCurrentTracklet < endtrackletindex) {
           // still on an mcm on this link
           tracklets = buildTrackletRawData(mCurrentTracklet, linkid); //returns # of 32 bits, header plus trackletdata words that would have come from the mcm.
@@ -683,7 +689,7 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& triggerrecord, cons
         adccounter = 0;
         rawwordsbefore = rawwords;
         //always write the digit hc header
-        hcheaderwords = writeDigitHCHeader(triggercount, linkid);
+        int hcheaderwords = writeDigitHCHeader(triggercount, linkid);
         linkwordswritten += hcheaderwords;
         rawwords += hcheaderwords;
         //although if there are trackelts there better be some digits unless the digits are switched off.

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -51,7 +51,7 @@ namespace bpo = boost::program_options;
 
 void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName,
               const std::string& outDir, int digitrate, bool verbose, std::string filePerLink,
-              uint32_t rdhV = 6, bool noEmptyHBF = false, bool tracklethcheader = false, int superPageSizeInB = 1024 * 1024);
+              uint32_t rdhV = 6, bool noEmptyHBF = false, int tracklethcheader = 0, int superPageSizeInB = 1024 * 1024);
 
 int main(int argc, char** argv)
 {
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     add_option("input-file-tracklets,t", bpo::value<std::string>()->default_value("trdtracklets.root"), "input Trapsim tracklets file");
     add_option("fileper,l", bpo::value<std::string>()->default_value("halfcru"), "all : raw file(false), halfcru : cru end point, cru : one file per cru, sm: one file per supermodule");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
-    add_option("trackletHCHeader,x", bpo::value<bool>()->default_value("false")->implicit_value(true), "include tracklet half chamber header (for run3) comes after tracklets and before the digit half chamber header, that has always been there.");
+    add_option("tracklethcheader,x", bpo::value<int>()->default_value(0), "include tracklet half chamber header (for run3). 0 never, 1 if there is tracklet data, 2 always");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(6), "rdh version in use default");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
@@ -104,13 +104,12 @@ int main(int argc, char** argv)
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   std::cout << "yay it ran" << std::endl;
-  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["digitrate"].as<int>(), vm["verbosity"].as<int>(),
-           vm["fileper"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["trackletHCHeader"].as<bool>());
+  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["digitrate"].as<int>(), vm["verbosity"].as<int>(), vm["fileper"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>());
 
   return 0;
 }
 
-void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName, const std::string& outDir, int digitrate, bool verbose, std::string filePer, uint32_t rdhV, bool noEmptyHBF, bool trackletHCHeader, int superPageSizeInB)
+void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName, const std::string& outDir, int digitrate, bool verbose, std::string filePer, uint32_t rdhV, bool noEmptyHBF, int trackletHCHeader, int superPageSizeInB)
 {
   TStopwatch swTot;
   swTot.Start();


### PR DESCRIPTION
- make tracklet half chamber header optional
- defaulted to option 0 never there.
- options added to mc2raw to enable checking.

Options:
- 0 no hcheader
- 1 hcheader iff tracklet data
- 2 hcheader always there irrespective of tracklet data.

Option 1 is unlikely.

It will mostly give TrackletHCHeader sanity check warning if options get muddled. Not full proof and can cause a seg fault if options chosen badly. This is merely to enable data taking with unkown status of tracklet hc header, but suspect to be option 0.