### PR TITLE
Modifications for extendend async workflow 

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -20,6 +20,7 @@
 #include "ReconstructionDataFormats/GlobalTrackAccessor.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/MatchingType.h"
 #include "CommonDataFormat/AbstractRefAccessor.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -112,6 +113,14 @@ namespace globaltracking
 struct DataRequest {
   std::vector<o2::framework::InputSpec> inputs;
   std::unordered_map<std::string, bool> requestMap;
+  MatchingType matchingInputType = MatchingType::Standard; // use subspec = 0 for inputs
+
+  auto getMatchingInputType() const { return matchingInputType; }
+  void setMatchingInputStrict() { matchingInputType = MatchingType::Strict; }
+  void setMatchingInputFull() { matchingInputType = MatchingType::Full; }
+  void setMatchingInputStandard() { matchingInputType = MatchingType::Standard; }
+  uint32_t getMatchingInputSubSpec() const { return getSubSpec(matchingInputType); }
+
   void addInput(const o2::framework::InputSpec&& isp);
 
   bool isRequested(const std::string& t) const { return !t.empty() && requestMap.find(t) != requestMap.end(); }
@@ -398,18 +407,28 @@ struct RecoContainer {
   gsl::span<const o2::trd::TriggerRecord> getTRDTriggerRecords() const;
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* getTRDTrackletsMCLabels() const;
 
+  // TOF
+  const o2::dataformats::MatchInfoTOF& getTOFMatch(GTrackID id) const { return getObject<o2::dataformats::MatchInfoTOF>(id, MATCHES); } // generic match getter
   // TPC-TOF, made of refitted TPC track and separate matchInfo
   const o2::dataformats::TrackTPCTOF& getTPCTOFTrack(GTrackID gid) const { return getTrack<o2::dataformats::TrackTPCTOF>(gid); }
   const o2::dataformats::MatchInfoTOF& getTPCTOFMatch(GTrackID id) const { return getObject<o2::dataformats::MatchInfoTOF>(id, MATCHES); }
   auto getTPCTOFTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
   auto getTPCTOFTracks() const { return getTracks<o2::dataformats::TrackTPCTOF>(GTrackID::TPCTOF); }
+  // TPC-TOF matches
   auto getTPCTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::TPCTOF, MATCHES); }
   auto getTPCTOFTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::TPCTOF, MCLABELS); }
-  // global ITS-TPC-TOF matches, TODO: add ITS-TPC-TRD-TOF and TPC-TRD-TOF
-  const o2::dataformats::MatchInfoTOF& getTOFMatch(GTrackID id) const { return getObject<o2::dataformats::MatchInfoTOF>(id, MATCHES); }
+  // TPC-TRD-TOF matches
+  auto getTPCTRDTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::TPCTRDTOF, MATCHES); }
+  auto getTPCTRDTOFTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::TPCTRDTOF, MCLABELS); }
+  // global ITS-TPC-TOF matches
   const o2::dataformats::TrackTPCITS& getITSTPCTOFTrack(GTrackID id) const; // this is special since global TOF track is just a reference on TPCITS
-  auto getTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::ITSTPCTOF, MATCHES); }
-  auto getTOFMatchesMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTOF, MCLABELS); }
+  auto getITSTPCTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::ITSTPCTOF, MATCHES); }
+  auto getITSTPCTOFMatchesMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTOF, MCLABELS); }
+  // global ITS-TPC-TRD-TOF matches
+  //  const o2::dataformats::TrackTPCITS& getITSTPCTRDTOFTrack(GTrackID id) const; // TODO this is special since global TOF track is just a reference on TPCITS
+  auto getITSTPCTRDTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::ITSTPCTRDTOF, MATCHES); }
+  auto getITSTPCTRDTOFMatchesMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTRDTOF, MCLABELS); }
+
   // TOF clusters
   auto getTOFClusters() const { return getSpan<o2::tof::Cluster>(GTrackID::TOF, CLUSTERS); }
   auto getTOFClustersMCLabels() const { return mcTOFClusters.get(); }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -69,7 +69,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   const auto tracksTPCTOF = getTPCTOFTracks();   // TOF-TPC tracks with refit
   const auto matchesTPCTOF = getTPCTOFMatches(); // and corresponding matches
   const auto tracksTPCTRD = getTPCTRDTracks<o2::trd::TrackTRD>();
-  const auto matchesITSTPCTOF = getTOFMatches(); // just matches, no refit done
+  const auto matchesITSTPCTOF = getITSTPCTOFMatches(); // just matches, no refit done
   const auto tofClusters = getTOFClusters();
   const auto tracksITSTPCTRD = getITSTPCTRDTracks<o2::trd::TrackTRD>();
 
@@ -81,7 +81,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
   usedData[GTrackID::ITSTPC].resize(tracksTPCITS.size());                                // to flag used ITSTPC tracks
   usedData[GTrackID::ITSTPCTRD].resize(tracksITSTPCTRD.size());                          // to flag used ITSTPCTRD tracks
   usedData[GTrackID::TPCTRD].resize(tracksTPCTRD.size());                                // to flag used TPCTRD tracks
