### PR TITLE
DPL: fix handling of timepipelining in reader

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
+++ b/DataFormats/Headers/include/Headers/DataHeaderHelpers.h
@@ -69,7 +69,7 @@ struct fmt::formatter<o2::header::DataHeader> {
   template <typename FormatContext>
   auto format(const o2::header::DataHeader& h, FormatContext& ctx)
   {
-    auto res = fmt::format("Data header version %u, flags: %u\n", h.headerVersion, h.flags) +
+    auto res = fmt::format("Data header version {}, flags: {}\n", h.headerVersion, h.flags) +
                fmt::format("  origin       : {}\n", h.dataOrigin.str) +
                fmt::format("  serialization: {}\n", h.payloadSerializationMethod.str) +
                fmt::format("  description  : {}\n", h.dataDescription.str) +

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -238,7 +238,10 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback()
 
       auto ioStart = uv_hrtime();
 
-      for (auto route : requestedTables) {
+      for (auto& route : requestedTables) {
+        if ((device.inputTimesliceId % route.maxTimeslices) != route.timeslice) {
+          continue;
+        }
 
         // create header
         auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -495,6 +495,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     outputsInputsAOD.emplace_back(InputSpec{"tfn", "TFN", "TFNumber"});
     auto fileSink = CommonDataProcessors::getGlobalAODSink(dod, outputsInputsAOD);
     extraSpecs.push_back(fileSink);
+
+    auto it = std::find_if(outputsInputs.begin(), outputsInputs.end(), [](InputSpec& spec) -> bool {
+      return DataSpecUtils::partialMatch(spec, o2::header::DataOrigin("TFN"));
+    });
+    size_t ii = std::distance(outputsInputs.begin(), it);
+    outputTypes[ii] &= ~((char)OutputType::DANGLING);
   }
 
   workflow.insert(workflow.end(), extraSpecs.begin(), extraSpecs.end());


### PR DESCRIPTION
Up to now, a reader device was erroneously sending extra tables around if a timeline pipelined device (e.g. a spawner) was present. This causes deadlocks for certain topologies. 