### PR TITLE
Ignore clangd .cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cmake_install.cmake
 compile_commands.json
 
 # IDEs files
+.cache
 .cproject
 .devcontainer*
 .project


### PR DESCRIPTION
Looks like clangd index is now under `.cache/clangd/index` instead of `.clangd/index` next to `compile_commands.json`
https://reviews.llvm.org/D83099 https://clangd.llvm.org/design/indexing.html