### PR TITLE
[WIP][EMCAL-660, EMCAL-703] Add option to auto-configure subspecification

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -345,6 +345,13 @@ class MappingHandler
   /// \param branch Branch index (0 or 1) in DDL
   int getFEEForChannelInDDL(int dll, int channelFEC, int branch);
 
+  /// \brief Get index of the FLP based on the DDL ID
+  /// \param ddl Absolute DDL index
+  /// \return FLP index
+  ///
+  /// Current DDL - FLP indexing can be found in EMCAL-660
+  int getFLPIndex(int ddl);
+
  private:
   std::array<Mapper, 4> mMappings; ///< Mapping container
 

--- a/Detectors/EMCAL/base/src/Mapper.cxx
+++ b/Detectors/EMCAL/base/src/Mapper.cxx
@@ -131,6 +131,17 @@ int MappingHandler::getFEEForChannelInDDL(int ddl, int channelFEC, int branch)
   return fecID;
 }
 
+int MappingHandler::getFLPIndex(int ddl)
+{
+  if ((ddl >= 0 && ddl <= 23) || ddl == 44) {
+    return 146; // EMCAL Links (44 - STU) -> FLP 146
+  }
+  if ((ddl >= 24 && ddl <= 38) || ddl == 45) {
+    return 147; // DCAL Links (45 - STU) -> FLP 147
+  }
+  throw DDLInvalid(ddl);
+}
+
 std::ostream& o2::emcal::operator<<(std::ostream& stream, const Mapper::ChannelID& channel)
 {
   stream << "Row " << static_cast<int>(channel.mRow) << ", Column " << static_cast<int>(channel.mColumn) << ", type " << o2::emcal::channelTypeToString(channel.mChannelType);

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -37,9 +37,8 @@ namespace reco_workflow
 class RawToCellConverterSpec : public framework::Task
 {
  public:
-  /// \brief Constructor
-  /// \param subspecification Output subspecification for parallel running on multiple nodes
-  RawToCellConverterSpec(int subspecification) : framework::Task(), mSubspecification(subspecification){};
+  /// \brief Default constructor
+  RawToCellConverterSpec() = default;
 
   /// \brief Destructor
   ~RawToCellConverterSpec() override;
@@ -63,7 +62,16 @@ class RawToCellConverterSpec : public framework::Task
   /// Error messages will be suppressed once the maximum is reached
   void setMaxErrorMessages(int maxMessages) { mMaxErrorMessages = maxMessages; }
 
-  void setNoiseThreshold(int thresold) { mNoiseThreshold = thresold; }
+  /// \brief Set the noise threshold
+  /// \param threshold Noise threshold
+  ///
+  /// ADC values below the noise threshold are suppressed in the raw fit
+  void setNoiseThreshold(int threshold) { mNoiseThreshold = threshold; }
+
+  /// \brief Get the noise threshold
+  /// \return Noise threshold
+  ///
+  /// ADC values below the noise threshold are suppressed in the raw fit
   int getNoiseThreshold() const { return mNoiseThreshold; }
 
   /// \brief Set ID of the subspecification
@@ -81,26 +89,43 @@ class RawToCellConverterSpec : public framework::Task
   header::DataHeader::SubSpecificationType getSubspecification() const { return mSubspecification; }
 
  private:
+  /// \brief Determine whether the timeframe is empty
+  /// \param ctx Processing context with all inputs
+  ///
+  /// Empty timeframes are detected via the deadbeaf
+  /// subspecification of the input channel.
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
-  void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const;
 
-  header::DataHeader::SubSpecificationType mSubspecification = 0; ///< Subspecification for output channels
-  int mNoiseThreshold = 0;                                        ///< Noise threshold in raw fit
-  int mNumErrorMessages = 0;                                      ///< Current number of error messages
-  int mErrorMessagesSuppressed = 0;                               ///< Counter of suppressed error messages
-  int mMaxErrorMessages = 100;                                    ///< Max. number of error messages
-  Geometry* mGeometry = nullptr;                                  ///!<! Geometry pointer
-  std::unique_ptr<MappingHandler> mMapper = nullptr;              ///!<! Mapper
-  std::unique_ptr<CaloRawFitter> mRawFitter;                      ///!<! Raw fitter
-  std::vector<Cell> mOutputCells;                                 ///< Container with output cells
-  std::vector<TriggerRecord> mOutputTriggerRecords;               ///< Container with output cells
-  std::vector<ErrorTypeFEE> mOutputDecoderErrors;                 ///< Container with decoder errors
+  /// \brief Send data to output channels
+  /// \param cells Container with output cells for timeframe
+  /// \param triggers Container with trigger records for timeframe
+  /// \param decodingErrors Container with decoding errors for timeframe
+  /// \param subspecification Output subspecification
+  ///
+  /// Send data to all output channels for the given subspecification. The subspecification
+  /// is determined on the fly in the run method and therefore used as parameter. Consumers
+  /// must use wildcard subspecification via ConcreteDataTypeMatcher.
+  void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors, header::DataHeader::SubSpecificationType subspecification) const;
+
+  header::DataHeader::SubSpecificationType mSubspecification = UINT32_MAX; ///< Subspecification for output channels
+  int mNoiseThreshold = 0;                                                 ///< Noise threshold in raw fit
+  int mNumErrorMessages = 0;                                               ///< Current number of error messages
+  int mErrorMessagesSuppressed = 0;                                        ///< Counter of suppressed error messages
+  int mMaxErrorMessages = 100;                                             ///< Max. number of error messages
+  bool mAutoDefineSubspec = false;                                         ///< Automatically determine the subspecification based on the FEE ID of the first RDH
+  Geometry* mGeometry = nullptr;                                           ///!<! Geometry pointer
+  std::unique_ptr<MappingHandler> mMapper = nullptr;                       ///!<! Mapper
+  std::unique_ptr<CaloRawFitter> mRawFitter;                               ///!<! Raw fitter
+  std::vector<Cell> mOutputCells;                                          ///< Container with output cells
+  std::vector<TriggerRecord> mOutputTriggerRecords;                        ///< Container with output cells
+  std::vector<ErrorTypeFEE> mOutputDecoderErrors;                          ///< Container with decoder errors
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec
+/// \param askDISTSTF if true the task subscribes also to FLP/DISTSUBTIMEFRAME
 ///
-/// Refer to RawToCellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF, int subspecification);
+/// Refer to RawToCellConverterSpec::run for input and output specs.
+framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -48,7 +48,6 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param propagateMC If true MC labels are propagated to the output files
 /// \param askDISTSTF If true the Raw->Cell converter subscribes to FLP/DISTSUBTIMEFRAME
 /// \param enableDigitsPrinter If true then the simple digits printer is added as dummy task
-/// \param subspecification Subspecification in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
 /// \return EMCAL reconstruction workflow for the configuration provided
@@ -56,7 +55,6 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool askDISTSTF = true,
                                     bool enableDigitsPrinter = false,
-                                    int subspecification = 0,
                                     std::string const& cfgInput = "digits",
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -58,6 +58,12 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
     LOG(ERROR) << "Failed to initialize mapper";
   }
 
