### PR TITLE
speed up and fix up trd raw data reading.

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -72,7 +72,8 @@ constexpr int TRACKLETENDMARKER = 0x10001000; // marker for the end of tracklets
 constexpr int DIGITENDMARKER = 0x0;           // marker for the end of digits in raw data, 2 of these
 constexpr int MAXDATAPERLINK32 = 13824;       // max number of 32 bit words per link ((21x12+2+4)*64) 64 mcm, 21 channels, 10 words per channel 2 header words(DigitMCMHeader DigitMCMADCmask) 4 words for tracklets.
 constexpr int MAXDATAPERLINK256 = 1728;       // max number of linkwords per cru link. (256bit words)
-
+constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far appart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
+constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
 } //namespace constants
 } // namespace trd
 } // namespace o2

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -136,10 +136,10 @@ struct HelperMethods {
   }
   inline static unsigned int swapByteOrderreturn(unsigned int word)
   {
-    word = (word >> 24) |
-           ((word << 8) & 0x00FF0000) |
-           ((word >> 8) & 0x0000FF00) |
-           (word << 24);
+    //    word = (word >> 24) |
+    //         ((word << 8) & 0x00FF0000) |
+    //        ((word >> 8) & 0x0000FF00) |
+    //       (word << 24);
     return word;
   }
 };

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -71,11 +71,11 @@ struct HelperMethods {
   static int getStack(int det)
   {
     return det % (constants::NSTACK * constants::NLAYER) / constants::NLAYER;
-  };
+  }
   static int getLayer(int det)
   {
     return det % constants::NLAYER;
-  };
+  }
 
   static int getORIinSuperModule(int detector, int readoutboard)
   {
@@ -112,7 +112,7 @@ struct HelperMethods {
     }
     //see TDP for explanation of mapping TODO should probably come from CCDB
     return ori;
-  };
+  }
 
   static int getLinkIDfromHCID(int hcid)
   {
@@ -125,7 +125,15 @@ struct HelperMethods {
     int ori = -1;
     // now offset for supermodule (+60*supermodule);
     return HelperMethods::getORIinSuperModule(detector, chamberside) + 60 * supermodule; // it takes readoutboard but only cares if its odd or even hence side here.
-  };
+  }
+
+  inline static void swapByteOrder(unsigned int& word)
+  {
+    word = (word >> 24) |
+           ((word << 8) & 0x00FF0000) |
+           ((word >> 8) & 0x0000FF00) |
+           (word << 24);
+  }
 };
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -134,6 +134,14 @@ struct HelperMethods {
            ((word >> 8) & 0x0000FF00) |
            (word << 24);
   }
+  inline static unsigned int swapByteOrderreturn(unsigned int word)
+  {
+    word = (word >> 24) |
+           ((word << 8) & 0x00FF0000) |
+           ((word >> 8) & 0x0000FF00) |
+           (word << 24);
+    return word;
+  }
 };
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -307,10 +307,10 @@ struct DigitMCMADCMask {
   union {
     uint32_t word; //MCM ADC MASK header
     struct {
-      uint32_t j : 4; // unused always 0xc
+      uint32_t j : 4; // 0xc
       uint32_t adcmask : 21;
-      uint32_t c : 5; // unused always 0x1f
-      uint32_t n : 2; // unused always 0x3
+      uint32_t c : 5; // ~(number of bits set in adcmask)
+      uint32_t n : 2; // 0b01
     } __attribute__((__packed__));
   };
 };
@@ -440,6 +440,8 @@ std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
 bool trackletMCMHeaderSanityCheck(o2::trd::TrackletMCMHeader& header);
 bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header);
 bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header);
