### PR TITLE
[EMCAL-630] Skip TRU and LEDMON cells in raw->cell conversion

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -89,6 +89,7 @@ class RawToCellConverterSpec : public framework::Task
   int mNumErrorMessages = 0;                                      ///< Current number of error messages
   int mErrorMessagesSuppressed = 0;                               ///< Counter of suppressed error messages
   int mMaxErrorMessages = 100;                                    ///< Max. number of error messages
+  bool mPrintTrailer = false;
   Geometry* mGeometry = nullptr;                                  ///!<! Geometry pointer
   std::unique_ptr<MappingHandler> mMapper = nullptr;              ///!<! Mapper
   std::unique_ptr<CaloRawFitter> mRawFitter;                      ///!<! Raw fitter

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -66,6 +66,8 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
     mRawFitter = std::unique_ptr<CaloRawFitter>(new o2::emcal::CaloRawFitterGamma2);
   }
 
+  mPrintTrailer = ctx.options().get<bool>("printtrailer");
+
   mMaxErrorMessages = ctx.options().get<int>("maxmessage");
   LOG(INFO) << "Suppressing error messages after " << mMaxErrorMessages << " messages";
 
@@ -188,7 +190,11 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         continue;
       }
 
-      LOG(DEBUG) << decoder.getRCUTrailer();
+      if (mPrintTrailer) {
+        // Can become very verbose, therefore must be switched on explicitly in addition
+        // to high debug level
+        LOG(DEBUG4) << decoder.getRCUTrailer();
+      }
       // Apply zero suppression only in case it was enabled
       mRawFitter->setIsZeroSuppressed(decoder.getRCUTrailer().hasZeroSuppression());
 
@@ -361,5 +367,6 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
                                           o2::framework::adaptFromTask<o2::emcal::reco_workflow::RawToCellConverterSpec>(subspecification),
                                           o2::framework::Options{
                                             {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}},
-                                            {"maxmessage", o2::framework::VariantType::Int, 100, {"Max. amout of error messages to be displayed"}}}};
+                                            {"maxmessage", o2::framework::VariantType::Int, 100, {"Max. amout of error messages to be displayed"}},
+                                            {"printtrailer", o2::framework::VariantType::Bool, false, {"Print RCU trailer (for debugging)"}}}};
 }


### PR DESCRIPTION
TRU and LEDMON need to be discarded in the
raw to cell conversion as they have different geometry
mapping than FEC cells and then raw fitting procedure
cannot be applied to them.