### PR TITLE
[CPV] Fix CPV calibration objects

### DIFF
--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
@@ -94,20 +94,28 @@ class BadChannelMap
   /// Only bad or warm cells are added to the container. In case
   /// the mask type is GOOD_CELL, the entry is removed from the
   /// container if present before, otherwise the cell is ignored.
-  void addBadChannel(unsigned short channelID) { mBadCells.set(channelID); } //set bit to true
+  void addBadChannel(unsigned short channelID)
+  {
+    if (channelID < NCHANNELS)
+      mBadCells.set(channelID);
+  } //set bit to true
 
   /// \brief Mark channel as good
   /// \param channelID Absolute ID of the channel
   ///
   /// Setting channel as good.
-  void setChannelGood(unsigned short channelID) { mBadCells.set(channelID, false); }
+  void setChannelGood(unsigned short channelID)
+  {
+    if (channelID < NCHANNELS)
+      mBadCells.set(channelID, false);
+  }
 
   /// \brief Get the status of a certain cell
   /// \param channelID channel for which to obtain the channel status
   /// \return true if good channel
   ///
   /// Provide the mask status of a cell.
-  bool isChannelGood(unsigned short channelID) const { return !mBadCells.test(channelID); }
+  bool isChannelGood(unsigned short channelID) const { return channelID < NCHANNELS ? !mBadCells.test(channelID) : false; }
 
   /// \brief Convert map into 2D histogram representation
   /// \param mod Module number

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
@@ -106,8 +106,9 @@ class BadChannelMap
   /// Setting channel as good.
   void setChannelGood(unsigned short channelID)
   {
-    if (channelID < NCHANNELS)
+    if (channelID < NCHANNELS) {
       mBadCells.set(channelID, false);
+    }
   }
 
   /// \brief Get the status of a certain cell
@@ -115,7 +116,7 @@ class BadChannelMap
   /// \return true if good channel
   ///
   /// Provide the mask status of a cell.
-  bool isChannelGood(unsigned short channelID) const { return channelID < NCHANNELS ? !mBadCells.test(channelID) : false; }
+  bool isChannelGood(unsigned short channelID) const { return !mBadCells.test(channelID); }
 
   /// \brief Convert map into 2D histogram representation
   /// \param mod Module number

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/BadChannelMap.h
@@ -96,8 +96,9 @@ class BadChannelMap
   /// container if present before, otherwise the cell is ignored.
   void addBadChannel(unsigned short channelID)
   {
-    if (channelID < NCHANNELS)
+    if (channelID < NCHANNELS) {
       mBadCells.set(channelID);
+    }
   } //set bit to true
 
   /// \brief Mark channel as good

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/CalibParams.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/CalibParams.h
@@ -46,15 +46,16 @@ class CalibParams
   /// \brief Get High Gain energy calibration coefficients
   /// \param cellID Absolute ID of cell
   /// \return high gain energy calibration coefficient of the cell
-  float getGain(unsigned short cellID) const { return cellID < o2::cpv::Geometry::kNCHANNELS ? mGainCalib[cellID] : 0.0; }
+  float getGain(unsigned short cellID) const { return mGainCalib[cellID]; }
 
   /// \brief Set High Gain energy calibration coefficient
   /// \param cellID Absolute ID of cell
   /// \param c is the calibration coefficient
   void setGain(unsigned short cellID, float c)
   {
-    if (cellID < o2::cpv::Geometry::kNCHANNELS)
+    if (cellID < o2::cpv::Geometry::kNCHANNELS) {
       mGainCalib[cellID] = c;
+    }
   }
 
   /// \brief Set High Gain energy calibration coefficients for one module in the form of 2D histogram

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/CalibParams.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/CalibParams.h
@@ -21,6 +21,7 @@
 
 #include <array>
 #include "TObject.h"
+#include "CPVBase/Geometry.h"
 
 class TH2;
 
@@ -45,12 +46,16 @@ class CalibParams
   /// \brief Get High Gain energy calibration coefficients
   /// \param cellID Absolute ID of cell
   /// \return high gain energy calibration coefficient of the cell
-  float getGain(unsigned short cellID) const { return mGainCalib[cellID]; }
+  float getGain(unsigned short cellID) const { return cellID < o2::cpv::Geometry::kNCHANNELS ? mGainCalib[cellID] : 0.0; }
 
   /// \brief Set High Gain energy calibration coefficient
   /// \param cellID Absolute ID of cell
   /// \param c is the calibration coefficient