+bool digitMCMADCMaskSanityCheck(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
+bool digitMCMWordSanityCheck(o2::trd::DigitMCMData* word, int adcchannel);
 void printDigitMCMHeader(o2::trd::DigitMCMHeader& header);
 void printDigitHCHeader(o2::trd::DigitHCHeader& header);
 DigitMCMADCMask buildBlankADCMask();

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -307,10 +307,10 @@ struct DigitMCMADCMask {
   union {
     uint32_t word; //MCM ADC MASK header
     struct {
-      uint32_t n : 2; // unused always 0x3
-      uint32_t c : 5; // unused always 0x1f
-      uint32_t adcmask : 21;
       uint32_t j : 4; // unused always 0xc
+      uint32_t adcmask : 21;
+      uint32_t c : 5; // unused always 0x1f
+      uint32_t n : 2; // unused always 0x3
     } __attribute__((__packed__));
   };
 };

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -451,6 +451,8 @@ int nextmcmadc(unsigned int& bp, int channel)
   while (!(bp & m)) {
     m = m << 1;
     position++;
+    if (position > 31)
+      break;
   }
   bp &= ~(1UL << (position));
   return position;

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -124,7 +124,7 @@ uint32_t getQFromRaw(const o2::trd::TrackletMCMHeader* header, const o2::trd::Tr
       qa = header->pid2;
       break;
     default:
-      LOG(warn) << " unknown trackletindex to getQFromRaw : " << pidindex;
+      LOG(warn) << " unknown trackletindex of " << trackletindex << " to getQFromRaw : " << pidindex;
       break;
   }
   //qa is 6bits of Q2 and 2 bits of Q1
@@ -253,7 +253,7 @@ void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
   for (int i = 0; i < 15; i++) {
     LOGF(INFO, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
   }
-  LOG(INFO) << "Raw: " << std::hex << halfcru.word0<< " " << halfcru.word12[0]<< " " << halfcru.word12[1]<< " " << halfcru.word3<< " " << halfcru.word47[0]<< " " << halfcru.word47[1]<< " " <<halfcru.word47[2]<< " " <<halfcru.word47[3];
+  LOG(INFO) << "Raw: " << std::hex << halfcru.word0 << " " << halfcru.word12[0] << " " << halfcru.word12[1] << " " << halfcru.word3 << " " << halfcru.word47[0] << " " << halfcru.word47[1] << " " << halfcru.word47[2] << " " << halfcru.word47[3];
   for (int i = 0; i < 15; i++) {
     LOGF(INFO, "Raw: %d word: %ul x", i, sizes[i], errorflags[i]);
   }
@@ -444,15 +444,16 @@ void setNumberOfTrackletsInHeader(o2::trd::TrackletMCMHeader& header, int number
 int nextmcmadc(unsigned int& bp, int channel)
 {
   //given a bitpattern (adcmask) find next channel with in the mask starting from the current channel;
-  if(bp==0) return 22;
-  int position=channel;
-  int m=1<<channel;
+  if (bp == 0)
+    return 22;
+  int position = channel;
+  int m = 1 << channel;
   while (!(bp & m)) {
-    m= m<<1;
+    m = m << 1;
     position++;
   }
   bp &= ~(1UL << (position));
-  return position; 
+  return position;
 }
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -253,6 +253,10 @@ void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
   for (int i = 0; i < 15; i++) {
     LOGF(INFO, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
   }
+  LOG(INFO) << "Raw: " << std::hex << halfcru.word0<< " " << halfcru.word12[0]<< " " << halfcru.word12[1]<< " " << halfcru.word3<< " " << halfcru.word47[0]<< " " << halfcru.word47[1]<< " " <<halfcru.word47[2]<< " " <<halfcru.word47[3];
+  for (int i = 0; i < 15; i++) {
+    LOGF(INFO, "Raw: %d word: %ul x", i, sizes[i], errorflags[i]);
+  }
 }
 
 void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
@@ -440,14 +444,15 @@ void setNumberOfTrackletsInHeader(o2::trd::TrackletMCMHeader& header, int number
 int nextmcmadc(unsigned int& bp, int channel)
 {
   //given a bitpattern (adcmask) find next channel with in the mask starting from the current channel;
-  while ((bp & (1 << channel)) == 0) {
-    channel++;
-    if (channel == 21) {
-      break;
-    }
+  if(bp==0) return 22;
+  int position=channel;
+  int m=1<<channel;
+  while (!(bp & m)) {
+    m= m<<1;
+    position++;
   }
-  bp &= ~(1UL << (channel));
-  return channel; // zero based
+  bp &= ~(1UL << (position));
+  return position; 
 }
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -361,6 +361,56 @@ bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header)
   return goodheader;
 }
 
+bool digitMCMADCMaskSanityCheck(o2::trd::DigitMCMADCMask& mask, int numberofbitsset)
+{
+  bool goodadcmask = true;
+  uint32_t count = (unsigned int)mask.c;
+  count = ~count;
+  /*  if(count != numberofbitsset){
+    goodadcmask=false;
+    LOG(warn) << "***DigitMCMADCMask bad bit count maskcount:" << ~mask.c << " bitscounting:" << numberofbitsset;
+  }*/
+  if (mask.n != 0x1) {
+    goodadcmask = false;
+    LOG(warn) << "***DigitMCMADCMask bad n value should be 0x01 but:0x" << std::hex << mask.n;
+  }
+  if (mask.j != 0xc) {
+    goodadcmask = false;
+    LOG(warn) << "***DigitMCMADCMask bad j value should be 0xc but:0x" << std::hex << mask.c;
+  }
+  return goodadcmask;
+}
+
+bool digitMCMWordSanityCheck(o2::trd::DigitMCMData* word, int adcchannel)
+{
+  bool gooddata = true;
+  // DigitMCMWord0x3 is odd 10 for odd adc channels and 11 for even, counted as the first of the 3.
+  switch (word->c) {
+    case 3: // even adc channnel
+      if (adcchannel % 2 == 0) {
+        gooddata = true;
+      } else {
+        gooddata = false;
+      }
+      break;
+    case 2: // odd adc channel
+      if (adcchannel % 2 == 1) {
+        gooddata = true;
+      } else {
+        gooddata = false;
+      }
+      break;
+    case 1: // error
+      gooddata = false;
+      break;
+    case 0: // error
+      gooddata = false;
+      break;
+      // no default all cases taken care of
+  }
+  return gooddata;
+}
+
 void printDigitHCHeader(o2::trd::DigitHCHeader& header)
 {
   LOGF(INFO, "Digit HalfChamber Header\n Raw:0x%08x 0x%08x reserve:%01x side:%01x stack:0x%02x layer:0x%02x supermod:0x%02x numberHCW:0x%02x minor:0x%03x major:0x%03x version:0x%01x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x\n",
@@ -444,15 +494,17 @@ void setNumberOfTrackletsInHeader(o2::trd::TrackletMCMHeader& header, int number
 int nextmcmadc(unsigned int& bp, int channel)
 {
   //given a bitpattern (adcmask) find next channel with in the mask starting from the current channel;
-  if (bp == 0)
+  if (bp == 0) {
     return 22;
+  }
   int position = channel;
   int m = 1 << channel;
   while (!(bp & m)) {
     m = m << 1;
     position++;
-    if (position > 31)
+    if (position > 31) {
       break;
+    }
   }
   bp &= ~(1UL << (position));
   return position;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -98,6 +98,8 @@ class CruRawReader
   int getTrackletsFound() { return mTotalTrackletsFound; }
   int sumTrackletsFound() { return mEventRecords.sumTracklets(); }
   int sumDigitsFound() { return mEventRecords.sumDigits(); }
+  int getWordsRead() { return mTotalDigitWordsRead; }
+  int getWordsRejected() { return mTotalDigitWordsRejected; }
   void clearall()
   {
     mEventRecords.clear();
@@ -176,6 +178,10 @@ class CruRawReader
   uint32_t mDatareadfromhbf;
   uint32_t mTotalHBFPayLoad = 0; // total data payload of the heart beat frame in question.
   uint32_t mHBFoffset32 = 0;     // total data payload of the heart beat frame in question.
+  uint64_t mDigitWordsRead = 0;
+  uint64_t mDigitWordsRejected = 0;
+  uint64_t mTotalDigitWordsRead = 0;
+  uint64_t mTotalDigitWordsRejected = 0;
   //pointers to the data as we read them in, again no point in copying.
   HalfCRUHeader* mhalfcruheader;
   o2::InteractionRecord mIR;
@@ -204,14 +210,18 @@ class CruRawReader
     std::array<uint32_t, 1080> LinkPadWordCounts; // units of 32 bits the data pad word size.
     std::array<uint32_t, 1080> LinkFreq;          //units of 256bits "cru word"
     //from the above you can get the stats for supermodule and detector.
-    std::array<bool, 1080> LinkEmpty; // Link only has padding words, probably not serious in pp.
-    uint32_t EmptyLinks;
+    std::array<bool, 1080> LinkEmpty; // Link only has padding words only, probably not serious in pp.
     //maybe change this to actual traps ?? but it will get large.
     std::array<uint32_t, 1080> LinkTrackletPerTrap1; // incremented if a trap on this link has 1 tracklet
     std::array<uint32_t, 1080> LinkTrackletPerTrap2; // incremented if a trap on this link has 2 tracklet
     std::array<uint32_t, 1080> LinkTrackletPerTrap3; // incremented if a trap on this link has 3 tracklet
+    std::array<uint32_t, 1080> LinkMCMsWithData;
+    std::array<uint16_t, 1080> MCMStatus;
+    std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
+    std::array<uint16_t, constants::TIMEBINS> mADCValues{};
+    std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
     std::vector<uint32_t> EmptyTraps;                // MCM indexes of traps that are empty ?? list might better
-  } TRDStatCounters;
+  } TRDStatCountersPerEvent;
 
   /** summary data **/
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -110,6 +110,7 @@ class CruRawReader
     mTrackletsParser.clear();
     mDigitsParser.clear();
   }
+  void OutputHalfCruRawData();
 
  protected:
   bool processHBFs(int datasizealreadyread = 0, bool verbose = false);
@@ -140,6 +141,8 @@ class CruRawReader
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; //this holds the O2 payload held with in the HBFs to pass to parsing.
   uint32_t mHalfCRUPayLoadRead{0};                                    // the words current read in for the currnt cru payload.
   uint32_t mO2PayLoadRead{0};                                         // the words current read in for the currnt cru payload.
+  std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, start and end points for parsing.
+  std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   int mCurrentHalfCRULinkHeaderPoisition = 0;
   // no need to waste time doing the copy  std::array<uint32_t,8> mCurrentCRUWord; // data for a cru comes in words of 256 bits.
   uint32_t mCurrentLinkDataPosition256;    // count of data read for current link in units of 256 bits
@@ -204,24 +207,27 @@ class CruRawReader
 
   EventStorage mEventRecords; // store data range indexes into the above vectors.
   bool mReturnBlob{0};        // whether to return blobs or vectors;
-  struct TRDDataCounters_t {  //thisis on a per event basis
+  struct TRDDataCountersPerEvent_t { //thisis on a per event basis
     //TODO this should go into a dpl message for catching by qc ?? I think.
-    std::array<uint32_t, 1080> LinkWordCounts;    //units of 256bits "cru word"
-    std::array<uint32_t, 1080> LinkPadWordCounts; // units of 32 bits the data pad word size.
-    std::array<uint32_t, 1080> LinkFreq;          //units of 256bits "cru word"
+    std::array<uint32_t, 1080> mLinkWordCounts;    //units of 256bits "cru word"
+    std::array<uint32_t, 1080> mLinkPadWordCounts; // units of 32 bits the data pad word size.
+    std::array<uint32_t, 1080> mLinkFreq;          //units of 256bits "cru word"
+    std::array<uint8_t, 1080> mLinkErrorFlag;      //units of 256bits "cru word"
     //from the above you can get the stats for supermodule and detector.
-    std::array<bool, 1080> LinkEmpty; // Link only has padding words only, probably not serious in pp.
+    std::array<bool, 1080> LinkEmpty; // Link only has padding words only, probably not serious.
     //maybe change this to actual traps ?? but it will get large.
-    std::array<uint32_t, 1080> LinkTrackletPerTrap1; // incremented if a trap on this link has 1 tracklet
-    std::array<uint32_t, 1080> LinkTrackletPerTrap2; // incremented if a trap on this link has 2 tracklet
-    std::array<uint32_t, 1080> LinkTrackletPerTrap3; // incremented if a trap on this link has 3 tracklet
-    std::array<uint32_t, 1080> LinkMCMsWithData;
+    std::array<uint32_t, 1080> mLinkTrackletPerTrap1; // incremented if a trap on this link has 1 tracklet
+    std::array<uint32_t, 1080> mLinkTrackletPerTrap2; // incremented if a trap on this link has 2 tracklet
+    std::array<uint32_t, 1080> mLinkTrackletPerTrap3; // incremented if a trap on this link has 3 tracklet
+    std::array<uint32_t, 1080> mLinkMCMsWithData;
     std::array<uint16_t, 1080> MCMStatus;
-    std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
-    std::array<uint16_t, constants::TIMEBINS> mADCValues{};
     std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
-    std::vector<uint32_t> EmptyTraps;                // MCM indexes of traps that are empty ?? list might better
+    std::vector<uint32_t> mEmptyTraps;                      // MCM indexes of traps that are empty ?? list might better
   } TRDStatCountersPerEvent;
+
+  struct TRDDataCountersRunning_t { //those counters that keep counting
+    //??
+  } TRDStatCountersRunning;
 
   /** summary data **/
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -164,7 +164,7 @@ class CruRawReader
   uint16_t mCRUEndpoint;               // the upper or lower half of the currently parsed cru 0-14 or 15-29
   uint16_t mCRUID;
   uint16_t mHCID;
-  uint16_t mFEEID; // current Fee ID working on
+  TRDFeeID mFEEID; // current Fee ID working on
   std::array<uint32_t, 15> mCurrentHalfCRULinkLengths;
   std::array<uint32_t, 15> mCurrentHalfCRULinkErrorFlags;
   uint32_t mCRUState; // the state of what we are expecting to read currently from the data stream, *not* what we have just read.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -55,6 +55,8 @@ class DataReaderTask : public Task
   bool mCompressedData{false};   // are we dealing with the compressed data from the flp (send via option)
   bool mByteSwap{true};          // whether we are to byteswap the incoming data, mc is not byteswapped, raw data is (too be changed in cru at some point)
                                  //  o2::header::DataDescription mDataDesc; // Data description of the incoming data
+  uint64_t mWordsRead = 0;
+  uint64_t mWordsRejected = 0;
   int mTrackletHCHeaderState{0}; // what to do about tracklethcheader, 0 never there, 2 always there, 1 there iff tracklet data, i.e. only there if next word is *not* endmarker 10001000.
 
   std::string mDataDesc;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -39,13 +39,11 @@ class DigitsParser
   DigitsParser() = default;
   ~DigitsParser() = default;
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
-  //  void setLinkLengths(std::array<uint32_t, 15>& lengths) { mCurrentHalfCRULinkLengths = lengths; };
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
             std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
   {
     setData(data);
-    //   setLinkLengths(lengths);
     mStartParse = start;
     mEndParse = end;
     mDetector = detector;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -112,7 +112,7 @@ class DigitsParser
   uint16_t mChannel;
   uint16_t mEventCounter;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
-                                                                                           // std::array<uint16_t, 60>/*constants::TIMEBINS>*/ mADCValues;
+  std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
   //uint32_t mCurrentLinkDataPosition;                   // count of data read for current link in units of 256 bits
   //uhint32_t mCurrentHalfCRUDataPosition256;             //count of data read for this half cru.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -41,13 +41,16 @@ class DigitsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, DigitHCHeader& hcheader, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, DigitHCHeader& hcheader, TRDFeeID& feeid, unsigned int linkindex, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
   {
     setData(data);
     mStartParse = start;
     mEndParse = end;
     mDetector = detector;
+   mStack= stack;
+   mLayer=layer;
     mDigitHCHeader = hcheader;
+    mFEEID=feeid;
     setVerbose(verbose, headerverbose, dataverbose);
     if (cleardigits) {
       clearDigits();
@@ -109,7 +112,10 @@ class DigitsParser
   uint16_t mMCM;
   uint16_t mROB;
   uint16_t mChannel;
+  uint16_t mStack;
+  uint16_t mLayer;
   uint16_t mEventCounter;
+  TRDFeeID mFEEID;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -41,24 +41,9 @@ class DigitsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, DigitHCHeader& hcheader, TRDFeeID& feeid, unsigned int linkindex, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
-  {
-    setData(data);
-    mStartParse = start;
-    mEndParse = end;
-    mDetector = detector;
-    mStack = stack;
-    mLayer = layer;
-    mDigitHCHeader = hcheader;
-    mFEEID = feeid;
-    setVerbose(verbose, headerverbose, dataverbose);
-    if (cleardigits) {
-      clearDigits();
-    }
-    setByteSwap(disablebyteswap);
-    mReturnVectorPos = 0;
-    return Parse();
-  };
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, DigitHCHeader& hcheader,
+            TRDFeeID& feeid, unsigned int linkindex, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false,
+            bool headerverbose = false, bool dataverbose = false);
   enum DigitParserState { StateDigitHCHeader, // always the start of a half chamber.
                           StateDigitMCMHeader,
                           StateDigitMCMData,
@@ -82,6 +67,7 @@ class DigitsParser
   uint64_t getDumpedDataCount() { return mWordsDumped; }
   uint64_t getDataWordsParsed() { return mDataWordsParsed; }
   void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
+  void OutputIncomingData();
 
  private:
   int mState;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -47,10 +47,10 @@ class DigitsParser
     mStartParse = start;
     mEndParse = end;
     mDetector = detector;
-   mStack= stack;
-   mLayer=layer;
+    mStack = stack;
+    mLayer = layer;
     mDigitHCHeader = hcheader;
-    mFEEID=feeid;
+    mFEEID = feeid;
     setVerbose(verbose, headerverbose, dataverbose);
     if (cleardigits) {
       clearDigits();
@@ -79,6 +79,9 @@ class DigitsParser
   std::vector<Digit>& getDigits() { return mDigits; }
   void clearDigits() { mDigits.clear(); }
   void clear() { mDigits.clear(); }
+  uint64_t getDumpedDataCount() { return mWordsDumped; }
+  uint64_t getDataWordsParsed() { return mDataWordsParsed; }
+  void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
 
  private:
   int mState;
@@ -87,6 +90,7 @@ class DigitsParser
   int mBufferLocation;
   int mPaddingWordsCounter;
   bool mSanityCheck{true};
+  bool mDumpUnknownData{false}; // if the various sanity checks fail, bail out and dump the rest of the data, keeps stats.
   bool mByteOrderFix{false}; // simulated data is not byteswapped, real is, so deal with it accodringly.
   bool mReturnVector{true};  // whether we are returing a vector or the raw data buffer.
   // yes this is terrible design but it works,
@@ -98,7 +102,8 @@ class DigitsParser
   // this means that successive calls to Parse simply appends the new digits onto the vector.
   // at the end of the event the calling object must pull/copy the vector and clear or clear on next parse.
   //
-  int mParsedWords{0}; // words parsed in data vector, last complete bit is not parsed, and left for another round of data update.
+  // int mParsedWords{0}; // words parsed in data vector, last complete bit is not parsed, and left for another round of data update.
+  uint64_t mWordsDumped{0}; // words rejected for various reasons.
   DigitHCHeader mDigitHCHeader;
   DigitMCMHeader* mDigitMCMHeader;
   DigitMCMADCMask* mDigitMCMADCMask;
@@ -111,13 +116,15 @@ class DigitsParser
   uint16_t mDetector;
   uint16_t mMCM;
   uint16_t mROB;
-  uint16_t mChannel;
+  uint16_t mCurrentADCChannel;
+  uint16_t mDigitWordCount;
   uint16_t mStack;
   uint16_t mLayer;
   uint16_t mEventCounter;
   TRDFeeID mFEEID;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
+  std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
   //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
   //uint32_t mCurrentLinkDataPosition;                   // count of data read for current link in units of 256 bits
   //uhint32_t mCurrentHalfCRUDataPosition256;             //count of data read for this half cru.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -41,12 +41,13 @@ class DigitsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, DigitHCHeader& hcheader, bool cleardigits = false, bool disablebyteswap = false, bool verbose = false, bool headerverbose = false, bool dataverbose = false)
   {
     setData(data);
     mStartParse = start;
     mEndParse = end;
     mDetector = detector;
+    mDigitHCHeader = hcheader;
     setVerbose(verbose, headerverbose, dataverbose);
     if (cleardigits) {
       clearDigits();
@@ -95,7 +96,7 @@ class DigitsParser
   // at the end of the event the calling object must pull/copy the vector and clear or clear on next parse.
   //
   int mParsedWords{0}; // words parsed in data vector, last complete bit is not parsed, and left for another round of data update.
-  DigitHCHeader* mDigitHCHeader;
+  DigitHCHeader mDigitHCHeader;
   DigitMCMHeader* mDigitMCMHeader;
   DigitMCMADCMask* mDigitMCMADCMask;
   uint32_t mADCMask;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -36,7 +36,7 @@ class TrackletsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, uint32_t feeid, int robside, int detector, int stack, int layer, bool cleardigits = false, bool disablebyteswap = false, int usetracklethcheader = 0, bool verbose = true, bool headerverbose = false, bool dataverbose = false)
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside, int detector, int stack, int layer, bool cleardigits = false, bool disablebyteswap = false, int usetracklethcheader = 0, bool verbose = true, bool headerverbose = false, bool dataverbose = false)
   {
     mStartParse = start;
     mEndParse = end;
@@ -116,7 +116,7 @@ class TrackletsParser
   uint16_t mRobSide;
   uint16_t mStack;
   uint16_t mLayer;
-  uint16_t mFEEID; // current Fee ID working on
+  TRDFeeID mFEEID; // current Fee ID working on
   uint16_t mMCM;
   uint16_t mROB;
   //  std::array<uint32_t, 16> mAverageNumTrackletsPerTrap; TODO come back to this stat.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -98,10 +98,9 @@ class TrackletsParser
   bool mHeaderVerbose{false};
   bool mDataVerbose{false};
   int mTrackletHCHeaderState{0}; //what to with the tracklet half chamber header 0,1,2
-
   bool mIgnoreTrackletHCHeader{false}; // Is the data with out the tracklet HC Header? defaults to having it in.
   bool mByteOrderFix{false};           // simulated data is not byteswapped, real is, so deal with it accodringly.
-  bool mReturnVector{false};           // whether weare returing a vector or the raw data buffer.
+  uint64_t mWordsDumped{0};
 
   uint16_t mEventCounter;
   std::chrono::duration<double> mTrackletparsetime;                                        // store the time it takes to parse

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -35,27 +35,10 @@ class TrackletsParser
   ~TrackletsParser() = default;
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(); // presupposes you have set everything up already.
-  int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside, int detector, int stack, int layer, bool cleardigits = false, bool disablebyteswap = false, int usetracklethcheader = 0, bool verbose = true, bool headerverbose = false, bool dataverbose = false)
-  {
-    mStartParse = start;
-    mEndParse = end;
-    mDetector = detector;
-    mFEEID = feeid;
-    mRobSide = robside;
-    mStack = stack;
-    mLayer = layer;
-    setData(data);
-    setVerbose(verbose, headerverbose, dataverbose);
-    setByteSwap(disablebyteswap);
-    mWordsRead = 0;
-    mDataWordsParsed = 0;
-    mTrackletsFound = 0;
-    mPaddingWordsCounter = 0;
-    mTrackletHCHeaderState = usetracklethcheader; //what to with the tracklet half chamber header 0,1,2
-    //    mTracklets.clear();
-    return Parse();
-  };
+  int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside,
+            int detector, int stack, int layer, bool cleardigits = false,
+            bool disablebyteswap = false, int usetracklethcheader = 0, bool verbose = true,
+            bool headerverbose = false, bool dataverbose = false);
   void setVerbose(bool verbose, bool header = false, bool data = false)
   {
     mVerbose = verbose;
@@ -79,6 +62,7 @@ class TrackletsParser
   {
     mTracklets.clear();
   }
+  void OutputIncomingData();
 
  private:
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* mData;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -104,7 +104,7 @@ class TrackletsParser
   bool mReturnVector{false};           // whether weare returing a vector or the raw data buffer.
 
   uint16_t mEventCounter;
-  std::chrono::duration<double>mTrackletparsetime; // store the time it takes to parse
+  std::chrono::duration<double> mTrackletparsetime;                                        // store the time it takes to parse
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -104,6 +104,7 @@ class TrackletsParser
   bool mReturnVector{false};           // whether weare returing a vector or the raw data buffer.
 
   uint16_t mEventCounter;
+  std::chrono::duration<double>mTrackletparsetime; // store the time it takes to parse
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
 

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -201,7 +201,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
                                                decltype(mCurrentHalfCRULinkLengths)::value_type(0));
   mTotalHalfCRUDataLength = mTotalHalfCRUDataLength256 * 32; //convert to bytes.
   //check for cru errors :
-  if (mHeaderVerbose) {
+  if (mDataVerbose) {
     int linkerrorcounter = 0;
     LOG(info) << "link errors";
     for (auto& linkerror : mCurrentHalfCRULinkErrorFlags) {
@@ -279,10 +279,10 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
     int oriindex = currentlinkindex + constants::NLINKSPERHALFCRU * endpoint; // endpoint denotes the pci side, upper or lower for the pair of 15 fibres.
     FeeParam::unpackORI(oriindex, side, stack, layer, halfchamberside);
     int currentdetector = stack * constants::NLAYER + layer + supermodule * constants::NLAYER * constants::NSTACK;
-    if (mVerbose) {
+    if (mDataVerbose) {
       LOG(info) << "******* LINK # " << currentlinkindex << " and  starting at " << mHBFoffset32 << " unpackORI(" << oriindex << "," << side << "," << stack << "," << layer << "," << halfchamberside << ") and an FEEID:" << std::hex << mFEEID << " det:" << std::dec << currentdetector;
+      LOG(info) << "******* LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID << " det:" << std::dec << currentdetector << " Error Flags : " << mCurrentHalfCRULinkErrorFlags[currentlinkindex];
     }
-    LOG(info) << "******* LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID << " det:" << std::dec << currentdetector << " Error Flags : " << mCurrentHalfCRULinkErrorFlags[currentlinkindex];
     // tracklet first then digit ??
     // tracklets end with tracklet end marker(0x10001000 0x10001000), digits end with digit endmarker (0x0 0x0)
     if (linkstart != linkend) { // if link is not empty

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -96,7 +96,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     Options{}});
 
   if (cfgc.options().get<bool>("enable-root-output")) {
-    workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));
+    workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, true));
     workflow.emplace_back(o2::trd::getTRDTrackletWriterSpec(false));
   }
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -106,6 +106,7 @@ void DataReaderTask::run(ProcessingContext& pc)
     int inputpartscount = 0;
     int emptyframe = 0;
     for (auto const& ref : iit) {
+      auto inputprocessingstart = std::chrono::high_resolution_clock::now(); // measure total processing time
       if (mVerbose) {
         const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
         LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",
@@ -114,7 +115,7 @@ void DataReaderTask::run(ProcessingContext& pc)
       const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto payloadIn = ref.payload;
       auto payloadInSize = headerIn->payloadSize;
-      const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+  //    const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (std::string(headerIn->dataDescription.str) != std::string("DISTSUBTIMEFRAMEFLP")) {
         if (!mCompressedData) { //we have raw data coming in from flp
           if (mVerbose) {
@@ -134,13 +135,17 @@ void DataReaderTask::run(ProcessingContext& pc)
           mCompressedReader.run();
         }
       } // ignore the input of DISTSUBTIMEFRAMEFLP
+//      auto inputprocessingtime = std::chrono::high_resolution_clock::now() - inputprocessingstart;
+ //     LOGP(info, "Input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : processed in {} us",
+  //           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,std::chrono::duration_cast<std::chrono::microseconds>(inputprocessingtime).count());
+
     }
     /* output */
     sendData(pc, false);
   }
 
   auto dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
-  LOG(info) << "Processing time for Data reading  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
+  LOG(info) << "Processing time for Data reading  " << std::chrono::duration_cast<std::chrono::microseconds>(dataReadTime).count() << "us";
   if (!mCompressedData) {
     LOG(info) << "Digits found : " << mReader.getDigitsFound();
     LOG(info) << "Tracklets found : " << mReader.getTrackletsFound();

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -115,7 +115,7 @@ void DataReaderTask::run(ProcessingContext& pc)
       const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto payloadIn = ref.payload;
       auto payloadInSize = headerIn->payloadSize;
-  //    const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      //    const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (std::string(headerIn->dataDescription.str) != std::string("DISTSUBTIMEFRAMEFLP")) {
         if (!mCompressedData) { //we have raw data coming in from flp
           if (mVerbose) {
@@ -135,10 +135,9 @@ void DataReaderTask::run(ProcessingContext& pc)
           mCompressedReader.run();
         }
       } // ignore the input of DISTSUBTIMEFRAMEFLP
-//      auto inputprocessingtime = std::chrono::high_resolution_clock::now() - inputprocessingstart;
- //     LOGP(info, "Input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : processed in {} us",
-  //           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,std::chrono::duration_cast<std::chrono::microseconds>(inputprocessingtime).count());
-
+        //      auto inputprocessingtime = std::chrono::high_resolution_clock::now() - inputprocessingstart;
+        //     LOGP(info, "Input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : processed in {} us",
+        //           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,std::chrono::duration_cast<std::chrono::microseconds>(inputprocessingtime).count());
     }
     /* output */
     sendData(pc, false);

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -91,6 +91,7 @@ void DataReaderTask::run(ProcessingContext& pc)
     sendData(pc, true); //send the empty tf data.
     return;
   }
+  uint64_t total1 = 0, total2 = 0;
   /* set encoder output buffer */
   char bufferOut[o2::trd::constants::HBFBUFFERMAX];
   int loopcounter = 0;
@@ -121,10 +122,16 @@ void DataReaderTask::run(ProcessingContext& pc)
           if (mVerbose) {
             LOG(info) << " parsing non compressed data in the data reader task with a payload of " << payloadInSize << " payload size";
           }
+          //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " headerIn->payloadSize:0x" << headerIn->payloadSize <<" headerIn->headerSize:0x" <<headerIn->headerSize;
+          total1 += headerIn->payloadSize;
+          total2 += headerIn->headerSize;
+          //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
           mReader.setDataBuffer(payloadIn);
           mReader.setDataBufferSize(payloadInSize);
           mReader.configure(mByteSwap, mFixDigitEndCorruption, mTrackletHCHeaderState, mVerbose, mHeaderVerbose, mDataVerbose);
           mReader.run();
+          mWordsRead += mReader.getWordsRead();
+          mWordsRejected += mReader.getWordsRejected();
           if (mVerbose) {
             LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";
           }
@@ -148,6 +155,10 @@ void DataReaderTask::run(ProcessingContext& pc)
   if (!mCompressedData) {
     LOG(info) << "Digits found : " << mReader.getDigitsFound();
     LOG(info) << "Tracklets found : " << mReader.getTrackletsFound();
+    LOG(info) << "DataRead in :" << mWordsRead * 4 << " bytes";
+    LOG(info) << "DataRejected in :" << mWordsRejected * 4 << " bytes";
+    LOG(info) << "DataRetention :bad/good" << (double)mWordsRejected / (double)mWordsRead << "";
+    LOG(info) << "Total % good data bad/(good+bad)" << (double)mWordsRejected / ((double)mWordsRead + (double)mWordsRejected) * 100.0 << " %";
   }
 }
 

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -26,6 +26,8 @@
 #include <vector>
 #include <array>
 #include <iterator>
+#include <bitset>
+#include <iostream>
 
 namespace o2::trd
 {
@@ -41,6 +43,7 @@ inline void DigitsParser::swapByteOrder(unsigned int& word)
 int DigitsParser::Parse(bool verbose)
 {
 
+    auto timedigitparsestart = std::chrono::high_resolution_clock::now(); // measure total processing time
   //we are handed the buffer payload of an rdh and need to parse its contents.
   //producing a vector of digits.
   mVerbose = verbose;
@@ -52,7 +55,6 @@ int DigitsParser::Parse(bool verbose)
   mDigitsFound = 0;     // tracklets found in the data block, mostly used for debugging.
   mBufferLocation = 0;
   mPaddingWordsCounter = 0;
-  std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   if (mVerbose) {
     LOG(info) << "Digit Parser parse of data sitting at :" << std::hex << (void*)mData << " starting at pos " << mStartParse;
     if (mByteOrderFix) {
@@ -123,7 +125,9 @@ int DigitsParser::Parse(bool verbose)
     //move over the DigitHCHeader;
     mState = StateDigitMCMHeader;
   }
-  for (auto word = mStartParse; word != mEndParse; word++) { // loop over the entire data buffer (a complete link of digits)
+
+  for (auto& word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of digits)
+    auto looptime = std::chrono::high_resolution_clock::now() - timedigitparsestart;
     //loop over all the words
     if (mDataVerbose || mVerbose) {
       LOG(info) << "parsing word : " << std::hex << *word;
@@ -166,184 +170,211 @@ int DigitsParser::Parse(bool verbose)
           LOG(info) << "state mcmheader and word : 0x" << std::hex << *word;
           printDigitMCMHeader(*mDigitMCMHeader);
         }
-        if (mDigitHCHeader->major == 4) {
+        if (mDigitHCHeader->major == 0x21){
           //zero suppressed
           //so we have an adcmask next
           std::advance(word, 1);
+          if (mByteOrderFix) {
+            // byte swap if needed.
+            swapByteOrder(*word);
+          }
           mDigitMCMADCMask = (DigitMCMADCMask*)(word);
           mADCMask = mDigitMCMADCMask->adcmask;
-          //std::advance(word, 1);
+          //TODO why does the following not hold, its defined as such in the tdp ...  ??? come back
+//          if(mDigitMCMADCMask->c!=0x1f || mDigitMCMADCMask->n!=0x3 || mDigitMCMADCMask->j!=0xc){
+//            LOG(error) << "ADCMask constant values are not right ; mask: 0x:"<< std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " 0x" << mDigitMCMADCMask->c << " 0x" << mDigitMCMADCMask->j << " full:0x" << *word;
+//        }
           if (mVerbose || mHeaderVerbose) {
-            LOG(info) << "adc mask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word;
+            LOG(info) << "**adc mask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word;
           }
           //TODO check for end of loop?
           if (word == mEndParse) {
             LOG(warn) << "we have a problem we have advanced from MCMHeader to the adcmask but are now at the end of the loop";
           }
-        }
-        //sanity check of digitheader ??  Still to implement.
-        if (mHeaderVerbose) {
-          std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator tmpword;
+//output all the adc data for the described adc mask, i.e 10 32 bit words per bit in mask./
+          if(mDataVerbose){
+            LOG(info) << "RAW ADC DUMP start ";
+            std::bitset<21> adcmask(mADCMask);
+            int bitsinmask=adcmask.count();
+            LOG(info) << " channel account as per bp:"<< std::hex << mADCMask << " has count of :" << std::dec << bitsinmask << "   ADCMask constant values are not right ; mask: 0x:"<< std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " "<< std::dec << mDigitMCMADCMask->c << " 0x" << std::hex << mDigitMCMADCMask->j << " full:0x" << *word;
+            int z;
+            for(z=0;z<bitsinmask*10;++z){
+              if(z%10==0 && z!=0) LOG(info) <<"gap";
+              auto nextadcword=std::next(word,z+1);
+              LOG(info)<< "ADCraw: z:"<< z << " " << std::hex << *nextadcword;
 
-          if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
-            LOG(warn) << "Sanity check Failure Digit MCMHeader : " << std::hex << mDigitMCMHeader->word;
-          } else {
-            LOG(info) << "Sanity check passed for digitmcmheader";
-            printDigitMCMHeader(*mDigitMCMHeader);
+            }
+            LOG(info) << "next 8 words for clarity";
+            int offset=z;
+            for(z=offset;z<offset+8;++z){
+              auto nextadcword=std::next(word,z+1);
+              LOG(info)<< "??ADCraw: z:"<< z << " " << std::hex << *nextadcword;
+            }
+            LOG(info) << "RAW ADC DUMP end";
           }
         }
-        mBufferLocation++;
-        //new header so digit word count becomes zero
-        digitwordcount = 0;
-        mState = StateDigitMCMData;
-        mMCM = mDigitMCMHeader->mcm;
-        mROB = mDigitMCMHeader->rob;
-        //cru /2 = supermodule
-        //link channel == readoutboard as per guido doc.
-        int layer = mDigitHCHeader->layer;
-        int stack = mDigitHCHeader->stack;
-        int sector = mDigitHCHeader->supermodule;
-        mDetector = layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK;
-        //TODO check that his matches up with the CRU Link info
-        //TOOD does it match the feeid which ncodes this information as well.
-        //
-        mEventCounter = mDigitMCMHeader->eventcount;
-        mDataWordsParsed++; // header
-        if (mDigitHCHeader->major == 4) {
-          //zero suppressed digits
-          mDataWordsParsed++; // adc mask
-        }
-        mChannel = 0;
-        mADCValues.fill(0);
-        digittimebinoffset = 0;
-        if (!mReturnVector) {
-          //returning the raw "compressed" data stream.
-          //build the digit header and add to outgoing buffer;
-          uint32_t* header = &(*mData)[mReturnVectorPos];
-          //build header.
-        }
-        // we dont care about the year flag, we are >2007 already.
-      } else {
-        if (*word == o2::trd::constants::CRUPADDING32) {
-          if (mVerbose) {
-            LOG(info) << "state padding and word : 0x" << std::hex << *word << "  state is:" << mState;
+          else {
+            LOG(info) << "NOT zero suppressed";
           }
-          //another pointer with padding.
+
+          //sanity check of digitheader ??  Still to implement.
+          if (mHeaderVerbose) {
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator tmpword;
+
+            if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
+              LOG(warn) << "Sanity check Failure Digit MCMHeader : " << std::hex << mDigitMCMHeader->word;
+            } else {
+              LOG(info) << "Sanity check passed for digitmcmheader";
+              printDigitMCMHeader(*mDigitMCMHeader);
+            }
+          }
           mBufferLocation++;
-          mPaddingWordsCounter++;
-          mState = StatePadding;
-          mDataWordsParsed++;
-          mcmdatacount = 0;
-
-          // this is supposed to carry on till the end of the buffer, hence the term padding.
-          //TRDStatCounters.LinkPadWordCounts[mHCID]++; // keep track off all the padding words.
-        } else { // all we are left with is digitmcmdata words.
-          if (mState == StateDigitEndMarker) {
-
-            //we are at the end
-            // do nothing.
-            if (mDataVerbose) {
-              LOG(info) << " digit end marker state ...";
+          //new header so digit word count becomes zero
+          digitwordcount = 0;
+          mState = StateDigitMCMData;
+          mMCM = mDigitMCMHeader->mcm;
+          mROB = mDigitMCMHeader->rob;
+          //cru /2 = supermodule
+          //link channel == readoutboard as per guido doc.
+          int layer = mDigitHCHeader->layer;
+          int stack = mDigitHCHeader->stack;
+          int sector = mDigitHCHeader->supermodule;
+          mDetector = layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK;
+          //TODO check that his matches up with the CRU Link info
+          //TOOD does it match the feeid which ncodes this information as well.
+          //
+          mEventCounter = mDigitMCMHeader->eventcount;
+          mDataWordsParsed++; // header
+          if (mDigitHCHeader->major & 0x20) {
+            //zero suppressed digits
+            mDataWordsParsed++; // adc mask
+          }
+          mChannel = 0;
+          mADCValues.fill(0);
+          digittimebinoffset = 0;
+          if (!mReturnVector) {
+            //returning the raw "compressed" data stream.
+            //build the digit header and add to outgoing buffer;
+            uint32_t* header = &(*mData)[mReturnVectorPos];
+            //build header.
+          }
+          // we dont care about the year flag, we are >2007 already.
+        } else {
+          //LOG(info) << "state not digitmcmheader so checking for other";
+          if (*word == o2::trd::constants::CRUPADDING32) {
+            if (mVerbose) {
+              LOG(info) << "state padding and word : 0x" << std::hex << *word << "  state is:" << mState;
             }
-          } else {
-            //for the case of on flp build a vector of tracklets, then pack them into a data stream with a header.
-            //for dpl build a vector and connect it with a triggerrecord.
-            mDataWordsParsed++;
-            mcmdatacount++;
-            mDigitMCMData = (DigitMCMData*)word;
+            //another pointer with padding.
             mBufferLocation++;
-            mState = StateDigitMCMData;
-            digitwordcount++;
-            if (mVerbose || mDataVerbose) {
-              LOG(info) << "adc values : " << mDigitMCMData->x << "::" << mDigitMCMData->y << "::" << mDigitMCMData->z;
-              LOG(info) << "digittimebinoffset = " << digittimebinoffset;
-            }
-            mADCValues[digittimebinoffset++] = mDigitMCMData->x;
-            mADCValues[digittimebinoffset++] = mDigitMCMData->y;
-            mADCValues[digittimebinoffset++] = mDigitMCMData->z;
+            mPaddingWordsCounter++;
+            mState = StatePadding;
+            mDataWordsParsed++;
+            mcmdatacount = 0;
 
-            if (digittimebinoffset > constants::TIMEBINS) {
-              LOG(fatal) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
-            }
-            if (mVerbose || mDataVerbose) {
-              LOG(info) << "digit word count is : " << digitwordcount << " digittimebinoffset = " << digittimebinoffset;
-            }
-            if (digitwordcount == constants::TIMEBINS / 3) {
-              //sanity check, next word shouldbe either a. end of digit marker, digitMCMHeader,or padding.
+            // this is supposed to carry on till the end of the buffer, hence the term padding.
+            //TRDStatCounters.LinkPadWordCounts[mHCID]++; // keep track off all the padding words.
+          } else { // all we are left with is digitmcmdata words.
+            if (mState == StateDigitEndMarker) {
+
               if (mDataVerbose) {
-                LOG(info) << "change of adc hopefully adcmask is non zero " << std::hex << mADCMask;
+                LOG(info) << "**DigitEndMarker State : " << std::hex << *word;
+                LOG(info) << " digit end marker state ...";
+                //we are at the end
+                // do nothing.
               }
-              mcmadccount++;
-              //write out adc value to vector
-              //zero digittimebinoffset
-              if (mDigitHCHeader->major == 4) {
-                //zero suppressed, so channel must be extracted from next available bit in adcmask
-                if (mDataVerbose) {
-                  LOG(info) << "adcmask: 0x" << std::hex << mADCMask << " and channel : " << std::dec << mChannel;
-                }
-                mChannel = nextmcmadc(mADCMask, mChannel);
-                if (mDataVerbose) {
-                  LOG(info) << "after mask check adcmask: 0x" << std::hex << mADCMask << " and channel : " << std::dec << mChannel;
-                  LOG(info) << "the above is the preceding digit above us not the one below us ";
-                }
-                if (mChannel == 22) {
-                  LOG(error) << "invalid bitpattern for this mcm";
-                }
-                //set that bit to zero
-                if (mADCMask == 0) {
-                  //no more adc for zero suppression.
-                  //now we should either have another MCMHeader, or End marker
-                  if (*word != 0 && *(std::next(word)) != 0) { // end marker is a sequence of 32 bit 2 zeros.
-                    mState = StateDigitMCMHeader;
-                  } else {
-                    mState = StateDigitEndMarker;
+            } else {
+              //for the case of on flp build a vector of tracklets, then pack them into a data stream with a header.
+              //for dpl build a vector and connect it with a triggerrecord.
+              if(mDataVerbose){
+                LOG(info) << "**Digit word : " << std::hex << *word;
+              }
+              mDataWordsParsed++;
+              mcmdatacount++;
+              mDigitMCMData = (DigitMCMData*)word;
+              mBufferLocation++;
+              mState = StateDigitMCMData;
+              digitwordcount++;
+              if (mVerbose || mDataVerbose) {
+                LOG(info) << "adc values : raw 0x:" << std::hex << *word << std::dec << mDigitMCMData->x << "::" << mDigitMCMData->y << "::" << mDigitMCMData->z << " mask:0x" << std::hex << mADCMask;
+                LOG(info) << "digittimebinoffset = " << digittimebinoffset;
+              }
+              mADCValues[digittimebinoffset++] = mDigitMCMData->x;
+              mADCValues[digittimebinoffset++] = mDigitMCMData->y;
+              mADCValues[digittimebinoffset++] = mDigitMCMData->z;
+
+              if (digittimebinoffset > constants::TIMEBINS) {
+                LOG(fatal) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
+              }
+              if (mVerbose || mDataVerbose) {
+                LOG(info) << "digit word count is : " << digitwordcount << " digittimebinoffset = " << digittimebinoffset;
+              }
+              if (digitwordcount == constants::TIMEBINS / 3) {
+                //sanity check, next word shouldbe either a. end of digit marker, digitMCMHeader,or padding.
+                mcmadccount++;
+                //write out adc value to vector
+                //zero digittimebinoffset
+                if (mDigitHCHeader->major & 0x20) {
+                  //zero suppressed, so channel must be extracted from next available bit in adcmask
+                  mChannel = nextmcmadc(mADCMask, mChannel);
+                  if(mChannel==21){
+                    LOG(warn)<< "ADCMask is zero but we seem to have a digit";
+                  }
+                  if (mDataVerbose) {
+                    LOG(info) << "after mask check adcmask: 0x" << std::hex << mADCMask << " and channel : " << std::dec << mChannel;
+                    LOG(info) << "the above is the preceding digit above us not the one below us ";
+                  }
+                  if (mChannel == 22) {
+                    LOG(error) << "invalid bitpattern for this mcm 0x"<< std::hex << mADCMask;
+                    LOG(info) << "EEE " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << " :" ;
+                    for(auto adc : mADCValues ){
+                      std::cout << adc << ":" ;
+                    }
+                    std::cout << std::endl;
+                  }
+                  if (mADCMask == 0) {
+                    LOG(info) << "mADCMask is now zero ";
+                    //no more adc for zero suppression.
+                    //now we should either have another MCMHeader, or End marker
+                    if (*word != 0 && *(std::next(word)) != 0) { // end marker is a sequence of 32 bit 2 zeros.
+                             LOG(info)<< "Mask zero so changing state to StateDigitMCMHeader to read an MCMHeader on the next pass next 2 words are not digit end marker of zero";
+                      mState = StateDigitMCMHeader;
+                    } else {
+                            LOG(info)<< "Mask zero so changing state to StateDigitEndHeader as next 2 words are digit end marker of zero 0x"<< *word << " " << *(std::next(word));
+                      mState = StateDigitEndMarker;
+                    }
                   }
                 }
-              }
-              mDigits.emplace_back(mDetector, mROB, mMCM, mChannel, mADCValues); // outgoing parsed digits
-                                                                                 // if(mDataVerbose){
-                                                                                 //    CompressedDigit t = mDigits.back();
-              //now fill in the adc values --- here because in commented code above if all 3 increments were there then it froze
-              if (mDataVerbose) {
-                uint32_t adcsum = 0;
-                for (auto adc : mADCValues) {
-                  adcsum += adc;
+                mDigits.emplace_back(mDetector, mROB, mMCM, mChannel, mADCValues); // outgoing parsed digits
+                if(mDataVerbose){
+                  //    CompressedDigit t = mDigits.back();
+                  //now fill in the adc values --- here because in commented code above if all 3 increments were there then it froze
+                  uint32_t adcsum = 0;
+                  for (auto adc : mADCValues) {
+                    adcsum += adc;
+                  }
+                  LOG(info) << "DDDD #" << mDigitsFound << " det:rob:mcm:channel:adcsum ... "<< mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << ":" << adcsum << ":" << mADCValues[0] << ":" << mADCValues[1] << ":" << mADCValues[2] << "::" << mADCValues[27] << ":" << mADCValues[28] << ":" << mADCValues[29] ;
                 }
-                LOG(info) << "DDDD " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << ":" << adcsum << ":" << mADCValues[0] << ":" << mADCValues[1] << ":" << mADCValues[2] << "::" << mADCValues[27] << ":" << mADCValues[28] << ":" << mADCValues[29];
-              }
-              mDigitsFound++;
-              digittimebinoffset = 0;
-              digitwordcount = 0; // end of the digit.
-              if (mDigitHCHeader->major == 5) {
-                mChannel++; // we count channels as all 21 channels are present, no way to check this.
-              }
-            }
-
-          } //end state endmarker
-        }
-      }
-    }
-
+                mDigitsFound++;
+                digittimebinoffset = 0;
+                digitwordcount = 0; // end of the digit.
+                if (mDigitHCHeader->major == 5) {
+                  mChannel++; // we count channels as all 21 channels are present, no way to check this.
+                }
+              }// digitwordcount ==z timebins/3
+            }//else digitendmarker if statement
+          }// else of if crupadding word
+        }// else of if digitMCMheader
+    }// else of if digitendmarker
     //accounting
     // mCurrentLinkDataPosition256++;
     // mCurrentHalfCRUDataPosition256++;
     // mTotalHalfCRUDataLength++;
     //end of data so
-    if (word == mEndParse) {
-      if (mVerbose) {
-        LOG(info) << "word is mEndParse";
-      }
-    }
-    if (std::distance(word, mEndParse) < 0) {
-      if (mVerbose || mDataVerbose || mHeaderVerbose) {
-        LOG(info) << std::dec << "word to mEndParse is :" << std::distance(word, mEndParse);
-      }
-    }
-  }
+  }// for loop over word
   if (mVerbose) {
     LOG(info) << "***** parsing loop finished for this link";
   }
-
   if (!(mState == StateDigitMCMHeader || mState == StatePadding || mState == StateDigitEndMarker)) {
     LOG(warn) << "Exiting parsing but the state is wrong ... mState= " << mState;
   }

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -43,7 +43,7 @@ inline void DigitsParser::swapByteOrder(unsigned int& word)
 int DigitsParser::Parse(bool verbose)
 {
 
-    auto timedigitparsestart = std::chrono::high_resolution_clock::now(); // measure total processing time
+  auto timedigitparsestart = std::chrono::high_resolution_clock::now(); // measure total processing time
   //we are handed the buffer payload of an rdh and need to parse its contents.
   //producing a vector of digits.
   mVerbose = verbose;
@@ -51,6 +51,9 @@ int DigitsParser::Parse(bool verbose)
   //  mHeaderVerbose = true;
 
   mState = StateDigitHCHeader;
+  if (mHeaderVerbose) {
+    LOG(info) << " mState set to DigitHCHeader " << __LINE__;
+  }
   mDataWordsParsed = 0; // count of data wordsin data that have been parsed in current call to parse.
   mDigitsFound = 0;     // tracklets found in the data block, mostly used for debugging.
   mBufferLocation = 0;
@@ -124,6 +127,9 @@ int DigitsParser::Parse(bool verbose)
     std::advance(mStartParse, 2);
     //move over the DigitHCHeader;
     mState = StateDigitMCMHeader;
+    if (mHeaderVerbose) {
+      LOG(info) << "state set to MCMHEADER " << __LINE__;
+    }
   }
 
   for (auto& word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of digits)
@@ -156,6 +162,9 @@ int DigitsParser::Parse(bool verbose)
       mDataWordsParsed += 2;
       mState = StateDigitEndMarker;
     } else {
+      if (mHeaderVerbose) {
+        LOG(info) << " **** now to check for mDigitMCMHeader with a value " << std::hex << *word;
+      }
       if ((*word & 0xf) == 0xc && mState == StateDigitMCMHeader) { //marker for DigitMCMHeader.
         if (mVerbose) {
           LOG(info) << " **** mDigitMCMHeader has value " << std::hex << *word;
@@ -170,7 +179,7 @@ int DigitsParser::Parse(bool verbose)
           LOG(info) << "state mcmheader and word : 0x" << std::hex << *word;
           printDigitMCMHeader(*mDigitMCMHeader);
         }
-        if (mDigitHCHeader->major == 0x21){
+        if (mDigitHCHeader->major == 0x21) {
           //zero suppressed
           //so we have an adcmask next
           std::advance(word, 1);
@@ -180,10 +189,6 @@ int DigitsParser::Parse(bool verbose)
           }
           mDigitMCMADCMask = (DigitMCMADCMask*)(word);
           mADCMask = mDigitMCMADCMask->adcmask;
-          //TODO why does the following not hold, its defined as such in the tdp ...  ??? come back
-//          if(mDigitMCMADCMask->c!=0x1f || mDigitMCMADCMask->n!=0x3 || mDigitMCMADCMask->j!=0xc){
-//            LOG(error) << "ADCMask constant values are not right ; mask: 0x:"<< std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " 0x" << mDigitMCMADCMask->c << " 0x" << mDigitMCMADCMask->j << " full:0x" << *word;
-//        }
           if (mVerbose || mHeaderVerbose) {
             LOG(info) << "**adc mask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word;
           }
@@ -191,187 +196,221 @@ int DigitsParser::Parse(bool verbose)
           if (word == mEndParse) {
             LOG(warn) << "we have a problem we have advanced from MCMHeader to the adcmask but are now at the end of the loop";
           }
-//output all the adc data for the described adc mask, i.e 10 32 bit words per bit in mask./
-          if(mDataVerbose){
+          //output all the adc data for the described adc mask, i.e 10 32 bit words per bit in mask./
+          if (mDataVerbose) {
             LOG(info) << "RAW ADC DUMP start ";
             std::bitset<21> adcmask(mADCMask);
-            int bitsinmask=adcmask.count();
-            LOG(info) << " channel account as per bp:"<< std::hex << mADCMask << " has count of :" << std::dec << bitsinmask << "   ADCMask constant values are not right ; mask: 0x:"<< std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " "<< std::dec << mDigitMCMADCMask->c << " 0x" << std::hex << mDigitMCMADCMask->j << " full:0x" << *word;
+            int bitsinmask = adcmask.count();
+            LOG(info) << " channel account as per bp:" << std::hex << mADCMask << " has count of :" << std::dec << bitsinmask << "   ADCMask values ; mask: 0x:" << std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " " << std::dec << ~(mDigitMCMADCMask->c) << " 0x" << std::hex << mDigitMCMADCMask->j << " full:0x" << *word;
             int z;
-            for(z=0;z<bitsinmask*10;++z){
-              if(z%10==0 && z!=0) LOG(info) <<"gap";
-              auto nextadcword=std::next(word,z+1);
-              LOG(info)<< "ADCraw: z:"<< z << " " << std::hex << *nextadcword;
-
+            if (bitsinmask != ~(mDigitMCMADCMask->c)) {
+              LOG(warn) << " bitsinmask mismatch with adcmask->c";
+            } else {
+              LOG(info) << "bitmask matches adcmask->c";
+            }
+            for (z = 0; z < bitsinmask * 10; ++z) {
+              if (z % 10 == 0 && z != 0)
+                LOG(info) << "gap";
+              auto nextadcword = std::next(word, z + 1);
+              uint32_t adcword = *nextadcword;
+              swapByteOrder(adcword);
+              LOG(info) << "ADCraw: z:" << z << " byteswapped " << std::hex << adcword << " raw : 0x" << *nextadcword;
             }
             LOG(info) << "next 8 words for clarity";
-            int offset=z;
-            for(z=offset;z<offset+8;++z){
-              auto nextadcword=std::next(word,z+1);
-              LOG(info)<< "??ADCraw: z:"<< z << " " << std::hex << *nextadcword;
+            int offset = z;
+            for (z = offset; z < offset + 8; ++z) {
+              auto nextadcword = std::next(word, z + 1);
+              uint32_t adcword = *nextadcword;
+              swapByteOrder(adcword);
+              LOG(info) << "??ADCraw: z:" << z << " bswapped " << std::hex << adcword << " raw : 0x" << *nextadcword;
             }
             LOG(info) << "RAW ADC DUMP end";
           }
-        }
-          else {
-            LOG(info) << "NOT zero suppressed";
-          }
-
-          //sanity check of digitheader ??  Still to implement.
-          if (mHeaderVerbose) {
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator tmpword;
-
-            if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
-              LOG(warn) << "Sanity check Failure Digit MCMHeader : " << std::hex << mDigitMCMHeader->word;
-            } else {
-              LOG(info) << "Sanity check passed for digitmcmheader";
-              printDigitMCMHeader(*mDigitMCMHeader);
-            }
-          }
-          mBufferLocation++;
-          //new header so digit word count becomes zero
-          digitwordcount = 0;
-          mState = StateDigitMCMData;
-          mMCM = mDigitMCMHeader->mcm;
-          mROB = mDigitMCMHeader->rob;
-          //cru /2 = supermodule
-          //link channel == readoutboard as per guido doc.
-          int layer = mDigitHCHeader->layer;
-          int stack = mDigitHCHeader->stack;
-          int sector = mDigitHCHeader->supermodule;
-          mDetector = layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK;
-          //TODO check that his matches up with the CRU Link info
-          //TOOD does it match the feeid which ncodes this information as well.
-          //
-          mEventCounter = mDigitMCMHeader->eventcount;
-          mDataWordsParsed++; // header
-          if (mDigitHCHeader->major & 0x20) {
-            //zero suppressed digits
-            mDataWordsParsed++; // adc mask
-          }
-          mChannel = 0;
-          mADCValues.fill(0);
-          digittimebinoffset = 0;
-          if (!mReturnVector) {
-            //returning the raw "compressed" data stream.
-            //build the digit header and add to outgoing buffer;
-            uint32_t* header = &(*mData)[mReturnVectorPos];
-            //build header.
-          }
-          // we dont care about the year flag, we are >2007 already.
         } else {
-          //LOG(info) << "state not digitmcmheader so checking for other";
-          if (*word == o2::trd::constants::CRUPADDING32) {
-            if (mVerbose) {
-              LOG(info) << "state padding and word : 0x" << std::hex << *word << "  state is:" << mState;
+          LOG(info) << "NOT zero suppressed";
+        }
+
+        //sanity check of digitheader ??  Still to implement.
+        if (mHeaderVerbose) {
+          std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator tmpword;
+
+          if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
+            LOG(warn) << "Sanity check Failure Digit MCMHeader : " << std::hex << mDigitMCMHeader->word;
+          } else {
+            LOG(info) << "Sanity check passed for digitmcmheader";
+            printDigitMCMHeader(*mDigitMCMHeader);
+          }
+        }
+        mBufferLocation++;
+        //new header so digit word count becomes zero
+        digitwordcount = 0;
+        mState = StateDigitMCMData;
+        if (mHeaderVerbose) {
+          LOG(info) << "state set to MCMData " << __LINE__;
+        }
+        mMCM = mDigitMCMHeader->mcm;
+        mROB = mDigitMCMHeader->rob;
+        //cru /2 = supermodule
+        //link channel == readoutboard as per guido doc.
+        int layer = mDigitHCHeader->layer;
+        int stack = mDigitHCHeader->stack;
+        int sector = mDigitHCHeader->supermodule;
+        mDetector = layer + stack * constants::NLAYER + sector * constants::NLAYER * constants::NSTACK;
+        //TODO check that his matches up with the CRU Link info
+        //TOOD does it match the feeid which ncodes this information as well.
+        //
+        mEventCounter = mDigitMCMHeader->eventcount;
+        mDataWordsParsed++; // header
+        if (mDigitHCHeader->major & 0x20) {
+          //zero suppressed digits
+          mDataWordsParsed++; // adc mask
+        }
+        mChannel = 0;
+        mADCValues.fill(0);
+        digittimebinoffset = 0;
+        if (!mReturnVector) {
+          //returning the raw "compressed" data stream.
+          //build the digit header and add to outgoing buffer;
+          uint32_t* header = &(*mData)[mReturnVectorPos];
+          //build header.
+        }
+        // we dont care about the year flag, we are >2007 already.
+      } else {
+        if (mState == StateDigitMCMHeader) {
+          unsigned int lastbit = (*word) & 0xf;
+          LOG(info) << " we bypassed the mcmheader block but the state is MCMHeader ... 0x" << std::hex << *word << " " << lastbit << " should == 0xc";
+        }
+        if (*word == o2::trd::constants::CRUPADDING32) {
+          if (mVerbose) {
+            LOG(info) << "state padding and word : 0x" << std::hex << *word << "  state is:" << mState;
+          }
+          //another pointer with padding.
+          mBufferLocation++;
+          mPaddingWordsCounter++;
+          mState = StatePadding;
+          if (mHeaderVerbose) {
+            LOG(info) << "state set to Paddings " << __LINE__ << " data still to read is : " << std::distance(word, mEndParse);
+            for (int n = 0; n < std::distance(word, mEndParse) + 4; ++n) {
+              LOG(info) << "word " << n << " 0x" << *(std::next(word, n));
+              if (n == std::distance(word, mEndParse))
+                LOG(info) << "parsing should have ended here";
             }
-            //another pointer with padding.
-            mBufferLocation++;
-            mPaddingWordsCounter++;
-            mState = StatePadding;
+          }
+          // mDataWordsParsed++;
+          mDataWordsParsed += std::distance(word, mEndParse);
+          //dump the rest of the received buffer its the rdh with e's
+          word = mEndParse;
+          mcmdatacount = 0;
+          // this is supposed to carry on till the end of the buffer, hence the term padding.
+          //TRDStatCounters.LinkPadWordCounts[mHCID]++; // keep track off all the padding words.
+        } else { // all we are left with is digitmcmdata words.
+          if (mState == StateDigitEndMarker) {
+
+            if (mDataVerbose) {
+              LOG(info) << "**DigitEndMarker State : " << std::hex << *word;
+              LOG(info) << " digit end marker state ...";
+              //we are at the end
+              // do nothing.
+            }
+          } else {
+            //for the case of on flp build a vector of tracklets, then pack them into a data stream with a header.
+            //for dpl build a vector and connect it with a triggerrecord.
+            if (mDataVerbose) {
+              LOG(info) << "**Digit word : " << std::hex << *word;
+            }
             mDataWordsParsed++;
-            mcmdatacount = 0;
+            mcmdatacount++;
+            mDigitMCMData = (DigitMCMData*)word;
+            mBufferLocation++;
+            mState = StateDigitMCMData;
+            if (mHeaderVerbose) {
+              LOG(info) << "state set to DigitMCMData " << __LINE__;
+            }
+            digitwordcount++;
+            if (mVerbose || mDataVerbose) {
+              LOG(info) << "adc values : raw 0x:" << std::hex << *word << std::dec << mDigitMCMData->x << "::" << mDigitMCMData->y << "::" << mDigitMCMData->z << " mask:0x" << std::hex << mADCMask;
+              LOG(info) << "digittimebinoffset = " << digittimebinoffset;
+            }
+            mADCValues[digittimebinoffset++] = mDigitMCMData->x;
+            mADCValues[digittimebinoffset++] = mDigitMCMData->y;
+            mADCValues[digittimebinoffset++] = mDigitMCMData->z;
 
-            // this is supposed to carry on till the end of the buffer, hence the term padding.
-            //TRDStatCounters.LinkPadWordCounts[mHCID]++; // keep track off all the padding words.
-          } else { // all we are left with is digitmcmdata words.
-            if (mState == StateDigitEndMarker) {
-
+            if (digittimebinoffset > constants::TIMEBINS) {
+              LOG(fatal) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
+            }
+            if (mVerbose || mDataVerbose) {
+              LOG(info) << "digit word count is : " << digitwordcount << " digittimebinoffset = " << digittimebinoffset;
+            }
+            if (digitwordcount == constants::TIMEBINS / 3) {
+              //sanity check, next word shouldbe either a. end of digit marker, digitMCMHeader,or padding.
+              mcmadccount++;
+              //write out adc value to vector
+              //zero digittimebinoffset
+              if (mDigitHCHeader->major & 0x20) {
+                //zero suppressed, so channel must be extracted from next available bit in adcmask
+                mChannel = nextmcmadc(mADCMask, mChannel);
+                if (mChannel == 21) {
+                  LOG(warn) << "ADCMask is zero but we seem to have a digit";
+                }
+                if (mDataVerbose) {
+                  LOG(info) << "after mask check adcmask: 0x" << std::hex << mADCMask << " and channel : " << std::dec << mChannel;
+                  LOG(info) << "the above is the preceding digit above us not the one below us ";
+                  LOG(info) << "proceeding data after the mask as been zeroed and therefore end of this digit";
+                  for (int z = 0; z < 16; ++z) {
+                    auto nextadcword = std::next(word, z + 1);
+                    uint32_t adcword = *nextadcword;
+                    swapByteOrder(adcword);
+                    LOG(info) << "??ADCraw: z:" << z << " byteswapped raw " << std::hex << adcword << " raw : 0x" << *nextadcword;
+                  }
+                  LOG(info) << "RAW ADC end of mask output";
+                }
+                if (mChannel == 22) {
+                  LOG(error) << "invalid bitpattern for this mcm 0x" << std::hex << mADCMask;
+                  LOG(info) << "EEE " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << " :";
+                }
+                if (mADCMask == 0) {
+                  //no more adc for zero suppression.
+                  //now we should either have another MCMHeader, or End marker
+                  if (*word != 0 && *(std::next(word)) != 0) { // end marker is a sequence of 32 bit 2 zeros.
+                    if (mHeaderVerbose) {
+                      LOG(info) << "Mask zero so changing state to StateDigitMCMHeader to read an MCMHeader on the next pass next 2 words are not digit end marker of zero 0x" << *word << " " << *(std::next(word));
+                    }
+                    mState = StateDigitMCMHeader;
+                  } else {
+                    if (mHeaderVerbose) {
+                      LOG(info) << "Mask zero so changing state to StateDigitEndMarker as next 2 words are digit end marker of zero 0x" << *word << " " << *(std::next(word));
+                    }
+                    mState = StateDigitEndMarker;
+                  }
+                }
+              }
+              mDigits.emplace_back(mDetector, mROB, mMCM, mChannel, mADCValues); // outgoing parsed digits
               if (mDataVerbose) {
-                LOG(info) << "**DigitEndMarker State : " << std::hex << *word;
-                LOG(info) << " digit end marker state ...";
-                //we are at the end
-                // do nothing.
-              }
-            } else {
-              //for the case of on flp build a vector of tracklets, then pack them into a data stream with a header.
-              //for dpl build a vector and connect it with a triggerrecord.
-              if(mDataVerbose){
-                LOG(info) << "**Digit word : " << std::hex << *word;
-              }
-              mDataWordsParsed++;
-              mcmdatacount++;
-              mDigitMCMData = (DigitMCMData*)word;
-              mBufferLocation++;
-              mState = StateDigitMCMData;
-              digitwordcount++;
-              if (mVerbose || mDataVerbose) {
-                LOG(info) << "adc values : raw 0x:" << std::hex << *word << std::dec << mDigitMCMData->x << "::" << mDigitMCMData->y << "::" << mDigitMCMData->z << " mask:0x" << std::hex << mADCMask;
-                LOG(info) << "digittimebinoffset = " << digittimebinoffset;
-              }
-              mADCValues[digittimebinoffset++] = mDigitMCMData->x;
-              mADCValues[digittimebinoffset++] = mDigitMCMData->y;
-              mADCValues[digittimebinoffset++] = mDigitMCMData->z;
-
-              if (digittimebinoffset > constants::TIMEBINS) {
-                LOG(fatal) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
-              }
-              if (mVerbose || mDataVerbose) {
-                LOG(info) << "digit word count is : " << digitwordcount << " digittimebinoffset = " << digittimebinoffset;
-              }
-              if (digitwordcount == constants::TIMEBINS / 3) {
-                //sanity check, next word shouldbe either a. end of digit marker, digitMCMHeader,or padding.
-                mcmadccount++;
-                //write out adc value to vector
-                //zero digittimebinoffset
-                if (mDigitHCHeader->major & 0x20) {
-                  //zero suppressed, so channel must be extracted from next available bit in adcmask
-                  mChannel = nextmcmadc(mADCMask, mChannel);
-                  if(mChannel==21){
-                    LOG(warn)<< "ADCMask is zero but we seem to have a digit";
-                  }
-                  if (mDataVerbose) {
-                    LOG(info) << "after mask check adcmask: 0x" << std::hex << mADCMask << " and channel : " << std::dec << mChannel;
-                    LOG(info) << "the above is the preceding digit above us not the one below us ";
-                  }
-                  if (mChannel == 22) {
-                    LOG(error) << "invalid bitpattern for this mcm 0x"<< std::hex << mADCMask;
-                    LOG(info) << "EEE " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << " :" ;
-                    for(auto adc : mADCValues ){
-                      std::cout << adc << ":" ;
-                    }
-                    std::cout << std::endl;
-                  }
-                  if (mADCMask == 0) {
-                    LOG(info) << "mADCMask is now zero ";
-                    //no more adc for zero suppression.
-                    //now we should either have another MCMHeader, or End marker
-                    if (*word != 0 && *(std::next(word)) != 0) { // end marker is a sequence of 32 bit 2 zeros.
-                             LOG(info)<< "Mask zero so changing state to StateDigitMCMHeader to read an MCMHeader on the next pass next 2 words are not digit end marker of zero";
-                      mState = StateDigitMCMHeader;
-                    } else {
-                            LOG(info)<< "Mask zero so changing state to StateDigitEndHeader as next 2 words are digit end marker of zero 0x"<< *word << " " << *(std::next(word));
-                      mState = StateDigitEndMarker;
-                    }
-                  }
+                //    CompressedDigit t = mDigits.back();
+                //now fill in the adc values --- here because in commented code above if all 3 increments were there then it froze
+                uint32_t adcsum = 0;
+                for (auto adc : mADCValues) {
+                  adcsum += adc;
                 }
-                mDigits.emplace_back(mDetector, mROB, mMCM, mChannel, mADCValues); // outgoing parsed digits
-                if(mDataVerbose){
-                  //    CompressedDigit t = mDigits.back();
-                  //now fill in the adc values --- here because in commented code above if all 3 increments were there then it froze
-                  uint32_t adcsum = 0;
-                  for (auto adc : mADCValues) {
-                    adcsum += adc;
-                  }
-                  LOG(info) << "DDDD #" << mDigitsFound << " det:rob:mcm:channel:adcsum ... "<< mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << ":" << adcsum << ":" << mADCValues[0] << ":" << mADCValues[1] << ":" << mADCValues[2] << "::" << mADCValues[27] << ":" << mADCValues[28] << ":" << mADCValues[29] ;
-                }
-                mDigitsFound++;
-                digittimebinoffset = 0;
-                digitwordcount = 0; // end of the digit.
-                if (mDigitHCHeader->major == 5) {
-                  mChannel++; // we count channels as all 21 channels are present, no way to check this.
-                }
-              }// digitwordcount ==z timebins/3
-            }//else digitendmarker if statement
-          }// else of if crupadding word
-        }// else of if digitMCMheader
-    }// else of if digitendmarker
+                LOG(info) << "DDDD #" << mDigitsFound << " det:rob:mcm:channel:adcsum ... " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << ":" << adcsum << ":" << mADCValues[0] << ":" << mADCValues[1] << ":" << mADCValues[2] << "::" << mADCValues[27] << ":" << mADCValues[28] << ":" << mADCValues[29];
+              }
+              mDigitsFound++;
+              digittimebinoffset = 0;
+              digitwordcount = 0; // end of the digit.
+              if (mDigitHCHeader->major == 5) {
+                mChannel++; // we count channels as all 21 channels are present, no way to check this.
+              }
+            } // digitwordcount ==z timebins/3
+          }   //else digitendmarker if statement
+        }     // else of if crupadding word
+      }       // else of if digitMCMheader
+    }         // else of if digitendmarker
     //accounting
     // mCurrentLinkDataPosition256++;
     // mCurrentHalfCRUDataPosition256++;
     // mTotalHalfCRUDataLength++;
     //end of data so
-  }// for loop over word
+  } // for loop over word
   if (mVerbose) {
     LOG(info) << "***** parsing loop finished for this link";
   }

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -51,30 +51,37 @@ int DigitsParser::Parse(bool verbose)
 
   mState = StateDigitMCMHeader;
   mDataWordsParsed = 0; // count of data wordsin data that have been parsed in current call to parse.
+  mWordsDumped = 0;
   mDigitsFound = 0;     // tracklets found in the data block, mostly used for debugging.
   mBufferLocation = 0;
-  mPaddingWordsCounter = 0; 
-  int bitsinmask=0;
-  int overchannelcount=0;
-  if(mHeaderVerbose){
-    LOG(info)<< "Data buffer to parse for Digits begin " << mStartParse <<":"<< mEndParse;
-    int wordcount=0;
+  mPaddingWordsCounter = 0;
+  int bitsinmask = 0;
+  int overchannelcount = 0;
+  int lastmcmread = 0;
+  int lastrobread = 0;
+  int lasteventcounterread = 0;
+  if (mHeaderVerbose) {
+    LOG(info) << "Data buffer to parse for Digits begin " << mStartParse << ":" << mEndParse;
+    int wordcount = 0;
     std::stringstream outputstring;
-    auto word=mStartParse;
-    outputstring<< "digit 0x"<< std::hex << std::setfill('0') << std::setw(6) << 0 << " :: ";
-    while(word <= mEndParse) { // loop over the entire data buffer (a complete link of tracklets and digits)
+    auto word = mStartParse;
+    outputstring << "digit 0x" << std::hex << std::setfill('0') << std::setw(6) << 0 << " :: ";
+    while (word <= mEndParse) { // loop over the entire data buffer (a complete link of tracklets and digits)
 
-        if(wordcount!=0 && (wordcount %8 ==0 || word == mEndParse)){
-          LOG(info) << outputstring.str();
-          outputstring.str("");
-          outputstring<< "digit 0x"<< std::hex << std::setfill('0') << std::setw(6) << wordcount << " :: ";
-        }
-        if(wordcount==0)outputstring << " 0x"<< std::hex << std::setfill('0')<< std::setw(8) <<  HelperMethods::swapByteOrderreturn(*word); 
-        else outputstring << " 0x"<< std::hex << std::setfill('0')<< std::setw(8) <<  HelperMethods::swapByteOrderreturn(*word); 
-        word++;wordcount++;
+      if (wordcount != 0 && (wordcount % 8 == 0 || word == mEndParse)) {
+        LOG(info) << outputstring.str();
+        outputstring.str("");
+        outputstring << "digit 0x" << std::hex << std::setfill('0') << std::setw(6) << wordcount << " :: ";
+      }
+      if (wordcount == 0) {
+        outputstring << " 0x" << std::hex << std::setfill('0') << std::setw(8) << HelperMethods::swapByteOrderreturn(*word);
+      } else {
+        outputstring << " 0x" << std::hex << std::setfill('0') << std::setw(8) << HelperMethods::swapByteOrderreturn(*word);
+      }
+      word++;
+      wordcount++;
     }
-    LOG(info)<< "Data buffer to parse for Digits end";
-
+    LOG(info) << "Data buffer to parse for Digits end";
   }
   if (mVerbose) {
     LOG(info) << "Digit Parser parse of data sitting at :" << std::hex << (void*)mData << " starting at pos " << mStartParse;
@@ -106,14 +113,12 @@ int DigitsParser::Parse(bool verbose)
     }
   }
   int mcmdatacount = 0;
-  int mcmadccount = 0;
-  int digitwordcount = 9;
   int digittimebinoffset = 0;
   //mData holds a buffer containing digits parse placing the read digits where they need to be
   // due to the nature of the incoming data, there will *never* straggling digits or for that matter trap outputs spanning a boundary.
   // data starts with a DigitHCHeader, so pull that off first to simplify looping
 
-  for (auto& word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of digits)
+  for (auto word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of digits)
     auto looptime = std::chrono::high_resolution_clock::now() - timedigitparsestart;
     //loop over all the words
     if (mDataVerbose || mVerbose) {
@@ -128,7 +133,7 @@ int DigitsParser::Parse(bool verbose)
     if ((*word) == 0x0 && (*nextword == 0x0)) { // no need to byte swap nextword
       // end of digits marker.
       if (mHeaderVerbose) {
-        LOG(info) << "*** DigitEndMarker :0x" << std::hex << *word << "::0x" << *nextword << " at offset "<<std::distance(mStartParse,word);
+        LOG(info) << "*** DigitEndMarker :0x" << std::hex << *word << "::0x" << *nextword << " at offset " << std::distance(mStartParse, word);
       }
       //state *should* be StateDigitMCMData check that it is
       if (mState == StateDigitMCMData || mState == StateDigitEndMarker || mState == StateDigitHCHeader || mState == StateDigitMCMHeader) {
@@ -142,29 +147,69 @@ int DigitsParser::Parse(bool verbose)
       mDataWordsParsed += 2;
       mState = StateDigitEndMarker;
     } else {
-      if (mHeaderVerbose) {
-        LOG(info) << " *** now to check for mDigitMCMHeader with a value " << std::hex << *word << " at offset "<<std::distance(mStartParse,word);
-      }
-      if ((*word & 0xf) == 0xc && mState == StateDigitMCMHeader) { //marker for DigitMCMHeader.
-        if (mHeaderVerbose) {
-          LOG(info) << " *** mDigitMCMHeader " << std::hex << *word << " at offset "<<std::distance(mStartParse,word);;
-          DigitMCMHeader headerword;
-          headerword.word = *word;
-          printDigitMCMHeader(headerword);
-        }
+      if ((*word & 0xf) == 0xc && (mState == StateDigitMCMHeader || mState == StateDigitMCMData)) { //marker for DigitMCMHeader.
         //read the header OR padding of 0xeeee;
         //we actually have an header word.
-        mcmadccount = 0;
         mcmdatacount = 0;
-        mChannel = 0;
+        mCurrentADCChannel = 0;
         mDigitMCMHeader = (DigitMCMHeader*)(word);
         if (mHeaderVerbose) {
-          LOG(info) << "state mcmheader and word : 0x" << std::hex << *word << " at offset "<<std::distance(mStartParse,word);;
+          LOG(info) << "***DigitMCMHeader 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
           printDigitMCMHeader(*mDigitMCMHeader);
         }
-        if (mHeaderVerbose) {
-          LOG(info) << "mDigitHCHeader format definition:0x" << mDigitHCHeader.major << "." << mDigitHCHeader.minor << " at offset "<<std::distance(mStartParse,word);
+        //checkDigitMCMHeader(mDigitMCMHeader,lastmcmreader,lastrobread,lastevencounterread):
+        if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
+          LOG(warn) << "***DigitMCMHeader Sanity Check Failure 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
+          printDigitMCMHeader(*mDigitMCMHeader);
+          if (mDumpUnknownData) {
+            // we dump the remainig data pending better options.
+            // we can try a 16 bit bitshift...
+            mWordsDumped = std::distance(mStartParse, word);
+            LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
+            tryFindMCMHeaderAndDisplay(word);
+            word = mEndParse;
+          }
         }
+        // now check mcm/rob are read in correct order
+        if (mDigitMCMHeader->rob > lastrobread) {
+          lastmcmread = 0;
+        } else {
+          if (mDigitMCMHeader->rob < lastrobread) {
+            LOG(warn) << "**DigitMCMHeader ROB number is not increasing was:" << lastrobread << " now:" << mDigitMCMHeader->rob << " 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
+            printDigitMCMHeader(*mDigitMCMHeader);
+            if (mDumpUnknownData) {
+              // we dump the remainig data pending better options.
+              // we can try a 16 bit bitshift...
+              LOG(error) << " dump?";
+              mWordsDumped = std::distance(mStartParse, word);
+              LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
+              tryFindMCMHeaderAndDisplay(word);
+              word = mEndParse;
+            }
+          }
+          //the case of rob not changing we ignore, error condition handled by mcm # increasing.
+        }
+        if (mDigitMCMHeader->mcm < lastmcmread && mDigitMCMHeader->rob == lastrobread) {
+          LOG(warn) << "**DigitMCMHeader MCM number is not increasing 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
+          printDigitMCMHeader(*mDigitMCMHeader);
+          tryFindMCMHeaderAndDisplay(word);
+          if (mDumpUnknownData) {
+            // we dump the remainig data pending better options.
+            // we can try a 16 bit bitshift...
+            LOG(error) << " dump?";
+          }
+        }
+        /*      if(mDigitMCMHeader->eventcount-lasteventcounterread < constants::MAXEVENTCOUNTERSEPERATION){   disable for now until a sane value
+                if(mHeaderVerbose){
+                LOG(info) << "***DigitMCMHeader acceptable event gap of :"<< mDigitMCMHeader->eventcount - lasteventcounterread;
+                }
+                }
+                else{
+                LOG(info) << "***DigitMCMHeader eventcounter seperation too great needs to be < "<< constants::MAXEVENTCOUNTERSEPERATION << ":"<< mDigitMCMHeader->eventcount - lasteventcounterread << " now:"<< mDigitMCMHeader->eventcount << " last:"<<lasteventcounterread;
+                }*/
+        lastmcmread = mDigitMCMHeader->mcm;
+        lastrobread = mDigitMCMHeader->rob;
+        lasteventcounterread = mDigitMCMHeader->eventcount;
         if (mDigitHCHeader.major & 0x20) {
           //zero suppressed
           //so we have an adcmask next
@@ -176,7 +221,7 @@ int DigitsParser::Parse(bool verbose)
           mDigitMCMADCMask = (DigitMCMADCMask*)(word);
           mADCMask = mDigitMCMADCMask->adcmask;
           if (mHeaderVerbose) {
-            LOG(info) << "**DigitADCMask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word << " at offset "<<std::distance(mStartParse,word);;
+            LOG(info) << "**DigitADCMask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word << " at offset " << std::distance(mStartParse, word);
           }
           //TODO check for end of loop?
           if (word == mEndParse) {
@@ -184,39 +229,20 @@ int DigitsParser::Parse(bool verbose)
           }
           std::bitset<21> adcmask(mADCMask);
           bitsinmask = adcmask.count();
-          overchannelcount=0;
-          //output all the adc data for the described adc mask, i.e 10 32 bit words per bit in mask./
-          if (mDataVerbose) {
-            LOG(info) << "RAW ADC DUMP start ";
-            LOG(info) << " channel account as per bp:" << std::hex << mADCMask << " has count of :" << std::dec << bitsinmask << "   ADCMask values ; mask: 0x:" << std::hex << mADCMask << " n c n fullword 0x" << std::hex << mDigitMCMADCMask->n << " " << std::dec << ~(mDigitMCMADCMask->c) << " 0x" << std::hex << mDigitMCMADCMask->j << " full:0x" << *word;
-            int z;
-            if (bitsinmask != ~(mDigitMCMADCMask->c)) {
-              LOG(warn) << " bitsinmask mismatch with adcmask->c";
-            } else {
-              LOG(info) << "bitmask matches adcmask->c";
-            }
-            for (z = 0; z < bitsinmask * 10; ++z) {
-              if (z % 10 == 0 && z != 0)
-                LOG(info) << "gap";
-              auto nextadcword = std::next(word, z + 1);
-              uint32_t adcword = *nextadcword;
-              swapByteOrder(adcword);
-              LOG(info) << "ADCraw: z:" << z << " byteswapped " << std::hex << adcword << " raw : 0x" << *nextadcword;
-            }
-            LOG(info) << "next 8 words for clarity";
-            int offset = z;
-            for (z = offset; z < offset + 8; ++z) {
-              auto nextadcword = std::next(word, z + 1);
-              uint32_t adcword = *nextadcword;
-              swapByteOrder(adcword);
-              LOG(info) << "??ADCraw: z:" << z << " bswapped " << std::hex << adcword << " raw : 0x" << *nextadcword;
-            }
-            LOG(info) << "RAW ADC DUMP end";
+          //check ADCMask:
+          if (!digitMCMADCMaskSanityCheck(*mDigitMCMADCMask, bitsinmask)) {
+            LOG(info) << "**DigitADCMask SANITY CHECK FAILURE " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word << " at offset " << std::distance(mStartParse, word);
+            mWordsDumped = std::distance(mStartParse, word);
+            LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
+            tryFindMCMHeaderAndDisplay(word);
+            word = mEndParse;
           }
+          overchannelcount = 0;
+          //output all the adc data for the described adc mask, i.e 10 32 bit words per bit in mask./
         }
         mBufferLocation++;
         //new header so digit word count becomes zero
-        digitwordcount = 0;
+        mDigitWordCount = 0;
         mState = StateDigitMCMData;
         mMCM = mDigitMCMHeader->mcm;
         mROB = mDigitMCMHeader->rob;
@@ -235,7 +261,7 @@ int DigitsParser::Parse(bool verbose)
           //zero suppressed digits
           mDataWordsParsed++; // adc mask
         }
-        mChannel = 0;
+        mCurrentADCChannel = 0;
         mADCValues.fill(0);
         digittimebinoffset = 0;
         if (!mReturnVector) {
@@ -269,7 +295,7 @@ int DigitsParser::Parse(bool verbose)
           if (mState == StateDigitEndMarker) {
 
             if (mHeaderVerbose) {
-              LOG(info) << "***DigitEndMarker State : " << std::hex << *word << " at offset "<<std::distance(mStartParse,word);;
+              LOG(info) << "***DigitEndMarker State : " << std::hex << *word << " at offset " << std::distance(mStartParse, word);
               //we are at the end
               // do nothing.
             }
@@ -277,44 +303,21 @@ int DigitsParser::Parse(bool verbose)
             //for the case of on flp build a vector of tracklets, then pack them into a data stream with a header.
             //for dpl build a vector and connect it with a triggerrecord.
             if (mHeaderVerbose) {
-              LOG(info) << "***DigitMCMword : " << std::hex << *word << " at offset "<<std::distance(mStartParse,word);;
+              LOG(info) << "***DigitMCMWord : " << std::hex << *word << " channel:" << std::dec << mCurrentADCChannel << " wordcount:" << mDigitWordCount << " at offset " << std::hex << std::distance(mStartParse, word);
             }
-            mDataWordsParsed++;
-            mcmdatacount++;
-            mDigitMCMData = (DigitMCMData*)word;
-            mBufferLocation++;
-            mState = StateDigitMCMData;
-            digitwordcount++;
-            if (mDataVerbose) {
-              LOG(info) << "adc values : raw 0x:" << std::hex << *word << std::dec << mDigitMCMData->x << "::" << mDigitMCMData->y << "::" << mDigitMCMData->z << " mask:0x" << std::hex << mADCMask << " at offset "<<std::distance(mStartParse,word);;;
-              LOG(info) << "digittimebinoffset = " << digittimebinoffset;
-            }
-            mADCValues[digittimebinoffset++] = mDigitMCMData->x;
-            mADCValues[digittimebinoffset++] = mDigitMCMData->y;
-            mADCValues[digittimebinoffset++] = mDigitMCMData->z;
-
-            if (digittimebinoffset > constants::TIMEBINS) {
-              LOG(fatal) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
-            }
-            if (mVerbose || mDataVerbose) {
-              LOG(info) << "digit word count is : " << digitwordcount << " digittimebinoffset = " << digittimebinoffset;
-            }
-            if (digitwordcount == constants::TIMEBINS / 3) {
-              //sanity check, next word shouldbe either a. end of digit marker, digitMCMHeader,or padding.
-              mcmadccount++;
-              //write out adc value to vector
-              //zero digittimebinoffset
-              if (mDigitHCHeader.major & 0x20) {
+            if (mDigitWordCount == 0 || mDigitWordCount == constants::TIMEBINS / 3) {
+              //new adc expected so set channel accord to bitpattern or sequential depending on zero suppressed or not.
+              if (mDigitHCHeader.major & 0x20) { // zero suppressed
                 //zero suppressed, so channel must be extracted from next available bit in adcmask
-                mChannel = nextmcmadc(mADCMask, mChannel);
-                if (mChannel == 21) {
+                mCurrentADCChannel = nextmcmadc(mADCMask, mCurrentADCChannel);
+                if (mCurrentADCChannel == 21) {
                   LOG(warn) << "ADCMask is zero but we seem to have a digit";
                 }
-                if (mChannel == 22) {
-                  LOG(error) << "invalid bitpattern for this mcm 0x" << std::hex << mADCMask << " at offset "<<std::distance(mStartParse,word);;;
-                  mChannel=100*bitsinmask+overchannelcount++;
-                  LOG(info) << "EEE " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel
-                            << " supermodule:stack:layer:side : "<< mDigitHCHeader.supermodule << ":"<< mDigitHCHeader.stack << ":"<< mDigitHCHeader.layer <<":"<< mDigitHCHeader.side;
+                if (mCurrentADCChannel > 22) {
+                  LOG(error) << "invalid bitpattern (read a zero) for this mcm 0x" << std::hex << mADCMask << " at offset " << std::distance(mStartParse, word);
+                  mCurrentADCChannel = 100 * bitsinmask + overchannelcount++;
+                  LOG(info) << "EEE " << mDetector << ":" << mROB << ":" << mMCM << ":" << mCurrentADCChannel
+                            << " supermodule:stack:layer:side : " << mDigitHCHeader.supermodule << ":" << mDigitHCHeader.stack << ":" << mDigitHCHeader.layer << ":" << mDigitHCHeader.side;
                 }
                 if (mADCMask == 0) {
                   //no more adc for zero suppression.
@@ -331,24 +334,57 @@ int DigitsParser::Parse(bool verbose)
                     mState = StateDigitEndMarker;
                   }
                 }
+              } else { // non zero suppressed to simply increment to the next expected channel
+                mCurrentADCChannel++;
               }
-              mDigits.emplace_back(mDetector, mROB, mMCM, mChannel, mADCValues); // outgoing parsed digits
-              if (mDataVerbose) {
-                //    CompressedDigit t = mDigits.back();
-                //now fill in the adc values --- here because in commented code above if all 3 increments were there then it froze
-                uint32_t adcsum = 0;
-                for (auto adc : mADCValues) {
-                  adcsum += adc;
-                }
-                LOG(info) << "DDDD #" << mDigitsFound << " det:rob:mcm:channel:adcsum ... " << mDetector << ":" << mROB << ":" << mMCM << ":" << mChannel << ":" << adcsum << ":" << mADCValues[0] << ":" << mADCValues[1] << ":" << mADCValues[2] << "::" << mADCValues[27] << ":" << mADCValues[28] << ":" << mADCValues[29] << " at offset "<<std::distance(mStartParse,word);;;
-              }
+            }
+            if (mDigitWordCount > constants::TIMEBINS / 3) {
+              LOG(error) << "***DigitMCMData with more than 10 adc's! currently on 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
+              //bale out or not? TODO definitely bale out.
+            }
+            mDigitMCMData = (DigitMCMData*)word;
+            mBufferLocation++;
+            mDataWordsParsed++;
+            mcmdatacount++;
+            // digit sanity check
+            if (!digitMCMWordSanityCheck(mDigitMCMData, mCurrentADCChannel)) {
+              LOG(error) << "***DigitMCMword : " << std::hex << *word << " has invalid last 2 lsb of 0x"
+                         << std::hex << mDigitMCMData->c << ((mCurrentADCChannel % 2) ? " even should have 0x3" : " odd shoul d have 0x10 for an") << "  for channel of :"
+                         << std::dec << mCurrentADCChannel << std::hex << " at offset "
+                         << std::distance(mStartParse, word);
+              // to bale or not to bale?
+              mWordsDumped = std::distance(mStartParse, word);
+              LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
+              tryFindMCMHeaderAndDisplay(word);
+              word = mEndParse;
+            }
+            mState = StateDigitMCMData;
+            mDigitWordCount++;
+            mADCValues[digittimebinoffset++] = mDigitMCMData->x;
+            mADCValues[digittimebinoffset++] = mDigitMCMData->y;
+            mADCValues[digittimebinoffset++] = mDigitMCMData->z;
+
+            if (digittimebinoffset > constants::TIMEBINS) {
+              LOG(error) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
+              //bale out TODO
+              mWordsDumped = std::distance(mStartParse, word);
+              LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
+              word = mEndParse;
+            }
+            if (mVerbose || mDataVerbose) {
+              LOG(info) << "digit word count is : " << mDigitWordCount << " digittimebinoffset = " << digittimebinoffset;
+            }
+            if (mDigitWordCount == constants::TIMEBINS / 3) {
+              //write out adc value to vector
+              //zero digittimebinoffset
+              mDigits.emplace_back(mDetector, mROB, mMCM, mCurrentADCChannel, mADCValues); // outgoing parsed digits
               mDigitsFound++;
               digittimebinoffset = 0;
-              digitwordcount = 0; // end of the digit.
-              if (mDigitHCHeader.major & 0x10) {
-                mChannel++; // we count channels as all 21 channels are present, no way to check this.
+              mDigitWordCount = 0; // end of the digit.
+              if (mDigitHCHeader.major & 0x3) {
+                mCurrentADCChannel++; // we count channels as all 21 channels are present, no way to check this.
               }
-            } // digitwordcount == timebins/3
+            } // mDigitWordCount == timebins/3
           }   //else digitendmarker if statement
         }     // else of if crupadding word
       }       // else of if digitMCMheader
@@ -365,7 +401,35 @@ int DigitsParser::Parse(bool verbose)
   if (!(mState == StateDigitMCMHeader || mState == StatePadding || mState == StateDigitEndMarker)) {
     LOG(warn) << "Exiting parsing but the state is wrong ... mState= " << mState;
   }
+  if (std::distance(mStartParse, mEndParse) != mDataWordsParsed) {
+    LOG(info) << " we rejected " << mWordsDumped << " word and parse " << mDataWordsParsed << " % loss rate of " << (double)mWordsDumped / (double)mDataWordsParsed * 100.0;
+  }
   return mDataWordsParsed;
+}
+
+void DigitsParser::tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator word)
+{
+  // given something has gone wrong, assume its a 16 bit shift and see if we can find a valid mcmheader,
+  // note the mcm and rob and output to log
+  // merely for debugging to see if we can find a pattern in where the 16 bit shifts/losses occur.
+  // maybe more recoverly logic later.
+  uint32_t current = *word;
+  uint32_t next = *(std::next(word, 1));
+  uint32_t previous = *(std::prev(word, 1));
+  DigitMCMHeader firstguess; // 16 bits somewhere before the mcmheader got dropped, manifesting as directly before.
+  DigitMCMHeader secondguess;
+  DigitMCMHeader thirdguess;
+  //first  last 16 bits of previous and first 16 bits of current
+  uint32_t a = previous & 0xffff << 16;
+  uint32_t b = current & 0xffff;
+  firstguess.word = a + b;
+  if (digitMCMHeaderSanityCheck(&firstguess)) {
+    //sanity check passed to prossibly correct.
+    LOG(warn) << "***DigitMCMHeader GUESS ??? to follow";
+    printDigitMCMHeader(firstguess);
+  } else {
+    LOG(warn) << "***DigitMCMHeader GUESS failed " << std::hex << firstguess.word << " words were 0x" << previous << " 0x" << current << " 0x" << next;
+  }
 }
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -108,11 +108,11 @@ int TrackletsParser::Parse()
 
     // a hack to clean the data bit.
     // sometimes we get some erroneos digit data at the beginning to find *either* the first trackletMCMHeader or the end of trackletmarker or the end of digit marker or padding words.
-    if (word == mStartParse) {
+    /* if (word == mStartParse) { // this is a terrible idea, but leaving here for now
       //we are at the start
       //
       int countadvance = 0;
-      LOG(info) << "Tracklet parsing skipping over 0x" << std::hex << *word;
+//      LOG(info) << "Tracklet parsing skipping over 0x" << std::hex << *word;
       while (word != mEndParse) {
         uint32_t bsword = *word;
         swapByteOrder(bsword);
@@ -128,7 +128,7 @@ int TrackletsParser::Parse()
       if (word == mEndParse) {
         LOG(warn) << " something odd is going on, we skipped over the entire buffer trying to find a trackletmcmheader, trackletendmarker, digitendmarker, or paddingword";
       }
-    }
+    }*/
     if (mState == StateFinished) {
       mTrackletparsetime += std::chrono::high_resolution_clock::now() - parsetimestart;
       LOG(info) << "state finished so bailing out tracklet parsing having read : " << mWordsRead << " words";
@@ -159,7 +159,7 @@ int TrackletsParser::Parse()
         LOG(warn) << "State should be trackletend marker current ?= end marker  ?? " << mState << " ?=" << StateTrackletEndMarker;
       }
       if (mHeaderVerbose) {
-        LOG(info) << "TrackletEndMarker : 0x" << std::hex << *word << " and " << nextwordcopy;
+        LOG(info) << "***TrackletEndMarker : 0x" << std::hex << *word << " and 0x" << nextwordcopy;
       }
       mWordsRead += 2;
       //we should now have a tracklet half chamber header.
@@ -185,7 +185,7 @@ int TrackletsParser::Parse()
         }
         //read the header
         if (mHeaderVerbose) {
-          LOG(info) << "TrackletHCHeader : 0x" << std::hex << *word;
+          LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word;
         }
         //we actually have a header word.
         mTrackletHCHeader = (TrackletHCHeader*)&word;
@@ -200,7 +200,7 @@ int TrackletsParser::Parse()
           //mcmheader
           mTrackletMCMHeader = (TrackletMCMHeader*)&(*word);
           if (mHeaderVerbose) {
-            LOG(info) << "TrackletMCMHeader : 0x" << std::hex << *word;
+            LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word;
             TrackletMCMHeader a;
             a.word = *word;
             printTrackletMCMHeader(a);
@@ -213,8 +213,8 @@ int TrackletsParser::Parse()
           mState = StateTrackletMCMData;
           //tracklet data;
           mTrackletMCMData = (TrackletMCMData*)&(*word);
-          if (mDataVerbose) {
-            LOG(info) << "TrackletMCMData : 0x" << std::hex << *word;
+          if (mHeaderVerbose) {
+            LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word;
             printTrackletMCMData(*mTrackletMCMData);
           }
           mWordsRead++;
@@ -273,11 +273,11 @@ int TrackletsParser::Parse()
           if (mcmtrackletcount > 3) {
             LOG(warn) << "We have more than 3 Tracklets in parsing the TrackletMCMData attached to a single TrackletMCMHeader";
             //dump out preceeding 8 words and subsequent 8 words, might help in diagnostics
-            if (mDataVerbose) {
-              auto debugword = std::prev(word, -8); //
-              int debugcount = -8;
+            if (mVerbose) {
+              auto debugword = std::prev(word, -4); //
+              int debugcount = -4;
               //now output it to info
-              while (debugcount != 16) {
+              while (debugcount != 4) {
                 LOG(info) << "tracklet debug " << debugcount << " 0x" << std::hex << *debugword;
                 debugword++;
                 debugcount++;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -44,24 +44,28 @@ int TrackletsParser::Parse()
   //we are handed the buffer payload of an rdh and need to parse its contents.
   //producing a vector of digits.
 
-  if(mHeaderVerbose){
+  if (mHeaderVerbose) {
     LOG(info) << "Data to parse for Tracklets from " << std::hex << mStartParse << " to " << mEndParse;
-    int wordcount=0;
+    int wordcount = 0;
     std::stringstream outputstring;
-    auto word=mStartParse;
-    outputstring<< "tracklet 0x"<< std::hex << std::setfill('0') << std::setw(6) << 0 << " :: ";
-    while(word <= mEndParse) { // loop over the entire data buffer (a complete link of tracklets and digits)
+    auto word = mStartParse;
+    outputstring << "tracklet 0x" << std::hex << std::setfill('0') << std::setw(6) << 0 << " :: ";
+    while (word <= mEndParse) { // loop over the entire data buffer (a complete link of tracklets and digits)
 
-        if(wordcount!=0 && (wordcount %8 ==0 || word == mEndParse)){
-          LOG(info) << outputstring.str();
-          outputstring.str("");
-          outputstring<< "tracklet 0x"<< std::hex << std::setfill('0') << std::setw(6) << wordcount << " :: ";
-        }
-        if(wordcount==0)outputstring << " 0x"<< std::hex << std::setfill('0')<< std::setw(8) <<  HelperMethods::swapByteOrderreturn(*word); 
-        else outputstring << " 0x"<< std::hex << std::setfill('0')<< std::setw(8) <<  HelperMethods::swapByteOrderreturn(*word); 
-        word++;wordcount++;
+      if (wordcount != 0 && (wordcount % 8 == 0 || word == mEndParse)) {
+        LOG(info) << outputstring.str();
+        outputstring.str("");
+        outputstring << "tracklet 0x" << std::hex << std::setfill('0') << std::setw(6) << wordcount << " :: ";
+      }
+      if (wordcount == 0) {
+        outputstring << " 0x" << std::hex << std::setfill('0') << std::setw(8) << HelperMethods::swapByteOrderreturn(*word);
+      } else {
+        outputstring << " 0x" << std::hex << std::setfill('0') << std::setw(8) << HelperMethods::swapByteOrderreturn(*word);
+      }
+      word++;
+      wordcount++;
     }
-    LOG(info)<< "Data buffer to parse for Digits end";
+    LOG(info) << "Data buffer to parse for Digits end";
     /*for (auto word = mStartParse; word != mEndParse; word+=8) { // loop over the entire data buffer (a complete link of tracklets and digits)
         LOGP(info,"0x{0:08x} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ",std::distance(mStartParse,word),
             HelperMethods::swapByteOrderreturn(*word), HelperMethods::swapByteOrderreturn(*std::next(word,1)),
@@ -71,13 +75,12 @@ int TrackletsParser::Parse()
     }
     LOG(info) << "Data to parse for Tracklets end";*/
   }
-  LOG(info) << "Data to parse for Tracklets properly " << std::hex << mStartParse << " to " << mEndParse;
   //mData holds a buffer containing tracklets parse placing tracklets in the output vector.
   //mData holds 2048 digits.
   mCurrentLink = 0;
   mWordsRead = 0;
   mTrackletsFound = 0;
-  if (mTrackletHCHeaderState == 0) {//TODO move this to the reader as done for the digithcheader
+  if (mTrackletHCHeaderState == 0) { //TODO move this to the reader as done for the digithcheader
     // tracklet hc header is never present
     mState = StateTrackletMCMHeader;
   } else {
@@ -103,9 +106,9 @@ int TrackletsParser::Parse()
   int mcmtrackletcount = 0;
   int trackletloopcount = 0;
   int headertrackletcount = 0;
-//  if (mDataVerbose) {
+  if (mDataVerbose) {
     LOG(info) << "distance to parse over is " << std::distance(mStartParse, mEndParse);
-//  }
+  }
   for (auto word = mStartParse; word != mEndParse; word++) { // loop over the entire data buffer (a complete link of tracklets and digits)
 
     if (mState == StateFinished) {
@@ -131,7 +134,7 @@ int TrackletsParser::Parse()
         LOG(warn) << "State should be trackletend marker current ?= end marker  ?? " << mState << " ?=" << StateTrackletEndMarker;
       }
       if (mHeaderVerbose) {
-        LOG(info) << "***TrackletEndMarker : 0x" << std::hex << *word << " and 0x" << nextwordcopy << " at offset "<<std::distance(mStartParse,word);
+        LOG(info) << "***TrackletEndMarker : 0x" << std::hex << *word << " and 0x" << nextwordcopy << " at offset " << std::distance(mStartParse, word);
       }
       mWordsRead += 2;
       //we should now have a tracklet half chamber header.
@@ -145,7 +148,8 @@ int TrackletsParser::Parse()
     }
     if (*word == o2::trd::constants::CRUPADDING32) {
       //padding word first as it clashes with the hcheader.
-      LOG(info) << "Padding : 0x" << std::hex << *word <<std::distance(mStartParse,word);;
+      LOG(info) << "Padding : 0x" << std::hex << *word << std::distance(mStartParse, word);
+      ;
       mState = StatePadding;
       mWordsRead++;
       LOG(warn) << "CRU Padding word while parsing tracklets. This should *never* happen, this should happen after the tracklet end markers when we are outside the tracklet parsing";
@@ -157,13 +161,13 @@ int TrackletsParser::Parse()
         }
         //read the header
         if (mHeaderVerbose) {
-          LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset "<<std::distance(mStartParse,word);
+          LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
         }
         //we actually have a header word.
         mTrackletHCHeader = (TrackletHCHeader*)&word;
         //sanity check of trackletheader ??
         if (!trackletHCHeaderSanityCheck(*mTrackletHCHeader)) {
-          LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word <<std::distance(mStartParse,word);
+          LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word << std::distance(mStartParse, word);
         }
         mWordsRead++;
         mState = StateTrackletMCMHeader;                                // now we should read a MCMHeader next time through loop
@@ -172,7 +176,8 @@ int TrackletsParser::Parse()
           //mcmheader
           mTrackletMCMHeader = (TrackletMCMHeader*)&(*word);
           if (mHeaderVerbose) {
-            LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word <<std::distance(mStartParse,word);;
+            LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word << std::distance(mStartParse, word);
+            ;
             TrackletMCMHeader a;
             a.word = *word;
             printTrackletMCMHeader(a);
@@ -186,7 +191,8 @@ int TrackletsParser::Parse()
           //tracklet data;
           mTrackletMCMData = (TrackletMCMData*)&(*word);
           if (mHeaderVerbose) {
-            LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word <<std::distance(mStartParse,word);;
+            LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word << std::distance(mStartParse, word);
+            ;
             printTrackletMCMData(*mTrackletMCMData);
           }
           mWordsRead++;

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -573,7 +573,7 @@ int Trap2CRU::writeDigitHCHeader(const int eventcount, const uint32_t linkid)
   digitheader.supermodule = linkid / 60;
   digitheader.numberHCW = 1; // number of additional words in th header, we are using 2 header words so 1 here.
   digitheader.minor = 42;    // my (shtm) version, not used
-  digitheader.major = 4;     // zero suppressed
+  digitheader.major = 0x20;     // zero suppressed
   digitheader.version = 1;   //new version of the header. we only have 1 version
   digitheader.res1 = 1;
   digitheader.ptrigcount = 1;             //TODO put something more real in here?

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -573,7 +573,7 @@ int Trap2CRU::writeDigitHCHeader(const int eventcount, const uint32_t linkid)
   digitheader.supermodule = linkid / 60;
   digitheader.numberHCW = 1; // number of additional words in th header, we are using 2 header words so 1 here.
   digitheader.minor = 42;    // my (shtm) version, not used
-  digitheader.major = 0x20;     // zero suppressed
+  digitheader.major = 0x20;  // zero suppressed
   digitheader.version = 1;   //new version of the header. we only have 1 version
   digitheader.res1 = 1;
   digitheader.ptrigcount = 1;             //TODO put something more real in here?

--- a/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
@@ -75,8 +75,9 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth, bool writeT
                                 // setting a custom callback for closing the writer
                                 MakeRootTreeWriterSpec::CustomClose(finishWriting),
                                 BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS"}, "TRDDigit"},
-                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord", (writeTrigRec ? 1 : 0)},
-                                std::move(labelsdef))();
+                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"tracklettrigs", "TRD", "TRKTRGRD"}, "TrackTrg"})();
+  //                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord", (writeTrigRec ? 1 : 0)},
+  //  std::move(labelsdef))();
 }
 
 } // end namespace trd


### PR DESCRIPTION
fix parsing of zero suppressed digits.
increase verbose output
fix bitcounting error causing slow readout
other speed ups, 7 hours per timeframe now down to .7ms per timeframe.
byteswap the adc bit pattern word
fix the  DigitMCMADCMask it was reversed.

attempt to jump the non tracklet data at the beginning of the tracklet parse block, partially successful.
erroneous additional digits are marked with EEE in info output

change datareader to write out triggers with the digits (temporary most likely)

This could well change depending on the testing tomorrow.