### PR TITLE
DPL Analysis: Configurable process switches

### DIFF
--- a/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -193,7 +193,7 @@ struct femtoDreamPairTaskTrackTrack {
     }
   }
 
-  PROCESS_SWITCH(processSame, "processSame", "Enable processing same event", &femtoDreamPairTaskTrackTrack::processSameEvent, true);
+  PROCESS_SWITCH(processSameEvent, "Enable processing same event", femtoDreamPairTaskTrackTrack, true);
 
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
@@ -255,7 +255,7 @@ struct femtoDreamPairTaskTrackTrack {
     }
   }
 
-  PROCESS_SWITCH(processMixed, "processMixed", "Enable processing mixed events", &femtoDreamPairTaskTrackTrack::processMixedEvent, true);
+  PROCESS_SWITCH(processMixedEvent, "Enable processing mixed events", femtoDreamPairTaskTrackTrack, true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -193,6 +193,8 @@ struct femtoDreamPairTaskTrackTrack {
     }
   }
 
+  PROCESS_SWITCH(processSame, "processSame", "Enable processing same event", &femtoDreamPairTaskTrackTrack::processSameEvent, true);
+
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
   void processMixedEvent(o2::aod::FemtoDreamCollisions& cols,
@@ -252,12 +254,14 @@ struct femtoDreamPairTaskTrackTrack {
       }
     }
   }
+
+  PROCESS_SWITCH(processMixed, "processMixed", "Enable processing mixed events", &femtoDreamPairTaskTrackTrack::processMixedEvent, true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<femtoDreamPairTaskTrackTrack>(cfgc, framework::Processes{&femtoDreamPairTaskTrackTrack::processSameEvent, &femtoDreamPairTaskTrackTrack::processMixedEvent}),
+    adaptAnalysisTask<femtoDreamPairTaskTrackTrack>(cfgc),
   };
 
   return workflow;

--- a/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/Analysis/Tasks/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -193,7 +193,7 @@ struct femtoDreamPairTaskTrackTrack {
     }
   }
 
-  PROCESS_SWITCH(processSameEvent, "Enable processing same event", femtoDreamPairTaskTrackTrack, true);
+  PROCESS_SWITCH(femtoDreamPairTaskTrackTrack, processSameEvent, "Enable processing same event", true);
 
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
@@ -255,7 +255,7 @@ struct femtoDreamPairTaskTrackTrack {
     }
   }
 
-  PROCESS_SWITCH(processMixedEvent, "Enable processing mixed events", femtoDreamPairTaskTrackTrack, true);
+  PROCESS_SWITCH(femtoDreamPairTaskTrackTrack, processMixedEvent, "Enable processing mixed events", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -289,6 +289,8 @@ struct CorrelationTask {
     fillCorrelations(same, tracks, tracks, centrality, collision.posZ(), bSign);
   }
 
+  PROCESS_SWITCH(doProcessSame, "doProcessSame", "Process same event", &CorrelationTask::processSame, true);
+
   void processMixed(soa::Join<aod::Collisions, aod::Hashes, aod::EvSels, aod::Cents>& collisions, myTracks const& tracks)
   {
     // TODO loading of efficiency histogram missing here, because it will happen somehow in the CCDBConfigurable
@@ -334,6 +336,8 @@ struct CorrelationTask {
       fillCorrelations(mixed, tracks1, tracks2, collision1.centV0M(), collision1.posZ(), bSign);
     }
   }
+
+  PROCESS_SWITCH(doProcessMixed, "doProcessMixed", "Process mixed events", &CorrelationTask::processMixed, true);
 
   // Version with combinations
   void processWithCombinations(soa::Join<aod::Collisions, aod::Cents>::iterator const& collision, soa::Filtered<aod::Tracks> const& tracks)
@@ -390,6 +394,8 @@ struct CorrelationTask {
       //mixed->getPairHist()->Fill(values, CorrelationContainer::kCFStepReconstructed);
     }
   }
+
+  PROCESS_SWITCH(doProcessCombinations, "doProcessCombinations", "Process with combinations", &CorrelationTask::processWithCombinations, false);
 
   double getEfficiency(THn* eff, float eta, float pt, float centrality, float posZ)
   {
@@ -494,5 +500,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
     adaptAnalysisTask<CorrelationHashTask>(cfgc),
-    adaptAnalysisTask<CorrelationTask>(cfgc, Processes{&CorrelationTask::processSame, &CorrelationTask::processMixed})};
+    adaptAnalysisTask<CorrelationTask>(cfgc)};
 }

--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -289,7 +289,7 @@ struct CorrelationTask {
     fillCorrelations(same, tracks, tracks, centrality, collision.posZ(), bSign);
   }
 
-  PROCESS_SWITCH(processSame, "Process same event", CorrelationTask, true);
+  PROCESS_SWITCH(CorrelationTask, processSame, "Process same event", true);
 
   void processMixed(soa::Join<aod::Collisions, aod::Hashes, aod::EvSels, aod::Cents>& collisions, myTracks const& tracks)
   {
@@ -337,7 +337,7 @@ struct CorrelationTask {
     }
   }
 
-  PROCESS_SWITCH(processMixed, "Process mixed events", CorrelationTask, true);
+  PROCESS_SWITCH(CorrelationTask, processMixed, "Process mixed events", true);
 
   // Version with combinations
   void processWithCombinations(soa::Join<aod::Collisions, aod::Cents>::iterator const& collision, soa::Filtered<aod::Tracks> const& tracks)
@@ -395,7 +395,7 @@ struct CorrelationTask {
     }
   }
 
