### PR TITLE
DPL: Return the result code if noCatch is enabled

### DIFF
--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -236,7 +236,7 @@ int main(int argc, char** argv)
     UserCustomizationsHelper::userDefinedCustomization(onWorkflowTerminationHook, 0);
     onWorkflowTerminationHook(idstring);
     doDefaultWorkflowTerminationHook();
-    return result;
   }
+  return result;
 }
 #endif


### PR DESCRIPTION
This should silence the warning at https://github.com/AliceO2Group/AliceO2/pull/6419 and bring back the expected (I suppose) behaviour.