### PR TITLE
Improve GPU benchmark

### DIFF
--- a/GPU/GPUbenchmark/CMakeLists.txt
+++ b/GPU/GPUbenchmark/CMakeLists.txt
@@ -33,6 +33,7 @@ if(HIP_ENABLED)
     add_custom_command(
       OUTPUT ${HIP_KERNEL_PATH}
       COMMAND ${HIPIFY_EXECUTABLE} --quiet-warnings ${CU_KERNEL} | sed '1{/\#include \"hip\\/hip_runtime.h\"/d}' > ${HIP_KERNEL_PATH}
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cuda/Kernels.cu
     )
     set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
     set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})

--- a/GPU/GPUbenchmark/CMakeLists.txt
+++ b/GPU/GPUbenchmark/CMakeLists.txt
@@ -9,8 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-set(HDRS_INSTALL ../Shared/Kernels.h)
-
 if(CUDA_ENABLED)
   o2_add_executable(gpu-memory-benchmark-cuda
                   SOURCES benchmark.cxx

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -65,24 +65,11 @@ class GPUbenchmark final
   void printDevices();   // Dump info
 
   // Initializations/Finalizations of tests. Not to be measured, in principle used for report
-  void readInit();
-  void readFinalize();
+  void initTest(Test);
+  void finalizeTest(Test);
 
-  void writeInit();
-  void writeFinalize();
-
-  void copyInit();
-  void copyFinalize();
-
-  // Kernel calling wrappers
-  void readSequential(SplitLevel sl);
-  void readConcurrent(SplitLevel sl, int nRegions = 2);
-
-  void writeSequential(SplitLevel sl);
-  void writeConcurrent(SplitLevel sl, int nRegions = 2);
-
-  void copySequential(SplitLevel sl);
-  void copyConcurrent(SplitLevel sl, int nRegions = 2);
+  // Kernel calling wrapper
+  void runTest(Test, Mode, KernelConfig);
 
  private:
   gpuState<chunk_t> mState;

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -53,6 +53,7 @@ class GPUbenchmark final
   std::vector<float> runConcurrent(void (*kernel)(chunk_t*, T...),
                                    int nChunks,
                                    int nLaunches,
+                                   int dimStreams,
                                    int dimGrid,
                                    int dimBlock,
                                    T&... args);

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -41,17 +41,21 @@ class GPUbenchmark final
 
   // Single stream synchronous (sequential kernels) execution
   template <typename... T>
-  float benchmarkSync(void (*kernel)(int, chunk_t*, T...),
+  float runSequential(void (*kernel)(chunk_t*, T...),
                       int nLaunches,
                       int chunkId,
-                      int blocks,
-                      int threads,
+                      int dimGrid,
+                      int dimBlock,
                       T&... args);
 
   // Multi-streams asynchronous executions on whole memory
   template <typename... T>
-  std::vector<float> benchmarkAsync(void (*kernel)(int, chunk_t*, T...),
-                                    int nStreams, int nLaunches, int blocks, int threads, T&... args);
+  std::vector<float> runConcurrent(void (*kernel)(chunk_t*, T...),
+                                   int nChunks,
+                                   int nLaunches,
+                                   int dimGrid,
+                                   int dimBlock,
+                                   T&... args);
 
   // Main interface
   void globalInit();     // Allocate scratch buffers and compute runtime parameters

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -41,12 +41,16 @@ class GPUbenchmark final
 
   // Single stream synchronous (sequential kernels) execution
   template <typename... T>
-  float benchmarkSync(void (*kernel)(T...),
-                      int nLaunches, int blocks, int threads, T&... args);
+  float benchmarkSync(void (*kernel)(int, chunk_type*, T...),
+                      int nLaunches,
+                      int chunkId,
+                      int blocks,
+                      int threads,
+                      T&... args);
 
   // Multi-streams asynchronous executions on whole memory
   template <typename... T>
-  std::vector<float> benchmarkAsync(void (*kernel)(int, T...),
+  std::vector<float> benchmarkAsync(void (*kernel)(int, chunk_type*, T...),
                                     int nStreams, int nLaunches, int blocks, int threads, T&... args);
 
   // Main interface

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -58,6 +58,16 @@ class GPUbenchmark final
                                    int dimBlock,
                                    T&... args);
 
+  // Custom run with selected buffers
+  template <typename... T>
+  std::vector<float> runArbitrary(void (*kernel)(chunk_t*, T...),
+                                  std::vector<std::pair<int, int>> chunkRanges,
+                                  int nLaunches,
+                                  int dimStreams,
+                                  int nBlocks,
+                                  int nThreads,
+                                  T&... args);
+
   // Main interface
   void globalInit();     // Allocate scratch buffers and compute runtime parameters
   void run();            // Execute all specified callbacks

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -27,7 +27,7 @@ namespace o2
 namespace benchmark
 {
 
-template <class chunk_type>
+template <class chunk_t>
 class GPUbenchmark final
 {
  public:
@@ -41,7 +41,7 @@ class GPUbenchmark final
 
   // Single stream synchronous (sequential kernels) execution
   template <typename... T>
-  float benchmarkSync(void (*kernel)(int, chunk_type*, T...),
+  float benchmarkSync(void (*kernel)(int, chunk_t*, T...),
                       int nLaunches,
                       int chunkId,
                       int blocks,
@@ -50,7 +50,7 @@ class GPUbenchmark final
 
   // Multi-streams asynchronous executions on whole memory
   template <typename... T>
-  std::vector<float> benchmarkAsync(void (*kernel)(int, chunk_type*, T...),
+  std::vector<float> benchmarkAsync(void (*kernel)(int, chunk_t*, T...),
                                     int nStreams, int nLaunches, int blocks, int threads, T&... args);
 
   // Main interface
@@ -80,7 +80,7 @@ class GPUbenchmark final
   void copyConcurrent(SplitLevel sl, int nRegions = 2);
 
  private:
-  gpuState<chunk_type> mState;
+  gpuState<chunk_t> mState;
   std::shared_ptr<ResultWriter> mResultWriter;
   benchmarkOpts mOptions;
 };

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -41,32 +41,22 @@ class GPUbenchmark final
 
   // Single stream synchronous (sequential kernels) execution
   template <typename... T>
-  float runSequential(void (*kernel)(chunk_t*, T...),
+  float runSequential(void (*kernel)(chunk_t*, size_t, T...),
+                      std::pair<int, int>& chunkRanges,
                       int nLaunches,
-                      int chunkId,
                       int dimGrid,
                       int dimBlock,
                       T&... args);
 
   // Multi-streams asynchronous executions on whole memory
   template <typename... T>
-  std::vector<float> runConcurrent(void (*kernel)(chunk_t*, T...),
-                                   int nChunks,
+  std::vector<float> runConcurrent(void (*kernel)(chunk_t*, size_t, T...),
+                                   std::vector<std::pair<int, int>>& chunkRanges,
                                    int nLaunches,
                                    int dimStreams,
-                                   int dimGrid,
-                                   int dimBlock,
+                                   int nBlocks,
+                                   int nThreads,
                                    T&... args);
-
-  // Custom run with selected buffers
-  template <typename... T>
-  std::vector<float> runArbitrary(void (*kernel)(chunk_t*, T...),
-                                  std::vector<std::pair<int, int>> chunkRanges,
-                                  int nLaunches,
-                                  int dimStreams,
-                                  int nBlocks,
-                                  int nThreads,
-                                  T&... args);
 
   // Main interface
   void globalInit();     // Allocate scratch buffers and compute runtime parameters

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -192,19 +192,6 @@ class BSDRnd : public LCGRnd
   __host__ __device__ int rnd() { return LCGRnd::rnd(); }
 };
 
-
-// CUDA does not support <type4> operations:
-// https://forums.developer.nvidia.com/t/swizzling-float4-arithmetic-support/217
-#ifndef __HIPCC__ 
-inline __host__ __device__ void operator+=(int4 &a, int4 b)
-{
-    a.x += b.x;
-    a.y += b.y;
-    a.z += b.z;
-    a.w += b.w;
-}
-#endif
-
 namespace o2
 {
 namespace benchmark

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -70,6 +70,7 @@ struct benchmarkOpts {
   std::vector<Test> tests = {Test::Read, Test::Write, Test::Copy};
   std::vector<Mode> modes = {Mode::Sequential, Mode::Concurrent};
   std::vector<SplitLevel> pools = {SplitLevel::Blocks, SplitLevel::Threads};
+  std::vector<std::string> dtypes = {"char", "int", "ulong"};
   float chunkReservedGB = 1.f;
   int nRegions = 2;
   float freeMemoryFractionToAllocate = 0.95f;

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <iostream>
+#include <sstream>
 #include <iomanip>
 #include <typeinfo>
 #include <boost/program_options.hpp>
@@ -143,6 +144,13 @@ inline chunk_t* getPartPtr(chunk_t* scratchPtr, float chunkReservedGB, int partN
   return reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * chunkReservedGB) * partNumber);
 }
 
+// Return pointer to custom offset (GB)
+template <class chunk_t>
+inline chunk_t* getCustomPtr(chunk_t* scratchPtr, int partNumber)
+{
+  return reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * partNumber));
+}
+
 inline float computeThroughput(Test test, float result, float chunkSizeGB, int ntests)
 {
   // https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html
@@ -205,6 +213,7 @@ struct benchmarkOpts {
   std::vector<Mode> modes = {Mode::Sequential, Mode::Concurrent};
   std::vector<KernelConfig> pools = {KernelConfig::Single, KernelConfig::Multi};
   std::vector<std::string> dtypes = {"char", "int", "ulong"};
+  std::vector<std::pair<int, int>> arbitraryChunks;
   float chunkReservedGB = 1.f;
   float threadPoolFraction = 1.f;
   int nRegions = 2;

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -139,7 +139,7 @@ class ResultWriter
  public:
   explicit ResultWriter(const std::string resultsTreeFilename = "benchmark_results.root");
   ~ResultWriter() = default;
-  void storeBenchmarkEntry(int chunk, float entry, float chunkSizeGB);
+  void storeBenchmarkEntry(int chunk, float entry, float chunkSizeGB, int nLaunches);
   void addBenchmarkEntry(const std::string bName, const std::string type, const int nChunks);
   void snapshotBenchmark();
   void saveToFile();
@@ -170,10 +170,10 @@ inline void ResultWriter::addBenchmarkEntry(const std::string bName, const std::
   mThroughputTrees.back()->Branch("throughput", &mThroughputResults);
 }
 
-inline void ResultWriter::storeBenchmarkEntry(int chunk, float entry, float chunkSizeGB)
+inline void ResultWriter::storeBenchmarkEntry(int chunk, float entry, float chunkSizeGB, int nLaunches)
 {
   mTimeResults[chunk] = entry;
-  mThroughputResults[chunk] = 1e3 * chunkSizeGB / entry;
+  mThroughputResults[chunk] = 1e3 * chunkSizeGB * nLaunches / entry;
 }
 
 inline void ResultWriter::snapshotBenchmark()

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -89,7 +89,8 @@ inline std::ostream& operator<<(std::ostream& os, Mode mode)
 
 enum class KernelConfig {
   Single,
-  Multi
+  Multi,
+  All
 };
 
 inline std::ostream& operator<<(std::ostream& os, KernelConfig config)
@@ -100,6 +101,9 @@ inline std::ostream& operator<<(std::ostream& os, KernelConfig config)
       break;
     case KernelConfig::Multi:
       os << "multiple";
+      break;
+    case KernelConfig::All:
+      os << "all";
       break;
   }
   return os;

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -156,27 +156,11 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
   // https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html
   // Eff_bandwidth (GB/s) = (B_r + B_w) / (~1e9 * Time (s))
 
-  float throughput;
-  switch (test) {
-    case Test::Read: {
-      throughput = 1e3 * chunkSizeGB * ntests / result;
-      break;
-    }
-    case Test::Write: {
-      throughput = 1e3 * chunkSizeGB * ntests / result;
-      break;
-    }
-    case Test::Copy: {
-      throughput = 1e3 * chunkSizeGB * ntests / result;
-      break;
-    }
-  }
-
-  return throughput;
+  return 1e3 * chunkSizeGB * ntests / result;
 }
 
 template <class chunk_t>
-inline size_t getBufferCapacity(float chunkReservedGB)
+inline size_t getBufferCapacity(int chunkReservedGB)
 {
   return static_cast<size_t>(GB * chunkReservedGB / sizeof(chunk_t));
 }
@@ -235,23 +219,10 @@ struct gpuState {
     return (double)scratchSize / (chunkReservedGB * GB);
   }
 
-  // void computeScratchPtrs()
-  // {
-  //   partAddrOnHost.resize(getMaxChunks());
-  //   for (size_t iBuffAddress{0}; iBuffAddress < getMaxChunks(); ++iBuffAddress) {
-  //     partAddrOnHost[iBuffAddress] = reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * chunkReservedGB) * iBuffAddress);
-  //   }
-  // }
-
   size_t getChunkCapacity()
   {
     return getBufferCapacity<chunk_t>(chunkReservedGB);
   }
-
-  // std::vector<chunk_t*> getScratchPtrs()
-  // {
-  //   return partAddrOnHost;
-  // }
 
   int getNKernelLaunches() { return iterations; }
   int getStreamsPoolSize() { return streams; }
@@ -264,9 +235,9 @@ struct gpuState {
   float chunkReservedGB; // Size of each partition (GB)
 
   // General containers and state
-  chunk_t* scratchPtr;                           // Pointer to scratch buffer
-  size_t scratchSize;                            // Size of scratch area (B)
-  std::vector<chunk_t*> partAddrOnHost;          // Pointers to scratch partitions on host vector
+  chunk_t* scratchPtr;                         // Pointer to scratch buffer
+  size_t scratchSize;                          // Size of scratch area (B)
+  std::vector<chunk_t*> partAddrOnHost;        // Pointers to scratch partitions on host vector
   std::vector<std::pair<int, int>> testChunks; // Vector of definitions for arbitrary chunks
 
   // Static info

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -192,6 +192,19 @@ class BSDRnd : public LCGRnd
   __host__ __device__ int rnd() { return LCGRnd::rnd(); }
 };
 
+
+// CUDA does not support <type4> operations:
+// https://forums.developer.nvidia.com/t/swizzling-float4-arithmetic-support/217
+#ifndef __HIPCC__ 
+inline __host__ __device__ void operator+=(int4 &a, int4 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+    a.w += b.w;
+}
+#endif
+
 namespace o2
 {
 namespace benchmark

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -75,6 +75,7 @@ struct benchmarkOpts {
   float freeMemoryFractionToAllocate = 0.95f;
   int kernelLaunches = 1;
   int nTests = 1;
+  int streams = 8;
   std::string outFileName = "benchmark_result";
 };
 
@@ -109,10 +110,12 @@ struct gpuState {
   }
 
   int getNKernelLaunches() { return iterations; }
+  int getStreamsPoolSize() { return streams; }
 
   // Configuration
   size_t nMaxThreadsPerDimension;
   int iterations;
+  int streams;
 
   float chunkReservedGB; // Size of each partition (GB)
 

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -163,6 +163,31 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
   return throughput;
 }
 
+// LCG: https://rosettacode.org/wiki/Linear_congruential_generator
+class LCGRnd
+{
+ public:
+  __host__ __device__ void seed(unsigned int s) { mSeed = s; }
+
+ protected:
+  __host__ __device__ LCGRnd() : mSeed{0}, mA{0}, mC{0}, mM(2147483648) {}
+  __host__ __device__ int rnd() { return (mSeed = (mA * mSeed + mC) % mM); }
+
+  int mA, mC;
+  unsigned int mM, mSeed;
+};
+
+class BSDRnd : public LCGRnd
+{
+ public:
+  __host__ __device__ BSDRnd()
+  {
+    mA = 1103515245;
+    mC = 12345;
+  }
+  __host__ __device__ int rnd() { return LCGRnd::rnd(); }
+};
+
 namespace o2
 {
 namespace benchmark

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -159,7 +159,7 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
       break;
     }
     case Test::Copy: {
-      throughput = 2 * 1e3 * chunkSizeGB * ntests / result;
+      throughput = 1e3 * chunkSizeGB * ntests / result;
       break;
     }
   }
@@ -206,6 +206,7 @@ struct benchmarkOpts {
   std::vector<KernelConfig> pools = {KernelConfig::Single, KernelConfig::Multi};
   std::vector<std::string> dtypes = {"char", "int", "ulong"};
   float chunkReservedGB = 1.f;
+  float threadPoolFraction = 1.f;
   int nRegions = 2;
   float freeMemoryFractionToAllocate = 0.95f;
   int kernelLaunches = 1;

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -75,6 +75,7 @@ struct benchmarkOpts {
   float freeMemoryFractionToAllocate = 0.95f;
   int kernelLaunches = 1;
   int nTests = 1;
+  std::string outFileName = "benchmark_result";
 };
 
 template <class T>

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -164,10 +164,10 @@ inline void ResultWriter::addBenchmarkEntry(const std::string bName, const std::
   mTimeResults.resize(nChunks);
   mTimeTrees.back()->Branch("elapsed", &mTimeResults);
 
-  mThroughputTrees.emplace_back(new TTree((bName + "_" + type).data(), (bName + "_" + type + "_TP").data()));
+  mThroughputTrees.emplace_back(new TTree((bName + "_" + type + "_TP").data(), (bName + "_" + type + "_TP").data()));
   mThroughputResults.clear();
   mThroughputResults.resize(nChunks);
-  mThroughputTrees.back()->Branch("throughput", &mTimeResults);
+  mThroughputTrees.back()->Branch("throughput", &mThroughputResults);
 }
 
 inline void ResultWriter::storeBenchmarkEntry(int chunk, float entry, float chunkSizeGB)

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -24,7 +24,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read, write, copy"), "Tests to be performed.")(
     "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq, con"), "Mode: sequential or concurrent.")(
-    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb, mb"}, "sb, mb"), "Pool strategy: single or multi blocks.")(
+    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb"}, "sb, mb"), "Pool strategy: single or multi blocks.")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
@@ -48,7 +48,6 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   conf.deviceId = vm["device"].as<int>();
   conf.freeMemoryFractionToAllocate = vm["freeMemFraction"].as<float>();
   conf.chunkReservedGB = vm["chunkSize"].as<float>();
-  conf.nRegions = vm["regions"].as<int>();
   conf.kernelLaunches = vm["launches"].as<int>();
   conf.nTests = vm["nruns"].as<int>();
 

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -84,9 +84,9 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   conf.pools.clear();
   for (auto& pool : vm["pool"].as<std::vector<std::string>>()) {
     if (pool == "sb") {
-      conf.pools.push_back(SplitLevel::Blocks);
+      conf.pools.push_back(KernelConfig::Single);
     } else if (pool == "mb") {
-      conf.pools.push_back(SplitLevel::Threads);
+      conf.pools.push_back(KernelConfig::Multi);
     } else {
       std::cerr << "Unkonwn pool: " << pool << std::endl;
       exit(1);

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -28,7 +28,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
     "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong"}, "char int ulong"), "Test data type to be used.")(
     "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
-    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb"}, "sb mb"), "Pool strategy: single or multi blocks.")(
+    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
@@ -102,6 +102,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       conf.pools.push_back(KernelConfig::Single);
     } else if (pool == "mb") {
       conf.pools.push_back(KernelConfig::Multi);
+    } else if (pool == "ab") {
+      conf.pools.push_back(KernelConfig::All);
     } else {
       std::cerr << "Unkonwn pool: " << pool << std::endl;
       exit(1);

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -28,7 +28,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
     "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
     "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
-    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
+    "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
+    "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
@@ -65,6 +66,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 
   conf.deviceId = vm["device"].as<int>();
   conf.freeMemoryFractionToAllocate = vm["freeMemFraction"].as<float>();
+  conf.threadPoolFraction = vm["threadPool"].as<float>();
   conf.chunkReservedGB = vm["chunkSize"].as<float>();
   conf.kernelLaunches = vm["launches"].as<int>();
   conf.nTests = vm["nruns"].as<int>();
@@ -97,7 +99,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   }
 
   conf.pools.clear();
-  for (auto& pool : vm["pool"].as<std::vector<std::string>>()) {
+  for (auto& pool : vm["blockPool"].as<std::vector<std::string>>()) {
     if (pool == "sb") {
       conf.pools.push_back(KernelConfig::Single);
     } else if (pool == "mb") {

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -22,7 +22,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::options_description options("Benchmark options");
   options.add_options()(
     "help,h", "Print help message.")(
-    "version,v", "print version")(
+    "version,v", "Print version.")(
+    "extra,x", "Print extra info for each available device.")(
     "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
     "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong"}, "char int ulong"), "Test data type to be used.")(
@@ -43,6 +44,13 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 
     if (vm.count("version")) {
       std::cout << VERSION << std::endl;
+      return false;
+    }
+
+    if (vm.count("extra")) {
+      o2::benchmark::benchmarkOpts opts;
+      o2::benchmark::GPUbenchmark<char> bm_dummy{opts, nullptr};
+      bm_dummy.printDevices();
       return false;
     }
 

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -29,6 +29,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
     "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
+    "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
     "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
@@ -51,6 +52,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   conf.chunkReservedGB = vm["chunkSize"].as<float>();
   conf.kernelLaunches = vm["launches"].as<int>();
   conf.nTests = vm["nruns"].as<int>();
+  conf.streams = vm["streams"].as<int>();
 
   conf.tests.clear();
   for (auto& test : vm["test"].as<std::vector<std::string>>()) {
@@ -110,10 +112,10 @@ int main(int argc, const char* argv[])
 
   o2::benchmark::GPUbenchmark<char> bm_char{opts, writer};
   bm_char.run();
-  o2::benchmark::GPUbenchmark<int> bm_int{opts, writer};
-  bm_int.run();
-  o2::benchmark::GPUbenchmark<size_t> bm_size_t{opts, writer};
-  bm_size_t.run();
+  // o2::benchmark::GPUbenchmark<int> bm_int{opts, writer};
+  // bm_int.run();
+  // o2::benchmark::GPUbenchmark<size_t> bm_size_t{opts, writer};
+  // bm_size_t.run();
 
   // save results
   writer.get()->saveToFile();

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -26,7 +26,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "extra,x", "Print extra info for each available device.")(
     "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
-    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong"}, "char int ulong"), "Test data type to be used.")(
+    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
     "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
     "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
@@ -138,6 +138,9 @@ int main(int argc, const char* argv[])
       bm_int.run();
     } else if (dtype == "ulong") {
       o2::benchmark::GPUbenchmark<size_t> bm_size_t{opts, writer};
+      bm_size_t.run();
+    } else if (dtype == "int4") {
+      o2::benchmark::GPUbenchmark<int4> bm_size_t{opts, writer};
       bm_size_t.run();
     } else {
       std::cerr << "Unkonwn data type: " << dtype << std::endl;

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -13,6 +13,7 @@
 /// \author mconcas@cern.ch
 ///
 #include "Shared/Kernels.h"
+#define VERSION "version 0.1-latest-#6773"
 
 bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 {
@@ -21,11 +22,12 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::options_description options("Benchmark options");
   options.add_options()(
     "help,h", "Print help message.")(
+    "version,v", "print version")(
     "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
-    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read, write, copy"), "Tests to be performed.")(
-    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong"}, "char, int, ulong"), "Test data type to be used.")(
-    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq, con"), "Mode: sequential or concurrent.")(
-    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb"}, "sb, mb"), "Pool strategy: single or multi blocks.")(
+    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
+    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong"}, "char int ulong"), "Test data type to be used.")(
+    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
+    "pool,p", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb"}, "sb mb"), "Pool strategy: single or multi blocks.")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
@@ -36,6 +38,11 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {
       std::cout << options << std::endl;
+      return false;
+    }
+
+    if (vm.count("version")) {
+      std::cout << VERSION << std::endl;
       return false;
     }
 

--- a/GPU/GPUbenchmark/benchmark.cxx
+++ b/GPU/GPUbenchmark/benchmark.cxx
@@ -28,7 +28,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
-    "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.");
+    "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
+    "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {
@@ -89,6 +90,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     }
   }
 
+  conf.outFileName = vm["outfile"].as<std::string>();
+
   return true;
 }
 
@@ -103,7 +106,7 @@ int main(int argc, const char* argv[])
     return -1;
   }
 
-  std::shared_ptr<ResultWriter> writer = std::make_shared<ResultWriter>(std::to_string(opts.deviceId) + "_benchmark_results.root");
+  std::shared_ptr<ResultWriter> writer = std::make_shared<ResultWriter>(std::to_string(opts.deviceId) + "_" + opts.outFileName + ".root");
 
   o2::benchmark::GPUbenchmark<char> bm_char{opts, writer};
   bm_char.run();

--- a/GPU/GPUbenchmark/cuda/CMakeLists.txt
+++ b/GPU/GPUbenchmark/cuda/CMakeLists.txt
@@ -10,11 +10,13 @@
 # or submit itself to any jurisdiction.
 
 if(CUDA_ENABLED)
-  add_subdirectory(cuda)
+message(STATUS "Building GPU CUDA benchmark")
+set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+  o2_add_executable(gpu-memory-benchmark-cuda
+                  SOURCES benchmark.cu
+                          Kernels.cu
+                  PUBLIC_LINK_LIBRARIES Boost::program_options
+                                        ROOT::Tree
+                  TARGETVARNAME targetName)
+                  set_target_properties(${targeName} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 endif()
-
-if(HIP_ENABLED)
-  add_subdirectory(hip)
-endif()
-
-o2_add_test_root_macro(macro/showBenchmarks.C)

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -363,7 +363,8 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
   mResultWriter.get()->addBenchmarkEntry(getTestName(mode, test, config), getType<chunk_t>(), mState.getMaxChunks());
   auto dimGrid{mState.nMultiprocessors};
   auto nThreads{std::min(mState.nMaxThreadsPerDimension, mState.nMaxThreadsPerBlock)};
-  auto nBlocks{(config == KernelConfig::Single) ? 1 : dimGrid / mState.getMaxChunks()};
+  auto nBlocks{(config == KernelConfig::Single) ? 1 : (config == KernelConfig::Multi) ? dimGrid / mState.getMaxChunks()
+                                                                                      : dimGrid};
   auto chunks{mState.getMaxChunks()};
   auto capacity{mState.getChunkCapacity()};
   void (*kernel)(chunk_t*, size_t);

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -49,7 +49,7 @@ __global__ void read_k(
 {
   chunk_t sink{0};
   for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
-    sink = chunkPtr[i] + sink;
+    sink += chunkPtr[i];
   }
   chunkPtr[threadIdx.x] = sink;
 }

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -31,6 +31,18 @@
 double bytesToconfig(size_t s) { return (double)s / (1024.0); }
 double bytesToGB(size_t s) { return (double)s / GB; }
 
+// CUDA does not support <type4> operations:
+// https://forums.developer.nvidia.com/t/swizzling-float4-arithmetic-support/217
+#ifndef __HIPCC__
+inline __host__ __device__ void operator+=(int4& a, int4 b)
+{
+  a.x += b.x;
+  a.y += b.y;
+  a.z += b.z;
+  a.w += b.w;
+}
+#endif
+
 namespace o2
 {
 namespace benchmark

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -406,8 +406,8 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
   for (auto measurement{0}; measurement < mOptions.nTests; ++measurement) {
     std::cout << "    ├ " << mode << " " << test << " " << config << " block(s) (" << measurement + 1 << "/" << mOptions.nTests << "): \n"
               << "    │   - blocks per kernel: " << nBlocks << "/" << dimGrid << "\n"
-              << "    │   - threads per block: " << nThreads << "\n";
-    std::cout << "    │   - per chunk throughput:\n";
+              << "    │   - threads per block: " << nThreads << "\n"
+              << "    │   - per chunk throughput:\n";
     if (mode == Mode::Sequential) {
       for (auto iChunk{0}; iChunk < mState.getMaxChunks(); ++iChunk) { // loop over single chunks separately
         auto result = runSequential(kernel,
@@ -417,7 +417,7 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
                                     nThreads, // args...
                                     capacity);
         auto throughput = computeThroughput(test, result, mState.chunkReservedGB, mState.getNKernelLaunches());
-        std::cout << "    │     ├ " << iChunk + 1 << "/" << mState.getMaxChunks() << ": \e[1m" << throughput << " GB/s \e[0m (" << result * 1e-3 << " s)\n";
+        std::cout << "    │     " << ((mState.getMaxChunks() - iChunk != 1) ? "├ " : "└ ") << iChunk + 1 << "/" << mState.getMaxChunks() << ": \e[1m" << throughput << " GB/s \e[0m (" << result * 1e-3 << " s)\n";
         mResultWriter.get()->storeBenchmarkEntry(test, iChunk, result, mState.chunkReservedGB, mState.getNKernelLaunches());
       }
     } else {
@@ -430,7 +430,7 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
                                    capacity);
       for (auto iChunk{0}; iChunk < results.size(); ++iChunk) {
         auto throughput = computeThroughput(test, results[iChunk], mState.chunkReservedGB, mState.getNKernelLaunches());
-        std::cout << "    │     ├ " << iChunk + 1 << "/" << results.size() << ": \e[1m" << throughput << " GB/s \e[0m (" << results[iChunk] * 1e-3 << " s)\n";
+        std::cout << "    │     " << ((results.size() - iChunk != 1) ? "├ " : "└ ") << iChunk + 1 << "/" << results.size() << ": \e[1m" << throughput << " GB/s \e[0m (" << results[iChunk] * 1e-3 << " s)\n";
         mResultWriter.get()->storeBenchmarkEntry(test, iChunk, results[iChunk], mState.chunkReservedGB, mState.getNKernelLaunches());
       }
     }

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -109,7 +109,7 @@ __global__ void writeChunkSBKernel(
 {
   if (chunkId == blockIdx.x) { // runs only if blockIdx.x is allowed in given split
     for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
-      chunkPtr[i] = 1;
+      chunkPtr[i] = 0;
     }
   }
 }
@@ -122,7 +122,7 @@ __global__ void writeChunkMBKernel(
   size_t chunkSize)
 {
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
-    chunkPtr[i] = 1;
+    chunkPtr[i] = 0;
   }
 }
 
@@ -657,7 +657,7 @@ void GPUbenchmark<chunk_type>::copyInit()
   mState.hostCopyInputsVector.resize(mState.getMaxChunks());
   GPUCHECK(cudaSetDevice(mOptions.deviceId));
   GPUCHECK(cudaMalloc(reinterpret_cast<void**>(&(mState.deviceCopyInputsPtr)), mState.getMaxChunks() * sizeof(chunk_type)));
-  GPUCHECK(cudaMemset(mState.deviceCopyInputsPtr, 1, mState.getMaxChunks() * sizeof(chunk_type)));
+  GPUCHECK(cudaMemset(mState.deviceCopyInputsPtr, 0, mState.getMaxChunks() * sizeof(chunk_type)));
 }
 
 template <class chunk_type>

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -74,11 +74,10 @@ __global__ void readChunkSBKernel(
   size_t chunkSize)
 {
   chunk_t sink{0}; // local memory -> excluded from bandwidth accounting
-  size_t last{0};
-  for (last = threadIdx.x; last < chunkSize; last += blockDim.x) {
-    sink += chunkPtr[last]; // 1 read operation, performed "chunkSize" times
+  for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
+    sink = chunkPtr[i]; // 1 read operation, performed "chunkSize" times
   }
-  chunkPtr[last] = sink; // writing done once
+  chunkPtr[threadIdx.x] = sink; // writing done once
 }
 
 template <class chunk_t>
@@ -87,11 +86,10 @@ __global__ void readChunkMBKernel(
   size_t chunkSize)
 {
   chunk_t sink{0}; // local memory -> excluded from bandwidth accounting
-  size_t last{0};
-  for (last = blockIdx.x * blockDim.x + threadIdx.x; last < chunkSize; last += blockDim.x * gridDim.x) {
-    sink += chunkPtr[last]; // 1 read operation, performed "chunkSize" times
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+    sink = chunkPtr[i]; // 1 read operation, performed "chunkSize" times
   }
-  chunkPtr[last] = sink;
+  chunkPtr[threadIdx.x] = sink;
 }
 
 // Write
@@ -853,7 +851,7 @@ void GPUbenchmark<chunk_t>::run()
 template class GPUbenchmark<char>;
 template class GPUbenchmark<size_t>;
 template class GPUbenchmark<int>;
-// template class GPUbenchmark<uint4>;
+// template class GPUbenchmark<int4>;
 
 } // namespace benchmark
 } // namespace o2

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -480,7 +480,10 @@ void GPUbenchmark<chunk_t>::readConcurrent(SplitLevel sl, int nRegions)
                                      1, // single Block
                                      nThreads,
                                      capacity);
