### PR TITLE
GPUTRDTracker: Use CAMath::Abs

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -131,7 +131,7 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
 
   float Bz = Param().par.bzkG;
   GPUInfo("Initializing with B-field: %f kG", Bz);
-  if (abs(abs(Bz) - 2) < 0.1) {
+  if (CAMath::Abs(CAMath::Abs(Bz) - 2) < 0.1) {
     // magnetic field +-0.2 T
     if (Bz > 0) {
       GPUInfo("Loading error parameterization for Bz = +2 kG");
@@ -144,7 +144,7 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
       mDyA2 = 1.225e-3f, mDyB = 9.8e-3f, mDyC2 = 3.88e-2f;
       mAngleToDyA = 0.1f, mAngleToDyB = 1.89f, mAngleToDyC = 0.4f;
     }
-  } else if (abs(abs(Bz) - 5) < 0.1) {
+  } else if (CAMath::Abs(CAMath::Abs(Bz) - 5) < 0.1) {
     // magnetic field +-0.5 T
     if (Bz > 0) {
       GPUInfo("Loading error parameterization for Bz = +5 kG");


### PR DESCRIPTION
Clang on CentOS 7 warns that `int abs(int)` would be called for the argument of a floating point type