### PR TITLE
Use ClassDefNV when there are no virtual functions

### DIFF
--- a/Analysis/Core/include/AnalysisCore/JetFinder.h
+++ b/Analysis/Core/include/AnalysisCore/JetFinder.h
@@ -168,7 +168,7 @@ class JetFinder
   std::unique_ptr<fastjet::Subtractor> sub;
   std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
 
-  ClassDef(JetFinder, 1);
+  ClassDefNV(JetFinder, 1);
 };
 
 //does this belong here?

--- a/Analysis/Core/include/AnalysisCore/TrackSelection.h
+++ b/Analysis/Core/include/AnalysisCore/TrackSelection.h
@@ -210,7 +210,7 @@ class TrackSelection
   // vector of ITS requirements (minNRequiredHits in specific requiredLayers)
   std::vector<std::pair<int8_t, std::set<uint8_t>>> mRequiredITSHits{};
 
-  ClassDef(TrackSelection, 1);
+  ClassDefNV(TrackSelection, 1);
 };
 
 #endif

--- a/Analysis/EventFiltering/PWGUD/cutHolder.h
+++ b/Analysis/EventFiltering/PWGUD/cutHolder.h
@@ -93,7 +93,7 @@ class cutHolder
   float mMaxnSigmaTPC; // maximum nSigma TPC
   float mMaxnSigmaTOF; // maximum nSigma TOF
 
-  ClassDef(cutHolder, 1);
+  ClassDefNV(cutHolder, 1);
 };
 
 #endif // O2_ANALYSIS_DIFFCUT_HOLDER_H_

--- a/Analysis/Tutorials/include/Analysis/configurableCut.h
+++ b/Analysis/Tutorials/include/Analysis/configurableCut.h
@@ -58,7 +58,7 @@ class configurableCut
   std::vector<std::string> labels;
   o2::framework::Array2D<double> cuts;
 
-  ClassDef(configurableCut, 5);
+  ClassDefNV(configurableCut, 5);
 };
 
 std::ostream& operator<<(std::ostream& os, configurableCut const& c);

--- a/Common/Field/include/Field/MagFieldFast.h
+++ b/Common/Field/include/Field/MagFieldFast.h
@@ -86,7 +86,7 @@ class MagFieldFast
   float mFactorSol; // scaling factor
   SolParam mSolPar[kNSolRRanges][kNSolZRanges][kNQuadrants];
 
-  ClassDef(MagFieldFast, 1);
+  ClassDefNV(MagFieldFast, 1);
 };
 
 inline float MagFieldFast::CalcPol(const float* cf, float x, float y, float z) const

--- a/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Hit.h
+++ b/DataFormats/Detectors/HMPID/include/DataFormatsHMP/Hit.h
@@ -35,7 +35,7 @@ class HitType : public o2::BasicXYZEHit<float>
  public:
   using BasicXYZEHit<float>::BasicXYZEHit;
 
-  ClassDef(HitType, 1);
+  ClassDefNV(HitType, 1);
 };
 
 } // namespace hmpid

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
@@ -44,7 +44,7 @@ class Flex
   Double_t* mFlexOrigin;
   LadderSegmentation* mLadderSeg;
 