-  usedData[GTrackID::TOF].resize(getTOFMatches().size());                                // to flag used ITSTPC-TOF matches
+  usedData[GTrackID::ITSTPCTOF].resize(getITSTPCTOFMatches().size());                    // to flag used ITSTPC-TOF matches
 
   // ITS-TPC-TRD-TOF
   // TODO, will flag used ITS-TPC-TRD
@@ -124,7 +124,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
       float timeTOFMUS = (tofCl.getTime() - match.getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS; // tof time in \mus, FIXME: account for time of flight to R TOF
       const float timeErr = 0.010f;                                                                          // assume 10 ns error FIXME
       if (creator(tracksTPCITS[gidx.getIndex()], {i, GTrackID::ITSTPCTOF}, timeTOFMUS, timeErr)) {
-        flagUsed2(i, GTrackID::TOF); // flag used TOF match // TODO might be not needed
+        //flagUsed2(i, GTrackID::TOF); // flag used TOF match // TODO might be not needed
         flagUsed(gidx);              // flag used ITS-TPC tracks
       }
     }
@@ -175,7 +175,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
     }
     for (unsigned i = 0; i < matchesTPCTOF.size(); i++) {
       const auto& match = matchesTPCTOF[i];
-      const auto& gidx = match.getEvIdxTrack().getIndex(); // TPC (or other? but w/o ITS) track global idx (FIXME: TOF has to git rid of EvIndex stuff)
+      const auto& gidx = match.getEvIdxTrack().getIndex(); // TPC track global idx
       if (isUsed(gidx)) {                                  // is TPC track already used
         continue;
       }

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -101,10 +101,11 @@ void DataRequest::requestITSTPCTracks(bool mc)
 
 void DataRequest::requestTPCTOFTracks(bool mc)
 {
-  addInput({"matchTPCTOF", "TOF", "MATCHINFOS_TPC", 0, Lifetime::Timeframe});
-  addInput({"trackTPCTOF", "TOF", "TOFTRACKS_TPC", 0, Lifetime::Timeframe});
+  auto ss = getMatchingInputSubSpec();
+  addInput({"matchTPCTOF", "TOF", "MTC_TPC", ss, Lifetime::Timeframe});
+  addInput({"trackTPCTOF", "TOF", "TOFTRACKS_TPC", ss, Lifetime::Timeframe});
   if (mc) {
-    addInput({"clsTOF_TPC_MCTR", "TOF", "MCMATCHTOF_TPC", 0, Lifetime::Timeframe});
+    addInput({"clsTOF_TPC_MCTR", "TOF", "MCMATCHTOF_TPC", ss, Lifetime::Timeframe});
   }
   requestMap["trackTPCTOF"] = mc;
 }
@@ -121,8 +122,9 @@ void DataRequest::requestITSTPCTRDTracks(bool mc)
 
 void DataRequest::requestTPCTRDTracks(bool mc)
 {
-  addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", 0, Lifetime::Timeframe});
-  addInput({"trigTPCTRD", "TRD", "TRKTRG_TPC", 0, Lifetime::Timeframe});
+  auto ss = getMatchingInputSubSpec();
+  addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", ss, Lifetime::Timeframe});
+  addInput({"trigTPCTRD", "TRD", "TRKTRG_TPC", ss, Lifetime::Timeframe});
   if (mc) {
     LOG(WARNING) << "TRD Tracks does not support MC truth, dummy label will be returned";
   }
@@ -131,7 +133,7 @@ void DataRequest::requestTPCTRDTracks(bool mc)
 
 void DataRequest::requestTOFMatches(bool mc)
 {
-  addInput({"matchITSTPCTOF", "TOF", "MATCHINFOS", 0, Lifetime::Timeframe});
+  addInput({"matchITSTPCTOF", "TOF", "MTC_ITSTPC", 0, Lifetime::Timeframe});
   if (mc) {
     addInput({"clsTOF_GLO_MCTR", "TOF", "MCMATCHTOF", 0, Lifetime::Timeframe});
   }
@@ -648,6 +650,7 @@ void RecoContainer::fillTrackMCLabels(const gsl::span<GTrackID> gids, std::vecto
   }
 }
 
+//________________________________________________________
 void o2::globaltracking::RecoContainer::createTracks(std::function<bool(const o2::track::TrackParCov&, o2::dataformats::GlobalTrackID)> const& creator) const
 {
   createTracksVariadic([&creator](const auto& _tr, GTrackID _origID, float t0, float terr) {
@@ -666,6 +669,14 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
   GlobalIDSet table;
   auto src = gidx.getSource();
   table[src] = gidx;
+  if (src == GTrackID::ITSTPCTRD) {
+    const auto& parent0 = getITSTPCTRDTrack<o2::trd::TrackTRD>(gidx);
+    const auto& parent1 = getTPCITSTrack(parent0.getRefGlobalTrackId());
+    table[GTrackID::ITSTPC] = parent0.getRefGlobalTrackId();
+    table[parent1.getRefITS().getSource()] = parent1.getRefITS();
+    table[GTrackID::TPC] = parent1.getRefTPC();
+    table[GTrackID::TRD] = gidx; // there is no standalone TRD track, so use the index for the ITSTPCTRD track array
+  }
   if (src == GTrackID::ITSTPCTOF) {
     const auto& parent0 = getTOFMatch(gidx); //ITS/TPC : TOF
     const auto& parent1 = getTPCITSTrack(parent0.getEvIdxTrack().getIndex());
@@ -685,12 +696,17 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
   return std::move(table);
 }
 
+//________________________________________________________
 // get contributing TPC GTrackID to the source. If source gidx is not contributed by TPC,
 // returned GTrackID.isSourceSet()==false
 GTrackID RecoContainer::getTPCContributorGID(GTrackID gidx) const
 {
   auto src = gidx.getSource();
-  if (src == GTrackID::ITSTPCTOF) {
+  if (src == GTrackID::ITSTPCTRD) {
+    const auto& parent0 = getITSTPCTRDTrack<o2::trd::TrackTRD>(gidx);
+    const auto& parent1 = getTPCITSTrack(parent0.getRefGlobalTrackId());
+    return parent1.getRefTPC();
+  } else if (src == GTrackID::ITSTPCTOF) {
     const auto& parent0 = getTOFMatch(gidx); //ITS/TPC : TOF
     const auto& parent1 = getTPCITSTrack(parent0.getEvIdxTrack().getIndex());
     return parent1.getRefTPC();
@@ -704,6 +720,7 @@ GTrackID RecoContainer::getTPCContributorGID(GTrackID gidx) const
   return src == GTrackID::TPC ? gidx : GTrackID{};
 }
 
+//________________________________________________________
 // get contributing ITS GTrackID to the source. If source gidx is not contributed by TPC,
 // returned GTrackID.isSourceSet()==false
 GTrackID RecoContainer::getITSContributorGID(GTrackID gidx) const

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchingType.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchingType.h
@@ -9,25 +9,33 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TOFMatcherSpec.h
+/// @file  MatchingType.h
+/// \brief Defintions for the inter-detector matching type
+/// \author ruben.shahoyan@cern.ch
 
-#ifndef O2_TOF_MATCHER_SPEC
-#define O2_TOF_MATCHER_SPEC
-
-#include "Framework/DataProcessorSpec.h"
-#include "ReconstructionDataFormats/MatchInfoTOFReco.h"
-
-using namespace o2::framework;
+#ifndef O2_MATCHING_TYPE
+#define O2_MATCHING_TYPE
 
 namespace o2
 {
 namespace globaltracking
 {
+enum class MatchingType {
+  Standard, // standard matching, i.e. no extended workflow was applied
+  Full,     // device is in the full matching mode
+  Strict,   // device is in the strict matching mode
+  NModes
+};
 
-/// create a processor spec
-framework::DataProcessorSpec getTOFMatcherSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict);
+static constexpr uint32_t getSubSpec(MatchingType t)
+{
+  return t == MatchingType::Strict ? 1 : 0; // Only strict matching inputs and outputs need special SubSpec
+  if (t == MatchingType::Standard) {
+    return 0;
+  }
+}
 
 } // namespace globaltracking
 } // namespace o2
 
-#endif /* O2_TOF_MATCHER_SPEC */
+#endif

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1299,6 +1299,12 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
     }
     float chi2Out = 0;
     auto posStart = tracOut.getXYZGlo();
+    auto tImposed = timeC * mTPCTBinMUSInv;
+    if (std::abs(tImposed - mTPCTracksArray[tTPC.sourceID].getTime0()) > 550) { // RS FIXME: should be removed once TOF fixes https://github.com/AliceO2Group/AliceO2/pull/6540#issuecomment-880060760
+      LOG(ERROR) << "Impossible imposed timebin " << tImposed << " for TPC track with timebin0 " << mTPCTracksArray[tTPC.sourceID].getTime0() << " TB";
+      mMatchedTracks.pop_back(); // destroy failed track
+      return false;
+    }
     int retVal = mTPCRefitter->RefitTrackAsTrackParCov(tracOut, mTPCTracksArray[tTPC.sourceID].getClusterRef(), timeC * mTPCTBinMUSInv, &chi2Out, true, false); // outward refit
     if (retVal < 0) {
       LOG(DEBUG) << "Refit failed";

--- a/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
+++ b/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
@@ -30,7 +30,12 @@ class InputHelper
   // If useMC is false, maskClustersMC and maskTracksMC are overwritten to NONE.
   // The masks define what data to load in a quite generic way, masks with MC suffix are for the corresponding MC labels.
   // For matched tracks, maskMatches refers only to the matching information, while the corresponding maskTracks can still be set to load also the refit matched tracks
-  static int addInputSpecs(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, GID::mask_t maskClusters, GID::mask_t maskMatches, GID::mask_t maskTracks, bool useMC = true, GID::mask_t maskClustersMC = GID::getSourcesMask(GID::ALL), GID::mask_t maskTracksMC = GID::getSourcesMask(GID::ALL));
+  // If subSpecStrict==true, then those inputs which are supposed to be produced in the "strict" mode of the extended matching workflow will by pushed with special
+  // subspec corresponding to this mode (see MatchingType.h)
+  static int addInputSpecs(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs,
+                           GID::mask_t maskClusters, GID::mask_t maskMatches, GID::mask_t maskTracks,
+                           bool useMC = true, GID::mask_t maskClustersMC = GID::getSourcesMask(GID::ALL), GID::mask_t maskTracksMC = GID::getSourcesMask(GID::ALL),
+                           bool subSpecStrict = false);
   static int addInputSpecsPVertex(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, bool mc);
   static int addInputSpecsSVertex(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs);
   static int addInputSpecsCosmics(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, bool mc);

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -35,7 +35,10 @@ using namespace o2::globaltracking;
 using namespace o2::dataformats;
 using GID = o2::dataformats::GlobalTrackID;
 
-int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec& specs, GID::mask_t maskClusters, GID::mask_t maskMatches, GID::mask_t maskTracks, bool useMC, GID::mask_t maskClustersMC, GID::mask_t maskTracksMC)
+int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec& specs,
+                               GID::mask_t maskClusters, GID::mask_t maskMatches, GID::mask_t maskTracks,
+                               bool useMC, GID::mask_t maskClustersMC, GID::mask_t maskTracksMC,
+                               bool subSpecStrict)
 {
   if (configcontext.options().get<bool>("disable-root-input")) {
     return 0;
@@ -76,7 +79,7 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
     specs.emplace_back(o2::tof::getClusterReaderSpec(maskClustersMC[GID::TOF]));
   }
   if (maskMatches[GID::TPCTOF]) {
-    specs.emplace_back(o2::tof::getTOFMatchedReaderSpec(maskTracksMC[GID::TPCTOF], true, maskTracks[GID::TPCTOF]));
+    specs.emplace_back(o2::tof::getTOFMatchedReaderSpec(maskTracksMC[GID::TPCTOF], true, maskTracks[GID::TPCTOF], subSpecStrict));
   }
   if (maskTracks[GID::FT0] || maskClusters[GID::FT0]) {
     specs.emplace_back(o2::ft0::getRecPointReaderSpec(maskTracksMC[GID::FT0] || maskClustersMC[GID::FT0]));
@@ -88,7 +91,7 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
     specs.emplace_back(o2::trd::getTRDGlobalTrackReaderSpec(false));
   }
   if (maskTracks[GID::TPCTRD]) {
-    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(false));
+    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(false, subSpecStrict));
   }
 
   return 0;

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -166,6 +166,9 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
 {
   std::vector<OutputSpec> outputs;
   auto dataRequest = std::make_shared<DataRequest>();
+  if ((src & GTrackID::getSourcesMask("TPC-TRD,TPC-TOF,TPC-TRD-TOF")).any()) { // preliminary stage of extended workflow ?
+    dataRequest->setMatchingInputStrict();
+  }
 
   dataRequest->requestTracks(src, useMC);
   dataRequest->requestTPCClusters(false);

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -42,7 +42,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use: allowed TPC,ITS-TPC,TPC-TRD,ITS-TPC-TRD (all)"}},
     {"use-fit", o2::framework::VariantType::Bool, false, {"enable access to fit info for calibration"}},
     {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}},
-    {"high-purity", o2::framework::VariantType::Bool, false, {"enable high purity matching cuts"}},
+    {"strict-matching", o2::framework::VariantType::Bool, false, {"High purity preliminary matching"}},
     {"output-type", o2::framework::VariantType::String, "matching-info,calib-info", {"matching-info, calib-info"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
@@ -58,8 +58,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
-  GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC");
-  //  GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC,TPC-TRD,ITS-TPC-TRD");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
@@ -71,7 +69,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto useFIT = configcontext.options().get<bool>("use-fit");
   auto useCCDB = configcontext.options().get<bool>("use-ccdb");
-  auto highpur = configcontext.options().get<bool>("high-purity");
+  auto strict = configcontext.options().get<bool>("strict-matching");
 
   bool writematching = 0;
   bool writecalib = 0;
@@ -95,9 +93,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   LOG(INFO) << "TOF use-fit = " << useFIT;
   LOG(INFO) << "TOF disable-root-input = " << disableRootIn;
   LOG(INFO) << "TOF disable-root-output = " << disableRootOut;
-  LOG(INFO) << "TOF matching enable high-purity = " << highpur;
+  LOG(INFO) << "TOF matching in strict mode = " << strict;
 
+  GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC");
+  //  GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC,TPC-TRD,ITS-TPC-TRD");
   GID::mask_t src = alowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  if (strict && (src & ~GID::getSourcesMask("TPC,TPC-TRD")).any()) {
+    LOGP(WARNING, "In strict matching mode only TPC and TPC-TRD sources allowed, {} asked, redefining", GID::getSourcesNames(src));
+    src &= GID::getSourcesMask("TPC,TPC-TRD");
+  }
   GID::mask_t mcmaskcl;
   GID::mask_t nonemask = GID::getSourcesMask(GID::NONE);
   GID::mask_t clustermask = GID::getSourcesMask("TOF");
@@ -108,15 +112,19 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (useMC) {
     mcmaskcl |= GID::getSourceMask(GID::TOF);
   }
+  // pass strict flag to fetch eventual TPC-TRD input with correct subspec
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, clustermask, nonemask, src, useMC, mcmaskcl, GID::getSourcesMask(GID::ALL), strict);
 
-  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, clustermask, nonemask, src, useMC, mcmaskcl);
-
-  specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, false, highpur)); // doTPCrefit not yet supported (need to load TPC clusters?)
+  specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, false, strict)); // doTPCrefit not yet supported (need to load TPC clusters?)
 
   if (!disableRootOut) {
     if (writematching) {
-      specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_tof_tpc.root", 1));
-      specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_tof_itstpc.root", 0));
+      if (GID::includesSource(GID::TPC, src)) { // matching to TPC was requested
+        specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_tof_tpc.root", 1, strict));
+      }
+      if (GID::includesSource(GID::ITSTPC, src)) { // matching to ITS-TPC was requested, there is not strict mode in this case
+        specs.emplace_back(o2::tof::getTOFMatchedWriterSpec(useMC, "o2match_tof_itstpc.root", 0));
+      }
     }
     if (writecalib) {
       specs.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_tof.root", 0));

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -106,7 +106,7 @@ class TOFDPLRecoWorkflowTask
     //           << " DIGITS TO " << mClustersArray.size() << " CLUSTERS";
 
     // send matching-info
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MTC_ITSTPC", 0, Lifetime::Timeframe}, mMatcher.getMatchedTrackVector());
     if (mUseMC) {
       pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe}, mMatcher.getMatchedTOFLabelsVector());
     }