-  void setGain(unsigned short cellID, float c) { mGainCalib[cellID] = c; }
+  void setGain(unsigned short cellID, float c)
+  {
+    if (cellID < o2::cpv::Geometry::kNCHANNELS)
+      mGainCalib[cellID] = c;
+  }
 
   /// \brief Set High Gain energy calibration coefficients for one module in the form of 2D histogram
   /// \param 2D(64,56) histogram with calibration coefficients

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
@@ -46,8 +46,8 @@ class Pedestals
   /// \brief Get pedestal
   /// \param cellID Absolute ID of cell
   /// \return pedestal for the cell
-  short getPedestal(short cellID) const { mPedestals.at(cellID); }
-  float getPedSigma(short cellID) const { mPedSigmas.at(cellID); }
+  short getPedestal(short cellID) const { return mPedestals.at(cellID); }
+  float getPedSigma(short cellID) const { return mPedSigmas.at(cellID); }
 
   /// \brief Set pedestal
   /// \param cellID Absolute ID of cell

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
@@ -46,21 +46,23 @@ class Pedestals
   /// \brief Get pedestal
   /// \param cellID Absolute ID of cell
   /// \return pedestal for the cell
-  short getPedestal(short cellID) const { return ((cellID >= 0) && (cellID < NCHANNELS)) ? short(mPedestals.at(cellID)) : 0; }
-  float getPedSigma(short cellID) const { return ((cellID >= 0) && (cellID < NCHANNELS)) ? mPedSigmas.at(cellID) : 0.0; }
+  short getPedestal(short cellID) const { mPedestals.at(cellID); }
+  float getPedSigma(short cellID) const { mPedSigmas.at(cellID); }
 
   /// \brief Set pedestal
   /// \param cellID Absolute ID of cell
   /// \param c is the pedestal (expected to be in range <254)
   void setPedestal(short cellID, short c)
   {
-    if ((cellID >= 0) && (cellID < NCHANNELS))
+    if ((cellID >= 0) && (cellID < NCHANNELS)) {
       mPedestals[cellID] = (c > 0 && c < 511) ? c : mPedestals[cellID];
+    }
   }
   void setPedSigma(short cellID, float c)
   {
-    if ((cellID >= 0) && (cellID < NCHANNELS))
+    if ((cellID >= 0) && (cellID < NCHANNELS)) {
       mPedSigmas[cellID] = (c > 0) ? c : mPedSigmas[cellID];
+    }
   }
 
   /// \brief Set pedestals from 1D histogram with cell absId in x axis

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/Pedestals.h
@@ -46,14 +46,22 @@ class Pedestals
   /// \brief Get pedestal
   /// \param cellID Absolute ID of cell
   /// \return pedestal for the cell
-  short getPedestal(short cellID) const { return short(mPedestals.at(cellID)); }
-  float getPedSigma(short cellID) const { return mPedSigmas.at(cellID); }
+  short getPedestal(short cellID) const { return ((cellID >= 0) && (cellID < NCHANNELS)) ? short(mPedestals.at(cellID)) : 0; }
+  float getPedSigma(short cellID) const { return ((cellID >= 0) && (cellID < NCHANNELS)) ? mPedSigmas.at(cellID) : 0.0; }
 
   /// \brief Set pedestal
   /// \param cellID Absolute ID of cell
   /// \param c is the pedestal (expected to be in range <254)
-  void setPedestal(short cellID, short c) { mPedestals[cellID] = (c > 0 && c < 511) ? c : mPedestals[cellID]; }
-  void setPedSigma(short cellID, float c) { mPedSigmas[cellID] = (c > 0) ? c : mPedSigmas[cellID]; }
+  void setPedestal(short cellID, short c)
+  {
+    if ((cellID >= 0) && (cellID < NCHANNELS))
+      mPedestals[cellID] = (c > 0 && c < 511) ? c : mPedestals[cellID];
+  }
+  void setPedSigma(short cellID, float c)
+  {
+    if ((cellID >= 0) && (cellID < NCHANNELS))
+      mPedSigmas[cellID] = (c > 0) ? c : mPedSigmas[cellID];
+  }
 
   /// \brief Set pedestals from 1D histogram with cell absId in x axis
   /// \param 1D(NCHANNELS) histogram with calibration coefficients