-        for (auto iResult{0}; iResult < results.size(); ++iResult) {
+        std::cout << "    │   · Per chunk throughput:\n" for (auto iResult{0}; iResult < results.size(); ++iResult)
+        {
+          auto throughput = 1e3 * capacity * sizeof(chunk_t) / (results[iResult] * GB * nState.getNKernelLaunches());
+          std::cout << "    │     ├ " << iResult << "/" << results.size() << ": \e[1m" << throughput << " GB/s \e[0m (" << results[iResult] << " ms)\n";
           mResultWriter.get()->storeBenchmarkEntry(Test::Read, iResult, results[iResult], mState.chunkReservedGB, mState.getNKernelLaunches());
         }
         mResultWriter.get()->snapshotBenchmark();
@@ -506,7 +509,10 @@ void GPUbenchmark<chunk_t>::readConcurrent(SplitLevel sl, int nRegions)
                                      nBlocks,
                                      nThreads,
                                      capacity);
+        std::cout << "    │   · Per chunk throughput:\n";
         for (auto iResult{0}; iResult < results.size(); ++iResult) {
+          auto throughput = 1e3 * capacity * sizeof(chunk_t) / (results[iResult] * GB * nState.getNKernelLaunches());
+          std::cout << "    │     ├ " << iResult << "/" << results.size() << ": \e[1m" << throughput << " GB/s \e[0m (" << results[iResult] << " ms)\n";
           mResultWriter.get()->storeBenchmarkEntry(Test::Read, iResult, results[iResult], mState.chunkReservedGB, mState.getNKernelLaunches());
         }
         mResultWriter.get()->snapshotBenchmark();

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -91,12 +91,11 @@ __global__ void readChunkMBKernel(
   chunk_type* results,
   size_t chunkSize)
 {
+  chunk_type sink{0};
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
-    if (chunkPtr[i] == static_cast<chunk_type>(1)) { // actual read operation is performed here
-      results[chunkId] += chunkPtr[i];               // this case should never happen and waves should be always in sync
-      printf("Should never happen\n");
-    }
+    sink += chunkPtr[i];
   }