-  PROCESS_SWITCH(processWithCombinations, "Process with combinations", CorrelationTask, false);
+  PROCESS_SWITCH(CorrelationTask, processWithCombinations, "Process with combinations", false);
 
   double getEfficiency(THn* eff, float eta, float pt, float centrality, float posZ)
   {

--- a/Analysis/Tasks/PWGCF/correlations.cxx
+++ b/Analysis/Tasks/PWGCF/correlations.cxx
@@ -289,7 +289,7 @@ struct CorrelationTask {
     fillCorrelations(same, tracks, tracks, centrality, collision.posZ(), bSign);
   }
 
-  PROCESS_SWITCH(doProcessSame, "doProcessSame", "Process same event", &CorrelationTask::processSame, true);
+  PROCESS_SWITCH(processSame, "Process same event", CorrelationTask, true);
 
   void processMixed(soa::Join<aod::Collisions, aod::Hashes, aod::EvSels, aod::Cents>& collisions, myTracks const& tracks)
   {
@@ -337,7 +337,7 @@ struct CorrelationTask {
     }
   }
 
-  PROCESS_SWITCH(doProcessMixed, "doProcessMixed", "Process mixed events", &CorrelationTask::processMixed, true);
+  PROCESS_SWITCH(processMixed, "Process mixed events", CorrelationTask, true);
 
   // Version with combinations
   void processWithCombinations(soa::Join<aod::Collisions, aod::Cents>::iterator const& collision, soa::Filtered<aod::Tracks> const& tracks)
@@ -395,7 +395,7 @@ struct CorrelationTask {
     }
   }
 
-  PROCESS_SWITCH(doProcessCombinations, "doProcessCombinations", "Process with combinations", &CorrelationTask::processWithCombinations, false);
+  PROCESS_SWITCH(processWithCombinations, "Process with combinations", CorrelationTask, false);
 
   double getEfficiency(THn* eff, float eta, float pt, float centrality, float posZ)
   {

--- a/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
+++ b/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
@@ -702,7 +702,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(processWithCent, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, true);
+  PROCESS_SWITCH(DptDptCorrelationsFilterAnalysisTask, processWithCent, "Process with centrality", true);
 
   void processWithoutCent(aod::CollisionEvSel const& collision, soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TracksExtended, aod::TrackSelection> const& ftracks)
   {
@@ -731,7 +731,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(processWithoutCent, "Process without centrality", DptDptCorrelationsFilterAnalysisTask, false);
+  PROCESS_SWITCH(DptDptCorrelationsFilterAnalysisTask, processWithoutCent, "Process without centrality", false);
 
   //  void processWithCentMC(aod::McCollision const& mccollision,
   //                         soa::Join<aod::McCollisionLabels, aod::CollisionsEvSelCent> const& collisions,
@@ -778,7 +778,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     }
   }
 
-  PROCESS_SWITCH(processWithCentMC, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, false);
+  PROCESS_SWITCH(DptDptCorrelationsFilterAnalysisTask, processWithCentMC, "Process with centrality", false);
 
   void processWithoutCentMC(aod::McCollision const& mccollision,
                             aod::McParticles const& mcparticles)
@@ -808,7 +808,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedtrueevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(processWithoutCentMC, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, false);
+  PROCESS_SWITCH(DptDptCorrelationsFilterAnalysisTask, processWithoutCentMC, "Process with centrality", false);
 };
 
 // Task for building <dpt,dpt> correlations