+  if (ctx.options().get<bool>("autosubspec")) {
+    mAutoDefineSubspec = true;
+  } else {
+    mSubspecification = ctx.options().get<int>("subspec");
+  }
+
   auto fitmethod = ctx.options().get<std::string>("fitmethod");
   if (fitmethod == "standard") {
     LOG(INFO) << "Using standard raw fitter";
@@ -85,7 +91,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   mOutputDecoderErrors.clear();
 
   if (isLostTimeframe(ctx)) {
-    sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
+    sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors, 0xdeadbeaf);
     return;
   }
 
@@ -101,6 +107,19 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
     auto rdhblock = reinterpret_cast<const o2::header::RDHAny*>(rawData.payload);
     if (o2::raw::RDHUtils::getHeaderSize(rdhblock) == static_cast<int>(o2::framework::DataRefUtils::getPayloadSize(rawData))) {
       continue;
+    }
+
+    // handle subspecificaiton for output channels
+    if (mSubspecification == UINT32_MAX) {
+      // Subspecification not defined
+      if (mAutoDefineSubspec) {
+        // get the subspecification from the first FEE ID
+        mSubspecification = mMapper->getFLPIndex(raw::RDHUtils::getFEEID(rdhblock));
+      } else {
+        // Use defaut subspecification 0
+        mSubspecification = 0;
+      }
+      LOG(INFO) << "Using output subspecification " << mSubspecification;
     }
 
     //o2::emcal::RawReaderMemory<o2::header::RAWDataHeaderV4> rawreader(gsl::span(rawData.payload, o2::framework::DataRefUtils::getPayloadSize(rawData)));
@@ -253,7 +272,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   }
 
   LOG(DEBUG) << "[EMCALRawToCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
-  sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
+  sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors, mSubspecification);
 }
 
 bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) const
@@ -272,22 +291,21 @@ bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) 
   return false;
 }
 