@@ -140,7 +140,7 @@ o2::framework::DataProcessorSpec getTOFRecoWorkflowSpec(bool useMC, bool useFIT)
     inputs.emplace_back("fitrecpoints", o2::header::gDataOriginFT0, "RECPOINTS", 0, Lifetime::Timeframe);
   }
 
-  outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTOF, "MTC_ITSTPC", 0, Lifetime::Timeframe);
   if (useMC) {
     outputs.emplace_back(o2::header::gDataOriginTOF, "MCMATCHTOF", 0, Lifetime::Timeframe);
   }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -92,7 +92,7 @@ DataProcessorSpec getTPCInterpolationSpec(bool useMC)
   inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
 
   inputs.emplace_back("match", "GLO", "TPCITS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("matchTOF", "TOF", "MATCHINFOS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("matchTOF", "TOF", "MTC_ITSTPC", 0, Lifetime::Timeframe);
   inputs.emplace_back("clustersTOF", "TOF", "CLUSTERS", 0, Lifetime::Timeframe);
 
   if (useMC) {

--- a/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchedReaderSpec.h
+++ b/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchedReaderSpec.h
@@ -31,7 +31,7 @@ namespace tof
 class TOFMatchedReader : public o2::framework::Task
 {
  public:
-  TOFMatchedReader(bool useMC, bool tpcmatch, bool readTracks) : mUseMC(useMC), mTPCMatch(tpcmatch), mReadTracks(readTracks) {}
+  TOFMatchedReader(bool useMC, bool tpcmatch, bool readTracks, bool subSpecStrict = false) : mUseMC(useMC), mTPCMatch(tpcmatch), mReadTracks(readTracks), mSubSpecStrict(subSpecStrict) {}
   ~TOFMatchedReader() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
@@ -42,6 +42,7 @@ class TOFMatchedReader : public o2::framework::Task
   bool mUseMC = false;
   bool mTPCMatch = false;
   bool mReadTracks = false;
+  bool mSubSpecStrict = false;
 
   std::string mInFileName{"o2match_tof.root"};
   std::string mInTreeName{"matchTOF"};
@@ -54,7 +55,7 @@ class TOFMatchedReader : public o2::framework::Task
 
 /// create a processor spec
 /// read matched TOF clusters from a ROOT file
-framework::DataProcessorSpec getTOFMatchedReaderSpec(bool useMC, bool tpcmatch = false, bool readTracks = false);
+framework::DataProcessorSpec getTOFMatchedReaderSpec(bool useMC, bool tpcmatch = false, bool readTracks = false, bool subSpecStrict = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchedWriterSpec.h
+++ b/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchedWriterSpec.h
@@ -25,7 +25,7 @@ namespace tof
 
 /// create a processor spec
 /// write TOF matching info in a root file
-o2::framework::DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef = "o2match_tof.root", bool writeTracks = false);
+o2::framework::DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef = "o2match_tof.root", bool writeTracks = false, bool strictMode = false);
 
 } // namespace tof
 } // namespace o2

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -34,7 +34,7 @@ namespace trd
 class TRDGlobalTracking : public o2::framework::Task
 {
  public:
-  TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive) : mUseMC(useMC), mDataRequest(dataRequest), mTrkMask(src), mTrigRecFilter(trigRecFilterActive) {}
+  TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mDataRequest(dataRequest), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
   void updateTimeDependentParams();