--- a/DataFormats/Detectors/CPV/src/BadChannelMap.cxx
+++ b/DataFormats/Detectors/CPV/src/BadChannelMap.cxx
@@ -20,28 +20,32 @@
 
 using namespace o2::cpv;
 
-BadChannelMap::BadChannelMap(short /*dummy*/)
+BadChannelMap::BadChannelMap(short test)
 {
+  //reset all channels to be good
+  mBadCells.reset();
 
-  //Mark few channels as bad for test peurposes
-  for (short i = 0; i < 60; i++) {
-    //module 2
-    unsigned short channelID = 3584 + i * 57;
-    mBadCells.set(channelID);
-    channelID = 3640 + i * 55;
-    mBadCells.set(channelID);
-  }
+  if (test == 2) {
+    //Mark few channels as bad for test peurposes
+    for (short i = 0; i < 60; i++) {
+      //module 2
+      unsigned short channelID = 3584 + i * 57;
+      mBadCells.set(channelID);
+      channelID = 3640 + i * 55;
+      mBadCells.set(channelID);
+    }
 
-  for (short i = 0; i < 16; i++) {
-    //module 3
-    unsigned short channelID = 8972 + i * 57;
-    mBadCells.set(channelID);
-    channelID = 8092 + i * 57;
-    mBadCells.set(channelID);
-    channelID = 8147 + i * 55;
-    mBadCells.set(channelID);
-    channelID = 9059 + i * 55;
-    mBadCells.set(channelID);
+    for (short i = 0; i < 16; i++) {
+      //module 3
+      unsigned short channelID = 8972 + i * 57;
+      mBadCells.set(channelID);
+      channelID = 8092 + i * 57;
+      mBadCells.set(channelID);
+      channelID = 8147 + i * 55;
+      mBadCells.set(channelID);
+      channelID = 9059 + i * 55;
+      mBadCells.set(channelID);
+    }
   }
 }
 

--- a/DataFormats/Detectors/CPV/src/CalibParams.cxx
+++ b/DataFormats/Detectors/CPV/src/CalibParams.cxx
@@ -40,12 +40,12 @@ bool CalibParams::setGain(TH2* h, short module)
     return false;
   }
 
-  short relid[3] = {module, 1, 1};
+  short relid[3] = {module, 0, 0};
   unsigned short absId;
   for (short ix = 1; ix <= MAXX; ix++) {
-    relid[1] = ix;
+    relid[1] = ix - 1;
     for (short iz = 1; iz <= MAXZ; iz++) {
-      relid[2] = iz;
+      relid[2] = iz - 1;
 
       if (Geometry::relToAbsNumbering(relid, absId)) {
         mGainCalib[absId] = h->GetBinContent(ix, iz);

--- a/DataFormats/Detectors/CPV/src/Pedestals.cxx
+++ b/DataFormats/Detectors/CPV/src/Pedestals.cxx
@@ -42,7 +42,7 @@ bool Pedestals::setPedestals(TH1* h)
                  << " exceeds max possible value 511 (limited by CPV electronics)";
       continue;
     }
-    mPedestals[i] = short(h->GetBinContent(i));
+    mPedestals[i - 1] = short(h->GetBinContent(i));
   }
   return true;
 }
@@ -66,7 +66,7 @@ bool Pedestals::setPedSigmas(TH1F* h)
                  << " cannot be less than 0";
       continue;
     }
-    mPedSigmas[i] = float(h->GetBinContent(i));
+    mPedSigmas[i - 1] = float(h->GetBinContent(i));
   }
   return true;
 }

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -224,7 +224,7 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
   }
   digitBuffer.clear();
 
-  LOG(INFO) << "[CPVRawToDigitConverter - run] Writing " << mOutputDigits.size() << " digits ...";
+  LOG(DEBUG) << "[CPVRawToDigitConverter - run] Writing " << mOutputDigits.size() << " digits ...";
   ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
   ctx.outputs().snapshot(o2::framework::Output{"CPV", "DIGITTRIGREC", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggerRecords);
   ctx.outputs().snapshot(o2::framework::Output{"CPV", "RAWHWERRORS", 0, o2::framework::Lifetime::Timeframe}, mOutputHWErrors);


### PR DESCRIPTION
Added protection against accessing non-existing addresses in o2::cpv::CalibParams,  o2::cpv::BadChannelMap and o2::cpv::Pedestals.