--- a/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
+++ b/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
@@ -430,7 +430,6 @@ inline void AcceptTrueTrack(ParticleObject& particle, ParticleListObject& partic
 using namespace dptdptcorrelations;
 
 struct DptDptCorrelationsFilterAnalysisTask {
-
   Configurable<int> cfgTrackType{"trktype", 1, "Type of selected tracks: 0 = no selection, 1 = global tracks FB96"};
   Configurable<bool> cfgProcessPairs{"processpairs", true, "Process pairs: false = no, just singles, true = yes, process pairs"};
   Configurable<std::string> cfgCentMultEstimator{"centmultestimator", "V0M", "Centrality/multiplicity estimator detector: default V0M"};
@@ -703,6 +702,8 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
 
+  PROCESS_SWITCH(doProcessWithCent, "doProcessWithCent", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithCent, true);
+
   void processWithoutCent(aod::CollisionEvSel const& collision, soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TracksExtended, aod::TrackSelection> const& ftracks)
   {
     using namespace filteranalysistask;
@@ -729,6 +730,8 @@ struct DptDptCorrelationsFilterAnalysisTask {
     }
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
+
+  PROCESS_SWITCH(doProcessWithoutCent, "doProcessWithoutCent", "Process without centrality", &DptDptCorrelationsFilterAnalysisTask::processWithoutCent, false);
 
   //  void processWithCentMC(aod::McCollision const& mccollision,
   //                         soa::Join<aod::McCollisionLabels, aod::CollisionsEvSelCent> const& collisions,
@@ -775,6 +778,8 @@ struct DptDptCorrelationsFilterAnalysisTask {
     }
   }
 
+  PROCESS_SWITCH(doProcessWithCentMC, "doProcessWithCentMC", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithCentMC, false);
+
   void processWithoutCentMC(aod::McCollision const& mccollision,
                             aod::McParticles const& mcparticles)
   {
@@ -802,6 +807,8 @@ struct DptDptCorrelationsFilterAnalysisTask {
     }
     acceptedtrueevents((uint8_t)acceptedevent, centormult);
   }
+
+  PROCESS_SWITCH(doProcessWithoutCentMC, "doProcessWithoutCentMC", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithoutCentMC, false);
 };
 
 // Task for building <dpt,dpt> correlations
@@ -1410,8 +1417,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       /* no centrality/multiplicity classes available */
       WorkflowSpec workflow{
         adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc,
-                                                                Processes{&DptDptCorrelationsFilterAnalysisTask::processWithoutCent,
-                                                                          &DptDptCorrelationsFilterAnalysisTask::processWithoutCentMC}),
+                                                                SetDefaultProcesses{{{"doProcessWithCent", false},
+                                                                                     {"doProcessWithoutCent", true},
+                                                                                     {"doProcessWithoutCentMC", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<TracksAndEventClassificationQAGen>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
@@ -1419,9 +1427,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     } else {
       /* centrality/multiplicity classes available */
       WorkflowSpec workflow{
-        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc,
-                                                                Processes{&DptDptCorrelationsFilterAnalysisTask::processWithCent,
-                                                                          &DptDptCorrelationsFilterAnalysisTask::processWithCentMC}),
+        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"doProcessWithCentMC", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<TracksAndEventClassificationQAGen>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
@@ -1431,14 +1437,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     if (multest == "NOCM") {
       /* no centrality/multiplicity classes available */
       WorkflowSpec workflow{
-        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, Processes{&DptDptCorrelationsFilterAnalysisTask::processWithoutCent}),
+        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"doProcessWithCent", false}, {"doProcessWithoutCent", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
       return workflow;
     } else {
       /* centrality/multiplicity classes available */
       WorkflowSpec workflow{
-        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, Processes{&DptDptCorrelationsFilterAnalysisTask::processWithCent}),
+        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
       return workflow;

--- a/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
+++ b/Analysis/Tasks/PWGCF/dptdptcorrelations-simchl.cxx
@@ -702,7 +702,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(doProcessWithCent, "doProcessWithCent", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithCent, true);
+  PROCESS_SWITCH(processWithCent, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, true);
 
   void processWithoutCent(aod::CollisionEvSel const& collision, soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TracksExtended, aod::TrackSelection> const& ftracks)
   {
@@ -731,7 +731,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(doProcessWithoutCent, "doProcessWithoutCent", "Process without centrality", &DptDptCorrelationsFilterAnalysisTask::processWithoutCent, false);
+  PROCESS_SWITCH(processWithoutCent, "Process without centrality", DptDptCorrelationsFilterAnalysisTask, false);
 
   //  void processWithCentMC(aod::McCollision const& mccollision,
   //                         soa::Join<aod::McCollisionLabels, aod::CollisionsEvSelCent> const& collisions,
@@ -778,7 +778,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     }
   }
 
-  PROCESS_SWITCH(doProcessWithCentMC, "doProcessWithCentMC", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithCentMC, false);
+  PROCESS_SWITCH(processWithCentMC, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, false);
 
   void processWithoutCentMC(aod::McCollision const& mccollision,
                             aod::McParticles const& mcparticles)
@@ -808,7 +808,7 @@ struct DptDptCorrelationsFilterAnalysisTask {
     acceptedtrueevents((uint8_t)acceptedevent, centormult);
   }
 
-  PROCESS_SWITCH(doProcessWithoutCentMC, "doProcessWithoutCentMC", "Process with centrality", &DptDptCorrelationsFilterAnalysisTask::processWithoutCentMC, false);
+  PROCESS_SWITCH(processWithoutCentMC, "Process with centrality", DptDptCorrelationsFilterAnalysisTask, false);
 };
 
 // Task for building <dpt,dpt> correlations
@@ -1417,9 +1417,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       /* no centrality/multiplicity classes available */
       WorkflowSpec workflow{
         adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc,
-                                                                SetDefaultProcesses{{{"doProcessWithCent", false},
-                                                                                     {"doProcessWithoutCent", true},
-                                                                                     {"doProcessWithoutCentMC", true}}}),
+                                                                SetDefaultProcesses{{{"processWithCent", false},
+                                                                                     {"processWithoutCent", true},
+                                                                                     {"processWithoutCentMC", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<TracksAndEventClassificationQAGen>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
@@ -1427,7 +1427,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     } else {
       /* centrality/multiplicity classes available */
       WorkflowSpec workflow{
-        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"doProcessWithCentMC", true}}}),
+        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"processWithCentMC", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<TracksAndEventClassificationQAGen>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
@@ -1437,7 +1437,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     if (multest == "NOCM") {
       /* no centrality/multiplicity classes available */
       WorkflowSpec workflow{
-        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"doProcessWithCent", false}, {"doProcessWithoutCent", true}}}),
+        adaptAnalysisTask<DptDptCorrelationsFilterAnalysisTask>(cfgc, SetDefaultProcesses{{{"processWithCent", false}, {"processWithoutCent", true}}}),
         adaptAnalysisTask<TracksAndEventClassificationQARec>(cfgc),
         adaptAnalysisTask<DptDptCorrelationsTask>(cfgc)};
       return workflow;

--- a/Analysis/Tasks/PWGGA/gammaConversions.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversions.cxx
@@ -200,7 +200,7 @@ struct GammaConversions {
     }
   }
 
-  PROCESS_SWITCH(doProcessData, "doProcessData", "Process data", &GammaConversions::processData, true);
+  PROCESS_SWITCH(processData, "Process data", GammaConversions, true);
 
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)

--- a/Analysis/Tasks/PWGGA/gammaConversions.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversions.cxx
@@ -200,6 +200,8 @@ struct GammaConversions {
     }
   }
 
+  PROCESS_SWITCH(doProcessData, "doProcessData", "Process data", &GammaConversions::processData, true);
+
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)
   {
@@ -345,5 +347,5 @@ struct GammaConversions {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<GammaConversions>(cfgc, Processes{&GammaConversions::processData})};
+  return WorkflowSpec{adaptAnalysisTask<GammaConversions>(cfgc)};
 }