@@ -49,6 +49,7 @@ class TRDGlobalTracking : public o2::framework::Task
   std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
   bool mUseMC{false};                                 ///< MC flag
   bool mTrigRecFilter{false};                         ///< if true, TRD trigger records without matching ITS IR are filtered out
+  bool mStrict{false};                                ///< preliminary matching in strict mode
   float mTPCTBinMUS{.2f};                             ///< width of a TPC time bin in us
   float mTPCVdrift{2.58f};                            ///< TPC drift velocity (for shifting TPC tracks along Z)
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< seeding input (TPC-only, ITS-TPC or both)
@@ -57,7 +58,7 @@ class TRDGlobalTracking : public o2::framework::Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive);
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict = false);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
@@ -42,7 +42,7 @@ class TRDTrackReader : public Task
     TPCTRD
   };
 
-  TRDTrackReader(bool useMC, Mode mode) : mUseMC(useMC), mMode(mode) {}
+  TRDTrackReader(bool useMC, Mode mode, bool subSpecStrict = false) : mUseMC(useMC), mMode(mode) {}
   ~TRDTrackReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -50,6 +50,7 @@ class TRDTrackReader : public Task
  private:
   void connectTree(const std::string& filename);
   bool mUseMC = false;
+  bool mSubSpecStrict = false;
   Mode mMode;
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
@@ -59,7 +60,7 @@ class TRDTrackReader : public Task
 };
 
 /// read TPC-TRD matched tracks from a root file