+  results[chunkId] = sink;
 }
 
 // Write

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -75,13 +75,11 @@ __global__ void readChunkSBKernel(
   chunk_type* results,
   size_t chunkSize)
 {
-  if (chunkId == blockIdx.x) { // runs only if blockIdx.x is allowed in given split
-    chunk_type sink{0};
-    for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
-      sink += chunkPtr[i];
-    }
-    results[chunkId] = sink;
+  chunk_type sink{0};
+  for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
+    sink += chunkPtr[i];
   }
+  results[chunkId] = sink;
 }
 
 template <class chunk_type>
@@ -106,10 +104,8 @@ __global__ void writeChunkSBKernel(
   chunk_type* results,
   size_t chunkSize)
 {
-  if (chunkId == blockIdx.x) { // runs only if blockIdx.x is allowed in given split
-    for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
-      chunkPtr[i] = 0;
-    }
+  for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
+    chunkPtr[i] = 0;
   }
 }
 
@@ -133,10 +129,8 @@ __global__ void copyChunkSBKernel(
   chunk_type* inputs,
   size_t chunkSize)
 {
-  if (chunkId == blockIdx.x) { // runs only if blockIdx.x is allowed in given split
-    for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
-      chunkPtr[i] = inputs[chunkId];
-    }
+  for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
+    chunkPtr[i] = inputs[chunkId];
   }
 }
 