-void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const
+void RawToCellConverterSpec::sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors, header::DataHeader::SubSpecificationType subspecification) const
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", mSubspecification, framework::Lifetime::Timeframe}, cells);
-  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", mSubspecification, framework::Lifetime::Timeframe}, triggers);
-  ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", mSubspecification, framework::Lifetime::Timeframe}, decodingErrors);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLS", subspecification, framework::Lifetime::Timeframe}, cells);
+  ctx.outputs().snapshot(framework::Output{originEMC, "CELLSTRGR", subspecification, framework::Lifetime::Timeframe}, triggers);
+  ctx.outputs().snapshot(framework::Output{originEMC, "DECODERERR", subspecification, framework::Lifetime::Timeframe}, decodingErrors);
 }
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF, int subspecification)
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverterSpec(bool askDISTSTF)
 {
   constexpr auto originEMC = o2::header::gDataOriginEMC;
-  std::vector<o2::framework::OutputSpec> outputs;
-
-  outputs.emplace_back(originEMC, "CELLS", subspecification, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back(originEMC, "CELLSTRGR", subspecification, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back(originEMC, "DECODERERR", subspecification, o2::framework::Lifetime::Timeframe);
+  std::vector<o2::framework::OutputSpec> outputs{
+    {framework::ConcreteDataTypeMatcher(originEMC, "CELLS"), framework::Lifetime::Timeframe},
+    {framework::ConcreteDataTypeMatcher(originEMC, "CELLSTRGR"), framework::Lifetime::Timeframe},
+    {framework::ConcreteDataTypeMatcher(originEMC, "DECODERERR"), framework::Lifetime::Timeframe}};
 
   std::vector<o2::framework::InputSpec> inputs{{"stf", o2::framework::ConcreteDataTypeMatcher{originEMC, o2::header::gDataDescriptionRawData}, o2::framework::Lifetime::Optional}};
   if (askDISTSTF) {
@@ -297,8 +315,10 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
   return o2::framework::DataProcessorSpec{"EMCALRawToCellConverterSpec",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(subspecification),
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(),
                                           o2::framework::Options{
+                                            {"autosubspec", o2::framework::VariantType::Bool, false, {"Automatically configure output spec from RDH"}},
+                                            {"subspec", o2::framework::VariantType::Int, 0, {"Subspecification (if set manually and not auto-configured"}},
                                             {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}},
                                             {"maxmessage", o2::framework::VariantType::Int, 100, {"Max. amout of error messages to be displayed"}}}};
 }

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -48,7 +48,6 @@ namespace reco_workflow
 o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         bool askDISTSTF,
                                         bool enableDigitsPrinter,
-                                        int subspecification,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
@@ -170,7 +169,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
-      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, subspecification));
+      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF));
     }
   }
 
@@ -288,13 +287,13 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       specs.push_back(makeWriterSpec_CellsTR("emcal-cells-writer",
                                              "emccells.root",
                                              "o2sim",
-                                             BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
+                                             BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", framework::ConcreteDataTypeMatcher("EMC", "CELLS")},
                                                                              "EMCALCell",
                                                                              "cell-branch-name"},
-                                             BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
+                                             BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", framework::ConcreteDataTypeMatcher("EMC", "CELLSTRGR")},
                                                                                      "EMCALCellTRGR",
                                                                                      "celltrigger-branch-name"},
-                                             BranchDefinition<DecoderErrorsDataType>{o2::framework::InputSpec{"errors", "EMC", "DECODERERR", 0},
+                                             BranchDefinition<DecoderErrorsDataType>{o2::framework::InputSpec{"errors", framework::ConcreteDataTypeMatcher("EMC", "DECODERERR")},
                                                                                      "EMCALDECODERERR",
                                                                                      "decodererror-branch-name"})());
     }

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -37,8 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not initialize root file writers"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
-    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
-    {"subspecification", o2::framework::VariantType::Int, 0, {"Subspecification in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
+    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
 
@@ -65,7 +64,6 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   auto wf = o2::emcal::reco_workflow::getWorkflow(!cfgc.options().get<bool>("disable-mc"),
                                                   !cfgc.options().get<bool>("ignore-dist-stf"),
                                                   cfgc.options().get<bool>("enable-digits-printer"),
-                                                  cfgc.options().get<int>("subspecification"),
                                                   cfgc.options().get<std::string>("input-type"),
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),


### PR DESCRIPTION
In case of auto-configure mode the subspecification
is determined based on the first header in the
payload using the ID of the FLP determined via the
FEE ID. The output specs are defined with wildcard
subspecification according to the discussion in
https://alice-talk.web.cern.ch/t/flp-specific-subspecifications/1035/6.
In case of empty timeframe empty cell containers are
sent to the deadbeaf subspecification which must be
caught by receiver processors.