-framework::DataProcessorSpec getTRDTPCTrackReaderSpec(bool useMC);
+framework::DataProcessorSpec getTRDTPCTrackReaderSpec(bool useMC, bool subSpecStrict = false);
 
 /// read ITS-TPC-TRD matched tracks from a root file
 framework::DataProcessorSpec getTRDGlobalTrackReaderSpec(bool useMC);

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackWriterSpec.h
@@ -25,7 +25,7 @@ namespace trd
 framework::DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC);
 
 /// writer for matches with TPC-only tracks
-framework::DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC);
+framework::DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC, bool strictMode = false);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
@@ -14,7 +14,7 @@
 #include <vector>
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsTRD/TrackTriggerRecord.h"
-
+#include "ReconstructionDataFormats/MatchingType.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TRDWorkflowIO/TRDTrackWriterSpec.h"
 
@@ -65,7 +65,7 @@ DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
                                                              "labels-branch-name"})();
 }
 
-DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC)
+DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC, bool strictMode)
 {
   // TODO: not clear if the writer is supposed to write MC labels at some point
   // this is just a dummy definition for the template branch definition below
@@ -79,22 +79,22 @@ DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC)
   auto tracksLogger = [tracksSize](std::vector<o2::trd::TrackTRD> const& tracks) {
     *tracksSize = tracks.size();
   };