@@ -409,7 +403,7 @@ void GPUbenchmark<chunk_type>::readSequential(SplitLevel sl)
   switch (sl) {
     case SplitLevel::Blocks: {
       mResultWriter.get()->addBenchmarkEntry("seq_read_SB", getType<chunk_type>(), mState.getMaxChunks());
-      auto nBlocks{mState.nMultiprocessors};
+      // auto nBlocks{mState.nMultiprocessors};
       auto nThreads{std::min(mState.nMaxThreadsPerDimension, mState.nMaxThreadsPerBlock)};
       auto capacity{mState.getChunkCapacity()};
 
@@ -419,7 +413,7 @@ void GPUbenchmark<chunk_type>::readSequential(SplitLevel sl)
           auto result = benchmarkSync(&gpu::readChunkSBKernel<chunk_type>,
                                       mState.getNKernelLaunches(),
                                       iChunk,
-                                      nBlocks,
+                                      1,
                                       nThreads, // args...
                                       mState.deviceReadResultsPtr,
                                       capacity);
@@ -536,7 +530,7 @@ void GPUbenchmark<chunk_type>::writeSequential(SplitLevel sl)
   switch (sl) {
     case SplitLevel::Blocks: {
       mResultWriter.get()->addBenchmarkEntry("seq_write_SB", getType<chunk_type>(), mState.getMaxChunks());
-      auto nBlocks{mState.nMultiprocessors};
+      // auto nBlocks{mState.nMultiprocessors};
       auto nThreads{std::min(mState.nMaxThreadsPerDimension, mState.nMaxThreadsPerBlock)};
       auto capacity{mState.getChunkCapacity()};
 
@@ -546,7 +540,7 @@ void GPUbenchmark<chunk_type>::writeSequential(SplitLevel sl)
           auto result = benchmarkSync(&gpu::writeChunkSBKernel<chunk_type>,
                                       mState.getNKernelLaunches(),
                                       iChunk,
-                                      nBlocks,
+                                      1,
                                       nThreads,
                                       mState.deviceWriteResultsPtr,
                                       capacity);
@@ -665,7 +659,7 @@ void GPUbenchmark<chunk_type>::copySequential(SplitLevel sl)
   switch (sl) {
     case SplitLevel::Blocks: {
       mResultWriter.get()->addBenchmarkEntry("seq_copy_SB", getType<chunk_type>(), mState.getMaxChunks());
-      auto nBlocks{mState.nMultiprocessors};
+      // auto nBlocks{mState.nMultiprocessors};
       auto nThreads{std::min(mState.nMaxThreadsPerDimension, mState.nMaxThreadsPerBlock)};
       auto capacity{mState.getChunkCapacity()};
 
@@ -675,7 +669,7 @@ void GPUbenchmark<chunk_type>::copySequential(SplitLevel sl)
           auto result = benchmarkSync(&gpu::copyChunkSBKernel<chunk_type>,
                                       mState.getNKernelLaunches(),
                                       iChunk,
-                                      nBlocks,
+                                      1,
                                       nThreads,
                                       mState.deviceCopyInputsPtr,
                                       capacity);

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -49,7 +49,7 @@ __global__ void read_k(
 {
   chunk_t sink{0};
   for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
-    sink = chunkPtr[i];
+    sink += chunkPtr[i];
   }
   chunkPtr[threadIdx.x] = sink;
 }
@@ -63,6 +63,16 @@ __global__ void write_k(
   for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
     chunkPtr[i] = 0;
   }
+}
+
+template <>
+__global__ void write_k(
+  int4* chunkPtr,
+  size_t chunkSize)
+{
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+    chunkPtr[i] = {0, 1, 0, 0};
+  };
 }
 
 // Copy
@@ -453,7 +463,7 @@ void GPUbenchmark<chunk_t>::run()
 template class GPUbenchmark<char>;
 template class GPUbenchmark<size_t>;
 template class GPUbenchmark<int>;
-// template class GPUbenchmark<int4>;
+template class GPUbenchmark<int4>;
 
 } // namespace benchmark
 } // namespace o2

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -108,7 +108,7 @@ __global__ void writeChunkMBKernel(
   chunk_t* chunkPtr,
   size_t chunkSize)
 {
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
     chunkPtr[i] = 0;
   }
 }
@@ -129,7 +129,7 @@ __global__ void copyChunkMBKernel(
   chunk_t* chunkPtr,
   size_t chunkSize)
 {
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
     chunkPtr[chunkSize - i - 1] = chunkPtr[i];
   }
 }

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -391,6 +391,7 @@ void GPUbenchmark<chunk_t>::globalInit()
             << "    ├ Allocated: " << std::setprecision(2) << bytesToGB(mState.scratchSize) << "/" << std::setprecision(2) << bytesToGB(mState.totalMemory)
             << "(GB) [" << std::setprecision(3) << (100.f) * (mState.scratchSize / (float)mState.totalMemory) << "%]\n"
             << "    ├ Number of scratch chunks: " << mState.getMaxChunks() << " of " << mOptions.chunkReservedGB << "GB each\n"