-  ClassDef(Flex, 1);
+  ClassDefNV(Flex, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
@@ -32,7 +32,7 @@ class GeometryBuilder
   void buildGeometry();
 
  private:
-  ClassDef(GeometryBuilder, 1);
+  ClassDefNV(GeometryBuilder, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
@@ -43,7 +43,7 @@ class HalfCone
   TGeoVolumeAssembly* mHalfCone;
 
  private:
-  ClassDef(HalfCone, 1);
+  ClassDefNV(HalfCone, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
@@ -140,7 +140,7 @@ class HeatExchanger
   Double_t mAngle4fifth[4];  // angle of torus for fifth pipe of disk 4
   Double_t mRadius4fifth[4]; // radius of torus for fifth pipe of disk 4
 
-  ClassDef(HeatExchanger, 2);
+  ClassDefNV(HeatExchanger, 2);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/PCBSupport.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/PCBSupport.h
@@ -74,7 +74,7 @@ class PCBSupport
   Int_t mNumberOfHoles[5];    // Number of Holes in each PCB
   Double_t (*mHoles[5])[3];   // Holes on each PCB
 
-  ClassDef(PCBSupport, 1);
+  ClassDefNV(PCBSupport, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/PatchPanel.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/PatchPanel.h
@@ -35,7 +35,7 @@ class PatchPanel
   TGeoVolumeAssembly* createPatchPanel();
 
  private:
-  ClassDef(PatchPanel, 1);
+  ClassDefNV(PatchPanel, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
@@ -37,7 +37,7 @@ class PowerSupplyUnit
   TGeoVolumeAssembly* create();
 
  private:
-  ClassDef(PowerSupplyUnit, 2);
+  ClassDefNV(PowerSupplyUnit, 2);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
@@ -61,7 +61,7 @@ class Segmentation
  private:
   TClonesArray* mHalves; ///< \brief Array of pointer to HalfSegmentation
 
-  ClassDef(Segmentation, 1);
+  ClassDefNV(Segmentation, 1);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
@@ -111,7 +111,7 @@ class Support
   Double_t mHeight_D2;
   Double_t (*mD2Holes[5])[2]; // Positions of D2 mm holes on disk
 
-  ClassDef(Support, 1);
+  ClassDefNV(Support, 1);
 };
 
 //Template to reduce boilerplate for TGeo boolean operations

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/GeometryMisAligner.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/GeometryMisAligner.h
@@ -240,7 +240,7 @@ class GeometryMisAligner
   Double_t fXYAngMisAligFactor; ///< factor (<1) to apply to angular misalignment range since range of motion is restricted out of the xy plane
   Double_t fZCartMisAligFactor; ///< factor (<1) to apply to cartetian misalignment range since range of motion is restricted in z direction
 
-  ClassDef(GeometryMisAligner, 0) // Geometry parametrisation
+  ClassDefNV(GeometryMisAligner, 0) // Geometry parametrisation
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/AlpideSimResponse.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/AlpideSimResponse.h
@@ -142,7 +142,7 @@ class AlpideSimResponse
   const std::string& getColRowDataFmt() const { return mColRowDataFmt; }
   void print() const;
 
-  ClassDef(AlpideSimResponse, 1);
+  ClassDefNV(AlpideSimResponse, 1);
 };
 
 //-----------------------------------------------------

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
@@ -86,7 +86,7 @@ class TOFDCSProcessor
   //int process(const std::vector<DPCOM>& dps);
   int process(const gsl::span<const DPCOM> dps);
   int processDP(const DPCOM& dpcom);
-  virtual uint64_t processFlags(uint64_t flag, const char* pid);
+  uint64_t processFlags(uint64_t flag, const char* pid);
 
   void updateDPsCCDB();
   void getStripsConnectedToFEAC(int nDDL, int nFEAC, TOFFEACinfo& info) const;

--- a/Detectors/TRD/base/include/TRDBase/CommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/CommonParam.h
@@ -79,7 +79,7 @@ class CommonParam
   /// This is a singleton, constructor is private!
   CommonParam() = default;
 
-  ClassDef(CommonParam, 1); // The constant parameters common to simulation and reconstruction
+  ClassDefNV(CommonParam, 1); // The constant parameters common to simulation and reconstruction
 };
 } // namespace trd
 } // namespace o2


### PR DESCRIPTION
See https://root-forum.cern.ch/t/classdef-variants/44736/6

`TOFDCSProcessor::processFlags` doesn't need to be virtual https://github.com/AliceO2Group/AliceO2/commit/0fe332f79c6aca092b2299c5d203e973cf269987#r53937585