-
+  uint32_t ss = o2::globaltracking::getSubSpec(strictMode ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
   return MakeRootTreeWriterSpec("trd-track-writer-tpc",
                                 "trdmatches_tpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", 0},
+                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", ss},
                                                                                  "tracks",
                                                                                  "tracks-branch-name",
                                                                                  1,
                                                                                  tracksLogger},
-                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRKTRG_TPC", 0},
+                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRKTRG_TPC", ss},
                                                                                            "trgrec",
                                                                                            "trgrec-branch-name",
                                                                                            1},
                                 // NOTE: this branch template is to show how the conditional MC labels can
                                 // be defined, the '0' disables the branch for the moment
-                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", ss},
                                                              "labels",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "labels-branch-name"})();

--- a/Detectors/TRD/workflow/io/src/trd-track-reader-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-track-reader-workflow.cxx
@@ -27,6 +27,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<o2::framework::ConfigParamSpec> options{
     {"disable-mc", o2::framework::VariantType::Bool, true, {"disable MC propagation"}},
     {"track-types", VariantType::String, std::string{GTrackID::ALL}, {"comma-separated list of sources to use for tracking"}},
+    {"output-strict", o2::framework::VariantType::Bool, false, {"outputs specs should correspond to strict matching mode"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);
@@ -55,7 +56,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::trd::getTRDGlobalTrackReaderSpec(useMC));
   }
   if (GTrackID::includesSource(GTrackID::Source::TPCTRD, srcTRD)) {
-    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(useMC));
+    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(useMC, configcontext.options().get<bool>("output-strict")));
   }
   return std::move(specs);
 }

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -26,9 +26,11 @@ std::shared_ptr<const o2::event_visualisation::EveWorkflowHelper::tmpDataContain
                                                       GID::mask_t maskTrk, GID::mask_t maskMatch)
 {
   unsigned int nTracksTPCITSO2 = 0;
-  unsigned int nTOFMatches = 0;
   unsigned int nTRDTracksITSTPCTRD = 0;
   unsigned int nTRDTracksTPCTRD = 0;
+  unsigned int nITSTPCTOFMatches = 0;
+  unsigned int nITSTPCTRDTOFMatches = 0;
+  unsigned int nTPCTRDTOFMatches = 0;
   unsigned int nTPCTOFMatches = 0;
 
   auto retVal = std::make_shared<tmpDataContainer>();
@@ -54,19 +56,33 @@ std::shared_ptr<const o2::event_visualisation::EveWorkflowHelper::tmpDataContain
     LOG(info) << "Got " << nTracksTPCITSO2 << " ITS-TPC Tracks";
   }
 