--- a/Analysis/Tasks/PWGGA/gammaConversions.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversions.cxx
@@ -200,7 +200,7 @@ struct GammaConversions {
     }
   }
 
-  PROCESS_SWITCH(processData, "Process data", GammaConversions, true);
+  PROCESS_SWITCH(GammaConversions, processData, "Process data", true);
 
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)

--- a/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
@@ -230,6 +230,8 @@ struct GammaConversionsmc {
     }
   }
 
+  PROCESS_SWITCH(doProcessMC, "doProcessMC", "Process MC", &GammaConversionsmc::processMC, true);
+
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)
   {
@@ -375,5 +377,5 @@ struct GammaConversionsmc {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<GammaConversionsmc>(cfgc, Processes{&GammaConversionsmc::processMC})};
+  return WorkflowSpec{adaptAnalysisTask<GammaConversionsmc>(cfgc)};
 }

--- a/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
@@ -230,7 +230,7 @@ struct GammaConversionsmc {
     }
   }
 
-  PROCESS_SWITCH(doProcessMC, "doProcessMC", "Process MC", &GammaConversionsmc::processMC, true);
+  PROCESS_SWITCH(processMC, "Process MC", GammaConversionsmc, true);
 
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)

--- a/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
+++ b/Analysis/Tasks/PWGGA/gammaConversionsmc.cxx
@@ -230,7 +230,7 @@ struct GammaConversionsmc {
     }
   }
 
-  PROCESS_SWITCH(processMC, "Process MC", GammaConversionsmc, true);
+  PROCESS_SWITCH(GammaConversionsmc, processMC, "Process MC", true);
 
   template <typename T>
   void fillHistogramsBeforeCuts(const T& theV0)

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -122,7 +122,7 @@ struct HfTagSelCollisions {
     rowSelectedCollision(statusCollision);
   };
 
-  PROCESS_SWITCH(processEvSel, "Use event selection", HfTagSelCollisions, true);
+  PROCESS_SWITCH(HfTagSelCollisions, processEvSel, "Use event selection", true);
 
   // no event selection in case of no event-selection task attached
   void processNoEvSel(aod::Collision const&)
@@ -138,7 +138,7 @@ struct HfTagSelCollisions {
     rowSelectedCollision(statusCollision);
   };
 
-  PROCESS_SWITCH(processNoEvSel, "Do not use event selection", HfTagSelCollisions, false);
+  PROCESS_SWITCH(HfTagSelCollisions, processNoEvSel, "Do not use event selection", false);
 };
 
 /// Track selection

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -122,6 +122,8 @@ struct HfTagSelCollisions {
     rowSelectedCollision(statusCollision);
   };
 
+  PROCESS_SWITCH(withEvSel, "withEvSel", "Use event selection", &HfTagSelCollisions::processEvSel, true);
+
   // no event selection in case of no event-selection task attached
   void processNoEvSel(aod::Collision const&)
   {
@@ -135,6 +137,8 @@ struct HfTagSelCollisions {
     // fill table row
     rowSelectedCollision(statusCollision);
   };
+
+  PROCESS_SWITCH(withoutEvSel, "withoutEvSel", "Do not use event selection", &HfTagSelCollisions::processNoEvSel, false);
 };
 
 /// Track selection
@@ -1417,9 +1421,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   const bool doEvSel = cfgc.options().get<bool>("doEvSel");
   if (doEvSel) {
-    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc, Processes{&HfTagSelCollisions::processEvSel}));
+    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc));
   } else {
-    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc, Processes{&HfTagSelCollisions::processNoEvSel}));
+    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc, SetDefaultProcesses{{{"withEvSel", false}, {"withoutEvSel", true}}}));
   }
 
   workflow.push_back(adaptAnalysisTask<HfTagSelTracks>(cfgc));

--- a/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
+++ b/Analysis/Tasks/PWGHF/HFTrackIndexSkimsCreator.cxx
@@ -122,7 +122,7 @@ struct HfTagSelCollisions {
     rowSelectedCollision(statusCollision);
   };
 
-  PROCESS_SWITCH(withEvSel, "withEvSel", "Use event selection", &HfTagSelCollisions::processEvSel, true);
+  PROCESS_SWITCH(processEvSel, "Use event selection", HfTagSelCollisions, true);
 
   // no event selection in case of no event-selection task attached
   void processNoEvSel(aod::Collision const&)
@@ -138,7 +138,7 @@ struct HfTagSelCollisions {
     rowSelectedCollision(statusCollision);
   };
 
-  PROCESS_SWITCH(withoutEvSel, "withoutEvSel", "Do not use event selection", &HfTagSelCollisions::processNoEvSel, false);
+  PROCESS_SWITCH(processNoEvSel, "Do not use event selection", HfTagSelCollisions, false);
 };
 
 /// Track selection
@@ -1423,7 +1423,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (doEvSel) {
     workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc));
   } else {
-    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc, SetDefaultProcesses{{{"withEvSel", false}, {"withoutEvSel", true}}}));
+    workflow.push_back(adaptAnalysisTask<HfTagSelCollisions>(cfgc, SetDefaultProcesses{{{"processEvSel", false}, {"processNoEvSel", true}}}));
   }
 
   workflow.push_back(adaptAnalysisTask<HfTagSelTracks>(cfgc));