+            << "    ├ Number of streams allocated: " << mState.getStreamsPoolSize() << "\n"
             << "    └ Each chunk can store up to: " << mState.getChunkCapacity() << " elements" << std::endl
             << std::endl;
 }

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -391,12 +391,15 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
   switch (test) {
     case Test::Read: {
       kernel = (config == KernelConfig::Single) ? &gpu::readChunkSBKernel<chunk_t> : &gpu::readChunkMBKernel<chunk_t>;
+      break;
     }
     case Test::Write: {
       kernel = (config == KernelConfig::Single) ? &gpu::writeChunkSBKernel<chunk_t> : &gpu::writeChunkMBKernel<chunk_t>;
+      break;
     }
     case Test::Copy: {
       kernel = (config == KernelConfig::Single) ? &gpu::copyChunkSBKernel<chunk_t> : &gpu::copyChunkMBKernel<chunk_t>;
+      break;
     }
   }
 
@@ -473,4 +476,3 @@ template class GPUbenchmark<int>;
 
 } // namespace benchmark
 } // namespace o2
-void readConcurrent(KernelConfig config);

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -49,7 +49,7 @@ __global__ void read_k(
 {
   chunk_t sink{0};
   for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
-    sink += chunkPtr[i];
+    sink = chunkPtr[i] + sink;
   }
   chunkPtr[threadIdx.x] = sink;
 }

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -22,7 +22,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::options_description options("Benchmark options");
   options.add_options()(
     "help,h", "Print help message.")(
-    "version,v", "Print version.")("extra,x", "Print extra info for each available device.")("arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Arbitrary defined chunks syntax p:s. P is starting GB, S is the size in GB.")("device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")("test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")("kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")("mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")("blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")("threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")("chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")("freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")("launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")("nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")("streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")("outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
+    "version,v", "Print version.")("extra,x", "Print extra info for each available device.")("arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Custom selected chunks syntax <p>:<s>. P is starting GB, S is the size in GB.")("device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")("test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")("kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")("mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")("blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")("threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")("chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")("freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")("launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")("nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")("streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")("outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {
@@ -99,11 +99,12 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     }
   }
 