-  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTOF] || maskMatch[GID::ITSTPCTRDTOF])) {
-    const auto& tofMatches = recoCont.getTOFMatches();
+  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTOF])) {
+    const auto& tofMatches = recoCont.getITSTPCTOFMatches();
     if (tofMatches.size()) {
-      nTOFMatches = tofMatches.size();
+      nITSTPCTOFMatches = tofMatches.size();
     }
+    LOG(info) << "Got " << nITSTPCTOFMatches << " ITS-TPC-TOF Matches";
   }
-
-  if (maskMatch[GID::TPCTOF] && nTPCTOFMatches == 0) {
+  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTRDTOF])) {
+    const auto& tofMatches = recoCont.getITSTPCTRDTOFMatches();
+    if (tofMatches.size()) {
+      nITSTPCTRDTOFMatches = tofMatches.size();
+    }
+    LOG(info) << "Got " << nITSTPCTRDTOFMatches << " ITS-TPC-TRD-TOF Matches";
+  }
+  if (maskMatch[GID::TOF] || (maskMatch[GID::TPCTOF])) {
     const auto& tpctofMatches = recoCont.getTPCTOFMatches();
     if (tpctofMatches.size()) {
       nTPCTOFMatches = tpctofMatches.size();
     }
     LOG(info) << "Got " << nTPCTOFMatches << " TPC-TOF Matches";
+  }
+  if (maskMatch[GID::TOF] || (maskMatch[GID::TPCTRDTOF])) {
+    const auto& tpctofMatches = recoCont.getTPCTRDTOFMatches();
+    if (tpctofMatches.size()) {
+      nTPCTRDTOFMatches = tpctofMatches.size();
+    }
+    LOG(info) << "Got " << nTPCTRDTOFMatches << " TPC-TRD-TOF Matches";
   }
 
   if (maskTrk[GID::ITSTPCTRD]) {
@@ -91,7 +107,7 @@ std::shared_ptr<const o2::event_visualisation::EveWorkflowHelper::tmpDataContain
     if (nTracksTPCITSO2) {
       retVal->tpcLinkITS.resize(tpcTracks.size(), -1);
     }
-    if (nTOFMatches || nTPCTOFMatches) {
+    if (nITSTPCTRDTOFMatches || nITSTPCTOFMatches || nTPCTRDTOFMatches || nTPCTOFMatches) {
       retVal->tpcLinkTOF.resize(tpcTracks.size(), -1);
     }
     if (nTRDTracksITSTPCTRD || nTRDTracksTPCTRD) {

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -305,8 +305,12 @@ struct GPUTrackingInOutPointers {
   // TOF
   const o2::tof::Cluster* tofClusters = nullptr;
   unsigned int nTOFClusters = 0;
-  const o2::dataformats::MatchInfoTOF* tofMatches = nullptr;
-  unsigned int nTOFMatches = 0;
+  const o2::dataformats::MatchInfoTOF* itstpctofMatches = nullptr;
+  unsigned int nITSTPCTOFMatches = 0;
+  const o2::dataformats::MatchInfoTOF* itstpctrdtofMatches = nullptr;
+  unsigned int nITSTPCTRDTOFMatches = 0;
+  const o2::dataformats::MatchInfoTOF* tpctrdtofMatches = nullptr;
+  unsigned int nTPCTRDTOFMatches = 0;
   const o2::dataformats::MatchInfoTOF* tpctofMatches = nullptr;
   unsigned int nTPCTOFMatches = 0;
 

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -89,20 +89,38 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
     //LOG(info) << "Got " << ioPtr.nTOFClusters << " TOF Clusters";
   }
 
-  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTOF] || maskMatch[GID::ITSTPCTRDTOF]) && ioPtr.nTOFMatches == 0) {
-    const auto& tofMatches = recoCont.getTOFMatches();
-    if (tofMatches.size()) {
-      ioPtr.nTOFMatches = tofMatches.size();
-      ioPtr.tofMatches = tofMatches.data();
+  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTOF]) && ioPtr.nITSTPCTOFMatches == 0) {
+    const auto& itstpctofMatches = recoCont.getITSTPCTOFMatches();
+    if (itstpctofMatches.size()) {
+      ioPtr.nITSTPCTOFMatches = itstpctofMatches.size();
+      ioPtr.itstpctofMatches = itstpctofMatches.data();
     }
-    //LOG(info) << "Got " << ioPtr.nTOFMatches << " TOF Matches";
+    //LOG(info) << "Got " << ioPtr.nITSTPCTOFMatches << " ITS-TPC-TOF Matches";
   }
 