--- a/Analysis/Tutorials/src/multiProcess.cxx
+++ b/Analysis/Tutorials/src/multiProcess.cxx
@@ -66,7 +66,7 @@ struct MultipleProcessExample {
 
   /// name, description, function pointer, default value
   /// note that it has to be declared after the function, so that the pointer is known
-  PROCESS_SWITCH(prec, "prec", "Process reco level", &MultipleProcessExample::processRec, true);
+  PROCESS_SWITCH(processRec, "Process reco level", MultipleProcessExample, true);
 
   void processGen(soa::Filtered<aod::McCollisions>::iterator const&, aod::McParticles const& mcParticles)
   {
@@ -76,7 +76,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PROCESS_SWITCH(pgen, "pgen", "Process gen level", &MultipleProcessExample::processGen, false);
+  PROCESS_SWITCH(processGen, "Process gen level", MultipleProcessExample, false);
 
   void processResolution(soa::Filtered<soa::Join<aod::Collisions, aod::McCollisionLabels>>::iterator const& collision, soa::Join<aod::Tracks, aod::McTrackLabels> const& tracks, aod::McParticles const&, aod::McCollisions const&)
   {
@@ -87,7 +87,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PROCESS_SWITCH(pres, "pres", "Process reco/gen matching", &MultipleProcessExample::processResolution, false);
+  PROCESS_SWITCH(processResolution, "Process reco/gen matching", MultipleProcessExample, false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Analysis/Tutorials/src/multiProcess.cxx
+++ b/Analysis/Tutorials/src/multiProcess.cxx
@@ -23,13 +23,6 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-
-void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
-{
-  ConfigParamSpec optionDoMC{"doMC", VariantType::Bool, false, {"Use MC info"}};
-  workflowOptions.push_back(optionDoMC);
-}
-
 #include "Framework/runDataProcessing.h"
 
 namespace

--- a/Analysis/Tutorials/src/multiProcess.cxx
+++ b/Analysis/Tutorials/src/multiProcess.cxx
@@ -66,7 +66,7 @@ struct MultipleProcessExample {
 
   /// name, description, function pointer, default value
   /// note that it has to be declared after the function, so that the pointer is known
-  PROCESS_SWITCH(processRec, "Process reco level", MultipleProcessExample, true);
+  PROCESS_SWITCH(MultipleProcessExample, processRec, "Process reco level", true);
 
   void processGen(soa::Filtered<aod::McCollisions>::iterator const&, aod::McParticles const& mcParticles)
   {
@@ -76,7 +76,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PROCESS_SWITCH(processGen, "Process gen level", MultipleProcessExample, false);
+  PROCESS_SWITCH(MultipleProcessExample, processGen, "Process gen level", false);
 
   void processResolution(soa::Filtered<soa::Join<aod::Collisions, aod::McCollisionLabels>>::iterator const& collision, soa::Join<aod::Tracks, aod::McTrackLabels> const& tracks, aod::McParticles const&, aod::McCollisions const&)
   {
@@ -87,7 +87,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PROCESS_SWITCH(processResolution, "Process reco/gen matching", MultipleProcessExample, false);
+  PROCESS_SWITCH(MultipleProcessExample, processResolution, "Process reco/gen matching", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Analysis/Tutorials/src/multiProcess.cxx
+++ b/Analysis/Tutorials/src/multiProcess.cxx
@@ -71,7 +71,8 @@ struct MultipleProcessExample {
     }
   }
 
-  // name, description, function pointer, default value
+  /// name, description, function pointer, default value
+  /// note that it has to be declared after the function, so that the pointer is known
   PROCESS_SWITCH(prec, "prec", "Process reco level", &MultipleProcessExample::processRec, true);
 
   void processGen(soa::Filtered<aod::McCollisions>::iterator const&, aod::McParticles const& mcParticles)

--- a/Analysis/Tutorials/src/multiProcess.cxx
+++ b/Analysis/Tutorials/src/multiProcess.cxx
@@ -71,7 +71,8 @@ struct MultipleProcessExample {
     }
   }
 
-  PCONF(prec, "prec", "Process reco level", &MultipleProcessExample::processRec, true);
+  // name, description, function pointer, default value
+  PROCESS_SWITCH(prec, "prec", "Process reco level", &MultipleProcessExample::processRec, true);
 
   void processGen(soa::Filtered<aod::McCollisions>::iterator const&, aod::McParticles const& mcParticles)
   {
@@ -81,7 +82,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PCONF(pgen, "pgen", "Process gen level", &MultipleProcessExample::processGen, false);
+  PROCESS_SWITCH(pgen, "pgen", "Process gen level", &MultipleProcessExample::processGen, false);
 
   void processResolution(soa::Filtered<soa::Join<aod::Collisions, aod::McCollisionLabels>>::iterator const& collision, soa::Join<aod::Tracks, aod::McTrackLabels> const& tracks, aod::McParticles const&, aod::McCollisions const&)
   {
@@ -92,7 +93,7 @@ struct MultipleProcessExample {
     }
   }
 
-  PCONF(pres, "pres", "Process reco/gen matching", &MultipleProcessExample::processResolution, false);
+  PROCESS_SWITCH(pres, "pres", "Process reco/gen matching", &MultipleProcessExample::processResolution, false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -21,6 +21,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ConfigurableHelpers.h"
 #include "Framework/InitContext.h"
+#include "Framework/ConfigContext.h"
 #include "Framework/RootConfigParamHelpers.h"
 #include "Framework/ExpressionHelpers.h"
 
@@ -399,6 +400,21 @@ struct OptionManager<Configurable<T, K, IP>> {
   }
 };
 
+template <typename R, typename T, typename... As>
+struct OptionManager<ProcessConfigurable<R, T, As...>> {
+  static bool appendOption(std::vector<ConfigParamSpec>& options, ProcessConfigurable<R, T, As...>& what)
+  {
+    options.emplace_back(ConfigParamSpec{what.name, variant_trait_v<std::decay_t<bool>>, what.value, {what.help}, what.kind});
+    return true;
+  }
+
+  static bool prepare(InitContext& context, ProcessConfigurable<R, T, As...>& what)
+  {
+    what.value = context.options().get<bool>(what.name.c_str());
+    return true;
+  }
+};
+
 /// Manager template to facilitate extended tables spawning
 template <typename T>
 struct SpawnManager {
@@ -438,6 +454,7 @@ struct IndexManager<Builds<IDX, P>> {
     return true;
   }
 };
+
 } // namespace o2::framework
 
 #endif // ANALYSISMANAGERS_H

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -415,6 +415,26 @@ struct OptionManager<ProcessConfigurable<R, T, As...>> {
   }
 };
 
+template <typename ANY>
+struct UpdateProcessSwitches {
+  static bool set(std::pair<std::string, bool>, ANY&)
+  {
+    return false;
+  }
+};
+
+template <typename R, typename T, typename... As>
+struct UpdateProcessSwitches<ProcessConfigurable<R, T, As...>> {
+  static bool set(std::pair<std::string, bool> setting, ProcessConfigurable<R, T, As...>& what)
+  {
+    if (what.name == setting.first) {
+      what.value = setting.second;
+      return true;
+    }
+    return false;
+  }
+};
+
 /// Manager template to facilitate extended tables spawning
 template <typename T>
 struct SpawnManager {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -774,7 +774,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   // no static way to check if the task defines any processing, we can only make sure it subscribes to at least something
   if (inputs.empty() == true) {
-    throw runtime_error_f("Task %s has no inputs.", name_str.c_str());
+    LOG(WARN) << "Task " << name_str << " has no inputs";
   }
 
   homogeneous_apply_refs([&outputs, &hash](auto& x) { return OutputManager<std::decay_t<decltype(x)>>::appendOutput(outputs, x, hash); }, *task.get());

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -84,6 +84,20 @@ using MutableConfigurable = Configurable<T, K, ConfigurablePolicyMutable<T, K>>;
 
 using ConfigurableAxis = Configurable<std::vector<double>, ConfigParamKind::kAxisSpec, ConfigurablePolicyConst<std::vector<double>, ConfigParamKind::kAxisSpec>>;
 
+template <typename R, typename T, typename... As>
+struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
+  ProcessConfigurable(R (T::*process_)(As...), std::string const& name_, bool&& value_, std::string const& help_)
+    : process{process_},
+      Configurable<bool, ConfigParamKind::kProcessFlag>(name_, std::forward<bool>(value_), help_)
+  {
+  }
+  R(T::*process)
+  (As...);
+};
+
+#define PROCESS_SWITCH(_Class_, _Name_, _Help_, _Default_) \
+  decltype(ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
+
 template <typename T, ConfigParamKind K, typename IP>
 std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)
 {

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -90,5 +90,6 @@ std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)
   os << c.value;
   return os;
 }
+
 } // namespace o2::framework
 #endif // O2_FRAMEWORK_CONFIGURABLE_H_

--- a/Framework/Core/include/Framework/ConfigurableKinds.h
+++ b/Framework/Core/include/Framework/ConfigurableKinds.h
@@ -14,7 +14,8 @@ namespace o2::framework
 {
 enum ConfigParamKind : int {
   kGeneric = 0,
-  kAxisSpec = 1
+  kAxisSpec = 1,
+  kProcessFlag = 2
 };
 }
 #endif // O2_FRAMEWORK_CONFIGURABLEKINDS_H_

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -103,6 +103,10 @@ struct TaskStreamInfo {
   bool running = false;
 };
 
+struct DeviceConfigurationHelpers {
+  static std::unique_ptr<ConfigParamStore> getConfiguration(ServiceRegistry& registry, const char* name, std::vector<ConfigParamSpec> const& options);
+};
+
 /// A device actually carrying out all the DPL
 /// Data Processing needs.
 class DataProcessingDevice : public FairMQDevice

--- a/Framework/Core/include/Framework/ExpressionHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionHelpers.h
@@ -135,7 +135,7 @@ struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
   (As...);
 };
 
-#define PCONF(_Var_, _Name_, _Help_, _Function_, _Default_) \
+#define PROCESS_SWITCH(_Var_, _Name_, _Help_, _Function_, _Default_) \
   decltype(ProcessConfigurable{_Function_, _Name_, _Default_, _Help_}) _Var_ = ProcessConfigurable{_Function_, _Name_, _Default_, _Help_};
 } // namespace o2::framework
 

--- a/Framework/Core/include/Framework/ExpressionHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionHelpers.h
@@ -135,8 +135,11 @@ struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
   (As...);
 };
 