-  conf.arbitraryChunks.clear();
-  conf.arbitraryChunks.resize(0);
+  conf.testChunks.clear();
   for (auto& aChunk : vm["arbitrary"].as<std::vector<std::string>>()) {
     const size_t sep = aChunk.find(':');
-    conf.arbitraryChunks.emplace_back(std::stoi(aChunk.substr(0, sep)), std::stoi(aChunk.substr(sep + 1)));
+    if (sep != std::string::npos) {
+      conf.testChunks.emplace_back(std::stoi(aChunk.substr(0, sep)), std::stoi(aChunk.substr(sep + 1)));
+    }
   }
 
   conf.dtypes = vm["kind"].as<std::vector<std::string>>();

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -9,10 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file benchmark.cxx
 /// \author mconcas@cern.ch
 ///
-#include "Shared/Kernels.h"
+
+#include "../Shared/Kernels.h"
 #define VERSION "version 0.1-latest-#6773"
 
 bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -13,7 +13,7 @@
 ///
 
 #include "../Shared/Kernels.h"
-#define VERSION "version 0.1-latest-#6773"
+#define VERSION "version 0.1-pr#6773"
 
 bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 {
@@ -22,7 +22,21 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::options_description options("Benchmark options");
   options.add_options()(
     "help,h", "Print help message.")(
-    "version,v", "Print version.")("extra,x", "Print extra info for each available device.")("arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Custom selected chunks syntax <p>:<s>. P is starting GB, S is the size in GB.")("device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")("test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")("kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")("mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")("blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")("threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")("chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")("freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")("launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")("nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")("streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")("outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
+    "version,v", "Print version.")(
+    "extra,x", "Print extra info for each available device.")(
+    "arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Custom selected chunks syntax <p>:<s>. P is starting GB, S is the size in GB.")(
+    "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
+    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
+    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
+    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
+    "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
+    "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
+    "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
+    "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
+    "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
+    "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
+    "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
+    "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -22,20 +22,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::options_description options("Benchmark options");
   options.add_options()(
     "help,h", "Print help message.")(
-    "version,v", "Print version.")(
-    "extra,x", "Print extra info for each available device.")(
-    "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
-    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
-    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
-    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
-    "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
-    "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
-    "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
-    "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
-    "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
-    "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
-    "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
-    "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
+    "version,v", "Print version.")("extra,x", "Print extra info for each available device.")("arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Arbitrary defined chunks syntax p:s. P is starting GB, S is the size in GB.")("device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")("test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")("kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")("mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")("blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")("threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")("chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")("freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")("launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")("nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")("streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")("outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {
@@ -112,6 +99,13 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     }
   }
 
+  conf.arbitraryChunks.clear();
+  conf.arbitraryChunks.resize(0);
+  for (auto& aChunk : vm["arbitrary"].as<std::vector<std::string>>()) {
+    const size_t sep = aChunk.find(':');
+    conf.arbitraryChunks.emplace_back(std::stoi(aChunk.substr(0, sep)), std::stoi(aChunk.substr(sep + 1)));
+  }
+
   conf.dtypes = vm["kind"].as<std::vector<std::string>>();
   conf.outFileName = vm["outfile"].as<std::string>();
 
@@ -122,7 +116,6 @@ using o2::benchmark::ResultWriter;
 
 int main(int argc, const char* argv[])
 {
-
   o2::benchmark::benchmarkOpts opts;
 
   if (!parseArgs(opts, argc, argv)) {

--- a/GPU/GPUbenchmark/hip/CMakeLists.txt
+++ b/GPU/GPUbenchmark/hip/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+message(STATUS "Building GPU HIP benchmark")
+# Hipify-perl to generate HIP sources
+set(HIPIFY_EXECUTABLE "/opt/rocm/bin/hipify-perl")
+file(GLOB CUDA_SOURCES_FULL_PATH "../cuda/*.cu")
+foreach(file ${CUDA_SOURCES_FULL_PATH})
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${file})
+  get_filename_component(CUDA_SOURCE ${file} NAME)
+  string(REPLACE ".cu" "" CUDA_SOURCE_NAME ${CUDA_SOURCE})
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${CUDA_SOURCE_NAME}.hip.cxx
+    COMMAND ${HIPIFY_EXECUTABLE} --quiet-warnings ${CMAKE_CURRENT_SOURCE_DIR}/../cuda/${CUDA_SOURCE} | sed '1{/\#include \"hip\\/hip_runtime.h\"/d}' > ${CMAKE_CURRENT_SOURCE_DIR}/${CUDA_SOURCE_NAME}.hip.cxx
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../cuda/${CUDA_SOURCE}
+  )
+endforeach()
+
+set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
+set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${O2_HIP_CMAKE_CXX_FLAGS} -fgpu-rdc")
+o2_add_executable(gpu-memory-benchmark-hip
+                  SOURCES benchmark.hip.cxx
+                          Kernels.hip.cxx
+                  PUBLIC_LINK_LIBRARIES hip::host
+                                        Boost::program_options
+                                        ROOT::Tree
+                  TARGETVARNAME targetName)
+if(HIP_AMDGPUTARGET)
+  # Need to add gpu target also to link flags due to gpu-rdc option
+  target_link_options(${targetName} PUBLIC --amdgpu-target=${HIP_AMDGPUTARGET})
+endif()

--- a/GPU/GPUbenchmark/macro/showBenchmarks.C
+++ b/GPU/GPUbenchmark/macro/showBenchmarks.C
@@ -13,7 +13,7 @@
 
 int nBins{500};
 float minHist{0.f}, maxHist{1e4};
-void showBenchmarks(const TString fileName = "0_benchmark_results.root")
+void showBenchmarks(const bool times = false, const TString fileName = "0_benchmark_results.root")
 {
   auto f = TFile::Open(fileName.Data(), "read");
   std::unordered_map<std::string, TTree*> um_trees;
@@ -40,40 +40,79 @@ void showBenchmarks(const TString fileName = "0_benchmark_results.root")
               if (keyPair.first.find(type) != std::string::npos) {
                 for (auto& pattern : patterns) {
                   if (keyPair.first.find(pattern) != std::string::npos) {
-                    // Single Tree entry, we know test, type, mode, pattern
-                    std::vector<float>* measures = 0;
-                    TBranch* elapsed;
-                    keyPair.second->SetBranchAddress("elapsed", &measures, &elapsed);
-                    elapsed->GetEntry(keyPair.second->LoadTree(0));
-                    auto nChunk = measures->size();
-                    histograms.emplace_back(nChunk);
-                    for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
-                      histograms.back()[iHist] = new TH1F(Form("Chunk_%d_%s", iHist, keyPair.first.c_str()), Form("Chunk_%d_%s;ms", iHist, keyPair.first.c_str()), 500, 0, 1e4);
-                    }
-                    for (size_t iEntry(0); iEntry < (size_t)keyPair.second->GetEntriesFast(); ++iEntry) {
-                      auto tentry = keyPair.second->LoadTree(iEntry);
-                      elapsed->GetEntry(tentry);
-                      for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
-                        histograms.back()[iHist]->Fill((*measures)[iHist]);
+                    if ((keyPair.first.find("TP") == std::string::npos)) {
+                      if (times) {
+                        // Single Tree entry, we know test, type, mode, pattern
+                        std::vector<float>* measures = 0;
+                        TBranch* elapsed;
+                        keyPair.second->SetBranchAddress("elapsed", &measures, &elapsed);
+                        elapsed->GetEntry(keyPair.second->LoadTree(0));
+                        auto nChunk = measures->size();
+                        histograms.emplace_back(nChunk);
+                        for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
+                          histograms.back()[iHist] = new TH1F(Form("Chunk_%d_%s", iHist, keyPair.first.c_str()), Form("Chunk_%d_%s;ms", iHist, keyPair.first.c_str()), 1000, 0, 1e4);
+                        }
+                        for (size_t iEntry(0); iEntry < (size_t)keyPair.second->GetEntriesFast(); ++iEntry) {
+                          auto tentry = keyPair.second->LoadTree(iEntry);
+                          elapsed->GetEntry(tentry);
+                          for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
+                            histograms.back()[iHist]->Fill((*measures)[iHist]);
+                          }
+                        }
+
+                        std::vector<float> xCoord(nChunk), exCoord(nChunk), yCoord(nChunk), eyCoord(nChunk);
+
+                        for (size_t i{0}; i < nChunk; ++i) {
+                          xCoord[i] = (float)i;
+                          yCoord[i] = histograms.back()[i]->GetMean();
+                          eyCoord[i] = histograms.back()[i]->GetRMS();
+                          exCoord[i] = 0.f;
+                        }
+                        TCanvas* c = new TCanvas(Form("c%s", keyPair.first.c_str()), Form("%s", keyPair.first.c_str()));
+                        c->cd();
+                        TGraphErrors* g = new TGraphErrors(nChunk, xCoord.data(), yCoord.data(), exCoord.data(), eyCoord.data());
+                        g->GetYaxis()->SetRangeUser(0, 5000);
+                        g->GetXaxis()->SetRangeUser(-2.f, nChunk);
+                        g->SetTitle(Form("%s, N_{test}=%d;chunk_id;elapsed (GB/s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
+                        g->SetFillColor(40);
+                        g->Draw("AB");
                       }
-                    }
+                    } else { // TP plots //
+                      // Single Tree entry, we know test, type, mode, pattern
+                      std::vector<float>* measures = 0;
+                      TBranch* throughput;
+                      keyPair.second->SetBranchAddress("throughput", &measures, &throughput);
+                      throughput->GetEntry(keyPair.second->LoadTree(0));
+                      auto nChunk = measures->size();
+                      histograms.emplace_back(nChunk);
+                      for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
+                        histograms.back()[iHist] = new TH1F(Form("Chunk_%d_%s", iHist, keyPair.first.c_str()), Form("Chunk_%d_%s;GB/s", iHist, keyPair.first.c_str()), 1000, 0, 1e3);
+                      }
+                      for (size_t iEntry(0); iEntry < (size_t)keyPair.second->GetEntriesFast(); ++iEntry) {
+                        auto tentry = keyPair.second->LoadTree(iEntry);
+                        throughput->GetEntry(tentry);
+                        for (int iHist{0}; iHist < (int)nChunk; ++iHist) {
+                          histograms.back()[iHist]->Fill((*measures)[iHist]);
+                        }
+                      }
 
-                    std::vector<float> xCoord(nChunk), exCoord(nChunk), yCoord(nChunk), eyCoord(nChunk);
+                      std::vector<float> xCoord(nChunk), exCoord(nChunk), yCoord(nChunk), eyCoord(nChunk);
 
-                    for (size_t i{0}; i < nChunk; ++i) {
-                      xCoord[i] = (float)i;
-                      yCoord[i] = histograms.back()[i]->GetMean();
-                      eyCoord[i] = histograms.back()[i]->GetRMS();
-                      exCoord[i] = 0.f;
+                      for (size_t i{0}; i < nChunk; ++i) {
+                        xCoord[i] = (float)i;
+                        yCoord[i] = histograms.back()[i]->GetMean();
+                        eyCoord[i] = histograms.back()[i]->GetRMS();
+                        exCoord[i] = 0.f;
+                      }
+                      TCanvas* c = new TCanvas(Form("c%s", keyPair.first.c_str()), Form("%s", keyPair.first.c_str()));
+                      c->cd();
+                      TGraphErrors* g = new TGraphErrors(nChunk, xCoord.data(), yCoord.data(), exCoord.data(), eyCoord.data());
+                      g->GetYaxis()->SetRangeUser(0, 500);
+                      g->GetXaxis()->SetRangeUser(-2.f, nChunk);
+                      g->SetTitle(Form("%s, N_{test}=%d;chunk_id;throughput (GB/s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
+                      g->SetFillColor(40);
+                      g->Draw("AB");
                     }
-                    TCanvas* c = new TCanvas(Form("c%s", keyPair.first.c_str()), Form("%s", keyPair.first.c_str()));
-                    c->cd();
-                    TGraphErrors* g = new TGraphErrors(nChunk, xCoord.data(), yCoord.data(), exCoord.data(), eyCoord.data());
-                    g->GetYaxis()->SetRangeUser(0, 5000);
-                    g->GetXaxis()->SetRangeUser(-2.f, nChunk);
-                    g->SetTitle(Form("%s, N_{test}=%d;chunk_id;elapsed (ms)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
-                    g->SetFillColor(40);
-                    g->Draw("AB");
                   }
                 }
               }

--- a/GPU/GPUbenchmark/macro/showBenchmarks.C
+++ b/GPU/GPUbenchmark/macro/showBenchmarks.C
@@ -16,7 +16,7 @@ int nBins{500};
 float minHist{0.f}, maxHist{1e4};
 void showBenchmarks(const bool times = false, const TString fileName = "0_benchmark_results.root")
 {
-  auto f = TFile::Open(fileName.Data(), "read");
+  auto f = TFile::Open(fileName.Data(), "UPDATE");
   std::unordered_map<std::string, TTree*> um_trees;
   std::vector<std::vector<TH1F*>> histograms;
   std::vector<TGraphErrors*> results;
@@ -74,9 +74,9 @@ void showBenchmarks(const bool times = false, const TString fileName = "0_benchm
                         TGraphErrors* g = new TGraphErrors(nChunk, xCoord.data(), yCoord.data(), exCoord.data(), eyCoord.data());
                         g->GetYaxis()->SetRangeUser(0, 5000);
                         g->GetXaxis()->SetRangeUser(-2.f, nChunk);
-                        g->SetTitle(Form("%s, N_{test}=%d;chunk_id;elapsed (GB/s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
+                        g->SetTitle(Form("%s, N_{test}=%d;chunk_id;elapsed (s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
                         g->SetFillColor(kBlue);
-                        g->SetFillStyle(3335);
+                        g->SetFillStyle(3001);
                         g->Draw("AB");
                       }
                     } else { // TP plots //
@@ -109,11 +109,13 @@ void showBenchmarks(const bool times = false, const TString fileName = "0_benchm
                       TCanvas* c = new TCanvas(Form("c%s", keyPair.first.c_str()), Form("%s", keyPair.first.c_str()));
                       c->cd();
                       TGraphErrors* g = new TGraphErrors(nChunk, xCoord.data(), yCoord.data(), exCoord.data(), eyCoord.data());
-                      g->GetYaxis()->SetRangeUser(0, 500);
+                      g->GetYaxis()->SetRangeUser(0, 150);
                       g->GetXaxis()->SetRangeUser(-2.f, nChunk);
                       g->SetTitle(Form("%s, N_{test}=%d;chunk_id;throughput (GB/s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
-                      g->SetFillColor(40);
+                      g->SetFillColor(kBlue);
+                      g->SetFillStyle(3001);
                       g->Draw("AB");
+                      g->Write();
                     }
                   }
                 }
@@ -124,4 +126,5 @@ void showBenchmarks(const bool times = false, const TString fileName = "0_benchm
       }
     }
   }
+  f->Close();
 }

--- a/GPU/GPUbenchmark/macro/showBenchmarks.C
+++ b/GPU/GPUbenchmark/macro/showBenchmarks.C
@@ -14,7 +14,7 @@
 
 int nBins{500};
 float minHist{0.f}, maxHist{1e4};
-void showBenchmarks(const bool times = false, const TString fileName = "0_benchmark_results.root")
+void showBenchmarks(const bool times = false, const TString fileName = "0_benchmark_result.root")
 {
   auto f = TFile::Open(fileName.Data(), "UPDATE");
   std::unordered_map<std::string, TTree*> um_trees;

--- a/GPU/GPUbenchmark/macro/showBenchmarks.C
+++ b/GPU/GPUbenchmark/macro/showBenchmarks.C
@@ -3,6 +3,7 @@
 #include <TFile.h>
 #include <TH1F.h>
 #include <TTree.h>
+#include <TKey.h>
 #include <TBranch.h>
 #include <TCanvas.h>
 #include <TGraphErrors.h>

--- a/GPU/GPUbenchmark/macro/showBenchmarks.C
+++ b/GPU/GPUbenchmark/macro/showBenchmarks.C
@@ -75,7 +75,8 @@ void showBenchmarks(const bool times = false, const TString fileName = "0_benchm
                         g->GetYaxis()->SetRangeUser(0, 5000);
                         g->GetXaxis()->SetRangeUser(-2.f, nChunk);
                         g->SetTitle(Form("%s, N_{test}=%d;chunk_id;elapsed (GB/s)", keyPair.first.c_str(), (int)keyPair.second->GetEntriesFast()));
-                        g->SetFillColor(40);
+                        g->SetFillColor(kBlue);
+                        g->SetFillStyle(3335);
                         g->Draw("AB");
                       }
                     } else { // TP plots //


### PR DESCRIPTION
TODO:
- [x] Replace single block kernels with kernels launches with 1 block
- [x] Change copyKernel to read on the same chunk but from different halves
- [x] Remove multiple streams approach and use only one also for concurrency (Max is 8)
- [x] Show result in bandwidth
- [x] Code refactoring to generalize test execution call
- [x] Add support for `int4`
- [x] Add support for targeted chunks 