-  if (maskMatch[GID::TPCTOF] && ioPtr.nTPCTOFMatches == 0) {
+  if ((maskMatch[GID::TOF] || maskMatch[GID::ITSTPCTRDTOF]) && ioPtr.nITSTPCTRDTOFMatches == 0) {
+    const auto& itstpctrdtofMatches = recoCont.getITSTPCTRDTOFMatches();
+    if (itstpctrdtofMatches.size()) {
+      ioPtr.nITSTPCTRDTOFMatches = itstpctrdtofMatches.size();
+      ioPtr.itstpctrdtofMatches = itstpctrdtofMatches.data();
+    }
+    //LOG(info) << "Got " << ioPtr.nITSTPCTRDTOFMatches << " ITS-TPC-TRD-TOF Matches";
+  }
+
+  if ((maskMatch[GID::TOF] || maskMatch[GID::TPCTOF]) && ioPtr.nTPCTOFMatches == 0) {
     const auto& tpctofMatches = recoCont.getTPCTOFMatches();
     if (tpctofMatches.size()) {
       ioPtr.nTPCTOFMatches = tpctofMatches.size();
       ioPtr.tpctofMatches = tpctofMatches.data();
+    }
+    //LOG(info) << "Got " << ioPtr.nTPCTOFMatches << " TPC-TOF Matches";
+  }
+
+  if ((maskMatch[GID::TOF] || maskMatch[GID::TPCTRDTOF]) && ioPtr.nTPCTRDTOFMatches == 0) {
+    const auto& tpctrdtofMatches = recoCont.getTPCTRDTOFMatches();
+    if (tpctrdtofMatches.size()) {
+      ioPtr.nTPCTRDTOFMatches = tpctrdtofMatches.size();
+      ioPtr.tpctrdtofMatches = tpctrdtofMatches.data();
     }
     //LOG(info) << "Got " << ioPtr.nTPCTOFMatches << " TPC-TOF Matches";
   }
@@ -150,7 +168,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
       retVal->tpcLinkITS.resize(ioPtr.nOutputTracksTPCO2, -1);
       ioPtr.tpcLinkITS = retVal->tpcLinkITS.data();
     }
-    if (ioPtr.nTOFMatches || ioPtr.nTPCTOFMatches) {
+    if (ioPtr.nITSTPCTOFMatches || ioPtr.nTPCTRDTOFMatches || ioPtr.nITSTPCTRDTOFMatches || ioPtr.nTPCTOFMatches) {
       retVal->tpcLinkTOF.resize(ioPtr.nOutputTracksTPCO2, -1);
       ioPtr.tpcLinkTOF = retVal->tpcLinkTOF.data();
     }

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -51,10 +51,10 @@ TRD_TRANSFORMER_CONFIG=
 if [ $SYNCMODE == 1 ]; then
   ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=30;fastMultConfig.cutMultClusHigh=2000;fastMultConfig.cutMultVtxHigh=500;"
   GPU_CONFIG_KEY+="GPU_global.synchronousProcessing=1;GPU_proc.clearO2OutputFromGPU=1;"
-  TRD_CONFIG+=" --tracking-sources ITS-TPC --filter-trigrec --configKeyValues 'GPU_proc.ompThreads=1;'"
+  TRD_CONFIG+=" --track-sources ITS-TPC --filter-trigrec --configKeyValues 'GPU_proc.ompThreads=1;'"
   TRD_TRANSFORMER_CONFIG+=" --filter-trigrec"
 else
-  TRD_CONFIG+=" --tracking-sources TPC,ITS-TPC"
+  TRD_CONFIG+=" --track-sources TPC,ITS-TPC"
 fi
 if [ $CTFINPUT == 1 ]; then
   ITS_CONFIG+=" --tracking-mode async"


### PR DESCRIPTION
* Option `--strict-matching` (def: false) added to `o2-trd-global-tracking` and
`o2-tof-matcher-workflow` to impose the preliminary strict matching mode of the
extended workflow. If true, it will make sure that trd-matching gets as input
TPC tracks only while `o2-tof-matcher-workflow` TPC and/or TPC-TRD.
In this mode the outputs of these matcher will have `subspecs=1`, while
the `subspec=0` is reserved for the final matches.

* The TOF and TRD tracks/matches readers and writers modified to accept inputs
and provide outputs with this `subspec=1` when strict mode is selected.

* The `o2-tpcits-match-workflow` will automatically impose this strict mode on
TRD and TOF readers if TPC-TRD or TPC-TOF or TPC-TRD-TOF inputs are requested.

* DataRequest class for the RecoContainer got `setMatchingInputStrict()` method to
signal that TRD and TOF inputs has to be received with `subspec=1`.

* `InputHelper::addInputSpecs` got extra bool argument `subSpecStrict` to request
reading TRD and TOF inputs with `subspec=1` when needed.

* Set meaningful names for different TOF matching outputs.

* Added to `RecoContainer::getSingleDetectorRefs(..,)` filling of TRD-related slots.

* RecoContainer getter TOF matches got distinct names of input sources.

* GPUDataTypes and GPUWorkflowHelper will handle separately TOF mathches to
different input track sources.

* Add to TRDGlobalTrackReaderSpec option to load the material LUT, so far it was using TGeo.
----------------

* Temporary hack to avoid wrongly imposed refit time.
Will be removed once https://github.com/AliceO2Group/AliceO2/pull/6540#issuecomment-880060760 fixed