-#define PROCESS_SWITCH(_Var_, _Name_, _Help_, _Function_, _Default_) \
+#define PROCESS_SWITCH_FULL(_Var_, _Name_, _Help_, _Function_, _Default_) \
   decltype(ProcessConfigurable{_Function_, _Name_, _Default_, _Help_}) _Var_ = ProcessConfigurable{_Function_, _Name_, _Default_, _Help_};
+
+#define PROCESS_SWITCH(_Name_, _Help_, _Class_, _Default_) \
+  decltype(ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_EXPRESSIONS_HELPERS_H_

--- a/Framework/Core/include/Framework/ExpressionHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionHelpers.h
@@ -122,4 +122,21 @@ struct NodeRecord {
 };
 } // namespace o2::framework::expressions
 
+namespace o2::framework
+{
+template <typename R, typename T, typename... As>
+struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
+  ProcessConfigurable(R (T::*process_)(As...), std::string const& name_, bool&& value_, std::string const& help_)
+    : process{process_},
+      Configurable<bool, ConfigParamKind::kProcessFlag>(name_, std::forward<bool>(value_), help_)
+  {
+  }
+  R(T::*process)
+  (As...);
+};
+
+#define PCONF(_Var_, _Name_, _Help_, _Function_, _Default_) \
+  decltype(ProcessConfigurable{_Function_, _Name_, _Default_, _Help_}) _Var_ = ProcessConfigurable{_Function_, _Name_, _Default_, _Help_};
+} // namespace o2::framework
+
 #endif // O2_FRAMEWORK_EXPRESSIONS_HELPERS_H_

--- a/Framework/Core/include/Framework/ExpressionHelpers.h
+++ b/Framework/Core/include/Framework/ExpressionHelpers.h
@@ -122,24 +122,4 @@ struct NodeRecord {
 };
 } // namespace o2::framework::expressions
 
-namespace o2::framework
-{
-template <typename R, typename T, typename... As>
-struct ProcessConfigurable : Configurable<bool, ConfigParamKind::kProcessFlag> {
-  ProcessConfigurable(R (T::*process_)(As...), std::string const& name_, bool&& value_, std::string const& help_)
-    : process{process_},
-      Configurable<bool, ConfigParamKind::kProcessFlag>(name_, std::forward<bool>(value_), help_)
-  {
-  }
-  R(T::*process)
-  (As...);
-};
-
-#define PROCESS_SWITCH_FULL(_Var_, _Name_, _Help_, _Function_, _Default_) \
-  decltype(ProcessConfigurable{_Function_, _Name_, _Default_, _Help_}) _Var_ = ProcessConfigurable{_Function_, _Name_, _Default_, _Help_};
-
-#define PROCESS_SWITCH(_Name_, _Help_, _Class_, _Default_) \
-  decltype(ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_}) do##_Name_ = ProcessConfigurable{&_Class_ ::_Name_, #_Name_, _Default_, _Help_};
-} // namespace o2::framework
-
 #endif // O2_FRAMEWORK_EXPRESSIONS_HELPERS_H_

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -47,7 +47,7 @@ class Filter;
 using atype = arrow::Type;
 struct ExpressionInfo {
   int argumentIndex;
-  int processIndex;
+  size_t processHash;
   std::set<size_t> hashes;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree;

--- a/Framework/Core/include/Framework/StringHelpers.h
+++ b/Framework/Core/include/Framework/StringHelpers.h
@@ -163,4 +163,10 @@ constexpr auto get_size(const std::string_view& str)
     return const_str_details::as_chars<literal_to_chars>(); \
   }()
 
+template <typename T>
+constexpr auto typeHash()
+{
+  return compile_time_hash(typeid(T).name());
+}
+
 #endif // O2_FRAMEWORK_STRINGHELPERS_H

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -92,8 +92,8 @@ DataProcessingDevice::DataProcessingDevice(RunningDeviceRef ref, ServiceRegistry
     mStatelessProcess{mSpec.algorithm.onProcess},
     mError{mSpec.algorithm.onError},
     mConfigRegistry{nullptr},
-    mAllocator{&mTimingInfo, &registry, mSpec.outputs},
     mServiceRegistry{registry},
+    mAllocator{&mTimingInfo, &registry, mSpec.outputs},
     mQuotaEvaluator{registry.get<ComputingQuotaEvaluator>()}
 {
   /// FIXME: move erro handling to a service?
@@ -213,30 +213,36 @@ void DataProcessingDevice::Init()
   mRelayer = &mServiceRegistry.get<DataRelayer>();
   // If available use the ConfigurationInterface, otherwise go for
   // the command line options.
-  bool hasConfiguration = false;
-  bool hasOverrides = false;
-  if (mServiceRegistry.active<ConfigurationInterface>()) {
-    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
-    hasConfiguration = true;
-    try {
-      cfg.getRecursive(mSpec.name);
-      hasOverrides = true;
-    } catch (...) {
-      // No overrides...
-    }
-  }
-  // We only use the configuration file if we have a stanza for the given
-  // dataprocessor
-  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
-  if (hasConfiguration && hasOverrides) {
-    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
-    retrievers.emplace_back(std::make_unique<ConfigurationOptionsRetriever>(&cfg, mSpec.name));
-  } else {
+  //  bool hasConfiguration = false;
+  //  bool hasOverrides = false;
+  //  if (mServiceRegistry.active<ConfigurationInterface>()) {
+  //    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
+  //    hasConfiguration = true;
+  //    try {
+  //      cfg.getRecursive(mSpec.name);
+  //      hasOverrides = true;
+  //    } catch (...) {
+  //      // No overrides...
+  //    }
+  //  }
+  //  // We only use the configuration file if we have a stanza for the given
+  //  // dataprocessor
+  //  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+  //  if (hasConfiguration && hasOverrides) {
+  //    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
+  //    retrievers.emplace_back(std::make_unique<ConfigurationOptionsRetriever>(&cfg, mSpec.name));
+  //  } else {
+  //    retrievers.emplace_back(std::make_unique<FairOptionsRetriever>(GetConfig()));
+  //  }
+  auto configStore = DeviceConfigurationHelpers::getConfiguration(mServiceRegistry, mSpec.name.c_str(), mSpec.options);
+  if (configStore == nullptr) {
+    std::vector<std::unique_ptr<ParamRetriever>> retrievers;
     retrievers.emplace_back(std::make_unique<FairOptionsRetriever>(GetConfig()));
+    configStore = std::make_unique<ConfigParamStore>(mSpec.options, std::move(retrievers));
+    configStore->preload();
+    configStore->activate();
   }
-  auto configStore = std::make_unique<ConfigParamStore>(mSpec.options, std::move(retrievers));
-  configStore->preload();
-  configStore->activate();
+
   using boost::property_tree::ptree;
 
   /// Dump the configuration so that we can get it from the driver.
@@ -1328,6 +1334,26 @@ void DataProcessingDevice::error(const char* msg)
 {
   LOG(ERROR) << msg;
   mServiceRegistry.get<DataProcessingStats>().errorCount++;
+}
+
+std::unique_ptr<ConfigParamStore> DeviceConfigurationHelpers::getConfiguration(ServiceRegistry& registry, const char* name, std::vector<ConfigParamSpec> const& options)
+{
+
+  if (registry.active<ConfigurationInterface>()) {
+    auto& cfg = registry.get<ConfigurationInterface>();
+    try {
+      cfg.getRecursive(name);
+      std::vector<std::unique_ptr<ParamRetriever>> retrievers;
+      retrievers.emplace_back(std::make_unique<ConfigurationOptionsRetriever>(&cfg, name));
+      auto configStore = std::make_unique<ConfigParamStore>(options, std::move(retrievers));
+      configStore->preload();
+      configStore->activate();
+      return configStore;
+    } catch (...) {
+      // No overrides...
+    }
+  }
+  return std::unique_ptr<ConfigParamStore>(nullptr);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -211,29 +211,7 @@ void DataProcessingDevice::Init()
   TracyAppInfo(mSpec.name.data(), mSpec.name.size());
   ZoneScopedN("DataProcessingDevice::Init");
   mRelayer = &mServiceRegistry.get<DataRelayer>();
-  // If available use the ConfigurationInterface, otherwise go for
-  // the command line options.
-  //  bool hasConfiguration = false;
-  //  bool hasOverrides = false;
-  //  if (mServiceRegistry.active<ConfigurationInterface>()) {
-  //    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
-  //    hasConfiguration = true;
-  //    try {
-  //      cfg.getRecursive(mSpec.name);
-  //      hasOverrides = true;
-  //    } catch (...) {
-  //      // No overrides...
-  //    }
-  //  }
-  //  // We only use the configuration file if we have a stanza for the given
-  //  // dataprocessor
-  //  std::vector<std::unique_ptr<ParamRetriever>> retrievers;
-  //  if (hasConfiguration && hasOverrides) {
-  //    auto& cfg = mServiceRegistry.get<ConfigurationInterface>();
-  //    retrievers.emplace_back(std::make_unique<ConfigurationOptionsRetriever>(&cfg, mSpec.name));
-  //  } else {
-  //    retrievers.emplace_back(std::make_unique<FairOptionsRetriever>(GetConfig()));
-  //  }
+
   auto configStore = DeviceConfigurationHelpers::getConfiguration(mServiceRegistry, mSpec.name.c_str(), mSpec.options);
   if (configStore == nullptr) {
     std::vector<std::unique_ptr<ParamRetriever>> retrievers;

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -180,7 +180,7 @@ void addMissingOutputsToBuilder(std::vector<InputSpec>&& requestedIDXs,
     std::regex word_regex("(\\w+)");
     auto words = std::sregex_iterator(s.begin(), s.end(), word_regex);
     if (std::distance(words, std::sregex_iterator()) != 3) {
-      throw runtime_error_f("Malformed spec: %s", s.c_str());
+      throw runtime_error_f("Malformed input spec metadata: %s", s.c_str());
     }
     std::vector<std::string> data;
     for (auto i = words; i != std::sregex_iterator(); ++i) {
@@ -197,12 +197,14 @@ void addMissingOutputsToBuilder(std::vector<InputSpec>&& requestedIDXs,
     auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
     publisher.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec});
     for (auto& i : input.metadata) {
-      auto spec = inputSpecFromString(i.defaultValue.get<std::string>());
-      auto j = std::find_if(publisher.inputs.begin(), publisher.inputs.end(), [&](auto x) { return x.binding == spec.binding; });
-      if (j == publisher.inputs.end()) {
-        publisher.inputs.push_back(spec);
+      if ((i.type == VariantType::String) && (i.name.find("input:") != std::string::npos)) {
+        auto spec = inputSpecFromString(i.defaultValue.get<std::string>());
+        auto j = std::find_if(publisher.inputs.begin(), publisher.inputs.end(), [&](auto x) { return x.binding == spec.binding; });
+        if (j == publisher.inputs.end()) {
+          publisher.inputs.push_back(spec);
+        }
+        requestedAODs.push_back(spec);
       }
-      requestedAODs.push_back(spec);
     }
   }
 }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1505,7 +1505,13 @@ int runStateMachine(DataProcessorSpecs const& workflow,
             if (device.inputs.empty() == true) {
               continue;
             }
-
+            //ignore devices with no metadata in inputs
+            auto hasMetadata = std::any_of(device.inputs.begin(), device.inputs.end(), [](InputSpec const& spec) {
+              return spec.metadata.empty() == false;
+            });
+            if (!hasMetadata) {
+              continue;
+            }
             // ignore devices with no control options
             auto hasControls = std::any_of(device.inputs.begin(), device.inputs.end(), [](InputSpec const& spec) {
               return std::any_of(spec.metadata.begin(), spec.metadata.end(), [](ConfigParamSpec const& param) {

--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -55,8 +55,9 @@ constexpr long brace_constructible_size()
 {
   using A = any_type;
   using type = std::decay_t<T>;
-
-  if constexpr (is_braces_constructible<type, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A>{}) {
+  if constexpr (is_braces_constructible<type, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A>{}) {
+    return 40;
+  } else if constexpr (is_braces_constructible<type, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A>{}) {
     return 39;
   } else if constexpr (is_braces_constructible<type, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A>{}) {
     return 38;


### PR DESCRIPTION
This introduces a way to dynamically configure which process functions a task will run.
* Added a `ProcessConfigurable` with a distinct kind to be used with hyperloop
* Added a macro to declare process configurables in a task
* Added workflow adjustment from supplied configuration (WARN: only JSON configuration is supported currently, commandline switches will not work)
* Updated multiple process tutorial example